### PR TITLE
[CRE-875, CRE-981] Migrate CREv2 system-tests to v2 contracts + amend CI

### DIFF
--- a/.changeset/sixty-kiwis-hope.md
+++ b/.changeset/sixty-kiwis-hope.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#internal Make CREv2 system tests to run with v2 contracts/registries

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -89,10 +89,10 @@ jobs:
 
           # Add list of tests with certain topologies
           PER_TEST_TOPOLOGIES_JSON=${PER_TEST_TOPOLOGIES_JSON:-'{
-            "Test_SecureMint": [
+            "Test_CRE_Suite_V1_SecureMint": [
                {"topology":"workflow","configs":"configs/workflow-solana-don.toml"}
              ],
-            "Test_CRE_Suite_Tron": [
+            "Test_CRE_Suite_V1_Tron": [
                {"topology":"workflow","configs":"configs/workflow-don-tron.toml"}
              ]
               }'}
@@ -132,9 +132,20 @@ jobs:
                 | $e.value[] | {test_name: $e.key} + .
               ] as $extra
 
-            # Combine and add test_id
+            # Combine and add test_id and CRE version
             | ($base + $extra)
-            | to_entries | map(.value + {test_id: .key})
+            | to_entries 
+            | map(
+                .value + {
+                  test_id: .key,
+                  # Add CRE version based on test name pattern
+                  cre_version: (
+                    if (.value.test_name | test("V2")) then "v2"
+                    else "v1"
+                    end
+                  )
+                }
+              )
           ')
 
           tests=$(echo "$tests" | jq -c .)
@@ -204,7 +215,7 @@ jobs:
           go install gotest.tools/gotestsum@v1.12.3
           echo "::endgroup::"
 
-      - name: Start local CRE
+      - name: Start local CRE${{ matrix.tests.cre_version }}
         shell: bash
         id: start-local-cre
         env:
@@ -213,17 +224,27 @@ jobs:
           E2E_TEST_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name }}"
           E2E_TEST_CHAINLINK_VERSION: ${{ inputs.chainlink_image_tag != '' && inputs.chainlink_image_tag || inputs.chainlink_version }}
           CTF_CONFIGS: ${{ matrix.tests.configs }}
+          CRE_VERSION: ${{ matrix.tests.cre_version }}
+          TEST_NAME: ${{ matrix.tests.test_name }}
         run: |
           cd core/scripts/cre/environment
-          go run . env start --with-plugins-docker-image "${E2E_TEST_CHAINLINK_IMAGE}:${E2E_TEST_CHAINLINK_VERSION}"
-          exit_code=$?
 
+          # Start CRE with the appropriate contracts version (i.e. Workflow/CapabilityRegistry)
+          if [[ "${CRE_VERSION}" == "v1" ]]; then
+            echo "Starting CRE with v1 contracts for test: '${TEST_NAME}'"
+            go run . env start --with-plugins-docker-image "${E2E_TEST_CHAINLINK_IMAGE}:${E2E_TEST_CHAINLINK_VERSION}"
+          else
+            echo "Starting CRE with v2 contracts for test: '${TEST_NAME}'"
+            go run . env start --with-plugins-docker-image "${E2E_TEST_CHAINLINK_IMAGE}:${E2E_TEST_CHAINLINK_VERSION}" --with-contracts-version v2
+          fi
+          
+          exit_code=$?
           if [ $exit_code -ne 0 ]; then
-            echo "Error: failed to start local CRE, exit code $exit_code"
+            echo "Error: failed to start local CRE ${CRE_VERSION}, exit code $exit_code"
             exit $exit_code
           fi
 
-      - name: Run CRE Smoke system tests
+      - name: Run CRE${{ matrix.tests.cre_version }} Smoke system tests
         id: run-tests
         shell: bash
         working-directory: system-tests/tests
@@ -252,7 +273,7 @@ jobs:
           # when auto-quarantine is enabled, allow this to determine test failures
           trunk-upload-only: ${{ env.ENABLE_AUTO_QUARANTINE != 'true' }}
 
-      - name: Run CRE Regression system tests
+      - name: Run CRE${{ matrix.tests.cre_version }} Regression system tests
         if: ${{ inputs.with_regression }}
         shell: bash
         working-directory: system-tests/tests

--- a/system-tests/tests/regression/cre/cre_regression_suite_test.go
+++ b/system-tests/tests/regression/cre/cre_regression_suite_test.go
@@ -21,7 +21,7 @@ Inside `core/scripts/cre/environment` directory
  6. Execute the tests in `system-tests/tests/smoke/cre` with CTF_CONFIG set to the corresponding topology file:
     `export  CTF_CONFIGS=../../../../core/scripts/cre/environment/configs/<topology>.toml; go test -timeout 15m -run ^Test_CRE_Suite$`.
 */
-func Test_CRE_Suite_Regression(t *testing.T) {
+func Test_CRE_Suite_V2_Regression(t *testing.T) {
 	flags := []string{"--with-contracts-version", "v2"}
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), flags...)
 
@@ -35,7 +35,7 @@ func Test_CRE_Suite_Regression(t *testing.T) {
 	})
 }
 
-func Test_CRE_Suite_EVM_Regression(t *testing.T) {
+func Test_CRE_Suite_V2_EVM_Regression(t *testing.T) {
 	flags := []string{"--with-contracts-version", "v2"}
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), flags...)
 	// TODO remove this when OCR works properly with multiple chains in Local CRE

--- a/system-tests/tests/regression/cre/cre_regression_suite_test.go
+++ b/system-tests/tests/regression/cre/cre_regression_suite_test.go
@@ -22,7 +22,9 @@ Inside `core/scripts/cre/environment` directory
     `export  CTF_CONFIGS=../../../../core/scripts/cre/environment/configs/<topology>.toml; go test -timeout 15m -run ^Test_CRE_Suite$`.
 */
 func Test_CRE_Suite_Regression(t *testing.T) {
-	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t))
+	flags := []string{"--with-contracts-version", "v2"}
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), flags...)
+
 	t.Run("[v2] CRE Regression Suite", func(t *testing.T) {
 		for _, tCase := range cronInvalidSchedulesTests {
 			testName := "[v2] Cron (Beholder) fails when schedule is " + tCase.name
@@ -34,7 +36,8 @@ func Test_CRE_Suite_Regression(t *testing.T) {
 }
 
 func Test_CRE_Suite_EVM_Regression(t *testing.T) {
-	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t))
+	flags := []string{"--with-contracts-version", "v2"}
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), flags...)
 	// TODO remove this when OCR works properly with multiple chains in Local CRE
 	testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
 

--- a/system-tests/tests/regression/cre/v2_cron_beholder_regression_test.go
+++ b/system-tests/tests/regression/cre/v2_cron_beholder_regression_test.go
@@ -38,7 +38,7 @@ func CronBeholderFailsWithInvalidScheduleTest(t *testing.T, testEnv *ttypes.Test
 	t_helpers.CompileAndDeployWorkflow(t, testEnv, testLogger, workflowName, &workflowConfig, workflowFileLocation)
 
 	testLogger.Warn().Msgf("Expecting Cron workflow to fail with invalid schedule: %s", invalidSchedule)
-	expectedBeholderLog := "expecting the error from a Beholder messages test validator" // no empty string, because it may match a message
+	expectedBeholderLog := "beholder found engine initialization failure message!"
 	timeout := 2 * time.Minute
 	expectedError := t_helpers.AssertBeholderMessage(listenerCtx, t, expectedBeholderLog, testLogger, messageChan, kafkaErrChan, timeout)
 	require.Error(t, expectedError, "Cron (Beholder) test failed. This test expects to fail with an error, but did not.")

--- a/system-tests/tests/regression/cre/v2_cron_beholder_regression_test.go
+++ b/system-tests/tests/regression/cre/v2_cron_beholder_regression_test.go
@@ -39,7 +39,7 @@ func CronBeholderFailsWithInvalidScheduleTest(t *testing.T, testEnv *ttypes.Test
 
 	testLogger.Warn().Msgf("Expecting Cron workflow to fail with invalid schedule: %s", invalidSchedule)
 	expectedBeholderLog := "expecting the error from a Beholder messages test validator" // no empty string, because it may match a message
-	timeout := 1 * time.Minute
+	timeout := 2 * time.Minute
 	expectedError := t_helpers.AssertBeholderMessage(listenerCtx, t, expectedBeholderLog, testLogger, messageChan, kafkaErrChan, timeout)
 	require.Error(t, expectedError, "Cron (Beholder) test failed. This test expects to fail with an error, but did not.")
 

--- a/system-tests/tests/smoke/cre/cre_suite_test.go
+++ b/system-tests/tests/smoke/cre/cre_suite_test.go
@@ -7,7 +7,11 @@ import (
 	t_helpers "github.com/smartcontractkit/chainlink/system-tests/tests/test-helpers"
 )
 
-// SMOKE TESTS target happy path and sanity checks, all other tests (e.g. edge cases, negative conditions) should go to a `regression` package.
+//////////// SMOKE TESTS /////////////
+// target happy path and sanity checks
+// all other tests (e.g. edge cases, negative conditions)
+// should go to a `regression` package.
+/////////////////////////////////////
 
 /*
 To execute tests locally start the local CRE first:
@@ -26,43 +30,67 @@ func Test_CRE_Suite(t *testing.T) {
 	// logging into CL node with GraphQL API, which allows only 1 session per user at a time.
 	t.Run("[v1] CRE Suite", func(t *testing.T) {
 		// requires `readcontract`, `cron`
-		t.Run("[v1] CRE Proof of Reserve (PoR) Test", func(t *testing.T) {
+		t.Run("[v1] Proof of Reserve (PoR) Test", func(t *testing.T) {
 			priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV1", PoRWFV1Location)
 			ExecutePoRTest(t, testEnv, priceProvider, porWfCfg)
 		})
 	})
+}
 
-	t.Run("[v2] CRE Suite", func(t *testing.T) {
-		t.Run("[v2] vault DON test", func(t *testing.T) {
-			ExecuteVaultTest(t, testEnv)
-		})
+func Test_CRE_Suite_Tron(t *testing.T) {
+	t.Run("[v1] Tron Write Test with PoR", func(t *testing.T) {
+		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetTestConfig(t, "/configs/workflow-don-tron.toml"))
 
-		t.Run("[v2] Cron (Beholder) happy path", func(t *testing.T) {
-			ExecuteCronBeholderTest(t, testEnv)
-		})
+		priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV1", PoRWFV1Location)
+		ExecutePoRTest(t, testEnv, priceProvider, porWfCfg)
+	})
+}
 
-		t.Run("[v2] HTTP trigger and action test", func(t *testing.T) {
-			ExecuteHTTPTriggerActionTest(t, testEnv)
-		})
+/*
+To execute tests with v2 contracts start the local CRE first:
+ 1. Inside `core/scripts/cre/environment` directory: `go run . env restart --with-beholder --with-contracts-version v2`
+ 2. Execute the tests in `system-tests/tests/smoke/cre` with CTF_CONFIG set to the corresponding topology file:
+    `export  CTF_CONFIGS=../../../../core/scripts/cre/environment/configs/<topology>.toml; go test -timeout 15m -run ^Test_CRE_Suite$`.
+*/
+func Test_CRE_Suite_WithV2Registries(t *testing.T) {
+	flags := []string{"--with-contracts-version", "v2"}
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), flags...)
 
-		t.Run("[v2] DON Time test", func(t *testing.T) {
-			ExecuteDonTimeTest(t, testEnv)
-		})
+	t.Run("[v2] CRE Proof of Reserve (PoR) Test", func(t *testing.T) {
+		priceProvider, wfConfig := beforePoRTest(t, testEnv, "por-workflow", PoRWFV1Location)
+		ExecutePoRTest(t, testEnv, priceProvider, wfConfig)
+	})
 
-		t.Run("[v2] Billing test", func(t *testing.T) {
-			ExecuteBillingTest(t, testEnv)
-		})
+	t.Run("[v2] Vault DON test", func(t *testing.T) {
+		ExecuteVaultTest(t, testEnv)
+	})
 
-		t.Run("[v2] Consensus test", func(t *testing.T) {
-			executeConsensusTest(t, testEnv)
-		})
+	t.Run("[v2] Cron (Beholder) happy path", func(t *testing.T) {
+		ExecuteCronBeholderTest(t, testEnv)
+	})
+
+	t.Run("[v2] HTTP trigger and action test", func(t *testing.T) {
+		ExecuteHTTPTriggerActionTest(t, testEnv)
+	})
+
+	t.Run("[v2] DON Time test", func(t *testing.T) {
+		ExecuteDonTimeTest(t, testEnv)
+	})
+
+	t.Run("[v2] Billing test", func(t *testing.T) {
+		ExecuteBillingTest(t, testEnv)
+	})
+
+	t.Run("[v2] Consensus test", func(t *testing.T) {
+		ExecuteConsensusTest(t, testEnv)
 	})
 }
 
 func Test_CRE_Suite_EVM(t *testing.T) {
-	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t))
+	flags := []string{"--with-contracts-version", "v2"}
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), flags...)
 
-	// TODO remove this when OCR works properly with multiple chains in Local CRE
+	// TODO: remove this when OCR works properly with multiple chains in Local CRE
 	testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
 	t.Run("[v2] EVM Write happy path test", func(t *testing.T) {
 		priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV2", PoRWFV2Location)
@@ -72,23 +100,5 @@ func Test_CRE_Suite_EVM(t *testing.T) {
 
 	t.Run("[v2] EVM Read happy path test", func(t *testing.T) {
 		ExecuteEVMReadTest(t, testEnv)
-	})
-}
-
-func Test_CRE_Suite_Tron(t *testing.T) {
-	t.Run("Write Test", func(t *testing.T) {
-		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetTestConfig(t, "/configs/workflow-don-tron.toml"))
-
-		priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV1", PoRWFV1Location)
-		ExecutePoRTest(t, testEnv, priceProvider, porWfCfg)
-	})
-}
-
-func Test_CRE_Suite_withV2Registries(t *testing.T) {
-	t.Run("[v1] CRE Proof of Reserve (PoR) Test", func(t *testing.T) {
-		flags := []string{"--with-contracts-version", "v2"}
-		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), flags...)
-		priceProvider, wfConfig := beforePoRTest(t, testEnv, "por-workflow", PoRWFV1Location)
-		ExecutePoRTest(t, testEnv, priceProvider, wfConfig)
 	})
 }

--- a/system-tests/tests/smoke/cre/cre_suite_test.go
+++ b/system-tests/tests/smoke/cre/cre_suite_test.go
@@ -24,7 +24,7 @@ Inside `core/scripts/cre/environment` directory
  6. Execute the tests in `system-tests/tests/smoke/cre` with CTF_CONFIG set to the corresponding topology file:
     `export  CTF_CONFIGS=../../../../core/scripts/cre/environment/configs/<topology>.toml; go test -timeout 15m -run ^Test_CRE_Suite$`.
 */
-func Test_CRE_Suite(t *testing.T) {
+func Test_CRE_Suite_V1(t *testing.T) {
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t))
 	// WARNING: currently we can't run these tests in parallel, because each test rebuilds environment structs and that includes
 	// logging into CL node with GraphQL API, which allows only 1 session per user at a time.
@@ -37,22 +37,31 @@ func Test_CRE_Suite(t *testing.T) {
 	})
 }
 
-func Test_CRE_Suite_Tron(t *testing.T) {
-	t.Run("[v1] Tron Write Test with PoR", func(t *testing.T) {
-		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetTestConfig(t, "/configs/workflow-don-tron.toml"))
+func Test_CRE_Suite_V1_Tron(t *testing.T) {
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetTestConfig(t, "/configs/workflow-don-tron.toml"))
 
+	t.Run("[v1] Tron Write Test with PoR", func(t *testing.T) {
 		priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV1", PoRWFV1Location)
 		ExecutePoRTest(t, testEnv, priceProvider, porWfCfg)
 	})
 }
 
+func Test_CRE_Suite_V1_SecureMint(t *testing.T) {
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetTestConfig(t, "/configs/workflow-solana-don.toml"))
+
+	t.Run("[v1] SecureMint Test with PoR", func(t *testing.T) {
+		ExecuteSecureMintTest(t, testEnv)
+	})
+}
+
+//////////// V2 TESTS /////////////
 /*
 To execute tests with v2 contracts start the local CRE first:
  1. Inside `core/scripts/cre/environment` directory: `go run . env restart --with-beholder --with-contracts-version v2`
  2. Execute the tests in `system-tests/tests/smoke/cre` with CTF_CONFIG set to the corresponding topology file:
     `export  CTF_CONFIGS=../../../../core/scripts/cre/environment/configs/<topology>.toml; go test -timeout 15m -run ^Test_CRE_Suite$`.
 */
-func Test_CRE_Suite_WithV2Registries(t *testing.T) {
+func Test_CRE_Suite_V2(t *testing.T) {
 	flags := []string{"--with-contracts-version", "v2"}
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), flags...)
 
@@ -86,7 +95,7 @@ func Test_CRE_Suite_WithV2Registries(t *testing.T) {
 	})
 }
 
-func Test_CRE_Suite_EVM(t *testing.T) {
+func Test_CRE_Suite_V2_EVM(t *testing.T) {
 	flags := []string{"--with-contracts-version", "v2"}
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), flags...)
 

--- a/system-tests/tests/smoke/cre/v1_securemint_test.go
+++ b/system-tests/tests/smoke/cre/v1_securemint_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"path/filepath"
 	"strings"
 	"testing"
 	texttmpl "text/template"
@@ -46,20 +45,10 @@ import (
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/mock/pb"
 	"github.com/smartcontractkit/chainlink/v2/core/testdata/testspecs"
 
-	t_helpers "github.com/smartcontractkit/chainlink/system-tests/tests/test-helpers"
 	ttypes "github.com/smartcontractkit/chainlink/system-tests/tests/test-helpers/configuration"
 )
 
-func Test_SecureMint(t *testing.T) {
-	tconf := t_helpers.GetDefaultTestConfig(t)
-	tconf.EnvironmentConfigPath = filepath.Join(tconf.EnvironmentDirPath, "/configs/workflow-solana-don.toml")
-
-	tenv := t_helpers.SetupTestEnvironmentWithConfig(t, tconf)
-
-	executeSecureMintTest(t, tenv)
-}
-
-func executeSecureMintTest(t *testing.T, tenv *ttypes.TestEnvironment) {
+func ExecuteSecureMintTest(t *testing.T, tenv *ttypes.TestEnvironment) {
 	creEnvironment := tenv.CreEnvironment
 	wrappedBlockchainOutputs := tenv.WrappedBlockchainOutputs
 	ds := creEnvironment.CldfEnvironment.DataStore

--- a/system-tests/tests/smoke/cre/v2_consensus_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_consensus_capability_test.go
@@ -19,7 +19,7 @@ import (
 	ttypes "github.com/smartcontractkit/chainlink/system-tests/tests/test-helpers/configuration"
 )
 
-func executeConsensusTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
+func ExecuteConsensusTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 	testLogger := framework.L
 
 	beholder, err := t_helpers.NewBeholder(testLogger, testEnv.TestConfig.RelativePathToRepoRoot, testEnv.TestConfig.EnvironmentDirPath)

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -149,6 +149,7 @@ func StartBeholder(t *testing.T, testLogger zerolog.Logger, testEnv *ttypes.Test
 	})
 
 	beholderMsgChan, beholderErrChan := beholder.SubscribeToBeholderMessages(listenerCtx, messageTypes)
+	drainChannels(beholderMsgChan, beholderErrChan) // drain any old messages, if any
 	return listenerCtx, beholderMsgChan, beholderErrChan
 }
 
@@ -185,9 +186,6 @@ func AssertBeholderMessage(ctx context.Context, t *testing.T, expectedLog string
 	foundExpectedLog := make(chan bool, 1) // Channel to signal when expected log is found
 	foundErrorLog := make(chan bool, 1)    // Channel to signal when engine initialization failure is detected
 	receivedUserLogs := 0
-
-	// Drain any existing messages in the channels before validation
-	drainChannels(messageChan, kafkaErrChan)
 
 	// Start message processor goroutine
 	go func() {

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -607,11 +607,13 @@ func deleteWorkflows(t *testing.T, uniqueWorkflowName string,
 	switch tv.Version.Major() {
 	case 2:
 		// TODO(CRE-876): delete with workflowID
+		testLogger.Warn().Msg("Skipping workflow deletion from the registry for v2 workflows (not implemented yet, see CRE-876)")
 		return
 	default:
 	}
 	deleteErr := creworkflow.DeleteWithContract(t.Context(), blockchainOutputs[0].SethClient, workflowRegistryAddress, tv, uniqueWorkflowName)
 	require.NoError(t, deleteErr, "failed to delete workflow '%s'. Please delete/unregister it manually.", uniqueWorkflowName)
+	testLogger.Info().Msgf("Workflow '%s' deleted successfully from the registry.", uniqueWorkflowName)
 }
 
 func CompileAndDeployWorkflow[T WorkflowConfig](t *testing.T,


### PR DESCRIPTION
[CRE-875](https://smartcontract-it.atlassian.net/browse/CRE-875)
Migrate CREv2 system tests to v2 contracts/registries.

[CRE-981](https://smartcontract-it.atlassian.net/browse/CRE-981)
Update CI workflows so that before a CRE test is triggered, it starts the required version of the CRE environment with the appropriate versions of contracts and registries, based on the contract versions needed for the tests.
The version of CRE to run is displayed in the GH job names, as shown in the screenshot.
<img width="825" height="741" alt="image" src="https://github.com/user-attachments/assets/f7a6dca9-3ead-4b1d-82bd-5d794194bacb" />


[CRE-875]: https://smartcontract-it.atlassian.net/browse/CRE-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRE-981]: https://smartcontract-it.atlassian.net/browse/CRE-981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ