### PR TITLE
logging incomplete metadata for activated events

### DIFF
--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -191,7 +191,7 @@ func (h *eventHandler) Handle(ctx context.Context, event Event) error {
 		cma := h.emitter.With(
 			platform.KeyWorkflowID, wfID,
 			platform.KeyWorkflowName, payload.WorkflowName,
-			platform.KeyWorkflowOwner, hex.EncodeToString(payload.WorkflowOwner),
+			platform.KeyWorkflowOwner, wfOwner,
 			platform.KeyWorkflowTag, payload.WorkflowTag,
 			platform.KeyOrganizationID, orgID,
 			platform.WorkflowRegistryChainSelector, h.workflowRegistryChainSelector,


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/CRE-1009 - we are observing that activated deployment events sometimes report missing data for wf owner and wf id. It seems more likely to me to be an issue on the event consumer side, but adding some warn logging just in case.