### PR TITLE
fix block number bug in balanceAt

### DIFF
--- a/.changeset/slick-pianos-warn.md
+++ b/.changeset/slick-pianos-warn.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix fix block number nil issue in fake evm

--- a/core/capabilities/fakes/evm_chain.go
+++ b/core/capabilities/fakes/evm_chain.go
@@ -302,10 +302,15 @@ func (fc *FakeEVMChain) BalanceAt(ctx context.Context, metadata commonCap.Reques
 
 	// Prepare balance at request
 	address := common.Address(input.Account)
-	blockNumber := new(big.Int).SetBytes(input.BlockNumber.AbsVal)
+
+	// Convert proto big-int to *big.Int; nil ⇒ latest (handled by geth toBlockNumArg)
+	var blockArg *big.Int
+	if input != nil {
+		blockArg = pb.NewIntFromBigInt(input.BlockNumber) // returns nil if input.BlockNumber is nil
+	}
 
 	// Get balance at block number
-	balance, err := fc.gethClient.BalanceAt(ctx, address, blockNumber)
+	balance, err := fc.gethClient.BalanceAt(ctx, address, blockArg)
 	if err != nil {
 		return nil, err
 	}

--- a/core/capabilities/fakes/evm_chain.go
+++ b/core/capabilities/fakes/evm_chain.go
@@ -3,6 +3,7 @@ package fakes
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -300,14 +301,15 @@ func (fc *FakeEVMChain) FilterLogs(ctx context.Context, metadata commonCap.Reque
 func (fc *FakeEVMChain) BalanceAt(ctx context.Context, metadata commonCap.RequestMetadata, input *evmcappb.BalanceAtRequest) (*commonCap.ResponseAndMetadata[*evmcappb.BalanceAtReply], error) {
 	fc.eng.Infow("EVM Chain BalanceAt Started", "input", input)
 
+	if input == nil {
+		return nil, errors.New("BalanceAtRequest is nil")
+	}
+
 	// Prepare balance at request
 	address := common.Address(input.Account)
 
 	// Convert proto big-int to *big.Int; nil ⇒ latest (handled by geth toBlockNumArg)
-	var blockArg *big.Int
-	if input != nil {
-		blockArg = pb.NewIntFromBigInt(input.BlockNumber) // returns nil if input.BlockNumber is nil
-	}
+	blockArg := pb.NewIntFromBigInt(input.BlockNumber)
 
 	// Get balance at block number
 	balance, err := fc.gethClient.BalanceAt(ctx, address, blockArg)


### PR DESCRIPTION
confirmed @george-dorin 's workflow succeeded after the fix:

```
leishi@MB-MJ2FP47WKD test117 % cre workflow simulate flow117
Workflow compiled
2025-10-28T11:12:19Z [SIMULATION] Simulator Initialized

2025-10-28T11:12:19Z [SIMULATION] Running trigger trigger=cron-trigger@1.0.0
2025-10-28T11:12:19Z [USER LOG] msg="PoR workflow started" payload="scheduled_execution_time:{seconds:1761675139 nanos:105663000}"
2025-10-28T11:12:19Z [USER LOG] msg="Got EVM client" chainSelector=16015286601757825753
2025-10-28T11:12:19Z [USER LOG] msg="[logger] Got on-chain balance with BalanceAt() for address 0x13CB6AE34A13a0977F4d7101eBc24B87Bb23F0d5: abs_val:\"F\\x97\\xa0;\\xfd\\x97\\x97\\xa0M\" sign:1"
2025-10-28T11:12:19Z [USER LOG] msg="[logger] Got on-chain balance with BalanceAt() for address 0x13CB6AE34A13a0977F4d7101eBc24B87Bb23F0d5: 1302197883816025497677"
2025-10-28T11:12:19Z [USER LOG] msg="getting Balance Reader contract ABI"
2025-10-28T11:12:19Z [USER LOG] msg="successfully got Balance Reader contract ABI"
2025-10-28T11:12:19Z [USER LOG] msg="Got raw CallContract output: 0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000007b54a731a48e364"
2025-10-28T11:12:19Z [USER LOG] msg="Read on-onchain balances for address 0xDc58480363fca702ADbECD61911314E602D324EA: &[555431987272803172]"
2025-10-28T11:12:19Z [USER LOG] msg="Total on-chain balance for addresses 1302753315803298300849"
2025-10-28T11:12:19Z [USER LOG] msg="Response is account name: TrueUSD, totalTrust: 501931400.8799999952, ripcord: false, updatedAt: 2025-10-28 18:12:05.985 +0000 UTC"
2025-10-28T11:12:19Z [USER LOG] msg="Got price: 1302753315853491440937, for feed: 018e16c38e000320000000000000000000000000000000000000000000000000, at time: 1761675125"
2025-10-28T11:12:19Z [USER LOG] msg="final report generated\n"
2025-10-28T11:12:20Z [USER LOG] msg="Submitted report on-chain"

Workflow Simulation Result:
 "PoR Workflow successfully completed"

2025-10-28T11:12:20Z [SIMULATION] Execution finished signal received
2025-10-28T11:12:20Z [SIMULATION] Skipping WorkflowEngineV2
leishi@MB-MJ2FP47WKD test117 % 

```