### PR TITLE
[CRE-1250] use CTF way of injecting images in CI

### DIFF
--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -138,10 +138,8 @@ jobs:
         working-directory: core/scripts/cre/environment
         env:
           CTF_CONFIGS: "./configs/workflow-don.toml,./configs/ci-override.toml"
-          E2E_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor"
-          E2E_JD_VERSION: "0.22.1"
-          E2E_TEST_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink"
-          E2E_TEST_CHAINLINK_VERSION: ${{ github.event_name == 'pull_request' && format('nightly-{0}-plugins', steps.set-date.outputs.date) || inputs.chainlink_image_tag }}
+          CTF_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.22.1"
+          CTF_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink:${{ github.event_name == 'pull_request' && format('nightly-{0}-plugins', steps.set-date.outputs.date) || inputs.chainlink_image_tag }}"
           DISABLE_DX_TRACKING: "true"
           CI: "true"
         run: |

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -123,21 +123,12 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
-      - name: Overwrite chainlink version in TOML config
-        shell: bash
-        run: |
-          cat > core/scripts/cre/environment/configs/ci-override.toml<< EOF
-          [jd]
-            csa_encryption_key = "d1093c0060d50a3c89c189b2e485da5a3ce57f3dcb38ab7e2c0d5f0bb2314a44"
-            image = "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.22.1"
-          EOF
-
       - name: Start the environment
         id: start-cli
         shell: bash
         working-directory: core/scripts/cre/environment
         env:
-          CTF_CONFIGS: "./configs/workflow-don.toml,./configs/ci-override.toml"
+          CTF_CONFIGS: "./configs/workflow-don.toml"
           CTF_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.22.1"
           CTF_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink:${{ github.event_name == 'pull_request' && format('nightly-{0}-plugins', steps.set-date.outputs.date) || inputs.chainlink_image_tag }}"
           DISABLE_DX_TRACKING: "true"

--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -151,10 +151,8 @@ jobs:
         shell: bash
         id: start-local-cre
         env:
-          E2E_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor"
-          E2E_JD_VERSION: "0.22.1"
-          E2E_TEST_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name }}"
-          E2E_TEST_CHAINLINK_VERSION: ${{ inputs.chainlink_image_tag != '' && inputs.chainlink_image_tag || inputs.chainlink_version }}
+          CTF_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.22.1"
+          CTF_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name }}:${{ inputs.chainlink_image_tag != '' && inputs.chainlink_image_tag || inputs.chainlink_version }}"
           CTF_CONFIGS: configs/workflow-gateway-capabilities-don.toml
           CRE_VERSION: ${{ matrix.tests.cre_version }}
           TEST_NAME: ${{ matrix.tests.test_name }}
@@ -164,10 +162,10 @@ jobs:
           # Start CRE with the appropriate contracts version (i.e. Workflow/CapabilityRegistry)
           if [[ "${CRE_VERSION}" == "v1" ]]; then
             echo "Starting CRE with v1 contracts for test: '${TEST_NAME}' and configs: '${CTF_CONFIGS}'"
-            go run . env start --with-plugins-docker-image "${E2E_TEST_CHAINLINK_IMAGE}:${E2E_TEST_CHAINLINK_VERSION}"
+            go run . env start --with-plugins-docker-image "${CTF_CHAINLINK_IMAGE}"
           else
             echo "Starting CRE with v2 contracts for test: '${TEST_NAME}' and configs: '${CTF_CONFIGS}'"
-            go run . env start --with-plugins-docker-image "${E2E_TEST_CHAINLINK_IMAGE}:${E2E_TEST_CHAINLINK_VERSION}" --with-contracts-version v2
+            go run . env start --with-plugins-docker-image "${CTF_CHAINLINK_IMAGE}" --with-contracts-version v2
           fi
 
           exit_code=$?

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -196,10 +196,8 @@ jobs:
         shell: bash
         id: start-local-cre
         env:
-          E2E_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor"
-          E2E_JD_VERSION: "0.22.1"
-          E2E_TEST_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name }}"
-          E2E_TEST_CHAINLINK_VERSION: ${{ inputs.chainlink_image_tag != '' && inputs.chainlink_image_tag || inputs.chainlink_version }}
+          CTF_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.22.1"
+          CTF_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name }}:${{ inputs.chainlink_image_tag != '' && inputs.chainlink_image_tag || inputs.chainlink_version }}"
           CTF_CONFIGS: ${{ matrix.tests.configs }}
           CRE_VERSION: ${{ matrix.tests.cre_version }}
           TEST_NAME: ${{ matrix.tests.test_name }}
@@ -210,10 +208,10 @@ jobs:
           # Do not remove Docker containers on error to allow log collection
           if [[ "${CRE_VERSION}" == "v1" ]]; then
             echo "Starting CRE with v1 contracts for test: '${TEST_NAME}'"
-            go run . env start --with-plugins-docker-image "${E2E_TEST_CHAINLINK_IMAGE}:${E2E_TEST_CHAINLINK_VERSION}" --cleanup-on-error=false
+            go run . env start --with-plugins-docker-image "${CTF_CHAINLINK_IMAGE}" --cleanup-on-error=false
           else
             echo "Starting CRE with v2 contracts for test: '${TEST_NAME}'"
-            go run . env start --with-plugins-docker-image "${E2E_TEST_CHAINLINK_IMAGE}:${E2E_TEST_CHAINLINK_VERSION}" --with-contracts-version v2 --cleanup-on-error=false
+            go run . env start --with-plugins-docker-image "${CTF_CHAINLINK_IMAGE}" --with-contracts-version v2 --cleanup-on-error=false
           fi
 
           exit_code=$?

--- a/.github/workflows/cre-workflow-don-benchmark.yaml
+++ b/.github/workflows/cre-workflow-don-benchmark.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Set date variable
         id: set-date
-        if:  ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' }}
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
       - name: Build Image
@@ -76,7 +76,7 @@ jobs:
           image-tag: ${{ format('PR-{0}-{1}',github.event.pull_request.number, github.sha ) }}
           dockerfile: core/chainlink.Dockerfile
           docker-registry-url: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com
-          docker-repository-name: 'chainlink'
+          docker-repository-name: "chainlink"
           docker-additional-build-args: |
             CL_INSTALL_PRIVATE_PLUGINS=true
             CL_INSTALL_TESTING_PLUGINS=true
@@ -129,10 +129,8 @@ jobs:
       - name: Start the test
         shell: bash
         env:
-          E2E_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor"
-          E2E_JD_VERSION: "0.9.0"
-          E2E_TEST_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink"
-          E2E_TEST_CHAINLINK_VERSION: ${{ github.event_name == 'pull_request' && format('PR-{0}-{1}',github.event.pull_request.number, github.sha ) || inputs.chainlink_image_tag }}
+          CTF_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.22.1"
+          CTF_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink:${{ github.event_name == 'pull_request' && format('PR-{0}-{1}',github.event.pull_request.number, github.sha ) || inputs.chainlink_image_tag }}"
           # Anvil developer key, not a secret
           PRIVATE_KEY: "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
           CTF_CONFIGS: "workflow-don-benchmark-ci.toml"
@@ -150,16 +148,16 @@ jobs:
         id: parse-regressions
         run: |
           cd system-tests/tests/load/cre
-          
+
           # Count the number of regressions - handle exit code properly
           if grep -c "PERFORMANCE REGRESSION:" test_output.log > /tmp/count.txt; then
             regression_count=$(cat /tmp/count.txt)
           else
             regression_count=0
           fi
-          
+
           echo "regression_count=${regression_count}" >> $GITHUB_OUTPUT
-          
+
           if [ $regression_count -gt 0 ]; then
             echo "::warning::$regression_count performance regressions detected"
             echo "See the regression_reports artifact for details"
@@ -199,7 +197,7 @@ jobs:
 
           # Read regression details
           REGRESSION_DETAILS=$(cat logs/regression_details.txt)
-          
+
           # Create JSON payload with properly escaped details
           cat > $GITHUB_WORKSPACE/slack_payload.json << EOF
           {

--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -882,7 +882,7 @@ func ensureDockerIsRunning(ctx context.Context) error {
 }
 
 func ensureDockerImagesExist(ctx context.Context, logger zerolog.Logger, in *envconfig.Config, withPluginsDockerImageFlag string) error {
-	// skip this check in CI, as we inject images at runtime and this check would fail
+	// Skip checks in CI environment
 	if os.Getenv("CI") == "true" {
 		return nil
 	}

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251021010742-3f8d3dba17d8
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
-	github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.6
+	github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.17
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251021010742-3f8d3dba17d8
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
-	github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c
+	github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.8
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.17
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1662,8 +1662,8 @@ github.com/smartcontractkit/chainlink-sui v0.0.0-20251029234211-ed9dc839af35 h1:
 github.com/smartcontractkit/chainlink-sui v0.0.0-20251029234211-ed9dc839af35/go.mod h1:VlyZhVw+a93Sk8rVHOIH6tpiXrMzuWLZrjs1eTIExW8=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251029234211-ed9dc839af35 h1:WgLgaH/1IMSKi4DYC3VUh4a2EMk4LZn0Ko+XHMGKBy0=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251029234211-ed9dc839af35/go.mod h1:uDAtSOVjQh6/xDf4T5DOgCw6kb02ENkFt4MxjD17NoQ=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c h1:1rv+a7KY2yFRNkSul8vI5uZCiJJ+Im2rIFFsx7tohto=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c/go.mod h1:BTUmWJGbOQtMdDW8cy4fu0wLoj8tKFQiLR7SE+OyTXU=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.8 h1:0d7CVHUsG3Lt4LNIMt7/GQLjzrWMpA+KtUC/9gZFeAQ=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.8/go.mod h1:BTUmWJGbOQtMdDW8cy4fu0wLoj8tKFQiLR7SE+OyTXU=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.17 h1:rOYrH9lx2nXyqtvpuTq50RlW5VtplJFWtXD6cf7uEWc=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.17/go.mod h1:caEHEfBrWnY+zwkUkssL6GN9J47FLL3fEXx8qv3bKbE=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1612,10 +1612,10 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-f
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:Ve1xD71bl193YIZQEoJMmBqLGQJdNs29bwbuObwvbhQ=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5 h1:Z4t2ZY+ZyGWxtcXvPr11y4o3CGqhg3frJB5jXkCSvWA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251030115044-5d80c1c62afd h1:XiCm3HxadUnzWOFokAYIilVPx6lCy78+/pf3JZchYhc=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251030115044-5d80c1c62afd/go.mod h1:al5VNrscTtWnxJaYJN6E3jixY17CvazC4VA6rOpLEHI=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251030115044-5d80c1c62afd h1:XiCm3HxadUnzWOFokAYIilVPx6lCy78+/pf3JZchYhc=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251030115044-5d80c1c62afd/go.mod h1:al5VNrscTtWnxJaYJN6E3jixY17CvazC4VA6rOpLEHI=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
@@ -1662,8 +1662,8 @@ github.com/smartcontractkit/chainlink-sui v0.0.0-20251029234211-ed9dc839af35 h1:
 github.com/smartcontractkit/chainlink-sui v0.0.0-20251029234211-ed9dc839af35/go.mod h1:VlyZhVw+a93Sk8rVHOIH6tpiXrMzuWLZrjs1eTIExW8=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251029234211-ed9dc839af35 h1:WgLgaH/1IMSKi4DYC3VUh4a2EMk4LZn0Ko+XHMGKBy0=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251029234211-ed9dc839af35/go.mod h1:uDAtSOVjQh6/xDf4T5DOgCw6kb02ENkFt4MxjD17NoQ=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.6 h1:vlSXlcmz2OTpsu2GTIle/NpnkxNqbYeblXZfZoCTynY=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.6/go.mod h1:BTUmWJGbOQtMdDW8cy4fu0wLoj8tKFQiLR7SE+OyTXU=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c h1:1rv+a7KY2yFRNkSul8vI5uZCiJJ+Im2rIFFsx7tohto=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c/go.mod h1:BTUmWJGbOQtMdDW8cy4fu0wLoj8tKFQiLR7SE+OyTXU=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.17 h1:rOYrH9lx2nXyqtvpuTq50RlW5VtplJFWtXD6cf7uEWc=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.17/go.mod h1:caEHEfBrWnY+zwkUkssL6GN9J47FLL3fEXx8qv3bKbE=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=

--- a/system-tests/lib/cre/environment/dons.go
+++ b/system-tests/lib/cre/environment/dons.go
@@ -3,7 +3,6 @@ package environment
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	ns "github.com/smartcontractkit/chainlink-testing-framework/framework/components/simple_node_set"
 
-	ctfconfig "github.com/smartcontractkit/chainlink-testing-framework/lib/config"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 	crecapabilities "github.com/smartcontractkit/chainlink/system-tests/lib/cre/capabilities"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/crib"
@@ -120,19 +118,19 @@ func StartDONs(
 
 	// Hack for CI that allows us to dynamically set the chainlink image and version
 	// CTFv2 currently doesn't support dynamic image and version setting
-	if os.Getenv("CI") == "true" {
-		// Due to how we pass custom env vars to reusable workflow we need to use placeholders, so first we need to resolve what's the name of the target environment variable
-		// that stores chainlink version and then we can use it to resolve the image name
-		for i := range nodeSets {
-			image := fmt.Sprintf("%s:%s", os.Getenv(ctfconfig.E2E_TEST_CHAINLINK_IMAGE_ENV), ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_CHAINLINK_VERSION_ENV))
-			for j := range nodeSets[i].NodeSpecs {
-				nodeSets[i].NodeSpecs[j].Node.Image = image
-				// unset docker context and file path, so that we can use the image from the registry
-				nodeSets[i].NodeSpecs[j].Node.DockerContext = ""
-				nodeSets[i].NodeSpecs[j].Node.DockerFilePath = ""
-			}
-		}
-	}
+	// if os.Getenv("CI") == "true" {
+	// 	// Due to how we pass custom env vars to reusable workflow we need to use placeholders, so first we need to resolve what's the name of the target environment variable
+	// 	// that stores chainlink version and then we can use it to resolve the image name
+	// 	for i := range nodeSets {
+	// 		image := fmt.Sprintf("%s:%s", os.Getenv(ctfconfig.E2E_TEST_CHAINLINK_IMAGE_ENV), ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_CHAINLINK_VERSION_ENV))
+	// 		for j := range nodeSets[i].NodeSpecs {
+	// 			nodeSets[i].NodeSpecs[j].Node.Image = image
+	// 			// unset docker context and file path, so that we can use the image from the registry
+	// 			nodeSets[i].NodeSpecs[j].Node.DockerContext = ""
+	// 			nodeSets[i].NodeSpecs[j].Node.DockerFilePath = ""
+	// 		}
+	// 	}
+	// }
 
 	errGroup, _ := errgroup.WithContext(ctx)
 	var resultMap sync.Map

--- a/system-tests/lib/cre/environment/dons.go
+++ b/system-tests/lib/cre/environment/dons.go
@@ -116,22 +116,6 @@ func StartDONs(
 		}
 	}
 
-	// Hack for CI that allows us to dynamically set the chainlink image and version
-	// CTFv2 currently doesn't support dynamic image and version setting
-	// if os.Getenv("CI") == "true" {
-	// 	// Due to how we pass custom env vars to reusable workflow we need to use placeholders, so first we need to resolve what's the name of the target environment variable
-	// 	// that stores chainlink version and then we can use it to resolve the image name
-	// 	for i := range nodeSets {
-	// 		image := fmt.Sprintf("%s:%s", os.Getenv(ctfconfig.E2E_TEST_CHAINLINK_IMAGE_ENV), ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_CHAINLINK_VERSION_ENV))
-	// 		for j := range nodeSets[i].NodeSpecs {
-	// 			nodeSets[i].NodeSpecs[j].Node.Image = image
-	// 			// unset docker context and file path, so that we can use the image from the registry
-	// 			nodeSets[i].NodeSpecs[j].Node.DockerContext = ""
-	// 			nodeSets[i].NodeSpecs[j].Node.DockerFilePath = ""
-	// 		}
-	// 	}
-	// }
-
 	errGroup, _ := errgroup.WithContext(ctx)
 	var resultMap sync.Map
 

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -42,12 +42,6 @@ import (
 	"github.com/smartcontractkit/chainlink/system-tests/lib/worker"
 )
 
-const (
-	GithubReadTokenEnvVarName = "GITHUB_READ_TOKEN"
-	// E2eJobDistributorImageEnvVarName   = "E2E_JD_IMAGE"
-	// E2eJobDistributorVersionEnvVarName = "E2E_JD_VERSION"
-)
-
 type SetupOutput struct {
 	WorkflowRegistryConfigurationOutput *cre.WorkflowRegistryOutput
 	CreEnvironment                      *cre.Environment
@@ -114,7 +108,7 @@ func SetupTestEnvironment(
 		return nil, pkgerrors.New("input is nil")
 	}
 
-	//TODO: remove in December 2025
+	//TODO: remove these checks in December 2025, when everyone has migrated
 	if val := os.Getenv("E2E_JD_IMAGE"); val != "" {
 		return nil, errors.New("E2E_JD_IMAGE and E2E_JD_VERSION are deprecated, please use CTF_JD_IMAGE instead to specify the Job Distributor image with tag")
 	}

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"os"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
@@ -42,9 +43,9 @@ import (
 )
 
 const (
-	GithubReadTokenEnvVarName          = "GITHUB_READ_TOKEN"
-	E2eJobDistributorImageEnvVarName   = "E2E_JD_IMAGE"
-	E2eJobDistributorVersionEnvVarName = "E2E_JD_VERSION"
+	GithubReadTokenEnvVarName = "GITHUB_READ_TOKEN"
+	// E2eJobDistributorImageEnvVarName   = "E2E_JD_IMAGE"
+	// E2eJobDistributorVersionEnvVarName = "E2E_JD_VERSION"
 )
 
 type SetupOutput struct {
@@ -111,6 +112,15 @@ func SetupTestEnvironment(
 ) (*SetupOutput, error) {
 	if input == nil {
 		return nil, pkgerrors.New("input is nil")
+	}
+
+	//TODO: remove in December 2025
+	if val := os.Getenv("E2E_JD_IMAGE"); val != "" {
+		return nil, errors.New("E2E_JD_IMAGE and E2E_JD_VERSION are deprecated, please use CTF_JD_IMAGE instead to specify the Job Distributor image with tag")
+	}
+
+	if val := os.Getenv("E2E_TEST_CHAINLINK_IMAGE"); val != "" {
+		return nil, errors.New("E2E_TEST_CHAINLINK_IMAGE and E2E_TEST_CHAINLINK_VERSION are deprecated, please use CTF_CHAINLINK_IMAGE instead to specify the Chainlink Node image with tag")
 	}
 
 	if err := input.Validate(); err != nil {

--- a/system-tests/lib/cre/environment/jobs.go
+++ b/system-tests/lib/cre/environment/jobs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -16,7 +15,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/jd"
-	ctfconfig "github.com/smartcontractkit/chainlink-testing-framework/lib/config"
 
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/crib"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/infra"
@@ -45,11 +43,11 @@ func StartJD(ctx context.Context, lggr zerolog.Logger, jdInput jd.Input, infraIn
 		}
 	}
 
-	if os.Getenv("CI") == "true" {
-		jdImage := ctfconfig.MustReadEnvVar_String(E2eJobDistributorImageEnvVarName)
-		jdVersion := os.Getenv(E2eJobDistributorVersionEnvVarName)
-		jdInput.Image = fmt.Sprintf("%s:%s", jdImage, jdVersion)
-	}
+	// if os.Getenv("CI") == "true" {
+	// 	jdImage := ctfconfig.MustReadEnvVar_String(E2eJobDistributorImageEnvVarName)
+	// 	jdVersion := os.Getenv(E2eJobDistributorVersionEnvVarName)
+	// 	jdInput.Image = fmt.Sprintf("%s:%s", jdImage, jdVersion)
+	// }
 
 	jdOutput, jdErr := jd.NewWithContext(ctx, &jdInput)
 	if jdErr != nil {

--- a/system-tests/lib/cre/environment/jobs.go
+++ b/system-tests/lib/cre/environment/jobs.go
@@ -43,12 +43,6 @@ func StartJD(ctx context.Context, lggr zerolog.Logger, jdInput jd.Input, infraIn
 		}
 	}
 
-	// if os.Getenv("CI") == "true" {
-	// 	jdImage := ctfconfig.MustReadEnvVar_String(E2eJobDistributorImageEnvVarName)
-	// 	jdVersion := os.Getenv(E2eJobDistributorVersionEnvVarName)
-	// 	jdInput.Image = fmt.Sprintf("%s:%s", jdImage, jdVersion)
-	// }
-
 	jdOutput, jdErr := jd.NewWithContext(ctx, &jdInput)
 	if jdErr != nil {
 		jdErr = fmt.Errorf("failed to start JD container for image %s: %w", jdInput.Image, jdErr)

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251021010742-3f8d3dba17d8
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20251020193713-b63bc17bfeb1
-	github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.6
+	github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251021010742-3f8d3dba17d8
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20251020193713-b63bc17bfeb1
-	github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c
+	github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.8
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1629,6 +1629,8 @@ github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251029234211-ed9dc
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251029234211-ed9dc839af35/go.mod h1:uDAtSOVjQh6/xDf4T5DOgCw6kb02ENkFt4MxjD17NoQ=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c h1:1rv+a7KY2yFRNkSul8vI5uZCiJJ+Im2rIFFsx7tohto=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c/go.mod h1:BTUmWJGbOQtMdDW8cy4fu0wLoj8tKFQiLR7SE+OyTXU=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.8 h1:0d7CVHUsG3Lt4LNIMt7/GQLjzrWMpA+KtUC/9gZFeAQ=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.8/go.mod h1:BTUmWJGbOQtMdDW8cy4fu0wLoj8tKFQiLR7SE+OyTXU=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15 h1:usf6YCNmSO8R1/rU28wUfIdp7zXlqGGOAttXW5mgkXU=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15/go.mod h1:YqrpawYGRkT/jcvXcmaZeZPOtu0erIenrHl5Mb8+U/c=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1627,8 +1627,6 @@ github.com/smartcontractkit/chainlink-sui v0.0.0-20251029234211-ed9dc839af35 h1:
 github.com/smartcontractkit/chainlink-sui v0.0.0-20251029234211-ed9dc839af35/go.mod h1:VlyZhVw+a93Sk8rVHOIH6tpiXrMzuWLZrjs1eTIExW8=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251029234211-ed9dc839af35 h1:WgLgaH/1IMSKi4DYC3VUh4a2EMk4LZn0Ko+XHMGKBy0=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251029234211-ed9dc839af35/go.mod h1:uDAtSOVjQh6/xDf4T5DOgCw6kb02ENkFt4MxjD17NoQ=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c h1:1rv+a7KY2yFRNkSul8vI5uZCiJJ+Im2rIFFsx7tohto=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c/go.mod h1:BTUmWJGbOQtMdDW8cy4fu0wLoj8tKFQiLR7SE+OyTXU=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.8 h1:0d7CVHUsG3Lt4LNIMt7/GQLjzrWMpA+KtUC/9gZFeAQ=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.8/go.mod h1:BTUmWJGbOQtMdDW8cy4fu0wLoj8tKFQiLR7SE+OyTXU=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15 h1:usf6YCNmSO8R1/rU28wUfIdp7zXlqGGOAttXW5mgkXU=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1577,10 +1577,10 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-f
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:Ve1xD71bl193YIZQEoJMmBqLGQJdNs29bwbuObwvbhQ=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5 h1:Z4t2ZY+ZyGWxtcXvPr11y4o3CGqhg3frJB5jXkCSvWA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251030115044-5d80c1c62afd h1:XiCm3HxadUnzWOFokAYIilVPx6lCy78+/pf3JZchYhc=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251030115044-5d80c1c62afd/go.mod h1:al5VNrscTtWnxJaYJN6E3jixY17CvazC4VA6rOpLEHI=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251030115044-5d80c1c62afd h1:XiCm3HxadUnzWOFokAYIilVPx6lCy78+/pf3JZchYhc=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251030115044-5d80c1c62afd/go.mod h1:al5VNrscTtWnxJaYJN6E3jixY17CvazC4VA6rOpLEHI=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
@@ -1627,8 +1627,8 @@ github.com/smartcontractkit/chainlink-sui v0.0.0-20251029234211-ed9dc839af35 h1:
 github.com/smartcontractkit/chainlink-sui v0.0.0-20251029234211-ed9dc839af35/go.mod h1:VlyZhVw+a93Sk8rVHOIH6tpiXrMzuWLZrjs1eTIExW8=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251029234211-ed9dc839af35 h1:WgLgaH/1IMSKi4DYC3VUh4a2EMk4LZn0Ko+XHMGKBy0=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251029234211-ed9dc839af35/go.mod h1:uDAtSOVjQh6/xDf4T5DOgCw6kb02ENkFt4MxjD17NoQ=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.6 h1:vlSXlcmz2OTpsu2GTIle/NpnkxNqbYeblXZfZoCTynY=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.6/go.mod h1:BTUmWJGbOQtMdDW8cy4fu0wLoj8tKFQiLR7SE+OyTXU=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c h1:1rv+a7KY2yFRNkSul8vI5uZCiJJ+Im2rIFFsx7tohto=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c/go.mod h1:BTUmWJGbOQtMdDW8cy4fu0wLoj8tKFQiLR7SE+OyTXU=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15 h1:usf6YCNmSO8R1/rU28wUfIdp7zXlqGGOAttXW5mgkXU=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15/go.mod h1:YqrpawYGRkT/jcvXcmaZeZPOtu0erIenrHl5Mb8+U/c=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20251025021331-aa7746850cc4
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20251020193713-b63bc17bfeb1
-	github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c
+	github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.8
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.7
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20251025021331-aa7746850cc4
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20251020193713-b63bc17bfeb1
-	github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.6
+	github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.7
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1832,8 +1832,8 @@ github.com/smartcontractkit/chainlink-sui v0.0.0-20251029234211-ed9dc839af35 h1:
 github.com/smartcontractkit/chainlink-sui v0.0.0-20251029234211-ed9dc839af35/go.mod h1:VlyZhVw+a93Sk8rVHOIH6tpiXrMzuWLZrjs1eTIExW8=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251029234211-ed9dc839af35 h1:WgLgaH/1IMSKi4DYC3VUh4a2EMk4LZn0Ko+XHMGKBy0=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251029234211-ed9dc839af35/go.mod h1:uDAtSOVjQh6/xDf4T5DOgCw6kb02ENkFt4MxjD17NoQ=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c h1:1rv+a7KY2yFRNkSul8vI5uZCiJJ+Im2rIFFsx7tohto=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c/go.mod h1:BTUmWJGbOQtMdDW8cy4fu0wLoj8tKFQiLR7SE+OyTXU=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.8 h1:0d7CVHUsG3Lt4LNIMt7/GQLjzrWMpA+KtUC/9gZFeAQ=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.8/go.mod h1:BTUmWJGbOQtMdDW8cy4fu0wLoj8tKFQiLR7SE+OyTXU=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15 h1:usf6YCNmSO8R1/rU28wUfIdp7zXlqGGOAttXW5mgkXU=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15/go.mod h1:YqrpawYGRkT/jcvXcmaZeZPOtu0erIenrHl5Mb8+U/c=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1782,10 +1782,10 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-f
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:Ve1xD71bl193YIZQEoJMmBqLGQJdNs29bwbuObwvbhQ=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5 h1:Z4t2ZY+ZyGWxtcXvPr11y4o3CGqhg3frJB5jXkCSvWA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251030115044-5d80c1c62afd h1:XiCm3HxadUnzWOFokAYIilVPx6lCy78+/pf3JZchYhc=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251030115044-5d80c1c62afd/go.mod h1:al5VNrscTtWnxJaYJN6E3jixY17CvazC4VA6rOpLEHI=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251030115044-5d80c1c62afd h1:XiCm3HxadUnzWOFokAYIilVPx6lCy78+/pf3JZchYhc=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251030115044-5d80c1c62afd/go.mod h1:al5VNrscTtWnxJaYJN6E3jixY17CvazC4VA6rOpLEHI=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
@@ -1832,8 +1832,8 @@ github.com/smartcontractkit/chainlink-sui v0.0.0-20251029234211-ed9dc839af35 h1:
 github.com/smartcontractkit/chainlink-sui v0.0.0-20251029234211-ed9dc839af35/go.mod h1:VlyZhVw+a93Sk8rVHOIH6tpiXrMzuWLZrjs1eTIExW8=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251029234211-ed9dc839af35 h1:WgLgaH/1IMSKi4DYC3VUh4a2EMk4LZn0Ko+XHMGKBy0=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20251029234211-ed9dc839af35/go.mod h1:uDAtSOVjQh6/xDf4T5DOgCw6kb02ENkFt4MxjD17NoQ=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.6 h1:vlSXlcmz2OTpsu2GTIle/NpnkxNqbYeblXZfZoCTynY=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.6/go.mod h1:BTUmWJGbOQtMdDW8cy4fu0wLoj8tKFQiLR7SE+OyTXU=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c h1:1rv+a7KY2yFRNkSul8vI5uZCiJJ+Im2rIFFsx7tohto=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7-0.20251103133728-17d15719ed3c/go.mod h1:BTUmWJGbOQtMdDW8cy4fu0wLoj8tKFQiLR7SE+OyTXU=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15 h1:usf6YCNmSO8R1/rU28wUfIdp7zXlqGGOAttXW5mgkXU=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15/go.mod h1:YqrpawYGRkT/jcvXcmaZeZPOtu0erIenrHl5Mb8+U/c=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=

--- a/system-tests/tests/smoke/cre/README.md
+++ b/system-tests/tests/smoke/cre/README.md
@@ -185,9 +185,8 @@ Example `launch.json` entry:
 
 **CI behavior differs**: In CI, workflows and binaries are uploaded ahead of time, and images are injected via:
 
-- `E2E_JD_VERSION`
-- `E2E_TEST_CHAINLINK_IMAGE`
-- `E2E_TEST_CHAINLINK_VERSION`
+- `CTF_JD_IMAGE`
+- `CTF_CHAINLINK_IMAGE`
 
 ---
 


### PR DESCRIPTION
`CTF_CHAINLINK_IMAGE` instead of `E2E_TEST_CHAINLINK_IMAGE: E2E_TEST_CHAINLINK_VERSION`
and
`CTF_JD_IMAGE` instead of `E2E_JD_IMAGE: E2E_JD_VERSION`

plus

no more handling of these env vars on our side, CTF will handle them for us.