### PR TITLE
[CRE-1023] Optimize beholder validator in system tests (part 1)

### DIFF
--- a/system-tests/tests/test-helpers/beholder_provider.go
+++ b/system-tests/tests/test-helpers/beholder_provider.go
@@ -21,6 +21,7 @@ const (
 	// Channel buffer sizes
 	messageChannelBufferSize = 20
 	errorChannelBufferSize   = 1
+	channelFullRetryTimeout  = 100 * time.Millisecond
 
 	// Kafka configuration
 	kafkaSessionTimeoutMs = 10000
@@ -28,7 +29,6 @@ const (
 
 	// Timing configuration
 	messageReadInterval = 50 * time.Millisecond
-	channelDrainTimeout = 2 * time.Second
 
 	// CloudEvents protobuf offset
 	protobufOffset = 6
@@ -93,6 +93,7 @@ func (b *Beholder) SubscribeToBeholderMessages(
 ) (<-chan proto.Message, <-chan error) {
 	kafkaErrChan := make(chan error, errorChannelBufferSize)
 	messageChan := make(chan proto.Message, messageChannelBufferSize)
+	readyChan := make(chan bool, 1)
 
 	// Start listening for messages in the background
 	go func() {
@@ -109,10 +110,34 @@ func (b *Beholder) SubscribeToBeholderMessages(
 
 		kafkaURL := b.cfg.ChipIngress.Output.RedPanda.KafkaExternalURL
 		topic := b.cfg.Kafka.Topics[0]
-		listenForKafkaMessages(ctx, b.lggr, kafkaURL, topic, messageTypes, messageChan, kafkaErrChan)
+		listenForKafkaMessages(ctx, b.lggr, kafkaURL, topic, messageTypes, messageChan, kafkaErrChan, readyChan)
 	}()
 
+	// Wait for consumer to be ready before returning channels
+	// This ensures proper coordination between consumer readiness and workflow execution
+	select {
+	case <-readyChan:
+		b.lggr.Info().Msg("Kafka consumer is ready and subscribed - safe to start workflow execution")
+	case <-time.After(15 * time.Second): // Increased timeout for CI environments
+		select {
+		case kafkaErrChan <- errors.New("timeout waiting for consumer to be ready"):
+		default:
+		}
+		b.lggr.Error().Msg("Timeout waiting for Kafka consumer to be ready - check broker connectivity")
+	case <-ctx.Done():
+		b.lggr.Info().Msg("Context cancelled while waiting for consumer readiness")
+	}
+
 	return messageChan, kafkaErrChan
+}
+
+// Helper function to get map keys for logging
+func getMapKeys(m map[string]func() proto.Message) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func listenForKafkaMessages(
@@ -123,8 +148,9 @@ func listenForKafkaMessages(
 	messageTypes map[string]func() proto.Message, // ce_type -> protobuf factory function
 	messageChan chan proto.Message, // channel to send deserialized messages
 	errChan chan<- error,
+	readyChan chan<- bool,
 ) {
-	logger.Info().Str("broker", brokerAddress).Str("topic", topic).Msg("Starting Kafka listener")
+	logger.Info().Str("broker", brokerAddress).Str("topic", topic).Msg("Starting Kafka listener with readiness signaling")
 
 	// Ensure channel is closed when function exits to prevent goroutine leaks
 	defer func() {
@@ -161,18 +187,25 @@ func listenForKafkaMessages(
 	startTime := time.Now()
 	logger.Info().Time("start_time", startTime).Msg("Consumer ready - will process messages from this point forward")
 
-	ticker := time.NewTicker(messageReadInterval) // Check every 100ms instead of tight loop
+	// Signal that consumer is ready - this is the key improvement for coordination
+	select {
+	case readyChan <- true:
+		logger.Info().Msg("Signaled consumer readiness - workflow execution can now begin safely")
+	default:
+		logger.Debug().Msg("Ready channel already signaled or closed")
+	}
+
+	ticker := time.NewTicker(messageReadInterval)
 	defer ticker.Stop()
 
 	interestedTypes := getMapKeys(messageTypes)
 	logger.Debug().Strs("interested_types", interestedTypes).Msg("Starting message listening loop")
 
-	// Start consuming messages
+	// Start consuming messages]
 	for {
 		select {
 		case <-ctx.Done():
-			logger.Warn().Msg("Context cancelled, draining remaining messages before stopping Kafka listener")
-			drainMessagesWithTimeout(logger, messageChan, channelDrainTimeout)
+			logger.Warn().Msg("Context cancelled, stopping Kafka listener")
 			return
 		case <-ticker.C:
 			msg, err := consumer.ReadMessage(kafkaReadTimeoutMs) // Non-blocking read
@@ -188,15 +221,15 @@ func listenForKafkaMessages(
 				return
 			}
 
-			// Check message timestamp to ensure it's from current listener session
-			// Only skip messages that are significantly older (more than 1 minute before start)
-			// This gives more flexibility while still filtering out truly stale messages
+			// More lenient timestamp filtering - only skip very old messages (30+ seconds)
 			msgTime := msg.Timestamp
-			if !msgTime.IsZero() && msgTime.Before(startTime.Add(-30*time.Second)) {
+			const oldMessageThreshold = 30 * time.Second
+			if !msgTime.IsZero() && msgTime.Before(startTime.Add(-oldMessageThreshold)) {
 				logger.Debug().
 					Time("msg_time", msgTime).
 					Time("start_time", startTime).
-					Msg("Skipping very old message from before listener start")
+					Dur("old_message_threshold", oldMessageThreshold).
+					Msg("Skipping old messages")
 				continue
 			}
 
@@ -257,41 +290,19 @@ func listenForKafkaMessages(
 			case messageChan <- message:
 				logger.Debug().Msg("Message sent to channel successfully")
 			case <-ctx.Done():
-				logger.Info().Msg("Context cancelled while sending message, draining remaining messages")
-				drainMessagesWithTimeout(logger, messageChan, channelDrainTimeout)
+				logger.Info().Msg("Context cancelled while sending message")
 				return
 			default:
-				logger.Warn().Msg("Message channel full, dropping message")
+				// Channel is full - try with a brief timeout instead of dropping immediately
+				select {
+				case messageChan <- message:
+					logger.Warn().Msg("Message sent to channel after brief delay (channel was full)")
+				case <-time.After(channelFullRetryTimeout):
+					logger.Error().Msg("Message channel full for too long, dropping message")
+				case <-ctx.Done():
+					return
+				}
 			}
-		}
-	}
-}
-
-// Helper function to get map keys for logging
-func getMapKeys(m map[string]func() proto.Message) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
-}
-
-// drainMessagesWithTimeout drains remaining messages from the channel with a timeout
-func drainMessagesWithTimeout(logger zerolog.Logger, messageChan chan proto.Message, timeout time.Duration) {
-	drainCtx, drainCancel := context.WithTimeout(context.Background(), timeout)
-	defer drainCancel()
-
-	drainedCount := 0
-	for {
-		select {
-		case <-messageChan:
-			drainedCount++
-		case <-drainCtx.Done():
-			logger.Info().Int("drained_messages", drainedCount).Msg("Finished draining messages (timeout reached)")
-			return
-		default:
-			logger.Info().Int("drained_messages", drainedCount).Msg("Finished draining messages (channel empty)")
-			return
 		}
 	}
 }

--- a/system-tests/tests/test-helpers/beholder_provider.go
+++ b/system-tests/tests/test-helpers/beholder_provider.go
@@ -126,8 +126,6 @@ func listenForKafkaMessages(
 	errChan chan<- error,
 ) {
 	logger.Info().Str("broker", brokerAddress).Str("topic", topic).Msg("Starting Kafka listener")
-	startTime := time.Now()
-	logger.Debug().Time("start_time", startTime).Msg("Listener start time - will process messages from this point forward")
 
 	// Ensure channel is closed when function exits to prevent goroutine leaks
 	defer func() {
@@ -135,11 +133,12 @@ func listenForKafkaMessages(
 		logger.Info().Msg("Listener message channel closed")
 	}()
 
-	// Configure Kafka consumer to start from latest messages (test start time)
+	// Configure Kafka consumer to start from earliest messages to avoid missing messages
+	// Use current time for unique group ID but start from earliest to catch all messages
 	kafkaConfig := &kafka.ConfigMap{
 		"bootstrap.servers":  brokerAddress,
-		"group.id":           fmt.Sprintf("workshop-listener-%d", startTime.Unix()), // Unique group per listener
-		"auto.offset.reset":  "latest",                                              // Start from latest messages, not earliest
+		"group.id":           fmt.Sprintf("workshop-listener-%d", time.Now().Unix()), // Unique group per listener
+		"auto.offset.reset":  "latest",                                               // Start from earliest messages to avoid missing messages
 		"session.timeout.ms": kafkaSessionTimeoutMs,
 		"enable.auto.commit": true,             // Commit messages after processing
 		"isolation.level":    "read_committed", // Only read committed messages
@@ -160,7 +159,11 @@ func listenForKafkaMessages(
 		return
 	}
 
-	logger.Info().Str("topic", topic).Msg("Subscribed to topic (consuming from latest offset)")
+	logger.Info().Str("topic", topic).Msg("Subscribed to topic (consuming from earliest offset)")
+
+	// Record start time AFTER consumer is ready to avoid race condition
+	startTime := time.Now()
+	logger.Debug().Time("start_time", startTime).Msg("Consumer ready - will process messages from this point forward")
 
 	ticker := time.NewTicker(messageReadInterval) // Check every 100ms instead of tight loop
 	defer ticker.Stop()
@@ -190,12 +193,14 @@ func listenForKafkaMessages(
 			}
 
 			// Check message timestamp to ensure it's from current listener session
+			// Only skip messages that are significantly older (more than 1 minute before start)
+			// This gives more flexibility while still filtering out truly stale messages
 			msgTime := msg.Timestamp
-			if !msgTime.IsZero() && msgTime.Before(startTime) {
+			if !msgTime.IsZero() && msgTime.Before(startTime.Add(-30*time.Second)) {
 				logger.Debug().
 					Time("msg_time", msgTime).
 					Time("start_time", startTime).
-					Msg("Skipping old message from before listener start")
+					Msg("Skipping very old message from before listener start")
 				continue
 			}
 

--- a/system-tests/tests/test-helpers/beholder_provider.go
+++ b/system-tests/tests/test-helpers/beholder_provider.go
@@ -19,7 +19,7 @@ import (
 // Constants for configuration
 const (
 	// Channel buffer sizes
-	messageChannelBufferSize = 10
+	messageChannelBufferSize = 20
 	errorChannelBufferSize   = 1
 
 	// Kafka configuration
@@ -27,9 +27,8 @@ const (
 	kafkaReadTimeoutMs    = 0 // Non-blocking read
 
 	// Timing configuration
-	messageReadInterval      = 100 * time.Millisecond
-	channelDrainTimeout      = 5 * time.Second
-	channelDrainTimeoutShort = 2 * time.Second
+	messageReadInterval = 50 * time.Millisecond
+	channelDrainTimeout = 2 * time.Second
 
 	// CloudEvents protobuf offset
 	protobufOffset = 6
@@ -133,12 +132,10 @@ func listenForKafkaMessages(
 		logger.Info().Msg("Listener message channel closed")
 	}()
 
-	// Configure Kafka consumer to start from earliest messages to avoid missing messages
-	// Use current time for unique group ID but start from earliest to catch all messages
 	kafkaConfig := &kafka.ConfigMap{
 		"bootstrap.servers":  brokerAddress,
 		"group.id":           fmt.Sprintf("workshop-listener-%d", time.Now().Unix()), // Unique group per listener
-		"auto.offset.reset":  "latest",                                               // Start from earliest messages to avoid missing messages
+		"auto.offset.reset":  "latest",
 		"session.timeout.ms": kafkaSessionTimeoutMs,
 		"enable.auto.commit": true,             // Commit messages after processing
 		"isolation.level":    "read_committed", // Only read committed messages
@@ -150,8 +147,7 @@ func listenForKafkaMessages(
 		return
 	}
 	defer consumer.Close()
-
-	logger.Debug().Msg("Kafka consumer created successfully")
+	logger.Info().Msg("Kafka consumer created successfully")
 
 	err = consumer.Subscribe(topic, nil)
 	if err != nil {
@@ -159,23 +155,23 @@ func listenForKafkaMessages(
 		return
 	}
 
-	logger.Info().Str("topic", topic).Msg("Subscribed to topic (consuming from earliest offset)")
+	logger.Info().Str("topic", topic).Msg("Subscribed to topic (consuming from latest offset)")
 
 	// Record start time AFTER consumer is ready to avoid race condition
 	startTime := time.Now()
-	logger.Debug().Time("start_time", startTime).Msg("Consumer ready - will process messages from this point forward")
+	logger.Info().Time("start_time", startTime).Msg("Consumer ready - will process messages from this point forward")
 
 	ticker := time.NewTicker(messageReadInterval) // Check every 100ms instead of tight loop
 	defer ticker.Stop()
 
 	interestedTypes := getMapKeys(messageTypes)
-	logger.Info().Strs("interested_types", interestedTypes).Msg("Starting message listening loop")
+	logger.Debug().Strs("interested_types", interestedTypes).Msg("Starting message listening loop")
 
 	// Start consuming messages
 	for {
 		select {
 		case <-ctx.Done():
-			logger.Info().Msg("Context cancelled, draining remaining messages before stopping Kafka listener")
+			logger.Warn().Msg("Context cancelled, draining remaining messages before stopping Kafka listener")
 			drainMessagesWithTimeout(logger, messageChan, channelDrainTimeout)
 			return
 		case <-ticker.C:
@@ -262,7 +258,7 @@ func listenForKafkaMessages(
 				logger.Debug().Msg("Message sent to channel successfully")
 			case <-ctx.Done():
 				logger.Info().Msg("Context cancelled while sending message, draining remaining messages")
-				drainMessagesWithTimeout(logger, messageChan, channelDrainTimeoutShort)
+				drainMessagesWithTimeout(logger, messageChan, channelDrainTimeout)
 				return
 			default:
 				logger.Warn().Msg("Message channel full, dropping message")

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -152,26 +152,30 @@ func StartBeholder(t *testing.T, testLogger zerolog.Logger, testEnv *ttypes.Test
 
 	beholderMsgChan, beholderErrChan := beholder.SubscribeToBeholderMessages(listenerCtx, messageTypes)
 
-	// Wait to allow Beholder to fully initialize, it helps to avoid flakiness in tests
-	initTimeout := 5 * time.Second
-	testLogger.Info().Dur("timeout", initTimeout).Msg("Forcefully waiting for Beholder to warm up...")
+	// Reduced initialization timeout to minimize window for legitimate messages to be discarded
+	initTimeout := 2 * time.Second
+	testLogger.Info().Dur("timeout", initTimeout).Msg("Waiting for Beholder to warm up...")
 	time.Sleep(initTimeout)
 
-	drainChannels(listenerCtx, t, testLogger, beholderMsgChan, beholderErrChan) // drain any messages that arrived during initialization
+	// Only drain channels if we detect stale messages from before consumer was ready
+	// This is more conservative to avoid discarding legitimate test messages
+	testLogger.Info().Msg("Performing conservative channel drain to remove only pre-consumer messages...")
+	drainChannelsConservatively(listenerCtx, t, testLogger, beholderMsgChan, beholderErrChan)
 
 	return listenerCtx, beholderMsgChan, beholderErrChan
 }
 
-// Drains any remaining messages from the channels to avoid processing stale messages
-func drainChannels(ctx context.Context, t *testing.T, testLogger zerolog.Logger, messageChan <-chan proto.Message, kafkaErrChan <-chan error) {
+// Conservative channel draining that only removes messages for a short period
+// to avoid discarding legitimate test messages
+func drainChannelsConservatively(ctx context.Context, t *testing.T, testLogger zerolog.Logger, messageChan <-chan proto.Message, kafkaErrChan <-chan error) {
 	t.Helper()
 
-	testLogger.Info().Msg("Starting async drain of Beholder channels for stale messages...")
+	testLogger.Debug().Msg("Starting drain of Beholder channels...")
 	msgCount := 0
 	errCount := 0
 
-	// Drain messages for up to 500ms
-	drainTimeout := time.After(500 * time.Millisecond)
+	// Much shorter drain timeout to be more conservative
+	drainTimeout := time.After(200 * time.Millisecond)
 
 	for {
 		select {
@@ -179,22 +183,22 @@ func drainChannels(ctx context.Context, t *testing.T, testLogger zerolog.Logger,
 			msgCount++
 			switch msg.(type) {
 			case *workflowevents.UserLogs:
-				testLogger.Debug().Msg("Drained UserLogs message")
+				testLogger.Warn().Msg("drained UserLogs message (likely stale)")
 			case *commonevents.BaseMessage:
-				testLogger.Debug().Msg("Drained BaseMessage")
+				testLogger.Warn().Msg("drained BaseMessage (likely stale)")
 			default:
-				testLogger.Debug().Msgf("Drained unknown message type: %T", msg)
+				testLogger.Warn().Msgf("drained unknown message type: %T (likely stale)", msg)
 			}
 
 		case err := <-kafkaErrChan:
 			errCount++
-			testLogger.Debug().Err(err).Msg("Drained error message")
+			testLogger.Debug().Err(err).Msg("drained error message")
 
 		case <-drainTimeout:
 			if msgCount > 0 || errCount > 0 {
-				testLogger.Info().Int("messages_drained", msgCount).Int("errors_drained", errCount).Msg("Finished draining Beholder channels")
+				testLogger.Warn().Int("messages_drained", msgCount).Int("errors_drained", errCount).Msg("Finished draining of Beholder channels")
 			} else {
-				testLogger.Info().Msg("No stale Beholder messages found in channels")
+				testLogger.Info().Msg("No stale Beholder messages found during drain")
 			}
 			return
 		}

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -152,57 +152,11 @@ func StartBeholder(t *testing.T, testLogger zerolog.Logger, testEnv *ttypes.Test
 
 	beholderMsgChan, beholderErrChan := beholder.SubscribeToBeholderMessages(listenerCtx, messageTypes)
 
-	// Reduced initialization timeout to minimize window for legitimate messages to be discarded
-	initTimeout := 2 * time.Second
-	testLogger.Info().Dur("timeout", initTimeout).Msg("Waiting for Beholder to warm up...")
-	time.Sleep(initTimeout)
-
-	// Only drain channels if we detect stale messages from before consumer was ready
-	// This is more conservative to avoid discarding legitimate test messages
-	testLogger.Info().Msg("Performing conservative channel drain to remove only pre-consumer messages...")
-	drainChannelsConservatively(listenerCtx, t, testLogger, beholderMsgChan, beholderErrChan)
+	// No more draining - let all messages through for processing
+	// The consumer is ready and any messages received are legitimate
+	testLogger.Info().Msg("Beholder listener ready - all messages will be processed")
 
 	return listenerCtx, beholderMsgChan, beholderErrChan
-}
-
-// Conservative channel draining that only removes messages for a short period
-// to avoid discarding legitimate test messages
-func drainChannelsConservatively(ctx context.Context, t *testing.T, testLogger zerolog.Logger, messageChan <-chan proto.Message, kafkaErrChan <-chan error) {
-	t.Helper()
-
-	testLogger.Debug().Msg("Starting drain of Beholder channels...")
-	msgCount := 0
-	errCount := 0
-
-	// Much shorter drain timeout to be more conservative
-	drainTimeout := time.After(200 * time.Millisecond)
-
-	for {
-		select {
-		case msg := <-messageChan:
-			msgCount++
-			switch msg.(type) {
-			case *workflowevents.UserLogs:
-				testLogger.Warn().Msg("drained UserLogs message (likely stale)")
-			case *commonevents.BaseMessage:
-				testLogger.Warn().Msg("drained BaseMessage (likely stale)")
-			default:
-				testLogger.Warn().Msgf("drained unknown message type: %T (likely stale)", msg)
-			}
-
-		case err := <-kafkaErrChan:
-			errCount++
-			testLogger.Debug().Err(err).Msg("drained error message")
-
-		case <-drainTimeout:
-			if msgCount > 0 || errCount > 0 {
-				testLogger.Warn().Int("messages_drained", msgCount).Int("errors_drained", errCount).Msg("Finished draining of Beholder channels")
-			} else {
-				testLogger.Info().Msg("No stale Beholder messages found during drain")
-			}
-			return
-		}
-	}
 }
 
 /*


### PR DESCRIPTION
[CRE-1023](https://smartcontract-it.atlassian.net/browse/CRE-1023) Optimize beholder validator in system tests (part 1)

- Improved performance with no more delays, drains, or waits...
- Increased `messageChannelBufferSize` 2x, from 10 to 20, to handle more concurrent messages
- Reduced `messageReadInterval` from 100ms to 50ms for faster message processing
- Added a new `readyChan` parameter to signal when Kafka consumer is fully ready. The calling code waits for this signal before proceeding.
- The `SubscribeToBeholderMessages` function now waits for the consumer to be ready before returning channels.
- Included a 15-second timeout for CI environments where consumer startup might be slower.
- If the consumer isn't ready within the timeout, an error is sent to the error channel.
- When the message channel is exhausted, it now tries a brief 100ms timeout instead of immediately dropping messages.
- Added more detailed logs for debugging consumer readiness and message flow.
- Removed the complex `drainMessagesWithTimeout` logic and related timeout constants.
- Eliminated the 5-second `time.Sleep()` used to "warm up" Beholder.
- Completely removed the `drainChannels` function used to clear "stale" messages.

[CRE-1023]: https://smartcontract-it.atlassian.net/browse/CRE-1023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ