### PR TITLE
feat(deployment): Aptos CCIP check token owner to grant permission

### DIFF
--- a/deployment/ccip/changeset/aptos/cs_add_token_pool.go
+++ b/deployment/ccip/changeset/aptos/cs_add_token_pool.go
@@ -6,14 +6,12 @@ import (
 
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
 	"github.com/smartcontractkit/mcms"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
+	mcmsbind "github.com/smartcontractkit/chainlink-aptos/bindings/mcms"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/operation"
@@ -157,10 +155,15 @@ func (cs AddTokenPool) Apply(env cldf.Environment, cfg config.AddTokenPoolConfig
 	// Deploy Aptos token pool
 	tokenPoolAddress := cfg.TokenPoolAddress
 	if cfg.TokenPoolAddress == (aptos.AccountAddress{}) {
+		isOwned, err := isTokenOwnedByMCMS(deps, tokenCodeObjAddress)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to check if token is owned by MCMS: %w", err)
+		}
 		depInput := seq.DeployTokenPoolSeqInput{
 			TokenCodeObjAddress: tokenCodeObjAddress,
 			TokenAddress:        tokenAddress,
 			PoolType:            cfg.PoolType,
+			IsTokenOwnedByMCMS:  isOwned,
 		}
 		deploySeq, err := operations.ExecuteSequence(env.OperationsBundle, seq.DeployAptosTokenPoolSequence, deps, depInput)
 		if err != nil {
@@ -212,6 +215,20 @@ func (cs AddTokenPool) Apply(env cldf.Environment, cfg config.AddTokenPoolConfig
 		MCMSTimelockProposals: proposals,
 		Reports:               seqReports,
 	}, nil
+}
+
+func isTokenOwnedByMCMS(deps operation.AptosDeps, cfgTokenAddress aptos.AccountAddress) (bool, error) {
+	if cfgTokenAddress == (aptos.AccountAddress{}) {
+		// Token cfg not provided, so token is newly deployed and owned by MCMS
+		return true, nil
+	}
+	mcmsAddress := deps.CCIPOnChainState.AptosChains[deps.AptosChain.Selector].MCMSAddress
+	mcmsContract := mcmsbind.Bind(mcmsAddress, deps.AptosChain.Client)
+	isOwned, err := mcmsContract.MCMSRegistry().IsOwnedCodeObject(nil, cfgTokenAddress)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if token is owned by MCMS: %w", err)
+	}
+	return isOwned, nil
 }
 
 func toRemotePools(evmRemoteCfg map[uint64]config.EVMRemoteConfig) map[uint64]seq.RemotePool {

--- a/deployment/ccip/changeset/aptos/cs_add_token_pool.go
+++ b/deployment/ccip/changeset/aptos/cs_add_token_pool.go
@@ -10,8 +10,6 @@ import (
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
 	mcmsbind "github.com/smartcontractkit/chainlink-aptos/bindings/mcms"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/operation"
@@ -19,6 +17,9 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/utils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
 var _ cldf.ChangeSetV2[config.AddTokenPoolConfig] = AddTokenPool{}
@@ -155,7 +156,7 @@ func (cs AddTokenPool) Apply(env cldf.Environment, cfg config.AddTokenPoolConfig
 	// Deploy Aptos token pool
 	tokenPoolAddress := cfg.TokenPoolAddress
 	if cfg.TokenPoolAddress == (aptos.AccountAddress{}) {
-		isOwned, err := isTokenOwnedByMCMS(deps, tokenCodeObjAddress)
+		isOwned, err := isTokenOwnedByMCMS(deps, cfg.TokenCodeObjAddress)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to check if token is owned by MCMS: %w", err)
 		}

--- a/deployment/ccip/changeset/aptos/cs_add_token_pool.go
+++ b/deployment/ccip/changeset/aptos/cs_add_token_pool.go
@@ -3,6 +3,7 @@ package aptos
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/ethereum/go-ethereum/common"
@@ -227,6 +228,12 @@ func isTokenOwnedByMCMS(deps operation.AptosDeps, cfgTokenAddress aptos.AccountA
 	mcmsContract := mcmsbind.Bind(mcmsAddress, deps.AptosChain.Client)
 	isOwned, err := mcmsContract.MCMSRegistry().IsOwnedCodeObject(nil, cfgTokenAddress)
 	if err != nil {
+		eMsg := err.Error()
+		if strings.Contains(eMsg, "E_ADDRESS_NOT_REGISTERED") {
+			// If token is not registered, treat as just not owned by MCMS
+			// This is not an error per se
+			return false, nil
+		}
 		return false, fmt.Errorf("failed to check if token is owned by MCMS: %w", err)
 	}
 	return isOwned, nil

--- a/deployment/ccip/changeset/aptos/sequence/token_pool.go
+++ b/deployment/ccip/changeset/aptos/sequence/token_pool.go
@@ -29,6 +29,7 @@ type DeployTokenPoolSeqInput struct {
 	TokenAddress        aptos.AccountAddress
 	TokenOwnerAddress   aptos.AccountAddress
 	PoolType            cldf.ContractType
+	IsTokenOwnedByMCMS  bool
 }
 type DeployTokenPoolSeqOutput struct {
 	TokenPoolAddress aptos.AccountAddress
@@ -117,8 +118,8 @@ func deployAptosTokenPoolSequence(b operations.Bundle, deps operation.AptosDeps,
 	txs = append(txs, spReport.Output)
 
 	// 7 - Grant BnM permission to the token pool
-	switch in.PoolType {
-	case shared.AptosManagedTokenPoolType:
+	switch {
+	case in.PoolType == shared.AptosManagedTokenPoolType && in.IsTokenOwnedByMCMS:
 		tokenPoolStateAddress := tokenPoolObjectAddress.ResourceAccount([]byte("CcipManagedTokenPool"))
 		gmReport, err := operations.ExecuteOperation(b, operation.ApplyAllowedMintersOp, deps, operation.ApplyAllowedMintersInput{
 			TokenCodeObjectAddress: in.TokenCodeObjAddress,
@@ -137,7 +138,7 @@ func deployAptosTokenPoolSequence(b operations.Bundle, deps operation.AptosDeps,
 			return DeployTokenPoolSeqOutput{}, fmt.Errorf("failed to execute ApplyAllowedBurnersOp: %w", err)
 		}
 		txs = append(txs, gbReport.Output)
-	case shared.AptosRegulatedTokenPoolType:
+	case in.PoolType == shared.AptosRegulatedTokenPoolType && in.IsTokenOwnedByMCMS:
 		tokenPoolStateAddress := tokenPoolObjectAddress.ResourceAccount([]byte("CcipRegulatedTokenPool"))
 		gmReport, err := operations.ExecuteOperation(b, operation.GrantRoleOp, deps, operation.GrantRoleInput{
 			TokenCodeObjectAddress: in.TokenCodeObjAddress,


### PR DESCRIPTION
# Summary
Add Token Pools changeset need to work for tokens that are not managed by MCMS. When that's the case, grant BnM permissions can't run via MCMS operation, they'll have to be set by the owner of the Token. This PR adds a skip when Token Object is not owned by MCMS.

# Features
- Check if token is owned by MCMS
- Execute `Grant BnM permission` only if Token is owned by MCMS

# Testing
Test this PR by applying a migration locally using both a `TokenCodeObjAddress` owned by MCMS and another one that is not owned.