### PR TITLE
chore: update MCMS solana tests to use test engine runtime

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
@@ -2311,6 +2311,63 @@ func DefaultRouterMessage(receiverAddress common.Address) router.ClientEVM2AnyMe
 	}
 }
 
+// GetSolanaPreloadedAddressBook returns an address book with the preloaded Solana addresses for
+// the given selector.
+//
+// This is used because Solana programs have already been predeployed, and we need to seed the
+// address book with the preloaded addresses.
+func GetSolanaPreloadedAddressBook(t *testing.T, selector uint64) *cldf.AddressBookMap {
+	t.Helper()
+
+	ab := cldf.NewMemoryAddressBook()
+
+	tv := cldf.NewTypeAndVersion(shared.Router, deployment.Version1_0_0)
+	err := ab.Save(selector, memory.SolanaProgramIDs["ccip_router"], tv)
+	require.NoError(t, err)
+
+	tv = cldf.NewTypeAndVersion(shared.Receiver, deployment.Version1_0_0)
+	err = ab.Save(selector, memory.SolanaProgramIDs["test_ccip_receiver"], tv)
+	require.NoError(t, err)
+
+	tv = cldf.NewTypeAndVersion(shared.FeeQuoter, deployment.Version1_0_0)
+	err = ab.Save(selector, memory.SolanaProgramIDs["fee_quoter"], tv)
+	require.NoError(t, err)
+
+	tv = cldf.NewTypeAndVersion(shared.OffRamp, deployment.Version1_0_0)
+	err = ab.Save(selector, memory.SolanaProgramIDs["ccip_offramp"], tv)
+	require.NoError(t, err)
+
+	tv = cldf.NewTypeAndVersion(shared.BurnMintTokenPool, deployment.Version1_0_0)
+	err = ab.Save(selector, memory.SolanaProgramIDs["burnmint_token_pool"], tv)
+	require.NoError(t, err)
+
+	tv = cldf.NewTypeAndVersion(shared.LockReleaseTokenPool, deployment.Version1_0_0)
+	err = ab.Save(selector, memory.SolanaProgramIDs["lockrelease_token_pool"], tv)
+	require.NoError(t, err)
+
+	tv = cldf.NewTypeAndVersion(shared.CCTPTokenPool, deployment.Version1_0_0)
+	err = ab.Save(selector, memory.SolanaProgramIDs["cctp_token_pool"], tv)
+	require.NoError(t, err)
+
+	tv = cldf.NewTypeAndVersion(commontypes.ManyChainMultisigProgram, deployment.Version1_0_0)
+	err = ab.Save(selector, memory.SolanaProgramIDs["mcm"], tv)
+	require.NoError(t, err)
+
+	tv = cldf.NewTypeAndVersion(commontypes.AccessControllerProgram, deployment.Version1_0_0)
+	err = ab.Save(selector, memory.SolanaProgramIDs["access_controller"], tv)
+	require.NoError(t, err)
+
+	tv = cldf.NewTypeAndVersion(commontypes.RBACTimelockProgram, deployment.Version1_0_0)
+	err = ab.Save(selector, memory.SolanaProgramIDs["timelock"], tv)
+	require.NoError(t, err)
+
+	tv = cldf.NewTypeAndVersion(shared.RMNRemote, deployment.Version1_0_0)
+	err = ab.Save(selector, memory.SolanaProgramIDs["rmn_remote"], tv)
+	require.NoError(t, err)
+
+	return ab
+}
+
 // TODO: this should be linked to the solChain function
 func SavePreloadedSolAddresses(e cldf.Environment, solChainSelector uint64) error {
 	tv := cldf.NewTypeAndVersion(shared.Router, deployment.Version1_0_0)

--- a/deployment/common/changeset/solana/fund_mcm_pdas_test.go
+++ b/deployment/common/changeset/solana/fund_mcm_pdas_test.go
@@ -1,4 +1,4 @@
-package solana_test
+package solana
 
 import (
 	"fmt"
@@ -6,68 +6,34 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
-	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
-	"github.com/smartcontractkit/quarantine"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
+	"github.com/smartcontractkit/quarantine"
+	"github.com/stretchr/testify/require"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
-
-	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	commonSolana "github.com/smartcontractkit/chainlink/deployment/common/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
-	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
-
-// setupFundingTestEnv deploys all required contracts for the funding test
-func setupFundingTestEnv(t *testing.T) cldf.Environment {
-	lggr := logger.TestLogger(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:     1,
-		SolChains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
-
-	config := proposalutils.SingleGroupTimelockConfigV2(t)
-	err := testhelpers.SavePreloadedSolAddresses(env, chainSelector)
-	require.NoError(t, err)
-	// Initialize the address book with a dummy address to avoid deploy precondition errors.
-	err = env.ExistingAddresses.Save(chainSelector, "dummyAddress", cldf.TypeAndVersion{Type: "dummy", Version: deployment.Version1_0_0})
-	require.NoError(t, err)
-
-	// Deploy MCMS and Timelock
-	env, err = changeset.Apply(t, env,
-		changeset.Configure(
-			cldf.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2),
-			map[uint64]types.MCMSWithTimelockConfigV2{
-				chainSelector: config,
-			},
-		),
-	)
-	require.NoError(t, err)
-
-	return env
-}
 
 func TestFundMCMSignersChangeset_VerifyPreconditions(t *testing.T) {
 	t.Parallel()
-	lggr := logger.TestLogger(t)
-	validEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{SolChains: 1})
-	validSolChainSelector := validEnv.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
 
+	selector1 := chainselectors.TEST_22222222222222222222222222222222222222222222.Selector
+	selector2 := chainselectors.TEST_33333333333333333333333333333333333333333333.Selector
+
+	env, err := environment.New(t.Context(),
+		environment.WithSolanaContainer(t, []uint64{selector1, selector2}, t.TempDir(), map[string]string{}),
+	)
+	require.NoError(t, err)
+
+	// Setup selector1 to have a chain where programs are deployed to pass validation
 	timelockID := mcmsSolana.ContractAddress(
 		solana.NewWallet().PublicKey(),
 		[32]byte{'t', 'e', 's', 't'},
@@ -87,60 +53,51 @@ func TestFundMCMSignersChangeset_VerifyPreconditions(t *testing.T) {
 		mcmDummyProgram,
 		[32]byte{'t', 'e', 's', 't', '3'},
 	)
-	err := validEnv.ExistingAddresses.Save(validSolChainSelector, timelockID, cldf.TypeAndVersion{
+	err = env.ExistingAddresses.Save(selector1, timelockID, cldf.TypeAndVersion{
 		Type:    types.RBACTimelock,
 		Version: deployment.Version1_0_0,
 	})
 	require.NoError(t, err)
-	err = validEnv.ExistingAddresses.Save(validSolChainSelector, mcmsProposerID, cldf.TypeAndVersion{
+	err = env.ExistingAddresses.Save(selector1, mcmsProposerID, cldf.TypeAndVersion{
 		Type:    types.ProposerManyChainMultisig,
 		Version: deployment.Version1_0_0,
 	})
 	require.NoError(t, err)
-	err = validEnv.ExistingAddresses.Save(validSolChainSelector, mcmsCancellerID, cldf.TypeAndVersion{
+	err = env.ExistingAddresses.Save(selector1, mcmsCancellerID, cldf.TypeAndVersion{
 		Type:    types.CancellerManyChainMultisig,
 		Version: deployment.Version1_0_0,
 	})
 	require.NoError(t, err)
-	err = validEnv.ExistingAddresses.Save(validSolChainSelector, mcmsBypasserID, cldf.TypeAndVersion{
+	err = env.ExistingAddresses.Save(selector1, mcmsBypasserID, cldf.TypeAndVersion{
 		Type:    types.BypasserManyChainMultisig,
 		Version: deployment.Version1_0_0,
 	})
 	require.NoError(t, err)
+
+	// Setup selector2 to have a chain where the MCMS contracts have not been deployed,
+	// e.g. missing the required addresses so that the state loader returns empty seeds.
 	mcmsProposerIDEmpty := mcmsSolana.ContractAddress(
 		mcmDummyProgram,
 		[32]byte{},
 	)
 
-	// Create an environment that simulates a chain where the MCMS contracts have not been deployed,
-	// e.g. missing the required addresses so that the state loader returns empty seeds.
-	noMCMSEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{})
-	noMCMSEnv.BlockChains = cldf_chain.NewBlockChains(map[uint64]cldf_chain.BlockChain{
-		chainselectors.SOLANA_DEVNET.Selector: cldf_solana.Chain{},
-	})
-	err = noMCMSEnv.ExistingAddresses.Save(chainselectors.SOLANA_DEVNET.Selector, mcmsProposerIDEmpty, cldf.TypeAndVersion{
+	err = env.ExistingAddresses.Save(selector2, mcmsProposerIDEmpty, cldf.TypeAndVersion{
 		Type:    types.BypasserManyChainMultisig,
 		Version: deployment.Version1_0_0,
 	})
 	require.NoError(t, err)
 
-	// Create an environment with a Solana chain that has an invalid (zero) underlying chain.
-	invalidSolChainEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{})
-	invalidSolChainEnv.BlockChains = cldf_chain.NewBlockChains(map[uint64]cldf_chain.BlockChain{
-		validSolChainSelector: cldf_solana.Chain{},
-	})
-
 	tests := []struct {
 		name          string
-		env           cldf.Environment
-		config        commonSolana.FundMCMSignerConfig
+		env           func(t *testing.T) cldf.Environment
+		config        FundMCMSignerConfig
 		expectedError string
 	}{
 		{
 			name: "All preconditions satisfied",
-			env:  validEnv,
-			config: commonSolana.FundMCMSignerConfig{
-				AmountsPerChain: map[uint64]commonSolana.AmountsToTransfer{validSolChainSelector: {
+			env:  func(t *testing.T) cldf.Environment { t.Helper(); return *env },
+			config: FundMCMSignerConfig{
+				AmountsPerChain: map[uint64]AmountsToTransfer{selector1: {
 					ProposeMCM:   100,
 					CancellerMCM: 100,
 					BypasserMCM:  100,
@@ -151,26 +108,29 @@ func TestFundMCMSignersChangeset_VerifyPreconditions(t *testing.T) {
 		},
 		{
 			name: "No Solana chains found in environment",
-			env: memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-				Bootstraps: 1,
-				Chains:     1,
-				SolChains:  0,
-				Nodes:      1,
-			}),
-			config: commonSolana.FundMCMSignerConfig{
-				AmountsPerChain: map[uint64]commonSolana.AmountsToTransfer{validSolChainSelector: {
+			env: func(t *testing.T) cldf.Environment {
+				t.Helper()
+
+				// Create an environment with no solana chains
+				emptyEnv, err := environment.New(t.Context())
+				require.NoError(t, err)
+
+				return *emptyEnv
+			},
+			config: FundMCMSignerConfig{
+				AmountsPerChain: map[uint64]AmountsToTransfer{selector1: {
 					ProposeMCM:   100,
 					CancellerMCM: 100,
 					BypasserMCM:  100,
 					Timelock:     100,
 				}},
 			},
-			expectedError: fmt.Sprintf("solana chain not found for selector %d", validSolChainSelector),
+			expectedError: fmt.Sprintf("solana chain not found for selector %d", selector1),
 		},
 		{
 			name: "Chain selector not found in environment",
-			env:  validEnv,
-			config: commonSolana.FundMCMSignerConfig{AmountsPerChain: map[uint64]commonSolana.AmountsToTransfer{99999: {
+			env:  func(t *testing.T) cldf.Environment { t.Helper(); return *env },
+			config: FundMCMSignerConfig{AmountsPerChain: map[uint64]AmountsToTransfer{99999: {
 				ProposeMCM:   100,
 				CancellerMCM: 100,
 				BypasserMCM:  100,
@@ -180,9 +140,9 @@ func TestFundMCMSignersChangeset_VerifyPreconditions(t *testing.T) {
 		},
 		{
 			name: "MCMS contracts not deployed (empty seeds)",
-			env:  noMCMSEnv,
-			config: commonSolana.FundMCMSignerConfig{
-				AmountsPerChain: map[uint64]commonSolana.AmountsToTransfer{chainselectors.SOLANA_DEVNET.Selector: {
+			env:  func(t *testing.T) cldf.Environment { t.Helper(); return *env },
+			config: FundMCMSignerConfig{
+				AmountsPerChain: map[uint64]AmountsToTransfer{selector2: {
 					ProposeMCM:   100,
 					CancellerMCM: 100,
 					BypasserMCM:  100,
@@ -193,9 +153,9 @@ func TestFundMCMSignersChangeset_VerifyPreconditions(t *testing.T) {
 		},
 		{
 			name: "Insufficient deployer balance",
-			env:  validEnv,
-			config: commonSolana.FundMCMSignerConfig{
-				AmountsPerChain: map[uint64]commonSolana.AmountsToTransfer{validSolChainSelector: {
+			env:  func(t *testing.T) cldf.Environment { t.Helper(); return *env },
+			config: FundMCMSignerConfig{
+				AmountsPerChain: map[uint64]AmountsToTransfer{selector1: {
 					ProposeMCM:   9999999999999999999,
 					CancellerMCM: 9999999999999999999,
 					BypasserMCM:  9999999999999999999,
@@ -206,9 +166,19 @@ func TestFundMCMSignersChangeset_VerifyPreconditions(t *testing.T) {
 		},
 		{
 			name: "Invalid Solana chain in environment",
-			env:  invalidSolChainEnv,
-			config: commonSolana.FundMCMSignerConfig{
-				AmountsPerChain: map[uint64]commonSolana.AmountsToTransfer{validSolChainSelector: {
+			env: func(t *testing.T) cldf.Environment {
+				t.Helper()
+
+				invalidEnv, err := environment.New(t.Context())
+				require.NoError(t, err)
+				invalidEnv.BlockChains = cldf_chain.NewBlockChains(map[uint64]cldf_chain.BlockChain{
+					selector1: cldf_solana.Chain{}, // Empty chain is invalid
+				})
+
+				return *invalidEnv
+			},
+			config: FundMCMSignerConfig{
+				AmountsPerChain: map[uint64]AmountsToTransfer{selector1: {
 					ProposeMCM:   100,
 					CancellerMCM: 100,
 					BypasserMCM:  100,
@@ -219,16 +189,16 @@ func TestFundMCMSignersChangeset_VerifyPreconditions(t *testing.T) {
 		},
 	}
 
-	cs := commonSolana.FundMCMSignersChangeset{}
+	cs := FundMCMSignersChangeset{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := cs.VerifyPreconditions(tt.env, tt.config)
+			err := cs.VerifyPreconditions(tt.env(t), tt.config)
 			if tt.expectedError == "" {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.expectedError)
+				require.ErrorContains(t, err, tt.expectedError)
 			}
 		})
 	}
@@ -237,36 +207,29 @@ func TestFundMCMSignersChangeset_VerifyPreconditions(t *testing.T) {
 func TestFundMCMSignersChangeset_Apply(t *testing.T) {
 	quarantine.Flaky(t, "DX-1776")
 	t.Parallel()
-	env := setupFundingTestEnv(t)
-	cfgAmounts := commonSolana.AmountsToTransfer{
+
+	rt, selector := setupTest(t)
+
+	chain := rt.Environment().BlockChains.SolanaChains()[selector]
+	cfgAmounts := AmountsToTransfer{
 		ProposeMCM:   100 * solana.LAMPORTS_PER_SOL,
 		CancellerMCM: 350 * solana.LAMPORTS_PER_SOL,
 		BypasserMCM:  75 * solana.LAMPORTS_PER_SOL,
 		Timelock:     83 * solana.LAMPORTS_PER_SOL,
 	}
-	solChains := env.BlockChains.SolanaChains()
-	amountsPerChain := make(map[uint64]commonSolana.AmountsToTransfer)
-	for chainSelector := range solChains {
-		amountsPerChain[chainSelector] = cfgAmounts
-	}
-	config := commonSolana.FundMCMSignerConfig{
-		AmountsPerChain: amountsPerChain,
-	}
 
-	changesetInstance := commonSolana.FundMCMSignersChangeset{}
-
-	env, _, err := changeset.ApplyChangesets(t, env, []changeset.ConfiguredChangeSet{
-		changeset.Configure(changesetInstance, config),
-	})
+	err := rt.Exec(
+		runtime.ChangesetTask(FundMCMSignersChangeset{}, FundMCMSignerConfig{
+			AmountsPerChain: map[uint64]AmountsToTransfer{selector: cfgAmounts},
+		}),
+	)
 	require.NoError(t, err)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
-	solChain := solChains[chainSelector]
-	addresses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+	addresses, err := rt.State().AddressBook.AddressesForChain(selector)
 	require.NoError(t, err)
 
 	// Check balances of MCM Signer PDAS
-	mcmState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(solChain, addresses)
+	mcmState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
 	require.NoError(t, err)
 
 	accounts := []solana.PublicKey{
@@ -277,7 +240,7 @@ func TestFundMCMSignersChangeset_Apply(t *testing.T) {
 	}
 	var balances []uint64
 	for _, account := range accounts {
-		balance, err := solChain.Client.GetBalance(env.GetContext(), account, rpc.CommitmentConfirmed)
+		balance, err := chain.Client.GetBalance(t.Context(), account, rpc.CommitmentConfirmed)
 		require.NoError(t, err)
 		t.Logf("Account: %s, Balance: %d", account, balance.Value)
 		balances = append(balances, balance.Value)

--- a/deployment/common/changeset/solana/grant_role_timelock_test.go
+++ b/deployment/common/changeset/solana/grant_role_timelock_test.go
@@ -1,96 +1,88 @@
-package solana_test
+package solana
 
 import (
+	"crypto/ecdsa"
 	"testing"
 	"time"
 
 	"github.com/gagliardetto/solana-go"
-	chainselectors "github.com/smartcontractkit/chain-selectors"
 	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	timelockbindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/timelock"
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
-	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	solanachangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func TestGrantRoleTimelockSolana(t *testing.T) {
 	t.Skip("fails with Program is not deployed (DoajfR5tK24xVw51fWcawUZWhAXD8yrBJVacc13neVQA) in CI")
 	t.Parallel()
+
 	// --- arrange ---
-	log := logger.TestLogger(t)
-	envConfig := memory.MemoryEnvironmentConfig{Chains: 0, SolChains: 1}
-	env := memory.NewMemoryEnvironment(t, log, zapcore.InfoLevel, envConfig)
-	solanaSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
-	deployer := env.BlockChains.SolanaChains()[solanaSelector].DeployerKey
-	rpcClient := env.BlockChains.SolanaChains()[solanaSelector].Client
+	rt, selector := setupTest(t)
+
+	chain := rt.Environment().BlockChains.SolanaChains()[selector]
 	executors1 := randomSolanaAccounts(t, 2)
 	executors2 := randomSolanaAccounts(t, 2)
+	addresses, err := rt.State().AddressBook.AddressesForChain(selector)
+	require.NoError(t, err)
+	mcmsState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
+	require.NoError(t, err)
 
-	commonchangeset.SetPreloadedSolanaAddresses(t, env, solanaSelector)
-	chainState := deployMCMS(t, env, solanaSelector)
-	fundSignerPDAs(t, env, solanaSelector, chainState)
+	fundSignerPDAs(t, chain, mcmsState)
 
 	// validate initial executors
-	inspector := mcmssolanasdk.NewTimelockInspector(rpcClient)
-	onChainExecutors, err := inspector.GetExecutors(t.Context(), timelockAddress(chainState))
+	inspector := mcmssolanasdk.NewTimelockInspector(chain.Client)
+	onChainExecutors, err := inspector.GetExecutors(t.Context(), timelockAddress(mcmsState))
 	require.NoError(t, err)
-	require.ElementsMatch(t, onChainExecutors, []string{deployer.PublicKey().String()})
+	require.ElementsMatch(t, onChainExecutors, []string{chain.DeployerKey.PublicKey().String()})
 
 	t.Run("without MCMS", func(t *testing.T) {
-		nomcmsChangeset := commonchangeset.Configure(
-			&solanachangesets.GrantRoleTimelockSolana{},
-			solanachangesets.GrantRoleTimelockSolanaConfig{
+		err = rt.Exec(
+			runtime.ChangesetTask(&GrantRoleTimelockSolana{}, GrantRoleTimelockSolanaConfig{
 				Role:     timelockbindings.Executor_Role,
-				Accounts: map[uint64][]solana.PublicKey{solanaSelector: executors1},
-			},
+				Accounts: map[uint64][]solana.PublicKey{selector: executors1},
+			}),
 		)
 
-		// --- act ---
-		_, _, err = commonchangeset.ApplyChangesets(t, env, []commonchangeset.ConfiguredChangeSet{nomcmsChangeset})
-		require.NoError(t, err)
-
-		// --- assert ---
-		onChainExecutors, err = inspector.GetExecutors(t.Context(), timelockAddress(chainState))
+		onChainExecutors, err = inspector.GetExecutors(t.Context(), timelockAddress(mcmsState))
 		require.NoError(t, err)
 		require.ElementsMatch(t, onChainExecutors, []string{
-			deployer.PublicKey().String(), executors1[0].String(), executors1[1].String(),
+			chain.DeployerKey.PublicKey().String(), executors1[0].String(), executors1[1].String(),
 		})
 	})
 
 	t.Run("with MCMS", func(t *testing.T) {
-		transferMCMSToTimelock(t, env, solanaSelector)
+		err = rt.Exec(
+			runtime.ChangesetTask(&TransferMCMSToTimelockSolana{}, TransferMCMSToTimelockSolanaConfig{
+				Chains:  []uint64{selector},
+				MCMSCfg: proposalutils.TimelockConfig{MinDelay: 1 * time.Second},
+			}),
+			runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+		)
+		require.NoError(t, err)
 
-		mcmsChangeset := commonchangeset.Configure(
-			&solanachangesets.GrantRoleTimelockSolana{},
-			solanachangesets.GrantRoleTimelockSolanaConfig{
+		err = rt.Exec(
+			runtime.ChangesetTask(&GrantRoleTimelockSolana{}, GrantRoleTimelockSolanaConfig{
 				Role:     timelockbindings.Executor_Role,
-				Accounts: map[uint64][]solana.PublicKey{solanaSelector: executors2},
+				Accounts: map[uint64][]solana.PublicKey{selector: executors2},
 				MCMS: &proposalutils.TimelockConfig{
 					MinDelay:   1 * time.Second,
 					MCMSAction: mcmstypes.TimelockActionSchedule,
 				},
-			},
+			}),
+			runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
 		)
-
-		// --- act ---
-		_, _, err = commonchangeset.ApplyChangesets(t, env, []commonchangeset.ConfiguredChangeSet{mcmsChangeset})
 		require.NoError(t, err)
 
 		// --- assert ---
-		onChainExecutors, err = inspector.GetExecutors(t.Context(), timelockAddress(chainState))
+		onChainExecutors, err = inspector.GetExecutors(t.Context(), timelockAddress(mcmsState))
 		require.NoError(t, err)
 		require.ElementsMatch(t, onChainExecutors, []string{
-			deployer.PublicKey().String(),
+			chain.DeployerKey.PublicKey().String(),
 			executors1[0].String(), executors1[1].String(),
 			executors2[0].String(), executors2[1].String(),
 		})
@@ -107,21 +99,6 @@ func randomSolanaAccounts(t *testing.T, n int) []solana.PublicKey {
 	}
 
 	return accounts
-}
-
-func transferMCMSToTimelock(t *testing.T, env cldf.Environment, selector uint64) {
-	t.Helper()
-	configuredChangeset := commonchangeset.Configure(
-		&solanachangesets.TransferMCMSToTimelockSolana{},
-		solanachangesets.TransferMCMSToTimelockSolanaConfig{
-			Chains:  []uint64{selector},
-			MCMSCfg: proposalutils.TimelockConfig{MinDelay: 1 * time.Second},
-		},
-	)
-
-	_, _, err := commonchangeset.ApplyChangesets(t, env, []commonchangeset.ConfiguredChangeSet{configuredChangeset})
-	require.NoError(t, err)
-	t.Logf("transferred MCMS contracts to timelock")
 }
 
 func timelockAddress(chainState *state.MCMSWithTimelockStateSolana) string {

--- a/deployment/common/changeset/solana/setup_test.go
+++ b/deployment/common/changeset/solana/setup_test.go
@@ -1,0 +1,84 @@
+package solana
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+)
+
+// setupTest sets up a test runtime with a single solana chain with deployed the MCMS and Timelock
+// contracts
+func setupTest(t *testing.T) (*runtime.Runtime, uint64) {
+	memory.DownloadSolanaProgramArtifactsForTest(t)
+
+	// Setup the runtime with preloaded programs. The address book is updated with the preloaded programs.
+	selector := chainselectors.TEST_22222222222222222222222222222222222222222222.Selector
+	ab := getPreloadedAddressBook(t, selector)
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithSolanaContainer(t, []uint64{selector}, memory.ProgramsPath, memory.SolanaProgramIDs),
+		environment.WithAddressBook(ab),
+		environment.WithLogger(logger.Test(t)),
+	))
+	require.NoError(t, err)
+
+	// Deploy MCMS and Timelock
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2), map[uint64]commontypes.MCMSWithTimelockConfigV2{
+			selector: proposalutils.SingleGroupTimelockConfigV2(t),
+		}),
+	)
+	require.NoError(t, err)
+
+	return rt, selector
+}
+
+// getPreloadedAddressBook returns an address book with the preloaded MCMS Solana addresses for
+// the given selector.
+func getPreloadedAddressBook(t *testing.T, selector uint64) *cldf.AddressBookMap {
+	t.Helper()
+
+	ab := cldf.NewMemoryAddressBook()
+
+	tv := cldf.NewTypeAndVersion(commontypes.ManyChainMultisigProgram, deployment.Version1_0_0)
+	err := ab.Save(selector, memory.SolanaProgramIDs["mcm"], tv)
+	require.NoError(t, err)
+
+	tv = cldf.NewTypeAndVersion(commontypes.AccessControllerProgram, deployment.Version1_0_0)
+	err = ab.Save(selector, memory.SolanaProgramIDs["access_controller"], tv)
+	require.NoError(t, err)
+
+	tv = cldf.NewTypeAndVersion(commontypes.RBACTimelockProgram, deployment.Version1_0_0)
+	err = ab.Save(selector, memory.SolanaProgramIDs["timelock"], tv)
+	require.NoError(t, err)
+
+	return ab
+}
+
+// fundSignerPDAs funds the timelock signer and MCMS signer PDAs with 1 SOL
+func fundSignerPDAs(
+	t *testing.T, chain cldf_solana.Chain, mcmsState *state.MCMSWithTimelockStateSolana,
+) {
+	t.Helper()
+
+	timelockSignerPDA := state.GetTimelockSignerPDA(mcmsState.TimelockProgram, mcmsState.TimelockSeed)
+	mcmSignerPDA := state.GetMCMSignerPDA(mcmsState.McmProgram, mcmsState.ProposerMcmSeed)
+	signerPDAs := []solana.PublicKey{timelockSignerPDA, mcmSignerPDA}
+	err := memory.FundSolanaAccounts(t.Context(), signerPDAs, 1, chain.Client)
+	require.NoError(t, err)
+}

--- a/deployment/common/changeset/solana/transfer_ownership_test.go
+++ b/deployment/common/changeset/solana/transfer_ownership_test.go
@@ -1,138 +1,105 @@
-package solana_test
+package solana
 
 import (
-	"math/big"
+	"crypto/ecdsa"
 	"testing"
 	"time"
 
 	"github.com/gagliardetto/solana-go"
-	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/quarantine"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	accessControllerBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/access_controller"
 	mcmBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/mcm"
 	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/timelock"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
-	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	solanachangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset/solana"
-	solanaMCMS "github.com/smartcontractkit/chainlink/deployment/common/changeset/solana/mcms"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
-	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func TestTransferToMCMSToTimelockSolana(t *testing.T) {
 	quarantine.Flaky(t, "DX-1773")
 	t.Parallel()
+
 	// --- arrange ---
-	log := logger.TestLogger(t)
-	envConfig := memory.MemoryEnvironmentConfig{Chains: 0, SolChains: 1}
-	env := memory.NewMemoryEnvironment(t, log, zapcore.InfoLevel, envConfig)
-	solanaSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
+	rt, selector := setupTest(t)
 
-	commonchangeset.SetPreloadedSolanaAddresses(t, env, solanaSelector)
-	chainState := deployMCMS(t, env, solanaSelector)
-	fundSignerPDAs(t, env, solanaSelector, chainState)
+	addresses, err := rt.State().AddressBook.AddressesForChain(selector)
+	require.NoError(t, err)
 
-	configuredChangeset := commonchangeset.Configure(
-		&solanachangesets.TransferMCMSToTimelockSolana{},
-		solanachangesets.TransferMCMSToTimelockSolanaConfig{
-			Chains:  []uint64{solanaSelector},
-			MCMSCfg: proposalutils.TimelockConfig{MinDelay: 1 * time.Second},
-		},
-	)
+	chain := rt.Environment().BlockChains.SolanaChains()[selector]
+
+	mcmsState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
+	require.NoError(t, err)
+
+	fundSignerPDAs(t, chain, mcmsState)
+
 	// validate initial owner
-	deployer := env.BlockChains.SolanaChains()[solanaSelector].DeployerKey.PublicKey()
-	assertOwner(t, env, solanaSelector, chainState, deployer)
+	deployer := rt.Environment().BlockChains.SolanaChains()[selector].DeployerKey.PublicKey()
+	assertOwner(t, chain, mcmsState, deployer)
 
 	// --- act ---
-	_, _, err := commonchangeset.ApplyChangesets(t, env, []commonchangeset.ConfiguredChangeSet{configuredChangeset})
+	err = rt.Exec(
+		runtime.ChangesetTask(&TransferMCMSToTimelockSolana{}, TransferMCMSToTimelockSolanaConfig{
+			Chains:  []uint64{selector},
+			MCMSCfg: proposalutils.TimelockConfig{MinDelay: 1 * time.Second},
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
 	require.NoError(t, err)
 
 	// --- assert ---
-	timelockSignerPDA := state.GetTimelockSignerPDA(chainState.TimelockProgram, chainState.TimelockSeed)
-	assertOwner(t, env, solanaSelector, chainState, timelockSignerPDA)
-}
-
-func deployMCMS(t *testing.T, env cldf.Environment, selector uint64) *state.MCMSWithTimelockStateSolana {
-	t.Helper()
-
-	solanaChain := env.BlockChains.SolanaChains()[selector]
-	addressBook := cldf.NewMemoryAddressBook()
-	mcmsConfig := commontypes.MCMSWithTimelockConfigV2{
-		Canceller:        proposalutils.SingleGroupMCMSV2(t),
-		Bypasser:         proposalutils.SingleGroupMCMSV2(t),
-		Proposer:         proposalutils.SingleGroupMCMSV2(t),
-		TimelockMinDelay: big.NewInt(1),
-	}
-
-	chainState, err := solanaMCMS.DeployMCMSWithTimelockProgramsSolana(env, solanaChain, addressBook, mcmsConfig)
-	require.NoError(t, err)
-	err = env.ExistingAddresses.Merge(addressBook)
-	require.NoError(t, err)
-
-	return chainState
+	timelockSignerPDA := state.GetTimelockSignerPDA(mcmsState.TimelockProgram, mcmsState.TimelockSeed)
+	assertOwner(t, chain, mcmsState, timelockSignerPDA)
 }
 
 func assertOwner(
-	t *testing.T, env cldf.Environment, selector uint64, chainState *state.MCMSWithTimelockStateSolana, owner solana.PublicKey,
+	t *testing.T, chain cldf_solana.Chain, mcmsState *state.MCMSWithTimelockStateSolana, owner solana.PublicKey,
 ) {
-	assertMCMOwner(t, owner, state.GetMCMConfigPDA(chainState.McmProgram, chainState.ProposerMcmSeed), env, selector)
-	assertMCMOwner(t, owner, state.GetMCMConfigPDA(chainState.McmProgram, chainState.CancellerMcmSeed), env, selector)
-	assertMCMOwner(t, owner, state.GetMCMConfigPDA(chainState.McmProgram, chainState.BypasserMcmSeed), env, selector)
-	assertTimelockOwner(t, owner, state.GetTimelockConfigPDA(chainState.TimelockProgram, chainState.TimelockSeed), env, selector)
-	assertAccessControllerOwner(t, owner, chainState.ProposerAccessControllerAccount, env, selector)
-	assertAccessControllerOwner(t, owner, chainState.ExecutorAccessControllerAccount, env, selector)
-	assertAccessControllerOwner(t, owner, chainState.CancellerAccessControllerAccount, env, selector)
-	assertAccessControllerOwner(t, owner, chainState.BypasserAccessControllerAccount, env, selector)
+	t.Helper()
+
+	assertMCMOwner(t, owner, state.GetMCMConfigPDA(mcmsState.McmProgram, mcmsState.ProposerMcmSeed), chain)
+	assertMCMOwner(t, owner, state.GetMCMConfigPDA(mcmsState.McmProgram, mcmsState.CancellerMcmSeed), chain)
+	assertMCMOwner(t, owner, state.GetMCMConfigPDA(mcmsState.McmProgram, mcmsState.BypasserMcmSeed), chain)
+	assertTimelockOwner(t, owner, state.GetTimelockConfigPDA(mcmsState.TimelockProgram, mcmsState.TimelockSeed), chain)
+	assertAccessControllerOwner(t, owner, mcmsState.ProposerAccessControllerAccount, chain)
+	assertAccessControllerOwner(t, owner, mcmsState.ExecutorAccessControllerAccount, chain)
+	assertAccessControllerOwner(t, owner, mcmsState.CancellerAccessControllerAccount, chain)
+	assertAccessControllerOwner(t, owner, mcmsState.BypasserAccessControllerAccount, chain)
 }
 
 func assertMCMOwner(
-	t *testing.T, want solana.PublicKey, configPDA solana.PublicKey, env cldf.Environment, selector uint64,
+	t *testing.T, want solana.PublicKey, configPDA solana.PublicKey, chain cldf_solana.Chain,
 ) {
 	t.Helper()
+
 	var config mcmBindings.MultisigConfig
-	err := env.BlockChains.SolanaChains()[selector].GetAccountDataBorshInto(env.GetContext(), configPDA, &config)
+	err := chain.GetAccountDataBorshInto(t.Context(), configPDA, &config)
 	require.NoError(t, err)
 	require.Equal(t, want, config.Owner)
 }
 
 func assertTimelockOwner(
-	t *testing.T, want solana.PublicKey, configPDA solana.PublicKey, env cldf.Environment, selector uint64,
+	t *testing.T, want solana.PublicKey, configPDA solana.PublicKey, chain cldf_solana.Chain,
 ) {
 	t.Helper()
+
 	var config timelockBindings.Config
-	err := env.BlockChains.SolanaChains()[selector].GetAccountDataBorshInto(env.GetContext(), configPDA, &config)
+	err := chain.GetAccountDataBorshInto(t.Context(), configPDA, &config)
 	require.NoError(t, err)
 	require.Equal(t, want, config.Owner)
 }
 
 func assertAccessControllerOwner(
-	t *testing.T, want solana.PublicKey, account solana.PublicKey, env cldf.Environment, selector uint64,
+	t *testing.T, want solana.PublicKey, account solana.PublicKey, chain cldf_solana.Chain,
 ) {
 	t.Helper()
+
 	var config accessControllerBindings.AccessController
-	err := env.BlockChains.SolanaChains()[selector].GetAccountDataBorshInto(env.GetContext(), account, &config)
+	err := chain.GetAccountDataBorshInto(t.Context(), account, &config)
 	require.NoError(t, err)
 	require.Equal(t, want, config.Owner)
-}
-
-func fundSignerPDAs(
-	t *testing.T, env cldf.Environment, chainSelector uint64, chainState *state.MCMSWithTimelockStateSolana,
-) {
-	t.Helper()
-	solChain := env.BlockChains.SolanaChains()[chainSelector]
-	timelockSignerPDA := state.GetTimelockSignerPDA(chainState.TimelockProgram, chainState.TimelockSeed)
-	mcmSignerPDA := state.GetMCMSignerPDA(chainState.McmProgram, chainState.ProposerMcmSeed)
-	signerPDAs := []solana.PublicKey{timelockSignerPDA, mcmSignerPDA}
-	err := memory.FundSolanaAccounts(env.GetContext(), signerPDAs, 1, solChain.Client)
-	require.NoError(t, err)
 }

--- a/deployment/common/changeset/solana/update_delay_timelock.go
+++ b/deployment/common/changeset/solana/update_delay_timelock.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gagliardetto/solana-go"
 
 	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/timelock"
+
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"

--- a/deployment/environment/memory/solana_chains.go
+++ b/deployment/environment/memory/solana_chains.go
@@ -256,6 +256,19 @@ func FundSolanaAccountsWithLogging(
 	return nil
 }
 
+// DownloadSolanaProgramArtifactsForTest downloads the Solana program artifacts for the test environment.
+//
+// This is a temporary function which will be replaced by a more comprehensive package which can
+// handle a more customizable download of artifacts.
+func DownloadSolanaProgramArtifactsForTest(t *testing.T) {
+	once.Do(func() {
+		err := DownloadSolanaProgramArtifacts(t.Context(), ProgramsPath, logger.Test(t), "b0f7cd3fbdbb")
+		require.NoError(t, err)
+		err = DownloadSolanaCCIPProgramArtifacts(t.Context(), ProgramsPath, logger.Test(t), "")
+		require.NoError(t, err)
+	})
+}
+
 func generateChainsSol(t *testing.T, numChains int, commitSha string) []cldf_chain.BlockChain {
 	t.Helper()
 


### PR DESCRIPTION
Update MCMS solana tests to use test engine runtime and simplifies the test setup with test helpers.

