### PR TITLE
chore: update evm common changesets tests to use test runtime

### DIFF
--- a/deployment/common/changeset/deploy_link_token_test.go
+++ b/deployment/common/changeset/deploy_link_token_test.go
@@ -3,16 +3,44 @@ package changeset_test
 import (
 	"testing"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	commonState "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 )
 
 func TestDeployLinkToken(t *testing.T) {
 	t.Parallel()
-	changeset.DeployLinkTokenTest(t, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
+
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
+
+	chain := rt.Environment().BlockChains.EVMChains()[selector]
+
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployLinkToken), []uint64{selector}),
+	)
+	require.NoError(t, err)
+
+	addrs, err := rt.State().AddressBook.AddressesForChain(selector)
+	require.NoError(t, err)
+
+	state, err := commonState.MaybeLoadLinkTokenChainState(chain, addrs)
+	require.NoError(t, err)
+
+	// View itself already unit tested
+	_, err = state.GenerateLinkView()
+	require.NoError(t, err)
 }
 
 func TestDeployLinkTokenZk(t *testing.T) {
@@ -20,7 +48,27 @@ func TestDeployLinkTokenZk(t *testing.T) {
 	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/CCIP-6427")
 
 	t.Parallel()
-	changeset.DeployLinkTokenTest(t, memory.MemoryEnvironmentConfig{
-		ZkChains: 1,
-	})
+
+	selector := chain_selectors.TEST_90000050.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithZKSyncContainer(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
+
+	chain := rt.Environment().BlockChains.EVMChains()[selector]
+
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployLinkToken), []uint64{selector}),
+	)
+	require.NoError(t, err)
+
+	addrs, err := rt.State().AddressBook.AddressesForChain(selector)
+	require.NoError(t, err)
+
+	state, err := commonState.MaybeLoadLinkTokenChainState(chain, addrs)
+	require.NoError(t, err)
+
+	// View itself already unit tested
+	_, err = state.GenerateLinkView()
+	require.NoError(t, err)
 }

--- a/deployment/common/changeset/example/add_mint_burners_link_test.go
+++ b/deployment/common/changeset/example/add_mint_burners_link_test.go
@@ -1,16 +1,11 @@
 package example_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
-
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/example"
@@ -19,13 +14,14 @@ import (
 // TestAddMintersBurnersLink tests the AddMintersBurnersLink changeset
 func TestAddMintersBurnersLink(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-	// Deploy Link Token and Timelock contracts and add addresses to environment
-	env := setupLinkTransferTestEnv(t)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	chain := env.BlockChains.EVMChains()[chainSelector]
-	addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+	var (
+		ctx          = t.Context()
+		rt, selector = setupLinkTransferRuntime(t) // Deploy Link Token and Timelock contracts and add addresses to environment
+	)
+
+	chain := rt.Environment().BlockChains.EVMChains()[selector]
+	addrs, err := rt.State().AddressBook.AddressesForChain(selector)
 	require.NoError(t, err)
 	require.Len(t, addrs, 6)
 
@@ -37,8 +33,8 @@ func TestAddMintersBurnersLink(t *testing.T) {
 	timelockAddress := mcmsState.Timelock.Address()
 
 	// Mint some funds
-	_, err = example.AddMintersBurnersLink(env, &example.AddMintersBurnersLinkConfig{
-		ChainSelector: chainSelector,
+	_, err = example.AddMintersBurnersLink(rt.Environment(), &example.AddMintersBurnersLinkConfig{
+		ChainSelector: selector,
 		Minters:       []common.Address{timelockAddress},
 		Burners:       []common.Address{timelockAddress},
 	})

--- a/deployment/common/changeset/example/datastore/exemplar_deploy_link_token_test.go
+++ b/deployment/common/changeset/example/datastore/exemplar_deploy_link_token_test.go
@@ -3,23 +3,20 @@ package example
 import (
 	"testing"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 )
 
 func Test_ExemplarDeployLinkToken(t *testing.T) {
 	t.Parallel()
 
-	lggr := logger.TestLogger(t)
-	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
-	chain1 := e.BlockChains.ListChainSelectors()[0]
+	selector := chainselectors.TEST_90000001.Selector
+	env, err := environment.New(t.Context(), environment.WithEVMSimulated(t, []uint64{selector}))
+	require.NoError(t, err)
 
-	result, err := ExemplarDeployLinkToken{}.Apply(e, chain1)
+	result, err := ExemplarDeployLinkToken{}.Apply(*env, selector)
 	require.NoError(t, err)
 
 	// Check that one address ref was created

--- a/deployment/common/changeset/example/link_transfer_test.go
+++ b/deployment/common/changeset/example/link_transfer_test.go
@@ -233,8 +233,6 @@ func TestLinkTransferMCMSV2(t *testing.T) {
 		rt, selector = setupLinkTransferRuntime(t)
 	)
 
-	// env := setupLinkTransferTestEnv(t)
-	// chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	chain := rt.Environment().BlockChains.EVMChains()[selector]
 	addrs, err := rt.State().AddressBook.AddressesForChain(selector)
 	require.NoError(t, err)

--- a/deployment/common/changeset/example/link_transfer_test.go
+++ b/deployment/common/changeset/example/link_transfer_test.go
@@ -1,7 +1,7 @@
 package example_test
 
 import (
-	"context"
+	"crypto/ecdsa"
 	"math/big"
 	"testing"
 	"time"
@@ -10,71 +10,73 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/example"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
-// setupLinkTransferContracts deploys all required contracts for the link transfer tests and returns the updated env.
-func setupLinkTransferTestEnv(t *testing.T) cldf.Environment {
-	lggr := logger.TestLogger(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
-		Chains: 2,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	config := proposalutils.SingleGroupMCMSV2(t)
+// setupLinkTransferRuntime deploys all required contracts on a simulated chain to run tests which
+// operate on the link token and MCMS contracts.
+//
+// Returns the test runtime and the chain selector.
+func setupLinkTransferRuntime(t *testing.T) (*runtime.Runtime, uint64) {
+	t.Helper()
+
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
 
 	// Deploy MCMS and Timelock
-	env, err := changeset.Apply(t, env, changeset.Configure(
-		cldf.CreateLegacyChangeSet(changeset.DeployLinkToken),
-		[]uint64{chainSelector},
-	), changeset.Configure(
-		cldf.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2),
-		map[uint64]types.MCMSWithTimelockConfigV2{
-			chainSelector: {
+	config := proposalutils.SingleGroupMCMSV2(t)
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployLinkToken), []uint64{selector}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2), map[uint64]types.MCMSWithTimelockConfigV2{
+			selector: {
 				Canceller:        config,
 				Bypasser:         config,
 				Proposer:         config,
 				TimelockMinDelay: big.NewInt(0),
 			},
-		},
-	))
+		}),
+	)
 	require.NoError(t, err)
-	return env
+
+	return rt, selector
 }
 
 func TestValidate(t *testing.T) {
-	env := setupLinkTransferTestEnv(t)
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	chain := env.BlockChains.EVMChains()[chainSelector]
-	addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+	rt, selector := setupLinkTransferRuntime(t)
+
+	chain := rt.Environment().BlockChains.EVMChains()[selector]
+	addrs, err := rt.State().AddressBook.AddressesForChain(selector)
 	require.NoError(t, err)
 	require.Len(t, addrs, 6)
+
 	mcmsState, err := changeset.MaybeLoadMCMSWithTimelockChainState(chain, addrs)
 	require.NoError(t, err)
 	linkState, err := changeset.MaybeLoadLinkTokenChainState(chain, addrs)
 	require.NoError(t, err)
+
 	tx, err := linkState.LinkToken.GrantMintRole(chain.DeployerKey, chain.DeployerKey.From)
 	require.NoError(t, err)
 	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
+
 	tx, err = linkState.LinkToken.Mint(chain.DeployerKey, chain.DeployerKey.From, big.NewInt(750))
 	require.NoError(t, err)
 	_, err = cldf.ConfirmIfNoError(chain, tx, err)
-
 	require.NoError(t, err)
+
 	tests := []struct {
 		name     string
 		cfg      example.LinkTransferConfig
@@ -84,7 +86,7 @@ func TestValidate(t *testing.T) {
 			name: "valid config",
 			cfg: example.LinkTransferConfig{
 				Transfers: map[uint64][]example.TransferConfig{
-					chainSelector: {{To: mcmsState.Timelock.Address(), Value: big.NewInt(100)}}},
+					selector: {{To: mcmsState.Timelock.Address(), Value: big.NewInt(100)}}},
 				From: chain.DeployerKey.From,
 				McmsConfig: &proposalutils.TimelockConfig{
 					MinDelay: time.Hour,
@@ -95,7 +97,7 @@ func TestValidate(t *testing.T) {
 			name: "valid non mcms config",
 			cfg: example.LinkTransferConfig{
 				Transfers: map[uint64][]example.TransferConfig{
-					chainSelector: {{To: mcmsState.Timelock.Address(), Value: big.NewInt(100)}}},
+					selector: {{To: mcmsState.Timelock.Address(), Value: big.NewInt(100)}}},
 				From: chain.DeployerKey.From,
 			},
 		},
@@ -103,7 +105,7 @@ func TestValidate(t *testing.T) {
 			name: "insufficient funds",
 			cfg: example.LinkTransferConfig{
 				Transfers: map[uint64][]example.TransferConfig{
-					chainSelector: {
+					selector: {
 						{To: chain.DeployerKey.From, Value: big.NewInt(100)},
 						{To: chain.DeployerKey.From, Value: big.NewInt(500)},
 						{To: chain.DeployerKey.From, Value: big.NewInt(1250)},
@@ -141,7 +143,7 @@ func TestValidate(t *testing.T) {
 			name: "empty transfer list",
 			cfg: example.LinkTransferConfig{
 				Transfers: map[uint64][]example.TransferConfig{
-					chainSelector: {},
+					selector: {},
 				},
 			},
 			errorMsg: "transfers for chainSel 909606746561742123 must have at least one LinkTransfer",
@@ -150,7 +152,7 @@ func TestValidate(t *testing.T) {
 			name: "empty value",
 			cfg: example.LinkTransferConfig{
 				Transfers: map[uint64][]example.TransferConfig{
-					chainSelector: {
+					selector: {
 						{To: chain.DeployerKey.From, Value: nil},
 					},
 				},
@@ -161,7 +163,7 @@ func TestValidate(t *testing.T) {
 			name: "zero value",
 			cfg: example.LinkTransferConfig{
 				Transfers: map[uint64][]example.TransferConfig{
-					chainSelector: {
+					selector: {
 						{To: chain.DeployerKey.From, Value: big.NewInt(0)},
 					},
 				},
@@ -172,7 +174,7 @@ func TestValidate(t *testing.T) {
 			name: "negative value",
 			cfg: example.LinkTransferConfig{
 				Transfers: map[uint64][]example.TransferConfig{
-					chainSelector: {
+					selector: {
 						{To: chain.DeployerKey.From, Value: big.NewInt(-5)},
 					},
 				},
@@ -192,7 +194,7 @@ func TestValidate(t *testing.T) {
 			name: "delay greater than max allowed",
 			cfg: example.LinkTransferConfig{
 				Transfers: map[uint64][]example.TransferConfig{
-					chainSelector: {{To: mcmsState.Timelock.Address(), Value: big.NewInt(100)}}},
+					selector: {{To: mcmsState.Timelock.Address(), Value: big.NewInt(100)}}},
 				From: chain.DeployerKey.From,
 				McmsConfig: &proposalutils.TimelockConfig{
 					MinDelay: time.Hour * 24 * 10,
@@ -204,7 +206,7 @@ func TestValidate(t *testing.T) {
 			name: "invalid config: transfer to address missing",
 			cfg: example.LinkTransferConfig{
 				Transfers: map[uint64][]example.TransferConfig{
-					chainSelector: {{To: common.Address{}, Value: big.NewInt(100)}}},
+					selector: {{To: common.Address{}, Value: big.NewInt(100)}}},
 			},
 			errorMsg: "'to' address for transfers must be set",
 		},
@@ -212,7 +214,7 @@ func TestValidate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.cfg.Validate(env)
+			err := tt.cfg.Validate(rt.Environment())
 			if tt.errorMsg != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errorMsg)
@@ -225,12 +227,16 @@ func TestValidate(t *testing.T) {
 
 func TestLinkTransferMCMSV2(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
-	env := setupLinkTransferTestEnv(t)
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	chain := env.BlockChains.EVMChains()[chainSelector]
-	addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+	var (
+		ctx          = t.Context()
+		rt, selector = setupLinkTransferRuntime(t)
+	)
+
+	// env := setupLinkTransferTestEnv(t)
+	// chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	chain := rt.Environment().BlockChains.EVMChains()[selector]
+	addrs, err := rt.State().AddressBook.AddressesForChain(selector)
 	require.NoError(t, err)
 	require.Len(t, addrs, 6)
 
@@ -253,27 +259,18 @@ func TestLinkTransferMCMSV2(t *testing.T) {
 	require.NoError(t, err)
 
 	// Apply the changeset
-	_, err = changeset.Apply(t, env,
-		// the changeset produces proposals, ApplyChangesets will sign & execute them.
-		// in practice, signing and executing are separated processes.
-		changeset.Configure(
-			cldf.CreateLegacyChangeSet(example.LinkTransferV2),
-			&example.LinkTransferConfig{
-				From: timelockAddress,
-				Transfers: map[uint64][]example.TransferConfig{
-					chainSelector: {
-						{
-							To:    chain.DeployerKey.From,
-							Value: big.NewInt(500),
-						},
-					},
-				},
-				McmsConfig: &proposalutils.TimelockConfig{
-					MinDelay:     0,
-					OverrideRoot: true,
-				},
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(example.LinkTransferV2), &example.LinkTransferConfig{
+			From: timelockAddress,
+			Transfers: map[uint64][]example.TransferConfig{
+				selector: {{To: chain.DeployerKey.From, Value: big.NewInt(500)}},
 			},
-		),
+			McmsConfig: &proposalutils.TimelockConfig{
+				MinDelay:     0,
+				OverrideRoot: true,
+			},
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
 	)
 	require.NoError(t, err)
 

--- a/deployment/common/changeset/example/operations/deploy_and_mint_example_test.go
+++ b/deployment/common/changeset/example/operations/deploy_and_mint_example_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDeployAndMintExampleChangeset(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
-	env, err := environment.New(t.Context(), environment.WithEVMSimulatedN(t, 1))
+	env, err := environment.New(t.Context(), environment.WithEVMSimulated(t, []uint64{selector}))
 	require.NoError(t, err)
 
 	changesetInput := SqDeployLinkInput{

--- a/deployment/common/changeset/example/operations/deploy_and_mint_example_test.go
+++ b/deployment/common/changeset/example/operations/deploy_and_mint_example_test.go
@@ -7,28 +7,22 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 )
 
 func TestDeployAndMintExampleChangeset(t *testing.T) {
-	lggr := logger.TestLogger(t)
-	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
-	chain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	selector := chain_selectors.TEST_90000001.Selector
+	env, err := environment.New(t.Context(), environment.WithEVMSimulatedN(t, 1))
+	require.NoError(t, err)
 
 	changesetInput := SqDeployLinkInput{
 		MintAmount: big.NewInt(1000000000000000000),
 		Amount:     big.NewInt(1000000000000),
 		To:         common.HexToAddress("0x1"),
-		ChainID:    chain1,
+		ChainID:    selector,
 	}
-	result, err := DeployAndMintExampleChangeset{}.Apply(e, changesetInput)
+	result, err := DeployAndMintExampleChangeset{}.Apply(*env, changesetInput)
 	require.NoError(t, err)
 
 	require.Len(t, result.Reports, 4) // 3 ops + 1 seq report

--- a/deployment/common/changeset/example/operations/retry_config_example_test.go
+++ b/deployment/common/changeset/example/operations/retry_config_example_test.go
@@ -4,32 +4,26 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func TestDisableRetryExampleChangeset(t *testing.T) {
-	lggr := logger.TestLogger(t)
-	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
+	env, err := environment.New(t.Context())
+	require.NoError(t, err)
 
 	changesetInput := operations.EmptyInput{}
-	_, err := DisableRetryExampleChangeset{}.Apply(e, changesetInput)
+	_, err = DisableRetryExampleChangeset{}.Apply(*env, changesetInput)
 	require.ErrorContains(t, err, "operation failed")
 }
 
 func TestUpdateInputExampleChangeset(t *testing.T) {
-	lggr := logger.TestLogger(t)
-	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
+
+	env, err := environment.New(t.Context())
+	require.NoError(t, err)
 
 	changesetInput := operations.EmptyInput{}
-	_, err := UpdateInputExampleChangeset{}.Apply(e, changesetInput)
+	_, err = UpdateInputExampleChangeset{}.Apply(*env, changesetInput)
 	require.NoError(t, err)
 }

--- a/deployment/common/changeset/example/operations/terminal_error_example_test.go
+++ b/deployment/common/changeset/example/operations/terminal_error_example_test.go
@@ -4,21 +4,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func TestTerminalErrorExampleChangeset(t *testing.T) {
-	lggr := logger.TestLogger(t)
-	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
+	env, err := environment.New(t.Context())
+	require.NoError(t, err)
 
 	changesetInput := operations.EmptyInput{}
-	_, err := TerminalErrorExampleChangeset{}.Apply(e, changesetInput)
+	_, err = TerminalErrorExampleChangeset{}.Apply(*env, changesetInput)
 	require.ErrorContains(t, err, "terminal error")
 }

--- a/deployment/common/changeset/state/evm_test.go
+++ b/deployment/common/changeset/state/evm_test.go
@@ -13,13 +13,9 @@ import (
 	mcmsevmsdk "github.com/smartcontractkit/mcms/sdk/evm"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
-
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -28,9 +24,13 @@ import (
 )
 
 func TestMCMSWithTimelockState_GenerateMCMSWithTimelockViewV2(t *testing.T) {
-	envConfig := memory.MemoryEnvironmentConfig{Chains: 1}
-	env := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, envConfig)
-	chain := env.BlockChains.EVMChains()[env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	selector := chain_selectors.TEST_90000001.Selector
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	)
+	require.NoError(t, err)
+
+	chain := env.BlockChains.EVMChains()[selector]
 
 	proposerMcm := deployMCMEvm(t, chain, &mcmstypes.Config{Quorum: 1, Signers: []common.Address{
 		common.HexToAddress("0x0000000000000000000000000000000000000001"),

--- a/deployment/common/opsutils/evm_test.go
+++ b/deployment/common/opsutils/evm_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	mcmslib "github.com/smartcontractkit/mcms"
@@ -23,6 +22,7 @@ import (
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf_evm_provider "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations/optest"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
@@ -31,8 +31,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/common/opsutils"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func TestCloneTransactOptsWithGas(t *testing.T) {
@@ -107,18 +105,18 @@ func TestRetryDeploymentWithGasBoost(t *testing.T) {
 
 func TestAddEVMCallSequenceToCSOutput_SequenceError(t *testing.T) {
 	t.Parallel()
-	lggr := logger.TestLogger(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
-		Chains: 2,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
+
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulatedN(t, 1),
+	)
+	require.NoError(t, err)
+
 	csOutput := cldf.ChangesetOutput{}
 	seqReport := operations.SequenceReport[string, map[uint64][]opsutils.EVMCallOutput]{}
 	seqErr := errors.New("sequence failed")
 
 	result, err := opsutils.AddEVMCallSequenceToCSOutput(
-		env,
+		*env,
 		csOutput,
 		seqReport,
 		seqErr,
@@ -135,17 +133,17 @@ func TestAddEVMCallSequenceToCSOutput_SequenceError(t *testing.T) {
 
 func TestAddEVMCallSequenceToCSOutput_NoMCMS(t *testing.T) {
 	t.Parallel()
-	lggr := logger.TestLogger(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
-		Chains: 2,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
+
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulatedN(t, 1),
+	)
+	require.NoError(t, err)
+
 	csOutput := cldf.ChangesetOutput{}
 	seqReport := operations.SequenceReport[string, map[uint64][]opsutils.EVMCallOutput]{}
 
 	result, err := opsutils.AddEVMCallSequenceToCSOutput(
-		env,
+		*env,
 		csOutput,
 		seqReport,
 		nil,
@@ -160,18 +158,18 @@ func TestAddEVMCallSequenceToCSOutput_NoMCMS(t *testing.T) {
 
 func TestAddEVMCallSequenceToCSOutput_AllConfirmed(t *testing.T) {
 	t.Parallel()
-	lggr := logger.TestLogger(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
-		Chains: 2,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
+
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulatedN(t, 1),
+	)
+	require.NoError(t, err)
+
 	csOutput := cldf.ChangesetOutput{}
 	seqReport := operations.SequenceReport[string, map[uint64][]opsutils.EVMCallOutput]{}
 	mcmsCfg := &proposalutils.TimelockConfig{}
 
 	result, err := opsutils.AddEVMCallSequenceToCSOutput(
-		env,
+		*env,
 		csOutput,
 		seqReport,
 		nil,
@@ -297,7 +295,7 @@ func TestNewEVMCallOperation(t *testing.T) {
 	version, _ := semver.NewVersion("1.0.0")
 
 	t.Run("ChainSelectorMismatch", func(t *testing.T) {
-		op := opsutils.NewEVMCallOperation[string, any](
+		op := opsutils.NewEVMCallOperation(
 			"test",
 			version,
 			"description",

--- a/deployment/common/view/v1_0/link_token_test.go
+++ b/deployment/common/view/v1_0/link_token_test.go
@@ -6,25 +6,23 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/link_token"
-
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func TestLinkTokenView(t *testing.T) {
-	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
-	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	selector := chainselectors.TEST_90000001.Selector
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	)
+	require.NoError(t, err)
+
+	chain := env.BlockChains.EVMChains()[selector]
 	_, tx, lt, err := link_token.DeployLinkToken(chain.DeployerKey, chain.Client)
 	require.NoError(t, err)
 	_, err = chain.Confirm(tx)
@@ -35,12 +33,15 @@ func TestLinkTokenView(t *testing.T) {
 
 func TestLinkTokenViewZk(t *testing.T) {
 	// Timeouts in CI
-	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/CCIP-6427")
+	// tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/CCIP-6427")
 
-	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		ZkChains: 1,
-	})
-	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	selector := chainselectors.TEST_90000050.Selector
+	env, err := environment.New(t.Context(),
+		environment.WithZKSyncContainer(t, []uint64{selector}),
+	)
+	require.NoError(t, err)
+
+	chain := env.BlockChains.EVMChains()[selector]
 	_, _, lt, err := link_token.DeployLinkTokenZk(nil, chain.ClientZkSyncVM, chain.DeployerKeyZkSyncVM, chain.Client)
 	require.NoError(t, err)
 

--- a/deployment/common/view/v1_0/link_token_test.go
+++ b/deployment/common/view/v1_0/link_token_test.go
@@ -4,15 +4,16 @@ import (
 	"math/big"
 	"testing"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	chainselectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/link_token"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
-
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/link_token"
 )
 
 func TestLinkTokenView(t *testing.T) {
@@ -33,7 +34,7 @@ func TestLinkTokenView(t *testing.T) {
 
 func TestLinkTokenViewZk(t *testing.T) {
 	// Timeouts in CI
-	// tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/CCIP-6427")
+	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/CCIP-6427")
 
 	selector := chainselectors.TEST_90000050.Selector
 	env, err := environment.New(t.Context(),

--- a/deployment/common/view/v1_0/static_link_token_test.go
+++ b/deployment/common/view/v1_0/static_link_token_test.go
@@ -7,22 +7,21 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/link_token_interface"
-
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func TestStaticLinkTokenView(t *testing.T) {
-	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
-	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	selector := chain_selectors.TEST_90000001.Selector
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	)
+	require.NoError(t, err)
+
+	chain := env.BlockChains.EVMChains()[selector]
 	_, tx, lt, err := link_token_interface.DeployLinkToken(chain.DeployerKey, chain.Client)
 	require.NoError(t, err)
 	_, err = chain.Confirm(tx)


### PR DESCRIPTION
This updates the `deployment/common` package to use the test runtime instead of the memory environment. This is limited to changesets which only interact with EVM chains, while other non EVM changesets remain using the memory environment and will be updated in a separate PR.
