### PR TITLE
[ARCH-330] Ensure that no postgres triggers are created

### DIFF
--- a/core/store/migrate/migrate_test.go
+++ b/core/store/migrate/migrate_test.go
@@ -455,7 +455,7 @@ func TestNoTriggers(t *testing.T) {
 	require.NoError(t, err)
 	_, err = p.Up(testutils.Context(t))
 	require.NoError(t, err)
-	row := db.DB.QueryRow("select count(*) from information_schema.triggers")
+	row := db.QueryRow("select count(*) from information_schema.triggers")
 	var count int
 	err = row.Scan(&count)
 	require.NoError(t, err)

--- a/core/store/migrate/migrate_test.go
+++ b/core/store/migrate/migrate_test.go
@@ -451,27 +451,15 @@ func TestSetMigrationENVVars(t *testing.T) {
 
 func TestNoTriggers(t *testing.T) {
 	_, db := heavyweight.FullTestDBEmptyV2(t, nil)
-
-	assert_num_triggers := func(expected int) {
-		row := db.DB.QueryRow("select count(*) from information_schema.triggers")
-		var count int
-		err := row.Scan(&count)
-
-		require.NoError(t, err)
-		require.Equal(t, expected, count)
-	}
-
-	// if you find yourself here and are tempted to add a trigger, something has gone wrong
-	// and you should talk to the foundations team before proceeding
-	assert_num_triggers(0)
-
-	// version prior to removal of all triggers
-	v := int64(217)
 	p, err := migrate.NewProvider(testutils.Context(t), db.DB)
 	require.NoError(t, err)
-	_, err = p.UpTo(testutils.Context(t), v)
+	_, err = p.Up(testutils.Context(t))
 	require.NoError(t, err)
-	assert_num_triggers(1)
+	row := db.DB.QueryRow("select count(*) from information_schema.triggers")
+	var count int
+	err = row.Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
 }
 
 func BenchmarkBackfillingRecordsWithMigration202(b *testing.B) {


### PR DESCRIPTION
Before this PR we had TestNoTriggers that checked the db trigger count at the migration 217, which is very specific. In this PR we simply apply **all** migrations and check that no triggers are created.