### PR TITLE
feat: add SetTokenTransferFeeConfig for EVM v1_5_1

### DIFF
--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
@@ -1,0 +1,229 @@
+package v1_5_1
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_onramp"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
+)
+
+var _ cldf.ChangeSetV2[SetTokenTransferFeeConfig] = SetTokenTransferFeeConfigChangeset
+
+// SetTokenTransferFeeConfigChangeset is a changeset that allows you to set configurations such as DestGasOverhead
+// for v1_5 lanes. The changeset is intended to replace the current approach where we use RDD CCIP and/or Gauntlet
+// to perform this op: https://github.com/smartcontractkit/reference-data-directory-ccip/pull/1656/files. If you'd
+// like to view the underlying solidity function that this changeset invokes, then the code for EVM2EVMOnRamp will
+// be of interest: https://etherscan.io/address/0xb8a882f3B88bd52D1Ff56A873bfDB84b70431937#code.
+var SetTokenTransferFeeConfigChangeset = cldf.CreateChangeSet(setTokenTransferFeeConfigLogic, setTokenTransferFeeConfigPrecondition)
+
+type SetTokenTransferFeeConfig struct {
+	// A map of chain selector => token transfer fee input which describes the updates to make on each chain
+	InputsByChain map[uint64]SetTokenTransferFeeArgs `json:"inputsByChain"`
+
+	// The timelock config - all updates can be merged into one MCMS proposal with this setting
+	MCMS *proposalutils.TimelockConfig `json:"mcms"`
+}
+
+type SetTokenTransferFeeArgs struct {
+	// Tokens specified here will be given custom token transfer fee configs (isEnabled will be set to true on-chain)
+	TokenTransferFeeConfigArgs []TokenTransferFeeArgs
+
+	// Tokens specified here will have their custom token transfer fee configs reset (isEnabled will be set to false on-chain)
+	TokensToUseDefaultFeeConfigs []common.Address
+}
+
+// NOTE: the contract's _setTokenTransferFeeConfig method replaces the entire TokenTransferFeeConfig
+// for each token included in TokenTransferFeeConfigArgs (it does not merge fields) so we need to be
+// extra careful here. In Go, it is *very* easy to unintentionally pass an input struct with missing
+// fields to a function without realizing that default values are being used for the missing fields.
+// This isn't ideal for this changeset because it can lead to some configs being set to zero onchain
+// (which more often than not is a mistake). To avoid these types of situations, we use pointers for
+// each config field in the struct below to make things much more explicit. If a field isn't defined
+// or set to nil then the Go code will fall back to the value onchain before sending. Otherwise, the
+// user's provided value is used. When a token has no preexisting custom config (isEnabled == false)
+// then all fields must be explicitly provided by the caller.
+type TokenTransferFeeArgs struct {
+	Token                     common.Address
+	MinFeeUSDCents            *uint32
+	MaxFeeUSDCents            *uint32
+	DeciBps                   *uint16
+	DestGasOverhead           *uint32
+	DestBytesOverhead         *uint32
+	AggregateRateLimitEnabled *bool
+}
+
+func (args TokenTransferFeeArgs) HasMissingFields() bool {
+	return args.MinFeeUSDCents == nil ||
+		args.MaxFeeUSDCents == nil ||
+		args.DeciBps == nil ||
+		args.DestGasOverhead == nil ||
+		args.DestBytesOverhead == nil ||
+		args.AggregateRateLimitEnabled == nil
+}
+
+func setTokenTransferFeeConfigPrecondition(e cldf.Environment, cfg SetTokenTransferFeeConfig) error {
+	if len(cfg.InputsByChain) == 0 {
+		e.Logger.Warn("no inputs were provided - exiting precondition stage gracefully")
+		return nil
+	}
+
+	state, err := stateview.LoadOnchainState(e)
+	if err != nil {
+		return fmt.Errorf("failed to load onchain state: %w", err)
+	}
+
+	for selector, input := range cfg.InputsByChain {
+		chainState, ok := state.EVMChainState(selector)
+		if !ok {
+			return fmt.Errorf("selector %d does not exist in state", selector)
+		}
+		if onramp := chainState.EVM2EVMOnRamp[selector]; onramp == nil {
+			return fmt.Errorf("missing EVM2EVMOnRamp on chain with selector %d", selector)
+		}
+		if err := stateview.ValidateChain(e, state, selector, cfg.MCMS); err != nil {
+			return fmt.Errorf("failed to validate chain %d: %w", selector, err)
+		}
+
+		tokensToReset := map[common.Address]bool{}
+		for _, address := range input.TokensToUseDefaultFeeConfigs {
+			if _, exists := tokensToReset[address]; exists {
+				return fmt.Errorf("found duplicate address (%s) in TokensToUseDefaultFeeConfigs for chain with selector %d", address.Hex(), selector)
+			}
+			if address == utils.ZeroAddress {
+				return fmt.Errorf("for selector %d - zero address is not allowed in TokensToUseDefaultFeeConfigs", selector)
+			}
+			tokensToReset[address] = true
+		}
+
+		tokensToSetup := map[common.Address]bool{}
+		for _, args := range input.TokenTransferFeeConfigArgs {
+			if _, exists := tokensToSetup[args.Token]; exists {
+				return fmt.Errorf("found duplicate token address (%s) in TokenTransferFeeConfigArgs for chain with selector %d", args.Token.Hex(), selector)
+			}
+			if args.Token == utils.ZeroAddress {
+				return fmt.Errorf("for selector %d - zero address is not allowed in TokenTransferFeeConfigArgs", selector)
+			}
+			tokensToSetup[args.Token] = true
+		}
+
+		for addr := range tokensToSetup {
+			if _, exists := tokensToReset[addr]; exists {
+				return fmt.Errorf("for selector %d - TokensToUseDefaultFeeConfigs and TokenTransferFeeConfigArgs must not reference the same address (%s)", selector, addr.Hex())
+			}
+		}
+	}
+
+	return nil
+}
+
+func setTokenTransferFeeConfigLogic(e cldf.Environment, cfg SetTokenTransferFeeConfig) (cldf.ChangesetOutput, error) {
+	if len(cfg.InputsByChain) == 0 {
+		e.Logger.Warn("no inputs were provided - exiting apply stage gracefully")
+		return cldf.ChangesetOutput{}, nil
+	}
+
+	state, err := stateview.LoadOnchainState(e)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
+	}
+
+	e.Logger.Info("preparing deployer group transactions")
+	deployerGroup := deployergroup.NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext("SetTokenTransferFeeConfig")
+	for selector, input := range cfg.InputsByChain {
+		e.Logger.Infof("processing chain with selector %d", selector)
+
+		blockChain, exists := e.BlockChains.EVMChains()[selector]
+		if !exists {
+			return cldf.ChangesetOutput{}, fmt.Errorf("could not find EVM chain with selector %d in environment", selector)
+		}
+
+		chainState, exists := state.Chains[selector]
+		if !exists {
+			return cldf.ChangesetOutput{}, fmt.Errorf("could not find chain %s in state", blockChain.String())
+		}
+
+		opts, err := deployerGroup.GetDeployer(selector)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get deployer for chain %s: %w", blockChain.String(), err)
+		}
+
+		onramp, exists := chainState.EVM2EVMOnRamp[selector]
+		if !exists {
+			return cldf.ChangesetOutput{}, fmt.Errorf("could not find EVM2EVMOnRamp for chain %s", blockChain.String())
+		}
+
+		tokenTransferFeeConfigArgs := []evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs{}
+		for _, args := range input.TokenTransferFeeConfigArgs {
+			// This gets the token transfer fee config for the given token - if it doesn't exist, then the zero struct will be returned and `IsEnabled` will be `false`
+			e.Logger.Infof("getting token transfer fee config for token %s on chain %s", args.Token.Hex(), blockChain.String())
+			curConfig, err := onramp.GetTokenTransferFeeConfig(&bind.CallOpts{Context: e.GetContext()}, args.Token)
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to get TokenTransferFeeConfig for token %s on chain %s: %w", args.Token.Hex(), blockChain.String(), err)
+			}
+
+			// If no custom config already exists on-chain for the token, then we have no fallback values to use - in this case the caller must explicitly provide all fields
+			if !curConfig.IsEnabled && args.HasMissingFields() {
+				return cldf.ChangesetOutput{}, fmt.Errorf("token %s on %s: when enabling a new token, all fields must be provided", args.Token.Hex(), blockChain.String())
+			}
+
+			// At this point, we're either using fallback values from the chain or the caller has explicitly provided the inputs
+			newConfig := evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs{
+				Token:                     args.Token,
+				MinFeeUSDCents:            pointer.Coalesce(args.MinFeeUSDCents, curConfig.MinFeeUSDCents),
+				MaxFeeUSDCents:            pointer.Coalesce(args.MaxFeeUSDCents, curConfig.MaxFeeUSDCents),
+				DeciBps:                   pointer.Coalesce(args.DeciBps, curConfig.DeciBps),
+				DestGasOverhead:           pointer.Coalesce(args.DestGasOverhead, curConfig.DestGasOverhead),
+				DestBytesOverhead:         pointer.Coalesce(args.DestBytesOverhead, curConfig.DestBytesOverhead),
+				AggregateRateLimitEnabled: pointer.Coalesce(args.AggregateRateLimitEnabled, curConfig.AggregateRateLimitEnabled),
+			}
+
+			// Check if the new config is different from the on-chain config
+			isDifferent := !curConfig.IsEnabled
+			if curConfig.IsEnabled {
+				isDifferent = newConfig.MinFeeUSDCents != curConfig.MinFeeUSDCents ||
+					newConfig.MaxFeeUSDCents != curConfig.MaxFeeUSDCents ||
+					newConfig.DeciBps != curConfig.DeciBps ||
+					newConfig.DestGasOverhead != curConfig.DestGasOverhead ||
+					newConfig.DestBytesOverhead != curConfig.DestBytesOverhead ||
+					newConfig.AggregateRateLimitEnabled != curConfig.AggregateRateLimitEnabled
+			}
+
+			// Only perform an update if the new config is different from the on-chain config
+			if isDifferent {
+				tokenTransferFeeConfigArgs = append(tokenTransferFeeConfigArgs, newConfig)
+			} else {
+				e.Logger.Infof("token %s on %s: input config is the same as on-chain config (%+v) - skipping", args.Token.Hex(), blockChain.String(), curConfig)
+			}
+		}
+
+		resetsCount := len(input.TokensToUseDefaultFeeConfigs)
+		updateCount := len(tokenTransferFeeConfigArgs)
+		if updateCount == 0 && resetsCount == 0 {
+			e.Logger.Infof("detected no changes for chain %s - skipping", blockChain.String())
+			continue
+		}
+
+		e.Logger.Infof("setting token transfer fee config for chain %s (updates = %d, resets = %d)", blockChain.String(), updateCount, resetsCount)
+		_, err = onramp.SetTokenTransferFeeConfig(opts,
+			tokenTransferFeeConfigArgs,
+			input.TokensToUseDefaultFeeConfigs,
+		)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf(
+				"failed to create SetTokenTransferFeeConfig transaction on chain %s: %w",
+				blockChain.String(),
+				err,
+			)
+		}
+	}
+
+	e.Logger.Info("running deployer group")
+	return deployerGroup.Enact()
+}

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
@@ -36,24 +36,22 @@ type SetTokenTransferFeeConfig struct {
 
 type SetTokenTransferFeeArgs struct {
 	// Tokens specified here will be given custom token transfer fee configs (isEnabled will be set to true on-chain)
-	TokenTransferFeeConfigArgs []TokenTransferFeeArgs
+	TokenTransferFeeConfigArgs map[common.Address]TokenTransferFeeArgs
 
 	// Tokens specified here will have their custom token transfer fee configs reset (isEnabled will be set to false on-chain)
 	TokensToUseDefaultFeeConfigs []common.Address
 }
 
-// NOTE: the contract's _setTokenTransferFeeConfig method replaces the entire TokenTransferFeeConfig
-// for each token included in TokenTransferFeeConfigArgs (it does not merge fields) so we need to be
+// NOTE: the _setTokenTransferFeeConfig method in the Solidity contract overwrites all config values
+// for each token included in TokenTransferFeeConfigArgs (it doesn't upsert values) so we need to be
 // extra careful here. In Go, it is *very* easy to unintentionally pass an input struct with missing
-// fields to a function without realizing that default values are being used for the missing fields.
-// This isn't ideal for this changeset because it can lead to some configs being set to zero onchain
-// (which more often than not is a mistake). To avoid these types of situations, we use pointers for
-// each config field in the struct below to make things much more explicit. If a field isn't defined
-// or set to nil then the Go code will fall back to the value onchain before sending. Otherwise, the
-// user's provided value is used. When a token has no preexisting custom config (isEnabled == false)
-// then all fields must be explicitly provided by the caller.
+// fields to a func without realizing that zero values are really being used for the missing fields.
+// To avoid these types of situations, we use pointers for each config field in the struct below. If
+// a field is undefined or set to nil in the struct, then we will fallback to using any pre-existing
+// values from the chain before sending the transaction. Otherwise the user's input values are used.
+// If a token has no pre-existing config values on-chain (i.e. isEnabled == false), then every field
+// must be explicitly provided by the caller.
 type TokenTransferFeeArgs struct {
-	Token                     common.Address
 	MinFeeUSDCents            *uint32
 	MaxFeeUSDCents            *uint32
 	DeciBps                   *uint16
@@ -101,34 +99,26 @@ func setTokenTransferFeeConfigPrecondition(env cldf.Environment, cfg SetTokenTra
 			}
 
 			tokensToReset := map[common.Address]bool{}
-			for _, address := range input.TokensToUseDefaultFeeConfigs {
-				if _, exists := tokensToReset[address]; exists {
-					return fmt.Errorf("duplicate address in TokensToUseDefaultFeeConfigs (src = %d, dst = %d, addr = %s)", srcSelector, dstSelector, address.Hex())
+			for _, tokenAddress := range input.TokensToUseDefaultFeeConfigs {
+				if _, exists := tokensToReset[tokenAddress]; exists {
+					return fmt.Errorf("duplicate address in TokensToUseDefaultFeeConfigs (src = %d, dst = %d, addr = %s)", srcSelector, dstSelector, tokenAddress.Hex())
 				}
-				if address == utils.ZeroAddress {
+				if tokenAddress == utils.ZeroAddress {
 					return fmt.Errorf("zero address not allowed in TokensToUseDefaultFeeConfigs (src = %d, dst = %d)", srcSelector, dstSelector)
 				}
-				tokensToReset[address] = true
+				tokensToReset[tokenAddress] = true
 			}
 
-			tokensToSetup := map[common.Address]bool{}
-			for _, args := range input.TokenTransferFeeConfigArgs {
-				if _, exists := tokensToSetup[args.Token]; exists {
-					return fmt.Errorf("duplicate token in TokenTransferFeeConfigArgs (src = %d, dst = %d, token = %s)", srcSelector, dstSelector, args.Token.Hex())
-				}
-				if args.Token == utils.ZeroAddress {
+			for tokenAddress := range input.TokenTransferFeeConfigArgs {
+				if tokenAddress == utils.ZeroAddress {
 					return fmt.Errorf("zero address not allowed in TokenTransferFeeConfigArgs (src = %d, dst = %d)", srcSelector, dstSelector)
 				}
-				tokensToSetup[args.Token] = true
-			}
-
-			for addr := range tokensToSetup {
-				if _, exists := tokensToReset[addr]; exists {
+				if _, exists := tokensToReset[tokenAddress]; exists {
 					return fmt.Errorf(
 						"the same address cannot be referenced in both TokensToUseDefaultFeeConfigs and TokenTransferFeeConfigArgs (src = %d, dst = %d, addr = %s)",
 						srcSelector,
 						dstSelector,
-						addr.Hex(),
+						tokenAddress.Hex(),
 					)
 				}
 			}
@@ -188,23 +178,23 @@ func setTokenTransferFeeConfigLogic(env cldf.Environment, cfg SetTokenTransferFe
 			}
 
 			tokenTransferFeeConfigArgs := []evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs{}
-			for _, args := range input.TokenTransferFeeConfigArgs {
+			for tokenAddress, args := range input.TokenTransferFeeConfigArgs {
 				// This gets the token transfer fee config for the given token - if it doesn't exist, then the zero struct will be returned and `IsEnabled` will be `false`
-				env.Logger.Infof("fetching token transfer fee config (src = %s, dst = %s, token = %s)", srcChain.String(), dstChain.String(), args.Token.Hex())
-				curConfig, err := onramp.GetTokenTransferFeeConfig(&bind.CallOpts{Context: env.GetContext()}, args.Token)
+				env.Logger.Infof("fetching token transfer fee config (src = %s, dst = %s, token = %s)", srcChain.String(), dstChain.String(), tokenAddress.Hex())
+				curConfig, err := onramp.GetTokenTransferFeeConfig(&bind.CallOpts{Context: env.GetContext()}, tokenAddress)
 				if err != nil {
-					return cldf.ChangesetOutput{}, fmt.Errorf("failed to fetch token transfer fee config (src = %s, dst = %s, token = %s): %w", srcChain.String(), dstChain.String(), args.Token.Hex(), err)
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to fetch token transfer fee config (src = %s, dst = %s, token = %s): %w", srcChain.String(), dstChain.String(), tokenAddress.Hex(), err)
 				}
 
 				// If no custom config already exists on-chain for the token, then we have no fallback values to use - in this case the caller must explicitly provide all fields
-				env.Logger.Infof("fetched token transfer fee config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), args.Token.Hex(), curConfig)
+				env.Logger.Infof("fetched token transfer fee config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), curConfig)
 				if !curConfig.IsEnabled && args.HasMissingFields() {
-					return cldf.ChangesetOutput{}, fmt.Errorf("invalid args - when enabling a new token, all fields must be provided (src = %s, dst = %s, token = %s)", srcChain.String(), dstChain.String(), args.Token.Hex())
+					return cldf.ChangesetOutput{}, fmt.Errorf("invalid args - when enabling a new token, all fields must be provided (src = %s, dst = %s, token = %s)", srcChain.String(), dstChain.String(), tokenAddress.Hex())
 				}
 
 				// At this point, we're either using fallback values from the chain or the caller has explicitly provided the inputs
 				newConfig := evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs{
-					Token:                     args.Token,
+					Token:                     tokenAddress,
 					MinFeeUSDCents:            pointer.Coalesce(args.MinFeeUSDCents, curConfig.MinFeeUSDCents),
 					MaxFeeUSDCents:            pointer.Coalesce(args.MaxFeeUSDCents, curConfig.MaxFeeUSDCents),
 					DeciBps:                   pointer.Coalesce(args.DeciBps, curConfig.DeciBps),
@@ -225,11 +215,11 @@ func setTokenTransferFeeConfigLogic(env cldf.Environment, cfg SetTokenTransferFe
 				}
 
 				// Only perform an update if the new config is different from the on-chain config
-				env.Logger.Infof("constructed token transfer fee config (src = %s, dst = %s, token = %s, new_cfg = %+v)", srcChain.String(), dstChain.String(), args.Token.Hex(), newConfig)
+				env.Logger.Infof("constructed token transfer fee config (src = %s, dst = %s, token = %s, new_cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), newConfig)
 				if isDifferent {
 					tokenTransferFeeConfigArgs = append(tokenTransferFeeConfigArgs, newConfig)
 				} else {
-					env.Logger.Infof("skipping update since input config is the same as on-chain config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), args.Token.Hex(), curConfig)
+					env.Logger.Infof("skipping update since input config is the same as on-chain config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), curConfig)
 				}
 			}
 

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
@@ -5,12 +5,15 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_onramp"
+
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_onramp"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 )
 
@@ -25,7 +28,7 @@ var SetTokenTransferFeeConfigChangeset = cldf.CreateChangeSet(setTokenTransferFe
 
 type SetTokenTransferFeeConfig struct {
 	// A map of chain selector => token transfer fee input which describes the updates to make on each chain
-	InputsByChain map[uint64]SetTokenTransferFeeArgs `json:"inputsByChain"`
+	InputsByChain map[uint64]map[uint64]SetTokenTransferFeeArgs `json:"inputsByChain"`
 
 	// The timelock config - all updates can be merged into one MCMS proposal with this setting
 	MCMS *proposalutils.TimelockConfig `json:"mcms"`
@@ -68,54 +71,66 @@ func (args TokenTransferFeeArgs) HasMissingFields() bool {
 		args.AggregateRateLimitEnabled == nil
 }
 
-func setTokenTransferFeeConfigPrecondition(e cldf.Environment, cfg SetTokenTransferFeeConfig) error {
+func setTokenTransferFeeConfigPrecondition(env cldf.Environment, cfg SetTokenTransferFeeConfig) error {
 	if len(cfg.InputsByChain) == 0 {
-		e.Logger.Warn("no inputs were provided - exiting precondition stage gracefully")
+		env.Logger.Warn("no inputs were provided - exiting precondition stage gracefully")
 		return nil
 	}
 
-	state, err := stateview.LoadOnchainState(e)
+	state, err := stateview.LoadOnchainState(env, stateview.WithLoadLegacyContracts(true))
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
 	}
 
-	for selector, input := range cfg.InputsByChain {
-		chainState, ok := state.EVMChainState(selector)
+	for srcSelector, inputs := range cfg.InputsByChain {
+		err := stateview.ValidateChain(env, state, srcSelector, cfg.MCMS)
+		if err != nil {
+			return fmt.Errorf("failed to validate src chain (src = %d): %w", srcSelector, err)
+		}
+		chainState, ok := state.EVMChainState(srcSelector)
 		if !ok {
-			return fmt.Errorf("selector %d does not exist in state", selector)
-		}
-		if onramp := chainState.EVM2EVMOnRamp[selector]; onramp == nil {
-			return fmt.Errorf("missing EVM2EVMOnRamp on chain with selector %d", selector)
-		}
-		if err := stateview.ValidateChain(e, state, selector, cfg.MCMS); err != nil {
-			return fmt.Errorf("failed to validate chain %d: %w", selector, err)
+			return fmt.Errorf("selector does not exist in EVM chain state (src = %d)", srcSelector)
 		}
 
-		tokensToReset := map[common.Address]bool{}
-		for _, address := range input.TokensToUseDefaultFeeConfigs {
-			if _, exists := tokensToReset[address]; exists {
-				return fmt.Errorf("found duplicate address (%s) in TokensToUseDefaultFeeConfigs for chain with selector %d", address.Hex(), selector)
+		for dstSelector, input := range inputs {
+			if err := stateview.ValidateChain(env, state, dstSelector, cfg.MCMS); err != nil {
+				return fmt.Errorf("failed to validate dst chain (src = %d, dst = %d): %w", srcSelector, dstSelector, err)
 			}
-			if address == utils.ZeroAddress {
-				return fmt.Errorf("for selector %d - zero address is not allowed in TokensToUseDefaultFeeConfigs", selector)
+			if _, exists := chainState.EVM2EVMOnRamp[dstSelector]; !exists {
+				return fmt.Errorf("no EVM2EVMOnRamp exists (src = %d, dst = %d)", srcSelector, dstSelector)
 			}
-			tokensToReset[address] = true
-		}
 
-		tokensToSetup := map[common.Address]bool{}
-		for _, args := range input.TokenTransferFeeConfigArgs {
-			if _, exists := tokensToSetup[args.Token]; exists {
-				return fmt.Errorf("found duplicate token address (%s) in TokenTransferFeeConfigArgs for chain with selector %d", args.Token.Hex(), selector)
+			tokensToReset := map[common.Address]bool{}
+			for _, address := range input.TokensToUseDefaultFeeConfigs {
+				if _, exists := tokensToReset[address]; exists {
+					return fmt.Errorf("duplicate address in TokensToUseDefaultFeeConfigs (src = %d, dst = %d, addr = %s)", srcSelector, dstSelector, address.Hex())
+				}
+				if address == utils.ZeroAddress {
+					return fmt.Errorf("zero address not allowed in TokensToUseDefaultFeeConfigs (src = %d, dst = %d)", srcSelector, dstSelector)
+				}
+				tokensToReset[address] = true
 			}
-			if args.Token == utils.ZeroAddress {
-				return fmt.Errorf("for selector %d - zero address is not allowed in TokenTransferFeeConfigArgs", selector)
-			}
-			tokensToSetup[args.Token] = true
-		}
 
-		for addr := range tokensToSetup {
-			if _, exists := tokensToReset[addr]; exists {
-				return fmt.Errorf("for selector %d - TokensToUseDefaultFeeConfigs and TokenTransferFeeConfigArgs must not reference the same address (%s)", selector, addr.Hex())
+			tokensToSetup := map[common.Address]bool{}
+			for _, args := range input.TokenTransferFeeConfigArgs {
+				if _, exists := tokensToSetup[args.Token]; exists {
+					return fmt.Errorf("duplicate token in TokenTransferFeeConfigArgs (src = %d, dst = %d, token = %s)", srcSelector, dstSelector, args.Token.Hex())
+				}
+				if args.Token == utils.ZeroAddress {
+					return fmt.Errorf("zero address not allowed in TokenTransferFeeConfigArgs (src = %d, dst = %d)", srcSelector, dstSelector)
+				}
+				tokensToSetup[args.Token] = true
+			}
+
+			for addr := range tokensToSetup {
+				if _, exists := tokensToReset[addr]; exists {
+					return fmt.Errorf(
+						"the same address cannot be referenced in both TokensToUseDefaultFeeConfigs and TokenTransferFeeConfigArgs (src = %d, dst = %d, addr = %s)",
+						srcSelector,
+						dstSelector,
+						addr.Hex(),
+					)
+				}
 			}
 		}
 	}
@@ -123,107 +138,124 @@ func setTokenTransferFeeConfigPrecondition(e cldf.Environment, cfg SetTokenTrans
 	return nil
 }
 
-func setTokenTransferFeeConfigLogic(e cldf.Environment, cfg SetTokenTransferFeeConfig) (cldf.ChangesetOutput, error) {
+func setTokenTransferFeeConfigLogic(env cldf.Environment, cfg SetTokenTransferFeeConfig) (cldf.ChangesetOutput, error) {
 	if len(cfg.InputsByChain) == 0 {
-		e.Logger.Warn("no inputs were provided - exiting apply stage gracefully")
+		env.Logger.Warn("no inputs were provided - exiting apply stage gracefully")
 		return cldf.ChangesetOutput{}, nil
 	}
 
-	state, err := stateview.LoadOnchainState(e)
+	state, err := stateview.LoadOnchainState(env, stateview.WithLoadLegacyContracts(true))
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
 
-	e.Logger.Info("preparing deployer group transactions")
-	deployerGroup := deployergroup.NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext("SetTokenTransferFeeConfig")
-	for selector, input := range cfg.InputsByChain {
-		e.Logger.Infof("processing chain with selector %d", selector)
+	deployerGroup := deployergroup.
+		NewDeployerGroup(env, state, cfg.MCMS).
+		WithDeploymentContext("SetTokenTransferFeeConfig")
 
-		blockChain, exists := e.BlockChains.EVMChains()[selector]
-		if !exists {
-			return cldf.ChangesetOutput{}, fmt.Errorf("could not find EVM chain with selector %d in environment", selector)
-		}
-
-		chainState, exists := state.Chains[selector]
-		if !exists {
-			return cldf.ChangesetOutput{}, fmt.Errorf("could not find chain %s in state", blockChain.String())
-		}
-
-		opts, err := deployerGroup.GetDeployer(selector)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get deployer for chain %s: %w", blockChain.String(), err)
-		}
-
-		onramp, exists := chainState.EVM2EVMOnRamp[selector]
-		if !exists {
-			return cldf.ChangesetOutput{}, fmt.Errorf("could not find EVM2EVMOnRamp for chain %s", blockChain.String())
-		}
-
-		tokenTransferFeeConfigArgs := []evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs{}
-		for _, args := range input.TokenTransferFeeConfigArgs {
-			// This gets the token transfer fee config for the given token - if it doesn't exist, then the zero struct will be returned and `IsEnabled` will be `false`
-			e.Logger.Infof("getting token transfer fee config for token %s on chain %s", args.Token.Hex(), blockChain.String())
-			curConfig, err := onramp.GetTokenTransferFeeConfig(&bind.CallOpts{Context: e.GetContext()}, args.Token)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to get TokenTransferFeeConfig for token %s on chain %s: %w", args.Token.Hex(), blockChain.String(), err)
-			}
-
-			// If no custom config already exists on-chain for the token, then we have no fallback values to use - in this case the caller must explicitly provide all fields
-			if !curConfig.IsEnabled && args.HasMissingFields() {
-				return cldf.ChangesetOutput{}, fmt.Errorf("token %s on %s: when enabling a new token, all fields must be provided", args.Token.Hex(), blockChain.String())
-			}
-
-			// At this point, we're either using fallback values from the chain or the caller has explicitly provided the inputs
-			newConfig := evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs{
-				Token:                     args.Token,
-				MinFeeUSDCents:            pointer.Coalesce(args.MinFeeUSDCents, curConfig.MinFeeUSDCents),
-				MaxFeeUSDCents:            pointer.Coalesce(args.MaxFeeUSDCents, curConfig.MaxFeeUSDCents),
-				DeciBps:                   pointer.Coalesce(args.DeciBps, curConfig.DeciBps),
-				DestGasOverhead:           pointer.Coalesce(args.DestGasOverhead, curConfig.DestGasOverhead),
-				DestBytesOverhead:         pointer.Coalesce(args.DestBytesOverhead, curConfig.DestBytesOverhead),
-				AggregateRateLimitEnabled: pointer.Coalesce(args.AggregateRateLimitEnabled, curConfig.AggregateRateLimitEnabled),
-			}
-
-			// Check if the new config is different from the on-chain config
-			isDifferent := !curConfig.IsEnabled
-			if curConfig.IsEnabled {
-				isDifferent = newConfig.MinFeeUSDCents != curConfig.MinFeeUSDCents ||
-					newConfig.MaxFeeUSDCents != curConfig.MaxFeeUSDCents ||
-					newConfig.DeciBps != curConfig.DeciBps ||
-					newConfig.DestGasOverhead != curConfig.DestGasOverhead ||
-					newConfig.DestBytesOverhead != curConfig.DestBytesOverhead ||
-					newConfig.AggregateRateLimitEnabled != curConfig.AggregateRateLimitEnabled
-			}
-
-			// Only perform an update if the new config is different from the on-chain config
-			if isDifferent {
-				tokenTransferFeeConfigArgs = append(tokenTransferFeeConfigArgs, newConfig)
-			} else {
-				e.Logger.Infof("token %s on %s: input config is the same as on-chain config (%+v) - skipping", args.Token.Hex(), blockChain.String(), curConfig)
-			}
-		}
-
-		resetsCount := len(input.TokensToUseDefaultFeeConfigs)
-		updateCount := len(tokenTransferFeeConfigArgs)
-		if updateCount == 0 && resetsCount == 0 {
-			e.Logger.Infof("detected no changes for chain %s - skipping", blockChain.String())
+	env.Logger.Info("preparing deployer group transactions")
+	for srcSelector, inputs := range cfg.InputsByChain {
+		env.Logger.Infof("processing src %d", srcSelector)
+		if len(inputs) == 0 {
+			env.Logger.Infof("no inputs were detected for src %d - skipping", srcSelector)
 			continue
 		}
 
-		e.Logger.Infof("setting token transfer fee config for chain %s (updates = %d, resets = %d)", blockChain.String(), updateCount, resetsCount)
-		_, err = onramp.SetTokenTransferFeeConfig(opts,
-			tokenTransferFeeConfigArgs,
-			input.TokensToUseDefaultFeeConfigs,
-		)
+		srcChain, exists := env.BlockChains.EVMChains()[srcSelector]
+		if !exists {
+			return cldf.ChangesetOutput{}, fmt.Errorf("could not find src EVM chain in environment (src = %d)", srcSelector)
+		}
+
+		chainState, exists := state.Chains[srcSelector]
+		if !exists {
+			return cldf.ChangesetOutput{}, fmt.Errorf("could not find chain in state (src = %s)", srcChain.String())
+		}
+
+		opts, err := deployerGroup.GetDeployer(srcSelector)
 		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf(
-				"failed to create SetTokenTransferFeeConfig transaction on chain %s: %w",
-				blockChain.String(),
-				err,
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get deployer (src = %s): %w", srcChain.String(), err)
+		}
+
+		for dstSelector, input := range inputs {
+			dstChain, exists := env.BlockChains.EVMChains()[dstSelector]
+			if !exists {
+				return cldf.ChangesetOutput{}, fmt.Errorf("could not find dst EVM chain in environment (src = %s, dst = %d)", srcChain.String(), dstSelector)
+			}
+
+			onramp, exists := chainState.EVM2EVMOnRamp[dstSelector]
+			if !exists {
+				return cldf.ChangesetOutput{}, fmt.Errorf("no EVM2EVMOnRamp (src = %s, dst = %s)", srcChain.String(), dstChain.String())
+			}
+
+			tokenTransferFeeConfigArgs := []evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs{}
+			for _, args := range input.TokenTransferFeeConfigArgs {
+				// This gets the token transfer fee config for the given token - if it doesn't exist, then the zero struct will be returned and `IsEnabled` will be `false`
+				env.Logger.Infof("fetching token transfer fee config (src = %s, dst = %s, token = %s)", srcChain.String(), dstChain.String(), args.Token.Hex())
+				curConfig, err := onramp.GetTokenTransferFeeConfig(&bind.CallOpts{Context: env.GetContext()}, args.Token)
+				if err != nil {
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to fetch token transfer fee config (src = %s, dst = %s, token = %s): %w", srcChain.String(), dstChain.String(), args.Token.Hex(), err)
+				}
+
+				// If no custom config already exists on-chain for the token, then we have no fallback values to use - in this case the caller must explicitly provide all fields
+				env.Logger.Infof("fetched token transfer fee config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), args.Token.Hex(), curConfig)
+				if !curConfig.IsEnabled && args.HasMissingFields() {
+					return cldf.ChangesetOutput{}, fmt.Errorf("invalid args - when enabling a new token, all fields must be provided (src = %s, dst = %s, token = %s)", srcChain.String(), dstChain.String(), args.Token.Hex())
+				}
+
+				// At this point, we're either using fallback values from the chain or the caller has explicitly provided the inputs
+				newConfig := evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs{
+					Token:                     args.Token,
+					MinFeeUSDCents:            pointer.Coalesce(args.MinFeeUSDCents, curConfig.MinFeeUSDCents),
+					MaxFeeUSDCents:            pointer.Coalesce(args.MaxFeeUSDCents, curConfig.MaxFeeUSDCents),
+					DeciBps:                   pointer.Coalesce(args.DeciBps, curConfig.DeciBps),
+					DestGasOverhead:           pointer.Coalesce(args.DestGasOverhead, curConfig.DestGasOverhead),
+					DestBytesOverhead:         pointer.Coalesce(args.DestBytesOverhead, curConfig.DestBytesOverhead),
+					AggregateRateLimitEnabled: pointer.Coalesce(args.AggregateRateLimitEnabled, curConfig.AggregateRateLimitEnabled),
+				}
+
+				// Check if the new config is different from the on-chain config
+				isDifferent := !curConfig.IsEnabled
+				if curConfig.IsEnabled {
+					isDifferent = newConfig.MinFeeUSDCents != curConfig.MinFeeUSDCents ||
+						newConfig.MaxFeeUSDCents != curConfig.MaxFeeUSDCents ||
+						newConfig.DeciBps != curConfig.DeciBps ||
+						newConfig.DestGasOverhead != curConfig.DestGasOverhead ||
+						newConfig.DestBytesOverhead != curConfig.DestBytesOverhead ||
+						newConfig.AggregateRateLimitEnabled != curConfig.AggregateRateLimitEnabled
+				}
+
+				// Only perform an update if the new config is different from the on-chain config
+				env.Logger.Infof("constructed token transfer fee config (src = %s, dst = %s, token = %s, new_cfg = %+v)", srcChain.String(), dstChain.String(), args.Token.Hex(), newConfig)
+				if isDifferent {
+					tokenTransferFeeConfigArgs = append(tokenTransferFeeConfigArgs, newConfig)
+				} else {
+					env.Logger.Infof("skipping update since input config is the same as on-chain config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), args.Token.Hex(), curConfig)
+				}
+			}
+
+			resetsCount := len(input.TokensToUseDefaultFeeConfigs)
+			updateCount := len(tokenTransferFeeConfigArgs)
+			if updateCount == 0 && resetsCount == 0 {
+				env.Logger.Infof("no changes detected (src = %s, dst = %s) - skipping", srcChain.String(), dstChain.String())
+				continue
+			}
+
+			env.Logger.Infof("setting token transfer fee configs (src = %s, dst = %s, updates = %d, resets = %d)", srcChain.String(), dstChain.String(), updateCount, resetsCount)
+			_, err = onramp.SetTokenTransferFeeConfig(opts,
+				tokenTransferFeeConfigArgs,
+				input.TokensToUseDefaultFeeConfigs,
 			)
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf(
+					"failed to create SetTokenTransferFeeConfig transaction (src = %s, dst = %s): %w",
+					srcChain.String(),
+					dstChain.String(),
+					err,
+				)
+			}
 		}
 	}
 
-	e.Logger.Info("running deployer group")
+	env.Logger.Info("running deployer group")
 	return deployerGroup.Enact()
 }

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
@@ -27,7 +27,7 @@ var _ cldf.ChangeSetV2[SetTokenTransferFeeConfig] = SetTokenTransferFeeConfigCha
 var SetTokenTransferFeeConfigChangeset = cldf.CreateChangeSet(setTokenTransferFeeConfigLogic, setTokenTransferFeeConfigPrecondition)
 
 type SetTokenTransferFeeConfig struct {
-	// A map of chain selector => token transfer fee input which describes the updates to make on each chain
+	// A mapping from src chain selector => dst chain selector => token transfer fee input
 	InputsByChain map[uint64]map[uint64]SetTokenTransferFeeArgs `json:"inputsByChain"`
 
 	// The timelock config - all updates can be merged into one MCMS proposal with this setting

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config_test.go
@@ -1,0 +1,568 @@
+package v1_5_1_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_onramp"
+	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/v1_5"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1"
+	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
+)
+
+// Two weeks in seconds
+const SetTokenTransferFeePriceRegStalenessThreshold = 60 * 60 * 24 * 14
+
+// Helper to read back a token's config from the onramp
+func ReadTokenTransferFeeConfig(t *testing.T, e testhelpers.DeployedEnv, srcSelector, dstSelector uint64, token common.Address) (evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfig, error) {
+	t.Helper()
+
+	s, err := stateview.LoadOnchainState(e.Env, stateview.WithLoadLegacyContracts(true))
+	if err != nil {
+		return evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfig{}, err
+	}
+	chainState, ok := s.EVMChainState(srcSelector)
+	if !ok {
+		return evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfig{}, fmt.Errorf("no EVM chain state for %d", srcSelector)
+	}
+	onramp, ok := chainState.EVM2EVMOnRamp[dstSelector]
+	if !ok {
+		return evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfig{}, fmt.Errorf("no onramp %d -> %d", srcSelector, dstSelector)
+	}
+
+	return onramp.GetTokenTransferFeeConfig(&bind.CallOpts{Context: e.Env.GetContext()}, token)
+}
+
+func TestSetTokenTransferFeeConfig_Validations(t *testing.T) {
+	t.Parallel()
+
+	// Spin up a memory env with minimal prerequisite deployment
+	e, _ := testhelpers.NewMemoryEnvironment(t,
+		testhelpers.WithNumOfChains(2),
+		testhelpers.WithPrerequisiteDeploymentOnly(&changeset.V1_5DeploymentConfig{
+			// NOTE: this property needs to be defined otherwise we will encounter an
+			// error. For now it's set to a value that was found in another test case
+			PriceRegStalenessThreshold: SetTokenTransferFeePriceRegStalenessThreshold,
+		}),
+	)
+
+	// Ensure the chains exist
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
+	require.Len(t, allChains, 2)
+	src := allChains[0]
+	dst := allChains[1]
+
+	// Take a snapshot of the current state
+	state, err := stateview.LoadOnchainState(e.Env, stateview.WithLoadLegacyContracts(true))
+	require.NoError(t, err)
+
+	// Wire up a bi-directional lane
+	e.Env = v1_5.AddLanes(t, e.Env, state, []testhelpers.SourceDestPair{
+		{SourceChainSelector: src, DestChainSelector: dst},
+		{SourceChainSelector: dst, DestChainSelector: src},
+	})
+
+	// Define helper vars
+	mcmCfg := &proposalutils.TimelockConfig{MinDelay: 0 * time.Second}
+	tokenA := utils.RandomAddress()
+	tokenB := utils.RandomAddress()
+
+	// Define test cases
+	tests := []struct {
+		Config v1_5_1.SetTokenTransferFeeConfig
+		Msg    string
+		Err    string
+	}{
+		{
+			Msg: "Nonexistent chain selector",
+			Err: "failed to validate src chain",
+			Config: v1_5_1.SetTokenTransferFeeConfig{
+				MCMS: mcmCfg,
+				InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
+					0: {},
+				},
+			},
+		},
+		{
+			Msg: "Invalid EVM chain selector",
+			Err: fmt.Sprintf("selector %d does not exist in environment", chain_selectors.SOLANA_DEVNET.Selector),
+			Config: v1_5_1.SetTokenTransferFeeConfig{
+				MCMS: mcmCfg,
+				InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
+					chain_selectors.SOLANA_DEVNET.Selector: {},
+				},
+			},
+		},
+		{
+			Msg: "Duplicate addresses in reset list",
+			Err: "duplicate address in TokensToUseDefaultFeeConfigs",
+			Config: v1_5_1.SetTokenTransferFeeConfig{
+				MCMS: mcmCfg,
+				InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
+					src: {
+						dst: {
+							TokensToUseDefaultFeeConfigs: []common.Address{tokenA, tokenA},
+						},
+					},
+				},
+			},
+		},
+		{
+			Msg: "Zero address in reset list",
+			Err: "zero address not allowed in TokensToUseDefaultFeeConfigs",
+			Config: v1_5_1.SetTokenTransferFeeConfig{
+				MCMS: mcmCfg,
+				InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
+					src: {
+						dst: {
+							TokensToUseDefaultFeeConfigs: []common.Address{utils.ZeroAddress},
+						},
+					},
+				},
+			},
+		},
+		{
+			Msg: "Duplicate token in update args",
+			Err: "duplicate token in TokenTransferFeeConfigArgs",
+			Config: v1_5_1.SetTokenTransferFeeConfig{
+				MCMS: mcmCfg,
+				InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
+					src: {
+						dst: {
+							TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
+								{Token: tokenA, MinFeeUSDCents: pointer.To(uint32(1)), MaxFeeUSDCents: pointer.To(uint32(2)), DeciBps: pointer.To(uint16(10)), DestGasOverhead: pointer.To(uint32(100)), DestBytesOverhead: pointer.To(uint32(200)), AggregateRateLimitEnabled: pointer.To(true)},
+								{Token: tokenA, MinFeeUSDCents: pointer.To(uint32(1)), MaxFeeUSDCents: pointer.To(uint32(2)), DeciBps: pointer.To(uint16(10)), DestGasOverhead: pointer.To(uint32(100)), DestBytesOverhead: pointer.To(uint32(200)), AggregateRateLimitEnabled: pointer.To(true)},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Msg: "Zero token in update args",
+			Err: "zero address not allowed in TokenTransferFeeConfigArgs",
+			Config: v1_5_1.SetTokenTransferFeeConfig{
+				MCMS: mcmCfg,
+				InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
+					src: {
+						dst: {
+							TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
+								{Token: utils.ZeroAddress},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Msg: "Same address in updates and resets",
+			Err: "the same address cannot be referenced in both TokensToUseDefaultFeeConfigs and TokenTransferFeeConfigArgs",
+			Config: v1_5_1.SetTokenTransferFeeConfig{
+				MCMS: mcmCfg,
+				InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
+					src: {
+						dst: {
+							TokensToUseDefaultFeeConfigs: []common.Address{tokenB},
+							TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
+								{Token: tokenB, MinFeeUSDCents: pointer.To(uint32(1)), MaxFeeUSDCents: pointer.To(uint32(2)), DeciBps: pointer.To(uint16(10)), DestGasOverhead: pointer.To(uint32(100)), DestBytesOverhead: pointer.To(uint32(200)), AggregateRateLimitEnabled: pointer.To(true)},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Msg: "Enabling new token with missing fields (logic-time check)",
+			Err: "invalid args - when enabling a new token, all fields must be provided",
+			Config: v1_5_1.SetTokenTransferFeeConfig{
+				MCMS: mcmCfg,
+				InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
+					src: {
+						dst: {
+							TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
+								{Token: utils.RandomAddress(), MinFeeUSDCents: pointer.To(uint32(1))}, // others nil -> should error
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Run all tests
+	for _, tt := range tests {
+		t.Run(tt.Msg, func(t *testing.T) {
+			_, err := commonchangeset.Apply(t, e.Env,
+				commonchangeset.Configure(
+					v1_5_1.SetTokenTransferFeeConfigChangeset,
+					tt.Config,
+				),
+			)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.Err)
+		})
+	}
+}
+
+func TestSetTokenTransferFeeConfig_EmptyConfigIsGracefullyHandled(t *testing.T) {
+	// Spin up a memory env with minimal prerequisite deployment
+	e, _ := testhelpers.NewMemoryEnvironment(t,
+		testhelpers.WithNumOfChains(2),
+		testhelpers.WithPrerequisiteDeploymentOnly(&changeset.V1_5DeploymentConfig{
+			// NOTE: this property needs to be defined otherwise we will encounter an
+			// error. For now it's set to a value that was found in another test case
+			PriceRegStalenessThreshold: SetTokenTransferFeePriceRegStalenessThreshold,
+		}),
+	)
+
+	// Ensure the chains exist
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
+	require.Len(t, allChains, 2)
+	src := allChains[0]
+	dst := allChains[1]
+
+	// Take a snapshot of the current state
+	state, err := stateview.LoadOnchainState(e.Env, stateview.WithLoadLegacyContracts(true))
+	require.NoError(t, err)
+
+	// Wire up a bi-directional lane
+	e.Env = v1_5.AddLanes(t, e.Env, state, []testhelpers.SourceDestPair{
+		{SourceChainSelector: src, DestChainSelector: dst},
+		{SourceChainSelector: dst, DestChainSelector: src},
+	})
+
+	// Running the changeset with an empty config should exit early and do nothing
+	_, err = commonchangeset.Apply(t, e.Env,
+		commonchangeset.Configure(
+			v1_5_1.SetTokenTransferFeeConfigChangeset,
+			v1_5_1.SetTokenTransferFeeConfig{},
+		),
+	)
+	require.NoError(t, err)
+}
+
+func TestSetTokenTransferFeeConfig_Execution_WithoutMCMS(t *testing.T) {
+	// Spin up a memory env with minimal prerequisite deployment
+	e, _ := testhelpers.NewMemoryEnvironment(t,
+		testhelpers.WithNumOfChains(2),
+		testhelpers.WithPrerequisiteDeploymentOnly(&changeset.V1_5DeploymentConfig{
+			// NOTE: this property needs to be defined otherwise we will encounter an
+			// error. For now it's set to a value that was found in another test case
+			PriceRegStalenessThreshold: SetTokenTransferFeePriceRegStalenessThreshold,
+		}),
+	)
+
+	// Ensure the chains exist
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
+	require.Len(t, allChains, 2)
+	src := allChains[0]
+	dst := allChains[1]
+
+	// Take a snapshot of the current state
+	state, err := stateview.LoadOnchainState(e.Env, stateview.WithLoadLegacyContracts(true))
+	require.NoError(t, err)
+
+	// Wire up a bi-directional lane
+	e.Env = v1_5.AddLanes(t, e.Env, state, []testhelpers.SourceDestPair{
+		{SourceChainSelector: src, DestChainSelector: dst},
+		{SourceChainSelector: dst, DestChainSelector: src},
+	})
+
+	// Token under test (enable and verify)
+	tokenA := utils.RandomAddress()
+
+	// Run the changeset without MCMS
+	e.Env, err = commonchangeset.Apply(t, e.Env,
+		commonchangeset.Configure(
+			v1_5_1.SetTokenTransferFeeConfigChangeset,
+			v1_5_1.SetTokenTransferFeeConfig{
+				MCMS: nil, // direct execution
+				InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
+					src: {
+						dst: {
+							TokensToUseDefaultFeeConfigs: []common.Address{},
+							TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
+								{
+									Token:                     tokenA,
+									MinFeeUSDCents:            pointer.To(uint32(100)),
+									MaxFeeUSDCents:            pointer.To(uint32(5000)),
+									DeciBps:                   pointer.To(uint16(25)),
+									DestGasOverhead:           pointer.To(uint32(100_000)),
+									DestBytesOverhead:         pointer.To(uint32(1200)),
+									AggregateRateLimitEnabled: pointer.To(true),
+								},
+							},
+						},
+					},
+				},
+			},
+		),
+	)
+	require.NoError(t, err, "direct execution should succeed")
+
+	// Verify that the config was set
+	cfgA, err := ReadTokenTransferFeeConfig(t, e, src, dst, tokenA)
+	require.NoError(t, err)
+	require.True(t, cfgA.IsEnabled)
+	require.Equal(t, uint32(100), cfgA.MinFeeUSDCents)
+	require.Equal(t, uint32(5000), cfgA.MaxFeeUSDCents)
+	require.Equal(t, uint16(25), cfgA.DeciBps)
+	require.Equal(t, uint32(100_000), cfgA.DestGasOverhead)
+	require.Equal(t, uint32(1200), cfgA.DestBytesOverhead)
+	require.True(t, cfgA.AggregateRateLimitEnabled)
+}
+
+func TestSetTokenTransferFeeConfig_Execution_WithMCMS(t *testing.T) {
+	// Spin up a memory env with minimal prerequisite deployment
+	e, _ := testhelpers.NewMemoryEnvironment(t,
+		testhelpers.WithNumOfChains(2),
+		testhelpers.WithPrerequisiteDeploymentOnly(&changeset.V1_5DeploymentConfig{
+			// NOTE: this property needs to be defined otherwise we will encounter an
+			// error. For now it's set to a value that was found in another test case
+			PriceRegStalenessThreshold: SetTokenTransferFeePriceRegStalenessThreshold,
+		}),
+	)
+
+	// Ensure the chains exist
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
+	require.Len(t, allChains, 2)
+	src := allChains[0]
+	dst := allChains[1]
+
+	// Take a snapshot of the current state
+	state, err := stateview.LoadOnchainState(e.Env, stateview.WithLoadLegacyContracts(true))
+	require.NoError(t, err)
+
+	// Wire up a bi-directional lane
+	e.Env = v1_5.AddLanes(t, e.Env, state, []testhelpers.SourceDestPair{
+		{SourceChainSelector: src, DestChainSelector: dst},
+		{SourceChainSelector: dst, DestChainSelector: src},
+	})
+
+	// Define helper vars
+	mcmCfg := proposalutils.TimelockConfig{MinDelay: 0 * time.Second}
+	tokenA := utils.RandomAddress()
+	tokenB := utils.RandomAddress() // will be reset via MCMS
+
+	// Start by enabling tokenA directly so we have on-chain values to partially override via MCMS
+	e.Env, err = commonchangeset.Apply(t, e.Env, commonchangeset.Configure(
+		v1_5_1.SetTokenTransferFeeConfigChangeset,
+		v1_5_1.SetTokenTransferFeeConfig{
+			MCMS: nil,
+			InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
+				src: {
+					dst: {
+						TokensToUseDefaultFeeConfigs: []common.Address{},
+						TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
+							{
+								Token:                     tokenA,
+								MinFeeUSDCents:            pointer.To(uint32(100)),
+								MaxFeeUSDCents:            pointer.To(uint32(5000)),
+								DeciBps:                   pointer.To(uint16(25)),
+								DestGasOverhead:           pointer.To(uint32(100_000)),
+								DestBytesOverhead:         pointer.To(uint32(1200)),
+								AggregateRateLimitEnabled: pointer.To(true),
+							},
+						},
+					},
+				},
+			},
+		},
+	))
+	require.NoError(t, err)
+
+	// Take a fresh snapshot of the state and transfer the OnRamps to timelock
+	state, err = stateview.LoadOnchainState(e.Env, stateview.WithLoadLegacyContracts(true))
+	require.NoError(t, err)
+	e.Env, err = commonchangeset.Apply(t, e.Env,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelockV2),
+			commonchangeset.TransferToMCMSWithTimelockConfig{
+				ContractsByChain: map[uint64][]common.Address{
+					src: {state.MustGetEVMChainState(src).EVM2EVMOnRamp[dst].Address()},
+					dst: {state.MustGetEVMChainState(dst).EVM2EVMOnRamp[src].Address()},
+				},
+				MCMSConfig: mcmCfg,
+			},
+		),
+	)
+	require.NoError(t, err)
+
+	// Now mutate via MCMS (partial fields; others fallback to on-chain values)
+	e.Env, err = commonchangeset.Apply(t, e.Env, commonchangeset.Configure(
+		v1_5_1.SetTokenTransferFeeConfigChangeset,
+		v1_5_1.SetTokenTransferFeeConfig{
+			MCMS: &mcmCfg,
+			InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
+				src: {
+					dst: {
+						TokensToUseDefaultFeeConfigs: []common.Address{tokenB},
+						TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
+							{
+								Token:                     tokenA,
+								MinFeeUSDCents:            nil,                    // keep current
+								MaxFeeUSDCents:            nil,                    // keep current
+								DeciBps:                   pointer.To(uint16(30)), // change
+								DestGasOverhead:           nil,                    // keep current
+								DestBytesOverhead:         nil,                    // keep current
+								AggregateRateLimitEnabled: nil,                    // keep current
+							},
+						},
+					},
+				},
+			},
+		},
+	))
+	require.NoError(t, err, "MCMS execution should succeed")
+
+	// Verify tokenA was updated
+	cfgA, err := ReadTokenTransferFeeConfig(t, e, src, dst, tokenA)
+	require.NoError(t, err)
+	require.True(t, cfgA.IsEnabled)
+	require.Equal(t, uint16(30), cfgA.DeciBps)
+
+	// Verify tokenB was reset to default
+	cfgB, err := ReadTokenTransferFeeConfig(t, e, src, dst, tokenB)
+	require.NoError(t, err)
+	require.False(t, cfgB.IsEnabled, "tokenB should be using default fee config after reset")
+}
+
+func TestSetTokenTransferFeeConfig_MultipleChains(t *testing.T) {
+	// Spin up a memory env with minimal prerequisite deployment
+	e, _ := testhelpers.NewMemoryEnvironment(t,
+		testhelpers.WithNumOfChains(2),
+		testhelpers.WithPrerequisiteDeploymentOnly(&changeset.V1_5DeploymentConfig{
+			// NOTE: this property needs to be defined otherwise we will encounter an
+			// error. For now it's set to a value that was found in another test case
+			PriceRegStalenessThreshold: SetTokenTransferFeePriceRegStalenessThreshold,
+		}),
+	)
+
+	// Ensure the chains exist
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
+	require.Len(t, allChains, 2)
+	src := allChains[0]
+	dst := allChains[1]
+
+	// Take a snapshot of the current state
+	state, err := stateview.LoadOnchainState(e.Env, stateview.WithLoadLegacyContracts(true))
+	require.NoError(t, err)
+
+	// Wire up a bi-directional lane
+	e.Env = v1_5.AddLanes(t, e.Env, state, []testhelpers.SourceDestPair{
+		{SourceChainSelector: src, DestChainSelector: dst},
+		{SourceChainSelector: dst, DestChainSelector: src},
+	})
+
+	// For src->dst
+	tokenA := utils.RandomAddress() // enable with full config
+	tokenB := utils.RandomAddress() // include in resets (default/no-op)
+
+	// For dst->src
+	tokenC := utils.RandomAddress() // enable with full config
+	tokenD := utils.RandomAddress() // include in resets (default/no-op)
+
+	// Prepare a single config that touches both directions (multiple chains)
+	cfg := v1_5_1.SetTokenTransferFeeConfig{
+		MCMS: nil, // direct execution is fine; the point is fan-out to multiple chains
+		InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
+			src: {
+				dst: {
+					TokensToUseDefaultFeeConfigs: []common.Address{tokenB},
+					TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
+						{
+							Token:                     tokenA,
+							MinFeeUSDCents:            pointer.To(uint32(101)),
+							MaxFeeUSDCents:            pointer.To(uint32(5001)),
+							DeciBps:                   pointer.To(uint16(26)),
+							DestGasOverhead:           pointer.To(uint32(110_000)),
+							DestBytesOverhead:         pointer.To(uint32(1300)),
+							AggregateRateLimitEnabled: pointer.To(true),
+						},
+					},
+				},
+			},
+			dst: {
+				src: {
+					TokensToUseDefaultFeeConfigs: []common.Address{tokenD},
+					TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
+						{
+							Token:                     tokenC,
+							MinFeeUSDCents:            pointer.To(uint32(202)),
+							MaxFeeUSDCents:            pointer.To(uint32(6002)),
+							DeciBps:                   pointer.To(uint16(31)),
+							DestGasOverhead:           pointer.To(uint32(120_000)),
+							DestBytesOverhead:         pointer.To(uint32(1400)),
+							AggregateRateLimitEnabled: pointer.To(false),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Apply once; should fan out to both lanes/chains
+	e.Env, err = commonchangeset.Apply(t, e.Env, commonchangeset.Configure(v1_5_1.SetTokenTransferFeeConfigChangeset, cfg))
+	require.NoError(t, err, "multi-chain execution should succeed in a single apply")
+
+	// ---- Verify src -> dst lane; token config A should be set
+	cfgA1, err := ReadTokenTransferFeeConfig(t, e, src, dst, tokenA)
+	require.NoError(t, err)
+	require.True(t, cfgA1.IsEnabled)
+	require.Equal(t, uint32(101), cfgA1.MinFeeUSDCents)
+	require.Equal(t, uint32(5001), cfgA1.MaxFeeUSDCents)
+	require.Equal(t, uint16(26), cfgA1.DeciBps)
+	require.Equal(t, uint32(110_000), cfgA1.DestGasOverhead)
+	require.Equal(t, uint32(1300), cfgA1.DestBytesOverhead)
+	require.True(t, cfgA1.AggregateRateLimitEnabled)
+
+	// ---- Verify src -> dst lane; token config B should still be disabled (no-op)
+	cfgB, err := ReadTokenTransferFeeConfig(t, e, src, dst, tokenB)
+	require.NoError(t, err)
+	require.False(t, cfgB.IsEnabled, "tokenB should be using default fee config after reset")
+
+	// ---- Verify dst -> src lane; token config C should be set
+	cfgC1, err := ReadTokenTransferFeeConfig(t, e, dst, src, tokenC)
+	require.NoError(t, err)
+	require.True(t, cfgC1.IsEnabled)
+	require.Equal(t, uint32(202), cfgC1.MinFeeUSDCents)
+	require.Equal(t, uint32(6002), cfgC1.MaxFeeUSDCents)
+	require.Equal(t, uint16(31), cfgC1.DeciBps)
+	require.Equal(t, uint32(120_000), cfgC1.DestGasOverhead)
+	require.Equal(t, uint32(1400), cfgC1.DestBytesOverhead)
+	require.False(t, cfgC1.AggregateRateLimitEnabled)
+
+	// ---- Verify dst -> src lane; token config D should still be disabled (no-op)
+	cfgD, err := ReadTokenTransferFeeConfig(t, e, dst, src, tokenD)
+	require.NoError(t, err)
+	require.False(t, cfgD.IsEnabled, "tokenD should be using default fee config after reset")
+
+	// Idempotency-ish check: re-applying the exact same config should be a no-op but still succeed
+	_, err = commonchangeset.Apply(t, e.Env, commonchangeset.Configure(v1_5_1.SetTokenTransferFeeConfigChangeset, cfg))
+	require.NoError(t, err, "re-applying same config should be a no-op and succeed")
+
+	// Re-read to ensure nothing regressed
+	cfgA2, err := ReadTokenTransferFeeConfig(t, e, src, dst, tokenA)
+	require.NoError(t, err)
+	require.Equal(t, cfgA1, cfgA2)
+	cfgC2, err := ReadTokenTransferFeeConfig(t, e, dst, src, tokenC)
+	require.NoError(t, err)
+	require.Equal(t, cfgC1, cfgC2)
+}

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config_test.go
@@ -139,23 +139,6 @@ func TestSetTokenTransferFeeConfig_Validations(t *testing.T) {
 			},
 		},
 		{
-			Msg: "Duplicate token in update args",
-			Err: "duplicate token in TokenTransferFeeConfigArgs",
-			Config: v1_5_1.SetTokenTransferFeeConfig{
-				MCMS: mcmCfg,
-				InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
-					src: {
-						dst: {
-							TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
-								{Token: tokenA, MinFeeUSDCents: pointer.To(uint32(1)), MaxFeeUSDCents: pointer.To(uint32(2)), DeciBps: pointer.To(uint16(10)), DestGasOverhead: pointer.To(uint32(100)), DestBytesOverhead: pointer.To(uint32(200)), AggregateRateLimitEnabled: pointer.To(true)},
-								{Token: tokenA, MinFeeUSDCents: pointer.To(uint32(1)), MaxFeeUSDCents: pointer.To(uint32(2)), DeciBps: pointer.To(uint16(10)), DestGasOverhead: pointer.To(uint32(100)), DestBytesOverhead: pointer.To(uint32(200)), AggregateRateLimitEnabled: pointer.To(true)},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			Msg: "Zero token in update args",
 			Err: "zero address not allowed in TokenTransferFeeConfigArgs",
 			Config: v1_5_1.SetTokenTransferFeeConfig{
@@ -163,8 +146,8 @@ func TestSetTokenTransferFeeConfig_Validations(t *testing.T) {
 				InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
 					src: {
 						dst: {
-							TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
-								{Token: utils.ZeroAddress},
+							TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
+								utils.ZeroAddress: {},
 							},
 						},
 					},
@@ -180,8 +163,15 @@ func TestSetTokenTransferFeeConfig_Validations(t *testing.T) {
 					src: {
 						dst: {
 							TokensToUseDefaultFeeConfigs: []common.Address{tokenB},
-							TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
-								{Token: tokenB, MinFeeUSDCents: pointer.To(uint32(1)), MaxFeeUSDCents: pointer.To(uint32(2)), DeciBps: pointer.To(uint16(10)), DestGasOverhead: pointer.To(uint32(100)), DestBytesOverhead: pointer.To(uint32(200)), AggregateRateLimitEnabled: pointer.To(true)},
+							TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
+								tokenB: {
+									MinFeeUSDCents:            pointer.To(uint32(1)),
+									MaxFeeUSDCents:            pointer.To(uint32(2)),
+									DeciBps:                   pointer.To(uint16(10)),
+									DestGasOverhead:           pointer.To(uint32(100)),
+									DestBytesOverhead:         pointer.To(uint32(200)),
+									AggregateRateLimitEnabled: pointer.To(true),
+								},
 							},
 						},
 					},
@@ -196,8 +186,8 @@ func TestSetTokenTransferFeeConfig_Validations(t *testing.T) {
 				InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
 					src: {
 						dst: {
-							TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
-								{Token: utils.RandomAddress(), MinFeeUSDCents: pointer.To(uint32(1))}, // others nil -> should error
+							TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
+								utils.RandomAddress(): {MinFeeUSDCents: pointer.To(uint32(1))}, // others nil -> should error
 							},
 						},
 					},
@@ -298,9 +288,8 @@ func TestSetTokenTransferFeeConfig_Execution_WithoutMCMS(t *testing.T) {
 					src: {
 						dst: {
 							TokensToUseDefaultFeeConfigs: []common.Address{},
-							TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
-								{
-									Token:                     tokenA,
+							TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
+								tokenA: {
 									MinFeeUSDCents:            pointer.To(uint32(100)),
 									MaxFeeUSDCents:            pointer.To(uint32(5000)),
 									DeciBps:                   pointer.To(uint16(25)),
@@ -370,9 +359,8 @@ func TestSetTokenTransferFeeConfig_Execution_WithMCMS(t *testing.T) {
 				src: {
 					dst: {
 						TokensToUseDefaultFeeConfigs: []common.Address{},
-						TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
-							{
-								Token:                     tokenA,
+						TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
+							tokenA: {
 								MinFeeUSDCents:            pointer.To(uint32(100)),
 								MaxFeeUSDCents:            pointer.To(uint32(5000)),
 								DeciBps:                   pointer.To(uint16(25)),
@@ -414,9 +402,8 @@ func TestSetTokenTransferFeeConfig_Execution_WithMCMS(t *testing.T) {
 				src: {
 					dst: {
 						TokensToUseDefaultFeeConfigs: []common.Address{tokenB},
-						TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
-							{
-								Token:                     tokenA,
+						TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
+							tokenA: {
 								MinFeeUSDCents:            nil,                    // keep current
 								MaxFeeUSDCents:            nil,                    // keep current
 								DeciBps:                   pointer.To(uint16(30)), // change
@@ -486,9 +473,8 @@ func TestSetTokenTransferFeeConfig_MultipleChains(t *testing.T) {
 			src: {
 				dst: {
 					TokensToUseDefaultFeeConfigs: []common.Address{tokenB},
-					TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
-						{
-							Token:                     tokenA,
+					TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
+						tokenA: {
 							MinFeeUSDCents:            pointer.To(uint32(101)),
 							MaxFeeUSDCents:            pointer.To(uint32(5001)),
 							DeciBps:                   pointer.To(uint16(26)),
@@ -502,9 +488,8 @@ func TestSetTokenTransferFeeConfig_MultipleChains(t *testing.T) {
 			dst: {
 				src: {
 					TokensToUseDefaultFeeConfigs: []common.Address{tokenD},
-					TokenTransferFeeConfigArgs: []v1_5_1.TokenTransferFeeArgs{
-						{
-							Token:                     tokenC,
+					TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
+						tokenC: {
 							MinFeeUSDCents:            pointer.To(uint32(202)),
 							MaxFeeUSDCents:            pointer.To(uint32(6002)),
 							DeciBps:                   pointer.To(uint16(31)),

--- a/deployment/helpers/pointer/pointer.go
+++ b/deployment/helpers/pointer/pointer.go
@@ -1,5 +1,12 @@
 package pointer
 
+func Coalesce[T any](p *T, fallback T) T {
+	if p != nil {
+		return *p
+	}
+	return fallback
+}
+
 func To[T any](v T) *T {
 	return &v
 }


### PR DESCRIPTION
This PR adds a new changeset named `SetTokenTransferFeeConfigChangeset`, which allows you to set configurations such as DestGasOverhead for EVM v1.5 lanes

The changeset is intended to replace the current approach where we use RDD CCIP and/or Gauntlet to perform this op: https://github.com/smartcontractkit/reference-data-directory-ccip/pull/1656/files

If you'd like to view the underlying solidity function that this changeset invokes, then the code for EVM2EVMOnRamp can be found here: https://etherscan.io/address/0xb8a882f3B88bd52D1Ff56A873bfDB84b70431937#code

Here's an example usage of the changeset:

```go
commonchangeset.Apply(t, env,
	commonchangeset.Configure(
		v1_5_1.SetTokenTransferFeeConfigChangeset,
		v1_5_1.SetTokenTransferFeeConfig{
			MCMS: nil,
			InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
				src: {
					dst: {
						TokensToUseDefaultFeeConfigs: []common.Address{
							tokenB,
						},
						TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
							tokenA: {
								MinFeeUSDCents:            pointer.To(uint32(100)),
								MaxFeeUSDCents:            pointer.To(uint32(5000)),
								DeciBps:                   pointer.To(uint16(25)),
								DestGasOverhead:           pointer.To(uint32(100_000)),
								DestBytesOverhead:         pointer.To(uint32(1200)),
								AggregateRateLimitEnabled: pointer.To(true),
							},
						},
					},
				},
			},
		},
	),
)
```

In the example above, note the usage of pointers for the struct fields. **If a field is omitted or set to nil in the struct, then we will fallback to using any pre-existing values from the chain before sending the transaction.** Otherwise the user's input values are used. If a token has no pre-existing config values on-chain (i.e. isEnabled == false), then every field must be explicitly provided by the caller.