### PR TITLE
fixing WorkflowUserLogs entity name

### DIFF
--- a/core/services/workflows/events/emit.go
+++ b/core/services/workflows/events/emit.go
@@ -405,7 +405,7 @@ func emitProtoMessage(ctx context.Context, msg proto.Message) error {
 		entity = "workflows.v2." + TriggerExecutionStarted
 	case *eventsv2.WorkflowUserLog:
 		schema = SchemaUserLogsV2
-		entity = "workflows.v2." + UserLogs
+		entity = "workflows.v2." + WorkflowUserLog
 	case *eventsv2.WorkflowActivated:
 		schema = SchemaWorkflowActivatedV2
 		entity = "workflows.v2." + WorkflowActivated

--- a/core/services/workflows/events/emit_test.go
+++ b/core/services/workflows/events/emit_test.go
@@ -107,7 +107,7 @@ func TestEmit(t *testing.T) {
 		assert.Equal(t, logLines[1].Message, receivedV1.LogLines[1].Message)
 
 		// Verify v2 events are emitted (one per log line)
-		v2Msgs := beholderObserver.Messages(t, "beholder_entity", "workflows.v2."+events.UserLogs)
+		v2Msgs := beholderObserver.Messages(t, "beholder_entity", "workflows.v2."+events.WorkflowUserLog)
 		require.Len(t, v2Msgs, 2)
 
 		var msg1 eventsv2.WorkflowUserLog

--- a/core/services/workflows/events/types.go
+++ b/core/services/workflows/events/types.go
@@ -20,7 +20,9 @@ const (
 	CapabilityExecutionFinished string = "CapabilityExecutionFinished"
 	// TriggerExecutionStarted represents a trigger execution started event
 	TriggerExecutionStarted string = "TriggerExecutionStarted"
-	// UserLogs represents user log events
+	// WorkflowUserLog represents user log events
+	WorkflowUserLog string = "WorkflowUserLog"
+	// UserLogs represents user logs events (v1 event type)
 	UserLogs string = "UserLogs"
 
 	// SchemaWorkflowStatusChanged represents the schema for workflow status changed events


### PR DESCRIPTION
Fixing a mismatch in the [ironflask config](https://github.com/smartcontractkit/chainlink-protos/blob/a1c6dad8dd1a1eaefd27721759d359e16852af8d/workflows/iron-flask-platform.yaml#L213) and entity name.
