### PR TITLE
[CRE-1174] worker swallows panics

### DIFF
--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -229,6 +229,7 @@ func SetupTestEnvironment(
 	defer queue.StopAndWait() // Ensure cleanup on any exit path
 
 	jdStartedFuture := queue.SubmitAny(func(ctx context.Context) (any, error) {
+		// TODO: pass context after we update the CTF to accept context, when creating new JD instance
 		jdOutput, startJDErr := StartJD(testLogger, *input.JdInput, input.Provider)
 		if startJDErr != nil {
 			return nil, pkgerrors.Wrap(startJDErr, "failed to start Job Distributor")

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -2,6 +2,7 @@ package environment
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 
@@ -224,8 +225,10 @@ func SetupTestEnvironment(
 	}
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.WrapAndNext("Applied Features in %.2f seconds", input.StageGen.Elapsed().Seconds())))
 
-	queue := worker.New(10)
-	jdStartedFuture := queue.SubmitAny(func() (any, error) {
+	queue := worker.New(ctx, 10)
+	defer queue.StopAndWait() // Ensure cleanup on any exit path
+
+	jdStartedFuture := queue.SubmitAny(func(ctx context.Context) (any, error) {
 		jdOutput, startJDErr := StartJD(testLogger, *input.JdInput, input.Provider)
 		if startJDErr != nil {
 			return nil, pkgerrors.Wrap(startJDErr, "failed to start Job Distributor")
@@ -233,7 +236,7 @@ func SetupTestEnvironment(
 		return jdOutput, nil
 	})
 
-	donsStartedFuture := queue.SubmitAny(func() (any, error) {
+	donsStartedFuture := queue.SubmitAny(func(ctx context.Context) (any, error) {
 		nodeSetOutput, startDonsErr := StartDONs(ctx, testLogger, topology, input.Provider, deployedBlockchains.RegistryChain().CtfOutput(), input.CapabilityConfigs, input.CopyCapabilityBinaries, updatedNodeSets)
 		if startDonsErr != nil {
 			return nil, pkgerrors.Wrap(startDonsErr, "failed to start DONs")
@@ -242,13 +245,26 @@ func SetupTestEnvironment(
 		return nodeSetOutput, nil
 	})
 
-	// First wait for JD to start, because it will be faster than DONs
+	// Await both futures to ensure proper cleanup even if one fails
 	startedJD, jdStartErr := worker.AwaitAs[*StartedJD](ctx, jdStartedFuture)
+	startedDONs, donStartErr := worker.AwaitAs[*StartedDONs](ctx, donsStartedFuture)
+
+	// Check errors after both awaits complete
+	// If both failed, prefer the non-context-cancelled error as it's likely the root cause
+	if jdStartErr != nil && donStartErr != nil {
+		// If one is context.Canceled, it was likely caused by the other task's error
+		if pkgerrors.Is(jdStartErr, context.Canceled) && !pkgerrors.Is(donStartErr, context.Canceled) {
+			return nil, pkgerrors.Wrap(donStartErr, "failed to start DONs")
+		}
+		if pkgerrors.Is(donStartErr, context.Canceled) && !pkgerrors.Is(jdStartErr, context.Canceled) {
+			return nil, pkgerrors.Wrap(jdStartErr, "failed to start Job Distributor")
+		}
+		// Both real errors
+		return nil, pkgerrors.Wrap(errors.Join(fmt.Errorf("JD failed to start: %w", jdStartErr), fmt.Errorf("DONs failed to start: %w", donStartErr)), "failed to start Job Distributor AND Dons")
+	}
 	if jdStartErr != nil {
 		return nil, pkgerrors.Wrap(jdStartErr, "failed to start Job Distributor")
 	}
-
-	startedDONs, donStartErr := worker.AwaitAs[*StartedDONs](ctx, donsStartedFuture)
 	if donStartErr != nil {
 		return nil, pkgerrors.Wrap(donStartErr, "failed to start DONs")
 	}
@@ -339,7 +355,13 @@ func SetupTestEnvironment(
 		return nil, pkgerrors.Wrap(wfErr, "failed to configure workflow registry")
 	}
 
-	wfFiltersFuture := queue.SubmitErr(func() error {
+	wfFiltersFuture := queue.SubmitErr(func(ctx context.Context) error {
+		// we currently have no way of checking if filters were registered, when code runs in CRIB
+		// as we don't have a way to get its database connection string
+		if input.Provider.Type == infra.CRIB {
+			return nil
+		}
+
 		fmt.Print(libformat.PurpleText("\n---> [BACKGROUND] Waiting for Workflow Registry filters registration\n\n"))
 		defer fmt.Print(libformat.PurpleText("\n---> [BACKGROUND] Finished waiting for Workflow Registry filters registration\n\n"))
 
@@ -349,7 +371,7 @@ func SetupTestEnvironment(
 			// There are no filters registered with the V2 WF Registry Syncer
 			return nil
 		default:
-			return workflow.WaitForWorkflowRegistryFiltersRegistration(testLogger, singleFileLogger, input.Provider.Type, deployedBlockchains.RegistryChain().ChainID(), dons, updatedNodeSets)
+			return workflow.WaitForAllNodesToHaveExpectedFiltersRegistered(ctx, singleFileLogger, testLogger, deployedBlockchains.RegistryChain().ChainID(), dons, updatedNodeSets)
 		}
 	})
 
@@ -407,7 +429,6 @@ func SetupTestEnvironment(
 	if err := worker.AwaitErr(ctx, wfFiltersFuture); err != nil {
 		return nil, pkgerrors.Wrap(err, "failed while waiting for workflow registry filters registration")
 	}
-	queue.StopAndWait()
 
 	appendOutputsToInput(input, startedDONs.NodeOutputs(), deployedBlockchains.Outputs, startedJD.JDOutput)
 

--- a/system-tests/lib/cre/workflow/registry.go
+++ b/system-tests/lib/cre/workflow/registry.go
@@ -230,15 +230,14 @@ func WaitForAllNodesToHaveExpectedFiltersRegistered(ctx context.Context, singleF
 		timeoutDuration := 2 * time.Minute
 
 		checkCtx, cancel := context.WithTimeout(ctx, timeoutDuration)
-		defer cancel()
-
 		ticker := time.NewTicker(tickInterval)
-		defer ticker.Stop()
 
 	INNER_LOOP:
 		for {
 			select {
 			case <-checkCtx.Done():
+				cancel()
+				ticker.Stop()
 				if errors.Is(checkCtx.Err(), context.DeadlineExceeded) {
 					return fmt.Errorf("timed out after %.2f seconds waiting for all nodes to have expected filters registered", timeoutDuration.Seconds())
 				}
@@ -246,6 +245,9 @@ func WaitForAllNodesToHaveExpectedFiltersRegistered(ctx context.Context, singleF
 			case <-ticker.C:
 				if len(results) == len(workerNodes) {
 					testLogger.Info().Msgf("All %d nodes in DON %d have expected filters registered", len(workerNodes), don.ID)
+					cancel()
+					ticker.Stop()
+
 					break INNER_LOOP
 				}
 
@@ -257,6 +259,8 @@ func WaitForAllNodesToHaveExpectedFiltersRegistered(ctx context.Context, singleF
 					testLogger.Info().Msgf("Checking if all WorkflowRegistry filters are registered for worker node %d", workerNode.Index)
 					allFilters, filtersErr := getAllFilters(checkCtx, singleFileLogger, big.NewInt(libc.MustSafeInt64(homeChainID)), workerNode.Index, nodeSet[donIdx].DbInput.Port)
 					if filtersErr != nil {
+						cancel()
+						ticker.Stop()
 						return errors.Wrap(filtersErr, "failed to get filters")
 					}
 
@@ -276,6 +280,9 @@ func WaitForAllNodesToHaveExpectedFiltersRegistered(ctx context.Context, singleF
 				// return if we have results for all nodes, don't wait for next tick
 				if len(results) == len(workerNodes) {
 					testLogger.Info().Msgf("All %d nodes in DON %d have expected filters registered", len(workerNodes), don.ID)
+					cancel()
+					ticker.Stop()
+
 					break INNER_LOOP
 				}
 			}

--- a/system-tests/lib/cre/workflow/registry.go
+++ b/system-tests/lib/cre/workflow/registry.go
@@ -30,28 +30,10 @@ import (
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/stagegen"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/flags"
 	libformat "github.com/smartcontractkit/chainlink/system-tests/lib/format"
-	"github.com/smartcontractkit/chainlink/system-tests/lib/infra"
 )
 
 // must match nubmer of events we track in core/services/workflows/syncer/handler.go
 const NumberOfTrackedWorkflowRegistryEvents = 6
-
-func WaitForWorkflowRegistryFiltersRegistration(
-	testLogger zerolog.Logger,
-	singleFileLogger logger.Logger,
-	infraType infra.Type,
-	registryChainID uint64,
-	dons *cre.Dons,
-	nodeSet []*cre.NodeSet,
-) error {
-	// we currently have no way of checking if filters were registered, when code runs in CRIB
-	// as we don't have a way to get its database connection string
-	if infraType == infra.CRIB {
-		return nil
-	}
-
-	return waitForAllNodesToHaveExpectedFiltersRegistered(singleFileLogger, testLogger, registryChainID, dons, nodeSet)
-}
 
 type OwnershipProofSignaturePayload struct {
 	RequestType              uint8          // should be uint8 in Solidity, 1 byte
@@ -231,8 +213,8 @@ func ConfigureWorkflowRegistry(
 	}
 }
 
-// waitForAllNodesToHaveExpectedFiltersRegistered manually checks if all WorkflowRegistry filters used by the LogPoller are registered for all nodes. We want to see if this will help with the flakiness.
-func waitForAllNodesToHaveExpectedFiltersRegistered(singleFileLogger logger.Logger, testLogger zerolog.Logger, homeChainID uint64, dons *cre.Dons, nodeSet []*cre.NodeSet) error {
+// WaitForAllNodesToHaveExpectedFiltersRegistered manually checks if all WorkflowRegistry filters used by the LogPoller are registered for all nodes. We want to see if this will help with the flakiness.
+func WaitForAllNodesToHaveExpectedFiltersRegistered(ctx context.Context, singleFileLogger logger.Logger, testLogger zerolog.Logger, homeChainID uint64, dons *cre.Dons, nodeSet []*cre.NodeSet) error {
 	for donIdx, don := range dons.List() {
 		if !flags.HasFlag(don.Flags, cre.WorkflowDON) {
 			continue
@@ -244,15 +226,24 @@ func waitForAllNodesToHaveExpectedFiltersRegistered(singleFileLogger logger.Logg
 		}
 
 		results := make(map[int]bool)
-		ticker := 5 * time.Second
-		timeout := 2 * time.Minute
+		tickInterval := 5 * time.Second
+		timeoutDuration := 2 * time.Minute
+
+		checkCtx, cancel := context.WithTimeout(ctx, timeoutDuration)
+		defer cancel()
+
+		ticker := time.NewTicker(tickInterval)
+		defer ticker.Stop()
 
 	INNER_LOOP:
 		for {
 			select {
-			case <-time.After(timeout):
-				return fmt.Errorf("timed out, when waiting for %.2f seconds, waiting for all nodes to have expected filters registered", timeout.Seconds())
-			case <-time.Tick(ticker):
+			case <-checkCtx.Done():
+				if errors.Is(checkCtx.Err(), context.DeadlineExceeded) {
+					return fmt.Errorf("timed out after %.2f seconds waiting for all nodes to have expected filters registered", timeoutDuration.Seconds())
+				}
+				return fmt.Errorf("context cancelled while waiting for all nodes to have expected filters registered: %w", checkCtx.Err())
+			case <-ticker.C:
 				if len(results) == len(workerNodes) {
 					testLogger.Info().Msgf("All %d nodes in DON %d have expected filters registered", len(workerNodes), don.ID)
 					break INNER_LOOP
@@ -264,7 +255,7 @@ func waitForAllNodesToHaveExpectedFiltersRegistered(singleFileLogger logger.Logg
 					}
 
 					testLogger.Info().Msgf("Checking if all WorkflowRegistry filters are registered for worker node %d", workerNode.Index)
-					allFilters, filtersErr := getAllFilters(context.Background(), singleFileLogger, big.NewInt(libc.MustSafeInt64(homeChainID)), workerNode.Index, nodeSet[donIdx].DbInput.Port)
+					allFilters, filtersErr := getAllFilters(checkCtx, singleFileLogger, big.NewInt(libc.MustSafeInt64(homeChainID)), workerNode.Index, nodeSet[donIdx].DbInput.Port)
 					if filtersErr != nil {
 						return errors.Wrap(filtersErr, "failed to get filters")
 					}

--- a/system-tests/lib/worker/worker.go
+++ b/system-tests/lib/worker/worker.go
@@ -9,7 +9,7 @@ import (
 
 type Pool struct {
 	pool   pond.Pool
-	ctx    context.Context
+	ctx    context.Context //nolint:containedctx // Pool needs to manage a shared context for all tasks
 	cancel context.CancelCauseFunc
 }
 

--- a/system-tests/lib/worker/worker.go
+++ b/system-tests/lib/worker/worker.go
@@ -47,15 +47,27 @@ func (p *Pool) SubmitAny(fn func() (any, error)) FutureAny {
 		err   error
 	}, 1)
 
-	p.pool.Submit(func() {
+	task := p.pool.Submit(func() {
+		// If there was no panic, execute the function and send the result to the channel (value or error)
 		value, err := fn()
 		ch <- struct {
 			value any
 			err   error
 		}{value, err}
-
-		close(ch)
 	})
+
+	// Monitor the task for panics that pond caught
+	go func() {
+		defer close(ch)
+		if taskErr := task.Wait(); taskErr != nil {
+			// If there was a panic, pond caught it and the task function never sent to the channel
+			// So we send the panic as error instead
+			ch <- struct {
+				value any
+				err   error
+			}{nil, taskErr}
+		}
+	}()
 
 	return FutureAny{ch: ch}
 }

--- a/system-tests/lib/worker/worker.go
+++ b/system-tests/lib/worker/worker.go
@@ -8,12 +8,17 @@ import (
 )
 
 type Pool struct {
-	pool pond.Pool
+	pool   pond.Pool
+	ctx    context.Context
+	cancel context.CancelCauseFunc
 }
 
-func New(maxConcurrency int, opts ...pond.Option) *Pool {
+func New(ctx context.Context, maxConcurrency int, opts ...pond.Option) *Pool {
+	poolCtx, cancel := context.WithCancelCause(ctx)
 	return &Pool{
-		pool: pond.NewPool(maxConcurrency, opts...),
+		pool:   pond.NewPool(maxConcurrency, opts...),
+		ctx:    poolCtx,
+		cancel: cancel,
 	}
 }
 
@@ -26,9 +31,9 @@ type FutureAny struct {
 	}
 }
 
-func (p *Pool) SubmitErr(fn func() error) FutureAny {
-	return p.SubmitAny(func() (any, error) {
-		return nil, fn()
+func (p *Pool) SubmitErr(fn func(context.Context) error) FutureAny {
+	return p.SubmitAny(func(ctx context.Context) (any, error) {
+		return nil, fn(ctx)
 	})
 }
 
@@ -41,7 +46,7 @@ func AwaitErr(ctx context.Context, future FutureAny) error {
 	}
 }
 
-func (p *Pool) SubmitAny(fn func() (any, error)) FutureAny {
+func (p *Pool) SubmitAny(fn func(context.Context) (any, error)) FutureAny {
 	ch := make(chan struct {
 		value any
 		err   error
@@ -49,11 +54,16 @@ func (p *Pool) SubmitAny(fn func() (any, error)) FutureAny {
 
 	task := p.pool.Submit(func() {
 		// If there was no panic, execute the function and send the result to the channel (value or error)
-		value, err := fn()
+		value, err := fn(p.ctx)
 		ch <- struct {
 			value any
 			err   error
 		}{value, err}
+
+		// Cancel pool context if there was an error
+		if err != nil {
+			p.cancel(err)
+		}
 	})
 
 	// Monitor the task for panics that pond caught
@@ -66,6 +76,9 @@ func (p *Pool) SubmitAny(fn func() (any, error)) FutureAny {
 				value any
 				err   error
 			}{nil, taskErr}
+
+			// Cancel pool context on panic
+			p.cancel(taskErr)
 		}
 	}()
 


### PR DESCRIPTION
This pull request refactors the test environment setup and worker pool logic to improve error handling, context management, and reliability in system tests. The main changes include passing contexts through background tasks, ensuring proper cleanup and error reporting, and making filter registration checks more robust and context-aware.

**Test environment and worker pool improvements:**

* Worker pool (`worker.Pool`) now accepts a parent context, propagates cancellation, and provides better error handling for background tasks. The `SubmitAny` and `SubmitErr` methods now pass context to tasks and cancel the pool context on errors or panics. [[1]](diffhunk://#diff-6e967bb5c35e9092e51f04e04b9f37bd922035e83822a38ceec72b88b4feca64R12-R21) [[2]](diffhunk://#diff-6e967bb5c35e9092e51f04e04b9f37bd922035e83822a38ceec72b88b4feca64L29-R36) [[3]](diffhunk://#diff-6e967bb5c35e9092e51f04e04b9f37bd922035e83822a38ceec72b88b4feca64L44-R84)
* In `SetupTestEnvironment`, the worker pool is created with a context, and `defer queue.StopAndWait()` ensures cleanup. Task functions for starting the Job Distributor and DONs now receive context, and both are awaited before error checking, allowing for more accurate error reporting when both tasks fail. [[1]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L227-R239) [[2]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L245-L251) [[3]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L410)
* The workflow registry filter registration check is now skipped for the CRIB provider, and uses a new context-aware function, `WaitForAllNodesToHaveExpectedFiltersRegistered`, which replaces the previous implementation and is called with context in the test environment setup. [[1]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L342-R364) [[2]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L352-R374) [[3]](diffhunk://#diff-6ff418ccb57ccfe73cb12a8c2626760f87e3a3217518251b7d997078358ae757L33-L55) [[4]](diffhunk://#diff-6ff418ccb57ccfe73cb12a8c2626760f87e3a3217518251b7d997078358ae757L234-R217)
* The filter registration check itself now uses context for timeouts and cancellation, and provides clearer error messages for timeout and cancellation scenarios. It also passes the context through to lower-level filter retrieval calls. [[1]](diffhunk://#diff-6ff418ccb57ccfe73cb12a8c2626760f87e3a3217518251b7d997078358ae757L247-R246) [[2]](diffhunk://#diff-6ff418ccb57ccfe73cb12a8c2626760f87e3a3217518251b7d997078358ae757L267-R258)
* Added missing `errors` import for error joining and context error checks.