### PR TITLE
[PRIV-209] Fix inconsistent writes

### DIFF
--- a/core/services/ocr2/plugins/vault/kvstore.go
+++ b/core/services/ocr2/plugins/vault/kvstore.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
@@ -30,27 +31,34 @@ type WriteKVStore interface {
 	ReadKVStore
 	WriteSecret(id *vault.SecretIdentifier, secret *vault.StoredSecret) error
 	WriteMetadata(owner string, metadata *vault.StoredMetadata) error
-	AddIDToMetadata(id *vault.SecretIdentifier) error
-	RemoveIDFromMetadata(id *vault.SecretIdentifier) error
 	DeleteSecret(id *vault.SecretIdentifier) error
 }
 
-func NewReadStore(reader ocr3_1types.KeyValueReader) ReadKVStore {
+func NewReadStore(reader ocr3_1types.KeyValueReader) *KVStore {
 	return &KVStore{reader: reader}
 }
 
-func NewWriteStore(writer ocr3_1types.KeyValueReadWriter) WriteKVStore {
+func NewWriteStore(writer ocr3_1types.KeyValueReadWriter) *KVStore {
 	return &KVStore{reader: writer, writer: writer}
 }
 
 func (s *KVStore) GetSecret(id *vault.SecretIdentifier) (*vault.StoredSecret, error) {
+	found, err := s.metadataContainsID(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if metadata contains id: %w", err)
+	}
+
+	if !found {
+		return nil, nil
+	}
+
 	b, err := s.reader.Read([]byte(keyPrefix + vaulttypes.KeyFor(id)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read secret: %w", err)
 	}
 
 	if b == nil {
-		return nil, nil
+		return nil, errors.New("invariant violation: metadata contains id but secret not found")
 	}
 
 	secret := &vault.StoredSecret{}
@@ -106,7 +114,26 @@ func (s *KVStore) WriteMetadata(owner string, metadata *vault.StoredMetadata) er
 	return nil
 }
 
-func (s *KVStore) AddIDToMetadata(id *vault.SecretIdentifier) error {
+func (s *KVStore) metadataContainsID(id *vault.SecretIdentifier) (bool, error) {
+	md, err := s.GetMetadata(id.Owner)
+	if err != nil {
+		return false, fmt.Errorf("failed to get metadata for owner %s: %w", id.Owner, err)
+	}
+
+	if md == nil {
+		return false, nil
+	}
+
+	for _, i := range md.SecretIdentifiers {
+		if vaulttypes.KeyFor(id) == vaulttypes.KeyFor(i) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (s *KVStore) addIDToMetadata(id *vault.SecretIdentifier) error {
 	md, err := s.GetMetadata(id.Owner)
 	if err != nil {
 		return fmt.Errorf("failed to get metadata for owner %s: %w", id.Owner, err)
@@ -117,6 +144,13 @@ func (s *KVStore) AddIDToMetadata(id *vault.SecretIdentifier) error {
 			SecretIdentifiers: []*vault.SecretIdentifier{id},
 		}
 	} else {
+		for _, i := range md.SecretIdentifiers {
+			if vaulttypes.KeyFor(id) == vaulttypes.KeyFor(i) {
+				// Nothing to do, early exit.
+				return nil
+			}
+		}
+
 		md.SecretIdentifiers = append(md.SecretIdentifiers, id)
 	}
 
@@ -128,7 +162,7 @@ func (s *KVStore) AddIDToMetadata(id *vault.SecretIdentifier) error {
 	return nil
 }
 
-func (s *KVStore) RemoveIDFromMetadata(id *vault.SecretIdentifier) error {
+func (s *KVStore) removeIDFromMetadata(id *vault.SecretIdentifier) error {
 	md, err := s.GetMetadata(id.Owner)
 	if err != nil {
 		return fmt.Errorf("failed to get metadata for owner %s: %w", id.Owner, err)
@@ -174,7 +208,7 @@ func (s *KVStore) WriteSecret(id *vault.SecretIdentifier, secret *vault.StoredSe
 		return fmt.Errorf("failed to write secret: %w", err)
 	}
 
-	if err := s.AddIDToMetadata(id); err != nil {
+	if err := s.addIDToMetadata(id); err != nil {
 		return fmt.Errorf("failed to add id to metadata: %w", err)
 	}
 
@@ -182,14 +216,14 @@ func (s *KVStore) WriteSecret(id *vault.SecretIdentifier, secret *vault.StoredSe
 }
 
 func (s *KVStore) DeleteSecret(id *vault.SecretIdentifier) error {
-	err := s.writer.Delete([]byte(keyPrefix + vaulttypes.KeyFor(id)))
-	if err != nil {
-		return fmt.Errorf("failed to delete secret: %w", err)
-	}
-
-	err = s.RemoveIDFromMetadata(id)
+	err := s.removeIDFromMetadata(id)
 	if err != nil {
 		return fmt.Errorf("failed to remove id from metadata: %w", err)
+	}
+
+	err = s.writer.Delete([]byte(keyPrefix + vaulttypes.KeyFor(id)))
+	if err != nil {
+		return fmt.Errorf("failed to delete secret: %w", err)
 	}
 
 	return nil

--- a/core/services/ocr2/plugins/vault/plugin_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_test.go
@@ -2672,14 +2672,21 @@ func TestPlugin_StateTransition_UpdateSecretsRequest_WritesSecrets(t *testing.T)
 		Namespace: "main",
 		Key:       "secret",
 	}
-	d, err := proto.Marshal(&vaultcommon.StoredSecret{
+	secret, err := proto.Marshal(&vaultcommon.StoredSecret{
 		EncryptedSecret: []byte("old-encrypted-value"),
+	})
+	require.NoError(t, err)
+	metadata, err := proto.Marshal(&vaultcommon.StoredMetadata{
+		SecretIdentifiers: []*vaultcommon.SecretIdentifier{id},
 	})
 	require.NoError(t, err)
 	kv := &kv{
 		m: map[string]response{
 			keyPrefix + vaulttypes.KeyFor(id): {
-				data: d,
+				data: secret,
+			},
+			metadataPrefix + "owner": {
+				data: metadata,
 			},
 		},
 	}
@@ -2740,6 +2747,7 @@ func TestPlugin_StateTransition_UpdateSecretsRequest_WritesSecrets(t *testing.T)
 
 	ss, err := rs.GetSecret(id)
 	require.NoError(t, err)
+	require.NotNil(t, ss)
 
 	assert.Equal(t, ss.EncryptedSecret, []byte("encrypted-value"))
 


### PR DESCRIPTION
* The previous implementation assumed incorrectly that a failed write to the KV store would abort the state transition transaction. The order of writes to the KV store therefore didn't matter (i.e. whether we wrote the item or the metadata first).
* During testing we uncovered a bug where the write to the metadata failed, but the write to the item succeeded. This left the KV store in an inconsistent state and would prevent users from being able to update the item. At the same time, they would not be able to see the item when listing the secret.
* To address this, we treat the metadata record as the source of truth -- writing to it last when updating the record, and deleting it first. Additionally, we always check whether the item exists in the metadata before reading it.