### PR TITLE
[CRE-915] Add negative system tests for evm.getTransactionReceipts

### DIFF
--- a/.changeset/common-rats-agree.md
+++ b/.changeset/common-rats-agree.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#internal Add evm.getTransactionReceipts negative system tests

--- a/system-tests/tests/regression/cre/cre_regression_suite_test.go
+++ b/system-tests/tests/regression/cre/cre_regression_suite_test.go
@@ -94,3 +94,7 @@ func Test_CRE_V2_EVM_FilterLogs_Invalid_ToBlock_Regression(t *testing.T) {
 func Test_CRE_V2_EVM_GetTransactionByHash_Invalid_Hash_Regression(t *testing.T) {
 	runEVMNegativeTestSuite(t, evmNegativeTestsGetTransactionByHashInvalidHash)
 }
+
+func Test_CRE_V2_EVM_GetTransactionReceipt_Invalid_Hash_Regression(t *testing.T) {
+	runEVMNegativeTestSuite(t, evmNegativeTestsGetTransactionReceiptInvalidHash)
+}

--- a/system-tests/tests/regression/cre/evm/evmread-negative/main.go
+++ b/system-tests/tests/regression/cre/evm/evmread-negative/main.go
@@ -63,6 +63,8 @@ func onEVMReadTrigger(wfCfg config.Config, runtime sdk.Runtime, payload *cron.Pa
 		return runFilterLogsWithInvalidToBlock(client, runtime, wfCfg)
 	case "GetTransactionByHash - invalid hash":
 		return runGetTransactionByHashWithInvalidHash(client, runtime, wfCfg)
+	case "GetTransactionReceipt - invalid hash":
+		return runGetTransactionReceiptWithInvalidHash(client, runtime, wfCfg)
 	default:
 		runtime.Logger().Warn("The provided name for function to execute did not match any known functions", "functionToTest", wfCfg.FunctionToTest)
 	}
@@ -135,13 +137,16 @@ func runCallContractForInvalidContractAddress(evmClient evm.Client, runtime sdk.
 			Data: readBalancesCall,
 		},
 	}).Await()
-	runtime.Logger().Info("CallContract for invalid balance reader contract address completed", "output_data", readBalancesOutput.Data)
-	if err != nil || len(readBalancesOutput.Data) == 0 {
-		runtime.Logger().Error("got expected error for invalid balance reader contract address", "invalid_rb_address", invalidReadBalancesContractAddr.String(), "error", err, "output_data", readBalancesOutput.Data)
+	runtime.Logger().Info("CallContract for invalid balance reader contract address completed", "balance_reader_output", readBalancesOutput)
+	if err != nil || readBalancesOutput == nil {
+		runtime.Logger().Error("got expected error for invalid balance reader contract address", "invalid_rb_address", invalidReadBalancesContractAddr.String(), "balance_reader_output", readBalancesOutput, "error", err)
+		return nil, fmt.Errorf("failed to get balances for address '%s': %w", invalidReadBalancesContractAddr.String(), err)
+	} else if len(readBalancesOutput.Data) == 0 {
+		runtime.Logger().Error("got expected empty response for invalid balance reader contract address", "invalid_rb_address", invalidReadBalancesContractAddr.String(), "balance_reader_output", readBalancesOutput, "error", err)
 		return nil, fmt.Errorf("failed to get balances for address '%s': %w", invalidReadBalancesContractAddr.String(), err)
 	}
 
-	runtime.Logger().Info("this is not expected: reading from invalid balance reader contract address should return an error or empty response", "invalid_rb_address", invalidReadBalancesContractAddr.String(), "output", readBalancesOutput.Data)
+	runtime.Logger().Info("this is not expected: reading from invalid balance reader contract address should return an error or empty response", "invalid_rb_address", invalidReadBalancesContractAddr.String(), "balance_reader_output", readBalancesOutput)
 	return readBalancesOutput, nil
 }
 
@@ -287,4 +292,25 @@ func runGetTransactionByHashWithInvalidHash(client evm.Client, runtime sdk.Runti
 
 	runtime.Logger().Info("this is not expected: GetTransactionByHash with invalid hash should return an error or nil", "invalid_hash", invalidHash, "tx_by_hash_output", txByHashOutput)
 	return txByHashOutput, nil
+}
+
+// runGetTransactionReceiptWithInvalidHash tries to get transaction receipt using an invalid hash
+// it should return an error
+func runGetTransactionReceiptWithInvalidHash(client evm.Client, runtime sdk.Runtime, wfCfg config.Config) (*evm.GetTransactionReceiptReply, error) {
+	runtime.Logger().Info("Attempting to GetTransactionReceipt using invalid hash", "invalid_hash", wfCfg.InvalidInput)
+
+	// Convert the invalid input to bytes - this will handle various invalid formats
+	invalidHash := common.FromHex(wfCfg.InvalidInput)
+	runtime.Logger().Info("Starting GetTransactionReceipt request with parsed hash", "invalid_hash", invalidHash)
+	txReceiptOutput, err := client.GetTransactionReceipt(runtime, &evm.GetTransactionReceiptRequest{
+		Hash: invalidHash,
+	}).Await()
+	runtime.Logger().Info("GetTransactionReceipt completed", "tx_receipt_output", txReceiptOutput)
+	if err != nil || txReceiptOutput == nil {
+		runtime.Logger().Error("got expected error for GetTransactionReceipt with invalid hash", "invalid_hash", invalidHash, "tx_receipt_output", txReceiptOutput, "error", err)
+		return nil, fmt.Errorf("expected error for GetTransactionReceipt with invalid hash '%s': %w", invalidHash, err)
+	}
+
+	runtime.Logger().Info("this is not expected: GetTransactionReceipt with invalid hash should return an error or nil", "invalid_hash", invalidHash, "tx_receipt_output", txReceiptOutput)
+	return txReceiptOutput, nil
 }

--- a/system-tests/tests/regression/cre/v2_evm_regression_test.go
+++ b/system-tests/tests/regression/cre/v2_evm_regression_test.go
@@ -19,13 +19,14 @@ import (
 
 // regression
 const (
-	// ...Function methods should literally match the name of the switch-case statements in the workflow
+	// ...Function variables should literally match the name of the switch-case statements in the workflow (evm/evmread-negative/main.go)
+	// in each case the corresponding evm capability function is called with the invalid input
 	balanceAtFunction                          = "BalanceAt"
 	expectedBalanceAtError                     = "balanceAt errored"
 	callContractInvalidAddressToReadFunction   = "CallContract - invalid address to read"
 	expectedCallContractInvalidAddressToRead   = "balances=&[+0]" // expecting empty array of balances
 	callContractInvalidBRContractAddress       = "CallContract - invalid balance reader contract address"
-	expectedCallContractInvalidContractAddress = "got expected error for invalid balance reader contract address"
+	expectedCallContractInvalidContractAddress = "got expected empty response for invalid balance reader contract address"
 	estimateGasInvalidToAddress                = "EstimateGas - invalid 'to' address"
 	filterLogsInvalidAddresses                 = "FilterLogs - invalid addresses"
 	expectedFilterLogsInvalidAddresses         = "got expected error or empty logs"
@@ -34,7 +35,7 @@ const (
 	filterLogsInvalidToBlock                   = "FilterLogs - invalid ToBlock"
 	expectedFilterLogsInvalidToBlock           = "got expected error for FilterLogs with invalid toBlock"
 	getTransactionByHashInvalidHash            = "GetTransactionByHash - invalid hash"
-	expectedGetTransactionByHashInvalidHash    = "not found"
+	getTransactionReceiptInvalidHash           = "GetTransactionReceipt - invalid hash"
 )
 
 type evmNegativeTest struct {
@@ -70,14 +71,10 @@ var evmNegativeTestsCallContractInvalidAddressToRead = []evmNegativeTest{
 
 var evmNegativeTestsCallContractInvalidBalanceReaderContract = []evmNegativeTest{
 	// CallContract - invalid balance reader contract address
-	// TODO: Uncomment tests after https://smartcontract-it.atlassian.net/browse/CRE-943
-	// "empty" will default to the 0-address which is valid but has no contract deployed, so we expect an error.
-	// {"empty", "", callContractInvalidBRContractAddress, expectedCallContractInvalidContractAddress},
-	// {"a letter", "a", callContractInvalidBRContractAddress, expectedCallContractInvalidContractAddress},
-	// {"a symbol", "/", callContractInvalidBRContractAddress, expectedCallContractInvalidContractAddress},
+	{"empty", "", callContractInvalidBRContractAddress, "EVM error OpcodeNotFound"}, // equivalent to "0x", "0x0", we do not care if anything but contract may be at this address
+	{"a letter", "a", callContractInvalidBRContractAddress, "EVM error PrecompileError"},
+	{"a symbol", "/", callContractInvalidBRContractAddress, "EVM error OpcodeNotFound"},
 	{"a number", "1", callContractInvalidBRContractAddress, expectedCallContractInvalidContractAddress},
-	// {"empty hex", "0x", callContractInvalidBRContractAddress, expectedCallContractInvalidContractAddress}, // we do not care if anything but contract may be at this address
-	// {"cut hex", "0x0", callContractInvalidBRContractAddress, expectedCallContractInvalidContractAddress},  // we do not care if anything but contract may be at this address
 	{"short address", "0x123456789012345678901234567890123456789", callContractInvalidBRContractAddress, expectedCallContractInvalidContractAddress},
 	{"long address", "0x12345678901234567890123456789012345678901", callContractInvalidBRContractAddress, expectedCallContractInvalidContractAddress},
 	{"invalid address", "0x1234567890abcdefg1234567890abcdef123456", callContractInvalidBRContractAddress, expectedCallContractInvalidContractAddress},
@@ -145,6 +142,19 @@ var evmNegativeTestsGetTransactionByHashInvalidHash = []evmNegativeTest{
 	{"malformed (non-hex) correct length", "0x123gggggggggggggggggggggggggggggggggggggggggggggggggggggggggg", getTransactionByHashInvalidHash, "got 2 bytes, expected 32"}, // produces x01#
 	{"short hash", "0x647b7f17f9edba01d1f75ce071d0bc10173bc66b5d072f28b644275bf13bb99", getTransactionByHashInvalidHash, "RPC call failed: not found"},
 	{"non-existent hash", "0x1234567890123456789012345678901234567890123456789012345678901234", getTransactionByHashInvalidHash, "RPC call failed: not found"},
+}
+
+var evmNegativeTestsGetTransactionReceiptInvalidHash = []evmNegativeTest{
+	// GetTransactionReceipt - invalid hash (requires 32 bytes)
+	{"empty", "", getTransactionReceiptInvalidHash, "hash can't be nil"}, // equivalent to whitespace " "
+	{"a symbol", ";", getTransactionReceiptInvalidHash, "hash can't be nil"},
+	{"a char", "0xz", getTransactionReceiptInvalidHash, "hash can't be nil"},         // equivalent to any alfa-numeric string/character
+	{"null-0-like hex", "0x", getTransactionReceiptInvalidHash, "hash can't be nil"}, // equivalent to "0x0", empty
+	{"31 bytes (short) non-0x-prefixed", "12345678901234567890123456789012345678901234567890123456789012", getTransactionReceiptInvalidHash, "got 31 bytes, expected 32"},
+	{"33 bytes (long) non-0x-prefixed", "12345678901234567890123456789012345678901234567890123456789012345", getTransactionReceiptInvalidHash, "got 33 bytes, expected 32"},
+	{"malformed (non-hex) correct length", "0x123gggggggggggggggggggggggggggggggggggggggggggggggggggggggggg", getTransactionReceiptInvalidHash, "got 2 bytes, expected 32"}, // produces x01#
+	{"short hash", "0x647b7f17f9edba01d1f75ce071d0bc10173bc66b5d072f28b644275bf13bb99", getTransactionReceiptInvalidHash, "RPC call failed: not found"},
+	{"non-existent hash", "0x1234567890123456789012345678901234567890123456789012345678901234", getTransactionReceiptInvalidHash, "RPC call failed: not found"},
 }
 
 func EVMReadFailsTest(t *testing.T, testEnv *ttypes.TestEnvironment, evmNegativeTest evmNegativeTest) {


### PR DESCRIPTION
[CRE-915] Add negative system tests for evm capability getTransactionReceipts

[CRE-915]: https://smartcontract-it.atlassian.net/browse/CRE-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ