### PR TITLE
chore: update data-feeds EVM changeset tests to use test engine runtime

### DIFF
--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1544,6 +1544,8 @@ github.com/scylladb/go-reflectx v1.0.1/go.mod h1:rWnOfDIRWBGN0miMLIcoPt/Dhi2doCM
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0 h1:b23VGrQhTA8cN2CbBw7/FulN9fTtqYUdS5+Oxzt+DUE=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0/go.mod h1:FGBZgq2tXWICsxWQW1msNf49F0Pf2Op5Htayx335Qbs=
+github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
+github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/serialx/hashring v0.0.0-20200727003509-22c0c7ab6b1b h1:h+3JX2VoWTFuyQEo87pStk/a99dzIO1mM9KxIyLPGTU=

--- a/deployment/data-feeds/changeset/accept_ownership_test.go
+++ b/deployment/data-feeds/changeset/accept_ownership_test.go
@@ -1,53 +1,44 @@
 package changeset
 
 import (
+	"crypto/ecdsa"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-
-	chainselectors "github.com/smartcontractkit/chain-selectors"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
 func TestAcceptOwnership(t *testing.T) {
 	t.Parallel()
 
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
-	chain := env.BlockChains.EVMChains()[chainSelector]
+	chain := rt.Environment().BlockChains.EVMChains()[selector]
 
-	newEnv, err := commonChangesets.Apply(t, env,
-		commonChangesets.Configure(
-			cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-			map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-				chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-			},
-		),
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(
+			commonChangesets.DeployMCMSWithTimelockV2), map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			selector: proposalutils.SingleGroupTimelockConfigV2(t),
+		}),
 	)
 	require.NoError(t, err)
 
-	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
+	records := rt.Environment().DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
 	require.Len(t, records, 1)
 	timeLockAddress := records[0].Address
 
@@ -56,17 +47,17 @@ func TestAcceptOwnership(t *testing.T) {
 	_, err = chain.Confirm(tx)
 	require.NoError(t, err)
 
-	_, err = commonChangesets.Apply(t, newEnv,
-		commonChangesets.Configure(
-			AcceptOwnershipChangeset,
-			types.AcceptOwnershipConfig{
-				ChainSelector:     chainSelector,
-				ContractAddresses: []common.Address{cache.Contract.Address()},
-				McmsConfig: &types.MCMSConfig{
-					MinDelay: 1,
-				},
+	err = rt.Exec(
+		runtime.ChangesetTask(AcceptOwnershipChangeset, types.AcceptOwnershipConfig{
+			ChainSelector:     selector,
+			ContractAddresses: []common.Address{cache.Contract.Address()},
+			McmsConfig: &types.MCMSConfig{
+				MinDelay: 1,
 			},
-		),
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
 	)
 	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 1)
+	require.True(t, rt.State().Proposals[0].IsExecuted)
 }

--- a/deployment/data-feeds/changeset/confirm_aggregator_test.go
+++ b/deployment/data-feeds/changeset/confirm_aggregator_test.go
@@ -1,109 +1,104 @@
 package changeset_test
 
 import (
+	"crypto/ecdsa"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
-	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestConfirmAggregator(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-
-	// without MCMS
-	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		changeset.DeployCacheChangeset,
-		types.DeployConfig{
-			ChainsToDeploy: []uint64{chainSelector},
-			Labels:         []string{"data-feeds"},
-		},
-	), commonChangesets.Configure(
-		changeset.DeployAggregatorProxyChangeset,
-		types.DeployAggregatorProxyConfig{
-			ChainsToDeploy:   []uint64{chainSelector},
-			AccessController: []common.Address{common.HexToAddress("0x")},
-		},
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
 	))
 	require.NoError(t, err)
 
-	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("AggregatorProxy"))
+	// without MCMS
+
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.DeployCacheChangeset, types.DeployConfig{
+			ChainsToDeploy: []uint64{selector},
+			Labels:         []string{"data-feeds"},
+		}),
+		runtime.ChangesetTask(changeset.DeployAggregatorProxyChangeset, types.DeployAggregatorProxyConfig{
+			ChainsToDeploy:   []uint64{selector},
+			AccessController: []common.Address{common.HexToAddress("0x")},
+		}),
+	)
+	require.NoError(t, err)
+
+	records := rt.Environment().DataStore.Addresses().Filter(datastore.AddressRefByType("AggregatorProxy"))
 	require.Len(t, records, 1)
 	proxyAddress := records[0].Address
 
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.ProposeAggregatorChangeset,
-		types.ProposeConfirmAggregatorConfig{
-			ChainSelector:        chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.ProposeAggregatorChangeset, types.ProposeConfirmAggregatorConfig{
+			ChainSelector:        selector,
 			ProxyAddress:         common.HexToAddress(proxyAddress),
 			NewAggregatorAddress: common.HexToAddress("0x123"),
-		},
-	), commonChangesets.Configure(
-		changeset.ConfirmAggregatorChangeset,
-		types.ProposeConfirmAggregatorConfig{
-			ChainSelector:        chainSelector,
+		}),
+		runtime.ChangesetTask(changeset.ConfirmAggregatorChangeset, types.ProposeConfirmAggregatorConfig{
+			ChainSelector:        selector,
 			ProxyAddress:         common.HexToAddress(proxyAddress),
 			NewAggregatorAddress: common.HexToAddress("0x123"),
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-		},
-	))
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2), map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			selector: proposalutils.SingleGroupTimelockConfigV2(t),
+		}),
+	)
 	require.NoError(t, err)
 
 	// with MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.ProposeAggregatorChangeset,
-		types.ProposeConfirmAggregatorConfig{
-			ChainSelector:        chainSelector,
+
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.ProposeAggregatorChangeset, types.ProposeConfirmAggregatorConfig{
+			ChainSelector:        selector,
 			ProxyAddress:         common.HexToAddress(proxyAddress),
 			NewAggregatorAddress: common.HexToAddress("0x124"),
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
-		commonChangesets.TransferToMCMSWithTimelockConfig{
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2), commonChangesets.TransferToMCMSWithTimelockConfig{
 			ContractsByChain: map[uint64][]common.Address{
-				chainSelector: {common.HexToAddress(proxyAddress)},
+				selector: {common.HexToAddress(proxyAddress)},
 			},
 			MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
-		},
-	), commonChangesets.Configure(
-		changeset.ConfirmAggregatorChangeset,
-		types.ProposeConfirmAggregatorConfig{
-			ChainSelector:        chainSelector,
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
+	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 1)
+	require.True(t, rt.State().Proposals[0].IsExecuted)
+
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.ConfirmAggregatorChangeset, types.ProposeConfirmAggregatorConfig{
+			ChainSelector:        selector,
 			ProxyAddress:         common.HexToAddress(proxyAddress),
 			NewAggregatorAddress: common.HexToAddress("0x124"),
 			McmsConfig: &types.MCMSConfig{
 				MinDelay: 0,
 			},
-		},
-	))
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
 	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 2)
+	require.True(t, rt.State().Proposals[1].IsExecuted)
+
+	// We expect 8 outputs for the 8 changesets we ran.
+	require.Len(t, rt.State().Outputs, 8)
 }

--- a/deployment/data-feeds/changeset/deploy_aggregator_proxy_test.go
+++ b/deployment/data-feeds/changeset/deploy_aggregator_proxy_test.go
@@ -6,46 +6,35 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
-	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestAggregatorProxy(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-
-	resp, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		DeployCacheChangeset,
-		types.DeployConfig{
-			ChainsToDeploy: []uint64{chainSelector},
-			Labels:         []string{"data-feeds"},
-		},
-	), commonChangesets.Configure(
-		DeployAggregatorProxyChangeset,
-		types.DeployAggregatorProxyConfig{
-			ChainsToDeploy:   []uint64{chainSelector},
-			AccessController: []common.Address{common.HexToAddress("0x")},
-		},
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
 	))
-
 	require.NoError(t, err)
-	require.NotNil(t, resp)
 
-	addrs, err := resp.DataStore.Addresses().Fetch()
+	err = rt.Exec(
+		runtime.ChangesetTask(DeployCacheChangeset, types.DeployConfig{
+			ChainsToDeploy: []uint64{selector},
+			Labels:         []string{"data-feeds"},
+		}),
+		runtime.ChangesetTask(DeployAggregatorProxyChangeset, types.DeployAggregatorProxyConfig{
+			ChainsToDeploy:   []uint64{selector},
+			AccessController: []common.Address{common.HexToAddress("0x")},
+		}),
+	)
+	require.NoError(t, err)
+
+	addrs, err := rt.State().DataStore.Addresses().Fetch()
 	require.NoError(t, err)
 	require.Len(t, addrs, 2) // AggregatorProxy and DataFeedsCache
 }

--- a/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy_test.go
+++ b/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy_test.go
@@ -6,46 +6,37 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
-	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestBundleAggregatorProxy(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 2,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
 
-	resp, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		DeployCacheChangeset,
-		types.DeployConfig{
-			ChainsToDeploy: []uint64{chainSelector},
+	err = rt.Exec(
+		runtime.ChangesetTask(DeployCacheChangeset, types.DeployConfig{
+			ChainsToDeploy: []uint64{selector},
 			Labels:         []string{"data-feeds"},
-		},
-	), commonChangesets.Configure(
-		DeployBundleAggregatorProxyChangeset,
-		types.DeployBundleAggregatorProxyConfig{
-			ChainsToDeploy: []uint64{chainSelector},
-			Owners:         map[uint64]common.Address{chainSelector: common.HexToAddress("0x1234")},
+		}),
+		runtime.ChangesetTask(DeployBundleAggregatorProxyChangeset, types.DeployBundleAggregatorProxyConfig{
+			ChainsToDeploy: []uint64{selector},
+			Owners:         map[uint64]common.Address{selector: common.HexToAddress("0x1234")},
 			Labels:         []string{"data-feeds"},
 			CacheLabel:     "data-feeds",
-		},
-	))
-
+		}),
+	)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
 
-	addrs, err := resp.DataStore.Addresses().Fetch()
+	addrs, err := rt.State().DataStore.Addresses().Fetch()
 	require.NoError(t, err)
 	require.Len(t, addrs, 2) // BundleAggregatorProxy and DataFeedsCache
 }

--- a/deployment/data-feeds/changeset/deploy_cache_test.go
+++ b/deployment/data-feeds/changeset/deploy_cache_test.go
@@ -5,41 +5,31 @@ import (
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
-	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestDeployCache(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 2,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
 
-	resp, err := commonChangesets.Apply(t, env,
-		commonChangesets.Configure(
-			changeset.DeployCacheChangeset,
-			types.DeployConfig{
-				ChainsToDeploy: []uint64{chainSelector},
-			},
-		),
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.DeployCacheChangeset, types.DeployConfig{
+			ChainsToDeploy: []uint64{selector},
+		}),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
 
-	addrs, err := resp.DataStore.Addresses().Fetch()
+	addrs, err := rt.State().DataStore.Addresses().Fetch()
 	require.NoError(t, err)
 	require.Len(t, addrs, 1)
 }

--- a/deployment/data-feeds/changeset/migrate_feeds_test.go
+++ b/deployment/data-feeds/changeset/migrate_feeds_test.go
@@ -5,65 +5,51 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/stretchr/testify/require"
 
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestMigrateFeeds(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
 
-	newEnv, err := commonChangesets.Apply(t, env,
-		commonChangesets.Configure(
-			changeset.DeployCacheChangeset,
-			types.DeployConfig{
-				ChainsToDeploy: []uint64{chainSelector},
-				Labels:         []string{"data-feeds"},
-				Qualifier:      "data-feeds",
-			},
-		),
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.DeployCacheChangeset, types.DeployConfig{
+			ChainsToDeploy: []uint64{selector},
+			Labels:         []string{"data-feeds"},
+			Qualifier:      "data-feeds",
+		}),
 	)
 	require.NoError(t, err)
 
-	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	records := rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
 	require.Len(t, records, 1)
 	cacheAddress := records[0].Address
 
-	resp, err := commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.SetFeedAdminChangeset,
-		types.SetFeedAdminConfig{
-			ChainSelector: chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedAdminChangeset, types.SetFeedAdminConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
-			AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
+			AdminAddress:  common.HexToAddress(rt.Environment().BlockChains.EVMChains()[selector].DeployerKey.From.Hex()),
 			IsAdmin:       true,
-		},
-	), commonChangesets.Configure(
-		changeset.MigrateFeedsChangeset,
-		types.MigrationConfig{
-			ChainSelector: chainSelector,
+		}),
+		runtime.ChangesetTask(changeset.MigrateFeedsChangeset, types.MigrationConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
 			Proxies: []*types.MigrationSchema{
 				{
@@ -92,11 +78,11 @@ func TestMigrateFeeds(t *testing.T) {
 					AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
 				},
 			},
-		},
-	))
+		}),
+	)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
-	addresses, err := resp.DataStore.Addresses().Fetch()
+
+	addresses, err := rt.State().DataStore.Addresses().Fetch()
 	require.NoError(t, err)
 	require.Len(t, addresses, 3) // DataFeedsCache and two migrated proxies
 }

--- a/deployment/data-feeds/changeset/new_feed_with_proxy_test.go
+++ b/deployment/data-feeds/changeset/new_feed_with_proxy_test.go
@@ -1,113 +1,103 @@
 package changeset_test
 
 import (
+	"crypto/ecdsa"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestNewFeedWithProxy(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-
-	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		changeset.DeployCacheChangeset,
-		types.DeployConfig{
-			ChainsToDeploy: []uint64{chainSelector},
-			Labels:         []string{"data-feeds"},
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-		},
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
 	))
 	require.NoError(t, err)
 
-	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.DeployCacheChangeset, types.DeployConfig{
+			ChainsToDeploy: []uint64{selector},
+			Labels:         []string{"data-feeds"},
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2), map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			selector: proposalutils.SingleGroupTimelockConfigV2(t),
+		}),
+	)
+	require.NoError(t, err)
+
+	records := rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
 	require.Len(t, records, 1)
 	cacheAddress := records[0].Address
 
-	records = newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
+	records = rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
 	require.Len(t, records, 1)
 	timeLockAddress := records[0].Address
 
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.SetFeedAdminChangeset,
-		types.SetFeedAdminConfig{
-			ChainSelector: chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedAdminChangeset, types.SetFeedAdminConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
 			AdminAddress:  common.HexToAddress(timeLockAddress),
 			IsAdmin:       true,
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
-		commonChangesets.TransferToMCMSWithTimelockConfig{
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2), commonChangesets.TransferToMCMSWithTimelockConfig{
 			ContractsByChain: map[uint64][]common.Address{
-				chainSelector: {common.HexToAddress(cacheAddress)},
+				selector: {common.HexToAddress(cacheAddress)},
 			},
 			MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
-		},
-	))
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
 	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 1)
+	require.True(t, rt.State().Proposals[0].IsExecuted)
 
 	dataid := "0x01bb0467f50003040000000000000000"
 	dataid2 := "0x01475851f90003320000000000000000"
 	dataid3 := "0x01465851f90003320000000000000000"
 
-	newEnv, err = commonChangesets.Apply(t, newEnv,
-		commonChangesets.Configure(
-			changeset.NewFeedWithProxyChangeset,
-			types.NewFeedWithProxyConfig{
-				ChainSelector:    chainSelector,
-				AccessController: common.HexToAddress("0x00"),
-				DataIDs:          []string{dataid, dataid2, dataid3},
-				Descriptions:     []string{"feed1", "feed2", "feed3"},
-				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					{
-						AllowedSender:        common.HexToAddress("0x22"),
-						AllowedWorkflowOwner: common.HexToAddress("0x33"),
-						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
-					},
-				},
-				Qualifiers: []string{"qualifier1", "qualifier2", "qualifier3"},
-				McmsConfig: &types.MCMSConfig{
-					MinDelay: 0,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.NewFeedWithProxyChangeset, types.NewFeedWithProxyConfig{
+			ChainSelector:    selector,
+			AccessController: common.HexToAddress("0x00"),
+			DataIDs:          []string{dataid, dataid2, dataid3},
+			Descriptions:     []string{"feed1", "feed2", "feed3"},
+			WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
+				{
+					AllowedSender:        common.HexToAddress("0x22"),
+					AllowedWorkflowOwner: common.HexToAddress("0x33"),
+					AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
 				},
 			},
-		),
+			Qualifiers: []string{"qualifier1", "qualifier2", "qualifier3"},
+			McmsConfig: &types.MCMSConfig{
+				MinDelay: 0,
+			},
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
 	)
 	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 2)
+	require.True(t, rt.State().Proposals[1].IsExecuted)
 
-	addrs, err := newEnv.DataStore.Addresses().Fetch()
+	addrs, err := rt.State().DataStore.Addresses().Fetch()
 	require.NoError(t, err)
 	// 3 AggregatorProxy, DataFeedsCache, CallProxy, RBACTimelock, ProposerManyChainMultiSig, BypasserManyChainMultiSig, CancellerManyChainMultiSig
 	require.Len(t, addrs, 9)

--- a/deployment/data-feeds/changeset/propose_aggregator_test.go
+++ b/deployment/data-feeds/changeset/propose_aggregator_test.go
@@ -1,96 +1,89 @@
 package changeset_test
 
 import (
+	"crypto/ecdsa"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
-	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestProposeAggregator(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-
-	// without MCMS
-	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		changeset.DeployCacheChangeset,
-		types.DeployConfig{
-			ChainsToDeploy: []uint64{chainSelector},
-			Labels:         []string{"data-feeds"},
-		},
-	), commonChangesets.Configure(
-		changeset.DeployAggregatorProxyChangeset,
-		types.DeployAggregatorProxyConfig{
-			ChainsToDeploy:   []uint64{chainSelector},
-			AccessController: []common.Address{common.HexToAddress("0x")},
-		},
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
 	))
 	require.NoError(t, err)
 
-	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("AggregatorProxy"))
+	// without MCMS
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.DeployCacheChangeset, types.DeployConfig{
+			ChainsToDeploy: []uint64{selector},
+			Labels:         []string{"data-feeds"},
+		}),
+		runtime.ChangesetTask(changeset.DeployAggregatorProxyChangeset, types.DeployAggregatorProxyConfig{
+			ChainsToDeploy:   []uint64{selector},
+			AccessController: []common.Address{common.HexToAddress("0x")},
+		}),
+	)
+	require.NoError(t, err)
+
+	records := rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("AggregatorProxy"))
 	require.Len(t, records, 1)
 	proxyAddress := records[0].Address
 
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.ProposeAggregatorChangeset,
-		types.ProposeConfirmAggregatorConfig{
-			ChainSelector:        chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.ProposeAggregatorChangeset, types.ProposeConfirmAggregatorConfig{
+			ChainSelector:        selector,
 			ProxyAddress:         common.HexToAddress(proxyAddress),
 			NewAggregatorAddress: common.HexToAddress("0x123"),
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-		},
-	))
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2), map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			selector: proposalutils.SingleGroupTimelockConfigV2(t),
+		}),
+	)
 	require.NoError(t, err)
 
 	// with MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
-		commonChangesets.TransferToMCMSWithTimelockConfig{
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2), commonChangesets.TransferToMCMSWithTimelockConfig{
 			ContractsByChain: map[uint64][]common.Address{
-				chainSelector: {common.HexToAddress(proxyAddress)},
+				selector: {common.HexToAddress(proxyAddress)},
 			},
 			MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
-		},
-	), commonChangesets.Configure(
-		changeset.ProposeAggregatorChangeset,
-		types.ProposeConfirmAggregatorConfig{
-			ChainSelector:        chainSelector,
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
+	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 1)
+	require.True(t, rt.State().Proposals[0].IsExecuted)
+
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.ProposeAggregatorChangeset, types.ProposeConfirmAggregatorConfig{
+			ChainSelector:        selector,
 			ProxyAddress:         common.HexToAddress(proxyAddress),
 			NewAggregatorAddress: common.HexToAddress("0x123"),
 			McmsConfig: &types.MCMSConfig{
 				MinDelay: 0,
 			},
-		},
-	))
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
 	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 2)
+	require.True(t, rt.State().Proposals[1].IsExecuted)
 }

--- a/deployment/data-feeds/changeset/remove_feed_config_test.go
+++ b/deployment/data-feeds/changeset/remove_feed_config_test.go
@@ -1,74 +1,63 @@
 package changeset_test
 
 import (
+	"crypto/ecdsa"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestRemoveFeedConfig(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-
-	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		changeset.DeployCacheChangeset,
-		types.DeployConfig{
-			ChainsToDeploy: []uint64{chainSelector},
-			Labels:         []string{"data-feeds"},
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-		},
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
 	))
 	require.NoError(t, err)
 
-	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.DeployCacheChangeset, types.DeployConfig{
+			ChainsToDeploy: []uint64{selector},
+			Labels:         []string{"data-feeds"},
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2), map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			selector: proposalutils.SingleGroupTimelockConfigV2(t),
+		}),
+	)
+	require.NoError(t, err)
+
+	records := rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
 	require.Len(t, records, 1)
 	cacheAddress := records[0].Address
 
 	dataid := "0x01bb0467f50003040000000000000000"
 
 	// without MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.SetFeedAdminChangeset,
-		types.SetFeedAdminConfig{
-			ChainSelector: chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedAdminChangeset, types.SetFeedAdminConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
-			AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
+			AdminAddress:  common.HexToAddress(rt.Environment().BlockChains.EVMChains()[selector].DeployerKey.From.Hex()),
 			IsAdmin:       true,
-		},
-	), commonChangesets.Configure(
-		changeset.SetFeedConfigChangeset,
-		types.SetFeedDecimalConfig{
-			ChainSelector: chainSelector,
+		}),
+		runtime.ChangesetTask(changeset.SetFeedConfigChangeset, types.SetFeedDecimalConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
 			DataIDs:       []string{dataid},
 			Descriptions:  []string{"test"},
@@ -79,46 +68,43 @@ func TestRemoveFeedConfig(t *testing.T) {
 					AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
 				},
 			},
-		},
-	), commonChangesets.Configure(
-		changeset.RemoveFeedConfigChangeset,
-		types.RemoveFeedConfigCSConfig{
-			ChainSelector: chainSelector,
+		}),
+		runtime.ChangesetTask(changeset.RemoveFeedConfigChangeset, types.RemoveFeedConfigCSConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
 			DataIDs:       []string{dataid},
-		},
-	))
+		}),
+	)
 	require.NoError(t, err)
 
 	// with MCMS
-	records = newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
+	records = rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
 	require.Len(t, records, 1)
 	timeLockAddress := records[0].Address
 
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.SetFeedAdminChangeset,
-		types.SetFeedAdminConfig{
-			ChainSelector: chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedAdminChangeset, types.SetFeedAdminConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
 			AdminAddress:  common.HexToAddress(timeLockAddress),
 			IsAdmin:       true,
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
-		commonChangesets.TransferToMCMSWithTimelockConfig{
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2), commonChangesets.TransferToMCMSWithTimelockConfig{
 			ContractsByChain: map[uint64][]common.Address{
-				chainSelector: {common.HexToAddress(cacheAddress)},
+				selector: {common.HexToAddress(cacheAddress)},
 			},
 			MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
-		},
-	))
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
 	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 1)
+	require.True(t, rt.State().Proposals[0].IsExecuted)
 
 	// Set and remove the feed config with MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.SetFeedConfigChangeset,
-		types.SetFeedDecimalConfig{
-			ChainSelector: chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedConfigChangeset, types.SetFeedDecimalConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
 			DataIDs:       []string{dataid},
 			Descriptions:  []string{"test2"},
@@ -132,17 +118,25 @@ func TestRemoveFeedConfig(t *testing.T) {
 			McmsConfig: &types.MCMSConfig{
 				MinDelay: 0,
 			},
-		},
-	), commonChangesets.Configure(
-		changeset.RemoveFeedConfigChangeset,
-		types.RemoveFeedConfigCSConfig{
-			ChainSelector: chainSelector,
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
+	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 2)
+	require.True(t, rt.State().Proposals[1].IsExecuted)
+
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.RemoveFeedConfigChangeset, types.RemoveFeedConfigCSConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
 			DataIDs:       []string{dataid},
 			McmsConfig: &types.MCMSConfig{
 				MinDelay: 0,
 			},
-		},
-	))
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
 	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 3)
+	require.True(t, rt.State().Proposals[2].IsExecuted)
 }

--- a/deployment/data-feeds/changeset/remove_feed_test.go
+++ b/deployment/data-feeds/changeset/remove_feed_test.go
@@ -1,75 +1,63 @@
 package changeset_test
 
 import (
+	"crypto/ecdsa"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestRemoveFeed(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-
-	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		changeset.DeployCacheChangeset,
-		types.DeployConfig{
-			ChainsToDeploy: []uint64{chainSelector},
-			Labels:         []string{"data-feeds"},
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-		},
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
 	))
 	require.NoError(t, err)
 
-	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.DeployCacheChangeset, types.DeployConfig{
+			ChainsToDeploy: []uint64{selector},
+			Labels:         []string{"data-feeds"},
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2), map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			selector: proposalutils.SingleGroupTimelockConfigV2(t),
+		}),
+	)
+	require.NoError(t, err)
+
+	records := rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
 	require.Len(t, records, 1)
 	cacheAddress := records[0].Address
 
 	dataid := "0x01bb0467f50003040000000000000000"
 
 	// without MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.SetFeedAdminChangeset,
-		types.SetFeedAdminConfig{
-			ChainSelector: chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedAdminChangeset, types.SetFeedAdminConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
-			AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
+			AdminAddress:  common.HexToAddress(rt.Environment().BlockChains.EVMChains()[selector].DeployerKey.From.Hex()),
 			IsAdmin:       true,
-		},
-	), commonChangesets.Configure(
-		changeset.SetFeedConfigChangeset,
-		types.SetFeedDecimalConfig{
-			ChainSelector: chainSelector,
+		}),
+		runtime.ChangesetTask(changeset.SetFeedConfigChangeset, types.SetFeedDecimalConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
 			DataIDs:       []string{dataid},
 			Descriptions:  []string{"test"},
@@ -80,47 +68,44 @@ func TestRemoveFeed(t *testing.T) {
 					AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
 				},
 			},
-		},
-	), commonChangesets.Configure(
-		changeset.RemoveFeedChangeset,
-		types.RemoveFeedConfig{
-			ChainSelector:  chainSelector,
+		}),
+		runtime.ChangesetTask(changeset.RemoveFeedChangeset, types.RemoveFeedConfig{
+			ChainSelector:  selector,
 			CacheAddress:   common.HexToAddress(cacheAddress),
 			DataIDs:        []string{dataid},
 			ProxyAddresses: []common.Address{common.HexToAddress("0x123")},
-		},
-	))
+		}),
+	)
 	require.NoError(t, err)
 
 	// with MCMS
-	records = newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
+	records = rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
 	require.Len(t, records, 1)
 	timeLockAddress := records[0].Address
 
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.SetFeedAdminChangeset,
-		types.SetFeedAdminConfig{
-			ChainSelector: chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedAdminChangeset, types.SetFeedAdminConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
 			AdminAddress:  common.HexToAddress(timeLockAddress),
 			IsAdmin:       true,
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
-		commonChangesets.TransferToMCMSWithTimelockConfig{
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2), commonChangesets.TransferToMCMSWithTimelockConfig{
 			ContractsByChain: map[uint64][]common.Address{
-				chainSelector: {common.HexToAddress(cacheAddress)},
+				selector: {common.HexToAddress(cacheAddress)},
 			},
 			MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
-		},
-	))
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
 	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 1)
+	require.True(t, rt.State().Proposals[0].IsExecuted)
 
 	// Set and remove the feed config with MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.SetFeedConfigChangeset,
-		types.SetFeedDecimalConfig{
-			ChainSelector: chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedConfigChangeset, types.SetFeedDecimalConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
 			DataIDs:       []string{dataid},
 			Descriptions:  []string{"test2"},
@@ -134,18 +119,27 @@ func TestRemoveFeed(t *testing.T) {
 			McmsConfig: &types.MCMSConfig{
 				MinDelay: 0,
 			},
-		},
-	), commonChangesets.Configure(
-		changeset.RemoveFeedChangeset,
-		types.RemoveFeedConfig{
-			ChainSelector:  chainSelector,
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
+
+	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 2)
+	require.True(t, rt.State().Proposals[1].IsExecuted)
+
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.RemoveFeedChangeset, types.RemoveFeedConfig{
+			ChainSelector:  selector,
 			CacheAddress:   common.HexToAddress(cacheAddress),
 			DataIDs:        []string{dataid},
 			ProxyAddresses: []common.Address{common.HexToAddress("0x123")},
 			McmsConfig: &types.MCMSConfig{
 				MinDelay: 0,
 			},
-		},
-	))
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
 	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 3)
+	require.True(t, rt.State().Proposals[2].IsExecuted)
 }

--- a/deployment/data-feeds/changeset/set_bundle_feed_config_test.go
+++ b/deployment/data-feeds/changeset/set_bundle_feed_config_test.go
@@ -1,75 +1,63 @@
 package changeset_test
 
 import (
+	"crypto/ecdsa"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestSetBundleFeedConfig(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(
-		cldf_chain.WithFamily(chain_selectors.FamilyEVM),
-	)[0]
-
-	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		changeset.DeployCacheChangeset,
-		types.DeployConfig{
-			ChainsToDeploy: []uint64{chainSelector},
-			Labels:         []string{"data-feeds"},
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-		},
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
 	))
 	require.NoError(t, err)
 
-	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.DeployCacheChangeset, types.DeployConfig{
+			ChainsToDeploy: []uint64{selector},
+			Labels:         []string{"data-feeds"},
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2), map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			selector: proposalutils.SingleGroupTimelockConfigV2(t),
+		}),
+	)
+	require.NoError(t, err)
+
+	records := rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
 	require.Len(t, records, 1)
 	cacheAddress := records[0].Address
 
 	dataid := "0x01bb0467f50003040000000000000000"
 
 	// without MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.SetFeedAdminChangeset,
-		types.SetFeedAdminConfig{
-			ChainSelector: chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedAdminChangeset, types.SetFeedAdminConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
-			AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
+			AdminAddress:  common.HexToAddress(rt.Environment().BlockChains.EVMChains()[selector].DeployerKey.From.Hex()),
 			IsAdmin:       true,
-		},
-	), commonChangesets.Configure(
-		changeset.SetBundleFeedConfigChangeset,
-		types.SetFeedBundleConfig{
-			ChainSelector:  chainSelector,
+		}),
+		runtime.ChangesetTask(changeset.SetBundleFeedConfigChangeset, types.SetFeedBundleConfig{
+			ChainSelector:  selector,
 			CacheAddress:   common.HexToAddress(cacheAddress),
 			DataIDs:        []string{dataid},
 			Descriptions:   []string{"test"},
@@ -81,56 +69,56 @@ func TestSetBundleFeedConfig(t *testing.T) {
 					AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
 				},
 			},
-		},
-	))
+		}),
+	)
 	require.NoError(t, err)
 
 	// with MCMS
-	records = newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
+	records = rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
 	require.Len(t, records, 1)
 	timeLockAddress := records[0].Address
 
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.SetFeedAdminChangeset,
-		types.SetFeedAdminConfig{
-			ChainSelector: chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedAdminChangeset, types.SetFeedAdminConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
 			AdminAddress:  common.HexToAddress(timeLockAddress),
 			IsAdmin:       true,
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
-		commonChangesets.TransferToMCMSWithTimelockConfig{
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2), commonChangesets.TransferToMCMSWithTimelockConfig{
 			ContractsByChain: map[uint64][]common.Address{
-				chainSelector: {common.HexToAddress(cacheAddress)},
+				selector: {common.HexToAddress(cacheAddress)},
 			},
 			MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
-		},
-	))
-	require.NoError(t, err)
-
-	// Set the feed config with MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv,
-		commonChangesets.Configure(
-			changeset.SetBundleFeedConfigChangeset,
-			types.SetFeedBundleConfig{
-				ChainSelector:  chainSelector,
-				CacheAddress:   common.HexToAddress(cacheAddress),
-				DataIDs:        []string{dataid},
-				Descriptions:   []string{"test2"},
-				DecimalsMatrix: [][]uint8{{18, 8, 6}},
-				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					{
-						AllowedSender:        common.HexToAddress("0x22"),
-						AllowedWorkflowOwner: common.HexToAddress("0x33"),
-						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
-					},
-				},
-				McmsConfig: &types.MCMSConfig{
-					MinDelay: 0,
-				},
-			},
-		),
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
 	)
 	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 1)
+	require.True(t, rt.State().Proposals[0].IsExecuted)
+
+	// Set the feed config with MCMS
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetBundleFeedConfigChangeset, types.SetFeedBundleConfig{
+			ChainSelector:  selector,
+			CacheAddress:   common.HexToAddress(cacheAddress),
+			DataIDs:        []string{dataid},
+			Descriptions:   []string{"test2"},
+			DecimalsMatrix: [][]uint8{{18, 8, 6}},
+			WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
+				{
+					AllowedSender:        common.HexToAddress("0x22"),
+					AllowedWorkflowOwner: common.HexToAddress("0x33"),
+					AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
+				},
+			},
+			McmsConfig: &types.MCMSConfig{
+				MinDelay: 0,
+			},
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
+	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 2)
+	require.True(t, rt.State().Proposals[1].IsExecuted)
 }

--- a/deployment/data-feeds/changeset/set_feed_admin_test.go
+++ b/deployment/data-feeds/changeset/set_feed_admin_test.go
@@ -1,103 +1,87 @@
 package changeset_test
 
 import (
+	"crypto/ecdsa"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
-	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestSetCacheAdmin(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-
-	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		changeset.DeployCacheChangeset,
-		types.DeployConfig{
-			ChainsToDeploy: []uint64{chainSelector},
-			Labels:         []string{"data-feeds"},
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-		},
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
 	))
 	require.NoError(t, err)
 
-	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.DeployCacheChangeset, types.DeployConfig{
+			ChainsToDeploy: []uint64{selector},
+			Labels:         []string{"data-feeds"},
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2), map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			selector: proposalutils.SingleGroupTimelockConfigV2(t),
+		}),
+	)
+	require.NoError(t, err)
+
+	records := rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
 	require.Len(t, records, 1)
 	cacheAddress := records[0].Address
 
 	// without MCMS
-	resp, err := commonChangesets.Apply(t, newEnv,
-		commonChangesets.Configure(
-			changeset.SetFeedAdminChangeset,
-			types.SetFeedAdminConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress("0x123"),
-				IsAdmin:       true,
-			},
-		),
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedAdminChangeset, types.SetFeedAdminConfig{
+			ChainSelector: selector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			AdminAddress:  common.HexToAddress("0x123"),
+			IsAdmin:       true,
+		}),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
 
 	// with MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv,
-		commonChangesets.Configure(
-			cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
-			commonChangesets.TransferToMCMSWithTimelockConfig{
-				ContractsByChain: map[uint64][]common.Address{
-					chainSelector: {common.HexToAddress(cacheAddress)},
-				},
-				MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2), commonChangesets.TransferToMCMSWithTimelockConfig{
+			ContractsByChain: map[uint64][]common.Address{
+				selector: {common.HexToAddress(cacheAddress)},
 			},
-		),
+			MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
 	)
 	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 1)
+	require.True(t, rt.State().Proposals[0].IsExecuted)
 
-	resp, err = commonChangesets.Apply(t, newEnv,
-		commonChangesets.Configure(
-			changeset.SetFeedAdminChangeset,
-			types.SetFeedAdminConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress("0x123"),
-				IsAdmin:       true,
-				McmsConfig: &types.MCMSConfig{
-					MinDelay: 0,
-				},
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedAdminChangeset, types.SetFeedAdminConfig{
+			ChainSelector: selector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			AdminAddress:  common.HexToAddress("0x123"),
+			IsAdmin:       true,
+			McmsConfig: &types.MCMSConfig{
+				MinDelay: 0,
 			},
-		),
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
+	require.Len(t, rt.State().Proposals, 2)
+	require.True(t, rt.State().Proposals[1].IsExecuted)
 }

--- a/deployment/data-feeds/changeset/set_feed_config_test.go
+++ b/deployment/data-feeds/changeset/set_feed_config_test.go
@@ -1,77 +1,63 @@
 package changeset_test
 
 import (
+	"crypto/ecdsa"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
-	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestSetFeedConfig(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-
-	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		changeset.DeployCacheChangeset,
-		types.DeployConfig{
-			ChainsToDeploy: []uint64{chainSelector},
-			Labels:         []string{"data-feeds"},
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-		},
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
 	))
 	require.NoError(t, err)
 
-	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.DeployCacheChangeset, types.DeployConfig{
+			ChainsToDeploy: []uint64{selector},
+			Labels:         []string{"data-feeds"},
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2), map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			selector: proposalutils.SingleGroupTimelockConfigV2(t),
+		}),
+	)
+	require.NoError(t, err)
+
+	records := rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
 	require.Len(t, records, 1)
 	cacheAddress := records[0].Address
 
 	dataid := "0x01bb0467f50003040000000000000000"
 
 	// without MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.SetFeedAdminChangeset,
-		types.SetFeedAdminConfig{
-			ChainSelector: chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedAdminChangeset, types.SetFeedAdminConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
-			AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
+			AdminAddress:  common.HexToAddress(rt.Environment().BlockChains.EVMChains()[selector].DeployerKey.From.Hex()),
 			IsAdmin:       true,
-		},
-	), commonChangesets.Configure(
-		changeset.SetFeedConfigChangeset,
-		types.SetFeedDecimalConfig{
-			ChainSelector: chainSelector,
+		}),
+		runtime.ChangesetTask(changeset.SetFeedConfigChangeset, types.SetFeedDecimalConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
 			DataIDs:       []string{dataid},
 			Descriptions:  []string{"test"},
@@ -82,55 +68,56 @@ func TestSetFeedConfig(t *testing.T) {
 					AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
 				},
 			},
-		},
-	))
+		}),
+	)
 	require.NoError(t, err)
 
 	// with MCMS
-	records = newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
+	records = rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
 	require.Len(t, records, 1)
 	timeLockAddress := records[0].Address
 
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.SetFeedAdminChangeset,
-		types.SetFeedAdminConfig{
-			ChainSelector: chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedAdminChangeset, types.SetFeedAdminConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
 			AdminAddress:  common.HexToAddress(timeLockAddress),
 			IsAdmin:       true,
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
-		commonChangesets.TransferToMCMSWithTimelockConfig{
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2), commonChangesets.TransferToMCMSWithTimelockConfig{
 			ContractsByChain: map[uint64][]common.Address{
-				chainSelector: {common.HexToAddress(cacheAddress)},
+				selector: {common.HexToAddress(cacheAddress)},
 			},
 			MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
-		},
-	))
-	require.NoError(t, err)
-
-	// Set the feed config with MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv,
-		commonChangesets.Configure(
-			changeset.SetFeedConfigChangeset,
-			types.SetFeedDecimalConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				DataIDs:       []string{dataid},
-				Descriptions:  []string{"test2"},
-				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					{
-						AllowedSender:        common.HexToAddress("0x22"),
-						AllowedWorkflowOwner: common.HexToAddress("0x33"),
-						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
-					},
-				},
-				McmsConfig: &types.MCMSConfig{
-					MinDelay: 0,
-				},
-			},
-		),
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
 	)
 	require.NoError(t, err)
+
+	require.Len(t, rt.State().Proposals, 1)
+	require.True(t, rt.State().Proposals[0].IsExecuted)
+
+	// Set the feed config with MCMS
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedConfigChangeset, types.SetFeedDecimalConfig{
+			ChainSelector: selector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			DataIDs:       []string{dataid},
+			Descriptions:  []string{"test2"},
+			WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
+				{
+					AllowedSender:        common.HexToAddress("0x22"),
+					AllowedWorkflowOwner: common.HexToAddress("0x33"),
+					AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
+				},
+			},
+			McmsConfig: &types.MCMSConfig{
+				MinDelay: 0,
+			},
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
+	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 2)
+	require.True(t, rt.State().Proposals[1].IsExecuted)
 }

--- a/deployment/data-feeds/changeset/update_data_id_proxy_test.go
+++ b/deployment/data-feeds/changeset/update_data_id_proxy_test.go
@@ -1,117 +1,105 @@
 package changeset_test
 
 import (
+	"crypto/ecdsa"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	chainselectors "github.com/smartcontractkit/chain-selectors"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestUpdateDataIDProxyMap(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
-
-	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		changeset.DeployCacheChangeset,
-		types.DeployConfig{
-			ChainsToDeploy: []uint64{chainSelector},
-			Labels:         []string{"data-feeds"},
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-		},
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
 	))
 	require.NoError(t, err)
 
-	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.DeployCacheChangeset, types.DeployConfig{
+			ChainsToDeploy: []uint64{selector},
+			Labels:         []string{"data-feeds"},
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2), map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			selector: proposalutils.SingleGroupTimelockConfigV2(t),
+		}),
+	)
+	require.NoError(t, err)
+
+	records := rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
 	require.Len(t, records, 1)
 	cacheAddress := records[0].Address
 
 	dataID := "0x01bb0467f50003040000000000000000"
 
 	// without MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.SetFeedAdminChangeset,
-		types.SetFeedAdminConfig{
-			ChainSelector: chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedAdminChangeset, types.SetFeedAdminConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
-			AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
+			AdminAddress:  common.HexToAddress(rt.Environment().BlockChains.EVMChains()[selector].DeployerKey.From.Hex()),
 			IsAdmin:       true,
-		},
-	), commonChangesets.Configure(
-		changeset.UpdateDataIDProxyChangeset,
-		types.UpdateDataIDProxyConfig{
-			ChainSelector:  chainSelector,
+		}),
+		runtime.ChangesetTask(changeset.UpdateDataIDProxyChangeset, types.UpdateDataIDProxyConfig{
+			ChainSelector:  selector,
 			CacheAddress:   common.HexToAddress(cacheAddress),
 			ProxyAddresses: []common.Address{common.HexToAddress("0x11")},
 			DataIDs:        []string{dataID},
-		},
-	))
+		}),
+	)
 	require.NoError(t, err)
 
 	// with MCMS
-	records = newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
+	records = rt.State().DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
 	require.Len(t, records, 1)
 	timeLockAddress := records[0].Address
 
-	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
-		changeset.SetFeedAdminChangeset,
-		types.SetFeedAdminConfig{
-			ChainSelector: chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.SetFeedAdminChangeset, types.SetFeedAdminConfig{
+			ChainSelector: selector,
 			CacheAddress:  common.HexToAddress(cacheAddress),
 			AdminAddress:  common.HexToAddress(timeLockAddress),
 			IsAdmin:       true,
-		},
-	), commonChangesets.Configure(
-		cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
-		commonChangesets.TransferToMCMSWithTimelockConfig{
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2), commonChangesets.TransferToMCMSWithTimelockConfig{
 			ContractsByChain: map[uint64][]common.Address{
-				chainSelector: {common.HexToAddress(cacheAddress)},
+				selector: {common.HexToAddress(cacheAddress)},
 			},
 			MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
-		},
-	))
-	require.NoError(t, err)
-
-	newEnv, err = commonChangesets.Apply(t, newEnv,
-		commonChangesets.Configure(
-			changeset.UpdateDataIDProxyChangeset,
-			types.UpdateDataIDProxyConfig{
-				ChainSelector:  chainSelector,
-				CacheAddress:   common.HexToAddress(cacheAddress),
-				ProxyAddresses: []common.Address{common.HexToAddress("0x11")},
-				DataIDs:        []string{dataID},
-				McmsConfig: &types.MCMSConfig{
-					MinDelay: 0,
-				},
-			},
-		),
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
 	)
 	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 1)
+	require.True(t, rt.State().Proposals[0].IsExecuted)
+
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.UpdateDataIDProxyChangeset, types.UpdateDataIDProxyConfig{
+			ChainSelector:  selector,
+			CacheAddress:   common.HexToAddress(cacheAddress),
+			ProxyAddresses: []common.Address{common.HexToAddress("0x11")},
+			DataIDs:        []string{dataID},
+			McmsConfig: &types.MCMSConfig{
+				MinDelay: 0,
+			},
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
+	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 2)
+	require.True(t, rt.State().Proposals[1].IsExecuted)
 }

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1522,6 +1522,8 @@ github.com/scylladb/go-reflectx v1.0.1/go.mod h1:rWnOfDIRWBGN0miMLIcoPt/Dhi2doCM
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0 h1:b23VGrQhTA8cN2CbBw7/FulN9fTtqYUdS5+Oxzt+DUE=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0/go.mod h1:FGBZgq2tXWICsxWQW1msNf49F0Pf2Op5Htayx335Qbs=
+github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
+github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/serialx/hashring v0.0.0-20200727003509-22c0c7ab6b1b h1:h+3JX2VoWTFuyQEo87pStk/a99dzIO1mM9KxIyLPGTU=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1723,6 +1723,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUt
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0 h1:b23VGrQhTA8cN2CbBw7/FulN9fTtqYUdS5+Oxzt+DUE=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0/go.mod h1:FGBZgq2tXWICsxWQW1msNf49F0Pf2Op5Htayx335Qbs=
+github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
+github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sercand/kuberesolver/v6 v6.0.0 h1:ScvS2Ga9snVkpOahln/BCLySr3/iBAHJf25u66DweZ0=
 github.com/sercand/kuberesolver/v6 v6.0.0/go.mod h1:Dxkqms3OJadP5zirIBPLi9FV8Qpys3T3w40XPEcVsu0=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=


### PR DESCRIPTION
Updates the data-feeds EVM changeset tests to use the test engine runtime instead of the memory environment.
