### PR TITLE
core/cmd: restore background context to avoid race

### DIFF
--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -315,7 +315,7 @@ func (s *Shell) runNode(c *cli.Context) error {
 	}
 
 	// rootCtx will be cancelled when SIGINT|SIGTERM is received
-	rootCtx, cancelRootCtx := context.WithCancel(ctx)
+	rootCtx, cancelRootCtx := context.WithCancel(context.Background())
 
 	// cleanExit is used to skip "fail fast" routine
 	cleanExit := make(chan struct{})


### PR DESCRIPTION
Follow up from #19089

Wiring the CLI context directly through takes away the happens-before guarantee from cancelling in the shutdown goroutine after setting the `shutdownStartTime`, leading to a data race.