### PR TITLE
feat(request): improves logging on mismatched payloads

### DIFF
--- a/.changeset/ten-clowns-marry.md
+++ b/.changeset/ten-clowns-marry.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal logs errors on mismatched payloads for same response ID

--- a/core/capabilities/remote/executable/request/client_request.go
+++ b/core/capabilities/remote/executable/request/client_request.go
@@ -43,6 +43,7 @@ type ClientRequest struct {
 	totalErrorCount   int
 	responseReceived  map[p2ptypes.PeerID]bool
 	lggr              logger.Logger
+	comparator        *payloadComparator
 
 	requiredIdenticalResponses int
 	remoteNodeCount            int
@@ -195,6 +196,7 @@ func newClientRequest(ctx context.Context, lggr logger.Logger, requestID string,
 		errorCount:                 make(map[string]int),
 		responseReceived:           responseReceived,
 		responseCh:                 make(chan clientResponse, 1),
+		comparator:                 NewPayloadComparator(logger.Named(lggr, "PayloadComparator")),
 		wg:                         &wg,
 		lggr:                       lggr,
 	}, nil
@@ -302,7 +304,7 @@ func (c *ClientRequest) OnMessage(_ context.Context, msg *types.MessageBody) err
 		// metering values are extracted from the CapabilityResponse, added to an array, and the CapabilityResponse
 		// is marshalled without the metering value to get the hash. each node could have a different metering value
 		// which would result in different hashes. removing the metering detail allows for direct comparison of results.
-		responseID, metadata, err := c.getMessageHashAndMetadata(msg)
+		responseID, metadata, err := GetMessageHashAndMetadata(c.lggr, msg)
 		if err != nil {
 			return fmt.Errorf("failed to get message hash: %w", err)
 		}
@@ -326,8 +328,16 @@ func (c *ClientRequest) OnMessage(_ context.Context, msg *types.MessageBody) err
 		c.responseIDCount[responseID]++
 		c.meteringResponses[responseID] = nodeReports
 
+		c.comparator.Compare(msg)
+
 		if len(c.responseIDCount) > 1 {
 			lggr.Warnw("received multiple unique responses for the same request", "count for responseID", len(c.responseIDCount))
+
+			uniqueIDs := make([]string, 0, len(c.responseIDCount))
+			for hash, count := range c.responseIDCount {
+				uniqueIDs = append(uniqueIDs, fmt.Sprintf("%s (count: %d)", hex.EncodeToString(hash[:]), count))
+			}
+			lggr.Errorw("Response disagreement detected", "uniqueResponseIDs", uniqueIDs)
 		}
 
 		if c.responseIDCount[responseID] == c.requiredIdenticalResponses {
@@ -367,7 +377,18 @@ func (c *ClientRequest) sendResponse(response clientResponse) {
 	c.lggr.Debugw("received OK response")
 }
 
-func (c *ClientRequest) getMessageHashAndMetadata(msg *types.MessageBody) ([32]byte, commoncap.ResponseMetadata, error) {
+func (c *ClientRequest) encodePayloadWithMetadata(msg *types.MessageBody, metadata commoncap.ResponseMetadata) ([]byte, error) {
+	resp, err := pb.UnmarshalCapabilityResponse(msg.Payload)
+	if err != nil {
+		return nil, err
+	}
+
+	resp.Metadata = metadata
+
+	return pb.MarshalCapabilityResponse(resp)
+}
+
+func GetMessageHashAndMetadata(lggr logger.Logger, msg *types.MessageBody) ([32]byte, commoncap.ResponseMetadata, error) {
 	var metadata commoncap.ResponseMetadata
 
 	resp, err := pb.UnmarshalCapabilityResponse(msg.Payload)
@@ -384,15 +405,4 @@ func (c *ClientRequest) getMessageHashAndMetadata(msg *types.MessageBody) ([32]b
 	}
 
 	return sha256.Sum256(payload), metadata, nil
-}
-
-func (c *ClientRequest) encodePayloadWithMetadata(msg *types.MessageBody, metadata commoncap.ResponseMetadata) ([]byte, error) {
-	resp, err := pb.UnmarshalCapabilityResponse(msg.Payload)
-	if err != nil {
-		return nil, err
-	}
-
-	resp.Metadata = metadata
-
-	return pb.MarshalCapabilityResponse(resp)
 }

--- a/core/capabilities/remote/executable/request/client_request_test.go
+++ b/core/capabilities/remote/executable/request/client_request_test.go
@@ -703,38 +703,6 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 	})
 }
 
-func TestPayloadComparator_DivergenceLogging(t *testing.T) {
-	lggr, obs := logger.TestObserved(t, zapcore.DebugLevel)
-	comparator := request.NewPayloadComparator(lggr)
-
-	md := commoncap.ResponseMetadata{
-		CapDON_N: 10,
-	}
-	msgA := createMessageBody(t, 0x41, 5, md) // Content byte at index 5 is 'A' (0x41)
-	msgB := createMessageBody(t, 0x42, 5, md) // Content byte at index 5 is 'B' (0x42)
-
-	comparator.Compare(msgA)
-	assert.Equal(t,
-		obs.FilterMessage("Comparator stored first unique response payload.").Len(),
-		1,
-	)
-
-	comparator.Compare(msgB)
-
-	assert.Equal(t,
-		obs.FilterMessage("Divergent response hash detected. Running detailed payload comparison.").Len(),
-		1,
-		"Did not log the start of divergence check.",
-	)
-
-	filtered := obs.FilterFieldKey("byte_diff_report")
-	assert.Equal(t,
-		filtered.Len(),
-		1,
-		"Did not log the byte difference report.",
-	)
-}
-
 func TestGetMessageHashAndMetadata_IgnoresMetadataDiff(t *testing.T) {
 	lggr := logger.Test(t)
 

--- a/core/capabilities/remote/executable/request/client_request_test.go
+++ b/core/capabilities/remote/executable/request/client_request_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/smartcontractkit/chainlink-protos/workflows/go/events"
 
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/executable/request"
@@ -699,6 +701,111 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 			assert.Equal(t, delays[i-1]+1000, delays[i], "delays should increment by 1000ms")
 		}
 	})
+}
+
+func TestPayloadComparator_DivergenceLogging(t *testing.T) {
+	lggr, obs := logger.TestObserved(t, zapcore.DebugLevel)
+	comparator := request.NewPayloadComparator(lggr)
+
+	md := commoncap.ResponseMetadata{
+		CapDON_N: 10,
+	}
+	msgA := createMessageBody(t, 0x41, 5, md) // Content byte at index 5 is 'A' (0x41)
+	msgB := createMessageBody(t, 0x42, 5, md) // Content byte at index 5 is 'B' (0x42)
+
+	comparator.Compare(msgA)
+	assert.Equal(t,
+		obs.FilterMessage("Comparator stored first unique response payload.").Len(),
+		1,
+	)
+
+	comparator.Compare(msgB)
+
+	assert.Equal(t,
+		obs.FilterMessage("Divergent response hash detected. Running detailed payload comparison.").Len(),
+		1,
+		"Did not log the start of divergence check.",
+	)
+
+	filtered := obs.FilterFieldKey("byte_diff_report")
+	assert.Equal(t,
+		filtered.Len(),
+		1,
+		"Did not log the byte difference report.",
+	)
+}
+
+func TestGetMessageHashAndMetadata_IgnoresMetadataDiff(t *testing.T) {
+	lggr := logger.Test(t)
+
+	// Create two messages with identical core payload but different metadata
+	msg1 := createMessageBody(t, 0x41, 5, commoncap.ResponseMetadata{
+		CapDON_N: 10,
+	})
+	msg2 := createMessageBody(t, 0x41, 5, commoncap.ResponseMetadata{
+		CapDON_N: 10,
+		Metering: []commoncap.MeteringNodeDetail{
+			{
+				SpendUnit: "foo",
+			},
+		},
+	})
+
+	hash1, _, err1 := request.GetMessageHashAndMetadata(lggr, msg1)
+	require.NoError(t, err1, "getMessageHashAndMetadata should not return an error for msg1")
+
+	hash2, _, err2 := request.GetMessageHashAndMetadata(lggr, msg2)
+	require.NoError(t, err2, "getMessageHashAndMetadata should not return an error for msg2")
+
+	assert.Equal(t, hash1, hash2, "Hashes must be identical when only ResponseMetadata differs, proving metadata was successfully stripped before hashing.")
+}
+
+// Verify that modifying the underlying value of anypb payload can identify
+// differences at a known index.
+func Test_createAnyPayload(t *testing.T) {
+	content := []byte("this is a test payload content.")
+	payloadA := createAnyPayload(t, content, 0x41, 5)
+	payloadB := createAnyPayload(t, content, 0x42, 5)
+	rawA, rawB := payloadA.GetValue(), payloadB.GetValue()
+
+	diffIndex := -1
+	for i := 0; i < len(rawA) && i < len(rawB); i++ {
+		if rawA[i] != rawB[i] {
+			diffIndex = i
+			break
+		}
+	}
+	require.Equal(t, 5, diffIndex, "The two inner payloads must differ for this test to be valid.")
+}
+
+func createAnyPayload(t *testing.T, payloadData []byte, uniqueByte byte, uniqueIndex int) *anypb.Any {
+	payloadData[uniqueIndex] = uniqueByte
+	innerPayload := wrapperspb.BytesValue{Value: payloadData}
+	anyPayload, err := anypb.New(&innerPayload)
+	require.NoError(t, err)
+	return anyPayload
+}
+
+func createMessageBody(t *testing.T, uniqueByte byte, uniqueIndex int, md commoncap.ResponseMetadata) *types.MessageBody {
+	anyPayload := createAnyPayload(t, []byte("this is a test message"), uniqueByte, uniqueIndex)
+
+	// Create the CapabilityResponse wrapper
+	capResp := commoncap.CapabilityResponse{
+		Payload: anyPayload,
+		Metadata: commoncap.ResponseMetadata{
+			CapDON_N: md.CapDON_N,
+			Metering: md.Metering,
+		},
+	}
+
+	marshaledCapResp, err := pb.MarshalCapabilityResponse(capResp)
+	require.NoError(t, err)
+
+	return &types.MessageBody{
+		MessageId:    []byte("test-request-1"),
+		Payload:      marshaledCapResp,
+		CapabilityId: "test-cap",
+	}
 }
 
 func capabilityDon(t *testing.T, numCapabilityPeers int, f uint8) ([]p2ptypes.PeerID, commoncap.DON, commoncap.CapabilityInfo) {

--- a/core/capabilities/remote/executable/request/payload_comparator.go
+++ b/core/capabilities/remote/executable/request/payload_comparator.go
@@ -1,0 +1,155 @@
+package request
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"sync/atomic"
+
+	"google.golang.org/protobuf/proto"
+
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+)
+
+type ComparatorState struct {
+	Message    *types.MessageBody
+	Metadata   commoncap.ResponseMetadata
+	Hash       [32]byte
+	ResponseID string // The hex-encoded hash string
+}
+
+// payloadComparator handles logging and comparing divergent payloads.
+type payloadComparator struct {
+	lggr       logger.Logger
+	firstState atomic.Pointer[ComparatorState]
+}
+
+// NewPayloadComparator creates and initializes a new comparator.
+func NewPayloadComparator(lggr logger.Logger) *payloadComparator {
+	return &payloadComparator{
+		lggr: lggr,
+	}
+}
+
+// Compare accepts an incoming message, stores the first unique instance, and logs
+// differences against subsequent unique messages.
+func (pc *payloadComparator) Compare(incomingMsg *types.MessageBody) {
+	incomingHash, md, err := GetMessageHashAndMetadata(pc.lggr, incomingMsg)
+	if err != nil {
+		pc.lggr.Errorw("failed to get message data and hash", "error", err)
+		return
+	}
+
+	if pc.firstState.Load() == nil {
+		newState := &ComparatorState{
+			Message:    incomingMsg,
+			Metadata:   md,
+			Hash:       incomingHash,
+			ResponseID: hex.EncodeToString(incomingHash[:]),
+		}
+
+		if !pc.firstState.CompareAndSwap(nil, newState) {
+			pc.lggr.Error("failed to load first state in comparator")
+			return
+		} else {
+			pc.lggr.Debugw("Comparator stored first unique response payload.",
+				"responseID", newState.ResponseID,
+				"metadata", newState.Metadata,
+			)
+		}
+	}
+
+	existingState := pc.firstState.Load()
+	if bytes.Equal(existingState.Hash[:], incomingHash[:]) {
+		return
+	}
+
+	pc.lggr.Warnw("Divergent response hash detected. Running detailed payload comparison.",
+		"firstResponseID", existingState.ResponseID,
+		"firstMetadata", existingState.Metadata,
+		"incomingResponseID", hex.EncodeToString(incomingHash[:]),
+		"incomingMetadata", md,
+	)
+
+	incomingResp, err := pb.UnmarshalCapabilityResponse(incomingMsg.Payload)
+	if err != nil {
+		pc.lggr.Warnw("failed to unmarshal incoming message", err)
+		return
+	}
+
+	expectedResp, err := pb.UnmarshalCapabilityResponse(existingState.Message.Payload)
+	if err != nil {
+		pc.lggr.Warnw("failed to unmarshal first message", err)
+		return
+	}
+
+	logAnyPayloadByteDiffs(pc.lggr, incomingResp, expectedResp, incomingHash, existingState.Hash)
+}
+
+func logAnyPayloadByteDiffs(lggr logger.Logger, respA, respB commoncap.CapabilityResponse, hashA, hashB [32]byte) {
+	if (respA.Payload == nil) != (respB.Payload == nil) {
+		lggr.Errorw("Payload divergence: One response has a Payload and the other doesn't",
+			"hashA_has_payload", respA.Payload != nil,
+			"hashB_has_payload", respB.Payload != nil,
+		)
+		return
+	}
+	if respA.Payload == nil && respB.Payload == nil {
+		return
+	}
+
+	if proto.Equal(respA.Payload, respB.Payload) {
+		return
+	}
+
+	valA := respA.Payload.GetValue()
+	valB := respB.Payload.GetValue()
+
+	lenA := len(valA)
+	lenB := len(valB)
+	minLen := lenA
+	if lenB < minLen {
+		minLen = lenB
+	}
+
+	var logBuffer bytes.Buffer
+
+	// Header for the report
+	logBuffer.WriteString(
+		fmt.Sprintf(
+			"\n--- Payload Byte Difference Report (Type: %s vs %s) ---\n",
+			respA.Payload.GetTypeUrl(), respB.Payload.GetTypeUrl(),
+		),
+	)
+	logBuffer.WriteString(fmt.Sprintf("Raw Byte Lengths: HashA=%d, HashB=%d\n", lenA, lenB))
+	diffsFound := 0
+
+	// Compare byte by byte up to the minimum length
+	for i := 0; i < minLen; i++ {
+		if valA[i] != valB[i] {
+			// Log the index and the hexadecimal value of the differing bytes
+			logBuffer.WriteString(fmt.Sprintf("Index %d: HashA=0x%x, HashB=0x%x\n", i, valA[i], valB[i]))
+			diffsFound++
+		}
+	}
+
+	// Report differences in length, if any
+	if lenA != lenB {
+		diffLen := map[bool]int{true: lenA - lenB, false: lenB - lenA}[lenA != minLen]
+		source := map[bool]string{true: "A", false: "B"}[lenA > lenB]
+		logBuffer.WriteString(fmt.Sprintf("Payloads differ in length. Remaining bytes in Hash%s: %d\n", source, diffLen))
+	}
+
+	// Footer
+	logBuffer.WriteString(fmt.Sprintf("Total Byte Differences Found: %d\n", diffsFound))
+
+	lggr.Errorw("Divergence detected in *anypb.Any Payload content.",
+		"hashA", hex.EncodeToString(hashA[:]),
+		"hashB", hex.EncodeToString(hashB[:]),
+		"byte_diff_report", logBuffer.String(),
+	)
+}

--- a/core/capabilities/remote/executable/request/payload_comparator.go
+++ b/core/capabilities/remote/executable/request/payload_comparator.go
@@ -3,10 +3,7 @@ package request
 import (
 	"bytes"
 	"encoding/hex"
-	"fmt"
 	"sync/atomic"
-
-	"google.golang.org/protobuf/proto"
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
@@ -55,12 +52,12 @@ func (pc *payloadComparator) Compare(incomingMsg *types.MessageBody) {
 		if !pc.firstState.CompareAndSwap(nil, newState) {
 			pc.lggr.Error("failed to load first state in comparator")
 			return
-		} else {
-			pc.lggr.Debugw("Comparator stored first unique response payload.",
-				"responseID", newState.ResponseID,
-				"metadata", newState.Metadata,
-			)
 		}
+
+		pc.lggr.Debugw("Comparator stored first unique response payload.",
+			"responseID", newState.ResponseID,
+			"metadata", newState.Metadata,
+		)
 	}
 
 	existingState := pc.firstState.Load()
@@ -68,88 +65,26 @@ func (pc *payloadComparator) Compare(incomingMsg *types.MessageBody) {
 		return
 	}
 
-	pc.lggr.Warnw("Divergent response hash detected. Running detailed payload comparison.",
-		"firstResponseID", existingState.ResponseID,
-		"firstMetadata", existingState.Metadata,
-		"incomingResponseID", hex.EncodeToString(incomingHash[:]),
-		"incomingMetadata", md,
-	)
-
 	incomingResp, err := pb.UnmarshalCapabilityResponse(incomingMsg.Payload)
 	if err != nil {
-		pc.lggr.Warnw("failed to unmarshal incoming message", err)
+		pc.lggr.Warnf("failed to unmarshal incoming message: %s", err)
 		return
 	}
 
 	expectedResp, err := pb.UnmarshalCapabilityResponse(existingState.Message.Payload)
 	if err != nil {
-		pc.lggr.Warnw("failed to unmarshal first message", err)
+		pc.lggr.Warnf("failed to unmarshal first message: %s", err)
 		return
 	}
 
-	logAnyPayloadByteDiffs(pc.lggr, incomingResp, expectedResp, incomingHash, existingState.Hash)
-}
-
-func logAnyPayloadByteDiffs(lggr logger.Logger, respA, respB commoncap.CapabilityResponse, hashA, hashB [32]byte) {
-	if (respA.Payload == nil) != (respB.Payload == nil) {
-		lggr.Errorw("Payload divergence: One response has a Payload and the other doesn't",
-			"hashA_has_payload", respA.Payload != nil,
-			"hashB_has_payload", respB.Payload != nil,
-		)
-		return
-	}
-	if respA.Payload == nil && respB.Payload == nil {
-		return
-	}
-
-	if proto.Equal(respA.Payload, respB.Payload) {
-		return
-	}
-
-	valA := respA.Payload.GetValue()
-	valB := respB.Payload.GetValue()
-
-	lenA := len(valA)
-	lenB := len(valB)
-	minLen := lenA
-	if lenB < minLen {
-		minLen = lenB
-	}
-
-	var logBuffer bytes.Buffer
-
-	// Header for the report
-	logBuffer.WriteString(
-		fmt.Sprintf(
-			"\n--- Payload Byte Difference Report (Type: %s vs %s) ---\n",
-			respA.Payload.GetTypeUrl(), respB.Payload.GetTypeUrl(),
-		),
-	)
-	logBuffer.WriteString(fmt.Sprintf("Raw Byte Lengths: HashA=%d, HashB=%d\n", lenA, lenB))
-	diffsFound := 0
-
-	// Compare byte by byte up to the minimum length
-	for i := 0; i < minLen; i++ {
-		if valA[i] != valB[i] {
-			// Log the index and the hexadecimal value of the differing bytes
-			logBuffer.WriteString(fmt.Sprintf("Index %d: HashA=0x%x, HashB=0x%x\n", i, valA[i], valB[i]))
-			diffsFound++
-		}
-	}
-
-	// Report differences in length, if any
-	if lenA != lenB {
-		diffLen := map[bool]int{true: lenA - lenB, false: lenB - lenA}[lenA != minLen]
-		source := map[bool]string{true: "A", false: "B"}[lenA > lenB]
-		logBuffer.WriteString(fmt.Sprintf("Payloads differ in length. Remaining bytes in Hash%s: %d\n", source, diffLen))
-	}
-
-	// Footer
-	logBuffer.WriteString(fmt.Sprintf("Total Byte Differences Found: %d\n", diffsFound))
-
-	lggr.Errorw("Divergence detected in *anypb.Any Payload content.",
-		"hashA", hex.EncodeToString(hashA[:]),
-		"hashB", hex.EncodeToString(hashB[:]),
-		"byte_diff_report", logBuffer.String(),
+	pc.lggr.Warnw("Divergent response hash detected",
+		"expectedResponseID", existingState.ResponseID,
+		"expectedMetadata", existingState.Metadata,
+		"expectedPayload", existingState.Message.Payload,
+		"expectedResp", expectedResp,
+		"incomingResponseID", hex.EncodeToString(incomingHash[:]),
+		"incomingMetadata", md,
+		"incomingPayload", incomingMsg.Payload,
+		"incomingResp", incomingResp,
 	)
 }


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

Adds byte by byte comparison in the event that there are mismatched response payloads received in the capability executable client.
Adds additional unmarshalling, but only in the case that we get mismatched responses.  That's a failure state and we can pay the time cost because the execution will most likely fail.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
