### PR TITLE
chore: update vault tests to use the CLDF test engine

### DIFF
--- a/deployment/vault/changeset/batch_native_transfer_test.go
+++ b/deployment/vault/changeset/batch_native_transfer_test.go
@@ -1,24 +1,23 @@
 package changeset
 
 import (
+	"crypto/ecdsa"
 	"fmt"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/vault/changeset/types"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 const (
@@ -37,12 +36,10 @@ var (
 )
 
 func TestBatchNativeTransferValidation(t *testing.T) {
-	lggr := logger.TestLogger(t)
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 0,
-	})
-	// Ensure a non-nil datastore for validation that inspects whitelist state
-	env.DataStore = datastore.NewMemoryDataStore().Seal()
+	t.Parallel()
+
+	env, err := environment.New(t.Context())
+	require.NoError(t, err)
 
 	tests := []struct {
 		name      string
@@ -108,7 +105,9 @@ func TestBatchNativeTransferValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateBatchNativeTransferConfig(env.GetContext(), env, tt.config)
+			t.Parallel()
+
+			err := ValidateBatchNativeTransferConfig(env.GetContext(), *env, tt.config)
 
 			if tt.wantError {
 				require.Error(t, err)
@@ -123,10 +122,10 @@ func TestBatchNativeTransferValidation(t *testing.T) {
 }
 
 func TestSetWhitelist(t *testing.T) {
-	lggr := logger.TestLogger(t)
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 0,
-	})
+	t.Parallel()
+
+	rt, err := runtime.New(t.Context())
+	require.NoError(t, err)
 
 	initialConfig := types.SetWhitelistConfig{
 		WhitelistByChain: map[uint64][]types.WhitelistAddress{
@@ -145,13 +144,13 @@ func TestSetWhitelist(t *testing.T) {
 		},
 	}
 
-	output, err := SetWhitelistChangeset.Apply(env, initialConfig)
+	initialTask := runtime.ChangesetTask(SetWhitelistChangeset, initialConfig)
+	err = rt.Exec(initialTask)
+
 	require.NoError(t, err)
-	require.NotNil(t, output.DataStore)
+	require.NotNil(t, rt.State().Outputs[initialTask.ID()].DataStore)
 
-	env.DataStore = output.DataStore.Seal()
-
-	whitelist, err := GetWhitelistedAddresses(env, []uint64{testChainID})
+	whitelist, err := GetWhitelistedAddresses(rt.Environment(), []uint64{testChainID})
 	require.NoError(t, err)
 	require.Len(t, whitelist[testChainID], 2)
 
@@ -168,13 +167,13 @@ func TestSetWhitelist(t *testing.T) {
 		},
 	}
 
-	output2, err := SetWhitelistChangeset.Apply(env, updatedConfig)
+	removeTask := runtime.ChangesetTask(SetWhitelistChangeset, updatedConfig)
+	err = rt.Exec(removeTask)
+
 	require.NoError(t, err)
-	require.NotNil(t, output2.DataStore)
+	require.NotNil(t, rt.State().Outputs[removeTask.ID()].DataStore)
 
-	env.DataStore = output2.DataStore.Seal()
-
-	updatedWhitelist, err := GetWhitelistedAddresses(env, []uint64{testChainID})
+	updatedWhitelist, err := GetWhitelistedAddresses(rt.Environment(), []uint64{testChainID})
 	require.NoError(t, err)
 	require.Len(t, updatedWhitelist[testChainID], 1)
 	require.Equal(t, testAddr2, updatedWhitelist[testChainID][0].Address)
@@ -182,40 +181,41 @@ func TestSetWhitelist(t *testing.T) {
 
 func TestBatchNativeTransferIntegration(t *testing.T) {
 	t.Parallel()
-	lggr := logger.TestLogger(t)
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 2,
-	})
-
-	chainSelectors := make([]uint64, 0)
-	for chainSel := range env.BlockChains.EVMChains() {
-		chainSelectors = append(chainSelectors, chainSel)
-	}
-	require.Len(t, chainSelectors, 2, "Need 2 chains for testing")
 
 	t.Run("full workflow with MCMS setup", func(t *testing.T) {
-		env = setupMCMSInfrastructure(t, env, chainSelectors)
-		fundDeployerAccounts(t, env, chainSelectors)
-		env = setupWhitelist(t, env, chainSelectors...)
-		env = fundTimelockContracts(t, env, chainSelectors...)
-		executeBatchTransfersWithMCMS(t, env, chainSelectors...)
+		rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+			environment.WithEVMSimulatedN(t, 2),
+		))
+		require.NoError(t, err)
+
+		chainSelectors := make([]uint64, 0)
+		for chainSel := range rt.Environment().BlockChains.EVMChains() {
+			chainSelectors = append(chainSelectors, chainSel)
+		}
+		require.Len(t, chainSelectors, 2, "Need 2 chains for testing")
+
+		setupMCMSInfrastructure(t, rt, chainSelectors)
+		fundDeployerAccounts(t, rt.Environment(), chainSelectors)
+		setupWhitelist(t, rt, chainSelectors...)
+		fundTimelockContracts(t, rt, chainSelectors...)
+		executeBatchTransfersWithMCMS(t, rt, chainSelectors...)
 	})
 
 	t.Run("direct execution without MCMS", func(t *testing.T) {
-		lggr := logger.TestLogger(t)
-		env := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-			Chains: 2,
-		})
-		chainSelectors := getChainSelectors(env)
+		rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+			environment.WithEVMSimulatedN(t, 2),
+		))
+		require.NoError(t, err)
+
+		chainSelectors := getChainSelectors(rt.Environment())
 		testChain := chainSelectors[0]
-		env = setupWhitelist(t, env, testChain)
-		executeDirectTransfers(t, env, testChain)
+		setupWhitelist(t, rt, testChain)
+		executeDirectTransfers(t, rt, testChain)
 	})
 }
 
-func setupMCMSInfrastructure(t *testing.T, env cldf.Environment, chainSelectors []uint64) cldf.Environment {
-	lggr := env.Logger
-	lggr.Info("Setting up MCMS infrastructure with real deployment")
+func setupMCMSInfrastructure(t *testing.T, rt *runtime.Runtime, chainSelectors []uint64) {
+	t.Log("Setting up MCMS infrastructure with real deployment")
 
 	timelockCfgs := make(map[uint64]commontypes.MCMSWithTimelockConfigV2)
 	for _, sel := range chainSelectors {
@@ -223,8 +223,8 @@ func setupMCMSInfrastructure(t *testing.T, env cldf.Environment, chainSelectors 
 		timelockCfgs[sel] = proposalutils.SingleGroupTimelockConfigV2(t)
 	}
 
-	updatedEnv, err := commonchangeset.Apply(t, env,
-		commonchangeset.Configure(
+	err := rt.Exec(
+		runtime.ChangesetTask(
 			cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
 			timelockCfgs,
 		),
@@ -232,23 +232,21 @@ func setupMCMSInfrastructure(t *testing.T, env cldf.Environment, chainSelectors 
 	require.NoError(t, err)
 
 	for _, chainSel := range chainSelectors {
-		timelockAddr, err := GetContractAddress(updatedEnv.DataStore, chainSel, commontypes.RBACTimelock)
+		timelockAddr, err := GetContractAddress(rt.State().DataStore, chainSel, commontypes.RBACTimelock)
 		require.NoError(t, err)
-		lggr.Infow("Timelock deployed", "chain", chainSel, "address", timelockAddr)
+		t.Logf("Timelock deployed on chain %d with address %s", chainSel, timelockAddr)
 
-		proposerAddr, err := GetContractAddress(updatedEnv.DataStore, chainSel, commontypes.ProposerManyChainMultisig)
+		proposerAddr, err := GetContractAddress(rt.State().DataStore, chainSel, commontypes.ProposerManyChainMultisig)
 		require.NoError(t, err)
-		lggr.Infow("Proposer deployed", "chain", chainSel, "address", proposerAddr)
+		t.Logf("Proposer deployed on chain %d with address %s", chainSel, proposerAddr)
 	}
 
-	lggr.Info("MCMS deployment completed successfully")
-	return updatedEnv
+	t.Log("MCMS deployment completed successfully")
 }
 
 // fundDeployerAccounts ensures deployer accounts have sufficient native tokens
 func fundDeployerAccounts(t *testing.T, env cldf.Environment, chainSelectors []uint64) {
-	lggr := env.Logger
-	lggr.Info("Funding deployer accounts")
+	t.Log("Funding deployer accounts")
 
 	for _, chainSel := range chainSelectors {
 		chain := env.BlockChains.EVMChains()[chainSel]
@@ -259,13 +257,12 @@ func fundDeployerAccounts(t *testing.T, env cldf.Environment, chainSelectors []u
 		minBalance := HundredETH
 		require.GreaterOrEqual(t, balance.Cmp(minBalance), 0, "Deployer account has insufficient balance on chain %d: balance=%s, required=%s", chainSel, balance.String(), minBalance.String())
 
-		lggr.Infow("Deployer account funded", "chain", chainSel, "balance", balance.String())
+		t.Logf("Deployer account funded on chain %d with balance %s", chainSel, balance.String())
 	}
 }
 
-func setupWhitelist(t *testing.T, env cldf.Environment, chainSelectors ...uint64) cldf.Environment {
-	lggr := env.Logger
-	lggr.Info("Setting up whitelist")
+func setupWhitelist(t *testing.T, rt *runtime.Runtime, chainSelectors ...uint64) {
+	t.Log("Setting up whitelist")
 
 	whitelistByChain := make(map[uint64][]types.WhitelistAddress)
 
@@ -297,31 +294,23 @@ func setupWhitelist(t *testing.T, env cldf.Environment, chainSelectors ...uint64
 		WhitelistByChain: whitelistByChain,
 	}
 
-	output, err := SetWhitelistChangeset.Apply(env, whitelistConfig)
-	require.NoError(t, err)
-	require.NotNil(t, output.DataStore)
+	setTask := runtime.ChangesetTask(SetWhitelistChangeset, whitelistConfig)
+	err := rt.Exec(setTask)
 
-	// Merge the new whitelist DataStore with existing DataStore (which contains MCMS addresses)
-	mergedDS := datastore.NewMemoryDataStore()
-	err = mergedDS.Merge(env.DataStore)
 	require.NoError(t, err)
-	err = mergedDS.Merge(output.DataStore.Seal())
-	require.NoError(t, err)
-
-	env.DataStore = mergedDS.Seal()
+	require.NotNil(t, rt.State().Outputs[setTask.ID()].DataStore)
 
 	totalAddresses := 0
 	for _, addresses := range whitelistByChain {
 		totalAddresses += len(addresses)
 	}
-	lggr.Infow("Whitelist configured", "chains", len(whitelistByChain), "total_addresses", totalAddresses)
-	return env
+
+	t.Logf("Whitelist configured | chains: %d, total_addresses: %d", len(whitelistByChain), totalAddresses)
 }
 
 // fundTimelockContracts funds timelock contracts with native tokens
-func fundTimelockContracts(t *testing.T, env cldf.Environment, chainSelectors ...uint64) cldf.Environment {
-	lggr := env.Logger
-	lggr.Info("Funding timelock contracts")
+func fundTimelockContracts(t *testing.T, rt *runtime.Runtime, chainSelectors ...uint64) {
+	t.Log("Funding timelock contracts")
 
 	fundingConfig := types.FundTimelockConfig{
 		FundingByChain: make(map[uint64]*big.Int),
@@ -329,31 +318,39 @@ func fundTimelockContracts(t *testing.T, env cldf.Environment, chainSelectors ..
 
 	fundingAmount := TenETH
 
-	timelockBalances, err := GetTimelockBalances(env, chainSelectors)
+	timelockBalances, err := GetTimelockBalances(rt.Environment(), chainSelectors)
 	require.NoError(t, err, "Failed to get timelock balances - contracts may not be deployed")
 
 	for _, chainSel := range chainSelectors {
 		balance, exists := timelockBalances[chainSel]
 		require.True(t, exists, "Timelock balance info not found for chain %d", chainSel)
-		lggr.Infow("Found timelock to fund", "chain", chainSel, "address", balance.TimelockAddr, "current_balance", balance.Balance.String())
+		t.Logf("Found timelock to fund on chain %d with address %s and current balance %s", chainSel, balance.TimelockAddr, balance.Balance.String())
 
 		fundingConfig.FundingByChain[chainSel] = fundingAmount
 	}
 
-	output, err := FundTimelockChangeset.Apply(env, fundingConfig)
+	err = rt.Exec(
+		runtime.ChangesetTask(FundTimelockChangeset, fundingConfig),
+	)
+
 	require.NoError(t, err)
 
-	if output.DataStore != nil {
-		env.DataStore = output.DataStore.Seal()
+	timelockBalances, err = GetTimelockBalances(rt.Environment(), chainSelectors)
+	require.NoError(t, err, "Failed to get timelock balances - contracts may not be deployed")
+
+	for _, chainSel := range chainSelectors {
+		balance, exists := timelockBalances[chainSel]
+		require.True(t, exists, "Timelock balance info not found for chain %d", chainSel)
+		t.Logf("Found timelock to fund on chain %d with address %s and current balance %s", chainSel, balance.TimelockAddr, balance.Balance.String())
+
+		fundingConfig.FundingByChain[chainSel] = fundingAmount
 	}
 
-	lggr.Info("Timelock contracts funded successfully")
-	return env
+	t.Log("Timelock contracts funded successfully")
 }
 
-func executeBatchTransfersWithMCMS(t *testing.T, env cldf.Environment, chainSelectors ...uint64) {
-	lggr := env.Logger
-	lggr.Info("Executing batch transfers with MCMS")
+func executeBatchTransfersWithMCMS(t *testing.T, rt *runtime.Runtime, chainSelectors ...uint64) {
+	t.Log("Executing batch transfers with MCMS")
 
 	transferConfig := types.BatchNativeTransferConfig{
 		TransfersByChain: make(map[uint64][]types.NativeTransfer),
@@ -381,10 +378,13 @@ func executeBatchTransfersWithMCMS(t *testing.T, env cldf.Environment, chainSele
 		}
 	}
 
-	output, err := BatchNativeTransferChangeset.Apply(env, transferConfig)
+	transferTask := runtime.ChangesetTask(BatchNativeTransferChangeset, transferConfig)
+	err := rt.Exec(transferTask)
 	require.NoError(t, err)
-	require.NotEmpty(t, output.MCMSTimelockProposals, "Should create MCMS proposals")
 
+	output := rt.State().Outputs[transferTask.ID()]
+
+	require.NotEmpty(t, output.MCMSTimelockProposals, "Should create MCMS proposals")
 	require.Len(t, output.MCMSTimelockProposals, 1, "Should create exactly 1 MCMS proposal for all chains")
 
 	proposal := output.MCMSTimelockProposals[0]
@@ -399,35 +399,23 @@ func executeBatchTransfersWithMCMS(t *testing.T, env cldf.Environment, chainSele
 		require.True(t, operationChains[expectedChain], "Proposal should contain operation for chain %d", expectedChain)
 	}
 
-	lggr.Infow("MCMS proposals created", "count", len(output.MCMSTimelockProposals), "operations_in_proposal", len(proposal.Operations), "chains_in_proposal", len(operationChains))
+	err = rt.Exec(
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
+	require.NoError(t, err)
 
-	for i, proposal := range output.MCMSTimelockProposals {
-		require.NotEmpty(t, proposal.Operations, "Proposal %d should have operations", i)
+	t.Log("MCMS proposal executed successfully")
 
-		lggr.Infow("Executing MCMS proposal", "index", i, "operations", len(proposal.Operations))
-
-		mcmProp := proposalutils.SignMCMSTimelockProposal(t, env, &proposal, false)
-
-		err = proposalutils.ExecuteMCMSProposalV2(t, env, mcmProp)
-		require.NoError(t, err, "Failed to execute MCMS proposal %d", i)
-
-		err = proposalutils.ExecuteMCMSTimelockProposalV2(t, env, &proposal)
-		require.NoError(t, err, "Failed to execute timelock proposal %d", i)
-
-		lggr.Infow("MCMS proposal executed successfully", "index", i)
-	}
-
-	verifyTransferExecution(t, env, transferConfig, chainSelectors)
+	verifyTransferExecution(t, rt.Environment(), transferConfig, chainSelectors)
 }
 
-func executeDirectTransfers(t *testing.T, env cldf.Environment, chainSelector uint64) {
-	lggr := env.Logger
-	lggr.Info("Executing direct transfers without MCMS")
+func executeDirectTransfers(t *testing.T, rt *runtime.Runtime, chainSelector uint64) {
+	t.Log("Executing direct transfers without MCMS")
 
 	recipient := common.HexToAddress(testRecipientAddr1)
 	transferAmount := OneETH
 
-	chain := env.BlockChains.EVMChains()[chainSelector]
+	chain := rt.Environment().BlockChains.EVMChains()[chainSelector]
 	initialBalance, err := chain.Client.BalanceAt(testutils.Context(t), recipient, nil)
 	require.NoError(t, err)
 
@@ -444,8 +432,9 @@ func executeDirectTransfers(t *testing.T, env cldf.Environment, chainSelector ui
 		Description: "Direct transfer test",
 	}
 
-	output, err := BatchNativeTransferChangeset.Apply(env, transferConfig)
+	output, err := BatchNativeTransferChangeset.Apply(rt.Environment(), transferConfig)
 	require.NoError(t, err)
+
 	require.NotNil(t, output.Reports, "Should have execution reports")
 
 	finalBalance, err := chain.Client.BalanceAt(testutils.Context(t), recipient, nil)
@@ -454,13 +443,13 @@ func executeDirectTransfers(t *testing.T, env cldf.Environment, chainSelector ui
 	expectedBalance := big.NewInt(0).Add(initialBalance, transferAmount)
 	require.Equal(t, expectedBalance, finalBalance, "Recipient balance should increase by transfer amount")
 
-	lggr.Info("Direct transfers executed and verified successfully")
+	t.Log("Direct transfers executed and verified successfully")
 }
 
 // verifyTransferExecution verifies that transfers were executed by checking recipient balances
 func verifyTransferExecution(t *testing.T, env cldf.Environment, config types.BatchNativeTransferConfig, chainSelectors []uint64) {
 	lggr := env.Logger
-	lggr.Info("Verifying transfer execution")
+	t.Log("Verifying transfer execution")
 
 	evmChains := env.BlockChains.EVMChains()
 

--- a/deployment/vault/changeset/manage_whitelist_test.go
+++ b/deployment/vault/changeset/manage_whitelist_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/vault/changeset/types"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 const (
@@ -22,17 +22,14 @@ const (
 )
 
 func TestSetWhitelistValidation(t *testing.T) {
-	lggr := logger.TestLogger(t)
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
+	t.Parallel()
 
-	chainSelectors := make([]uint64, 0)
-	for chainSel := range env.BlockChains.EVMChains() {
-		chainSelectors = append(chainSelectors, chainSel)
-	}
-	require.Len(t, chainSelectors, 1)
-	testChainSel := chainSelectors[0]
+	selector1 := chainselectors.TEST_90000001.Selector
+
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selector1}),
+	)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name      string
@@ -52,7 +49,7 @@ func TestSetWhitelistValidation(t *testing.T) {
 			name: "zero address in whitelist",
 			config: types.SetWhitelistConfig{
 				WhitelistByChain: map[uint64][]types.WhitelistAddress{
-					testChainSel: {
+					selector1: {
 						{
 							Address:     "0x0000000000000000000000000000000000000000",
 							Description: "Zero address",
@@ -68,7 +65,7 @@ func TestSetWhitelistValidation(t *testing.T) {
 			name: "duplicate addresses in same chain",
 			config: types.SetWhitelistConfig{
 				WhitelistByChain: map[uint64][]types.WhitelistAddress{
-					testChainSel: {
+					selector1: {
 						{
 							Address:     common.HexToAddress(whitelistTestAddr1).Hex(),
 							Description: "First instance",
@@ -105,7 +102,7 @@ func TestSetWhitelistValidation(t *testing.T) {
 			name: "valid whitelist config",
 			config: types.SetWhitelistConfig{
 				WhitelistByChain: map[uint64][]types.WhitelistAddress{
-					testChainSel: {
+					selector1: {
 						{
 							Address:     common.HexToAddress(whitelistTestAddr1).Hex(),
 							Description: "Test address 1",
@@ -125,12 +122,12 @@ func TestSetWhitelistValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateSetWhitelistConfig(env, tt.config)
+			err := ValidateSetWhitelistConfig(*env, tt.config)
 
 			if tt.wantError {
 				require.Error(t, err)
 				if tt.errorMsg != "" {
-					require.Contains(t, err.Error(), tt.errorMsg)
+					require.ErrorContains(t, err, tt.errorMsg)
 				}
 			} else {
 				require.NoError(t, err)
@@ -140,98 +137,128 @@ func TestSetWhitelistValidation(t *testing.T) {
 }
 
 func TestGetWhitelistedAddresses(t *testing.T) {
-	lggr := logger.TestLogger(t)
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 2,
-	})
+	t.Parallel()
 
-	chainSelectors := make([]uint64, 0)
-	for chainSel := range env.BlockChains.EVMChains() {
-		chainSelectors = append(chainSelectors, chainSel)
-	}
-	require.Len(t, chainSelectors, 2)
-
-	chain1 := chainSelectors[0]
-	chain2 := chainSelectors[1]
-
-	t.Run("get whitelist from uninitialized datastore", func(t *testing.T) {
-		envNoDS := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-			Chains: 2,
-		})
-		envNoDS.DataStore = nil
-
-		_, err := GetWhitelistedAddresses(envNoDS, []uint64{chain1})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "datastore is nil")
-	})
-
-	t.Run("get whitelist from empty whitelist", func(t *testing.T) {
-		env.DataStore = datastore.NewMemoryDataStore().Seal()
-
-		whitelist, err := GetWhitelistedAddresses(env, []uint64{chain1})
-		require.NoError(t, err)
-		require.Empty(t, whitelist[chain1])
-	})
-
-	t.Run("get whitelist after setting addresses", func(t *testing.T) {
-		config := types.SetWhitelistConfig{
-			WhitelistByChain: map[uint64][]types.WhitelistAddress{
-				chain1: {
-					{
-						Address:     common.HexToAddress(whitelistTestAddr1).Hex(),
-						Description: "Test address 1",
-						Labels:      []string{"team", "approved"},
-					},
-					{
-						Address:     common.HexToAddress(whitelistTestAddr2).Hex(),
-						Description: "Test address 2",
-						Labels:      []string{"partner"},
-					},
+	selector1 := chainselectors.TEST_90000001.Selector
+	selector2 := chainselectors.TEST_90000002.Selector
+	setConfig := &types.SetWhitelistConfig{
+		WhitelistByChain: map[uint64][]types.WhitelistAddress{
+			selector1: {
+				{
+					Address:     common.HexToAddress(whitelistTestAddr1).Hex(),
+					Description: "Test address 1",
+					Labels:      []string{"team", "approved"},
 				},
-				chain2: {
-					{
-						Address:     common.HexToAddress(whitelistTestAddr3).Hex(),
-						Description: "Test address 3",
-						Labels:      []string{"contractor"},
-					},
+				{
+					Address:     common.HexToAddress(whitelistTestAddr2).Hex(),
+					Description: "Test address 2",
+					Labels:      []string{"partner"},
 				},
 			},
-		}
+			selector2: {
+				{
+					Address:     common.HexToAddress(whitelistTestAddr3).Hex(),
+					Description: "Test address 3",
+					Labels:      []string{"contractor"},
+				},
+			},
+		},
+	}
 
-		output, err := SetWhitelistChangeset.Apply(env, config)
-		require.NoError(t, err)
-		env.DataStore = output.DataStore.Seal()
+	tests := []struct {
+		name          string
+		before        func(t *testing.T, env *cldf.Environment)
+		setConfig     *types.SetWhitelistConfig
+		giveSelectors []uint64
+		wantErr       string
+		want          func(t *testing.T, got map[uint64][]WhitelistEntry)
+	}{
+		{
+			name:          "get whitelist for specific chain only",
+			setConfig:     setConfig,
+			giveSelectors: []uint64{selector1},
+			want: func(t *testing.T, got map[uint64][]WhitelistEntry) {
+				require.Len(t, got, 1)
+				require.Contains(t, got, selector1)
+				require.NotContains(t, got, selector2)
+				require.Len(t, got[selector1], 2)
+			},
+		},
+		{
+			name:          "get whitelist for multiple chains",
+			setConfig:     setConfig,
+			giveSelectors: []uint64{selector1, selector2},
+			want: func(t *testing.T, got map[uint64][]WhitelistEntry) {
+				require.Len(t, got[selector1], 2)
+				require.Equal(t, whitelistTestAddr1, got[selector1][0].Address)
+				require.Equal(t, []string{"team", "approved"}, got[selector1][0].Labels)
+				require.Equal(t, whitelistTestAddr2, got[selector1][1].Address)
+				require.Equal(t, []string{"partner"}, got[selector1][1].Labels)
 
-		whitelist, err := GetWhitelistedAddresses(env, []uint64{chain1, chain2})
-		require.NoError(t, err)
+				require.Len(t, got[selector2], 1)
+				require.Equal(t, whitelistTestAddr3, got[selector2][0].Address)
+				require.Equal(t, []string{"contractor"}, got[selector2][0].Labels)
+			},
+		},
+		{
+			name:          "get whitelist from empty whitelist",
+			giveSelectors: []uint64{selector1},
+			want: func(t *testing.T, got map[uint64][]WhitelistEntry) {
+				require.Empty(t, got[selector1])
+				require.Empty(t, got[selector2])
+			},
+		},
+		{
+			name: "get whitelist from uninitialized datastore",
+			before: func(t *testing.T, env *cldf.Environment) {
+				env.DataStore = nil
+			},
+			giveSelectors: []uint64{selector1},
+			wantErr:       "datastore is nil",
+		},
+	}
 
-		require.Len(t, whitelist[chain1], 2)
-		require.Equal(t, whitelistTestAddr1, whitelist[chain1][0].Address)
-		require.Equal(t, []string{"team", "approved"}, whitelist[chain1][0].Labels)
-		require.Equal(t, whitelistTestAddr2, whitelist[chain1][1].Address)
-		require.Equal(t, []string{"partner"}, whitelist[chain1][1].Labels)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		require.Len(t, whitelist[chain2], 1)
-		require.Equal(t, whitelistTestAddr3, whitelist[chain2][0].Address)
-		require.Equal(t, []string{"contractor"}, whitelist[chain2][0].Labels)
-	})
+			env, err := environment.New(t.Context(),
+				environment.WithEVMSimulated(t, []uint64{selector1, selector2}),
+			)
+			require.NoError(t, err)
 
-	t.Run("get whitelist for specific chain only", func(t *testing.T) {
-		whitelist, err := GetWhitelistedAddresses(env, []uint64{chain1})
-		require.NoError(t, err)
+			if tt.before != nil {
+				tt.before(t, env)
+			}
 
-		require.Len(t, whitelist, 1)
-		require.Contains(t, whitelist, chain1)
-		require.NotContains(t, whitelist, chain2)
-		require.Len(t, whitelist[chain1], 2)
-	})
+			if tt.setConfig != nil {
+				output, err := SetWhitelistChangeset.Apply(*env, *tt.setConfig)
+				require.NoError(t, err)
+				env.DataStore = output.DataStore.Seal()
+			}
+
+			got, err := GetWhitelistedAddresses(*env, tt.giveSelectors)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				if tt.want != nil {
+					tt.want(t, got)
+				}
+			}
+		})
+	}
 }
 
 func TestValidateWhitelist(t *testing.T) {
-	lggr := logger.TestLogger(t)
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 2,
-	})
+	t.Parallel()
+
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulatedN(t, 2),
+	)
+	require.NoError(t, err)
 
 	chainSelectors := make([]uint64, 0)
 	for chainSel := range env.BlockChains.EVMChains() {
@@ -270,7 +297,7 @@ func TestValidateWhitelist(t *testing.T) {
 		},
 	}
 
-	output, err := SetWhitelistChangeset.Apply(env, whitelistConfig)
+	output, err := SetWhitelistChangeset.Apply(*env, whitelistConfig)
 	require.NoError(t, err)
 	env.DataStore = output.DataStore.Seal()
 
@@ -287,7 +314,7 @@ func TestValidateWhitelist(t *testing.T) {
 			},
 		}
 
-		errors, err := ValidateWhitelist(env, config)
+		errors, err := ValidateWhitelist(*env, config)
 		require.NoError(t, err)
 		require.Empty(t, errors)
 	})
@@ -307,7 +334,7 @@ func TestValidateWhitelist(t *testing.T) {
 			},
 		}
 
-		validationErrors, err := ValidateWhitelist(env, config)
+		validationErrors, err := ValidateWhitelist(*env, config)
 		require.NoError(t, err)
 		require.Len(t, validationErrors, 2)
 
@@ -327,21 +354,13 @@ func TestValidateWhitelist(t *testing.T) {
 }
 
 func TestGetChainWhitelist(t *testing.T) {
-	lggr := logger.TestLogger(t)
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
+	t.Parallel()
 
-	chainSelectors := make([]uint64, 0)
-	for chainSel := range env.BlockChains.EVMChains() {
-		chainSelectors = append(chainSelectors, chainSel)
-	}
-	require.Len(t, chainSelectors, 1)
-	testChainSel := chainSelectors[0]
+	selector := chainselectors.TEST_90000001.Selector
 
 	t.Run("get whitelist from empty datastore", func(t *testing.T) {
 		ds := datastore.NewMemoryDataStore().Seal()
-		metadata, err := GetChainWhitelist(ds, testChainSel)
+		metadata, err := GetChainWhitelist(ds, selector)
 		require.NoError(t, err)
 		require.NotNil(t, metadata)
 		require.Empty(t, metadata.Addresses)
@@ -366,13 +385,13 @@ func TestGetChainWhitelist(t *testing.T) {
 		}
 
 		err := ds.ChainMetadata().Upsert(datastore.ChainMetadata{
-			ChainSelector: testChainSel,
+			ChainSelector: selector,
 			Metadata:      whitelistMetadata,
 		})
 		require.NoError(t, err)
 
 		sealedDS := ds.Seal()
-		metadata, err := GetChainWhitelist(sealedDS, testChainSel)
+		metadata, err := GetChainWhitelist(sealedDS, selector)
 		require.NoError(t, err)
 		require.NotNil(t, metadata)
 		require.Len(t, metadata.Addresses, 2)
@@ -388,24 +407,23 @@ func TestGetChainWhitelist(t *testing.T) {
 }
 
 func TestSetWhitelistChangeset(t *testing.T) {
-	lggr := logger.TestLogger(t)
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 2,
-	})
+	t.Parallel()
 
-	chainSelectors := make([]uint64, 0)
-	for chainSel := range env.BlockChains.EVMChains() {
-		chainSelectors = append(chainSelectors, chainSel)
-	}
-	require.Len(t, chainSelectors, 2)
+	var (
+		selector1 = chainselectors.TEST_90000001.Selector
+		selector2 = chainselectors.TEST_90000002.Selector
+		selectors = []uint64{selector1, selector2}
+	)
 
-	chain1 := chainSelectors[0]
-	chain2 := chainSelectors[1]
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, selectors),
+	)
+	require.NoError(t, err)
 
 	t.Run("set whitelist for multiple chains", func(t *testing.T) {
 		config := types.SetWhitelistConfig{
 			WhitelistByChain: map[uint64][]types.WhitelistAddress{
-				chain1: {
+				selector1: {
 					{
 						Address:     common.HexToAddress(whitelistTestAddr1).Hex(),
 						Description: "Team A wallet",
@@ -417,7 +435,7 @@ func TestSetWhitelistChangeset(t *testing.T) {
 						Labels:      []string{"team", "payments"},
 					},
 				},
-				chain2: {
+				selector2: {
 					{
 						Address:     common.HexToAddress(whitelistTestAddr3).Hex(),
 						Description: "Partner wallet",
@@ -427,36 +445,36 @@ func TestSetWhitelistChangeset(t *testing.T) {
 			},
 		}
 
-		output, err := SetWhitelistChangeset.Apply(env, config)
+		output, err := SetWhitelistChangeset.Apply(*env, config)
 		require.NoError(t, err)
 		require.NotNil(t, output.DataStore)
 
 		env.DataStore = output.DataStore.Seal()
 
-		whitelist, err := GetWhitelistedAddresses(env, []uint64{chain1, chain2})
+		whitelist, err := GetWhitelistedAddresses(*env, selectors)
 		require.NoError(t, err)
 
-		require.Len(t, whitelist[chain1], 2)
-		require.Len(t, whitelist[chain2], 1)
+		require.Len(t, whitelist[selector1], 2)
+		require.Len(t, whitelist[selector2], 1)
 
-		require.Equal(t, whitelistTestAddr1, whitelist[chain1][0].Address)
-		require.Equal(t, []string{"team", "payments"}, whitelist[chain1][0].Labels)
+		require.Equal(t, whitelistTestAddr1, whitelist[selector1][0].Address)
+		require.Equal(t, []string{"team", "payments"}, whitelist[selector1][0].Labels)
 
-		require.Equal(t, whitelistTestAddr3, whitelist[chain2][0].Address)
-		require.Equal(t, []string{"partner", "contractor"}, whitelist[chain2][0].Labels)
+		require.Equal(t, whitelistTestAddr3, whitelist[selector2][0].Address)
+		require.Equal(t, []string{"partner", "contractor"}, whitelist[selector2][0].Labels)
 	})
 
 	t.Run("update existing whitelist", func(t *testing.T) {
 		updatedConfig := types.SetWhitelistConfig{
 			WhitelistByChain: map[uint64][]types.WhitelistAddress{
-				chain1: {
+				selector1: {
 					{
 						Address:     common.HexToAddress(whitelistTestAddr2).Hex(),
 						Description: "Team B wallet updated",
 						Labels:      []string{"team", "payments", "updated"},
 					},
 				},
-				chain2: {
+				selector2: {
 					{
 						Address:     common.HexToAddress(whitelistTestAddr3).Hex(),
 						Description: "Partner wallet",
@@ -471,37 +489,37 @@ func TestSetWhitelistChangeset(t *testing.T) {
 			},
 		}
 
-		output, err := SetWhitelistChangeset.Apply(env, updatedConfig)
+		output, err := SetWhitelistChangeset.Apply(*env, updatedConfig)
 		require.NoError(t, err)
 		require.NotNil(t, output.DataStore)
 
 		env.DataStore = output.DataStore.Seal()
 
-		whitelist, err := GetWhitelistedAddresses(env, []uint64{chain1, chain2})
+		whitelist, err := GetWhitelistedAddresses(*env, selectors)
 		require.NoError(t, err)
 
-		require.Len(t, whitelist[chain1], 1)
-		require.Len(t, whitelist[chain2], 2)
+		require.Len(t, whitelist[selector1], 1)
+		require.Len(t, whitelist[selector2], 2)
 
-		require.Equal(t, whitelistTestAddr2, whitelist[chain1][0].Address)
-		require.Equal(t, []string{"team", "payments", "updated"}, whitelist[chain1][0].Labels)
+		require.Equal(t, whitelistTestAddr2, whitelist[selector1][0].Address)
+		require.Equal(t, []string{"team", "payments", "updated"}, whitelist[selector1][0].Labels)
 	})
 
 	t.Run("clear whitelist for a chain", func(t *testing.T) {
 		clearConfig := types.SetWhitelistConfig{
 			WhitelistByChain: map[uint64][]types.WhitelistAddress{
-				chain1: {},
+				selector1: {},
 			},
 		}
 
-		output, err := SetWhitelistChangeset.Apply(env, clearConfig)
+		output, err := SetWhitelistChangeset.Apply(*env, clearConfig)
 		require.NoError(t, err)
 		require.NotNil(t, output.DataStore)
 
 		env.DataStore = output.DataStore.Seal()
 
-		whitelist, err := GetWhitelistedAddresses(env, []uint64{chain1})
+		whitelist, err := GetWhitelistedAddresses(*env, []uint64{selector1})
 		require.NoError(t, err)
-		require.Empty(t, whitelist[chain1])
+		require.Empty(t, whitelist[selector1])
 	})
 }


### PR DESCRIPTION
Refactors vault tests to use the CLDF test engine, removing reliance on the memory environment.
