### PR TITLE
Update delve to match the compiler version.

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 # Install Delve for debugging with cache mounts
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go install github.com/go-delve/delve/cmd/dlv@v1.24.2
+    go install github.com/go-delve/delve/cmd/dlv@v1.25.2
 
 # Flag to control installation of private plugins (default: true).
 ARG CL_INSTALL_PRIVATE_PLUGINS=true

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -20,7 +20,7 @@ COPY . .
 # Install Delve for debugging with cache mounts
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go install github.com/go-delve/delve/cmd/dlv@v1.24.2
+    go install github.com/go-delve/delve/cmd/dlv@v1.25.2
 
 # Flag to control installation of private plugins (default: false).
 ARG CL_INSTALL_PRIVATE_PLUGINS=false


### PR DESCRIPTION
The version of delve in the docker image needs to be updated to avoid an error:
> Version of Delve is too old for Go version go1.25.3 (maximum supported version 1.24, suppress this error with --check-go-version=false)
