### PR TITLE
[PRIV-214] Remove TODO

### DIFF
--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -922,8 +922,6 @@ func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq 
 			}
 			obsMap[o.Id] = append(obsMap[o.Id], o)
 		}
-
-		// TODO -- we need to validate that a single oracle doesn't submit multiple observations for the same request.
 	}
 
 	os := &vaultcommon.Outcomes{


### PR DESCRIPTION
* Remove the TODO as we validate observations to ensure that a single observation batch doesn't contain multiple entries for the same request ID. See: https://github.com/smartcontractkit/chainlink/blob/c505b1dd3c18cb2930ee05bc2dcb04de8829abca/core/services/ocr2/plugins/vault/plugin.go#L783 