### PR TITLE
[Local CRE] allow reading of Docker settings store to fail

### DIFF
--- a/core/scripts/cre/environment/environment/setup.go
+++ b/core/scripts/cre/environment/environment/setup.go
@@ -706,6 +706,10 @@ func checkDockerConfiguration() error {
 		// Check settings
 		settings, err := os.ReadFile(configFile)
 		if err != nil {
+			if strings.Contains(err.Error(), "operation not permitted") {
+				logger.Warn().Msgf("  ! Could not check Docker settings due to restrictive TCC policies (can't read file). You need to manually verify the settings in the Docker Desktop UI.")
+				return nil
+			}
 			return fmt.Errorf("failed to read Docker settings: %w", err)
 		}
 


### PR DESCRIPTION
On some systems Apple's TCC is CRAZY and trying to read Docker settings file that has proper ownership and permissions is not possible unless an app is signed by Appel's developer key AND granted explicit access 🤯 

Trying to read it throws this nice error:
```
Operation not permitted: '~/Library/Group Containers/group.com.docker/settings-store.json'
```

Thus let's make that Docker settings check optional and allow the users to run the rest of the setup.