### PR TITLE
[CRE-491] Organize imports and minor cleanups

### DIFF
--- a/core/services/relay/evm/ccip.go
+++ b/core/services/relay/evm/ccip.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/abihelpers"
 	ccipconfig "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/config"

--- a/core/services/relay/evm/chain_reader.go
+++ b/core/services/relay/evm/chain_reader.go
@@ -15,7 +15,6 @@ import (
 	commoncodec "github.com/smartcontractkit/chainlink-common/pkg/codec"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
-	commonservices "github.com/smartcontractkit/chainlink-common/pkg/services"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/evm"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
@@ -43,7 +42,7 @@ type chainReader struct {
 	parsed   *codec.ParsedTypes
 	bindings *read.BindingsRegistry
 	codec    commontypes.RemoteCodec
-	commonservices.StateMachine
+	services.StateMachine
 }
 
 type EVMClient interface {
@@ -185,8 +184,8 @@ func (cr *chainReader) HealthReport() map[string]error {
 		cr.Name(): cr.Healthy(),
 	}
 
-	commonservices.CopyHealth(report, cr.lp.HealthReport())
-	commonservices.CopyHealth(report, cr.ht.HealthReport())
+	services.CopyHealth(report, cr.lp.HealthReport())
+	services.CopyHealth(report, cr.ht.HealthReport())
 	return report
 }
 

--- a/core/services/relay/evm/chain_reader.go
+++ b/core/services/relay/evm/chain_reader.go
@@ -14,6 +14,7 @@ import (
 
 	commoncodec "github.com/smartcontractkit/chainlink-common/pkg/codec"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	commonservices "github.com/smartcontractkit/chainlink-common/pkg/services"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/evm"
@@ -21,16 +22,15 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 	"github.com/smartcontractkit/chainlink-evm/pkg/codec"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config"
-	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
-
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink/v2/core/services"
+	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/read"
 )
 
 type ChainReaderService interface {
-	services.ServiceCtx
+	services.Service
 	commontypes.ContractReader
 }
 

--- a/core/services/relay/evm/chain_writer.go
+++ b/core/services/relay/evm/chain_writer.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fbsobreira/gotron-sdk/pkg/address"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	commonservices "github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	evmclient "github.com/smartcontractkit/chainlink-evm/pkg/client"
@@ -24,12 +24,10 @@ import (
 	"github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
 	trontxm "github.com/smartcontractkit/chainlink-tron/relayer/txm"
-
-	"github.com/smartcontractkit/chainlink/v2/core/services"
 )
 
 type ChainWriterService interface {
-	services.ServiceCtx
+	services.Service
 	commontypes.ContractWriter
 }
 
@@ -67,7 +65,7 @@ func NewChainWriterService(logger logger.Logger, client evmclient.Client, txm ev
 }
 
 type chainWriter struct {
-	commonservices.StateMachine
+	services.StateMachine
 
 	logger      logger.Logger
 	client      evmclient.Client

--- a/core/services/relay/evm/chain_writer_test.go
+++ b/core/services/relay/evm/chain_writer_test.go
@@ -22,6 +22,7 @@ import (
 	gasmocks "github.com/smartcontractkit/chainlink-evm/pkg/gas/mocks"
 	rollupmocks "github.com/smartcontractkit/chainlink-evm/pkg/gas/rollups/mocks"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
+
 	txmmocks "github.com/smartcontractkit/chainlink/v2/common/txmgr/mocks"
 )
 

--- a/core/services/relay/evm/commit_provider.go
+++ b/core/services/relay/evm/commit_provider.go
@@ -11,15 +11,14 @@ import (
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
-
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/estimatorconfig"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter"

--- a/core/services/relay/evm/config_poller.go
+++ b/core/services/relay/evm/config_poller.go
@@ -17,9 +17,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
-	"github.com/smartcontractkit/chainlink-evm/pkg/config"
-
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
+	"github.com/smartcontractkit/chainlink-evm/pkg/config"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 )
 

--- a/core/services/relay/evm/config_poller_test.go
+++ b/core/services/relay/evm/config_poller_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
-
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/link_token_interface"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
 	evmclient "github.com/smartcontractkit/chainlink-evm/pkg/client"
@@ -39,6 +38,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils"
+
 	"github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/testhelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"

--- a/core/services/relay/evm/evm_service.go
+++ b/core/services/relay/evm/evm_service.go
@@ -15,7 +15,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/chains/evm"
-	evmtypes "github.com/smartcontractkit/chainlink-common/pkg/types/chains/evm"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 	evmprimitives "github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives/evm"
@@ -34,7 +33,7 @@ type evmService struct {
 }
 
 // Direct RPC
-func (e *evmService) CallContract(ctx context.Context, request evmtypes.CallContractRequest) (*evmtypes.CallContractReply, error) {
+func (e *evmService) CallContract(ctx context.Context, request evm.CallContractRequest) (*evm.CallContractReply, error) {
 	opts := types.CallContractOpts{
 		ConfidenceLevel:   request.ConfidenceLevel,
 		IsExternalRequest: request.IsExternal,
@@ -47,10 +46,10 @@ func (e *evmService) CallContract(ctx context.Context, request evmtypes.CallCont
 		return nil, err
 	}
 
-	return &evmtypes.CallContractReply{Data: result}, nil
+	return &evm.CallContractReply{Data: result}, nil
 }
 
-func (e *evmService) FilterLogs(ctx context.Context, request evmtypes.FilterLogsRequest) (*evmtypes.FilterLogsReply, error) {
+func (e *evmService) FilterLogs(ctx context.Context, request evm.FilterLogsRequest) (*evm.FilterLogsReply, error) {
 	opts := types.FilterLogsOpts{
 		ConfidenceLevel:   request.ConfidenceLevel,
 		IsExternalRequest: request.IsExternal,
@@ -60,31 +59,31 @@ func (e *evmService) FilterLogs(ctx context.Context, request evmtypes.FilterLogs
 		return nil, err
 	}
 
-	logs := make([]*evmtypes.Log, 0, len(rawLogs))
+	logs := make([]*evm.Log, 0, len(rawLogs))
 	for _, l := range rawLogs {
 		logs = append(logs, convertLog(&l))
 	}
 
-	return &evmtypes.FilterLogsReply{Logs: logs}, nil
+	return &evm.FilterLogsReply{Logs: logs}, nil
 }
 
-func (e *evmService) BalanceAt(ctx context.Context, request evmtypes.BalanceAtRequest) (*evmtypes.BalanceAtReply, error) {
+func (e *evmService) BalanceAt(ctx context.Context, request evm.BalanceAtRequest) (*evm.BalanceAtReply, error) {
 	balance, err := e.chain.Client().BalanceAtWithOpts(ctx, request.Address, request.BlockNumber, types.BalanceAtOpts{ConfidenceLevel: request.ConfidenceLevel})
 	if err != nil {
 		return nil, err
 	}
 
-	return &evmtypes.BalanceAtReply{Balance: balance}, nil
+	return &evm.BalanceAtReply{Balance: balance}, nil
 }
 
-func (e *evmService) EstimateGas(ctx context.Context, call *evmtypes.CallMsg) (uint64, error) {
+func (e *evmService) EstimateGas(ctx context.Context, call *evm.CallMsg) (uint64, error) {
 	if call == nil {
 		return 0, errors.New("call can not be nil")
 	}
 	return e.chain.Client().EstimateGas(ctx, toEthMsg(*call))
 }
 
-func (e *evmService) GetTransactionByHash(ctx context.Context, request evmtypes.GetTransactionByHashRequest) (*evmtypes.Transaction, error) {
+func (e *evmService) GetTransactionByHash(ctx context.Context, request evm.GetTransactionByHashRequest) (*evm.Transaction, error) {
 	tx, err := e.chain.Client().TransactionByHashWithOpts(ctx, request.Hash, types.TransactionByHashOpts{IsExternalRequest: request.IsExternal})
 	if err != nil {
 		return nil, err
@@ -93,7 +92,7 @@ func (e *evmService) GetTransactionByHash(ctx context.Context, request evmtypes.
 	return convertTransaction(tx), nil
 }
 
-func (e *evmService) GetTransactionReceipt(ctx context.Context, request evmtypes.GeTransactionReceiptRequest) (*evmtypes.Receipt, error) {
+func (e *evmService) GetTransactionReceipt(ctx context.Context, request evm.GeTransactionReceiptRequest) (*evm.Receipt, error) {
 	receipt, err := e.chain.Client().TransactionReceiptWithOpts(ctx, request.Hash, types.TransactionReceiptOpts{IsExternalRequest: request.IsExternal})
 	if err != nil {
 		return nil, err
@@ -103,11 +102,11 @@ func (e *evmService) GetTransactionReceipt(ctx context.Context, request evmtypes
 }
 
 // ChainService
-func (e *evmService) GetTransactionFee(ctx context.Context, transactionID commontypes.IdempotencyKey) (*evmtypes.TransactionFee, error) {
+func (e *evmService) GetTransactionFee(ctx context.Context, transactionID commontypes.IdempotencyKey) (*evm.TransactionFee, error) {
 	return e.chain.TxManager().GetTransactionFee(ctx, transactionID)
 }
 
-func (e *evmService) HeaderByNumber(ctx context.Context, request evmtypes.HeaderByNumberRequest) (*evmtypes.HeaderByNumberReply, error) {
+func (e *evmService) HeaderByNumber(ctx context.Context, request evm.HeaderByNumberRequest) (*evm.HeaderByNumberReply, error) {
 	var err error
 	var h *types.Head
 	switch {
@@ -139,13 +138,13 @@ func (e *evmService) HeaderByNumber(ctx context.Context, request evmtypes.Header
 	}
 
 	header := convertHead(h)
-	return &evmtypes.HeaderByNumberReply{Header: header}, nil
+	return &evm.HeaderByNumberReply{Header: header}, nil
 }
 
 // TODO introduce parameters validation PLEX-1437
 func (e *evmService) QueryTrackedLogs(ctx context.Context, filterQuery []query.Expression,
 	limitAndSort query.LimitAndSort, confidenceLevel primitives.ConfidenceLevel,
-) ([]*evmtypes.Log, error) {
+) ([]*evm.Log, error) {
 	conformations := confidenceToConformations(confidenceLevel)
 	filterQuery = append(filterQuery, logpoller.NewConfirmationsFilter(conformations))
 	queryName := queryNameFromFilter(filterQuery)
@@ -167,7 +166,7 @@ func (e *evmService) GetFiltersNames(_ context.Context) ([]string, error) {
 	return filterNames, nil
 }
 
-func (e *evmService) RegisterLogTracking(ctx context.Context, filter evmtypes.LPFilterQuery) error {
+func (e *evmService) RegisterLogTracking(ctx context.Context, filter evm.LPFilterQuery) error {
 	lpfilter, err := convertLPFilter(filter)
 	if err != nil {
 		return err
@@ -199,7 +198,7 @@ func (e *evmService) GetTransactionStatus(ctx context.Context, transactionID com
 	return status, nil
 }
 
-func (e *evmService) SubmitTransaction(ctx context.Context, txRequest evmtypes.SubmitTransactionRequest) (*evmtypes.TransactionResult, error) {
+func (e *evmService) SubmitTransaction(ctx context.Context, txRequest evm.SubmitTransactionRequest) (*evm.TransactionResult, error) {
 	config := e.chain.Config()
 
 	fromAddress := config.EVM().Workflow().FromAddress().Address()
@@ -260,7 +259,7 @@ func (e *evmService) SubmitTransaction(ctx context.Context, txRequest evmtypes.S
 	}
 
 	if txStatus == evm.TxFatal {
-		return &evmtypes.TransactionResult{TxStatus: txStatus, TxIdempotencyKey: txID}, nil
+		return &evm.TransactionResult{TxStatus: txStatus, TxIdempotencyKey: txID}, nil
 	}
 
 	receipt, err := retry.Do(retryContext, e.logger, func(ctx context.Context) (*evmtxmgr.ChainReceipt, error) {
@@ -278,7 +277,7 @@ func (e *evmService) SubmitTransaction(ctx context.Context, txRequest evmtypes.S
 		return nil, fmt.Errorf("failed getting transaction receipt. %w", err)
 	}
 
-	return &evmtypes.TransactionResult{
+	return &evm.TransactionResult{
 		TxStatus:         evm.TxSuccess,
 		TxHash:           (*receipt).GetTxHash(),
 		TxIdempotencyKey: txID,
@@ -290,7 +289,7 @@ func (e *evmService) CalculateTransactionFee(ctx context.Context, receipt evm.Re
 		GasUsed:           receipt.GasUsed,
 		EffectiveGasPrice: receipt.EffectiveGasPrice,
 	})
-	return &evmtypes.TransactionFee{
+	return &evm.TransactionFee{
 		TransactionFee: txFee,
 	}, nil
 }
@@ -320,8 +319,8 @@ func queryNameFromFilter(filterQuery []query.Expression) string {
 	return address + "-" + eventSig
 }
 
-func convertHead(h *types.Head) *evmtypes.Header {
-	return &evmtypes.Header{
+func convertHead(h *types.Head) *evm.Header {
+	return &evm.Header{
 		Timestamp:  uint64(h.GetTimestamp().Unix()),
 		Hash:       bytesToHash(h.BlockHash().Bytes()),
 		Number:     big.NewInt(h.BlockNumber()),
@@ -329,8 +328,8 @@ func convertHead(h *types.Head) *evmtypes.Header {
 	}
 }
 
-func convertReceipt(r *gethtypes.Receipt) *evmtypes.Receipt {
-	return &evmtypes.Receipt{
+func convertReceipt(r *gethtypes.Receipt) *evm.Receipt {
+	return &evm.Receipt{
 		Status:            r.Status,
 		Logs:              convertLogs(r.Logs),
 		TxHash:            r.TxHash,
@@ -343,7 +342,7 @@ func convertReceipt(r *gethtypes.Receipt) *evmtypes.Receipt {
 	}
 }
 
-func convertEthFilter(q evmtypes.FilterQuery) ethereum.FilterQuery {
+func convertEthFilter(q evm.FilterQuery) ethereum.FilterQuery {
 	return ethereum.FilterQuery{
 		FromBlock: q.FromBlock,
 		ToBlock:   q.ToBlock,
@@ -354,7 +353,7 @@ func convertEthFilter(q evmtypes.FilterQuery) ethereum.FilterQuery {
 
 var errEmptyFilterName = errors.New("filter name can't be empty")
 
-func convertLPFilter(q evmtypes.LPFilterQuery) (logpoller.Filter, error) {
+func convertLPFilter(q evm.LPFilterQuery) (logpoller.Filter, error) {
 	if q.Name == "" {
 		return logpoller.Filter{}, errEmptyFilterName
 	}
@@ -371,13 +370,13 @@ func convertLPFilter(q evmtypes.LPFilterQuery) (logpoller.Filter, error) {
 	}, nil
 }
 
-func convertTransaction(tx *gethtypes.Transaction) *evmtypes.Transaction {
+func convertTransaction(tx *gethtypes.Transaction) *evm.Transaction {
 	var to evm.Address
 	if tx.To() != nil {
 		to = *tx.To()
 	}
 
-	return &evmtypes.Transaction{
+	return &evm.Transaction{
 		To:       to,
 		Data:     tx.Data(),
 		Hash:     tx.Hash(),
@@ -425,7 +424,7 @@ func hashesToArrays(input []common.Hash) [][32]byte {
 
 var empty common.Address
 
-func toEthMsg(msg evmtypes.CallMsg) ethereum.CallMsg {
+func toEthMsg(msg evm.CallMsg) ethereum.CallMsg {
 	var to *common.Address
 
 	if empty.Cmp(msg.To) != 0 {
@@ -440,8 +439,8 @@ func toEthMsg(msg evmtypes.CallMsg) ethereum.CallMsg {
 	}
 }
 
-func convertLogs(logs []*gethtypes.Log) []*evmtypes.Log {
-	ret := make([]*evmtypes.Log, 0, len(logs))
+func convertLogs(logs []*gethtypes.Log) []*evm.Log {
+	ret := make([]*evm.Log, 0, len(logs))
 
 	for _, l := range logs {
 		ret = append(ret, convertLog(l))
@@ -450,8 +449,8 @@ func convertLogs(logs []*gethtypes.Log) []*evmtypes.Log {
 	return ret
 }
 
-func convertLPLogs(logs []logpoller.Log) []*evmtypes.Log {
-	ret := make([]*evmtypes.Log, 0, len(logs))
+func convertLPLogs(logs []logpoller.Log) []*evm.Log {
+	ret := make([]*evm.Log, 0, len(logs))
 	for _, l := range logs {
 		gl := l.ToGethLog()
 		ret = append(ret, convertLog(&gl))
@@ -460,7 +459,7 @@ func convertLPLogs(logs []logpoller.Log) []*evmtypes.Log {
 	return ret
 }
 
-func convertLog(log *gethtypes.Log) *evmtypes.Log {
+func convertLog(log *gethtypes.Log) *evm.Log {
 	topics := hashesToArrays(log.Topics)
 
 	var eventSig [32]byte
@@ -468,7 +467,7 @@ func convertLog(log *gethtypes.Log) *evmtypes.Log {
 		eventSig = log.Topics[0]
 	}
 
-	return &evmtypes.Log{
+	return &evm.Log{
 		LogIndex:    uint32(log.Index),
 		BlockHash:   log.BlockHash,
 		BlockNumber: new(big.Int).SetUint64(log.BlockNumber),

--- a/core/services/relay/evm/evm_service.go
+++ b/core/services/relay/evm/evm_service.go
@@ -13,11 +13,9 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink-common/pkg/types/chains/evm"
-
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/chains/evm"
 	evmtypes "github.com/smartcontractkit/chainlink-common/pkg/types/chains/evm"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 	evmprimitives "github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives/evm"

--- a/core/services/relay/evm/evm_service_test.go
+++ b/core/services/relay/evm/evm_service_test.go
@@ -10,28 +10,24 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
-
-	gethtypes "github.com/ethereum/go-ethereum/core/types"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/chains/evm"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	configmocks "github.com/smartcontractkit/chainlink-evm/pkg/config/mocks"
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads/headstest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
-
+	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	evmmocks "github.com/smartcontractkit/chainlink/v2/common/chains/mocks"
 	lpmocks "github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
 	txmmocks "github.com/smartcontractkit/chainlink/v2/common/txmgr/mocks"
-
-	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 )
 
 const ExpectedTxHash = "0xabcd"

--- a/core/services/relay/evm/evm_test.go
+++ b/core/services/relay/evm/evm_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 )
 

--- a/core/services/relay/evm/functions.go
+++ b/core/services/relay/evm/functions.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
 	txm "github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/functions/config"
 	functionsRelay "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/functions"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter"

--- a/core/services/relay/evm/functions/contract_transmitter.go
+++ b/core/services/relay/evm/functions/contract_transmitter.go
@@ -19,13 +19,14 @@ import (
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
-	"github.com/smartcontractkit/chainlink/v2/core/services"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/functions/encoding"
 )
 
@@ -34,7 +35,7 @@ type txManager interface {
 }
 
 type FunctionsContractTransmitter interface {
-	services.ServiceCtx
+	services.Service
 	ocrtypes.ContractTransmitter
 }
 

--- a/core/services/relay/evm/median.go
+++ b/core/services/relay/evm/median.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
+
 	offchain_aggregator_wrapper "github.com/smartcontractkit/chainlink/v2/core/internal/gethwrappers2/generated/offchainaggregator"
 )
 

--- a/core/services/relay/evm/median_test.go
+++ b/core/services/relay/evm/median_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config"
-
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+
 	"github.com/smartcontractkit/chainlink/v2/common/chains/mocks"
 )
 

--- a/core/services/relay/evm/mercury_config_provider.go
+++ b/core/services/relay/evm/mercury_config_provider.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury"
 )
 

--- a/core/services/relay/evm/ocr3_capability_provider.go
+++ b/core/services/relay/evm/ocr3_capability_provider.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
-
-	"github.com/ethereum/go-ethereum/crypto"
-
 	ocr3_capability "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/ocr3_capability_1_0_0"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 )
 

--- a/core/services/relay/evm/plugin_provider.go
+++ b/core/services/relay/evm/plugin_provider.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/transmitter"
 )
 

--- a/core/services/relay/evm/relayer_extender.go
+++ b/core/services/relay/evm/relayer_extender.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas/rollups"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 )
 

--- a/core/services/relay/evm/request_round_db_test.go
+++ b/core/services/relay/evm/request_round_db_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/testhelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 )
 
@@ -30,7 +30,7 @@ func Test_DB_LatestRoundRequested(t *testing.T) {
 
 	rr := ocr2aggregator.OCR2AggregatorRoundRequested{
 		Requester:    testutils.NewAddress(),
-		ConfigDigest: testhelpers.MakeConfigDigest(t),
+		ConfigDigest: types.ConfigDigest{},
 		Epoch:        42,
 		Round:        9,
 		Raw:          rawLog,
@@ -46,7 +46,7 @@ func Test_DB_LatestRoundRequested(t *testing.T) {
 		// Now overwrite to prove that updating works
 		rr = ocr2aggregator.OCR2AggregatorRoundRequested{
 			Requester:    testutils.NewAddress(),
-			ConfigDigest: testhelpers.MakeConfigDigest(t),
+			ConfigDigest: types.ConfigDigest{},
 			Epoch:        43,
 			Round:        8,
 			Raw:          rawLog,

--- a/core/services/relay/evm/request_round_tracker.go
+++ b/core/services/relay/evm/request_round_tracker.go
@@ -15,9 +15,9 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-
 	evmclient "github.com/smartcontractkit/chainlink-evm/pkg/client"
 	"github.com/smartcontractkit/chainlink-evm/pkg/log"
+
 	offchain_aggregator_wrapper "github.com/smartcontractkit/chainlink/v2/core/internal/gethwrappers2/generated/offchainaggregator"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 )

--- a/core/services/relay/evm/request_round_tracker_test.go
+++ b/core/services/relay/evm/request_round_tracker_test.go
@@ -15,7 +15,6 @@ import (
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/configtest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads/headstest"
@@ -25,7 +24,6 @@ import (
 	logmocks "github.com/smartcontractkit/chainlink/v2/common/log/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	offchain_aggregator_wrapper "github.com/smartcontractkit/chainlink/v2/core/internal/gethwrappers2/generated/offchainaggregator"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/testhelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mocks"
 )
@@ -256,7 +254,7 @@ func Test_OCRContractTracker_HandleLog_OCRContractLatestRoundRequested(t *testin
 		rawLog := cltest.LogFromFixture(t, "../../../testdata/jsonrpc/ocr2_round_requested_log_1_1.json")
 		rr := ocr2aggregator.OCR2AggregatorRoundRequested{
 			Requester:    testutils.NewAddress(),
-			ConfigDigest: testhelpers.MakeConfigDigest(t),
+			ConfigDigest: ocrtypes.ConfigDigest{},
 			Epoch:        42,
 			Round:        9,
 			Raw:          rawLog,

--- a/core/services/relay/evm/standard_config_provider.go
+++ b/core/services/relay/evm/standard_config_provider.go
@@ -11,9 +11,8 @@ import (
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink-evm/pkg/config"
-
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
+	"github.com/smartcontractkit/chainlink-evm/pkg/config"
 )
 
 func newStandardConfigProvider(ctx context.Context, lggr logger.Logger, chain legacyevm.Chain, opts *config.RelayOpts) (*configWatcher, error) {

--- a/core/services/relay/evm/target_strategy.go
+++ b/core/services/relay/evm/target_strategy.go
@@ -17,7 +17,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
-
 	evmtxmgr "github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	"github.com/smartcontractkit/chainlink-framework/capabilities/writetarget"
 )

--- a/core/services/relay/evm/write_target.go
+++ b/core/services/relay/evm/write_target.go
@@ -14,20 +14,17 @@ import (
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/config"
-	dfprocessor "github.com/smartcontractkit/chainlink-evm/pkg/report/datafeeds/processor"
-	porprocessor "github.com/smartcontractkit/chainlink-evm/pkg/report/por/processor"
-	df "github.com/smartcontractkit/chainlink-framework/capabilities/writetarget/monitoring/pb/data-feeds/on-chain/registry"
-	"github.com/smartcontractkit/chainlink-framework/capabilities/writetarget/report/platform/processor"
-
-	"github.com/smartcontractkit/chainlink-framework/capabilities/writetarget"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	ocr3types "github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
 	forwarder "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/forwarder_1_0_0"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
+	"github.com/smartcontractkit/chainlink-evm/pkg/config"
+	dfprocessor "github.com/smartcontractkit/chainlink-evm/pkg/report/datafeeds/processor"
+	porprocessor "github.com/smartcontractkit/chainlink-evm/pkg/report/por/processor"
+	"github.com/smartcontractkit/chainlink-framework/capabilities/writetarget"
+	df "github.com/smartcontractkit/chainlink-framework/capabilities/writetarget/monitoring/pb/data-feeds/on-chain/registry"
+	"github.com/smartcontractkit/chainlink-framework/capabilities/writetarget/report/platform/processor"
 )
 
 func NewWriteTarget(ctx context.Context, relayer *Relayer, chain legacyevm.Chain, gasLimitDefault uint64, lggr logger.Logger) (capabilities.ExecutableCapability, error) {


### PR DESCRIPTION
- Organized imports
- Use empty `ocrtypes.ConfigDigest{}` instead `testhelpers.MakeConfigDigest(t)` in tests
- Use common's `services.Service` instead of `services.ServiceCtx`.