### PR TITLE
allow duplication registry hashes

### DIFF
--- a/core/services/registrysyncer/orm.go
+++ b/core/services/registrysyncer/orm.go
@@ -131,19 +131,33 @@ func NewORM(ds sqlutil.DataSource, lggr logger.Logger) orm {
 }
 
 func (orm orm) AddLocalRegistry(ctx context.Context, localRegistry LocalRegistry) error {
+	orm.lggr.Debugw("Adding local registry to DB...")
 	return sqlutil.TransactDataSource(ctx, orm.ds, nil, func(tx sqlutil.DataSource) error {
 		localRegistryJSON, err := localRegistry.MarshalJSON()
 		if err != nil {
 			return err
 		}
 		hash := sha256.Sum256(localRegistryJSON)
-		_, err = tx.ExecContext(
+		r, err := tx.ExecContext(
 			ctx,
-			`INSERT INTO registry_syncer_states (data, data_hash) VALUES ($1, $2) ON CONFLICT (data_hash) DO NOTHING`,
+			`INSERT INTO registry_syncer_states (data, data_hash) 
+            SELECT $1, $2 
+            WHERE $2 NOT IN (
+                SELECT data_hash FROM registry_syncer_states 
+                ORDER BY id DESC LIMIT 1
+            )`,
 			localRegistryJSON, hex.EncodeToString(hash[:]),
 		)
 		if err != nil {
 			return err
+		}
+
+		n, _ := r.RowsAffected()
+		if n != 0 {
+			id, _ := r.LastInsertId()
+			orm.lggr.Debugw("Inserted new local registry", "id", id, "hash", hex.EncodeToString(hash[:]), "registry", localRegistry)
+		} else {
+			orm.lggr.Debugw("No rows affected, local registry updated. ", "hash", hex.EncodeToString(hash[:]))
 		}
 		_, err = tx.ExecContext(ctx, `DELETE FROM registry_syncer_states
 WHERE data_hash NOT IN (
@@ -162,9 +176,12 @@ func (orm orm) LatestLocalRegistry(ctx context.Context) (*LocalRegistry, error) 
 	if err != nil {
 		return nil, err
 	}
+	hash := sha256.Sum256([]byte(localRegistryJSON))
 	err = localRegistry.UnmarshalJSON([]byte(localRegistryJSON))
 	if err != nil {
 		return nil, err
 	}
+	orm.lggr.Debugw("Fetched latest local registry from DB", "hash", hex.EncodeToString(hash[:]), "registry", localRegistry)
+
 	return &localRegistry, nil
 }

--- a/core/services/registrysyncer/orm_test.go
+++ b/core/services/registrysyncer/orm_test.go
@@ -145,3 +145,81 @@ func generateState(t *testing.T) registrysyncer.LocalRegistry {
 		},
 	}
 }
+
+func TestRegistrySyncerORM_AddLocalRegistry_DuplicateHandling(t *testing.T) {
+	db := pgtest.NewSqlxDB(t)
+	ctx := testutils.Context(t)
+	lggr := logger.Test(t)
+	orm := registrysyncer.NewORM(db, lggr)
+
+	t.Run("duplicate_handling", func(t *testing.T) {
+		// Generate original state
+		originalState := generateState(t)
+
+		// First insertion - should succeed
+		err := orm.AddLocalRegistry(ctx, originalState)
+		require.NoError(t, err)
+
+		// Get the initial ID and hash
+		var initialID int
+		var initialHash string
+		err = db.Get(&initialID, `SELECT id FROM registry_syncer_states ORDER BY id DESC LIMIT 1`)
+		require.NoError(t, err)
+		err = db.Get(&initialHash, `SELECT data_hash FROM registry_syncer_states ORDER BY id DESC LIMIT 1`)
+		require.NoError(t, err)
+
+		// Second insertion with same data - should not insert (no new row)
+		err = orm.AddLocalRegistry(ctx, originalState)
+		require.NoError(t, err)
+
+		// Check that latest ID hasn't changed (no new insertion)
+		var currentID int
+		var currentHash string
+		err = db.Get(&currentID, `SELECT id FROM registry_syncer_states ORDER BY id DESC LIMIT 1`)
+		require.NoError(t, err)
+		err = db.Get(&currentHash, `SELECT data_hash FROM registry_syncer_states ORDER BY id DESC LIMIT 1`)
+		require.NoError(t, err)
+
+		assert.Equal(t, initialID, currentID, "ID should not change when inserting duplicate data")
+		assert.Equal(t, initialHash, currentHash, "Hash should not change when inserting duplicate data")
+
+		// Generate new state with different data
+		newState := generateState(t)
+
+		// Third insertion with new data - should succeed and increment ID
+		err = orm.AddLocalRegistry(ctx, newState)
+		require.NoError(t, err)
+
+		// Check that latest ID is incremented and hash is new
+		var newID int
+		var newHash string
+		err = db.Get(&newID, `SELECT id FROM registry_syncer_states ORDER BY id DESC LIMIT 1`)
+		require.NoError(t, err)
+		err = db.Get(&newHash, `SELECT data_hash FROM registry_syncer_states ORDER BY id DESC LIMIT 1`)
+		require.NoError(t, err)
+
+		assert.Greater(t, newID, currentID, "ID should increment when inserting new data")
+		assert.NotEqual(t, newHash, currentHash, "Hash should change when inserting new data")
+
+		// Fourth insertion with original data again - should succeed and increment ID
+		err = orm.AddLocalRegistry(ctx, originalState)
+		require.NoError(t, err)
+
+		// Check that latest ID is incremented again and hash is back to original
+		var finalID int
+		var finalHash string
+		err = db.Get(&finalID, `SELECT id FROM registry_syncer_states ORDER BY id DESC LIMIT 1`)
+		require.NoError(t, err)
+		err = db.Get(&finalHash, `SELECT data_hash FROM registry_syncer_states ORDER BY id DESC LIMIT 1`)
+		require.NoError(t, err)
+
+		assert.Greater(t, finalID, newID, "ID should increment when re-inserting original data")
+		assert.Equal(t, finalHash, initialHash, "Hash should match original data hash when re-inserting original data")
+
+		// Verify total count - should have 3 records (original, new, original again)
+		var totalCount int
+		err = db.Get(&totalCount, `SELECT count(*) FROM registry_syncer_states`)
+		require.NoError(t, err)
+		assert.Equal(t, 3, totalCount, "Should have exactly 3 records")
+	})
+}

--- a/core/store/migrate/migrations/0279_allow_duplicate_registry_hash.sql
+++ b/core/store/migrate/migrations/0279_allow_duplicate_registry_hash.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE registry_syncer_states DROP CONSTRAINT registry_syncer_states_data_hash_key;
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE registry_syncer_states ADD CONSTRAINT registry_syncer_states_data_hash_key UNIQUE (data_hash);
+-- +goose StatementEnd


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
This change allows duplicate registry hashes. In is important for the case when the on chain registry reverts to a previous state (say, back a config change)

We update the query to only insert a new row if the hash is not the hash of the latest row rather than exclude duplicate hashes
### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
