### PR TITLE
consistent cap request hasher

### DIFF
--- a/core/capabilities/remote/executable/hasher.go
+++ b/core/capabilities/remote/executable/hasher.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	evmcappb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/chain-capabilities/evm"
@@ -103,11 +103,16 @@ func (r *writeReportExcludeSignaturesHasher) Hash(msg *types.MessageBody) ([32]b
 	}
 
 	wrReq.Report.Sigs = nil // exclude signatures from hash
-	filteredPayload, err := proto.Marshal(&wrReq)
+
+	req.Payload, err = anypb.New(&wrReq)
 	if err != nil {
-		return [32]byte{}, fmt.Errorf("failed to marshal WriteReportRequest without signatures: %w", err)
+		return [32]byte{}, fmt.Errorf("failed to marshal WriteReportRequest back to anypb: %w", err)
 	}
-	return sha256.Sum256(filteredPayload), nil
+	reqBytes, err := pb.MarshalCapabilityRequest(req)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("failed to marshal capability request: %w", err)
+	}
+	return sha256.Sum256(reqBytes), nil
 }
 
 func NewWriteReportExcludeSignaturesHasher() types.MessageHasher {

--- a/core/capabilities/remote/executable/hasher.go
+++ b/core/capabilities/remote/executable/hasher.go
@@ -90,6 +90,10 @@ func (r *writeReportExcludeSignaturesHasher) Hash(msg *types.MessageBody) ([32]b
 		return [32]byte{}, errors.New("capability request payload is nil")
 	}
 
+	// Exclude SpendLimits from RequestMetadata to ensure identical requests
+	// with different SpendLimits produce the same hash
+	req.Metadata.SpendLimits = nil
+
 	var wrReq evmcappb.WriteReportRequest
 	if err = req.Payload.UnmarshalTo(&wrReq); err != nil {
 		return [32]byte{}, fmt.Errorf("failed to unmarshal Payload to WriteReportRequest: %w", err)

--- a/core/capabilities/remote/executable/hasher.go
+++ b/core/capabilities/remote/executable/hasher.go
@@ -57,7 +57,21 @@ type simpleHasher struct {
 }
 
 func (r *simpleHasher) Hash(msg *types.MessageBody) ([32]byte, error) {
-	return sha256.Sum256(msg.Payload), nil
+	req, err := pb.UnmarshalCapabilityRequest(msg.Payload)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("failed to unmarshal capability request: %w", err)
+	}
+
+	// Exclude SpendLimits from RequestMetadata to ensure identical requests
+	// with different SpendLimits produce the same hash
+	req.Metadata.SpendLimits = nil
+
+	reqBytes, err := pb.MarshalCapabilityRequest(req)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("failed to marshal capability request: %w", err)
+	}
+	hash := sha256.Sum256(reqBytes)
+	return hash, nil
 }
 
 func NewSimpleHasher() types.MessageHasher {

--- a/core/capabilities/remote/executable/hasher_test.go
+++ b/core/capabilities/remote/executable/hasher_test.go
@@ -72,6 +72,33 @@ func TestWriteReportExcludeSignaturesHasher_Hash_InvalidPayload(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to unmarshal capability request")
 }
 
+func TestSimpleHasher_ExcludesSpendLimits(t *testing.T) {
+	// Create two requests with identical payloads but different SpendLimits
+	req1 := getRequestWithSpendLimits(t, []byte("testdata"), []capabilities.SpendLimit{
+		{SpendType: "gas", Limit: "1000"},
+		{SpendType: "compute", Limit: "500"},
+	})
+	req2 := getRequestWithSpendLimits(t, []byte("testdata"), []capabilities.SpendLimit{
+		{SpendType: "gas", Limit: "2000"},
+		{SpendType: "compute", Limit: "1000"},
+	})
+	req3 := getRequestWithSpendLimits(t, []byte("otherdata"), []capabilities.SpendLimit{
+		{SpendType: "gas", Limit: "1000"},
+		{SpendType: "compute", Limit: "500"},
+	})
+
+	hasher := NewSimpleHasher()
+	hash1, err := hasher.Hash(req1)
+	require.NoError(t, err)
+	hash2, err := hasher.Hash(req2)
+	require.NoError(t, err)
+	hash3, err := hasher.Hash(req3)
+	require.NoError(t, err)
+
+	require.Equal(t, hash1, hash2)    // same data, different SpendLimits should produce same hash
+	require.NotEqual(t, hash1, hash3) // different data should produce different hash
+}
+
 func getRequest(t *testing.T, data []byte, sigs [][]byte) *types.MessageBody {
 	attrSigs := []*sdk.AttributedSignature{}
 	for i, sig := range sigs {
@@ -91,6 +118,31 @@ func getRequest(t *testing.T, data []byte, sigs [][]byte) *types.MessageBody {
 	require.NoError(t, err)
 	capReq := capabilities.CapabilityRequest{
 		Payload: wrAny,
+	}
+	capReqBytes, err := pb.MarshalCapabilityRequest(capReq)
+	require.NoError(t, err)
+	return &types.MessageBody{
+		Payload: capReqBytes,
+	}
+}
+
+func getRequestWithSpendLimits(t *testing.T, data []byte, spendLimits []capabilities.SpendLimit) *types.MessageBody {
+	report := &sdk.ReportResponse{
+		RawReport: data,
+		Sigs:      []*sdk.AttributedSignature{},
+	}
+	wrReq := &evmcappb.WriteReportRequest{
+		Report: report,
+	}
+	wrAny, err := anypb.New(wrReq)
+	require.NoError(t, err)
+	capReq := capabilities.CapabilityRequest{
+		Payload: wrAny,
+		Metadata: capabilities.RequestMetadata{
+			WorkflowID:          "test-workflow",
+			WorkflowExecutionID: "test-execution",
+			SpendLimits:         spendLimits,
+		},
 	}
 	capReqBytes, err := pb.MarshalCapabilityRequest(capReq)
 	require.NoError(t, err)

--- a/core/capabilities/remote/executable/hasher_test.go
+++ b/core/capabilities/remote/executable/hasher_test.go
@@ -99,6 +99,33 @@ func TestSimpleHasher_ExcludesSpendLimits(t *testing.T) {
 	require.NotEqual(t, hash1, hash3) // different data should produce different hash
 }
 
+func TestWriteReportExcludeSignaturesHasher_ExcludesSpendLimits(t *testing.T) {
+	// Create two requests with identical payloads but different SpendLimits
+	req1 := getWriteReportRequestWithSpendLimits(t, []byte("testdata"), [][]byte{[]byte("sig1"), []byte("sig2")}, []capabilities.SpendLimit{
+		{SpendType: "gas", Limit: "1000"},
+		{SpendType: "compute", Limit: "500"},
+	})
+	req2 := getWriteReportRequestWithSpendLimits(t, []byte("testdata"), [][]byte{[]byte("sig3"), []byte("sig4")}, []capabilities.SpendLimit{
+		{SpendType: "gas", Limit: "2000"},
+		{SpendType: "compute", Limit: "1000"},
+	})
+	req3 := getWriteReportRequestWithSpendLimits(t, []byte("otherdata"), [][]byte{[]byte("sig1"), []byte("sig2")}, []capabilities.SpendLimit{
+		{SpendType: "gas", Limit: "1000"},
+		{SpendType: "compute", Limit: "500"},
+	})
+
+	hasher := NewWriteReportExcludeSignaturesHasher()
+	hash1, err := hasher.Hash(req1)
+	require.NoError(t, err)
+	hash2, err := hasher.Hash(req2)
+	require.NoError(t, err)
+	hash3, err := hasher.Hash(req3)
+	require.NoError(t, err)
+
+	require.Equal(t, hash1, hash2)    // same data, different SpendLimits and signatures should produce same hash
+	require.NotEqual(t, hash1, hash3) // different data should produce different hash
+}
+
 func getRequest(t *testing.T, data []byte, sigs [][]byte) *types.MessageBody {
 	attrSigs := []*sdk.AttributedSignature{}
 	for i, sig := range sigs {
@@ -130,6 +157,38 @@ func getRequestWithSpendLimits(t *testing.T, data []byte, spendLimits []capabili
 	report := &sdk.ReportResponse{
 		RawReport: data,
 		Sigs:      []*sdk.AttributedSignature{},
+	}
+	wrReq := &evmcappb.WriteReportRequest{
+		Report: report,
+	}
+	wrAny, err := anypb.New(wrReq)
+	require.NoError(t, err)
+	capReq := capabilities.CapabilityRequest{
+		Payload: wrAny,
+		Metadata: capabilities.RequestMetadata{
+			WorkflowID:          "test-workflow",
+			WorkflowExecutionID: "test-execution",
+			SpendLimits:         spendLimits,
+		},
+	}
+	capReqBytes, err := pb.MarshalCapabilityRequest(capReq)
+	require.NoError(t, err)
+	return &types.MessageBody{
+		Payload: capReqBytes,
+	}
+}
+
+func getWriteReportRequestWithSpendLimits(t *testing.T, data []byte, sigs [][]byte, spendLimits []capabilities.SpendLimit) *types.MessageBody {
+	attrSigs := []*sdk.AttributedSignature{}
+	for i, sig := range sigs {
+		attrSigs = append(attrSigs, &sdk.AttributedSignature{
+			Signature: sig,
+			SignerId:  uint32(i), //nolint:gosec // G115
+		})
+	}
+	report := &sdk.ReportResponse{
+		RawReport: data,
+		Sigs:      attrSigs,
 	}
 	wrReq := &evmcappb.WriteReportRequest{
 		Report: report,


### PR DESCRIPTION
In the case we don't choose to cache rate cards on the billing service, this will ensure consistent hashes of capability requests.