### PR TITLE
add -race to dev builds

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -56,7 +56,7 @@ install-chainlink: operator-ui ## Install the chainlink binary.
 
 .PHONY: install-chainlink-dev
 install-chainlink-dev: operator-ui ## Install the chainlink binary.
-	go install -tags dev $(GCFLAGS) $(GOFLAGS) .
+	go install -race -tags dev $(GCFLAGS) $(GOFLAGS) .
 
 .PHONY: install-chainlink-cover
 install-chainlink-cover: operator-ui ## Install the chainlink binary with cover flag.
@@ -68,7 +68,7 @@ chainlink: ## Build the chainlink binary.
 
 .PHONY: chainlink-dev
 chainlink-dev: ## Build a dev build of chainlink binary.
-	go build -tags dev $(GOFLAGS) .
+	go build -race -tags dev $(GOFLAGS) .
 
 .PHONY: chainlink-test
 chainlink-test: ## Build a test build of chainlink binary.


### PR DESCRIPTION
This is an experiment to see the effects and evaluate weather it would be valuable without being too disruptive.
The direct effects are on `make chainlink-dev` and `make install-chainlink-dev`, but the latter is used from our docker files when building w/o `CL_IS_PROD_BUILD`, so it should affect E2E tests and more. We may want to dial it back before committing :shrug: 