### PR TITLE
[ARCH-330] Add new keystore table

### DIFF
--- a/core/store/migrate/migrations/0280_create_keystore_table.sql
+++ b/core/store/migrate/migrations/0280_create_keystore_table.sql
@@ -15,7 +15,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER encrypted_keystore_set_updated_at_trigger
+CREATE TRIGGER encrypted_keystore_set_updated_at_trigger
     BEFORE UPDATE ON encrypted_keystore
     FOR EACH ROW
 EXECUTE FUNCTION encrypted_keystore_set_updated_at();

--- a/core/store/migrate/migrations/0280_create_keystore_table.sql
+++ b/core/store/migrate/migrations/0280_create_keystore_table.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS encrypted_keystore (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    created_at timestamptz NOT NULL DEFAULT NOW(),
+    updated_at timestamptz NOT NULL DEFAULT NOW(),
+    encrypted_data BYTEA NOT NULL
+);
+
+CREATE OR REPLACE FUNCTION encrypted_keystore_set_updated_at() RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER encrypted_keystore_set_updated_at_trigger
+    BEFORE UPDATE ON encrypted_keystore
+    FOR EACH ROW
+EXECUTE FUNCTION encrypted_keystore_set_updated_at();
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS encrypted_keystore_set_updated_at_trigger on encrypted_keystore;
+DROP FUNCTION IF EXISTS encrypted_keystore_set_updated_at;
+DROP TABLE IF EXISTS encrypted_keystore;
+-- +goose StatementEnd

--- a/core/store/migrate/migrations/0280_create_keystore_table.sql
+++ b/core/store/migrate/migrations/0280_create_keystore_table.sql
@@ -1,5 +1,4 @@
 -- +goose Up
--- +goose StatementBegin
 CREATE TABLE IF NOT EXISTS encrypted_keystore (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL UNIQUE,
@@ -8,22 +7,5 @@ CREATE TABLE IF NOT EXISTS encrypted_keystore (
     encrypted_data BYTEA NOT NULL
 );
 
-CREATE OR REPLACE FUNCTION encrypted_keystore_set_updated_at() RETURNS TRIGGER AS $$
-BEGIN
-    NEW.updated_at = NOW();
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER encrypted_keystore_set_updated_at_trigger
-    BEFORE UPDATE ON encrypted_keystore
-    FOR EACH ROW
-EXECUTE FUNCTION encrypted_keystore_set_updated_at();
--- +goose StatementEnd
-
 -- +goose Down
--- +goose StatementBegin
-DROP TRIGGER IF EXISTS encrypted_keystore_set_updated_at_trigger on encrypted_keystore;
-DROP FUNCTION IF EXISTS encrypted_keystore_set_updated_at;
 DROP TABLE IF EXISTS encrypted_keystore;
--- +goose StatementEnd

--- a/core/store/migrate/migrations/0280_create_keystore_table.sql
+++ b/core/store/migrate/migrations/0280_create_keystore_table.sql
@@ -15,7 +15,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER encrypted_keystore_set_updated_at_trigger
+CREATE OR REPLACE TRIGGER encrypted_keystore_set_updated_at_trigger
     BEFORE UPDATE ON encrypted_keystore
     FOR EACH ROW
 EXECUTE FUNCTION encrypted_keystore_set_updated_at();


### PR DESCRIPTION
The new table `encrypted_keystore` will be used to store keystores created in https://github.com/smartcontractkit/chainlink-common/tree/main/keystore 