### PR TITLE
core/services/job: parallelize spawner Close

### DIFF
--- a/core/services/job/spawner.go
+++ b/core/services/job/spawner.go
@@ -178,9 +178,9 @@ func (js *spawner) stopAllServices() {
 func (js *spawner) stopService(jobID int32) {
 	lggr := js.lggr.With("jobID", jobID)
 	js.activeJobsMu.Lock()
-	defer js.activeJobsMu.Unlock()
-
 	aj := js.activeJobs[jobID]
+	delete(js.activeJobs, jobID)f
+	js.activeJobsMu.Unlock()	
 
 	for i := len(aj.services) - 1; i >= 0; i-- {
 		service := aj.services[i]
@@ -195,8 +195,6 @@ func (js *spawner) stopService(jobID int32) {
 			js.SvcErrBuffer.Append(pkgerrors.Wrap(err, "error stopping job service"))
 		}
 	}
-
-	delete(js.activeJobs, jobID)
 }
 
 func (js *spawner) StartService(ctx context.Context, jb Job) error {

--- a/core/services/job/spawner.go
+++ b/core/services/job/spawner.go
@@ -179,8 +179,8 @@ func (js *spawner) stopService(jobID int32) {
 	lggr := js.lggr.With("jobID", jobID)
 	js.activeJobsMu.Lock()
 	aj := js.activeJobs[jobID]
-	delete(js.activeJobs, jobID)f
-	js.activeJobsMu.Unlock()	
+	delete(js.activeJobs, jobID)
+	js.activeJobsMu.Unlock()
 
 	for i := len(aj.services) - 1; i >= 0; i-- {
 		service := aj.services[i]


### PR DESCRIPTION
By holding the lock until returning, we undermined the goroutine parallelism from the caller. Instead, we can read & delete, then unlock before closing the services.