### PR TITLE
fix(ci): increase default fuzz test timeout to 6 minutes

### DIFF
--- a/tools/bin/go_core_fuzz
+++ b/tools/bin/go_core_fuzz
@@ -5,15 +5,16 @@ set +e
 SCRIPT_PATH=`dirname "$0"`; SCRIPT_PATH=`eval "cd \"$SCRIPT_PATH\" && pwd"`
 OUTPUT_FILE=${OUTPUT_FILE:-"./output.txt"}
 FUZZ_TIMEOUT_MINUTES=${FUZZ_TIMEOUT_MINUTES:-"6"}
+FUZZ_SCRIPT_OVERHEAD_SECONDS=${FUZZ_SCRIPT_OVERHEAD_SECONDS:-90}
 
-TOTAL_SECONDS=$((FUZZ_TIMEOUT_MINUTES * 60))
-if (( TOTAL_SECONDS >= 180 )); then
-    # Allow for a buffer between the timeout and the fuzz test runtime
-    FUZZ_SECONDS=$((TOTAL_SECONDS - 90))
-else
-    echo "Increase FUZZ_TIMEOUT_MINUTES to >=3, received $FUZZ_TIMEOUT_MINUTES"
+if (( FUZZ_TIMEOUT_MINUTES <= 3 )); then
+    echo "::error::Increase FUZZ_TIMEOUT_MINUTES to >3, received $FUZZ_TIMEOUT_MINUTES"
     exit 1
 fi
+
+TOTAL_SECONDS=$((FUZZ_TIMEOUT_MINUTES * 60))
+# Allow for a buffer between the timeout and the fuzz test runtime
+FUZZ_SECONDS=$((TOTAL_SECONDS - FUZZ_SCRIPT_OVERHEAD_SECONDS))
 
 echo "total timeout minutes: $FUZZ_TIMEOUT_MINUTES"
 echo "fuzz seconds: $FUZZ_SECONDS"
@@ -21,35 +22,36 @@ echo ""
 timeout "${FUZZ_TIMEOUT_MINUTES}"m ./fuzz/fuzz_all_native.py --ci --seconds "$FUZZ_SECONDS" --go_module_root ./ | tee $OUTPUT_FILE | grep -Ev '\[no test files\]|\[no tests to run\]'
 EXITCODE=${PIPESTATUS[0]}
 
+echo "Fuzz test exit code: $EXITCODE (0=pass,124=timeout,others=fail)"
+
 # Assert no known sensitive strings present in test logger output
 printf "\n----------------------------------------------\n\n"
 echo "Beginning check of output logs for sensitive strings"
 $SCRIPT_PATH/scrub_logs $OUTPUT_FILE
 if [[ $? != 0 ]]; then
-  exit 1
+    echo "::error::Sensitive strings found in output logs"
+    exit 1
 fi
-
-echo "Exit code: $EXITCODE"
 
 case $EXITCODE in
     0)
         echo "All fuzz tests passed!"
         ;;
     124)
-        echo "ERROR: Fuzz tests timed out after ${FUZZ_TIMEOUT_MINUTES} minutes"
+        echo "::error::Python fuzz script tests timed out after ${FUZZ_TIMEOUT_MINUTES} minutes."
         ;;
     125)
-        echo "ERROR: The timeout command itself failed"
+        echo "::error::The timeout command itself failed."
         ;;
     126)
-        echo "ERROR: The fuzz test command could not be executed"
+        echo "::error::The fuzz test command could not be executed."
         ;;
     127)
-        echo "ERROR: The fuzz test command was not found"
+        echo "::error::The fuzz test command was not found."
         ;;
     *)
         if [[ $EXITCODE != 0 ]]; then
-            echo "ERROR: Fuzz tests failed with exit code $EXITCODE"
+            echo "::error::Fuzz tests failed with exit code $EXITCODE"
             echo "Encountered fuzz test failures. Logging all failing fuzz inputs:"
             find . -type f|fgrep '/testdata/fuzz/'|while read f; do echo $f; cat $f; done
         fi

--- a/tools/bin/go_core_fuzz
+++ b/tools/bin/go_core_fuzz
@@ -4,12 +4,12 @@ set +e
 
 SCRIPT_PATH=`dirname "$0"`; SCRIPT_PATH=`eval "cd \"$SCRIPT_PATH\" && pwd"`
 OUTPUT_FILE=${OUTPUT_FILE:-"./output.txt"}
-FUZZ_TIMEOUT_MINUTES=${FUZZ_TIMEOUT_MINUTES:-"4"}
+FUZZ_TIMEOUT_MINUTES=${FUZZ_TIMEOUT_MINUTES:-"6"}
 
 TOTAL_SECONDS=$((FUZZ_TIMEOUT_MINUTES * 60))
 if (( TOTAL_SECONDS >= 180 )); then
     # Allow for a buffer between the timeout and the fuzz test runtime
-    FUZZ_SECONDS=$((TOTAL_SECONDS - 60))
+    FUZZ_SECONDS=$((TOTAL_SECONDS - 90))
 else
     echo "Increase FUZZ_TIMEOUT_MINUTES to >=3, received $FUZZ_TIMEOUT_MINUTES"
     exit 1


### PR DESCRIPTION
### Changes

* Increase default fuzz test timeout to 6 minutes, with 4.5 minutes of actual fuzzing for the python script
* Update logging so failures are more clear

### Motivation

Timeouts occurring:
- https://github.com/smartcontractkit/chainlink/actions/runs/18351124941/job/52271163559?pr=19784

```
Beginning check of output logs for sensitive strings
No matches in test log output against known set of sensitive strings
Exit code: 124
ERROR: Fuzz tests timed out after 4 minutes
Error: Process completed with exit code 124.
```

The process is timing out before the python script is finishing. This means that the overhead of the python script is now >60 seconds and causing timeouts.