### PR TITLE
refactor: update tokens changesets to use the testing framework engine

### DIFF
--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -393,6 +393,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/scylladb/go-reflectx v1.0.1 // indirect
+	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/shirou/gopsutil/v3 v3.24.3 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.6 // indirect

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1288,6 +1288,8 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/scylladb/go-reflectx v1.0.1 h1:b917wZM7189pZdlND9PbIJ6NQxfDPfBvUaQ7cjj1iZQ=
 github.com/scylladb/go-reflectx v1.0.1/go.mod h1:rWnOfDIRWBGN0miMLIcoPt/Dhi2doCMZqwMCJ3KupFc=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
+github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sethvargo/go-retry v0.2.4 h1:T+jHEQy/zKJf5s95UkguisicE0zuF9y7+/vgz08Ocec=

--- a/deployment/tokens/changesets/deploy_evm_link_tokens_test.go
+++ b/deployment/tokens/changesets/deploy_evm_link_tokens_test.go
@@ -5,16 +5,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 	"github.com/smartcontractkit/chainlink/deployment/tokens/internal/ops"
 )
 
@@ -163,27 +162,28 @@ func Test_DeployEVMLinkTokens_Apply(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			var (
-				lggr = logger.Test(t)
-				e    = memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-					Chains: 1,
-				})
-				cs = deployEVMLinkTokens{}
+			rt, err := runtime.New(t.Context(),
+				runtime.WithEnvOpts(
+					environment.WithEVMSimulatedN(t, 1),
+				),
 			)
+			require.NoError(t, err)
 
-			got, err := cs.Apply(e, tt.giveFunc(e))
+			err = rt.Exec(
+				runtime.ChangesetTask(DeployEVMLinkTokens, tt.giveFunc(rt.Environment())),
+			)
 			require.NoError(t, err)
 
 			// Check that the address book has the link token contract for each chain
-			for _, csel := range e.BlockChains.ListChainSelectors() {
-				addrBookByChain, err := got.AddressBook.AddressesForChain(csel) //nolint:staticcheck // Will be removed once the address book is no longer required.
+			for _, csel := range rt.Environment().BlockChains.ListChainSelectors() {
+				addrBookByChain, err := rt.State().AddressBook.AddressesForChain(csel)
 				require.NoError(t, err)
 				require.NotEmpty(t, addrBookByChain)
 				require.Len(t, addrBookByChain, 1)
 			}
 
 			// Check the address book has the link token contract for each chain
-			addrRefs, err := got.DataStore.Addresses().Fetch()
+			addrRefs, err := rt.State().DataStore.Addresses().Fetch()
 			require.NoError(t, err)
 			require.Len(t, addrRefs, 1)
 		})

--- a/deployment/tokens/internal/seqs/seq_deploy_evm_tokens_test.go
+++ b/deployment/tokens/internal/seqs/seq_deploy_evm_tokens_test.go
@@ -7,19 +7,18 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	chainevm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	chainevmprovider "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations/optest"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func Test_SeqDeployEVMTokens(t *testing.T) {
 	t.Parallel()
 
 	var (
-		chainID       = chain_selectors.ETHEREUM_TESTNET_SEPOLIA.EvmChainID
 		chainSelector = chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector
 	)
 
@@ -59,17 +58,22 @@ func Test_SeqDeployEVMTokens(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			prov := chainevmprovider.NewSimChainProvider(
+				t, chainSelector, chainevmprovider.SimChainProviderConfig{},
+			)
+			blockchain, err := prov.Initialize(t.Context())
+			require.NoError(t, err)
+
+			chain, ok := blockchain.(chainevm.Chain)
+			require.True(t, ok)
+
 			var (
 				ab = cldf.NewMemoryAddressBook()
 				ds = datastore.NewMemoryDataStore()
 
-				chains = cldf_chain.NewBlockChainsFromSlice(
-					memory.NewMemoryChainsEVMWithChainIDs(t, []uint64{chainID}, 1),
-				).EVMChains()
-
 				b    = optest.NewBundle(t)
 				deps = SeqDeployEVMTokensDeps{
-					EVMChains: chains,
+					EVMChains: map[uint64]chainevm.Chain{chainSelector: chain},
 					AddrBook:  ab,
 					Datastore: ds,
 				}


### PR DESCRIPTION
This updates all the changesets in the `tokens` package to use the new testing framework engine. This is intended to reduce reliance on the `memory` package so we can deprecate it in the future.

