### PR TITLE
feat: use sensible defaults for SetTokenTransferFeeConfig changesets

### DIFF
--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
@@ -6,6 +6,8 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -49,8 +51,8 @@ type SetTokenTransferFeeArgs struct {
 // To avoid these types of situations, we use pointers for each config field in the struct below. If
 // a field is undefined or set to nil in the struct, then we will fallback to using any pre-existing
 // values from the chain before sending the transaction. Otherwise the user's input values are used.
-// If a token has no pre-existing config values on-chain (i.e. isEnabled == false), then every field
-// must be explicitly provided by the caller.
+// If a token has no pre-existing config values on-chain (i.e. isEnabled == false), then we use some
+// sensible defaults for the missing fields.
 type TokenTransferFeeArgs struct {
 	MinFeeUSDCents            *uint32
 	MaxFeeUSDCents            *uint32
@@ -60,13 +62,36 @@ type TokenTransferFeeArgs struct {
 	AggregateRateLimitEnabled *bool
 }
 
-func (args TokenTransferFeeArgs) HasMissingFields() bool {
-	return args.MinFeeUSDCents == nil ||
-		args.MaxFeeUSDCents == nil ||
-		args.DeciBps == nil ||
-		args.DestGasOverhead == nil ||
-		args.DestBytesOverhead == nil ||
-		args.AggregateRateLimitEnabled == nil
+func (args TokenTransferFeeArgs) FillMissingValues(srcSelector uint64, dstSelector uint64) TokenTransferFeeArgs {
+	// this config is dynamically adjusted (ethereum is very expensive)
+	minFeeUsdCentsVal := uint32(25)
+
+	// NOTE: we validate that src != dst so only one of these if statements will execute
+	if srcSelector == chain_selectors.ETHEREUM_MAINNET.Selector {
+		minFeeUsdCentsVal = 50
+	}
+	if dstSelector == chain_selectors.ETHEREUM_MAINNET.Selector {
+		minFeeUsdCentsVal = 150
+	}
+
+	// if the user has already provided the config values, then prefer those over sensible defaults
+	aggregateRateLimitEnabled := pointer.Coalesce(args.AggregateRateLimitEnabled, false)
+	minFeeUsdCents := pointer.Coalesce(args.MinFeeUSDCents, minFeeUsdCentsVal)
+	maxFeeUsdCents := pointer.Coalesce(args.MaxFeeUSDCents, uint32(4_294_967_295))
+	destGasOverhead := pointer.Coalesce(args.DestGasOverhead, uint32(90_000))
+	destBytesOverhead := pointer.Coalesce(args.DestBytesOverhead, uint32(32))
+	deciBps := pointer.Coalesce(args.DeciBps, uint16(0))
+
+	// modify the struct in-place
+	args.MinFeeUSDCents = &minFeeUsdCents
+	args.MaxFeeUSDCents = &maxFeeUsdCents
+	args.DeciBps = &deciBps
+	args.DestGasOverhead = &destGasOverhead
+	args.DestBytesOverhead = &destBytesOverhead
+	args.AggregateRateLimitEnabled = &aggregateRateLimitEnabled
+
+	// return the modified config
+	return args
 }
 
 func setTokenTransferFeeConfigPrecondition(env cldf.Environment, cfg SetTokenTransferFeeConfig) error {
@@ -180,6 +205,12 @@ func setTokenTransferFeeConfigLogic(env cldf.Environment, cfg SetTokenTransferFe
 				return cldf.ChangesetOutput{}, fmt.Errorf("no EVM2EVMOnRamp (src = %s, dst = %s)", srcChain.String(), dstChain.String())
 			}
 
+			env.Logger.Infof("found OnRamp on source chain (src = %s, dst = %s, onramp = %s)",
+				srcChain.String(),
+				dstChain.String(),
+				onramp.Address().Hex(),
+			)
+
 			tokenTransferFeeConfigArgs := []evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs{}
 			for tokenAddress, args := range input.TokenTransferFeeConfigArgs {
 				// This gets the token transfer fee config for the given token - if it doesn't exist, then the zero struct will be returned and `IsEnabled` will be `false`
@@ -189,13 +220,15 @@ func setTokenTransferFeeConfigLogic(env cldf.Environment, cfg SetTokenTransferFe
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to fetch token transfer fee config (src = %s, dst = %s, token = %s): %w", srcChain.String(), dstChain.String(), tokenAddress.Hex(), err)
 				}
 
-				// If no custom config already exists on-chain for the token, then we have no fallback values to use - in this case the caller must explicitly provide all fields
+				// If no custom config already exists on-chain for the token, then use sensible defaults for any missing fields
 				env.Logger.Infof("fetched token transfer fee config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), curConfig)
-				if !curConfig.IsEnabled && args.HasMissingFields() {
-					return cldf.ChangesetOutput{}, fmt.Errorf("invalid args - when enabling a new token, all fields must be provided (src = %s, dst = %s, token = %s)", srcChain.String(), dstChain.String(), tokenAddress.Hex())
+				if !curConfig.IsEnabled {
+					env.Logger.Infof("no token transfer fee config exists on chain - filling in missing values (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
+					args = args.FillMissingValues(srcSelector, dstSelector)
+					env.Logger.Infof("missing values have been filled in with sensible defaults (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
 				}
 
-				// At this point, we're either using fallback values from the chain or the caller has explicitly provided the inputs
+				// At this point, we're either using inputs from the user (highest precedence), fallback values from the chain, or pre-defined sensible defaults
 				newConfig := evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs{
 					Token:                     tokenAddress,
 					MinFeeUSDCents:            pointer.Coalesce(args.MinFeeUSDCents, curConfig.MinFeeUSDCents),

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config_test.go
@@ -178,22 +178,6 @@ func TestSetTokenTransferFeeConfig_Validations(t *testing.T) {
 				},
 			},
 		},
-		{
-			Msg: "Enabling new token with missing fields (logic-time check)",
-			Err: "invalid args - when enabling a new token, all fields must be provided",
-			Config: v1_5_1.SetTokenTransferFeeConfig{
-				MCMS: mcmCfg,
-				InputsByChain: map[uint64]map[uint64]v1_5_1.SetTokenTransferFeeArgs{
-					src: {
-						dst: {
-							TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
-								utils.RandomAddress(): {MinFeeUSDCents: pointer.To(uint32(1))}, // others nil -> should error
-							},
-						},
-					},
-				},
-			},
-		},
 	}
 
 	// Run all tests

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -2360,20 +2360,43 @@ type OptionalFeeQuoterTokenTransferFeeConfig struct {
 	IsEnabled         *bool
 }
 
-func (cfg OptionalFeeQuoterTokenTransferFeeConfig) HasMissingFields() bool {
-	return cfg.MinFeeUSDCents == nil ||
-		cfg.MaxFeeUSDCents == nil ||
-		cfg.DeciBps == nil ||
-		cfg.DestGasOverhead == nil ||
-		cfg.DestBytesOverhead == nil ||
-		cfg.IsEnabled == nil
+func (args OptionalFeeQuoterTokenTransferFeeConfig) FillMissingValues(srcSelector uint64, dstSelector uint64) OptionalFeeQuoterTokenTransferFeeConfig {
+	// this config is dynamically adjusted (ethereum is very expensive)
+	minFeeUsdCentsVal := uint32(25)
+
+	// NOTE: we validate that src != dst so only one of these if statements will execute
+	if srcSelector == chain_selectors.ETHEREUM_MAINNET.Selector {
+		minFeeUsdCentsVal = 50
+	}
+	if dstSelector == chain_selectors.ETHEREUM_MAINNET.Selector {
+		minFeeUsdCentsVal = 150
+	}
+
+	// if the user has already provided the config values, then prefer those over sensible defaults
+	minFeeUsdCents := pointer.Coalesce(args.MinFeeUSDCents, minFeeUsdCentsVal)
+	maxFeeUsdCents := pointer.Coalesce(args.MaxFeeUSDCents, uint32(4_294_967_295))
+	destGasOverhead := pointer.Coalesce(args.DestGasOverhead, uint32(90_000))
+	destBytesOverhead := pointer.Coalesce(args.DestBytesOverhead, uint32(32))
+	deciBps := pointer.Coalesce(args.DeciBps, uint16(0))
+	isEnabled := pointer.Coalesce(args.IsEnabled, true)
+
+	// modify the struct in-place
+	args.MinFeeUSDCents = &minFeeUsdCents
+	args.MaxFeeUSDCents = &maxFeeUsdCents
+	args.DeciBps = &deciBps
+	args.DestGasOverhead = &destGasOverhead
+	args.DestBytesOverhead = &destBytesOverhead
+	args.IsEnabled = &isEnabled
+
+	// return the modified config
+	return args
 }
 
 // ApplyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2 applies per-source/per-dest token transfer fee updates directly to
 // the FeeQuoter using address-keyed inputs. It validates source and dest selectors, forbids zero / duplicate token addresses,
-// enforces that all fields are provided when no on-chain config exists for a token, merges partial inputs with the current
-// on-chain config, skips no-op updates, and sends a single call per (src,dst). Source chains must be EVM; destinations may be
-// EVM or non-EVM.
+// fills in missing values with sensible defaults when no on-chain config exists for a token, merges partial inputs with the
+// current on-chain config if it exists, skips no-op updates, and sends a single call per (src,dst). Source chains must be EVM
+// and destinations may be EVM or non-EVM.
 var ApplyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2 = cldf.CreateChangeSet(
 	applyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2Logic,
 	applyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2Precondition,
@@ -2490,6 +2513,12 @@ func applyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2Logic(env cldf.Enviro
 				tokensToUseDefaultFeeConfigs[i] = fee_quoter.FeeQuoterTokenTransferFeeConfigRemoveArgs{DestChainSelector: dstSelector, Token: tokenAddress}
 			}
 
+			env.Logger.Infof("found fee quoter on source chain (src = %s, dst = %s, fq = %s)",
+				srcChain.String(),
+				dstChain.String(),
+				chainState.FeeQuoter.Address().Hex(),
+			)
+
 			tokenTransferFeeConfigs := []fee_quoter.FeeQuoterTokenTransferFeeConfigSingleTokenArgs{}
 			for tokenAddress, args := range input.TokenTransferFeeConfigArgs {
 				// This gets the token transfer fee config for the given token - if it doesn't exist, then the zero struct will be returned and `IsEnabled` will be `false`
@@ -2499,13 +2528,15 @@ func applyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2Logic(env cldf.Enviro
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to fetch token transfer fee config (src = %s, dst = %s, token = %s): %w", srcChain.String(), dstChain.String(), tokenAddress.Hex(), err)
 				}
 
-				// If no custom config already exists on-chain for the token, then we have no fallback values to use - in this case the caller must explicitly provide all fields
+				// If no custom config already exists on-chain for the token, then use sensible defaults for any missing fields
 				env.Logger.Infof("fetched token transfer fee config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), curConfig)
-				if !curConfig.IsEnabled && args.HasMissingFields() {
-					return cldf.ChangesetOutput{}, fmt.Errorf("invalid args - when enabling a new token, all fields must be provided (src = %s, dst = %s, token = %s)", srcChain.String(), dstChain.String(), tokenAddress.Hex())
+				if !curConfig.IsEnabled {
+					env.Logger.Infof("no token transfer fee config exists on chain - filling in missing values (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
+					args = args.FillMissingValues(srcSelector, dstSelector)
+					env.Logger.Infof("missing values have been filled in with sensible defaults (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
 				}
 
-				// At this point, we're either using fallback values from the chain or the caller has explicitly provided the inputs
+				// At this point, we're either using inputs from the user (highest precedence), fallback values from the chain, or pre-defined sensible defaults
 				newConfig := fee_quoter.FeeQuoterTokenTransferFeeConfigSingleTokenArgs{
 					Token: tokenAddress,
 					TokenTransferFeeConfig: fee_quoter.FeeQuoterTokenTransferFeeConfig{


### PR DESCRIPTION
Changes:
- **Logs the OnRamp address on the source chain for v1.5 SetTokenTransferFeeConfig changeset**
- **Logs the FeeQuoter address on the source chain for v1.6 SetTokenTransferFeeConfig changeset**
- **If a token config has not been set yet and some fields are missing from the input, then automatically fill them in (for v1.5 and v1.6)**