### PR TITLE
order workflow metadata chronologically

### DIFF
--- a/core/services/gateway/common/aggregation/workflow_metadata_aggregator.go
+++ b/core/services/gateway/common/aggregation/workflow_metadata_aggregator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -127,8 +128,9 @@ func (agg *WorkflowMetadataAggregator) Collect(obs *gateway_common.WorkflowMetad
 	_, ok = agg.observations[digest]
 	if !ok {
 		agg.observations[digest] = &NodeObservations{
-			observation: obs,
-			nodes:       make(StringSet),
+			observation:     obs,
+			nodes:           make(StringSet),
+			firstObservedAt: time.Now(),
 		}
 	}
 	agg.observations[digest].nodes.Add(nodeAddress)
@@ -136,20 +138,43 @@ func (agg *WorkflowMetadataAggregator) Collect(obs *gateway_common.WorkflowMetad
 }
 
 // Aggregate returns the aggregated workflow metadata for workflows that have reached the threshold.
+// Results are sorted chronologically by first observation time (newest first, oldest last).
 func (agg *WorkflowMetadataAggregator) Aggregate() ([]gateway_common.WorkflowMetadata, error) {
 	agg.mu.RLock()
 	defer agg.mu.RUnlock()
 
-	var aggregated []gateway_common.WorkflowMetadata
+	type aggregatedObs struct {
+		metadata        gateway_common.WorkflowMetadata
+		firstObservedAt time.Time
+	}
+
+	var toSort []aggregatedObs
 	for _, nodeObs := range agg.observations {
 		if len(nodeObs.nodes) >= agg.threshold {
-			aggregated = append(aggregated, *nodeObs.observation)
+			toSort = append(toSort, aggregatedObs{
+				metadata:        *nodeObs.observation,
+				firstObservedAt: nodeObs.firstObservedAt,
+			})
 		}
 	}
+
+	// Sort chronologically (newest first) so that workflows that were registered most recently
+	// takes precedence
+	sort.Slice(toSort, func(i, j int) bool {
+		return toSort[i].firstObservedAt.After(toSort[j].firstObservedAt)
+	})
+
+	// Extract just the metadata
+	aggregated := make([]gateway_common.WorkflowMetadata, len(toSort))
+	for i, obs := range toSort {
+		aggregated[i] = obs.metadata
+	}
+
 	return aggregated, nil
 }
 
 type NodeObservations struct {
-	observation *gateway_common.WorkflowMetadata
-	nodes       StringSet
+	observation     *gateway_common.WorkflowMetadata
+	nodes           StringSet
+	firstObservedAt time.Time
 }

--- a/core/services/gateway/common/aggregation/workflow_metadata_aggregator.go
+++ b/core/services/gateway/common/aggregation/workflow_metadata_aggregator.go
@@ -28,6 +28,8 @@ type WorkflowMetadataAggregator struct {
 	observedAt      map[string]map[string]time.Time
 	cleanupInterval time.Duration
 	metrics         *metrics.Metrics
+	// sequenceCounter is incremented for each new observation to establish ordering
+	sequenceCounter uint64
 }
 
 func NewWorkflowMetadataAggregator(lggr logger.Logger, threshold int, cleanupInterval time.Duration, metrics *metrics.Metrics) *WorkflowMetadataAggregator {
@@ -127,10 +129,11 @@ func (agg *WorkflowMetadataAggregator) Collect(obs *gateway_common.WorkflowMetad
 
 	_, ok = agg.observations[digest]
 	if !ok {
+		agg.sequenceCounter++
 		agg.observations[digest] = &NodeObservations{
-			observation:     obs,
-			nodes:           make(StringSet),
-			firstObservedAt: time.Now(),
+			observation: obs,
+			nodes:       make(StringSet),
+			sequence:    agg.sequenceCounter,
 		}
 	}
 	agg.observations[digest].nodes.Add(nodeAddress)
@@ -138,22 +141,22 @@ func (agg *WorkflowMetadataAggregator) Collect(obs *gateway_common.WorkflowMetad
 }
 
 // Aggregate returns the aggregated workflow metadata for workflows that have reached the threshold.
-// Results are sorted chronologically by first observation time (newest first, oldest last).
+// Results are sorted chronologically by sequence number (newest first, oldest last).
 func (agg *WorkflowMetadataAggregator) Aggregate() ([]gateway_common.WorkflowMetadata, error) {
 	agg.mu.RLock()
 	defer agg.mu.RUnlock()
 
 	type aggregatedObs struct {
-		metadata        gateway_common.WorkflowMetadata
-		firstObservedAt time.Time
+		metadata gateway_common.WorkflowMetadata
+		sequence uint64
 	}
 
 	var toSort []aggregatedObs
 	for _, nodeObs := range agg.observations {
 		if len(nodeObs.nodes) >= agg.threshold {
 			toSort = append(toSort, aggregatedObs{
-				metadata:        *nodeObs.observation,
-				firstObservedAt: nodeObs.firstObservedAt,
+				metadata: *nodeObs.observation,
+				sequence: nodeObs.sequence,
 			})
 		}
 	}
@@ -161,7 +164,7 @@ func (agg *WorkflowMetadataAggregator) Aggregate() ([]gateway_common.WorkflowMet
 	// Sort chronologically (newest first) so that workflows that were registered most recently
 	// takes precedence
 	sort.Slice(toSort, func(i, j int) bool {
-		return toSort[i].firstObservedAt.After(toSort[j].firstObservedAt)
+		return toSort[i].sequence > toSort[j].sequence
 	})
 
 	// Extract just the metadata
@@ -174,7 +177,7 @@ func (agg *WorkflowMetadataAggregator) Aggregate() ([]gateway_common.WorkflowMet
 }
 
 type NodeObservations struct {
-	observation     *gateway_common.WorkflowMetadata
-	nodes           StringSet
-	firstObservedAt time.Time
+	observation *gateway_common.WorkflowMetadata
+	nodes       StringSet
+	sequence    uint64 // sequence number for ordering (higher = newer)
 }


### PR DESCRIPTION
- ensure workflow metadata are returned in chronological order, with the most recently observed workflows appearing first. This improves customer experience when workflow is updated with same name/tag combination
