### PR TITLE
fix of missing message about the config mismatch

### DIFF
--- a/deployment/common/view/v2_0/capreg_test.go
+++ b/deployment/common/view/v2_0/capreg_test.go
@@ -25,8 +25,7 @@ type fields struct {
 
 func TestCapRegView_Denormalize(t *testing.T) {
 	donConfig := map[string]any{
-		"consensus": "basic",
-		"timeout":   "30s",
+		"defaultConfig": map[string]any{},
 	}
 	donCfgProto := pkg.CapabilityConfig(donConfig)
 	donConfigBytes, err := donCfgProto.MarshalProto()
@@ -39,8 +38,9 @@ func TestCapRegView_Denormalize(t *testing.T) {
 	capMetadataBytes, err := json.Marshal(capMetadata)
 	require.NoError(t, err)
 
-	capMetadataProto := pkg.CapabilityConfig(capMetadata)
-	capMetadataProtoBytes, err := capMetadataProto.MarshalProto()
+	// Capability configuration is separate from metadata - use a valid proto config structure
+	capConfig := pkg.CapabilityConfig(map[string]any{"defaultConfig": map[string]any{}})
+	capConfigProtoBytes, err := capConfig.MarshalProto()
 	require.NoError(t, err)
 
 	t.Run("empty", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestCapRegView_Denormalize(t *testing.T) {
 			CapabilityConfigurations: []cr.CapabilitiesRegistryCapabilityConfiguration{
 				{
 					CapabilityId: "test-cap-id",
-					Config:       capMetadataProtoBytes,
+					Config:       capConfigProtoBytes,
 				},
 			},
 		})
@@ -123,11 +123,11 @@ func TestCapRegView_Denormalize(t *testing.T) {
 			CapabilityConfigurations: []cr.CapabilitiesRegistryCapabilityConfiguration{
 				{
 					CapabilityId: "test-cap-id",
-					Config:       capMetadataProtoBytes,
+					Config:       capConfigProtoBytes,
 				},
 				{
 					CapabilityId: "test-cap-id-2",
-					Config:       capMetadataProtoBytes,
+					Config:       capConfigProtoBytes,
 				},
 			},
 		})
@@ -142,7 +142,7 @@ func TestCapRegView_Denormalize(t *testing.T) {
 			CapabilityConfigurations: []cr.CapabilitiesRegistryCapabilityConfiguration{
 				{
 					CapabilityId: "other-cap-id",
-					Config:       capMetadataProtoBytes,
+					Config:       capConfigProtoBytes,
 				},
 			},
 		})

--- a/deployment/cre/capabilities_registry/v2/changeset/configure_capabilities_registry_test.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/configure_capabilities_registry_test.go
@@ -231,8 +231,7 @@ func TestConfigureCapabilitiesRegistryInput_YAMLSerialization(t *testing.T) {
 				Name:        "workflow-don-1",
 				DonFamilies: []string{"workflow", "test"},
 				Config: map[string]any{
-					"consensus": "basic",
-					"timeout":   "30s",
+					"defaultConfig": map[string]any{},
 				},
 				CapabilityConfigurations: []CapabilitiesRegistryCapabilityConfiguration{
 					{
@@ -364,7 +363,7 @@ dons:
   - name: "workflow-don-production"
     donFamilies: ["workflow", "production"]
     config:
-      consensus: "basic"
+      defaultConfig: {}
     capabilityConfigurations:
       - capabilityID: "write-chain@1.0.0"
         config:
@@ -418,7 +417,7 @@ dons:
 
 	// Verify config is decoded properly
 	expectedConfig := map[string]any{
-		"consensus": "basic",
+		"defaultConfig": map[string]any{},
 	}
 	assert.Equal(t, expectedConfig, input.DONs[0].Config)
 

--- a/deployment/cre/capabilities_registry/v2/changeset/configure_capabilities_registry_test.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/configure_capabilities_registry_test.go
@@ -555,8 +555,7 @@ func setupCapabilitiesRegistryWithMCMS(t *testing.T) *testFixture {
 			Name:        "test-don-mcms-1",
 			DonFamilies: []string{"don-family-mcms-1"},
 			Config: map[string]any{
-				"name": "test-don-mcms-config",
-				"type": "workflow",
+				"defaultConfig": map[string]any{},
 			},
 			CapabilityConfigurations: []CapabilitiesRegistryCapabilityConfiguration{
 				{
@@ -704,8 +703,7 @@ func setupCapabilitiesRegistryTest(t *testing.T) *testFixture {
 			Name:        "test-don-1",
 			DonFamilies: []string{"don-family-1"},
 			Config: map[string]any{
-				"name": "test-don-v2-config",
-				"type": "workflow",
+				"defaultConfig": map[string]any{},
 			},
 			CapabilityConfigurations: []CapabilitiesRegistryCapabilityConfiguration{
 				{
@@ -722,8 +720,7 @@ func setupCapabilitiesRegistryTest(t *testing.T) *testFixture {
 			Name:        "test-don-2",
 			DonFamilies: []string{"don-family-2"},
 			Config: map[string]any{
-				"name": "test-don-v2-config",
-				"type": "trigger",
+				"defaultConfig": map[string]any{},
 			},
 			CapabilityConfigurations: []CapabilitiesRegistryCapabilityConfiguration{
 				{

--- a/deployment/cre/capabilities_registry/v2/changeset/pkg/capability_config.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/pkg/capability_config.go
@@ -4,20 +4,36 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 // CapabilityConfig is an untyped map representation of the CapabilityConfig proto message
 // It provides methods to marshal/unmarshal to/from proto bytes
 type CapabilityConfig map[string]any
 
+// UnmarshalWithValidation unmarshals JSON into a proto message, but first validates
+// that all fields in the JSON match the proto schema. If there are unknown fields,
+// it returns an error listing them
+func UnmarshalWithValidation(jsonData []byte, msg proto.Message) error {
+	strictOps := protojson.UnmarshalOptions{DiscardUnknown: false}
+	if err := strictOps.Unmarshal(jsonData, msg); err != nil {
+		return fmt.Errorf("config validation failed: %w", err)
+	}
+
+	return nil
+}
+
 // MarshalProto marshals the CapabilityConfig to proto bytes
 // If the CapabilityConfig is nil, it returns nil, nil, to support empty configs
 func (c CapabilityConfig) MarshalProto() ([]byte, error) {
+	lggr := logger.Nop()
+
 	if c == nil {
 		return nil, nil
 	}
@@ -27,9 +43,13 @@ func (c CapabilityConfig) MarshalProto() ([]byte, error) {
 	}
 
 	pbCfg := &pb.CapabilityConfig{}
-	ops := protojson.UnmarshalOptions{DiscardUnknown: true}
-	if err = ops.Unmarshal(jsonEncodedCfg, pbCfg); err != nil {
-		return nil, fmt.Errorf("failed to protojson unmarshal json encoded config %w", err)
+	if errValidation := UnmarshalWithValidation(jsonEncodedCfg, pbCfg); errValidation != nil {
+		// log the error with the specific field names that don't match
+		lggr.Warnf("⚠️  WARNING: Config validation failed: %v", errValidation)
+		// Also print to stderr so it's visible no matter what
+		fmt.Fprintf(os.Stderr, "⚠️  WARNING: Config validation failed: %v\n", errValidation)
+
+		return nil, fmt.Errorf("failed to protojson unmarshal json encoded config: %w", errValidation)
 	}
 
 	protoEncodedCfg, err := proto.Marshal(pbCfg)

--- a/deployment/cre/capabilities_registry/v2/changeset/pkg/capability_config_test.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/pkg/capability_config_test.go
@@ -53,3 +53,108 @@ func TestCapabilityConfig_MarshalUnmarshal(t *testing.T) {
 		assert.Equal(t, rawMap, map[string]any(result))
 	})
 }
+
+func TestCapabilityConfig_UnmarshalWithValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unknown fields are detected and reported", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a config with an intentional typo - "methodConfigsTypo" instead of "methodConfigs"
+		rawMap := map[string]any{
+			"restrictedConfig": map[string]any{
+				"fields": map[string]any{
+					"spendRatios": map[string]any{
+						"mapValue": map[string]any{
+							"fields": map[string]any{
+								"RESOURCE_TYPE_COMPUTE": map[string]any{
+									"stringValue": "1.0",
+								},
+							},
+						},
+					},
+				},
+			},
+			"methodConfigsTypo": map[string]any{ // intentional typo: should be "methodConfigs"
+				"BalanceAt": map[string]any{
+					"remoteExecutableConfig": map[string]any{
+						"requestTimeout":            "30s",
+						"serverMaxParallelRequests": float64(10),
+					},
+				},
+			},
+		}
+
+		cfg := pkg.CapabilityConfig(rawMap)
+		_, err := cfg.MarshalProto()
+
+		// Should return an error with the specific field name
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "config validation failed")
+		assert.Contains(t, err.Error(), "methodConfigsTypo")
+	})
+
+	t.Run("deltaStageNanos vs deltaStage field name typo", func(t *testing.T) {
+		t.Parallel()
+
+		// Using incorrect field name "deltaStageNanos" instead of correct "deltaStage"
+		rawMap := map[string]any{
+			"methodConfigs": map[string]any{
+				"BalanceAt": map[string]any{
+					"remoteExecutableConfig": map[string]any{
+						"requestTimeout":            "30s",
+						"serverMaxParallelRequests": float64(10),
+						"deltaStageNanos":           "1000000", // Typo: should be "deltaStage"
+					},
+				},
+			},
+		}
+
+		cfg := pkg.CapabilityConfig(rawMap)
+		_, err := cfg.MarshalProto()
+
+		// Should return an error with the specific field name
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "config validation failed")
+		assert.Contains(t, err.Error(), "deltaStageNanos")
+	})
+
+	t.Run("valid config passes validation", func(t *testing.T) {
+		t.Parallel()
+
+		// Valid config matching proto schema
+		rawMap := map[string]any{
+			"restrictedConfig": map[string]any{
+				"fields": map[string]any{
+					"spendRatios": map[string]any{
+						"mapValue": map[string]any{
+							"fields": map[string]any{
+								"RESOURCE_TYPE_COMPUTE": map[string]any{
+									"stringValue": "1.0",
+								},
+							},
+						},
+					},
+				},
+			},
+			"methodConfigs": map[string]any{
+				"BalanceAt": map[string]any{
+					"remoteExecutableConfig": map[string]any{
+						"requestTimeout":            "30s",
+						"serverMaxParallelRequests": float64(10),
+					},
+					"aggregatorConfig": map[string]any{
+						"aggregatorType": "SignedReport",
+					},
+				},
+			},
+		}
+
+		cfg := pkg.CapabilityConfig(rawMap)
+		protoBts, err := cfg.MarshalProto()
+
+		// Should succeed with no errors
+		require.NoError(t, err)
+		require.NotNil(t, protoBts)
+	})
+}

--- a/deployment/cre/capabilities_registry/v2/changeset/update_don_test.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/update_don_test.go
@@ -137,8 +137,7 @@ func setupRegistryForUpdateDON(t *testing.T, isWorkflow bool) *updFixture {
 				Name:        donName,
 				DonFamilies: []string{"upd-family"},
 				Config: map[string]any{
-					"name": "don-config",
-					"type": "workflow",
+					"defaultConfig": map[string]any{},
 				},
 				CapabilityConfigurations: []changeset.CapabilitiesRegistryCapabilityConfiguration{
 					{CapabilityID: writeChain.CapabilityId, Config: cfg},
@@ -237,7 +236,16 @@ func TestUpdateDONChangeset_ByName_Workflow_Force_Succeeds(t *testing.T) {
 	t.Parallel()
 	fx := setupRegistryForUpdateDON(t /*isWorkflow=*/, true)
 
-	newCfg := map[string]any{"defaultConfig": map[string]any{"bump": "1"}}
+	// Use a valid protobuf structure with proper fields format
+	newCfg := map[string]any{
+		"defaultConfig": map[string]any{
+			"fields": map[string]any{
+				"testKey": map[string]any{
+					"stringValue": "testValue",
+				},
+			},
+		},
+	}
 	wantProto, err := pkg.CapabilityConfig(newCfg).MarshalProto()
 	require.NoError(t, err)
 

--- a/deployment/cre/test/env_setup.go
+++ b/deployment/cre/test/env_setup.go
@@ -185,7 +185,7 @@ func SetupEnvV2(t *testing.T, useMCMS bool) *EnvWrapperV2 {
 						F:           uint8(donCfg.F), //nolint:gosec // disable G115
 						Nodes:       nodesP2PIDs,
 						DonFamilies: []string{"test-family"},
-						Config:      map[string]any{"consensus": "basic", "timeout": "30s"},
+						Config:      map[string]any{"defaultConfig": map[string]any{}},
 						CapabilityConfigurations: []changeset2.CapabilitiesRegistryCapabilityConfiguration{
 							{
 								CapabilityID: "test-capability@1.0.0",


### PR DESCRIPTION
- testing resulted in a really hard debug in case of the config typo
- PR is surfacing config mismatch via logger and stderr
- surfacing errors resulted in other tests needing config upgrade to newest structs (previously this problem was just hidden)
