### PR TITLE
fix(ci): skip codeql scanning for operator-ui assets

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,16 +31,20 @@ jobs:
           - language: go
             build-mode: manual
             runs-on: ${{ needs.runner-config.outputs.go-runner }}
-            is-self-hosted: ${{ needs.runner-config.outputs.go-is-self-hosted }}
 
           - language: javascript-typescript
             build-mode: none
+            codeql-config: |
+              paths-ignore:
+                - 'core/web/assets'
+                - '**/node_modules/**'
 
           - language: python
             build-mode: none
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners
-        if: matrix.is-self-hosted == 'true'
+        # these env vars are set (and exposed) when it is a self-hosted runner with extras=s3-cache
+        if: ${{ env.RUNS_ON_INSTANCE_ID != '' && env.ACTIONS_CACHE_URL != '' }}
         uses: runs-on/action@66d4449b717b5462159659523d1241051ff470b9 # v1
 
       - name: Checkout repository
@@ -63,6 +67,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          config: ${{ matrix.codeql-config || '' }}
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
@@ -92,8 +97,6 @@ jobs:
       SH_GO_RUNNER: runs-on=${{ github.run_id }}/cpu=32/ram=64/family=c6i/spot=false/extras=s3-cache+tmpfs
       GH_GO_RUNNER: ubuntu24.04-8cores-32GB
     outputs:
-      # go codeql runner
-      go-is-self-hosted: ${{ steps.go-codeql.outputs.go-is-self-hosted }}
       go-runner: ${{ steps.go-codeql.outputs.go-runner }}
     steps:
       - name: Get PR Labels
@@ -110,7 +113,6 @@ jobs:
         run: |
           if [[ "$OPT_OUT" == "true" ]]; then
             echo "Opt-out is true for current run. Using gh-hosted runner for Go codeql."
-            echo "go-is-self-hosted=false" | tee -a $GITHUB_OUTPUT
             echo "go-runner=${GH_GO_RUNNER}" | tee -a $GITHUB_OUTPUT
             exit 0
           fi


### PR DESCRIPTION
### Changes

* Adds a custom config for the `javascript-typescript` codeql scanning, so we don't scan `operator-ui` assets, or potentially `node_modules` directories
* Small change for enabling s3 cache, using contextual clues for detecting a self-hosted runner

### Motivation

These assets are generated from https://github.com/smartcontractkit/operator-ui/, which also has codeql scanning. Having it here is redundant and requires extra work from developers.

### Testing

This PR (https://github.com/smartcontractkit/chainlink/actions/runs/18106607695/job/51522648091?pr=19603):

```
2025-09-29T18:19:31.9957879Z While resolving threads, found a cgroup CPUs file with 4 CPUs in /sys/fs/cgroup/cpuset.cpus.effective.
2025-09-29T18:19:31.9971505Z Writing augmented user configuration file to /home/runner/work/_temp/user-config.yaml
2025-09-29T18:19:31.9972381Z ##[group]Augmented user configuration file contents
2025-09-29T18:19:31.9986470Z paths-ignore:
2025-09-29T18:19:31.9986865Z   - core/web/assets
2025-09-29T18:19:31.9987221Z   - '**/node_modules/**'
2025-09-29T18:19:31.9987603Z query-filters:
2025-09-29T18:19:31.9987850Z   - exclude:
2025-09-29T18:19:31.9988104Z       tags: exclude-from-incremental
2025-09-29T18:19:31.9988316Z 
2025-09-29T18:19:31.9988576Z ##[endgroup]
```

Other PR (https://github.com/smartcontractkit/chainlink/actions/runs/18094493793/job/51482356276?pr=19592)

```
2025-09-29T10:52:11.0465105Z While resolving threads, found a cgroup CPUs file with 4 CPUs in /sys/fs/cgroup/cpuset.cpus.effective.
2025-09-29T10:52:11.0478710Z Writing augmented user configuration file to /home/runner/work/_temp/user-config.yaml
2025-09-29T10:52:11.0479746Z ##[group]Augmented user configuration file contents
2025-09-29T10:52:11.0491314Z query-filters:
2025-09-29T10:52:11.0491659Z   - exclude:
2025-09-29T10:52:11.0492045Z       tags: exclude-from-incremental
2025-09-29T10:52:11.0492347Z 
2025-09-29T10:52:11.0492744Z ##[endgroup]
```

### Notes

I find CodeQL very opaque, and I'm not actually sure if this will fix the problem. I think it will as `paths-ignore` is a valid part of the codeql schema (https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#specifying-directories-to-scan).


---

DX-1916