### PR TITLE
fix: add missing AccountAddressPublicKey

### DIFF
--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+
 	ccip "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/validate"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/fluxmonitorv2"
@@ -1518,11 +1519,12 @@ func (s *service) newChainConfigMsg(cfg ChainConfig) (*pb.ChainConfig, error) {
 			Id:   cfg.ChainID,
 			Type: protoChainType,
 		},
-		AccountAddress:    cfg.AccountAddress,
-		AdminAddress:      cfg.AdminAddress,
-		FluxMonitorConfig: s.newFluxMonitorConfigMsg(cfg.FluxMonitorConfig),
-		Ocr1Config:        ocr1Cfg,
-		Ocr2Config:        ocr2Cfg,
+		AccountAddress:          cfg.AccountAddress,
+		AdminAddress:            cfg.AdminAddress,
+		AccountAddressPublicKey: cfg.AccountAddressPublicKey.Ptr(),
+		FluxMonitorConfig:       s.newFluxMonitorConfigMsg(cfg.FluxMonitorConfig),
+		Ocr1Config:              ocr1Cfg,
+		Ocr2Config:              ocr2Cfg,
 	}
 
 	if cfg.AccountAddressPublicKey.Valid {


### PR DESCRIPTION
This pull request introduces a small update to the `service.go` file in the feeds service. The main change is the addition of the `AccountAddressPublicKey` field to the chain configuration message, which allows the public key associated with the account address to be included in the protobuf message.

Configuration message improvements:

* Added the `AccountAddressPublicKey` field to the `pb.ChainConfig` message in the `newChainConfigMsg` function, using the value from `cfg.AccountAddressPublicKey.Ptr()`.