### PR TITLE
[CRE-1083] add option to not cleanup docker containers on error

### DIFF
--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -207,12 +207,13 @@ jobs:
           cd core/scripts/cre/environment
 
           # Start CRE with the appropriate contracts version (i.e. Workflow/CapabilityRegistry)
+          # Do not remove Docker containers on error to allow log collection
           if [[ "${CRE_VERSION}" == "v1" ]]; then
             echo "Starting CRE with v1 contracts for test: '${TEST_NAME}'"
-            go run . env start --with-plugins-docker-image "${E2E_TEST_CHAINLINK_IMAGE}:${E2E_TEST_CHAINLINK_VERSION}"
+            go run . env start --with-plugins-docker-image "${E2E_TEST_CHAINLINK_IMAGE}:${E2E_TEST_CHAINLINK_VERSION}" --cleanup-on-error=false
           else
             echo "Starting CRE with v2 contracts for test: '${TEST_NAME}'"
-            go run . env start --with-plugins-docker-image "${E2E_TEST_CHAINLINK_IMAGE}:${E2E_TEST_CHAINLINK_VERSION}" --with-contracts-version v2
+            go run . env start --with-plugins-docker-image "${E2E_TEST_CHAINLINK_IMAGE}:${E2E_TEST_CHAINLINK_VERSION}" --with-contracts-version v2 --cleanup-on-error=false
           fi
 
           exit_code=$?

--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -332,7 +332,6 @@ func startCmd() *cobra.Command {
 			}
 
 			output, startErr := StartCLIEnvironment(cmdContext, relativePathToRepoRoot, in, topology, withPluginsDockerImage, defaultCapabilities, extraJobSpecFunctions, envDependencies)
-			startErr = errors.New("on purpose")
 			if startErr != nil {
 				fmt.Fprintf(os.Stderr, "Error: %s\n", startErr)
 				fmt.Fprintf(os.Stderr, "Stack trace: %s\n", string(debug.Stack()))

--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -136,7 +136,7 @@ var StartCmdPreRunFunc = func(cmd *cobra.Command, args []string) {
 	}()
 }
 
-var StartCmdRecoverHandlerFunc = func(p any, cleanupWait time.Duration) {
+var StartCmdRecoverHandlerFunc = func(p any, cleanupOnFailure bool, cleanupWait time.Duration) {
 	if p != nil {
 		fmt.Println("Panicked when starting environment")
 
@@ -163,15 +163,17 @@ var StartCmdRecoverHandlerFunc = func(p any, cleanupWait time.Duration) {
 			fmt.Fprintf(os.Stderr, "failed to track startup: %s\n", tracingErr)
 		}
 
-		waitToCleanUp(cleanupWait)
-		_, saveErr := framework.SaveContainerLogs("./logs")
-		if saveErr != nil {
-			fmt.Fprintf(os.Stderr, "failed to save container logs: %s\n", saveErr)
-		}
+		if cleanupOnFailure {
+			waitToCleanUp(cleanupWait)
+			_, saveErr := framework.SaveContainerLogs("./logs")
+			if saveErr != nil {
+				fmt.Fprintf(os.Stderr, "failed to save container logs: %s\n", saveErr)
+			}
 
-		removeErr := framework.RemoveTestContainers()
-		if removeErr != nil {
-			fmt.Fprint(os.Stderr, errors.Wrap(removeErr, manualCtfCleanupMsg).Error())
+			removeErr := framework.RemoveTestContainers()
+			if removeErr != nil {
+				fmt.Fprint(os.Stderr, errors.Wrap(removeErr, manualCtfCleanupMsg).Error())
+			}
 		}
 
 		// signal that the environment failed to start
@@ -230,6 +232,7 @@ func startCmd() *cobra.Command {
 		withPluginsDockerImage   string
 		withContractsVersion     string
 		doSetup                  bool
+		cleanupOnFailure         bool
 		cleanupWait              time.Duration
 		withBeholder             bool
 		withDashboards           bool
@@ -246,7 +249,7 @@ func startCmd() *cobra.Command {
 		PersistentPreRun: StartCmdPreRunFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			defer func() {
-				StartCmdRecoverHandlerFunc(recover(), cleanupWait)
+				StartCmdRecoverHandlerFunc(recover(), cleanupOnFailure, cleanupWait)
 			}()
 
 			if doSetup {
@@ -329,6 +332,7 @@ func startCmd() *cobra.Command {
 			}
 
 			output, startErr := StartCLIEnvironment(cmdContext, relativePathToRepoRoot, in, topology, withPluginsDockerImage, defaultCapabilities, extraJobSpecFunctions, envDependencies)
+			startErr = errors.New("on purpose")
 			if startErr != nil {
 				fmt.Fprintf(os.Stderr, "Error: %s\n", startErr)
 				fmt.Fprintf(os.Stderr, "Stack trace: %s\n", string(debug.Stack()))
@@ -338,15 +342,17 @@ func startCmd() *cobra.Command {
 					fmt.Fprintf(os.Stderr, "failed to track startup: %s\n", dxErr)
 				}
 
-				waitToCleanUp(cleanupWait)
-				_, saveErr := framework.SaveContainerLogs("./logs")
-				if saveErr != nil {
-					fmt.Fprintf(os.Stderr, "failed to save container logs: %s\n", saveErr)
-				}
+				if cleanupOnFailure {
+					waitToCleanUp(cleanupWait)
+					_, saveErr := framework.SaveContainerLogs("./logs")
+					if saveErr != nil {
+						fmt.Fprintf(os.Stderr, "failed to save container logs: %s\n", saveErr)
+					}
 
-				removeErr := framework.RemoveTestContainers()
-				if removeErr != nil {
-					return errors.Wrap(removeErr, manualCtfCleanupMsg)
+					removeErr := framework.RemoveTestContainers()
+					if removeErr != nil {
+						return errors.Wrap(removeErr, manualCtfCleanupMsg)
+					}
 				}
 
 				return errors.Wrap(startErr, "failed to start environment")
@@ -480,6 +486,7 @@ func startCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&topology, "topology", "t", TopologyWorkflow, "Topology to use for the environment (workflow, workflow-gateway, workflow-gateway-capabilities)")
 	cmd.Flags().DurationVarP(&cleanupWait, "wait-on-error-timeout", "w", 15*time.Second, "Wait on error timeout (e.g. 10s, 1m, 1h)")
+	cmd.Flags().BoolVarP(&cleanupOnFailure, "cleanup-on-error", "l", false, "Whether to remove Docker containers if startup fails")
 	cmd.Flags().IntSliceVarP(&extraAllowedGatewayPorts, "extra-allowed-gateway-ports", "e", []int{}, "Extra allowed ports for outgoing connections from the Gateway DON (e.g. 8080,8081)")
 	cmd.Flags().BoolVarP(&withExampleFlag, "with-example", "x", false, "Deploy and register example workflow")
 	cmd.Flags().DurationVarP(&exampleWorkflowTimeout, "example-workflow-timeout", "u", 5*time.Minute, "Time to wait until example workflow succeeds")


### PR DESCRIPTION
* add a cmd line flag for **NOT** removing Docker containers if environment startup fails
* use that flag in CI, so that we always have Docker logs if environment startup does fail