### PR TITLE
PRIV-207 Miscellaneous secrets fixes

### DIFF
--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -447,7 +447,8 @@ func (h *eventHandler) fetchOrganizationID(ctx context.Context, workflowOwner st
 }
 
 func (h *eventHandler) engineFactoryFn(ctx context.Context, workflowID string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte) (services.Service, error) {
-	moduleConfig := &host.ModuleConfig{Logger: h.lggr, Labeler: h.emitter}
+	lggr := h.lggr.Named("WorkflowEngine.Module").With("workflowID", workflowID, "workflowName", name, "workflowOwner", owner)
+	moduleConfig := &host.ModuleConfig{Logger: lggr, Labeler: h.emitter}
 
 	h.lggr.Debugf("Creating module for workflowID %s", workflowID)
 	module, err := host.NewModule(moduleConfig, binary, host.WithDeterminism())

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -123,17 +123,6 @@ func NewEngine(cfg *EngineConfig) (*Engine, error) {
 		beholderLogger.Errorw("WARNING: Debug mode is enabled, this is not suitable for production")
 	}
 
-	if cfg.SecretsFetcher == nil {
-		cfg.SecretsFetcher = NewSecretsFetcher(
-			metricsLabeler,
-			cfg.CapRegistry,
-			beholderLogger,
-			cfg.LocalLimiters.SecretsConcurrency,
-			cfg.WorkflowOwner,
-			cfg.WorkflowName.String(),
-			cfg.WorkflowEncryptionKey)
-	}
-
 	engine := &Engine{
 		cfg:                     cfg,
 		lggr:                    beholderLogger,
@@ -236,7 +225,7 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 		Request:         &sdkpb.ExecuteRequest_Subscribe{},
 		MaxResponseSize: uint64(moduleExecuteMaxResponseSizeBytes), //nolint:gosec // G115
 		Config:          e.cfg.WorkflowConfig,
-	}, NewDisallowedExecutionHelper(e.lggr, userLogChan, timeProvider, e.cfg.SecretsFetcher))
+	}, NewDisallowedExecutionHelper(e.lggr, userLogChan, timeProvider, e.secretsFetcher(e.cfg.WorkflowID)))
 	if err != nil {
 		return fmt.Errorf("failed to execute subscribe: %w", err)
 	}
@@ -474,7 +463,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		MaxResponseSize: uint64(moduleExecuteMaxResponseSizeBytes), //nolint:gosec // G115
 		Config:          e.cfg.WorkflowConfig,
 	}, &ExecutionHelper{Engine: e, WorkflowExecutionID: executionID, UserLogChan: userLogChan,
-		TimeProvider: timeProvider, SecretsFetcher: e.cfg.SecretsFetcher})
+		TimeProvider: timeProvider, SecretsFetcher: e.secretsFetcher(executionID)})
 
 	endTime := e.cfg.Clock.Now()
 	executionDuration := endTime.Sub(startTime)
@@ -534,6 +523,26 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String()).IncrementWorkflowExecutionSucceededCounter(ctx)
 	e.cfg.Hooks.OnResultReceived(result)
 	e.cfg.Hooks.OnExecutionFinished(executionID, executionStatus)
+}
+
+func (e *Engine) secretsFetcher(phaseID string) SecretsFetcher {
+	if e.cfg.SecretsFetcher != nil {
+		return e.cfg.SecretsFetcher
+	}
+
+	return NewSecretsFetcher(
+		e.metrics,
+		e.cfg.CapRegistry,
+		e.lggr,
+		e.cfg.LocalLimiters.SecretsConcurrency,
+		e.cfg.WorkflowOwner,
+		e.cfg.WorkflowName.String(),
+		e.cfg.WorkflowID,
+		// phaseID is the executionID if called during an execution,
+		// or the workflowID if called during trigger subscription
+		phaseID,
+		e.cfg.WorkflowEncryptionKey,
+	)
 }
 
 func (e *Engine) close() error {

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -1535,6 +1535,8 @@ func TestSecretsFetcher_Integration(t *testing.T) {
 		cfg.LocalLimiters.SecretsConcurrency,
 		cfg.WorkflowOwner,
 		cfg.WorkflowName.String(),
+		cfg.WorkflowID,
+		"",
 		cfg.WorkflowEncryptionKey,
 	)
 	cfg.SecretsFetcher = secretsFetcher

--- a/core/services/workflows/v2/secrets.go
+++ b/core/services/workflows/v2/secrets.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -37,6 +38,8 @@ type secretsFetcher struct {
 
 	workflowOwner         string
 	workflowName          string
+	workflowID            string
+	phaseID               string
 	workflowEncryptionKey workflowkey.Key
 
 	metrics *monitoring.WorkflowsMetricLabeler
@@ -49,6 +52,8 @@ func NewSecretsFetcher(
 	semaphore limits.ResourcePoolLimiter[int],
 	workflowOwner string,
 	workflowName string,
+	workflowID string,
+	phaseID string,
 	workflowEncryptionKey workflowkey.Key,
 ) *secretsFetcher {
 	return &secretsFetcher{
@@ -57,6 +62,7 @@ func NewSecretsFetcher(
 		semaphore:             semaphore,
 		workflowOwner:         workflowOwner,
 		workflowName:          workflowName,
+		phaseID:               phaseID,
 		workflowEncryptionKey: workflowEncryptionKey,
 		metrics:               metrics,
 	}
@@ -88,6 +94,14 @@ func (s *secretsFetcher) GetSecrets(ctx context.Context, request *sdkpb.GetSecre
 	).RecordGetSecretsDuration(ctx, time.Since(start).Milliseconds())
 
 	return resp, err
+}
+
+func sha(strs ...string) string {
+	h := sha256.New()
+	for _, s := range strs {
+		h.Write([]byte(s))
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func (s *secretsFetcher) getSecretsForBatch(ctx context.Context, request *sdkpb.GetSecretsRequest) ([]*sdkpb.SecretResponse, error) {
@@ -160,8 +174,11 @@ func (s *secretsFetcher) getSecretsForBatch(ctx context.Context, request *sdkpb.
 		Method:       vault.MethodGetSecrets,
 		CapabilityId: vault.CapabilityID,
 		Metadata: capabilities.RequestMetadata{
-			WorkflowOwner: s.workflowOwner,
-			WorkflowName:  s.workflowName,
+			WorkflowID:          s.workflowID,
+			WorkflowOwner:       s.workflowOwner,
+			WorkflowName:        s.workflowName,
+			WorkflowExecutionID: sha(s.phaseID, strconv.FormatInt(int64(request.CallbackId), 10)),
+			ReferenceID:         strconv.FormatInt(int64(request.CallbackId), 10),
 		},
 	})
 	if err != nil {

--- a/core/services/workflows/v2/secrets.go
+++ b/core/services/workflows/v2/secrets.go
@@ -56,9 +56,11 @@ func NewSecretsFetcher(
 	phaseID string,
 	workflowEncryptionKey workflowkey.Key,
 ) *secretsFetcher {
+	lggr = logger.Named(lggr, "WorkflowEngine.SecretsFetcher")
+	lggr = logger.With(lggr, "workflowID", workflowID, "workflowName", workflowName, "workflowOwner", workflowOwner, "phaseID", phaseID)
 	return &secretsFetcher{
 		capRegistry:           capRegistry,
-		lggr:                  logger.Named(lggr, "SecretsFetcher"),
+		lggr:                  lggr,
 		semaphore:             semaphore,
 		workflowOwner:         workflowOwner,
 		workflowName:          workflowName,
@@ -166,7 +168,7 @@ func (s *secretsFetcher) getSecretsForBatch(ctx context.Context, request *sdkpb.
 		return nil, fmt.Errorf("failed to convert vault request to any: %w", err)
 	}
 
-	lggr := logger.With(s.lggr, "requestedKeys", logKeys, "owner", s.workflowOwner, "workflow", s.workflowName)
+	lggr := logger.With(s.lggr, "requestedKeys", logKeys)
 	lggr.Debug("fetching secrets...")
 
 	capabilityResponse, err := vaultCap.Execute(ctx, capabilities.CapabilityRequest{

--- a/core/services/workflows/v2/secrets_test.go
+++ b/core/services/workflows/v2/secrets_test.go
@@ -169,6 +169,8 @@ func TestSecretsFetcher_BulkFetchesSecretsFromCapability(t *testing.T) {
 		limits.WorkflowResourcePoolLimiter[int](5),
 		"owner",
 		"workflowName",
+		"workflowID",
+		"workflowExecID",
 		workflowEncryptionKey,
 	)
 
@@ -223,6 +225,8 @@ func TestSecretsFetcher_ReturnsErrorIfCapabilityNoFound(t *testing.T) {
 		limits.WorkflowResourcePoolLimiter[int](5),
 		"owner",
 		"workflowName",
+		"workflowID",
+		"workflowExecID",
 		workflowkey.MustNewXXXTestingOnly(big.NewInt(1)),
 	)
 
@@ -263,6 +267,8 @@ func TestSecretsFetcher_ReturnsErrorIfCapabilityErrors(t *testing.T) {
 		limits.WorkflowResourcePoolLimiter[int](5),
 		"owner",
 		"workflowName",
+		"workflowID",
+		"workflowExecID",
 		workflowkey.MustNewXXXTestingOnly(big.NewInt(1)),
 	)
 
@@ -304,6 +310,8 @@ func TestSecretsFetcher_ReturnsErrorIfNoResponseForRequest(t *testing.T) {
 		limits.WorkflowResourcePoolLimiter[int](5),
 		"owner",
 		"workflowName",
+		"workflowID",
+		"workflowExecID",
 		workflowkey.MustNewXXXTestingOnly(big.NewInt(1)),
 	)
 	resp, err := sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
@@ -367,6 +375,8 @@ func TestSecretsFetcher_ReturnsErrorIfMissingEncryptionSharesForNode(t *testing.
 		limits.WorkflowResourcePoolLimiter[int](5),
 		"owner",
 		"workflowName",
+		"workflowID",
+		"workflowExecID",
 		workflowkey.MustNewXXXTestingOnly(big.NewInt(1)),
 	)
 
@@ -460,6 +470,8 @@ func TestSecretsFetcher_ReturnsErrorIfCantCombineShares(t *testing.T) {
 		limits.WorkflowResourcePoolLimiter[int](5),
 		"owner",
 		"workflowName",
+		"workflowID",
+		"workflowExecID",
 		workflowEncryptionKey,
 	)
 


### PR DESCRIPTION
* Pass through the ExecutionID and WorkflowID when making a request to the Vault DON. This is required by Don2don.
* Also add more logging to improve visibility of errors in the workflow engine.