### PR TITLE
Vault DON: Fix e2e CRE Vault test

### DIFF
--- a/core/capabilities/vault/capability.go
+++ b/core/capabilities/vault/capability.go
@@ -203,13 +203,13 @@ func (s *Capability) CreateSecrets(ctx context.Context, request *vaultcommon.Cre
 	s.lggr.Infof("Received Request: %s", request.String())
 	err := ValidateCreateSecretsRequest(s.publicKey.Get(), request)
 	if err != nil {
-		s.lggr.Infof("Request: [%s] failed validation checks: %s", request.String(), err.Error())
+		s.lggr.Infof("RequestId: [%s] failed validation checks: %s", request.RequestId, err.Error())
 		return nil, err
 	}
-	authorized, owner, err := s.isAuthorizedRequest(ctx, request, vaulttypes.MethodSecretsCreate)
+	authorized, owner, err := s.authorizeCreateSecrets(ctx, *request)
 	if !authorized || err != nil {
-		s.lggr.Infof("Request [%s] not authorized for owner: %s", request.String(), owner)
-		return nil, errors.New("request not authorized: " + err.Error())
+		s.lggr.Infof("Request Id[%s] not authorized for owner: %s", request.RequestId, owner)
+		return nil, errors.New("request ID: " + request.RequestId + " not authorized: " + err.Error())
 	}
 	if !strings.HasPrefix(request.RequestId, owner) {
 		// Gateway should ensure it prefixes request ids with the owner, to ensure request uniqueness
@@ -235,13 +235,13 @@ func (s *Capability) UpdateSecrets(ctx context.Context, request *vaultcommon.Upd
 	s.lggr.Infof("Received Request: %s", request.String())
 	err := ValidateUpdateSecretsRequest(s.publicKey.Get(), request)
 	if err != nil {
-		s.lggr.Infof("Request: [%s] failed validation checks: %s", request.String(), err.Error())
+		s.lggr.Infof("RequestId: [%s] failed validation checks: %s", request.RequestId, err.Error())
 		return nil, err
 	}
-	authorized, owner, err := s.isAuthorizedRequest(ctx, request, vaulttypes.MethodSecretsUpdate)
+	authorized, owner, err := s.authorizeUpdateSecrets(ctx, *request)
 	if !authorized || err != nil {
-		s.lggr.Infof("Request [%s] not authorized for owner: %s", request.String(), owner)
-		return nil, errors.New("request not authorized: " + err.Error())
+		s.lggr.Infof("Request Id[%s] not authorized for owner: %s", request.RequestId, owner)
+		return nil, errors.New("request ID: " + request.RequestId + " not authorized: " + err.Error())
 	}
 	if !strings.HasPrefix(request.RequestId, owner) {
 		// Gateway should ensure it prefixes request ids with the owner, to ensure request uniqueness
@@ -291,10 +291,10 @@ func (s *Capability) DeleteSecrets(ctx context.Context, request *vaultcommon.Del
 		return nil, err
 	}
 
-	authorized, owner, err := s.isAuthorizedRequest(ctx, request, vaulttypes.MethodSecretsDelete)
+	authorized, owner, err := s.authorizeDeleteSecrets(ctx, *request)
 	if !authorized || err != nil {
-		s.lggr.Infof("Request [%s] not authorized for owner: %s", request.String(), owner)
-		return nil, errors.New("request not authorized: " + err.Error())
+		s.lggr.Infof("Request Id[%s] not authorized for owner: %s", request.RequestId, owner)
+		return nil, errors.New("request ID: " + request.RequestId + " not authorized: " + err.Error())
 	}
 	if !strings.HasPrefix(request.RequestId, owner) {
 		// Gateway should ensure it prefixes request ids with the owner, to ensure request uniqueness
@@ -358,10 +358,10 @@ func (s *Capability) ListSecretIdentifiers(ctx context.Context, request *vaultco
 		return nil, err
 	}
 
-	authorized, owner, err := s.isAuthorizedRequest(ctx, request, vaulttypes.MethodSecretsList)
+	authorized, owner, err := s.authorizeListSecrets(ctx, *request)
 	if !authorized || err != nil {
-		s.lggr.Infof("Request [%s] not authorized for owner: %s", request.String(), owner)
-		return nil, errors.New("request not authorized: " + err.Error())
+		s.lggr.Infof("Request ID[%s] not authorized for owner: %s", request.RequestId, owner)
+		return nil, errors.New("request ID: " + request.RequestId + " not authorized: " + err.Error())
 	}
 	if !strings.HasPrefix(request.RequestId, owner) {
 		// Gateway should ensure it prefixes request ids with the owner, to ensure request uniqueness
@@ -424,14 +424,64 @@ func (s *Capability) handleRequest(ctx context.Context, requestID string, reques
 	}
 }
 
-func (s *Capability) isAuthorizedRequest(ctx context.Context, request any, method string) (bool, string, error) {
+func (s *Capability) getOriginalRequestID(transformedRequestID string) (string, error) {
+	// The transformed RequestID provided to Vault Nodes is of format <owner>::<user-provided-id>.
+	// However, the RequestAuthorizer expects just the <user-provided-id> as the JSONRequest's ID fields,
+	// since that's what was used by the caller when generating the request digest.
+	requestIDParts := strings.Split(transformedRequestID, vaulttypes.RequestIDSeparator)
+	if len(requestIDParts) != 2 {
+		return "", errors.New("internal error: request ID must be in format <owner>::<user-provided-id>")
+	}
+	return requestIDParts[1], nil
+}
+
+func (s *Capability) authorizeCreateSecrets(ctx context.Context, request vaultcommon.CreateSecretsRequest) (bool, string, error) {
+	originalRequestID, err := s.getOriginalRequestID(request.RequestId)
+	if err != nil {
+		return false, "", err
+	}
+	request.RequestId = originalRequestID
+
+	return s.isAuthorizedRequest(ctx, &request, originalRequestID, vaulttypes.MethodSecretsCreate)
+}
+
+func (s *Capability) authorizeUpdateSecrets(ctx context.Context, request vaultcommon.UpdateSecretsRequest) (bool, string, error) {
+	originalRequestID, err := s.getOriginalRequestID(request.RequestId)
+	if err != nil {
+		return false, "", err
+	}
+	request.RequestId = originalRequestID
+	return s.isAuthorizedRequest(ctx, &request, originalRequestID, vaulttypes.MethodSecretsUpdate)
+}
+
+func (s *Capability) authorizeDeleteSecrets(ctx context.Context, request vaultcommon.DeleteSecretsRequest) (bool, string, error) {
+	originalRequestID, err := s.getOriginalRequestID(request.RequestId)
+	if err != nil {
+		return false, "", err
+	}
+	request.RequestId = originalRequestID
+	return s.isAuthorizedRequest(ctx, &request, originalRequestID, vaulttypes.MethodSecretsDelete)
+}
+
+func (s *Capability) authorizeListSecrets(ctx context.Context, request vaultcommon.ListSecretIdentifiersRequest) (bool, string, error) {
+	originalRequestID, err := s.getOriginalRequestID(request.RequestId)
+	if err != nil {
+		return false, "", err
+	}
+	request.RequestId = originalRequestID
+	return s.isAuthorizedRequest(ctx, &request, originalRequestID, vaulttypes.MethodSecretsList)
+}
+
+func (s *Capability) isAuthorizedRequest(ctx context.Context, request any, requestID, method string) (bool, string, error) {
 	var params json.RawMessage
 	params, err := json.Marshal(request)
 	if err != nil {
 		return false, "", fmt.Errorf("could not marshal CreateSecretsRequest: %w", err)
 	}
+	s.lggr.Debugw("Authorizing request", "method", method, "requestID", requestID)
 	jsonRequest := jsonrpc.Request[json.RawMessage]{
 		Version: jsonrpc.JsonRpcVersion,
+		ID:      requestID,
 		Method:  method,
 		Params:  &params,
 	}

--- a/core/capabilities/vault/capability.go
+++ b/core/capabilities/vault/capability.go
@@ -435,7 +435,7 @@ func (s *Capability) getOriginalRequestID(transformedRequestID string) (string, 
 	return requestIDParts[1], nil
 }
 
-func (s *Capability) authorizeCreateSecrets(ctx context.Context, request vaultcommon.CreateSecretsRequest) (bool, string, error) {
+func (s *Capability) authorizeCreateSecrets(ctx context.Context, request vaultcommon.CreateSecretsRequest) (bool, string, error) { //nolint:govet // The mutex isn't used
 	originalRequestID, err := s.getOriginalRequestID(request.RequestId)
 	if err != nil {
 		return false, "", err
@@ -445,7 +445,7 @@ func (s *Capability) authorizeCreateSecrets(ctx context.Context, request vaultco
 	return s.isAuthorizedRequest(ctx, &request, originalRequestID, vaulttypes.MethodSecretsCreate)
 }
 
-func (s *Capability) authorizeUpdateSecrets(ctx context.Context, request vaultcommon.UpdateSecretsRequest) (bool, string, error) {
+func (s *Capability) authorizeUpdateSecrets(ctx context.Context, request vaultcommon.UpdateSecretsRequest) (bool, string, error) { //nolint:govet // The mutex isn't used
 	originalRequestID, err := s.getOriginalRequestID(request.RequestId)
 	if err != nil {
 		return false, "", err
@@ -454,7 +454,7 @@ func (s *Capability) authorizeUpdateSecrets(ctx context.Context, request vaultco
 	return s.isAuthorizedRequest(ctx, &request, originalRequestID, vaulttypes.MethodSecretsUpdate)
 }
 
-func (s *Capability) authorizeDeleteSecrets(ctx context.Context, request vaultcommon.DeleteSecretsRequest) (bool, string, error) {
+func (s *Capability) authorizeDeleteSecrets(ctx context.Context, request vaultcommon.DeleteSecretsRequest) (bool, string, error) { //nolint:govet // The mutex isn't used
 	originalRequestID, err := s.getOriginalRequestID(request.RequestId)
 	if err != nil {
 		return false, "", err
@@ -463,7 +463,7 @@ func (s *Capability) authorizeDeleteSecrets(ctx context.Context, request vaultco
 	return s.isAuthorizedRequest(ctx, &request, originalRequestID, vaulttypes.MethodSecretsDelete)
 }
 
-func (s *Capability) authorizeListSecrets(ctx context.Context, request vaultcommon.ListSecretIdentifiersRequest) (bool, string, error) {
+func (s *Capability) authorizeListSecrets(ctx context.Context, request vaultcommon.ListSecretIdentifiersRequest) (bool, string, error) { //nolint:govet // The mutex isn't used
 	originalRequestID, err := s.getOriginalRequestID(request.RequestId)
 	if err != nil {
 		return false, "", err

--- a/core/capabilities/vault/capability.go
+++ b/core/capabilities/vault/capability.go
@@ -206,7 +206,7 @@ func (s *Capability) CreateSecrets(ctx context.Context, request *vaultcommon.Cre
 		s.lggr.Infof("RequestId: [%s] failed validation checks: %s", request.RequestId, err.Error())
 		return nil, err
 	}
-	authorized, owner, err := s.authorizeCreateSecrets(ctx, *request)
+	authorized, owner, err := s.authorizeCreateSecrets(ctx, *request) //nolint:govet // The mutex isn't used
 	if !authorized || err != nil {
 		s.lggr.Infof("Request Id[%s] not authorized for owner: %s", request.RequestId, owner)
 		return nil, errors.New("request ID: " + request.RequestId + " not authorized: " + err.Error())
@@ -238,7 +238,7 @@ func (s *Capability) UpdateSecrets(ctx context.Context, request *vaultcommon.Upd
 		s.lggr.Infof("RequestId: [%s] failed validation checks: %s", request.RequestId, err.Error())
 		return nil, err
 	}
-	authorized, owner, err := s.authorizeUpdateSecrets(ctx, *request)
+	authorized, owner, err := s.authorizeUpdateSecrets(ctx, *request) //nolint:govet // The mutex isn't used
 	if !authorized || err != nil {
 		s.lggr.Infof("Request Id[%s] not authorized for owner: %s", request.RequestId, owner)
 		return nil, errors.New("request ID: " + request.RequestId + " not authorized: " + err.Error())
@@ -291,7 +291,7 @@ func (s *Capability) DeleteSecrets(ctx context.Context, request *vaultcommon.Del
 		return nil, err
 	}
 
-	authorized, owner, err := s.authorizeDeleteSecrets(ctx, *request)
+	authorized, owner, err := s.authorizeDeleteSecrets(ctx, *request) //nolint:govet // The mutex isn't used
 	if !authorized || err != nil {
 		s.lggr.Infof("Request Id[%s] not authorized for owner: %s", request.RequestId, owner)
 		return nil, errors.New("request ID: " + request.RequestId + " not authorized: " + err.Error())
@@ -358,7 +358,7 @@ func (s *Capability) ListSecretIdentifiers(ctx context.Context, request *vaultco
 		return nil, err
 	}
 
-	authorized, owner, err := s.authorizeListSecrets(ctx, *request)
+	authorized, owner, err := s.authorizeListSecrets(ctx, *request) //nolint:govet // The mutex isn't used
 	if !authorized || err != nil {
 		s.lggr.Infof("Request ID[%s] not authorized for owner: %s", request.RequestId, owner)
 		return nil, errors.New("request ID: " + request.RequestId + " not authorized: " + err.Error())

--- a/core/capabilities/vault/vaulttypes/types.go
+++ b/core/capabilities/vault/vaulttypes/types.go
@@ -31,6 +31,10 @@ const (
 	MethodSecretsList   = "vault.secrets.list"
 	MethodPublicKeyGet  = "vault.publicKey.get"
 
+	// RequestIDSeparator is used to separate parts(owner, user-provided-requestId) of the request ID.
+	RequestIDSeparator = "::"
+
+	// MaxBatchSize is the maximum number of secrets that can be created/updated/deleted in a single request.
 	MaxBatchSize = 10
 )
 

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -281,7 +281,7 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 		return errors.New("request not authorized: " + err.Error())
 	}
 	// Prefix request id with owner, to ensure uniqueness across different owners
-	req.ID = owner + "::" + req.ID
+	req.ID = owner + vaulttypes.RequestIDSeparator + req.ID
 
 	h.lggr.Infow("handling authorized vault request", "method", req.Method, "requestID", req.ID, "owner", owner)
 	if h.getActiveRequest(req.ID) != nil {
@@ -412,7 +412,7 @@ func (h *handler) tryCachePublicKeyResponse(resp *jsonrpc.Response[json.RawMessa
 func (h *handler) sendSuccessResponse(ctx context.Context, l logger.Logger, ar *activeRequest, resp *jsonrpc.Response[json.RawMessage]) error {
 	// Strip the owner prefix from the response ID before sending it back to the user
 	// This ensures compliance with JSONRPC 2.0 spec, which requires response id to match request id
-	index := strings.Index(resp.ID, "::")
+	index := strings.Index(resp.ID, vaulttypes.RequestIDSeparator)
 	if index != -1 {
 		resp.ID = resp.ID[index+2:]
 	}
@@ -657,7 +657,7 @@ func (h *handler) errorResponse(
 
 	// Strip the owner prefix from the json response ID before sending it back to the user
 	// This ensures compliance with JSONRPC 2.0 spec, which requires response id to match request id
-	index := strings.Index(req.ID, "::")
+	index := strings.Index(req.ID, vaulttypes.RequestIDSeparator)
 	if index != -1 {
 		req.ID = req.ID[index+2:]
 	}

--- a/core/services/gateway/handlers/vault/handler_test.go
+++ b/core/services/gateway/handlers/vault/handler_test.go
@@ -162,7 +162,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		}
 		resultBytes, err := json.Marshal(responseData)
 		require.NoError(t, err)
-		expectedRequestID := owner + "::" + requestID
+		expectedRequestID := owner + vaulttypes.RequestIDSeparator + requestID
 		response := jsonrpc.Response[json.RawMessage]{
 			ID:     expectedRequestID,
 			Result: (*json.RawMessage)(&resultBytes),
@@ -262,7 +262,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		}
 		resultBytes, err := json.Marshal(responseData)
 		require.NoError(t, err)
-		expectedRequestID := owner + "::" + requestID
+		expectedRequestID := owner + vaulttypes.RequestIDSeparator + requestID
 		response := jsonrpc.Response[json.RawMessage]{
 			ID:     expectedRequestID,
 			Result: (*json.RawMessage)(&resultBytes),
@@ -321,7 +321,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		}
 		resultBytes, err := json.Marshal(responseData)
 		require.NoError(t, err)
-		expectedRequestID := owner + "::" + requestID
+		expectedRequestID := owner + vaulttypes.RequestIDSeparator + requestID
 		response := jsonrpc.Response[json.RawMessage]{
 			ID:     expectedRequestID,
 			Result: (*json.RawMessage)(&resultBytes),
@@ -380,7 +380,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		}
 		resultBytes, err := json.Marshal(responseData)
 		require.NoError(t, err)
-		expectedRequestID := owner + "::" + requestID
+		expectedRequestID := owner + vaulttypes.RequestIDSeparator + requestID
 		response := jsonrpc.Response[json.RawMessage]{
 			ID:     expectedRequestID,
 			Result: (*json.RawMessage)(&resultBytes),
@@ -434,7 +434,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: (*json.RawMessage)(&reqDataBytes),
 		}
 
-		expectedRequestID := owner + "::" + requestID
+		expectedRequestID := owner + vaulttypes.RequestIDSeparator + requestID
 		response := jsonrpc.Response[json.RawMessage]{
 			ID:     expectedRequestID,
 			Method: vaulttypes.MethodSecretsList,


### PR DESCRIPTION
Issues fixed:
- Previously the requestId used in RequestAuthorizer inside Vault Nodes was not set. Now changed it to using the requestId user provided, by stripping out owner:: prefix from the requestId.
- In tests, even for invalid requests, the Owner field must be set correctly for the request to even be picked up by the Vault DON. An unauthorized Owner in the request will be rejected by Vault Nodes even before consensus step.
- ListSecrets() e2e test was reusing the same nonce via tx opts, thus failing with "nonce too low" error. Fixed it by creating new TxOpts on each onchain call.
