### PR TITLE
update http trigger response aggregation from 2f+1 to BFT quorum

### DIFF
--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -374,8 +374,9 @@ func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string
 		return errors.New("in-flight request ID: " + requestID)
 	}
 
-	// 2f + 1 is chosen to ensure that majority of honest nodes are executing the request
-	agg, err := aggregation.NewIdenticalNodeResponseAggregator(2*h.donConfig.F + 1)
+	// (N+F)//2 + 1 threshold where N = number of nodes, F = number of faulty nodes
+	threshold := (len(h.donConfig.Members)+h.donConfig.F)/2 + 1
+	agg, err := aggregation.NewIdenticalNodeResponseAggregator(threshold)
 	if err != nil {
 		return errors.New("failed to create response aggregator: " + err.Error())
 	}

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
@@ -277,7 +277,7 @@ func TestHttpTriggerHandler_HandleNodeTriggerResponse(t *testing.T) {
 			Result:  &rawRes,
 		}
 
-		// Send responses from multiple nodes (need 2f+1 = 3 for f=1)
+		// Send responses from multiple nodes (need (N+F)//2+1 = (3+1)//2+1 = 3 for N=3, F=1)
 		err = handler.HandleNodeTriggerResponse(testutils.Context(t), nodeResp, "node1")
 		require.NoError(t, err)
 
@@ -493,7 +493,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_Retries(t *testing.T) {
 
 	donConfig := &config.DONConfig{
 		DonId: "test-don",
-		F:     1, // 1 faulty node, so 2*1+1=3 for threshold
+		F:     1, // 1 faulty node, so (N+F)//2+1=(3+1)//2+1=3 for threshold
 		Members: []config.NodeConfig{
 			{Address: "node1"},
 			{Address: "node2"},
@@ -1354,7 +1354,7 @@ func createTestTriggerHandler(t *testing.T) (*httpTriggerHandler, *handlermocks.
 func createTestTriggerHandlerWithConfig(t *testing.T, cfg ServiceConfig) (*httpTriggerHandler, *handlermocks.DON) {
 	donConfig := &config.DONConfig{
 		DonId: "test-don",
-		F:     1, // This means we need 2f+1 = 3 responses for consensus
+		F:     1, // This means we need (N+F)//2+1 = (3+1)//2+1 = 3 responses for consensus
 		Members: []config.NodeConfig{
 			{Address: "node1"},
 			{Address: "node2"},


### PR DESCRIPTION
update http trigger response aggregation from 2f+1 to BFT quorum (n+f)//2 + 1 because number of nodes is not always 3f+1