### PR TITLE
Fix DKG key import error to use 'ErrKeyExists' error

### DIFF
--- a/.changeset/soft-tips-go.md
+++ b/.changeset/soft-tips-go.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#fixed #bug update DKGRecipient keystore error to work correctly in shell_cmd.go for imports.

--- a/core/services/keystore/dkg_recipient.go
+++ b/core/services/keystore/dkg_recipient.go
@@ -114,7 +114,7 @@ func (ks *dkgRecipient) Import(ctx context.Context, keyJSON []byte, password str
 		return dkgrecipientkey.Key{}, errors.Wrap(err, "dkgRecipient#ImportKey failed to decrypt key")
 	}
 	if _, found := ks.keyRing.DKGRecipient[key.ID()]; found {
-		return dkgrecipientkey.Key{}, fmt.Errorf("key with ID %s already exists", key.ID())
+		return dkgrecipientkey.Key{}, fmt.Errorf("%w: key with ID %s already exists", ErrKeyExists, key.ID())
 	}
 	return key, ks.safeAddKey(ctx, key)
 }

--- a/core/services/keystore/dkgrecipient_test.go
+++ b/core/services/keystore/dkgrecipient_test.go
@@ -84,7 +84,8 @@ func Test_DKGRecipientKeyStore_E2E(t *testing.T) {
 
 			assert.Zero(t, k)
 			require.Error(t, err2)
-			assert.Equal(t, fmt.Sprintf("key with ID %s already exists", key.ID()), err2.Error())
+			assert.Equal(t, fmt.Sprintf("Key already exists: key with ID %s already exists", key.ID()), err2.Error())
+			assert.True(t, errors.Is(err2, keystore.ErrKeyExists))
 		})
 
 		t.Run("fails to import malformed key", func(t *testing.T) {


### PR DESCRIPTION
Fixes a bug in shell_cmd: https://github.com/smartcontractkit/chainlink/blob/develop/core/cmd/shell_local.go#L534C32-L534C44, where the error is not the expected type.