### PR TITLE
adding wfExecID to GWER calls to trigger streams cache path

### DIFF
--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -192,6 +192,7 @@ func NewReport(
 			WorkflowOwner:           labels[platform.KeyWorkflowOwner],
 			WorkflowRegistryAddress: report.workflowRegistryAddress,
 			ChainSelector:           report.workflowRegistryChainSelector,
+			WorkflowExecutionId:     labels[platform.KeyWorkflowID], // we return early if this is empty
 		})
 		if err != nil {
 			report.switchToMeteringMode(err)


### PR DESCRIPTION
In https://github.com/smartcontractkit/billing-platform-service/pull/407, we created a streams cache to lock in gas conversion rates for a workflow execution. This triggers the use of that cache by specifying a workflowExecutionID in the GWER call, b/c without it, the streams cache can't know which execution to supply rates for.