### PR TITLE
[CRE-876, 913, 963, 964, 989] Parallelize regression system-tests, run them by default.

### DIFF
--- a/.changeset/tiny-insects-judge.md
+++ b/.changeset/tiny-insects-judge.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#internal Parallelize CRE regression system-tests

--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -64,8 +64,6 @@ jobs:
         id: define-matrix
         shell: bash
         working-directory: system-tests/tests
-        env:
-          WITH_REGRESSION: ${{ inputs.with_regression }}
         run: |
           test_names=$(go test \
           github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre \
@@ -78,7 +76,7 @@ jobs:
             | map({
                 test_name: .value,
                 test_id: .key,
-                cre_version: (if (.value | test("V2")) then "v2" else "v1" end)
+                cre_version: (if (.value | test("V1")) then "v1" else "v2" end)
               })
           ')
 
@@ -157,7 +155,7 @@ jobs:
           E2E_JD_VERSION: "0.12.7"
           E2E_TEST_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name }}"
           E2E_TEST_CHAINLINK_VERSION: ${{ inputs.chainlink_image_tag != '' && inputs.chainlink_image_tag || inputs.chainlink_version }}
-          CTF_CONFIGS: configs/workflow-gateway-capabilities-don.toml
+          CTF_CONFIGS: configs/workflow-gateway-don.toml
           CRE_VERSION: ${{ matrix.tests.cre_version }}
           TEST_NAME: ${{ matrix.tests.test_name }}
         run: |
@@ -165,10 +163,10 @@ jobs:
 
           # Start CRE with the appropriate contracts version (i.e. Workflow/CapabilityRegistry)
           if [[ "${CRE_VERSION}" == "v1" ]]; then
-            echo "Starting CRE with v1 contracts for test: '${TEST_NAME}'"
+            echo "Starting CRE with v1 contracts for test: '${TEST_NAME}' and configs: '${CTF_CONFIGS}'"
             go run . env start --with-plugins-docker-image "${E2E_TEST_CHAINLINK_IMAGE}:${E2E_TEST_CHAINLINK_VERSION}"
           else
-            echo "Starting CRE with v2 contracts for test: '${TEST_NAME}'"
+            echo "Starting CRE with v2 contracts for test: '${TEST_NAME}' and configs: '${CTF_CONFIGS}'"
             go run . env start --with-plugins-docker-image "${E2E_TEST_CHAINLINK_IMAGE}:${E2E_TEST_CHAINLINK_VERSION}" --with-contracts-version v2
           fi
 
@@ -179,12 +177,14 @@ jobs:
           fi
 
       - name: Run CRE${{ matrix.tests.cre_version }} Regression system tests
+        id: run-regression-tests
         shell: bash
         working-directory: system-tests/tests
         env:
           TEST_NAME: ${{ matrix.tests.test_name }}
-          TEST_TIMEOUT: 200m
+          TEST_TIMEOUT: 30m
         run: |
+          echo "Starting test: '${TEST_NAME}'"
           gotestsum \
             --jsonfile=/tmp/gotest-regression.log \
             --junitfile=/tmp/junit-report-regression.xml \
@@ -192,15 +192,21 @@ jobs:
             -- \
             -v -run "^(${TEST_NAME})$" -timeout ${TEST_TIMEOUT} -count=1 -parallel=1 \
             github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre
+          
+          exit_code=$?
+          if [ $exit_code -eq 0 ]; then
+            echo "tests_result=✅ Tests passed" >> $GITHUB_OUTPUT
+          fi
+          exit $exit_code
 
-      - name: Process and upload flaky Regression tests results
+      - name: Process and upload flaky Regression tests results (${{ steps.run-regression-tests.outputs.tests_result }})
         if: ${{ !cancelled() }}
         uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/0.1.0
         with:
           junit-file-path: "/tmp/junit-report-regression.xml"
           trunk-org-slug: chainlink
           trunk-token: ${{ secrets.TRUNK_API_KEY }}
-          trunk-previous-step-outcome: ${{ steps.run-tests.outcome }}
+          trunk-previous-step-outcome: ${{ steps.run-regression-tests.outcome }}
           trunk-job-url: ${{ format('https://github.com/{0}/actions/runs/{1}/jobs/{2}', github.repository, github.run_id, job.check_run_id) }}
           # when auto-quarantine is enabled, allow this to determine test failures
           trunk-upload-only: ${{ env.ENABLE_AUTO_QUARANTINE != 'true' }}

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -77,10 +77,10 @@ jobs:
 
           # Add list of tests with certain topologies
           PER_TEST_TOPOLOGIES_JSON=${PER_TEST_TOPOLOGIES_JSON:-'{
-            "Test_CRE_Suite_V1_SecureMint": [
+            "Test_CRE_V1_SecureMint": [
                {"topology":"workflow","configs":"configs/workflow-solana-don.toml"}
              ],
-            "Test_CRE_Suite_V1_Tron": [
+            "Test_CRE_V1_Tron": [
                {"topology":"workflow","configs":"configs/workflow-don-tron.toml"}
              ]
               }'}
@@ -231,6 +231,7 @@ jobs:
           TEST_TIMEOUT: 30m
           RUN_QUARANTINED_TESTS: "true" # always run quarantined tests in CI
         run: |
+          echo "Starting test: '${TEST_NAME}'"
           gotestsum \
             --jsonfile=/tmp/gotest.log \
             --junitfile=/tmp/junit-report.xml \
@@ -239,7 +240,12 @@ jobs:
             -v -run "^(${TEST_NAME})$" -timeout "${TEST_TIMEOUT}" -count=1 -parallel=1 \
             github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre
 
-      - name: Process and upload flaky Smoke test results
+          exit_code=$?
+          if [ $exit_code -eq 0 ]; then
+            echo "tests_result=✅ Tests passed" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Process and upload flaky Regression tests results (${{ steps.run-tests.outputs.tests_result }})
         if: ${{ !cancelled() }}
         uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/0.1.0
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -158,12 +158,12 @@ jobs:
         with:
           check-label: "run-e2e-tests"
 
-      - name: Get PR Labels (run-e2e-regression)
+      - name: Get PR Labels (skip-e2e-regression)
         if: github.event_name == 'pull_request'
         id: label-runs-e2e-regression
         uses: smartcontractkit/.github/actions/get-pr-labels@get-pr-labels/v1
         with:
-          check-label: "run-e2e-regression"
+          check-label: "skip-e2e-regression"
 
       - name: Set runner labels
         id: runner-labels
@@ -310,11 +310,13 @@ jobs:
             # Run Core CRE E2E tests on PRs if there are relevant changes
             if [[ "${CONTAINS_CHANGES}" == 'true' ]]; then
               echo "should-run=true" | tee -a "$GITHUB_OUTPUT"
-            fi
-            if [[ "${RUN_E2E_TESTS_REGRESSION_LABEL_FOUND}" == 'true' ]]; then
-              echo "Running CRE regression tests as the label 'run-e2e-regression' is found"
-              echo "should-run=true" | tee -a "$GITHUB_OUTPUT"
               echo "with-regression=true" | tee -a "$GITHUB_OUTPUT"
+            fi
+            # Opt-out of CRE regression tests if the label 'skip-e2e-regression' is found
+            if [[ "${RUN_E2E_TESTS_REGRESSION_LABEL_FOUND}" == 'true' ]]; then
+              echo "Skipping CRE regression tests: label 'skip-e2e-regression' is found"
+              echo "should-run=true" | tee -a "$GITHUB_OUTPUT"
+              echo "with-regression=false" | tee -a "$GITHUB_OUTPUT"
             fi
 
           elif [[ "${GITHUB_EVENT_NAME}" == 'merge_group' ]]; then

--- a/system-tests/lib/cre/workflow/workflow.go
+++ b/system-tests/lib/cre/workflow/workflow.go
@@ -30,11 +30,78 @@ import (
 	libnet "github.com/smartcontractkit/chainlink/system-tests/lib/net"
 )
 
-func LinkOwner(
-	sc *seth.Client,
-	workflowRegistryAddr common.Address,
-	tv deployment.TypeAndVersion,
-) error {
+const (
+	// defaultWorkflowQueryLimit is the default limit for querying workflow lists
+	defaultWorkflowQueryLimit = 100
+
+	// File URL template for container artifacts
+	fileURLTemplate = "file://%s/%s"
+
+	// Default values for workflow registration
+	defaultWorkflowTag    = "some-tag"
+	defaultWorkflowStatus = uint8(0)
+
+	// Common error message templates
+	errCreateContractInstance  = "failed to create %s %s instance"
+	errCreateRegistryInstance  = "failed to create workflow registry instance"
+	errGetWorkflowMetadataList = "failed to get workflow metadata list"
+	errDeleteWorkflow          = "failed to delete workflow %q"
+)
+
+func RegisterWithContract(ctx context.Context, sc *seth.Client,
+	workflowRegistryAddr common.Address, typeVersion deployment.TypeAndVersion,
+	donID uint64, workflowName, binaryURL string,
+	configURL, secretsURL *string,
+	artifactsDirInContainer *string,
+) (string, error) {
+	// Download and decode workflow binary
+	workflowData, err := libnet.DownloadAndDecodeBase64(ctx, binaryURL)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to download and decode workflow binary")
+	}
+
+	// Construct binary URL for container if needed
+	binaryURLToUse := constructArtifactURL(binaryURL, artifactsDirInContainer)
+
+	// Handle config URL if provided
+	var configData []byte
+	configURLToUse := ""
+	if configURL != nil && *configURL != "" {
+		configData, err = libnet.Download(ctx, *configURL)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to download workflow config")
+		}
+		configURLToUse = constructArtifactURL(*configURL, artifactsDirInContainer)
+	}
+
+	// Handle secrets URL if provided
+	secretsURLToUse := ""
+	if secretsURL != nil && *secretsURL != "" {
+		secretsURLToUse = constructArtifactURL(*secretsURL, artifactsDirInContainer)
+	}
+
+	// Generate workflow ID
+	workflowID, err := generateWorkflowIDFromStrings(sc.MustGetRootKeyAddress().Hex(), workflowName, workflowData, configData, secretsURLToUse)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate workflow ID")
+	}
+
+	// Register workflow based on version
+	switch typeVersion.Version.Major() {
+	case 2:
+		if err := registerWorkflowV2(sc, workflowRegistryAddr, typeVersion, workflowName, workflowID, binaryURLToUse, configURLToUse); err != nil {
+			return "", err
+		}
+	default:
+		if err := registerWorkflowV1(sc, workflowRegistryAddr, donID, workflowName, workflowID, binaryURLToUse, configURLToUse, secretsURLToUse); err != nil {
+			return "", err
+		}
+	}
+
+	return workflowID, nil
+}
+
+func LinkOwner(sc *seth.Client, workflowRegistryAddr common.Address, tv deployment.TypeAndVersion) error {
 	switch tv.Version.Major() {
 	case 2:
 		validity := time.Now().UTC().Add(time.Hour * 24)
@@ -47,17 +114,14 @@ func LinkOwner(
 		ownershipProof := hex.EncodeToString(hash[:])
 		linkRequestType := uint8(0)
 
-		wr, err := workflow_registry_wrapper_v2.NewWorkflowRegistry(
-			workflowRegistryAddr,
-			sc.Client,
-		)
-		if err != nil {
-			return errors.Wrapf(err, "could not get instance of %s %s", tv.Type, tv.Version)
-		}
-
-		version, err := wr.TypeAndVersion(sc.NewCallOpts())
+		registry, err := getRegistryV2Instance(sc, workflowRegistryAddr, tv)
 		if err != nil {
 			return err
+		}
+
+		version, versionErr := registry.TypeAndVersion(sc.NewCallOpts())
+		if versionErr != nil {
+			return versionErr
 		}
 
 		messageDigest, err := PreparePayloadForSigning(
@@ -81,7 +145,7 @@ func LinkOwner(
 
 		signature[64] += 27
 
-		_, err = sc.Decode(wr.LinkOwner(sc.NewTXOpts(), validityTimestamp, common.HexToHash(ownershipProof), signature))
+		_, err = sc.Decode(registry.LinkOwner(sc.NewTXOpts(), validityTimestamp, common.HexToHash(ownershipProof), signature))
 		if err != nil {
 			return err
 		}
@@ -92,187 +156,183 @@ func LinkOwner(
 	}
 }
 
-func RegisterWithContract(ctx context.Context, sc *seth.Client,
-	workflowRegistryAddr common.Address, typeVersion deployment.TypeAndVersion,
-	donID uint64, workflowName, binaryURL string,
-	configURL, secretsURL *string,
-	artifactsDirInContainer *string,
-) (string, error) {
-	workFlowData, workFlowErr := libnet.DownloadAndDecodeBase64(ctx, binaryURL)
-	if workFlowErr != nil {
-		return "", errors.Wrap(workFlowErr, "failed to download and decode workflow binary")
-	}
-
-	var binaryURLToUse string
-	if artifactsDirInContainer != nil {
-		binaryURLToUse = fmt.Sprintf("file://%s/%s", *artifactsDirInContainer, filepath.Base(binaryURL))
-	} else {
-		binaryURLToUse = binaryURL
-	}
-
-	var configData []byte
-	var configErr error
-	configURLToUse := ""
-	if configURL != nil && *configURL != "" {
-		configData, configErr = libnet.Download(ctx, *configURL)
-		if configErr != nil {
-			return "", errors.Wrap(configErr, "failed to download workflow config")
-		}
-
-		if artifactsDirInContainer != nil {
-			configURLToUse = fmt.Sprintf("file://%s/%s", *artifactsDirInContainer, filepath.Base(*configURL))
-		} else {
-			configURLToUse = *configURL
-		}
-	}
-
-	secretsURLToUse := ""
-	if secretsURL != nil && *secretsURL != "" {
-		if artifactsDirInContainer != nil {
-			secretsURLToUse = fmt.Sprintf("file://%s/%s", *artifactsDirInContainer, filepath.Base(*secretsURL))
-		} else {
-			secretsURLToUse = *secretsURL
-		}
-	}
-
-	// use non-encoded workflow name
-	workflowID, idErr := generateWorkflowIDFromStrings(sc.MustGetRootKeyAddress().Hex(), workflowName, workFlowData, configData, secretsURLToUse)
-	if idErr != nil {
-		return "", errors.Wrap(idErr, "failed to generate workflow ID")
-	}
-
-	switch typeVersion.Version.Major() {
-	case 2:
-		wr, err := workflow_registry_wrapper_v2.NewWorkflowRegistry(
-			workflowRegistryAddr,
-			sc.Client,
-		)
-		if err != nil {
-			return "", errors.Wrapf(err, "could not get instance of %s %s", typeVersion.Type, typeVersion.Version)
-		}
-
-		addr := sc.MustGetRootKeyAddress()
-		linked, err := wr.IsOwnerLinked(sc.NewCallOpts(), addr)
-		if err != nil {
-			return "", errors.Wrap(err, "failed to check link status of owner")
-		}
-
-		if !linked {
-			err := LinkOwner(sc, workflowRegistryAddr, typeVersion)
-			if err != nil {
-				return "", errors.Wrap(err, "failed to link owner to org")
-			}
-		}
-
-		_, decodeErr := sc.Decode(wr.UpsertWorkflow(sc.NewTXOpts(), workflowName, "some-tag", [32]byte(common.Hex2Bytes(workflowID)), uint8(0), contracts.DonFamily, binaryURLToUse, configURLToUse, nil, false))
-		if decodeErr != nil {
-			return "", errors.Wrap(decodeErr, "failed to register workflow")
-		}
-		return workflowID, nil
-	default:
-		workflowRegistryInstance, instanceErr := workflow_registry_wrapper.NewWorkflowRegistry(workflowRegistryAddr, sc.Client)
-		if instanceErr != nil {
-			return "", errors.Wrap(instanceErr, "failed to create workflow registry instance")
-		}
-
-		// use non-encoded workflow name
-		_, decodeErr := sc.Decode(workflowRegistryInstance.RegisterWorkflow(sc.NewTXOpts(), workflowName, [32]byte(common.Hex2Bytes(workflowID)), libc.MustSafeUint32FromUint64(donID), uint8(0), binaryURLToUse, configURLToUse, secretsURLToUse))
-		if decodeErr != nil {
-			return "", errors.Wrap(decodeErr, "failed to register workflow")
-		}
-		return workflowID, nil
-	}
-}
-
-func GetWorkflowNames(ctx context.Context, sc *seth.Client,
-	workflowRegistryAddr common.Address, tv deployment.TypeAndVersion,
-) ([]string, error) {
-	workflows := make([]string, 0)
+// GetWorkflowNames retrieves all workflow names for the given registry contract.
+// It supports both v1 and v2 workflow registry versions.
+func GetWorkflowNames(ctx context.Context, sc *seth.Client, workflowRegistryAddr common.Address, tv deployment.TypeAndVersion) ([]string, error) {
 	switch tv.Version.Major() {
 	case 2:
-		wr, err := workflow_registry_wrapper_v2.NewWorkflowRegistry(
-			workflowRegistryAddr,
-			sc.Client,
-		)
-		if err != nil {
-			return nil, errors.Wrapf(err, "could not get instance of %s %s", tv.Type, tv.Version)
-		}
-
-		md, err := wr.GetWorkflowListByOwner(sc.NewCallOpts(), sc.MustGetRootKeyAddress(), big.NewInt(0), big.NewInt(10))
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get workflow metadata list")
-		}
-
-		for _, m := range md {
-			workflows = append(workflows, m.WorkflowName)
-		}
-		return workflows, nil
+		return getWorkflowNamesV2(sc, workflowRegistryAddr, tv)
 	default:
-		workflowRegistryInstance, err := workflow_registry_wrapper.NewWorkflowRegistry(workflowRegistryAddr, sc.Client)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to create workflow registry instance")
-		}
-		metadataList, metadataListErr := workflowRegistryInstance.GetWorkflowMetadataListByOwner(sc.NewCallOpts(), sc.MustGetRootKeyAddress(), big.NewInt(0), big.NewInt(10))
-		if metadataListErr != nil {
-			return nil, errors.Wrap(metadataListErr, "failed to get workflow metadata list")
-		}
-
-		for _, metadata := range metadataList {
-			workflows = append(workflows, metadata.WorkflowName)
-		}
-
-		return workflows, nil
+		return getWorkflowNamesV1(sc, workflowRegistryAddr)
 	}
 }
 
-func DeleteAllWithContract(ctx context.Context, sc *seth.Client,
+// DeleteWithContract removes a workflow from the workflow registry contract.
+// It supports both v1 and v2 workflow registry versions.
+func DeleteWithContract(ctx context.Context, sc *seth.Client,
 	workflowRegistryAddr common.Address, tv deployment.TypeAndVersion,
+	workflowName string,
 ) error {
 	switch tv.Version.Major() {
 	case 2:
-		wr, err := workflow_registry_wrapper_v2.NewWorkflowRegistry(
-			workflowRegistryAddr,
-			sc.Client,
-		)
-		if err != nil {
-			return errors.Wrapf(err, "could not get instance of %s %s", tv.Type, tv.Version)
-		}
-
-		md, err := wr.GetWorkflowListByOwner(sc.NewCallOpts(), sc.MustGetRootKeyAddress(), big.NewInt(0), big.NewInt(10))
-		if err != nil {
-			return errors.Wrap(err, "failed to get workflow metadata list")
-		}
-
-		for _, m := range md {
-			workflowHashKey := computeHashKey(sc.MustGetRootKeyAddress(), m.WorkflowName)
-			if _, deleteErr := sc.Decode(wr.DeleteWorkflow(sc.NewTXOpts(), workflowHashKey)); deleteErr != nil {
-				return errors.Wrapf(deleteErr, "failed to delete workflow named %s", m.WorkflowName)
-			}
-		}
-		return nil
+		return deleteWorkflowV2(ctx, sc, workflowRegistryAddr, tv, workflowName)
 	default:
-		workflowRegistryInstance, err := workflow_registry_wrapper.NewWorkflowRegistry(workflowRegistryAddr, sc.Client)
-		if err != nil {
-			return errors.Wrap(err, "failed to create workflow registry instance")
-		}
-
-		metadataList, metadataListErr := workflowRegistryInstance.GetWorkflowMetadataListByOwner(sc.NewCallOpts(), sc.MustGetRootKeyAddress(), big.NewInt(0), big.NewInt(10))
-		if metadataListErr != nil {
-			return errors.Wrap(metadataListErr, "failed to get workflow metadata list")
-		}
-
-		for _, metadata := range metadataList {
-			workflowHashKey := computeHashKey(sc.MustGetRootKeyAddress(), metadata.WorkflowName)
-			_, deleteErr := sc.Decode(workflowRegistryInstance.DeleteWorkflow(sc.NewTXOpts(), workflowHashKey))
-			if deleteErr != nil {
-				return errors.Wrap(deleteErr, "failed to delete workflow named "+metadata.WorkflowName)
-			}
-		}
-
-		return nil
+		return deleteWorkflowV1(ctx, sc, workflowRegistryAddr, workflowName)
 	}
 }
 
+// DeleteAllWithContract removes all workflows owned by the caller from the workflow registry contract.
+// It supports both v1 and v2 workflow registry versions.
+func DeleteAllWithContract(ctx context.Context, sc *seth.Client, workflowRegistryAddr common.Address, tv deployment.TypeAndVersion) error {
+	switch tv.Version.Major() {
+	case 2:
+		return deleteAllWorkflowsV2(ctx, sc, workflowRegistryAddr, tv)
+	default:
+		return deleteAllWorkflowsV1(ctx, sc, workflowRegistryAddr)
+	}
+}
+
+// RemoveWorkflowArtifactsFromLocalEnv removes workflow artifact files from the local filesystem.
+// Empty file paths are silently skipped.
+func RemoveWorkflowArtifactsFromLocalEnv(artifactPaths ...string) error {
+	for _, path := range artifactPaths {
+		if path == "" {
+			continue
+		}
+
+		if err := os.Remove(path); err != nil {
+			return errors.Wrapf(err, "failed to remove workflow artifact at %q", path)
+		}
+	}
+	return nil
+}
+
+// constructArtifactURL constructs the appropriate URL based on whether artifacts are in a container
+func constructArtifactURL(originalURL string, artifactsDirInContainer *string) string {
+	if artifactsDirInContainer != nil {
+		return fmt.Sprintf(fileURLTemplate, *artifactsDirInContainer, filepath.Base(originalURL))
+	}
+	return originalURL
+}
+
+// registerWorkflowV2 handles workflow registration for v2 registry contracts
+func registerWorkflowV2(sc *seth.Client, workflowRegistryAddr common.Address, tv deployment.TypeAndVersion,
+	workflowName, workflowID, binaryURL, configURL string) error {
+	registry, err := getRegistryV2Instance(sc, workflowRegistryAddr, tv)
+	if err != nil {
+		return err
+	}
+
+	// Check and link owner if needed using existing helper function
+	if verifyErr := verifyOwnerLinkedWithRegistry(registry, sc, workflowName); verifyErr != nil {
+		// If owner is not linked, try to link them
+		if linkErr := LinkOwner(sc, workflowRegistryAddr, tv); linkErr != nil {
+			return errors.Wrap(linkErr, "failed to link owner to org")
+		}
+	}
+
+	// Register workflow
+	_, err = sc.Decode(registry.UpsertWorkflow(
+		sc.NewTXOpts(),
+		workflowName,
+		defaultWorkflowTag,
+		[32]byte(common.Hex2Bytes(workflowID)),
+		defaultWorkflowStatus,
+		contracts.DonFamily,
+		binaryURL,
+		configURL,
+		nil,
+		false,
+	))
+	if err != nil {
+		return errors.Wrap(err, "failed to register workflow")
+	}
+
+	return nil
+}
+
+// registerWorkflowV1 handles workflow registration for v1 registry contracts
+func registerWorkflowV1(sc *seth.Client, workflowRegistryAddr common.Address, donID uint64,
+	workflowName, workflowID, binaryURL, configURL, secretsURL string) error {
+	registry, err := createRegistryV1Instance(sc, workflowRegistryAddr)
+	if err != nil {
+		return err
+	}
+
+	// Register workflow
+	_, err = sc.Decode(registry.RegisterWorkflow(
+		sc.NewTXOpts(),
+		workflowName,
+		[32]byte(common.Hex2Bytes(workflowID)),
+		libc.MustSafeUint32FromUint64(donID),
+		defaultWorkflowStatus,
+		binaryURL,
+		configURL,
+		secretsURL,
+	))
+	if err != nil {
+		return errors.Wrap(err, "failed to register workflow")
+	}
+
+	return nil
+}
+
+// deleteAllWorkflowsV2 removes all workflows for v2 registry contracts.
+func deleteAllWorkflowsV2(ctx context.Context, sc *seth.Client, workflowRegistryAddr common.Address, tv deployment.TypeAndVersion) error {
+	// Create registry instance once for all operations
+	registry, err := getRegistryV2Instance(sc, workflowRegistryAddr, tv)
+	if err != nil {
+		return err
+	}
+
+	// Verify owner linking before attempting any deletions
+	if verifyErr := verifyOwnerLinkedWithRegistry(registry, sc, ""); verifyErr != nil {
+		return verifyErr
+	}
+
+	// Get list of workflows to delete using the same registry instance
+	workflows, err := getWorkflowListWithRegistryV2(registry, sc)
+	if err != nil {
+		return err
+	}
+
+	// Delete each workflow using the same registry instance
+	for _, workflow := range workflows {
+		if _, err := sc.Decode(registry.DeleteWorkflow(sc.NewTXOpts(), workflow.WorkflowId)); err != nil {
+			return errors.Wrapf(err, errDeleteWorkflow, workflow.WorkflowName)
+		}
+	}
+
+	return nil
+}
+
+// deleteAllWorkflowsV1 removes all workflows for v1 registry contracts.
+func deleteAllWorkflowsV1(ctx context.Context, sc *seth.Client, workflowRegistryAddr common.Address) error {
+	// Create registry instance once for all operations
+	registry, err := createRegistryV1Instance(sc, workflowRegistryAddr)
+	if err != nil {
+		return err
+	}
+
+	// Get list of workflows to delete using the same registry instance
+	workflows, err := getWorkflowListWithRegistryV1(registry, sc)
+	if err != nil {
+		return err
+	}
+
+	// Delete each workflow using the same registry instance
+	for _, workflow := range workflows {
+		workflowHashKey := computeHashKey(sc.MustGetRootKeyAddress(), workflow.WorkflowName)
+		if _, err := sc.Decode(registry.DeleteWorkflow(sc.NewTXOpts(), workflowHashKey)); err != nil {
+			return errors.Wrapf(err, errDeleteWorkflow, workflow.WorkflowName)
+		}
+	}
+
+	return nil
+}
+
+// computeHashKey generates a Keccak256 hash from owner address and workflow name.
+// This is used for v1 workflow registry contract operations.
 func computeHashKey(owner common.Address, workflowName string) [32]byte {
 	ownerBytes := owner.Bytes()
 	nameBytes := []byte(workflowName)
@@ -283,70 +343,196 @@ func computeHashKey(owner common.Address, workflowName string) [32]byte {
 	return crypto.Keccak256Hash(data)
 }
 
-func DeleteWithContract(ctx context.Context, sc *seth.Client,
-	workflowRegistryAddr common.Address, tv deployment.TypeAndVersion,
-	workflowName string,
+// deleteWorkflowV2 handles workflow deletion for v2 registry contracts.
+func deleteWorkflowV2(ctx context.Context, sc *seth.Client, workflowRegistryAddr common.Address, tv deployment.TypeAndVersion, workflowName string,
 ) error {
-	switch tv.Version.Major() {
-	case 2:
-		wr, err := workflow_registry_wrapper_v2.NewWorkflowRegistry(
-			workflowRegistryAddr,
-			sc.Client,
-		)
-		if err != nil {
-			return errors.Wrapf(err, "could not get instance of %s %s", tv.Type, tv.Version)
-		}
-
-		workflowHashKey := computeHashKey(sc.MustGetRootKeyAddress(), workflowName)
-		if _, deleteErr := sc.Decode(wr.DeleteWorkflow(sc.NewTXOpts(), workflowHashKey)); deleteErr != nil {
-			return errors.Wrap(deleteErr, "failed to delete workflow named "+workflowName)
-		}
-		return nil
-	default:
-		workflowRegistryInstance, err := workflow_registry_wrapper.NewWorkflowRegistry(workflowRegistryAddr, sc.Client)
-		if err != nil {
-			return errors.Wrap(err, "failed to create workflow registry instance")
-		}
-
-		workflowHashKey := computeHashKey(sc.MustGetRootKeyAddress(), workflowName)
-		_, deleteErr := sc.Decode(workflowRegistryInstance.DeleteWorkflow(sc.NewTXOpts(), workflowHashKey))
-		if deleteErr != nil {
-			return errors.Wrap(deleteErr, "failed to delete workflow named "+workflowName)
-		}
-
-		return nil
+	// Create registry instance once for all operations
+	registry, err := getRegistryV2Instance(sc, workflowRegistryAddr, tv)
+	if err != nil {
+		return err
 	}
-}
 
-func RemoveWorkflowArtifactsFromLocalEnv(workflowArtifactsLocations ...string) error {
-	for _, artifactLocation := range workflowArtifactsLocations {
-		if artifactLocation == "" {
-			continue
-		}
-
-		err := os.Remove(artifactLocation)
-		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("failed to remove workflow artifact located at %s: %s", artifactLocation, err.Error()))
-		}
+	// Find workflow using the same registry instance
+	workflowID, err := findWorkflowByNameWithRegistry(registry, sc, workflowName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to find workflow %q", workflowName)
 	}
+
+	// Verify owner linking using the same registry instance
+	if err := verifyOwnerLinkedWithRegistry(registry, sc, workflowName); err != nil {
+		return err
+	}
+
+	// Delete workflow using the same registry instance
+	if _, err := sc.Decode(registry.DeleteWorkflow(sc.NewTXOpts(), workflowID)); err != nil {
+		return errors.Wrapf(err, "failed to delete workflow %q (ID: %x)", workflowName, workflowID)
+	}
+
 	return nil
 }
 
-func generateWorkflowIDFromStrings(owner string, name string, workflow []byte, config []byte, secretsURL string) (string, error) {
-	ownerWithoutPrefix := owner
-	if strings.HasPrefix(owner, "0x") {
-		ownerWithoutPrefix = owner[2:]
-	}
-
-	ownerb, err := hex.DecodeString(ownerWithoutPrefix)
+// deleteWorkflowV1 handles workflow deletion for v1 registry contracts.
+func deleteWorkflowV1(ctx context.Context, sc *seth.Client,
+	workflowRegistryAddr common.Address, workflowName string,
+) error {
+	registry, err := createRegistryV1Instance(sc, workflowRegistryAddr)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	wid, err := pkgworkflows.GenerateWorkflowID(ownerb, name, workflow, config, secretsURL)
+	workflowHashKey := computeHashKey(sc.MustGetRootKeyAddress(), workflowName)
+	if _, err := sc.Decode(registry.DeleteWorkflow(sc.NewTXOpts(), workflowHashKey)); err != nil {
+		return errors.Wrapf(err, "failed to delete workflow %q", workflowName)
+	}
+
+	return nil
+}
+
+// findWorkflowByNameWithRegistry finds a workflow by name using an existing registry instance and returns its ID.
+func findWorkflowByNameWithRegistry(registry *workflow_registry_wrapper_v2.WorkflowRegistry, sc *seth.Client, workflowName string) ([32]byte, error) {
+	workflows, err := getWorkflowListWithRegistryV2(registry, sc)
 	if err != nil {
-		return "", err
+		return [32]byte{}, err
 	}
 
-	return hex.EncodeToString(wid[:]), nil
+	for _, workflow := range workflows {
+		if workflow.WorkflowName == workflowName {
+			return workflow.WorkflowId, nil
+		}
+	}
+
+	return [32]byte{}, errors.Errorf("workflow %q not found in registry", workflowName)
+}
+
+// verifyOwnerLinkedWithRegistry checks if the owner is properly linked using an existing registry instance.
+func verifyOwnerLinkedWithRegistry(registry *workflow_registry_wrapper_v2.WorkflowRegistry, sc *seth.Client, workflowName string) error {
+	ownerAddr := sc.MustGetRootKeyAddress()
+	isLinked, err := registry.IsOwnerLinked(sc.NewCallOpts(), ownerAddr)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check owner link status for workflow %q", workflowName)
+	}
+
+	if !isLinked {
+		return errors.Errorf("owner %s is not linked to an organization, cannot delete workflow %q",
+			ownerAddr.Hex(), workflowName)
+	}
+
+	return nil
+}
+
+// getRegistryV2Instance creates a new v2 workflow registry instance.
+func getRegistryV2Instance(sc *seth.Client, workflowRegistryAddr common.Address, tv deployment.TypeAndVersion) (*workflow_registry_wrapper_v2.WorkflowRegistry, error) {
+	registry, err := workflow_registry_wrapper_v2.NewWorkflowRegistry(workflowRegistryAddr, sc.Client)
+	if err != nil {
+		return nil, errors.Wrapf(err, errCreateContractInstance, tv.Type, tv.Version)
+	}
+	return registry, nil
+}
+
+// createRegistryV1Instance creates a new v1 workflow registry instance.
+func createRegistryV1Instance(sc *seth.Client, workflowRegistryAddr common.Address) (*workflow_registry_wrapper.WorkflowRegistry, error) {
+	registry, err := workflow_registry_wrapper.NewWorkflowRegistry(workflowRegistryAddr, sc.Client)
+	if err != nil {
+		return nil, errors.Wrap(err, errCreateRegistryInstance)
+	}
+	return registry, nil
+}
+
+// getWorkflowListWithRegistryV2 retrieves the full workflow list using an existing v2 registry instance.
+func getWorkflowListWithRegistryV2(registry *workflow_registry_wrapper_v2.WorkflowRegistry, sc *seth.Client) ([]workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView, error) {
+	workflows, err := registry.GetWorkflowListByOwner(
+		sc.NewCallOpts(),
+		sc.MustGetRootKeyAddress(),
+		big.NewInt(0),
+		big.NewInt(defaultWorkflowQueryLimit),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, errGetWorkflowMetadataList)
+	}
+
+	return workflows, nil
+}
+
+// getWorkflowListV2 retrieves the full workflow list for v2 registry contracts.
+func getWorkflowListV2(sc *seth.Client, workflowRegistryAddr common.Address, tv deployment.TypeAndVersion) ([]workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView, error) {
+	registry, err := getRegistryV2Instance(sc, workflowRegistryAddr, tv)
+	if err != nil {
+		return nil, err
+	}
+
+	return getWorkflowListWithRegistryV2(registry, sc)
+}
+
+// getWorkflowNamesV2 retrieves all workflow names for v2 registry contracts.
+func getWorkflowNamesV2(sc *seth.Client, workflowRegistryAddr common.Address, tv deployment.TypeAndVersion) ([]string, error) {
+	workflows, err := getWorkflowListV2(sc, workflowRegistryAddr, tv)
+	if err != nil {
+		return nil, err
+	}
+
+	workflowNames := make([]string, 0, len(workflows))
+	for _, workflow := range workflows {
+		workflowNames = append(workflowNames, workflow.WorkflowName)
+	}
+
+	return workflowNames, nil
+}
+
+// getWorkflowListWithRegistryV1 retrieves the full workflow list using an existing v1 registry instance.
+func getWorkflowListWithRegistryV1(registry *workflow_registry_wrapper.WorkflowRegistry, sc *seth.Client) ([]workflow_registry_wrapper.WorkflowRegistryWorkflowMetadata, error) {
+	workflows, err := registry.GetWorkflowMetadataListByOwner(
+		sc.NewCallOpts(),
+		sc.MustGetRootKeyAddress(),
+		big.NewInt(0),
+		big.NewInt(defaultWorkflowQueryLimit),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, errGetWorkflowMetadataList)
+	}
+
+	return workflows, nil
+}
+
+// getWorkflowListV1 retrieves the full workflow list for v1 registry contracts.
+func getWorkflowListV1(sc *seth.Client, workflowRegistryAddr common.Address) ([]workflow_registry_wrapper.WorkflowRegistryWorkflowMetadata, error) {
+	registry, err := createRegistryV1Instance(sc, workflowRegistryAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return getWorkflowListWithRegistryV1(registry, sc)
+}
+
+// getWorkflowNamesV1 retrieves all workflow names for v1 registry contracts.
+func getWorkflowNamesV1(sc *seth.Client, workflowRegistryAddr common.Address) ([]string, error) {
+	workflows, err := getWorkflowListV1(sc, workflowRegistryAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	workflowNames := make([]string, 0, len(workflows))
+	for _, workflow := range workflows {
+		workflowNames = append(workflowNames, workflow.WorkflowName)
+	}
+
+	return workflowNames, nil
+}
+
+// generateWorkflowIDFromStrings creates a workflow ID from string inputs.
+// The owner address can be provided with or without the "0x" prefix.
+func generateWorkflowIDFromStrings(owner, name string, workflow, config []byte, secretsURL string) (string, error) {
+	// Remove "0x" prefix if present
+	ownerHex := strings.TrimPrefix(owner, "0x")
+
+	ownerBytes, err := hex.DecodeString(ownerHex)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to decode owner address")
+	}
+
+	workflowID, err := pkgworkflows.GenerateWorkflowID(ownerBytes, name, workflow, config, secretsURL)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate workflow ID")
+	}
+
+	return hex.EncodeToString(workflowID[:]), nil
 }

--- a/system-tests/tests/regression/cre/cre_regression_suite_test.go
+++ b/system-tests/tests/regression/cre/cre_regression_suite_test.go
@@ -10,6 +10,8 @@ import (
 
 // REGRESSION TESTS target edge cases, negative conditions, etc., all happy path and sanity checks should go to a `smoke` package.
 
+var v2RegistriesFlags = []string{"--with-contracts-version", "v2"}
+
 /*
 To execute tests locally start the local CRE first:
 Inside `core/scripts/cre/environment` directory
@@ -21,29 +23,67 @@ Inside `core/scripts/cre/environment` directory
  6. Execute the tests in `system-tests/tests/smoke/cre` with CTF_CONFIG set to the corresponding topology file:
     `export  CTF_CONFIGS=../../../../core/scripts/cre/environment/configs/<topology>.toml; go test -timeout 15m -run ^Test_CRE_Suite$`.
 */
-func Test_CRE_Suite_V2_Regression(t *testing.T) {
-	flags := []string{"--with-contracts-version", "v2"}
-	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), flags...)
+func Test_CRE_V2_Cron_Regression(t *testing.T) {
+	for _, tCase := range cronInvalidSchedulesTests {
+		testName := "[v2] Cron (Beholder) fails when schedule is " + tCase.name
+		t.Run(testName, func(t *testing.T) {
+			testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
 
-	t.Run("[v2] CRE Regression Suite", func(t *testing.T) {
-		for _, tCase := range cronInvalidSchedulesTests {
-			testName := "[v2] Cron (Beholder) fails when schedule is " + tCase.name
-			t.Run(testName, func(t *testing.T) {
-				CronBeholderFailsWithInvalidScheduleTest(t, testEnv, tCase.invalidSchedule)
-			})
-		}
-	})
+			CronBeholderFailsWithInvalidScheduleTest(t, testEnv, tCase.invalidSchedule)
+		})
+	}
 }
 
-func Test_CRE_Suite_V2_EVM_Regression(t *testing.T) {
-	flags := []string{"--with-contracts-version", "v2"}
-	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), flags...)
-	// TODO remove this when OCR works properly with multiple chains in Local CRE
-	testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
+// a template for EVM negative tests names to avoid duplication
+const evmTestNameTemplate = "[v2] EVM.%s fails with %s" // e.g. "[v2] EVM.<Function> fails with <invalid input>"
 
-	for _, tCase := range evmNegativeTests {
-		testName := fmt.Sprintf("[v2] EVM.%s fails with %s", tCase.functionToTest, tCase.name)
+func Test_CRE_V2_EVM_BalanceAt_Invalid_Address_Regression(t *testing.T) {
+	for _, tCase := range evmNegativeTestsBalanceAtInvalidAddress {
+		testName := fmt.Sprintf(evmTestNameTemplate, tCase.functionToTest, tCase.name)
 		t.Run(testName, func(t *testing.T) {
+			testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+			// TODO remove this when OCR works properly with multiple chains in Local CRE
+			testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
+
+			EVMReadFailsTest(t, testEnv, tCase)
+		})
+	}
+}
+
+func Test_CRE_V2_EVM_CallContract_Invalid_Addr_To_Read_Regression(t *testing.T) {
+	for _, tCase := range evmNegativeTestsCallContractInvalidAddressToRead {
+		testName := fmt.Sprintf(evmTestNameTemplate, tCase.functionToTest, tCase.name)
+		t.Run(testName, func(t *testing.T) {
+			testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+			// TODO remove this when OCR works properly with multiple chains in Local CRE
+			testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
+
+			EVMReadFailsTest(t, testEnv, tCase)
+		})
+	}
+}
+
+func Test_CRE_V2_EVM_CallContract_Invalid_Balance_Reader_Contract_Regression(t *testing.T) {
+	for _, tCase := range evmNegativeTestsCallContractInvalidBalanceReaderContract {
+		testName := fmt.Sprintf(evmTestNameTemplate, tCase.functionToTest, tCase.name)
+		t.Run(testName, func(t *testing.T) {
+			testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+			// TODO remove this when OCR works properly with multiple chains in Local CRE
+			testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
+
+			EVMReadFailsTest(t, testEnv, tCase)
+		})
+	}
+}
+
+func Test_CRE_V2_EVM_EstimateGas_Invalid_To_Address_Regression(t *testing.T) {
+	for _, tCase := range evmNegativeTestsEstimateGasInvalidToAddress {
+		testName := fmt.Sprintf(evmTestNameTemplate, tCase.functionToTest, tCase.name)
+		t.Run(testName, func(t *testing.T) {
+			testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+			// TODO remove this when OCR works properly with multiple chains in Local CRE
+			testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
+
 			EVMReadFailsTest(t, testEnv, tCase)
 		})
 	}

--- a/system-tests/tests/regression/cre/cre_regression_suite_test.go
+++ b/system-tests/tests/regression/cre/cre_regression_suite_test.go
@@ -34,61 +34,6 @@ func Test_CRE_V2_Cron_Regression(t *testing.T) {
 	}
 }
 
-// a template for EVM negative tests names to avoid duplication
-const evmTestNameTemplate = "[v2] EVM.%s fails with %s" // e.g. "[v2] EVM.<Function> fails with <invalid input>"
-
-func Test_CRE_V2_EVM_BalanceAt_Invalid_Address_Regression(t *testing.T) {
-	for _, tCase := range evmNegativeTestsBalanceAtInvalidAddress {
-		testName := fmt.Sprintf(evmTestNameTemplate, tCase.functionToTest, tCase.name)
-		t.Run(testName, func(t *testing.T) {
-			testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
-			// TODO remove this when OCR works properly with multiple chains in Local CRE
-			testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
-
-			EVMReadFailsTest(t, testEnv, tCase)
-		})
-	}
-}
-
-func Test_CRE_V2_EVM_CallContract_Invalid_Addr_To_Read_Regression(t *testing.T) {
-	for _, tCase := range evmNegativeTestsCallContractInvalidAddressToRead {
-		testName := fmt.Sprintf(evmTestNameTemplate, tCase.functionToTest, tCase.name)
-		t.Run(testName, func(t *testing.T) {
-			testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
-			// TODO remove this when OCR works properly with multiple chains in Local CRE
-			testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
-
-			EVMReadFailsTest(t, testEnv, tCase)
-		})
-	}
-}
-
-func Test_CRE_V2_EVM_CallContract_Invalid_Balance_Reader_Contract_Regression(t *testing.T) {
-	for _, tCase := range evmNegativeTestsCallContractInvalidBalanceReaderContract {
-		testName := fmt.Sprintf(evmTestNameTemplate, tCase.functionToTest, tCase.name)
-		t.Run(testName, func(t *testing.T) {
-			testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
-			// TODO remove this when OCR works properly with multiple chains in Local CRE
-			testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
-
-			EVMReadFailsTest(t, testEnv, tCase)
-		})
-	}
-}
-
-func Test_CRE_V2_EVM_EstimateGas_Invalid_To_Address_Regression(t *testing.T) {
-	for _, tCase := range evmNegativeTestsEstimateGasInvalidToAddress {
-		testName := fmt.Sprintf(evmTestNameTemplate, tCase.functionToTest, tCase.name)
-		t.Run(testName, func(t *testing.T) {
-			testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
-			// TODO remove this when OCR works properly with multiple chains in Local CRE
-			testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
-
-			EVMReadFailsTest(t, testEnv, tCase)
-		})
-	}
-}
-
 func Test_CRE_Suite_V2_HTTP_Regression(t *testing.T) {
 	flags := []string{"--with-contracts-version", "v2"}
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), flags...)
@@ -99,4 +44,50 @@ func Test_CRE_Suite_V2_HTTP_Regression(t *testing.T) {
 			HTTPTriggerFailsTest(t, testEnv, tCase)
 		})
 	}
+}
+
+// runEVMNegativeTestSuite runs a suite of EVM negative tests with the given test cases
+func runEVMNegativeTestSuite(t *testing.T, testCases []evmNegativeTest) {
+	// a template for EVM negative tests names to avoid duplication
+	const evmTestNameTemplate = "[v2] EVM.%s fails with %s" // e.g. "[v2] EVM.<Function> fails with <invalid input>"
+
+	for _, tCase := range testCases {
+		testName := fmt.Sprintf(evmTestNameTemplate, tCase.functionToTest, tCase.name)
+		t.Run(testName, func(t *testing.T) {
+			testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+			// TODO remove this when OCR works properly with multiple chains in Local CRE
+			testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
+
+			EVMReadFailsTest(t, testEnv, tCase)
+		})
+	}
+}
+
+func Test_CRE_V2_EVM_BalanceAt_Invalid_Address_Regression(t *testing.T) {
+	runEVMNegativeTestSuite(t, evmNegativeTestsBalanceAtInvalidAddress)
+}
+
+func Test_CRE_V2_EVM_CallContract_Invalid_Addr_To_Read_Regression(t *testing.T) {
+	runEVMNegativeTestSuite(t, evmNegativeTestsCallContractInvalidAddressToRead)
+}
+
+func Test_CRE_V2_EVM_CallContract_Invalid_Balance_Reader_Contract_Regression(t *testing.T) {
+	runEVMNegativeTestSuite(t, evmNegativeTestsCallContractInvalidBalanceReaderContract)
+}
+
+func Test_CRE_V2_EVM_EstimateGas_Invalid_To_Address_Regression(t *testing.T) {
+	runEVMNegativeTestSuite(t, evmNegativeTestsEstimateGasInvalidToAddress)
+}
+
+func Test_CRE_V2_EVM_FilterLogs_Invalid_Addresses_Regression(t *testing.T) {
+	t.Skip("Skipping because evm.FilterLogs does not return an error or nil for invalid/not existing addresses")
+	runEVMNegativeTestSuite(t, evmNegativeTestsFilterLogsWithInvalidAddress)
+}
+
+func Test_CRE_V2_EVM_FilterLogs_Invalid_FromBlock_Regression(t *testing.T) {
+	runEVMNegativeTestSuite(t, evmNegativeTestsFilterLogsWithInvalidFromBlock)
+}
+
+func Test_CRE_V2_EVM_FilterLogs_Invalid_ToBlock_Regression(t *testing.T) {
+	runEVMNegativeTestSuite(t, evmNegativeTestsFilterLogsWithInvalidToBlock)
 }

--- a/system-tests/tests/regression/cre/evm/evmread-negative/go.mod
+++ b/system-tests/tests/regression/cre/evm/evmread-negative/go.mod
@@ -5,6 +5,7 @@ go 1.24.5
 require (
 	github.com/ethereum/go-ethereum v1.16.2
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250917110014-65bff6568f77
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20250829155125-f4655b0b4605
 	github.com/smartcontractkit/cre-sdk-go v0.6.0
 	github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/evm v0.6.0
 	github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron v0.6.0
@@ -33,7 +34,6 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20250829155125-f4655b0b4605 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/supranational/blst v0.3.14 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect

--- a/system-tests/tests/regression/cre/evm/evmread-negative/main.go
+++ b/system-tests/tests/regression/cre/evm/evmread-negative/main.go
@@ -88,6 +88,7 @@ func runCallContractForInvalidAddressesToRead(evmClient evm.Client, runtime sdk.
 			Data: readBalancesCallWithInvalidAddressToRead,
 		},
 	}).Await()
+	runtime.Logger().Info("CallContract balance reading completed", "output_data", readBalancesOutput.Data)
 	if err != nil {
 		runtime.Logger().Error("this is not expected: reading invalid balances should return 0", "invalid_address", invalidAddressToRead, "error", err)
 		return nil, fmt.Errorf("failed to get balances for address '%s': %w", invalidAddressToRead, err)
@@ -144,11 +145,13 @@ func getPackedReadBalancesCall(methodName, addressToRead string, readBalancesABI
 }
 
 func getReadBalanceAbi(runtime sdk.Runtime) (*abi.ABI, error) {
+	runtime.Logger().Info("getting Balance Reader contract ABI")
 	readBalancesABI, abiErr := balance_reader.BalanceReaderMetaData.GetAbi()
 	if abiErr != nil {
 		runtime.Logger().Error("failed to get Balance Reader contract ABI", "error", abiErr)
 		return nil, fmt.Errorf("failed to get Balance Reader contract ABI: %w", abiErr)
 	}
+	runtime.Logger().Info("successfully got Balance Reader contract ABI.")
 	return readBalancesABI, nil
 }
 

--- a/system-tests/tests/regression/cre/evm/evmread-negative/main.go
+++ b/system-tests/tests/regression/cre/evm/evmread-negative/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink-protos/cre/go/values/pb"
 	"github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/evm"
 	"github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron"
 	sdk "github.com/smartcontractkit/cre-sdk-go/cre"
@@ -54,6 +55,12 @@ func onEVMReadTrigger(wfCfg config.Config, runtime sdk.Runtime, payload *cron.Pa
 	case "EstimateGas - invalid 'to' address":
 		// it does not make sense to test with invalid CallMsg.Data because any bytes will be correctly processed
 		return runEstimateGasForInvalidToAddress(client, runtime, wfCfg)
+	case "FilterLogs - invalid addresses":
+		return runFilterLogsWithInvalidAddresses(client, runtime, wfCfg)
+	case "FilterLogs - invalid FromBlock":
+		return runFilterLogsWithInvalidFromBlock(client, runtime, wfCfg)
+	case "FilterLogs - invalid ToBlock":
+		return runFilterLogsWithInvalidToBlock(client, runtime, wfCfg)
 	default:
 		runtime.Logger().Warn("The provided name for function to execute did not match any known functions", "functionToTest", wfCfg.FunctionToTest)
 	}
@@ -151,7 +158,7 @@ func getReadBalanceAbi(runtime sdk.Runtime) (*abi.ABI, error) {
 		runtime.Logger().Error("failed to get Balance Reader contract ABI", "error", abiErr)
 		return nil, fmt.Errorf("failed to get Balance Reader contract ABI: %w", abiErr)
 	}
-	runtime.Logger().Info("successfully got Balance Reader contract ABI.")
+	runtime.Logger().Info("successfully got Balance Reader contract ABI")
 	return readBalancesABI, nil
 }
 
@@ -174,4 +181,81 @@ func runEstimateGasForInvalidToAddress(client evm.Client, runtime sdk.Runtime, w
 
 	runtime.Logger().Info("this is not expected: GasEstimate for invalid 'to' address should return an error or empty response", "invalid_to_address", invalidToAddress.String(), "output_data", estimatedGasReply)
 	return estimatedGasReply, nil
+}
+
+// runFilterLogsWithInvalidAddresses tries to filter logs using invalid addresses in the request
+// it should return an error or empty logs
+func runFilterLogsWithInvalidAddresses(client evm.Client, runtime sdk.Runtime, wfCfg config.Config) (*evm.FilterLogsReply, error) {
+	invalidAddress := common.HexToAddress(wfCfg.InvalidInput)
+	runtime.Logger().Info("Attempting to filter logs using invalid addresses", "invalid_address", invalidAddress)
+
+	filterLogsOutput, err := client.FilterLogs(runtime, &evm.FilterLogsRequest{
+		FilterQuery: &evm.FilterQuery{
+			Addresses: [][]byte{invalidAddress.Bytes()},
+			FromBlock: pb.NewBigIntFromInt(big.NewInt(100)),
+			ToBlock:   pb.NewBigIntFromInt(big.NewInt(200)),
+		},
+	}).Await()
+	runtime.Logger().Info("FilterLogs completed", "filtered_logs_output", filterLogsOutput)
+	if err != nil || filterLogsOutput == nil {
+		runtime.Logger().Error("got expected error or empty logs for FilterLogs with invalid addresses", "invalid_address", invalidAddress, "filter_logs_output", filterLogsOutput, "error", err)
+		return filterLogsOutput, fmt.Errorf("expected error or empty logs for FilterLogs with invalid address '%s': %w", invalidAddress, err)
+	}
+
+	runtime.Logger().Info("this is not expected: FilterLogs with invalid addresses in the request should return an error or empty logs", "invalid_address", invalidAddress, "filter_logs_output", filterLogsOutput)
+	return filterLogsOutput, nil
+}
+
+// runFilterLogsWithInvalidFromBlock tries to filter logs using invalid fromBlock values
+// it should return an error
+func runFilterLogsWithInvalidFromBlock(client evm.Client, runtime sdk.Runtime, wfCfg config.Config) (*evm.FilterLogsReply, error) {
+	return runFilterLogsWithInvalidBlock(client, runtime, wfCfg, "fromBlock")
+}
+
+// runFilterLogsWithInvalidToBlock tries to filter logs using invalid toBlock values
+// it should return an error
+func runFilterLogsWithInvalidToBlock(client evm.Client, runtime sdk.Runtime, wfCfg config.Config) (*evm.FilterLogsReply, error) {
+	return runFilterLogsWithInvalidBlock(client, runtime, wfCfg, "toBlock")
+}
+
+// runFilterLogsWithInvalidBlock tries to filter logs using invalid block values
+// it should return an error for invalid block values
+func runFilterLogsWithInvalidBlock(client evm.Client, runtime sdk.Runtime, wfCfg config.Config, blockType string) (*evm.FilterLogsReply, error) {
+	invalidBlockStr := wfCfg.InvalidInput
+	runtime.Logger().Info("Attempting to filter logs using invalid block", "block_type", blockType, "invalid_block", invalidBlockStr)
+
+	// Parse the invalid block string to big.Int
+	newBlock := big.NewInt(0)
+	invalidBlock, _ := newBlock.SetString(invalidBlockStr, 10)
+
+	// A valid address for FilterLogs
+	validAddress := common.HexToAddress("0x0000000000000000000000000000000000000000")
+
+	// Set up the filter query based on which block type is being tested
+	var filterQuery *evm.FilterQuery
+	if blockType == "fromBlock" {
+		filterQuery = &evm.FilterQuery{
+			Addresses: [][]byte{validAddress.Bytes()},
+			FromBlock: pb.NewBigIntFromInt(invalidBlock),
+			ToBlock:   pb.NewBigIntFromInt(big.NewInt(150)),
+		}
+	} else { // toBlock
+		filterQuery = &evm.FilterQuery{
+			Addresses: [][]byte{validAddress.Bytes()},
+			FromBlock: pb.NewBigIntFromInt(big.NewInt(2)),
+			ToBlock:   pb.NewBigIntFromInt(invalidBlock),
+		}
+	}
+
+	filterLogsOutput, err := client.FilterLogs(runtime, &evm.FilterLogsRequest{
+		FilterQuery: filterQuery,
+	}).Await()
+	runtime.Logger().Info("FilterLogs with invalid block completed", "block_type", blockType, "filtered_logs_output", filterLogsOutput)
+	if err != nil || filterLogsOutput == nil {
+		runtime.Logger().Error("got expected error for FilterLogs with invalid block", "block_type", blockType, "invalid_block", invalidBlockStr, "filter_logs_output", filterLogsOutput, "error", err)
+		return filterLogsOutput, fmt.Errorf("expected error for FilterLogs with invalid %s '%s': %w", blockType, invalidBlockStr, err)
+	}
+
+	runtime.Logger().Info("this is not expected: FilterLogs with invalid block should return an error or nil", "block_type", blockType, "invalid_block", invalidBlockStr, "filter_logs_output", filterLogsOutput)
+	return filterLogsOutput, nil
 }

--- a/system-tests/tests/regression/cre/v2_evm_capability_regression_test.go
+++ b/system-tests/tests/regression/cre/v2_evm_capability_regression_test.go
@@ -1,6 +1,8 @@
 package cre
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -34,7 +36,21 @@ type evmNegativeTest struct {
 	expectedError  string
 }
 
-var evmNegativeTests = []evmNegativeTest{
+var evmNegativeTestsBalanceAtInvalidAddress = []evmNegativeTest{
+	// BalanceAt
+	// TODO: Move BalanceAt to the top after fixing https://smartcontract-it.atlassian.net/browse/CRE-934
+	{"empty", "", balanceAtFunction, expectedBalanceAtError},
+	{"a letter", "a", balanceAtFunction, expectedBalanceAtError},
+	{"a symbol", "/", balanceAtFunction, expectedBalanceAtError},
+	{"a number", "1", balanceAtFunction, expectedBalanceAtError},
+	{"empty hex", "0x", balanceAtFunction, expectedBalanceAtError},
+	{"cut hex", "0x0", balanceAtFunction, expectedBalanceAtError},
+	{"short address", "0x123456789012345678901234567890123456789", balanceAtFunction, expectedBalanceAtError},
+	{"long address", "0x12345678901234567890123456789012345678901", balanceAtFunction, expectedBalanceAtError},
+	{"invalid address", "0x1234567890abcdefg1234567890abcdef123456", balanceAtFunction, expectedBalanceAtError},
+}
+
+var evmNegativeTestsCallContractInvalidAddressToRead = []evmNegativeTest{
 	// CallContract - invalid address to read
 	// Some invalid inputs are skipped (empty, symbols, "0x", "0x0") as they may map to the zero address and return a balance instead of empty.
 	{"a letter", "a", callContractInvalidAddressToReadFunction, expectedCallContractInvalidAddressToRead},
@@ -42,7 +58,9 @@ var evmNegativeTests = []evmNegativeTest{
 	{"short address", "0x123456789012345678901234567890123456789", callContractInvalidAddressToReadFunction, expectedCallContractInvalidAddressToRead},
 	{"long address", "0x12345678901234567890123456789012345678901", callContractInvalidAddressToReadFunction, expectedCallContractInvalidAddressToRead},
 	{"invalid address", "0x1234567890abcdefg1234567890abcdef123456", callContractInvalidAddressToReadFunction, expectedCallContractInvalidAddressToRead},
+}
 
+var evmNegativeTestsCallContractInvalidBalanceReaderContract = []evmNegativeTest{
 	// CallContract - invalid balance reader contract address
 	// TODO: Uncomment tests after https://smartcontract-it.atlassian.net/browse/CRE-943
 	// "empty" will default to the 0-address which is valid but has no contract deployed, so we expect an error.
@@ -55,7 +73,9 @@ var evmNegativeTests = []evmNegativeTest{
 	{"short address", "0x123456789012345678901234567890123456789", callContractInvalidBRContractAddress, expectedCallContractInvalidContractAddress},
 	{"long address", "0x12345678901234567890123456789012345678901", callContractInvalidBRContractAddress, expectedCallContractInvalidContractAddress},
 	{"invalid address", "0x1234567890abcdefg1234567890abcdef123456", callContractInvalidBRContractAddress, expectedCallContractInvalidContractAddress},
+}
 
+var evmNegativeTestsEstimateGasInvalidToAddress = []evmNegativeTest{
 	// EstimateGas - invalid 'to' address
 	// do not use 1, short, long addresses because common.Address will convert them to a valid address
 	// also it does not make sense to use invalid CallMsg.Data because any bytes will be correctly processed
@@ -64,18 +84,6 @@ var evmNegativeTests = []evmNegativeTest{
 	{"a symbol", "/", estimateGasInvalidToAddress, "EVM error StackUnderflow"},
 	{"not authored contract", "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512", estimateGasInvalidToAddress, "execution reverted"},
 	{"cut hex", "0x", estimateGasInvalidToAddress, "EVM error StackUnderflow"}, // equivalent to "0x0"
-
-	// BalanceAt
-	// TODO: Move BalanceAt to the top after fixing https://smartcontract-it.atlassian.net/browse/CRE-934
-	{"empty", "", balanceAtFunction, expectedBalanceAtError},
-	{"a letter", "a", balanceAtFunction, expectedBalanceAtError},
-	{"a symbol", "/", balanceAtFunction, expectedBalanceAtError},
-	{"a number", "1", balanceAtFunction, expectedBalanceAtError},
-	{"empty hex", "0x", balanceAtFunction, expectedBalanceAtError},
-	{"cut hex", "0x0", balanceAtFunction, expectedBalanceAtError},
-	{"short address", "0x123456789012345678901234567890123456789", balanceAtFunction, expectedBalanceAtError},
-	{"long address", "0x12345678901234567890123456789012345678901", balanceAtFunction, expectedBalanceAtError},
-	{"invalid address", "0x1234567890abcdefg1234567890abcdef123456", balanceAtFunction, expectedBalanceAtError},
 }
 
 func EVMReadFailsTest(t *testing.T, testEnv *ttypes.TestEnvironment, evmNegativeTest evmNegativeTest) {
@@ -107,11 +115,11 @@ func EVMReadFailsTest(t *testing.T, testEnv *ttypes.TestEnvironment, evmNegative
 				BalanceReaderAddress: readBalancesAddress,
 			},
 		}
-		workflowName := "evm-read-fail-workflow-" + chainID
+		workflowName := fmt.Sprintf("evm-read-fail-workflow-%s-%04d", chainID, rand.Intn(10000))
 		t_helpers.CompileAndDeployWorkflow(t, testEnv, testLogger, workflowName, &workflowConfig, workflowFileLocation)
 
 		expectedError := evmNegativeTest.expectedError
-		timeout := 75 * time.Second
+		timeout := 90 * time.Second
 		err := t_helpers.AssertBeholderMessage(listenerCtx, t, expectedError, testLogger, messageChan, kafkaErrChan, timeout)
 		require.NoError(t, err, "EVM Read Fail test failed")
 		testLogger.Info().Msg("EVM Read Fail test successfully completed")

--- a/system-tests/tests/regression/cre/v2_evm_regression_test.go
+++ b/system-tests/tests/regression/cre/v2_evm_regression_test.go
@@ -27,6 +27,12 @@ const (
 	callContractInvalidBRContractAddress       = "CallContract - invalid balance reader contract address"
 	expectedCallContractInvalidContractAddress = "got expected error for invalid balance reader contract address"
 	estimateGasInvalidToAddress                = "EstimateGas - invalid 'to' address"
+	filterLogsInvalidAddresses                 = "FilterLogs - invalid addresses"
+	expectedFilterLogsInvalidAddresses         = "failed to convert addresses"
+	filterLogsInvalidFromBlock                 = "FilterLogs - invalid FromBlock"
+	expectedFilterLogsInvalidFromBlock         = "got expected error for FilterLogs with invalid fromBlock"
+	filterLogsInvalidToBlock                   = "FilterLogs - invalid ToBlock"
+	expectedFilterLogsInvalidToBlock           = "got expected error for FilterLogs with invalid toBlock"
 )
 
 type evmNegativeTest struct {
@@ -84,6 +90,46 @@ var evmNegativeTestsEstimateGasInvalidToAddress = []evmNegativeTest{
 	{"a symbol", "/", estimateGasInvalidToAddress, "EVM error StackUnderflow"},
 	{"not authored contract", "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512", estimateGasInvalidToAddress, "execution reverted"},
 	{"cut hex", "0x", estimateGasInvalidToAddress, "EVM error StackUnderflow"}, // equivalent to "0x0"
+}
+
+// TODO: evm.FilterLogs should return an error or nil for invalid/not existing addresses.
+var evmNegativeTestsFilterLogsWithInvalidAddress = []evmNegativeTest{
+	// FilterLogs - invalid addresses
+	// do not use empty, 1, short, long addresses because common.Address will convert them to a valid address
+	// those address are valid for FilterLogs and may return empty logs, which is a valid response
+	{"a letter", "a", filterLogsInvalidAddresses, expectedFilterLogsInvalidAddresses},
+	{"a number", "1", filterLogsInvalidAddresses, expectedFilterLogsInvalidAddresses},
+	{"a symbol", "/", filterLogsInvalidAddresses, expectedFilterLogsInvalidAddresses},
+	{"short address", "0x123456789012345678901234567890123456789", filterLogsInvalidAddresses, expectedFilterLogsInvalidAddresses},
+	{"long address", "0x12345678901234567890123456789012345678901", filterLogsInvalidAddresses, expectedFilterLogsInvalidAddresses},
+	{"invalid address", "0x1234567890abcdefg1234567890abcdef123456", filterLogsInvalidAddresses, expectedFilterLogsInvalidAddresses},
+}
+
+var evmNegativeTestsFilterLogsWithInvalidFromBlock = []evmNegativeTest{
+	// FilterLogs - invalid TromBlock/ToBlock values
+	// Border values and equivalent partitioning for positive integers only
+	// Distance between blocks should not be more than 100
+	{"negative number", "-1", filterLogsInvalidFromBlock, "block number -1 is not supported"},
+	{"zero", "0", filterLogsInvalidFromBlock, "block number 0 is not supported"},
+	{"very large number", "9223372036854775808", filterLogsInvalidFromBlock, "is not an int64"}, // int64 max + 1
+	{"non-numeric string", "abc", filterLogsInvalidFromBlock, "toBlock 150 is less than fromBlock"},
+	{"empty string", "", filterLogsInvalidFromBlock, "toBlock 150 is less than fromBlock"},
+	{"decimal", "100.5", filterLogsInvalidFromBlock, "toBlock 150 is less than fromBlock"},
+	{"fromBlock greater than toBlock by more than 100", "49", filterLogsInvalidFromBlock, "exceeds maximum allowed range of 100"}, // toBlock is 150, so distance is 100+
+}
+
+var evmNegativeTestsFilterLogsWithInvalidToBlock = []evmNegativeTest{
+	// FilterLogs - invalid toBlock values
+	// Border values and equivalent partitioning for positive integers only
+	// Distance between blocks should not be more than 100
+	{"negative number", "-1", filterLogsInvalidToBlock, "block number -1 is not supported"},
+	{"zero", "0", filterLogsInvalidToBlock, "block number 0 is not supported"},
+	{"less then FromBlock", "1", filterLogsInvalidToBlock, "toBlock 1 is less than fromBlock"},
+	{"very large number", "9223372036854775808", filterLogsInvalidToBlock, "is not an int64"}, // int64 max + 1
+	{"non-numeric string", "abc", filterLogsInvalidToBlock, "exceeds maximum allowed range of 100"},
+	{"empty string", "", filterLogsInvalidToBlock, "exceeds maximum allowed range of 100"}, // equivalent to "current block"
+	{"decimal", "100.5", filterLogsInvalidToBlock, "exceeds maximum allowed range of 100"},
+	{"toBlock greater than fromBlock by more than 100", "103", filterLogsInvalidToBlock, "exceeds maximum allowed range of 100"}, // fromBlock is 2
 }
 
 func EVMReadFailsTest(t *testing.T, testEnv *ttypes.TestEnvironment, evmNegativeTest evmNegativeTest) {

--- a/system-tests/tests/smoke/cre/billing_helpers.go
+++ b/system-tests/tests/smoke/cre/billing_helpers.go
@@ -206,6 +206,7 @@ func assertBillingStateChanged(t *testing.T, initial billingAssertionState, time
 	t.Helper()
 
 	// set up a connection to the billing database and run query until data exists
+	const pollInterval = 2 * time.Second
 	assert.Eventually(t, func() bool {
 		finalCredits := queryCredits(t, initial.DB)
 
@@ -237,7 +238,7 @@ func assertBillingStateChanged(t *testing.T, initial billingAssertionState, time
 		}
 
 		return true
-	}, timeout, 10*time.Second)
+	}, timeout, pollInterval)
 }
 
 type billingCredit struct {

--- a/system-tests/tests/smoke/cre/cre_suite_test.go
+++ b/system-tests/tests/smoke/cre/cre_suite_test.go
@@ -12,8 +12,10 @@ import (
 //////////// SMOKE TESTS /////////////
 // target happy path and sanity checks
 // all other tests (e.g. edge cases, negative conditions)
-// should go to a `regression` package.
+// should go to a `regression` package
 /////////////////////////////////////
+
+var v2RegistriesFlags = []string{"--with-contracts-version", "v2"}
 
 /*
 To execute tests locally start the local CRE first:
@@ -26,37 +28,31 @@ Inside `core/scripts/cre/environment` directory
  6. Execute the tests in `system-tests/tests/smoke/cre` with CTF_CONFIG set to the corresponding topology file:
     `export  CTF_CONFIGS=../../../../core/scripts/cre/environment/configs/<topology>.toml; go test -timeout 15m -run ^Test_CRE_Suite$`.
 */
-func Test_CRE_Suite_V1(t *testing.T) {
+func Test_CRE_V1_Proof_Of_Reserve(t *testing.T) {
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t))
 	// WARNING: currently we can't run these tests in parallel, because each test rebuilds environment structs and that includes
 	// logging into CL node with GraphQL API, which allows only 1 session per user at a time.
-	t.Run("[v1] CRE Suite", func(t *testing.T) {
-		// requires `readcontract`, `cron`
-		t.Run("[v1] Proof of Reserve (PoR) Test", func(t *testing.T) {
-			priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV1", PoRWFV1Location)
-			ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, false)
-		})
-	})
+
+	// requires `readcontract`, `cron`
+	priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV1", PoRWFV1Location)
+	ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, false)
 }
 
-func Test_CRE_Suite_V1_Tron(t *testing.T) {
+func Test_CRE_V1_Tron(t *testing.T) {
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetTestConfig(t, "/configs/workflow-don-tron.toml"))
 
-	t.Run("[v1] Tron Write Test with PoR", func(t *testing.T) {
-		priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV1", PoRWFV1Location)
-		ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, false)
-	})
+	priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV1", PoRWFV1Location)
+	ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, false)
 }
 
-func Test_CRE_Suite_V1_SecureMint(t *testing.T) {
+func Test_CRE_V1_SecureMint(t *testing.T) {
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetTestConfig(t, "/configs/workflow-solana-don.toml"))
 
-	t.Run("[v1] SecureMint Test with PoR", func(t *testing.T) {
-		ExecuteSecureMintTest(t, testEnv)
-	})
+	ExecuteSecureMintTest(t, testEnv)
 }
 
-func Test_CRE_Suite_Billing(t *testing.T) {
+// TODO: Move Billing tests to v2 Registries
+func Test_CRE_V1_Billing_EVM_Write(t *testing.T) {
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t))
 
 	// TODO remove this when OCR works properly with multiple chains in Local CRE
@@ -68,15 +64,24 @@ func Test_CRE_Suite_Billing(t *testing.T) {
 		"failed to start Billing stack",
 	)
 
-	t.Run("[v2] EVM Write Test", func(t *testing.T) {
-		priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV2-billing", PoRWFV2Location)
-		porWfCfg.FeedIDs = []string{porWfCfg.FeedIDs[0]}
-		ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, true)
-	})
+	priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV2-billing", PoRWFV2Location)
+	porWfCfg.FeedIDs = []string{porWfCfg.FeedIDs[0]}
+	ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, true)
+}
 
-	t.Run("[v2] Cron Beholder", func(t *testing.T) {
-		ExecuteBillingTest(t, testEnv)
-	})
+func Test_CRE_V1_Billing_Cron_Beholder(t *testing.T) {
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t))
+
+	// TODO remove this when OCR works properly with multiple chains in Local CRE
+	testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
+
+	require.NoError(
+		t,
+		startBillingStackIfIsNotRunning(t, testEnv.TestConfig.RelativePathToRepoRoot, testEnv.TestConfig.EnvironmentDirPath, testEnv),
+		"failed to start Billing stack",
+	)
+
+	ExecuteBillingTest(t, testEnv)
 }
 
 //////////// V2 TESTS /////////////
@@ -86,49 +91,63 @@ To execute tests with v2 contracts start the local CRE first:
  2. Execute the tests in `system-tests/tests/smoke/cre` with CTF_CONFIG set to the corresponding topology file:
     `export  CTF_CONFIGS=../../../../core/scripts/cre/environment/configs/<topology>.toml; go test -timeout 15m -run ^Test_CRE_Suite$`.
 */
-func Test_CRE_Suite_V2(t *testing.T) {
-	flags := []string{"--with-contracts-version", "v2"}
-	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), flags...)
-
-	t.Run("[v2] CRE Proof of Reserve (PoR) Test", func(t *testing.T) {
-		priceProvider, wfConfig := beforePoRTest(t, testEnv, "por-workflow", PoRWFV1Location)
-		ExecutePoRTest(t, testEnv, priceProvider, wfConfig, false)
-	})
-
-	t.Run("[v2] Vault DON test", func(t *testing.T) {
-		ExecuteVaultTest(t, testEnv)
-	})
-
-	t.Run("[v2] Cron (Beholder) happy path", func(t *testing.T) {
-		ExecuteCronBeholderTest(t, testEnv)
-	})
-
-	t.Run("[v2] HTTP trigger and action test", func(t *testing.T) {
-		ExecuteHTTPTriggerActionTest(t, testEnv)
-	})
-
-	t.Run("[v2] DON Time test", func(t *testing.T) {
-		ExecuteDonTimeTest(t, testEnv)
-	})
-
-	t.Run("[v2] Consensus test", func(t *testing.T) {
-		ExecuteConsensusTest(t, testEnv)
-	})
-}
-
-func Test_CRE_Suite_V2_EVM(t *testing.T) {
-	flags := []string{"--with-contracts-version", "v2"}
-	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), flags...)
+func Test_CRE_V2_Proof_Of_Reserve(t *testing.T) {
+	// TODO: Review why this test cannot run with two chains? How to configure evm for both chains?
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
 
 	// TODO: remove this when OCR works properly with multiple chains in Local CRE
 	testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
-	t.Run("[v2] EVM Write happy path test", func(t *testing.T) {
-		priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV2", PoRWFV2Location)
-		porWfCfg.FeedIDs = []string{porWfCfg.FeedIDs[0]}
-		ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, false)
-	})
+	priceProvider, wfConfig := beforePoRTest(t, testEnv, "por-workflow-v2", PoRWFV2Location)
+	wfConfig.FeedIDs = []string{wfConfig.FeedIDs[0]}
+	ExecutePoRTest(t, testEnv, priceProvider, wfConfig, false)
+}
 
-	t.Run("[v2] EVM Read happy path test", func(t *testing.T) {
-		ExecuteEVMReadTest(t, testEnv)
-	})
+func Test_CRE_V2_Vault_DON(t *testing.T) {
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+
+	ExecuteVaultTest(t, testEnv)
+}
+
+func Test_CRE_V2_Cron_Beholder(t *testing.T) {
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+
+	ExecuteCronBeholderTest(t, testEnv)
+}
+
+func Test_CRE_V2_HTTP_Trigger_Action(t *testing.T) {
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+
+	ExecuteHTTPTriggerActionTest(t, testEnv)
+}
+
+func Test_CRE_V2_DON_Time(t *testing.T) {
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+
+	ExecuteDonTimeTest(t, testEnv)
+}
+
+func Test_CRE_V2_Consensus(t *testing.T) {
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+
+	ExecuteConsensusTest(t, testEnv)
+}
+
+func Test_CRE_V2_EVM_Write(t *testing.T) {
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+
+	// TODO: remove this when OCR works properly with multiple chains in Local CRE
+	testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
+
+	priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV2", PoRWFV2Location)
+	porWfCfg.FeedIDs = []string{porWfCfg.FeedIDs[0]}
+	ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, false)
+}
+
+func Test_CRE_V2_EVM_Read(t *testing.T) {
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+
+	// TODO: remove this when OCR works properly with multiple chains in Local CRE
+	testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
+
+	ExecuteEVMReadTest(t, testEnv)
 }

--- a/system-tests/tests/smoke/cre/por_price_provider.go
+++ b/system-tests/tests/smoke/cre/por_price_provider.go
@@ -31,6 +31,8 @@ func setupFakeDataProvider(testLogger zerolog.Logger, input *fake.Input, authKey
 		_, err := fake.NewFakeDataProvider(input)
 		if err != nil {
 			testLogger.Error().Err(err).Msg("Failed to start fake data provider")
+		} else {
+			testLogger.Info().Msg("Fake data provider started successfully")
 		}
 	})
 

--- a/system-tests/tests/smoke/cre/por_price_provider.go
+++ b/system-tests/tests/smoke/cre/por_price_provider.go
@@ -22,9 +22,16 @@ import (
 var fakeProviderStarted sync.Once
 
 func setupFakeDataProvider(testLogger zerolog.Logger, input *fake.Input, authKey string, expectedPrices map[string][]float64, priceIndexes map[string]*int) (string, error) {
+	// This sync.Once ensures that the fake data provider is only started once across all test runs.
+	// The fake data provider is a shared HTTP server that serves mock price data for testing.
+	// Starting it multiple times would cause port conflicts and test failures.
 	fakeProviderStarted.Do(func() {
+		// Log any errors that occur during startup - this is critical for debugging
+		// test failures related to the mock price provider not being available
 		_, err := fake.NewFakeDataProvider(input)
-		testLogger.Error().Err(err).Msg("Failed to start fake data provider")
+		if err != nil {
+			testLogger.Error().Err(err).Msg("Failed to start fake data provider")
+		}
 	})
 
 	fakeAPIPath := "/fake/api/price"

--- a/system-tests/tests/smoke/cre/por_test.go
+++ b/system-tests/tests/smoke/cre/por_test.go
@@ -165,7 +165,8 @@ func ExecutePoRTest(t *testing.T, testEnv *ttypes.TestEnvironment, priceProvider
 	validatePoRPrices(t, testEnv, priceProvider, &cfg, *amountToFund)
 
 	if withBilling {
-		assertBillingStateChanged(t, billingState, 2*time.Minute, 49)
+		expectedMinChange := float64(49)
+		assertBillingStateChanged(t, billingState, 2*time.Minute, expectedMinChange)
 	}
 }
 

--- a/system-tests/tests/smoke/cre/por_test.go
+++ b/system-tests/tests/smoke/cre/por_test.go
@@ -48,7 +48,6 @@ type WorkflowTestConfig struct {
 	FeedIDs              []string
 }
 
-// TODO: Fake Price Provider should be "parallellized" (see: https://github.com/smartcontractkit/chainlink/actions/runs/18059602029/job/51394224440?pr=19587)
 func beforePoRTest(t *testing.T, testEnv *ttypes.TestEnvironment, workflowName, workflowLocation string) (PriceProvider, WorkflowTestConfig) {
 	porWfCfg := WorkflowTestConfig{
 		FeedIDs:              []string{"018e16c38e000320000000000000000000000000000000000000000000000000", "018e16c39e000320000000000000000000000000000000000000000000000000"},

--- a/system-tests/tests/smoke/cre/por_test.go
+++ b/system-tests/tests/smoke/cre/por_test.go
@@ -48,6 +48,7 @@ type WorkflowTestConfig struct {
 	FeedIDs              []string
 }
 
+// TODO: Fake Price Provider should be "parallellized" (see: https://github.com/smartcontractkit/chainlink/actions/runs/18059602029/job/51394224440?pr=19587)
 func beforePoRTest(t *testing.T, testEnv *ttypes.TestEnvironment, workflowName, workflowLocation string) (PriceProvider, WorkflowTestConfig) {
 	porWfCfg := WorkflowTestConfig{
 		FeedIDs:              []string{"018e16c39e000320000000000000000000000000000000000000000000000000", "018e16c38e000320000000000000000000000000000000000000000000000000"},
@@ -93,7 +94,6 @@ func ExecutePoRTest(t *testing.T, testEnv *ttypes.TestEnvironment, priceProvider
 	var amountToFund *big.Int
 	numberOfAddressesToCreate := 2
 	var workflowOwner common.Address
-	fmt.Printf("Each address to read will be funded with %s wei\n", amountToFund.String())
 	for idx, bcOutput := range blockchainOutputs {
 		chainFamily := bcOutput.BlockchainOutput.Family
 		chainID := bcOutput.ChainID

--- a/system-tests/tests/smoke/cre/por_test.go
+++ b/system-tests/tests/smoke/cre/por_test.go
@@ -51,7 +51,7 @@ type WorkflowTestConfig struct {
 // TODO: Fake Price Provider should be "parallellized" (see: https://github.com/smartcontractkit/chainlink/actions/runs/18059602029/job/51394224440?pr=19587)
 func beforePoRTest(t *testing.T, testEnv *ttypes.TestEnvironment, workflowName, workflowLocation string) (PriceProvider, WorkflowTestConfig) {
 	porWfCfg := WorkflowTestConfig{
-		FeedIDs:              []string{"018e16c39e000320000000000000000000000000000000000000000000000000", "018e16c38e000320000000000000000000000000000000000000000000000000"},
+		FeedIDs:              []string{"018e16c38e000320000000000000000000000000000000000000000000000000", "018e16c39e000320000000000000000000000000000000000000000000000000"},
 		WorkflowName:         workflowName,
 		WorkflowFileLocation: workflowLocation,
 	}

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -2,7 +2,9 @@ package cre
 
 import (
 	"context"
+	"fmt"
 	"math/big"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -43,7 +45,7 @@ func ExecuteEVMReadTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 
 		lggr.Info().Msg("Creating EVM Read workflow configuration...")
 		workflowConfig := configureEVMReadWorkflow(t, lggr, bcOutput)
-		workflowName := "evm-read-workflow-" + chainID
+		workflowName := fmt.Sprintf("evm-read-workflow-%s-%04d", chainID, rand.Intn(10000))
 		t_helpers.CompileAndDeployWorkflow(t, testEnv, lggr, workflowName, &workflowConfig, workflowFileLocation)
 
 		workflowsWg.Add(1)

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -616,13 +616,6 @@ func deleteWorkflows(t *testing.T, uniqueWorkflowName string,
 	localEnvErr := creworkflow.RemoveWorkflowArtifactsFromLocalEnv(workflowConfigFilePath, compressedWorkflowWasmPath)
 	require.NoError(t, localEnvErr, "failed to remove workflow artifacts from local environment")
 
-	switch tv.Version.Major() {
-	case 2:
-		// TODO(CRE-876): delete with workflowID
-		testLogger.Warn().Msg("Skipping workflow deletion from the registry for v2 workflows (not implemented yet, see CRE-876)")
-		return
-	default:
-	}
 	deleteErr := creworkflow.DeleteWithContract(t.Context(), blockchainOutputs[0].SethClient, workflowRegistryAddress, tv, uniqueWorkflowName)
 	require.NoError(t, deleteErr, "failed to delete workflow '%s'. Please delete/unregister it manually.", uniqueWorkflowName)
 	testLogger.Info().Msgf("Workflow '%s' deleted successfully from the registry.", uniqueWorkflowName)

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -154,7 +154,7 @@ func StartBeholder(t *testing.T, testLogger zerolog.Logger, testEnv *ttypes.Test
 	drainChannels(listenerCtx, t, testLogger, beholderMsgChan, beholderErrChan) // drain any old messages
 
 	// Wait to allow Beholder to fully initialize, it helps to avoid flakiness in tests
-	timeout = 3 * time.Second
+	timeout = 5 * time.Second
 	testLogger.Info().Dur("timeout", timeout).Msg("Forcefully waiting for Beholder to initialize...")
 	time.Sleep(timeout)
 


### PR DESCRIPTION
[CRE-876](https://smartcontract-it.atlassian.net/browse/CRE-876):
**Delete workflows v2 from v2 registries on system-tests cleanup** 
Refactoring of the `workflows.go`:
- v2 workflow deletion now uses the actual `workflowID` from the registry instead of a computed hash
- Added missing owner verification: `deleteAllWorkflowsV2` now checks owner linking to org before deletions
- Decomposed functions for v1 and v2 workflows creation/deletion
- Reduced code duplications with reused helper functions

[CRE-964](https://smartcontract-it.atlassian.net/browse/CRE-964):
**[CI] Parallelize system-tests** ()

**!!!! The regression suite will run on the workflow-gateway topology due to errors to be fixed in [CRE-983](https://smartcontract-it.atlassian.net/browse/CRE-983).**

**Note:**
In this specific case, parallelization of tests is achieved by moving small but equivalent groups of negative tests into the `Test_` functions for each capability method. This allows CI to run tests in parallel with a separate test environment for each set. Since sets are small, we consider the decrease of the current execution time to 6 min acceptable (compared to 30 min before), 500% increase. 

It is not the ideal solution at present, as it uses many resources (i.e., each test starts a new environment multiplied by the number of topologies, currently three). An improvement would be to pre-create separate, funded EOAs for the negative test case (table case) and run with `t.Parallel()`, which would fix nonce collisions and be more idiomatic in Go.

[CRE-963](https://smartcontract-it.atlassian.net/browse/CRE-963):
**[CI] Run regression system-tests on PR by default and skip on `skip-e2e-regression`** ([click me to see workflow execution example](https://github.com/smartcontractkit/chainlink/actions/runs/18095326974/job/51484961153?pr=19578))

All system tests will run by default. It is each engineer's responsibility to decide whether to skip those tests; skipping regression tests is an opt-out option that can be enabled by adding the `skip-e2e-regression` label.

[CRE-913](https://smartcontract-it.atlassian.net/browse/CRE-913): `evm.FilterLogs` negative tests with invalid addresses
[CRE-989](https://smartcontract-it.atlassian.net/browse/CRE-989): `evm.FilterLogs` negative tests with invalid To/FromBlock

[CRE-876]: https://smartcontract-it.atlassian.net/browse/CRE-876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRE-964]: https://smartcontract-it.atlassian.net/browse/CRE-964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRE-983]: https://smartcontract-it.atlassian.net/browse/CRE-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRE-963]: https://smartcontract-it.atlassian.net/browse/CRE-963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ