### PR TITLE
fix(ci): no unit test reruns when quarantining

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -298,6 +298,7 @@ jobs:
           CL_DATABASE_URL: ${{ env.DB_URL }}
           OUTPUT_FILE: ./output.txt
           PRODUCE_JUNIT_XML: ${{ matrix.type.trunk-auto-quarantine }}
+          TRUNK_AUTO_QUARANTINE: ${{ matrix.type.trunk-auto-quarantine }}
           RUN_QUARANTINED_TESTS: 'true' # always run quarantined tests in CI
           JUNIT_FILE: ${{ github.workspace }}/junit.xml
         run: |

--- a/core/services/workflows/syncer/workflow_syncer_test.go
+++ b/core/services/workflows/syncer/workflow_syncer_test.go
@@ -794,7 +794,7 @@ func Test_StratReconciliation_InitialStateSync(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			return len(testEventHandler.GetEvents()) == numberWorkflows
-		}, 30*time.Second, 1*time.Second)
+		}, 60*time.Second, 1*time.Second)
 
 		for _, event := range testEventHandler.GetEvents() {
 			assert.Equal(t, WorkflowRegisteredEvent, event.EventType)

--- a/tools/bin/go_core_ccip_deployment_tests
+++ b/tools/bin/go_core_ccip_deployment_tests
@@ -23,7 +23,13 @@ if [[ "$GITHUB_EVENT_NAME" == 'push' ]]; then
 elif [[ "$GITHUB_EVENT_NAME" == 'schedule' ]]; then
   GO_TEST_FLAGS="$GO_TEST_FLAGS -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt"
 elif [[ "$GITHUB_EVENT_NAME" == 'pull_request' || "$GITHUB_EVENT_NAME" == 'merge_group' ]]; then
-  RERUN_FLAGS="--rerun-fails-abort-on-data-race --rerun-fails=3"
+  RERUN_FLAGS=""
+  if [[ "$TRUNK_AUTO_QUARANTINE" != "true" ]]; then
+    echo "TRUNK_AUTO_QUARANTINE disabled, allowing for gotestsum to rerun failed tests"
+    RERUN_FLAGS="--rerun-fails-abort-on-data-race --rerun-fails=3"
+  else
+    echo "TRUNK_AUTO_QUARANTINE enabled, gotestsum will not rerun failed tests"
+  fi
 fi
 
 if [[ "$PRODUCE_JUNIT_XML" == "true" ]]; then

--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -19,7 +19,13 @@ if [[ "$GITHUB_EVENT_NAME" == 'push' ]]; then
 elif [[ "$GITHUB_EVENT_NAME" == 'schedule' ]]; then
   GO_TEST_FLAGS="$GO_TEST_FLAGS -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt"
 elif [[ "$GITHUB_EVENT_NAME" == 'pull_request' || "$GITHUB_EVENT_NAME" == 'merge_group' ]]; then
-  RERUN_FLAGS="--rerun-fails-abort-on-data-race --rerun-fails=3"
+  RERUN_FLAGS=""
+  if [[ "$TRUNK_AUTO_QUARANTINE" != "true" ]]; then
+    echo "TRUNK_AUTO_QUARANTINE disabled, allowing for gotestsum to rerun failed tests"
+    RERUN_FLAGS="--rerun-fails-abort-on-data-race --rerun-fails=3"
+  else
+    echo "TRUNK_AUTO_QUARANTINE enabled, gotestsum will not rerun failed tests"
+  fi
 fi
 
 if [[ "$PRODUCE_JUNIT_XML" == "true" ]]; then


### PR DESCRIPTION
### Changes

- Disables `gotestsum` auto retry functionality when quarantining is enabled
- Increase timeout on `Test_StratReconciliation_InitialStateSync/with_heavy_load` test as it has been consistenly failing first run for ~5 days

### Motivation

Auto-retries are saving some runs but realistically these tests should be quarantined. So we should move towards that rather than allowing flaky tests to slip through the cracks with re-runs
