### PR TITLE
chore: update deployment/common MCMS tests

### DIFF
--- a/deployment/common/changeset/example/solana_transfer_mcm_test.go
+++ b/deployment/common/changeset/example/solana_transfer_mcm_test.go
@@ -1,115 +1,78 @@
 package example_test
 
 import (
+	"crypto/ecdsa"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
-	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
-	"github.com/smartcontractkit/quarantine"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
+	"github.com/smartcontractkit/quarantine"
+	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
-
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/example"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/deployment/internal/soltestutils"
+	"github.com/smartcontractkit/chainlink/deployment/internal/solutils"
 )
-
-// setupFundingTestEnv deploys all required contracts for the funding test
-func setupFundingTestEnv(t *testing.T) cldf.Environment {
-	lggr := logger.TestLogger(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		SolChains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
-
-	config := proposalutils.SingleGroupTimelockConfigV2(t)
-	err := testhelpers.SavePreloadedSolAddresses(env, chainSelector)
-	require.NoError(t, err)
-	// Initialize the address book with a dummy address to avoid deploy precondition errors.
-	err = env.ExistingAddresses.Save(chainSelector, "dummyAddress", cldf.TypeAndVersion{Type: "dummy", Version: deployment.Version1_0_0})
-	require.NoError(t, err)
-
-	// Deploy MCMS and Timelock
-	env, err = changeset.Apply(t, env,
-		changeset.Configure(
-			cldf.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2),
-			map[uint64]types.MCMSWithTimelockConfigV2{
-				chainSelector: config,
-			},
-		),
-	)
-	require.NoError(t, err)
-
-	return env
-}
 
 func TestTransferFromTimelockConfig_VerifyPreconditions(t *testing.T) {
 	t.Parallel()
-	lggr := logger.TestLogger(t)
-	validEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{SolChains: 1})
-	validSolChainSelector := validEnv.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
+
 	receiverKey := solana.NewWallet().PublicKey()
-	cs := example.TransferFromTimelock{}
+	selector := chainselectors.TEST_22222222222222222222222222222222222222222222.Selector
+
+	// Save the timelock contract address to the address book
+	ab := cldf.NewMemoryAddressBook()
 	timelockID := mcmsSolana.ContractAddress(
 		solana.NewWallet().PublicKey(),
 		[32]byte{'t', 'e', 's', 't'},
 	)
-	err := validEnv.ExistingAddresses.Save(validSolChainSelector, timelockID, cldf.TypeAndVersion{
+	require.NoError(t, ab.Save(selector, timelockID, cldf.TypeAndVersion{
 		Type:    types.RBACTimelock,
 		Version: deployment.Version1_0_0,
-	})
+	}))
+
+	env, err := environment.New(t.Context(),
+		environment.WithSolanaContainer(t, []uint64{selector}, t.TempDir(), map[string]string{}),
+		environment.WithAddressBook(ab),
+		environment.WithLogger(logger.Test(t)),
+	)
 	require.NoError(t, err)
 
-	// Create an environment that simulates a chain where the MCMS contracts have not been deployed,
-	// e.g. missing the required addresses so that the state loader returns empty seeds.
-	noTimelockEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{})
-	noTimelockEnv.BlockChains = cldf_chain.NewBlockChains(map[uint64]cldf_chain.BlockChain{
-		chainselectors.SOLANA_DEVNET.Selector: cldf_solana.Chain{},
-	})
-	err = noTimelockEnv.ExistingAddresses.Save(chainselectors.SOLANA_DEVNET.Selector, "dummy", cldf.TypeAndVersion{
-		Type:    "Sometype",
-		Version: deployment.Version1_0_0,
-	})
+	// Create an environment with a Solana chain that has an invalid (zero value) underlying chain.
+	invalidEnv, err := environment.New(t.Context())
 	require.NoError(t, err)
-
-	// Create an environment with a Solana chain that has an invalid (zero) underlying chain.
-	invalidSolChainEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		SolChains: 0,
-	})
-	invalidSolChainEnv.BlockChains = cldf_chain.NewBlockChains(map[uint64]cldf_chain.BlockChain{
-		validSolChainSelector: cldf_solana.Chain{},
+	invalidEnv.BlockChains = cldf_chain.NewBlockChains(map[uint64]cldf_chain.BlockChain{
+		selector: cldf_solana.Chain{},
 	})
 
 	tests := []struct {
 		name          string
-		env           cldf.Environment
+		env           func(t *testing.T) cldf.Environment
 		config        example.TransferFromTimelockConfig
 		expectedError string
 	}{
 		{
 			name: "All preconditions satisfied",
-			env:  validEnv,
+			env:  func(t *testing.T) cldf.Environment { t.Helper(); return *env },
 			config: example.TransferFromTimelockConfig{
-				AmountsPerChain: map[uint64]example.TransferData{validSolChainSelector: {
+				AmountsPerChain: map[uint64]example.TransferData{selector: {
 					Amount: 100,
 					To:     receiverKey,
 				}},
@@ -118,34 +81,56 @@ func TestTransferFromTimelockConfig_VerifyPreconditions(t *testing.T) {
 		},
 		{
 			name: "No Solana chains found in environment",
-			env: memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-				Bootstraps: 1,
-				Chains:     1,
-				SolChains:  0,
-				Nodes:      1,
-			}),
+			env: func(t *testing.T) cldf.Environment {
+				t.Helper()
+
+				emptyEnv, gerr := environment.New(t.Context())
+				require.NoError(t, gerr)
+
+				return *emptyEnv
+			},
 			config: example.TransferFromTimelockConfig{
-				AmountsPerChain: map[uint64]example.TransferData{validSolChainSelector: {
+				AmountsPerChain: map[uint64]example.TransferData{selector: {
 					Amount: 100,
 					To:     receiverKey,
 				}},
 			},
-			expectedError: fmt.Sprintf("solana chain not found for selector %d", validSolChainSelector),
+			expectedError: fmt.Sprintf("solana chain not found for selector %d", selector),
 		},
 		{
 			name: "Chain selector not found in environment",
-			env:  validEnv,
-			config: example.TransferFromTimelockConfig{AmountsPerChain: map[uint64]example.TransferData{99999: {
-				Amount: 100,
-				To:     receiverKey,
-			}}},
+			env:  func(t *testing.T) cldf.Environment { t.Helper(); return *env },
+			config: example.TransferFromTimelockConfig{
+				AmountsPerChain: map[uint64]example.TransferData{99999: {
+					Amount: 100,
+					To:     receiverKey,
+				}}},
 			expectedError: "solana chain not found for selector 99999",
 		},
 		{
 			name: "timelock contracts not deployed (empty seeds)",
-			env:  noTimelockEnv,
+			env: func(t *testing.T) cldf.Environment {
+				t.Helper()
+
+				// Create an environment that simulates a chain where the MCMS contracts have not been deployed,
+				// e.g. missing the required addresses so that the state loader returns empty seeds.
+				emptyEnv, gerr := environment.New(t.Context())
+
+				require.NoError(t, gerr)
+
+				emptyEnv.BlockChains = cldf_chain.NewBlockChainsFromSlice([]cldf_chain.BlockChain{
+					cldf_solana.Chain{Selector: selector},
+				})
+				gerr = emptyEnv.ExistingAddresses.Save(selector, "dummy", cldf.TypeAndVersion{
+					Type:    "Sometype",
+					Version: deployment.Version1_0_0,
+				})
+				require.NoError(t, gerr)
+
+				return *emptyEnv
+			},
 			config: example.TransferFromTimelockConfig{
-				AmountsPerChain: map[uint64]example.TransferData{chainselectors.SOLANA_DEVNET.Selector: {
+				AmountsPerChain: map[uint64]example.TransferData{selector: {
 					Amount: 100,
 					To:     receiverKey,
 				}},
@@ -154,23 +139,10 @@ func TestTransferFromTimelockConfig_VerifyPreconditions(t *testing.T) {
 		},
 		{
 			name: "Insufficient deployer balance",
-			env:  validEnv,
+			env:  func(t *testing.T) cldf.Environment { t.Helper(); return *env },
 			config: example.TransferFromTimelockConfig{
 				AmountsPerChain: map[uint64]example.TransferData{
-					validSolChainSelector: {
-						Amount: 999999999999999999,
-						To:     receiverKey,
-					},
-				},
-			},
-			expectedError: "deployer balance is insufficient",
-		},
-		{
-			name: "Insufficient deployer balance",
-			env:  validEnv,
-			config: example.TransferFromTimelockConfig{
-				AmountsPerChain: map[uint64]example.TransferData{
-					validSolChainSelector: {
+					selector: {
 						Amount: 999999999999999999,
 						To:     receiverKey,
 					},
@@ -180,9 +152,9 @@ func TestTransferFromTimelockConfig_VerifyPreconditions(t *testing.T) {
 		},
 		{
 			name: "Invalid Solana chain in environment",
-			env:  invalidSolChainEnv,
+			env:  func(t *testing.T) cldf.Environment { t.Helper(); return *invalidEnv },
 			config: example.TransferFromTimelockConfig{
-				AmountsPerChain: map[uint64]example.TransferData{validSolChainSelector: {
+				AmountsPerChain: map[uint64]example.TransferData{selector: {
 					Amount: 100,
 					To:     receiverKey,
 				}},
@@ -191,9 +163,9 @@ func TestTransferFromTimelockConfig_VerifyPreconditions(t *testing.T) {
 		},
 		{
 			name: "empty from field",
-			env:  invalidSolChainEnv,
+			env:  func(t *testing.T) cldf.Environment { t.Helper(); return *invalidEnv },
 			config: example.TransferFromTimelockConfig{
-				AmountsPerChain: map[uint64]example.TransferData{validSolChainSelector: {
+				AmountsPerChain: map[uint64]example.TransferData{selector: {
 					Amount: 100,
 					To:     solana.PublicKey{},
 				}},
@@ -204,7 +176,7 @@ func TestTransferFromTimelockConfig_VerifyPreconditions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := cs.VerifyPreconditions(tt.env, tt.config)
+			err := example.TransferFromTimelock{}.VerifyPreconditions(tt.env(t), tt.config)
 			if tt.expectedError == "" {
 				require.NoError(t, err)
 			} else {
@@ -218,40 +190,57 @@ func TestTransferFromTimelockConfig_VerifyPreconditions(t *testing.T) {
 func TestTransferFromTimelockConfig_Apply(t *testing.T) {
 	quarantine.Flaky(t, "DX-1754")
 	t.Parallel()
-	env := setupFundingTestEnv(t)
+
+	selector := chainselectors.TEST_22222222222222222222222222222222222222222222.Selector
+	programsPath, programIDs, ab := soltestutils.PreloadMCMS(t, selector)
+
+	// Initialize the address book with a dummy address to avoid deploy precondition errors.
+	err := ab.Save(selector, "dummyAddress", cldf.TypeAndVersion{Type: "dummy", Version: deployment.Version1_0_0})
+	require.NoError(t, err)
+
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithSolanaContainer(t, []uint64{selector}, programsPath, programIDs),
+		environment.WithAddressBook(ab),
+		environment.WithLogger(logger.Test(t)),
+	))
+	require.NoError(t, err)
+
+	chain := rt.Environment().BlockChains.SolanaChains()[selector]
+
+	// Deploy MCMS and Timelock
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2), map[uint64]types.MCMSWithTimelockConfigV2{
+			selector: proposalutils.SingleGroupTimelockConfigV2(t),
+		}),
+	)
+	require.NoError(t, err)
+
+	// Fund the signer PDAs for the MCMS contracts
+	mcmState := soltestutils.GetMCMSStateFromAddressBook(t, rt.State().AddressBook, chain)
+	timelockSigner := state.GetTimelockSignerPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
+	mcmSigner := state.GetMCMSignerPDA(mcmState.McmProgram, mcmState.ProposerMcmSeed)
+
+	err = solutils.FundAccounts(t.Context(), chain.Client, []solana.PublicKey{timelockSigner, mcmSigner, chain.DeployerKey.PublicKey()}, 150)
+	require.NoError(t, err)
+
+	// Execute the transfer from timelock changeset
 	cfgAmounts := example.TransferData{
 		Amount: 100 * solana.LAMPORTS_PER_SOL,
 		To:     solana.NewWallet().PublicKey(),
 	}
-	amountsPerChain := make(map[uint64]example.TransferData)
-	solChains := env.BlockChains.SolanaChains()
-	for chainSelector := range solChains {
-		amountsPerChain[chainSelector] = cfgAmounts
-	}
-	config := example.TransferFromTimelockConfig{
-		TimelockCfg:     proposalutils.TimelockConfig{MinDelay: 1 * time.Second},
-		AmountsPerChain: amountsPerChain,
-	}
-	solChainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
-	addresses, err := env.ExistingAddresses.AddressesForChain(solChainSelector)
-	require.NoError(t, err)
-	mcmState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(solChains[solChainSelector], addresses)
-	require.NoError(t, err)
-	timelockSigner := state.GetTimelockSignerPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
-	mcmSigner := state.GetMCMSignerPDA(mcmState.McmProgram, mcmState.ProposerMcmSeed)
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
-	solChain := solChains[chainSelector]
-	err = memory.FundSolanaAccounts(env.GetContext(), []solana.PublicKey{timelockSigner, mcmSigner, solChain.DeployerKey.PublicKey()}, 150, solChain.Client)
+
+	err = rt.Exec(
+		runtime.ChangesetTask(example.TransferFromTimelock{}, example.TransferFromTimelockConfig{
+			TimelockCfg: proposalutils.TimelockConfig{MinDelay: 1 * time.Second},
+			AmountsPerChain: map[uint64]example.TransferData{
+				selector: cfgAmounts,
+			},
+		}),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
+	)
 	require.NoError(t, err)
 
-	changesetInstance := example.TransferFromTimelock{}
-
-	env, _, err = changeset.ApplyChangesets(t, env, []changeset.ConfiguredChangeSet{
-		changeset.Configure(changesetInstance, config),
-	})
-	require.NoError(t, err)
-
-	balance, err := solChain.Client.GetBalance(env.GetContext(), cfgAmounts.To, rpc.CommitmentConfirmed)
+	balance, err := chain.Client.GetBalance(t.Context(), cfgAmounts.To, rpc.CommitmentConfirmed)
 	require.NoError(t, err)
 	t.Logf("Account: %s, Balance: %d", cfgAmounts.To, balance.Value)
 

--- a/deployment/common/changeset/mcms_firedrill_test.go
+++ b/deployment/common/changeset/mcms_firedrill_test.go
@@ -6,94 +6,74 @@ import (
 	"github.com/gagliardetto/solana-go"
 	mcmsTypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/deployment/internal/soltestutils"
+	"github.com/smartcontractkit/chainlink/deployment/internal/solutils"
 )
-
-// setupFiredrillTestEnv deploys all required contracts for the firedrill proposal execution
-func setupFiredrillTestEnv(t *testing.T) cldf.Environment {
-	lggr := logger.TestLogger(t)
-	cfg := memory.MemoryEnvironmentConfig{
-		Chains:    2,
-		SolChains: 1,
-	}
-	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	chainSelector2 := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1]
-	chainSelectorSolana := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
-
-	commonchangeset.SetPreloadedSolanaAddresses(t, env, chainSelectorSolana)
-	config := proposalutils.SingleGroupTimelockConfigV2(t)
-	// Deploy MCMS and Timelock
-	env, err := commonchangeset.Apply(t, env,
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
-			map[uint64]commontypes.MCMSWithTimelockConfigV2{
-				chainSelector:       config,
-				chainSelector2:      config,
-				chainSelectorSolana: config,
-			},
-		),
-	)
-	require.NoError(t, err)
-
-	addresses, err := env.ExistingAddresses.AddressesForChain(chainSelectorSolana)
-	require.NoError(t, err)
-	chainSelectorSolana = env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
-	mcmState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(env.BlockChains.SolanaChains()[chainSelectorSolana], addresses)
-	require.NoError(t, err)
-	timelockSigner := state.GetTimelockSignerPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
-	mcmSigner := state.GetMCMSignerPDA(mcmState.McmProgram, mcmState.ProposerMcmSeed)
-	mcmSignerBypasser := state.GetMCMSignerPDA(mcmState.McmProgram, mcmState.BypasserMcmSeed)
-	solChain := env.BlockChains.SolanaChains()[chainSelectorSolana]
-	err = memory.FundSolanaAccounts(env.GetContext(), []solana.PublicKey{timelockSigner, mcmSigner, mcmSignerBypasser, solChain.DeployerKey.PublicKey()}, 150, solChain.Client)
-	require.NoError(t, err)
-	return env
-}
 
 func TestMCMSSignFireDrillChangeset(t *testing.T) {
 	t.Parallel()
-	env := setupFiredrillTestEnv(t)
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	chainSelector2 := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1]
-	chainSelectorSolana := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
-	// Add the timelock as a signer to check state changes
-	for _, tc := range []struct {
-		name       string
-		changeSets func() []commonchangeset.ConfiguredChangeSet
-	}{
-		{
-			name: "MCMS Firedrill execution",
-			changeSets: func() []commonchangeset.ConfiguredChangeSet {
-				return []commonchangeset.ConfiguredChangeSet{
-					commonchangeset.Configure(
-						cldf.CreateLegacyChangeSet(commonchangeset.MCMSSignFireDrillChangeset),
-						commonchangeset.FireDrillConfig{
-							Selectors: []uint64{chainSelector, chainSelector2, chainSelectorSolana},
-							TimelockCfg: proposalutils.TimelockConfig{
-								MCMSAction: mcmsTypes.TimelockActionBypass,
-							},
-						},
-					),
-				}
+
+	evmSelector1 := chain_selectors.TEST_90000001.Selector
+	evmSelector2 := chain_selectors.TEST_90000002.Selector
+	solSelector := chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector
+	programsPath, programIDs, ab := soltestutils.PreloadMCMS(t, solSelector)
+
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{evmSelector1, evmSelector2}),
+		environment.WithSolanaContainer(t, []uint64{solSelector}, programsPath, programIDs),
+		environment.WithAddressBook(ab),
+		environment.WithLogger(logger.Test(t)),
+	))
+	require.NoError(t, err)
+
+	solChain := rt.Environment().BlockChains.SolanaChains()[solSelector]
+
+	// Deploy MCMS and Timelock
+	config := proposalutils.SingleGroupTimelockConfigV2(t)
+
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2), map[uint64]commontypes.MCMSWithTimelockConfigV2{
+			evmSelector1: config,
+			evmSelector2: config,
+			solSelector:  config,
+		}),
+	)
+	require.NoError(t, err)
+
+	// Fund the signer PDAs for the MCMS contracts
+	mcmsState := soltestutils.GetMCMSStateFromAddressBook(t, rt.State().AddressBook, solChain)
+
+	timelockSigner := state.GetTimelockSignerPDA(mcmsState.TimelockProgram, mcmsState.TimelockSeed)
+	mcmSigner := state.GetMCMSignerPDA(mcmsState.McmProgram, mcmsState.ProposerMcmSeed)
+	mcmSignerBypasser := state.GetMCMSignerPDA(mcmsState.McmProgram, mcmsState.BypasserMcmSeed)
+
+	// Note we cannot use FundSignerPDAs here because we also have to fund the bypasser signer PDA.
+	err = solutils.FundAccounts(t.Context(),
+		solChain.Client,
+		[]solana.PublicKey{timelockSigner, mcmSigner, mcmSignerBypasser},
+		150,
+	)
+	require.NoError(t, err)
+
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commonchangeset.MCMSSignFireDrillChangeset), commonchangeset.FireDrillConfig{
+			Selectors: []uint64{evmSelector1, evmSelector2, solSelector},
+			TimelockCfg: proposalutils.TimelockConfig{
+				MCMSAction: mcmsTypes.TimelockActionBypass,
 			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			changesetsToApply := tc.changeSets()
-			_, _, err := commonchangeset.ApplyChangesets(t, env, changesetsToApply)
-			require.NoError(t, err)
-		})
-	}
+		}),
+	)
+	require.NoError(t, err)
 }

--- a/deployment/common/changeset/solana/grant_role_timelock_test.go
+++ b/deployment/common/changeset/solana/grant_role_timelock_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	"github.com/smartcontractkit/chainlink/deployment/internal/soltestutils"
 )
 
 func TestGrantRoleTimelockSolana(t *testing.T) {
@@ -32,7 +33,7 @@ func TestGrantRoleTimelockSolana(t *testing.T) {
 	mcmsState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
 	require.NoError(t, err)
 
-	fundSignerPDAs(t, chain, mcmsState)
+	soltestutils.FundSignerPDAs(t, chain, mcmsState)
 
 	// validate initial executors
 	inspector := mcmssolanasdk.NewTimelockInspector(chain.Client)

--- a/deployment/common/changeset/solana/setup_test.go
+++ b/deployment/common/changeset/solana/setup_test.go
@@ -3,35 +3,29 @@ package solana
 import (
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/deployment/internal/soltestutils"
 )
 
 // setupTest sets up a test runtime with a single solana chain with deployed the MCMS and Timelock
 // contracts
 func setupTest(t *testing.T) (*runtime.Runtime, uint64) {
-	memory.DownloadSolanaProgramArtifactsForTest(t)
-
 	// Setup the runtime with preloaded programs. The address book is updated with the preloaded programs.
 	selector := chainselectors.TEST_22222222222222222222222222222222222222222222.Selector
-	ab := getPreloadedAddressBook(t, selector)
+	programsPath, programIDs, ab := soltestutils.PreloadMCMS(t, selector)
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
-		environment.WithSolanaContainer(t, []uint64{selector}, memory.ProgramsPath, memory.SolanaProgramIDs),
+		environment.WithSolanaContainer(t, []uint64{selector}, programsPath, programIDs),
 		environment.WithAddressBook(ab),
 		environment.WithLogger(logger.Test(t)),
 	))
@@ -46,39 +40,4 @@ func setupTest(t *testing.T) (*runtime.Runtime, uint64) {
 	require.NoError(t, err)
 
 	return rt, selector
-}
-
-// getPreloadedAddressBook returns an address book with the preloaded MCMS Solana addresses for
-// the given selector.
-func getPreloadedAddressBook(t *testing.T, selector uint64) *cldf.AddressBookMap {
-	t.Helper()
-
-	ab := cldf.NewMemoryAddressBook()
-
-	tv := cldf.NewTypeAndVersion(commontypes.ManyChainMultisigProgram, deployment.Version1_0_0)
-	err := ab.Save(selector, memory.SolanaProgramIDs["mcm"], tv)
-	require.NoError(t, err)
-
-	tv = cldf.NewTypeAndVersion(commontypes.AccessControllerProgram, deployment.Version1_0_0)
-	err = ab.Save(selector, memory.SolanaProgramIDs["access_controller"], tv)
-	require.NoError(t, err)
-
-	tv = cldf.NewTypeAndVersion(commontypes.RBACTimelockProgram, deployment.Version1_0_0)
-	err = ab.Save(selector, memory.SolanaProgramIDs["timelock"], tv)
-	require.NoError(t, err)
-
-	return ab
-}
-
-// fundSignerPDAs funds the timelock signer and MCMS signer PDAs with 1 SOL
-func fundSignerPDAs(
-	t *testing.T, chain cldf_solana.Chain, mcmsState *state.MCMSWithTimelockStateSolana,
-) {
-	t.Helper()
-
-	timelockSignerPDA := state.GetTimelockSignerPDA(mcmsState.TimelockProgram, mcmsState.TimelockSeed)
-	mcmSignerPDA := state.GetMCMSignerPDA(mcmsState.McmProgram, mcmsState.ProposerMcmSeed)
-	signerPDAs := []solana.PublicKey{timelockSignerPDA, mcmSignerPDA}
-	err := memory.FundSolanaAccounts(t.Context(), signerPDAs, 1, chain.Client)
-	require.NoError(t, err)
 }

--- a/deployment/common/changeset/solana/transfer_ownership_test.go
+++ b/deployment/common/changeset/solana/transfer_ownership_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	"github.com/smartcontractkit/chainlink/deployment/internal/soltestutils"
 )
 
 func TestTransferToMCMSToTimelockSolana(t *testing.T) {
@@ -35,7 +36,7 @@ func TestTransferToMCMSToTimelockSolana(t *testing.T) {
 	mcmsState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
 	require.NoError(t, err)
 
-	fundSignerPDAs(t, chain, mcmsState)
+	soltestutils.FundSignerPDAs(t, chain, mcmsState)
 
 	// validate initial owner
 	deployer := rt.Environment().BlockChains.SolanaChains()[selector].DeployerKey.PublicKey()

--- a/deployment/common/changeset/test_helpers.go
+++ b/deployment/common/changeset/test_helpers.go
@@ -22,12 +22,8 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
-
 	commonState "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
-	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 type testMetadata struct {
@@ -191,20 +187,6 @@ func ApplyChangesets(t *testing.T, e cldf.Environment, changesetApplications []C
 		}
 	}
 	return currentEnv, outputs, nil
-}
-
-func SetPreloadedSolanaAddresses(t *testing.T, env cldf.Environment, selector uint64) {
-	typeAndVersion := cldf.NewTypeAndVersion(commontypes.ManyChainMultisigProgram, deployment.Version1_0_0)
-	err := env.ExistingAddresses.Save(selector, memory.SolanaProgramIDs["mcm"], typeAndVersion)
-	require.NoError(t, err)
-
-	typeAndVersion = cldf.NewTypeAndVersion(commontypes.AccessControllerProgram, deployment.Version1_0_0)
-	err = env.ExistingAddresses.Save(selector, memory.SolanaProgramIDs["access_controller"], typeAndVersion)
-	require.NoError(t, err)
-
-	typeAndVersion = cldf.NewTypeAndVersion(commontypes.RBACTimelockProgram, deployment.Version1_0_0)
-	err = env.ExistingAddresses.Save(selector, memory.SolanaProgramIDs["timelock"], typeAndVersion)
-	require.NoError(t, err)
 }
 
 func MustFundAddressWithLink(t *testing.T, e cldf.Environment, chain cldf_evm.Chain, to common.Address, amount int64) {

--- a/deployment/internal/soltestutils/datastore.go
+++ b/deployment/internal/soltestutils/datastore.go
@@ -1,0 +1,49 @@
+package soltestutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cldfsolana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+)
+
+// PreloadAddressBookWithMCMSPrograms creates and returns an address book containing preloaded MCMS
+// Solana program addresses for the specified selector.
+func PreloadAddressBookWithMCMSPrograms(t *testing.T, selector uint64) *cldf.AddressBookMap {
+	t.Helper()
+
+	ab := cldf.NewMemoryAddressBook()
+
+	tv := cldf.NewTypeAndVersion(commontypes.ManyChainMultisigProgram, deployment.Version1_0_0)
+	err := ab.Save(selector, MCMSProgramIDs["mcm"], tv)
+	require.NoError(t, err)
+
+	tv = cldf.NewTypeAndVersion(commontypes.AccessControllerProgram, deployment.Version1_0_0)
+	err = ab.Save(selector, MCMSProgramIDs["access_controller"], tv)
+	require.NoError(t, err)
+
+	tv = cldf.NewTypeAndVersion(commontypes.RBACTimelockProgram, deployment.Version1_0_0)
+	err = ab.Save(selector, MCMSProgramIDs["timelock"], tv)
+	require.NoError(t, err)
+
+	return ab
+}
+
+// GetMCMSStateFromAddressBook retrieves the state of the Solana MCMS contracts on the given chain.
+func GetMCMSStateFromAddressBook(
+	t *testing.T, ab cldf.AddressBook, chain cldfsolana.Chain,
+) *state.MCMSWithTimelockStateSolana {
+	addresses, err := ab.AddressesForChain(chain.Selector)
+	require.NoError(t, err)
+
+	mcmState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
+	require.NoError(t, err)
+
+	return mcmState
+}

--- a/deployment/internal/soltestutils/fund.go
+++ b/deployment/internal/soltestutils/fund.go
@@ -1,0 +1,26 @@
+package soltestutils
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+
+	cldfsolana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/internal/solutils"
+)
+
+// FundSignerPDAs funds the timelock signer and MCMS signer PDAs with 1 SOL for testing
+func FundSignerPDAs(
+	t *testing.T, chain cldfsolana.Chain, mcmsState *state.MCMSWithTimelockStateSolana,
+) {
+	t.Helper()
+
+	timelockSignerPDA := state.GetTimelockSignerPDA(mcmsState.TimelockProgram, mcmsState.TimelockSeed)
+	mcmSignerPDA := state.GetMCMSignerPDA(mcmsState.McmProgram, mcmsState.ProposerMcmSeed)
+	signerPDAs := []solana.PublicKey{timelockSignerPDA, mcmSignerPDA}
+	err := solutils.FundAccounts(t.Context(), chain.Client, signerPDAs, 1)
+	require.NoError(t, err)
+}

--- a/deployment/internal/soltestutils/preload.go
+++ b/deployment/internal/soltestutils/preload.go
@@ -1,0 +1,16 @@
+package soltestutils
+
+import (
+	"testing"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+)
+
+// PreloadMCMS provides a convenience function to preload the MCMS program artifacts and address
+// book for a given selector.
+func PreloadMCMS(t *testing.T, selector uint64) (string, map[string]string, *cldf.AddressBookMap) {
+	programsPath, programIDs := ProgramsForMCMS(t)
+	ab := PreloadAddressBookWithMCMSPrograms(t, selector)
+
+	return programsPath, programIDs, ab
+}

--- a/deployment/internal/soltestutils/programs.go
+++ b/deployment/internal/soltestutils/programs.go
@@ -1,0 +1,56 @@
+package soltestutils
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+)
+
+// MCMSProgramIDs is a map of predeployed MCMS Solana program IDs used in tests.
+var MCMSProgramIDs = map[string]string{
+	"mcm":               "5vNJx78mz7KVMjhuipyr9jKBKcMrKYGdjGkgE4LUmjKk",
+	"timelock":          "DoajfR5tK24xVw51fWcawUZWhAXD8yrBJVacc13neVQA",
+	"access_controller": "6KsN58MTnRQ8FfPaXHiFPPFGDRioikj9CdPvPxZJdCjb",
+}
+
+// MCMSPrograms downloads the MCMS program artifacts and returns the path to the cached artifacts
+// and the map of program IDs to paths.
+//
+// This can be used to preload the MCMS program artifacts into a test environment as arguments to
+// the WithSolanaContainer function.
+//
+// TODO: Remove the dependency on the memory package by extracting the download logic into a
+// separate solutils package.
+func ProgramsForMCMS(t *testing.T) (string, map[string]string) {
+	targetDir := t.TempDir()
+
+	// Download the MCMS program artifacts
+	memory.DownloadSolanaProgramArtifactsForTest(t)
+
+	// Copy the specific artifacts to the path provided
+	for name := range MCMSProgramIDs {
+		src := filepath.Join(memory.ProgramsPath, name+".so")
+		dst := filepath.Join(targetDir, name+".so")
+
+		// Copy the cached artifacts to the target directory
+		srcFile, err := os.Open(src)
+		require.NoError(t, err)
+
+		dstFile, err := os.Create(dst)
+		require.NoError(t, err)
+
+		_, err = io.Copy(dstFile, srcFile)
+		require.NoError(t, err)
+
+		srcFile.Close()
+		dstFile.Close()
+	}
+
+	// Return the path to the cached artifacts and the map of program IDs to paths
+	return targetDir, MCMSProgramIDs
+}

--- a/deployment/internal/solutils/fund.go
+++ b/deployment/internal/solutils/fund.go
@@ -1,0 +1,65 @@
+package solutils
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	solRpc "github.com/gagliardetto/solana-go/rpc"
+)
+
+// FundAccounts funds the given accounts with the given amount of SOL and waits for confirmation.
+func FundAccounts(
+	ctx context.Context, solanaGoClient *solRpc.Client, accounts []solana.PublicKey, solAmount uint64,
+) error {
+	sigs := make([]solana.Signature, 0, len(accounts))
+	for _, account := range accounts {
+		sig, err := solanaGoClient.RequestAirdrop(
+			ctx, account, solAmount*solana.LAMPORTS_PER_SOL, solRpc.CommitmentFinalized,
+		)
+		if err != nil {
+			return err
+		}
+
+		sigs = append(sigs, sig)
+	}
+
+	const timeout = 100 * time.Second
+	const pollInterval = 500 * time.Millisecond
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	remaining := len(sigs)
+	for remaining > 0 {
+		select {
+		case <-timeoutCtx.Done():
+			return errors.New("unable to fund transaction within timeout")
+		case <-ticker.C:
+			statusRes, sigErr := solanaGoClient.GetSignatureStatuses(ctx, true, sigs...)
+			if sigErr != nil {
+				return sigErr
+			}
+			if statusRes == nil {
+				return errors.New("status response is nil")
+			}
+			if statusRes.Value == nil {
+				return errors.New("status response value is nil")
+			}
+
+			unfinalizedCount := 0
+			for _, res := range statusRes.Value {
+				if res == nil || res.ConfirmationStatus == solRpc.ConfirmationStatusFinalized {
+					unfinalizedCount++
+				}
+			}
+			remaining = unfinalizedCount
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Updates the remaining deployment/common MCMS tests to use the test engine runtime.

This also adds a new soltestutils package to help with preloading MCMS programs and funding accounts.
