### PR TITLE
[CRE-1006] Add topology to system test name

### DIFF
--- a/.changeset/thirty-years-spend.md
+++ b/.changeset/thirty-years-spend.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#internal Add topology to smoke tests names

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -230,6 +230,7 @@ jobs:
           TEST_NAME: ${{ matrix.tests.test_name }}
           TEST_TIMEOUT: 30m
           RUN_QUARANTINED_TESTS: "true" # always run quarantined tests in CI
+          TOPOLOGY_NAME: ${{ matrix.tests.topology }}
         run: |
           echo "Starting test: '${TEST_NAME}'"
           gotestsum \

--- a/system-tests/tests/smoke/cre/cre_suite_test.go
+++ b/system-tests/tests/smoke/cre/cre_suite_test.go
@@ -1,6 +1,7 @@
 package cre
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -92,7 +93,9 @@ To execute tests with v2 contracts start the local CRE first:
     `export  CTF_CONFIGS=../../../../core/scripts/cre/environment/configs/<topology>.toml; go test -timeout 15m -run ^Test_CRE_Suite$`.
 */
 func Test_CRE_V2_Suite(t *testing.T) {
-	t.Run("[v2] Proof Of Reserve", func(t *testing.T) {
+	topology := os.Getenv("TOPOLOGY_NAME")
+
+	t.Run("[v2] Proof Of Reserve - "+topology, func(t *testing.T) {
 		// TODO: Review why this test cannot run with two chains? (CRE-983)
 		// How to configure evm for both chains and capabilities DON (DON<>DON topology)?
 		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
@@ -104,31 +107,31 @@ func Test_CRE_V2_Suite(t *testing.T) {
 		ExecutePoRTest(t, testEnv, priceProvider, wfConfig, false)
 	})
 
-	t.Run("[v2] Vault DON", func(t *testing.T) {
+	t.Run("[v2] Vault DON - "+topology, func(t *testing.T) {
 		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
 
 		ExecuteVaultTest(t, testEnv)
 	})
 
-	t.Run("[v2] Cron Beholder", func(t *testing.T) {
+	t.Run("[v2] Cron Beholder - "+topology, func(t *testing.T) {
 		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
 
 		ExecuteCronBeholderTest(t, testEnv)
 	})
 
-	t.Run("[v2] HTTP Trigger Action", func(t *testing.T) {
+	t.Run("[v2] HTTP Trigger Action - "+topology, func(t *testing.T) {
 		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
 
 		ExecuteHTTPTriggerActionTest(t, testEnv)
 	})
 
-	t.Run("[v2] DON Time", func(t *testing.T) {
+	t.Run("[v2] DON Time - "+topology, func(t *testing.T) {
 		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
 
 		ExecuteDonTimeTest(t, testEnv)
 	})
 
-	t.Run("[v2] Consensus", func(t *testing.T) {
+	t.Run("[v2] Consensus - "+topology, func(t *testing.T) {
 		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
 
 		ExecuteConsensusTest(t, testEnv)
@@ -136,17 +139,18 @@ func Test_CRE_V2_Suite(t *testing.T) {
 }
 
 func Test_CRE_V2_EVM_Suite(t *testing.T) {
+	topology := os.Getenv("TOPOLOGY_NAME")
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
 	// TODO: remove this when OCR works properly with multiple chains in Local CRE
 	testEnv.WrappedBlockchainOutputs = []*cre.WrappedBlockchainOutput{testEnv.WrappedBlockchainOutputs[0]}
 
-	t.Run("[v2] EVM Write", func(t *testing.T) {
+	t.Run("[v2] EVM Write - "+topology, func(t *testing.T) {
 		priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV2", PoRWFV2Location)
 		porWfCfg.FeedIDs = []string{porWfCfg.FeedIDs[0]}
 		ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, false)
 	})
 
-	t.Run("[v2] EVM Read", func(t *testing.T) {
+	t.Run("[v2] EVM Read - "+topology, func(t *testing.T) {
 		ExecuteEVMReadTest(t, testEnv)
 	})
 }


### PR DESCRIPTION
[CRE-1006](https://smartcontract-it.atlassian.net/browse/CRE-1006): Add topology name to the test name to ensure each test is unique.

[CRE-1006]: https://smartcontract-it.atlassian.net/browse/CRE-1006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ