### PR TITLE
chore(ci): hide skipped unit tests from summary

### DIFF
--- a/tools/bin/go_core_ccip_deployment_tests
+++ b/tools/bin/go_core_ccip_deployment_tests
@@ -37,8 +37,11 @@ echo "Using JUNIT_FLAG: $JUNIT_FLAG"
 echo "Test execution results: ---------------------"
 echo ""
 
+# For matching `go test` output - use --format='standard-quiet' and --hide-summary=skipped
+# For matching `go test -v` output - use only --format='standard-verbose'
 gotestsum \
   --format='standard-quiet' \
+  --hide-summary=skipped \
   $RERUN_FLAGS \
   --packages='./...' \
   --jsonfile "$OUTPUT_FILE" \

--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -33,8 +33,11 @@ echo "Using JUNIT_FLAG: $JUNIT_FLAG"
 echo "Test execution results: ---------------------"
 echo ""
 
+# For matching `go test` output - use --format='standard-quiet' and --hide-summary=skipped
+# For matching `go test -v` output - use only --format='standard-verbose'
 gotestsum \
   --format='standard-quiet' \
+  --hide-summary=skipped \
   $RERUN_FLAGS \
   --packages='./...' \
   --jsonfile "$OUTPUT_FILE" \


### PR DESCRIPTION
### Changes

* Add `--hide-summary=skipped` when running unit tests with gotestsum


### Testing

Before: https://github.com/smartcontractkit/chainlink/actions/runs/18325208160/job/52189397187#step:15:879

```
...
ok  	github.com/smartcontractkit/chainlink/v2/tools/flakeytests	2.932s
ok  	github.com/smartcontractkit/chainlink/v2/core/web	10.345s
ok  	github.com/smartcontractkit/chainlink/v2/core/services/relay/evm	16.296s

=== Skipped
...

=== SKIP: tools/flakeytests TestSkippedForTests (0.00s)
    runner_test.go:335: 

=== SKIP: tools/flakeytests TestSkippedForTests_Success (0.00s)
    runner_test.go:346: 

DONE 9555 tests, 127 skipped in 32.522s
```

After: https://github.com/smartcontractkit/chainlink/actions/runs/18326114214/job/52190954907?pr=19771#step:15:444

```
...

ok  	github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer/v2	130.089s
ok  	github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper	160.823s
ok  	github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip	178.118s
ok  	github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer	161.834s

DONE 9555 tests, 127 skipped in 218.882s
```