### PR TITLE
[CRE-1118] rename CapabilitiesAwareNodeSet to NodeSet

### DIFF
--- a/core/scripts/cre/environment/README.md
+++ b/core/scripts/cre/environment/README.md
@@ -608,7 +608,7 @@ func New() (*capabilities.Capability, error) {
     )
 }
 
-func registerWithV1(donFlags []string, _ *cre.CapabilitiesAwareNodeSet) ([]keystone_changeset.DONCapabilityWithConfig, error) {
+func registerWithV1(donFlags []string, _ *cre.NodeSet) ([]keystone_changeset.DONCapabilityWithConfig, error) {
     var capabilities []keystone_changeset.DONCapabilityWithConfig
 
     if flags.HasFlag(donFlags, flag) {
@@ -681,7 +681,7 @@ func New() (*capabilities.Capability, error) {
     )
 }
 
-func registerWithV1(_ []string, nodeSetInput *cre.CapabilitiesAwareNodeSet) ([]keystone_changeset.DONCapabilityWithConfig, error) {
+func registerWithV1(_ []string, nodeSetInput *cre.NodeSet) ([]keystone_changeset.DONCapabilityWithConfig, error) {
     capabilities := make([]keystone_changeset.DONCapabilityWithConfig, 0)
 
     if nodeSetInput == nil {

--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -700,21 +700,21 @@ func StartCLIEnvironment(
 	singleFileLogger := cldlogger.NewSingleFileLogger(nil)
 
 	universalSetupInput := &creenv.SetupInput{
-		CapabilitiesAwareNodeSets: in.NodeSets,
-		BlockchainsInput:          in.Blockchains,
-		ContractVersions:          env.ContractVersions(),
-		WithV2Registries:          env.WithV2Registries(),
-		JdInput:                   in.JD,
-		Provider:                  *in.Infra,
-		S3ProviderInput:           in.S3ProviderInput,
-		CapabilityConfigs:         in.CapabilityConfigs,
-		CopyCapabilityBinaries:    withPluginsDockerImageFlag == "", // do not copy any binaries to the containers, if we are using plugins image (they already have them)
-		Capabilities:              capabilities,
-		JobSpecFactoryFunctions:   extraJobSpecFunctions,
-		StageGen:                  initLocalCREStageGen(in),
-		Features:                  features,
-		GatewayWhitelistConfig:    gatewayWhitelistConfig,
-		BlockchainDeployers:       blockchains_sets.NewDeployerSet(testLogger, in.Infra, infra.CribConfigsDir),
+		NodeSets:                in.NodeSets,
+		BlockchainsInput:        in.Blockchains,
+		ContractVersions:        env.ContractVersions(),
+		WithV2Registries:        env.WithV2Registries(),
+		JdInput:                 in.JD,
+		Provider:                *in.Infra,
+		S3ProviderInput:         in.S3ProviderInput,
+		CapabilityConfigs:       in.CapabilityConfigs,
+		CopyCapabilityBinaries:  withPluginsDockerImageFlag == "", // do not copy any binaries to the containers, if we are using plugins image (they already have them)
+		Capabilities:            capabilities,
+		JobSpecFactoryFunctions: extraJobSpecFunctions,
+		StageGen:                initLocalCREStageGen(in),
+		Features:                features,
+		GatewayWhitelistConfig:  gatewayWhitelistConfig,
+		BlockchainDeployers:     blockchains_sets.NewDeployerSet(testLogger, in.Infra, infra.CribConfigsDir),
 	}
 
 	ctx, cancel := context.WithTimeout(cmdContext, 10*time.Minute)

--- a/system-tests/lib/cre/capabilities/node_config.go
+++ b/system-tests/lib/cre/capabilities/node_config.go
@@ -37,15 +37,15 @@ func MakeBinariesExecutable(customBinariesPaths map[cre.CapabilityFlag]string) e
 	return nil
 }
 
-func AppendBinariesPathsNodeSpec(nodeSetInput *cre.CapabilitiesAwareNodeSet, donMetadata *cre.DonMetadata, customBinariesPaths map[cre.CapabilityFlag]string) (*cre.CapabilitiesAwareNodeSet, error) {
+func AppendBinariesPathsNodeSpec(nodeSet *cre.NodeSet, donMetadata *cre.DonMetadata, customBinariesPaths map[cre.CapabilityFlag]string) (*cre.NodeSet, error) {
 	if len(customBinariesPaths) == 0 {
-		return nodeSetInput, nil
+		return nodeSet, nil
 	}
 
 	// if no capabilities are defined in TOML, but DON has ones that we know require custom binaries
 	// append them to the node specification
 	hasCapabilitiesBinaries := false
-	for _, nodeInput := range nodeSetInput.NodeSpecs {
+	for _, nodeInput := range nodeSet.NodeSpecs {
 		if len(nodeInput.Node.CapabilitiesBinaryPaths) > 0 {
 			hasCapabilitiesBinaries = true
 			break
@@ -64,12 +64,12 @@ func AppendBinariesPathsNodeSpec(nodeSetInput *cre.CapabilitiesAwareNodeSet, don
 			}
 
 			for _, workerNode := range workerNodes {
-				nodeSetInput.NodeSpecs[workerNode.Index].Node.CapabilitiesBinaryPaths = append(nodeSetInput.NodeSpecs[workerNode.Index].Node.CapabilitiesBinaryPaths, binaryPath)
+				nodeSet.NodeSpecs[workerNode.Index].Node.CapabilitiesBinaryPaths = append(nodeSet.NodeSpecs[workerNode.Index].Node.CapabilitiesBinaryPaths, binaryPath)
 			}
 		}
 	}
 
-	return nodeSetInput, nil
+	return nodeSet, nil
 }
 
 func DefaultContainerDirectory(infraType infra.Type) (string, error) {

--- a/system-tests/lib/cre/don/config/config.go
+++ b/system-tests/lib/cre/don/config/config.go
@@ -43,10 +43,10 @@ const TronEVMChainID = 3360022319
 func PrepareNodeTOMLs(
 	topology *cre.Topology,
 	creEnv *cre.Environment,
-	nodeSets []*cre.CapabilitiesAwareNodeSet,
+	nodeSets []*cre.NodeSet,
 	capabilities []cre.InstallableCapability, // Deprecated, use Features instead and modify node configs inside a Feature
 	nodeConfigTransformerFns []cre.NodeConfigTransformerFn,
-) ([]*cre.CapabilitiesAwareNodeSet, error) {
+) ([]*cre.NodeSet, error) {
 	bt, hasBootstrap := topology.Bootstrap()
 	if !hasBootstrap {
 		return nil, errors.New("no DON contains a bootstrap node, but exactly one is required")
@@ -57,7 +57,7 @@ func PrepareNodeTOMLs(
 		return nil, errors.Wrap(peeringErr, "failed to find peering data")
 	}
 
-	localNodeSets := topology.CapabilitiesAwareNodeSets()
+	localNodeSets := topology.NodeSets()
 	chainPerSelector := make(map[uint64]creblockchains.Blockchain)
 	for _, bc := range creEnv.Blockchains {
 		chainPerSelector[bc.ChainSelector()] = bc
@@ -493,7 +493,7 @@ func findEVMChains(input cre.GenerateConfigsInput) []*evmChain {
 
 		// if the DON doesn't support the chain, we skip it; if slice is empty, it means that the DON supports all chains
 		// TODO: review if we really need this SupportedChains functionality
-		if len(input.DonMetadata.CapabilitiesAwareNodeSet().EVMChains()) > 0 && !slices.Contains(input.DonMetadata.CapabilitiesAwareNodeSet().EVMChains(), bcOut.ChainID()) {
+		if len(input.DonMetadata.NodeSets().EVMChains()) > 0 && !slices.Contains(input.DonMetadata.NodeSets().EVMChains(), bcOut.ChainID()) {
 			continue
 		}
 

--- a/system-tests/lib/cre/don/gateway/gateway.go
+++ b/system-tests/lib/cre/don/gateway/gateway.go
@@ -37,7 +37,7 @@ type WhitelistConfig struct {
 func JobConfigs(
 	registryChainOutput *blockchain.Output,
 	topology *cre.Topology,
-	capabilitiesAwareNodeSets []*cre.CapabilitiesAwareNodeSet,
+	nodeSets []*cre.NodeSet,
 	whitelistConfig WhitelistConfig,
 ) (map[cre.NodeUUID]*config.GatewayConfig, error) {
 	if topology == nil {
@@ -273,7 +273,7 @@ func AddConnectors(donMetadata *cre.DonMetadata, registryChainID uint64, connect
 	}
 
 	for _, workerNode := range workers {
-		currentConfig := donMetadata.CapabilitiesAwareNodeSet().NodeSpecs[workerNode.Index].Node.TestConfigOverrides
+		currentConfig := donMetadata.NodeSets().NodeSpecs[workerNode.Index].Node.TestConfigOverrides
 
 		var typedConfig corechainlink.Config
 		unmarshallErr := toml.Unmarshal([]byte(currentConfig), &typedConfig)
@@ -321,7 +321,7 @@ func AddConnectors(donMetadata *cre.DonMetadata, registryChainID uint64, connect
 			return errors.Wrapf(mErr, "failed to marshal config for node index %d", workerNode.Index)
 		}
 
-		donMetadata.CapabilitiesAwareNodeSet().NodeSpecs[workerNode.Index].Node.TestConfigOverrides = string(stringifiedConfig)
+		donMetadata.NodeSets().NodeSpecs[workerNode.Index].Node.TestConfigOverrides = string(stringifiedConfig)
 	}
 
 	return nil

--- a/system-tests/lib/cre/environment/blockchains/evm/evm.go
+++ b/system-tests/lib/cre/environment/blockchains/evm/evm.go
@@ -165,9 +165,9 @@ func (e *Deployer) Deploy(input *blockchain.Input) (blockchains.Blockchain, erro
 
 	if e.provider.IsCRIB() {
 		deployCribBlockchainInput := &crib.DeployCribBlockchainInput{
-			BlockchainInput: input,
-			CribConfigsDir:  e.cribConfigsDir,
-			Namespace:       e.provider.CRIB.Namespace,
+			Blockchain:     input,
+			CribConfigsDir: e.cribConfigsDir,
+			Namespace:      e.provider.CRIB.Namespace,
 		}
 
 		bcOut, err = crib.DeployBlockchain(deployCribBlockchainInput)

--- a/system-tests/lib/cre/environment/config/config.go
+++ b/system-tests/lib/cre/environment/config/config.go
@@ -28,7 +28,7 @@ import (
 
 type Config struct {
 	Blockchains       []*blockchain.Input             `toml:"blockchains" validate:"required"`
-	NodeSets          []*cre.CapabilitiesAwareNodeSet `toml:"nodesets" validate:"required"`
+	NodeSets          []*cre.NodeSet                  `toml:"nodesets" validate:"required"`
 	JD                *jd.Input                       `toml:"jd" validate:"required"`
 	Infra             *infra.Provider                 `toml:"infra" validate:"required"`
 	Fake              *fake.Input                     `toml:"fake" validate:"required"`

--- a/system-tests/lib/cre/environment/create_jd_jobs_op.go
+++ b/system-tests/lib/cre/environment/create_jd_jobs_op.go
@@ -20,7 +20,7 @@ type CreateJobsWithJdOpDeps struct {
 	JobSpecFactoryFunctions   []cre.JobSpecFn
 	CreEnvironment            *cre.Environment
 	Dons                      *cre.Dons
-	CapabilitiesAwareNodeSets []*cre.CapabilitiesAwareNodeSet
+	NodeSets                  []*cre.NodeSet
 	Capabilities              []cre.InstallableCapability
 }
 
@@ -49,7 +49,7 @@ func CreateJobsWithJdOpFactory(id string, version string) *operations.Operation[
 						CreEnvironment: deps.CreEnvironment,
 						Don:            don,
 						Dons:           deps.Dons,
-						NodeSet:        cre.ConvertToNodeSetWithChainCapabilities(deps.CapabilitiesAwareNodeSets)[idx],
+						NodeSet:        cre.ConvertToNodeSetWithChainCapabilities(deps.NodeSets)[idx],
 					})
 					if jobSpecsErr != nil {
 						return CreateJobsWithJdOpOutput{}, pkgerrors.Wrap(jobSpecsErr, "failed to generate job specs")

--- a/system-tests/lib/cre/environment/env_artifact.go
+++ b/system-tests/lib/cre/environment/env_artifact.go
@@ -199,7 +199,7 @@ func DumpArtifact(
 	dons cre.Dons,
 	creEnv *cre.Environment,
 	jdOutput jd.Output,
-	nodeSets []*cre.CapabilitiesAwareNodeSet,
+	nodeSets []*cre.NodeSet,
 	capabilityRegistryFns []cre.CapabilityRegistryConfigFn,
 ) (string, error) {
 	artifact, err := GenerateArtifact(dons, creEnv, jdOutput, nodeSets, capabilityRegistryFns)
@@ -219,7 +219,7 @@ func GenerateArtifact(
 	dons cre.Dons,
 	creEnv *cre.Environment,
 	jdOutput jd.Output,
-	nodeSets []*cre.CapabilitiesAwareNodeSet,
+	nodeSets []*cre.NodeSet,
 	capabilityRegistryFns []cre.CapabilityRegistryConfigFn,
 ) (*EnvArtifact, error) {
 	var err error

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -56,22 +56,22 @@ type SetupOutput struct {
 }
 
 type SetupInput struct {
-	CapabilitiesAwareNodeSets []*cre.CapabilitiesAwareNodeSet
-	BlockchainsInput          []*blockchain.Input
-	JdInput                   *jd.Input
-	Provider                  infra.Provider
-	ContractVersions          map[string]string
-	WithV2Registries          bool
-	OCR3Config                *keystone_changeset.OracleConfig
-	DONTimeConfig             *keystone_changeset.OracleConfig
-	VaultOCR3Config           *keystone_changeset.OracleConfig
-	S3ProviderInput           *s3provider.Input
-	CapabilityConfigs         cre.CapabilityConfigs
-	CopyCapabilityBinaries    bool // if true, copy capability binaries to the containers (if false, we assume that the plugins image already has them)
-	Capabilities              []cre.InstallableCapability
-	Features                  cre.Features
-	GatewayWhitelistConfig    gateway.WhitelistConfig
-	BlockchainDeployers       map[blockchain.ChainFamily]blockchains.Deployer
+	NodeSets               []*cre.NodeSet
+	BlockchainsInput       []*blockchain.Input
+	JdInput                *jd.Input
+	Provider               infra.Provider
+	ContractVersions       map[string]string
+	WithV2Registries       bool
+	OCR3Config             *keystone_changeset.OracleConfig
+	DONTimeConfig          *keystone_changeset.OracleConfig
+	VaultOCR3Config        *keystone_changeset.OracleConfig
+	S3ProviderInput        *s3provider.Input
+	CapabilityConfigs      cre.CapabilityConfigs
+	CopyCapabilityBinaries bool // if true, copy capability binaries to the containers (if false, we assume that the plugins image already has them)
+	Capabilities           []cre.InstallableCapability
+	Features               cre.Features
+	GatewayWhitelistConfig gateway.WhitelistConfig
+	BlockchainDeployers    map[blockchain.ChainFamily]blockchains.Deployer
 
 	// allow to pass custom transformers for extensibility
 	ConfigFactoryFunctions               []cre.NodeConfigTransformerFn
@@ -86,7 +86,7 @@ func (s *SetupInput) Validate() error {
 		return pkgerrors.New("input is nil")
 	}
 
-	if len(s.CapabilitiesAwareNodeSets) == 0 {
+	if len(s.NodeSets) == 0 {
 		return pkgerrors.New("at least one nodeSet is required")
 	}
 
@@ -170,7 +170,7 @@ func SetupTestEnvironment(
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.WrapAndNext("Workflow and Capability Registry contracts deployed in %.2f seconds", input.StageGen.Elapsed().Seconds())))
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.Wrap("Preparing DONs configuration")))
 
-	topology, tErr := cre.NewTopology(input.CapabilitiesAwareNodeSets, creEnvironment.Provider)
+	topology, tErr := cre.NewTopology(input.NodeSets, creEnvironment.Provider)
 	if tErr != nil {
 		return nil, pkgerrors.Wrap(tErr, "failed to create topology")
 	}
@@ -178,7 +178,7 @@ func SetupTestEnvironment(
 	updatedNodeSets, topoErr := donconfig.PrepareNodeTOMLs(
 		topology,
 		creEnvironment,
-		input.CapabilitiesAwareNodeSets,
+		input.NodeSets,
 		input.Capabilities,
 		input.ConfigFactoryFunctions,
 	)
@@ -290,7 +290,7 @@ func SetupTestEnvironment(
 		JobSpecFactoryFunctions:   jobSpecFactoryFunctions,
 		CreEnvironment:            creEnvironment,
 		Dons:                      dons,
-		CapabilitiesAwareNodeSets: input.CapabilitiesAwareNodeSets,
+		NodeSets:                  input.NodeSets,
 		Capabilities:              input.Capabilities,
 	}
 	_, createJobsErr := operations.ExecuteOperation(deployKeystoneContractsOutput.Env.OperationsBundle, CreateJobsWithJdOp, createJobsDeps, CreateJobsWithJdOpInput{})
@@ -365,7 +365,7 @@ func SetupTestEnvironment(
 			input.ContractVersions[keystone_changeset.CapabilitiesRegistry.String()],
 			""),
 		),
-		NodeSets:                 input.CapabilitiesAwareNodeSets,
+		NodeSets:                 input.NodeSets,
 		WithV2Registries:         input.WithV2Registries,
 		DONCapabilityWithConfigs: make(map[uint64][]keystone_changeset.DONCapabilityWithConfig),
 	}
@@ -428,7 +428,7 @@ func SetupTestEnvironment(
 func appendOutputsToInput(input *SetupInput, nodeSetOutput []*cre.WrappedNodeOutput, blockchains []blockchains.Blockchain, jdOutput *jd.Output) {
 	// append the nodeset output, so that later it can be stored in the cached output, so that we can use the environment again without running setup
 	for idx, nsOut := range nodeSetOutput {
-		input.CapabilitiesAwareNodeSets[idx].Out = nsOut.Output
+		input.NodeSets[idx].Out = nsOut.Output
 	}
 
 	for idx, blockchain := range blockchains {

--- a/system-tests/lib/cre/features/evm/v1/evm.go
+++ b/system-tests/lib/cre/features/evm/v1/evm.go
@@ -56,7 +56,7 @@ func (o *EVM) PreEnvStartup(
 	topology *cre.Topology,
 	creEnv *cre.Environment,
 ) (*cre.PreEnvStartupOutput, error) {
-	chainsWithForwarders := evm.ChainsWithForwarders(creEnv.Blockchains, cre.ConvertToNodeSetWithChainCapabilities(topology.CapabilitiesAwareNodeSets()))
+	chainsWithForwarders := evm.ChainsWithForwarders(creEnv.Blockchains, cre.ConvertToNodeSetWithChainCapabilities(topology.NodeSets()))
 	evmForwardersSelectors, exist := chainsWithForwarders[blockchain.FamilyEVM]
 	if exist {
 		selectorsToDeploy := make([]uint64, 0)
@@ -91,17 +91,17 @@ func (o *EVM) PreEnvStartup(
 	}
 
 	for _, workerNode := range workerNodes {
-		currentConfig := don.CapabilitiesAwareNodeSet().NodeSpecs[workerNode.Index].Node.TestConfigOverrides
-		updatedConfig, updErr := updateNodeConfig(workerNode, currentConfig, don.CapabilitiesAwareNodeSet().ChainCapabilities, creEnv)
+		currentConfig := don.NodeSets().NodeSpecs[workerNode.Index].Node.TestConfigOverrides
+		updatedConfig, updErr := updateNodeConfig(workerNode, currentConfig, don.NodeSets().ChainCapabilities, creEnv)
 		if updErr != nil {
 			return nil, errors.Wrapf(updErr, "failed to update node config for node index %d", workerNode.Index)
 		}
 
-		don.CapabilitiesAwareNodeSet().NodeSpecs[workerNode.Index].Node.TestConfigOverrides = *updatedConfig
+		don.NodeSets().NodeSpecs[workerNode.Index].Node.TestConfigOverrides = *updatedConfig
 	}
 
 	capabilities := []keystone_changeset.DONCapabilityWithConfig{}
-	for _, chainID := range don.CapabilitiesAwareNodeSet().ChainCapabilities[flag].EnabledChains {
+	for _, chainID := range don.NodeSets().ChainCapabilities[flag].EnabledChains {
 		fullName := corevm.GenerateWriteTargetName(chainID)
 		splitName := strings.Split(fullName, "@")
 

--- a/system-tests/lib/cre/features/log_event_trigger/log_event_trigger.go
+++ b/system-tests/lib/cre/features/log_event_trigger/log_event_trigger.go
@@ -35,7 +35,7 @@ func (o *LogEventTrigger) PreEnvStartup(
 ) (*cre.PreEnvStartupOutput, error) {
 	capabilities := []keystone_changeset.DONCapabilityWithConfig{}
 
-	for _, chainID := range don.CapabilitiesAwareNodeSet().GetChainCapabilityConfigs()[flag].EnabledChains {
+	for _, chainID := range don.NodeSets().GetChainCapabilityConfigs()[flag].EnabledChains {
 		capabilities = append(capabilities, keystone_changeset.DONCapabilityWithConfig{
 			Capability: kcr.CapabilitiesRegistryCapability{
 				LabelledName:   fmt.Sprintf("log-event-trigger-evm-%d", chainID),

--- a/system-tests/lib/cre/features/read_contract/read_contract.go
+++ b/system-tests/lib/cre/features/read_contract/read_contract.go
@@ -34,7 +34,7 @@ func (o *ReadContract) PreEnvStartup(
 	creEnv *cre.Environment,
 ) (*cre.PreEnvStartupOutput, error) {
 	capabilities := []keystone_changeset.DONCapabilityWithConfig{}
-	for _, chainID := range don.CapabilitiesAwareNodeSet().GetChainCapabilityConfigs()[flag].EnabledChains {
+	for _, chainID := range don.NodeSets().GetChainCapabilityConfigs()[flag].EnabledChains {
 		capabilities = append(capabilities, keystone_changeset.DONCapabilityWithConfig{
 			Capability: kcr.CapabilitiesRegistryCapability{
 				LabelledName:   fmt.Sprintf("read-contract-evm-%d", chainID),

--- a/system-tests/lib/cre/features/solana/solana.go
+++ b/system-tests/lib/cre/features/solana/solana.go
@@ -84,12 +84,12 @@ func (o *Solana) PreEnvStartup(
 	}
 
 	for _, workerNode := range workerNodes {
-		currentConfig := don.CapabilitiesAwareNodeSet().NodeSpecs[workerNode.Index].Node.TestConfigOverrides
+		currentConfig := don.NodeSets().NodeSpecs[workerNode.Index].Node.TestConfigOverrides
 		updatedConfig, uErr := updateNodeConfig(workerNode, chainID, data, currentConfig, creEnv.CapabilityConfigs[cre.WriteSolanaCapability])
 		if uErr != nil {
 			return nil, errors.Wrapf(uErr, "failed to update node config for node index %d", workerNode.Index)
 		}
-		don.CapabilitiesAwareNodeSet().NodeSpecs[workerNode.Index].Node.TestConfigOverrides = *updatedConfig
+		don.NodeSets().NodeSpecs[workerNode.Index].Node.TestConfigOverrides = *updatedConfig
 	}
 
 	fullName := "write_solana_devnet@1.0.0"

--- a/system-tests/lib/cre/features/vault/vault.go
+++ b/system-tests/lib/cre/features/vault/vault.go
@@ -101,12 +101,12 @@ func (o *Vault) PreEnvStartup(
 	}
 
 	for _, workerNode := range workerNodes {
-		currentConfig := don.CapabilitiesAwareNodeSet().NodeSpecs[workerNode.Index].Node.TestConfigOverrides
+		currentConfig := don.NodeSets().NodeSpecs[workerNode.Index].Node.TestConfigOverrides
 		updatedConfig, uErr := updateNodeConfig(workerNode, currentConfig, registryChainID, workflowRegistryAddress, wfRegTypeVersion)
 		if uErr != nil {
 			return nil, errors.Wrapf(uErr, "failed to update node config for node index %d", workerNode.Index)
 		}
-		don.CapabilitiesAwareNodeSet().NodeSpecs[workerNode.Index].Node.TestConfigOverrides = *updatedConfig
+		don.NodeSets().NodeSpecs[workerNode.Index].Node.TestConfigOverrides = *updatedConfig
 	}
 
 	capabilities := []keystone_changeset.DONCapabilityWithConfig{{

--- a/system-tests/lib/cre/topology.go
+++ b/system-tests/lib/cre/topology.go
@@ -24,13 +24,13 @@ type Topology struct {
 	GatewayConnectors *GatewayConnectors `toml:"gateway_connectors" json:"gateway_connectors"`
 }
 
-func NewTopology(nodeSetInput []*CapabilitiesAwareNodeSet, provider infra.Provider) (*Topology, error) {
+func NewTopology(nodeSet []*NodeSet, provider infra.Provider) (*Topology, error) {
 	// TODO this setup is awkward, consider an withInfra opt to constructor
-	dm := make([]*DonMetadata, len(nodeSetInput))
-	for i := range nodeSetInput {
+	dm := make([]*DonMetadata, len(nodeSet))
+	for i := range nodeSet {
 		// TODO take more care about the ID assignment, it should match what the capabilities registry will assign
 		// currently we optimistically set the id to the that which the capabilities registry will assign it
-		d, err := NewDonMetadata(nodeSetInput[i], libc.MustSafeUint64FromInt(i+1), provider)
+		d, err := NewDonMetadata(nodeSet[i], libc.MustSafeUint64FromInt(i+1), provider)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create DON metadata: %w", err)
 		}
@@ -83,10 +83,10 @@ func NewTopology(nodeSetInput []*CapabilitiesAwareNodeSet, provider infra.Provid
 	return topology, nil
 }
 
-func (t *Topology) CapabilitiesAwareNodeSets() []*CapabilitiesAwareNodeSet {
-	sets := make([]*CapabilitiesAwareNodeSet, len(t.DonsMetadata.List()))
+func (t *Topology) NodeSets() []*NodeSet {
+	sets := make([]*NodeSet, len(t.DonsMetadata.List()))
 	for i, d := range t.DonsMetadata.List() {
-		ns := d.CapabilitiesAwareNodeSet()
+		ns := d.NodeSets()
 		sets[i] = ns
 	}
 	return sets

--- a/system-tests/lib/cre/workflow/registry.go
+++ b/system-tests/lib/cre/workflow/registry.go
@@ -42,7 +42,7 @@ func WaitForWorkflowRegistryFiltersRegistration(
 	infraType infra.Type,
 	registryChainID uint64,
 	dons *cre.Dons,
-	nodeSetInput []*cre.CapabilitiesAwareNodeSet,
+	nodeSet []*cre.NodeSet,
 ) error {
 	// we currently have no way of checking if filters were registered, when code runs in CRIB
 	// as we don't have a way to get its database connection string
@@ -50,7 +50,7 @@ func WaitForWorkflowRegistryFiltersRegistration(
 		return nil
 	}
 
-	return waitForAllNodesToHaveExpectedFiltersRegistered(singleFileLogger, testLogger, registryChainID, dons, nodeSetInput)
+	return waitForAllNodesToHaveExpectedFiltersRegistered(singleFileLogger, testLogger, registryChainID, dons, nodeSet)
 }
 
 type OwnershipProofSignaturePayload struct {
@@ -232,7 +232,7 @@ func ConfigureWorkflowRegistry(
 }
 
 // waitForAllNodesToHaveExpectedFiltersRegistered manually checks if all WorkflowRegistry filters used by the LogPoller are registered for all nodes. We want to see if this will help with the flakiness.
-func waitForAllNodesToHaveExpectedFiltersRegistered(singleFileLogger logger.Logger, testLogger zerolog.Logger, homeChainID uint64, dons *cre.Dons, nodeSetInput []*cre.CapabilitiesAwareNodeSet) error {
+func waitForAllNodesToHaveExpectedFiltersRegistered(singleFileLogger logger.Logger, testLogger zerolog.Logger, homeChainID uint64, dons *cre.Dons, nodeSet []*cre.NodeSet) error {
 	for donIdx, don := range dons.List() {
 		if !flags.HasFlag(don.Flags, cre.WorkflowDON) {
 			continue
@@ -264,7 +264,7 @@ func waitForAllNodesToHaveExpectedFiltersRegistered(singleFileLogger logger.Logg
 					}
 
 					testLogger.Info().Msgf("Checking if all WorkflowRegistry filters are registered for worker node %d", workerNode.Index)
-					allFilters, filtersErr := getAllFilters(context.Background(), singleFileLogger, big.NewInt(libc.MustSafeInt64(homeChainID)), workerNode.Index, nodeSetInput[donIdx].DbInput.Port)
+					allFilters, filtersErr := getAllFilters(context.Background(), singleFileLogger, big.NewInt(libc.MustSafeInt64(homeChainID)), workerNode.Index, nodeSet[donIdx].DbInput.Port)
 					if filtersErr != nil {
 						return errors.Wrap(filtersErr, "failed to get filters")
 					}

--- a/system-tests/tests/load/cre/writer_don_load_test.go
+++ b/system-tests/tests/load/cre/writer_don_load_test.go
@@ -80,14 +80,14 @@ func setupLoadTestWriterEnvironment(
 	t *testing.T,
 	testLogger zerolog.Logger,
 	in *TestConfigLoadTestWriter,
-	mustSetCapabilitiesFn func(input []*ns.Input) []*cretypes.CapabilitiesAwareNodeSet,
+	mustSetCapabilitiesFn func(input []*ns.Input) []*cretypes.NodeSet,
 	capabilityFactoryFns []cretypes.CapabilityRegistryConfigFn,
 	jobSpecFactoryFns []cretypes.JobSpecFn,
 	feedIDs []string,
 	workflowNames []string,
 ) *loadTestSetupOutput {
 	universalSetupInput := creenv.SetupInput{
-		CapabilitiesAwareNodeSets:            mustSetCapabilitiesFn(in.NodeSets),
+		NodeSets:                             mustSetCapabilitiesFn(in.NodeSets),
 		CapabilitiesContractFactoryFunctions: capabilityFactoryFns,
 		BlockchainsInput:                     in.Blockchains,
 		JdInput:                              in.JD,
@@ -160,8 +160,8 @@ func TestLoad_Writer_MockCapabilities(t *testing.T) {
 	require.NoError(t, err, "couldn't load test config")
 	require.Len(t, in.NodeSets, 1, "expected 1 node sets in the test config")
 
-	mustSetCapabilitiesFn := func(input []*ns.Input) []*cretypes.CapabilitiesAwareNodeSet {
-		return []*cretypes.CapabilitiesAwareNodeSet{
+	mustSetCapabilitiesFn := func(input []*ns.Input) []*cretypes.NodeSet {
+		return []*cretypes.NodeSet{
 			{
 				Input:        input[0],
 				Capabilities: []string{cretypes.MockCapability, cretypes.ConsensusCapability},
@@ -198,7 +198,7 @@ func TestLoad_Writer_MockCapabilities(t *testing.T) {
 		return jobSpecs, nil
 	}
 
-	WriterDONLoadTestCapabilitiesFactoryFn := func(donFlags []string, _ *cretypes.CapabilitiesAwareNodeSet) ([]keystone_changeset.DONCapabilityWithConfig, error) {
+	WriterDONLoadTestCapabilitiesFactoryFn := func(donFlags []string, _ *cretypes.NodeSet) ([]keystone_changeset.DONCapabilityWithConfig, error) {
 		var capabilities []keystone_changeset.DONCapabilityWithConfig
 
 		if flags.HasFlag(donFlags, cretypes.MockCapability) {


### PR DESCRIPTION
and `nodeSetInput` to `nodeSet`, when used as a variable name.