### PR TITLE
fixing early exit case in v1 engine

### DIFF
--- a/core/services/workflows/events/emit.go
+++ b/core/services/workflows/events/emit.go
@@ -150,7 +150,7 @@ func EmitExecutionFinishedEvent(ctx context.Context, labels map[string]string, s
 	// Convert status string to v2 ExecutionStatus enum
 	var executionStatus eventsv2.ExecutionStatus
 	switch status {
-	case "completed": // there are enums in workflows/store, but we shouldn't import that here
+	case "completed", "completed_early_exit": // there are enums in workflows/store, but we shouldn't import that here
 		executionStatus = eventsv2.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED
 	case "errored", "timeout":
 		executionStatus = eventsv2.ExecutionStatus_EXECUTION_STATUS_FAILED
@@ -261,7 +261,7 @@ func EmitCapabilityFinishedEvent(ctx context.Context, labels map[string]string, 
 	// Convert status string to v2 ExecutionStatus enum
 	var executionStatus eventsv2.ExecutionStatus
 	switch status {
-	case "completed":
+	case "completed", "completed_early_exit":
 		executionStatus = eventsv2.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED
 	case "errored", "timeout":
 		executionStatus = eventsv2.ExecutionStatus_EXECUTION_STATUS_FAILED


### PR DESCRIPTION
We emit both v1 and v2 events from the Keystone DONs, and while originally chose early exit to map to unspecified, I believe its cleaner for downstream data consumers to map it to success.