### PR TITLE
[CRE-491] Move EVM OCR/CCIP transmitters to the transmitter folder

### DIFF
--- a/core/services/ocr/contract_transmitter.go
+++ b/core/services/ocr/contract_transmitter.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter/ocr"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -25,7 +25,7 @@ type (
 	OCRContractTransmitter struct {
 		contractAddress             gethCommon.Address
 		contractABI                 abi.ABI
-		transmitter                 ocrcommon.Transmitter
+		transmitter                 ocr.Transmitter
 		contractCaller              *offchainaggregator.OffchainAggregatorCaller
 		tracker                     *OCRContractTracker
 		chainID                     *big.Int
@@ -37,7 +37,7 @@ func NewOCRContractTransmitter(
 	address gethCommon.Address,
 	contractCaller *offchainaggregator.OffchainAggregatorCaller,
 	contractABI abi.ABI,
-	transmitter ocrcommon.Transmitter,
+	transmitter ocr.Transmitter,
 	logBroadcaster log.Broadcaster,
 	tracker *OCRContractTracker,
 	chainID *big.Int,

--- a/core/services/ocr/delegate.go
+++ b/core/services/ocr/delegate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
+	ocr2 "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter/ocr"
 	"github.com/smartcontractkit/chainlink/v2/core/services/synchronization"
 	"github.com/smartcontractkit/chainlink/v2/core/services/telemetry"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
@@ -235,7 +236,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, jb job.Job) (services []
 		cid := chain.ID()
 		ks := keys.NewChainStore(keystore.NewEthSigner(d.ethKeyStore, cid), cid)
 
-		transmitter, err := ocrcommon.NewTransmitter(
+		transmitter, err := ocr2.NewTransmitter(
 			chain.TxManager(),
 			[]common.Address{concreteSpec.TransmitterAddress.Address()},
 			gasLimit,

--- a/core/services/relay/evm/transmitter/ccip/transmitter.go
+++ b/core/services/relay/evm/transmitter/ccip/transmitter.go
@@ -1,4 +1,4 @@
-package transmitter
+package ccip
 
 import (
 	"context"

--- a/core/services/relay/evm/transmitter/ocr/dual_transmitter.go
+++ b/core/services/relay/evm/transmitter/ocr/dual_transmitter.go
@@ -1,4 +1,4 @@
-package ocrcommon
+package ocr
 
 import (
 	"context"

--- a/core/services/relay/evm/transmitter/ocr/transmitter.go
+++ b/core/services/relay/evm/transmitter/ocr/transmitter.go
@@ -1,4 +1,4 @@
-package ocrcommon
+package ocr
 
 import (
 	"context"

--- a/core/services/relay/evm/transmitter/util.go
+++ b/core/services/relay/evm/transmitter/util.go
@@ -17,8 +17,8 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
 	evmtxmgr "github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	"github.com/smartcontractkit/chainlink-framework/chains/txmgr"
-	cciptransmitter "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/transmitter"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter/ccip"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter/ocr"
 )
 
 type ConfigTransmitterOpts struct {
@@ -148,7 +148,7 @@ func generateTransmitterFrom(ctx context.Context, rargs types.RelayArgs, ethKeys
 
 	switch types.OCR2PluginType(rargs.ProviderType) {
 	case types.Median:
-		transmitter, err = ocrcommon.NewOCR2FeedsTransmitter(
+		transmitter, err = ocr.NewOCR2FeedsTransmitter(
 			chain.TxManager(),
 			fromAddresses,
 			common.HexToAddress(rargs.ContractID),
@@ -160,7 +160,7 @@ func generateTransmitterFrom(ctx context.Context, rargs types.RelayArgs, ethKeys
 			relayConfig.DualTransmissionConfig,
 		)
 	case types.CCIPExecution:
-		transmitter, err = cciptransmitter.NewTransmitterWithStatusChecker(
+		transmitter, err = ccip.NewTransmitterWithStatusChecker(
 			chain.TxManager(),
 			fromAddresses,
 			gasLimit,
@@ -171,7 +171,7 @@ func generateTransmitterFrom(ctx context.Context, rargs types.RelayArgs, ethKeys
 			ethKeystore,
 		)
 	default:
-		transmitter, err = ocrcommon.NewTransmitter(
+		transmitter, err = ocr.NewTransmitter(
 			chain.TxManager(),
 			fromAddresses,
 			gasLimit,


### PR DESCRIPTION
After this PR the `evm/transmitter` folder becomes self-contained and is ready to be moved to the chainlink-evm repo.