### PR TITLE
Fix float rounding issue in por_test and add logging for future flakes

### DIFF
--- a/system-tests/tests/smoke/cre/por_test.go
+++ b/system-tests/tests/smoke/cre/por_test.go
@@ -394,6 +394,9 @@ func validatePoRPrices(t *testing.T, testEnv *ttypes.TestEnvironment, priceProvi
 			expected := totalPoRExpectedPrices(ppExpectedPrices, &additionalPrice)
 			actual := priceProvider.ActualPrices(feedID)
 
+			testEnv.Logger.Info().Msgf("Feed %s - expected): %v", feedID, expected)
+			testEnv.Logger.Info().Msgf("Feed %s - actual: %v", feedID, actual)
+
 			if len(expected) != len(actual) {
 				return fmt.Errorf("expected %d prices, got %d", len(expected), len(actual))
 			}


### PR DESCRIPTION
There have been some strange flakes in this test that have been difficult to identify ([example](https://github.com/smartcontractkit/chainlink/actions/runs/17965969861/job/51099024942)). This PR introduces additional logging to aid in debugging this flake in the future. 

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
