### PR TITLE
Make cap reg config items optional

### DIFF
--- a/deployment/cre/capabilities_registry/v2/changeset/operations/contracts/register_capabilities.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/operations/contracts/register_capabilities.go
@@ -43,6 +43,13 @@ var RegisterCapabilities = operations.NewOperation[RegisterCapabilitiesInput, Re
 	semver.MustParse("1.0.0"),
 	"Register Capabilities in Capabilities Registry",
 	func(b operations.Bundle, deps RegisterCapabilitiesDeps, input RegisterCapabilitiesInput) (RegisterCapabilitiesOutput, error) {
+		if len(input.Capabilities) == 0 {
+			b.Logger.Info("No capabilities to register, skipping")
+			return RegisterCapabilitiesOutput{
+				Capabilities: []*capabilities_registry_v2.CapabilitiesRegistryCapabilityConfigured{},
+			}, nil
+		}
+
 		chain, ok := deps.Env.BlockChains.EVMChains()[input.ChainSelector]
 		if !ok {
 			return RegisterCapabilitiesOutput{}, fmt.Errorf("chain not found for selector %d", input.ChainSelector)

--- a/deployment/cre/capabilities_registry/v2/changeset/operations/contracts/register_dons.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/operations/contracts/register_dons.go
@@ -42,6 +42,14 @@ var RegisterDons = operations.NewOperation[RegisterDonsInput, RegisterDonsOutput
 	semver.MustParse("1.0.0"),
 	"Register DONs in Capabilities Registry",
 	func(b operations.Bundle, deps RegisterDonsDeps, input RegisterDonsInput) (RegisterDonsOutput, error) {
+		if len(input.DONs) == 0 {
+			b.Logger.Info("No DONs to register, skipping")
+			// The contract allows to pass an empty array of nodes.
+			return RegisterDonsOutput{
+				DONs: []capabilities_registry_v2.CapabilitiesRegistryDONInfo{},
+			}, nil
+		}
+
 		// Get the target chain
 		chain, ok := deps.Env.BlockChains.EVMChains()[input.ChainSelector]
 		if !ok {

--- a/deployment/cre/capabilities_registry/v2/changeset/operations/contracts/register_node.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/operations/contracts/register_node.go
@@ -47,6 +47,7 @@ var RegisterNodes = operations.NewOperation[RegisterNodesInput, RegisterNodesOut
 			return RegisterNodesOutput{}, errors.New("address is not set")
 		}
 		if len(input.Nodes) == 0 {
+			b.Logger.Info("No nodes to register, skipping")
 			// The contract allows to pass an empty array of nodes.
 			return RegisterNodesOutput{
 				Nodes: []*capabilities_registry_v2.CapabilitiesRegistryNodeAdded{},

--- a/deployment/cre/capabilities_registry/v2/changeset/operations/contracts/register_nops.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/operations/contracts/register_nops.go
@@ -41,6 +41,12 @@ var RegisterNops = operations.NewOperation[RegisterNopsInput, RegisterNopsOutput
 	semver.MustParse("1.0.0"),
 	"Register Node Operators in Capabilities Registry",
 	func(b operations.Bundle, deps RegisterNopsDeps, input RegisterNopsInput) (RegisterNopsOutput, error) {
+		if len(input.Nops) == 0 {
+			b.Logger.Info("No node operators to register, skipping")
+			return RegisterNopsOutput{
+				Nops: []*capabilities_registry_v2.CapabilitiesRegistryNodeOperatorAdded{},
+			}, nil
+		}
 		// Get the target chain
 		chain, ok := deps.Env.BlockChains.EVMChains()[input.ChainSelector]
 		if !ok {

--- a/deployment/cre/capabilities_registry/v2/changeset/pkg/capability_config.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/pkg/capability_config.go
@@ -26,8 +26,6 @@ func (c CapabilityConfig) MarshalProto() ([]byte, error) {
 		return nil, fmt.Errorf("failed to json marshal config: %w", err)
 	}
 
-	fmt.Println("JSON Encoded Config:", string(jsonEncodedCfg))
-
 	pbCfg := &pb.CapabilityConfig{}
 	ops := protojson.UnmarshalOptions{DiscardUnknown: true}
 	if err = ops.Unmarshal(jsonEncodedCfg, pbCfg); err != nil {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
None of the items to configure the cap reg v2 are required, meaning we can pass empty arrays and only pass a certain list we would like to configure, for example: DONs, if we already have everything else in place.

This PR makes sure we can run the configuration changeset without having to pass an empty list of items we don't need to configure.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
