### PR TITLE
CCIP-7300 support multiple LBTC configurations

### DIFF
--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -2190,6 +2190,29 @@ runner-test-matrix:
     test_config_override_path: integration-tests/ccip-tests/testconfig/tomls/usdc_mock_deployment.toml
     test_go_project_path: integration-tests
 
+  - id: ccip-smoke-lbtc-multiple-tokens
+    path: integration-tests/ccip-tests/smoke/ccip_test.go
+    test_env_type: docker
+    runs_on: ubuntu-latest
+    triggers:
+      - PR E2E CCIP Tests
+      - Merge Queue E2E CCIP Tests
+      - Nightly E2E Tests
+      - Push E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP Tests
+    test_cmd: |
+      cd ccip-tests/smoke && \
+      gotestsum \
+        --junitfile=/tmp/junit.xml \
+        --jsonfile=/tmp/gotest.log \
+        --format=github-actions \
+        -- -run "^TestSmokeCCIPForBidirectionalLane$" -timeout 30m -count=1 -parallel=1
+    test_env_vars:
+      E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2
+      CHAINLINK_USER_TEAM: CCIP
+    test_config_override_path: integration-tests/ccip-tests/testconfig/tomls/lbtc_mock_deployment_multiple_tokens.toml
+    test_go_project_path: integration-tests
+
   - id: ccip-smoke-lbtc-32bytes-destination-pool-data
     path: integration-tests/ccip-tests/smoke/ccip_test.go
     test_env_type: docker

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -2239,7 +2239,7 @@ func (d *Delegate) ccipExecGetDstProvider(ctx context.Context, jb job.Job, plugi
 
 	// PROVIDER BASED ARG CONSTRUCTION
 	// Write PluginConfig bytes to send source/dest relayer provider + info outside of top level rargs/pargs over the wire
-	dstConfigBytes, err := newExecPluginConfig(false, pluginJobSpecConfig.SourceStartBlock, pluginJobSpecConfig.DestStartBlock, pluginJobSpecConfig.USDCConfig, pluginJobSpecConfig.LBTCConfig, string(jb.ID)).Encode()
+	dstConfigBytes, err := newExecPluginConfig(false, pluginJobSpecConfig.SourceStartBlock, pluginJobSpecConfig.DestStartBlock, pluginJobSpecConfig.USDCConfig, pluginJobSpecConfig.LBTCConfigsList(), string(jb.ID)).Encode()
 	if err != nil {
 		return nil, err
 	}
@@ -2272,7 +2272,7 @@ func (d *Delegate) ccipExecGetDstProvider(ctx context.Context, jb job.Job, plugi
 
 func (d *Delegate) ccipExecGetSrcProvider(ctx context.Context, jb job.Job, pluginJobSpecConfig ccipconfig.ExecPluginJobSpecConfig, transmitterID string, dstProvider types.CCIPExecProvider) (srcProvider types.CCIPExecProvider, srcChainID uint64, err error) {
 	spec := jb.OCR2OracleSpec
-	srcConfigBytes, err := newExecPluginConfig(true, pluginJobSpecConfig.SourceStartBlock, pluginJobSpecConfig.DestStartBlock, pluginJobSpecConfig.USDCConfig, pluginJobSpecConfig.LBTCConfig, string(jb.ID)).Encode()
+	srcConfigBytes, err := newExecPluginConfig(true, pluginJobSpecConfig.SourceStartBlock, pluginJobSpecConfig.DestStartBlock, pluginJobSpecConfig.USDCConfig, pluginJobSpecConfig.LBTCConfigsList(), string(jb.ID)).Encode()
 	if err != nil {
 		return nil, 0, err
 	}
@@ -2321,13 +2321,13 @@ func (d *Delegate) ccipExecGetSrcProvider(ctx context.Context, jb job.Job, plugi
 	return
 }
 
-func newExecPluginConfig(isSourceProvider bool, srcStartBlock uint64, dstStartBlock uint64, usdcConfig ccipconfig.USDCConfig, lbtcConfig ccipconfig.LBTCConfig, jobID string) config.ExecPluginConfig {
+func newExecPluginConfig(isSourceProvider bool, srcStartBlock uint64, dstStartBlock uint64, usdcConfig ccipconfig.USDCConfig, lbtcConfigs []ccipconfig.LBTCConfig, jobID string) config.ExecPluginConfig {
 	return config.ExecPluginConfig{
 		IsSourceProvider: isSourceProvider,
 		SourceStartBlock: srcStartBlock,
 		DestStartBlock:   dstStartBlock,
 		USDCConfig:       usdcConfig,
-		LBTCConfig:       lbtcConfig,
+		LBTCConfigs:      lbtcConfigs,
 		JobID:            jobID,
 	}
 }

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -2239,7 +2239,7 @@ func (d *Delegate) ccipExecGetDstProvider(ctx context.Context, jb job.Job, plugi
 
 	// PROVIDER BASED ARG CONSTRUCTION
 	// Write PluginConfig bytes to send source/dest relayer provider + info outside of top level rargs/pargs over the wire
-	dstConfigBytes, err := newExecPluginConfig(false, pluginJobSpecConfig.SourceStartBlock, pluginJobSpecConfig.DestStartBlock, pluginJobSpecConfig.USDCConfig, pluginJobSpecConfig.LBTCConfigsList(), string(jb.ID)).Encode()
+	dstConfigBytes, err := newExecPluginConfig(false, pluginJobSpecConfig.SourceStartBlock, pluginJobSpecConfig.DestStartBlock, pluginJobSpecConfig.USDCConfig, pluginJobSpecConfig.GetLBTCConfigs(), string(jb.ID)).Encode()
 	if err != nil {
 		return nil, err
 	}
@@ -2272,7 +2272,7 @@ func (d *Delegate) ccipExecGetDstProvider(ctx context.Context, jb job.Job, plugi
 
 func (d *Delegate) ccipExecGetSrcProvider(ctx context.Context, jb job.Job, pluginJobSpecConfig ccipconfig.ExecPluginJobSpecConfig, transmitterID string, dstProvider types.CCIPExecProvider) (srcProvider types.CCIPExecProvider, srcChainID uint64, err error) {
 	spec := jb.OCR2OracleSpec
-	srcConfigBytes, err := newExecPluginConfig(true, pluginJobSpecConfig.SourceStartBlock, pluginJobSpecConfig.DestStartBlock, pluginJobSpecConfig.USDCConfig, pluginJobSpecConfig.LBTCConfigsList(), string(jb.ID)).Encode()
+	srcConfigBytes, err := newExecPluginConfig(true, pluginJobSpecConfig.SourceStartBlock, pluginJobSpecConfig.DestStartBlock, pluginJobSpecConfig.USDCConfig, pluginJobSpecConfig.GetLBTCConfigs(), string(jb.ID)).Encode()
 	if err != nil {
 		return nil, 0, err
 	}

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -136,16 +136,19 @@ func NewExecServices(ctx context.Context, lggr logger.Logger, jb job.Job, srcPro
 		}
 		tokenDataProviders[cciptypes.Address(pluginConfig.USDCConfig.SourceTokenAddress.String())] = usdcReader
 	}
+
 	lbtcConfigs := pluginConfig.LBTCConfigsList()
 	err = ccipconfig.ValidateLBTCConfigs(lbtcConfigs)
 	if err != nil {
 		return nil, err
 	}
-
 	for _, lbtcConfig := range lbtcConfigs {
 		// init lbtc token data provider
 		if lbtcConfig.AttestationAPI != "" {
-			lggr.Infof("LBTC token data provider enabled")
+			lggr.Infow("LBTC token data provider enabled",
+				"sourceTokenAddress", lbtcConfig.SourceTokenAddress.String(),
+				"attestationURI", lbtcConfig.AttestationAPI,
+			)
 			lbtcReader, err2 := srcProvider.NewTokenDataReader(ctx, ccip.EvmAddrToGeneric(lbtcConfig.SourceTokenAddress))
 			if err2 != nil {
 				return nil, fmt.Errorf("new lbtc reader: %w", err2)

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -137,7 +137,7 @@ func NewExecServices(ctx context.Context, lggr logger.Logger, jb job.Job, srcPro
 		tokenDataProviders[cciptypes.Address(pluginConfig.USDCConfig.SourceTokenAddress.String())] = usdcReader
 	}
 
-	lbtcConfigs := pluginConfig.LBTCConfigsList()
+	lbtcConfigs := pluginConfig.GetLBTCConfigs()
 	err = ccipconfig.ValidateLBTCConfigs(lbtcConfigs)
 	if err != nil {
 		return nil, err

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -136,19 +136,22 @@ func NewExecServices(ctx context.Context, lggr logger.Logger, jb job.Job, srcPro
 		}
 		tokenDataProviders[cciptypes.Address(pluginConfig.USDCConfig.SourceTokenAddress.String())] = usdcReader
 	}
-	// init lbtc token data provider
-	if pluginConfig.LBTCConfig.AttestationAPI != "" {
-		lggr.Infof("LBTC token data provider enabled")
-		err2 := pluginConfig.LBTCConfig.ValidateLBTCConfig()
-		if err2 != nil {
-			return nil, err2
-		}
+	lbtcConfigs := pluginConfig.LBTCConfigsList()
+	err = ccipconfig.ValidateLBTCConfigs(lbtcConfigs)
+	if err != nil {
+		return nil, err
+	}
 
-		lbtcReader, err2 := srcProvider.NewTokenDataReader(ctx, ccip.EvmAddrToGeneric(pluginConfig.LBTCConfig.SourceTokenAddress))
-		if err2 != nil {
-			return nil, fmt.Errorf("new lbtc reader: %w", err2)
+	for _, lbtcConfig := range lbtcConfigs {
+		// init lbtc token data provider
+		if lbtcConfig.AttestationAPI != "" {
+			lggr.Infof("LBTC token data provider enabled")
+			lbtcReader, err2 := srcProvider.NewTokenDataReader(ctx, ccip.EvmAddrToGeneric(lbtcConfig.SourceTokenAddress))
+			if err2 != nil {
+				return nil, fmt.Errorf("new lbtc reader: %w", err2)
+			}
+			tokenDataProviders[cciptypes.Address(lbtcConfig.SourceTokenAddress.String())] = lbtcReader
 		}
-		tokenDataProviders[cciptypes.Address(pluginConfig.LBTCConfig.SourceTokenAddress.String())] = lbtcReader
 	}
 
 	// Prom wrappers

--- a/core/services/ocr2/plugins/ccip/config/config.go
+++ b/core/services/ocr2/plugins/ccip/config/config.go
@@ -12,7 +12,6 @@ import (
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/bytes"
-
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 )
 
@@ -204,7 +203,18 @@ func (c *DynamicPriceGetterConfig) UnmarshalJSON(data []byte) error {
 type ExecPluginJobSpecConfig struct {
 	SourceStartBlock, DestStartBlock uint64 // Only for first time job add.
 	USDCConfig                       USDCConfig
-	LBTCConfig                       LBTCConfig
+	// Deprecated: store config in LBTCConfigs, read using LBTCConfigsList. This is kept for backward compatibility
+	LBTCConfig  LBTCConfig
+	LBTCConfigs []LBTCConfig
+}
+
+func (c *ExecPluginJobSpecConfig) LBTCConfigsList() []LBTCConfig {
+	lbtcConfigs := make([]LBTCConfig, 0, len(c.LBTCConfigs)+1)
+	if c.LBTCConfig != (LBTCConfig{}) {
+		lbtcConfigs = append(lbtcConfigs, c.LBTCConfig)
+	}
+	lbtcConfigs = append(lbtcConfigs, c.LBTCConfigs...)
+	return lbtcConfigs
 }
 
 type USDCConfig struct {
@@ -228,7 +238,7 @@ type ExecPluginConfig struct {
 	SourceStartBlock, DestStartBlock uint64 // Only for first time job add.
 	IsSourceProvider                 bool
 	USDCConfig                       USDCConfig
-	LBTCConfig                       LBTCConfig
+	LBTCConfigs                      []LBTCConfig
 	JobID                            string
 }
 
@@ -257,15 +267,22 @@ func (uc *USDCConfig) ValidateUSDCConfig() error {
 	return nil
 }
 
-func (lc *LBTCConfig) ValidateLBTCConfig() error {
-	if lc.AttestationAPI == "" {
-		return errors.New("LBTCConfig: AttestationAPI is required")
-	}
-	if lc.AttestationAPIIntervalMilliseconds < -1 {
-		return errors.New("LBTCConfig: AttestationAPIIntervalMilliseconds must be -1 to disable, 0 for default or greater to define the exact interval")
-	}
-	if lc.SourceTokenAddress == utils.ZeroAddress {
-		return errors.New("LBTCConfig: SourceTokenAddress is required")
+func ValidateLBTCConfigs(lbtcConfigs []LBTCConfig) error {
+	seen := make(map[string]bool)
+	for _, lbtcConfig := range lbtcConfigs {
+		if lbtcConfig.AttestationAPI == "" {
+			return errors.New("LBTCConfig: AttestationAPI is required")
+		}
+		if lbtcConfig.AttestationAPIIntervalMilliseconds < -1 {
+			return errors.New("LBTCConfig: AttestationAPIIntervalMilliseconds must be -1 to disable, 0 for default or greater to define the exact interval")
+		}
+		if lbtcConfig.SourceTokenAddress == utils.ZeroAddress {
+			return errors.New("LBTCConfig: SourceTokenAddress is required")
+		}
+		if seen[lbtcConfig.SourceTokenAddress.String()] {
+			return errors.New("LBTCConfig: Duplicated SourceTokenAddress found")
+		}
+		seen[lbtcConfig.SourceTokenAddress.String()] = true
 	}
 	return nil
 }

--- a/core/services/ocr2/plugins/ccip/config/config.go
+++ b/core/services/ocr2/plugins/ccip/config/config.go
@@ -203,18 +203,20 @@ func (c *DynamicPriceGetterConfig) UnmarshalJSON(data []byte) error {
 type ExecPluginJobSpecConfig struct {
 	SourceStartBlock, DestStartBlock uint64 // Only for first time job add.
 	USDCConfig                       USDCConfig
-	// Deprecated: store config in LBTCConfigs, read using LBTCConfigsList. This is kept for backward compatibility
+	// Deprecated: store config in LBTCConfigs, read using GetLBTCConfigs. This is kept for backward compatibility
 	LBTCConfig  LBTCConfig
 	LBTCConfigs []LBTCConfig
 }
 
-func (c *ExecPluginJobSpecConfig) LBTCConfigsList() []LBTCConfig {
-	lbtcConfigs := make([]LBTCConfig, 0, len(c.LBTCConfigs)+1)
-	if c.LBTCConfig != (LBTCConfig{}) {
-		lbtcConfigs = append(lbtcConfigs, c.LBTCConfig)
+func (c *ExecPluginJobSpecConfig) GetLBTCConfigs() []LBTCConfig {
+	// prioritize plural LBTC configs field over singular
+	if len(c.LBTCConfigs) > 0 {
+		return c.LBTCConfigs
 	}
-	lbtcConfigs = append(lbtcConfigs, c.LBTCConfigs...)
-	return lbtcConfigs
+	if c.LBTCConfig != (LBTCConfig{}) {
+		return []LBTCConfig{c.LBTCConfig}
+	}
+	return []LBTCConfig{}
 }
 
 type USDCConfig struct {

--- a/core/services/ocr2/plugins/ccip/integration_test.go
+++ b/core/services/ocr2/plugins/ccip/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/smartcontractkit/freeport"
 
 	"github.com/smartcontractkit/quarantine"
 
@@ -111,7 +112,9 @@ func TestIntegration_CCIP(t *testing.T) {
 				require.NoError(t, err)
 				priceGetterConfigJson = string(priceGetterConfigBytes)
 			}
-			jobParams := ccipTH.SetUpNodesAndJobs(t, tokenPricesUSDPipeline, priceGetterConfigJson, "")
+			bootstrapNode, _, configBlock := ccipTH.SetupAndStartNodes(t.Context(), t, int64(freeport.GetOne(t)))
+			jobParams := ccipTH.NewCCIPJobSpecParams(tokenPricesUSDPipeline, priceGetterConfigJson, configBlock)
+			ccipTH.SetUpJobs(t, bootstrapNode, configBlock, jobParams)
 
 			// track sequence number and nonce separately since nonce doesn't bump for messages with allowOutOfOrderExecution == true,
 			// but sequence number always bumps.
@@ -396,7 +399,7 @@ func TestIntegration_CCIP(t *testing.T) {
 				ccipTH.Dest.Chain.Commit()
 
 				// create new jobs
-				jobParams = ccipTH.NewCCIPJobSpecParams(tokenPricesUSDPipeline, priceGetterConfigJson, newConfigBlock, "")
+				jobParams = ccipTH.NewCCIPJobSpecParams(tokenPricesUSDPipeline, priceGetterConfigJson, newConfigBlock)
 				jobParams.Version = "v2"
 				jobParams.SourceStartBlock = srcStartBlock
 				ccipTH.AddAllJobs(t, jobParams)
@@ -699,8 +702,9 @@ func TestReorg(t *testing.T) {
 	}
 	priceGetterConfigBytes, err := json.MarshalIndent(priceGetterConfig, "", " ")
 	require.NoError(t, err)
-	priceGetterConfigJSON := string(priceGetterConfigBytes)
-	ccipTH.SetUpNodesAndJobs(t, "", priceGetterConfigJSON, "")
+	bootstrapNode, _, configBlock := ccipTH.SetupAndStartNodes(t.Context(), t, int64(freeport.GetOne(t)))
+	jobParams := ccipTH.NewCCIPJobSpecParams("", string(priceGetterConfigBytes), configBlock)
+	ccipTH.SetUpJobs(t, bootstrapNode, configBlock, jobParams)
 
 	gasLimit := big.NewInt(200_00)
 	tokenAmount := big.NewInt(1)

--- a/core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go
@@ -979,13 +979,7 @@ func (c *CCIPIntegrationTestHarness) SetupAndStartNodes(ctx context.Context, t *
 	return bootstrapNode, nodes, uint64(configBlock)
 }
 
-// setup Jobs
-func (c *CCIPIntegrationTestHarness) SetUpNodesAndJobs(t *testing.T, pricePipeline string, priceGetterConfig string, usdcAttestationAPI string) CCIPJobSpecParams {
-	// Starts nodes and configures them in the OCR contracts.
-	bootstrapNode, _, configBlock := c.SetupAndStartNodes(t.Context(), t, int64(freeport.GetOne(t)))
-
-	jobParams := c.NewCCIPJobSpecParams(pricePipeline, priceGetterConfig, configBlock, usdcAttestationAPI)
-
+func (c *CCIPIntegrationTestHarness) SetUpJobs(t *testing.T, bootstrapNode Node, configBlock uint64, jobParams CCIPJobSpecParams) {
 	// Add the bootstrap job
 	c.Bootstrap.AddBootstrapJob(t, jobParams.BootstrapJob(c.Dest.CommitStore.Address().Hex()))
 	c.AddAllJobs(t, jobParams)
@@ -998,9 +992,8 @@ func (c *CCIPIntegrationTestHarness) SetUpNodesAndJobs(t *testing.T, pricePipeli
 	require.True(t, ok)
 	require.NoError(t, bc.LogPoller().Replay(t.Context(), int64(configBlock))) //nolint:gosec // G115 false positive
 	c.Dest.Chain.Commit()
-
-	return jobParams
 }
+
 func DecodeCommitOnChainConfig(encoded []byte) (ccipdata.CommitOnchainConfig, error) {
 	var onchainConfig ccipdata.CommitOnchainConfig
 	unpacked, err := abihelpers.DecodeOCR2Config(encoded)

--- a/core/services/ocr2/plugins/ccip/testhelpers/integration/jobspec.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/integration/jobspec.go
@@ -307,12 +307,11 @@ func (params CCIPJobSpecParams) ExecutionJobSpec() (*OCR2TaskJobSpec, error) {
 		ocrSpec.PluginConfig["USDCConfig.SourceMessageTransmitterAddress"] = fmt.Sprintf(`"%s"`, params.USDCConfig.SourceMessageTransmitterAddress)
 		ocrSpec.PluginConfig["USDCConfig.AttestationAPITimeoutSeconds"] = params.USDCConfig.AttestationAPITimeoutSeconds
 	}
-	if len(params.LBTCConfigs) == 1 {
+	if len(params.LBTCConfigs) >= 1 {
+		// duplicate LBTC configs in singular (first element) and in plural field
 		ocrSpec.PluginConfig["LBTCConfig.AttestationAPI"] = fmt.Sprintf(`"%s"`, params.LBTCConfigs[0].AttestationAPI)
 		ocrSpec.PluginConfig["LBTCConfig.SourceTokenAddress"] = fmt.Sprintf(`"%s"`, params.LBTCConfigs[0].SourceTokenAddress)
 		ocrSpec.PluginConfig["LBTCConfig.AttestationAPITimeoutSeconds"] = params.LBTCConfigs[0].AttestationAPITimeoutSeconds
-	}
-	if len(params.LBTCConfigs) > 1 {
 		// Write toml arrays in format
 		// [pluginConfig]
 		// LBTCConfigs = [
@@ -329,7 +328,7 @@ func (params CCIPJobSpecParams) ExecutionJobSpec() (*OCR2TaskJobSpec, error) {
 		ocrSpec.PluginConfig["LBTCConfigs"] = lbtcConfigs
 	}
 	// Always put some random config in PluginConfig to test forward compatibility
-	ocrSpec.PluginConfig["ConfigFromTheFuture.Value"] = fmt.Sprintf("\"%s\"", utils.RandomAddress().String())
+	ocrSpec.PluginConfig["ConfigsFromTheFuture"] = fmt.Sprintf("[ { Value = \"%s\" }, ]", utils.RandomAddress().String())
 	return &OCR2TaskJobSpec{
 		OCR2OracleSpec: ocrSpec,
 		JobType:        "offchainreporting2",

--- a/core/services/ocr2/plugins/ccip/testhelpers/integration/jobspec.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/integration/jobspec.go
@@ -328,6 +328,8 @@ func (params CCIPJobSpecParams) ExecutionJobSpec() (*OCR2TaskJobSpec, error) {
 		}
 		ocrSpec.PluginConfig["LBTCConfigs"] = lbtcConfigs
 	}
+	// Always put some random config in PluginConfig to test forward compatibility
+	ocrSpec.PluginConfig["ConfigFromTheFuture.Value"] = fmt.Sprintf("\"%s\"", utils.RandomAddress().String())
 	return &OCR2TaskJobSpec{
 		OCR2OracleSpec: ocrSpec,
 		JobType:        "offchainreporting2",

--- a/core/services/ocr2/plugins/ccip/testhelpers/integration/jobspec.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/integration/jobspec.go
@@ -307,7 +307,12 @@ func (params CCIPJobSpecParams) ExecutionJobSpec() (*OCR2TaskJobSpec, error) {
 		ocrSpec.PluginConfig["USDCConfig.SourceMessageTransmitterAddress"] = fmt.Sprintf(`"%s"`, params.USDCConfig.SourceMessageTransmitterAddress)
 		ocrSpec.PluginConfig["USDCConfig.AttestationAPITimeoutSeconds"] = params.USDCConfig.AttestationAPITimeoutSeconds
 	}
-	if len(params.LBTCConfigs) > 0 {
+	if len(params.LBTCConfigs) == 1 {
+		ocrSpec.PluginConfig["LBTCConfig.AttestationAPI"] = fmt.Sprintf(`"%s"`, params.LBTCConfigs[0].AttestationAPI)
+		ocrSpec.PluginConfig["LBTCConfig.SourceTokenAddress"] = fmt.Sprintf(`"%s"`, params.LBTCConfigs[0].SourceTokenAddress)
+		ocrSpec.PluginConfig["LBTCConfig.AttestationAPITimeoutSeconds"] = params.LBTCConfigs[0].AttestationAPITimeoutSeconds
+	}
+	if len(params.LBTCConfigs) > 1 {
 		// Write toml arrays in format
 		// [pluginConfig]
 		// LBTCConfigs = [

--- a/core/services/ocr2/plugins/ccip/testhelpers/integration/jobspec.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/integration/jobspec.go
@@ -181,7 +181,7 @@ type CCIPJobSpecParams struct {
 	DestStartBlock         uint64
 	USDCAttestationAPI     string
 	USDCConfig             *config.USDCConfig
-	LBTCConfig             *config.LBTCConfig
+	LBTCConfigs            []config.LBTCConfig
 	P2PV2Bootstrappers     pq.StringArray
 }
 
@@ -307,10 +307,21 @@ func (params CCIPJobSpecParams) ExecutionJobSpec() (*OCR2TaskJobSpec, error) {
 		ocrSpec.PluginConfig["USDCConfig.SourceMessageTransmitterAddress"] = fmt.Sprintf(`"%s"`, params.USDCConfig.SourceMessageTransmitterAddress)
 		ocrSpec.PluginConfig["USDCConfig.AttestationAPITimeoutSeconds"] = params.USDCConfig.AttestationAPITimeoutSeconds
 	}
-	if params.LBTCConfig != nil {
-		ocrSpec.PluginConfig["LBTCConfig.AttestationAPI"] = fmt.Sprintf(`"%s"`, params.LBTCConfig.AttestationAPI)
-		ocrSpec.PluginConfig["LBTCConfig.SourceTokenAddress"] = fmt.Sprintf(`"%s"`, params.LBTCConfig.SourceTokenAddress)
-		ocrSpec.PluginConfig["LBTCConfig.AttestationAPITimeoutSeconds"] = params.LBTCConfig.AttestationAPITimeoutSeconds
+	if len(params.LBTCConfigs) > 0 {
+		// Write toml arrays in format
+		// [pluginConfig]
+		// LBTCConfigs = [
+		// 	{ AttestationAPI = "http://lbtc.com", AttestationAPITimeoutSeconds = 5, SourceTokenAddress = "0x32b...EBd" },
+		//  { AttestationAPI = "http://lbtc-second.com", AttestationAPITimeoutSeconds = 5, SourceTokenAddress = "0x58f...372" },
+		// ]
+		lbtcConfigs := make([]string, len(params.LBTCConfigs))
+		for i, lbtcConfig := range params.LBTCConfigs {
+			lbtcConfigs[i] = fmt.Sprintf(
+				"{ AttestationAPI = \"%s\", AttestationAPITimeoutSeconds = %d, SourceTokenAddress = \"%s\" },",
+				lbtcConfig.AttestationAPI, lbtcConfig.AttestationAPITimeoutSeconds, lbtcConfig.SourceTokenAddress,
+			)
+		}
+		ocrSpec.PluginConfig["LBTCConfigs"] = lbtcConfigs
 	}
 	return &OCR2TaskJobSpec{
 		OCR2OracleSpec: ocrSpec,
@@ -336,7 +347,7 @@ func (params CCIPJobSpecParams) BootstrapJob(contractID string) *OCR2TaskJobSpec
 	}
 }
 
-func (c *CCIPIntegrationTestHarness) NewCCIPJobSpecParams(tokenPricesUSDPipeline string, priceGetterConfig string, configBlock uint64, usdcAttestationAPI string) CCIPJobSpecParams {
+func (c *CCIPIntegrationTestHarness) NewCCIPJobSpecParams(tokenPricesUSDPipeline string, priceGetterConfig string, configBlock uint64) CCIPJobSpecParams {
 	return CCIPJobSpecParams{
 		CommitStore:            c.Dest.CommitStore.Address(),
 		OffRamp:                c.Dest.OffRamp.Address(),
@@ -346,7 +357,6 @@ func (c *CCIPIntegrationTestHarness) NewCCIPJobSpecParams(tokenPricesUSDPipeline
 		TokenPricesUSDPipeline: tokenPricesUSDPipeline,
 		PriceGetterConfig:      priceGetterConfig,
 		DestStartBlock:         configBlock,
-		USDCAttestationAPI:     usdcAttestationAPI,
 	}
 }
 

--- a/core/services/ocr2/validate/validate.go
+++ b/core/services/ocr2/validate/validate.go
@@ -346,7 +346,7 @@ func validateOCR2CCIPExecutionSpec(jsonConfig job.JSONConfig) error {
 	if cfg.USDCConfig != (config.USDCConfig{}) {
 		return cfg.USDCConfig.ValidateUSDCConfig()
 	}
-	return nil
+	return config.ValidateLBTCConfigs(cfg.LBTCConfigs)
 }
 
 func validateDonTimePluginSpec(jsonConfig job.JSONConfig) error {

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -602,7 +602,7 @@ func (r *Relayer) NewCCIPExecProvider(ctx context.Context, rargs commontypes.Rel
 			execPluginConfig.SourceStartBlock,
 			execPluginConfig.JobID,
 			execPluginConfig.USDCConfig,
-			execPluginConfig.LBTCConfig,
+			execPluginConfig.LBTCConfigs,
 			feeEstimatorConfig,
 		)
 	}

--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -4145,11 +4145,12 @@ func (lane *CCIPLane) DeployNewCCIPLane(
 		}
 	}
 	if !lane.Source.Common.ExistingDeployment && lane.Source.Common.IsLBTCDeployment() {
-		// Only one LBTC allowed per chain
-		jobParams.LBTCConfig = &config.LBTCConfig{
-			SourceTokenAddress:           common.HexToAddress(lane.Source.Common.BridgeTokens[0].Address()),
-			AttestationAPI:               mockAdapterURL,
-			AttestationAPITimeoutSeconds: 5,
+		jobParams.LBTCConfigs = []config.LBTCConfig{
+			{
+				SourceTokenAddress:           common.HexToAddress(lane.Source.Common.BridgeTokens[0].Address()),
+				AttestationAPI:               mockAdapterURL,
+				AttestationAPITimeoutSeconds: 5,
+			},
 		}
 	}
 	if !bootstrapAdded.Load() {

--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -4149,8 +4149,13 @@ func (lane *CCIPLane) DeployNewCCIPLane(
 	if !lane.Source.Common.ExistingDeployment && lane.Source.Common.IsLBTCDeployment() {
 		jobParams.LBTCConfigs = make([]config.LBTCConfig, testConf.LBTCNoOfTokens)
 		for i := 0; i < testConf.LBTCNoOfTokens; i++ {
+			token := common.HexToAddress(lane.Source.Common.BridgeTokens[i].Address())
+			lane.Logger.Info().Str("attestationAPI", mockAdapterURL).
+				Str("token", token.String()).
+				Int("i", i).
+				Msg("Setting lbtc config")
 			jobParams.LBTCConfigs[i] = config.LBTCConfig{
-				SourceTokenAddress:           common.HexToAddress(lane.Source.Common.BridgeTokens[i].Address()),
+				SourceTokenAddress:           token,
 				AttestationAPI:               mockAdapterURL,
 				AttestationAPITimeoutSeconds: 5,
 			}

--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -189,6 +189,7 @@ type CCIPCommon struct {
 	USDCMockDeployment            *bool
 	LBTCMockDeployment            *bool
 	LBTCDestPoolDataAs32Bytes     *bool
+	LBTCNoOfTokens                int
 	TokenMessenger                *common.Address
 	TokenTransmitter              *contracts.TokenTransmitter
 	IsConnectionRestoredRecently  *atomic.Bool
@@ -945,7 +946,7 @@ func (ccipModule *CCIPCommon) DeployContracts(
 					if err != nil {
 						return fmt.Errorf("granting minter role to token transmitter shouldn't fail %w", err)
 					}
-				} else if ccipModule.IsLBTCDeployment() && i == 0 {
+				} else if ccipModule.IsLBTCDeployment() && i < ccipModule.LBTCNoOfTokens {
 					// if it's LBTC deployment, we deploy the burn mint token 677 with decimal 8 and cast it to ERC20Token
 					lbtcToken, err := ccipModule.tokenDeployer.DeployCustomBurnMintERC677Token("Lombard LBTC", "LBTC", uint8(8), new(big.Int).Mul(big.NewInt(1e6), big.NewInt(1e18)))
 					if err != nil {
@@ -1019,7 +1020,7 @@ func (ccipModule *CCIPCommon) DeployContracts(
 				}
 
 				ccipModule.BridgeTokenPools = append(ccipModule.BridgeTokenPools, usdcPool)
-			} else if ccipModule.IsLBTCDeployment() && i == 0 {
+			} else if ccipModule.IsLBTCDeployment() && i < ccipModule.LBTCNoOfTokens {
 				if ccipModule.RMNContract == nil {
 					return errors.New("RMNContract is not initialized")
 				}
@@ -1372,6 +1373,7 @@ func DefaultCCIPModule(
 		USDCMockDeployment:            testGroupConf.USDCMockDeployment,
 		LBTCMockDeployment:            testGroupConf.LBTCMockDeployment,
 		LBTCDestPoolDataAs32Bytes:     testGroupConf.LBTCDestPoolDataAs32Bytes,
+		LBTCNoOfTokens:                testGroupConf.LBTCNoOfTokens,
 		NoOfTokensNeedingDynamicPrice: pointer.GetInt(testGroupConf.TokenConfig.NoOfTokensWithDynamicPrice),
 		poolFunds:                     testhelpers.Link(5),
 		gasUpdateWatcherMu:            &sync.Mutex{},
@@ -4145,12 +4147,13 @@ func (lane *CCIPLane) DeployNewCCIPLane(
 		}
 	}
 	if !lane.Source.Common.ExistingDeployment && lane.Source.Common.IsLBTCDeployment() {
-		jobParams.LBTCConfigs = []config.LBTCConfig{
-			{
-				SourceTokenAddress:           common.HexToAddress(lane.Source.Common.BridgeTokens[0].Address()),
+		jobParams.LBTCConfigs = make([]config.LBTCConfig, testConf.LBTCNoOfTokens)
+		for i := 0; i < testConf.LBTCNoOfTokens; i++ {
+			jobParams.LBTCConfigs[i] = config.LBTCConfig{
+				SourceTokenAddress:           common.HexToAddress(lane.Source.Common.BridgeTokens[i].Address()),
 				AttestationAPI:               mockAdapterURL,
 				AttestationAPITimeoutSeconds: 5,
-			},
+			}
 		}
 	}
 	if !bootstrapAdded.Load() {

--- a/integration-tests/ccip-tests/testconfig/ccip.go
+++ b/integration-tests/ccip-tests/testconfig/ccip.go
@@ -286,6 +286,7 @@ type CCIPTestGroupConfig struct {
 	USDCMockDeployment                         *bool                                 `toml:",omitempty"`
 	LBTCMockDeployment                         *bool                                 `toml:",omitempty"`
 	LBTCDestPoolDataAs32Bytes                  *bool                                 `toml:",omitempty"`
+	LBTCNoOfTokens                             int                                   `toml:",omitempty"`
 	CommitOCRParams                            *contracts.OffChainAggregatorV2Config `toml:",omitempty"`
 	ExecOCRParams                              *contracts.OffChainAggregatorV2Config `toml:",omitempty"`
 	OffRampConfig                              *OffRampConfig                        `toml:",omitempty"`

--- a/integration-tests/ccip-tests/testconfig/tomls/lbtc_mock_deployment_multiple_tokens.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/lbtc_mock_deployment_multiple_tokens.toml
@@ -2,11 +2,11 @@
 [CCIP.Groups]
 [CCIP.Groups.smoke]
 LBTCMockDeployment = true
-LBTCDestPoolDataAs32Bytes = false
-LBTCNoOfTokens = 1
+LBTCDestPoolDataAs32Bytes = true
+LBTCNoOfTokens = 2
 
 [CCIP.Groups.smoke.TokenConfig]
-NoOfTokensPerChain = 1
+NoOfTokensPerChain = 2
 
 [CCIP.Groups.smoke.MsgDetails]
 NoOfTokens = 1

--- a/integration-tests/ccip-tests/testconfig/tomls/lbtc_mock_deployment_multiple_tokens.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/lbtc_mock_deployment_multiple_tokens.toml
@@ -9,4 +9,4 @@ LBTCNoOfTokens = 2
 NoOfTokensPerChain = 2
 
 [CCIP.Groups.smoke.MsgDetails]
-NoOfTokens = 1
+NoOfTokens = 2

--- a/integration-tests/ccip-tests/testconfig/tomls/lbtc_mock_deployment_with_32bytes_data.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/lbtc_mock_deployment_with_32bytes_data.toml
@@ -3,6 +3,7 @@
 [CCIP.Groups.smoke]
 LBTCMockDeployment = true
 LBTCDestPoolDataAs32Bytes = true
+LBTCNoOfTokens = 1
 
 [CCIP.Groups.smoke.TokenConfig]
 NoOfTokensPerChain = 1


### PR DESCRIPTION
Support multiple LBTC configurations for CCIP 1.5 exec config.
This work is needed in order to provide an ability to attest multiple tokens against Lombard Attestation API

Details:
* Added `LBTCConfigs` next to `LBTCConfig` (preserved for backward compatibility) + method to get final list of LBTC configs.
* Support multiple LBTC configs in CCIP exec provider. DIscard `LBTCConfig` completely if `LBTCConfigs` is present
* Added option to specify multiple LBTC configs in CCIP 1.5 E2E tests
  * Repeat CLO behavior in E2E by duplicating LBTC configs in both singular and plural fields
* Added `lbtc_mock_deployment_multiple_tokens` test which uses multiple LBTC configs populated to both fields
