### PR TITLE
fix(ci): run cre quarantined tests

### DIFF
--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -231,6 +231,7 @@ jobs:
         env:
           TEST_NAME: ${{ matrix.tests.test_name }}
           TEST_TIMEOUT: 30m
+          RUN_QUARANTINED_TESTS: 'true' # always run quarantined tests in CI
         run: |
           gotestsum \
             --jsonfile=/tmp/gotest.log \


### PR DESCRIPTION
### Changes

Add env var `RUN_QUARANTINED_TESTS` for CRE tests, otherwise `quarantine.Flaky(...)` calls will skip running them.


Related to  #19488

---

DX-1685

