### PR TITLE
CL64.3-2-JWT-Replay

### DIFF
--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -42,7 +42,7 @@ type httpTriggerHandler struct {
 	donConfig               *config.DONConfig
 	lggr                    logger.Logger
 	callbacksMu             sync.Mutex
-	callbacks               map[string]savedCallback // executionID -> savedCallback
+	callbacks               map[string]savedCallback // requestID -> savedCallback
 	stopCh                  services.StopChan
 	workflowMetadataHandler *WorkflowMetadataHandler
 	userRateLimiter         *ratelimit.RateLimiter
@@ -80,16 +80,6 @@ func (h *httpTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req *
 		return err
 	}
 
-	executionID, err := workflows.EncodeExecutionID(workflowID, req.ID)
-	if err != nil {
-		h.handleUserError(ctx, req.ID, jsonrpc.ErrInternal, internalErrorMessage, callback)
-		return errors.New("error generating execution ID: " + err.Error())
-	}
-
-	if err := h.setupCallback(ctx, executionID, req.ID, callback, requestStartTime); err != nil {
-		return err
-	}
-
 	key, err := h.authorizeRequest(ctx, workflowID, req, callback)
 	if err != nil {
 		return err
@@ -99,10 +89,20 @@ func (h *httpTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req *
 		return err
 	}
 
+	executionID, err := workflows.EncodeExecutionID(workflowID, req.ID)
+	if err != nil {
+		h.handleUserError(ctx, req.ID, jsonrpc.ErrInternal, internalErrorMessage, callback)
+		return errors.New("error generating execution ID: " + err.Error())
+	}
+
 	reqWithKey, err := reqWithAuthorizedKey(triggerReq, *key)
 	if err != nil {
 		h.handleUserError(ctx, req.ID, jsonrpc.ErrInvalidRequest, "Auth failure", callback)
 		return errors.Join(errors.New("auth failure"), err)
+	}
+
+	if err := h.setupCallback(ctx, req.ID, callback, requestStartTime); err != nil {
+		return err
 	}
 
 	return h.sendWithRetries(ctx, executionID, reqWithKey)
@@ -253,14 +253,13 @@ func (h *httpTriggerHandler) checkRateLimit(ctx context.Context, workflowID, req
 	return nil
 }
 
-func (h *httpTriggerHandler) setupCallback(ctx context.Context, executionID, requestID string, callback handlers.Callback, requestStartTime time.Time) error {
+func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string, callback handlers.Callback, requestStartTime time.Time) error {
 	h.callbacksMu.Lock()
 	defer h.callbacksMu.Unlock()
 
-	// If executionID is already in the progress, do not process it.
-	if _, found := h.callbacks[executionID]; found {
-		h.handleUserError(ctx, requestID, jsonrpc.ErrConflict, "execution already in progress. Ensure the requestID is unique for each request.", callback)
-		return errors.New("execution already in progress. Ensure the requestID is unique for each request.")
+	if _, found := h.callbacks[requestID]; found {
+		h.handleUserError(ctx, requestID, jsonrpc.ErrConflict, "in-flight request", callback)
+		return errors.New("in-flight request ID: " + requestID)
 	}
 
 	// 2f + 1 is chosen to ensure that majority of honest nodes are executing the request
@@ -269,7 +268,7 @@ func (h *httpTriggerHandler) setupCallback(ctx context.Context, executionID, req
 		return errors.New("failed to create response aggregator: " + err.Error())
 	}
 
-	h.callbacks[executionID] = savedCallback{
+	h.callbacks[requestID] = savedCallback{
 		Callback:           callback,
 		requestStartTime:   requestStartTime,
 		createdAt:          time.Now(),
@@ -279,21 +278,19 @@ func (h *httpTriggerHandler) setupCallback(ctx context.Context, executionID, req
 }
 
 func (h *httpTriggerHandler) HandleNodeTriggerResponse(ctx context.Context, resp *jsonrpc.Response[json.RawMessage], nodeAddr string) error {
-	executionID := resp.ID
-	h.lggr.Debugw("handling trigger response", "executionID", executionID, "nodeAddr", nodeAddr, "error", resp.Error, "result", resp.Result)
+	h.lggr.Debugw("handling trigger response", "requestID", resp.ID, "nodeAddr", nodeAddr, "error", resp.Error, "result", resp.Result)
 	h.callbacksMu.Lock()
 	defer h.callbacksMu.Unlock()
-
-	saved, exists := h.callbacks[executionID]
+	saved, exists := h.callbacks[resp.ID]
 	if !exists {
-		return errors.New("callback not found for execution ID: " + executionID)
+		return errors.New("callback not found for request ID: " + resp.ID)
 	}
 	aggResp, err := saved.responseAggregator.CollectAndAggregate(resp, nodeAddr)
 	if err != nil {
 		return err
 	}
 	if aggResp == nil {
-		h.lggr.Debugw("Not enough responses to aggregate", "executionID", executionID, "nodeAddress", nodeAddr)
+		h.lggr.Debugw("Not enough responses to aggregate", "requestID", resp.ID, "nodeAddress", nodeAddr)
 		return nil
 	}
 	rawResp, err := json.Marshal(aggResp)
@@ -308,7 +305,7 @@ func (h *httpTriggerHandler) HandleNodeTriggerResponse(ctx context.Context, resp
 	if err != nil {
 		return err
 	}
-	delete(h.callbacks, executionID)
+	delete(h.callbacks, resp.ID)
 	latencyMs := time.Since(saved.requestStartTime).Milliseconds()
 	h.metrics.Trigger.RecordRequestHandlerLatency(ctx, latencyMs, h.lggr)
 	return nil
@@ -347,10 +344,10 @@ func (h *httpTriggerHandler) reapExpiredCallbacks(ctx context.Context) {
 	defer h.callbacksMu.Unlock()
 	now := time.Now()
 	var expiredCount int
-	for executionID, callback := range h.callbacks {
+	for reqID, callback := range h.callbacks {
 		if now.Sub(callback.createdAt) > time.Duration(h.config.MaxTriggerRequestDurationMs)*time.Millisecond {
 			h.metrics.Trigger.IncrementRequestErrors(ctx, jsonrpc.ErrInternal, h.lggr)
-			delete(h.callbacks, executionID)
+			delete(h.callbacks, reqID)
 			expiredCount++
 		}
 	}

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -42,7 +42,7 @@ type httpTriggerHandler struct {
 	donConfig               *config.DONConfig
 	lggr                    logger.Logger
 	callbacksMu             sync.Mutex
-	callbacks               map[string]savedCallback // requestID -> savedCallback
+	callbacks               map[string]savedCallback // executionID -> savedCallback
 	stopCh                  services.StopChan
 	workflowMetadataHandler *WorkflowMetadataHandler
 	userRateLimiter         *ratelimit.RateLimiter
@@ -80,6 +80,16 @@ func (h *httpTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req *
 		return err
 	}
 
+	executionID, err := workflows.EncodeExecutionID(workflowID, req.ID)
+	if err != nil {
+		h.handleUserError(ctx, req.ID, jsonrpc.ErrInternal, internalErrorMessage, callback)
+		return errors.New("error generating execution ID: " + err.Error())
+	}
+
+	if err := h.setupCallback(ctx, executionID, req.ID, callback, requestStartTime); err != nil {
+		return err
+	}
+
 	key, err := h.authorizeRequest(ctx, workflowID, req, callback)
 	if err != nil {
 		return err
@@ -89,20 +99,10 @@ func (h *httpTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req *
 		return err
 	}
 
-	executionID, err := workflows.EncodeExecutionID(workflowID, req.ID)
-	if err != nil {
-		h.handleUserError(ctx, req.ID, jsonrpc.ErrInternal, internalErrorMessage, callback)
-		return errors.New("error generating execution ID: " + err.Error())
-	}
-
 	reqWithKey, err := reqWithAuthorizedKey(triggerReq, *key)
 	if err != nil {
 		h.handleUserError(ctx, req.ID, jsonrpc.ErrInvalidRequest, "Auth failure", callback)
 		return errors.Join(errors.New("auth failure"), err)
-	}
-
-	if err := h.setupCallback(ctx, req.ID, callback, requestStartTime); err != nil {
-		return err
 	}
 
 	return h.sendWithRetries(ctx, executionID, reqWithKey)
@@ -253,13 +253,14 @@ func (h *httpTriggerHandler) checkRateLimit(ctx context.Context, workflowID, req
 	return nil
 }
 
-func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string, callback handlers.Callback, requestStartTime time.Time) error {
+func (h *httpTriggerHandler) setupCallback(ctx context.Context, executionID, requestID string, callback handlers.Callback, requestStartTime time.Time) error {
 	h.callbacksMu.Lock()
 	defer h.callbacksMu.Unlock()
 
-	if _, found := h.callbacks[requestID]; found {
-		h.handleUserError(ctx, requestID, jsonrpc.ErrConflict, "in-flight request", callback)
-		return errors.New("in-flight request ID: " + requestID)
+	// If executionID is already in the progress, do not process it.
+	if _, found := h.callbacks[executionID]; found {
+		h.handleUserError(ctx, requestID, jsonrpc.ErrConflict, "execution already in progress. Ensure the requestID is unique for each request.", callback)
+		return errors.New("execution already in progress. Ensure the requestID is unique for each request.")
 	}
 
 	// 2f + 1 is chosen to ensure that majority of honest nodes are executing the request
@@ -268,7 +269,7 @@ func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string
 		return errors.New("failed to create response aggregator: " + err.Error())
 	}
 
-	h.callbacks[requestID] = savedCallback{
+	h.callbacks[executionID] = savedCallback{
 		Callback:           callback,
 		requestStartTime:   requestStartTime,
 		createdAt:          time.Now(),
@@ -278,19 +279,21 @@ func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string
 }
 
 func (h *httpTriggerHandler) HandleNodeTriggerResponse(ctx context.Context, resp *jsonrpc.Response[json.RawMessage], nodeAddr string) error {
-	h.lggr.Debugw("handling trigger response", "requestID", resp.ID, "nodeAddr", nodeAddr, "error", resp.Error, "result", resp.Result)
+	executionID := resp.ID
+	h.lggr.Debugw("handling trigger response", "executionID", executionID, "nodeAddr", nodeAddr, "error", resp.Error, "result", resp.Result)
 	h.callbacksMu.Lock()
 	defer h.callbacksMu.Unlock()
-	saved, exists := h.callbacks[resp.ID]
+
+	saved, exists := h.callbacks[executionID]
 	if !exists {
-		return errors.New("callback not found for request ID: " + resp.ID)
+		return errors.New("callback not found for execution ID: " + executionID)
 	}
 	aggResp, err := saved.responseAggregator.CollectAndAggregate(resp, nodeAddr)
 	if err != nil {
 		return err
 	}
 	if aggResp == nil {
-		h.lggr.Debugw("Not enough responses to aggregate", "requestID", resp.ID, "nodeAddress", nodeAddr)
+		h.lggr.Debugw("Not enough responses to aggregate", "executionID", executionID, "nodeAddress", nodeAddr)
 		return nil
 	}
 	rawResp, err := json.Marshal(aggResp)
@@ -305,7 +308,7 @@ func (h *httpTriggerHandler) HandleNodeTriggerResponse(ctx context.Context, resp
 	if err != nil {
 		return err
 	}
-	delete(h.callbacks, resp.ID)
+	delete(h.callbacks, executionID)
 	latencyMs := time.Since(saved.requestStartTime).Milliseconds()
 	h.metrics.Trigger.RecordRequestHandlerLatency(ctx, latencyMs, h.lggr)
 	return nil
@@ -344,10 +347,10 @@ func (h *httpTriggerHandler) reapExpiredCallbacks(ctx context.Context) {
 	defer h.callbacksMu.Unlock()
 	now := time.Now()
 	var expiredCount int
-	for reqID, callback := range h.callbacks {
+	for executionID, callback := range h.callbacks {
 		if now.Sub(callback.createdAt) > time.Duration(h.config.MaxTriggerRequestDurationMs)*time.Millisecond {
 			h.metrics.Trigger.IncrementRequestErrors(ctx, jsonrpc.ErrInternal, h.lggr)
-			delete(h.callbacks, reqID)
+			delete(h.callbacks, executionID)
 			expiredCount++
 		}
 	}

--- a/core/services/gateway/handlers/capabilities/v2/metrics/metrics.go
+++ b/core/services/gateway/handlers/capabilities/v2/metrics/metrics.go
@@ -56,6 +56,8 @@ type TriggerMetrics struct {
 	metadataRequestCount             metric.Int64Counter
 	metadataObservationsCleanUpCount metric.Int64Counter
 	metadataObservationsCount        metric.Int64Gauge
+	requestCacheSize                 metric.Int64Gauge
+	requestCacheCleanUpCount         metric.Int64Counter
 }
 
 // Metrics combines all gateway metrics for dependency injection
@@ -328,6 +330,22 @@ func newTriggerMetrics(meter metric.Meter) (*TriggerMetrics, error) {
 		return nil, fmt.Errorf("failed to create workflow metadata observations count metric: %w", err)
 	}
 
+	m.requestCacheSize, err = meter.Int64Gauge(
+		"http_trigger_request_cache_size",
+		metric.WithDescription("Current number of entries in JWT replay protection cache"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP trigger request cache size metric: %w", err)
+	}
+
+	m.requestCacheCleanUpCount, err = meter.Int64Counter(
+		"http_trigger_request_cache_cleanup_count",
+		metric.WithDescription("Number of JWT replay protection cache entries cleaned up"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP trigger request cache cleanup count metric: %w", err)
+	}
+
 	return m, nil
 }
 
@@ -455,4 +473,12 @@ func (m *TriggerMetrics) IncrementMetadataObservationsCleanUpCount(ctx context.C
 
 func (m *TriggerMetrics) RecordMetadataObservationsCount(ctx context.Context, count int64, lggr logger.Logger) {
 	m.metadataObservationsCount.Record(ctx, count)
+}
+
+func (m *TriggerMetrics) RecordRequestCacheSize(ctx context.Context, size int64, lggr logger.Logger) {
+	m.requestCacheSize.Record(ctx, size)
+}
+
+func (m *TriggerMetrics) IncrementRequestCacheCleanUpCount(ctx context.Context, count int64, lggr logger.Logger) {
+	m.requestCacheCleanUpCount.Add(ctx, count)
 }

--- a/core/services/gateway/handlers/capabilities/v2/metrics/metrics.go
+++ b/core/services/gateway/handlers/capabilities/v2/metrics/metrics.go
@@ -56,8 +56,8 @@ type TriggerMetrics struct {
 	metadataRequestCount             metric.Int64Counter
 	metadataObservationsCleanUpCount metric.Int64Counter
 	metadataObservationsCount        metric.Int64Gauge
-	requestCacheSize                 metric.Int64Gauge
-	requestCacheCleanUpCount         metric.Int64Counter
+	jwtCacheSize                     metric.Int64Gauge
+	jwtCacheCleanUpCount             metric.Int64Counter
 }
 
 // Metrics combines all gateway metrics for dependency injection
@@ -330,20 +330,20 @@ func newTriggerMetrics(meter metric.Meter) (*TriggerMetrics, error) {
 		return nil, fmt.Errorf("failed to create workflow metadata observations count metric: %w", err)
 	}
 
-	m.requestCacheSize, err = meter.Int64Gauge(
-		"http_trigger_request_cache_size",
+	m.jwtCacheSize, err = meter.Int64Gauge(
+		"http_trigger_jwt_cache_size",
 		metric.WithDescription("Current number of entries in JWT replay protection cache"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP trigger request cache size metric: %w", err)
+		return nil, fmt.Errorf("failed to create HTTP trigger JWT cache size metric: %w", err)
 	}
 
-	m.requestCacheCleanUpCount, err = meter.Int64Counter(
-		"http_trigger_request_cache_cleanup_count",
+	m.jwtCacheCleanUpCount, err = meter.Int64Counter(
+		"http_trigger_jwt_cache_cleanup_count",
 		metric.WithDescription("Number of JWT replay protection cache entries cleaned up"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP trigger request cache cleanup count metric: %w", err)
+		return nil, fmt.Errorf("failed to create HTTP trigger JWT cache cleanup count metric: %w", err)
 	}
 
 	return m, nil
@@ -475,10 +475,10 @@ func (m *TriggerMetrics) RecordMetadataObservationsCount(ctx context.Context, co
 	m.metadataObservationsCount.Record(ctx, count)
 }
 
-func (m *TriggerMetrics) RecordRequestCacheSize(ctx context.Context, size int64, lggr logger.Logger) {
-	m.requestCacheSize.Record(ctx, size)
+func (m *TriggerMetrics) RecordJwtCacheSize(ctx context.Context, size int64, lggr logger.Logger) {
+	m.jwtCacheSize.Record(ctx, size)
 }
 
-func (m *TriggerMetrics) IncrementRequestCacheCleanUpCount(ctx context.Context, count int64, lggr logger.Logger) {
-	m.requestCacheCleanUpCount.Add(ctx, count)
+func (m *TriggerMetrics) IncrementJwtCacheCleanUpCount(ctx context.Context, count int64, lggr logger.Logger) {
+	m.jwtCacheCleanUpCount.Add(ctx, count)
 }

--- a/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
@@ -28,6 +28,13 @@ type workflowReference struct {
 	workflowTag   string
 }
 
+// jwtReplayCache manages used JWT IDs to prevent replay attacks
+type jwtReplayCache struct {
+	mu            sync.RWMutex
+	cleanupPeriod time.Duration
+	cache         map[string]time.Time // jti -> timestamp
+}
+
 type WorkflowMetadataHandler struct {
 	services.StateMachine
 	lggr            logger.Logger
@@ -41,6 +48,7 @@ type WorkflowMetadataHandler struct {
 	donConfig       *config.DONConfig
 	stopCh          services.StopChan
 	metrics         *metrics.Metrics
+	jwtCache        *jwtReplayCache // JWT replay protection cache
 }
 
 // NewWorkflowMetadataHandler creates a new WorkflowMetadataHandler.
@@ -58,15 +66,22 @@ func NewWorkflowMetadataHandler(lggr logger.Logger, cfg ServiceConfig, don handl
 		config:          cfg,
 		stopCh:          make(services.StopChan),
 		metrics:         metrics,
+		jwtCache:        newJWTReplayCache(time.Duration(cfg.CleanUpPeriodMs) * time.Millisecond),
 	}
 }
 
 func (h *WorkflowMetadataHandler) Authorize(workflowID string, token string, req *jsonrpc.Request[json.RawMessage]) (*gateway.AuthorizedKey, error) {
-	_, signer, err := utils.VerifyRequestJWT(token, *req)
+	claims, signer, err := utils.VerifyRequestJWT(token, *req)
 	if err != nil {
 		h.lggr.Errorw("Failed to verify JWT", "error", err)
 		return nil, err
 	}
+
+	if h.jwtCache.isReplay(claims.ID) {
+		h.lggr.Warnw("JWT replay attack detected", "workflowID", workflowID, "signer", signer.Hex(), "jti", claims.ID)
+		return nil, errors.New("JWT token has already been used - replay attack detected")
+	}
+
 	keys, exists := h.authorizedKeys[workflowID]
 	if !exists {
 		h.lggr.Errorw("Workflow ID not found in authorized keys", "workflowID", workflowID)
@@ -80,6 +95,8 @@ func (h *WorkflowMetadataHandler) Authorize(workflowID string, token string, req
 		h.lggr.Errorw("Signer not found in authorized keys", "signer", signer.Hex())
 		return nil, errors.New("signer not found in authorized keys")
 	}
+	h.jwtCache.recordUsage(claims.ID)
+
 	return &key, nil
 }
 
@@ -205,6 +222,13 @@ func (h *WorkflowMetadataHandler) Start(ctx context.Context) error {
 			}
 		})
 		h.runTicker(time.Duration(h.config.MetadataAggregationIntervalMs)*time.Millisecond, h.syncMetadata)
+
+		h.runTicker(h.jwtCache.cleanupPeriod, func() {
+			now := time.Now()
+			// TODO: ADD METRICS AFTER REBASING
+			expiredCount := h.jwtCache.cleanupOldEntries(now.Add(-h.jwtCache.cleanupPeriod))
+			h.lggr.Debugw("JWT cache cleanup completed", "expired_entries", expiredCount, "remaining_entries", len(h.jwtCache.cache))
+		})
 		return nil
 	})
 }
@@ -276,4 +300,40 @@ func (h *WorkflowMetadataHandler) Close() error {
 		close(h.stopCh)
 		return nil
 	})
+}
+
+func newJWTReplayCache(cleanupPeriod time.Duration) *jwtReplayCache {
+	return &jwtReplayCache{
+		cache:         make(map[string]time.Time),
+		cleanupPeriod: cleanupPeriod,
+	}
+}
+
+func (cache *jwtReplayCache) isReplay(jti string) bool {
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
+
+	_, exists := cache.cache[jti]
+	return exists
+}
+
+func (cache *jwtReplayCache) recordUsage(jti string) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	cache.cache[jti] = time.Now()
+}
+
+// cleanupOldEntries removes expired entries from the cache
+func (cache *jwtReplayCache) cleanupOldEntries(cutoff time.Time) int {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	var expiredCount int
+	for jti, createdAt := range cache.cache {
+		if createdAt.Before(cutoff) {
+			delete(cache.cache, jti)
+			expiredCount++
+		}
+	}
+	return expiredCount
 }

--- a/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
@@ -78,8 +78,8 @@ func (h *WorkflowMetadataHandler) Authorize(workflowID string, token string, req
 	}
 
 	if h.jwtCache.isReplay(claims.ID) {
-		h.lggr.Warnw("JWT replay attack detected", "workflowID", workflowID, "signer", signer.Hex(), "jti", claims.ID)
-		return nil, errors.New("JWT token has already been used - replay attack detected")
+		h.lggr.Warnw("JWT token has already been used", "workflowID", workflowID, "signer", signer.Hex(), "jti", claims.ID)
+		return nil, errors.New("JWT token has already been used. Please generate a new one with new id (jti)")
 	}
 
 	keys, exists := h.authorizedKeys[workflowID]
@@ -225,9 +225,10 @@ func (h *WorkflowMetadataHandler) Start(ctx context.Context) error {
 
 		h.runTicker(h.jwtCache.cleanupPeriod, func() {
 			now := time.Now()
-			// TODO: ADD METRICS AFTER REBASING
 			expiredCount := h.jwtCache.cleanupOldEntries(now.Add(-h.jwtCache.cleanupPeriod))
-			h.lggr.Debugw("JWT cache cleanup completed", "expired_entries", expiredCount, "remaining_entries", len(h.jwtCache.cache))
+			h.metrics.Trigger.IncrementRequestCacheCleanUpCount(context.Background(), int64(expiredCount), h.lggr)
+			h.metrics.Trigger.RecordRequestCacheSize(context.Background(), int64(len(h.jwtCache.cache)), h.lggr)
+			h.lggr.Debugw("Workflow execution cache cleanup completed", "expired_entries", expiredCount, "remaining_entries", len(h.jwtCache.cache))
 		})
 		return nil
 	})

--- a/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
@@ -226,8 +226,8 @@ func (h *WorkflowMetadataHandler) Start(ctx context.Context) error {
 		h.runTicker(h.jwtCache.cleanupPeriod, func() {
 			now := time.Now()
 			expiredCount := h.jwtCache.cleanupOldEntries(now.Add(-h.jwtCache.cleanupPeriod))
-			h.metrics.Trigger.IncrementRequestCacheCleanUpCount(context.Background(), int64(expiredCount), h.lggr)
-			h.metrics.Trigger.RecordRequestCacheSize(context.Background(), int64(len(h.jwtCache.cache)), h.lggr)
+			h.metrics.Trigger.IncrementJwtCacheCleanUpCount(context.Background(), int64(expiredCount), h.lggr)
+			h.metrics.Trigger.RecordJwtCacheSize(context.Background(), int64(len(h.jwtCache.cache)), h.lggr)
 			h.lggr.Debugw("Workflow execution cache cleanup completed", "expired_entries", expiredCount, "remaining_entries", len(h.jwtCache.cache))
 		})
 		return nil

--- a/core/utils/jwt.go
+++ b/core/utils/jwt.go
@@ -5,17 +5,19 @@ import (
 	"crypto/ecdsa"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 )
 
 const (
-	defaultJWTExpiryDuration = time.Hour
+	maxJWTExpiryDuration = 5 * time.Minute // Maximum allowed expiry duration
 )
 
 // Option is a function type that allows configuring CreateRequestJWT.
@@ -123,6 +125,7 @@ type JWTClaims struct {
 //
 //	{
 //		digest: "<request-digest>",      // 32 byte hex string with "0x" prefix
+//		jti: "<unique-id>",              // JWT ID (UUID) for replay protection (REQUIRED)
 //		iss: "ethereum-address",         // Ethereum address of the issuer
 //		exp: <timestamp>,                // expiration time (Unix timestamp)
 //		iat: <timestamp>                 // issued at time (Unix timestamp)
@@ -132,8 +135,9 @@ type JWTClaims struct {
 //
 //	{
 //	  "digest": "0x4a1f2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a",
+//	  "jti": "550e8400-e29b-41d4-a716-446655440000",
 //	  "iss": "0xc40B35B10c5003C182e300a9a34F6ff559eB746d",
-//	  "exp": 1717600000,
+//	  "exp": 1717596700,
 //	  "iat": 1717596400
 //	}
 //
@@ -145,10 +149,12 @@ func CreateRequestJWT[T any](req jsonrpc.Request[T], opts ...Option) (*jwt.Token
 		opt(options)
 	}
 
-	// Set defaults if not provided
-	expiryDuration := defaultJWTExpiryDuration
+	expiryDuration := maxJWTExpiryDuration
 	if options.expiryDuration != nil {
 		expiryDuration = *options.expiryDuration
+	}
+	if expiryDuration > maxJWTExpiryDuration {
+		return nil, fmt.Errorf("expiry duration exceeds maximum allowed %.0f minutes", maxJWTExpiryDuration.Minutes())
 	}
 
 	digest, err := req.Digest()
@@ -172,9 +178,12 @@ func CreateRequestJWT[T any](req jsonrpc.Request[T], opts ...Option) (*jwt.Token
 	}
 
 	now := time.Now()
+	jti := uuid.New().String()
+
 	claims := JWTClaims{
 		Digest: "0x" + digest,
 		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        jti,
 			Issuer:    issuer,
 			Subject:   subject,
 			Audience:  jwt.ClaimStrings(audience),
@@ -238,5 +247,19 @@ func VerifyRequestJWT[T any](tokenString string, req jsonrpc.Request[T]) (*JWTCl
 	if verifiedClaims.Digest != "0x"+reqDigest {
 		return nil, gethcommon.Address{}, errors.New("JWT digest does not match request digest")
 	}
+	if verifiedClaims.ID == "" {
+		return nil, gethcommon.Address{}, errors.New("JWT ID (jti) is required but missing")
+	}
+	if verifiedClaims.ExpiresAt == nil {
+		return nil, gethcommon.Address{}, errors.New("expiredAt (exp) is required but missing")
+	}
+	if verifiedClaims.IssuedAt == nil {
+		return nil, gethcommon.Address{}, errors.New("issuedAt (iat) is required but missing")
+	}
+	duration := verifiedClaims.ExpiresAt.Sub(verifiedClaims.IssuedAt.Time)
+	if duration > maxJWTExpiryDuration {
+		return nil, gethcommon.Address{}, fmt.Errorf("expiry duration exceeds maximum allowed %.0f minutes", maxJWTExpiryDuration.Minutes())
+	}
+
 	return verifiedClaims, pubKey, nil
 }

--- a/core/utils/jwt.go
+++ b/core/utils/jwt.go
@@ -30,6 +30,13 @@ type jwtOptions struct {
 	subject        *string  // New field for optional subject
 }
 
+// VerifyOption is a function type that allows configuring VerifyRequestJWT.
+type VerifyOption func(*verifyOptions)
+
+type verifyOptions struct {
+	maxExpiryDuration *time.Duration
+}
+
 func WithExpiry(d time.Duration) Option {
 	return func(opts *jwtOptions) {
 		opts.expiryDuration = &d
@@ -51,6 +58,12 @@ func WithAudience(audience []string) Option {
 func WithSubject(subject string) Option {
 	return func(opts *jwtOptions) {
 		opts.subject = &subject
+	}
+}
+
+func WithMaxExpiryDuration(d time.Duration) VerifyOption {
+	return func(opts *verifyOptions) {
+		opts.maxExpiryDuration = &d
 	}
 }
 
@@ -153,9 +166,6 @@ func CreateRequestJWT[T any](req jsonrpc.Request[T], opts ...Option) (*jwt.Token
 	if options.expiryDuration != nil {
 		expiryDuration = *options.expiryDuration
 	}
-	if expiryDuration > maxJWTExpiryDuration {
-		return nil, fmt.Errorf("expiry duration exceeds maximum allowed %.0f minutes", maxJWTExpiryDuration.Minutes())
-	}
 
 	digest, err := req.Digest()
 	if err != nil {
@@ -208,7 +218,16 @@ func splitToken(tokenString string) (string, string, error) {
 // VerifyRequestJWT verifies a signed JWT for a JSON-RPC request
 // It recovers and returns the public key used to sign the JWT, checks the issuer, validates the digest,
 // and performs all validations done by jwt.ParseWithClaims() including expiration checks.
-func VerifyRequestJWT[T any](tokenString string, req jsonrpc.Request[T]) (*JWTClaims, gethcommon.Address, error) {
+func VerifyRequestJWT[T any](tokenString string, req jsonrpc.Request[T], opts ...VerifyOption) (*JWTClaims, gethcommon.Address, error) {
+	options := &verifyOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	maxExpiryDuration := maxJWTExpiryDuration
+	if options.maxExpiryDuration != nil {
+		maxExpiryDuration = *options.maxExpiryDuration
+	}
 	signedString, signature, err := splitToken(tokenString)
 	if err != nil {
 		return nil, gethcommon.Address{}, err
@@ -257,8 +276,8 @@ func VerifyRequestJWT[T any](tokenString string, req jsonrpc.Request[T]) (*JWTCl
 		return nil, gethcommon.Address{}, errors.New("issuedAt (iat) is required but missing")
 	}
 	duration := verifiedClaims.ExpiresAt.Sub(verifiedClaims.IssuedAt.Time)
-	if duration > maxJWTExpiryDuration {
-		return nil, gethcommon.Address{}, fmt.Errorf("expiry duration exceeds maximum allowed %.0f minutes", maxJWTExpiryDuration.Minutes())
+	if duration > maxExpiryDuration {
+		return nil, gethcommon.Address{}, fmt.Errorf("expiry duration exceeds maximum allowed %.0f minutes", maxExpiryDuration.Minutes())
 	}
 
 	return verifiedClaims, pubKey, nil

--- a/core/utils/jwt_test.go
+++ b/core/utils/jwt_test.go
@@ -153,7 +153,7 @@ func TestCreateRequestJWT(t *testing.T) {
 	})
 
 	t.Run("with custom options", func(t *testing.T) {
-		customExpiry := 2 * time.Hour
+		customExpiry := 3 * time.Minute // Use valid duration within 5-minute limit
 		issuer := "test-issuer"
 		audience := []string{"aud1", "aud2"}
 		subject := "test-subject"
@@ -239,7 +239,7 @@ func TestVerifyRequestJWT_Integration(t *testing.T) {
 		claims := JWTClaims{
 			Digest: "0x123", // different digest
 			RegisteredClaims: jwt.RegisteredClaims{
-				ExpiresAt: jwt.NewNumericDate(now.Add(defaultJWTExpiryDuration)),
+				ExpiresAt: jwt.NewNumericDate(now.Add(maxJWTExpiryDuration)),
 				IssuedAt:  jwt.NewNumericDate(now),
 			},
 		}
@@ -284,6 +284,100 @@ func TestVerifyRequestJWT_Integration(t *testing.T) {
 		_, _, err = VerifyRequestJWT(tokenString, req)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid signature: signature length must be 65 bytes")
+	})
+
+	t.Run("should validate that expiredAt is after time.Now()", func(t *testing.T) {
+		digest, err := req.Digest()
+		require.NoError(t, err)
+
+		// Create a token that expires in the past (1 minute ago)
+		now := time.Now()
+		pastTime := now.Add(-1 * time.Minute)
+
+		claims := JWTClaims{
+			Digest: "0x" + digest,
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(pastTime),
+				IssuedAt:  jwt.NewNumericDate(now.Add(-2 * time.Minute)),
+			},
+		}
+
+		token := jwt.NewWithClaims(&SigningMethodEth{}, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		_, _, err = VerifyRequestJWT(tokenString, req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "token is expired")
+	})
+
+	t.Run("should validate that expiredAt exceeds max expiry", func(t *testing.T) {
+		digest, err := req.Digest()
+		require.NoError(t, err)
+
+		now := time.Now()
+		issuedAt := now
+		expiresAt := now.Add(maxJWTExpiryDuration * 2)
+
+		claims := JWTClaims{
+			Digest: "0x" + digest,
+			RegisteredClaims: jwt.RegisteredClaims{
+				ID:        "test-jti",
+				ExpiresAt: jwt.NewNumericDate(expiresAt),
+				IssuedAt:  jwt.NewNumericDate(issuedAt),
+			},
+		}
+
+		token := jwt.NewWithClaims(&SigningMethodEth{}, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		_, _, err = VerifyRequestJWT(tokenString, req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expiry duration exceeds maximum allowed")
+	})
+
+	t.Run("should validate that required fields expiredAt and issuedAt are present", func(t *testing.T) {
+		digest, err := req.Digest()
+		require.NoError(t, err)
+
+		t.Run("missing expiredAt", func(t *testing.T) {
+			claims := JWTClaims{
+				Digest: "0x" + digest,
+				RegisteredClaims: jwt.RegisteredClaims{
+					ID: "test-jti",
+					// ExpiresAt is nil/missing
+					IssuedAt: jwt.NewNumericDate(time.Now()),
+				},
+			}
+
+			token := jwt.NewWithClaims(&SigningMethodEth{}, claims)
+			tokenString, err := token.SignedString(privateKey)
+			require.NoError(t, err)
+
+			_, _, err = VerifyRequestJWT(tokenString, req)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "expiredAt (exp) is required but missing")
+		})
+
+		t.Run("missing issuedAt", func(t *testing.T) {
+			claims := JWTClaims{
+				Digest: "0x" + digest,
+				RegisteredClaims: jwt.RegisteredClaims{
+					ID:        "test-jti", // Include required jti field
+					ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute)),
+					// IssuedAt is nil/missing
+				},
+			}
+
+			token := jwt.NewWithClaims(&SigningMethodEth{}, claims)
+			tokenString, err := token.SignedString(privateKey)
+			require.NoError(t, err)
+
+			_, _, err = VerifyRequestJWT(tokenString, req)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "issuedAt (iat) is required but missing")
+		})
 	})
 }
 

--- a/core/utils/jwt_test.go
+++ b/core/utils/jwt_test.go
@@ -379,6 +379,32 @@ func TestVerifyRequestJWT_Integration(t *testing.T) {
 			require.Contains(t, err.Error(), "issuedAt (iat) is required but missing")
 		})
 	})
+
+	t.Run("should respect custom max expiry duration option", func(t *testing.T) {
+		digest, err := req.Digest()
+		require.NoError(t, err)
+
+		now := time.Now()
+		claims := JWTClaims{
+			Digest: "0x" + digest,
+			RegisteredClaims: jwt.RegisteredClaims{
+				ID:        "test-jti",
+				ExpiresAt: jwt.NewNumericDate(now.Add(8 * time.Minute)),
+				IssuedAt:  jwt.NewNumericDate(now),
+			},
+		}
+
+		token := jwt.NewWithClaims(&SigningMethodEth{}, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		_, _, err = VerifyRequestJWT(tokenString, req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expiry duration exceeds maximum allowed 5 minutes")
+
+		_, _, err = VerifyRequestJWT(tokenString, req, WithMaxExpiryDuration(10*time.Minute))
+		require.NoError(t, err)
+	})
 }
 
 func TestSigningMethodRegistration(t *testing.T) {


### PR DESCRIPTION
- prevent JWT token replay by ensuring a given requestID is not used more than once.
- enforce JWT time duration by requiring `issuedAt` (`iat`) and `expiresAt` (`exp`)