### PR TITLE
chore: update ccip tests to use new test engine.

### DIFF
--- a/deployment/ccip/changeset/ccip-attestation/cs_deploy_evm_signer_registry_test.go
+++ b/deployment/ccip/changeset/ccip-attestation/cs_deploy_evm_signer_registry_test.go
@@ -5,20 +5,18 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	ccip_attestation "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/ccip-attestation"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	signer_registry "github.com/smartcontractkit/chainlink/deployment/ccip/shared/bindings/signer_registry"
-	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 // Helper function to find signer registry address in address book
@@ -58,10 +56,10 @@ func TestEVMSignerRegistry_Preconditions(t *testing.T) {
 	t.Parallel()
 
 	// Create a minimal environment for precondition tests
-	lggr := logger.TestLogger(t)
-	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
+	e, terr := environment.New(t.Context(),
+		environment.WithLogger(logger.Test(t)),
+	)
+	require.NoError(t, terr)
 
 	tests := []struct {
 		name        string
@@ -182,13 +180,14 @@ func TestEVMSignerRegistry_Preconditions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := commonchangeset.Apply(t, e,
-				commonchangeset.Configure(ccip_attestation.EVMSignerRegistryDeploymentChangeset, tt.config))
+			t.Parallel()
+
+			terr = ccip_attestation.EVMSignerRegistryDeploymentChangeset.VerifyPreconditions(*e, tt.config)
 
 			if tt.expectedErr != "" {
-				require.ErrorContains(t, err, tt.expectedErr)
+				require.ErrorContains(t, terr, tt.expectedErr)
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, terr)
 			}
 		})
 	}
@@ -198,10 +197,13 @@ func TestEVMSignerRegistry_DeploysOnlyOnBaseChains(t *testing.T) {
 	t.Parallel()
 
 	// Create environment with Base Mainnet and Base Sepolia chain IDs
-	lggr := logger.TestLogger(t)
-	evmChains := memory.NewMemoryChainsEVMWithChainIDs(t, []uint64{8453, 84532}, 1) // Base Mainnet: 8453, Base Sepolia: 84532
-	chains := cldf_chain.NewBlockChainsFromSlice(evmChains)
-	e := memory.NewMemoryEnvironmentFromChainsNodes(t.Context, lggr, chains, map[string]memory.Node{})
+	baseMainnetSelector := uint64(ccip_attestation.BaseMainnetSelector)
+	baseSepoliaSelector := uint64(ccip_attestation.BaseSepoliaSelector)
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{baseMainnetSelector, baseSepoliaSelector}),
+		environment.WithLogger(logger.Test(t)),
+	))
+	require.NoError(t, err)
 
 	// Create config with test signers
 	signer1 := utils.RandomAddress()
@@ -215,22 +217,23 @@ func TestEVMSignerRegistry_DeploysOnlyOnBaseChains(t *testing.T) {
 	}
 
 	// Apply changeset - should deploy to both Base chains
-	e, err := commonchangeset.Apply(t, e,
-		commonchangeset.Configure(ccip_attestation.EVMSignerRegistryDeploymentChangeset, config))
+	err = rt.Exec(
+		runtime.ChangesetTask(ccip_attestation.EVMSignerRegistryDeploymentChangeset, config),
+	)
 	require.NoError(t, err)
 
 	// Verify deployment on Base Mainnet
-	baseMainnetAddr, found := findSignerRegistryAddress(e, ccip_attestation.BaseMainnetSelector)
+	baseMainnetAddr, found := findSignerRegistryAddress(rt.Environment(), baseMainnetSelector)
 	require.True(t, found, "signer registry should be deployed on Base Mainnet")
 	require.NotEqual(t, common.Address{}, baseMainnetAddr)
 
 	// Verify deployment on Base Sepolia
-	baseSepoliaAddr, found := findSignerRegistryAddress(e, ccip_attestation.BaseSepoliaSelector)
+	baseSepoliaAddr, found := findSignerRegistryAddress(rt.Environment(), baseSepoliaSelector)
 	require.True(t, found, "signer registry should be deployed on Base Sepolia")
 	require.NotEqual(t, common.Address{}, baseSepoliaAddr)
 
 	// Verify contract state on Base Mainnet
-	baseMainnetChain := e.BlockChains.EVMChains()[ccip_attestation.BaseMainnetSelector]
+	baseMainnetChain := rt.Environment().BlockChains.EVMChains()[baseMainnetSelector]
 	registry, err := signer_registry.NewSignerRegistry(baseMainnetAddr, baseMainnetChain.Client)
 	require.NoError(t, err)
 
@@ -254,10 +257,11 @@ func TestEVMSignerRegistry_SkipsNonBaseChains(t *testing.T) {
 	t.Parallel()
 
 	// Create environment with non-Base chains
-	lggr := logger.TestLogger(t)
-	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 2, // These will be test chains, not Base chains
-	})
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulatedN(t, 2),
+		environment.WithLogger(logger.Test(t)),
+	))
+	require.NoError(t, err)
 
 	config := ccip_attestation.SignerRegistryChangesetConfig{
 		MaxSigners: ccip_attestation.MaxSigners,
@@ -267,13 +271,14 @@ func TestEVMSignerRegistry_SkipsNonBaseChains(t *testing.T) {
 	}
 
 	// Apply changeset - should skip all non-Base chains
-	e, err := commonchangeset.Apply(t, e,
-		commonchangeset.Configure(ccip_attestation.EVMSignerRegistryDeploymentChangeset, config))
+	err = rt.Exec(
+		runtime.ChangesetTask(ccip_attestation.EVMSignerRegistryDeploymentChangeset, config),
+	)
 	require.NoError(t, err)
 
 	// Verify no deployment on any chain
-	for selector := range e.BlockChains.EVMChains() {
-		_, found := findSignerRegistryAddress(e, selector)
+	for selector := range rt.Environment().BlockChains.EVMChains() {
+		_, found := findSignerRegistryAddress(rt.Environment(), selector)
 		require.False(t, found, "signer registry should not be deployed on non-Base chain %d", selector)
 	}
 }

--- a/deployment/ccip/changeset/cs_grant_and_mint_link_token_test.go
+++ b/deployment/ccip/changeset/cs_grant_and_mint_link_token_test.go
@@ -6,62 +6,59 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	tokencs "github.com/smartcontractkit/chainlink/deployment/tokens/changesets"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	tokencs "github.com/smartcontractkit/chainlink/deployment/tokens/changesets"
 )
 
 func TestDeployLinktokenAndTransferOwnershipCS(t *testing.T) {
 	t.Parallel()
-	lggr := logger.TestLogger(t)
 
-	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Bootstraps: 1,
-		Chains:     1,
-		Nodes:      4,
-	})
+	selector := chainselectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
+	))
+	require.NoError(t, err)
 
-	selectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
-	chainSelector := selectors[0]
-	e, err := commonchangeset.Apply(t, e,
-		commonchangeset.Configure(tokencs.DeployEVMLinkTokens, tokencs.DeployLinkTokensInput{
-			ChainSelectors: []uint64{chainSelector},
-		}))
-
+	err = rt.Exec(
+		runtime.ChangesetTask(tokencs.DeployEVMLinkTokens, tokencs.DeployLinkTokensInput{
+			ChainSelectors: []uint64{selector},
+		}),
+	)
 	require.NoError(t, err)
 
 	// Ensure the link token is deployed
-	state, err := stateview.LoadOnchainState(e)
+	state, err := stateview.LoadOnchainState(rt.Environment())
 	require.NoError(t, err)
-	chain := e.BlockChains.EVMChains()[chainSelector]
-	require.NotNil(t, state.Chains[chainSelector].LinkToken)
-	linkToken := state.Chains[chainSelector].LinkToken
+	chain := rt.Environment().BlockChains.EVMChains()[selector]
+	require.NotNil(t, state.Chains[selector].LinkToken)
+	linkToken := state.Chains[selector].LinkToken
 
 	recipientAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
 
 	cfg := changeset.GrantMintRoleAndMintConfig{
-		Selector:  chainSelector,
+		Selector:  selector,
 		ToAddress: recipientAddr,
 		Amount:    new(big.Int).Mul(big.NewInt(10), big.NewInt(1e18)), // 10 LINK tokens
 	}
 
 	expectedMintAmount := new(big.Int).Set(cfg.Amount)
-	err = changeset.GrantMintRoleAndMint.VerifyPreconditions(e, cfg)
+	err = changeset.GrantMintRoleAndMint.VerifyPreconditions(rt.Environment(), cfg)
 	require.NoError(t, err)
 
-	output, err := changeset.GrantMintRoleAndMint.Apply(e, cfg)
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.GrantMintRoleAndMint, cfg),
+	)
 	require.NoError(t, err)
-	require.NotNil(t, output)
 
 	// Verify deployer no longer has mint role
 	isMinter, err := linkToken.IsMinter(&bind.CallOpts{}, chain.DeployerKey.From)
@@ -86,45 +83,41 @@ func TestDeployLinktokenAndTransferOwnershipCS(t *testing.T) {
 
 func TestDeployLinktokenAndGrantMintRole(t *testing.T) {
 	t.Parallel()
-	lggr := logger.TestLogger(t)
 
-	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Bootstraps: 1,
-		Chains:     1,
-		Nodes:      4,
-	})
+	selector := chainselectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
+	))
+	require.NoError(t, err)
 
-	selectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
-	chainSelector := selectors[0]
-	e, err := commonchangeset.Apply(t, e,
-		commonchangeset.Configure(tokencs.DeployEVMLinkTokens, tokencs.DeployLinkTokensInput{
-			ChainSelectors: []uint64{chainSelector},
-		}))
-
+	err = rt.Exec(
+		runtime.ChangesetTask(tokencs.DeployEVMLinkTokens, tokencs.DeployLinkTokensInput{
+			ChainSelectors: []uint64{selector},
+		}),
+	)
 	require.NoError(t, err)
 
 	// Ensure the link token is deployed
-	state, err := stateview.LoadOnchainState(e)
+	state, err := stateview.LoadOnchainState(rt.Environment())
 	require.NoError(t, err)
-	require.NotNil(t, state.Chains[chainSelector].LinkToken)
-	linkToken := state.Chains[chainSelector].LinkToken
+	require.NotNil(t, state.Chains[selector].LinkToken)
+	linkToken := state.Chains[selector].LinkToken
 
 	newMinter := common.HexToAddress("0x1234567890123456789012345678901234567890")
 
 	cfg := changeset.GrantMintRoleInput{
 		GrantMintRoleByChain: map[uint64]changeset.GrantMintRoleConfig{
-			chainSelector: {
+			selector: {
 				ToAddress: newMinter,
 			},
 		},
 	}
 
-	err = changeset.GrantMintRole.VerifyPreconditions(e, cfg)
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.GrantMintRole, cfg),
+	)
 	require.NoError(t, err)
-
-	output, err := changeset.GrantMintRole.Apply(e, cfg)
-	require.NoError(t, err)
-	require.NotNil(t, output)
 
 	// Verify the newMinter has the mint role
 	isMinter, err := linkToken.IsMinter(&bind.CallOpts{}, newMinter)

--- a/deployment/ccip/changeset/save_existing_test.go
+++ b/deployment/ccip/changeset/save_existing_test.go
@@ -7,30 +7,31 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func TestSaveExistingCCIP(t *testing.T) {
 	t.Parallel()
-	lggr := logger.TestLogger(t)
-	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Bootstraps: 1,
-		Chains:     2,
-		Nodes:      4,
-	})
-	chains := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
+
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulatedN(t, 2),
+		environment.WithLogger(logger.Test(t)),
+	))
+	require.NoError(t, err)
+
+	chains := rt.Environment().BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	chain1 := chains[0]
 	chain2 := chains[1]
 	cfg := commonchangeset.ExistingContractsConfig{
@@ -63,11 +64,12 @@ func TestSaveExistingCCIP(t *testing.T) {
 		},
 	}
 
-	output, err := commonchangeset.SaveExistingContractsChangeset(e, cfg)
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonchangeset.SaveExistingContractsChangeset), cfg),
+	)
 	require.NoError(t, err)
-	err = e.ExistingAddresses.Merge(output.AddressBook)
-	require.NoError(t, err)
-	state, err := stateview.LoadOnchainState(e)
+
+	state, err := stateview.LoadOnchainState(rt.Environment())
 	require.NoError(t, err)
 	chainState, _ := state.EVMChainState(chain1)
 	require.Equal(t, chainState.LinkToken.Address(), common.BigToAddress(big.NewInt(1)))

--- a/deployment/ccip/changeset/v1_5_1/commonconfig.go
+++ b/deployment/ccip/changeset/v1_5_1/commonconfig.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
-	deployment2 "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
@@ -109,7 +108,7 @@ func (c TokenAdminRegistryChangesetConfig) Validate(
 // TokenPoolInfo defines the type & version of a token pool, along with an optional external administrator.
 type TokenPoolInfo struct {
 	// Type is the type of the token pool.
-	Type deployment2.ContractType
+	Type cldf.ContractType
 	// Version is the version of the token pool.
 	Version semver.Version
 	// ExternalAdmin is the external administrator of the token pool on the registry.
@@ -176,7 +175,7 @@ func GetTokenPoolAddressFromSymbolTypeAndVersion(
 	chainState evm.CCIPChainState,
 	chain cldf_evm.Chain,
 	symbol shared.TokenSymbol,
-	poolType deployment2.ContractType,
+	poolType cldf.ContractType,
 	version semver.Version,
 ) (common.Address, bool) {
 	switch poolType {

--- a/deployment/ccip/changeset/v1_6_2/cs_configure_cctp_message_transmitter_proxy_test.go
+++ b/deployment/ccip/changeset/v1_6_2/cs_configure_cctp_message_transmitter_proxy_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/quarantine"
@@ -19,9 +18,10 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/mock_usdc_token_transmitter"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_2/usdc_token_pool"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc677"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
@@ -29,18 +29,16 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-	commoncs "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
-func setupCCTPMsgTransmitterProxyEnvironmentForConfigure(t *testing.T, withPrereqs bool) (cldf.Environment, []uint64) {
-	env := memory.NewMemoryEnvironment(t,
-		logger.Test(t),
-		zapcore.InfoLevel,
-		memory.MemoryEnvironmentConfig{Chains: 2},
-	)
+func setupCCTPMsgTransmitterProxyEnvironmentForConfigure(t *testing.T, withPrereqs bool) *runtime.Runtime {
+	selectors := []uint64{chain_selectors.TEST_90000001.Selector, chain_selectors.TEST_90000002.Selector}
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, selectors),
+		environment.WithLogger(logger.Test(t)),
+	))
+	require.NoError(t, err)
 
-	selectors := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	if withPrereqs {
 		var err error
 
@@ -51,18 +49,15 @@ func setupCCTPMsgTransmitterProxyEnvironmentForConfigure(t *testing.T, withPrere
 			}
 		}
 
-		env, err = commoncs.Apply(t, env,
-			commoncs.Configure(
-				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
-				changeset.DeployPrerequisiteConfig{
-					Configs: prereqCfg,
-				},
-			),
+		err = rt.Exec(
+			runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset), changeset.DeployPrerequisiteConfig{
+				Configs: prereqCfg,
+			}),
 		)
 		require.NoError(t, err)
 	}
 
-	return env, selectors
+	return rt
 }
 
 func setupCCTPMsgTransmitterProxyContractsForConfigure(
@@ -129,28 +124,27 @@ func setupCCTPMsgTransmitterProxyContractsForConfigure(
 func TestValidateConfigureCCTPMessageTransmitterProxyInput(t *testing.T) {
 	t.Parallel()
 
-	env, selectors := setupCCTPMsgTransmitterProxyEnvironmentForConfigure(t, true)
-	require.GreaterOrEqual(t, len(selectors), 1)
-	chain := env.BlockChains.EVMChains()[selectors[0]]
+	rt := setupCCTPMsgTransmitterProxyEnvironmentForConfigure(t, true)
+	chains := rt.Environment().BlockChains.EVMChains()
+	require.GreaterOrEqual(t, len(chains), 1)
+
+	chain := slices.Collect(maps.Values(chains))[0]
 
 	addressBook := cldf.NewMemoryAddressBook()
-	_, tokenMsngr := setupCCTPMsgTransmitterProxyContractsForConfigure(t, env.Logger, chain, addressBook)
+	_, tokenMsngr := setupCCTPMsgTransmitterProxyContractsForConfigure(t, rt.Environment().Logger, chain, addressBook)
 
-	env, err := commoncs.Apply(t, env,
-		commoncs.Configure(
-			v1_6_2.DeployCCTPMessageTransmitterProxyNew,
-			v1_6_2.DeployCCTPMessageTransmitterProxyContractConfig{
-				USDCProxies: map[uint64]v1_6_2.DeployCCTPMessageTransmitterProxyInput{
-					chain.Selector: {
-						TokenMessenger: tokenMsngr.Address,
-					},
+	err := rt.Exec(
+		runtime.ChangesetTask(v1_6_2.DeployCCTPMessageTransmitterProxyNew, v1_6_2.DeployCCTPMessageTransmitterProxyContractConfig{
+			USDCProxies: map[uint64]v1_6_2.DeployCCTPMessageTransmitterProxyInput{
+				chain.Selector: {
+					TokenMessenger: tokenMsngr.Address,
 				},
 			},
-		),
+		}),
 	)
 	require.NoError(t, err)
 
-	state, err := stateview.LoadOnchainState(env)
+	state, err := stateview.LoadOnchainState(rt.Environment())
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -186,7 +180,7 @@ func TestValidateConfigureCCTPMessageTransmitterProxyInput(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Msg, func(t *testing.T) {
-			err := test.Input.Validate(env.GetContext(), chain, state.Chains[chain.Selector])
+			err := test.Input.Validate(t.Context(), chain, state.Chains[chain.Selector])
 			require.Contains(t, err.Error(), test.ErrStr)
 		})
 	}
@@ -196,23 +190,35 @@ func TestConfigureCCTPMessageTransmitterProxy(t *testing.T) {
 	quarantine.Flaky(t, "DX-2064")
 	t.Parallel()
 
-	env, selectors := setupCCTPMsgTransmitterProxyEnvironmentForConfigure(t, true)
+	rt := setupCCTPMsgTransmitterProxyEnvironmentForConfigure(t, true)
+	chains := rt.Environment().BlockChains.EVMChains()
 	addrBook := cldf.NewMemoryAddressBook()
 
-	newUSDCMsgProxies := make(map[uint64]v1_6_2.DeployCCTPMessageTransmitterProxyInput, len(selectors))
-	newUSDCTokenPools := make(map[uint64]v1_6_2.DeployUSDCTokenPoolInput, len(selectors))
-	for _, selector := range selectors {
+	newUSDCMsgProxies := make(map[uint64]v1_6_2.DeployCCTPMessageTransmitterProxyInput, len(chains))
+	newUSDCTokenPools := make(map[uint64]v1_6_2.DeployUSDCTokenPoolInput, len(chains))
+	for _, chain := range chains {
 		usdcToken, tokenMessenger := setupCCTPMsgTransmitterProxyContractsForConfigure(t,
-			env.Logger,
-			env.BlockChains.EVMChains()[selector],
+			rt.Environment().Logger,
+			chain,
 			addrBook,
 		)
 
-		newUSDCMsgProxies[selector] = v1_6_2.DeployCCTPMessageTransmitterProxyInput{
+		err := rt.Exec(
+			runtime.ChangesetTask(v1_6_2.DeployCCTPMessageTransmitterProxyNew, v1_6_2.DeployCCTPMessageTransmitterProxyContractConfig{
+				USDCProxies: map[uint64]v1_6_2.DeployCCTPMessageTransmitterProxyInput{
+					chain.Selector: {
+						TokenMessenger: tokenMessenger.Address,
+					},
+				},
+			}),
+		)
+		require.NoError(t, err)
+
+		newUSDCMsgProxies[chain.Selector] = v1_6_2.DeployCCTPMessageTransmitterProxyInput{
 			TokenMessenger: tokenMessenger.Address,
 		}
 
-		newUSDCTokenPools[selector] = v1_6_2.DeployUSDCTokenPoolInput{
+		newUSDCTokenPools[chain.Selector] = v1_6_2.DeployUSDCTokenPoolInput{
 			PreviousPoolAddress: v1_6_2.USDCTokenPoolSentinelAddress,
 			TokenMessenger:      tokenMessenger.Address,
 			TokenAddress:        usdcToken.Address,
@@ -220,32 +226,22 @@ func TestConfigureCCTPMessageTransmitterProxy(t *testing.T) {
 		}
 	}
 
-	env, err := commoncs.Apply(t, env,
-		commoncs.Configure(
-			v1_6_2.DeployCCTPMessageTransmitterProxyNew,
-			v1_6_2.DeployCCTPMessageTransmitterProxyContractConfig{
-				USDCProxies: newUSDCMsgProxies,
-			},
-		),
+	err := rt.Exec(
+		runtime.ChangesetTask(v1_6_2.DeployCCTPMessageTransmitterProxyNew, v1_6_2.DeployCCTPMessageTransmitterProxyContractConfig{
+			USDCProxies: newUSDCMsgProxies,
+		}),
+		runtime.ChangesetTask(v1_6_2.DeployUSDCTokenPoolNew, v1_6_2.DeployUSDCTokenPoolContractsConfig{
+			USDCPools: newUSDCTokenPools,
+		}),
 	)
 	require.NoError(t, err)
 
-	env, err = commoncs.Apply(t, env,
-		commoncs.Configure(
-			v1_6_2.DeployUSDCTokenPoolNew,
-			v1_6_2.DeployUSDCTokenPoolContractsConfig{
-				USDCPools: newUSDCTokenPools,
-			},
-		),
-	)
+	startState, err := stateview.LoadOnchainState(rt.Environment())
 	require.NoError(t, err)
 
-	startState, err := stateview.LoadOnchainState(env)
-	require.NoError(t, err)
-
-	newUSDCProxyCnfgs := make(map[uint64]v1_6_2.ConfigureCCTPMessageTransmitterProxyInput, len(selectors))
-	for _, selector := range selectors {
-		pools := startState.Chains[selector].USDCTokenPoolsV1_6
+	newUSDCProxyCnfgs := make(map[uint64]v1_6_2.ConfigureCCTPMessageTransmitterProxyInput, len(chains))
+	for _, chain := range chains {
+		pools := startState.Chains[chain.Selector].USDCTokenPoolsV1_6
 		input := make([]v1_6_2.AllowedCallerUpdate, len(pools))
 
 		for i, pool := range slices.AppendSeq([]*usdc_token_pool.USDCTokenPool{}, maps.Values(pools)) {
@@ -255,26 +251,23 @@ func TestConfigureCCTPMessageTransmitterProxy(t *testing.T) {
 			}
 		}
 
-		newUSDCProxyCnfgs[selector] = v1_6_2.ConfigureCCTPMessageTransmitterProxyInput{
+		newUSDCProxyCnfgs[chain.Selector] = v1_6_2.ConfigureCCTPMessageTransmitterProxyInput{
 			AllowedCallerUpdates: input,
 		}
 	}
 
-	env, err = commoncs.Apply(t, env,
-		commoncs.Configure(
-			v1_6_2.ConfigureCCTPMessageTransmitterProxy,
-			v1_6_2.ConfigureCCTPMessageTransmitterProxyContractConfig{
-				CCTPProxies: newUSDCProxyCnfgs,
-			},
-		),
+	err = rt.Exec(
+		runtime.ChangesetTask(v1_6_2.ConfigureCCTPMessageTransmitterProxy, v1_6_2.ConfigureCCTPMessageTransmitterProxyContractConfig{
+			CCTPProxies: newUSDCProxyCnfgs,
+		}),
 	)
 	require.NoError(t, err)
 
-	finalState, err := stateview.LoadOnchainState(env)
+	finalState, err := stateview.LoadOnchainState(rt.Environment())
 	require.NoError(t, err)
-	for _, selector := range selectors {
-		proxies := finalState.Chains[selector].CCTPMessageTransmitterProxies
-		updates := newUSDCProxyCnfgs[selector].AllowedCallerUpdates
+	for _, chain := range chains {
+		proxies := finalState.Chains[chain.Selector].CCTPMessageTransmitterProxies
+		updates := newUSDCProxyCnfgs[chain.Selector].AllowedCallerUpdates
 		require.Len(t, proxies, 1)
 
 		expectedCallers := make([]common.Address, len(updates))

--- a/deployment/ccip/view/v1_2/price_registry_test.go
+++ b/deployment/ccip/view/v1_2/price_registry_test.go
@@ -5,27 +5,29 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	price_registry_1_2_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/price_registry"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 )
 
 func TestGeneratePriceRegistryView(t *testing.T) {
-	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
-	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	t.Parallel()
+
+	selector := chainselectors.TEST_90000001.Selector
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
+	)
+	require.NoError(t, err)
+
+	chain := e.BlockChains.EVMChains()[selector]
+
 	f1, f2 := common.HexToAddress("0x1"), common.HexToAddress("0x2")
 	_, tx, c, err := price_registry_1_2_0.DeployPriceRegistry(
 		chain.DeployerKey, chain.Client, []common.Address{chain.DeployerKey.From}, []common.Address{f1, f2}, uint32(10))

--- a/deployment/ccip/view/v1_5/offramp_test.go
+++ b/deployment/ccip/view/v1_5/offramp_test.go
@@ -9,37 +9,43 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/commit_store"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_offramp"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 func TestOffRampView(t *testing.T) {
-	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
-	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
+	t.Parallel()
+
+	srcSelector := chainsel.TEST_90000001.Selector
+	dstSelector := chainsel.TEST_90000002.Selector
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{srcSelector, dstSelector}),
+		environment.WithLogger(logger.Test(t)),
+	)
+	require.NoError(t, err)
+
+	chain := e.BlockChains.EVMChains()[srcSelector]
+
 	_, tx, c, err := commit_store.DeployCommitStore(
 		chain.DeployerKey, chain.Client, commit_store.CommitStoreStaticConfig{
-			ChainSelector:       chainsel.TEST_90000002.Selector,
-			SourceChainSelector: chainsel.TEST_90000001.Selector,
+			ChainSelector:       dstSelector,
+			SourceChainSelector: srcSelector,
 			OnRamp:              common.HexToAddress("0x4"),
 			RmnProxy:            common.HexToAddress("0x1"),
 		})
 	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 	sc := evm_2_evm_offramp.EVM2EVMOffRampStaticConfig{
-		ChainSelector:       chainsel.TEST_90000002.Selector,
-		SourceChainSelector: chainsel.TEST_90000001.Selector,
+		ChainSelector:       dstSelector,
+		SourceChainSelector: srcSelector,
 		RmnProxy:            common.HexToAddress("0x1"),
 		CommitStore:         c.Address(),
 		TokenAdminRegistry:  common.HexToAddress("0x3"),

--- a/deployment/ccip/view/v1_5/rmn_test.go
+++ b/deployment/ccip/view/v1_5/rmn_test.go
@@ -5,25 +5,28 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/rmn_contract"
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 )
 
 func TestGenerateRMNView(t *testing.T) {
-	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
-	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	t.Parallel()
+
+	selector := chainsel.TEST_90000001.Selector
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
+	)
+	require.NoError(t, err)
+
+	chain := e.BlockChains.EVMChains()[selector]
+
 	cfg := rmn_contract.RMNConfig{
 		Voters: []rmn_contract.RMNVoter{
 			{

--- a/deployment/ccip/view/v1_6/ccip_home_test.go
+++ b/deployment/ccip/view/v1_6/ccip_home_test.go
@@ -4,27 +4,30 @@ import (
 	"encoding/json"
 	"testing"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/ccip_home"
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/ccip_home"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 )
 
 func TestCCIPHomeView(t *testing.T) {
-	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
-	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	t.Parallel()
+
+	selector := chain_selectors.TEST_90000001.Selector
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
+	)
+	require.NoError(t, err)
+
+	chain := e.BlockChains.EVMChains()[selector]
+
 	_, tx, cr, err := capabilities_registry.DeployCapabilitiesRegistry(
 		chain.DeployerKey, chain.Client)
 	require.NoError(t, err)

--- a/deployment/ccip/view/v1_6/rmnremote_test.go
+++ b/deployment/ccip/view/v1_6/rmnremote_test.go
@@ -4,28 +4,31 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
-	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func Test_RMNRemote_Curse_View(t *testing.T) {
-	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-	})
-	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
-	_, tx, remote, err := rmn_remote.DeployRMNRemote(chain.DeployerKey, chain.Client, e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0], common.Address{})
+	t.Parallel()
+
+	selector := chainselectors.TEST_90000001.Selector
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
+	)
+	require.NoError(t, err)
+
+	chain := e.BlockChains.EVMChains()[selector]
+
+	_, tx, remote, err := rmn_remote.DeployRMNRemote(chain.DeployerKey, chain.Client, selector, common.Address{})
 	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
@@ -33,10 +36,7 @@ func Test_RMNRemote_Curse_View(t *testing.T) {
 	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
-	family, err := chainsel.GetSelectorFamily(e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0])
-	require.NoError(t, err)
-
-	tx, err = remote.Curse(chain.DeployerKey, globals.FamilyAwareSelectorToSubject(e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0], family))
+	tx, err = remote.Curse(chain.DeployerKey, globals.FamilyAwareSelectorToSubject(selector, chain.Family()))
 	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
@@ -47,35 +47,35 @@ func Test_RMNRemote_Curse_View(t *testing.T) {
 	require.Len(t, view.CursedSubjectEntries, 2)
 	require.Equal(t, "01000000000000000000000000000001", view.CursedSubjectEntries[0].Subject)
 	require.Equal(t, uint64(0), view.CursedSubjectEntries[0].Selector)
-	require.Equal(t, e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0], view.CursedSubjectEntries[1].Selector)
+	require.Equal(t, selector, view.CursedSubjectEntries[1].Selector)
 }
 
 func Test_RMN_Selector_To_Solana_Subject(t *testing.T) {
-	subject := globals.FamilyAwareSelectorToSubject(chainsel.BINANCE_SMART_CHAIN_TESTNET.Selector, chainsel.FamilySolana)
+	subject := globals.FamilyAwareSelectorToSubject(chainselectors.BINANCE_SMART_CHAIN_TESTNET.Selector, chainselectors.FamilySolana)
 	require.Equal(t, []byte{251, 150, 143, 3, 112, 145, 21, 184, 0, 0, 0, 0, 0, 0, 0, 0}, subject[:])
 }
 
 func Test_RMN_Subject_To_Solana_Selector(t *testing.T) {
-	selector := globals.FamilyAwareSubjectToSelector([16]byte{251, 150, 143, 3, 112, 145, 21, 184, 0, 0, 0, 0, 0, 0, 0, 0}, chainsel.FamilySolana)
-	require.Equal(t, chainsel.BINANCE_SMART_CHAIN_TESTNET.Selector, selector)
+	selector := globals.FamilyAwareSubjectToSelector([16]byte{251, 150, 143, 3, 112, 145, 21, 184, 0, 0, 0, 0, 0, 0, 0, 0}, chainselectors.FamilySolana)
+	require.Equal(t, chainselectors.BINANCE_SMART_CHAIN_TESTNET.Selector, selector)
 }
 
 func Test_RMN_Selector_To_Subject(t *testing.T) {
-	subject := globals.FamilyAwareSelectorToSubject(chainsel.BINANCE_SMART_CHAIN_TESTNET.Selector, chainsel.FamilyEVM)
+	subject := globals.FamilyAwareSelectorToSubject(chainselectors.BINANCE_SMART_CHAIN_TESTNET.Selector, chainselectors.FamilyEVM)
 	require.Equal(t, []byte{0, 0, 0, 0, 0, 0, 0, 0, 184, 21, 145, 112, 3, 143, 150, 251}, subject[:])
 }
 
 func Test_RMN_Subject_To_Selector(t *testing.T) {
-	selector := globals.FamilyAwareSubjectToSelector([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 184, 21, 145, 112, 3, 143, 150, 251}, chainsel.FamilyEVM)
-	require.Equal(t, chainsel.BINANCE_SMART_CHAIN_TESTNET.Selector, selector)
+	selector := globals.FamilyAwareSubjectToSelector([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 184, 21, 145, 112, 3, 143, 150, 251}, chainselectors.FamilyEVM)
+	require.Equal(t, chainselectors.BINANCE_SMART_CHAIN_TESTNET.Selector, selector)
 }
 
 func Test_GlobalSubject_To_Selector(t *testing.T) {
-	selector := globals.FamilyAwareSubjectToSelector(globals.GlobalCurseSubject(), chainsel.FamilyEVM)
+	selector := globals.FamilyAwareSubjectToSelector(globals.GlobalCurseSubject(), chainselectors.FamilyEVM)
 	require.Equal(t, uint64(0), selector)
 }
 
 func Test_GlobalSubject_To_Selector_Solana(t *testing.T) {
-	selector := globals.FamilyAwareSubjectToSelector(globals.GlobalCurseSubject(), chainsel.FamilySolana)
+	selector := globals.FamilyAwareSubjectToSelector(globals.GlobalCurseSubject(), chainselectors.FamilySolana)
 	require.Equal(t, uint64(0), selector)
 }


### PR DESCRIPTION
This commit updates the ccip tests to use the new test engine. This covers the simple conversions mainly revolving EVM and Aptos chains.
