### PR TITLE
refactor: vault changeset refactor

### DIFF
--- a/deployment/vault/changeset/fund_timelock_test.go
+++ b/deployment/vault/changeset/fund_timelock_test.go
@@ -171,7 +171,7 @@ func TestCalculateFundingRequirements(t *testing.T) {
 			},
 		}
 
-		requirements, err := CalculateFundingRequirements(rt.Environment(), config)
+		requirements, err := calculateFundingRequirements(rt.Environment(), config)
 		require.NoError(t, err)
 		require.Len(t, requirements, 2)
 
@@ -196,7 +196,7 @@ func TestCalculateFundingRequirements(t *testing.T) {
 			TransfersByChain: map[uint64][]types.NativeTransfer{},
 		}
 
-		requirements, err := CalculateFundingRequirements(rt.Environment(), config)
+		requirements, err := calculateFundingRequirements(rt.Environment(), config)
 		require.NoError(t, err)
 		require.Empty(t, requirements)
 	})
@@ -210,7 +210,7 @@ func TestCalculateFundingRequirements(t *testing.T) {
 			},
 		}
 
-		requirements, err := CalculateFundingRequirements(rt.Environment(), config)
+		requirements, err := calculateFundingRequirements(rt.Environment(), config)
 		require.NoError(t, err)
 		require.Len(t, requirements, 1)
 

--- a/deployment/vault/changeset/manage_whitelist_test.go
+++ b/deployment/vault/changeset/manage_whitelist_test.go
@@ -313,7 +313,7 @@ func TestValidateWhitelist(t *testing.T) {
 			},
 		}
 
-		errors, err := ValidateWhitelist(*env, config)
+		errors, err := validateWhitelist(*env, config)
 		require.NoError(t, err)
 		require.Empty(t, errors)
 	})
@@ -333,7 +333,7 @@ func TestValidateWhitelist(t *testing.T) {
 			},
 		}
 
-		validationErrors, err := ValidateWhitelist(*env, config)
+		validationErrors, err := validateWhitelist(*env, config)
 		require.NoError(t, err)
 		require.Len(t, validationErrors, 2)
 
@@ -359,7 +359,7 @@ func TestGetChainWhitelist(t *testing.T) {
 
 	t.Run("get whitelist from empty datastore", func(t *testing.T) {
 		ds := datastore.NewMemoryDataStore().Seal()
-		metadata, err := GetChainWhitelist(ds, selector)
+		metadata, err := getChainWhitelist(ds, selector)
 		require.NoError(t, err)
 		require.NotNil(t, metadata)
 		require.Empty(t, metadata.Addresses)
@@ -390,7 +390,7 @@ func TestGetChainWhitelist(t *testing.T) {
 		require.NoError(t, err)
 
 		sealedDS := ds.Seal()
-		metadata, err := GetChainWhitelist(sealedDS, selector)
+		metadata, err := getChainWhitelist(sealedDS, selector)
 		require.NoError(t, err)
 		require.NotNil(t, metadata)
 		require.Len(t, metadata.Addresses, 2)

--- a/deployment/vault/changeset/operations.go
+++ b/deployment/vault/changeset/operations.go
@@ -26,7 +26,7 @@ import (
 type VaultDeps struct {
 	Chain       cldf_evm.Chain
 	Auth        *bind.TransactOpts
-	DataStore   datastore.MutableDataStore
+	DataStore   datastore.DataStore
 	Environment cldf.Environment
 }
 
@@ -81,7 +81,7 @@ var ValidateTransferOp = operations.NewOperation(
 
 		output := ValidateTransferOutput{Valid: true, Errors: []string{}}
 
-		whitelistMetadata, err := GetChainWhitelistMutable(deps.DataStore, input.ChainSelector)
+		whitelistMetadata, err := getChainWhitelistMutable(deps.DataStore, input.ChainSelector)
 		if err != nil {
 			return output, fmt.Errorf("failed to get whitelist for chain %d: %w", input.ChainSelector, err)
 		}


### PR DESCRIPTION
This commit performs the following refactorings:

- Convert all changesets to directly implement the `cldf.ChangeSetV2` interface instead of using `cldf.CreateChangeSet`
- Make functions that are not used outside of the `changeset` package as private
- Ensure that the immutable datastore is provded as a dep to the operations. Operations should not mutate the datastore.
