### PR TITLE
[CRE-1042] Use go-modernize in system tests

### DIFF
--- a/system-tests/tests/load/cre/workflow_don_load_test.go
+++ b/system-tests/tests/load/cre/workflow_don_load_test.go
@@ -538,7 +538,7 @@ type StreamsGun struct {
 	keyBundles  []ocr2key.KeyBundle
 	feeds       [][]FeedWithStreamID
 	triggerID   string
-	waitChans   map[int64]chan interface{}
+	waitChans   map[int64]chan any
 	receiveChan <-chan capabilities.CapabilityRequest
 	mu          sync.Mutex
 	feedLimit   int
@@ -637,12 +637,12 @@ func (s *StreamsGun) createWaitChannelForTimestamp(reportTimestamp int64) error 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.waitChans == nil {
-		s.waitChans = make(map[int64]chan interface{})
+		s.waitChans = make(map[int64]chan any)
 	}
 	if _, exists := s.waitChans[reportTimestamp]; exists {
 		return fmt.Errorf("cannot create wait channel, timestamp  %d already exits", reportTimestamp)
 	}
-	s.waitChans[reportTimestamp] = make(chan interface{})
+	s.waitChans[reportTimestamp] = make(chan any)
 	return nil
 }
 
@@ -929,7 +929,7 @@ func WorkflowsJob(nodeID string, workflowName string, feeds []FeedConfig) *jobv1
 		panic(err)
 	}
 	var renderedTemplate bytes.Buffer
-	err = tmpl.Execute(&renderedTemplate, map[string]interface{}{
+	err = tmpl.Execute(&renderedTemplate, map[string]any{
 		"WorkflowName": workflowName,
 		"Feeds":        feeds,
 		"JobID":        uuid.NewString(),
@@ -975,7 +975,7 @@ func MockCapabilitiesJob(nodeID, binaryPath string, mocks []*MockCapabilities) *
 
 	jobUUID := uuid.NewString()
 	var renderedTemplate bytes.Buffer
-	err = tmpl.Execute(&renderedTemplate, map[string]interface{}{
+	err = tmpl.Execute(&renderedTemplate, map[string]any{
 		"JobID":      jobUUID,
 		"ShortID":    jobUUID[0:8],
 		"BinaryPath": binaryPath,

--- a/system-tests/tests/load/cre/writer_don_load_test.go
+++ b/system-tests/tests/load/cre/writer_don_load_test.go
@@ -446,7 +446,7 @@ func exportTestParams(params testParams) error {
 	}
 
 	// Marshal data to JSON
-	data := map[string]interface{}{
+	data := map[string]any{
 		"workflowName":          params.workflowName,
 		"workflowOwner":         params.workflowOwner,
 		"workflowID":            params.workflowID,
@@ -479,7 +479,7 @@ func importTestParams() (testParams, error) {
 		return params, fmt.Errorf("failed to read test params file: %w", err)
 	}
 
-	var rawData map[string]interface{}
+	var rawData map[string]any
 	if err := json.Unmarshal(data, &rawData); err != nil {
 		return params, fmt.Errorf("failed to unmarshal test params: %w", err)
 	}
@@ -489,7 +489,7 @@ func importTestParams() (testParams, error) {
 	params.workflowID = rawData["workflowID"].(string)
 
 	// Convert interface{} array to []string
-	feedsRaw := rawData["feeds"].([]interface{})
+	feedsRaw := rawData["feeds"].([]any)
 	params.feeds = make([]string, len(feedsRaw))
 	for i, v := range feedsRaw {
 		params.feeds[i] = v.(string)
@@ -507,7 +507,7 @@ type WriterGun struct {
 	capProxy   *mock_capability.Controller
 	keyBundles []ocr2key.KeyBundle
 	triggerID  string
-	waitChans  map[uint8]chan interface{}
+	waitChans  map[uint8]chan any
 	mu         sync.Mutex
 	reportID   uint8
 	seqNr      uint32
@@ -525,7 +525,7 @@ func NewWriterGun(capProxy *mock_capability.Controller, keyBundles []ocr2key.Key
 		seqNr:      1,
 		seth:       seth,
 		testParams: params,
-		waitChans:  make(map[uint8]chan interface{}),
+		waitChans:  make(map[uint8]chan any),
 	}
 
 	go func() {
@@ -599,7 +599,7 @@ func (s *WriterGun) Call(l *wasp.Generator) *wasp.Response {
 	}
 
 	s.mu.Lock()
-	ch := make(chan interface{})
+	ch := make(chan any)
 	s.waitChans[s.reportID] = ch
 	s.mu.Unlock()
 	// Create executable request and execute

--- a/system-tests/tests/regression/cre/v2_http_trigger_regression_test.go
+++ b/system-tests/tests/regression/cre/v2_http_trigger_regression_test.go
@@ -296,7 +296,7 @@ func startTestOrderServer(t *testing.T, port int, testID string) (*fake.Output, 
 
 	// Set up a unique endpoint for this test
 	endpoint := "/orders-" + testID
-	response := map[string]interface{}{
+	response := map[string]any{
 		"orderId": "test-order-regression-" + testID,
 		"status":  "success",
 		"message": "Order processed successfully",

--- a/system-tests/tests/smoke/cre/por_price_provider.go
+++ b/system-tests/tests/smoke/cre/por_price_provider.go
@@ -40,7 +40,7 @@ func setupFakeDataProvider(testLogger zerolog.Logger, input *fake.Input, authKey
 	host := framework.HostDockerInternal()
 	fakeFinalURL := fmt.Sprintf("%s:%d%s", host, input.Port, fakeAPIPath)
 
-	getPriceResponseFn := func(feedID string) (map[string]interface{}, error) {
+	getPriceResponseFn := func(feedID string) (map[string]any, error) {
 		testLogger.Info().Msgf("Preparing response for feedID: %s", feedID)
 		priceIndex, ok := priceIndexes[feedID]
 		if !ok {
@@ -55,7 +55,7 @@ func setupFakeDataProvider(testLogger zerolog.Logger, input *fake.Input, authKey
 		currentPrice := expectedPrices[*priceIndex]
 		testLogger.Info().Msgf("HTTP response for feedID %s - priceIndex: %d, currentPrice: %.10f", feedID, *priceIndex, currentPrice)
 
-		response := map[string]interface{}{
+		response := map[string]any{
 			"accountName": "TrueUSD",
 			"totalTrust":  currentPrice,
 			"ripcord":     false,

--- a/system-tests/tests/smoke/cre/por_test.go
+++ b/system-tests/tests/smoke/cre/por_test.go
@@ -331,7 +331,7 @@ func validateTronPrices(t *testing.T, testEnv *ttypes.TestEnvironment, bcOutput 
 			tronChain.Address,          // caller address
 			cacheAddr,                  // contract address
 			"getLatestAnswer(bytes16)", // function signature
-			[]interface{}{"bytes16", [16]byte(common.Hex2Bytes(feedID))}, // parameters
+			[]any{"bytes16", [16]byte(common.Hex2Bytes(feedID))}, // parameters
 		)
 		if err != nil {
 			testEnv.Logger.Error().Err(err).Msgf("FAILED to call getLatestAnswer on Tron chain %d", bcOutput.ChainSelector)

--- a/system-tests/tests/smoke/cre/v1_securemint_test.go
+++ b/system-tests/tests/smoke/cre/v1_securemint_test.go
@@ -153,7 +153,7 @@ func waitForFeedUpdate(t *testing.T, solclient *rpc.Client, s *setup) {
 func parsePackedU128(le [16]byte) (amount *big.Int, block uint64, unused uint8) {
 	// Convert LE -> big.Int (big-endian expected by SetBytes)
 	be := make([]byte, 16)
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		be[15-i] = le[i]
 	}
 	x := new(big.Int).SetBytes(be)

--- a/system-tests/tests/smoke/cre/v2_http_trigger_action_test.go
+++ b/system-tests/tests/smoke/cre/v2_http_trigger_action_test.go
@@ -150,7 +150,7 @@ func validateHTTPWorkflowRequest(t *testing.T, testEnv *ttypes.TestEnvironment) 
 	require.Equal(t, "/orders", recordedRequest.Path, "expected /orders endpoint")
 	require.Equal(t, "application/json", recordedRequest.Headers.Get("Content-Type"), "expected JSON content type")
 
-	var workflowRequestBody map[string]interface{}
+	var workflowRequestBody map[string]any
 	err = json.Unmarshal([]byte(recordedRequest.ReqBody), &workflowRequestBody)
 	require.NoError(t, err, "request body should be valid JSON")
 
@@ -207,7 +207,7 @@ func startTestOrderServer(t *testing.T, port int) (*fake.Output, error) {
 	}
 
 	// Set up the /orders endpoint
-	response := map[string]interface{}{
+	response := map[string]any{
 		"orderId": "test-order-" + uuid.New().String()[0:8],
 		"status":  "success",
 		"message": "Order processed successfully",

--- a/system-tests/tests/smoke/cre/v2_vault_don_test.go
+++ b/system-tests/tests/smoke/cre/v2_vault_don_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -35,14 +36,7 @@ func ExecuteVaultTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 	testLogger.Info().Msgf("Ensuring DKG result packages are present...")
 	require.Eventually(t, func() bool {
 		for _, nodeSet := range testEnv.Config.NodeSets {
-			var vaultFound bool
-			for _, cap := range nodeSet.Capabilities {
-				if cap == cre.VaultCapability {
-					vaultFound = true
-					break
-				}
-			}
-			if vaultFound {
+			if slices.Contains(nodeSet.Capabilities, cre.VaultCapability) {
 				for i := range nodeSet.Nodes {
 					if i != nodeSet.BootstrapNodeIndex {
 						packageCount, err := vault.GetResultPackageCount(t.Context(), i, nodeSet.DbInput.Port)

--- a/system-tests/tests/test-helpers/beholder_provider.go
+++ b/system-tests/tests/test-helpers/beholder_provider.go
@@ -410,10 +410,7 @@ func (b *Beholder) consume(
 		// Calculate backoff with jitter
 		attempt++
 		jitter := time.Duration(rand.Float64() * float64(backoff) * 0.1) // 10% jitter
-		sleepDuration := backoff + jitter
-		if sleepDuration > maxBackoffTimeout {
-			sleepDuration = maxBackoffTimeout
-		}
+		sleepDuration := min(backoff+jitter, maxBackoffTimeout)
 
 		b.lggr.Warn().
 			Dur("backoff", sleepDuration).
@@ -428,10 +425,7 @@ func (b *Beholder) consume(
 		case <-time.After(sleepDuration):
 			b.lggr.Info().Int("attempt", attempt).Msg("Attempting to reconnect Kafka consumer...")
 			// Increase backoff for next iteration
-			backoff = time.Duration(float64(backoff) * backoffFactor)
-			if backoff > maxBackoffTimeout {
-				backoff = maxBackoffTimeout
-			}
+			backoff = min(time.Duration(float64(backoff)*backoffFactor), maxBackoffTimeout)
 		}
 	}
 }

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -188,6 +188,7 @@ func AssertBeholderMessage(ctx context.Context, t *testing.T, expectedLog string
 							testLogger.Info().
 								Str("expected_log", expectedLog).
 								Str("found_message", strings.TrimSpace(logLine.Message)).
+								Str("workflow_id", typedMsg.M.WorkflowExecutionID).
 								Msg("🎯 Found expected user log message!")
 
 							select {
@@ -196,6 +197,7 @@ func AssertBeholderMessage(ctx context.Context, t *testing.T, expectedLog string
 							}
 							return // Exit the processor goroutine
 						}
+
 						testLogger.Warn().
 							Str("expected_log", expectedLog).
 							Str("found_message", strings.TrimSpace(logLine.Message)).
@@ -247,7 +249,7 @@ func CreateAndFundAddresses(t *testing.T, testLogger zerolog.Logger, numberOfAdd
 	testLogger.Info().Msgf("Creating and funding %d addresses...", numberOfAddressesToCreate)
 	var addressesToRead []common.Address
 
-	for i := 0; i < numberOfAddressesToCreate; i++ {
+	for i := range numberOfAddressesToCreate {
 		addressToRead, _, addrErr := crecrypto.GenerateNewKeyPair()
 		require.NoError(t, addrErr, "failed to generate address to read")
 		orderNum := i + 1


### PR DESCRIPTION
[CRE-1042](https://smartcontract-it.atlassian.net/browse/CRE-1042): Use go-modernize in system tests.
See more in [Go docs](https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize).
Command triggered: `go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...`

[CRE-1042]: https://smartcontract-it.atlassian.net/browse/CRE-1042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ