### PR TITLE
Wire up ChIP ingress client for TelemetryIngress

### DIFF
--- a/.changeset/tricky-actors-run.md
+++ b/.changeset/tricky-actors-run.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#updated Wire up CHIP ingress client in telemetry manager

--- a/core/config/docs/core.toml
+++ b/core/config/docs/core.toml
@@ -105,6 +105,8 @@ SendInterval = '500ms' # Default
 SendTimeout = '10s' # Default
 # UseBatchSend toggles sending telemetry to the ingress server using the batch client.
 UseBatchSend = true # Default
+# ChipIngressEnabled enables sending telemetry to CHIP Ingress.
+ChipIngressEnabled = false # Default
 
 [[TelemetryIngress.Endpoints]] # Example
 # Network aka EVM, Solana, Starknet

--- a/core/config/mocks/telemetry_ingress.go
+++ b/core/config/mocks/telemetry_ingress.go
@@ -67,6 +67,51 @@ func (_c *TelemetryIngress_BufferSize_Call) RunAndReturn(run func() uint) *Telem
 	return _c
 }
 
+// ChipIngressEnabled provides a mock function with no fields
+func (_m *TelemetryIngress) ChipIngressEnabled() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChipIngressEnabled")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// TelemetryIngress_ChipIngressEnabled_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChipIngressEnabled'
+type TelemetryIngress_ChipIngressEnabled_Call struct {
+	*mock.Call
+}
+
+// ChipIngressEnabled is a helper method to define mock.On call
+func (_e *TelemetryIngress_Expecter) ChipIngressEnabled() *TelemetryIngress_ChipIngressEnabled_Call {
+	return &TelemetryIngress_ChipIngressEnabled_Call{Call: _e.mock.On("ChipIngressEnabled")}
+}
+
+func (_c *TelemetryIngress_ChipIngressEnabled_Call) Run(run func()) *TelemetryIngress_ChipIngressEnabled_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *TelemetryIngress_ChipIngressEnabled_Call) Return(_a0 bool) *TelemetryIngress_ChipIngressEnabled_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *TelemetryIngress_ChipIngressEnabled_Call) RunAndReturn(run func() bool) *TelemetryIngress_ChipIngressEnabled_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Endpoints provides a mock function with no fields
 func (_m *TelemetryIngress) Endpoints() []config.TelemetryIngressEndpoint {
 	ret := _m.Called()

--- a/core/config/telemetry_ingress_config.go
+++ b/core/config/telemetry_ingress_config.go
@@ -14,6 +14,7 @@ type TelemetryIngress interface {
 	SendTimeout() time.Duration
 	UseBatchSend() bool
 	Endpoints() []TelemetryIngressEndpoint
+	ChipIngressEnabled() bool
 }
 
 type TelemetryIngressEndpoint interface {

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -730,14 +730,15 @@ func (d *DatabaseBackup) setFrom(f *DatabaseBackup) {
 }
 
 type TelemetryIngress struct {
-	UniConn      *bool
-	Logging      *bool
-	BufferSize   *uint16
-	MaxBatchSize *uint16
-	SendInterval *commonconfig.Duration
-	SendTimeout  *commonconfig.Duration
-	UseBatchSend *bool
-	Endpoints    []TelemetryIngressEndpoint `toml:",omitempty"`
+	UniConn            *bool
+	Logging            *bool
+	BufferSize         *uint16
+	MaxBatchSize       *uint16
+	SendInterval       *commonconfig.Duration
+	SendTimeout        *commonconfig.Duration
+	UseBatchSend       *bool
+	Endpoints          []TelemetryIngressEndpoint `toml:",omitempty"`
+	ChipIngressEnabled *bool
 }
 
 type TelemetryIngressEndpoint struct {
@@ -771,6 +772,9 @@ func (t *TelemetryIngress) setFrom(f *TelemetryIngress) {
 	}
 	if v := f.Endpoints; v != nil {
 		t.Endpoints = v
+	}
+	if v := f.ChipIngressEnabled; v != nil {
+		t.ChipIngressEnabled = v
 	}
 }
 

--- a/core/services/chainlink/config_telemetry_ingress.go
+++ b/core/services/chainlink/config_telemetry_ingress.go
@@ -56,6 +56,10 @@ func (t *telemetryIngressConfig) Endpoints() []config.TelemetryIngressEndpoint {
 	return endpoints
 }
 
+func (t *telemetryIngressConfig) ChipIngressEnabled() bool {
+	return *t.c.ChipIngressEnabled
+}
+
 func (t *telemetryIngressEndpointConfig) Network() string {
 	return *t.c.Network
 }

--- a/core/services/chainlink/config_telemetry_ingress_test.go
+++ b/core/services/chainlink/config_telemetry_ingress_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/config/toml"
 )
 
 func TestTelemetryIngressConfig(t *testing.T) {
@@ -31,4 +33,26 @@ func TestTelemetryIngressConfig(t *testing.T) {
 	assert.Equal(t, "1", tec[0].ChainID())
 	assert.Equal(t, "prom.test", tec[0].URL().String())
 	assert.Equal(t, "test-pub-key", tec[0].ServerPubKey())
+}
+
+func TestTelemetryIngressConfig_ChipIngressEnabled(t *testing.T) {
+	t.Run("returns false when ChipIngressEnabled is explicitly false", func(t *testing.T) {
+		falseVal := false
+		config := &telemetryIngressConfig{
+			c: toml.TelemetryIngress{
+				ChipIngressEnabled: &falseVal,
+			},
+		}
+		assert.False(t, config.ChipIngressEnabled())
+	})
+
+	t.Run("returns true when ChipIngressEnabled is true", func(t *testing.T) {
+		trueVal := true
+		config := &telemetryIngressConfig{
+			c: toml.TelemetryIngress{
+				ChipIngressEnabled: &trueVal,
+			},
+		}
+		assert.True(t, config.ChipIngressEnabled())
+	})
 }

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -315,13 +315,14 @@ func TestConfig_Marshal(t *testing.T) {
 		},
 	}
 	full.TelemetryIngress = toml.TelemetryIngress{
-		UniConn:      ptr(false),
-		Logging:      ptr(true),
-		BufferSize:   ptr[uint16](1234),
-		MaxBatchSize: ptr[uint16](4321),
-		SendInterval: commoncfg.MustNewDuration(time.Minute),
-		SendTimeout:  commoncfg.MustNewDuration(5 * time.Second),
-		UseBatchSend: ptr(true),
+		UniConn:            ptr(false),
+		Logging:            ptr(true),
+		BufferSize:         ptr[uint16](1234),
+		MaxBatchSize:       ptr[uint16](4321),
+		SendInterval:       commoncfg.MustNewDuration(time.Minute),
+		SendTimeout:        commoncfg.MustNewDuration(5 * time.Second),
+		UseBatchSend:       ptr(true),
+		ChipIngressEnabled: ptr(false),
 		Endpoints: []toml.TelemetryIngressEndpoint{{
 			Network:      ptr("EVM"),
 			ChainID:      ptr("1"),
@@ -992,6 +993,7 @@ MaxBatchSize = 4321
 SendInterval = '1m0s'
 SendTimeout = '5s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [[TelemetryIngress.Endpoints]]
 Network = 'EVM'

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -43,6 +43,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = false

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -43,6 +43,7 @@ MaxBatchSize = 4321
 SendInterval = '1m0s'
 SendTimeout = '5s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [[TelemetryIngress.Endpoints]]
 Network = 'EVM'

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -43,6 +43,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = true

--- a/core/web/resolver/testdata/config-empty-effective.toml
+++ b/core/web/resolver/testdata/config-empty-effective.toml
@@ -43,6 +43,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = false

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -43,6 +43,7 @@ MaxBatchSize = 4321
 SendInterval = '1m0s'
 SendTimeout = '5s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [[TelemetryIngress.Endpoints]]
 Network = 'EVM'

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -43,6 +43,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = true

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -271,6 +271,7 @@ MaxBatchSize = 50 # Default
 SendInterval = '500ms' # Default
 SendTimeout = '10s' # Default
 UseBatchSend = true # Default
+ChipIngressEnabled = false # Default
 ```
 
 
@@ -315,6 +316,12 @@ SendTimeout is the max duration to wait for the request to complete when sending
 UseBatchSend = true # Default
 ```
 UseBatchSend toggles sending telemetry to the ingress server using the batch client.
+
+### ChipIngressEnabled
+```toml
+ChipIngressEnabled = false # Default
+```
+ChipIngressEnabled enables sending telemetry to CHIP Ingress.
 
 ## TelemetryIngress.Endpoints
 ```toml

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251029135506-45658d23dc49
+	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10
 	github.com/smartcontractkit/chainlink-data-streams v0.1.6
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b
@@ -345,7 +346,6 @@ require (
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/sethvargo/go-retry v0.2.4 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
-	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
 	github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20251020150604-8ab84f7bad1a // indirect
 	github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0 // indirect

--- a/testdata/scripts/config/merge_raw_configs.txtar
+++ b/testdata/scripts/config/merge_raw_configs.txtar
@@ -190,6 +190,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = false

--- a/testdata/scripts/node/validate/default.txtar
+++ b/testdata/scripts/node/validate/default.txtar
@@ -55,6 +55,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = false
@@ -399,4 +400,3 @@ IgnoreJoblessBridges = false
 Invalid configuration: invalid secrets: 2 errors:
 	- Database.URL: empty: must be provided and non-empty
 	- Password.Keystore: empty: must be provided and non-empty
-

--- a/testdata/scripts/node/validate/default.txtar
+++ b/testdata/scripts/node/validate/default.txtar
@@ -400,3 +400,4 @@ IgnoreJoblessBridges = false
 Invalid configuration: invalid secrets: 2 errors:
 	- Database.URL: empty: must be provided and non-empty
 	- Password.Keystore: empty: must be provided and non-empty
+

--- a/testdata/scripts/node/validate/defaults-override.txtar
+++ b/testdata/scripts/node/validate/defaults-override.txtar
@@ -116,6 +116,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = false

--- a/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
@@ -99,6 +99,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = false

--- a/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
@@ -99,6 +99,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = false

--- a/testdata/scripts/node/validate/disk-based-logging.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging.txtar
@@ -99,6 +99,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = false

--- a/testdata/scripts/node/validate/fallback-override.txtar
+++ b/testdata/scripts/node/validate/fallback-override.txtar
@@ -197,6 +197,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = false

--- a/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
+++ b/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
@@ -84,6 +84,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = false

--- a/testdata/scripts/node/validate/invalid.txtar
+++ b/testdata/scripts/node/validate/invalid.txtar
@@ -95,6 +95,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = false

--- a/testdata/scripts/node/validate/valid.txtar
+++ b/testdata/scripts/node/validate/valid.txtar
@@ -96,6 +96,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = false

--- a/testdata/scripts/node/validate/warnings.txtar
+++ b/testdata/scripts/node/validate/warnings.txtar
@@ -78,6 +78,7 @@ MaxBatchSize = 50
 SendInterval = '500ms'
 SendTimeout = '10s'
 UseBatchSend = true
+ChipIngressEnabled = false
 
 [AuditLogger]
 Enabled = false


### PR DESCRIPTION
## What

- Add chipIngressClient field to telemetry Manager struct
- Pass chipingress.Client to NewManager constructor
- Add ChipIngressEnabled option to TelemetryIngress config

Related PR's 
- https://github.com/smartcontractkit/chainlink-common/pull/1647
  - https://github.com/smartcontractkit/chainlink-common/pull/1646

## Why 

This is prep work for OTI Telemetry migration to ChIP ingress


