### PR TITLE
chore(ci): bump branch-out-upload to v1

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -312,7 +312,7 @@ jobs:
 
       - name: Run branch-out-upload
         if: ${{ matrix.type.should-run == 'true' && matrix.type.trunk-auto-quarantine == 'true' && !cancelled() }}
-        uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/0.1.0
+        uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/v1
         with:
           junit-file-path: "./junit.xml"
           trunk-org-slug: chainlink

--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -204,7 +204,7 @@ jobs:
 
       - name: Process and upload flaky Regression tests results (${{ steps.run-regression-tests.outputs.tests_result }})
         if: ${{ !cancelled() }}
-        uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/0.1.0
+        uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/v1
         with:
           junit-file-path: "/tmp/junit-report-regression.xml"
           trunk-org-slug: chainlink

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -249,7 +249,7 @@ jobs:
 
       - name: Process and upload flaky Regression tests results (${{ steps.run-tests.outputs.tests_result }})
         if: ${{ !cancelled() }}
-        uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/0.1.0
+        uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/v1
         with:
           junit-file-path: "/tmp/junit-report.xml"
           trunk-org-slug: chainlink


### PR DESCRIPTION
### Changes

* Bump `branch-out-upload` action to `v1` (https://github.com/smartcontractkit/.github/pull/1299)

### Motivation

* Patches a bug that could mask build failures in very specific scenarios

---

DX-2175
