### PR TITLE
Bump version to 2.29.2 for CCIP hotfix v2.29.2-ccip-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.29.1",
+  "version": "2.29.2",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Version bump for CCIP hotfix release v2.29.2-ccip-beta.0 (CCIP-7819 fix from PR #20109). Tag v2.29.2-ccip-beta.0 has already been created and pushed.