### PR TITLE
Fix concurrency for docker-build workflow runs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,7 +14,7 @@ on:
         required: true
 
 concurrency:
-  group: "docker-build-${{ github.ref_name }}"
+  group: "docker-build-${{ github.event_name }}-${{ github.ref_name }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Running the `docker-build.yml` workflow manually will default to run on the `develop` branch. If a PR gets merged to develop after that manual run starts, the manual run will be canceled since the concurrency group would be the same.