### PR TITLE
feat(ci): auto-quarantine for e2e tests

### DIFF
--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -1288,7 +1288,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestLogPollerFewFiltersFixedDepth$ -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestLogPollerFewFiltersFixedDepth$" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-smoke-log_poller-evm-simulated
     test_go_project_path: integration-tests
 
@@ -1302,7 +1308,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestLogPollerFewFiltersFinalityTag$ -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestLogPollerFewFiltersFinalityTag$" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-smoke-log_poller-evm-simulated
     test_go_project_path: integration-tests
 
@@ -1316,7 +1328,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestLogPollerWithChaosFixedDepth$ -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestLogPollerWithChaosFixedDepth$" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-smoke-log_poller-evm-simulated
     test_go_project_path: integration-tests
 
@@ -1330,7 +1348,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestLogPollerWithChaosFinalityTag$ -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestLogPollerWithChaosFinalityTag$" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-smoke-log_poller-evm-simulated
     test_go_project_path: integration-tests
 
@@ -1344,7 +1368,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestLogPollerWithChaosPostgresFinalityTag$ -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestLogPollerWithChaosPostgresFinalityTag$" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-smoke-log_poller-evm-simulated
     test_go_project_path: integration-tests
 
@@ -1358,7 +1388,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestLogPollerWithChaosPostgresFixedDepth$ -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestLogPollerWithChaosPostgresFixedDepth$" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-smoke-log_poller-evm-simulated
     test_go_project_path: integration-tests
 
@@ -1372,7 +1408,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestLogPollerReplayFixedDepth$ -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestLogPollerReplayFixedDepth$" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-smoke-log_poller-evm-simulated
     test_go_project_path: integration-tests
 
@@ -1386,7 +1428,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestLogPollerReplayFinalityTag$ -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestLogPollerReplayFinalityTag$" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-smoke-log_poller-evm-simulated
     test_go_project_path: integration-tests
   # END: LogPoller tests

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -1564,7 +1564,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd integration-tests/smoke/ccip && go test -run "Test_CCIPReorg_BelowFinality_OnSource|Test_CCIPReorg_BelowFinality_OnDest" ccip_reorg_test.go -timeout 25m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd integration-tests/smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "Test_CCIPReorg_BelowFinality_OnSource|Test_CCIPReorg_BelowFinality_OnDest" ccip_reorg_test.go -timeout 25m -parallel=1 -count=1
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1_DEEPER_FINALITY,SIMULATED_2_DEEPER_FINALITY
@@ -1579,7 +1585,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd integration-tests/smoke/ccip && go test -run "Test_CCIPReorg_GreaterThanFinality_OnSource|Test_CCIPReorg_GreaterThanFinality_OnDest" ccip_reorg_test.go -timeout 25m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd integration-tests/smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "Test_CCIPReorg_GreaterThanFinality_OnSource|Test_CCIPReorg_GreaterThanFinality_OnDest" ccip_reorg_test.go -timeout 25m -parallel=1 -count=1
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2,SIMULATED_3
@@ -1596,7 +1608,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip -v -run ^Test_CCIPTokenPriceUpdates$ -timeout 18m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^Test_CCIPTokenPriceUpdates$" -timeout 18m -count=1 -parallel=1 github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1614,7 +1632,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip -v -run ^Test_CCIPGasPriceUpdatesWriteFrequency$ -timeout 18m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^Test_CCIPGasPriceUpdatesWriteFrequency$" -timeout 18m -count=1 -parallel=1 github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1632,7 +1656,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip -v -run ^Test_CCIPGasPriceUpdatesDeviation$ -timeout 18m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^Test_CCIPGasPriceUpdatesDeviation$" -timeout 18m -count=1 -parallel=1 github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1650,7 +1680,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^TestFastTransfer1_6LanesWithMCMS$ -timeout 30m -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestFastTransfer1_6LanesWithMCMS$" -timeout 30m
     test_go_project_path: integration-tests
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1668,7 +1704,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^TestFastTransfer1_5LanesWithMCMS$ -timeout 30m -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestFastTransfer1_5LanesWithMCMS$" -timeout 30m
     test_go_project_path: integration-tests
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1686,7 +1728,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^TestFastTransfer1_6Lanes$ -timeout 30m -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestFastTransfer1_6Lanes$" -timeout 30m
     test_go_project_path: integration-tests
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1704,7 +1752,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^TestFastTransfer1_5Lanes$ -timeout 30m -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestFastTransfer1_5Lanes$" -timeout 30m
     test_go_project_path: integration-tests
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1748,7 +1802,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^TestRMN_MultipleMessagesOnOneLaneNoWaitForExec$ -timeout 30m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestRMN_MultipleMessagesOnOneLaneNoWaitForExec$" -timeout 30m -parallel=1 -count=1
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1767,7 +1827,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^TestRMN_NotEnoughObservers$ -timeout 30m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestRMN_NotEnoughObservers$" -timeout 30m -parallel=1 -count=1
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1786,7 +1852,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^TestRMN_DifferentSigners$ -timeout 30m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestRMN_DifferentSigners$" -timeout 30m -parallel=1 -count=1
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1805,7 +1877,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^TestRMN_NotEnoughSigners$ -timeout 30m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestRMN_NotEnoughSigners$" -timeout 30m -parallel=1 -count=1
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1824,7 +1902,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^TestRMN_DifferentRmnNodesForDifferentChains$ -timeout 30m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestRMN_DifferentRmnNodesForDifferentChains$" -timeout 30m -parallel=1 -count=1
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1843,7 +1927,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^TestRMN_TwoMessagesOneSourceChainCursed$ -timeout 30m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestRMN_TwoMessagesOneSourceChainCursed$" -timeout 30m -parallel=1 -count=1
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1888,7 +1978,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^TestRMN_IncorrectSig$ -timeout 30m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestRMN_IncorrectSig$" -timeout 30m -parallel=1 -count=1
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1907,7 +2003,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^TestRMN_TwoMessagesOnTwoLanesIncludingBatchingWithTemporaryPause$ -timeout 30m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestRMN_TwoMessagesOnTwoLanesIncludingBatchingWithTemporaryPause$" -timeout 30m -parallel=1 -count=1
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1926,7 +2028,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^Test_CCIPReorg_BelowFinality_OnSource_WithRMN$ -timeout 30m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^Test_CCIPReorg_BelowFinality_OnSource_WithRMN$" -timeout 30m -parallel=1 -count=1
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1945,7 +2053,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^Test_CCIPReorg_BelowFinality_OnSource_WithRMN_Recover$ -timeout 30m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^Test_CCIPReorg_BelowFinality_OnSource_WithRMN_Recover$" -timeout 30m -parallel=1 -count=1
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1964,7 +2078,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^Test_CCIPReorg_BelowFinality_OnSource_WithRMN_Block$ -timeout 30m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^Test_CCIPReorg_BelowFinality_OnSource_WithRMN_Block$" -timeout 30m -parallel=1 -count=1
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1984,7 +2104,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip -v -run ^TestDeleteCCIPJobs$ -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestDeleteCCIPJobs$" -count=1 -parallel=1 github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -2002,7 +2128,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip -v -run ^TestRevokeJobs$ -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestRevokeJobs$" -count=1 -parallel=1 github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -1449,7 +1449,12 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "TestRunLogBasic" -timeout 30m -count=1 -test.parallel=2 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "TestRunLogBasic" -timeout 30m -count=1 -parallel=2 github.com/smartcontractkit/chainlink/integration-tests/smoke
     pyroscope_env: ci-smoke-runlog-evm-simulated
     test_go_project_path: integration-tests
 
@@ -1461,7 +1466,12 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "TestCronBasic|TestCronJobReplacement" -timeout 30m -count=1 -test.parallel=2 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "TestCronBasic|TestCronJobReplacement" -timeout 30m -count=1 -parallel=2 github.com/smartcontractkit/chainlink/integration-tests/smoke
     pyroscope_env: ci-smoke-cron-evm-simulated
     test_go_project_path: integration-tests
 
@@ -1473,7 +1483,12 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "TestFluxBasic" -timeout 30m -count=1 -test.parallel=2 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "TestFluxBasic" -timeout 30m -count=1 -parallel=2 github.com/smartcontractkit/chainlink/integration-tests/smoke
     pyroscope_env: ci-smoke-flux-evm-simulated
     test_go_project_path: integration-tests
 
@@ -1487,7 +1502,12 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "TestRegisteringMultipleJobDistributor" -timeout 30m -count=1 -test.parallel=2 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "TestRegisteringMultipleJobDistributor" -timeout 30m -count=1 -parallel=2 github.com/smartcontractkit/chainlink/integration-tests/smoke
     pyroscope_env: ci-smoke-reorg-above-finality-evm-simulated
     test_go_project_path: integration-tests
 
@@ -1501,7 +1521,12 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/migration -v -run "TestVersionUpgrade" -timeout 30m -count=1 -test.parallel=2 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "TestVersionUpgrade" -timeout 30m -count=1 -parallel=2 github.com/smartcontractkit/chainlink/integration-tests/migration
     test_env_vars:
       E2E_TEST_CHAINLINK_IMAGE: public.ecr.aws/chainlink/chainlink
       E2E_TEST_CHAINLINK_VERSION: "{{ env.LATEST_CHAINLINK_RELEASE_VERSION }}"
@@ -1519,7 +1544,12 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "TestRegisteringMultipleJobDistributor" -timeout 30m -count=1 -test.parallel=2 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "TestRegisteringMultipleJobDistributor" -timeout 30m -count=1 -parallel=2 github.com/smartcontractkit/chainlink/integration-tests/smoke
     pyroscope_env: ci-smoke-jd-evm-simulated
     test_go_project_path: integration-tests
   # END: Other tests

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -1017,7 +1017,14 @@ runner-test-matrix:
       - Automation On Demand Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd reorg && DETACH_RUNNER=false go test -v -test.run ^TestAutomationReorg/registry_2_3 -test.parallel=2 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd reorg && \
+      DETACH_RUNNER=false \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationReorg/registry_2_3" -parallel=2 -timeout 30m -count=1
     pyroscope_env: ci-automation-on-demand-reorg
     test_go_project_path: integration-tests
 
@@ -1028,7 +1035,14 @@ runner-test-matrix:
     triggers:
       - Automation On Demand Tests
       - E2E Chaos Tests
-    test_cmd: cd chaos && DETACH_RUNNER=false go test -v -test.run ^TestAutomationChaos$ -test.parallel=20 -timeout 60m -count=1 -json
+    test_cmd: |
+      cd chaos && \
+      DETACH_RUNNER=false \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationChaos$" -parallel=20 -timeout 60m -count=1
     pyroscope_env: ci-automation-on-demand-chaos
     test_env_vars:
       TEST_SUITE: chaos
@@ -1042,7 +1056,13 @@ runner-test-matrix:
     runs_on: ubuntu-latest
     # triggers:
     # - Nightly E2E Tests
-    test_cmd: cd benchmark && go test -v -test.run ^TestAutomationBenchmark$ -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd benchmark && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationBenchmark$" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-benchmark-automation-nightly
     test_env_vars:
       TEST_LOG_LEVEL: info
@@ -1057,7 +1077,13 @@ runner-test-matrix:
     runs_on: ubuntu-latest
     # triggers:
     # - Nightly E2E Tests
-    test_cmd: cd benchmark && go test -v -test.run ^TestAutomationBenchmark$ -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd benchmark && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationBenchmark$" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-benchmark-automation-nightly
     test_env_vars:
       TEST_LOG_LEVEL: info

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -325,7 +325,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run "^TestAutomationBasic/registry_2_0|TestAutomationBasic/registry_2_1_conditional|TestAutomationBasic/registry_2_1_logtrigger$" -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^(TestAutomationBasic/registry_2_0|TestAutomationBasic/registry_2_1_conditional|TestAutomationBasic/registry_2_1_logtrigger)$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -337,7 +343,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run "^TestAutomationBasic/registry_2_1_with_mercury_v02|TestAutomationBasic/registry_2_1_with_mercury_v03|TestAutomationBasic/registry_2_1_with_logtrigger_and_mercury_v02$" -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^(TestAutomationBasic/registry_2_1_with_mercury_v02|TestAutomationBasic/registry_2_1_with_mercury_v03|TestAutomationBasic/registry_2_1_with_logtrigger_and_mercury_v02)$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -349,7 +361,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run "^TestAutomationBasic/registry_2_2_conditional|TestAutomationBasic/registry_2_2_logtrigger|TestAutomationBasic/registry_2_2_with_mercury_v02$" -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^(TestAutomationBasic/registry_2_2_conditional|TestAutomationBasic/registry_2_2_logtrigger|TestAutomationBasic/registry_2_2_with_mercury_v02)$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -361,7 +379,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run "^TestAutomationBasic/registry_2_2_with_mercury_v03|TestAutomationBasic/registry_2_2_with_logtrigger_and_mercury_v02$" -test.parallel=2 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^(TestAutomationBasic/registry_2_2_with_mercury_v03|TestAutomationBasic/registry_2_2_with_logtrigger_and_mercury_v02)$" -parallel=2 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -372,7 +396,13 @@ runner-test-matrix:
     triggers:
       - Nightly E2E Tests
       - Push E2E Core Tests
-    test_cmd: cd smoke && go test -test.run "^TestAutomationBasic/registry_2_3_conditional_native|TestAutomationBasic/registry_2_3_conditional_link$" -test.parallel=2 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^(TestAutomationBasic/registry_2_3_conditional_native|TestAutomationBasic/registry_2_3_conditional_link)$" -parallel=2 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -384,7 +414,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run "^TestAutomationBasic/registry_2_3_logtrigger_native|TestAutomationBasic/registry_2_3_logtrigger_link$" -test.parallel=2 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^(TestAutomationBasic/registry_2_3_logtrigger_native|TestAutomationBasic/registry_2_3_logtrigger_link)$" -parallel=2 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -396,7 +432,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run "^TestAutomationBasic/registry_2_3_with_mercury_v03_link|TestAutomationBasic/registry_2_3_with_logtrigger_and_mercury_v02_link$" -test.parallel=2 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^(TestAutomationBasic/registry_2_3_with_mercury_v03_link|TestAutomationBasic/registry_2_3_with_logtrigger_and_mercury_v02_link)$" -parallel=2 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -408,7 +450,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestSetUpkeepTriggerConfig$ -test.parallel=2 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestSetUpkeepTriggerConfig$" -parallel=2 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -420,7 +468,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestAutomationAddFunds$ -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationAddFunds$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -432,7 +486,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestAutomationPauseUnPause$ -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationPauseUnPause$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -444,7 +504,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestAutomationRegisterUpkeep$ -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationRegisterUpkeep$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -456,7 +522,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestAutomationPauseRegistry$ -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationPauseRegistry$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -468,7 +540,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestAutomationKeeperNodesDown$ -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationKeeperNodesDown$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -480,7 +558,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestAutomationPerformSimulation$ -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationPerformSimulation$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -492,7 +576,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestAutomationCheckPerformGasLimit$ -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationCheckPerformGasLimit$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -504,7 +594,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestUpdateCheckData$ -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestUpdateCheckData$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -516,7 +612,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestSetOffchainConfigWithMaxGasPrice$ -test.parallel=2 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestSetOffchainConfigWithMaxGasPrice$" -parallel=2 -timeout 30m -count=1
     pyroscope_env: ci-smoke-automation-evm-simulated
     test_go_project_path: integration-tests
 
@@ -528,7 +630,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestKeeperBasicSmoke$ -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestKeeperBasicSmoke$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-keeper-evm-simulated
     test_go_project_path: integration-tests
 
@@ -540,7 +648,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestKeeperBlockCountPerTurn$ -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestKeeperBlockCountPerTurn$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-keeper-evm-simulated
     test_go_project_path: integration-tests
 
@@ -552,7 +666,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestKeeperSimulation$ -test.parallel=2 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestKeeperSimulation$" -parallel=2 -timeout 30m -count=1
     pyroscope_env: ci-smoke-keeper-evm-simulated
     test_go_project_path: integration-tests
 
@@ -564,9 +684,16 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestKeeperCheckPerformGasLimit$ -test.parallel=2 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestKeeperCheckPerformGasLimit$" -parallel=2 -timeout 30m -count=1
     pyroscope_env: ci-smoke-keeper-evm-simulated
     test_go_project_path: integration-tests
+
 
   - id: smoke/keeper_test.go:^TestKeeperRegisterUpkeep$
     path: integration-tests/smoke/keeper_test.go

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -694,7 +694,6 @@ runner-test-matrix:
     pyroscope_env: ci-smoke-keeper-evm-simulated
     test_go_project_path: integration-tests
 
-
   - id: smoke/keeper_test.go:^TestKeeperRegisterUpkeep$
     path: integration-tests/smoke/keeper_test.go
     test_env_type: docker
@@ -703,7 +702,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestKeeperRegisterUpkeep$ -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestKeeperRegisterUpkeep$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-keeper-evm-simulated
     test_go_project_path: integration-tests
 
@@ -715,7 +720,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestKeeperAddFunds$ -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestKeeperAddFunds$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-keeper-evm-simulated
     test_go_project_path: integration-tests
 
@@ -727,7 +738,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestKeeperRemove$ -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestKeeperRemove$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-keeper-evm-simulated
     test_go_project_path: integration-tests
 
@@ -739,7 +756,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestKeeperPauseRegistry$ -test.parallel=2 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestKeeperPauseRegistry$" -parallel=2 -timeout 30m -count=1
     pyroscope_env: ci-smoke-keeper-evm-simulated
     test_go_project_path: integration-tests
 
@@ -751,7 +774,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestKeeperMigrateRegistry$ -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestKeeperMigrateRegistry$" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-smoke-keeper-evm-simulated
     test_go_project_path: integration-tests
 
@@ -763,7 +792,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestKeeperNodeDown$ -test.parallel=3 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestKeeperNodeDown$" -parallel=3 -timeout 30m -count=1
     pyroscope_env: ci-smoke-keeper-evm-simulated
     test_go_project_path: integration-tests
 
@@ -775,7 +810,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestKeeperPauseUnPauseUpkeep$ -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestKeeperPauseUnPauseUpkeep$" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-smoke-keeper-evm-simulated
     test_go_project_path: integration-tests
 
@@ -787,7 +828,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestKeeperUpdateCheckData$ -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestKeeperUpdateCheckData$" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-smoke-keeper-evm-simulated
     test_go_project_path: integration-tests
 
@@ -799,7 +846,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestKeeperJobReplacement$ -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestKeeperJobReplacement$" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-smoke-keeper-evm-simulated
     test_go_project_path: integration-tests
 
@@ -807,7 +860,13 @@ runner-test-matrix:
     path: integration-tests/load/automationv2_1/automationv2_1_test.go
     runs_on: ubuntu-latest
     test_env_type: k8s-remote-runner
-    test_cmd: cd load/automationv2_1 && go test -test.run TestLogTrigger -test.parallel=1 -timeout 60m -count=1 -json
+    test_cmd: |
+      cd load/automationv2_1 && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "TestLogTrigger" -parallel=1 -timeout 60m -count=1
     remote_runner_memory: 4Gi
     test_secrets_required: true
     test_env_vars:
@@ -824,7 +883,13 @@ runner-test-matrix:
       - Automation Nightly Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestAutomationNodeUpgrade/registry_2_0 -test.parallel=1 -timeout 60m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationNodeUpgrade/registry_2_0" -parallel=1 -timeout 60m -count=1
     test_env_vars:
       E2E_TEST_CHAINLINK_IMAGE: public.ecr.aws/chainlink/chainlink
       E2E_TEST_CHAINLINK_VERSION: latest
@@ -841,7 +906,13 @@ runner-test-matrix:
       - Automation Nightly Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestAutomationNodeUpgrade/registry_2_1 -test.parallel=5 -timeout 60m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationNodeUpgrade/registry_2_1" -parallel=5 -timeout 60m -count=1
     test_env_vars:
       E2E_TEST_CHAINLINK_IMAGE: public.ecr.aws/chainlink/chainlink
       E2E_TEST_CHAINLINK_VERSION: latest
@@ -858,7 +929,13 @@ runner-test-matrix:
       - Automation Nightly Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd smoke && go test -test.run ^TestAutomationNodeUpgrade/registry_2_2 -test.parallel=5 -timeout 60m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationNodeUpgrade/registry_2_2" -parallel=5 -timeout 60m -count=1
     test_env_vars:
       E2E_TEST_CHAINLINK_IMAGE: public.ecr.aws/chainlink/chainlink
       E2E_TEST_CHAINLINK_VERSION: latest
@@ -877,7 +954,14 @@ runner-test-matrix:
       - Automation On Demand Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd reorg && DETACH_RUNNER=false go test -v -test.run ^TestAutomationReorg/registry_2_0 -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd reorg && \
+      DETACH_RUNNER=false \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationReorg/registry_2_0" -parallel=1 -timeout 30m -count=1
     pyroscope_env: ci-automation-on-demand-reorg
     test_go_project_path: integration-tests
 
@@ -891,7 +975,14 @@ runner-test-matrix:
       - Automation On Demand Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd reorg && DETACH_RUNNER=false go test -v -test.run ^TestAutomationReorg/registry_2_1 -test.parallel=2 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd reorg && \
+      DETACH_RUNNER=false \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationReorg/registry_2_1" -parallel=2 -timeout 30m -count=1
     pyroscope_env: ci-automation-on-demand-reorg
     test_go_project_path: integration-tests
 
@@ -905,7 +996,14 @@ runner-test-matrix:
       - Automation On Demand Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: cd reorg && DETACH_RUNNER=false go test -v -test.run ^TestAutomationReorg/registry_2_2 -test.parallel=2 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd reorg && \
+      DETACH_RUNNER=false \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestAutomationReorg/registry_2_2" -parallel=2 -timeout 30m -count=1
     pyroscope_env: ci-automation-on-demand-reorg
     test_go_project_path: integration-tests
 

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -1098,7 +1098,13 @@ runner-test-matrix:
     path: integration-tests/smoke/vrfv2_test.go
     runs_on: ubuntu22.04-8cores-32GB
     test_env_type: docker
-    test_cmd: cd smoke && go test -v -test.run TestVRFv2Basic -test.parallel=1 -timeout 30m -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "TestVRFv2Basic" -parallel=1 -timeout 30m -count=1
     test_secrets_required: true
     triggers:
       - On Demand VRFV2 Smoke Test (Ethereum clients)
@@ -1108,7 +1114,13 @@ runner-test-matrix:
     path: integration-tests/load/vrfv2plus/vrfv2plus_test.go
     runs_on: ubuntu22.04-8cores-32GB
     test_env_type: docker
-    test_cmd: cd load/vrfv2plus && go test -v -test.run ^TestVRFV2PlusPerformance$ -test.parallel=1 -timeout 24h -count=1 -json
+    test_cmd: |
+      cd load/vrfv2plus && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestVRFV2PlusPerformance$" -parallel=1 -timeout 24h -count=1
     test_config_override_required: true
     test_secrets_required: true
     test_env_vars:
@@ -1121,7 +1133,13 @@ runner-test-matrix:
     path: integration-tests/load/vrfv2plus/vrfv2plus_test.go
     runs_on: ubuntu22.04-8cores-32GB
     test_env_type: docker
-    test_cmd: cd load/vrfv2plus && go test -v -test.run ^TestVRFV2PlusBHSPerformance$ -test.parallel=1 -timeout 24h -count=1 -json
+    test_cmd: |
+      cd load/vrfv2plus && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestVRFV2PlusBHSPerformance$" -parallel=1 -timeout 24h -count=1
     test_config_override_required: true
     test_secrets_required: true
     test_env_vars:
@@ -1134,7 +1152,13 @@ runner-test-matrix:
     path: integration-tests/load/vrfv2/vrfv2_test.go
     runs_on: ubuntu22.04-8cores-32GB
     test_env_type: docker
-    test_cmd: cd load/vrfv2 && go test -v -test.run ^TestVRFV2Performance$ -test.parallel=1 -timeout 24h -count=1 -json
+    test_cmd: |
+      cd load/vrfv2 && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestVRFV2Performance$" -parallel=1 -timeout 24h -count=1
     test_config_override_required: true
     test_secrets_required: true
     test_env_vars:
@@ -1147,7 +1171,13 @@ runner-test-matrix:
     path: integration-tests/load/vrfv2/vrfv2_test.go
     runs_on: ubuntu22.04-8cores-32GB
     test_env_type: docker
-    test_cmd: cd load/vrfv2 && go test -v -test.run ^TestVRFV2PlusBHSPerformance$ -test.parallel=1 -timeout 24h -count=1 -json
+    test_cmd: |
+      cd load/vrfv2 && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestVRFV2PlusBHSPerformance$" -parallel=1 -timeout 24h -count=1
     test_config_override_required: true
     test_secrets_required: true
     test_env_vars:
@@ -1166,7 +1196,12 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "TestVRFBasic|TestVRFJobReplacement" -timeout 30m -count=1 -test.parallel=2 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "TestVRFBasic|TestVRFJobReplacement" -timeout 30m -count=1 -parallel=2 github.com/smartcontractkit/chainlink/integration-tests/smoke
     pyroscope_env: ci-smoke-vrf-evm-simulated
     test_go_project_path: integration-tests
 
@@ -1180,7 +1215,12 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "^(TestVRFv2Basic|TestVRFV2WithBHS|TestVRFv2NodeReorg|TestVRFV2MultipleSendingKeys|TestVRFOwner|TestVRFV2BatchFulfillmentEnabledDisabled)$" -timeout 30m -count=1 -test.parallel=6 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^(TestVRFv2Basic|TestVRFV2WithBHS|TestVRFv2NodeReorg|TestVRFV2MultipleSendingKeys|TestVRFOwner|TestVRFV2BatchFulfillmentEnabledDisabled)$" -timeout 30m -count=1 -parallel=6 github.com/smartcontractkit/chainlink/integration-tests/smoke
     pyroscope_env: ci-smoke-vrf2-evm-simulated
     test_go_project_path: integration-tests
 
@@ -1194,7 +1234,12 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "^(TestVRFv2Plus|TestVRFv2PlusMultipleSendingKeys|TestVRFv2PlusMigration|TestVRFv2PlusReplayAfterTimeout|TestVRFv2PlusPendingBlockSimulationAndZeroConfirmationDelays|TestVRFv2PlusNodeReorg|TestVRFv2PlusBatchFulfillmentEnabledDisabled|TestVRFv2PlusWithBHS|TestVRFv2PlusWithBHF)$" -timeout 30m -count=1 -test.parallel=9 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^(TestVRFv2Plus|TestVRFv2PlusMultipleSendingKeys|TestVRFv2PlusMigration|TestVRFv2PlusReplayAfterTimeout|TestVRFv2PlusPendingBlockSimulationAndZeroConfirmationDelays|TestVRFv2PlusNodeReorg|TestVRFv2PlusBatchFulfillmentEnabledDisabled|TestVRFv2PlusWithBHS|TestVRFv2PlusWithBHF)$" -timeout 30m -count=1 -parallel=9 github.com/smartcontractkit/chainlink/integration-tests/smoke
     pyroscope_env: ci-smoke-vrf2plus-evm-simulated
     test_go_project_path: integration-tests
   # VRFv2Plus tests on any live testnet (test_config_override_path required)
@@ -1204,7 +1249,13 @@ runner-test-matrix:
     path: integration-tests/smoke/vrfv2plus_test.go
     runs_on: ubuntu-latest
     test_env_type: docker
-    test_cmd: cd smoke && go test -v -test.run "TestVRFv2Plus$/(Link_Billing|Native_Billing|Direct_Funding)|TestVRFV2PlusWithBHS" -test.parallel=1 -timeout 2h -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "TestVRFv2Plus$/(Link_Billing|Native_Billing|Direct_Funding)|TestVRFV2PlusWithBHS" -parallel=1 -timeout 2h -count=1
     test_go_project_path: integration-tests
   # VRFv2Plus release tests on Sepolia testnet
 
@@ -1212,7 +1263,13 @@ runner-test-matrix:
     path: integration-tests/smoke/vrfv2plus_test.go
     runs_on: ubuntu-latest
     test_env_type: docker
-    test_cmd: cd smoke && go test -v -test.run "TestVRFv2Plus$/(Link_Billing|Native_Billing|Direct_Funding)|TestVRFV2PlusWithBHS" -test.parallel=1 -timeout 2h -count=1 -json
+    test_cmd: |
+      cd smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "TestVRFv2Plus$/(Link_Billing|Native_Billing|Direct_Funding)|TestVRFV2PlusWithBHS" -parallel=1 -timeout 2h -count=1
     test_config_override_path: integration-tests/testconfig/vrfv2plus/overrides/new_env/sepolia_new_env_test_config.toml
     triggers:
       - VRF E2E Release Tests

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -2155,7 +2155,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPForBidirectionalLane$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPForBidirectionalLane$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP
@@ -2171,7 +2177,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPForBidirectionalLane$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPForBidirectionalLane$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP
@@ -2188,7 +2200,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPForBidirectionalLane$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPForBidirectionalLane$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP
@@ -2205,7 +2223,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPForBidirectionalLane$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPForBidirectionalLane$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP
@@ -2222,7 +2246,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPForBidirectionalLane$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPForBidirectionalLane$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP
@@ -2237,7 +2267,13 @@ runner-test-matrix:
     triggers:
     # - PR E2E CCIP Tests
     # - Nightly E2E Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPForBidirectionalLane$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPForBidirectionalLane$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP
@@ -2254,7 +2290,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPTokenPoolRateLimits$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPTokenPoolRateLimits$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP
@@ -2314,7 +2356,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPOnRampLimits$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPOnRampLimits$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP
@@ -2328,7 +2376,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPOffRampCapacityLimit$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPOffRampCapacityLimit$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP
@@ -2342,7 +2396,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPOffRampAggRateLimit$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPOffRampAggRateLimit$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP
@@ -2358,7 +2418,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPReorgBelowFinality$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPReorgBelowFinality$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP
@@ -2375,7 +2441,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPReorgAboveFinalityAtDestination$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPReorgAboveFinalityAtDestination$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP
@@ -2392,7 +2464,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPReorgAboveFinalityAtSource$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPReorgAboveFinalityAtSource$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP
@@ -2405,7 +2483,14 @@ runner-test-matrix:
     runs_on: ubuntu-latest
     triggers:
       - E2E CCIP Chaos Tests
-    test_cmd: cd ccip-tests/chaos && DETACH_RUNNER=false go test ccip_test.go -v -test.parallel=11 -timeout 60m -count=1 -json
+    test_cmd: |
+      cd ccip-tests/chaos && \
+      DETACH_RUNNER=false \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v ccip_test.go -parallel=11 -timeout 60m -count=1
     test_env_vars:
       TEST_SUITE: chaos
       TEST_TRIGGERED_BY: ccip-cron-chaos-eth

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -80,7 +80,12 @@ runner-test-matrix:
     path: integration-tests/soak/ocr_test.go
     test_env_type: k8s-remote-runner
     runs_on: ubuntu-latest
-    test_cmd: go test soak/ocr_test.go -v -test.run ^TestOCRv2Soak$ -test.parallel=1 -timeout 900h -count=1 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestOCRv2Soak$" -parallel=1 -timeout 900h -count=1 soak/ocr_test.go
     test_config_override_path: integration-tests/testconfig/ocr2/overrides/base_sepolia_quick_smoke_test.toml
     test_secrets_required: true
     test_env_vars:
@@ -91,7 +96,12 @@ runner-test-matrix:
     path: integration-tests/soak/ocr_test.go
     test_env_type: k8s-remote-runner
     runs_on: ubuntu-latest
-    test_cmd: go test soak/ocr_test.go -v -test.run ^TestForwarderOCRv1Soak$ -test.parallel=1 -timeout 900h -count=1 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestForwarderOCRv1Soak$" -parallel=1 -timeout 900h -count=1 soak/ocr_test.go
     test_secrets_required: true
     test_env_vars:
       TEST_SUITE: soak
@@ -101,7 +111,12 @@ runner-test-matrix:
     path: integration-tests/soak/ocr_test.go
     test_env_type: k8s-remote-runner
     runs_on: ubuntu-latest
-    test_cmd: go test soak/ocr_test.go -v -test.run ^TestForwarderOCRv2Soak$ -test.parallel=1 -timeout 900h -count=1 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestForwarderOCRv2Soak$" -parallel=1 -timeout 900h -count=1 soak/ocr_test.go
     test_secrets_required: true
     test_env_vars:
       TEST_SUITE: soak
@@ -111,7 +126,12 @@ runner-test-matrix:
     path: integration-tests/soak/ocr_test.go
     test_env_type: k8s-remote-runner
     runs_on: ubuntu-latest
-    test_cmd: go test soak/ocr_test.go -v -test.run TestOCRSoak_GethReorgBelowFinality_FinalityTagDisabled -test.parallel=1 -timeout 900h -count=1 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "TestOCRSoak_GethReorgBelowFinality_FinalityTagDisabled" -parallel=1 -timeout 900h -count=1 soak/ocr_test.go
     test_secrets_required: true
     test_env_vars:
       TEST_SUITE: soak
@@ -121,7 +141,12 @@ runner-test-matrix:
     path: integration-tests/soak/ocr_test.go
     test_env_type: k8s-remote-runner
     runs_on: ubuntu-latest
-    test_cmd: go test soak/ocr_test.go -v -test.run ^TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled$ -test.parallel=1 -timeout 900h -count=1 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled$" -parallel=1 -timeout 900h -count=1 soak/ocr_test.go
     test_secrets_required: true
     test_env_vars:
       TEST_SUITE: soak
@@ -131,7 +156,12 @@ runner-test-matrix:
     path: integration-tests/soak/ocr_test.go
     test_env_type: k8s-remote-runner
     runs_on: ubuntu-latest
-    test_cmd: go test soak/ocr_test.go -v -test.run ^TestOCRSoak_GasSpike$ -test.parallel=1 -timeout 900h -count=1 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestOCRSoak_GasSpike$" -parallel=1 -timeout 900h -count=1 soak/ocr_test.go
     test_secrets_required: true
     test_env_vars:
       TEST_SUITE: soak
@@ -141,7 +171,12 @@ runner-test-matrix:
     path: integration-tests/soak/ocr_test.go
     test_env_type: k8s-remote-runner
     runs_on: ubuntu-latest
-    test_cmd: go test soak/ocr_test.go -v -test.run ^TestOCRSoak_ChangeBlockGasLimit$ -test.parallel=1 -timeout 900h -count=1 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestOCRSoak_ChangeBlockGasLimit$" -parallel=1 -timeout 900h -count=1 soak/ocr_test.go
     test_secrets_required: true
     test_env_vars:
       TEST_SUITE: soak
@@ -151,7 +186,12 @@ runner-test-matrix:
     path: integration-tests/soak/ocr_test.go
     test_env_type: k8s-remote-runner
     runs_on: ubuntu-latest
-    test_cmd: go test soak/ocr_test.go -v -test.run ^TestOCRSoak_RPCDownForAllCLNodes$ -test.parallel=1 -timeout 900h -count=1 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestOCRSoak_RPCDownForAllCLNodes$" -parallel=1 -timeout 900h -count=1 soak/ocr_test.go
     test_secrets_required: true
     test_env_vars:
       TEST_SUITE: soak
@@ -161,7 +201,12 @@ runner-test-matrix:
     path: integration-tests/soak/ocr_test.go
     test_env_type: k8s-remote-runner
     runs_on: ubuntu-latest
-    test_cmd: go test soak/ocr_test.go -v -test.run ^TestOCRSoak_RPCDownForHalfCLNodes$ -test.parallel=1 -timeout 900h -count=1 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestOCRSoak_RPCDownForHalfCLNodes$" -parallel=1 -timeout 900h -count=1 soak/ocr_test.go
     test_secrets_required: true
     test_env_vars:
       TEST_SUITE: soak
@@ -177,7 +222,12 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "^(TestForwarderOCRBasic)$" -timeout 30m -count=1 -test.parallel=2 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^(TestForwarderOCRBasic)$" -timeout 30m -count=1 -parallel=2 github.com/smartcontractkit/chainlink/integration-tests/smoke
     pyroscope_env: ci-smoke-forwarder-ocr-evm-simulated
     test_go_project_path: integration-tests
 
@@ -191,7 +241,12 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "^(TestForwarderOCR2Basic)$" -timeout 30m -count=1 -test.parallel=2 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^(TestForwarderOCR2Basic)$" -timeout 30m -count=1 -parallel=2 github.com/smartcontractkit/chainlink/integration-tests/smoke
     pyroscope_env: ci-smoke-forwarder-ocr-evm-simulated
     test_go_project_path: integration-tests
 
@@ -205,7 +260,12 @@ runner-test-matrix:
       - Merge Queue E2E Core Tests
       - Nightly E2E Tests
       - Push E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "^(TestOCRv2Basic|TestOCRv2Request|TestOCRv2JobReplacement)$" -timeout 30m -count=1 -test.parallel=6 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^(TestOCRv2Basic|TestOCRv2Request|TestOCRv2JobReplacement)$" -timeout 30m -count=1 -parallel=6 github.com/smartcontractkit/chainlink/integration-tests/smoke
     pyroscope_env: ci-smoke-ocr2-evm-simulated
     test_env_vars:
       E2E_TEST_CHAINLINK_VERSION: "{{ env.DEFAULT_CHAINLINK_PLUGINS_VERSION }}" # This is the chainlink version that has the plugins
@@ -222,7 +282,12 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "^(TestOCRv2Basic|TestOCRv2Request|TestOCRv2JobReplacement)$" -timeout 30m -count=1 -test.parallel=6 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^(TestOCRv2Basic|TestOCRv2Request|TestOCRv2JobReplacement)$" -timeout 30m -count=1 -parallel=6 github.com/smartcontractkit/chainlink/integration-tests/smoke
     pyroscope_env: ci-smoke-ocr2-plugins-evm-simulated
     test_env_vars:
       E2E_TEST_CHAINLINK_VERSION: "{{ env.DEFAULT_CHAINLINK_PLUGINS_VERSION }}" # This is the chainlink version that has the plugins
@@ -236,7 +301,14 @@ runner-test-matrix:
     triggers:
       - Automation On Demand Tests
       - E2E Chaos Tests
-    test_cmd: cd chaos && DETACH_RUNNER=false go test -test.run "^TestOCRChaos$" -v -test.parallel=10 -timeout 60m -count=1 -json
+    test_cmd: |
+      cd chaos && \
+      DETACH_RUNNER=false \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestOCRChaos$" -parallel=10 -timeout 60m -count=1
     test_env_vars:
       TEST_SUITE: chaos
       CHAINLINK_USER_TEAM: Foundations

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -20,7 +20,12 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E Core Tests
       - Workflow Dispatch E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "^(TestOCRBasic|TestOCRJobReplacement)$" -timeout 30m -count=1 -test.parallel=2 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^(TestOCRBasic|TestOCRJobReplacement)$" -timeout 30m -count=1 -parallel=2 github.com/smartcontractkit/chainlink/integration-tests/smoke
     pyroscope_env: ci-smoke-ocr-evm-simulated
     test_go_project_path: integration-tests
 
@@ -28,8 +33,12 @@ runner-test-matrix:
     path: integration-tests/soak/ocr_test.go
     test_env_type: k8s-remote-runner
     runs_on: ubuntu-latest
-    test_cmd: go test soak/ocr_test.go -v -test.run ^TestOCRv1Soak$ -test.parallel=1 -timeout 900h -count=1 -json
-    test_cmd_opts: 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci -singlepackage -hidepassingtests=false
+    test_cmd: \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestOCRv1Soak$" -parallel=1 -timeout 900h -count=1 soak/ocr_test.go
     test_secrets_required: true
     test_env_vars:
       TEST_SUITE: soak
@@ -39,8 +48,12 @@ runner-test-matrix:
     path: integration-tests/soak/ocr_test.go
     test_env_type: k8s-remote-runner
     runs_on: ubuntu-latest
-    test_cmd: go test soak/ocr_test.go -v -test.run ^TestOCRv2Soak$ -test.parallel=1 -timeout 900h -count=1 -json
-    test_cmd_opts: 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci -singlepackage -hidepassingtests=false
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestOCRv2Soak$" -parallel=1 -timeout 900h -count=1 soak/ocr_test.go
     test_secrets_required: true
     test_env_vars:
       TEST_SUITE: soak
@@ -50,7 +63,12 @@ runner-test-matrix:
     path: integration-tests/soak/ocr_test.go
     test_env_type: k8s-remote-runner
     runs_on: ubuntu-latest
-    test_cmd: go test soak/ocr_test.go -v -test.run ^TestOCRv2Soak$ -test.parallel=1 -timeout 900h -count=1 -json
+    test_cmd: |
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestOCRv2Soak$" -parallel=1 -timeout 900h -count=1 soak/ocr_test.go
     test_config_override_path: integration-tests/testconfig/ocr2/overrides/wemix_testnet.toml
     test_secrets_required: true
     test_env_vars:
@@ -1247,7 +1265,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^TestRMN_TwoMessagesOnTwoLanesIncludingBatching$ -timeout 30m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -v -run "^TestRMN_TwoMessagesOnTwoLanesIncludingBatching$" -timeout 30m -parallel=1 -count=1
     test_go_project_path: integration-tests
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
@@ -1381,7 +1405,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd smoke/ccip && go test -test.run ^TestRMN_GlobalCurseTwoMessagesOnTwoLanes$ -timeout 30m -test.parallel=1 -count=1 -json
+    test_cmd: |
+      cd smoke/ccip && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/test.json \
+        --format=github-actions \
+        -- -v -run "^TestRMN_GlobalCurseTwoMessagesOnTwoLanes$" -timeout 30m -parallel=1 -count=1
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
@@ -1650,7 +1680,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPMulticall$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPMulticall$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP
@@ -1666,7 +1702,13 @@ runner-test-matrix:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
-    test_cmd: cd ccip-tests/smoke && go test -test.run ^TestSmokeCCIPManuallyExecuteAfterExecutionFailingDueToInsufficientGas$ -timeout 30m -count=1 -test.parallel=1 -json
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPManuallyExecuteAfterExecutionFailingDueToInsufficientGas$" -timeout 30m -count=1 -parallel=1
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
       CHAINLINK_USER_TEAM: CCIP

--- a/.github/workflows/integration-in-memory-tests.yml
+++ b/.github/workflows/integration-in-memory-tests.yml
@@ -82,7 +82,7 @@ jobs:
       contents: read
     needs: changes
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5cf24eba2fef708acd6050f0f9a0397b2dabbfb8 # 2025-10-01
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@7a90dc5af81a8c901fa2067a4a68b02ba169451e # 2025-11-03
     with:
       workflow_name: Run CCIP Integration Tests For PR
       chainlink_version: ${{ inputs.cl_ref || github.sha }}
@@ -112,7 +112,7 @@ jobs:
       contents: read
     needs: changes
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5cf24eba2fef708acd6050f0f9a0397b2dabbfb8 # 2025-10-01
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@7a90dc5af81a8c901fa2067a4a68b02ba169451e # 2025-11-03
     with:
       workflow_name: Run CCIP Integration Tests For Merge Queue
       chainlink_version: ${{ inputs.cl_ref || github.sha }}

--- a/.github/workflows/integration-in-memory-tests.yml
+++ b/.github/workflows/integration-in-memory-tests.yml
@@ -82,7 +82,7 @@ jobs:
       contents: read
     needs: changes
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@7a90dc5af81a8c901fa2067a4a68b02ba169451e # 2025-11-03
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@e77c336588c4642a825e13b35f381dccfa6a928a # 2025-10-03
     with:
       workflow_name: Run CCIP Integration Tests For PR
       chainlink_version: ${{ inputs.cl_ref || github.sha }}
@@ -112,7 +112,7 @@ jobs:
       contents: read
     needs: changes
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@7a90dc5af81a8c901fa2067a4a68b02ba169451e # 2025-11-03
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@e77c336588c4642a825e13b35f381dccfa6a928a # 2025-10-03
     with:
       workflow_name: Run CCIP Integration Tests For Merge Queue
       chainlink_version: ${{ inputs.cl_ref || github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -439,7 +439,7 @@ jobs:
       id-token: write
       contents: read
     if: needs.run-core-e2e-tests-setup.outputs.should-run == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@fix/cleanup-run-e2e-tests
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@7a90dc5af81a8c901fa2067a4a68b02ba169451e # 2025-11-03
     with:
       workflow_name: ${{ needs.run-core-e2e-tests-setup.outputs.workflow-name }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -537,7 +537,7 @@ jobs:
       contents: read
     needs: [build-chainlink, run-ccip-e2e-tests-setup, changes, labels]
     if: needs.run-ccip-e2e-tests-setup.outputs.should-run == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@fix/cleanup-run-e2e-tests
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@7a90dc5af81a8c901fa2067a4a68b02ba169451e # 2025-11-03
     with:
       workflow_name: ${{ needs.run-ccip-e2e-tests-setup.outputs.workflow-name }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -439,7 +439,7 @@ jobs:
       id-token: write
       contents: read
     if: needs.run-core-e2e-tests-setup.outputs.should-run == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@7120f3a614452e1c6b84876c055f574011a947d1 # 2025-07-08
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@feat/run-e2e-tests-branch-out
     with:
       workflow_name: ${{ needs.run-core-e2e-tests-setup.outputs.workflow-name }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -536,7 +536,7 @@ jobs:
       contents: read
     needs: [build-chainlink, run-ccip-e2e-tests-setup, changes, labels]
     if: needs.run-ccip-e2e-tests-setup.outputs.should-run == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@7120f3a614452e1c6b84876c055f574011a947d1 # 2025-07-08
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@feat/run-e2e-tests-branch-out
     with:
       workflow_name: ${{ needs.run-ccip-e2e-tests-setup.outputs.workflow-name }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -439,7 +439,7 @@ jobs:
       id-token: write
       contents: read
     if: needs.run-core-e2e-tests-setup.outputs.should-run == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@7a90dc5af81a8c901fa2067a4a68b02ba169451e # 2025-11-03
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@e77c336588c4642a825e13b35f381dccfa6a928a # 2025-10-03
     with:
       workflow_name: ${{ needs.run-core-e2e-tests-setup.outputs.workflow-name }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -537,7 +537,7 @@ jobs:
       contents: read
     needs: [build-chainlink, run-ccip-e2e-tests-setup, changes, labels]
     if: needs.run-ccip-e2e-tests-setup.outputs.should-run == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@7a90dc5af81a8c901fa2067a4a68b02ba169451e # 2025-11-03
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@e77c336588c4642a825e13b35f381dccfa6a928a # 2025-10-03
     with:
       workflow_name: ${{ needs.run-ccip-e2e-tests-setup.outputs.workflow-name }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -471,6 +471,7 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
       OPTIONAL_GATI_AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
       OPTIONAL_GATI_LAMBDA_URL: ${{  secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL}}
+      TRUNK_API_KEY: ${{ secrets.TRUNK_API_KEY }}
 
   run-ccip-e2e-tests-setup:
     name: Run CCIP E2E Tests Setup
@@ -571,6 +572,7 @@ jobs:
       AWS_K8S_CLUSTER_NAME_SDLC: ${{ secrets.AWS_K8S_CLUSTER_NAME_SDLC }}
       OPTIONAL_GATI_AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
       OPTIONAL_GATI_LAMBDA_URL: ${{  secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL}}
+      TRUNK_API_KEY: ${{ secrets.TRUNK_API_KEY }}
 
   check-e2e-test-results:
     if: always()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -439,17 +439,17 @@ jobs:
       id-token: write
       contents: read
     if: needs.run-core-e2e-tests-setup.outputs.should-run == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@feat/run-e2e-tests-branch-out
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@fix/cleanup-run-e2e-tests
     with:
       workflow_name: ${{ needs.run-core-e2e-tests-setup.outputs.workflow-name }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       test_trigger: ${{ needs.run-core-e2e-tests-setup.outputs.test-trigger }}
       upload_cl_node_coverage_artifact: true
-      upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
       use-self-hosted-runners: ${{ needs.labels.outputs.should-use-self-hosted-runners }}
       ecr_name: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
+      quarantine: true
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -537,18 +537,18 @@ jobs:
       contents: read
     needs: [build-chainlink, run-ccip-e2e-tests-setup, changes, labels]
     if: needs.run-ccip-e2e-tests-setup.outputs.should-run == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@feat/run-e2e-tests-branch-out
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@fix/cleanup-run-e2e-tests
     with:
       workflow_name: ${{ needs.run-ccip-e2e-tests-setup.outputs.workflow-name }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       test_trigger: ${{ needs.run-ccip-e2e-tests-setup.outputs.test-trigger }}
       upload_cl_node_coverage_artifact: true
-      upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
       use-self-hosted-runners: ${{ needs.labels.outputs.should-use-self-hosted-runners }}
       ecr_name: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
       team: "CCIP"
+      quarantine: true
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
### Changes

* Bump ref of `run-e2e-tests` to https://github.com/smartcontractkit/.github/commit/e77c336588c4642a825e13b35f381dccfa6a928a
* Update e2e test definitions to use `gotestsum` producing a junit report file
* Pass `quarantine: true` for e2e `docker` and `k8s` tests, allowing for auto quarantining capabilities


### Testing

These tests are all with the same test definitions file, only thing changed between them is the ref of the reusable workflow, and some inconsequential inputs changes.
- https://github.com/smartcontractkit/chainlink/actions/runs/18229742557?pr=19644
- https://github.com/smartcontractkit/chainlink/actions/runs/18229742557?pr=19644
- https://github.com/smartcontractkit/chainlink/actions/runs/18233694574?pr=19644


