### PR TITLE
[CRE-1001] Move v2 smoke tests to one suite

### DIFF
--- a/.changeset/brave-years-yawn.md
+++ b/.changeset/brave-years-yawn.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#internal: Move CREv2 system-tests to one suite

--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -185,6 +185,8 @@ jobs:
           TEST_TIMEOUT: 30m
         run: |
           echo "Starting test: '${TEST_NAME}'"
+          echo "⚠️⚠️⚠️ Add 'skip-e2e-regression' label to skip this step if necessary"
+
           gotestsum \
             --jsonfile=/tmp/gotest-regression.log \
             --junitfile=/tmp/junit-report-regression.xml \
@@ -193,6 +195,7 @@ jobs:
             -v -run "^(${TEST_NAME})$" -timeout ${TEST_TIMEOUT} -count=1 -parallel=1 \
             github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre
 
+          echo "⚠️⚠️⚠️ Add 'skip-e2e-regression' label to skip this step if necessary"
           exit_code=$?
           if [ $exit_code -eq 0 ]; then
             echo "tests_result=✅ Tests passed" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,5 @@ core/scripts/cre/environment/*.yaml
 core/scripts/cre/environment/*.yml
 core/scripts/cre/environment/logs/
 core/scripts/cre/environment/cron
+core/scripts/cre/environment/binaries/*
+*.br.b64

--- a/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/main.go
+++ b/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/main.go
@@ -67,7 +67,9 @@ func onTrigger(config types.WorkflowConfig, runtime cre.Runtime, payload *cron.P
 
 	// get balance with BalanceAt()
 	evmClient := evm.Client{ChainSelector: chain_selectors.GETH_TESTNET.Selector}
+	runtime.Logger().Info("Got EVM client", "chainSelector", evmClient.ChainSelector)
 	addressesToRead := config.BalanceReaderConfig.AddressesToRead
+	runtime.Logger().Info("Got addresses to read", "addresses", addressesToRead)
 
 	// For testing purposes, there is no handling of index out of range or nil cases.
 	// It allows for the configuration of empty addresses, a single address, or zero balances.

--- a/system-tests/tests/smoke/cre/cre_suite_test.go
+++ b/system-tests/tests/smoke/cre/cre_suite_test.go
@@ -91,63 +91,62 @@ To execute tests with v2 contracts start the local CRE first:
  2. Execute the tests in `system-tests/tests/smoke/cre` with CTF_CONFIG set to the corresponding topology file:
     `export  CTF_CONFIGS=../../../../core/scripts/cre/environment/configs/<topology>.toml; go test -timeout 15m -run ^Test_CRE_Suite$`.
 */
-func Test_CRE_V2_Proof_Of_Reserve(t *testing.T) {
-	// TODO: Review why this test cannot run with two chains? How to configure evm for both chains?
-	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+func Test_CRE_V2_Suite(t *testing.T) {
+	t.Run("[v2] Proof Of Reserve", func(t *testing.T) {
+		// TODO: Review why this test cannot run with two chains? (CRE-983)
+		// How to configure evm for both chains and capabilities DON (DON<>DON topology)?
+		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
 
-	// TODO: remove this when OCR works properly with multiple chains in Local CRE
-	testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
-	priceProvider, wfConfig := beforePoRTest(t, testEnv, "por-workflow-v2", PoRWFV2Location)
-	wfConfig.FeedIDs = []string{wfConfig.FeedIDs[0]}
-	ExecutePoRTest(t, testEnv, priceProvider, wfConfig, false)
+		// TODO: remove this when OCR works properly with multiple chains in Local CRE
+		testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
+		priceProvider, wfConfig := beforePoRTest(t, testEnv, "por-workflow-v2", PoRWFV2Location)
+		wfConfig.FeedIDs = []string{wfConfig.FeedIDs[0]}
+		ExecutePoRTest(t, testEnv, priceProvider, wfConfig, false)
+	})
+
+	t.Run("[v2] Vault DON", func(t *testing.T) {
+		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+
+		ExecuteVaultTest(t, testEnv)
+	})
+
+	t.Run("[v2] Cron Beholder", func(t *testing.T) {
+		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+
+		ExecuteCronBeholderTest(t, testEnv)
+	})
+
+	t.Run("[v2] HTTP Trigger Action", func(t *testing.T) {
+		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+
+		ExecuteHTTPTriggerActionTest(t, testEnv)
+	})
+
+	t.Run("[v2] DON Time", func(t *testing.T) {
+		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+
+		ExecuteDonTimeTest(t, testEnv)
+	})
+
+	t.Run("[v2] Consensus", func(t *testing.T) {
+		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
+
+		ExecuteConsensusTest(t, testEnv)
+	})
 }
 
-func Test_CRE_V2_Vault_DON(t *testing.T) {
+func Test_CRE_V2_EVM_Suite(t *testing.T) {
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
-
-	ExecuteVaultTest(t, testEnv)
-}
-
-func Test_CRE_V2_Cron_Beholder(t *testing.T) {
-	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
-
-	ExecuteCronBeholderTest(t, testEnv)
-}
-
-func Test_CRE_V2_HTTP_Trigger_Action(t *testing.T) {
-	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
-
-	ExecuteHTTPTriggerActionTest(t, testEnv)
-}
-
-func Test_CRE_V2_DON_Time(t *testing.T) {
-	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
-
-	ExecuteDonTimeTest(t, testEnv)
-}
-
-func Test_CRE_V2_Consensus(t *testing.T) {
-	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
-
-	ExecuteConsensusTest(t, testEnv)
-}
-
-func Test_CRE_V2_EVM_Write(t *testing.T) {
-	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
-
-	// TODO: remove this when OCR works properly with multiple chains in Local CRE
-	testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
-
-	priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV2", PoRWFV2Location)
-	porWfCfg.FeedIDs = []string{porWfCfg.FeedIDs[0]}
-	ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, false)
-}
-
-func Test_CRE_V2_EVM_Read(t *testing.T) {
-	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
-
 	// TODO: remove this when OCR works properly with multiple chains in Local CRE
 	testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
 
-	ExecuteEVMReadTest(t, testEnv)
+	t.Run("[v2] EVM Write", func(t *testing.T) {
+		priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV2", PoRWFV2Location)
+		porWfCfg.FeedIDs = []string{porWfCfg.FeedIDs[0]}
+		ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, false)
+	})
+
+	t.Run("[v2] EVM Read", func(t *testing.T) {
+		ExecuteEVMReadTest(t, testEnv)
+	})
 }


### PR DESCRIPTION
[CRE-1001](): Move v2 smoke tests to one suite.
In this way, we cover more cases and system permutations compared to a more atomic execution in separate test methods.
Cons: no parallelism.

[CRE-1001]: https://smartcontract-it.atlassian.net/browse/CRE-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ