### PR TITLE
Revert "refactor: update tokens changesets to use the testing framework engine (#19626)"

### DIFF
--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -393,7 +393,6 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/scylladb/go-reflectx v1.0.1 // indirect
-	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/shirou/gopsutil/v3 v3.24.3 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.6 // indirect

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1288,8 +1288,6 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/scylladb/go-reflectx v1.0.1 h1:b917wZM7189pZdlND9PbIJ6NQxfDPfBvUaQ7cjj1iZQ=
 github.com/scylladb/go-reflectx v1.0.1/go.mod h1:rWnOfDIRWBGN0miMLIcoPt/Dhi2doCMZqwMCJ3KupFc=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
-github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sethvargo/go-retry v0.2.4 h1:T+jHEQy/zKJf5s95UkguisicE0zuF9y7+/vgz08Ocec=

--- a/deployment/tokens/changesets/deploy_sol_link_tokens_test.go
+++ b/deployment/tokens/changesets/deploy_sol_link_tokens_test.go
@@ -6,13 +6,14 @@ import (
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
-	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/tokens/internal/ops"
 )
 
@@ -161,30 +162,27 @@ func Test_DeploySolLinkTokens_Apply(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			programsPath := t.TempDir() // We don't need programs in here to deploy the token
-
-			rt, err := runtime.New(t.Context(),
-				runtime.WithEnvOpts(
-					environment.WithSolanaContainerN(t, 1, programsPath, map[string]string{}),
-				),
+			var (
+				lggr = logger.Test(t)
+				e    = memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
+					SolChains: 1,
+				})
+				cs = deploySolLinkTokens{}
 			)
-			require.NoError(t, err)
 
-			err = rt.Exec(
-				runtime.ChangesetTask(DeploySolLinkTokens, tt.giveFunc(rt.Environment())),
-			)
+			got, err := cs.Apply(e, tt.giveFunc(e))
 			require.NoError(t, err)
 
 			// Check that the address book has the link token contract for each chain
-			for _, csel := range rt.Environment().BlockChains.ListChainSelectors() {
-				addrBookByChain, err := rt.State().AddressBook.AddressesForChain(csel)
+			for _, csel := range e.BlockChains.ListChainSelectors() {
+				addrBookByChain, err := got.AddressBook.AddressesForChain(csel) //nolint:staticcheck // Will be removed once the address book is no longer required.
 				require.NoError(t, err)
 				require.NotEmpty(t, addrBookByChain)
 				require.Len(t, addrBookByChain, 1)
 			}
 
 			// Check the address book has the link token contract for each chain
-			addrRefs, err := rt.State().DataStore.Addresses().Fetch()
+			addrRefs, err := got.DataStore.Addresses().Fetch()
 			require.NoError(t, err)
 			require.Len(t, addrRefs, 1)
 		})

--- a/deployment/tokens/internal/ops/ops_evm_test.go
+++ b/deployment/tokens/internal/ops/ops_evm_test.go
@@ -6,16 +6,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	chainevm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
-	chainevmprovider "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations/optest"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func Test_OpEVMDeployLinkToken(t *testing.T) {
 	t.Parallel()
 
 	var (
+		chainID       uint64 = 11155111
 		chainSelector uint64 = 16015286601757825753
 	)
 
@@ -48,18 +49,13 @@ func Test_OpEVMDeployLinkToken(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			prov := chainevmprovider.NewSimChainProvider(
-				t, chainSelector, chainevmprovider.SimChainProviderConfig{},
-			)
-			blockchain, err := prov.Initialize(t.Context())
-			require.NoError(t, err)
-
-			chain, ok := blockchain.(chainevm.Chain)
-			require.True(t, ok)
-
 			var (
-				auth = chain.DeployerKey
-				deps = OpEVMDeployLinkTokenDeps{
+				chains = cldf_chain.NewBlockChainsFromSlice(
+					memory.NewMemoryChainsEVMWithChainIDs(t, []uint64{chainID}, 1),
+				).EVMChains()
+				chain = chains[chainSelector]
+				auth  = chain.DeployerKey
+				deps  = OpEVMDeployLinkTokenDeps{
 					Auth:        auth,
 					Backend:     chain.Client,
 					ConfirmFunc: chain.Confirm,

--- a/deployment/tokens/internal/seqs/seq_deploy_evm_tokens_test.go
+++ b/deployment/tokens/internal/seqs/seq_deploy_evm_tokens_test.go
@@ -7,18 +7,19 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
-	chainevm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
-	chainevmprovider "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations/optest"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func Test_SeqDeployEVMTokens(t *testing.T) {
 	t.Parallel()
 
 	var (
+		chainID       = chain_selectors.ETHEREUM_TESTNET_SEPOLIA.EvmChainID
 		chainSelector = chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector
 	)
 
@@ -58,22 +59,17 @@ func Test_SeqDeployEVMTokens(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			prov := chainevmprovider.NewSimChainProvider(
-				t, chainSelector, chainevmprovider.SimChainProviderConfig{},
-			)
-			blockchain, err := prov.Initialize(t.Context())
-			require.NoError(t, err)
-
-			chain, ok := blockchain.(chainevm.Chain)
-			require.True(t, ok)
-
 			var (
 				ab = cldf.NewMemoryAddressBook()
 				ds = datastore.NewMemoryDataStore()
 
+				chains = cldf_chain.NewBlockChainsFromSlice(
+					memory.NewMemoryChainsEVMWithChainIDs(t, []uint64{chainID}, 1),
+				).EVMChains()
+
 				b    = optest.NewBundle(t)
 				deps = SeqDeployEVMTokensDeps{
-					EVMChains: map[uint64]chainevm.Chain{chainSelector: chain},
+					EVMChains: chains,
 					AddrBook:  ab,
 					Datastore: ds,
 				}

--- a/deployment/tokens/internal/seqs/seq_deploy_solana_tokens_test.go
+++ b/deployment/tokens/internal/seqs/seq_deploy_solana_tokens_test.go
@@ -2,21 +2,18 @@ package seqs
 
 import (
 	"fmt"
-	"sync"
 	"testing"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
-	chainsol "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
-	chainsolprovider "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana/provider"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations/optest"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
-
-var once sync.Once
 
 func Test_SeqDeploySolTokens(t *testing.T) {
 	t.Parallel()
@@ -27,19 +24,7 @@ func Test_SeqDeploySolTokens(t *testing.T) {
 
 	// Boots up a Solana testing chain in a container. This is done outside of the tests to
 	// avoid booting up the container for each test.
-	prov := chainsolprovider.NewCTFChainProvider(
-		t, chainSelector, chainsolprovider.CTFChainProviderConfig{
-			DeployerKeyGen: chainsolprovider.PrivateKeyRandom(),
-			Once:           &once,
-			ProgramsPath:   t.TempDir(),
-			ProgramIDs:     map[string]string{},
-		},
-	)
-	blockchain, err := prov.Initialize(t.Context())
-	require.NoError(t, err)
-
-	chain, ok := blockchain.(chainsol.Chain)
-	require.True(t, ok)
+	chains := cldf_chain.NewBlockChainsFromSlice(memory.NewMemoryChainsSol(t, 1, "")).SolanaChains()
 
 	tests := []struct {
 		name               string
@@ -86,7 +71,7 @@ func Test_SeqDeploySolTokens(t *testing.T) {
 
 				b    = optest.NewBundle(t)
 				deps = SeqDeploySolTokensDeps{
-					SolChains: map[uint64]chainsol.Chain{chainSelector: chain},
+					SolChains: chains,
 					AddrBook:  ab,
 					Datastore: ds,
 				}


### PR DESCRIPTION
This reverts commit `aa86ac2a53d0e006a53f23e99bf114b450f46f94`.


Reverts change introduced in #19626 as it is causing build errors.

### Notes

Tried bumping to v0.53.0 of `chainlink-deployments-framework` but that is causing test errors (#19690).

This is failing builds on develop and in merge queue:

```
# github.com/smartcontractkit/chainlink/deployment/tokens/changesets [github.com/smartcontractkit/chainlink/deployment/tokens/changesets.test]
Error: tokens/changesets/deploy_evm_link_tokens_test.go:165:23: undefined: runtime.New
Error: tokens/changesets/deploy_evm_link_tokens_test.go:166:13: undefined: runtime.WithEnvOpts
Error: tokens/changesets/deploy_sol_link_tokens_test.go:166:23: undefined: runtime.New
Error: tokens/changesets/deploy_sol_link_tokens_test.go:167:13: undefined: runtime.WithEnvOpts
```

This was able to be merged because go didn't invalidate the build/test cache when it clearly should have:

https://github.com/smartcontractkit/chainlink/actions/runs/18140475190/job/51629843700#step:15:298
```
github.com/smartcontractkit/chainlink/deployment/tokens/changesets	(cached)
```

We have seen similar problems before, this is a rare occurrence. Sometimes this is because the files are the same size before and after the change. 


