### PR TITLE
[DX-2206] Fix flakey TestPersistenceManagerAsyncDelete

### DIFF
--- a/core/services/relay/evm/mercury/persistence_manager.go
+++ b/core/services/relay/evm/mercury/persistence_manager.go
@@ -98,6 +98,10 @@ func (pm *PersistenceManager) runFlushDeletesLoop() {
 			return
 		case <-ticker.C:
 			queuedReqs := pm.resetDeleteQueue()
+			if len(queuedReqs) == 0 {
+				break
+			}
+
 			if err := pm.orm.DeleteTransmitRequests(ctx, pm.serverURL, queuedReqs); err != nil {
 				pm.lggr.Errorw("Failed to delete queued transmit requests", "err", err)
 				pm.addToDeleteQueue(queuedReqs...)


### PR DESCRIPTION
The persistence manager's `AsyncDelete` method puts items for deletion in a queue. A background goroutine periodically (every second) clears this queue and deletes the items from the DB.

The flakey test calls `AsyncDelete`, waits until the delete queue is empty, and then checks that the item marked for deletion has been deleted from the DB. It is flakey because sometimes this item has not been deleted yet.

The `RequireEventually` in the test checks that the delete queue is empty, and not that queued items were actually deleted. So it's possible the flake is due to a race between the RequireEventually and the delete loop actually deleting the items. The fix I added is to additionally check for a delete success log which verifies that the items were indeed deleted.

https://smartcontract-it.atlassian.net/browse/DX-2206?actionerId=712020%3A4cda46e1-b01b-42d6-8326-059ddf780e4f&sourceType=assign