### PR TITLE
feat: add crossfamily `SetTokenTransferFeeConfig` changeset

### DIFF
--- a/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config.go
@@ -24,6 +24,20 @@ import (
 
 var _ cldf.ChangeSetV2[SetTokenTransferFeeConfigInput] = SetTokenTransferFeeConfig
 
+// SetTokenTransferFeeConfig is a cross-family changeset that updates per-token transfer-fee
+// parameters for both EVM and Solana source chains in one operation. It accepts a two-level
+// map of source -> destination chain selectors with per-token configs, validates each entry,
+// and routes them to the appropriate version-specific changeset.
+//
+// Features:
+//   - Version-aware: automatically detects or respects VersionHints for each family (EVM v1.6.0 / v1.5.1 and Solana v0.1.1 supported).
+//   - Unified schema: validates and converts string token addresses (hex → EVM, base58 → Solana).
+//   - Strict validation: rejects invalid selectors and same-chain (src==dst) updates.
+//   - No-op friendly: skips empty updates and exits cleanly when no changes are needed.
+//   - MCMS integration: batches all family/version changes into a single orchestrated proposal.
+//
+// This changeset performs only validation, version routing, and type conversion. It delegates
+// all actual on-chain logic to the existing family/version changesets.
 var SetTokenTransferFeeConfig = cldf.CreateChangeSet(setTokenTransferFeeLogic, setTokenTransferFeePrecondition)
 
 var SetTokenTransferFeeLatestSupportedVersions = OptionalVersions{

--- a/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config.go
@@ -1,0 +1,311 @@
+package crossfamily
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/gagliardetto/solana-go"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
+
+	ccip_cs_common "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+	ccip_cs_sol_v0_1_1 "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana_v0_1_1"
+	ccip_cs_evm_v1_5_1 "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1"
+	ccip_cs_evm_v1_6_0 "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+)
+
+var _ cldf.ChangeSetV2[SetTokenTransferFeeConfigInput] = SetTokenTransferFeeConfig
+
+var SetTokenTransferFeeConfig = cldf.CreateChangeSet(setTokenTransferFeeLogic, setTokenTransferFeePrecondition)
+
+var SetTokenTransferFeeLatestSupportedVersions = OptionalVersions{
+	Solana: pointer.To(ccip_cs_sol_v0_1_1.VersionSolanaV0_1_1),
+	Evm:    pointer.To(deployment.Version1_6_0.String()),
+}
+
+type OptionalVersions struct {
+	Solana *string
+	Evm    *string
+}
+
+type OptionalTokenTransferFeeConfig struct {
+	DestBytesOverhead *uint32
+	DestGasOverhead   *uint32
+	MinFeeUsdCents    *uint32
+	MaxFeeUsdCents    *uint32
+	DeciBps           *uint16
+	IsEnabled         *bool
+}
+
+type TokenTransferFeeConfigArgs struct {
+	TokenAddressToFeeConfig map[string]OptionalTokenTransferFeeConfig
+}
+
+type SetTokenTransferFeeConfigInput struct {
+	InputsByChain map[uint64]map[uint64]TokenTransferFeeConfigArgs `json:"inputsByChain"`
+	VersionHints  *OptionalVersions                                `json:"versionHints"`
+	MCMS          *proposalutils.TimelockConfig                    `json:"mcms"`
+}
+
+func (cfg SetTokenTransferFeeConfigInput) buildOrchestrateChangesetsConfig(env cldf.Environment) (ccip_cs_common.OrchestrateChangesetsConfig, error) {
+	// Make sure MCMS config is specified
+	env.Logger.Info("building orchestrate changesets config")
+	if cfg.MCMS == nil {
+		return ccip_cs_common.OrchestrateChangesetsConfig{}, errors.New("MCMS config is required")
+	}
+
+	// Load state
+	state, err := stateview.LoadOnchainState(env)
+	if err != nil {
+		return ccip_cs_common.OrchestrateChangesetsConfig{}, fmt.Errorf("failed to load onchain state: %w", err)
+	}
+
+	// Default to latest supported version for each chain family if no version hints were specified
+	allVersionHints := pointer.Coalesce(cfg.VersionHints, SetTokenTransferFeeLatestSupportedVersions)
+	solanaVersion := pointer.Coalesce(allVersionHints.Solana, *SetTokenTransferFeeLatestSupportedVersions.Solana)
+	evmVersion := pointer.Coalesce(allVersionHints.Evm, *SetTokenTransferFeeLatestSupportedVersions.Evm)
+
+	// Define the configs for each version
+	solanaConfigV0_1_1 := map[uint64]map[uint64]ccip_cs_sol_v0_1_1.TokenTransferFeeForRemoteChainConfigArgsV2{}
+	evmConfigV1_6_0 := map[uint64]map[uint64]ccip_cs_evm_v1_6_0.ApplyTokenTransferFeeConfigUpdatesConfigV2Input{}
+	evmConfigV1_5_1 := map[uint64]map[uint64]ccip_cs_evm_v1_5_1.SetTokenTransferFeeArgs{}
+
+	// Populate configs
+	for srcSelector, inputs := range cfg.InputsByChain {
+		err := stateview.ValidateChain(env, state, srcSelector, cfg.MCMS)
+		if err != nil {
+			return ccip_cs_common.OrchestrateChangesetsConfig{}, fmt.Errorf("failed to validate src chain (src = %d): %w", srcSelector, err)
+		}
+		srcFamily, err := chainsel.GetSelectorFamily(srcSelector)
+		if err != nil {
+			return ccip_cs_common.OrchestrateChangesetsConfig{}, fmt.Errorf("failed to get src chain family (src = %d): %w", srcSelector, err)
+		}
+
+		for dstSelector, input := range inputs {
+			if err := stateview.ValidateChain(env, state, dstSelector, cfg.MCMS); err != nil {
+				return ccip_cs_common.OrchestrateChangesetsConfig{}, fmt.Errorf(
+					"failed to validate dst chain (src = %d, dst = %d): %w", srcSelector, dstSelector, err)
+			}
+			if srcSelector == dstSelector {
+				return ccip_cs_common.OrchestrateChangesetsConfig{}, fmt.Errorf(
+					"destination chain cannot be the same as source chain (src = %d, dst = %d)", srcSelector, dstSelector)
+			}
+
+			// Use the chain family and version to determine which config should be updated
+			switch srcFamily {
+			case chainsel.FamilyEVM:
+				switch evmVersion {
+				case deployment.Version1_6_0.String():
+					if err = updateEvmTokenTransferFeeConfigV1_6_0(srcSelector, dstSelector, input, evmConfigV1_6_0); err != nil {
+						return ccip_cs_common.OrchestrateChangesetsConfig{}, fmt.Errorf("failed to update EVM %s config: %w", evmVersion, err)
+					}
+				case deployment.Version1_5_1.String():
+					if err = updateEvmTokenTransferFeeConfigV1_5_1(srcSelector, dstSelector, input, evmConfigV1_5_1); err != nil {
+						return ccip_cs_common.OrchestrateChangesetsConfig{}, fmt.Errorf("failed to update EVM %s config: %w", evmVersion, err)
+					}
+				default:
+					return ccip_cs_common.OrchestrateChangesetsConfig{}, fmt.Errorf("unsupported EVM version: %s", evmVersion)
+				}
+			case chainsel.FamilySolana:
+				switch solanaVersion {
+				case ccip_cs_sol_v0_1_1.VersionSolanaV0_1_1:
+					if err = updateSolanaTokenTransferFeeConfigV0_1_1(srcSelector, dstSelector, input, solanaConfigV0_1_1); err != nil {
+						return ccip_cs_common.OrchestrateChangesetsConfig{}, fmt.Errorf("failed to update Solana %s config: %w", solanaVersion, err)
+					}
+				default:
+					return ccip_cs_common.OrchestrateChangesetsConfig{}, fmt.Errorf("unsupported Solana version: %s", solanaVersion)
+				}
+			default:
+				return ccip_cs_common.OrchestrateChangesetsConfig{}, fmt.Errorf("unsupported source family for selector %d: %s", srcSelector, srcFamily)
+			}
+		}
+	}
+
+	// Combine the results
+	changesets := []ccip_cs_common.WithConfig{}
+	if len(evmConfigV1_6_0) > 0 {
+		changesets = append(changesets, ccip_cs_common.CreateGenericChangeSetWithConfig(
+			ccip_cs_evm_v1_6_0.ApplyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2,
+			ccip_cs_evm_v1_6_0.ApplyTokenTransferFeeConfigUpdatesConfigV2{
+				InputsByChain: evmConfigV1_6_0,
+				MCMS:          cfg.MCMS,
+			},
+		))
+	}
+	if len(evmConfigV1_5_1) > 0 {
+		changesets = append(changesets, ccip_cs_common.CreateGenericChangeSetWithConfig(
+			ccip_cs_evm_v1_5_1.SetTokenTransferFeeConfigChangeset,
+			ccip_cs_evm_v1_5_1.SetTokenTransferFeeConfig{
+				InputsByChain: evmConfigV1_5_1,
+				MCMS:          cfg.MCMS,
+			},
+		))
+	}
+	if len(solanaConfigV0_1_1) > 0 {
+		changesets = append(changesets, ccip_cs_common.CreateGenericChangeSetWithConfig(
+			ccip_cs_sol_v0_1_1.AddTokenTransferFeeForRemoteChainV2,
+			ccip_cs_sol_v0_1_1.TokenTransferFeeForRemoteChainConfigV2{
+				InputsByChain: solanaConfigV0_1_1,
+				MCMS:          cfg.MCMS,
+			},
+		))
+	}
+
+	// Return the combined orchestrate config
+	return ccip_cs_common.OrchestrateChangesetsConfig{
+		Description: "Set Token Transfer Fee Config - Cross Family",
+		MCMS:        cfg.MCMS,
+		ChangeSets:  changesets,
+	}, nil
+}
+
+func setTokenTransferFeePrecondition(env cldf.Environment, cfg SetTokenTransferFeeConfigInput) error {
+	if len(cfg.InputsByChain) == 0 {
+		env.Logger.Info("no inputs were provided - exiting precondition stage gracefully")
+		return nil
+	}
+
+	input, err := cfg.buildOrchestrateChangesetsConfig(env)
+	if err != nil {
+		return fmt.Errorf("failed to build OrchestrateChangesetsConfig: %w", err)
+	}
+
+	if len(input.ChangeSets) == 0 {
+		env.Logger.Info("no changesets to orchestrate - exiting precondition stage gracefully")
+		return nil
+	}
+
+	return ccip_cs_common.OrchestrateChangesets.VerifyPreconditions(env, input)
+}
+
+func setTokenTransferFeeLogic(env cldf.Environment, cfg SetTokenTransferFeeConfigInput) (cldf.ChangesetOutput, error) {
+	if len(cfg.InputsByChain) == 0 {
+		env.Logger.Info("no inputs were provided - exiting apply stage gracefully")
+		return cldf.ChangesetOutput{}, nil
+	}
+
+	input, err := cfg.buildOrchestrateChangesetsConfig(env)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to build OrchestrateChangesetsConfig: %w", err)
+	}
+
+	if len(input.ChangeSets) == 0 {
+		env.Logger.Info("no changesets to orchestrate - exiting apply stage gracefully")
+		return cldf.ChangesetOutput{}, nil
+	}
+
+	return ccip_cs_common.OrchestrateChangesets.Apply(env, input)
+}
+
+// --- EVM helpers ----
+
+func updateEvmTokenTransferFeeConfigV1_6_0(
+	srcSelector uint64,
+	dstSelector uint64,
+	input TokenTransferFeeConfigArgs,
+	config map[uint64]map[uint64]ccip_cs_evm_v1_6_0.ApplyTokenTransferFeeConfigUpdatesConfigV2Input,
+) error {
+	configs := map[common.Address]ccip_cs_evm_v1_6_0.OptionalFeeQuoterTokenTransferFeeConfig{}
+	for rawTokenAddress, tokenFeeConfig := range input.TokenAddressToFeeConfig {
+		if !common.IsHexAddress(rawTokenAddress) {
+			return fmt.Errorf("invalid hex EVM address detected '%s'", rawTokenAddress)
+		}
+		configs[common.HexToAddress(rawTokenAddress)] = ccip_cs_evm_v1_6_0.OptionalFeeQuoterTokenTransferFeeConfig{
+			DestBytesOverhead: tokenFeeConfig.DestBytesOverhead,
+			DestGasOverhead:   tokenFeeConfig.DestGasOverhead,
+			MinFeeUSDCents:    tokenFeeConfig.MinFeeUsdCents,
+			MaxFeeUSDCents:    tokenFeeConfig.MaxFeeUsdCents,
+			IsEnabled:         tokenFeeConfig.IsEnabled,
+			DeciBps:           tokenFeeConfig.DeciBps,
+		}
+	}
+
+	if len(configs) > 0 {
+		if _, ok := config[srcSelector]; !ok {
+			config[srcSelector] = map[uint64]ccip_cs_evm_v1_6_0.ApplyTokenTransferFeeConfigUpdatesConfigV2Input{}
+		}
+		config[srcSelector][dstSelector] = ccip_cs_evm_v1_6_0.ApplyTokenTransferFeeConfigUpdatesConfigV2Input{
+			TokenTransferFeeConfigRemoveArgs: []common.Address{},
+			TokenTransferFeeConfigArgs:       configs,
+		}
+	}
+	return nil
+}
+
+func updateEvmTokenTransferFeeConfigV1_5_1(
+	srcSelector uint64,
+	dstSelector uint64,
+	input TokenTransferFeeConfigArgs,
+	config map[uint64]map[uint64]ccip_cs_evm_v1_5_1.SetTokenTransferFeeArgs,
+) error {
+	configs := map[common.Address]ccip_cs_evm_v1_5_1.TokenTransferFeeArgs{}
+	for rawTokenAddress, tokenFeeConfig := range input.TokenAddressToFeeConfig {
+		if !common.IsHexAddress(rawTokenAddress) {
+			return fmt.Errorf("invalid hex EVM address detected '%s'", rawTokenAddress)
+		}
+		configs[common.HexToAddress(rawTokenAddress)] = ccip_cs_evm_v1_5_1.TokenTransferFeeArgs{
+			DestBytesOverhead: tokenFeeConfig.DestBytesOverhead,
+			DestGasOverhead:   tokenFeeConfig.DestGasOverhead,
+			MinFeeUSDCents:    tokenFeeConfig.MinFeeUsdCents,
+			MaxFeeUSDCents:    tokenFeeConfig.MaxFeeUsdCents,
+			DeciBps:           tokenFeeConfig.DeciBps,
+
+			// The sensible default should always be used for this field
+			AggregateRateLimitEnabled: nil,
+		}
+	}
+
+	if len(configs) > 0 {
+		if _, ok := config[srcSelector]; !ok {
+			config[srcSelector] = map[uint64]ccip_cs_evm_v1_5_1.SetTokenTransferFeeArgs{}
+		}
+		config[srcSelector][dstSelector] = ccip_cs_evm_v1_5_1.SetTokenTransferFeeArgs{
+			TokensToUseDefaultFeeConfigs: []common.Address{},
+			TokenTransferFeeConfigArgs:   configs,
+		}
+	}
+	return nil
+}
+
+// --- Solana helpers ---
+
+func updateSolanaTokenTransferFeeConfigV0_1_1(
+	srcSelector uint64,
+	dstSelector uint64,
+	input TokenTransferFeeConfigArgs,
+	config map[uint64]map[uint64]ccip_cs_sol_v0_1_1.TokenTransferFeeForRemoteChainConfigArgsV2,
+) error {
+	configs := map[solana.PublicKey]ccip_cs_sol_v0_1_1.OptionalFeeQuoterTokenTransferFeeConfig{}
+	for rawTokenAddress, tokenFeeConfig := range input.TokenAddressToFeeConfig {
+		tokenAddress, err := solana.PublicKeyFromBase58(rawTokenAddress)
+		if err != nil {
+			return fmt.Errorf("invalid base58 solana address detected '%s': %w", rawTokenAddress, err)
+		}
+		configs[tokenAddress] = ccip_cs_sol_v0_1_1.OptionalFeeQuoterTokenTransferFeeConfig{
+			DestBytesOverhead: tokenFeeConfig.DestBytesOverhead,
+			DestGasOverhead:   tokenFeeConfig.DestGasOverhead,
+			MinFeeUsdcents:    tokenFeeConfig.MinFeeUsdCents,
+			MaxFeeUsdcents:    tokenFeeConfig.MaxFeeUsdCents,
+			IsEnabled:         tokenFeeConfig.IsEnabled,
+			DeciBps:           tokenFeeConfig.DeciBps,
+		}
+	}
+
+	if len(configs) > 0 {
+		if _, ok := config[srcSelector]; !ok {
+			config[srcSelector] = map[uint64]ccip_cs_sol_v0_1_1.TokenTransferFeeForRemoteChainConfigArgsV2{}
+		}
+		config[srcSelector][dstSelector] = ccip_cs_sol_v0_1_1.TokenTransferFeeForRemoteChainConfigArgsV2{
+			TokenAddressToFeeConfig: configs,
+		}
+	}
+	return nil
+}

--- a/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config_test.go
+++ b/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config_test.go
@@ -41,6 +41,8 @@ const SetTokenTransferFeePriceRegStalenessThreshold = 60 * 60 * 24 * 14 // two w
 var SetTokenTransferFeeMcmsConfig = proposalutils.TimelockConfig{MinDelay: 1 * time.Second}
 
 func deploySolanaToken(t *testing.T, tEnv cldf.Environment, solSelector uint64, tokenSymbol string) (cldf.Environment, solana.PublicKey, error) {
+	t.Helper()
+
 	e, err := commonchangeset.Apply(t, tEnv,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccip_cs_sol_v0_1_1.DeploySolanaToken),
@@ -74,6 +76,8 @@ func deploySolanaToken(t *testing.T, tEnv cldf.Environment, solSelector uint64, 
 }
 
 func getSolanaTokenTransferFeeConfig(t *testing.T, tEnv cldf.Environment, srcSelector, dstSelector uint64, fq, tokenPubKey solana.PublicKey) solfq.PerChainPerTokenConfig {
+	t.Helper()
+
 	pda, _, err := solstate.FindFqPerChainPerTokenConfigPDA(dstSelector, tokenPubKey, fq)
 	require.NoError(t, err)
 

--- a/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config_test.go
+++ b/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config_test.go
@@ -1,0 +1,655 @@
+package crossfamily_test
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/gagliardetto/solana-go"
+
+	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
+
+	solfq "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/fee_quoter"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink/deployment"
+	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
+
+	solstate "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/v1_5"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+
+	solstateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/crossfamily"
+	ccip_cs_sol_v0_1_1 "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana_v0_1_1"
+)
+
+const SetTokenTransferFeePriceRegStalenessThreshold = 60 * 60 * 24 * 14 // two weeks in seconds
+
+var SetTokenTransferFeeMcmsConfig = proposalutils.TimelockConfig{MinDelay: 1 * time.Second}
+
+func deploySolanaToken(t *testing.T, tEnv cldf.Environment, solSelector uint64, tokenSymbol string) (cldf.Environment, solana.PublicKey, error) {
+	e, err := commonchangeset.Apply(t, tEnv,
+		commonchangeset.Configure(
+			cldf.CreateLegacyChangeSet(ccip_cs_sol_v0_1_1.DeploySolanaToken),
+			ccip_cs_sol_v0_1_1.DeploySolanaTokenConfig{
+				MintAmountToAddress: map[string]uint64{},
+				TokenProgramName:    shared.SPLTokens,
+				ChainSelector:       solSelector,
+				TokenDecimals:       9,
+				TokenSymbol:         tokenSymbol,
+				ATAList:             []string{},
+			},
+		),
+	)
+	if err != nil {
+		return cldf.Environment{}, solana.PublicKey{}, err
+	}
+
+	addresses, err := e.ExistingAddresses.AddressesForChain(solSelector)
+	require.NoError(t, err)
+
+	tokenAddress := solstateview.FindSolanaAddress(
+		cldf.TypeAndVersion{
+			Version: deployment.Version1_0_0,
+			Labels:  cldf.NewLabelSet(tokenSymbol),
+			Type:    shared.SPLTokens,
+		},
+		addresses,
+	)
+
+	return e, tokenAddress, nil
+}
+
+func getSolanaTokenTransferFeeConfig(t *testing.T, tEnv cldf.Environment, srcSelector, dstSelector uint64, fq, tokenPubKey solana.PublicKey) solfq.PerChainPerTokenConfig {
+	pda, _, err := solstate.FindFqPerChainPerTokenConfigPDA(dstSelector, tokenPubKey, fq)
+	require.NoError(t, err)
+
+	var cfg solfq.PerChainPerTokenConfig
+	err = tEnv.BlockChains.SolanaChains()[srcSelector].GetAccountDataBorshInto(tEnv.GetContext(), pda, &cfg)
+	require.NoError(t, err)
+
+	return cfg
+}
+
+func TestSetTokenTransferFeeConfig_Validations(t *testing.T) {
+	// Build a mixed env with EVM + non-EVM so we can validate both families in one table-driven test
+	env, _ := testhelpers.NewMemoryEnvironment(t,
+		testhelpers.WithCCIPSolanaContractVersion(ccip_cs_sol_v0_1_1.SolanaContractV0_1_1),
+		testhelpers.WithNumOfChains(2),
+		testhelpers.WithSolChains(1),
+	)
+
+	// EVM selectors
+	evmSelectors := env.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))
+	require.GreaterOrEqual(t, len(evmSelectors), 2, "test requires at least 2 EVM chains in the memory env")
+	evmSrc := evmSelectors[0]
+	evmDst := evmSelectors[1]
+
+	// Solana selectors
+	solSelectors := env.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilySolana))
+	require.GreaterOrEqual(t, len(solSelectors), 1, "test requires at least 1 Solana chain in the memory env")
+	solSrc := solSelectors[0]
+
+	// Helper vars
+	evmAddr := utils.RandomAddress().String()
+	solAddr := solana.SolMint.String()
+
+	// Configure MCMS on Solana
+	_, _ = testhelpers.TransferOwnershipSolanaV0_1_1(t, &env.Env, solSrc, true,
+		ccip_cs_sol_v0_1_1.CCIPContractsToTransfer{
+			FeeQuoter: true,
+			Router:    true,
+			OffRamp:   true,
+		})
+	_, err := ccip_cs_sol_v0_1_1.FetchTimelockSigner(env.Env, solSrc)
+	require.NoError(t, err)
+
+	// Define test cases
+	tests := []struct {
+		MsgStr string
+		Config crossfamily.SetTokenTransferFeeConfigInput
+		ErrStr string
+	}{
+		{
+			ErrStr: "MCMS config is required",
+			MsgStr: "MCMS required when inputs present",
+			Config: crossfamily.SetTokenTransferFeeConfigInput{
+				InputsByChain: map[uint64]map[uint64]crossfamily.TokenTransferFeeConfigArgs{
+					evmSrc: {
+						evmDst: {
+							TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
+								evmAddr: {},
+							},
+						},
+					},
+				},
+				MCMS: nil, // required -> expect error
+			},
+		},
+		{
+			ErrStr: "invalid hex EVM address detected",
+			MsgStr: "Invalid EVM hex token address",
+			Config: crossfamily.SetTokenTransferFeeConfigInput{
+				InputsByChain: map[uint64]map[uint64]crossfamily.TokenTransferFeeConfigArgs{
+					evmSrc: {
+						evmDst: {
+							TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
+								"not-a-hex-address": {},
+							},
+						},
+					},
+				},
+				MCMS: &SetTokenTransferFeeMcmsConfig,
+			},
+		},
+		{
+			ErrStr: "failed to validate dst chain",
+			MsgStr: "Missing destination chain selector (dst=0)",
+			Config: crossfamily.SetTokenTransferFeeConfigInput{
+				InputsByChain: map[uint64]map[uint64]crossfamily.TokenTransferFeeConfigArgs{
+					evmSrc: {
+						0: {
+							TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
+								evmAddr: {},
+							},
+						},
+					},
+				},
+				MCMS: &SetTokenTransferFeeMcmsConfig,
+			},
+		},
+		{
+			ErrStr: "invalid base58 solana address detected",
+			MsgStr: "Solana: invalid base58 address",
+			Config: crossfamily.SetTokenTransferFeeConfigInput{
+				InputsByChain: map[uint64]map[uint64]crossfamily.TokenTransferFeeConfigArgs{
+					solSrc: {
+						evmDst: {
+							TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
+								"this-is-not-base58!!": {},
+							},
+						},
+					},
+				},
+				MCMS: &SetTokenTransferFeeMcmsConfig,
+			},
+		},
+		{
+			ErrStr: "failed to validate src chain",
+			MsgStr: "Solana: selector not in env (src validation)",
+			Config: crossfamily.SetTokenTransferFeeConfigInput{
+				InputsByChain: map[uint64]map[uint64]crossfamily.TokenTransferFeeConfigArgs{
+					chainsel.SOLANA_DEVNET.Selector: {
+						evmDst: {
+							TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
+								solAddr: {},
+							},
+						},
+					},
+				},
+				MCMS: &SetTokenTransferFeeMcmsConfig,
+			},
+		},
+		{
+			ErrStr: "destination chain cannot be the same as source chain",
+			MsgStr: "Reject same src/dst selector",
+			Config: crossfamily.SetTokenTransferFeeConfigInput{
+				InputsByChain: map[uint64]map[uint64]crossfamily.TokenTransferFeeConfigArgs{
+					evmSrc: {
+						evmSrc: { // same as src
+							TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
+								evmAddr: {},
+							},
+						},
+					},
+				},
+				MCMS: &SetTokenTransferFeeMcmsConfig,
+			},
+		},
+		{
+			ErrStr: "unsupported EVM version",
+			MsgStr: "Unsupported EVM version hint fails fast",
+			Config: crossfamily.SetTokenTransferFeeConfigInput{
+				VersionHints: &crossfamily.OptionalVersions{
+					Solana: pointer.To(ccip_cs_sol_v0_1_1.VersionSolanaV0_1_1), // valid solana (doesn't matter)
+					Evm:    pointer.To("1.4.9"),                                // bogus/unsupported
+				},
+				InputsByChain: map[uint64]map[uint64]crossfamily.TokenTransferFeeConfigArgs{
+					evmSrc: {
+						evmDst: {
+							TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
+								evmAddr: {},
+							},
+						},
+					},
+				},
+				MCMS: &SetTokenTransferFeeMcmsConfig,
+			},
+		},
+		{
+			ErrStr: "unsupported Solana version",
+			MsgStr: "Unsupported Solana version hint fails fast",
+			Config: crossfamily.SetTokenTransferFeeConfigInput{
+				VersionHints: &crossfamily.OptionalVersions{
+					Evm:    pointer.To(deployment.Version1_6_0.String()),
+					Solana: pointer.To("v0_0_9"), // bogus/unsupported
+				},
+				InputsByChain: map[uint64]map[uint64]crossfamily.TokenTransferFeeConfigArgs{
+					solSrc: {
+						evmDst: {
+							TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
+								solAddr: {},
+							},
+						},
+					},
+				},
+				MCMS: &SetTokenTransferFeeMcmsConfig,
+			},
+		},
+	}
+
+	// Run test cases
+	for _, test := range tests {
+		t.Run(test.MsgStr, func(t *testing.T) {
+			_, err := commonchangeset.Apply(t, env.Env,
+				commonchangeset.Configure(
+					crossfamily.SetTokenTransferFeeConfig,
+					test.Config,
+				),
+			)
+			require.Error(t, err)
+			require.ErrorContains(t, err, test.ErrStr)
+		})
+	}
+}
+
+func TestSetTokenTransferFeeConfig_EmptyConfigIsGracefullyHandled(t *testing.T) {
+	env, _ := testhelpers.NewMemoryEnvironment(t,
+		testhelpers.WithCCIPSolanaContractVersion(ccip_cs_sol_v0_1_1.SolanaContractV0_1_1),
+		testhelpers.WithNumOfChains(2),
+		testhelpers.WithSolChains(1),
+	)
+
+	_, err := commonchangeset.Apply(t, env.Env,
+		commonchangeset.Configure(
+			crossfamily.SetTokenTransferFeeConfig,
+			crossfamily.SetTokenTransferFeeConfigInput{},
+		),
+	)
+	require.NoError(t, err)
+}
+
+func TestSetTokenTransferFeeConfig_EVM_V1_6_0_Only(t *testing.T) {
+	// Setup EVM environment
+	env, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithNumOfChains(2))
+
+	// EVM selectors
+	evm := env.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))
+	require.GreaterOrEqual(t, len(evm), 2)
+	src, dst := evm[0], evm[1]
+
+	// Load state and transfer ownership to timelock so MCMS can execute
+	state, err := stateview.LoadOnchainState(env.Env)
+	require.NoError(t, err)
+	testhelpers.TransferToTimelock(t, env, state, []uint64{src, dst}, true)
+
+	// Helper vars
+	link := state.MustGetEVMChainState(src).LinkToken.Address()
+	opts := &bind.CallOpts{Context: env.Env.GetContext()}
+
+	// Define the token transfer fee config
+	cfg := crossfamily.SetTokenTransferFeeConfigInput{
+		InputsByChain: map[uint64]map[uint64]crossfamily.TokenTransferFeeConfigArgs{
+			src: {
+				dst: {
+					TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
+						link.Hex(): {
+							// partial fields: defaults should be auto-filled by the EVM changeset when none exist
+							MinFeeUsdCents:  pointer.To(uint32(800)),
+							DestGasOverhead: pointer.To(uint32(100)),
+						},
+					},
+				},
+			},
+		},
+		VersionHints: &crossfamily.OptionalVersions{
+			Evm: pointer.To(deployment.Version1_6_0.String()),
+		},
+		MCMS: &SetTokenTransferFeeMcmsConfig,
+	}
+
+	// Apply once
+	_, err = commonchangeset.Apply(t, env.Env, commonchangeset.Configure(crossfamily.SetTokenTransferFeeConfig, cfg))
+	require.NoError(t, err)
+
+	// Verify on FeeQuoter(src) for (dst, link)
+	cfg1, err := state.MustGetEVMChainState(src).FeeQuoter.GetTokenTransferFeeConfig(opts, dst, link)
+	require.NoError(t, err)
+	require.Equal(t, uint32(math.MaxUint32), cfg1.MaxFeeUSDCents)
+	require.Equal(t, uint32(800), cfg1.MinFeeUSDCents)
+	require.Equal(t, uint32(100), cfg1.DestGasOverhead)
+	require.Equal(t, uint32(32), cfg1.DestBytesOverhead)
+	require.Equal(t, uint16(0), cfg1.DeciBps)
+	require.True(t, cfg1.IsEnabled)
+
+	// Re-apply the exact same config: should be a no-op and succeed
+	_, err = commonchangeset.Apply(t, env.Env, commonchangeset.Configure(crossfamily.SetTokenTransferFeeConfig, cfg))
+	require.NoError(t, err)
+
+	// Verify on FeeQuoter(src) for (dst, link)
+	cfg2, err := state.MustGetEVMChainState(src).FeeQuoter.GetTokenTransferFeeConfig(opts, dst, link)
+	require.NoError(t, err)
+	require.Equal(t, cfg1, cfg2)
+}
+
+func TestSetTokenTransferFeeConfig_EVM_V1_5_1_Only(t *testing.T) {
+	// Setup EVM environment
+	env, _ := testhelpers.NewMemoryEnvironment(t,
+		testhelpers.WithNumOfChains(2),
+		testhelpers.WithPrerequisiteDeploymentOnly(&changeset.V1_5DeploymentConfig{
+			// NOTE: this property needs to be defined otherwise we will encounter an
+			// error. For now it's set to a value that was found in another test case
+			PriceRegStalenessThreshold: SetTokenTransferFeePriceRegStalenessThreshold,
+		}),
+	)
+
+	// EVM selectors
+	evm := env.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))
+	require.GreaterOrEqual(t, len(evm), 2)
+	src, dst := evm[0], evm[1]
+
+	// Load state and transfer ownership to timelock so MCMS can execute
+	state, err := stateview.LoadOnchainState(env.Env, stateview.WithLoadLegacyContracts(true))
+	require.NoError(t, err)
+
+	// Wire up a bi-directional lane
+	env.Env = v1_5.AddLanes(t, env.Env, state, []testhelpers.SourceDestPair{
+		{SourceChainSelector: src, DestChainSelector: dst},
+		{SourceChainSelector: dst, DestChainSelector: src},
+	})
+
+	// Take a fresh snapshot of the state and transfer the OnRamps to timelock
+	state, err = stateview.LoadOnchainState(env.Env, stateview.WithLoadLegacyContracts(true))
+	require.NoError(t, err)
+	env.Env, err = commonchangeset.Apply(t, env.Env,
+		commonchangeset.Configure(
+			cldf.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelockV2),
+			commonchangeset.TransferToMCMSWithTimelockConfig{
+				ContractsByChain: map[uint64][]common.Address{
+					src: {state.MustGetEVMChainState(src).EVM2EVMOnRamp[dst].Address()},
+					dst: {state.MustGetEVMChainState(dst).EVM2EVMOnRamp[src].Address()},
+				},
+				MCMSConfig: SetTokenTransferFeeMcmsConfig,
+			},
+		),
+	)
+	require.NoError(t, err)
+
+	// Helper vars
+	link := state.MustGetEVMChainState(src).LinkToken.Address()
+	opts := &bind.CallOpts{Context: env.Env.GetContext()}
+
+	// Define the token transfer fee config
+	cfg := crossfamily.SetTokenTransferFeeConfigInput{
+		InputsByChain: map[uint64]map[uint64]crossfamily.TokenTransferFeeConfigArgs{
+			src: {
+				dst: {
+					TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
+						link.Hex(): {
+							DestBytesOverhead: pointer.To(uint32(32)),
+							DestGasOverhead:   pointer.To(uint32(10)),
+							MaxFeeUsdCents:    pointer.To(uint32(math.MaxUint32)),
+							MinFeeUsdCents:    pointer.To(uint32(800)),
+							DeciBps:           pointer.To(uint16(0)),
+							IsEnabled:         pointer.To(true),
+						},
+					},
+				},
+			},
+		},
+		VersionHints: &crossfamily.OptionalVersions{
+			Evm: pointer.To(deployment.Version1_5_1.String()),
+		},
+		MCMS: &SetTokenTransferFeeMcmsConfig,
+	}
+
+	// Apply once
+	_, err = commonchangeset.Apply(t, env.Env, commonchangeset.Configure(crossfamily.SetTokenTransferFeeConfig, cfg))
+	require.NoError(t, err)
+
+	// Verify on OnRamp[src][dst] for link
+	cfg1, err := state.MustGetEVMChainState(src).EVM2EVMOnRamp[dst].GetTokenTransferFeeConfig(opts, link)
+	require.NoError(t, err)
+	require.Equal(t, uint32(math.MaxUint32), cfg1.MaxFeeUSDCents, cfg1)
+	require.Equal(t, uint32(800), cfg1.MinFeeUSDCents)
+	require.Equal(t, uint32(32), cfg1.DestBytesOverhead)
+	require.Equal(t, uint32(10), cfg1.DestGasOverhead)
+	require.Equal(t, uint16(0), cfg1.DeciBps)
+	require.True(t, cfg1.IsEnabled)
+
+	// Re-apply the exact same config: should be a no-op and succeed
+	_, err = commonchangeset.Apply(t, env.Env, commonchangeset.Configure(crossfamily.SetTokenTransferFeeConfig, cfg))
+	require.NoError(t, err)
+
+	// Verify on OnRamp[src][dst] for link
+	cfg2, err := state.MustGetEVMChainState(src).EVM2EVMOnRamp[dst].GetTokenTransferFeeConfig(opts, link)
+	require.NoError(t, err)
+	require.Equal(t, cfg1, cfg2)
+}
+
+func TestSetTokenTransferFeeConfig_Solana_V0_1_0_Only(t *testing.T) {
+	// Setup Solana environment
+	env, _ := testhelpers.NewMemoryEnvironment(t,
+		testhelpers.WithCCIPSolanaContractVersion(ccip_cs_sol_v0_1_1.SolanaContractV0_1_1),
+		testhelpers.WithNumOfChains(2),
+		testhelpers.WithSolChains(1),
+	)
+
+	// EVM selectors
+	evm := env.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))
+	require.GreaterOrEqual(t, len(evm), 1)
+	dst := evm[0]
+
+	// SOL selectors
+	sol := env.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilySolana))
+	require.GreaterOrEqual(t, len(sol), 1)
+	src := sol[0]
+
+	// Deploy a Solana test token X
+	e, tokenAddressX, err := deploySolanaToken(t, env.Env, src, "TEST_TOKEN_X")
+	require.NoError(t, err)
+	env.Env = e
+
+	// Deploy a Solana test token Y
+	e, tokenAddressY, err := deploySolanaToken(t, env.Env, src, "TEST_TOKEN_Y")
+	require.NoError(t, err)
+	env.Env = e
+
+	// Configure MCMS on Solana
+	_, _ = testhelpers.TransferOwnershipSolanaV0_1_1(t, &env.Env, src, true,
+		ccip_cs_sol_v0_1_1.CCIPContractsToTransfer{
+			FeeQuoter: true,
+			Router:    true,
+			OffRamp:   true,
+		})
+	_, err = ccip_cs_sol_v0_1_1.FetchTimelockSigner(env.Env, src)
+	require.NoError(t, err)
+
+	// Define the token transfer fee config
+	cfg := crossfamily.SetTokenTransferFeeConfigInput{
+		InputsByChain: map[uint64]map[uint64]crossfamily.TokenTransferFeeConfigArgs{
+			src: {
+				dst: {
+					TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
+						tokenAddressX.String(): {
+							// partial fields: defaults should be auto-filled by the SOL changeset when none exist
+							DestGasOverhead: pointer.To(uint32(10)),
+						},
+						tokenAddressY.String(): {
+							// partial fields: defaults should be auto-filled by the SOL changeset when none exist
+							DestBytesOverhead: pointer.To(uint32(64)),
+							DestGasOverhead:   pointer.To(uint32(10)),
+						},
+					},
+				},
+			},
+		},
+		VersionHints: &crossfamily.OptionalVersions{
+			Solana: pointer.To(ccip_cs_sol_v0_1_1.VersionSolanaV0_1_1),
+		},
+		MCMS: &SetTokenTransferFeeMcmsConfig,
+	}
+
+	// Set the token transfer fee config
+	e, err = commonchangeset.Apply(t, env.Env, commonchangeset.Configure(crossfamily.SetTokenTransferFeeConfig, cfg))
+	require.NoError(t, err)
+	env.Env = e
+
+	// Refresh state
+	state, err := stateview.LoadOnchainState(env.Env)
+	require.NoError(t, err)
+
+	// Verify on FeeQuoter(src) for (dst, tokenX)
+	solCfgX := getSolanaTokenTransferFeeConfig(t, env.Env, src, dst, state.SolChains[src].FeeQuoter, tokenAddressX)
+	require.Equal(t, tokenAddressX, solCfgX.Mint)
+	require.Equal(t, uint32(math.MaxUint32), solCfgX.TokenTransferConfig.MaxFeeUsdcents)
+	require.Equal(t, uint32(175_000), solCfgX.TokenTransferConfig.MinFeeUsdcents)
+	require.Equal(t, uint32(32), solCfgX.TokenTransferConfig.DestBytesOverhead)
+	require.Equal(t, uint32(10), solCfgX.TokenTransferConfig.DestGasOverhead)
+	require.Equal(t, uint16(0), solCfgX.TokenTransferConfig.DeciBps)
+	require.True(t, solCfgX.TokenTransferConfig.IsEnabled)
+
+	// Verify on FeeQuoter(src) for (dst, tokenY)
+	solCfgY := getSolanaTokenTransferFeeConfig(t, env.Env, src, dst, state.SolChains[src].FeeQuoter, tokenAddressY)
+	require.Equal(t, tokenAddressY, solCfgY.Mint)
+	require.Equal(t, uint32(math.MaxUint32), solCfgY.TokenTransferConfig.MaxFeeUsdcents)
+	require.Equal(t, uint32(175_000), solCfgY.TokenTransferConfig.MinFeeUsdcents)
+	require.Equal(t, uint32(64), solCfgY.TokenTransferConfig.DestBytesOverhead)
+	require.Equal(t, uint32(10), solCfgY.TokenTransferConfig.DestGasOverhead)
+	require.Equal(t, uint16(0), solCfgY.TokenTransferConfig.DeciBps)
+	require.True(t, solCfgY.TokenTransferConfig.IsEnabled)
+}
+
+func TestSetTokenTransferFeeConfig_MixedFamilies_SingleApply(t *testing.T) {
+	// Build a mixed env with EVM + non-EVM
+	env, _ := testhelpers.NewMemoryEnvironment(t,
+		testhelpers.WithCCIPSolanaContractVersion(ccip_cs_sol_v0_1_1.SolanaContractV0_1_1),
+		testhelpers.WithNumOfChains(2),
+		testhelpers.WithSolChains(1),
+	)
+
+	// EVM selectors
+	evm := env.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))
+	require.GreaterOrEqual(t, len(evm), 2)
+	evmSrc, evmDst := evm[0], evm[1]
+
+	// SOL selectors
+	sol := env.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilySolana))
+	require.GreaterOrEqual(t, len(sol), 1)
+	solSrc := sol[0]
+
+	// EVM: transfer to timelock so we can MCMS-apply
+	state, err := stateview.LoadOnchainState(env.Env)
+	require.NoError(t, err)
+	testhelpers.TransferToTimelock(t, env, state, []uint64{evmSrc, evmDst}, true)
+
+	// Solana: transfer to timelock so we can MCMS-apply
+	_, _ = testhelpers.TransferOwnershipSolanaV0_1_1(t, &env.Env, solSrc, true, ccip_cs_sol_v0_1_1.CCIPContractsToTransfer{
+		FeeQuoter: true,
+		Router:    true,
+		OffRamp:   true,
+	})
+	_, err = ccip_cs_sol_v0_1_1.FetchTimelockSigner(env.Env, solSrc)
+	require.NoError(t, err)
+
+	// EVM: token to configure = LINK on source chain
+	link := state.MustGetEVMChainState(evmSrc).LinkToken.Address()
+	opts := &bind.CallOpts{Context: env.Env.GetContext()}
+
+	// Solana: token to configure = deploy a test token
+	var mint solana.PublicKey
+	env.Env, mint, err = deploySolanaToken(t, env.Env, solSrc, "TEST_TOKEN_MIXED")
+	require.NoError(t, err)
+
+	// Define the token transfer fee config
+	cfg := crossfamily.SetTokenTransferFeeConfigInput{
+		InputsByChain: map[uint64]map[uint64]crossfamily.TokenTransferFeeConfigArgs{
+			// EVM src -> EVM dst
+			evmSrc: {
+				evmDst: {
+					TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
+						link.Hex(): {
+							MinFeeUsdCents:    pointer.To(uint32(12)),
+							DeciBps:           pointer.To(uint16(7)),
+							DestGasOverhead:   pointer.To(uint32(222)),
+							DestBytesOverhead: pointer.To(uint32(512)),
+							IsEnabled:         pointer.To(true),
+						},
+					},
+				},
+			},
+			// Solana src -> EVM dst
+			solSrc: {
+				evmDst: {
+					TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
+						mint.String(): {
+							// partial: defaults will fill any omitted fields
+							MinFeeUsdCents:    pointer.To(uint32(900)),
+							DestGasOverhead:   pointer.To(uint32(100)),
+							DestBytesOverhead: pointer.To(uint32(128)),
+							// DeciBps/IsEnabled left nil -> defaults (0 / true)
+						},
+					},
+				},
+			},
+		},
+		VersionHints: &crossfamily.OptionalVersions{
+			Solana: pointer.To(ccip_cs_sol_v0_1_1.VersionSolanaV0_1_1),
+			Evm:    pointer.To(deployment.Version1_6_0.String()),
+		},
+		MCMS: &SetTokenTransferFeeMcmsConfig,
+	}
+
+	// Apply
+	_, err = commonchangeset.Apply(t, env.Env, commonchangeset.Configure(crossfamily.SetTokenTransferFeeConfig, cfg))
+	require.NoError(t, err)
+
+	// Refresh state
+	state, err = stateview.LoadOnchainState(env.Env)
+	require.NoError(t, err)
+
+	// Get EVM token transfer fee config
+	evmCfg, err := state.MustGetEVMChainState(evmSrc).FeeQuoter.GetTokenTransferFeeConfig(opts, evmDst, link)
+	require.NoError(t, err)
+
+	// Verify EVM config
+	require.Equal(t, uint32(math.MaxUint32), evmCfg.MaxFeeUSDCents)
+	require.Equal(t, uint32(12), evmCfg.MinFeeUSDCents)
+	require.Equal(t, uint32(512), evmCfg.DestBytesOverhead)
+	require.Equal(t, uint32(222), evmCfg.DestGasOverhead)
+	require.Equal(t, uint16(7), evmCfg.DeciBps)
+	require.True(t, evmCfg.IsEnabled)
+
+	// Verify Solana config
+	solCfg := getSolanaTokenTransferFeeConfig(t, env.Env, solSrc, evmDst, state.SolChains[solSrc].FeeQuoter, mint)
+	require.Equal(t, mint, solCfg.Mint)
+	require.Equal(t, uint32(math.MaxUint32), solCfg.TokenTransferConfig.MaxFeeUsdcents) // default (not provided)
+	require.Equal(t, uint32(900), solCfg.TokenTransferConfig.MinFeeUsdcents)            // set explicitly
+	require.Equal(t, uint32(128), solCfg.TokenTransferConfig.DestBytesOverhead)         // set explicitly
+	require.Equal(t, uint32(100), solCfg.TokenTransferConfig.DestGasOverhead)           // set explicitly
+	require.Equal(t, uint16(0), solCfg.TokenTransferConfig.DeciBps)                     // default (not provided)
+	require.True(t, solCfg.TokenTransferConfig.IsEnabled)                               // defaulted to true
+}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
@@ -719,12 +719,17 @@ func SetMaxFeeJuelsPerMsg(e cldf.Environment, cfg SetMaxFeeJuelsPerMsgConfig) (c
 
 // ADD BILLING TOKEN FOR REMOTE CHAIN V2
 //
-// TokenTransferFeeForRemoteChainConfigV2 is a thin wrapper around the original AddTokenTransferFeeForRemoteChain changeset
-// with some added devex improvements. In the V2 version you can provide a partial (or empty) config and any missing fields
-// will be auto-filled with sensible defaults. It is also possible to provide multiple tokens as input and all of them will
-// be processed using a single MCMS proposal. A few other benefits include additional logging as well as a new input schema
-// format that aligns more closely with the EVM equivalent of this changeset. This changeset also handles no-ops gracefully
-// and uses the CLDF changeset V2 API.
+// AddTokenTransferFeeForRemoteChainV2 wraps the original AddTokenTransferFeeForRemoteChain changeset with several devex
+// improvements. In the V2 version you can provide a partial (or empty) config and any missing fields will be autofilled
+// with sensible defaults. It's also possible to provide multiple tokens as input and all of them will be processed with
+// a single MCMS proposal. A few other benefits include more detailed log messages and a new input schema structure that
+// aligns more closely with the EVM equivalent of this changeset. This changeset also handles no-ops gracefully and uses
+// the CLDF changeset V2 API.
+var AddTokenTransferFeeForRemoteChainV2 = cldf.CreateChangeSet(
+	addTokenTransferFeeForRemoteChainV2Logic,
+	addTokenTransferFeeForRemoteChainV2Precondition,
+)
+
 type TokenTransferFeeForRemoteChainConfigV2 struct {
 	// Map of source chain selector (solana family) => destination chain selector (any family) => config
 	InputsByChain map[uint64]map[uint64]TokenTransferFeeForRemoteChainConfigArgsV2
@@ -911,11 +916,6 @@ func (cfg TokenTransferFeeForRemoteChainConfigV2) buildOrchestrateChangesetsConf
 		MCMS:        cfg.MCMS,
 	}, nil
 }
-
-var AddTokenTransferFeeForRemoteChainV2 = cldf.CreateChangeSet(
-	addTokenTransferFeeForRemoteChainV2Logic,
-	addTokenTransferFeeForRemoteChainV2Precondition,
-)
 
 func addTokenTransferFeeForRemoteChainV2Precondition(env cldf.Environment, cfg TokenTransferFeeForRemoteChainConfigV2) error {
 	if len(cfg.InputsByChain) == 0 {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
@@ -2,11 +2,14 @@ package solana
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math"
 
 	solBinary "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
 	ata "github.com/gagliardetto/solana-go/programs/associated-token-account"
+	"github.com/gagliardetto/solana-go/rpc"
 
 	"github.com/smartcontractkit/mcms"
 	mcmsTypes "github.com/smartcontractkit/mcms/types"
@@ -15,6 +18,8 @@ import (
 	solFeeQuoter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/fee_quoter"
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 	solTokenUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
+	ccipcommoncs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -23,6 +28,9 @@ import (
 	solanastateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
+
+// use this changeset to add a token transfer fee for a remote chain to solana (used for very specific cases)
+var _ cldf.ChangeSetV2[TokenTransferFeeForRemoteChainConfigV2] = AddTokenTransferFeeForRemoteChainV2
 
 // use this changeset to add a billing token to solana
 var _ cldf.ChangeSet[BillingTokenConfig] = AddBillingTokenChangeset
@@ -707,4 +715,242 @@ func SetMaxFeeJuelsPerMsg(e cldf.Environment, cfg SetMaxFeeJuelsPerMsgConfig) (c
 	}
 
 	return cldf.ChangesetOutput{}, nil
+}
+
+// ADD BILLING TOKEN FOR REMOTE CHAIN V2
+//
+// TokenTransferFeeForRemoteChainConfigV2 is a thin wrapper around the original AddTokenTransferFeeForRemoteChain changeset
+// with some added devex improvements. In the V2 version you can provide a partial (or empty) config and any missing fields
+// will be auto-filled with sensible defaults. It is also possible to provide multiple tokens as input and all of them will
+// be processed using a single MCMS proposal. A few other benefits include additional logging as well as a new input schema
+// format that aligns more closely with the EVM equivalent of this changeset. This changeset also handles no-ops gracefully
+// and uses the CLDF changeset V2 API.
+type TokenTransferFeeForRemoteChainConfigV2 struct {
+	// Map of source chain selector (solana family) => destination chain selector (any family) => config
+	InputsByChain map[uint64]map[uint64]TokenTransferFeeForRemoteChainConfigArgsV2
+
+	// Required MCMS config
+	MCMS *proposalutils.TimelockConfig
+}
+
+type TokenTransferFeeForRemoteChainConfigArgsV2 struct {
+	// Maps each token address to its token fee config
+	TokenAddressToFeeConfig map[solana.PublicKey]OptionalFeeQuoterTokenTransferFeeConfig
+}
+
+type OptionalFeeQuoterTokenTransferFeeConfig struct {
+	MinFeeUsdcents    *uint32
+	MaxFeeUsdcents    *uint32
+	DeciBps           *uint16
+	DestGasOverhead   *uint32
+	DestBytesOverhead *uint32
+	IsEnabled         *bool
+}
+
+func (cfg TokenTransferFeeForRemoteChainConfigV2) buildOrchestrateChangesetsConfig(env cldf.Environment) (ccipcommoncs.OrchestrateChangesetsConfig, error) {
+	env.Logger.Info("building orchestrate changesets config")
+	if cfg.MCMS == nil {
+		return ccipcommoncs.OrchestrateChangesetsConfig{}, errors.New("MCMS config is required")
+	}
+
+	state, err := stateview.LoadOnchainState(env)
+	if err != nil {
+		return ccipcommoncs.OrchestrateChangesetsConfig{}, fmt.Errorf("failed to load onchain state: %w", err)
+	}
+
+	changesets := []ccipcommoncs.WithConfig{}
+	for srcSelector, dst := range cfg.InputsByChain {
+		// get solana chain state and solana chain info
+		err := stateview.ValidateChain(env, state, srcSelector, cfg.MCMS)
+		if err != nil {
+			return ccipcommoncs.OrchestrateChangesetsConfig{}, fmt.Errorf("failed to validate src chain (src = %d): %w", srcSelector, err)
+		}
+		solChainState, ok := state.SolChains[srcSelector]
+		if !ok {
+			return ccipcommoncs.OrchestrateChangesetsConfig{}, fmt.Errorf("failed to find solana chain with selector '%d' in state", srcSelector)
+		}
+		solChain, ok := env.BlockChains.SolanaChains()[srcSelector]
+		if !ok {
+			return ccipcommoncs.OrchestrateChangesetsConfig{}, fmt.Errorf("failed to find solana chain with selector '%d' in environment", srcSelector)
+		}
+
+		// prepare for iteration
+		remoteChainConfigsByToken := map[solana.PublicKey]map[uint64]solFeeQuoter.TokenTransferFeeConfig{}
+		env.Logger.Infof(
+			"successfully found Solana fee quoter in state for selector %d: %s",
+			srcSelector, solChainState.FeeQuoter.String(),
+		)
+
+		// 1st pass -> populate remote chain configs for each (token, dst) pair
+		env.Logger.Infof("building remote chain configs for chain %d", srcSelector)
+		for dstSelector, dstConfig := range dst {
+			// perform basic validations on the first pass
+			if srcSelector == dstSelector {
+				return ccipcommoncs.OrchestrateChangesetsConfig{}, fmt.Errorf("destination chain cannot be the same as source chain (src = %d, dst = %d)", srcSelector, dstSelector)
+			}
+			if err := stateview.ValidateChain(env, state, dstSelector, cfg.MCMS); err != nil {
+				return ccipcommoncs.OrchestrateChangesetsConfig{}, fmt.Errorf("failed to validate dst chain (src = %d, dst = %d): %w", srcSelector, dstSelector, err)
+			}
+
+			// build the config map
+			for tokenAddress, feeConfig := range dstConfig.TokenAddressToFeeConfig {
+				// get the remote billing PDA for the given (token, dst) pair
+				env.Logger.Infof("processing inputs src = %d, dst = %d, token = %s", srcSelector, dstSelector, tokenAddress.String())
+				remoteBillingPDA, _, err := solState.FindFqPerChainPerTokenConfigPDA(dstSelector, tokenAddress, solChainState.FeeQuoter)
+				if err != nil {
+					return ccipcommoncs.OrchestrateChangesetsConfig{}, fmt.Errorf("failed to find remote billing token config pda (src = %d, dst = %d, token = %s): %w", srcSelector, dstSelector, tokenAddress.String(), err)
+				}
+
+				// get the token transfer fee config from the fee quoter - if it doesn't exist, then the zero struct will be returned and `IsEnabled` will be `false`
+				env.Logger.Infof("remote billing PDA = %s", remoteBillingPDA.String())
+				var curConfig solFeeQuoter.PerChainPerTokenConfig
+				err = solChain.GetAccountDataBorshInto(env.GetContext(), remoteBillingPDA, &curConfig)
+				if !errors.Is(err, rpc.ErrNotFound) && err != nil {
+					return ccipcommoncs.OrchestrateChangesetsConfig{}, fmt.Errorf("failed to deserialize PerChainPerTokenConfig (src = %d, dst = %d, token = %s, pda = %s): %w", srcSelector, dstSelector, tokenAddress.String(), remoteBillingPDA.String(), err)
+				}
+
+				// if the config has not been set yet, we auto-fill any missing input fields with sensible defaults
+				env.Logger.Infof("current config = %+v", curConfig)
+				if !curConfig.TokenTransferConfig.IsEnabled {
+					// only use sensible defaults to fill in missing fields - do not overwrite anything that the user provided
+					minFeeUsdCents := pointer.Coalesce(feeConfig.MinFeeUsdcents, uint32(175_000))
+					maxFeeUsdCents := pointer.Coalesce(feeConfig.MaxFeeUsdcents, math.MaxUint32)
+					destGasOverhead := pointer.Coalesce(feeConfig.DestGasOverhead, uint32(90_000))
+					destBytesOverhead := pointer.Coalesce(feeConfig.DestBytesOverhead, uint32(32))
+					deciBps := pointer.Coalesce(feeConfig.DeciBps, uint16(0))
+					isEnabled := pointer.Coalesce(feeConfig.IsEnabled, true)
+					env.Logger.Infof("config is not set - populating missing fields in user input with sensible defaults: %+v", feeConfig)
+
+					// fill in the missing values in-place
+					feeConfig.MinFeeUsdcents = &minFeeUsdCents
+					feeConfig.MaxFeeUsdcents = &maxFeeUsdCents
+					feeConfig.DeciBps = &deciBps
+					feeConfig.DestGasOverhead = &destGasOverhead
+					feeConfig.DestBytesOverhead = &destBytesOverhead
+					feeConfig.IsEnabled = &isEnabled
+					env.Logger.Infof("missing fields in user input have been auto-filled with sensible defaults: %+v", feeConfig)
+				}
+
+				// at this point, we're either using inputs from the user (highest precedence), fallback values from the chain, or pre-defined sensible defaults
+				newConfig := solFeeQuoter.TokenTransferFeeConfig{
+					MinFeeUsdcents:    pointer.Coalesce(feeConfig.MinFeeUsdcents, curConfig.TokenTransferConfig.MinFeeUsdcents),
+					MaxFeeUsdcents:    pointer.Coalesce(feeConfig.MaxFeeUsdcents, curConfig.TokenTransferConfig.MaxFeeUsdcents),
+					DeciBps:           pointer.Coalesce(feeConfig.DeciBps, curConfig.TokenTransferConfig.DeciBps),
+					DestGasOverhead:   pointer.Coalesce(feeConfig.DestGasOverhead, curConfig.TokenTransferConfig.DestGasOverhead),
+					DestBytesOverhead: pointer.Coalesce(feeConfig.DestBytesOverhead, curConfig.TokenTransferConfig.DestBytesOverhead),
+					IsEnabled:         pointer.Coalesce(feeConfig.IsEnabled, curConfig.TokenTransferConfig.IsEnabled),
+				}
+
+				// make sure that the config is still valid after merge
+				if newConfig.MinFeeUsdcents >= newConfig.MaxFeeUsdcents {
+					return ccipcommoncs.OrchestrateChangesetsConfig{}, fmt.Errorf("min fee (%d) must be less than max fee (%d)", newConfig.MinFeeUsdcents, newConfig.MaxFeeUsdcents)
+				}
+
+				// check if the new config is different from the on-chain config
+				isDifferent := newConfig.MinFeeUsdcents != curConfig.TokenTransferConfig.MinFeeUsdcents ||
+					newConfig.MaxFeeUsdcents != curConfig.TokenTransferConfig.MaxFeeUsdcents ||
+					newConfig.DeciBps != curConfig.TokenTransferConfig.DeciBps ||
+					newConfig.DestGasOverhead != curConfig.TokenTransferConfig.DestGasOverhead ||
+					newConfig.DestBytesOverhead != curConfig.TokenTransferConfig.DestBytesOverhead ||
+					newConfig.IsEnabled != curConfig.TokenTransferConfig.IsEnabled
+
+				// only perform an update if the new config is different from the on-chain config
+				env.Logger.Infof("constructed new token transfer fee config: %+v", newConfig)
+				if !isDifferent {
+					env.Logger.Infof(
+						"skipping update since input config is the same as on-chain config (src=%d, dst=%d, token=%s): %+v",
+						srcSelector, dstSelector, tokenAddress.String(), curConfig,
+					)
+					continue
+				}
+
+				// update the config map
+				if _, ok := remoteChainConfigsByToken[tokenAddress]; !ok {
+					remoteChainConfigsByToken[tokenAddress] = map[uint64]solFeeQuoter.TokenTransferFeeConfig{}
+				}
+				remoteChainConfigsByToken[tokenAddress][dstSelector] = newConfig
+			}
+		}
+
+		// 2nd pass -> populate token transfer fee configs and changesets
+		env.Logger.Infof("detected %d token(s) to configure", len(remoteChainConfigsByToken))
+		for tokenPubKey, remoteChainConfigs := range remoteChainConfigsByToken {
+			if len(remoteChainConfigs) == 0 {
+				env.Logger.Infof("detected no changes for token %s - skipping", tokenPubKey.String())
+				continue
+			}
+
+			tokenTransferFeeConfig := TokenTransferFeeForRemoteChainConfig{
+				RemoteChainConfigs: remoteChainConfigs,
+				ChainSelector:      srcSelector,
+				TokenPubKey:        tokenPubKey,
+				MCMS:               cfg.MCMS,
+			}
+
+			err := tokenTransferFeeConfig.Validate(env, state)
+			if err != nil {
+				return ccipcommoncs.OrchestrateChangesetsConfig{}, fmt.Errorf(
+					"validation failed for token transfer fee config (src=%d, token=%s, input=%+v): %w",
+					srcSelector, tokenPubKey.String(), tokenTransferFeeConfig, err,
+				)
+			}
+
+			changesets = append(
+				changesets,
+				ccipcommoncs.CreateGenericChangeSetWithConfig(
+					cldf.CreateLegacyChangeSet(AddTokenTransferFeeForRemoteChain),
+					tokenTransferFeeConfig,
+				),
+			)
+		}
+	}
+
+	return ccipcommoncs.OrchestrateChangesetsConfig{
+		Description: "Apply token transfer fee configs from Solana -> *",
+		ChangeSets:  changesets,
+		MCMS:        cfg.MCMS,
+	}, nil
+}
+
+var AddTokenTransferFeeForRemoteChainV2 = cldf.CreateChangeSet(
+	addTokenTransferFeeForRemoteChainV2Logic,
+	addTokenTransferFeeForRemoteChainV2Precondition,
+)
+
+func addTokenTransferFeeForRemoteChainV2Precondition(env cldf.Environment, cfg TokenTransferFeeForRemoteChainConfigV2) error {
+	if len(cfg.InputsByChain) == 0 {
+		env.Logger.Info("no inputs were provided - exiting precondition stage gracefully")
+		return nil
+	}
+
+	input, err := cfg.buildOrchestrateChangesetsConfig(env)
+	if err != nil {
+		return fmt.Errorf("failed to build OrchestrateChangesetsConfig: %w", err)
+	}
+
+	if len(input.ChangeSets) == 0 {
+		env.Logger.Info("no changesets to orchestrate - exiting precondition stage gracefully")
+		return nil
+	}
+
+	return ccipcommoncs.OrchestrateChangesets.VerifyPreconditions(env, input)
+}
+
+func addTokenTransferFeeForRemoteChainV2Logic(env cldf.Environment, cfg TokenTransferFeeForRemoteChainConfigV2) (cldf.ChangesetOutput, error) {
+	if len(cfg.InputsByChain) == 0 {
+		env.Logger.Info("no inputs were provided - exiting apply stage gracefully")
+		return cldf.ChangesetOutput{}, nil
+	}
+
+	input, err := cfg.buildOrchestrateChangesetsConfig(env)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to build OrchestrateChangesetsConfig: %w", err)
+	}
+
+	if len(input.ChangeSets) == 0 {
+		env.Logger.Info("no changesets to orchestrate - exiting apply stage gracefully")
+		return cldf.ChangesetOutput{}, nil
+	}
+
+	return ccipcommoncs.OrchestrateChangesets.Apply(env, input)
 }

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_chain_contracts_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	solanastateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
+	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 
@@ -325,6 +326,13 @@ func doTestBilling(t *testing.T, mcms bool) {
 
 	e, tokenAddress, err := deployTokenAndMint(t, tenv.Env, solChain, []string{}, "TEST_TOKEN")
 	require.NoError(t, err)
+
+	e, tokenAddressB, err := deployTokenAndMint(t, tenv.Env, solChain, []string{}, "TEST_TOKEN_B")
+	require.NoError(t, err)
+
+	e, tokenAddressC, err := deployTokenAndMint(t, tenv.Env, solChain, []string{}, "TEST_TOKEN_C")
+	require.NoError(t, err)
+
 	state, err := stateview.LoadOnchainStateSolana(e)
 	require.NoError(t, err)
 	validTimestamp := int64(100)
@@ -393,6 +401,52 @@ func doTestBilling(t *testing.T, mcms bool) {
 	},
 	)
 	require.NoError(t, err)
+
+	if mcms {
+		e, err = commonchangeset.Apply(t, e,
+			commonchangeset.Configure(
+				ccipChangesetSolana.AddTokenTransferFeeForRemoteChainV2,
+				ccipChangesetSolana.TokenTransferFeeForRemoteChainConfigV2{
+					MCMS: mcmsConfig,
+					InputsByChain: map[uint64]map[uint64]ccipChangesetSolana.TokenTransferFeeForRemoteChainConfigArgsV2{
+						solChain: {
+							evmChain: {
+								TokenAddressToFeeConfig: map[solana.PublicKey]ccipChangesetSolana.OptionalFeeQuoterTokenTransferFeeConfig{
+									tokenAddressB: {
+										MinFeeUsdcents:    pointer.To(uint32(800)),
+										MaxFeeUsdcents:    pointer.To(uint32(1600)),
+										DestGasOverhead:   pointer.To(uint32(100)),
+										DestBytesOverhead: pointer.To(uint32(100)),
+										IsEnabled:         nil, // auto-filled
+										DeciBps:           nil, // auto-filled
+									},
+									tokenAddressC: {
+										// auto-fill everything with sensible defaults
+									},
+								},
+							},
+							evmChain2: {
+								TokenAddressToFeeConfig: map[solana.PublicKey]ccipChangesetSolana.OptionalFeeQuoterTokenTransferFeeConfig{
+									tokenAddressB: {
+										MinFeeUsdcents:    pointer.To(uint32(800)),
+										MaxFeeUsdcents:    pointer.To(uint32(1600)),
+										DestGasOverhead:   pointer.To(uint32(100)),
+										DestBytesOverhead: pointer.To(uint32(100)),
+										IsEnabled:         nil, // auto-filled
+										DeciBps:           nil, // auto-filled
+									},
+									tokenAddressC: {
+										// auto-fill everything with sensible defaults
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+		)
+		require.NoError(t, err)
+	}
 
 	billingConfigPDA, _, _ := solState.FindFqBillingTokenConfigPDA(tokenAddress, state.SolChains[solChain].FeeQuoter)
 	var token0ConfigAccount solFeeQuoter.BillingTokenConfigWrapper

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_chain_contracts_test.go
@@ -326,12 +326,15 @@ func doTestBilling(t *testing.T, mcms bool) {
 
 	e, tokenAddress, err := deployTokenAndMint(t, tenv.Env, solChain, []string{}, "TEST_TOKEN")
 	require.NoError(t, err)
+	tenv.Env = e
 
 	e, tokenAddressB, err := deployTokenAndMint(t, tenv.Env, solChain, []string{}, "TEST_TOKEN_B")
 	require.NoError(t, err)
+	tenv.Env = e
 
 	e, tokenAddressC, err := deployTokenAndMint(t, tenv.Env, solChain, []string{}, "TEST_TOKEN_C")
 	require.NoError(t, err)
+	tenv.Env = e
 
 	state, err := stateview.LoadOnchainStateSolana(e)
 	require.NoError(t, err)


### PR DESCRIPTION
### **Summary**

This PR introduces two related changesets to improve how token transfer fees are configured across EVM and Solana families:

- **`AddTokenTransferFeeForRemoteChainV2`** (Solana)
- **`SetTokenTransferFeeConfig`** (Cross Family)

---

### **🧩 `SetTokenTransferFeeConfig` (Cross-Family Changeset)**

`SetTokenTransferFeeConfig` provides a unified, version-aware entry point for setting per-token transfer-fee parameters across **EVM** and **Solana** chains.

**Highlights**

* **Cross-family orchestration:** Handles both EVM and Solana configurations within a single MCMS proposal.
* **Version-aware:** Automatically routes each update to the correct version-specific changeset
  (currently supports **EVM v1.6.0 / v1.5.1** and **Solana v0.1.1**).
* **Unified schema:** Accepts string token addresses (hex for EVM, base58 for Solana) and validates selectors.
* **No-op & safety handling:** Gracefully skips empty or invalid inputs and rejects `src == dst` cases.
* **Separation of concerns:** Performs validation, routing, and conversion, then delegates on-chain logic to the underlying family/version changesets.

This replaces the need to manually invoke multiple family-specific changesets when updating token transfer fees.

---

### **🪙 `AddTokenTransferFeeForRemoteChainV2` (Solana)**

`AddTokenTransferFeeForRemoteChainV2` modernizes the original Solana changeset with several DX and safety improvements.

**Highlights**

* **Partial/empty input support:** Missing fields are auto-filled with sensible defaults.
* **Batch processing:** Multiple tokens can be updated in a single MCMS proposal.
* **Improved developer experience:** Simplified schema and logs consistent with the EVM equivalents.
* **Graceful no-ops:** Skips tokens with no effective changes.
* **CLDF V2 API:** Built using the latest changeset API for consistency across families.