### PR TITLE
[CRE-1120] try to register node with JD 4x every 5 seconds

### DIFF
--- a/system-tests/lib/cre/don.go
+++ b/system-tests/lib/cre/don.go
@@ -621,21 +621,21 @@ func (n *Node) RegisterNodeToJobDistributor(ctx context.Context, jd *jd.JobDistr
 	}
 
 	var registerResponse *nodev1.RegisterNodeResponse
-	var err error
 
 	// register the node in the job distributor
-	retry.Do(ctx, retry.WithMaxRetries(4, retry.NewConstant(5*time.Second)), func(ctx context.Context) error {
-		registerResponse, err = jd.RegisterNode(ctx, &nodev1.RegisterNodeRequest{
+	err := retry.Do(ctx, retry.WithMaxRetries(4, retry.NewConstant(5*time.Second)), func(ctx context.Context) error {
+		var rErr error
+		registerResponse, rErr = jd.RegisterNode(ctx, &nodev1.RegisterNodeRequest{
 			PublicKey: strings.TrimPrefix(n.Keys.CSAKey.Key, "csa_"),
 			Labels:    labels,
 			Name:      n.Name,
 		})
 
-		if err != nil {
-			if strings.Contains(err.Error(), "AlreadyExists") {
-				return err
+		if rErr != nil {
+			if strings.Contains(rErr.Error(), "AlreadyExists") {
+				return rErr
 			}
-			return retry.RetryableError(fmt.Errorf("failed to register node %s in JD, retrying..: %w", n.Name, err))
+			return retry.RetryableError(fmt.Errorf("failed to register node %s in JD, retrying..: %w", n.Name, rErr))
 		}
 		return nil
 	})

--- a/system-tests/lib/cre/don.go
+++ b/system-tests/lib/cre/don.go
@@ -284,14 +284,6 @@ func RegisterWithJD(ctx context.Context, d *Don, supportedChains []blockchains.B
 			for _, role := range node.Roles {
 				switch role {
 				case RoleWorker, RoleBootstrap:
-					// jdChains := []JDChainConfigInput{}
-					// for _, chain := range supportedChains {
-					// 	jdChains = append(jdChains, JDChainConfigInput{
-					// 		ChainID:   strconv.FormatUint(chain.ChainID(), 10),
-					// 		ChainType: strings.ToUpper(chain.ChainFamily()),
-					// 	})
-					// }
-
 					if err := CreateJDChainConfigs(ctx, node, supportedChains, jd); err != nil {
 						return fmt.Errorf("failed to create supported chains in node %s: %w", node.Name, err)
 					}
@@ -624,16 +616,29 @@ func (n *Node) RegisterNodeToJobDistributor(ctx context.Context, jd *jd.JobDistr
 		Value: ptr.Ptr(n.Keys.P2PKey.PeerID.String()),
 	})
 
-	// register the node in the job distributor
-	registerResponse, err := jd.RegisterNode(ctx, &nodev1.RegisterNodeRequest{
-		PublicKey: strings.TrimPrefix(n.Keys.CSAKey.Key, "csa_"),
-		Labels:    labels,
-		Name:      n.Name,
-	})
-
 	if n.JobDistributorDetails == nil {
 		n.JobDistributorDetails = &JobDistributorDetails{}
 	}
+
+	var registerResponse *nodev1.RegisterNodeResponse
+	var err error
+
+	// register the node in the job distributor
+	retry.Do(ctx, retry.WithMaxRetries(4, retry.NewConstant(5*time.Second)), func(ctx context.Context) error {
+		registerResponse, err = jd.RegisterNode(ctx, &nodev1.RegisterNodeRequest{
+			PublicKey: strings.TrimPrefix(n.Keys.CSAKey.Key, "csa_"),
+			Labels:    labels,
+			Name:      n.Name,
+		})
+
+		if err != nil {
+			if strings.Contains(err.Error(), "AlreadyExists") {
+				return err
+			}
+			return retry.RetryableError(fmt.Errorf("failed to register node %s in JD, retrying..: %w", n.Name, err))
+		}
+		return nil
+	})
 
 	// node already registered, fetch it's id
 	if err != nil && strings.Contains(err.Error(), "AlreadyExists") {


### PR DESCRIPTION
Let's see if it fixes:
```
failed to set up job distributor in node workflow-node1: 
failed to register node workflow-node1: 
rpc error: code = Unavailable desc = connection error: 
desc = "error reading server preface: read tcp 127.0.0.1:45028->127.0.0.1:14231: read: connection reset by peer"
```