### PR TITLE
[CRE-491] Use `pgtest` and `configtest` variants from chainlink-evm in relay/evm

### DIFF
--- a/core/services/relay/evm/capabilities/testutils/backend.go
+++ b/core/services/relay/evm/capabilities/testutils/backend.go
@@ -26,7 +26,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 )
 
@@ -100,7 +99,7 @@ func NewEVMBackendTH(t *testing.T) *EVMBackendTH {
 
 // Setup core services like log poller and head tracker for the simulated backend
 func (th *EVMBackendTH) SetupCoreServices(t *testing.T) (logpoller.HeadTracker, logpoller.LogPoller) {
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	const finalityDepth = 2
 	ht := headstest.NewSimulatedHeadTracker(th.EVMClient, false, finalityDepth)
 	lp := logpoller.NewLogPoller(

--- a/core/services/relay/evm/chain_components_test.go
+++ b/core/services/relay/evm/chain_components_test.go
@@ -47,7 +47,6 @@ import (
 	lpmocks "github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
@@ -382,7 +381,7 @@ func (h *helper) Init(t *testing.T) {
 
 	h.accounts = h.Accounts(t)
 
-	h.db = pgtest.NewSqlxDB(t)
+	h.db = testutils.NewSqlxDB(t)
 
 	h.Backend()
 	h.client = h.Client(t)
@@ -448,7 +447,7 @@ func (h *helper) Database() *sqlx.DB {
 }
 
 func (h *helper) NewSqlxDB(t *testing.T) *sqlx.DB {
-	return pgtest.NewSqlxDB(t)
+	return testutils.NewSqlxDB(t)
 }
 
 func (h *helper) Context(t *testing.T) context.Context {

--- a/core/services/relay/evm/config_poller_test.go
+++ b/core/services/relay/evm/config_poller_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/testhelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
@@ -93,7 +92,7 @@ func TestConfigPoller(t *testing.T) {
 		require.NoError(t, err)
 		b.Commit()
 
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		ethClient = evmclient.NewSimulatedBackendClient(t, b, testutils.SimulatedChainID)
 
 		lorm := logpoller.NewORM(testutils.SimulatedChainID, db, lggr)

--- a/core/services/relay/evm/evmtesting/chain_components_interface_tester.go
+++ b/core/services/relay/evm/evmtesting/chain_components_interface_tester.go
@@ -28,7 +28,7 @@ import (
 	evmtxmgr "github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 
-	_ "github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest" // force binding for tx type
+	_ "github.com/smartcontractkit/chainlink-evm/pkg/testutils" // force binding for tx type
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 )
 

--- a/core/services/relay/evm/functions/config_poller_test.go
+++ b/core/services/relay/evm/functions/config_poller_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	functionsConfig "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/functions/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/testhelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
@@ -76,7 +75,7 @@ func runTest(t *testing.T, pluginType functions.FunctionsPluginType, expectedDig
 	)
 	require.NoError(t, err)
 	b.Commit()
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	defer db.Close()
 	ethClient := evmclient.NewSimulatedBackendClient(t, b, big.NewInt(1337))
 	defer ethClient.Close()

--- a/core/services/relay/evm/mercury/helpers_test.go
+++ b/core/services/relay/evm/mercury/helpers_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier_proxy"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	reportcodecv2 "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/v2/reportcodec"
 	reportcodecv3 "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/v3/reportcodec"
 )
@@ -145,7 +144,7 @@ func SetupTH(t *testing.T, feedID common.Hash) TestHarness {
 	require.NoError(t, err)
 	b.Commit()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	ethClient := evmclient.NewSimulatedBackendClient(t, b, big.NewInt(1337))
 	lggr := logger.Test(t)
 	lorm := logpoller.NewORM(big.NewInt(1337), db, lggr)

--- a/core/services/relay/evm/mercury/orm_test.go
+++ b/core/services/relay/evm/mercury/orm_test.go
@@ -10,7 +10,6 @@ import (
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/wsrpc/pb"
 )
 
@@ -22,11 +21,11 @@ var (
 
 func TestORM(t *testing.T) {
 	ctx := testutils.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 
 	jobID := rand.Int32() // foreign key constraints disabled so value doesn't matter
-	pgtest.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
-	pgtest.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
 	orm := NewORM(db)
 	feedID := sampleFeedID
 
@@ -153,11 +152,11 @@ func TestORM(t *testing.T) {
 
 func TestORM_InsertTransmitRequest_MultipleServerURLs(t *testing.T) {
 	ctx := testutils.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 
 	jobID := rand.Int32() // foreign key constraints disabled so value doesn't matter
-	pgtest.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
-	pgtest.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
 	orm := NewORM(db)
 	feedID := sampleFeedID
 
@@ -198,10 +197,10 @@ func TestORM_InsertTransmitRequest_MultipleServerURLs(t *testing.T) {
 
 func TestORM_PruneTransmitRequests(t *testing.T) {
 	ctx := testutils.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	jobID := rand.Int32() // foreign key constraints disabled so value doesn't matter
-	pgtest.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
-	pgtest.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
 
 	orm := NewORM(db)
 
@@ -291,10 +290,10 @@ func TestORM_PruneTransmitRequests(t *testing.T) {
 
 func TestORM_InsertTransmitRequest_LatestReport(t *testing.T) {
 	ctx := testutils.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	jobID := rand.Int32() // foreign key constraints disabled so value doesn't matter
-	pgtest.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
-	pgtest.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
 
 	orm := NewORM(db)
 	feedID := sampleFeedID

--- a/core/services/relay/evm/mercury/persistence_manager_test.go
+++ b/core/services/relay/evm/mercury/persistence_manager_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/wsrpc/pb"
 )
 
@@ -27,9 +26,9 @@ func TestPersistenceManager(t *testing.T) {
 	jobID2 := jobID1 + 1
 
 	ctx := testutils.Context(t)
-	db := pgtest.NewSqlxDB(t)
-	pgtest.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
-	pgtest.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
+	db := testutils.NewSqlxDB(t)
+	testutils.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
 	pm := bootstrapPersistenceManager(t, jobID1, db)
 
 	reports := sampleReports
@@ -67,9 +66,9 @@ func TestPersistenceManager(t *testing.T) {
 func TestPersistenceManagerAsyncDelete(t *testing.T) {
 	ctx := testutils.Context(t)
 	jobID := rand.Int32()
-	db := pgtest.NewSqlxDB(t)
-	pgtest.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
-	pgtest.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
+	db := testutils.NewSqlxDB(t)
+	testutils.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
 	pm := bootstrapPersistenceManager(t, jobID, db)
 
 	reports := sampleReports
@@ -115,9 +114,9 @@ func TestPersistenceManagerAsyncDelete(t *testing.T) {
 func TestPersistenceManagerPrune(t *testing.T) {
 	jobID1 := rand.Int32()
 	jobID2 := jobID1 + 1
-	db := pgtest.NewSqlxDB(t)
-	pgtest.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
-	pgtest.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
+	db := testutils.NewSqlxDB(t)
+	testutils.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
 
 	ctx := testutils.Context(t)
 

--- a/core/services/relay/evm/mercury/transmitter_test.go
+++ b/core/services/relay/evm/mercury/transmitter_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	mercurytypes "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/types"
 	mercuryutils "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/wsrpc"
@@ -44,10 +43,10 @@ func (m mockCfg) TransmitTimeout() time.Duration {
 
 func Test_MercuryTransmitter_Transmit(t *testing.T) {
 	lggr := logger.Test(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	var jobID int32
-	pgtest.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
-	pgtest.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS mercury_transmit_requests_job_id_fkey DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS feed_latest_reports_job_id_fkey DEFERRED`)
 	codec := new(mockCodec)
 	benchmarkPriceDecoder := func(ctx context.Context, feedID mercuryutils.FeedID, report ocrtypes.Report) (*big.Int, error) {
 		return codec.BenchmarkPriceFromReport(ctx, report)
@@ -129,7 +128,7 @@ func Test_MercuryTransmitter_Transmit(t *testing.T) {
 func Test_MercuryTransmitter_LatestTimestamp(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	var jobID int32
 	codec := new(mockCodec)
 	benchmarkPriceDecoder := func(ctx context.Context, feedID mercuryutils.FeedID, report ocrtypes.Report) (*big.Int, error) {
@@ -238,7 +237,7 @@ func (m *mockCodec) ObservationTimestampFromReport(ctx context.Context, report o
 func Test_MercuryTransmitter_LatestPrice(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	var jobID int32
 
 	codec := new(mockCodec)
@@ -318,7 +317,7 @@ func Test_MercuryTransmitter_FetchInitialMaxFinalizedBlockNumber(t *testing.T) {
 	t.Parallel()
 
 	lggr := logger.Test(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	var jobID int32
 	codec := new(mockCodec)
 	benchmarkPriceDecoder := func(ctx context.Context, feedID mercuryutils.FeedID, report ocrtypes.Report) (*big.Int, error) {
@@ -452,7 +451,7 @@ func Test_MercuryTransmitter_runQueueLoop(t *testing.T) {
 	feedIDHex := utils.NewHash().Hex()
 	lggr := logger.Test(t)
 	c := &mocks.MockWSRPCClient{}
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	orm := NewORM(db)
 	pm := NewPersistenceManager(lggr, sURL, orm, 0, 0, 0, 0)
 	cfg := mockCfg{}

--- a/core/services/relay/evm/request_round_db_test.go
+++ b/core/services/relay/evm/request_round_db_test.go
@@ -12,13 +12,12 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/testhelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 )
 
 func Test_DB_LatestRoundRequested(t *testing.T) {
-	sqlDB := pgtest.NewSqlxDB(t)
+	sqlDB := testutils.NewSqlxDB(t)
 
 	_, err := sqlDB.Exec(`SET CONSTRAINTS offchainreporting2_latest_round_oracle_spec_fkey DEFERRED`)
 	require.NoError(t, err)

--- a/core/services/relay/evm/request_round_tracker_test.go
+++ b/core/services/relay/evm/request_round_tracker_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
+	"github.com/smartcontractkit/chainlink-evm/pkg/config/configtest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads/headstest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
@@ -24,9 +25,6 @@ import (
 	logmocks "github.com/smartcontractkit/chainlink/v2/common/log/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	offchain_aggregator_wrapper "github.com/smartcontractkit/chainlink/v2/core/internal/gethwrappers2/generated/offchainaggregator"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/testhelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mocks"
@@ -65,8 +63,7 @@ func newContractTrackerUni(t *testing.T, opts ...interface{}) (uni contractTrack
 			t.Fatalf("unrecognised option type %T", v)
 		}
 	}
-	config := configtest.NewTestGeneralConfig(t)
-	chain := evmtest.NewChainScopedConfig(t, config)
+	chain := configtest.NewChainScopedConfig(t, nil)
 	if filterer == nil {
 		filterer = mustNewFilterer(t, testutils.NewAddress())
 	}
@@ -78,7 +75,7 @@ func newContractTrackerUni(t *testing.T, opts ...interface{}) (uni contractTrack
 	uni.hb = headstest.NewBroadcaster[*evmtypes.Head, common.Hash](t)
 	uni.ec = clienttest.NewClient(t)
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	lggr := logger.Test(t)
 	uni.requestRoundTracker = evm.NewRequestRoundTracker(
 		contract,

--- a/core/services/relay/evm/write_target_test.go
+++ b/core/services/relay/evm/write_target_test.go
@@ -20,39 +20,34 @@ import (
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	ocr3types "github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	commonevm "github.com/smartcontractkit/chainlink-common/pkg/types/chains/evm"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
-	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
-
+	forwarder "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/forwarder_1_0_0"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
+	"github.com/smartcontractkit/chainlink-evm/pkg/config/configtest"
+	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	gasmocks "github.com/smartcontractkit/chainlink-evm/pkg/gas/mocks"
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads/headstest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
 	"github.com/smartcontractkit/chainlink-evm/pkg/report/datafeeds"
 	df_processor "github.com/smartcontractkit/chainlink-evm/pkg/report/datafeeds/processor"
 	por_processor "github.com/smartcontractkit/chainlink-evm/pkg/report/por/processor"
+	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-
 	"github.com/smartcontractkit/chainlink-framework/capabilities/writetarget/report/platform"
+	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
 
-	ocr3types "github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3/types"
-	forwarder "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/forwarder_1_0_0"
-	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmmocks "github.com/smartcontractkit/chainlink/v2/common/chains/mocks"
 	lpmocks "github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
 	txmmocks "github.com/smartcontractkit/chainlink/v2/common/txmgr/mocks"
 	evmcapabilities "github.com/smartcontractkit/chainlink/v2/core/capabilities"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
-	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
-
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 )
 
@@ -132,24 +127,23 @@ func TestEvmWrite(t *testing.T) {
 
 	chain.On("Client").Return(evmClient)
 
-	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+	evmCfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 		a := testutils.NewAddress()
 		addr, err2 := evmtypes.NewEIP55Address(a.Hex())
 		require.NoError(t, err2)
-		c.EVM[0].Workflow.FromAddress = &addr
+		c.Workflow.FromAddress = &addr
 
 		forwarderA := testutils.NewAddress()
 		forwarderAddr, err2 := evmtypes.NewEIP55Address(forwarderA.Hex())
 		require.NoError(t, err2)
-		c.EVM[0].Workflow.ForwarderAddress = &forwarderAddr
+		c.Workflow.ForwarderAddress = &forwarderAddr
 	})
-	evmCfg := evmtest.NewChainScopedConfig(t, cfg)
 	ge := gasmocks.NewEvmFeeEstimator(t)
 
 	chain.On("Config").Return(evmCfg)
 	chain.On("GasEstimator").Return(ge)
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	keyStore := cltest.NewKeyStore(t, db)
 
 	lggr := logger.TestLogger(t, zapcore.DebugLevel)
@@ -454,17 +448,17 @@ func TestEvmWrite(t *testing.T) {
 	t.Run("Relayer fails to start WriteTarget capability on missing config", func(t *testing.T) {
 		ctx := testutils.Context(t)
 		testChain := evmmocks.NewChain(t)
-		testCfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-			c.EVM[0].Workflow.FromAddress = nil
+		testCfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
+			c.Workflow.FromAddress = nil
 			forwarderA := testutils.NewAddress()
 			forwarderAddr, err2 := evmtypes.NewEIP55Address(forwarderA.Hex())
 			require.NoError(t, err2)
-			c.EVM[0].Workflow.ForwarderAddress = &forwarderAddr
+			c.Workflow.ForwarderAddress = &forwarderAddr
 		})
 		testChain.On("Start", mock.Anything).Return(nil)
 		testChain.On("Close").Return(nil)
 		testChain.On("ID").Return(big.NewInt(11155111))
-		testChain.On("Config").Return(evmtest.NewChainScopedConfig(t, testCfg))
+		testChain.On("Config").Return(testCfg)
 		capabilityRegistry := evmcapabilities.NewRegistry(lggr)
 
 		relayer, err := evm.NewRelayer(lggr, testChain, evm.RelayerOpts{


### PR DESCRIPTION
Executed
```
find . -type f -name "*.go" -exec sed -i '' -e 's=pgtest.NewSqlxDB=testutils.NewSqlxDB=' {} \;    
find . -type f -name "*.go" -exec sed -i '' -e 's=pgtest.MustExec=testutils.MustExec=' {} \;   
find . -type f -name "*.go" -exec sed -i '' -e 's=evmtest.NewChainScopedConfig=evmconfigtest.NewChainScopedConfig=' {} \;   
```