### PR TITLE
use proper block number

### DIFF
--- a/.changeset/dry-buckets-lie.md
+++ b/.changeset/dry-buckets-lie.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix block number in fake evm cap

--- a/core/capabilities/fakes/evm_chain.go
+++ b/core/capabilities/fakes/evm_chain.go
@@ -3,6 +3,7 @@ package fakes
 import (
 	"context"
 	"crypto/ecdsa"
+	"fmt"
 	"math/big"
 	"strings"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	commonCap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	evmcappb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/chain-capabilities/evm"
@@ -425,13 +427,49 @@ func (fc *FakeEVMChain) GetTransactionReceipt(ctx context.Context, metadata comm
 func (fc *FakeEVMChain) HeaderByNumber(ctx context.Context, metadata commonCap.RequestMetadata, input *evmcappb.HeaderByNumberRequest) (*commonCap.ResponseAndMetadata[*evmcappb.HeaderByNumberReply], error) {
 	fc.eng.Infow("EVM Chain HeaderByNumber Started", "input", input)
 
-	// Prepare header by number request
-	blockNumber := new(big.Int).SetBytes(input.BlockNumber.AbsVal)
+	var (
+		header *types.Header
+		err    error
+	)
 
-	// Get header by number
-	header, err := fc.gethClient.HeaderByNumber(ctx, blockNumber)
+	// Convert the request block number preserving sign.
+	var reqNum *big.Int
+	if input != nil && input.BlockNumber != nil {
+		reqNum = fromProtoBigInt(input.BlockNumber)
+	}
+
+	// Enforce int64 constraint
+	if reqNum != nil && !reqNum.IsInt64() {
+		return nil, fmt.Errorf("block number %s is larger than int64: %w", reqNum.String(), ethereum.NotFound)
+	}
+
+	switch {
+	// latest block (nil or explicit "latest"): nil or -2
+	case reqNum == nil || reqNum.Int64() == rpc.LatestBlockNumber.Int64():
+		header, err = fc.gethClient.HeaderByNumber(ctx, nil)
+
+	// non-special, non-negative block number (including 0): >=0
+	case reqNum.Sign() >= 0:
+		header, err = fc.gethClient.HeaderByNumber(ctx, reqNum)
+
+	// finalized tag: -3
+	case reqNum.Int64() == rpc.FinalizedBlockNumber.Int64():
+		header, err = fc.gethClient.HeaderByNumber(ctx, big.NewInt(rpc.FinalizedBlockNumber.Int64()))
+
+	// safe tag: -4
+	case reqNum.Int64() == rpc.SafeBlockNumber.Int64():
+		header, err = fc.gethClient.HeaderByNumber(ctx, big.NewInt(rpc.SafeBlockNumber.Int64()))
+
+	// any other negative is unexpected
+	default:
+		return nil, fmt.Errorf("unexpected block number %s: %w", reqNum.String(), ethereum.NotFound)
+	}
+
 	if err != nil {
 		return nil, err
+	}
+	if header == nil {
+		return nil, ethereum.NotFound
 	}
 
 	// Convert header to protobuf
@@ -551,4 +589,22 @@ func (fc *FakeEVMChain) dryRunWriteReport(
 		ResponseMetadata: commonCap.ResponseMetadata{},
 	}
 	return &responseAndMetadata, nil
+}
+
+func fromProtoBigInt(b *pb.BigInt) *big.Int {
+	if b == nil {
+		return nil
+	}
+	// Zero shortcut
+	if len(b.AbsVal) == 0 {
+		return big.NewInt(0)
+	}
+	x := new(big.Int).SetBytes(b.AbsVal)
+	switch {
+	case b.Sign < 0:
+		x.Neg(x)
+	case b.Sign == 0:
+		x.SetInt64(0)
+	}
+	return x
 }

--- a/core/capabilities/fakes/evm_chain.go
+++ b/core/capabilities/fakes/evm_chain.go
@@ -434,8 +434,8 @@ func (fc *FakeEVMChain) HeaderByNumber(ctx context.Context, metadata commonCap.R
 
 	// Convert the request block number preserving sign.
 	var reqNum *big.Int
-	if input != nil && input.BlockNumber != nil {
-		reqNum = fromProtoBigInt(input.BlockNumber)
+	if input != nil {
+		reqNum = pb.NewIntFromBigInt(input.BlockNumber)
 	}
 
 	// Enforce int64 constraint
@@ -589,22 +589,4 @@ func (fc *FakeEVMChain) dryRunWriteReport(
 		ResponseMetadata: commonCap.ResponseMetadata{},
 	}
 	return &responseAndMetadata, nil
-}
-
-func fromProtoBigInt(b *pb.BigInt) *big.Int {
-	if b == nil {
-		return nil
-	}
-	// Zero shortcut
-	if len(b.AbsVal) == 0 {
-		return big.NewInt(0)
-	}
-	x := new(big.Int).SetBytes(b.AbsVal)
-	switch {
-	case b.Sign < 0:
-		x.Neg(x)
-	case b.Sign == 0:
-		x.SetInt64(0)
-	}
-	return x
 }


### PR DESCRIPTION
align with the real cap in https://github.com/smartcontractkit/chainlink/blob/develop/core/services/relay/evm/evm_service.go#L109

Tested with DCW's workflow in https://smartcontract-it.atlassian.net/browse/DEVSVCS-2812

```
leishi@MB-MJ2FP47WKD test108 % cre workflow simulate ./flow108
Workflow compiled
{"level":"info","ts":1761085834.129361,"caller":"simulate/simulate.go:433","msg":"Simulator Initialized","version":"v0.6.4-alpha.0.20251021222417-81805baee2bb@unset"}

{"level":"info","ts":1761085834.12951,"caller":"simulate/simulate.go:372","msg":"Running trigger","version":"v0.6.4-alpha.0.20251021222417-81805baee2bb@unset","trigger":"cron-trigger@1.0.0"}
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.138Z level=INFO msg="START ########FINALIZED BLOCK NUMBER#########"
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.139Z level=INFO msg="asking for finalized" block=-3
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.341Z level=INFO msg="Fetched block:" header="timestamp:1761084768 block_number:{abs_val:\"\\x90_\\xfc\" sign:1} hash:\"\\xe2Ck\\xa6>\\xd7'\\xd9\\xc5\\xd3\\xfd<^-yW\\x8c\\x80\\xdaEdH\\x86\\xc9\\xc8\\xf1\\xb1\\xf88\\x89AX\" parent_hash:\"\\x1e\\xb0w;\\xc05\\x88\\\\#\\x05\\x9d\\x03\\\\\\xbc\\xa7e(3\\xebQc\\x90\\x8d\\xe7I\\xf9;`4_\\x14\\xb9\""
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.341Z level=INFO msg="Fetched block:" timestamp="2025-10-21 22:12:48"
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.341Z level=INFO msg="Fetched block:" hash=0xe2436ba63ed727d9c5d3fd3c5e2d79578c80da45644886c9c8f1b1f838894158
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.342Z level=INFO msg="Fetched block:" "block number"=9461756
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.342Z level=INFO msg="Block number fetched" blocknumber=9461756
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.342Z level=INFO msg="END ########FINALIZED BLOCK NUMBER#########"
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.342Z level=INFO msg="START ########LATEST BLOCK NUMBER#########"
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.343Z level=INFO msg="asking for latest" block=-2
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.540Z level=INFO msg="Fetched block:" header="timestamp:1761085824 block_number:{abs_val:\"\\x90`P\" sign:1} hash:\"\\x0b\\xb5\\xeb\\x9e\\x11\\x85\\xa8Z\\xe0]<\\xb3\\x9a\\x8e\\x1a\\x13VK\\xc0\\x16\\x04\\xc7`Ĺ\\xa2\\xd4\\x12\\x1a\\xf6%\\xba\" parent_hash:\"^\\xa7\\x14\\xcb\\xe8\\x87\\xefn\\xab\\x1b*\\x97y\\xde\\xfe71?y$\\xb5\\xce\\xeb\\xcb\\x18Q\\xa4\\x9e\\xa6\\n\\xe8u\""
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.541Z level=INFO msg="Fetched block:" timestamp="2025-10-21 22:30:24"
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.541Z level=INFO msg="Fetched block:" hash=0x0bb5eb9e1185a85ae05d3cb39a8e1a13564bc01604c760c4b9a2d4121af625ba
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.541Z level=INFO msg="Fetched block:" "block number"=9461840
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.541Z level=INFO msg="Block number fetched" blocknumber=9461840
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.541Z level=INFO msg="END ########LATEST BLOCK NUMBER#########"
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.541Z level=INFO msg="START ########9434244 BLOCK NUMBER#########"
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.541Z level=INFO msg="asking for fixed block" block=9434244
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.756Z level=INFO msg="Fetched block:" header="timestamp:1760742504 block_number:{abs_val:\"\\x8f\\xf4\\x84\" sign:1} hash:\"\\xac\\xb8#\\x8f7\\x0f\\x86}Mt\\xb9}}Vʑ\\x8bh'/v\\xf1F4=j*%\\x9c\\xb8\\x8eW\" parent_hash:\"\\x81\\xd9\\xe6+y\\xbf\\xacd\\x00U\\x10\\x19\\x8f\\x13\\xa0\\x93\\x9ah\\xac\\x02\\xb5\\xd4\\x01r\\\\C\\x80\\xa4\\xf8{\\xefO\""
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.756Z level=INFO msg="Fetched block:" timestamp="2025-10-17 23:08:24"
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.756Z level=INFO msg="Fetched block:" hash=0xacb8238f370f867d4d74b97d7d56ca918b68272f76f146343d6a2a259cb88e57
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.756Z level=INFO msg="Fetched block:" "block number"=9434244
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.757Z level=INFO msg="Block number fetched" blocknumber=9434244
2025-10-21T15:30:34Z [USER LOG] time=2025-10-21T22:30:34.757Z level=INFO msg="END ########9434244 BLOCK NUMBER#########"

Workflow Simulation Result:
 "9434244"

```