### PR TITLE
chore: update keystone test engine to use test runtime

### DIFF
--- a/deployment/keystone/changeset/accept_ownership_test.go
+++ b/deployment/keystone/changeset/accept_ownership_test.go
@@ -1,63 +1,56 @@
 package changeset_test
 
 import (
+	"crypto/ecdsa"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 )
 
 func TestAcceptAllOwnership(t *testing.T) {
 	t.Parallel()
 
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-
-	registrySel := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	env, err := commonchangeset.Apply(t, env, commonchangeset.Configure(
-		cldf.CreateLegacyChangeSet(changeset.DeployCapabilityRegistryV2),
-		&changeset.DeployRequestV2{ChainSel: registrySel},
-	), commonchangeset.Configure(
-		cldf.CreateLegacyChangeSet(changeset.DeployOCR3V2),
-		&changeset.DeployRequestV2{ChainSel: registrySel},
-	), commonchangeset.Configure(
-		cldf.CreateLegacyChangeSet(changeset.DeployForwarder),
-		changeset.DeployForwarderRequest{},
-	), commonchangeset.Configure(
-		cldf.CreateLegacyChangeSet(changeset.DeployFeedsConsumer),
-		&changeset.DeployFeedsConsumerRequest{ChainSelector: registrySel},
-	), commonchangeset.Configure(
-		cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
-		map[uint64]types.MCMSWithTimelockConfigV2{
-			registrySel: proposalutils.SingleGroupTimelockConfigV2(t),
-		},
+	registrySel := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{registrySel}),
 	))
 	require.NoError(t, err)
 
-	_, err = commonchangeset.Apply(t, env,
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(changeset.AcceptAllOwnershipsProposal),
-			&changeset.AcceptAllOwnershipRequest{
-				ChainSelector: registrySel,
-				MinDelay:      0,
-			},
-		),
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployCapabilityRegistryV2), &changeset.DeployRequestV2{
+			ChainSel: registrySel,
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployOCR3V2), &changeset.DeployRequestV2{
+			ChainSel: registrySel,
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployForwarder), changeset.DeployForwarderRequest{}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployFeedsConsumer), &changeset.DeployFeedsConsumerRequest{
+			ChainSelector: registrySel,
+		}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2), map[uint64]types.MCMSWithTimelockConfigV2{
+			registrySel: proposalutils.SingleGroupTimelockConfigV2(t),
+		}),
 	)
 	require.NoError(t, err)
+
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.AcceptAllOwnershipsProposal), &changeset.AcceptAllOwnershipRequest{
+			ChainSelector: registrySel,
+			MinDelay:      0,
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
+	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 1)
+	require.True(t, rt.State().Proposals[0].IsExecuted)
 }

--- a/deployment/keystone/changeset/deploy_balance_reader_test.go
+++ b/deployment/keystone/changeset/deploy_balance_reader_test.go
@@ -5,55 +5,50 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 )
 
 func TestDeployBalanceReader(t *testing.T) {
 	t.Parallel()
 
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 2,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-
-	registrySel := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	registrySel := chain_selectors.TEST_90000001.Selector
+	otherSel := chain_selectors.TEST_90000002.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{registrySel, otherSel}),
+	))
+	require.NoError(t, err)
 
 	t.Run("should deploy balancereader", func(t *testing.T) {
-		ab := cldf.NewMemoryAddressBook()
 		qualifier := "my-balance-reader-qualifier"
 
-		// deploy balancereader
-		env.ExistingAddresses = ab
-		resp, err := changeset.DeployBalanceReader(env, changeset.DeployBalanceReaderRequest{
-			Qualifier: qualifier,
-		})
+		err = rt.Exec(
+			runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployBalanceReader), changeset.DeployBalanceReaderRequest{
+				Qualifier: qualifier,
+			}),
+		)
 		require.NoError(t, err)
-		require.NotNil(t, resp)
+
 		// registry, ocr3, balancereader should be deployed on registry chain
-		addrs, err := resp.AddressBook.AddressesForChain(registrySel)
+		addrs, err := rt.State().AddressBook.AddressesForChain(registrySel)
 		require.NoError(t, err)
 		assert.Len(t, addrs, 1)
 
-		dsAddrs, err := resp.DataStore.Addresses().Fetch()
+		dsAddrs, err := rt.State().DataStore.Addresses().Fetch()
 		require.NoError(t, err)
 		assert.Len(t, dsAddrs, 2) // 2 balance readers, one per chain
 		assert.Equal(t, qualifier, dsAddrs[0].Qualifier)
 		assert.Equal(t, qualifier, dsAddrs[1].Qualifier)
 
 		// only balancereader on chain 1
-		require.NotEqual(t, registrySel, env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
-		oaddrs, err := resp.AddressBook.AddressesForChain(env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
+		require.NotEqual(t, registrySel, otherSel)
+		oaddrs, err := rt.State().AddressBook.AddressesForChain(otherSel)
 		require.NoError(t, err)
 		assert.Len(t, oaddrs, 1)
 	})

--- a/deployment/keystone/changeset/deploy_consumer_test.go
+++ b/deployment/keystone/changeset/deploy_consumer_test.go
@@ -4,43 +4,44 @@ import (
 	"testing"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
-	"go.uber.org/zap/zapcore"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 )
 
 func TestDeployFeedsConsumer(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
-		Chains: 2,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	registrySel := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	resp, err := changeset.DeployFeedsConsumerV2(env, &changeset.DeployRequestV2{
-		ChainSel:  registrySel,
-		Qualifier: "my-test-feeds-consumer",
-	})
+	registrySel := chain_selectors.TEST_90000001.Selector
+	otherSel := chain_selectors.TEST_90000002.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{registrySel, otherSel}),
+	))
 	require.NoError(t, err)
-	require.NotNil(t, resp)
+
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployFeedsConsumerV2), &changeset.DeployRequestV2{
+			ChainSel:  registrySel,
+			Qualifier: "my-test-feeds-consumer",
+		}),
+	)
+	require.NoError(t, err)
+
 	// feeds consumer should be deployed on chain 0
-	addrs, err := resp.AddressBook.AddressesForChain(registrySel)
+	addrs, err := rt.State().AddressBook.AddressesForChain(registrySel)
 	require.NoError(t, err)
 	require.Len(t, addrs, 1)
-	require.Len(t, resp.DataStore.Addresses().Filter(datastore.AddressRefByQualifier("my-test-feeds-consumer")), 1, "expected to find 'my-test-feeds-consumer' qualifier")
+	require.Len(t, rt.State().DataStore.Addresses().Filter(datastore.AddressRefByQualifier("my-test-feeds-consumer")), 1, "expected to find 'my-test-feeds-consumer' qualifier")
 
 	// no feeds consumer registry on chain 1
-	require.NotEqual(t, registrySel, env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
-	oaddrs, _ := resp.AddressBook.AddressesForChain(env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
+	require.NotEqual(t, registrySel, otherSel)
+	oaddrs, _ := rt.State().AddressBook.AddressesForChain(otherSel)
 	require.Empty(t, oaddrs)
 }

--- a/deployment/keystone/changeset/deploy_registry_test.go
+++ b/deployment/keystone/changeset/deploy_registry_test.go
@@ -4,42 +4,42 @@ import (
 	"testing"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
-	"go.uber.org/zap/zapcore"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 )
 
 func TestDeployCapabilityRegistry(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
-		Chains: 2,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	registrySel := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	resp, err := changeset.DeployCapabilityRegistryV2(env, &changeset.DeployRequestV2{
-		ChainSel:  registrySel,
-		Qualifier: "my-test-capabilities-registry",
-	})
+	registrySel := chain_selectors.TEST_90000001.Selector
+	otherSel := chain_selectors.TEST_90000002.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{registrySel, otherSel}),
+	))
 	require.NoError(t, err)
-	require.NotNil(t, resp)
+
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployCapabilityRegistryV2), &changeset.DeployRequestV2{
+			ChainSel:  registrySel,
+			Qualifier: "my-test-capabilities-registry",
+		}),
+	)
+	require.NoError(t, err)
+
 	// capabilities registry should be deployed on chain 0
-	addrs, err := resp.AddressBook.AddressesForChain(registrySel)
+	addrs, err := rt.State().AddressBook.AddressesForChain(registrySel)
 	require.NoError(t, err)
 	require.Len(t, addrs, 1)
-	require.Len(t, resp.DataStore.Addresses().Filter(datastore.AddressRefByQualifier("my-test-capabilities-registry")), 1, "expected to find 'my-test-capabilities-registry' qualifier")
+	require.Len(t, rt.State().DataStore.Addresses().Filter(datastore.AddressRefByQualifier("my-test-capabilities-registry")), 1, "expected to find 'my-test-capabilities-registry' qualifier")
+
 	// no capabilities registry on chain 1
-	require.NotEqual(t, registrySel, env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
-	oaddrs, _ := resp.AddressBook.AddressesForChain(env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
+	require.NotEqual(t, registrySel, otherSel)
+	oaddrs, _ := rt.State().AddressBook.AddressesForChain(otherSel)
 	require.Empty(t, oaddrs)
 }

--- a/deployment/keystone/changeset/internal/update_nodes_test.go
+++ b/deployment/keystone/changeset/internal/update_nodes_test.go
@@ -21,11 +21,10 @@ import (
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/onchain"
 
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 	kstest "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/test"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
@@ -697,10 +696,12 @@ func testPeerID(t *testing.T, s string) p2pkey.PeerID {
 func testChain(t *testing.T) cldf_evm.Chain {
 	t.Helper()
 
-	chains := cldf_chain.NewBlockChainsFromSlice(memory.NewMemoryChainsEVM(t, 1, 5))
-	require.NotEmpty(t, chains)
+	chains, err := onchain.NewEVMSimLoaderWithConfig(onchain.EVMSimLoaderConfig{
+		NumAdditionalAccounts: 5,
+	}).LoadN(t, 1)
+	require.NoError(t, err)
 
-	return chains.EVMChains()[chains.ListChainSelectors()[0]]
+	return chains[0].(cldf_evm.Chain)
 }
 
 func testNop(t *testing.T, name string) kcr.CapabilitiesRegistryNodeOperator {

--- a/deployment/keystone/changeset/operations/contracts/deploy_capability_registry_op_test.go
+++ b/deployment/keystone/changeset/operations/contracts/deploy_capability_registry_op_test.go
@@ -5,29 +5,26 @@ import (
 	"testing"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
-	"github.com/smartcontractkit/wsrpc/logger"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations/optest"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/operations/contracts"
 )
 
 func Test_DeployRegistryOp(t *testing.T) {
 	t.Parallel()
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains: 2,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	registrySel := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	registrySel := chain_selectors.TEST_90000001.Selector
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{registrySel}),
+	)
+	require.NoError(t, err)
+
 	b := optest.NewBundle(t)
 	deps := contracts.DeployCapabilityRegistryOpDeps{
-		Env: &env,
+		Env: env,
 	}
 	input := contracts.DeployCapabilityRegistryInput{
 		ChainSelector: registrySel,

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -16,6 +16,8 @@ import (
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/onchain"
 	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -193,25 +195,23 @@ func (te EnvWrapper) GetP2PIDs(donName string) P2PIDs {
 	return te.dons.Get(donName).GetP2PIDs()
 }
 
-func initEnv(t *testing.T, nChains int) (registryChainSel uint64, env cldf.Environment) {
-	chains := cldf_chain.NewBlockChainsFromSlice(memory.NewMemoryChainsEVM(t, nChains, 1))
-	registryChainSel = registryChain(t, chains.EVMChains())
+func initEnv(t *testing.T, nChains int) (uint64, cldf.Environment) {
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulatedWithConfigN(t, nChains, onchain.EVMSimLoaderConfig{
+			NumAdditionalAccounts: 1,
+		}),
+	)
+	require.NoError(t, err)
+
+	registryChainSel := registryChain(t, env.BlockChains.EVMChains())
 
 	// note that all the nodes require TOML configuration of the cap registry address
 	// and writers need forwarder address as TOML config
 	// we choose to use changesets to deploy the initial contracts because that's how it's done in the real world
 	// this requires a initial environment to house the address book
-	env = cldf.Environment{
-		GetContext:        t.Context,
-		Logger:            logger.Test(t),
-		ExistingAddresses: cldf.NewMemoryAddressBook(),
-		DataStore:         datastore.NewMemoryDataStore().Seal(),
-		BlockChains:       chains,
-	}
-
 	forwarderChangesets := make([]commonchangeset.ConfiguredChangeSet, nChains)
 	i := 0
-	for _, c := range chains.EVMChains() {
+	for _, c := range env.BlockChains.EVMChains() {
 		forwarderChangesets[i] = commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(changeset.DeployForwarderV2),
 			&changeset.DeployRequestV2{
@@ -249,12 +249,12 @@ func initEnv(t *testing.T, nChains int) (registryChainSel uint64, env cldf.Envir
 		),
 	}
 	changes = append(changes, forwarderChangesets...)
-	env, _, err := commonchangeset.ApplyChangesets(t, env, changes)
+	updatedEnv, _, err := commonchangeset.ApplyChangesets(t, *env, changes)
 	require.NoError(t, err)
 	require.NotNil(t, env)
 	require.Len(t, env.BlockChains.EVMChains(), nChains)
-	validateInitialChainState(t, env, registryChainSel)
-	return registryChainSel, env
+	validateInitialChainState(t, updatedEnv, registryChainSel)
+	return registryChainSel, updatedEnv
 }
 
 // SetupContractTestEnv sets up a keystone test environment for contract testing with the given configuration

--- a/deployment/keystone/changeset/test/registry.go
+++ b/deployment/keystone/changeset/test/registry.go
@@ -22,9 +22,9 @@ import (
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/onchain"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 )
@@ -399,10 +399,12 @@ func (cc *CapabilityCache) AddCapabilities(_ logger.Logger, chain cldf_evm.Chain
 }
 
 func testChain(t *testing.T) cldf_evm.Chain {
-	chains := cldf_chain.NewBlockChainsFromSlice(memory.NewMemoryChainsEVM(t, 1, 5))
-	require.NotEmpty(t, chains)
+	chains, err := onchain.NewEVMSimLoaderWithConfig(onchain.EVMSimLoaderConfig{
+		NumAdditionalAccounts: 5,
+	}).LoadN(t, 1)
+	require.NoError(t, err)
 
-	return chains.EVMChains()[chains.ListChainSelectors()[0]]
+	return chains[0].(cldf_evm.Chain)
 }
 
 func capabilityIds(registry *capabilities_registry.CapabilitiesRegistry, rcs []internal.RegisteredCapability) ([][32]byte, error) {

--- a/deployment/keystone/changeset/tron/deploy_forwarder_test.go
+++ b/deployment/keystone/changeset/tron/deploy_forwarder_test.go
@@ -5,52 +5,40 @@ import (
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	cldf_tron "github.com/smartcontractkit/chainlink-deployments-framework/chain/tron"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/tron"
 )
 
 func TestDeployForwarder(t *testing.T) {
 	t.Parallel()
 
-	lggr := logger.Test(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		TronChains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-
-	registrySel := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyTron))[0]
+	registrySel := chain_selectors.TRON_DEVNET.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithTronContainer(t, []uint64{registrySel}),
+	))
+	require.NoError(t, err)
 
 	t.Run("should deploy forwarder", func(t *testing.T) {
-		ab := cldf.NewMemoryAddressBook()
-
-		// deploy forwarder
-		env.ExistingAddresses = ab
-
 		deployOptions := cldf_tron.DefaultDeployOptions()
 		deployOptions.FeeLimit = 1_000_000_000
 
-		deployChangeset := commonchangeset.Configure(tron.DeployForwarder{},
-			&tron.DeployForwarderRequest{
-				ChainSelectors: []uint64{registrySel},
-				Qualifier:      "my-test-forwarder",
-				DeployOptions:  deployOptions,
-			},
+		err = rt.Exec(
+			runtime.ChangesetTask(tron.DeployForwarder{},
+				&tron.DeployForwarderRequest{
+					ChainSelectors: []uint64{registrySel},
+					Qualifier:      "my-test-forwarder",
+					DeployOptions:  deployOptions,
+				},
+			),
 		)
-
-		// deploy
-		var err error
-		_, resp, err := commonchangeset.ApplyChangesets(t, env, []commonchangeset.ConfiguredChangeSet{deployChangeset})
 		require.NoError(t, err)
-		require.NotNil(t, resp)
+
+		addrs := rt.State().DataStore.Addresses().Filter(datastore.AddressRefByQualifier("my-test-forwarder"))
+		require.Len(t, addrs, 1)
 	})
 }

--- a/deployment/keystone/changeset/workflowregistry/setup_test.go
+++ b/deployment/keystone/changeset/workflowregistry/setup_test.go
@@ -8,11 +8,10 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	workflow_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper_v1"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/onchain"
 
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 )
 
@@ -48,8 +47,10 @@ func SetupTestWorkflowRegistry(t *testing.T, lggr logger.Logger, chainSel uint64
 }
 
 func testChain(t *testing.T) cldf_evm.Chain {
-	chains := cldf_chain.NewBlockChainsFromSlice(memory.NewMemoryChainsEVM(t, 1, 5))
-	require.NotEmpty(t, chains)
+	chains, err := onchain.NewEVMSimLoaderWithConfig(onchain.EVMSimLoaderConfig{
+		NumAdditionalAccounts: 5,
+	}).LoadN(t, 1)
+	require.NoError(t, err)
 
-	return chains.EVMChains()[chains.ListChainSelectors()[0]]
+	return chains[0].(cldf_evm.Chain)
 }

--- a/deployment/keystone/test/changeset/capability_registry.go
+++ b/deployment/keystone/test/changeset/capability_registry.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	chainsel "github.com/smartcontractkit/chain-selectors"
-
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/view/v1_0"
@@ -16,21 +14,20 @@ import (
 )
 
 type HydrateConfig struct {
-	ChainID uint64
+	ChainSelector uint64
 }
 
 // HydrateCapabilityRegistry deploys a new capabilities registry contract and hydrates it with the provided data.
 func HydrateCapabilityRegistry(t *testing.T, v v1_0.CapabilityRegistryView, env cldf.Environment, cfg HydrateConfig) (*capabilities_registry.CapabilitiesRegistry, error) {
 	t.Helper()
-	chainSelector, err := chainsel.SelectorFromChainId(cfg.ChainID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get chain selector from chain id: %w", err)
-	}
+
+	chainSelector := cfg.ChainSelector
 	evmChains := env.BlockChains.EVMChains()
-	chain, ok := evmChains[chainSelector]
+	chain, ok := evmChains[cfg.ChainSelector]
 	if !ok {
-		return nil, fmt.Errorf("chain with id %d not found", cfg.ChainID)
+		return nil, fmt.Errorf("chain with selector %d not found", cfg.ChainSelector)
 	}
+
 	changesetOutput, err := changeset.DeployCapabilityRegistryV2(env, &changeset.DeployRequestV2{ChainSel: chainSelector})
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy contract: %w", err)
@@ -45,7 +42,7 @@ func HydrateCapabilityRegistry(t *testing.T, v v1_0.CapabilityRegistryView, env 
 	}
 	cs, ok := resp.ContractSets[chainSelector]
 	if !ok {
-		return nil, fmt.Errorf("failed to get contract set for chain selector: %d, chain ID: %d", chainSelector, cfg.ChainID)
+		return nil, fmt.Errorf("failed to get contract set for chain selector: %d, chain selector: %d", chainSelector, cfg.ChainSelector)
 	}
 
 	deployedContract := cs.CapabilitiesRegistry


### PR DESCRIPTION
This updates the keystone test engine to use the test runtime instead of the memory environment. Only Solana changesets tests are remaining as this requires an update to the test engine to support seeding the state.
