### PR TITLE
core/services/relay/evm/mercury/wsrpc: syncronize access to connection client

### DIFF
--- a/core/services/relay/evm/mercury/wsrpc/pool_test.go
+++ b/core/services/relay/evm/mercury/wsrpc/pool_test.go
@@ -78,7 +78,7 @@ func Test_Pool(t *testing.T) {
 			require.IsType(t, &clientCheckout{}, c)
 
 			conn := c.(*clientCheckout).connection
-			require.Equal(t, conn.Client, client)
+			require.Equal(t, conn.client, client)
 
 			assert.Len(t, conn.checkouts, 1)
 			assert.Same(t, lggr, conn.lggr)
@@ -92,8 +92,8 @@ func Test_Pool(t *testing.T) {
 				require.NoError(t, err)
 
 				assert.Len(t, conn.checkouts, 0)
-				require.IsType(t, nil, conn.Client)
-				assert.Nil(t, conn.Client)
+				require.IsType(t, nil, conn.client)
+				assert.Nil(t, conn.client)
 				assert.True(t, client.closed)
 			})
 		})
@@ -138,37 +138,37 @@ func Test_Pool(t *testing.T) {
 			assert.Same(t, conn1, c2.(*clientCheckout).connection)
 			assert.Same(t, conn1, c3.(*clientCheckout).connection)
 			assert.Len(t, conn1.checkouts, 3)
-			assert.True(t, conn1.Client.(*mockClient).started)
+			assert.True(t, conn1.client.(*mockClient).started)
 
 			conn2 := c4.(*clientCheckout).connection
 			assert.NotEqual(t, conn1, conn2)
 			assert.Len(t, conn2.checkouts, 1)
-			assert.True(t, conn2.Client.(*mockClient).started)
+			assert.True(t, conn2.client.(*mockClient).started)
 
 			conn3 := c5.(*clientCheckout).connection
 			assert.NotEqual(t, conn1, conn3)
 			assert.NotEqual(t, conn2, conn3)
 			assert.Same(t, conn3, c6.(*clientCheckout).connection)
 			assert.Len(t, conn3.checkouts, 2)
-			assert.True(t, conn3.Client.(*mockClient).started)
+			assert.True(t, conn3.client.(*mockClient).started)
 
 			require.NoError(t, c1.Close())
 			assert.Len(t, conn1.checkouts, 2)
-			assert.NotNil(t, conn1.Client)
+			assert.NotNil(t, conn1.client)
 			assert.Len(t, p.connections, 2)
 			assert.Len(t, p.connections[serverURLs[0]], 2)
 			assert.Len(t, p.connections[serverURLs[1]], 1)
 
 			require.NoError(t, c2.Close())
 			assert.Len(t, conn1.checkouts, 1)
-			assert.NotNil(t, conn1.Client)
+			assert.NotNil(t, conn1.client)
 			assert.Len(t, p.connections, 2)
 			assert.Len(t, p.connections[serverURLs[0]], 2)
 			assert.Len(t, p.connections[serverURLs[1]], 1)
 
 			require.NoError(t, c3.Close())
 			assert.Len(t, conn1.checkouts, 0)
-			assert.Nil(t, conn1.Client)
+			assert.Nil(t, conn1.client)
 			assert.Len(t, p.connections, 2)
 			assert.Len(t, p.connections[serverURLs[0]], 1)
 			assert.Len(t, p.connections[serverURLs[1]], 1)
@@ -179,7 +179,7 @@ func Test_Pool(t *testing.T) {
 			assert.Len(t, conn1.checkouts, 0) // actually, conn1 has already been removed from the map and will be garbage collected
 			conn4 := c7.(*clientCheckout).connection
 			assert.Len(t, conn4.checkouts, 1)
-			assert.NotNil(t, conn4.Client)
+			assert.NotNil(t, conn4.client)
 			assert.Len(t, p.connections, 2)
 			assert.Len(t, p.connections[serverURLs[0]], 2)
 			assert.Len(t, p.connections[serverURLs[1]], 1)


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/actions/runs/18788109230/job/53611496555
```
==================
WARNING: DATA RACE
Write at 0x00c028178ea0 by goroutine 847494:
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/wsrpc.(*connection).checkin()
      /home/runner/_work/chainlink/chainlink/core/services/relay/evm/mercury/wsrpc/pool.go:86 +0x2c4
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/wsrpc.(*clientCheckout).Close()
      /home/runner/_work/chainlink/chainlink/core/services/relay/evm/mercury/wsrpc/pool.go:26 +0x35
  github.com/smartcontractkit/chainlink-common/pkg/services.multiCloser[go.shape.interface { Close() error }].Close.func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:84 +0x9a
  github.com/smartcontractkit/chainlink-common/pkg/services.multiCloser[go.shape.interface { Close() error }].Close.gowrap1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:87 +0x4f

Previous read at 0x00c028178ea0 by goroutine 797660:
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/wsrpc.(*clientCheckout).HealthReport()
      <autogenerated>:1 +0x45
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury.(*server).HealthReport()
      /home/runner/_work/chainlink/chainlink/core/services/relay/evm/mercury/transmitter.go:172 +0x51
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury.(*mercuryTransmitter).HealthReport()
      /home/runner/_work/chainlink/chainlink/core/services/relay/evm/mercury/transmitter.go:391 +0x19d
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm.(*mercuryProvider).HealthReport()
      /home/runner/_work/chainlink/chainlink/core/services/relay/evm/mercury_provider.go:141 +0x7a
  github.com/smartcontractkit/chainlink-common/pkg/services.(*HealthChecker).update()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/health.go:194 +0x61e
  github.com/smartcontractkit/chainlink-common/pkg/services.(*HealthChecker).run()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/health.go:173 +0xf9
  github.com/smartcontractkit/chainlink-common/pkg/services.(*HealthChecker).Start.func1.gowrap1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/health.go:150 +0x33

Goroutine 847494 (running) created at:
  github.com/smartcontractkit/chainlink-common/pkg/services.multiCloser[go.shape.interface { Close() error }].Close()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:82 +0xdc
  github.com/smartcontractkit/chainlink-common/pkg/services.CloseAll()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:61 +0x5d9
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury.(*mercuryTransmitter).Close.func1()
      /home/runner/_work/chainlink/chainlink/core/services/relay/evm/mercury/transmitter.go:382 +0x345
  github.com/smartcontractkit/chainlink-common/pkg/services.(*StateMachine).StopOnce()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/state.go:132 +0xf4
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury.(*mercuryTransmitter).Close()
      /home/runner/_work/chainlink/chainlink/core/services/relay/evm/mercury/transmitter.go:362 +0x6c
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).Close()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:48 +0xe1
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm.(*mercuryProvider).Close()
      /home/runner/_work/chainlink/chainlink/core/services/relay/evm/mercury_provider.go:127 +0x2e
  github.com/smartcontractkit/chainlink/v2/core/services/job.(*spawner).stopService()
      /home/runner/_work/chainlink/chainlink/core/services/job/spawner.go:193 +0x6da
  github.com/smartcontractkit/chainlink/v2/core/services/job.(*spawner).stopAllServices.func1()
      /home/runner/_work/chainlink/chainlink/core/services/job/spawner.go:169 +0x86
  github.com/smartcontractkit/chainlink/v2/core/services/job.(*spawner).stopAllServices.gowrap1()
      /home/runner/_work/chainlink/chainlink/core/services/job/spawner.go:170 +0x3e

Goroutine 797660 (running) created at:
  github.com/smartcontractkit/chainlink-common/pkg/services.(*HealthChecker).Start.func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/health.go:150 +0x139
  github.com/smartcontractkit/chainlink-common/pkg/services.(*StateMachine).StartOnce()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/state.go:93 +0x101
  github.com/smartcontractkit/chainlink-common/pkg/services.(*HealthChecker).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/health.go:143 +0x6c
  github.com/smartcontractkit/chainlink/v2/core/services/chainlink.(*ChainlinkApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/services/chainlink/application.go:1361 +0xd2d
  github.com/smartcontractkit/chainlink-common/pkg/services.(*StateMachine).StartOnce()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/state.go:93 +0x101
  github.com/smartcontractkit/chainlink/v2/core/services/job.(*spawner).Start()
      /home/runner/_work/chainlink/chainlink/core/services/job/spawner.go:105 +0xa4
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:35 +0x77
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:26 +0x1296
  github.com/smartcontractkit/chainlink/v2/core/services/chainlink.(*ChainlinkApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/services/chainlink/application.go:1354 +0xbaa
  github.com/smartcontractkit/chainlink/v2/core/services/relay.(*ServerAdapter).Start()
      <autogenerated>:1 +0x66
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm.(*relayAdapter).Start()
      <autogenerated>:1 +0x66
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:35 +0x77
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:26 +0x1296
  github.com/smartcontractkit/chainlink/v2/core/services/chainlink.(*ChainlinkApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/services/chainlink/application.go:1354 +0xbaa
  github.com/smartcontractkit/chainlink-common/pkg/services.(*service).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/service.go:255 +0x9b
  github.com/smartcontractkit/chainlink/v2/core/services/llo/retirement.(*retirementReportCache).Start()
      <autogenerated>:1 +0x63
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:35 +0x77
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:26 +0x1296
  github.com/smartcontractkit/chainlink/v2/core/services/chainlink.(*ChainlinkApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/services/chainlink/application.go:1354 +0xbaa
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.(*TestApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/cltest.go:722 +0xea
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.(*TestApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/cltest.go:717 +0xbd
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/mercury_test.setupNode()
      /home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/mercury/helpers_test.go:213 +0x76f
  github.com/smartcontractkit/chainlink/v2/core/services/keystore.(*keyManager).Unlock()
      /home/runner/_work/chainlink/chainlink/core/services/keystore/master.go:221 +0x417
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewApplicationWithConfig()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/cltest.go:431 +0x1470
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewApplicationWithConfigV2OnSimulatedBlockchain()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/simulated_backend.go:63 +0x9ed
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/mercury_test.setupNode()
      /home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/mercury/helpers_test.go:212 +0x684
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/mercury_test.integration_MercuryV2()
      /home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/mercury/integration_test.go:226 +0x1924
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:26 +0x1296
  github.com/smartcontractkit/chainlink/v2/core/services/chainlink.(*ChainlinkApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/services/chainlink/application.go:1354 +0xbaa
  github.com/smartcontractkit/chainlink/v2/core/services/relay.(*ServerAdapter).Start()
      <autogenerated>:1 +0x66
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm.(*relayAdapter).Start()
      <autogenerated>:1 +0x66
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:35 +0x77
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:26 +0x1296
  github.com/smartcontractkit/chainlink/v2/core/services/chainlink.(*ChainlinkApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/services/chainlink/application.go:1354 +0xbaa
  github.com/smartcontractkit/chainlink-common/pkg/services.(*service).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/service.go:255 +0x9b
  github.com/smartcontractkit/chainlink/v2/core/services/llo/retirement.(*retirementReportCache).Start()
      <autogenerated>:1 +0x63
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:35 +0x77
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:26 +0x1296
  github.com/smartcontractkit/chainlink/v2/core/services/chainlink.(*ChainlinkApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/services/chainlink/application.go:1354 +0xbaa
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.(*TestApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/cltest.go:722 +0xea
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.(*TestApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/cltest.go:717 +0xbd
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/mercury_test.setupNode()
      /home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/mercury/helpers_test.go:213 +0x76f
  github.com/smartcontractkit/chainlink/v2/core/services/keystore.(*keyManager).Unlock()
      /home/runner/_work/chainlink/chainlink/core/services/keystore/master.go:221 +0x417
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewApplicationWithConfig()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/cltest.go:431 +0x1470
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewApplicationWithConfigV2OnSimulatedBlockchain()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/simulated_backend.go:63 +0x9ed
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/mercury_test.setupNode()
      /home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/mercury/helpers_test.go:212 +0x684
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/mercury_test.integration_MercuryV2()
      /home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/mercury/integration_test.go:226 +0x1924
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:26 +0x1296
  github.com/smartcontractkit/chainlink/v2/core/services/chainlink.(*ChainlinkApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/services/chainlink/application.go:1354 +0xbaa
  github.com/smartcontractkit/chainlink/v2/core/services/relay.(*ServerAdapter).Start()
      <autogenerated>:1 +0x66
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm.(*relayAdapter).Start()
      <autogenerated>:1 +0x66
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:35 +0x77
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:26 +0x1296
  github.com/smartcontractkit/chainlink/v2/core/services/chainlink.(*ChainlinkApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/services/chainlink/application.go:1354 +0xbaa
  github.com/smartcontractkit/chainlink-common/pkg/services.(*service).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/service.go:255 +0x9b
  github.com/smartcontractkit/chainlink/v2/core/services/llo/retirement.(*retirementReportCache).Start()
      <autogenerated>:1 +0x63
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:35 +0x77
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251023122816-20bf9584c7f1/pkg/services/multi.go:26 +0x1296
  github.com/smartcontractkit/chainlink/v2/core/services/chainlink.(*ChainlinkApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/services/chainlink/application.go:1354 +0xbaa
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.(*TestApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/cltest.go:722 +0xea
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.(*TestApplication).Start()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/cltest.go:717 +0xbd
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/mercury_test.setupNode()
      /home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/mercury/helpers_test.go:213 +0x76f
  github.com/smartcontractkit/chainlink/v2/core/services/keystore.(*keyManager).Unlock()
      /home/runner/_work/chainlink/chainlink/core/services/keystore/master.go:221 +0x417
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewApplicationWithConfig()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/cltest.go:431 +0x1470
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewApplicationWithConfigV2OnSimulatedBlockchain()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/simulated_backend.go:63 +0x9ed
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/mercury_test.setupNode()
      /home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/mercury/helpers_test.go:212 +0x684
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/mercury_test.integration_MercuryV2()
      /home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/mercury/integration_test.go:209 +0x1424
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).sealBlock()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/eth/catalyst/simulated_beacon.go:266 +0x154b
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).sealBlock()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/eth/catalyst/simulated_beacon.go:259 +0x1326
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).sealBlock()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/eth/catalyst/simulated_beacon.go:227 +0xd2a
  github.com/ethereum/go-ethereum/eth/catalyst.(*ConsensusAPI).forkchoiceUpdated()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/eth/catalyst/api.go:360 +0x4b64
  github.com/ethereum/go-ethereum/eth/catalyst.(*ConsensusAPI).forkchoiceUpdated()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/eth/catalyst/api.go:335 +0x26fd
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).sealBlock()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/eth/catalyst/simulated_beacon.go:197 +0x9f1
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).Commit()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/eth/catalyst/simulated_beacon.go:318 +0xfa
  github.com/ethereum/go-ethereum/ethclient/simulated.(*Backend).Commit()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/ethclient/simulated/backend.go:159 +0x46
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.(*syncBackend).Commit()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/simulated_backend.go:41 +0xd0
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/mercury_test.setupBlockchain()
      /home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/mercury/integration_test.go:99 +0x163
  github.com/ethereum/go-ethereum/eth/catalyst.(*ConsensusAPI).forkchoiceUpdated()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/eth/catalyst/api.go:335 +0x26fd
  github.com/ethereum/go-ethereum/eth/catalyst.NewSimulatedBeacon()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/eth/catalyst/simulated_beacon.go:124 +0x364
  github.com/ethereum/go-ethereum/ethclient/simulated.newWithNode()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/ethclient/simulated/backend.go:123 +0x17a
  github.com/ethereum/go-ethereum/node.(*Node).Start()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/node/node.go:179 +0x12b
  github.com/ethereum/go-ethereum/ethclient/simulated.newWithNode()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/ethclient/simulated/backend.go:119 +0x151
  github.com/ethereum/go-ethereum/core.(*BlockChain).loadLastState()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/core/blockchain.go:629 +0xa8d
  github.com/ethereum/go-ethereum/core.NewBlockChain()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/core/blockchain.go:414 +0x2358
  github.com/ethereum/go-ethereum/core.(*BlockChain).GetHeaderByNumber()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/core/blockchain_reader.go:89 +0x200a
  github.com/ethereum/go-ethereum/core.NewBlockChain()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/core/blockchain.go:393 +0x1fea
  github.com/ethereum/go-ethereum/core.NewHeaderChain()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/core/headerchain.go:83 +0x5c4
  github.com/ethereum/go-ethereum/core.NewBlockChain()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/core/blockchain.go:383 +0x1b7a
  github.com/ethereum/go-ethereum/core.NewBlockChain()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/core/blockchain.go:356 +0x957
  github.com/ethereum/go-ethereum/eth.New()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/eth/backend.go:267 +0x261d
  github.com/ethereum/go-ethereum/eth.New()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/eth/backend.go:178 +0xe91
  github.com/ethereum/go-ethereum/core/rawdb.ParseStateScheme()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/core/rawdb/accessors_trie.go:272 +0x5b
  github.com/ethereum/go-ethereum/eth.New()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/eth/backend.go:165 +0xcd6
  github.com/ethereum/go-ethereum/ethclient/simulated.newWithNode()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/ethclient/simulated/backend.go:108 +0x59
  github.com/ethereum/go-ethereum/ethclient/simulated.NewBackend()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.16.2/ethclient/simulated/backend.go:98 +0x3d9
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewSimulatedBackend()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/simulated_backend.go:23 +0x8e
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/mercury_test.setupBlockchain()
      /home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/mercury/integration_test.go:98 +0x14a
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/mercury_test.integration_MercuryV2()
      /home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/mercury/integration_test.go:205 +0x1246
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/mercury_test.TestIntegration_MercuryV2()
      /home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/mercury/integration_test.go:145 +0x30
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1997 +0x44
==================
```