### PR TITLE
feat: add support for datastore on Validate() function for transfer ownership [DX-745]

### DIFF
--- a/deployment/common/changeset/state.go
+++ b/deployment/common/changeset/state.go
@@ -14,6 +14,7 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/common/view/v1_0"
@@ -289,4 +290,23 @@ func MaybeLoadStaticLinkTokenState(chain cldf_evm.Chain, addresses map[string]cl
 		}
 	}
 	return &state, nil
+}
+
+// SearchAddress searches for a contract address in both AddressBook and DataStore
+// Returns the address if found in either source
+func SearchAddress(e cldf.Environment, chainSelector uint64, address string) (bool, error) {
+	// Use the merged address loading from the EVM state function
+	addressesChain, err := state.AddressesForChain(e, chainSelector, "")
+	if err != nil {
+		return false, fmt.Errorf("failed to load addresses: %w", err)
+	}
+
+	// Search through merged addresses for the contract type
+	for addr := range addressesChain {
+		if addr == address {
+			return true, nil
+		}
+	}
+
+	return false, fmt.Errorf("%s not found", address)
 }

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock.go
@@ -10,13 +10,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	owner_helpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc677"
 	mcmslib "github.com/smartcontractkit/mcms"
 	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc677"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/evm/mcms/seqs"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
@@ -79,11 +80,10 @@ func searchAddressesInBothSources(e cldf.Environment, chainSelector uint64, addr
 	}
 
 	// Search through merged addresses for the contract type
-	for addr, _ := range addressesChain {
+	for addr := range addressesChain {
 		if addr == address {
 			return true, nil
 		}
-
 	}
 
 	return false, fmt.Errorf("%s not found", address)
@@ -230,7 +230,7 @@ func TransferToDeployer(e cldf.Environment, cfg TransferToDeployerConfig) (cldf.
 		},
 	}
 	var salt [32]byte
-	binary.BigEndian.PutUint32(salt[:], uint32(time.Now().Unix()))
+	binary.BigEndian.PutUint32(salt[:], uint32(time.Now().Unix())) //nolint:gosec // this is a salt, so any value is fine
 	tx, err = tls.Timelock.ScheduleBatch(evmChains[cfg.ChainSel].DeployerKey, calls, [32]byte{}, salt, big.NewInt(0))
 	if _, err = cldf.ConfirmIfNoErrorWithABI(evmChains[cfg.ChainSel], tx, owner_helpers.RBACTimelockABI, err); err != nil {
 		return cldf.ChangesetOutput{}, err

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock.go
@@ -70,32 +70,13 @@ func searchContractInBothSources(e cldf.Environment, chainSelector uint64, contr
 	return "", fmt.Errorf("%s not found", contractType)
 }
 
-// searchAddressesInBothSources searches for a contract address in both AddressBook and DataStore
-// Returns the address if found in either source
-func searchAddressesInBothSources(e cldf.Environment, chainSelector uint64, address string) (bool, error) {
-	// Use the merged address loading from the EVM state function
-	addressesChain, err := state.AddressesForChain(e, chainSelector, "")
-	if err != nil {
-		return false, fmt.Errorf("failed to load addresses: %w", err)
-	}
-
-	// Search through merged addresses for the contract type
-	for addr := range addressesChain {
-		if addr == address {
-			return true, nil
-		}
-	}
-
-	return false, fmt.Errorf("%s not found", address)
-}
-
 func (t TransferToMCMSWithTimelockConfig) Validate(e cldf.Environment) error {
 	evmChains := e.BlockChains.EVMChains()
 	for chainSelector, contracts := range t.ContractsByChain {
 		for _, contract := range contracts {
 			// Cannot transfer an unknown address.
 			// Note this also assures non-zero addresses.
-			if exists, err := searchAddressesInBothSources(e, chainSelector, contract.String()); err != nil || !exists {
+			if exists, err := SearchAddress(e, chainSelector, contract.String()); err != nil || !exists {
 				if err != nil {
 					return fmt.Errorf("failed to check address book: %w", err)
 				}

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock.go
@@ -10,14 +10,13 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	owner_helpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc677"
 	mcmslib "github.com/smartcontractkit/mcms"
 	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
-
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc677"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/evm/mcms/seqs"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
@@ -70,18 +69,39 @@ func searchContractInBothSources(e cldf.Environment, chainSelector uint64, contr
 	return "", fmt.Errorf("%s not found", contractType)
 }
 
+// searchAddressesInBothSources searches for a contract address in both AddressBook and DataStore
+// Returns the address if found in either source
+func searchAddressesInBothSources(e cldf.Environment, chainSelector uint64, address string) (bool, error) {
+	// Use the merged address loading from the EVM state function
+	addressesChain, err := state.AddressesForChain(e, chainSelector, "")
+	if err != nil {
+		return false, fmt.Errorf("failed to load addresses: %w", err)
+	}
+
+	// Search through merged addresses for the contract type
+	for addr, _ := range addressesChain {
+		if addr == address {
+			return true, nil
+		}
+
+	}
+
+	return false, fmt.Errorf("%s not found", address)
+}
+
 func (t TransferToMCMSWithTimelockConfig) Validate(e cldf.Environment) error {
 	evmChains := e.BlockChains.EVMChains()
 	for chainSelector, contracts := range t.ContractsByChain {
 		for _, contract := range contracts {
 			// Cannot transfer an unknown address.
 			// Note this also assures non-zero addresses.
-			if exists, err := cldf.AddressBookContains(e.ExistingAddresses, chainSelector, contract.String()); err != nil || !exists {
+			if exists, err := searchAddressesInBothSources(e, chainSelector, contract.String()); err != nil || !exists {
 				if err != nil {
 					return fmt.Errorf("failed to check address book: %w", err)
 				}
-				return fmt.Errorf("contract %s not found in address book", contract)
+				return fmt.Errorf("contract %s not found in address book or datstore", contract)
 			}
+
 			owner, _, err := LoadOwnableContract(contract, evmChains[chainSelector].Client)
 			if err != nil {
 				return fmt.Errorf("failed to load ownable: %w", err)

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
@@ -143,10 +144,6 @@ func TestTransferToMCMSWithTimelockV2DataStore(t *testing.T) {
 	newEnv.DataStore = ds.Seal()
 	// Re create runtime with new environment
 	rt = runtime.NewFromEnvironment(newEnv)
-
-	// re-load the addresses to ensure AddressBook is missing the LinkToken
-	addrs, err = rt.State().AddressBook.AddressesForChain(selector)
-	require.NoError(t, err)
 
 	err = rt.Exec(
 		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.TransferToMCMSWithTimelockV2), changeset.TransferToMCMSWithTimelockConfig{

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
@@ -5,9 +5,11 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
@@ -16,7 +18,9 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	state2 "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 )
@@ -81,6 +85,104 @@ func TestTransferToMCMSWithTimelockV2(t *testing.T) {
 	require.NoError(t, err)
 
 	o, err = link.LinkToken.Owner(nil)
+	require.NoError(t, err)
+	require.Equal(t, chain.DeployerKey.From, o)
+}
+
+func TestTransferToMCMSWithTimelockV2DataStore(t *testing.T) {
+	selector := chain_selectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
+
+	chain := rt.Environment().BlockChains.EVMChains()[selector]
+
+	// Setup contracts
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployLinkToken), []uint64{selector}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2), map[uint64]types.MCMSWithTimelockConfigV2{
+			selector: proposalutils.SingleGroupTimelockConfigV2(t),
+		}),
+	)
+	require.NoError(t, err)
+
+	addrs, err := rt.State().AddressBook.AddressesForChain(selector)
+	require.NoError(t, err)
+
+	state, err := changeset.MaybeLoadMCMSWithTimelockChainState(chain, addrs)
+	require.NoError(t, err)
+
+	link, err := changeset.MaybeLoadLinkTokenChainState(chain, addrs)
+	require.NoError(t, err)
+
+	// Remove LinkToken from AddressBook to simulate datastore only having the contract address
+	// TODO: migrate DeployLinkToken to use datastore only
+	linkAb := cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{
+		selector: {
+			link.LinkToken.Address().String(): cldf.NewTypeAndVersion(types.LinkToken, deployment.Version1_0_0),
+		},
+	})
+	err = rt.State().AddressBook.Remove(linkAb)
+	require.NoError(t, err)
+
+	// Add link token address to the datastore only
+	ds := datastore.NewMemoryDataStore()
+	typeAndVersion := cldf.NewTypeAndVersion(types.LinkToken, deployment.Version1_0_0)
+
+	err = ds.Addresses().Add(datastore.AddressRef{
+		Address:       link.LinkToken.Address().String(),
+		Type:          datastore.ContractType(typeAndVersion.Type.String()),
+		ChainSelector: selector,
+		Version:       semver.MustParse(typeAndVersion.Version.String()),
+	})
+	require.NoError(t, err)
+	err = ds.Merge(rt.State().DataStore)
+	rt.State().DataStore = ds.Seal()
+	newEnv := rt.Environment()
+	newEnv.DataStore = ds.Seal()
+	// Re create runtime with new environment
+	rt = runtime.NewFromEnvironment(newEnv)
+
+	// re-load the addresses to ensure AddressBook is missing the LinkToken
+	addrs, err = rt.State().AddressBook.AddressesForChain(selector)
+	require.NoError(t, err)
+
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.TransferToMCMSWithTimelockV2), changeset.TransferToMCMSWithTimelockConfig{
+			ContractsByChain: map[uint64][]common.Address{
+				selector: {link.LinkToken.Address()},
+			},
+			MCMSConfig: proposalutils.TimelockConfig{
+				MinDelay: 0,
+			},
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
+	require.NoError(t, err)
+	require.Len(t, rt.State().Proposals, 1)
+	require.True(t, rt.State().Proposals[0].IsExecuted)
+
+	// We expect now that the link token is owned by the MCMS timelock.
+	addrsDatastore, err := state2.LoadAddressesFromDataStore(rt.State().DataStore, selector, "")
+	require.NoError(t, err)
+	linkState, err := state2.MaybeLoadLinkTokenChainState(chain, addrsDatastore)
+	require.NoError(t, err)
+
+	o, err := linkState.LinkToken.Owner(nil)
+	require.NoError(t, err)
+	require.Equal(t, state.Timelock.Address(), o)
+
+	// Try a rollback to the deployer.
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.TransferToDeployer), changeset.TransferToDeployerConfig{
+			ContractAddress: link.LinkToken.Address(),
+			ChainSel:        selector,
+		}),
+	)
+	require.NoError(t, err)
+
+	o, err = linkState.LinkToken.Owner(nil)
 	require.NoError(t, err)
 	require.Equal(t, chain.DeployerKey.From, o)
 }

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
@@ -139,6 +139,7 @@ func TestTransferToMCMSWithTimelockV2DataStore(t *testing.T) {
 	})
 	require.NoError(t, err)
 	err = ds.Merge(rt.State().DataStore)
+	require.NoError(t, err)
 	rt.State().DataStore = ds.Seal()
 	newEnv := rt.Environment()
 	newEnv.DataStore = ds.Seal()


### PR DESCRIPTION
The transfer ownership changeset was migrated to use datastore on the changeset application, but we missed adding support to query the datastore during the changeset validation. This PR adds support for the datastore during validation and creates a test case for when the address to transfer is only available from the datastore.

## AI Summary
This pull request improves the contract address validation logic in the `TransferToMCMSWithTimelockV2` changeset and adds comprehensive test coverage for scenarios where contract addresses are stored only in the datastore (and not in the address book). The main changes include refactoring the address lookup logic to search both sources and introducing a new test to verify correct behavior when using the datastore.

**Address lookup and validation improvements:**

* Added a new helper function `searchAddressesInBothSources` in `transfer_to_mcms_with_timelock.go` to check for contract addresses in both the AddressBook and the DataStore, ensuring more robust validation.
* Updated the validation logic in `TransferToMCMSWithTimelockConfig.Validate` to use the new helper function, so contracts can be found in either source. Improved error messages to specify both address book and datastore.

**Test coverage enhancements:**

* Added `TestTransferToMCMSWithTimelockV2DataStore` in `transfer_to_mcms_with_timelock_test.go` to verify that contract transfers work correctly when the contract address is present only in the datastore, including ownership transfer and rollback scenarios.

**Dependency and import updates:**

* Updated imports in both implementation and test files to include new dependencies for datastore and state management, supporting the new validation logic and test scenarios. [[1]](diffhunk://#diff-5a2cf263ef459cb2a137d5f746043a28acb638059c1c2af5ba499ab8d2af7eb3R13-L21) [[2]](diffhunk://#diff-23ec71fcc2a48f01583a9da933e85bb52990075eafef08a382965bf06b80dcd1R8-R12) [[3]](diffhunk://#diff-23ec71fcc2a48f01583a9da933e85bb52990075eafef08a382965bf06b80dcd1R21-R23)