### PR TITLE
quick fix for negative credits

### DIFF
--- a/core/services/workflows/metering/balance_store.go
+++ b/core/services/workflows/metering/balance_store.go
@@ -172,7 +172,12 @@ func (bs *balanceStore) Add(amount decimal.Decimal) error {
 	}
 
 	bs.balance = bs.balance.Add(amount)
-	bs.spent = bs.spent.Sub(amount)
+	// If subtracting would make spent negative, set it to zero instead
+	if amount.GreaterThan(bs.spent) {
+		bs.spent = decimal.Zero
+	} else {
+		bs.spent = bs.spent.Sub(amount)
+	}
 
 	return nil
 }
@@ -192,7 +197,12 @@ func (bs *balanceStore) AddAs(resourceType string, amount decimal.Decimal) error
 	}
 
 	bs.balance = bs.balance.Add(bal)
-	bs.spent = bs.spent.Sub(bal)
+	// If subtracting would make spent negative, set it to zero instead
+	if bal.GreaterThan(bs.spent) {
+		bs.spent = decimal.Zero
+	} else {
+		bs.spent = bs.spent.Sub(bal)
+	}
 
 	return nil
 }

--- a/core/services/workflows/metering/balance_store_test.go
+++ b/core/services/workflows/metering/balance_store_test.go
@@ -15,6 +15,7 @@ func TestBalanceStore(t *testing.T) {
 	two := decimal.NewFromInt(2)
 	five := decimal.NewFromInt(5)
 	seven := decimal.NewFromInt(7)
+	eight := decimal.NewFromInt(8)
 	nine := decimal.NewFromInt(9)
 	ten := decimal.NewFromInt(10)
 	eleven := decimal.NewFromInt(11)
@@ -108,5 +109,21 @@ func TestBalanceStore(t *testing.T) {
 		assert.True(t, balanceStore.Get().Equal(two))
 		require.NoError(t, balanceStore.MinusAs("resourceA", one))
 		assert.True(t, balanceStore.Get().Equal(decimal.NewFromFloat(1.8)), balanceStore.Get())
+	})
+
+	t.Run("spent credits never go negative", func(t *testing.T) {
+		t.Parallel()
+
+		// Start with 10 credits, spend 5, then add back 8 (more than was spent)
+		balanceStore, err := NewBalanceStore(ten, map[string]decimal.Decimal{"resourceA": decimal.NewFromInt(1)})
+		require.NoError(t, err)
+
+		// Spend 5 credits
+		require.NoError(t, balanceStore.Minus(five))
+		assert.True(t, balanceStore.GetSpent().Equal(five), "should have spent 5 credits")
+
+		// Add back 8 credits (more than was spent) - spent should not go negative
+		require.NoError(t, balanceStore.Add(eight))
+		assert.True(t, balanceStore.GetSpent().Equal(decimal.Zero), "spent should be 0, not negative")
 	})
 }

--- a/system-tests/tests/smoke/cre/cre_suite_test.go
+++ b/system-tests/tests/smoke/cre/cre_suite_test.go
@@ -106,6 +106,7 @@ func Test_CRE_V2_Suite(t *testing.T) {
 	})
 
 	t.Run("[v2] Vault DON - "+topology, func(t *testing.T) {
+		t.Skip("PRIV-233: Quarantined")
 		testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t), v2RegistriesFlags...)
 
 		ExecuteVaultTest(t, testEnv)


### PR DESCRIPTION
We observed negative credit spend reported to the billing service when 0 credits are delivered back in the reserve call. This is b/c for smartcon capabilities aren't held to the spend limits, and we should allow overdrafts within the engine. This is a quick fix to get the credits endpoint in the UI operational.