### PR TITLE
Priv 204 expose API for dkg recipient key

### DIFF
--- a/core/web/dkg_recipient_keys_controller.go
+++ b/core/web/dkg_recipient_keys_controller.go
@@ -1,0 +1,31 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
+)
+
+const (
+	dkgRecipientKeysControllerName = "dkgRecipientKey"
+)
+
+// WorkflowKeysController exposes the workflow key
+type DKGRecipientKeysController struct {
+	App chainlink.Application
+}
+
+// Index lists workflow keys
+// Example:
+// "GET <application>/keys/dkgrecipient"
+func (drkc *DKGRecipientKeysController) Index(c *gin.Context) {
+	keys, err := drkc.App.GetKeyStore().DKGRecipient().GetAll()
+	if err != nil {
+		jsonAPIError(c, http.StatusInternalServerError, err)
+		return
+	}
+	jsonAPIResponse(c, presenters.NewDKGRecipientKeyResources(keys), dkgRecipientKeysControllerName)
+}

--- a/core/web/dkg_recipient_keys_controller_test.go
+++ b/core/web/dkg_recipient_keys_controller_test.go
@@ -1,0 +1,50 @@
+package web_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/web"
+	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupDKGRecipientKeysControllerTests(t *testing.T) (cltest.HTTPClientCleaner, keystore.Master) {
+	t.Helper()
+	ctx := testutils.Context(t)
+
+	app := cltest.NewApplication(t)
+	require.NoError(t, app.Start(ctx))
+
+	client := app.NewHTTPClient(nil)
+	err := app.GetKeyStore().DKGRecipient().EnsureKey(ctx)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, app.Stop()) })
+	return client, app.GetKeyStore()
+}
+
+func TestDKGRecipientKeysController_Index_HappyPath(t *testing.T) {
+	client, keyStore := setupDKGRecipientKeysControllerTests(t)
+	keys, err := keyStore.DKGRecipient().GetAll()
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+
+	response, cleanup := client.Get("/v2/keys/dkgrecipient")
+	t.Cleanup(cleanup)
+	cltest.AssertServerResponse(t, response, http.StatusOK)
+
+	resources := []presenters.DKGRecipientKeyResource{}
+	err = web.ParseJSONAPIResponse(cltest.ParseResponseBody(t, response), &resources)
+	require.NoError(t, err)
+
+	require.Len(t, resources, len(keys))
+
+	assert.Equal(t, keys[0].ID(), resources[0].ID)
+	assert.Equal(t, keys[0].PublicKeyString(), resources[0].PublicKey)
+}

--- a/core/web/presenters/dkg_recipient_key.go
+++ b/core/web/presenters/dkg_recipient_key.go
@@ -1,0 +1,31 @@
+package presenters
+
+import (
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/dkgrecipientkey"
+)
+
+type DKGRecipientKeyResource struct {
+	JAID
+	PublicKey string `json:"publicKey"`
+}
+
+// GetName implements the api2go EntityNamer interface
+func (DKGRecipientKeyResource) GetName() string {
+	return "dkgRecipientKeys"
+}
+
+func NewDKGRecipientKeyResource(key dkgrecipientkey.Key) *DKGRecipientKeyResource {
+	return &DKGRecipientKeyResource{
+		JAID:      NewJAID(key.PublicKeyString()),
+		PublicKey: key.PublicKeyString(),
+	}
+}
+
+func NewDKGRecipientKeyResources(keys []dkgrecipientkey.Key) []DKGRecipientKeyResource {
+	rs := []DKGRecipientKeyResource{}
+	for _, key := range keys {
+		rs = append(rs, *NewDKGRecipientKeyResource(key))
+	}
+
+	return rs
+}

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -382,6 +382,9 @@ func v2Routes(app chainlink.Application, r *gin.RouterGroup) {
 		wfkc := WorkflowKeysController{app}
 		authv2.GET("/keys/workflow", wfkc.Index)
 
+		dkrkc := DKGRecipientKeysController{app}
+		authv2.GET("/keys/dkgrecipient", dkrkc.Index)
+
 		jc := JobsController{app}
 		authv2.GET("/jobs", paginatedRequest(jc.Index))
 		authv2.GET("/jobs/:ID", jc.Show)


### PR DESCRIPTION
* Add an API to the core node to expose the DKG Recipient key. Needed to be able to set up the Vault DON.