### PR TITLE
Bumping WF Registry Contract ABI

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -50,8 +50,8 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251013174613-b1fd7ca40326
 	github.com/smartcontractkit/chainlink-data-streams v0.1.5
 	github.com/smartcontractkit/chainlink-deployments-framework v0.54.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962
-	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1
+	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251008161434-22d9bd439bba
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.13.1
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.34

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1609,10 +1609,10 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.5 h1:hdc5yy20ylaDML3NGYp
 github.com/smartcontractkit/chainlink-data-streams v0.1.5/go.mod h1:e9jETTzrVO8iu9Zp5gDuTCmBVhSJwUOk6K4Q/VFrJ6o=
 github.com/smartcontractkit/chainlink-deployments-framework v0.54.0 h1:KMkw64j2VUMWTGkWTSFcNrWXcY8189kTjc33n2FaA2w=
 github.com/smartcontractkit/chainlink-deployments-framework v0.54.0/go.mod h1:KmwLKwDuiYo8SfzoGb9TVehbodBU+yj7HuCfzgU6jx0=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962 h1:DDXZBuTkRxFP1+yLNDO2ewN/4Bqc5Kse0iPXKI/AyLo=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962/go.mod h1:NOlLmh4WMsQFqYOgQJOSXG+GlMRBW70m2gJwroarBmc=
-github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f h1:h3Ucy3L+UWaawB2PQT5vGGUa0FrNy7ucJdEui2kiDVM=
-github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1 h1:4yhP4WHgyWzny+6Vkmudb7ig67eZhwzx5c71D8pr20s=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1/go.mod h1:NOlLmh4WMsQFqYOgQJOSXG+GlMRBW70m2gJwroarBmc=
+github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1 h1:U0/wYRzESvhGnzbQy2Q/18gTP2UGp1DtZ19TL43NP5k=
+github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 h1:ACpDbAxG4fa4sA83dbtYcrnlpE/y7thNIZfHxTv2ZLs=

--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -564,32 +564,16 @@ func isEmptyWorkflowID(wfID [32]byte) bool {
 	return wfID == emptyID
 }
 
-// validateWorkflowMetadata logs warnings for incomplete workflow metadata from contract
-func validateWorkflowMetadata(wfMeta workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView, lggr logger.Logger) {
-	if isEmptyWorkflowID(wfMeta.WorkflowId) {
-		lggr.Warnw("Workflow has empty WorkflowID from contract",
-			"workflowName", wfMeta.WorkflowName,
-			"owner", hex.EncodeToString(wfMeta.Owner.Bytes()),
-			"binaryURL", wfMeta.BinaryUrl,
-			"configURL", wfMeta.ConfigUrl)
-	}
-
-	if len(wfMeta.Owner.Bytes()) == 0 {
-		lggr.Warnw("Workflow has empty Owner from contract",
-			"workflowID", hex.EncodeToString(wfMeta.WorkflowId[:]),
-			"workflowName", wfMeta.WorkflowName,
-			"binaryURL", wfMeta.BinaryUrl,
-			"configURL", wfMeta.ConfigUrl)
-	}
-
-	if wfMeta.BinaryUrl == "" || wfMeta.ConfigUrl == "" {
-		lggr.Warnw("Workflow has empty BinaryURL or ConfigURL from contract",
-			"workflowID", hex.EncodeToString(wfMeta.WorkflowId[:]),
-			"workflowName", wfMeta.WorkflowName,
-			"owner", hex.EncodeToString(wfMeta.Owner.Bytes()),
-			"binaryURL", wfMeta.BinaryUrl,
-			"configURL", wfMeta.ConfigUrl)
-	}
+// isValidWorkflowMetadata checks if workflowID, workflowOwner, binaryURL, and configURL exist
+// in the the metadata pulled from the contract. There is contract side validation to ensure these
+// fields are provided, but in the case of contract deletion bugs, or relaxing of contract validation,
+// this func can help filter out noisy deploys/workflow events.
+func isValidWorkflowMetadata(wfMeta workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView, lggr logger.Logger) bool {
+	invalid := isEmptyWorkflowID(wfMeta.WorkflowId) ||
+		len(wfMeta.Owner.Bytes()) == 0 ||
+		wfMeta.BinaryUrl == "" ||
+		wfMeta.ConfigUrl == ""
+	return !invalid
 }
 
 func (w *workflowRegistry) newWorkflowRegistryContractReader(
@@ -678,7 +662,17 @@ func (w *workflowRegistry) getWorkflowMetadata(ctx context.Context, don capabili
 
 			for _, wfMeta := range workflows.List {
 				// Log warnings for incomplete metadata but don't skip processing
-				validateWorkflowMetadata(wfMeta, w.lggr)
+				validMetadata := isValidWorkflowMetadata(wfMeta, w.lggr)
+				if !validMetadata {
+					w.lggr.Warnw("Workflow has incomplete metadata from contract, skipping",
+						"workflowName", wfMeta.WorkflowName,
+						"workflowID", hex.EncodeToString(wfMeta.WorkflowId[:]),
+						"owner", hex.EncodeToString(wfMeta.Owner.Bytes()),
+						"binaryURL", wfMeta.BinaryUrl,
+						"configURL", wfMeta.ConfigUrl,
+						"status", wfMeta.Status)
+					continue
+				}
 
 				// TODO: https://smartcontract-it.atlassian.net/browse/CAPPL-1021 load balance across workflow nodes in DON Family
 				allWorkflows = append(allWorkflows, WorkflowMetadataView{

--- a/core/services/workflows/syncer/v2/workflow_syncer_v2_test.go
+++ b/core/services/workflows/syncer/v2/workflow_syncer_v2_test.go
@@ -104,6 +104,7 @@ func Test_InitialStateSyncV2(t *testing.T) {
 			Status:    WorkflowStatusActive,
 			DonFamily: donFamily,
 			BinaryURL: "someurl",
+			ConfigURL: "https://config-url.com",
 			KeepAlive: false,
 		}
 		workflow.ID = workflowID
@@ -157,6 +158,7 @@ func Test_RegistrySyncer_SkipsEventsNotBelongingToDONV2(t *testing.T) {
 		backendTH = testutils.NewEVMBackendTH(t)
 
 		giveBinaryURL   = "https://original-url.com"
+		configURL       = "https://config-url.com"
 		donID           = uint32(1)
 		donFamily1      = "A"
 		donFamily2      = "B"
@@ -164,6 +166,7 @@ func Test_RegistrySyncer_SkipsEventsNotBelongingToDONV2(t *testing.T) {
 			Name:      "test-wf2",
 			Status:    WorkflowStatusActive,
 			BinaryURL: giveBinaryURL,
+			ConfigURL: configURL,
 			Tag:       "sometag",
 			DonFamily: donFamily2,
 			KeepAlive: false,
@@ -172,6 +175,7 @@ func Test_RegistrySyncer_SkipsEventsNotBelongingToDONV2(t *testing.T) {
 			Name:      "test-wf",
 			Status:    WorkflowStatusActive,
 			BinaryURL: "someurl",
+			ConfigURL: configURL,
 			Tag:       "sometag",
 			DonFamily: donFamily1,
 			KeepAlive: false,
@@ -245,12 +249,14 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyPausedV2(t *testing.T) {
 		orm       = artifacts.NewWorkflowRegistryDS(db, lggr)
 
 		giveBinaryURL = "https://original-url.com"
+		configURL     = "https://config-url.com"
 		donID         = uint32(1)
 		donFamily     = "A"
 		giveWorkflow  = RegisterWorkflowCMDV2{
 			Name:      "test-wf",
 			Status:    WorkflowStatusPaused,
 			BinaryURL: giveBinaryURL,
+			ConfigURL: configURL,
 			Tag:       "sometag",
 			DonFamily: donFamily,
 			KeepAlive: false,
@@ -349,6 +355,7 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyActivatedV2(t *testing.T) {
 			Name:      "test-wf",
 			Status:    WorkflowStatusActive,
 			BinaryURL: giveBinaryURL,
+			ConfigURL: "https://config-url.com",
 			Tag:       "sometag",
 			DonFamily: donFamily,
 			KeepAlive: false,
@@ -462,6 +469,7 @@ func Test_StratReconciliation_InitialStateSyncV2(t *testing.T) {
 				Name:      fmt.Sprintf("test-wf-%d", i),
 				Status:    WorkflowStatusActive,
 				BinaryURL: "someurl",
+				ConfigURL: "https://config-url.com",
 				Tag:       "sometag",
 				DonFamily: donFamily,
 				KeepAlive: false,
@@ -500,7 +508,7 @@ func Test_StratReconciliation_InitialStateSyncV2(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			return len(testEventHandler.GetEvents()) == numberWorkflows
-		}, 30*time.Second, 1*time.Second)
+		}, tests.WaitTimeout(t), 1*time.Second)
 
 		for _, event := range testEventHandler.GetEvents() {
 			assert.Equal(t, WorkflowActivated, event.Name)
@@ -530,6 +538,7 @@ func Test_StratReconciliation_RetriesWithBackoffV2(t *testing.T) {
 		Name:      "test-wf",
 		Status:    WorkflowStatusActive,
 		BinaryURL: "someurl",
+		ConfigURL: "https://config-url.com",
 		Tag:       "sometag",
 		DonFamily: donFamily,
 		KeepAlive: false,
@@ -574,7 +583,7 @@ func Test_StratReconciliation_RetriesWithBackoffV2(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return len(testEventHandler.GetEvents()) == 1
-	}, 30*time.Second, 1*time.Second)
+	}, tests.WaitTimeout(t), 1*time.Second)
 
 	event := testEventHandler.GetEvents()[0]
 	assert.Equal(t, WorkflowActivated, event.Name)

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -43,8 +43,8 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251013174613-b1fd7ca40326
 	github.com/smartcontractkit/chainlink-deployments-framework v0.54.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962
-	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1
+	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250729142306-508e798f6a5d
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251008161434-22d9bd439bba
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.13.1

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1346,10 +1346,10 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.5 h1:hdc5yy20ylaDML3NGYp
 github.com/smartcontractkit/chainlink-data-streams v0.1.5/go.mod h1:e9jETTzrVO8iu9Zp5gDuTCmBVhSJwUOk6K4Q/VFrJ6o=
 github.com/smartcontractkit/chainlink-deployments-framework v0.54.0 h1:KMkw64j2VUMWTGkWTSFcNrWXcY8189kTjc33n2FaA2w=
 github.com/smartcontractkit/chainlink-deployments-framework v0.54.0/go.mod h1:KmwLKwDuiYo8SfzoGb9TVehbodBU+yj7HuCfzgU6jx0=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962 h1:DDXZBuTkRxFP1+yLNDO2ewN/4Bqc5Kse0iPXKI/AyLo=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962/go.mod h1:NOlLmh4WMsQFqYOgQJOSXG+GlMRBW70m2gJwroarBmc=
-github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f h1:h3Ucy3L+UWaawB2PQT5vGGUa0FrNy7ucJdEui2kiDVM=
-github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1 h1:4yhP4WHgyWzny+6Vkmudb7ig67eZhwzx5c71D8pr20s=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1/go.mod h1:NOlLmh4WMsQFqYOgQJOSXG+GlMRBW70m2gJwroarBmc=
+github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1 h1:U0/wYRzESvhGnzbQy2Q/18gTP2UGp1DtZ19TL43NP5k=
+github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 h1:ACpDbAxG4fa4sA83dbtYcrnlpE/y7thNIZfHxTv2ZLs=

--- a/go.mod
+++ b/go.mod
@@ -87,8 +87,8 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251013174613-b1fd7ca40326
 	github.com/smartcontractkit/chainlink-data-streams v0.1.5
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962
-	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1
+	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250717121125-2350c82883e2

--- a/go.sum
+++ b/go.sum
@@ -1121,10 +1121,10 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.5 h1:hdc5yy20ylaDML3NGYp/tivm2a5Y+Ysw/e7sJK6eBTc=
 github.com/smartcontractkit/chainlink-data-streams v0.1.5/go.mod h1:e9jETTzrVO8iu9Zp5gDuTCmBVhSJwUOk6K4Q/VFrJ6o=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962 h1:DDXZBuTkRxFP1+yLNDO2ewN/4Bqc5Kse0iPXKI/AyLo=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962/go.mod h1:NOlLmh4WMsQFqYOgQJOSXG+GlMRBW70m2gJwroarBmc=
-github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f h1:h3Ucy3L+UWaawB2PQT5vGGUa0FrNy7ucJdEui2kiDVM=
-github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1 h1:4yhP4WHgyWzny+6Vkmudb7ig67eZhwzx5c71D8pr20s=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1/go.mod h1:NOlLmh4WMsQFqYOgQJOSXG+GlMRBW70m2gJwroarBmc=
+github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1 h1:U0/wYRzESvhGnzbQy2Q/18gTP2UGp1DtZ19TL43NP5k=
+github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 h1:ACpDbAxG4fa4sA83dbtYcrnlpE/y7thNIZfHxTv2ZLs=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -52,8 +52,8 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251013174613-b1fd7ca40326
 	github.com/smartcontractkit/chainlink-deployments-framework v0.54.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962
-	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1
+	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.13.1
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20251012014843-5d44e7731854
 	github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251012014843-5d44e7731854

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1590,10 +1590,10 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.5 h1:hdc5yy20ylaDML3NGYp
 github.com/smartcontractkit/chainlink-data-streams v0.1.5/go.mod h1:e9jETTzrVO8iu9Zp5gDuTCmBVhSJwUOk6K4Q/VFrJ6o=
 github.com/smartcontractkit/chainlink-deployments-framework v0.54.0 h1:KMkw64j2VUMWTGkWTSFcNrWXcY8189kTjc33n2FaA2w=
 github.com/smartcontractkit/chainlink-deployments-framework v0.54.0/go.mod h1:KmwLKwDuiYo8SfzoGb9TVehbodBU+yj7HuCfzgU6jx0=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962 h1:DDXZBuTkRxFP1+yLNDO2ewN/4Bqc5Kse0iPXKI/AyLo=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962/go.mod h1:NOlLmh4WMsQFqYOgQJOSXG+GlMRBW70m2gJwroarBmc=
-github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f h1:h3Ucy3L+UWaawB2PQT5vGGUa0FrNy7ucJdEui2kiDVM=
-github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1 h1:4yhP4WHgyWzny+6Vkmudb7ig67eZhwzx5c71D8pr20s=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1/go.mod h1:NOlLmh4WMsQFqYOgQJOSXG+GlMRBW70m2gJwroarBmc=
+github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1 h1:U0/wYRzESvhGnzbQy2Q/18gTP2UGp1DtZ19TL43NP5k=
+github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 h1:ACpDbAxG4fa4sA83dbtYcrnlpE/y7thNIZfHxTv2ZLs=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -34,8 +34,8 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251013174613-b1fd7ca40326
 	github.com/smartcontractkit/chainlink-deployments-framework v0.54.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962
-	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1
+	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.34
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.6

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1569,10 +1569,10 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.5 h1:hdc5yy20ylaDML3NGYp
 github.com/smartcontractkit/chainlink-data-streams v0.1.5/go.mod h1:e9jETTzrVO8iu9Zp5gDuTCmBVhSJwUOk6K4Q/VFrJ6o=
 github.com/smartcontractkit/chainlink-deployments-framework v0.54.0 h1:KMkw64j2VUMWTGkWTSFcNrWXcY8189kTjc33n2FaA2w=
 github.com/smartcontractkit/chainlink-deployments-framework v0.54.0/go.mod h1:KmwLKwDuiYo8SfzoGb9TVehbodBU+yj7HuCfzgU6jx0=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962 h1:DDXZBuTkRxFP1+yLNDO2ewN/4Bqc5Kse0iPXKI/AyLo=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962/go.mod h1:NOlLmh4WMsQFqYOgQJOSXG+GlMRBW70m2gJwroarBmc=
-github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f h1:h3Ucy3L+UWaawB2PQT5vGGUa0FrNy7ucJdEui2kiDVM=
-github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1 h1:4yhP4WHgyWzny+6Vkmudb7ig67eZhwzx5c71D8pr20s=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1/go.mod h1:NOlLmh4WMsQFqYOgQJOSXG+GlMRBW70m2gJwroarBmc=
+github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1 h1:U0/wYRzESvhGnzbQy2Q/18gTP2UGp1DtZ19TL43NP5k=
+github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 h1:ACpDbAxG4fa4sA83dbtYcrnlpE/y7thNIZfHxTv2ZLs=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -35,8 +35,8 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251013174613-b1fd7ca40326
 	github.com/smartcontractkit/chainlink-deployments-framework v0.54.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962
-	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1
+	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251008161434-22d9bd439bba
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.13.1
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20251007010318-c9a7b2d44524

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1587,10 +1587,10 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.5 h1:hdc5yy20ylaDML3NGYp
 github.com/smartcontractkit/chainlink-data-streams v0.1.5/go.mod h1:e9jETTzrVO8iu9Zp5gDuTCmBVhSJwUOk6K4Q/VFrJ6o=
 github.com/smartcontractkit/chainlink-deployments-framework v0.54.0 h1:KMkw64j2VUMWTGkWTSFcNrWXcY8189kTjc33n2FaA2w=
 github.com/smartcontractkit/chainlink-deployments-framework v0.54.0/go.mod h1:KmwLKwDuiYo8SfzoGb9TVehbodBU+yj7HuCfzgU6jx0=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962 h1:DDXZBuTkRxFP1+yLNDO2ewN/4Bqc5Kse0iPXKI/AyLo=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962/go.mod h1:NOlLmh4WMsQFqYOgQJOSXG+GlMRBW70m2gJwroarBmc=
-github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f h1:h3Ucy3L+UWaawB2PQT5vGGUa0FrNy7ucJdEui2kiDVM=
-github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1 h1:4yhP4WHgyWzny+6Vkmudb7ig67eZhwzx5c71D8pr20s=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1/go.mod h1:NOlLmh4WMsQFqYOgQJOSXG+GlMRBW70m2gJwroarBmc=
+github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1 h1:U0/wYRzESvhGnzbQy2Q/18gTP2UGp1DtZ19TL43NP5k=
+github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 h1:ACpDbAxG4fa4sA83dbtYcrnlpE/y7thNIZfHxTv2ZLs=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251013174613-b1fd7ca40326
 	github.com/smartcontractkit/chainlink-data-streams v0.1.5
 	github.com/smartcontractkit/chainlink-deployments-framework v0.54.0
-	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f
+	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251008161434-22d9bd439bba
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.13.1
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20251008185222-47a7460f5207
@@ -546,7 +546,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5 // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5 // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.6 // indirect
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962 // indirect
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250717121125-2350c82883e2 // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1790,10 +1790,10 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.5 h1:hdc5yy20ylaDML3NGYp
 github.com/smartcontractkit/chainlink-data-streams v0.1.5/go.mod h1:e9jETTzrVO8iu9Zp5gDuTCmBVhSJwUOk6K4Q/VFrJ6o=
 github.com/smartcontractkit/chainlink-deployments-framework v0.54.0 h1:KMkw64j2VUMWTGkWTSFcNrWXcY8189kTjc33n2FaA2w=
 github.com/smartcontractkit/chainlink-deployments-framework v0.54.0/go.mod h1:KmwLKwDuiYo8SfzoGb9TVehbodBU+yj7HuCfzgU6jx0=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962 h1:DDXZBuTkRxFP1+yLNDO2ewN/4Bqc5Kse0iPXKI/AyLo=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251007172225-ba2f4b5ef962/go.mod h1:NOlLmh4WMsQFqYOgQJOSXG+GlMRBW70m2gJwroarBmc=
-github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f h1:h3Ucy3L+UWaawB2PQT5vGGUa0FrNy7ucJdEui2kiDVM=
-github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251003185510-17234095940f/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1 h1:4yhP4WHgyWzny+6Vkmudb7ig67eZhwzx5c71D8pr20s=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251015115541-729ba0b2b1c1/go.mod h1:NOlLmh4WMsQFqYOgQJOSXG+GlMRBW70m2gJwroarBmc=
+github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1 h1:U0/wYRzESvhGnzbQy2Q/18gTP2UGp1DtZ19TL43NP5k=
+github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251015115541-729ba0b2b1c1/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 h1:ACpDbAxG4fa4sA83dbtYcrnlpE/y7thNIZfHxTv2ZLs=


### PR DESCRIPTION
We updated the wf registry to no longer return garbage metadata. We still need https://github.com/smartcontractkit/chainlink/pull/19895, as we won't redeploy the old contract to staging, but the newer version of this contract will be used in future envs. 