### PR TITLE
[DX-2081] Fix flakey LLO Telemeter tests

### DIFF
--- a/core/services/llo/telem/telemetry_test.go
+++ b/core/services/llo/telem/telemetry_test.go
@@ -430,12 +430,20 @@ func Test_Telemeter_outcomeTelemetry(t *testing.T) {
 		servicetest.Run(t, tm)
 		ch := tm.GetOutcomeTelemetryCh()
 		require.NotNil(t, ch)
+
 		t.Run("zero values", func(t *testing.T) {
 			opts := &mockOpts{}
 			cd := opts.ConfigDigest()
 			orig := &datastreamsllo.LLOOutcomeTelemetry{SeqNr: opts.SeqNr(), ConfigDigest: cd[:]}
 			ch <- orig
-			time.Sleep(5 * time.Millisecond)
+
+			// Wait until the telemetry is buffered.
+			testutils.RequireEventually(t, func() bool {
+				tm.telemetryBufferMu.Lock()
+				defer tm.telemetryBufferMu.Unlock()
+				return len(tm.telemetryBuffer[cd.Hex()][opts.SeqNr()]) > 0
+			})
+
 			tm.TrackSeqNr(opts.ConfigDigest(), opts.SeqNr())
 
 			tLog := <-m.chTypedLogs
@@ -451,6 +459,7 @@ func Test_Telemeter_outcomeTelemetry(t *testing.T) {
 			assert.Equal(t, cd[:], decoded.ConfigDigest)
 			assert.Zero(t, decoded.DonId)
 		})
+
 		t.Run("with values", func(t *testing.T) {
 			opts := &mockOpts{}
 			cd := opts.ConfigDigest()
@@ -487,7 +496,14 @@ func Test_Telemeter_outcomeTelemetry(t *testing.T) {
 				DonId:        10,
 			}
 			ch <- orig
-			time.Sleep(5 * time.Millisecond)
+
+			// Wait until the telemetry is buffered.
+			testutils.RequireEventually(t, func() bool {
+				tm.telemetryBufferMu.Lock()
+				defer tm.telemetryBufferMu.Unlock()
+				return len(tm.telemetryBuffer[cd.Hex()][opts.SeqNr()]) > 0
+			})
+
 			tm.TrackSeqNr(opts.ConfigDigest(), opts.SeqNr())
 
 			tLog := <-m.chTypedLogs
@@ -541,12 +557,20 @@ func Test_Telemeter_reportTelemetry(t *testing.T) {
 		servicetest.Run(t, tm)
 		ch := tm.GetReportTelemetryCh()
 		require.NotNil(t, ch)
+
 		t.Run("zero values", func(t *testing.T) {
 			opts := &mockOpts{}
 			cd := opts.ConfigDigest()
 			orig := &datastreamsllo.LLOReportTelemetry{SeqNr: opts.SeqNr(), ConfigDigest: cd[:]}
 			ch <- orig
-			time.Sleep(5 * time.Millisecond)
+
+			// Wait until the telemetry is buffered.
+			testutils.RequireEventually(t, func() bool {
+				tm.telemetryBufferMu.Lock()
+				defer tm.telemetryBufferMu.Unlock()
+				return len(tm.telemetryBuffer[cd.Hex()][opts.SeqNr()]) > 0
+			})
+
 			tm.TrackSeqNr(opts.ConfigDigest(), opts.SeqNr())
 
 			tLog := <-m.chTypedLogs
@@ -564,6 +588,7 @@ func Test_Telemeter_reportTelemetry(t *testing.T) {
 			assert.Equal(t, opts.SeqNr(), decoded.SeqNr)
 			assert.Equal(t, cd[:], decoded.ConfigDigest)
 		})
+
 		t.Run("with values", func(t *testing.T) {
 			opts := &mockOpts{}
 			cd := opts.ConfigDigest()
@@ -590,7 +615,14 @@ func Test_Telemeter_reportTelemetry(t *testing.T) {
 				ConfigDigest: cd[:],
 			}
 			ch <- orig
-			time.Sleep(5 * time.Millisecond)
+
+			// Wait until the telemetry is buffered.
+			testutils.RequireEventually(t, func() bool {
+				tm.telemetryBufferMu.Lock()
+				defer tm.telemetryBufferMu.Unlock()
+				return len(tm.telemetryBuffer[cd.Hex()][opts.SeqNr()]) > 0
+			})
+
 			tm.TrackSeqNr(opts.ConfigDigest(), opts.SeqNr())
 
 			tLog := <-m.chTypedLogs


### PR DESCRIPTION
Instead of waiting a hardcoded length of time which can be flakey depending on the testrunner's load, let's instead wait for the internal state to reflect our expectations.


* https://smartcontract-it.atlassian.net/browse/DX-2081?actionerId=712020%3A4cda46e1-b01b-42d6-8326-059ddf780e4f&sourceType=assign
* https://smartcontract-it.atlassian.net/browse/DX-2083?actionerId=712020%3A4cda46e1-b01b-42d6-8326-059ddf780e4f&sourceType=assign