### PR TITLE
feat: expose git version tag in build_info endpoint

### DIFF
--- a/.changeset/fuzzy-eels-sell.md
+++ b/.changeset/fuzzy-eels-sell.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#added versionTag build-time attribute with output of "git describe HEAD"

--- a/.changeset/fuzzy-eels-sell.md
+++ b/.changeset/fuzzy-eels-sell.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-#added versionTag build-time attribute with output of "git describe HEAD"
+#added versionTag build-time attribute with output of "git describe --always"

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -77,6 +77,7 @@ jobs:
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
+        VERSION_TAG=${{ github.ref_name }}
       docker-cache-behaviour: "disable"
       docker-manifest-sign: true
       docker-registry-url-override: public.ecr.aws/chainlink
@@ -108,6 +109,7 @@ jobs:
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
+        VERSION_TAG=${{ github.ref_name }}
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_CHAIN_DEFAULTS=/ccip-config
         CL_SOLANA_CMD=

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,6 +33,7 @@ jobs:
         }}
       runner-arm64: ${{ steps.runner-labels.outputs.runner-arm64 }}
       runner-amd64: ${{ steps.runner-labels.outputs.runner-amd64 }}
+      version-tag: ${{ steps.version-info.outputs.version-tag }}
     steps:
       - name: Get PR Labels
         id: pr-labels
@@ -59,6 +60,17 @@ jobs:
             echo "runner-amd64=${GH_RUNNER_LABEL_AMD64}" | tee -a "$GITHUB_OUTPUT"
           fi
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Version Info
+        id: version-info
+        run: |
+          version_tag=$( git describe --always )
+          echo "version-tag=${version_tag}" | tee -a "$GITHUB_OUTPUT"
+
   docker-core:
     needs: [init]
     if: ${{ needs.init.outputs.should-run == 'true' }}
@@ -75,6 +87,7 @@ jobs:
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
+        VERSION_TAG=${{ needs.init.outputs.version-tag }}
       docker-manifest-sign: true
       git-sha: ${{ inputs.git-ref || github.sha }}
       github-event-name: ${{ github.event_name }}
@@ -105,6 +118,7 @@ jobs:
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
+        VERSION_TAG=${{ needs.init.outputs.version-tag }}
         CL_INSTALL_PRIVATE_PLUGINS=true
       docker-manifest-sign: true
       docker-tag-custom-suffix: "-plugins"
@@ -137,6 +151,7 @@ jobs:
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
+        VERSION_TAG=${{ needs.init.outputs.version-tag }}
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_INSTALL_TESTING_PLUGINS=true
       docker-manifest-sign: true
@@ -170,6 +185,7 @@ jobs:
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
+        VERSION_TAG=${{ needs.init.outputs.version-tag }}
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_CHAIN_DEFAULTS=/ccip-config
         CL_SOLANA_CMD=
@@ -203,6 +219,7 @@ jobs:
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
+        VERSION_TAG=${{ needs.init.outputs.version-tag }}
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_CHAIN_DEFAULTS=/ccip-config
       docker-manifest-sign: true

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,6 +2,7 @@
 
 COMMIT_SHA ?= $(shell git rev-parse HEAD)
 VERSION = $(shell jq -r '.version' package.json)
+VERSION_TAG ?= $(shell git describe HEAD)
 GO_LDFLAGS := $(shell tools/bin/ldflags)
 GOFLAGS = -ldflags "$(GO_LDFLAGS)"
 GCFLAGS = -gcflags "$(GO_GCFLAGS)"
@@ -106,6 +107,7 @@ docker:
 	$(eval PRIVATE_PLUGIN_ARGS := $(if $(and $(or $(filter true,$(CL_INSTALL_PRIVATE_PLUGINS)),$(filter true,$(CL_INSTALL_TESTING_PLUGINS))),$(GITHUB_TOKEN)),--secret id=GIT_AUTH_TOKEN$(comma)env=GITHUB_TOKEN))
 	docker buildx build \
 	--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+	--build-arg VERSION_TAG=$(VERSION_TAG) \
 	--build-arg CL_INSTALL_PRIVATE_PLUGINS=$(CL_INSTALL_PRIVATE_PLUGINS) \
 	$(PRIVATE_PLUGIN_ARGS) \
 	-f core/chainlink.Dockerfile . \
@@ -116,10 +118,12 @@ docker:
 docker-ccip:
 	docker buildx build \
 	--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+	--build-arg VERSION_TAG=$(VERSION_TAG) \
 	-f core/chainlink.Dockerfile . -t chainlink-ccip:latest
 
 	docker buildx build \
 	--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+	--build-arg VERSION_TAG=$(VERSION_TAG) \
 	-f ccip/ccip.Dockerfile .
 
 # Define a comma variable for use in $(eval) (needed for the PRIVATE_PLUGIN_ARGS)
@@ -133,6 +137,7 @@ docker-plugins:
 	$(eval PRIVATE_PLUGIN_ARGS := $(if $(and $(or $(filter true,$(CL_INSTALL_PRIVATE_PLUGINS)),$(filter true,$(CL_INSTALL_TESTING_PLUGINS))),$(GITHUB_TOKEN)),--secret id=GIT_AUTH_TOKEN$(comma)env=GITHUB_TOKEN))
 	docker buildx build \
 	--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+	--build-arg VERSION_TAG=$(VERSION_TAG) \
 	--build-arg CL_INSTALL_TESTING_PLUGINS=$(CL_INSTALL_TESTING_PLUGINS) \
 	--build-arg CL_INSTALL_PRIVATE_PLUGINS=$(CL_INSTALL_PRIVATE_PLUGINS) \
 	$(PRIVATE_PLUGIN_ARGS) \
@@ -157,7 +162,7 @@ rm-mocked:
 testscripts: chainlink-test ## Install and run testscript against testdata/scripts/* files.
 	go install github.com/rogpeppe/go-internal/cmd/testscript@latest
 	go run ./tools/txtar/cmd/lstxtardirs -recurse=true | PATH="$(CURDIR):${PATH}" xargs -I % \
-		sh -c 'testscript -e COMMIT_SHA=$(COMMIT_SHA) -e HOME="$(TMPDIR)/home" -e VERSION=$(VERSION) $(TS_FLAGS) %/*.txtar'
+		sh -c 'testscript -e COMMIT_SHA=$(COMMIT_SHA) -e HOME="$(TMPDIR)/home" -e VERSION=$(VERSION) -e VERSION_TAG=$(VERSION_TAG) $(TS_FLAGS) %/*.txtar'
 
 .PHONY: testscripts-update
 testscripts-update: ## Update testdata/scripts/* files via testscript.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,7 @@
 
 COMMIT_SHA ?= $(shell git rev-parse HEAD)
 VERSION = $(shell jq -r '.version' package.json)
-VERSION_TAG ?= $(shell git describe HEAD)
+VERSION_TAG ?= $(shell git describe --always)
 GO_LDFLAGS := $(shell tools/bin/ldflags)
 GOFLAGS = -ldflags "$(GO_LDFLAGS)"
 GCFLAGS = -gcflags "$(GO_GCFLAGS)"

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -26,6 +26,7 @@ ARG CL_INSTALL_PRIVATE_PLUGINS=true
 ARG CL_INSTALL_TESTING_PLUGINS=false
 # Env vars needed for chainlink build
 ARG COMMIT_SHA
+ARG VERSION_TAG
 # Build chainlink bin with cover flag https://go.dev/doc/build-cover#FAQ
 ARG GO_COVER_FLAG=false
 

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -259,6 +259,7 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg chainlink.G
 		AuditLogger:              auditLogger,
 		ExternalInitiatorManager: webhook.NewExternalInitiatorManager(ds, unrestrictedClient),
 		Version:                  static.Version,
+		VersionTag:               static.VersionTag,
 		RestrictedHTTPClient:     clhttp.NewRestrictedClient(cfg.Database(), appLggr),
 		UnrestrictedHTTPClient:   unrestrictedClient,
 		SecretGenerator:          chainlink.FilePersistedSecretGenerator{},

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -217,6 +217,7 @@ type ApplicationOpts struct {
 	CloseLogger              func() error
 	ExternalInitiatorManager webhook.ExternalInitiatorManager
 	Version                  string
+	VersionTag               string
 	RestrictedHTTPClient     *http.Client
 	UnrestrictedHTTPClient   *http.Client
 	SecretGenerator          SecretGenerator
@@ -761,7 +762,7 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 			cfg.OCR2(),
 			legacyEVMChains,
 			globalLogger,
-			opts.Version,
+			opts.VersionTag,
 			loopRegistrarConfig,
 		)
 	} else {

--- a/core/static/static.go
+++ b/core/static/static.go
@@ -14,6 +14,8 @@ import (
 var (
 	// Version is the semantic version of the build or Unset.
 	Version = Unset
+	// VersionTag is the complete version string, including all suffixes (-ccip, -beta1, etc)
+	VersionTag = Unset
 	// Sha is the commit hash of the build or Unset.
 	Sha = Unset
 )

--- a/core/web/build_info_controller.go
+++ b/core/web/build_info_controller.go
@@ -16,5 +16,5 @@ type BuildInfoController struct {
 
 // Show returns the build info.
 func (eic *BuildInfoController) Show(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"version": static.Version, "commitSHA": static.Sha})
+	c.JSON(http.StatusOK, gin.H{"version": static.Version, "versionTag": static.VersionTag, "commitSHA": static.Sha})
 }

--- a/core/web/build_info_controller_test.go
+++ b/core/web/build_info_controller_test.go
@@ -28,6 +28,7 @@ func TestBuildInfoController_Show_APICredentials(t *testing.T) {
 
 	require.Contains(t, strings.TrimSpace(body), "commitSHA")
 	require.Contains(t, strings.TrimSpace(body), "version")
+	require.Contains(t, strings.TrimSpace(body), "versionTag")
 }
 
 func TestBuildInfoController_Show_NoCredentials(t *testing.T) {

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -226,6 +226,7 @@ check_github_token:
 build_docker_image: check_github_token
 	docker build -f ../core/chainlink.Dockerfile \
 		--build-arg COMMIT_SHA=$(git rev-parse HEAD) \
+		--build-arg VERSION_TAG=$(git describe HEAD) \
 		--build-arg CHAINLINK_USER=chainlink \
 		--secret id=GIT_AUTH_TOKEN,env=GITHUB_TOKEN \
 		-t $(image):$(tag) ../

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -226,7 +226,7 @@ check_github_token:
 build_docker_image: check_github_token
 	docker build -f ../core/chainlink.Dockerfile \
 		--build-arg COMMIT_SHA=$(git rev-parse HEAD) \
-		--build-arg VERSION_TAG=$(git describe HEAD) \
+		--build-arg VERSION_TAG=$(git describe --always) \
 		--build-arg CHAINLINK_USER=chainlink \
 		--secret id=GIT_AUTH_TOKEN,env=GITHUB_TOKEN \
 		-t $(image):$(tag) ../

--- a/integration-tests/ccip-tests/Makefile
+++ b/integration-tests/ccip-tests/Makefile
@@ -66,11 +66,11 @@ test_smoke_ccip_default: set_config
 # example usage: make build_ccip_image image=chainlink-ccip tag=latest
 .PHONY: build_ccip_image
 build_ccip_image:
-	docker build -f ../../core/chainlink.Dockerfile --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg CHAINLINK_USER=chainlink -t $(image):$(tag) ../../
+	docker build -f ../../core/chainlink.Dockerfile --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe HEAD) --build-arg CHAINLINK_USER=chainlink -t $(image):$(tag) ../../
 
 # image: the name for the chainlink image being built, example: image=chainlink
 # tag: the tag for the chainlink image being built, example: tag=latest
 # example usage: make build_ccip_image image=chainlink-ccip tag=latest
 .PHONY: build_ccip_debug_image
 build_ccip_debug_image:
-	docker build -f ../../core/chainlink.debug.Dockerfile --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg CHAINLINK_USER=chainlink -t $(image):$(tag) ../../
+	docker build -f ../../core/chainlink.debug.Dockerfile --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe HEAD) --build-arg CHAINLINK_USER=chainlink -t $(image):$(tag) ../../

--- a/integration-tests/ccip-tests/Makefile
+++ b/integration-tests/ccip-tests/Makefile
@@ -66,11 +66,11 @@ test_smoke_ccip_default: set_config
 # example usage: make build_ccip_image image=chainlink-ccip tag=latest
 .PHONY: build_ccip_image
 build_ccip_image:
-	docker build -f ../../core/chainlink.Dockerfile --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe HEAD) --build-arg CHAINLINK_USER=chainlink -t $(image):$(tag) ../../
+	docker build -f ../../core/chainlink.Dockerfile --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe --always) --build-arg CHAINLINK_USER=chainlink -t $(image):$(tag) ../../
 
 # image: the name for the chainlink image being built, example: image=chainlink
 # tag: the tag for the chainlink image being built, example: tag=latest
 # example usage: make build_ccip_image image=chainlink-ccip tag=latest
 .PHONY: build_ccip_debug_image
 build_ccip_debug_image:
-	docker build -f ../../core/chainlink.debug.Dockerfile --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe HEAD) --build-arg CHAINLINK_USER=chainlink -t $(image):$(tag) ../../
+	docker build -f ../../core/chainlink.debug.Dockerfile --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe --always) --build-arg CHAINLINK_USER=chainlink -t $(image):$(tag) ../../

--- a/integration-tests/smoke/QuickStart.md
+++ b/integration-tests/smoke/QuickStart.md
@@ -17,7 +17,7 @@ k3d cluster create --registry-use k3d-myregistry.localhost:5001
 run to create new build
 ```shell
 cd ~/go/src/github.com/chainlink
-env DOCKER_DEFAULT_PLATFORM=linux/amd64 docker buildx build --platform linux/amd64 -f ./core/chainlink.Dockerfile --build-arg ENVIRONMENT=release --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe HEAD) -t smartcontract/chainlink:develop-$(git rev-parse HEAD) .
+env DOCKER_DEFAULT_PLATFORM=linux/amd64 docker buildx build --platform linux/amd64 -f ./core/chainlink.Dockerfile --build-arg ENVIRONMENT=release --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe --always) -t smartcontract/chainlink:develop-$(git rev-parse HEAD) .
 export CHAINLINK_VERSION=develop-$(git rev-parse HEAD)
 docker tag docker.io/smartcontract/chainlink:$CHAINLINK_VERSION k3d-myregistry.localhost:5001/docker.io/smartcontract/chainlink:$CHAINLINK_VERSION
 docker push k3d-myregistry.localhost:5001/docker.io/smartcontract/chainlink:$CHAINLINK_VERSION
@@ -33,7 +33,7 @@ make test_smoke_simulated args="--focus-file=auto_ocr_test.go"
 build+run
 ```shell
 cd ~/go/src/github.com/chainlink
-env DOCKER_DEFAULT_PLATFORM=linux/amd64 docker buildx build --platform linux/amd64 -f ./core/chainlink.Dockerfile --build-arg ENVIRONMENT=release --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe HEAD) -t smartcontract/chainlink:develop-$(git rev-parse HEAD) .
+env DOCKER_DEFAULT_PLATFORM=linux/amd64 docker buildx build --platform linux/amd64 -f ./core/chainlink.Dockerfile --build-arg ENVIRONMENT=release --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe --always) -t smartcontract/chainlink:develop-$(git rev-parse HEAD) .
 export CHAINLINK_VERSION=develop-$(git rev-parse HEAD)
 export TEST_LOG_LEVEL="debug"
 docker tag docker.io/smartcontract/chainlink:$CHAINLINK_VERSION k3d-myregistry.localhost:5001/docker.io/smartcontract/chainlink:$CHAINLINK_VERSION
@@ -47,7 +47,7 @@ make test_smoke_simulated args="--focus-file=auto_ocr_test.go"
 1. Build a Docker image of the chainlink repo:
 
    ```shell
-   env DOCKER_DEFAULT_PLATFORM=linux/amd64 docker buildx build --platform linux/amd64 -f ./core/chainlink.Dockerfile --build-arg ENVIRONMENT=release --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe HEAD) -t smartcontract/chainlink:develop-$(git rev-parse HEAD) .
+   env DOCKER_DEFAULT_PLATFORM=linux/amd64 docker buildx build --platform linux/amd64 -f ./core/chainlink.Dockerfile --build-arg ENVIRONMENT=release --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe --always) -t smartcontract/chainlink:develop-$(git rev-parse HEAD) .
    ```
    last line of the output will have something like
    `=> => naming to docker.io/smartcontract/chainlink:develop-a4caf33ce0ed6b841294c5ef06563c1cd4de6dfc`

--- a/integration-tests/smoke/QuickStart.md
+++ b/integration-tests/smoke/QuickStart.md
@@ -17,7 +17,7 @@ k3d cluster create --registry-use k3d-myregistry.localhost:5001
 run to create new build
 ```shell
 cd ~/go/src/github.com/chainlink
-env DOCKER_DEFAULT_PLATFORM=linux/amd64 docker buildx build --platform linux/amd64 -f ./core/chainlink.Dockerfile --build-arg ENVIRONMENT=release --build-arg COMMIT_SHA=$(git rev-parse HEAD) -t smartcontract/chainlink:develop-$(git rev-parse HEAD) .
+env DOCKER_DEFAULT_PLATFORM=linux/amd64 docker buildx build --platform linux/amd64 -f ./core/chainlink.Dockerfile --build-arg ENVIRONMENT=release --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe HEAD) -t smartcontract/chainlink:develop-$(git rev-parse HEAD) .
 export CHAINLINK_VERSION=develop-$(git rev-parse HEAD)
 docker tag docker.io/smartcontract/chainlink:$CHAINLINK_VERSION k3d-myregistry.localhost:5001/docker.io/smartcontract/chainlink:$CHAINLINK_VERSION
 docker push k3d-myregistry.localhost:5001/docker.io/smartcontract/chainlink:$CHAINLINK_VERSION
@@ -33,7 +33,7 @@ make test_smoke_simulated args="--focus-file=auto_ocr_test.go"
 build+run
 ```shell
 cd ~/go/src/github.com/chainlink
-env DOCKER_DEFAULT_PLATFORM=linux/amd64 docker buildx build --platform linux/amd64 -f ./core/chainlink.Dockerfile --build-arg ENVIRONMENT=release --build-arg COMMIT_SHA=$(git rev-parse HEAD) -t smartcontract/chainlink:develop-$(git rev-parse HEAD) .
+env DOCKER_DEFAULT_PLATFORM=linux/amd64 docker buildx build --platform linux/amd64 -f ./core/chainlink.Dockerfile --build-arg ENVIRONMENT=release --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe HEAD) -t smartcontract/chainlink:develop-$(git rev-parse HEAD) .
 export CHAINLINK_VERSION=develop-$(git rev-parse HEAD)
 export TEST_LOG_LEVEL="debug"
 docker tag docker.io/smartcontract/chainlink:$CHAINLINK_VERSION k3d-myregistry.localhost:5001/docker.io/smartcontract/chainlink:$CHAINLINK_VERSION
@@ -47,7 +47,7 @@ make test_smoke_simulated args="--focus-file=auto_ocr_test.go"
 1. Build a Docker image of the chainlink repo:
 
    ```shell
-   env DOCKER_DEFAULT_PLATFORM=linux/amd64 docker buildx build --platform linux/amd64 -f ./core/chainlink.Dockerfile --build-arg ENVIRONMENT=release --build-arg COMMIT_SHA=$(git rev-parse HEAD) -t smartcontract/chainlink:develop-$(git rev-parse HEAD) .
+   env DOCKER_DEFAULT_PLATFORM=linux/amd64 docker buildx build --platform linux/amd64 -f ./core/chainlink.Dockerfile --build-arg ENVIRONMENT=release --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg VERSION_TAG=$(git describe HEAD) -t smartcontract/chainlink:develop-$(git rev-parse HEAD) .
    ```
    last line of the output will have something like
    `=> => naming to docker.io/smartcontract/chainlink:develop-a4caf33ce0ed6b841294c5ef06563c1cd4de6dfc`

--- a/main_test.go
+++ b/main_test.go
@@ -95,6 +95,7 @@ func commonEnv(t testing.TB) func(*testscript.Env) error {
 
 		te.Setenv("HOME", "$WORK/home")
 		te.Setenv("VERSION", static.Version)
+		te.Setenv("VERSION_TAG", static.VersionTag)
 		te.Setenv("COMMIT_SHA", static.Sha)
 
 		b, err := os.ReadFile(filepath.Join(te.WorkDir, testPortName))

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -30,6 +30,7 @@ ARG CL_INSTALL_TESTING_PLUGINS=false
 ARG GO_GCFLAGS
 # Env vars needed for chainlink build
 ARG COMMIT_SHA
+ARG VERSION_TAG
 
 ENV CL_LOOPINSTALL_OUTPUT_DIR=/tmp/loopinstall-output
 RUN --mount=type=secret,id=GIT_AUTH_TOKEN \

--- a/tools/bin/ldflags
+++ b/tools/bin/ldflags
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"
 
 COMMIT_SHA=${COMMIT_SHA:-$(git rev-parse HEAD)}
-VERSION_TAG=${VERSION_TAG:-$(git describe HEAD)}
+VERSION_TAG=${VERSION_TAG:-$(git describe --always)}
 VERSION=${VERSION:-$(jq -r '.version' ../../package.json)}
 
 echo "-X github.com/smartcontractkit/chainlink/v2/core/static.Version=$VERSION -X github.com/smartcontractkit/chainlink/v2/core/static.VersionTag=$VERSION_TAG -X github.com/smartcontractkit/chainlink/v2/core/static.Sha=$COMMIT_SHA"

--- a/tools/bin/ldflags
+++ b/tools/bin/ldflags
@@ -3,6 +3,7 @@
 cd "$(dirname "$0")"
 
 COMMIT_SHA=${COMMIT_SHA:-$(git rev-parse HEAD)}
+VERSION_TAG=${VERSION_TAG:-$(git describe HEAD)}
 VERSION=${VERSION:-$(jq -r '.version' ../../package.json)}
 
-echo "-X github.com/smartcontractkit/chainlink/v2/core/static.Version=$VERSION -X github.com/smartcontractkit/chainlink/v2/core/static.Sha=$COMMIT_SHA"
+echo "-X github.com/smartcontractkit/chainlink/v2/core/static.Version=$VERSION -X github.com/smartcontractkit/chainlink/v2/core/static.VersionTag=$VERSION_TAG -X github.com/smartcontractkit/chainlink/v2/core/static.Sha=$COMMIT_SHA"


### PR DESCRIPTION
Add another build-time attribute named `VersionTag` to the core's static variables. The build scripts and tasks were updated to set it as the output of `git describe HEAD`, which returns the last git tag associated with a commit in the current revision history. For releases, this means `VersionTag` should contain a string such as `2.26.1-ccip`. And for development builds, it should contain a string such as `v2.26.2-heartbeat-fix.0-8-gc2ef31b507`.

The new attribute is exposed in two places:
1. as another attribute of the `/build_info` endpoint
2. as the `Version` attribute sent to the job distributor instance

Item 2 means that JD/CLO will automatically display the VersionTag string (rather than the shorter Version string) in its UI:

<img width="1247" height="802" alt="screenshot" src="https://github.com/user-attachments/assets/619eb351-ebfa-421d-b042-ffbe5de975c8" />

---
[DX-1693](https://smartcontract-it.atlassian.net/browse/DX-1693)

[DX-1693]: https://smartcontract-it.atlassian.net/browse/DX-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ