### PR TITLE
fix: skip TestCoreRelayerChainInteroperators for sui relayer

### DIFF
--- a/core/services/chainlink/relayer_chain_interoperators_test.go
+++ b/core/services/chainlink/relayer_chain_interoperators_test.go
@@ -262,6 +262,8 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 					t.Skip("tron doesn't need a CoreRelayerChainInteroperator")
 				case relay.NetworkTON:
 					t.Skip("ton doesn't need a CoreRelayerChainInteroperator")
+				case relay.NetworkSui:
+					t.Skip("sui doesn't need a CoreRelayerChainInteroperator")
 
 				default:
 					require.Fail(t, "untested relay network", relayNetwork)


### PR DESCRIPTION
### Changes

Add missing switch case for `NetworkSui` in `TestCoreRelayerChainInteroperators`

### Motivation

[On some runs it fails because ](https://github.com/smartcontractkit/chainlink/blob/6f9d964775c9cfbbcc060393fd611f6590073229/core/services/chainlink/relayer_chain_interoperators_test.go#L267)it's finding SUI as a relay network: https://github.com/smartcontractkit/chainlink/actions/runs/18228376128/job/51905423615#step:15:884
```
=== Failed
=== FAIL: core/services/chainlink TestCoreRelayerChainInteroperators/2_solana_chain_with_2_node (0.00s)
    relayer_chain_interoperators_test.go:267: 
        	Error Trace:	/home/runner/_work/chainlink/chainlink/core/services/chainlink/relayer_chain_interoperators_test.go:267
        	Error:      	untested relay network
        	Test:       	TestCoreRelayerChainInteroperators/2_solana_chain_with_2_node
        	Messages:   	sui

=== FAIL: core/services/chainlink TestCoreRelayerChainInteroperators/2_evm_chains_with_3_nodes (0.03s)
    relayer_chain_interoperators_test.go:267: 
        	Error Trace:	/home/runner/_work/chainlink/chainlink/core/services/chainlink/relayer_chain_interoperators_test.go:267
        	Error:      	untested relay network
        	Test:       	TestCoreRelayerChainInteroperators/2_evm_chains_with_3_nodes
        	Messages:   	sui
```

[But on other runs it skips because](https://github.com/smartcontractkit/chainlink/blob/develop/core/services/chainlink/relayer_chain_interoperators_test.go#L260) it finds aptos as the relayer: https://github.com/smartcontractkit/chainlink/actions/runs/18228376128/job/51909975841#step:15:684).

```
=== SKIP: core/services/chainlink TestCoreRelayerChainInteroperators/2_solana_chain_with_2_node (0.03s)
    relayer_chain_interoperators_test.go:260: aptos doesn't need a CoreRelayerChainInteroperator

=== SKIP: core/services/chainlink TestCoreRelayerChainInteroperators/2_evm_chains_with_3_nodes (0.04s)
    relayer_chain_interoperators_test.go:260: aptos doesn't need a CoreRelayerChainInteroperator
```
    
Right now in trunk it's classified as broken, because it either skips or fails. Should this test be deleted instead?
