### PR TITLE
Bump ton version to support multiple deployments

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -496,8 +496,8 @@ require (
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2 // indirect
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2 // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc // indirect
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 // indirect
 	github.com/smartcontractkit/cre-sdk-go v0.7.0 // indirect
 	github.com/smartcontractkit/crib-sdk v0.4.0 // indirect

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -19,7 +19,7 @@ replace github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examp
 // Using a separate `require` here to avoid surrounding line changes
 // creating potential merge conflicts.
 require (
-	github.com/smartcontractkit/chainlink/deployment v0.0.0-20250906212935-a1521d24f47f
+	github.com/smartcontractkit/chainlink/deployment v0.0.0-20250926230623-96c13ca2551d
 	github.com/smartcontractkit/chainlink/v2 v2.27.3-0.20250908153844-03478edcd69f
 )
 

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -496,8 +496,8 @@ require (
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc // indirect
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d // indirect
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 // indirect
 	github.com/smartcontractkit/cre-sdk-go v0.7.0 // indirect
 	github.com/smartcontractkit/crib-sdk v0.4.0 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1655,10 +1655,10 @@ github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 h1:cWUHB6Q
 github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2/go.mod h1:Z4K5VJLjsfqIIaBcZ1Sfccxu0xsCxBjPa6zF+5gtQaM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6Be5//TyjPi1pS1uotnmcYq5vVkSyISIymSj8=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2 h1:GFS/eU30QYVJ/kT52IEA4SK2jHAJQblVRR5phE9yWhU=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2 h1:E88yV2JCK7Gv/m4aVpg/lQn7CNBZivh3vS6nFyxXbuw=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc h1:Y37eOi54c3CJ8pXN1vRJSR+D71th/O3Nl96Q9uSAGX0=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 h1:XRNxgcNqagXu6e4smJuS1crRK5cUAcCVd7u+iLduHDM=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250422175525-b7575d96bd4d h1:qLmSOOtB/Ogn79eIDkuujOu8M5Jd747V1H7Brk/nTvo=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1655,10 +1655,10 @@ github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 h1:cWUHB6Q
 github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2/go.mod h1:Z4K5VJLjsfqIIaBcZ1Sfccxu0xsCxBjPa6zF+5gtQaM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6Be5//TyjPi1pS1uotnmcYq5vVkSyISIymSj8=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc h1:Y37eOi54c3CJ8pXN1vRJSR+D71th/O3Nl96Q9uSAGX0=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d h1:zCzWrjYLi4w/2+WKP/a40d+aY272By6Q47WUHF9iqiU=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d h1:t8gAncyLcSlgGzjEfqgF/wvvvuF56QOIJ/lOS7e+pOw=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 h1:XRNxgcNqagXu6e4smJuS1crRK5cUAcCVd7u+iLduHDM=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250422175525-b7575d96bd4d h1:qLmSOOtB/Ogn79eIDkuujOu8M5Jd747V1H7Brk/nTvo=

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"maps"
 	"math/big"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
 	solanago "github.com/gagliardetto/solana-go"
+
 	ops "github.com/smartcontractkit/chainlink-ton/deployment/ccip"
 	tonOperation "github.com/smartcontractkit/chainlink-ton/deployment/ccip/operation"
 
@@ -1094,7 +1096,7 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 		if version := os.Getenv("CCIP_CONTRACTS_TON_VERSION"); version != "" {
 			contractVersion = version
 		}
-		cs := commonchangeset.Configure(ops.DeployCCIPContracts{}, ops.DeployChainContractsConfig(t, e.Env, tonChains[0], contractVersion))
+		cs := commonchangeset.Configure(ops.DeployCCIPContracts{}, ops.DeployChainContractsConfig(t, e.Env, tonChains[0], contractVersion, rand.Uint32()))
 		e.Env, _, err = commonchangeset.ApplyChangesets(t, e.Env, []commonchangeset.ConfiguredChangeSet{cs})
 		require.NoError(t, err, "failed to deploy TON ccip contracts")
 	}

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -1091,7 +1091,7 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 		_, err := memory.GetTONSha()
 		require.NoError(t, err, "failed to get TON commit sha")
 		// TODO replace the hardcoded commit sha with the one fetched from memory.GetTONSha()
-		contractVersion := "8be0359fbce5"
+		contractVersion := "96c13ca2551d"
 		// Allow overriding with a custom version, it's set to "loal" on chainlink-ton CI
 		if version := os.Getenv("CCIP_CONTRACTS_TON_VERSION"); version != "" {
 			contractVersion = version

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -50,8 +50,8 @@ require (
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250910230900-fa42dad2d413
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.24
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc
 	github.com/smartcontractkit/freeport v0.1.3-0.20250716200817-cb5dfd0e369e
 	github.com/smartcontractkit/libocr v0.0.0-20250905115425-2785a5cee79d
 	github.com/smartcontractkit/mcms v0.25.0

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -50,8 +50,8 @@ require (
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250910230900-fa42dad2d413
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.24
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d
 	github.com/smartcontractkit/freeport v0.1.3-0.20250716200817-cb5dfd0e369e
 	github.com/smartcontractkit/libocr v0.0.0-20250905115425-2785a5cee79d
 	github.com/smartcontractkit/mcms v0.25.0

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1388,10 +1388,10 @@ github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 h1:cWUHB6Q
 github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2/go.mod h1:Z4K5VJLjsfqIIaBcZ1Sfccxu0xsCxBjPa6zF+5gtQaM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6Be5//TyjPi1pS1uotnmcYq5vVkSyISIymSj8=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc h1:Y37eOi54c3CJ8pXN1vRJSR+D71th/O3Nl96Q9uSAGX0=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d h1:zCzWrjYLi4w/2+WKP/a40d+aY272By6Q47WUHF9iqiU=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d h1:t8gAncyLcSlgGzjEfqgF/wvvvuF56QOIJ/lOS7e+pOw=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 h1:XRNxgcNqagXu6e4smJuS1crRK5cUAcCVd7u+iLduHDM=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250422175525-b7575d96bd4d h1:qLmSOOtB/Ogn79eIDkuujOu8M5Jd747V1H7Brk/nTvo=

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1388,10 +1388,10 @@ github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 h1:cWUHB6Q
 github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2/go.mod h1:Z4K5VJLjsfqIIaBcZ1Sfccxu0xsCxBjPa6zF+5gtQaM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6Be5//TyjPi1pS1uotnmcYq5vVkSyISIymSj8=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2 h1:GFS/eU30QYVJ/kT52IEA4SK2jHAJQblVRR5phE9yWhU=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2 h1:E88yV2JCK7Gv/m4aVpg/lQn7CNBZivh3vS6nFyxXbuw=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc h1:Y37eOi54c3CJ8pXN1vRJSR+D71th/O3Nl96Q9uSAGX0=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 h1:XRNxgcNqagXu6e4smJuS1crRK5cUAcCVd7u+iLduHDM=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250422175525-b7575d96bd4d h1:qLmSOOtB/Ogn79eIDkuujOu8M5Jd747V1H7Brk/nTvo=

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250912140847-cbfb1710ac76
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250910230900-fa42dad2d413
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20250916145228-cc9dd5b92c88
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335
 	github.com/smartcontractkit/cre-sdk-go v0.7.0
 	github.com/smartcontractkit/cre-sdk-go/capabilities/networking/http v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250912140847-cbfb1710ac76
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250910230900-fa42dad2d413
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20250916145228-cc9dd5b92c88
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335
 	github.com/smartcontractkit/cre-sdk-go v0.7.0
 	github.com/smartcontractkit/cre-sdk-go/capabilities/networking/http v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1155,8 +1155,8 @@ github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250910230900-fa42dad2d41
 github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250910230900-fa42dad2d413/go.mod h1:LSZMvQYbdK20+21S68/lcTNHStehHPF1X764PICkrRU=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20250916145228-cc9dd5b92c88 h1:L2mllixqv7DOgkSnd4GDBuRz6UzYujrhETqRJNZOxOk=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20250916145228-cc9dd5b92c88/go.mod h1:CTR5agBB07sCpRltBkHmnkCZ+g8sXRafCJge/Hqr7aM=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d h1:zCzWrjYLi4w/2+WKP/a40d+aY272By6Q47WUHF9iqiU=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335 h1:7bxYNrPpygn8PUSBiEKn8riMd7CXMi/4bjTy0fHhcrY=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250422175525-b7575d96bd4d h1:qLmSOOtB/Ogn79eIDkuujOu8M5Jd747V1H7Brk/nTvo=

--- a/go.sum
+++ b/go.sum
@@ -1157,6 +1157,8 @@ github.com/smartcontractkit/chainlink-sui v0.0.0-20250916145228-cc9dd5b92c88 h1:
 github.com/smartcontractkit/chainlink-sui v0.0.0-20250916145228-cc9dd5b92c88/go.mod h1:CTR5agBB07sCpRltBkHmnkCZ+g8sXRafCJge/Hqr7aM=
 github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2 h1:GFS/eU30QYVJ/kT52IEA4SK2jHAJQblVRR5phE9yWhU=
 github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335 h1:7bxYNrPpygn8PUSBiEKn8riMd7CXMi/4bjTy0fHhcrY=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250422175525-b7575d96bd4d h1:qLmSOOtB/Ogn79eIDkuujOu8M5Jd747V1H7Brk/nTvo=

--- a/go.sum
+++ b/go.sum
@@ -1155,8 +1155,6 @@ github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250910230900-fa42dad2d41
 github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250910230900-fa42dad2d413/go.mod h1:LSZMvQYbdK20+21S68/lcTNHStehHPF1X764PICkrRU=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20250916145228-cc9dd5b92c88 h1:L2mllixqv7DOgkSnd4GDBuRz6UzYujrhETqRJNZOxOk=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20250916145228-cc9dd5b92c88/go.mod h1:CTR5agBB07sCpRltBkHmnkCZ+g8sXRafCJge/Hqr7aM=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2 h1:GFS/eU30QYVJ/kT52IEA4SK2jHAJQblVRR5phE9yWhU=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
 github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
 github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335 h1:7bxYNrPpygn8PUSBiEKn8riMd7CXMi/4bjTy0fHhcrY=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -499,8 +499,8 @@ require (
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250910230900-fa42dad2d413 // indirect
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.24 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2 // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250716200817-cb5dfd0e369e // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -499,8 +499,8 @@ require (
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250910230900-fa42dad2d413 // indirect
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.24 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250716200817-cb5dfd0e369e // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1642,10 +1642,10 @@ github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6B
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.0 h1:qaLw7J7oRRsj+lUzzIjGVlXAVNmkAEwjj7xTXe0hcAk=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.0/go.mod h1:eqV2n0vpqnY5N51je5/1vC/Qm8MMXVKvOXjLM+53Sog=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2 h1:GFS/eU30QYVJ/kT52IEA4SK2jHAJQblVRR5phE9yWhU=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2 h1:E88yV2JCK7Gv/m4aVpg/lQn7CNBZivh3vS6nFyxXbuw=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc h1:Y37eOi54c3CJ8pXN1vRJSR+D71th/O3Nl96Q9uSAGX0=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 h1:XRNxgcNqagXu6e4smJuS1crRK5cUAcCVd7u+iLduHDM=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250422175525-b7575d96bd4d h1:qLmSOOtB/Ogn79eIDkuujOu8M5Jd747V1H7Brk/nTvo=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1642,10 +1642,10 @@ github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6B
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.0 h1:qaLw7J7oRRsj+lUzzIjGVlXAVNmkAEwjj7xTXe0hcAk=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.0/go.mod h1:eqV2n0vpqnY5N51je5/1vC/Qm8MMXVKvOXjLM+53Sog=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc h1:Y37eOi54c3CJ8pXN1vRJSR+D71th/O3Nl96Q9uSAGX0=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d h1:zCzWrjYLi4w/2+WKP/a40d+aY272By6Q47WUHF9iqiU=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d h1:t8gAncyLcSlgGzjEfqgF/wvvvuF56QOIJ/lOS7e+pOw=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 h1:XRNxgcNqagXu6e4smJuS1crRK5cUAcCVd7u+iLduHDM=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250422175525-b7575d96bd4d h1:qLmSOOtB/Ogn79eIDkuujOu8M5Jd747V1H7Brk/nTvo=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -492,8 +492,8 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.51.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/sentinel v0.1.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2 // indirect
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2 // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc // indirect
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250716200817-cb5dfd0e369e // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -492,8 +492,8 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.51.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/sentinel v0.1.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc // indirect
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d // indirect
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250716200817-cb5dfd0e369e // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1621,10 +1621,10 @@ github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6B
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.0 h1:qaLw7J7oRRsj+lUzzIjGVlXAVNmkAEwjj7xTXe0hcAk=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.0/go.mod h1:eqV2n0vpqnY5N51je5/1vC/Qm8MMXVKvOXjLM+53Sog=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc h1:Y37eOi54c3CJ8pXN1vRJSR+D71th/O3Nl96Q9uSAGX0=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d h1:zCzWrjYLi4w/2+WKP/a40d+aY272By6Q47WUHF9iqiU=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d h1:t8gAncyLcSlgGzjEfqgF/wvvvuF56QOIJ/lOS7e+pOw=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 h1:XRNxgcNqagXu6e4smJuS1crRK5cUAcCVd7u+iLduHDM=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250422175525-b7575d96bd4d h1:qLmSOOtB/Ogn79eIDkuujOu8M5Jd747V1H7Brk/nTvo=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1621,10 +1621,10 @@ github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6B
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.0 h1:qaLw7J7oRRsj+lUzzIjGVlXAVNmkAEwjj7xTXe0hcAk=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.0/go.mod h1:eqV2n0vpqnY5N51je5/1vC/Qm8MMXVKvOXjLM+53Sog=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2 h1:GFS/eU30QYVJ/kT52IEA4SK2jHAJQblVRR5phE9yWhU=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2 h1:E88yV2JCK7Gv/m4aVpg/lQn7CNBZivh3vS6nFyxXbuw=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc h1:Y37eOi54c3CJ8pXN1vRJSR+D71th/O3Nl96Q9uSAGX0=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 h1:XRNxgcNqagXu6e4smJuS1crRK5cUAcCVd7u+iLduHDM=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250422175525-b7575d96bd4d h1:qLmSOOtB/Ogn79eIDkuujOu8M5Jd747V1H7Brk/nTvo=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -467,8 +467,8 @@ require (
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250912140847-cbfb1710ac76 // indirect
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc // indirect
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d // indirect
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250716200817-cb5dfd0e369e // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -467,8 +467,8 @@ require (
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250912140847-cbfb1710ac76 // indirect
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2 // indirect
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2 // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc // indirect
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250716200817-cb5dfd0e369e // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2
-	github.com/smartcontractkit/chainlink/deployment v0.0.0-20250906212935-a1521d24f47f
+	github.com/smartcontractkit/chainlink/deployment v0.0.0-20250926230623-96c13ca2551d
 	github.com/smartcontractkit/crib-sdk v0.4.0
 	github.com/smartcontractkit/libocr v0.0.0-20250905115425-2785a5cee79d
 	github.com/smartcontractkit/smdkg v0.0.0-20250916143931-2876ea233fd8

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1633,10 +1633,10 @@ github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 h1:cWUHB6Q
 github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2/go.mod h1:Z4K5VJLjsfqIIaBcZ1Sfccxu0xsCxBjPa6zF+5gtQaM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6Be5//TyjPi1pS1uotnmcYq5vVkSyISIymSj8=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2 h1:GFS/eU30QYVJ/kT52IEA4SK2jHAJQblVRR5phE9yWhU=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2 h1:E88yV2JCK7Gv/m4aVpg/lQn7CNBZivh3vS6nFyxXbuw=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc h1:Y37eOi54c3CJ8pXN1vRJSR+D71th/O3Nl96Q9uSAGX0=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 h1:XRNxgcNqagXu6e4smJuS1crRK5cUAcCVd7u+iLduHDM=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250422175525-b7575d96bd4d h1:qLmSOOtB/Ogn79eIDkuujOu8M5Jd747V1H7Brk/nTvo=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1633,10 +1633,10 @@ github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 h1:cWUHB6Q
 github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2/go.mod h1:Z4K5VJLjsfqIIaBcZ1Sfccxu0xsCxBjPa6zF+5gtQaM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6Be5//TyjPi1pS1uotnmcYq5vVkSyISIymSj8=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc h1:Y37eOi54c3CJ8pXN1vRJSR+D71th/O3Nl96Q9uSAGX0=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d h1:zCzWrjYLi4w/2+WKP/a40d+aY272By6Q47WUHF9iqiU=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d h1:t8gAncyLcSlgGzjEfqgF/wvvvuF56QOIJ/lOS7e+pOw=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 h1:XRNxgcNqagXu6e4smJuS1crRK5cUAcCVd7u+iLduHDM=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250422175525-b7575d96bd4d h1:qLmSOOtB/Ogn79eIDkuujOu8M5Jd747V1H7Brk/nTvo=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -555,8 +555,8 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.14-0.20250918200130-426cdc905d74 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2 // indirect
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2 // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc // indirect
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 // indirect
 	github.com/smartcontractkit/crib-sdk v0.4.0 // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250716200817-cb5dfd0e369e // indirect

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -555,8 +555,8 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.14-0.20250918200130-426cdc905d74 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc // indirect
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d // indirect
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 // indirect
 	github.com/smartcontractkit/crib-sdk v0.4.0 // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250716200817-cb5dfd0e369e // indirect

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.1
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based v0.0.0-20250923184312-03c1c70ed66b
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/cron v0.0.0-20250923184312-03c1c70ed66b
-	github.com/smartcontractkit/chainlink/deployment v0.0.0-20250906212935-a1521d24f47f
+	github.com/smartcontractkit/chainlink/deployment v0.0.0-20250926230623-96c13ca2551d
 	github.com/smartcontractkit/chainlink/system-tests/lib v0.0.0-20250826151008-ae5ec0ee6f2c
 	github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/evm/evmread-negative v0.0.0-20250923184312-03c1c70ed66b
 	github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/http v0.0.0-20250929083906-1fde9e41af0e

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1842,10 +1842,10 @@ github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6B
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.1 h1:azdJaWIyZJlHFEQQExHklfGfb30zzAx3WsxaCaMm4IM=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.1/go.mod h1:vB5W8mngbHvDFlpujHY8jIotHr0a8J/8TIsexP/yANo=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2 h1:GFS/eU30QYVJ/kT52IEA4SK2jHAJQblVRR5phE9yWhU=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250923170055-ba21c6ff1cc2/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2 h1:E88yV2JCK7Gv/m4aVpg/lQn7CNBZivh3vS6nFyxXbuw=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250923170055-ba21c6ff1cc2/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc h1:Y37eOi54c3CJ8pXN1vRJSR+D71th/O3Nl96Q9uSAGX0=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 h1:XRNxgcNqagXu6e4smJuS1crRK5cUAcCVd7u+iLduHDM=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250422175525-b7575d96bd4d h1:qLmSOOtB/Ogn79eIDkuujOu8M5Jd747V1H7Brk/nTvo=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1842,10 +1842,10 @@ github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6B
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.1 h1:azdJaWIyZJlHFEQQExHklfGfb30zzAx3WsxaCaMm4IM=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.1/go.mod h1:vB5W8mngbHvDFlpujHY8jIotHr0a8J/8TIsexP/yANo=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc h1:ZwVNxfNK0SEpibdSTahD1O/754FqWHqbbfesqtF9dzs=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc h1:Y37eOi54c3CJ8pXN1vRJSR+D71th/O3Nl96Q9uSAGX0=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926184555-8de1a56f13cc/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d h1:zCzWrjYLi4w/2+WKP/a40d+aY272By6Q47WUHF9iqiU=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20250926230623-96c13ca2551d/go.mod h1:8HcupBfNYQFTewBXisIqG+dHkjMEVeFa+hV5ZFWIwlo=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d h1:t8gAncyLcSlgGzjEfqgF/wvvvuF56QOIJ/lOS7e+pOw=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20250926230623-96c13ca2551d/go.mod h1:6A+vzX/1E+JCVYJtG3CTaed0PJsw4KP7jRRB6RirMck=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 h1:XRNxgcNqagXu6e4smJuS1crRK5cUAcCVd7u+iLduHDM=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250422175525-b7575d96bd4d h1:qLmSOOtB/Ogn79eIDkuujOu8M5Jd747V1H7Brk/nTvo=


### PR DESCRIPTION
Bump github.com/smartcontractkit/chainlink-ton version to provide deployment ids to prevent contract collisions in TON blockchain.

Related ticket [NONEVM-2651](https://smartcontract-it.atlassian.net/browse/NONEVM-2651)

### Requires
- https://github.com/smartcontractkit/chainlink-ton/pull/218

### Supports
- https://github.com/smartcontractkit/chainlink-ton/pull/218


[NONEVM-2651]: https://smartcontract-it.atlassian.net/browse/NONEVM-2651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ