### PR TITLE
adding naive retry policy to submit workflow receipt

### DIFF
--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -593,20 +593,11 @@ func (r *Report) FormatReport() *protoEvents.MeteringReport {
 
 // isRetryableError determines if an error is retryable based on gRPC status codes
 func isRetryableError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	st, ok := status.FromError(err)
-	if !ok {
-		// If we can't determine the status, don't retry
-		return false
-	}
-
-	switch st.Code() {
+	switch status.Code(err) {
 	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted:
 		return true
 	default:
+		// includes code.Unknown + err == nil
 		return false
 	}
 }
@@ -641,7 +632,7 @@ func (r *Report) SendReceipt(ctx context.Context) error {
 	var resp *emptypb.Empty
 	var err error
 
-	for attempt := 0; attempt <= maxRetries; attempt++ {
+	for attempt := 0; ; attempt++ {
 		resp, err = r.client.SubmitWorkflowReceipt(ctx, &req)
 		if err == nil {
 			break

--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -625,10 +625,6 @@ func (r *Report) SendReceipt(ctx context.Context) error {
 		CreditsConsumed:               r.balance.GetSpent().String(),
 	}
 
-	// Retry logic: max 1 retry with 300ms max wait time
-	maxRetries := 1
-	retryDelay := 150 * time.Millisecond // Half of max wait time for single retry
-
 	var resp *emptypb.Empty
 	var err error
 
@@ -638,20 +634,20 @@ func (r *Report) SendReceipt(ctx context.Context) error {
 			break
 		}
 
-		if attempt >= maxRetries || !isRetryableError(err) {
+		if attempt >= r.maxRetries || !isRetryableError(err) {
 			break
 		}
 
 		r.lggr.Warnw("SubmitWorkflowReceipt failed, retrying",
 			"attempt", attempt+1,
-			"maxRetries", maxRetries+1,
+			"maxRetries", r.maxRetries+1,
 			"error", err,
-			"retryDelay", retryDelay)
+			"retryDelay", r.retryDelay)
 
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(retryDelay):
+		case <-time.After(r.retryDelay):
 			// Continue to next attempt
 		}
 	}

--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -11,8 +11,11 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/shopspring/decimal"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
@@ -124,6 +127,11 @@ type Report struct {
 	workflowRegistryAddress string
 	// WorkflowRegistryChainSelector is the chain selector for the workflow registry
 	workflowRegistryChainSelector uint64
+
+	// maxRetries is number of attempts to retry SubmitWorkflowReceipt
+	maxRetries int
+	// retryDelay is the delay between retries on SubmitWorkflowReceipt
+	retryDelay time.Duration
 }
 
 func NewReport(
@@ -152,6 +160,9 @@ func NewReport(
 
 		reserved: false,
 		steps:    make(map[string]ReportStep),
+
+		maxRetries: 1,
+		retryDelay: 150 * time.Millisecond,
 	}
 
 	// for safety in evaluating the client interface.
@@ -580,6 +591,26 @@ func (r *Report) FormatReport() *protoEvents.MeteringReport {
 	return protoReport
 }
 
+// isRetryableError determines if an error is retryable based on gRPC status codes
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		// If we can't determine the status, don't retry
+		return false
+	}
+
+	switch st.Code() {
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted:
+		return true
+	default:
+		return false
+	}
+}
+
 func (r *Report) SendReceipt(ctx context.Context) error {
 	if !r.reserved {
 		return ErrNoReserve
@@ -603,7 +634,37 @@ func (r *Report) SendReceipt(ctx context.Context) error {
 		CreditsConsumed:               r.balance.GetSpent().String(),
 	}
 
-	resp, err := r.client.SubmitWorkflowReceipt(ctx, &req)
+	// Retry logic: max 1 retry with 300ms max wait time
+	maxRetries := 1
+	retryDelay := 150 * time.Millisecond // Half of max wait time for single retry
+
+	var resp *emptypb.Empty
+	var err error
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		resp, err = r.client.SubmitWorkflowReceipt(ctx, &req)
+		if err == nil {
+			break
+		}
+
+		if attempt >= maxRetries || !isRetryableError(err) {
+			break
+		}
+
+		r.lggr.Warnw("SubmitWorkflowReceipt failed, retrying",
+			"attempt", attempt+1,
+			"maxRetries", maxRetries+1,
+			"error", err,
+			"retryDelay", retryDelay)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(retryDelay):
+			// Continue to next attempt
+		}
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds a bit of resiliency to SubmitWorkflowReceipt in the case the billing service is temporarily down due to orchestration latency when recycling containers. This is not meant to be a thorough solution, there's a lot of clever and interesting things we can do here in the future (https://smartcontract-it.atlassian.net/browse/CRE-1087). This is designed for smartcon.