### PR TITLE
[CRE-968] Properly handle nils in SharedPeer and legacy PeerWrapper

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -630,7 +630,7 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 		relayChainInterops,
 		creServices.gatewayConnectorWrapper,
 		keyStore,
-		creServices.externalPeerWrapper,
+		creServices.getPeerID,
 		peerWrapper,
 		opts.NewOracleFactoryFn,
 		opts.FetcherFactoryFn,
@@ -855,9 +855,10 @@ type CREServices struct {
 	// it is exposed because there are contingent services in the application
 	gatewayConnectorWrapper *gatewayconnector.ServiceWrapper
 
-	// externalPeerWrapper is the wrapper for external peering
-	// it is exposed because there are contingent services in the application
-	externalPeerWrapper p2ptypes.PeerWrapper
+	// getter for PeerID from either externalPeerWrapper or don2donSharedPeer
+	// can be called only after the above services are started because
+	// they depend on Keystore, which itself has to be started first
+	getPeerID func() (p2ptypes.PeerID, error)
 
 	// srvs are all the services that are created, including those that are explicitly exposed
 	srvs []services.ServiceCtx
@@ -932,6 +933,9 @@ func newCREServices(
 	var externalPeerWrapper p2ptypes.PeerWrapper
 	var don2donSharedPeer p2ptypes.SharedPeer
 	var streamConfig config.StreamConfig
+	getPeerID := func() (p2ptypes.PeerID, error) {
+		return p2ptypes.PeerID{}, errors.New("getPeerID not initialized")
+	}
 	if capCfg.Peering().Enabled() || capCfg.SharedPeering().Enabled() {
 		var dispatcher remotetypes.Dispatcher
 		if opts.CapabilitiesDispatcher == nil {
@@ -946,6 +950,9 @@ func newCREServices(
 			if capCfg.SharedPeering().Enabled() {
 				if !cfg.P2P().Enabled() {
 					return nil, errors.New("top-level P2P must be enabled in order to use SharedPeering")
+				}
+				if singletonPeerWrapper == nil {
+					return nil, errors.New("singleton peer wrapper is required for shared peering (are OCR and P2P enabled?)")
 				}
 				bootstrappers := capCfg.SharedPeering().Bootstrappers()
 				if len(bootstrappers) == 0 {
@@ -983,6 +990,20 @@ func newCREServices(
 				return nil, err
 			}
 
+			getPeerID = func() (p2ptypes.PeerID, error) {
+				if don2donSharedPeer != nil {
+					return don2donSharedPeer.ID(), nil
+				}
+				if externalPeerWrapper != nil {
+					p := externalPeerWrapper.GetPeer()
+					if p == nil {
+						return p2ptypes.PeerID{}, errors.New("could not get peer from externalPeerWrapper")
+					}
+					return p.ID(), nil
+				}
+				return p2ptypes.PeerID{}, errors.New("could not get peer from any source")
+			}
+
 			workflowDonNotifier := capabilities.NewDonNotifier()
 			wfLauncher := capabilities.NewLauncher(
 				globalLogger,
@@ -998,14 +1019,7 @@ func newCREServices(
 			case 1:
 				registrySyncer, err := registrysyncerV1.New(
 					globalLogger,
-					func() (p2ptypes.PeerID, error) {
-						p := externalPeerWrapper.GetPeer()
-						if p == nil {
-							return p2ptypes.PeerID{}, errors.New("could not get peer")
-						}
-
-						return p.ID(), nil
-					},
+					getPeerID,
 					relayer,
 					registryAddress,
 					registrysyncerV1.NewORM(ds, globalLogger),
@@ -1019,14 +1033,7 @@ func newCREServices(
 			case 2:
 				registrySyncer, err := registrysyncerV2.New(
 					globalLogger,
-					func() (p2ptypes.PeerID, error) {
-						p := externalPeerWrapper.GetPeer()
-						if p == nil {
-							return p2ptypes.PeerID{}, errors.New("could not get peer")
-						}
-
-						return p.ID(), nil
-					},
+					getPeerID,
 					relayer,
 					registryAddress,
 					registrysyncerV1.NewORM(ds, globalLogger),
@@ -1245,7 +1252,7 @@ func newCREServices(
 		workflowRateLimiter:     workflowRateLimiter,
 		workflowLimits:          workflowLimits,
 		gatewayConnectorWrapper: gatewayConnectorWrapper,
-		externalPeerWrapper:     externalPeerWrapper,
+		getPeerID:               getPeerID,
 		srvs:                    srvcs,
 		workflowRegistrySyncer:  workflowRegistrySyncer,
 	}, nil

--- a/core/services/p2p/shared_peer.go
+++ b/core/services/p2p/shared_peer.go
@@ -84,6 +84,9 @@ func NewDon2DonSharedPeer(singletonPeerWrapper *ocrcommon.SingletonPeerWrapper, 
 
 func (sp *don2DonSharedPeer) start(ctx context.Context) error {
 	sp.lggr.Info("Starting Don2DonSharedPeer ...")
+	if sp.singletonPeerWrapper == nil {
+		return errors.New("field SingletonPeerWrapper is not set")
+	}
 	sp.pgFactory = sp.singletonPeerWrapper.PeerGroupFactory
 	if sp.pgFactory == nil {
 		return errors.New("PeerGroupFactory is not set in SingletonPeerWrapper. It's possible that SingletonPeerWrapper was not started before Don2DonSharedPeer or somehow failed to initialize")
@@ -308,7 +311,7 @@ func (sp *don2DonSharedPeer) updateConnections(donPairs []p2ptypes.DonPair, desi
 		for pid := range sp.remotePeers {
 			if _, ok := desiredRemotePeers[pid]; !ok {
 				rp := sp.remotePeers[pid]
-				if rp.peerPairGroup != nil {
+				if rp != nil && rp.peerPairGroup != nil {
 					rp.peerPairGroup.Close() // closes the stream
 				}
 				delete(sp.remotePeers, pid)

--- a/core/services/p2p/shared_peer_test.go
+++ b/core/services/p2p/shared_peer_test.go
@@ -55,6 +55,11 @@ func TestDon2DonSharedPeer_WithRealSingletonPeerWrapper(t *testing.T) {
 	require.NoError(t, sp.Close())
 }
 
+func TestDon2DonSharedPeer_ErrorOnNilSingletonPeerWrapper(t *testing.T) {
+	sp := p2p.NewDon2DonSharedPeer(nil, nil, logger.TestLogger(t))
+	require.Error(t, sp.Start(t.Context()))
+}
+
 func TestDon2DonSharedPeer_UpdateConnectionsByDONs(t *testing.T) {
 	pw := ocrcommon.NewSingletonPeerWrapper(nil, nil, nil, nil, logger.TestLogger(t)) // nils are ok, we won't Start() it
 	_, myPeerID := newKeyPair(t)


### PR DESCRIPTION
1. launcher.go: extra nil checks around legacy PeerWrapper use
2. application.go:
  - avoid nil ptr access when singletonPeerWrapper is not set.
  - pass getPeerID() function to dependencies instead of the whole legacy PeerWrapper object
3. shared_peer.go - extra nil checks