### PR TITLE
deployment/ccip/changeset/testhelpers: assert from goroutine

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_assertions.go
+++ b/deployment/ccip/changeset/testhelpers/test_assertions.go
@@ -286,7 +286,7 @@ func ConfirmCommitForAllWithExpectedSeqNums(
 
 	done := make(chan struct{})
 	go func() {
-		require.NoError(t, wg.Wait())
+		assert.NoError(t, wg.Wait())
 		close(done)
 	}()
 


### PR DESCRIPTION
Fatal errors (require) must only be recorded from the goroutine that spawned the test.
```
          	Test:       	Test_CCIP_Messaging_EVM2Aptos/Hello_World_Message_-_Should_Succeed 
  panic: Fail in goroutine after Test_CCIP_Messaging_EVM2Aptos/Hello_World_Message_-_Should_Succeed has completed 
  goroutine 77847 [running]:
  testing.(*common).Fail(0xc003e5ac40)
  	/opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:960 +0xca
  testing.(*common).Errorf(0xc003e5ac40, {0xe49398b?, 0x2?}, {0xc0099030a0?, 0xd8644e0?, 0x15b507e0?})
  	/opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1205 +0x59
  github.com/stretchr/testify/assert.Fail({0x10551680, 0xc003e5ac40}, {0xc009c72000, 0xb9}, {0x0, 0x0, 0x0})
  	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/assert/assertions.go:387 +0x370
  github.com/stretchr/testify/assert.NoError({0x10551680, 0xc003e5ac40}, {0x10551540, 0xc009903060}, {0x0, 0x0, 0x0})
  	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/assert/assertions.go:1638 +0x125
  github.com/stretchr/testify/require.NoError({0x10581248, 0xc003e5ac40}, {0x10551540, 0xc009903060}, {0x0, 0x0, 0x0})
  	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/require/require.go:1398 +0xb0
  github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers.ConfirmCommitForAllWithExpectedSeqNums.func2()
  	/home/runner/work/chainlink/chainlink/deployment/ccip/changeset/testhelpers/test_assertions.go:289 +0x48
  created by github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers.ConfirmCommitForAllWithExpectedSeqNums in goroutine 44461
  	/home/runner/work/chainlink/chainlink/deployment/ccip/changeset/testhelpers/test_assertions.go:288 +0x2f2
```