### PR TITLE
Bump run-e2e-tests for in-memory tests

### DIFF
--- a/.github/workflows/integration-in-memory-tests.yml
+++ b/.github/workflows/integration-in-memory-tests.yml
@@ -82,7 +82,7 @@ jobs:
       contents: read
     needs: changes
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5cf24eba2fef708acd6050f0f9a0397b2dabbfb8 # 2025-10-01
     with:
       workflow_name: Run CCIP Integration Tests For PR
       chainlink_version: ${{ inputs.cl_ref || github.sha }}
@@ -112,7 +112,7 @@ jobs:
       contents: read
     needs: changes
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5cf24eba2fef708acd6050f0f9a0397b2dabbfb8 # 2025-10.01
     with:
       workflow_name: Run CCIP Integration Tests For Merge Queue
       chainlink_version: ${{ inputs.cl_ref || github.sha }}

--- a/.github/workflows/integration-in-memory-tests.yml
+++ b/.github/workflows/integration-in-memory-tests.yml
@@ -112,7 +112,7 @@ jobs:
       contents: read
     needs: changes
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5cf24eba2fef708acd6050f0f9a0397b2dabbfb8 # 2025-10.01
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5cf24eba2fef708acd6050f0f9a0397b2dabbfb8 # 2025-10-01
     with:
       workflow_name: Run CCIP Integration Tests For Merge Queue
       chainlink_version: ${{ inputs.cl_ref || github.sha }}


### PR DESCRIPTION
### Description

This bumps `run-e2e-tests` workflow used for the in-memory tests to: https://github.com/smartcontractkit/.github/commit/5cf24eba2fef708acd6050f0f9a0397b2dabbfb8