### PR TITLE
[PRIV-36] Add confidential-http to proposable job specs

### DIFF
--- a/.changeset/cool-trees-laugh.md
+++ b/.changeset/cool-trees-laugh.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#added confidential-http to proposable job specs in chainlink/deployment

--- a/deployment/cre/jobs/propose_job_spec.go
+++ b/deployment/cre/jobs/propose_job_spec.go
@@ -61,7 +61,7 @@ func (u ProposeJobSpec) VerifyPreconditions(_ cldf.Environment, config ProposeJo
 		if err := verifyEVMJobSpecInputs(config.Inputs); err != nil {
 			return fmt.Errorf("invalid inputs for EVM job spec: %w", err)
 		}
-	case job_types.Cron, job_types.BootstrapOCR3, job_types.OCR3, job_types.Gateway, job_types.HTTPTrigger, job_types.HTTPAction, job_types.BootstrapVault, job_types.Consensus:
+	case job_types.Cron, job_types.BootstrapOCR3, job_types.OCR3, job_types.Gateway, job_types.HTTPTrigger, job_types.HTTPAction, job_types.ConfidentialHTTP, job_types.BootstrapVault, job_types.Consensus:
 	default:
 		return fmt.Errorf("unsupported template: %s", config.Template)
 	}
@@ -77,7 +77,7 @@ func (u ProposeJobSpec) Apply(e cldf.Environment, input ProposeJobSpecInput) (cl
 	var report operations.Report[any, any]
 	switch input.Template {
 	// This will hold all standard capabilities jobs as we add support for them.
-	case job_types.EVM, job_types.Cron, job_types.HTTPTrigger, job_types.HTTPAction, job_types.Consensus:
+	case job_types.EVM, job_types.Cron, job_types.HTTPTrigger, job_types.HTTPAction, job_types.ConfidentialHTTP, job_types.Consensus:
 		// Only consensus generates an oracle factory, for now...
 		job, err := input.Inputs.ToStandardCapabilityJob(input.JobName, input.Template == job_types.Consensus)
 		if err != nil {

--- a/deployment/cre/jobs/propose_job_spec_test.go
+++ b/deployment/cre/jobs/propose_job_spec_test.go
@@ -93,6 +93,27 @@ func TestProposeJobSpec_VerifyPreconditions(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "valid http action job",
+			input: jobs.ProposeJobSpecInput{
+				Environment: "test",
+				JobName:     "confidential-http-test",
+				Domain:      "cre",
+				DONName:     "test-don",
+				DONFilters: []offchain.TargetDONFilter{
+					{Key: offchain.FilterKeyDONName, Value: "d"},
+					{Key: "environment", Value: "e"},
+					{Key: "product", Value: offchain.ProductLabel},
+				},
+				Template: job_types.ConfidentialHTTP,
+				Inputs: job_types.JobSpecInput{
+					"command":       "confidential-http",
+					"config":        `{"proxyMode": "direct"}`,
+					"externalJobID": "confidential-http-job-id",
+				},
+			},
+			expectError: false,
+		},
+		{
 			name: "valid evm job",
 			input: jobs.ProposeJobSpecInput{
 				Environment: "test",

--- a/deployment/cre/jobs/types/job_spec_template.go
+++ b/deployment/cre/jobs/types/job_spec_template.go
@@ -17,6 +17,7 @@ const (
 	OCR3
 	HTTPTrigger
 	HTTPAction
+	ConfidentialHTTP
 	EVM
 	Gateway
 	BootstrapVault
@@ -35,6 +36,8 @@ func (jt JobSpecTemplate) String() string {
 		return "http-trigger"
 	case HTTPAction:
 		return "http-action"
+	case ConfidentialHTTP:
+		return "confidential-http"
 	case EVM:
 		return "evm"
 	case Gateway:
@@ -61,6 +64,8 @@ func parseJobSpecTemplate(s string) (JobSpecTemplate, error) {
 		return HTTPTrigger, nil
 	case "http-action":
 		return HTTPAction, nil
+	case "confidential-http":
+		return ConfidentialHTTP, nil
 	case "evm":
 		return EVM, nil
 	case "gateway":


### PR DESCRIPTION
## Summary

[PRIV-36] Adds the `confidential-http` capability to the set of proposable CRE job specs.

## Changes

- `deployment/cre/jobs/types/job_spec_template.go`: add the confidential-http template.
- `deployment/cre/jobs/propose_job_spec.go`: include it in the proposed specs.
- `propose_job_spec_test.go`: cover the new spec.

## Why

Operators proposing job specs for a DON needed confidential-http to be an option in the deployment framework.


[PRIV-36]: https://smartcontract-it.atlassian.net/browse/PRIV-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ