### PR TITLE
chore: updates CCIP tests to use the CLDF test engine

### DIFF
--- a/deployment/ccip/changeset/solana_v0_1_1/save_existing_test.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/save_existing_test.go
@@ -4,34 +4,33 @@ import (
 	"testing"
 
 	"github.com/gagliardetto/solana-go"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
 	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func TestSaveExistingCCIP(t *testing.T) {
 	t.Parallel()
-	skipInCI(t)
-	lggr := logger.TestLogger(t)
-	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Bootstraps: 1,
-		Chains:     2,
-		SolChains:  1,
-		Nodes:      4,
+
+	e, err := environment.New(t.Context())
+	require.NoError(t, err)
+
+	// Insert a fake Solana chain into the environment since we are not making any onchain calls.
+	selector := chainsel.TEST_22222222222222222222222222222222222222222222.Selector
+	e.BlockChains = cldf_chain.NewBlockChainsFromSlice([]cldf_chain.BlockChain{
+		cldf_solana.Chain{Selector: selector},
 	})
-	solChain := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilySolana))[0]
+
 	solAddr1 := solana.NewWallet().PublicKey().String()
 	solAddr2 := solana.NewWallet().PublicKey().String()
 	cfg := commonchangeset.ExistingContractsConfig{
@@ -39,37 +38,38 @@ func TestSaveExistingCCIP(t *testing.T) {
 			{
 				Address:        solAddr1,
 				TypeAndVersion: cldf.NewTypeAndVersion(shared.Router, deployment.Version1_0_0),
-				ChainSelector:  solChain,
+				ChainSelector:  selector,
 			},
 			{
 				Address:        solAddr2,
 				TypeAndVersion: cldf.NewTypeAndVersion(commontypes.LinkToken, deployment.Version1_0_0),
-				ChainSelector:  solChain,
+				ChainSelector:  selector,
 			},
 		},
 	}
 
-	output, err := commonchangeset.SaveExistingContractsChangeset(e, cfg)
+	output, err := commonchangeset.SaveExistingContractsChangeset(*e, cfg)
 	require.NoError(t, err)
-	err = e.ExistingAddresses.Merge(output.AddressBook)
+	err = e.ExistingAddresses.Merge(output.AddressBook) //nolint:staticcheck // AddressBook is deprecated but still in use for this changeset
 	require.NoError(t, err)
-	state, err := stateview.LoadOnchainState(e)
+	state, err := stateview.LoadOnchainState(*e)
 	require.NoError(t, err)
-	require.Equal(t, state.SolChains[solChain].Router.String(), solAddr1)
-	require.Equal(t, state.SolChains[solChain].LinkToken.String(), solAddr2)
+	require.Equal(t, state.SolChains[selector].Router.String(), solAddr1)
+	require.Equal(t, state.SolChains[selector].LinkToken.String(), solAddr2)
 }
 
 func TestSaveExisting(t *testing.T) {
 	t.Parallel()
-	dummyEnv := cldf.Environment{
-		Name:              "dummy",
-		Logger:            logger.TestLogger(t),
-		ExistingAddresses: cldf.NewMemoryAddressBook(),
-		BlockChains: cldf_chain.NewBlockChains(
-			map[uint64]cldf_chain.BlockChain{
-				chainsel.SOLANA_DEVNET.Selector: cldf_solana.Chain{},
-			}),
-	}
+
+	e, err := environment.New(t.Context())
+	require.NoError(t, err)
+
+	// Insert a fake Solana chain into the environment since we are not making any onchain calls.
+	selector := chainsel.TEST_22222222222222222222222222222222222222222222.Selector
+	e.BlockChains = cldf_chain.NewBlockChainsFromSlice([]cldf_chain.BlockChain{
+		cldf_solana.Chain{Selector: selector},
+	})
+
 	ExistingContracts := commonchangeset.ExistingContractsConfig{
 		ExistingContracts: []commonchangeset.Contract{
 			{
@@ -78,18 +78,18 @@ func TestSaveExisting(t *testing.T) {
 					Type:    "dummy3",
 					Version: deployment.Version1_1_0,
 				},
-				ChainSelector: chainsel.SOLANA_DEVNET.Selector,
+				ChainSelector: selector,
 			},
 		},
 	}
 
-	output, err := commonchangeset.SaveExistingContractsChangeset(dummyEnv, ExistingContracts)
+	output, err := commonchangeset.SaveExistingContractsChangeset(*e, ExistingContracts)
 	require.NoError(t, err)
-	require.NoError(t, dummyEnv.ExistingAddresses.Merge(output.AddressBook))
-	addresses, err := dummyEnv.ExistingAddresses.Addresses()
+	require.NoError(t, e.ExistingAddresses.Merge(output.AddressBook)) //nolint:staticcheck // AddressBook is deprecated but still in use for this changeset
+	addresses, err := e.ExistingAddresses.Addresses()
 	require.NoError(t, err)
 	require.Len(t, addresses, 1)
-	addressForSolana, exists := addresses[chainsel.SOLANA_DEVNET.Selector]
+	addressForSolana, exists := addresses[selector]
 	require.True(t, exists)
 	require.Len(t, addressForSolana, 1)
 }

--- a/deployment/ccip/changeset/testhelpers/test_token_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_token_helpers.go
@@ -1,6 +1,7 @@
 package testhelpers
 
 import (
+	"crypto/ecdsa"
 	"math/big"
 	"testing"
 	"time"
@@ -9,30 +10,26 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc677"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-
 	token_governor "github.com/smartcontractkit/chainlink/deployment/ccip/shared/bindings/token_governor"
-	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	commoncs "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 const (
@@ -71,12 +68,13 @@ func SetupTwoChainEnvironmentWithTokens(
 	lggr logger.Logger,
 	transferToTimelock bool,
 ) (env cldf.Environment, sel1 uint64, sel2 uint64, ercmap map[uint64]*cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]) {
-	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 2,
-	})
-	selectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
+	selectors := []uint64{chain_selectors.TEST_90000001.Selector, chain_selectors.TEST_90000002.Selector}
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, selectors),
+		environment.WithLogger(lggr),
+	))
+	require.NoError(t, err)
 
-	addressBook := cldf.NewMemoryAddressBook()
 	prereqCfg := make([]changeset.DeployPrerequisiteConfigPerChain, len(selectors))
 	for i, selector := range selectors {
 		prereqCfg[i] = changeset.DeployPrerequisiteConfigPerChain{
@@ -92,11 +90,13 @@ func SetupTwoChainEnvironmentWithTokens(
 	// Deploy one burn-mint token per chain to use in the tests
 	tokens := make(map[uint64]*cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677])
 	for _, selector := range selectors {
-		token, err := cldf.DeployContract(e.Logger, e.BlockChains.EVMChains()[selector], addressBook,
+		chain := rt.Environment().BlockChains.EVMChains()[selector]
+
+		token, err := cldf.DeployContract(lggr, chain, rt.State().AddressBook,
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
 				tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
-					e.BlockChains.EVMChains()[selector].DeployerKey,
-					e.BlockChains.EVMChains()[selector].Client,
+					chain.DeployerKey,
+					chain.Client,
 					string(TestTokenSymbol),
 					string(TestTokenSymbol),
 					LocalTokenDecimals,
@@ -116,16 +116,13 @@ func SetupTwoChainEnvironmentWithTokens(
 	}
 
 	// Deploy MCMS setup & prerequisite contracts
-	e, err := commoncs.Apply(t, e, commoncs.Configure(
-		cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
-		changeset.DeployPrerequisiteConfig{Configs: prereqCfg},
-	), commoncs.Configure(
-		cldf.CreateLegacyChangeSet(commoncs.DeployMCMSWithTimelockV2),
-		mcmsCfg,
-	))
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset), changeset.DeployPrerequisiteConfig{Configs: prereqCfg}),
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commoncs.DeployMCMSWithTimelockV2), mcmsCfg),
+	)
 	require.NoError(t, err)
 
-	state, err := stateview.LoadOnchainState(e)
+	state, err := stateview.LoadOnchainState(rt.Environment())
 	require.NoError(t, err)
 
 	// We only need the token admin registry to be owned by the timelock in these tests
@@ -136,25 +133,23 @@ func SetupTwoChainEnvironmentWithTokens(
 
 	if transferToTimelock {
 		// Transfer ownership of token admin registry to the Timelock
-		e, err = commoncs.Apply(t, e,
-			commoncs.Configure(
-				cldf.CreateLegacyChangeSet(commoncs.TransferToMCMSWithTimelockV2),
-				commoncs.TransferToMCMSWithTimelockConfig{
-					ContractsByChain: timelockOwnedContractsByChain,
-					MCMSConfig: proposalutils.TimelockConfig{
-						MinDelay: 0 * time.Second,
-					},
+		err = rt.Exec(
+			runtime.ChangesetTask(cldf.CreateLegacyChangeSet(commoncs.TransferToMCMSWithTimelockV2), commoncs.TransferToMCMSWithTimelockConfig{
+				ContractsByChain: timelockOwnedContractsByChain,
+				MCMSConfig: proposalutils.TimelockConfig{
+					MinDelay: 0 * time.Second,
 				},
-			),
+			}),
+			runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{proposalutils.TestXXXMCMSSigner}),
 		)
 		require.NoError(t, err)
 	}
 
-	return e, selectors[0], selectors[1], tokens
+	return rt.Environment(), selectors[0], selectors[1], tokens
 }
 
 // getPoolsOwnedByDeployer returns any pools that need to be transferred to timelock.
-func getPoolsOwnedByDeployer[T commonchangeset.Ownable](t *testing.T, contracts map[semver.Version]T, chain cldf_evm.Chain) []common.Address {
+func getPoolsOwnedByDeployer[T commoncs.Ownable](t *testing.T, contracts map[semver.Version]T, chain cldf_evm.Chain) []common.Address {
 	var addresses []common.Address
 	for _, contract := range contracts {
 		owner, err := contract.Owner(nil)
@@ -175,7 +170,7 @@ func DeployTestTokenPools(
 ) cldf.Environment {
 	selectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 
-	e, err := commonchangeset.Apply(t, e,
+	e, err := commoncs.Apply(t, e,
 		commoncs.Configure(
 			cldf.CreateLegacyChangeSet(v1_5_1.DeployTokenPoolContractsChangeset),
 			v1_5_1.DeployTokenPoolContractsConfig{


### PR DESCRIPTION
This commit updates the more CCIP tests to use the CLDF test engine. This focuses on updates to simple tests which do not require a node to be running.
