### PR TITLE
fixing chain-selector config for Org Resolver service

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -112,6 +112,8 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/plugins"
 
 	linkingclient "github.com/smartcontractkit/chainlink-protos/linking-service/go/v1"
+
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 )
 
 // Application implements the common functions used in the core node.
@@ -1184,9 +1186,14 @@ func newCREServices(
 					var orgResolver orgresolver.OrgResolver
 					if cfg.CRE().Linking().URL() != "" {
 						// Convert chain selector from string to uint64
-						chainSelector, err2 := strconv.ParseUint(capCfg.WorkflowRegistry().ChainID(), 10, 64)
+						chainID, err2 := strconv.ParseUint(capCfg.WorkflowRegistry().ChainID(), 10, 64)
 						if err2 != nil {
-							return nil, fmt.Errorf("invalid workflow registry chain selector: %w", err2)
+							return nil, fmt.Errorf("invalid workflow registry chain ID: %w", err2)
+						}
+
+						chainSelector, selErr := chainselectors.SelectorFromChainId(chainID)
+						if selErr != nil {
+							return nil, fmt.Errorf("invalid workflow registry chain selector: %w", selErr)
 						}
 
 						orgResolverConfig := orgresolver.Config{


### PR DESCRIPTION
https://grafana.ops.prod.cldev.sh/goto/TKDd_x3Hg?orgId=1: external linking service can't fetch the org because we're passing in chain ID instead of chain selector.