### PR TITLE
fix(core+system-tests): enables executing vault capability on remote don

### DIFF
--- a/core/capabilities/vault/request_authorizer.go
+++ b/core/capabilities/vault/request_authorizer.go
@@ -152,10 +152,13 @@ func CalculateRequestDigest(req any) [32]byte {
 	return hash
 }
 
-func NewRequestAuthorizer(lggr logger.Logger, workflowRegistrySyncer workflowsyncerv2.WorkflowRegistrySyncer) *requestAuthorizer {
+func NewRequestAuthorizer(lggr logger.Logger, workflowRegistrySyncer workflowsyncerv2.WorkflowRegistrySyncer) (*requestAuthorizer, error) {
+	if workflowRegistrySyncer == nil {
+		return nil, errors.New("cannot create request authorizer: workflow registry syncer is nil")
+	}
 	return &requestAuthorizer{
 		workflowRegistrySyncer:    workflowRegistrySyncer,
 		lggr:                      logger.Named(lggr, "VaultRequestAuthorizer"),
 		alreadyAuthorizedRequests: make(map[string]bool),
-	}
+	}, nil
 }

--- a/core/capabilities/vault/request_authorizer_test.go
+++ b/core/capabilities/vault/request_authorizer_test.go
@@ -150,7 +150,8 @@ func testAuthForRequests(t *testing.T, allowlistedRequest, notAllowlistedRequest
 	owner := common.Address{1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 
 	mockSyncer := syncerv2mocks.NewWorkflowRegistrySyncer(t)
-	auth := NewRequestAuthorizer(lggr, mockSyncer)
+	auth, err := NewRequestAuthorizer(lggr, mockSyncer)
+	require.NoError(t, err)
 
 	// Invalid method
 	invalidReq := jsonrpc.Request[json.RawMessage]{

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -1260,6 +1260,7 @@ func newCREServices(
 					}
 
 					srvcs = append(srvcs, wfSyncer)
+					workflowRegistrySyncer = wfSyncer
 					globalLogger.Debugw("Created WorkflowRegistrySyncer V2")
 
 				default:
@@ -1351,6 +1352,7 @@ func (app *ChainlinkApplication) StopIfStarted() error {
 func (app *ChainlinkApplication) GetLoopRegistry() *plugins.LoopRegistry {
 	return app.loopRegistry
 }
+
 func (app *ChainlinkApplication) GetLoopRegistrarConfig() plugins.RegistrarConfig {
 	return app.loopRegistrarConfig
 }
@@ -1522,7 +1524,8 @@ func (app *ChainlinkApplication) RunJobV2(
 					common.BigToHash(big.NewInt(42)).Bytes(), // seed
 					evmutils.NewHash().Bytes(),               // sender
 					evmutils.NewHash().Bytes(),               // fee
-					evmutils.NewHash().Bytes()},              // requestID
+					evmutils.NewHash().Bytes(),
+				}, // requestID
 					[]byte{}),
 				Topics:      []common.Hash{{}, jb.ExternalIDEncodeBytesToTopic()}, // jobID BYTES
 				TxHash:      evmutils.NewHash(),

--- a/core/services/gateway/handler_factory.go
+++ b/core/services/gateway/handler_factory.go
@@ -63,7 +63,10 @@ func (hf *handlerFactory) NewHandler(handlerType HandlerType, handlerConfig json
 	case HTTPCapabilityType:
 		return v2.NewGatewayHandler(handlerConfig, donConfig, don, hf.httpClient, hf.lggr)
 	case VaultHandlerType:
-		requestAuthorizer := vaultcap.NewRequestAuthorizer(hf.lggr, hf.workflowRegistrySyncer)
+		requestAuthorizer, err := vaultcap.NewRequestAuthorizer(hf.lggr, hf.workflowRegistrySyncer)
+		if err != nil {
+			return nil, err
+		}
 		return vault.NewHandler(handlerConfig, donConfig, don, hf.capabilitiesRegistry, requestAuthorizer, hf.lggr, clockwork.NewRealClock())
 	default:
 		return nil, fmt.Errorf("unsupported handler type %s", handlerType)

--- a/system-tests/lib/cre/don/config/config.go
+++ b/system-tests/lib/cre/don/config/config.go
@@ -361,7 +361,7 @@ func addWorkerNodeConfig(
 		ContractVersion: ptr.Ptr(commonInputs.capabilityRegistry.versionType.Version.String()),
 	}
 
-	if donMetadata.HasFlag(cre.WorkflowDON) {
+	if donMetadata.HasFlag(cre.WorkflowDON) || donMetadata.HasFlag("vault") {
 		existingConfig.Capabilities.WorkflowRegistry = coretoml.WorkflowRegistry{
 			Address:         ptr.Ptr(commonInputs.workflowRegistry.address.Hex()),
 			NetworkID:       ptr.Ptr("evm"),


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

This PR enables executing the vault capability on a remote DON in system-tests by:
- configures workflow registry contract on nodes with the vault capability
- sets the workflow registry syncer field when setting up CRE Services
- returns an error from starting NewRequestAuthorizer

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
