### PR TITLE
core/services/workflows/syncer/v2: fix logging race

### DIFF
--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -183,8 +183,8 @@ func (w *workflowRegistry) Start(_ context.Context) error {
 
 		w.wg.Add(1)
 		go func() {
-			defer w.lggr.Debugw("Successfully set ContractReader")
 			defer w.wg.Done()
+			defer w.lggr.Debugw("Successfully set ContractReader")
 			defer close(initDoneCh)
 
 			ticker := w.getTicker(defaultTickInterval)


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/actions/runs/18692438725/job/53301294931#logs

`sync.WaitGroup.Done()` calls must be the last operation performed by a goroutine.