### PR TITLE
fix(ci): separate go module cache for deployment module

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -200,10 +200,11 @@ jobs:
           - cmd: go_core_ccip_deployment_tests
             os: ${{ needs.runner-config.outputs.deployment-tests-runner }}
             should-run: ${{ needs.filter.outputs.should-run-deployment-tests }}
+            trunk-auto-quarantine: "true"
+            go-mod-directory: "deployment/"
             setup-solana: "true"
             setup-aptos: "true"
             setup-sui: "true"
-            trunk-auto-quarantine: "true"
 
     name: Core Tests (${{ matrix.type.cmd }}) # Be careful modifying the job name, as it is used to fetch the job URL
     # We don't directly merge dependabot PRs, so let's not waste the resources
@@ -234,6 +235,8 @@ jobs:
           # race/fuzz tests don't benefit repeated caching, so restore from develop's build cache
           restore-build-cache-only: ${{ matrix.type.cmd == 'go_core_fuzz' || matrix.type.cmd == 'go_core_race_tests' }}
           build-cache-version: ${{ matrix.type.cmd }}
+          go-version-file: ${{ matrix.type.go-mod-directory }}go.mod
+          go-module-file: ${{ matrix.type.go-mod-directory }}go.sum
 
       - name: Setup Solana
         if: ${{ matrix.type.should-run == 'true' && matrix.type.setup-solana == 'true' }}

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -34,10 +34,18 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-latest
-            suffix: "(Github-hosted)"
+            suffix: "Core (Github-hosted)"
+
+          - runs-on: ubuntu-latest
+            suffix: "Deployment (Github-hosted)"
+            go-mod-directory: "deployment/"
 
           - runs-on: runs-on=${{ github.run_id }}/cpu=8/ram=16/family=c6id/spot=false/extras=s3-cache
-            suffix: "(Self-hosted)"
+            suffix: "Core (Self-hosted)"
+
+          - runs-on: runs-on=${{ github.run_id }}/cpu=8/ram=16/family=c6id/spot=false/extras=s3-cache
+            suffix: "Deployment (Self-hosted)"
+            go-mod-directory: "deployment/"
 
     runs-on: ${{ matrix.runs-on }}
     permissions:
@@ -60,15 +68,22 @@ jobs:
         with:
           only-modules: "true"
           restore-module-cache-only: "false"
+          go-version-file: ${{ matrix.go-mod-directory }}go.mod
+          go-module-file: ${{ matrix.go-mod-directory }}go.sum
 
-      - name: Install Dependencies
+      - name: go mod download
         if: ${{ steps.setup-go.outputs.primary-cache-hit-modules != 'true' }}
         shell: bash
+        working-directory: ${{ matrix.go-mod-directory || '.' }}
         run: |
           echo "::group::go mod download"
           go mod download
           echo "::endgroup::"
 
+      - name: Fetch other dependencies
+        if: ${{ steps.setup-go.outputs.primary-cache-hit-modules != 'true' }}
+        shell: bash
+        run: |
           echo "::group::Install LOOP plugins"
           make install-plugins-public
           echo "::endgroup::"


### PR DESCRIPTION
### Changes

* Setup a separate module cache for `deployment` module
* Utilize this cache for deployment unit tests

### Testing

* ccip deployment unit tests with core's module cache: https://github.com/smartcontractkit/chainlink/actions/runs/18539924884/job/52844564919?pr=19911#step:16:43
* Cache created here: https://github.com/smartcontractkit/chainlink/actions/runs/18539924925/job/52844537273?pr=19911#step:12:10
* re-run with deployment specific module cache: https://github.com/smartcontractkit/chainlink/actions/runs/18539924884/job/52845757473?pr=19911