### PR TITLE
send TOML config as a baseMessage through Beholder

### DIFF
--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -25,6 +25,7 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger/otelzap"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
@@ -285,6 +286,28 @@ func initLocalSubCmds(s *Shell, safe bool) []cli.Command {
 
 // ownerPermsMask are the file permission bits reserved for owner.
 const ownerPermsMask = os.FileMode(0o700)
+
+// EmitNodeConfig emits the node configuration through beholder as a pb.BaseMessage
+func (s *Shell) EmitNodeConfig(ctx context.Context) {
+	cme := custmsg.NewLabeler()
+	labels := map[string]string{
+		"system":  "Application",
+		"version": static.Version,
+		"commit":  static.Sha,
+	}
+	emitter := cme.WithMapLabels(labels)
+
+	// Get the effective TOML configuration (with defaults applied)
+	_, effectiveTOML := s.Config.ConfigTOML()
+
+	// Emit the configuration as a message
+	err := emitter.Emit(ctx, effectiveTOML)
+	if err != nil {
+		s.Logger.Errorf("failed to emit node configuration through beholder: %v", err)
+	} else {
+		s.Logger.Debug("node configuration emitted through beholder")
+	}
+}
 
 // RunNode starts the Chainlink core.
 func (s *Shell) RunNode(c *cli.Context) error {
@@ -1115,6 +1138,9 @@ func (s *Shell) beforeNode(c *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed initializing globals")
 	}
+
+	// Emit node configuration through beholder
+	s.EmitNodeConfig(ctx)
 
 	// If log streaming is enabled swap core to add Otel
 	if s.Config.Telemetry().LogStreamingEnabled() {

--- a/core/cmd/shell_test.go
+++ b/core/cmd/shell_test.go
@@ -18,11 +18,11 @@ import (
 	"github.com/urfave/cli"
 	"google.golang.org/protobuf/proto"
 
-	commoncfg "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder/beholdertest"
+	commoncfg "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil/sqltest"
-	solcfg "github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 	commonevents "github.com/smartcontractkit/chainlink-protos/workflows/go/common"
+	solcfg "github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 
 	"github.com/smartcontractkit/chainlink/v2/core/cmd"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
@@ -625,40 +625,40 @@ func getFuncName(i any) string {
 
 func TestShell_emitNodeConfig(t *testing.T) {
 	// t.Parallel() // beholder tester uses t.SetEnv and cannot use t.Parallel
-	
+
 	ctx := testutils.Context(t)
 	lggr := logger.TestLogger(t)
-	
+
 	gcfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		// use defaults
 	})
-	
+
 	shell := &cmd.Shell{
 		Config: gcfg,
 		Logger: lggr,
 	}
-	
+
 	beholderObserver := beholdertest.NewObserver(t)
 	shell.EmitNodeConfig(ctx)
-	
+
 	// Verify that a BaseMessage was emitted
 	msgs := beholderObserver.Messages(t, "beholder_entity", "BaseMessage")
 	require.Len(t, msgs, 1, "Expected exactly one BaseMessage to be emitted")
-	
+
 	// Verify the message content
 	msg := msgs[0]
 	require.Equal(t, "BaseMessage", msg.Attrs["beholder_entity"])
-	
+
 	// Unmarshal the BaseMessage
 	var baseMsg commonevents.BaseMessage
 	require.NoError(t, proto.Unmarshal(msg.Body, &baseMsg))
-	
+
 	// Verify the message contains TOML configuration
 	require.NotEmpty(t, baseMsg.Msg, "BaseMessage should contain configuration")
 	require.Contains(t, baseMsg.Msg, "[Log]", "Configuration should contain Log section")
 	require.Contains(t, baseMsg.Msg, "[Database]", "Configuration should contain Database section")
 	require.Contains(t, baseMsg.Msg, "[WebServer]", "Configuration should contain WebServer section")
-	
+
 	// Verify labels are set correctly
 	require.Equal(t, "Application", baseMsg.Labels["system"])
 	require.Equal(t, static.Version, baseMsg.Labels["version"])

--- a/core/cmd/shell_test.go
+++ b/core/cmd/shell_test.go
@@ -16,10 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
+	"google.golang.org/protobuf/proto"
 
 	commoncfg "github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder/beholdertest"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil/sqltest"
 	solcfg "github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
+	commonevents "github.com/smartcontractkit/chainlink-protos/workflows/go/common"
 
 	"github.com/smartcontractkit/chainlink/v2/core/cmd"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
@@ -33,6 +36,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/sessions"
 	"github.com/smartcontractkit/chainlink/v2/core/sessions/localauth"
+	"github.com/smartcontractkit/chainlink/v2/core/static"
 	"github.com/smartcontractkit/chainlink/v2/plugins"
 )
 
@@ -617,4 +621,46 @@ func recursiveFindFlagsWithName(actionFuncName string, command cli.Command, pare
 
 func getFuncName(i any) string {
 	return runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+}
+
+func TestShell_emitNodeConfig(t *testing.T) {
+	// t.Parallel() // beholder tester uses t.SetEnv and cannot use t.Parallel
+	
+	ctx := testutils.Context(t)
+	lggr := logger.TestLogger(t)
+	
+	gcfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		// use defaults
+	})
+	
+	shell := &cmd.Shell{
+		Config: gcfg,
+		Logger: lggr,
+	}
+	
+	beholderObserver := beholdertest.NewObserver(t)
+	shell.EmitNodeConfig(ctx)
+	
+	// Verify that a BaseMessage was emitted
+	msgs := beholderObserver.Messages(t, "beholder_entity", "BaseMessage")
+	require.Len(t, msgs, 1, "Expected exactly one BaseMessage to be emitted")
+	
+	// Verify the message content
+	msg := msgs[0]
+	require.Equal(t, "BaseMessage", msg.Attrs["beholder_entity"])
+	
+	// Unmarshal the BaseMessage
+	var baseMsg commonevents.BaseMessage
+	require.NoError(t, proto.Unmarshal(msg.Body, &baseMsg))
+	
+	// Verify the message contains TOML configuration
+	require.NotEmpty(t, baseMsg.Msg, "BaseMessage should contain configuration")
+	require.Contains(t, baseMsg.Msg, "[Log]", "Configuration should contain Log section")
+	require.Contains(t, baseMsg.Msg, "[Database]", "Configuration should contain Database section")
+	require.Contains(t, baseMsg.Msg, "[WebServer]", "Configuration should contain WebServer section")
+	
+	// Verify labels are set correctly
+	require.Equal(t, "Application", baseMsg.Labels["system"])
+	require.Equal(t, static.Version, baseMsg.Labels["version"])
+	require.Equal(t, static.Sha, baseMsg.Labels["commit"])
 }


### PR DESCRIPTION
Visibility into effective TOML config without asking for logs. 