### PR TITLE
fix: pin plugins to version in go.mod

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -697,4 +697,8 @@ jobs:
             --plugin-file ./plugins/plugins.public.yaml \
             --module github.com/smartcontractkit/chainlink-data-streams \
             --module github.com/smartcontractkit/chainlink-feeds \
-            --module github.com/smartcontractkit/chainlink-solana
+            --module github.com/smartcontractkit/chainlink-solana \
+            --module github.com/smartcontractkit/chainlink-sui \
+            --module github.com/smartcontractkit/chainlink-aptos \
+            --module github.com/smartcontractkit/chainlink-ton \
+            --module github.com/smartcontractkit/chainlink-tron/relayer

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20251007010318-c9a7b2d44524
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20251012014843-5d44e7731854
 	github.com/smartcontractkit/chainlink-ton v0.0.0-20251015181357-b635fc06e2ea
-	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335
+	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513
 	github.com/smartcontractkit/cre-sdk-go v0.7.1-0.20250919133015-2df149f34a81
 	github.com/smartcontractkit/cre-sdk-go/capabilities/networking/http v0.7.0
 	github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron v0.8.0

--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20251008185222-47a7460f5207
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20251007010318-c9a7b2d44524
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20251012014843-5d44e7731854
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20251009173109-af31806bede5
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20251015181357-b635fc06e2ea
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335
 	github.com/smartcontractkit/cre-sdk-go v0.7.1-0.20250919133015-2df149f34a81
 	github.com/smartcontractkit/cre-sdk-go/capabilities/networking/http v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1157,8 +1157,8 @@ github.com/smartcontractkit/chainlink-sui v0.0.0-20251012014843-5d44e7731854 h1:
 github.com/smartcontractkit/chainlink-sui v0.0.0-20251012014843-5d44e7731854/go.mod h1:VlyZhVw+a93Sk8rVHOIH6tpiXrMzuWLZrjs1eTIExW8=
 github.com/smartcontractkit/chainlink-ton v0.0.0-20251015181357-b635fc06e2ea h1:zIvJnL9i5pOZXzJxyn05mjasFLrHmMY2vM3qiipi2dE=
 github.com/smartcontractkit/chainlink-ton v0.0.0-20251015181357-b635fc06e2ea/go.mod h1:L4KmKujzDxXBWu/Tk9HzQ9tysaW17PIv9hW0dB2/qsg=
-github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335 h1:7bxYNrPpygn8PUSBiEKn8riMd7CXMi/4bjTy0fHhcrY=
-github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
+github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 h1:XRNxgcNqagXu6e4smJuS1crRK5cUAcCVd7u+iLduHDM=
+github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20251014124537-af6b1684fe15 h1:idp/RjsFznR48JWGfZICsrpcl9JTrnMzoUNVz8MhQMI=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20251014124537-af6b1684fe15/go.mod h1:ea1LESxlSSOgc2zZBqf1RTkXTMthHaspdqUHd7W4lF0=
 github.com/smartcontractkit/cre-sdk-go v0.7.1-0.20250919133015-2df149f34a81 h1:CfnjzJvn3iX93PzdGucyGJmgv/KDXv8DfKcLw/mix24=

--- a/go.sum
+++ b/go.sum
@@ -1155,8 +1155,8 @@ github.com/smartcontractkit/chainlink-solana v1.1.2-0.20251007010318-c9a7b2d4452
 github.com/smartcontractkit/chainlink-solana v1.1.2-0.20251007010318-c9a7b2d44524/go.mod h1:vcms/UPnfg7LZ2txinn59yJR6rXZ31XOk5++03LOeys=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20251012014843-5d44e7731854 h1:7KMcSEptDirqBY/jzNhxFvWmDE2s5KQE6uMPQ1inad4=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20251012014843-5d44e7731854/go.mod h1:VlyZhVw+a93Sk8rVHOIH6tpiXrMzuWLZrjs1eTIExW8=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20251009173109-af31806bede5 h1:/nQQk0m0vcgOHS/7/uwdnIZFB632t4/I8lz+RTsQU/Q=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20251009173109-af31806bede5/go.mod h1:L4KmKujzDxXBWu/Tk9HzQ9tysaW17PIv9hW0dB2/qsg=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20251015181357-b635fc06e2ea h1:zIvJnL9i5pOZXzJxyn05mjasFLrHmMY2vM3qiipi2dE=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20251015181357-b635fc06e2ea/go.mod h1:L4KmKujzDxXBWu/Tk9HzQ9tysaW17PIv9hW0dB2/qsg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335 h1:7bxYNrPpygn8PUSBiEKn8riMd7CXMi/4bjTy0fHhcrY=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20251014124537-af6b1684fe15 h1:idp/RjsFznR48JWGfZICsrpcl9JTrnMzoUNVz8MhQMI=

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -50,7 +50,7 @@ plugins:
 
   ton:
     - moduleURI: "github.com/smartcontractkit/chainlink-ton"
-      gitRef: "b635fc06e2ea794fc46aa8993fa951b938537f9a"
+      gitRef: "v0.0.0-20251015181357-b635fc06e2ea"
       installPath: "./cmd/chainlink-ton"
 
   tron:

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -55,5 +55,5 @@ plugins:
 
   tron:
     - moduleURI: "github.com/smartcontractkit/chainlink-tron/relayer"
-      gitRef: "v0.0.11-0.20250815105909-75499abc4335"
+      gitRef: "v0.0.11-0.20250908203554-5bd9d2fe9513"
       installPath: "./cmd/chainlink-tron"

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -15,7 +15,7 @@ plugins:
 
   sui:
     - moduleURI: "github.com/smartcontractkit/chainlink-sui"
-      gitRef: "v0.0.0-20251010233212-b9ec3ced4b03"
+      gitRef: "v0.0.0-20251012014843-5d44e7731854"
       installPath: "./relayer/cmd/chainlink-sui"
 
   cosmos:
@@ -55,5 +55,5 @@ plugins:
 
   tron:
     - moduleURI: "github.com/smartcontractkit/chainlink-tron/relayer"
-      gitRef: "825077b2d5a7603be953fa23f98f18a6f2139cc0"
+      gitRef: "v0.0.11-0.20250815105909-75499abc4335"
       installPath: "./cmd/chainlink-tron"


### PR DESCRIPTION
### Changes

* Add missing modules to plugout CI check
* Synchronized plugin version to newer version between go.mod and plugins file
* Ran command locally with `--update`

### Reviewers

Added everyone who recently modified the plugins.public file for the updated plugins
