### PR TITLE
[bugfix][CRE-1040] Remove unnecessary peer groups from bootstrap nodes

### DIFF
--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -264,12 +264,8 @@ func (w *launcher) donPairsToUpdate(myID ragetypes.PeerID, localRegistry *regist
 		for _, idB := range allDONIds[i+1:] {
 			donB := localRegistry.IDsToDONs[idB]
 			pairAB := p2ptypes.DonPair{donA.DON, donB.DON}
-			if isBootstrap {
-				donPairs = append(donPairs, pairAB) // bootstrap adds all DON pairs
-				continue
-			}
 			nodeBelongsToB := slices.Contains(donB.Members, myID)
-			if !nodeBelongsToA && !nodeBelongsToB {
+			if !nodeBelongsToA && !nodeBelongsToB && !isBootstrap { // bootstrap adds all allowed DON pairs
 				continue // skip if node doesn't belong to either DON
 			}
 			if donA.AcceptsWorkflows && len(donB.CapabilityConfigurations) > 0 || // add DON pair if A is workflow and B is capability

--- a/core/capabilities/launcher_test.go
+++ b/core/capabilities/launcher_test.go
@@ -731,13 +731,23 @@ func TestLauncher_DonPairsToUpdate(t *testing.T) {
 	// peer (not bootstrap) that doesn't belong to any DON connects to nobody
 	require.Empty(t, launcher.donPairsToUpdate(other, localRegistry))
 
-	// bootstrap node adds all DON pairs
+	// bootstrap node adds all 3 DON pairs
 	sharedPeer.On("IsBootstrap").Return(true).Once()
 	res = launcher.donPairsToUpdate(pid, localRegistry)
 	require.Len(t, res, 3)
 	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[wfDONID].DON, localRegistry.IDsToDONs[capDONID].DON}, res[0])
 	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[wfDONID].DON, localRegistry.IDsToDONs[mixedDONID].DON}, res[1])
 	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[capDONID].DON, localRegistry.IDsToDONs[mixedDONID].DON}, res[2])
+
+	// bootstrap node adds only allowed DON pairs
+	mixedDON := localRegistry.IDsToDONs[mixedDONID]
+	mixedDON.AcceptsWorkflows = false
+	localRegistry.IDsToDONs[mixedDONID] = mixedDON
+	sharedPeer.On("IsBootstrap").Return(true).Once()
+	res = launcher.donPairsToUpdate(pid, localRegistry)
+	require.Len(t, res, 2)
+	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[wfDONID].DON, localRegistry.IDsToDONs[capDONID].DON}, res[0])
+	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[wfDONID].DON, localRegistry.IDsToDONs[mixedDONID].DON}, res[1])
 }
 
 func TestLauncher_V2CapabilitiesAddViaCombinedClient(t *testing.T) {


### PR DESCRIPTION
Bootstrap nodes don't have to create peer groups that don't exist anywhere else, such as (workflow, workflow) pairs. It's causing noisy warnings in logs.

