### PR TITLE
Fix Go base image to use golang:1.25.2-bookworm

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -1,7 +1,7 @@
 ##
 # Build image: Chainlink binary with plugins.
 ##
-FROM golang:1.25.2-bullseye AS buildgo
+FROM golang:1.25.2-bookworm AS buildgo
 RUN go version
 RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
- Updated from golang:1.24-bullseye to golang:1.25.2-bookworm
- Uses the correct Go 1.25.2 version with Debian 12 (bookworm)
- Meets security requirements for Go 1.25.2+ base image
- Fixes build error: golang:1.25.2-bullseye not found (bullseye variant doesn't exist)

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
