### PR TITLE
chore: update aptos set feed config test to use test runtime

### DIFF
--- a/deployment/data-feeds/changeset/accept_ownership_test.go
+++ b/deployment/data-feeds/changeset/accept_ownership_test.go
@@ -8,6 +8,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
@@ -25,6 +27,7 @@ func TestAcceptOwnership(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 

--- a/deployment/data-feeds/changeset/aptos/deploy_data_feeds_test.go
+++ b/deployment/data-feeds/changeset/aptos/deploy_data_feeds_test.go
@@ -7,52 +7,49 @@ import (
 	"github.com/aptos-labs/aptos-go-sdk"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
-	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	aptosCS "github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/aptos"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestDeployAptosCache(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		AptosChains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyAptos))[0]
-	chain := env.BlockChains.AptosChains()[chainSelector]
+	selector := chain_selectors.APTOS_LOCALNET.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithAptosContainer(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
+	))
+	require.NoError(t, err)
+
+	chain := rt.Environment().BlockChains.AptosChains()[selector]
+
+	// deploy platform
 	platform1, err := aptosCS.DeployPlatform(chain, aptos.AccountAddress{}, []string{})
 	require.NoError(t, err)
 	platform2, err := aptosCS.DeployPlatformSecondary(chain, aptos.AccountAddress{}, []string{})
 	require.NoError(t, err)
 
-	resp, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		aptosCS.DeployDataFeedsChangeset,
-		types.DeployAptosConfig{
-			ChainsToDeploy:           []uint64{chainSelector},
+	// deploy cache
+	err = rt.Exec(
+		runtime.ChangesetTask(aptosCS.DeployDataFeedsChangeset, types.DeployAptosConfig{
+			ChainsToDeploy:           []uint64{selector},
 			PlatformAddress:          platform1.Address.String(),
 			SecondaryPlatformAddress: platform2.Address.String(),
 			Qualifier:                "aptos",
-		},
-	),
+		}),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
 
-	addrs, err := resp.DataStore.Addresses().Get(
+	addrs, err := rt.State().DataStore.Addresses().Get(
 		datastore.NewAddressRefKey(
-			chainSelector,
+			selector,
 			"DataFeedsCache",
 			semver.MustParse("1.0.0"),
 			"aptos",

--- a/deployment/data-feeds/changeset/aptos/set_feed_config_test.go
+++ b/deployment/data-feeds/changeset/aptos/set_feed_config_test.go
@@ -30,6 +30,7 @@ func TestSetFeedConfig(t *testing.T) {
 
 	chain := rt.Environment().BlockChains.AptosChains()[selector]
 
+	// deploy platform
 	platform1, err := aptosCS.DeployPlatform(chain, aptos.AccountAddress{}, []string{})
 	require.NoError(t, err)
 	platform2, err := aptosCS.DeployPlatformSecondary(chain, aptos.AccountAddress{}, []string{})

--- a/deployment/data-feeds/changeset/aptos/set_feed_config_test.go
+++ b/deployment/data-feeds/changeset/aptos/set_feed_config_test.go
@@ -7,54 +7,48 @@ import (
 	"github.com/aptos-labs/aptos-go-sdk"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
-	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	aptosCS "github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/aptos"
-	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
+
+	aptosCS "github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/aptos"
+	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
 func TestSetFeedConfig(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		AptosChains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	// deploy platform
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyAptos))[0]
-	chain := env.BlockChains.AptosChains()[chainSelector]
+	selector := chain_selectors.APTOS_LOCALNET.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithAptosContainer(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
+	))
+	require.NoError(t, err)
+
+	chain := rt.Environment().BlockChains.AptosChains()[selector]
+
 	platform1, err := aptosCS.DeployPlatform(chain, aptos.AccountAddress{}, []string{})
 	require.NoError(t, err)
 	platform2, err := aptosCS.DeployPlatformSecondary(chain, aptos.AccountAddress{}, []string{})
 	require.NoError(t, err)
 
 	// deploy cache
-	resp, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		aptosCS.DeployDataFeedsChangeset,
-		types.DeployAptosConfig{
-			ChainsToDeploy:           []uint64{chainSelector},
+	err = rt.Exec(
+		runtime.ChangesetTask(aptosCS.DeployDataFeedsChangeset, types.DeployAptosConfig{
+			ChainsToDeploy:           []uint64{selector},
 			PlatformAddress:          platform1.Address.String(),
 			SecondaryPlatformAddress: platform2.Address.String(),
 			Qualifier:                "aptos",
-		},
-	),
+		}),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
 
-	addrs, err := resp.DataStore.Addresses().Get(
+	addrs, err := rt.State().DataStore.Addresses().Get(
 		datastore.NewAddressRefKey(
-			chainSelector,
+			selector,
 			"DataFeedsCache",
 			semver.MustParse("1.0.0"),
 			"aptos",
@@ -62,16 +56,13 @@ func TestSetFeedConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// set feed config
-	resp, err = commonChangesets.Apply(t, resp, commonChangesets.Configure(
-		aptosCS.SetFeedConfigChangeset,
-		types.SetRegistryFeedConfig{
+	err = rt.Exec(
+		runtime.ChangesetTask(aptosCS.SetFeedConfigChangeset, types.SetRegistryFeedConfig{
 			CacheAddress:  addrs.Address,
-			ChainSelector: chainSelector,
+			ChainSelector: selector,
 			Descriptions:  []string{"1", "2"},
 			DataIDs:       []string{"0x01a9dde66f0003320000000000000000", "0x0157e996b50003320000000000000000"},
-		},
-	),
+		}),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
 }

--- a/deployment/data-feeds/changeset/aptos/set_workflow_config_test.go
+++ b/deployment/data-feeds/changeset/aptos/set_workflow_config_test.go
@@ -7,54 +7,48 @@ import (
 	"github.com/aptos-labs/aptos-go-sdk"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
-	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	aptosCS "github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/aptos"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestSetWorkflowConfig(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		AptosChains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	// deploy platform
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyAptos))[0]
-	chain := env.BlockChains.AptosChains()[chainSelector]
+	selector := chain_selectors.APTOS_LOCALNET.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithAptosContainer(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
+	))
+	require.NoError(t, err)
+
+	chain := rt.Environment().BlockChains.AptosChains()[selector]
+
 	platform1, err := aptosCS.DeployPlatform(chain, aptos.AccountAddress{}, []string{})
 	require.NoError(t, err)
 	platform2, err := aptosCS.DeployPlatformSecondary(chain, aptos.AccountAddress{}, []string{})
 	require.NoError(t, err)
 
 	// deploy cache
-	resp, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		aptosCS.DeployDataFeedsChangeset,
-		types.DeployAptosConfig{
-			ChainsToDeploy:           []uint64{chainSelector},
+	err = rt.Exec(
+		runtime.ChangesetTask(aptosCS.DeployDataFeedsChangeset, types.DeployAptosConfig{
+			ChainsToDeploy:           []uint64{selector},
 			PlatformAddress:          platform1.Address.String(),
 			SecondaryPlatformAddress: platform2.Address.String(),
 			Qualifier:                "aptos",
-		},
-	),
+		}),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
 
-	addrs, err := resp.DataStore.Addresses().Get(
+	addrs, err := rt.State().DataStore.Addresses().Get(
 		datastore.NewAddressRefKey(
-			chainSelector,
+			selector,
 			"DataFeedsCache",
 			semver.MustParse("1.0.0"),
 			"aptos",
@@ -62,16 +56,13 @@ func TestSetWorkflowConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// set workflow config
-	resp, err = commonChangesets.Apply(t, resp, commonChangesets.Configure(
-		aptosCS.SetWorkflowConfigChangeset,
-		types.SetRegistryWorkflowConfig{
+	err = rt.Exec(
+		runtime.ChangesetTask(aptosCS.SetWorkflowConfigChangeset, types.SetRegistryWorkflowConfig{
 			CacheAddress:          addrs.Address,
-			ChainSelector:         chainSelector,
+			ChainSelector:         selector,
 			AllowedWorkflowOwners: []string{"0x0"},
 			AllowedWorkflowNames:  []string{"wf1"},
-		},
-	),
+		}),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
 }

--- a/deployment/data-feeds/changeset/aptos/transfer_ownership_test.go
+++ b/deployment/data-feeds/changeset/aptos/transfer_ownership_test.go
@@ -7,69 +7,62 @@ import (
 	"github.com/aptos-labs/aptos-go-sdk"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
-	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	aptosCS "github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/aptos"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 func TestTransferOwnership(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		AptosChains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
+	selector := chain_selectors.APTOS_LOCALNET.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithAptosContainer(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
+	))
+	require.NoError(t, err)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyAptos))[0]
-	chain := env.BlockChains.AptosChains()[chainSelector]
+	chain := rt.Environment().BlockChains.AptosChains()[selector]
+
+	// deploy platform
 	platform1, err := aptosCS.DeployPlatform(chain, aptos.AccountAddress{}, []string{})
 	require.NoError(t, err)
 	platform2, err := aptosCS.DeployPlatformSecondary(chain, aptos.AccountAddress{}, []string{})
 	require.NoError(t, err)
 
-	resp, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
-		aptosCS.DeployDataFeedsChangeset,
-		types.DeployAptosConfig{
-			ChainsToDeploy:           []uint64{chainSelector},
+	// deploy cache
+	err = rt.Exec(
+		runtime.ChangesetTask(aptosCS.DeployDataFeedsChangeset, types.DeployAptosConfig{
+			ChainsToDeploy:           []uint64{selector},
 			PlatformAddress:          platform1.Address.String(),
 			SecondaryPlatformAddress: platform2.Address.String(),
 			Qualifier:                "aptos",
-		},
-	),
+		}),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
 
-	addrs, err := resp.DataStore.Addresses().Get(
+	addrs, err := rt.State().DataStore.Addresses().Get(
 		datastore.NewAddressRefKey(
-			chainSelector,
+			selector,
 			"DataFeedsCache",
 			semver.MustParse("1.0.0"),
 			"aptos",
 		))
 	require.NoError(t, err)
 
-	resp, err = commonChangesets.Apply(t, resp, commonChangesets.Configure(
-		aptosCS.TransferOwnershipChangeset,
-		types.TransferDataFeedsAptosOwnershipConfig{
-			ChainSelector:    chainSelector,
+	err = rt.Exec(
+		runtime.ChangesetTask(aptosCS.TransferOwnershipChangeset, types.TransferDataFeedsAptosOwnershipConfig{
+			ChainSelector:    selector,
 			Address:          addrs.Address,
 			TransferRegistry: true,
 			TransferRouter:   true,
 			NewOwner:         "0x0000000000000000000000000000000000000003",
-		},
-	),
+		}),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
 }

--- a/deployment/data-feeds/changeset/confirm_aggregator_test.go
+++ b/deployment/data-feeds/changeset/confirm_aggregator_test.go
@@ -8,6 +8,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
@@ -26,6 +28,7 @@ func TestConfirmAggregator(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 

--- a/deployment/data-feeds/changeset/deploy_aggregator_proxy_test.go
+++ b/deployment/data-feeds/changeset/deploy_aggregator_proxy_test.go
@@ -7,6 +7,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
@@ -19,6 +21,7 @@ func TestAggregatorProxy(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 

--- a/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy_test.go
+++ b/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy_test.go
@@ -7,6 +7,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
@@ -19,6 +21,7 @@ func TestBundleAggregatorProxy(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 

--- a/deployment/data-feeds/changeset/deploy_cache_test.go
+++ b/deployment/data-feeds/changeset/deploy_cache_test.go
@@ -6,6 +6,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
@@ -19,6 +21,7 @@ func TestDeployCache(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 

--- a/deployment/data-feeds/changeset/migrate_feeds_test.go
+++ b/deployment/data-feeds/changeset/migrate_feeds_test.go
@@ -8,6 +8,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -25,6 +27,7 @@ func TestMigrateFeeds(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 

--- a/deployment/data-feeds/changeset/new_feed_with_proxy_test.go
+++ b/deployment/data-feeds/changeset/new_feed_with_proxy_test.go
@@ -8,6 +8,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -28,6 +30,7 @@ func TestNewFeedWithProxy(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 

--- a/deployment/data-feeds/changeset/propose_aggregator_test.go
+++ b/deployment/data-feeds/changeset/propose_aggregator_test.go
@@ -8,6 +8,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
@@ -26,6 +28,7 @@ func TestProposeAggregator(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 

--- a/deployment/data-feeds/changeset/remove_dataid_proxy_mapping_test.go
+++ b/deployment/data-feeds/changeset/remove_dataid_proxy_mapping_test.go
@@ -8,6 +8,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
@@ -26,6 +28,7 @@ func TestRemoveFeedProxyMapping(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 

--- a/deployment/data-feeds/changeset/remove_feed_config_test.go
+++ b/deployment/data-feeds/changeset/remove_feed_config_test.go
@@ -8,6 +8,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -28,6 +30,7 @@ func TestRemoveFeedConfig(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 

--- a/deployment/data-feeds/changeset/remove_feed_test.go
+++ b/deployment/data-feeds/changeset/remove_feed_test.go
@@ -8,6 +8,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -28,6 +30,7 @@ func TestRemoveFeed(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 

--- a/deployment/data-feeds/changeset/set_bundle_feed_config_test.go
+++ b/deployment/data-feeds/changeset/set_bundle_feed_config_test.go
@@ -8,6 +8,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -28,6 +30,7 @@ func TestSetBundleFeedConfig(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 

--- a/deployment/data-feeds/changeset/set_feed_admin_test.go
+++ b/deployment/data-feeds/changeset/set_feed_admin_test.go
@@ -8,6 +8,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
@@ -26,6 +28,7 @@ func TestSetCacheAdmin(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 

--- a/deployment/data-feeds/changeset/set_feed_config_test.go
+++ b/deployment/data-feeds/changeset/set_feed_config_test.go
@@ -8,6 +8,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -28,6 +30,7 @@ func TestSetFeedConfig(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 

--- a/deployment/data-feeds/changeset/update_data_id_proxy_test.go
+++ b/deployment/data-feeds/changeset/update_data_id_proxy_test.go
@@ -8,6 +8,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
@@ -26,6 +28,7 @@ func TestUpdateDataIDProxyMap(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
 	))
 	require.NoError(t, err)
 


### PR DESCRIPTION
This updates the aptos set feed config test to use the test runtime instead of the memory environment.
