### PR TITLE
CCIP-7724 leave from field empty when perform method read

### DIFF
--- a/core/services/relay/evm/chain_reader_test.go
+++ b/core/services/relay/evm/chain_reader_test.go
@@ -169,7 +169,7 @@ func TestChainReaderPrimitiveTypes(t *testing.T) {
 			wrapped.Setup(t)
 
 			svc := wrapped.GetContractReader(t)
-			binding := commontypes.BoundContract{Address: "0x21", Name: "Contract"}
+			binding := commontypes.BoundContract{Address: contractAddress.Hex(), Name: "Contract"}
 
 			require.NoError(t, svc.Bind(t.Context(), []commontypes.BoundContract{binding}))
 
@@ -187,6 +187,7 @@ func TestChainReaderPrimitiveTypes(t *testing.T) {
 type mockedClient struct {
 	value        any
 	internalType abi.Type
+	t            *testing.T
 }
 
 func newMockedClient(t *testing.T, value any, internalType string) *mockedClient {
@@ -199,20 +200,28 @@ func newMockedClient(t *testing.T, value any, internalType string) *mockedClient
 	return &mockedClient{
 		value:        value,
 		internalType: internal,
+		t:            t,
 	}
 }
 
 func (_m *mockedClient) BatchCallContext(_ context.Context, _ []rpc.BatchElem) error { return nil }
 
 func (_m *mockedClient) CallContract(_ context.Context, msg ethereum.CallMsg, _ *big.Int) ([]byte, error) {
+	require.NotEqual(_m.t, contractAddress, msg.From)
 	return abi.Arguments{abi.Argument{Type: _m.internalType}}.Pack(_m.value)
 }
 
-func (_m *mockedClient) CodeAt(_ context.Context, _ common.Address, _ *big.Int) ([]byte, error) {
-	return []byte{0, 1, 2}, nil
+func (_m *mockedClient) CodeAt(_ context.Context, addr common.Address, _ *big.Int) ([]byte, error) {
+	if addr.Cmp(contractAddress) == 0 {
+		return []byte{0, 1, 2}, nil
+	}
+
+	return nil, nil
 }
 
 const contractABI = `[{"inputs":[],"name":"GetValue","outputs":[{"internalType":"%s","name":"","type":"%s"}],"stateMutability":"pure","type":"function"}]`
+
+var contractAddress = common.Address{1, 2, 3}
 
 type simpleTester struct {
 	returnVal    any

--- a/core/services/relay/evm/chain_reader_test.go
+++ b/core/services/relay/evm/chain_reader_test.go
@@ -207,6 +207,7 @@ func newMockedClient(t *testing.T, value any, internalType string) *mockedClient
 func (_m *mockedClient) BatchCallContext(_ context.Context, _ []rpc.BatchElem) error { return nil }
 
 func (_m *mockedClient) CallContract(_ context.Context, msg ethereum.CallMsg, _ *big.Int) ([]byte, error) {
+	// ensure we never put msg.From to contractAddress to comply with EIP-3607
 	require.NotEqual(_m.t, contractAddress, msg.From)
 	return abi.Arguments{abi.Argument{Type: _m.internalType}}.Pack(_m.value)
 }

--- a/core/services/relay/evm/chain_reader_test.go
+++ b/core/services/relay/evm/chain_reader_test.go
@@ -55,7 +55,7 @@ func TestChainReaderSizedBigIntTypes(t *testing.T) {
 			wrapped.Setup(t)
 
 			svc := wrapped.GetContractReader(t)
-			binding := commontypes.BoundContract{Address: "0x21", Name: "Contract"}
+			binding := commontypes.BoundContract{Address: contractAddress.String(), Name: "Contract"}
 
 			require.NoError(t, svc.Bind(t.Context(), []commontypes.BoundContract{binding}))
 

--- a/core/services/relay/evm/read/method.go
+++ b/core/services/relay/evm/read/method.go
@@ -159,7 +159,6 @@ func (b *MethodBinding) GetLatestValueWithHeadData(ctx context.Context, addr com
 
 	callMsg := ethereum.CallMsg{
 		To:   &addr,
-		From: addr,
 		Data: data,
 	}
 


### PR DESCRIPTION
[JIRA](https://smartcontract-it.atlassian.net/browse/CCIP-7724)

Execution clients with REVM backend apply EIP-3607 (reject caller with code) even for eth_call's, therefore when to address is a contract, our calls fail.
There is no practical reasons to set from = to address for eth_call's.