### PR TITLE
fix(core): bump version to 2.29.1 for CRE-1131

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.29.0",
+  "version": "2.29.1",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Fixes version mismatch in release/2.29.1-cre branch causing staging environment failures.

## Details

The staging environment was failing with:
`CheckVersion: Application version (2.29.0) is lower than database version (2.29.1)`

This PR updates the version reference in `package.json` from `2.29.0` to `2.29.1`.

## Changes
- Updated `package.json` version to `2.29.1`

## Related
- JIRA: CRE-1131
- Tag: `v2.29.1-cre-beta.2` (already pushed to trigger image build)

## Verification
```bash
grep '"version"' package.json
# Output: "version": "2.29.1",
```

## Image Build
The signed tag `v2.29.1-cre-beta.2` has been pushed and will trigger the image build for:
`public.ecr.aws/chainlink/chainlink:2.29.1-cre-beta.2`