### PR TITLE
chore: refactor environment package to use cldf framework

### DIFF
--- a/deployment/environment/memory/job_service_client_test.go
+++ b/deployment/environment/memory/job_service_client_test.go
@@ -10,8 +10,8 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/onchain"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
@@ -21,8 +21,12 @@ import (
 
 func TestJobClientProposeJob(t *testing.T) {
 	t.Parallel()
-	ctx := testutils.Context(t)
-	blockchains := cldf_chain.NewBlockChainsFromSlice(memory.NewMemoryChainsEVM(t, 1, 1))
+	ctx := t.Context()
+
+	bc, err := onchain.NewEVMSimLoader().LoadN(t, 1)
+	require.NoError(t, err)
+
+	blockchains := cldf_chain.NewBlockChainsFromSlice(bc)
 	ports := freeport.GetN(t, 1)
 	c := memory.NewNodeConfig{
 		Port:           ports[0],
@@ -122,8 +126,12 @@ func TestJobClientProposeJob(t *testing.T) {
 
 func TestJobClientJobAPI(t *testing.T) {
 	t.Parallel()
-	ctx := testutils.Context(t)
-	blockchains := cldf_chain.NewBlockChainsFromSlice(memory.NewMemoryChainsEVM(t, 1, 1))
+
+	ctx := t.Context()
+	bc, err := onchain.NewEVMSimLoader().LoadN(t, 1)
+	require.NoError(t, err)
+
+	blockchains := cldf_chain.NewBlockChainsFromSlice(bc)
 	ports := freeport.GetN(t, 1)
 	c := memory.NewNodeConfig{
 		Port:           ports[0],

--- a/deployment/environment/test/jd.go
+++ b/deployment/environment/test/jd.go
@@ -15,7 +15,6 @@ import (
 	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-	//	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 )


### PR DESCRIPTION
This removes the usage of the memory package from the job service client test and jd service to load chains, and instead uses the CLDF.
