### PR TITLE
Add confidential http capability to plugins

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -48,7 +48,7 @@ plugins:
       gitRef: "d87af7545f5b2cc54337441907127e8cb794a218"
       installPath: "github.com/smartcontractkit/capabilities/mock"
   confidential-http:
-    - moduleURI: "https://github.com/smartcontractkit/confidential-compute/tree/main/enclave/apps/confidential-http/capability"
-      gitRef: "70df9516a1c73481554c904a9fa34e8d7ccae1e5"
-      installPath: "https://github.com/smartcontractkit/confidential-compute/tree/main/enclave/apps/confidential-http/capability"
+    - moduleURI: "https://github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
+      gitRef: "0ce762f7e03ba37d831f2b2ec0af38cd45ffe594"
+      installPath: "https://github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
 

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -48,7 +48,7 @@ plugins:
       gitRef: "d87af7545f5b2cc54337441907127e8cb794a218"
       installPath: "github.com/smartcontractkit/capabilities/mock"
   confidential-http:
-    - moduleURI: "https://github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
+    - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
       gitRef: "0ce762f7e03ba37d831f2b2ec0af38cd45ffe594"
-      installPath: "https://github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
+      installPath: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
 

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -49,6 +49,6 @@ plugins:
       installPath: "github.com/smartcontractkit/capabilities/mock"
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "c6945f0f6769771c49b1d5f230b90d6426b7bf0c"
+      gitRef: "02eeea529448080a3b3459975f11497671d15699"
       installPath: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
 

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -49,6 +49,6 @@ plugins:
       installPath: "github.com/smartcontractkit/capabilities/mock"
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "02eeea529448080a3b3459975f11497671d15699"
+      gitRef: "5002f9ffb9b1d7647619c6b7577ec42117b89995"
       installPath: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
 

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -47,4 +47,8 @@ plugins:
     - moduleURI: "github.com/smartcontractkit/capabilities/mock"
       gitRef: "d87af7545f5b2cc54337441907127e8cb794a218"
       installPath: "github.com/smartcontractkit/capabilities/mock"
+  confidential-http:
+    - moduleURI: "https://github.com/smartcontractkit/confidential-compute/tree/main/enclave/apps/confidential-http/capability"
+      gitRef: "70df9516a1c73481554c904a9fa34e8d7ccae1e5"
+      installPath: "https://github.com/smartcontractkit/confidential-compute/tree/main/enclave/apps/confidential-http/capability"
 

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -49,6 +49,6 @@ plugins:
       installPath: "github.com/smartcontractkit/capabilities/mock"
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "0ce762f7e03ba37d831f2b2ec0af38cd45ffe594"
+      gitRef: "c6945f0f6769771c49b1d5f230b90d6426b7bf0c"
       installPath: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
 


### PR DESCRIPTION
## Summary

Registers the `confidential-http` capability binary in `plugins/plugins.private.yaml` so the Chainlink node can load and serve it.
