### PR TITLE
core/services/workflows/v2: fix race for loggerLabels

### DIFF
--- a/core/services/workflows/v2/capability_executor.go
+++ b/core/services/workflows/v2/capability_executor.go
@@ -161,7 +161,8 @@ func (c *ExecutionHelper) callCapability(ctx context.Context, request *sdkpb.Cap
 
 	c.lggr.Debugw("Executing capability ...", "capID", request.Id, "capReqCallbackID", request.CallbackId, "capReqMethod", request.Method)
 	c.metrics.With(platform.KeyCapabilityID, request.Id).IncrementCapabilityInvocationCounter(ctx)
-	_ = events.EmitCapabilityStartedEvent(ctx, c.loggerLabels, c.WorkflowExecutionID, request.Id, meteringRef, request.Method)
+	loggerLabels := *c.loggerLabels.Load()
+	_ = events.EmitCapabilityStartedEvent(ctx, loggerLabels, c.WorkflowExecutionID, request.Id, meteringRef, request.Method)
 
 	execCtx, execCancel, err := c.cfg.LocalLimiters.CapabilityCallTime.WithTimeout(ctx)
 	if err != nil {
@@ -175,14 +176,14 @@ func (c *ExecutionHelper) callCapability(ctx context.Context, request *sdkpb.Cap
 	c.metrics.With(platform.KeyCapabilityID, request.Id).UpdateCapabilityExecutionDurationHistogram(ctx, int64(executionDuration.Seconds()))
 	if err != nil {
 		c.lggr.Debugw("Capability execution failed", "capID", request.Id, "capReqCallbackID", request.CallbackId, "err", err)
-		_ = events.EmitCapabilityFinishedEvent(ctx, c.loggerLabels, c.WorkflowExecutionID, request.Id, meteringRef, store.StatusErrored, request.Method, err)
+		_ = events.EmitCapabilityFinishedEvent(ctx, loggerLabels, c.WorkflowExecutionID, request.Id, meteringRef, store.StatusErrored, request.Method, err)
 		c.metrics.With(platform.KeyCapabilityID, request.Id).IncrementCapabilityFailureCounter(ctx)
 		c.metrics.IncrementTotalWorkflowStepErrorsCounter(ctx)
 		return nil, fmt.Errorf("failed to execute capability: %w", err)
 	}
 
 	c.lggr.Debugw("Capability execution succeeded", "capID", request.Id, "capReqCallbackID", request.CallbackId)
-	_ = events.EmitCapabilityFinishedEvent(ctx, c.loggerLabels, c.WorkflowExecutionID, request.Id, meteringRef, store.StatusCompleted, request.Method, nil)
+	_ = events.EmitCapabilityFinishedEvent(ctx, loggerLabels, c.WorkflowExecutionID, request.Id, meteringRef, store.StatusCompleted, request.Method, nil)
 
 	if meterReport != nil {
 		if err = meterReport.Settle(meteringRef, capResp.Metadata); err != nil {


### PR DESCRIPTION
```
created by sync.(*WaitGroup).Go in goroutine 92654
	/usr/local/go/src/sync/waitgroup.go:239 +0x4a
sync.(*WaitGroup).Go.func1()
	/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251101233406-f909e3fe15e7/pkg/services/service.go:82 +0x4b
github.com/smartcontractkit/chainlink/v2/core/services/workflows/v2.(*Engine).handleAllTriggerEvents.(*Engine).GoCtx.func2()
	/chainlink/core/services/workflows/v2/engine.go:414 +0x86
github.com/smartcontractkit/chainlink/v2/core/services/workflows/v2.(*Engine).handleAllTriggerEvents.func1({0x8247278?, 0xc007a8ae10?})
	/chainlink/core/services/workflows/v2/engine.go:438 +0x269
github.com/smartcontractkit/chainlink/v2/core/services/workflows/v2.(*Engine).startExecution(0xc018890c60, {0x8247278, 0xc007a8ae10}, {{0xc002b1a7e0, 0x2b}, 0x0, {0xc23a699c8f69921e, 0x91eaf39fd113, 0xb8163a0}, {{{0xc004280d50, ...}, ...}, ...}})
	/usr/local/go/src/runtime/panic.go:1046 +0x18
internal/runtime/maps.fatal({0x6fb1b57?, 0xc007a8ae60?})
goroutine 75658153 [running]:

fatal error: concurrent map writes
```