### PR TITLE
only allow https and 443 in deployments gateway job

### DIFF
--- a/deployment/cre/jobs/pkg/gateway_job.go
+++ b/deployment/cre/jobs/pkg/gateway_job.go
@@ -105,6 +105,8 @@ func (g GatewayJob) Resolve(gatewayNodeIdx int) (string, error) {
 		},
 		HTTPClientConfig: httpClientConfig{
 			MaxResponseBytes: 50_000_000,
+			AllowedPorts:     []int{443},
+			AllowedSchemes:   []string{"https"},
 		},
 		Dons: dons,
 	}
@@ -208,7 +210,9 @@ type member struct {
 }
 
 type httpClientConfig struct {
-	MaxResponseBytes int `toml:"MaxResponseBytes"`
+	MaxResponseBytes int      `toml:"MaxResponseBytes"`
+	AllowedPorts     []int    `toml:"AllowedPorts"`
+	AllowedSchemes   []string `toml:"AllowedSchemes"`
 }
 
 type nodeServerConfig struct {

--- a/deployment/cre/jobs/pkg/gateway_job_test.go
+++ b/deployment/cre/jobs/pkg/gateway_job_test.go
@@ -96,6 +96,8 @@ Name = 'Node 4'
 
 [gatewayConfig.HTTPClientConfig]
 MaxResponseBytes = 50000000
+AllowedPorts = [443]
+AllowedSchemes = ['https']
 
 [gatewayConfig.NodeServerConfig]
 HandshakeTimeoutMillis = 1000
@@ -206,6 +208,8 @@ Name = 'Node 4'
 
 [gatewayConfig.HTTPClientConfig]
 MaxResponseBytes = 50000000
+AllowedPorts = [443]
+AllowedSchemes = ['https']
 
 [gatewayConfig.NodeServerConfig]
 HandshakeTimeoutMillis = 1000
@@ -289,6 +293,8 @@ Name = 'Node 4'
 
 [gatewayConfig.HTTPClientConfig]
 MaxResponseBytes = 50000000
+AllowedPorts = [443]
+AllowedSchemes = ['https']
 
 [gatewayConfig.NodeServerConfig]
 HandshakeTimeoutMillis = 1000


### PR DESCRIPTION
only allow https and 443 in deployments gateway job