### PR TITLE
feat: add coalesce pipeline task

### DIFF
--- a/.changeset/wise-crews-provide.md
+++ b/.changeset/wise-crews-provide.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#added coalesce pipeline task

--- a/core/services/pipeline/common.go
+++ b/core/services/pipeline/common.go
@@ -311,6 +311,7 @@ const (
 	TaskTypeBase64Encode     TaskType = "base64encode"
 	TaskTypeBridge           TaskType = "bridge"
 	TaskTypeCBORParse        TaskType = "cborparse"
+	TaskTypeCoalesce         TaskType = "coalesce"
 	TaskTypeConditional      TaskType = "conditional"
 	TaskTypeDivide           TaskType = "divide"
 	TaskTypeETHABIDecode     TaskType = "ethabidecode"
@@ -436,6 +437,8 @@ func UnmarshalTaskFromMap(taskType TaskType, taskMap interface{}, ID int, dotID 
 		task = &Base64DecodeTask{BaseTask: BaseTask{id: ID, dotID: dotID}}
 	case TaskTypeBase64Encode:
 		task = &Base64EncodeTask{BaseTask: BaseTask{id: ID, dotID: dotID}}
+	case TaskTypeCoalesce:
+		task = &CoalesceTask{BaseTask: BaseTask{id: ID, dotID: dotID}}
 	default:
 		return nil, pkgerrors.Errorf(`unknown task type: "%v"`, taskType)
 	}

--- a/core/services/pipeline/task.coalesce.go
+++ b/core/services/pipeline/task.coalesce.go
@@ -1,0 +1,27 @@
+package pipeline
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+// CoalesceTask returns the first non-nil, non-error input, or nil if there are none.
+type CoalesceTask struct {
+	BaseTask `mapstructure:",squash"`
+}
+
+var _ Task = (*CoalesceTask)(nil)
+
+func (t *CoalesceTask) Type() TaskType {
+	return TaskTypeCoalesce
+}
+
+func (t *CoalesceTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs []Result) (result Result, runInfo RunInfo) {
+	for _, input := range inputs {
+		if input.Error == nil && input.Value != nil {
+			return input, runInfo
+		}
+	}
+	return Result{Value: nil}, runInfo
+}

--- a/core/services/pipeline/task.coalesce_test.go
+++ b/core/services/pipeline/task.coalesce_test.go
@@ -1,0 +1,111 @@
+package pipeline_test
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
+)
+
+func TestCoalesceTask(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		inputs []pipeline.Result
+		want   pipeline.Result
+	}{
+		{
+			"zero inputs",
+			[]pipeline.Result{},
+			pipeline.Result{Value: nil},
+		},
+		{
+			"one non-errored decimal input",
+			[]pipeline.Result{{Value: mustDecimal(t, "42")}},
+			pipeline.Result{Value: mustDecimal(t, "42")},
+		},
+		{
+			"one errored decimal input",
+			[]pipeline.Result{{Value: mustDecimal(t, "42"), Error: errors.New("foo")}},
+			pipeline.Result{Value: nil},
+		},
+		{
+			"one non-errored string input",
+			[]pipeline.Result{{Value: "42"}},
+			pipeline.Result{Value: "42"},
+		},
+		{
+			"one errored input and one non-errored input",
+			[]pipeline.Result{{Error: errors.New("foo"), Value: "1"}, {Value: "42"}},
+			pipeline.Result{Value: "42"},
+		},
+		{
+			"one non-errored input and one errored input",
+			[]pipeline.Result{{Value: "42"}, {Error: errors.New("foo"), Value: "1"}},
+			pipeline.Result{Value: "42"},
+		},
+		{
+			"two errored inputs",
+			[]pipeline.Result{{Value: "42", Error: errors.New("bar")}, {Error: errors.New("foo"), Value: "1"}},
+			pipeline.Result{Value: nil},
+		},
+		{
+			"one errored input and two non-errored inputs",
+			[]pipeline.Result{{Error: errors.New("foo")}, {Value: "42"}, {Value: "44"}},
+			pipeline.Result{Value: "42"},
+		},
+		{
+			"one nil input",
+			[]pipeline.Result{{Value: nil}},
+			pipeline.Result{Value: nil},
+		},
+		{
+			"two errored or nil inputs",
+			[]pipeline.Result{{Error: errors.New("foo")}, {Value: nil}},
+			pipeline.Result{Value: nil},
+		},
+		{
+			"one nil input and two non-errored inputs",
+			[]pipeline.Result{{Value: nil}, {Value: "42"}, {Value: "44"}},
+			pipeline.Result{Value: "42"},
+		},
+		{
+			"two non-errored inputs and one nil input",
+			[]pipeline.Result{{Value: "42"}, {Value: nil}, {Value: "44"}},
+			pipeline.Result{Value: "42"},
+		},
+		{
+			"three errored or nil inputs and one decimal input",
+			[]pipeline.Result{{Error: errors.New("foo")}, {Value: nil}, {Error: errors.New("bar")}, {Value: mustDecimal(t, "42")}},
+			pipeline.Result{Value: mustDecimal(t, "42")},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			task := pipeline.CoalesceTask{}
+			output, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), pipeline.NewVarsFrom(nil), test.inputs)
+			assert.False(t, runInfo.IsPending)
+			assert.False(t, runInfo.IsRetryable)
+			if output.Error != nil {
+				require.Equal(t, test.want.Error, errors.Cause(output.Error))
+				require.Nil(t, output.Value)
+			} else {
+				switch test.want.Value.(type) {
+				case *decimal.Decimal:
+					require.Equal(t, test.want.Value.(*decimal.Decimal).String(), output.Value.(*decimal.Decimal).String())
+				default:
+					require.Equal(t, test.want.Value, output.Value)
+				}
+				require.NoError(t, output.Error)
+			}
+		})
+	}
+}

--- a/core/services/pipeline/task.coalesce_test.go
+++ b/core/services/pipeline/task.coalesce_test.go
@@ -98,11 +98,11 @@ func TestCoalesceTask(t *testing.T) {
 				require.Equal(t, test.want.Error, errors.Cause(output.Error))
 				require.Nil(t, output.Value)
 			} else {
-				switch test.want.Value.(type) {
+				switch val := test.want.Value.(type) {
 				case *decimal.Decimal:
-					require.Equal(t, test.want.Value.(*decimal.Decimal).String(), output.Value.(*decimal.Decimal).String())
+					require.Equal(t, val.String(), output.Value.(*decimal.Decimal).String())
 				default:
-					require.Equal(t, test.want.Value, output.Value)
+					require.Equal(t, val, output.Value)
 				}
 				require.NoError(t, output.Error)
 			}

--- a/core/services/pipeline/task.jsonparse_test.go
+++ b/core/services/pipeline/task.jsonparse_test.go
@@ -196,6 +196,18 @@ func TestJSONParseTask(t *testing.T) {
 			"",
 		},
 		{
+			"empty path",
+			"",
+			"",
+			"",
+			"false",
+			pipeline.NewVarsFrom(nil),
+			[]pipeline.Result{{Value: `{"data": [[0, 1]],"timestamp": 1234567890}`}},
+			map[string]interface{}{"data": []interface{}{[]interface{}{int64(0), int64(1)}}, "timestamp": int64(1234567890)},
+			nil,
+			"",
+		},
+		{
 			"return false",
 			"",
 			"data",


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/DS-794

Add a simple pipeline task for coalescing values:
- Simply returns the first non-nil and non-error value
- If there are no inputs, returns nil
- If there are no inputs that are non-nil or non-errored, returns nil

This is intended to be used for coalescing timestamp values in Streams RWA jobs.

Also adds a test to the jsonparse task for an empty path input.