### PR TITLE
no reconciliations events in wf registry when missing metadata

### DIFF
--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -564,32 +564,16 @@ func isEmptyWorkflowID(wfID [32]byte) bool {
 	return wfID == emptyID
 }
 
-// validateWorkflowMetadata logs warnings for incomplete workflow metadata from contract
-func validateWorkflowMetadata(wfMeta workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView, lggr logger.Logger) {
-	if isEmptyWorkflowID(wfMeta.WorkflowId) {
-		lggr.Warnw("Workflow has empty WorkflowID from contract",
-			"workflowName", wfMeta.WorkflowName,
-			"owner", hex.EncodeToString(wfMeta.Owner.Bytes()),
-			"binaryURL", wfMeta.BinaryUrl,
-			"configURL", wfMeta.ConfigUrl)
-	}
-
-	if len(wfMeta.Owner.Bytes()) == 0 {
-		lggr.Warnw("Workflow has empty Owner from contract",
-			"workflowID", hex.EncodeToString(wfMeta.WorkflowId[:]),
-			"workflowName", wfMeta.WorkflowName,
-			"binaryURL", wfMeta.BinaryUrl,
-			"configURL", wfMeta.ConfigUrl)
-	}
-
-	if wfMeta.BinaryUrl == "" || wfMeta.ConfigUrl == "" {
-		lggr.Warnw("Workflow has empty BinaryURL or ConfigURL from contract",
-			"workflowID", hex.EncodeToString(wfMeta.WorkflowId[:]),
-			"workflowName", wfMeta.WorkflowName,
-			"owner", hex.EncodeToString(wfMeta.Owner.Bytes()),
-			"binaryURL", wfMeta.BinaryUrl,
-			"configURL", wfMeta.ConfigUrl)
-	}
+// isValidWorkflowMetadata checks if workflowID, workflowOwner, binaryURL, and configURL exist
+// in the the metadata pulled from the contract. There is contract side validation to ensure these
+// fields are provided, but in the case of contract deletion bugs, or relaxing of contract validation,
+// this func can help filter out noisy deploys/workflow events.
+func isValidWorkflowMetadata(wfMeta workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView, lggr logger.Logger) bool {
+	invalid := isEmptyWorkflowID(wfMeta.WorkflowId) ||
+		len(wfMeta.Owner.Bytes()) == 0 ||
+		wfMeta.BinaryUrl == "" ||
+		wfMeta.ConfigUrl == ""
+	return !invalid
 }
 
 func (w *workflowRegistry) newWorkflowRegistryContractReader(
@@ -678,7 +662,17 @@ func (w *workflowRegistry) getWorkflowMetadata(ctx context.Context, don capabili
 
 			for _, wfMeta := range workflows.List {
 				// Log warnings for incomplete metadata but don't skip processing
-				validateWorkflowMetadata(wfMeta, w.lggr)
+				validMetadata := isValidWorkflowMetadata(wfMeta, w.lggr)
+				if !validMetadata {
+					w.lggr.Warnw("Workflow has incomplete metadata from contract, skipping",
+						"workflowName", wfMeta.WorkflowName,
+						"workflowID", hex.EncodeToString(wfMeta.WorkflowId[:]),
+						"owner", hex.EncodeToString(wfMeta.Owner.Bytes()),
+						"binaryURL", wfMeta.BinaryUrl,
+						"configURL", wfMeta.ConfigUrl,
+						"status", wfMeta.Status)
+					continue
+				}
 
 				// TODO: https://smartcontract-it.atlassian.net/browse/CAPPL-1021 load balance across workflow nodes in DON Family
 				allWorkflows = append(allWorkflows, WorkflowMetadataView{

--- a/core/services/workflows/syncer/v2/workflow_syncer_v2_test.go
+++ b/core/services/workflows/syncer/v2/workflow_syncer_v2_test.go
@@ -104,6 +104,7 @@ func Test_InitialStateSyncV2(t *testing.T) {
 			Status:    WorkflowStatusActive,
 			DonFamily: donFamily,
 			BinaryURL: "someurl",
+			ConfigURL: "https://config-url.com",
 			KeepAlive: false,
 		}
 		workflow.ID = workflowID
@@ -157,6 +158,7 @@ func Test_RegistrySyncer_SkipsEventsNotBelongingToDONV2(t *testing.T) {
 		backendTH = testutils.NewEVMBackendTH(t)
 
 		giveBinaryURL   = "https://original-url.com"
+		configURL       = "https://config-url.com"
 		donID           = uint32(1)
 		donFamily1      = "A"
 		donFamily2      = "B"
@@ -164,6 +166,7 @@ func Test_RegistrySyncer_SkipsEventsNotBelongingToDONV2(t *testing.T) {
 			Name:      "test-wf2",
 			Status:    WorkflowStatusActive,
 			BinaryURL: giveBinaryURL,
+			ConfigURL: configURL,
 			Tag:       "sometag",
 			DonFamily: donFamily2,
 			KeepAlive: false,
@@ -172,6 +175,7 @@ func Test_RegistrySyncer_SkipsEventsNotBelongingToDONV2(t *testing.T) {
 			Name:      "test-wf",
 			Status:    WorkflowStatusActive,
 			BinaryURL: "someurl",
+			ConfigURL: configURL,
 			Tag:       "sometag",
 			DonFamily: donFamily1,
 			KeepAlive: false,
@@ -245,12 +249,14 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyPausedV2(t *testing.T) {
 		orm       = artifacts.NewWorkflowRegistryDS(db, lggr)
 
 		giveBinaryURL = "https://original-url.com"
+		configURL     = "https://config-url.com"
 		donID         = uint32(1)
 		donFamily     = "A"
 		giveWorkflow  = RegisterWorkflowCMDV2{
 			Name:      "test-wf",
 			Status:    WorkflowStatusPaused,
 			BinaryURL: giveBinaryURL,
+			ConfigURL: configURL,
 			Tag:       "sometag",
 			DonFamily: donFamily,
 			KeepAlive: false,
@@ -349,6 +355,7 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyActivatedV2(t *testing.T) {
 			Name:      "test-wf",
 			Status:    WorkflowStatusActive,
 			BinaryURL: giveBinaryURL,
+			ConfigURL: "https://config-url.com",
 			Tag:       "sometag",
 			DonFamily: donFamily,
 			KeepAlive: false,
@@ -462,6 +469,7 @@ func Test_StratReconciliation_InitialStateSyncV2(t *testing.T) {
 				Name:      fmt.Sprintf("test-wf-%d", i),
 				Status:    WorkflowStatusActive,
 				BinaryURL: "someurl",
+				ConfigURL: "https://config-url.com",
 				Tag:       "sometag",
 				DonFamily: donFamily,
 				KeepAlive: false,
@@ -500,7 +508,7 @@ func Test_StratReconciliation_InitialStateSyncV2(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			return len(testEventHandler.GetEvents()) == numberWorkflows
-		}, 30*time.Second, 1*time.Second)
+		}, tests.WaitTimeout(t), 1*time.Second)
 
 		for _, event := range testEventHandler.GetEvents() {
 			assert.Equal(t, WorkflowActivated, event.Name)
@@ -530,6 +538,7 @@ func Test_StratReconciliation_RetriesWithBackoffV2(t *testing.T) {
 		Name:      "test-wf",
 		Status:    WorkflowStatusActive,
 		BinaryURL: "someurl",
+		ConfigURL: "https://config-url.com",
 		Tag:       "sometag",
 		DonFamily: donFamily,
 		KeepAlive: false,
@@ -574,7 +583,7 @@ func Test_StratReconciliation_RetriesWithBackoffV2(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return len(testEventHandler.GetEvents()) == 1
-	}, 30*time.Second, 1*time.Second)
+	}, tests.WaitTimeout(t), 1*time.Second)
 
 	event := testEventHandler.GetEvents()[0]
 	assert.Equal(t, WorkflowActivated, event.Name)


### PR DESCRIPTION
Some events in the wf registry reconciliation loop had metadata with missing wf owner + wf ID. We determined this was from a cleanup bug on the contract. We need to skip these events because they can't be processed correctly, and are noisy to downstream consumers of the wf registry, such as deployment events for users.