### PR TITLE
Bump Go to 1.25.3 for v2.29.0-rc.1 rebuild

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.24.5
+golang 1.25.3
 mockery 2.53.0
 nodejs 20.13.1
 pnpm 10.6.5

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -1,7 +1,7 @@
 ##
 # Build image: Chainlink binary with plugins.
 ##
-FROM golang:1.25.2-bookworm AS buildgo
+FROM golang:1.25.3-bookworm AS buildgo
 RUN go version
 RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
 

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -3,7 +3,7 @@
 # XXX: Experimental -- not to be used to build images for production use.
 # See: ../core/chainlink.Dockerfile for the production Dockerfile.
 ##
-FROM golang:1.24-bullseye AS buildgo
+FROM golang:1.25.3-bookworm AS buildgo
 RUN go version
 RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Cherry-picked only the Go 1.25.3 base image bump from develop to fix TLS/SAN parsing regressions seen in 1.25.2 builds.