### PR TITLE
(fix): platform_engine_workflow_unregistered_count metric

### DIFF
--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -550,6 +550,7 @@ func (e *Engine) close() error {
 	e.triggersRegMu.Lock()
 	e.unregisterAllTriggers(ctx)
 	e.triggersRegMu.Unlock()
+	e.metrics.IncrementWorkflowUnregisteredCounter(ctx)
 
 	e.cfg.Module.Close()
 
@@ -576,7 +577,6 @@ func (e *Engine) unregisterAllTriggers(ctx context.Context) {
 	}
 	e.triggers = make(map[string]*triggerCapability)
 	e.lggr.Infow("All triggers unregistered", "numTriggers", len(e.triggers))
-	e.metrics.IncrementWorkflowUnregisteredCounter(ctx)
 }
 
 func (e *Engine) heartbeatLoop(ctx context.Context) {


### PR DESCRIPTION
### Description

#### Previous behavior:
When a v2 workflow fails to be registered on a node (i.e. with `error:  failed to register trigger: failed registering trigger: maximum fastest cron schedule is 30s` -> `Workflow Engine initialization failed`) the `platform_engine_workflow_unregistered_count` metric increments, even though the workflow was NOT "deleted". 

#### Expected behavior:
This metric should only increment on a workflow being removed, not failed setup. In the scenario of a failed setup it never reached the registered metric.


#### Changes 
`e.metrics.IncrementWorkflowUnregisteredCounter(ctx)` is only called in `close` , instead of the helper `e.unregisterAllTriggers` which is called in both setup failing and close.