### PR TITLE
[CRE-491] Move transmitter files to their own folder.

### DIFF
--- a/core/internal/features/ocr2/features_ocr2_helper.go
+++ b/core/internal/features/ocr2/features_ocr2_helper.go
@@ -58,7 +58,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/testhelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/validate"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrbootstrap"
-	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 	"github.com/smartcontractkit/chainlink/v2/core/utils/testutils/heavyweight"
 )
@@ -634,7 +634,7 @@ updateInterval = "1m"
 				store := keys.NewStore(keystore.NewEthSigner(apps[0].KeyStore.Eth(), testutils.SimulatedChainID))
 				mp := mocks.NewLogPoller(t)
 				mp.On("RegisterFilter", mock.Anything, mock.Anything).Return(nil)
-				ct, err2 := evm.NewOCRContractTransmitter(testutils.Context(t), ocrContractAddress, b.Client(), contractABI, nil, mp, lggr, store)
+				ct, err2 := transmitter.NewOCRContractTransmitter(testutils.Context(t), ocrContractAddress, b.Client(), contractABI, nil, mp, lggr, store)
 				require.NoError(t, err2)
 				configDigest, epoch, err2 := ct.LatestConfigDigestAndEpoch(testutils.Context(t))
 				require.NoError(t, err2)

--- a/core/internal/features/ocr2/features_ocr2_test.go
+++ b/core/internal/features/ocr2/features_ocr2_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/validate"
-	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 )
 
@@ -276,7 +276,7 @@ updateInterval = "1m"
 	store := keys.NewStore(keystore.NewEthSigner(apps[0].KeyStore.Eth(), testutils.SimulatedChainID))
 	chain, ok := apps[0].GetRelayers().LegacyEVMChains().Slice()[0].(legacyevm.Chain)
 	require.True(t, ok)
-	ct, err := evm.NewOCRContractTransmitter(testutils.Context(t), ocrContractAddress, chain.Client(), contractABI, nil, chain.LogPoller(), lggr, store)
+	ct, err := transmitter.NewOCRContractTransmitter(testutils.Context(t), ocrContractAddress, chain.Client(), contractABI, nil, chain.LogPoller(), lggr, store)
 	require.NoError(t, err)
 	configDigest, epoch, err := ct.LatestConfigDigestAndEpoch(testutils.Context(t))
 	require.NoError(t, err)

--- a/core/services/relay/evm/commit_provider.go
+++ b/core/services/relay/evm/commit_provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/estimatorconfig"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter"
 )
 
 var _ commontypes.CCIPCommitProvider = (*SrcCommitProvider)(nil)
@@ -68,7 +69,7 @@ type DstCommitProvider struct {
 	startBlock          uint64
 	client              client.Client
 	lp                  logpoller.LogPoller
-	contractTransmitter ContractTransmitter
+	contractTransmitter transmitter.ContractTransmitter
 	configWatcher       *configWatcher
 	gasEstimator        gas.EvmFeeEstimator
 	maxGasPrice         big.Int
@@ -87,7 +88,7 @@ func NewDstCommitProvider(
 	lp logpoller.LogPoller,
 	gasEstimator gas.EvmFeeEstimator,
 	maxGasPrice big.Int,
-	contractTransmitter ContractTransmitter,
+	contractTransmitter transmitter.ContractTransmitter,
 	configWatcher *configWatcher,
 	feeEstimatorConfig estimatorconfig.FeeEstimatorConfigProvider,
 ) commontypes.CCIPCommitProvider {

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -757,7 +757,7 @@ func FilterNamesFromRelayArgs(args commontypes.RelayArgs) (filterNames []string,
 	if relayConfig.FeedID != nil {
 		filterNames = []string{mercury.FilterName(addr.Address(), *relayConfig.FeedID)}
 	} else {
-		filterNames = []string{configPollerFilterName(addr.Address()), transmitter.TransmitterFilterName(addr.Address())}
+		filterNames = []string{configPollerFilterName(addr.Address()), transmitter.FilterName(addr.Address())}
 	}
 	return filterNames, err
 }

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -42,9 +42,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/chaintype"
 	"github.com/smartcontractkit/chainlink-evm/pkg/interceptors/mantle"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
-	txm "github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 
 	coreconfig "github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/llo"
@@ -55,12 +53,11 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/ccipexec"
 	ccipconfig "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/estimatorconfig"
-	cciptransmitter "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/transmitter"
 	mercuryconfig "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/mercury/config"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/functions"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/wsrpc"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter"
 )
 
 var (
@@ -346,7 +343,7 @@ func (r *Relayer) NewOCR3CapabilityProvider(ctx context.Context, rargs commontyp
 		return nil, err
 	}
 
-	transmitter, err := newOnChainContractTransmitter(ctx, r.lggr, rargs, r.evmKeystore, configWatcher, configTransmitterOpts{}, OCR2AggregatorTransmissionContractABI)
+	transmitter, err := transmitter.NewContractTransmitter(ctx, r.lggr, rargs, r.evmKeystore, configWatcher.chain, configWatcher.contractAddress, transmitter.ConfigTransmitterOpts{}, OCR2AggregatorTransmissionContractABI, false)
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +388,7 @@ func (r *Relayer) NewPluginProvider(ctx context.Context, rargs commontypes.Relay
 	if err != nil {
 		return nil, err
 	}
-	transmitter, err := newOnChainContractTransmitter(ctx, r.lggr, rargs, r.evmKeystore, configWatcher, configTransmitterOpts{}, OCR2AggregatorTransmissionContractABI)
+	transmitter, err := transmitter.NewContractTransmitter(ctx, r.lggr, rargs, r.evmKeystore, configWatcher.chain, configWatcher.contractAddress, transmitter.ConfigTransmitterOpts{}, OCR2AggregatorTransmissionContractABI, false)
 	if err != nil {
 		return nil, err
 	}
@@ -540,9 +537,9 @@ func (r *Relayer) NewCCIPCommitProvider(ctx context.Context, rargs commontypes.R
 	}
 	subjectID := chainToUUID(configWatcher.chain.ID())
 
-	contractTransmitter, err := newOnChainContractTransmitter(ctx, lggr, rargs, r.evmKeystore, configWatcher, configTransmitterOpts{
-		subjectID: &subjectID,
-	}, OCR2AggregatorTransmissionContractABI, WithReportToEthMetadata(fn), WithRetention(0))
+	contractTransmitter, err := transmitter.NewContractTransmitter(ctx, lggr, rargs, r.evmKeystore, configWatcher.chain, configWatcher.contractAddress, transmitter.ConfigTransmitterOpts{
+		SubjectID: &subjectID,
+	}, OCR2AggregatorTransmissionContractABI, false, transmitter.WithReportToEthMetadata(fn), transmitter.WithRetention(0))
 	if err != nil {
 		return nil, err
 	}
@@ -626,9 +623,17 @@ func (r *Relayer) NewCCIPExecProvider(ctx context.Context, rargs commontypes.Rel
 	}
 	subjectID := chainToUUID(configWatcher.chain.ID())
 
-	contractTransmitter, err := newOnChainContractTransmitter(ctx, lggr, rargs, r.evmKeystore, configWatcher, configTransmitterOpts{
-		subjectID: &subjectID,
-	}, OCR2AggregatorTransmissionContractABI, WithReportToEthMetadata(fn), WithRetention(0), WithExcludeSignatures())
+	contractTransmitter, err := transmitter.NewContractTransmitter(
+		ctx,
+		lggr,
+		rargs,
+		r.evmKeystore,
+		configWatcher.chain,
+		configWatcher.contractAddress,
+		transmitter.ConfigTransmitterOpts{SubjectID: &subjectID},
+		OCR2AggregatorTransmissionContractABI,
+		false,
+		transmitter.WithReportToEthMetadata(fn), transmitter.WithRetention(0), transmitter.WithExcludeSignatures())
 	if err != nil {
 		return nil, err
 	}
@@ -752,7 +757,7 @@ func FilterNamesFromRelayArgs(args commontypes.RelayArgs) (filterNames []string,
 	if relayConfig.FeedID != nil {
 		filterNames = []string{mercury.FilterName(addr.Address(), *relayConfig.FeedID)}
 	} else {
-		filterNames = []string{configPollerFilterName(addr.Address()), transmitterFilterName(addr.Address())}
+		filterNames = []string{configPollerFilterName(addr.Address()), transmitter.TransmitterFilterName(addr.Address())}
 	}
 	return filterNames, err
 }
@@ -822,175 +827,10 @@ func (c *configWatcher) ContractConfigTracker() ocrtypes.ContractConfigTracker {
 	return c.configPoller
 }
 
-type configTransmitterOpts struct {
-	// pluginGasLimit overrides the gas limit default provided in the config watcher.
-	pluginGasLimit *uint32
-	// subjectID overrides the queueing subject id (the job external id will be used by default).
-	subjectID *uuid.UUID
-}
-
-// newOnChainContractTransmitter creates a new contract transmitter.
-func newOnChainContractTransmitter(ctx context.Context, lggr logger.Logger, rargs commontypes.RelayArgs, ethKeystore keys.Store, configWatcher *configWatcher, opts configTransmitterOpts, transmissionContractABI abi.ABI, ocrTransmitterOpts ...OCRTransmitterOption) (ContractTransmitter, error) {
-	transmitter, err := generateTransmitterFrom(ctx, rargs, ethKeystore, configWatcher, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	evmTransmitter, err := NewOCRContractTransmitter(
-		ctx,
-		configWatcher.contractAddress,
-		configWatcher.chain.Client(),
-		transmissionContractABI,
-		transmitter,
-		configWatcher.chain.LogPoller(),
-		lggr,
-		ethKeystore,
-		ocrTransmitterOpts...,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// This code path should only be called when running CCIP 1.5 jobs on Tron.
-	// All other products should use the standard Tron relayer implementation.
-	if configWatcher.chain.Config().EVM().ChainType() == chaintype.ChainTron {
-		return NewTronContractTransmitter(ctx, TronContractTransmitterOpts{
-			Logger:             lggr,
-			TransmissionsCache: NewTronTransmissionsCache(evmTransmitter),
-			Keystore:           ethKeystore,
-			ConfigWatcher:      configWatcher,
-			OCRTransmitterOpts: ocrTransmitterOpts,
-		})
-	}
-
-	return evmTransmitter, err
-}
-
-// newOnChainDualContractTransmitter creates a new dual contract transmitter.
-func newOnChainDualContractTransmitter(ctx context.Context, lggr logger.Logger, rargs commontypes.RelayArgs, ethKeystore keys.Store, configWatcher *configWatcher, opts configTransmitterOpts, transmissionContractABI abi.ABI, ocrTransmitterOpts ...OCRTransmitterOption) (*dualContractTransmitter, error) {
-	transmitter, err := generateTransmitterFrom(ctx, rargs, ethKeystore, configWatcher, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewOCRDualContractTransmitter(
-		ctx,
-		configWatcher.contractAddress,
-		configWatcher.chain.Client(),
-		transmissionContractABI,
-		transmitter,
-		configWatcher.chain.LogPoller(),
-		lggr,
-		ethKeystore,
-		ocrTransmitterOpts...,
-	)
-}
-
-func NewContractTransmitter(ctx context.Context, lggr logger.Logger, rargs commontypes.RelayArgs, ethKeystore keys.Store, configWatcher *configWatcher, opts configTransmitterOpts, transmissionContractABI abi.ABI, dualTransmission bool, ocrTransmitterOpts ...OCRTransmitterOption) (ContractTransmitter, error) {
-	if dualTransmission {
-		return newOnChainDualContractTransmitter(ctx, lggr, rargs, ethKeystore, configWatcher, opts, transmissionContractABI, ocrTransmitterOpts...)
-	}
-
-	return newOnChainContractTransmitter(ctx, lggr, rargs, ethKeystore, configWatcher, opts, transmissionContractABI, ocrTransmitterOpts...)
-}
-
 type Keystore interface {
 	keys.AddressChecker
 	keys.RoundRobin
 	keys.Locker
-}
-
-func generateTransmitterFrom(ctx context.Context, rargs commontypes.RelayArgs, ethKeystore Keystore, configWatcher *configWatcher, opts configTransmitterOpts) (Transmitter, error) {
-	var relayConfig config.RelayConfig
-	if err := json.Unmarshal(rargs.RelayConfig, &relayConfig); err != nil {
-		return nil, err
-	}
-	var fromAddresses []common.Address
-	sendingKeys := relayConfig.SendingKeys
-	if !relayConfig.EffectiveTransmitterID.Valid {
-		return nil, pkgerrors.New("EffectiveTransmitterID must be specified")
-	}
-	effectiveTransmitterAddress := common.HexToAddress(relayConfig.EffectiveTransmitterID.String)
-
-	sendingKeysLength := len(sendingKeys)
-	if sendingKeysLength == 0 {
-		return nil, pkgerrors.New("no sending keys provided")
-	}
-
-	// If we are using multiple sending keys, then a forwarder is needed to rotate transmissions.
-	// Ensure that this forwarder is not set to a local sending key, and ensure our sending keys are enabled.
-	for _, s := range sendingKeys {
-		if sendingKeysLength > 1 && s == effectiveTransmitterAddress.String() {
-			return nil, pkgerrors.New("the transmitter is a local sending key with transaction forwarding enabled")
-		}
-		if err := ethKeystore.CheckEnabled(ctx, common.HexToAddress(s)); err != nil {
-			return nil, pkgerrors.Wrap(err, "one of the sending keys given is not enabled")
-		}
-		fromAddresses = append(fromAddresses, common.HexToAddress(s))
-	}
-
-	subject := rargs.ExternalJobID
-	if opts.subjectID != nil {
-		subject = *opts.subjectID
-	}
-	strategy := txmgrcommon.NewQueueingTxStrategy(subject, relayConfig.DefaultTransactionQueueDepth)
-
-	var checker txm.TransmitCheckerSpec
-	if relayConfig.SimulateTransactions {
-		checker.CheckerType = txm.TransmitCheckerTypeSimulate
-	}
-
-	gasLimit := configWatcher.chain.Config().EVM().GasEstimator().LimitDefault()
-	ocr2Limit := configWatcher.chain.Config().EVM().GasEstimator().LimitJobType().OCR2()
-	if ocr2Limit != nil {
-		gasLimit = uint64(*ocr2Limit)
-	}
-	if opts.pluginGasLimit != nil {
-		gasLimit = uint64(*opts.pluginGasLimit)
-	}
-
-	var transmitter Transmitter
-	var err error
-
-	switch commontypes.OCR2PluginType(rargs.ProviderType) {
-	case commontypes.Median:
-		transmitter, err = ocrcommon.NewOCR2FeedsTransmitter(
-			configWatcher.chain.TxManager(),
-			fromAddresses,
-			common.HexToAddress(rargs.ContractID),
-			gasLimit,
-			effectiveTransmitterAddress,
-			strategy,
-			checker,
-			ethKeystore,
-			relayConfig.DualTransmissionConfig,
-		)
-	case commontypes.CCIPExecution:
-		transmitter, err = cciptransmitter.NewTransmitterWithStatusChecker(
-			configWatcher.chain.TxManager(),
-			fromAddresses,
-			gasLimit,
-			effectiveTransmitterAddress,
-			strategy,
-			checker,
-			configWatcher.chain.ID(),
-			ethKeystore,
-		)
-	default:
-		transmitter, err = ocrcommon.NewTransmitter(
-			configWatcher.chain.TxManager(),
-			fromAddresses,
-			gasLimit,
-			effectiveTransmitterAddress,
-			strategy,
-			checker,
-			ethKeystore,
-		)
-	}
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "failed to create transmitter")
-	}
-	return transmitter, nil
 }
 
 func (r *Relayer) NewContractWriter(_ context.Context, bytes []byte) (commontypes.ContractWriter, error) {
@@ -1046,7 +886,7 @@ func (r *Relayer) NewMedianProvider(ctx context.Context, rargs commontypes.Relay
 
 	reportCodec := evmreportcodec.ReportCodec{}
 
-	ct, err := NewContractTransmitter(ctx, lggr, rargs, r.evmKeystore, configWatcher, configTransmitterOpts{}, OCR2AggregatorTransmissionContractABI, relayConfig.EnableDualTransmission)
+	ct, err := transmitter.NewContractTransmitter(ctx, lggr, rargs, r.evmKeystore, configWatcher.chain, configWatcher.contractAddress, transmitter.ConfigTransmitterOpts{}, OCR2AggregatorTransmissionContractABI, relayConfig.EnableDualTransmission)
 	if err != nil {
 		return nil, err
 	}
@@ -1104,7 +944,7 @@ var _ commontypes.MedianProvider = (*medianProvider)(nil)
 type medianProvider struct {
 	lggr                logger.Logger
 	configWatcher       *configWatcher
-	contractTransmitter ContractTransmitter
+	contractTransmitter transmitter.ContractTransmitter
 	reportCodec         median.ReportCodec
 	medianContract      *medianContract
 	chainReader         ChainReaderService

--- a/core/services/relay/evm/exec_provider.go
+++ b/core/services/relay/evm/exec_provider.go
@@ -12,22 +12,22 @@ import (
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
-
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/config"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/tokendata/lbtc"
-
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/estimatorconfig"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/tokendata/lbtc"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/tokendata/usdc"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter"
 )
 
 type SrcExecProvider struct {
@@ -260,7 +260,7 @@ type DstExecProvider struct {
 	client              client.Client
 	lp                  logpoller.LogPoller
 	startBlock          uint64
-	contractTransmitter ContractTransmitter
+	contractTransmitter transmitter.ContractTransmitter
 	configWatcher       *configWatcher
 	gasEstimator        gas.EvmFeeEstimator
 	maxGasPrice         big.Int
@@ -278,7 +278,7 @@ func NewDstExecProvider(
 	client client.Client,
 	lp logpoller.LogPoller,
 	startBlock uint64,
-	contractTransmitter ContractTransmitter,
+	contractTransmitter transmitter.ContractTransmitter,
 	configWatcher *configWatcher,
 	gasEstimator gas.EvmFeeEstimator,
 	maxGasPrice big.Int,

--- a/core/services/relay/evm/functions.go
+++ b/core/services/relay/evm/functions.go
@@ -20,6 +20,7 @@ import (
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/functions/config"
 	functionsRelay "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/functions"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter"
 )
 
 type functionsProvider struct {
@@ -27,11 +28,11 @@ type functionsProvider struct {
 	eng *services.Engine
 
 	configWatcher       *configWatcher
-	contractTransmitter ContractTransmitter
+	contractTransmitter transmitter.ContractTransmitter
 	logPollerWrapper    evmconfig.LogPollerWrapper
 }
 
-func newFunctionsProvider(lggr logger.Logger, cw *configWatcher, ct ContractTransmitter, lpw evmconfig.LogPollerWrapper) *functionsProvider {
+func newFunctionsProvider(lggr logger.Logger, cw *configWatcher, ct transmitter.ContractTransmitter, lpw evmconfig.LogPollerWrapper) *functionsProvider {
 	p := &functionsProvider{
 		configWatcher:       cw,
 		contractTransmitter: ct,
@@ -107,7 +108,7 @@ func NewFunctionsProvider(ctx context.Context, chain legacyevm.Chain, rargs comm
 	if err != nil {
 		return nil, err
 	}
-	var contractTransmitter ContractTransmitter
+	var contractTransmitter transmitter.ContractTransmitter
 	if relayConfig.SendingKeys != nil {
 		contractTransmitter, err = newFunctionsContractTransmitter(ctx, pluginConfig.ContractVersion, rargs, pargs.TransmitterID, configWatcher, ethKeystore, logPollerWrapper, lggr)
 		if err != nil {
@@ -138,7 +139,7 @@ func newFunctionsConfigProvider(ctx context.Context, pluginType functionsRelay.F
 	return newConfigWatcher(lggr, routerContractAddress, offchainConfigDigester, cp, chain, fromBlock, args.New), nil
 }
 
-func newFunctionsContractTransmitter(ctx context.Context, contractVersion uint32, rargs commontypes.RelayArgs, transmitterID string, configWatcher *configWatcher, ethKeystore keys.Store, logPollerWrapper evmconfig.LogPollerWrapper, lggr logger.Logger) (ContractTransmitter, error) {
+func newFunctionsContractTransmitter(ctx context.Context, contractVersion uint32, rargs commontypes.RelayArgs, transmitterID string, configWatcher *configWatcher, ethKeystore keys.Store, logPollerWrapper evmconfig.LogPollerWrapper, lggr logger.Logger) (transmitter.ContractTransmitter, error) {
 	var relayConfig evmconfig.RelayConfig
 	if err := json.Unmarshal(rargs.RelayConfig, &relayConfig); err != nil {
 		return nil, err

--- a/core/services/relay/evm/ocr2keeper.go
+++ b/core/services/relay/evm/ocr2keeper.go
@@ -28,6 +28,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/transmit"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter"
 )
 
 var (
@@ -87,7 +88,7 @@ func (r *ocr2keeperRelayer) NewOCR2KeeperProvider(ctx context.Context, rargs com
 	}
 
 	gasLimit := cfgWatcher.chain.Config().EVM().OCR2().Automation().GasLimit()
-	contractTransmitter, err := newOnChainContractTransmitter(ctx, r.lggr, rargs, r.ethKeystore, cfgWatcher, configTransmitterOpts{pluginGasLimit: &gasLimit}, OCR2AggregatorTransmissionContractABI)
+	contractTransmitter, err := transmitter.newOnChainContractTransmitter(ctx, r.lggr, rargs, r.ethKeystore, cfgWatcher, transmitter.configTransmitterOpts{pluginGasLimit: &gasLimit}, OCR2AggregatorTransmissionContractABI)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +178,7 @@ func (t *ocr3keeperProviderContractTransmitter) FromAccount(ctx context.Context)
 
 type ocr2keeperProvider struct {
 	*configWatcher
-	contractTransmitter       ContractTransmitter
+	contractTransmitter       transmitter.ContractTransmitter
 	registry                  automation.Registry
 	encoder                   automation.Encoder
 	transmitEventProvider     automation.EventProvider

--- a/core/services/relay/evm/ocr2keeper.go
+++ b/core/services/relay/evm/ocr2keeper.go
@@ -88,7 +88,7 @@ func (r *ocr2keeperRelayer) NewOCR2KeeperProvider(ctx context.Context, rargs com
 	}
 
 	gasLimit := cfgWatcher.chain.Config().EVM().OCR2().Automation().GasLimit()
-	contractTransmitter, err := transmitter.newOnChainContractTransmitter(ctx, r.lggr, rargs, r.ethKeystore, cfgWatcher, transmitter.configTransmitterOpts{pluginGasLimit: &gasLimit}, OCR2AggregatorTransmissionContractABI)
+	contractTransmitter, err := transmitter.NewContractTransmitter(ctx, r.lggr, rargs, r.ethKeystore, cfgWatcher.chain, cfgWatcher.contractAddress, transmitter.ConfigTransmitterOpts{PluginGasLimit: &gasLimit}, OCR2AggregatorTransmissionContractABI, false)
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/relay/evm/plugin_provider.go
+++ b/core/services/relay/evm/plugin_provider.go
@@ -8,13 +8,14 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter"
 )
 
 type pluginProvider struct {
 	services.Service
 	chainReader         ChainReaderService
 	codec               types.Codec
-	contractTransmitter ContractTransmitter
+	contractTransmitter transmitter.ContractTransmitter
 	configWatcher       *configWatcher
 	lggr                logger.Logger
 	ms                  services.MultiStart
@@ -25,7 +26,7 @@ var _ types.PluginProvider = (*pluginProvider)(nil)
 func NewPluginProvider(
 	chainReader ChainReaderService,
 	codec types.Codec,
-	contractTransmitter ContractTransmitter,
+	contractTransmitter transmitter.ContractTransmitter,
 	configWatcher *configWatcher,
 	lggr logger.Logger,
 ) *pluginProvider {

--- a/core/services/relay/evm/transmitter/contract_transmitter.go
+++ b/core/services/relay/evm/transmitter/contract_transmitter.go
@@ -96,7 +96,7 @@ type contractTransmitter struct {
 	transmitterOptions *transmitterOps
 }
 
-func TransmitterFilterName(addr common.Address) string {
+func FilterName(addr common.Address) string {
 	return logpoller.FilterName("OCR ContractTransmitter", addr.String())
 }
 
@@ -137,7 +137,7 @@ func NewOCRContractTransmitter(
 		opt(newContractTransmitter.transmitterOptions)
 	}
 
-	err := lp.RegisterFilter(ctx, logpoller.Filter{Name: TransmitterFilterName(address), EventSigs: []common.Hash{transmitted.ID}, Addresses: []common.Address{address}, Retention: newContractTransmitter.transmitterOptions.retention, MaxLogsKept: newContractTransmitter.transmitterOptions.maxLogsKept})
+	err := lp.RegisterFilter(ctx, logpoller.Filter{Name: FilterName(address), EventSigs: []common.Hash{transmitted.ID}, Addresses: []common.Address{address}, Retention: newContractTransmitter.transmitterOptions.retention, MaxLogsKept: newContractTransmitter.transmitterOptions.maxLogsKept})
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/relay/evm/transmitter/contract_transmitter.go
+++ b/core/services/relay/evm/transmitter/contract_transmitter.go
@@ -1,4 +1,4 @@
-package evm
+package transmitter
 
 import (
 	"context"
@@ -17,16 +17,15 @@ import (
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	evmkeystore "github.com/smartcontractkit/chainlink-evm/pkg/keys"
-
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	"github.com/smartcontractkit/chainlink/v2/core/services"
 )
 
 type ContractTransmitter interface {
-	services.ServiceCtx
+	services.Service
 	ocrtypes.ContractTransmitter
 }
 
@@ -62,6 +61,14 @@ func WithExcludeSignatures() OCRTransmitterOption {
 	}
 }
 
+func HasExcludeSignatures(opts []OCRTransmitterOption) bool {
+	transmitterOptions := &transmitterOps{}
+	for _, opt := range opts {
+		opt(transmitterOptions)
+	}
+	return transmitterOptions.excludeSigs
+}
+
 func WithRetention(retention time.Duration) OCRTransmitterOption {
 	return func(ct *transmitterOps) {
 		ct.retention = retention
@@ -89,7 +96,7 @@ type contractTransmitter struct {
 	transmitterOptions *transmitterOps
 }
 
-func transmitterFilterName(addr common.Address) string {
+func TransmitterFilterName(addr common.Address) string {
 	return logpoller.FilterName("OCR ContractTransmitter", addr.String())
 }
 
@@ -130,7 +137,7 @@ func NewOCRContractTransmitter(
 		opt(newContractTransmitter.transmitterOptions)
 	}
 
-	err := lp.RegisterFilter(ctx, logpoller.Filter{Name: transmitterFilterName(address), EventSigs: []common.Hash{transmitted.ID}, Addresses: []common.Address{address}, Retention: newContractTransmitter.transmitterOptions.retention, MaxLogsKept: newContractTransmitter.transmitterOptions.maxLogsKept})
+	err := lp.RegisterFilter(ctx, logpoller.Filter{Name: TransmitterFilterName(address), EventSigs: []common.Hash{transmitted.ID}, Addresses: []common.Address{address}, Retention: newContractTransmitter.transmitterOptions.retention, MaxLogsKept: newContractTransmitter.transmitterOptions.maxLogsKept})
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/relay/evm/transmitter/contract_transmitter_test.go
+++ b/core/services/relay/evm/transmitter/contract_transmitter_test.go
@@ -1,4 +1,4 @@
-package evm
+package transmitter
 
 import (
 	"context"
@@ -12,9 +12,12 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/chains/evmutil"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	libocr "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
@@ -25,32 +28,28 @@ import (
 	lpmocks "github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
 )
 
-var sampleAddressPrimary = testutils.NewAddress()
+var sampleAddress = testutils.NewAddress()
 
-type mockDualTransmitter struct {
-	lastPrimaryPayload   []byte
-	lastSecondaryPayload []byte
+type mockTransmitter struct {
+	lastPayload []byte
 }
 
-func (m *mockDualTransmitter) SecondaryFromAddress(ctx context.Context) (gethcommon.Address, error) {
+func (m *mockTransmitter) SecondaryFromAddress(ctx context.Context) (gethcommon.Address, error) {
 	return gethcommon.Address{}, nil
 }
 
-func (*mockDualTransmitter) FromAddress(ctx context.Context) gethcommon.Address {
-	return sampleAddressPrimary
-}
-
-func (m *mockDualTransmitter) CreateEthTransaction(ctx context.Context, toAddress gethcommon.Address, payload []byte, _ *txmgr.TxMeta) error {
-	m.lastPrimaryPayload = payload
+func (m *mockTransmitter) CreateSecondaryEthTransaction(ctx context.Context, bytes []byte, meta *txmgr.TxMeta) error {
 	return nil
 }
 
-func (m *mockDualTransmitter) CreateSecondaryEthTransaction(ctx context.Context, payload []byte, _ *txmgr.TxMeta) error {
-	m.lastSecondaryPayload = payload
+func (m *mockTransmitter) CreateEthTransaction(ctx context.Context, toAddress gethcommon.Address, payload []byte, _ *txmgr.TxMeta) error {
+	m.lastPayload = payload
 	return nil
 }
 
-func TestDualContractTransmitter(t *testing.T) {
+func (*mockTransmitter) FromAddress(ctx context.Context) gethcommon.Address { return sampleAddress }
+
+func TestContractTransmitter(t *testing.T) {
 	t.Parallel()
 
 	lggr := logger.Test(t)
@@ -68,7 +67,8 @@ func TestDualContractTransmitter(t *testing.T) {
 	reportToEvmTxMeta := func(b []byte) (*txmgr.TxMeta, error) {
 		return &txmgr.TxMeta{}, nil
 	}
-	ot, err := NewOCRDualContractTransmitter(ctx, gethcommon.Address{}, c, contractABI, &mockDualTransmitter{}, lp, lggr, &keystest.FakeChainStore{}, WithReportToEthMetadata(reportToEvmTxMeta))
+	ot, err := NewOCRContractTransmitter(ctx, gethcommon.Address{}, c, contractABI, &mockTransmitter{}, lp, lggr, &keystest.FakeChainStore{},
+		WithReportToEthMetadata(reportToEvmTxMeta))
 	require.NoError(t, err)
 	digest, epoch, err := ot.LatestConfigDigestAndEpoch(testutils.Context(t))
 	require.NoError(t, err)
@@ -94,20 +94,20 @@ func TestDualContractTransmitter(t *testing.T) {
 	assert.Equal(t, uint32(2), epoch)
 	from, err := ot.FromAccount(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, sampleAddressPrimary.String(), string(from))
+	assert.Equal(t, sampleAddress.String(), string(from))
 }
 
-func Test_dualContractTransmitterNoSignatures_Transmit_SignaturesAreNotTransmitted(t *testing.T) {
+func Test_contractTransmitterNoSignatures_Transmit_SignaturesAreNotTransmitted(t *testing.T) {
 	t.Parallel()
 
-	transmitter := &mockDualTransmitter{}
+	transmitter := &mockTransmitter{}
 
 	ctx := context.Background()
 	reportCtx := types.ReportContext{}
 	report := types.Report{}
 	var signatures = oneSignature()
 
-	oc := createDualContractTransmitter(ctx, t, transmitter, WithExcludeSignatures())
+	oc := createContractTransmitter(ctx, t, transmitter, WithExcludeSignatures())
 
 	err := oc.Transmit(ctx, reportCtx, report, signatures)
 	require.NoError(t, err)
@@ -115,44 +115,57 @@ func Test_dualContractTransmitterNoSignatures_Transmit_SignaturesAreNotTransmitt
 	var emptyRs [][32]byte
 	var emptySs [][32]byte
 	var emptyVs [32]byte
-	emptySignaturesPayloadPrimary, err := oc.contractABI.Pack("transmit", evmutil.RawReportContext(reportCtx), []byte(report), emptyRs, emptySs, emptyVs)
+	emptySignaturesPayload, err := oc.contractABI.Pack("transmit", evmutil.RawReportContext(reportCtx), []byte(report), emptyRs, emptySs, emptyVs)
 	require.NoError(t, err)
-	emptySignaturesPayloadSecondary, err := oc.dualTransmissionABI.Pack("transmitSecondary", evmutil.RawReportContext(reportCtx), []byte(report), emptyRs, emptySs, emptyVs)
-	require.NoError(t, err)
-	require.Equal(t, transmitter.lastPrimaryPayload, emptySignaturesPayloadPrimary, "primary payload not equal")
-	require.Equal(t, transmitter.lastSecondaryPayload, emptySignaturesPayloadSecondary, "secondary payload not equal")
+	require.Equal(t, transmitter.lastPayload, emptySignaturesPayload)
 }
 
-func Test_dualContractTransmitter_Transmit_SignaturesAreTransmitted(t *testing.T) {
+func Test_contractTransmitter_Transmit_SignaturesAreTransmitted(t *testing.T) {
 	t.Parallel()
 
-	transmitter := &mockDualTransmitter{}
+	transmitter := &mockTransmitter{}
 
 	ctx := context.Background()
 	reportCtx := types.ReportContext{}
 	report := types.Report{}
 	var signatures = oneSignature()
 
-	oc := createDualContractTransmitter(ctx, t, transmitter)
+	oc := createContractTransmitter(ctx, t, transmitter)
 
 	err := oc.Transmit(ctx, reportCtx, report, signatures)
 	require.NoError(t, err)
 
 	rs, ss, vs := signaturesAsPayload(t, signatures)
-	withSignaturesPayloadPrimary, err := oc.contractABI.Pack("transmit", evmutil.RawReportContext(reportCtx), []byte(report), rs, ss, vs)
+	withSignaturesPayload, err := oc.contractABI.Pack("transmit", evmutil.RawReportContext(reportCtx), []byte(report), rs, ss, vs)
 	require.NoError(t, err)
-	withSignaturesPayloadSecondary, err := oc.dualTransmissionABI.Pack("transmitSecondary", evmutil.RawReportContext(reportCtx), []byte(report), rs, ss, vs)
-	require.NoError(t, err)
-	require.Equal(t, transmitter.lastPrimaryPayload, withSignaturesPayloadPrimary, "primary payload not equal")
-	require.Equal(t, transmitter.lastSecondaryPayload, withSignaturesPayloadSecondary, "secondary payload not equal")
+	require.Equal(t, transmitter.lastPayload, withSignaturesPayload)
 }
 
-func createDualContractTransmitter(ctx context.Context, t *testing.T, transmitter Transmitter, ops ...OCRTransmitterOption) *dualContractTransmitter {
+func signaturesAsPayload(t *testing.T, signatures []ocrtypes.AttributedOnchainSignature) ([][32]byte, [][32]byte, [32]byte) {
+	var rs [][32]byte
+	var ss [][32]byte
+	var vs [32]byte
+	r, s, v, err := evmutil.SplitSignature(signatures[0].Signature)
+	require.NoError(t, err)
+	rs = append(rs, r)
+	ss = append(ss, s)
+	vs[0] = v
+	return rs, ss, vs
+}
+
+func oneSignature() []ocrtypes.AttributedOnchainSignature {
+	signaturesData := make([]byte, 65)
+	signaturesData[9] = 8
+	signaturesData[7] = 6
+	return []libocr.AttributedOnchainSignature{{Signature: signaturesData, Signer: commontypes.OracleID(54)}}
+}
+
+func createContractTransmitter(ctx context.Context, t *testing.T, transmitter Transmitter, ops ...OCRTransmitterOption) *contractTransmitter {
 	contractABI, err := abi.JSON(strings.NewReader(ocr2aggregator.OCR2AggregatorMetaData.ABI))
 	require.NoError(t, err)
 	lp := lpmocks.NewLogPoller(t)
 	lp.On("RegisterFilter", mock.Anything, mock.Anything).Return(nil)
-	contractTransmitter, err := NewOCRDualContractTransmitter(
+	contractTransmitter, err := NewOCRContractTransmitter(
 		ctx,
 		gethcommon.Address{},
 		clienttest.NewClient(t),

--- a/core/services/relay/evm/transmitter/dual_contract_transmitter.go
+++ b/core/services/relay/evm/transmitter/dual_contract_transmitter.go
@@ -87,7 +87,7 @@ func NewOCRDualContractTransmitter(
 		opt(newContractTransmitter.transmitterOptions)
 	}
 
-	err := lp.RegisterFilter(ctx, logpoller.Filter{Name: TransmitterFilterName(address), EventSigs: []gethcommon.Hash{transmitted.ID}, Addresses: []gethcommon.Address{address}, Retention: newContractTransmitter.transmitterOptions.retention, MaxLogsKept: newContractTransmitter.transmitterOptions.maxLogsKept})
+	err := lp.RegisterFilter(ctx, logpoller.Filter{Name: FilterName(address), EventSigs: []gethcommon.Hash{transmitted.ID}, Addresses: []gethcommon.Address{address}, Retention: newContractTransmitter.transmitterOptions.retention, MaxLogsKept: newContractTransmitter.transmitterOptions.maxLogsKept})
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/relay/evm/transmitter/dual_contract_transmitter.go
+++ b/core/services/relay/evm/transmitter/dual_contract_transmitter.go
@@ -1,4 +1,4 @@
-package evm
+package transmitter
 
 import (
 	"context"
@@ -87,7 +87,7 @@ func NewOCRDualContractTransmitter(
 		opt(newContractTransmitter.transmitterOptions)
 	}
 
-	err := lp.RegisterFilter(ctx, logpoller.Filter{Name: transmitterFilterName(address), EventSigs: []gethcommon.Hash{transmitted.ID}, Addresses: []gethcommon.Address{address}, Retention: newContractTransmitter.transmitterOptions.retention, MaxLogsKept: newContractTransmitter.transmitterOptions.maxLogsKept})
+	err := lp.RegisterFilter(ctx, logpoller.Filter{Name: TransmitterFilterName(address), EventSigs: []gethcommon.Hash{transmitted.ID}, Addresses: []gethcommon.Address{address}, Retention: newContractTransmitter.transmitterOptions.retention, MaxLogsKept: newContractTransmitter.transmitterOptions.maxLogsKept})
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/relay/evm/transmitter/util.go
+++ b/core/services/relay/evm/transmitter/util.go
@@ -99,7 +99,6 @@ func generateTransmitterFrom(ctx context.Context, rargs types.RelayArgs, ethKeys
 	if err := json.Unmarshal(rargs.RelayConfig, &relayConfig); err != nil {
 		return nil, err
 	}
-	var fromAddresses []common.Address
 	sendingKeys := relayConfig.SendingKeys
 	if !relayConfig.EffectiveTransmitterID.Valid {
 		return nil, errors.New("EffectiveTransmitterID must be specified")
@@ -113,6 +112,7 @@ func generateTransmitterFrom(ctx context.Context, rargs types.RelayArgs, ethKeys
 
 	// If we are using multiple sending keys, then a forwarder is needed to rotate transmissions.
 	// Ensure that this forwarder is not set to a local sending key, and ensure our sending keys are enabled.
+	var fromAddresses = make([]common.Address, 0, sendingKeysLength)
 	for _, s := range sendingKeys {
 		if sendingKeysLength > 1 && s == effectiveTransmitterAddress.String() {
 			return nil, errors.New("the transmitter is a local sending key with transaction forwarding enabled")

--- a/core/services/relay/evm/transmitter/util.go
+++ b/core/services/relay/evm/transmitter/util.go
@@ -1,0 +1,188 @@
+package transmitter
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
+	"github.com/smartcontractkit/chainlink-evm/pkg/config"
+	"github.com/smartcontractkit/chainlink-evm/pkg/config/chaintype"
+	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
+	evmtxmgr "github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
+	"github.com/smartcontractkit/chainlink-framework/chains/txmgr"
+	cciptransmitter "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/transmitter"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
+)
+
+type ConfigTransmitterOpts struct {
+	// PluginGasLimit overrides the gas limit default provided in the config watcher.
+	PluginGasLimit *uint32
+	// SubjectID overrides the queueing subject id (the job external id will be used by default).
+	SubjectID *uuid.UUID
+}
+
+// newOnChainContractTransmitter creates a new contract transmitter.
+func newOnChainContractTransmitter(ctx context.Context, lggr logger.Logger, rargs types.RelayArgs, ethKeystore keys.Store, chain legacyevm.Chain, address common.Address, opts ConfigTransmitterOpts, transmissionContractABI abi.ABI, ocrTransmitterOpts ...OCRTransmitterOption) (ContractTransmitter, error) {
+	transmitter, err := generateTransmitterFrom(ctx, rargs, ethKeystore, chain, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	evmTransmitter, err := NewOCRContractTransmitter(
+		ctx,
+		address,
+		chain.Client(),
+		transmissionContractABI,
+		transmitter,
+		chain.LogPoller(),
+		lggr,
+		ethKeystore,
+		ocrTransmitterOpts...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// This code path should only be called when running CCIP 1.5 jobs on Tron.
+	// All other products should use the standard Tron relayer implementation.
+	if chain.Config().EVM().ChainType() == chaintype.ChainTron {
+		return NewTronContractTransmitter(ctx, TronContractTransmitterOpts{
+			Logger:             lggr,
+			TransmissionsCache: NewTronTransmissionsCache(evmTransmitter),
+			Keystore:           ethKeystore,
+			Chain:              chain,
+			ContractAddress:    address,
+			OCRTransmitterOpts: ocrTransmitterOpts,
+		})
+	}
+
+	return evmTransmitter, err
+}
+
+// newOnChainDualContractTransmitter creates a new dual contract transmitter.
+func newOnChainDualContractTransmitter(ctx context.Context, lggr logger.Logger, rargs types.RelayArgs, ethKeystore keys.Store, chain legacyevm.Chain, address common.Address, opts ConfigTransmitterOpts, transmissionContractABI abi.ABI, ocrTransmitterOpts ...OCRTransmitterOption) (*dualContractTransmitter, error) {
+	transmitter, err := generateTransmitterFrom(ctx, rargs, ethKeystore, chain, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewOCRDualContractTransmitter(
+		ctx,
+		address,
+		chain.Client(),
+		transmissionContractABI,
+		transmitter,
+		chain.LogPoller(),
+		lggr,
+		ethKeystore,
+		ocrTransmitterOpts...,
+	)
+}
+
+func NewContractTransmitter(ctx context.Context, lggr logger.Logger, rargs types.RelayArgs, ethKeystore keys.Store, chain legacyevm.Chain, address common.Address, opts ConfigTransmitterOpts, transmissionContractABI abi.ABI, dualTransmission bool, ocrTransmitterOpts ...OCRTransmitterOption) (ContractTransmitter, error) {
+	if dualTransmission {
+		return newOnChainDualContractTransmitter(ctx, lggr, rargs, ethKeystore, chain, address, opts, transmissionContractABI, ocrTransmitterOpts...)
+	}
+
+	return newOnChainContractTransmitter(ctx, lggr, rargs, ethKeystore, chain, address, opts, transmissionContractABI, ocrTransmitterOpts...)
+}
+
+func generateTransmitterFrom(ctx context.Context, rargs types.RelayArgs, ethKeystore keys.Store, chain legacyevm.Chain, opts ConfigTransmitterOpts) (Transmitter, error) {
+	var relayConfig config.RelayConfig
+	if err := json.Unmarshal(rargs.RelayConfig, &relayConfig); err != nil {
+		return nil, err
+	}
+	var fromAddresses []common.Address
+	sendingKeys := relayConfig.SendingKeys
+	if !relayConfig.EffectiveTransmitterID.Valid {
+		return nil, errors.New("EffectiveTransmitterID must be specified")
+	}
+	effectiveTransmitterAddress := common.HexToAddress(relayConfig.EffectiveTransmitterID.String)
+
+	sendingKeysLength := len(sendingKeys)
+	if sendingKeysLength == 0 {
+		return nil, errors.New("no sending keys provided")
+	}
+
+	// If we are using multiple sending keys, then a forwarder is needed to rotate transmissions.
+	// Ensure that this forwarder is not set to a local sending key, and ensure our sending keys are enabled.
+	for _, s := range sendingKeys {
+		if sendingKeysLength > 1 && s == effectiveTransmitterAddress.String() {
+			return nil, errors.New("the transmitter is a local sending key with transaction forwarding enabled")
+		}
+		if err := ethKeystore.CheckEnabled(ctx, common.HexToAddress(s)); err != nil {
+			return nil, errors.Wrap(err, "one of the sending keys given is not enabled")
+		}
+		fromAddresses = append(fromAddresses, common.HexToAddress(s))
+	}
+
+	subject := rargs.ExternalJobID
+	if opts.SubjectID != nil {
+		subject = *opts.SubjectID
+	}
+	strategy := txmgr.NewQueueingTxStrategy(subject, relayConfig.DefaultTransactionQueueDepth)
+
+	var checker evmtxmgr.TransmitCheckerSpec
+	if relayConfig.SimulateTransactions {
+		checker.CheckerType = evmtxmgr.TransmitCheckerTypeSimulate
+	}
+
+	gasLimit := chain.Config().EVM().GasEstimator().LimitDefault()
+	ocr2Limit := chain.Config().EVM().GasEstimator().LimitJobType().OCR2()
+	if ocr2Limit != nil {
+		gasLimit = uint64(*ocr2Limit)
+	}
+	if opts.PluginGasLimit != nil {
+		gasLimit = uint64(*opts.PluginGasLimit)
+	}
+
+	var transmitter Transmitter
+	var err error
+
+	switch types.OCR2PluginType(rargs.ProviderType) {
+	case types.Median:
+		transmitter, err = ocrcommon.NewOCR2FeedsTransmitter(
+			chain.TxManager(),
+			fromAddresses,
+			common.HexToAddress(rargs.ContractID),
+			gasLimit,
+			effectiveTransmitterAddress,
+			strategy,
+			checker,
+			ethKeystore,
+			relayConfig.DualTransmissionConfig,
+		)
+	case types.CCIPExecution:
+		transmitter, err = cciptransmitter.NewTransmitterWithStatusChecker(
+			chain.TxManager(),
+			fromAddresses,
+			gasLimit,
+			effectiveTransmitterAddress,
+			strategy,
+			checker,
+			chain.ID(),
+			ethKeystore,
+		)
+	default:
+		transmitter, err = ocrcommon.NewTransmitter(
+			chain.TxManager(),
+			fromAddresses,
+			gasLimit,
+			effectiveTransmitterAddress,
+			strategy,
+			checker,
+			ethKeystore,
+		)
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create transmitter")
+	}
+	return transmitter, nil
+}


### PR DESCRIPTION
I could not move transmitter files directly to chainlink-evm, so started with the following refactorings:

- Pass `cfgWatcher.chain` and `cfgWatcher.contractAddress` to `NewContractTransmitter` instead of the whole `cfgWatcher`.
- Use `github.com/smartcontractkit/chainlink-common/pkg/services.Service` instead of `github.com/smartcontractkit/chainlink/v2/core/services.ServiceCtx`
- Added method `HasExcludeSignatures` to not use plain low level `transmitterOps`
- Consistently used `NewContractTransmitter` instead of the low level `newOnChainContractTransmitter`

Exported the following types/methods:
- `transmitterFilterName` as `FilterName`
-  `ConfigTransmitterOpts`