### PR TITLE
add cresettings job

### DIFF
--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -34,12 +34,9 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
-	"github.com/smartcontractkit/chainlink-common/pkg/loop"
-	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
-	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
-	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-
 	clhttp "github.com/smartcontractkit/chainlink-common/pkg/http"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/build"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
@@ -256,11 +253,6 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg chainlink.G
 		MercuryPool:              mercuryPool,
 		RetirementReportCache:    retirement.NewRetirementReportCache(appLggr, ds),
 		LLOTransmissionReaper:    llo.NewTransmissionReaper(ds, appLggr, cfg.Mercury().Transmitter().ReaperFrequency(), cfg.Mercury().Transmitter().ReaperMaxAge()),
-		LimitsFactory: limits.Factory{
-			Meter:    beholder.GetMeter(),
-			Logger:   appLggr.Named("Limits"),
-			Settings: cresettings.DefaultGetter,
-		},
 	})
 }
 

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -37,7 +37,6 @@ import (
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	"github.com/smartcontractkit/chainlink/v2/core/config/env"
 	"github.com/smartcontractkit/chainlink/v2/core/services/llo/retirement"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/metering"
@@ -471,7 +470,6 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 		LLOTransmissionReaper:    llo.NewTransmissionReaper(ds, lggr, cfg.Mercury().Transmitter().ReaperFrequency(), cfg.Mercury().Transmitter().ReaperMaxAge()),
 		EVMFactoryConfigFn:       evmFactoryConfigFn,
 		DonTimeStore:             dontime.NewStore(dontime.DefaultRequestTimeout),
-		LimitsFactory:            limits.Factory{Logger: lggr.Named("Limits")},
 	})
 
 	require.NoError(t, err)

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20251105200616-e158f436aa95
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201
 	github.com/smartcontractkit/chainlink-data-streams v0.1.6
 	github.com/smartcontractkit/chainlink-deployments-framework v0.62.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1613,8 +1613,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424 h1:hBwTReAElITu5uRvPEPy5vac2Kjr9ieByWD5lE9hp5U=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201 h1:qM3GpFTsEK5X45YmYsQBRqBFp7VnFsly9SrYP2F0zLc=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/core/services/cresettings/delegate.go
+++ b/core/services/cresettings/delegate.go
@@ -1,0 +1,63 @@
+// cresettings jobs are used to distribute updates for CRE settings overrides.
+// See: https://pkg.go.dev/github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings
+// Only one Job of type CRESettings may run at a time. Attempts to create a second job will fail.
+package cresettings
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+)
+
+func NewDelegate(lggr logger.Logger, atomicSettings *loop.AtomicSettings) *delegate {
+	return &delegate{lggr: lggr, atomicSettings: atomicSettings}
+}
+
+var _ job.Delegate = (*delegate)(nil)
+
+// delegate manages job.CRESettings jobs.
+// It ensures that only one job is created at a time, and broadcasts changes via loop.AtomicSettings.
+type delegate struct {
+	lggr           logger.Logger
+	atomicSettings *loop.AtomicSettings
+
+	activeJobID atomic.Pointer[int32]
+}
+
+func (d *delegate) JobType() job.Type {
+	return job.CRESettings
+}
+
+func (d *delegate) BeforeJobCreated(j job.Job) {}
+
+func (d *delegate) ServicesForSpec(ctx context.Context, j job.Job) ([]job.ServiceCtx, error) {
+	if activeJobID := d.activeJobID.Load(); activeJobID != nil {
+		return nil, fmt.Errorf("another %s job is already active: %d", job.CRESettings, activeJobID)
+	}
+
+	if err := d.atomicSettings.Store(core.SettingsUpdate{
+		Settings: j.CRESettingsSpec.Settings,
+		Hash:     j.CRESettingsSpec.Hash,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to update settings: %w", err)
+	}
+	d.lggr.Info("Updated settings", "hash", j.CRESettingsSpec.Hash)
+
+	return nil, nil // no active services
+}
+
+func (d *delegate) AfterJobCreated(j job.Job) {}
+
+func (d *delegate) BeforeJobDeleted(j job.Job) {}
+
+func (d *delegate) OnDeleteJob(ctx context.Context, jb job.Job) error {
+	if !d.activeJobID.CompareAndSwap(&jb.ID, nil) {
+		d.lggr.Errorf("job %d was not active", jb.ID)
+	}
+	return nil
+}

--- a/core/services/cresettings/validate.go
+++ b/core/services/cresettings/validate.go
@@ -1,0 +1,55 @@
+package cresettings
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/pelletier/go-toml"
+	"github.com/pkg/errors"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/settings"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+)
+
+func ValidatedCRESettingsSpec(tomlString string) (job.Job, error) {
+	var jb = job.Job{
+		ExternalJobID: uuid.New(), // Default to generating a uuid, can be overwritten by the specified one in tomlString.
+	}
+
+	tree, err := toml.Load(tomlString)
+	if err != nil {
+		return jb, errors.Wrap(err, "toml error on load")
+	}
+
+	err = tree.Unmarshal(&jb)
+	if err != nil {
+		return jb, errors.Wrap(err, "toml unmarshal error on spec")
+	}
+
+	var spec job.CRESettingsSpec
+	err = tree.Unmarshal(&spec)
+	if err != nil {
+		return jb, errors.Wrap(err, "toml unmarshal error on job")
+	}
+
+	jb.CRESettingsSpec = &spec
+	if jb.Type != job.CRESettings {
+		return jb, errors.Errorf("unsupported type %s", jb.Type)
+	}
+
+	_, err = settings.NewTOMLGetter([]byte(jb.CRESettingsSpec.Settings))
+	if err != nil {
+		return jb, errors.Wrap(err, "invalid settings toml")
+	}
+	shaSum := sha256.Sum256([]byte(spec.Settings))
+	hash := hex.EncodeToString(shaSum[:])
+	if spec.Hash == "" {
+		spec.Hash = hash
+	} else if spec.Hash != hash {
+		return jb, fmt.Errorf("invalid sha256 hash %s: calculated %s", spec.Hash, hash)
+	}
+
+	return jb, nil
+}

--- a/core/services/cresettings/validate_test.go
+++ b/core/services/cresettings/validate_test.go
@@ -1,0 +1,70 @@
+package cresettings
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+)
+
+func TestValidatedCRESettingsSpec(t *testing.T) {
+	settingsString := `Foo = "bar"
+`
+	base := fmt.Sprintf(`type = "cresettings"
+externalJobID = "7dcfa33b-8ed9-4e9f-9216-5b4d3f5c7887"
+Settings = '''
+%s'''`, settingsString)
+	tests := []struct {
+		name    string
+		toml    string
+		want    job.Job
+		wantErr string
+	}{
+		{name: "empty", toml: `type = "cresettings"
+externalJobID = "7dcfa33b-8ed9-4e9f-9216-5b4d3f5c7887"`, want: job.Job{
+			ID:            0,
+			ExternalJobID: uuid.MustParse("7dcfa33b-8ed9-4e9f-9216-5b4d3f5c7887"),
+			CRESettingsSpec: &job.CRESettingsSpec{
+				Settings: "",
+				Hash:     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			},
+		}},
+		{name: "hash", toml: base + `
+Hash = "dca1decf4530b4aaa0b6cf8f11ed62f3af75b4ecc4915e4a35292c6918e9160a"
+`, want: job.Job{
+			ID:            0,
+			ExternalJobID: uuid.MustParse("7dcfa33b-8ed9-4e9f-9216-5b4d3f5c7887"),
+			CRESettingsSpec: &job.CRESettingsSpec{
+				Settings: settingsString,
+				Hash:     "dca1decf4530b4aaa0b6cf8f11ed62f3af75b4ecc4915e4a35292c6918e9160a",
+			},
+		}},
+		{name: "no-hash", toml: base, want: job.Job{
+			ID:            0,
+			ExternalJobID: uuid.MustParse("7dcfa33b-8ed9-4e9f-9216-5b4d3f5c7887"),
+			CRESettingsSpec: &job.CRESettingsSpec{
+				Settings: settingsString,
+				Hash:     "dca1decf4530b4aaa0b6cf8f11ed62f3af75b4ecc4915e4a35292c6918e9160a",
+			},
+		}},
+		{name: "wrong-type", toml: `type = "asdf"`, wantErr: "unsupported type"},
+		{name: "wrong-hash", toml: base + `
+Hash = "asdf"`, wantErr: "invalid sha256 hash"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.want.Type = job.CRESettings
+
+			got, err := ValidatedCRESettingsSpec(tt.toml)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -40,6 +40,7 @@ const (
 	BlockHeaderFeeder       Type = (Type)(pipeline.BlockHeaderFeederJobType)
 	BlockhashStore          Type = (Type)(pipeline.BlockhashStoreJobType)
 	Bootstrap               Type = (Type)(pipeline.BootstrapJobType)
+	CRESettings             Type = (Type)(pipeline.CRESettings)
 	Cron                    Type = (Type)(pipeline.CronJobType)
 	CCIP                    Type = (Type)(pipeline.CCIPJobType)
 	DirectRequest           Type = (Type)(pipeline.DirectRequestJobType)
@@ -81,6 +82,7 @@ var (
 		BlockHeaderFeeder:       false,
 		BlockhashStore:          false,
 		Bootstrap:               false,
+		CRESettings:             false,
 		Cron:                    true,
 		CCIP:                    false,
 		DirectRequest:           true,
@@ -101,6 +103,7 @@ var (
 		BlockHeaderFeeder:       false,
 		BlockhashStore:          false,
 		Bootstrap:               false,
+		CRESettings:             false,
 		Cron:                    true,
 		CCIP:                    false,
 		DirectRequest:           true,
@@ -121,6 +124,7 @@ var (
 		BlockHeaderFeeder:       1,
 		BlockhashStore:          1,
 		Bootstrap:               1,
+		CRESettings:             1,
 		Cron:                    1,
 		CCIP:                    1,
 		DirectRequest:           1,
@@ -185,6 +189,8 @@ type Job struct {
 	CCIPSpecID                    *int32
 	CCIPSpec                      *CCIPSpec
 	CCIPBootstrapSpecID           *int32
+	CRESettingsSpecID             *int32
+	CRESettingsSpec               *CRESettingsSpec
 	JobSpecErrors                 []SpecError
 	Type                          Type          `toml:"type"`
 	SchemaVersion                 uint32        `toml:"schemaVersion"`
@@ -1115,4 +1121,13 @@ type CCIPSpec struct {
 	// PluginConfig contains plugin-specific config, like token price pipelines
 	// and RMN network info for offchain blessing.
 	PluginConfig JSONConfig `toml:"pluginConfig"`
+}
+
+type CRESettingsSpec struct {
+	ID        int32
+	CreatedAt time.Time `toml:"-"`
+	UpdatedAt time.Time `toml:"-"`
+
+	Settings string
+	Hash     string
 }

--- a/core/services/job/validate.go
+++ b/core/services/job/validate.go
@@ -15,6 +15,7 @@ var (
 		BlockHeaderFeeder:       {},
 		BlockhashStore:          {},
 		Bootstrap:               {},
+		CRESettings:             {},
 		Cron:                    {},
 		DirectRequest:           {},
 		FluxMonitor:             {},

--- a/core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go
@@ -34,7 +34,6 @@ import (
 	types4 "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
-	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	pb "github.com/smartcontractkit/chainlink-protos/orchestrator/feedsmanager"
@@ -470,7 +469,6 @@ func setupNodeCCIP(
 		UnrestrictedHTTPClient:   &http.Client{},
 		RestrictedHTTPClient:     &http.Client{},
 		AuditLogger:              audit.NoopLogger,
-		LimitsFactory:            limits.Factory{Logger: lggr.Named("Limits")},
 	})
 	require.NoError(t, err)
 	require.NoError(t, app.GetKeyStore().Unlock(ctx, "password"))

--- a/core/services/ocr2/plugins/ccip/testhelpers/testhelpers_1_4_0/chainlink.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/testhelpers_1_4_0/chainlink.go
@@ -34,7 +34,6 @@ import (
 	types4 "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
-	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	pb "github.com/smartcontractkit/chainlink-protos/orchestrator/feedsmanager"
@@ -473,7 +472,6 @@ func setupNodeCCIP(
 		UnrestrictedHTTPClient:   &http.Client{},
 		RestrictedHTTPClient:     &http.Client{},
 		AuditLogger:              audit.NoopLogger,
-		LimitsFactory:            limits.Factory{Logger: lggr.Named("Limits")},
 	})
 
 	require.NoError(t, err)

--- a/core/services/pipeline/common.go
+++ b/core/services/pipeline/common.go
@@ -29,6 +29,7 @@ const (
 	BlockHeaderFeederJobType       string = "blockheaderfeeder"
 	BlockhashStoreJobType          string = "blockhashstore"
 	BootstrapJobType               string = "bootstrap"
+	CRESettings                    string = "cresettings"
 	CronJobType                    string = "cron"
 	CCIPJobType                    string = "ccip"
 	DirectRequestJobType           string = "directrequest"

--- a/core/services/standardcapabilities/delegate.go
+++ b/core/services/standardcapabilities/delegate.go
@@ -58,6 +58,7 @@ type Delegate struct {
 	computeFetcherFactoryFn compute.FetcherFactory
 	selectorOpts            []func(*gateway.RoundRobinSelector)
 	orgResolver             orgresolver.OrgResolver
+	creSettings             core.SettingsBroadcaster
 
 	isNewlyCreatedJob bool
 }
@@ -86,6 +87,7 @@ func NewDelegate(
 	newOracleFactoryFn NewOracleFactoryFn,
 	fetcherFactoryFn compute.FetcherFactory,
 	orgResolver orgresolver.OrgResolver,
+	creSettings core.SettingsBroadcaster,
 	opts ...func(*gateway.RoundRobinSelector),
 ) *Delegate {
 	return &Delegate{
@@ -105,6 +107,7 @@ func NewDelegate(
 		newOracleFactoryFn:      newOracleFactoryFn,
 		computeFetcherFactoryFn: fetcherFactoryFn,
 		orgResolver:             orgResolver,
+		creSettings:             creSettings,
 		selectorOpts:            opts,
 	}
 }
@@ -320,6 +323,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.Ser
 		GatewayConnector:   connector,
 		P2PKeystore:        ks,
 		OrgResolver:        d.orgResolver,
+		CRESettings:        d.creSettings,
 	}
 	standardCapability := NewStandardCapabilities(log, spec.StandardCapabilitiesSpec, d.cfg, dependencies)
 

--- a/core/services/standardcapabilities/standard_capabilities.go
+++ b/core/services/standardcapabilities/standard_capabilities.go
@@ -38,6 +38,7 @@ type StandardCapabilities struct {
 	oracleFactory        core.OracleFactory
 	gatewayConnector     core.GatewayConnector
 	orgResolver          orgresolver.OrgResolver
+	creSettings          core.SettingsBroadcaster
 
 	capabilitiesLoop *loop.StandardCapabilitiesService
 
@@ -67,6 +68,7 @@ func NewStandardCapabilities(
 		gatewayConnector:     dependencies.GatewayConnector,
 		keystore:             dependencies.P2PKeystore,
 		orgResolver:          dependencies.OrgResolver,
+		creSettings:          dependencies.CRESettings,
 		stopChan:             make(chan struct{}),
 		readyChan:            make(chan struct{}),
 	}
@@ -119,6 +121,7 @@ func (s *StandardCapabilities) Start(ctx context.Context) error {
 				GatewayConnector:   s.gatewayConnector,
 				P2PKeystore:        s.keystore,
 				OrgResolver:        s.orgResolver,
+				CRESettings:        s.creSettings,
 			}
 			if err = s.capabilitiesLoop.Service.Initialise(cctx, dependencies); err != nil {
 				s.log.Errorf("error initialising standard capabilities service: %v", err)

--- a/core/store/migrate/migrations/0281_create_cre_settings_specs.sql
+++ b/core/store/migrate/migrations/0281_create_cre_settings_specs.sql
@@ -1,0 +1,75 @@
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TABLE cre_settings_specs(
+    id BIGSERIAL PRIMARY KEY,
+
+    settings TEXT NOT NULL,
+    hash TEXT NOT NULL,
+
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+
+);
+
+ALTER TABLE jobs
+    ADD COLUMN cre_settings_spec_id INT REFERENCES cre_settings_specs (id),
+DROP CONSTRAINT chk_specs,
+    ADD CONSTRAINT chk_specs CHECK (
+      num_nonnulls(
+        ocr_oracle_spec_id, ocr2_oracle_spec_id,
+        direct_request_spec_id, flux_monitor_spec_id,
+        keeper_spec_id, cron_spec_id, webhook_spec_id,
+        vrf_spec_id, blockhash_store_spec_id,
+        block_header_feeder_spec_id, bootstrap_spec_id,
+        gateway_spec_id,
+        legacy_gas_station_server_spec_id,
+        legacy_gas_station_sidecar_spec_id,
+        eal_spec_id,
+        workflow_spec_id,
+        standard_capabilities_spec_id,
+        ccip_spec_id,
+        ccip_bootstrap_spec_id,
+        cre_settings_spec_id,
+        CASE "type"
+	  WHEN 'stream'
+	  THEN 1
+	  ELSE NULL
+        END -- 'stream' type lacks a spec but should not cause validation to fail
+      ) = 1
+    );
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE jobs
+DROP CONSTRAINT chk_specs,
+     ADD CONSTRAINT chk_specs CHECK (
+      num_nonnulls(
+        ocr_oracle_spec_id, ocr2_oracle_spec_id,
+        direct_request_spec_id, flux_monitor_spec_id,
+        keeper_spec_id, cron_spec_id, webhook_spec_id,
+        vrf_spec_id, blockhash_store_spec_id,
+        block_header_feeder_spec_id, bootstrap_spec_id,
+        gateway_spec_id,
+        legacy_gas_station_server_spec_id,
+        legacy_gas_station_sidecar_spec_id,
+        eal_spec_id,
+        workflow_spec_id,
+        standard_capabilities_spec_id,
+        ccip_spec_id,
+        ccip_bootstrap_spec_id,
+        CASE "type"
+	  WHEN 'stream'
+	  THEN 1
+	  ELSE NULL
+        END -- 'stream' type lacks a spec but should not cause validation to fail
+      ) = 1
+    );
+
+ALTER TABLE jobs
+DROP COLUMN cre_settings_spec_id;
+
+DROP TABLE cre_settings_specs;
+
+-- +goose StatementEnd

--- a/core/web/jobs_controller.go
+++ b/core/web/jobs_controller.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/blockhashstore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/blockheaderfeeder"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/v2/core/services/cresettings"
 	"github.com/smartcontractkit/chainlink/v2/core/services/cron"
 	"github.com/smartcontractkit/chainlink/v2/core/services/directrequest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/fluxmonitorv2"
@@ -239,6 +240,8 @@ func (jc *JobsController) validateJobSpec(ctx context.Context, tomlString string
 		jb, err = fluxmonitorv2.ValidatedFluxMonitorSpec(config.JobPipeline(), tomlString)
 	case job.Keeper:
 		jb, err = keeper.ValidatedKeeperSpec(tomlString)
+	case job.CRESettings:
+		jb, err = cresettings.ValidatedCRESettingsSpec(tomlString)
 	case job.Cron:
 		jb, err = cron.ValidatedCronSpec(tomlString)
 	case job.VRF:

--- a/core/web/presenters/job.go
+++ b/core/web/presenters/job.go
@@ -493,6 +493,22 @@ func NewCCIPSpec(spec *job.CCIPSpec) *CCIPSpec {
 	}
 }
 
+type CRESettingsSpec struct {
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	Settings  string    `json:"settings"`
+	Hash      string    `json:"hash"`
+}
+
+func NewCRESettingsSpec(spec *job.CRESettingsSpec) *CRESettingsSpec {
+	return &CRESettingsSpec{
+		CreatedAt: spec.CreatedAt,
+		UpdatedAt: spec.UpdatedAt,
+		Settings:  spec.Settings,
+		Hash:      spec.Hash,
+	}
+}
+
 // JobError represents errors on the job
 type JobError struct {
 	ID          int64     `json:"id"`
@@ -525,6 +541,7 @@ type JobResource struct {
 	ExternalJobID            uuid.UUID                 `json:"externalJobID"`
 	DirectRequestSpec        *DirectRequestSpec        `json:"directRequestSpec"`
 	FluxMonitorSpec          *FluxMonitorSpec          `json:"fluxMonitorSpec"`
+	CRESettings              *CRESettingsSpec          `json:"creSettingsSpec"`
 	CronSpec                 *CronSpec                 `json:"cronSpec"`
 	OffChainReportingSpec    *OffChainReportingSpec    `json:"offChainReportingOracleSpec"`
 	OffChainReporting2Spec   *OffChainReporting2Spec   `json:"offChainReporting2OracleSpec"`
@@ -562,6 +579,8 @@ func NewJobResource(j job.Job) *JobResource {
 		resource.DirectRequestSpec = NewDirectRequestSpec(j.DirectRequestSpec)
 	case job.FluxMonitor:
 		resource.FluxMonitorSpec = NewFluxMonitorSpec(j.FluxMonitorSpec)
+	case job.CRESettings:
+		resource.CRESettings = NewCRESettingsSpec(j.CRESettingsSpec)
 	case job.Cron:
 		resource.CronSpec = NewCronSpec(j.CronSpec)
 	case job.OffchainReporting:

--- a/core/web/presenters/job_test.go
+++ b/core/web/presenters/job_test.go
@@ -132,6 +132,7 @@ func TestJob(t *testing.T) {
 						"gatewaySpec": null,
 						"standardCapabilitiesSpec": null,
 						"ccipSpec": null,
+						"creSettingsSpec": null,
 						"errors": []
 					}
 				}
@@ -211,6 +212,7 @@ func TestJob(t *testing.T) {
 						"gatewaySpec": null,
 						"standardCapabilitiesSpec": null,
 						"ccipSpec": null,
+						"creSettingsSpec": null,
 						"errors": []
 					}
 				}
@@ -300,6 +302,7 @@ func TestJob(t *testing.T) {
 						"gatewaySpec": null,
 						"standardCapabilitiesSpec": null,
 						"ccipSpec": null,
+						"creSettingsSpec": null,
 						"errors": []
 					}
 				}
@@ -366,6 +369,7 @@ func TestJob(t *testing.T) {
 						"gatewaySpec": null,
 						"standardCapabilitiesSpec": null,
 						"ccipSpec": null,
+						"creSettingsSpec": null,
 						"errors": []
 					}
 				}
@@ -429,6 +433,7 @@ func TestJob(t *testing.T) {
 						"gatewaySpec": null,
 						"standardCapabilitiesSpec": null,
 						"ccipSpec": null,
+						"creSettingsSpec": null,
                         "errors": []
                     }
                 }
@@ -488,6 +493,7 @@ func TestJob(t *testing.T) {
 						"gatewaySpec": null,
 						"standardCapabilitiesSpec": null,
 						"ccipSpec": null,
+						"creSettingsSpec": null,
 						"errors": []
 					}
 				}
@@ -576,6 +582,7 @@ func TestJob(t *testing.T) {
 						"standardCapabilitiesSpec": null,
 						"standardCapabilitiesSpec": null,
 						"ccipSpec": null,
+						"creSettingsSpec": null,
 						"errors": []
 					}
 				}
@@ -659,6 +666,7 @@ func TestJob(t *testing.T) {
 						"gatewaySpec": null,
 						"standardCapabilitiesSpec": null,
 						"ccipSpec": null,
+						"creSettingsSpec": null,
 						"errors": []
 					}
 				}
@@ -742,6 +750,7 @@ func TestJob(t *testing.T) {
 						"gatewaySpec": null,
 						"standardCapabilitiesSpec": null,
 						"ccipSpec": null,
+						"creSettingsSpec": null,
 						"errors": []
 					}
 				}
@@ -809,6 +818,7 @@ func TestJob(t *testing.T) {
 						"gatewaySpec": null,
 						"standardCapabilitiesSpec": null,
 						"ccipSpec": null,
+						"creSettingsSpec": null,
 						"errors": []
 					}
 				}
@@ -868,6 +878,7 @@ func TestJob(t *testing.T) {
 						},
 						"standardCapabilitiesSpec": null,
 						"ccipSpec": null,
+						"creSettingsSpec": null,
 						"pipelineSpec": {
 							"id": 1,
 							"jobID": 0,
@@ -933,6 +944,7 @@ func TestJob(t *testing.T) {
 						"gatewaySpec": null,
 						"standardCapabilitiesSpec": null,
 						"ccipSpec": null,
+						"creSettingsSpec": null,
 						"pipelineSpec": {
 							"id": 1,
 							"jobID": 0,
@@ -994,6 +1006,7 @@ func TestJob(t *testing.T) {
 							"updatedAt":"0001-01-01T00:00:00Z"
 						},
 						"ccipSpec": null,
+						"creSettingsSpec": null,
 						"pipelineSpec": {
 							"id": 1,
 							"jobID": 0,
@@ -1059,12 +1072,76 @@ func TestJob(t *testing.T) {
 							"createdAt":"2000-01-01T00:00:00Z",
 							"updatedAt":"2000-01-01T00:00:00Z"
 						},
+						"creSettingsSpec": null,
 						"pipelineSpec": {
 							"id": 1,
 							"jobID": 0,
 							"dotDagSource": ""
 						},
 						"errors": []
+					}
+				}
+			}`,
+		},
+		{
+			name: "cresettings spec",
+			job: job.Job{
+				ID: 1,
+				CRESettingsSpec: &job.CRESettingsSpec{
+					ID:        4,
+					CreatedAt: timestamp,
+					UpdatedAt: timestamp,
+					Settings:  `Foo = 'Bar'`,
+					Hash:      `ASDF`,
+				},
+				PipelineSpec: &pipeline.Spec{
+					ID:           1,
+					DotDagSource: "",
+				},
+				Type:          job.CRESettings,
+				SchemaVersion: 1,
+				Name:          null.StringFrom("cresettings test"),
+			},
+			want: `
+			{
+				"data": {	
+					"type": "jobs",
+					"id": "1",
+					"attributes": {
+						"name": "cresettings test",
+						"type": "cresettings",
+						"schemaVersion": 1,
+						"maxTaskDuration": "0s",
+						"directRequestSpec": null,
+						"externalJobID": "00000000-0000-0000-0000-000000000000",
+						"fluxMonitorSpec": null,
+						"gasLimit": null,
+						"forwardingAllowed": false,
+						"creSettingsSpec": {
+							"createdAt":"2000-01-01T00:00:00Z",
+							"updatedAt":"2000-01-01T00:00:00Z",
+							"settings": "Foo = 'Bar'",
+							"hash": "ASDF"
+						},
+						"cronSpec": null,
+						"offChainReportingOracleSpec": null,
+						"offChainReporting2OracleSpec": null,
+						"keeperSpec": null,
+						"vrfSpec": null,
+						"webhookSpec": null,
+						"workflowSpec": null,
+						"blockhashStoreSpec": null,
+						"blockHeaderFeederSpec": null,
+						"bootstrapSpec": null,
+						"gatewaySpec": null,
+						"standardCapabilitiesSpec": null,
+						"ccipSpec": null,
+						"pipelineSpec": {
+							"id": 1,
+							"jobID": 0,
+							"dotDagSource": ""
+						},
+						"errors": []						
 					}
 				}
 			}`,
@@ -1126,6 +1203,7 @@ func TestJob(t *testing.T) {
 						"fluxMonitorSpec": null,
 						"gasLimit": null,
 						"forwardingAllowed": false,
+						"creSettingsSpec": null,
 						"directRequestSpec": null,
 						"cronSpec": null,
 						"webhookSpec": null,

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -22,6 +22,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/blockhashstore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/blockheaderfeeder"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/v2/core/services/cresettings"
 	"github.com/smartcontractkit/chainlink/v2/core/services/cron"
 	"github.com/smartcontractkit/chainlink/v2/core/services/directrequest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/feeds"
@@ -1092,6 +1093,8 @@ func (r *Resolver) CreateJob(ctx context.Context, args struct {
 		jb, err = fluxmonitorv2.ValidatedFluxMonitorSpec(config.JobPipeline(), args.Input.TOML)
 	case job.Keeper:
 		jb, err = keeper.ValidatedKeeperSpec(args.Input.TOML)
+	case job.CRESettings:
+		jb, err = cresettings.ValidatedCRESettingsSpec(args.Input.TOML)
 	case job.Cron:
 		jb, err = cron.ValidatedCronSpec(args.Input.TOML)
 	case job.VRF:

--- a/core/web/resolver/spec.go
+++ b/core/web/resolver/spec.go
@@ -156,6 +156,14 @@ func (r *SpecResolver) ToCCIPSpec() (*CCIPSpecResolver, bool) {
 	return &CCIPSpecResolver{spec: *r.j.CCIPSpec}, true
 }
 
+func (r *SpecResolver) ToCRESettingsSpec() (*CRESettingsSpecResolver, bool) {
+	if r.j.Type != job.CRESettings {
+		return nil, false
+	}
+
+	return &CRESettingsSpecResolver{spec: *r.j.CRESettingsSpec}, true
+}
+
 type CronSpecResolver struct {
 	spec job.CronSpec
 }
@@ -1134,4 +1142,28 @@ func (r *CCIPSpecResolver) PluginConfig() gqlscalar.Map {
 
 func (r *CCIPSpecResolver) P2PKeyID() string {
 	return r.spec.P2PKeyID
+}
+
+type CRESettingsSpecResolver struct {
+	spec job.CRESettingsSpec
+}
+
+func (r *CRESettingsSpecResolver) CreatedAt() graphql.Time {
+	return graphql.Time{Time: r.spec.CreatedAt}
+}
+
+func (r *CRESettingsSpecResolver) UpdatedAt() graphql.Time {
+	return graphql.Time{Time: r.spec.UpdatedAt}
+}
+
+func (r *CRESettingsSpecResolver) ID() graphql.ID {
+	return graphql.ID(stringutils.FromInt32(r.spec.ID))
+}
+
+func (r *CRESettingsSpecResolver) Settings() string {
+	return r.spec.Settings
+}
+
+func (r *CRESettingsSpecResolver) Hash() string {
+	return r.spec.Hash
 }

--- a/deployment/environment/memory/node.go
+++ b/deployment/environment/memory/node.go
@@ -21,7 +21,6 @@ import (
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
-	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
@@ -456,7 +455,6 @@ func NewNode(
 		RestrictedHTTPClient:     &http.Client{},
 		AuditLogger:              audit.NoopLogger,
 		RetirementReportCache:    retirement.NewRetirementReportCache(lggr, db),
-		LimitsFactory:            limits.Factory{Logger: lggr.Named("Limits")},
 	})
 	require.NoError(t, err)
 	keys := CreateKeys(t, app,

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20251105200616-e158f436aa95
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201
 	github.com/smartcontractkit/chainlink-deployments-framework v0.62.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1337,8 +1337,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424 h1:hBwTReAElITu5uRvPEPy5vac2Kjr9ieByWD5lE9hp5U=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201 h1:qM3GpFTsEK5X45YmYsQBRqBFp7VnFsly9SrYP2F0zLc=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20251105200616-e158f436aa95
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10
 	github.com/smartcontractkit/chainlink-data-streams v0.1.6
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f

--- a/go.sum
+++ b/go.sum
@@ -1113,8 +1113,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-f
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:Ve1xD71bl193YIZQEoJMmBqLGQJdNs29bwbuObwvbhQ=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5 h1:Z4t2ZY+ZyGWxtcXvPr11y4o3CGqhg3frJB5jXkCSvWA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424 h1:hBwTReAElITu5uRvPEPy5vac2Kjr9ieByWD5lE9hp5U=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201 h1:qM3GpFTsEK5X45YmYsQBRqBFp7VnFsly9SrYP2F0zLc=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20251105200616-e158f436aa95
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201
 	github.com/smartcontractkit/chainlink-deployments-framework v0.62.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1581,8 +1581,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424 h1:hBwTReAElITu5uRvPEPy5vac2Kjr9ieByWD5lE9hp5U=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201 h1:qM3GpFTsEK5X45YmYsQBRqBFp7VnFsly9SrYP2F0zLc=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20251105200616-e158f436aa95
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201
 	github.com/smartcontractkit/chainlink-deployments-framework v0.62.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1560,8 +1560,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424 h1:hBwTReAElITu5uRvPEPy5vac2Kjr9ieByWD5lE9hp5U=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201 h1:qM3GpFTsEK5X45YmYsQBRqBFp7VnFsly9SrYP2F0zLc=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -10,17 +10,17 @@ defaults:
 plugins:
   cron:
     - moduleURI: "github.com/smartcontractkit/capabilities/cron"
-      gitRef: "484ab95d45e485ef91e077dd1ebedd3bba5afa7c"
+      gitRef: "5f5cab3fe9fb8ab8c969d0c0fe77de70454ad86b"
       installPath: "github.com/smartcontractkit/capabilities/cron"
       flags: "-tags timetzdata"
   kvstore:
     - enabled: false
       moduleURI: "github.com/smartcontractkit/capabilities/kvstore"
-      gitRef: "484ab95d45e485ef91e077dd1ebedd3bba5afa7c"
+      gitRef: "5f5cab3fe9fb8ab8c969d0c0fe77de70454ad86b"
       installPath: "github.com/smartcontractkit/capabilities/kvstore"
   readcontract:
     - moduleURI: "github.com/smartcontractkit/capabilities/readcontract"
-      gitRef: "484ab95d45e485ef91e077dd1ebedd3bba5afa7c"
+      gitRef: "5f5cab3fe9fb8ab8c969d0c0fe77de70454ad86b"
       installPath: "github.com/smartcontractkit/capabilities/readcontract"
   consensus:
     - moduleURI: "github.com/smartcontractkit/capabilities/consensus"
@@ -29,23 +29,23 @@ plugins:
   workflowevent:
     - enabled: false
       moduleURI: "github.com/smartcontractkit/capabilities/workflowevent"
-      gitRef: "484ab95d45e485ef91e077dd1ebedd3bba5afa7c"
+      gitRef: "5f5cab3fe9fb8ab8c969d0c0fe77de70454ad86b"
       installPath: "github.com/smartcontractkit/capabilities/workflowevent"
   httpaction:
     - moduleURI: "github.com/smartcontractkit/capabilities/http_action"
-      gitRef: "484ab95d45e485ef91e077dd1ebedd3bba5afa7c"
+      gitRef: "5f5cab3fe9fb8ab8c969d0c0fe77de70454ad86b"
       installPath: "github.com/smartcontractkit/capabilities/http_action"
   httptrigger:
     - moduleURI: "github.com/smartcontractkit/capabilities/http_trigger"
-      gitRef: "484ab95d45e485ef91e077dd1ebedd3bba5afa7c"
+      gitRef: "5f5cab3fe9fb8ab8c969d0c0fe77de70454ad86b"
       installPath: "github.com/smartcontractkit/capabilities/http_trigger"
   evm:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
-      gitRef: "484ab95d45e485ef91e077dd1ebedd3bba5afa7c"
+      gitRef: "5f5cab3fe9fb8ab8c969d0c0fe77de70454ad86b"
       installPath: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
   mock:
     - moduleURI: "github.com/smartcontractkit/capabilities/mock"
-      gitRef: "484ab95d45e485ef91e077dd1ebedd3bba5afa7c"
+      gitRef: "5f5cab3fe9fb8ab8c969d0c0fe77de70454ad86b"
       installPath: "github.com/smartcontractkit/capabilities/mock"
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/sethvargo/go-retry v0.2.4
 	github.com/smartcontractkit/chain-selectors v1.0.78
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201
 	github.com/smartcontractkit/chainlink-deployments-framework v0.62.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1578,8 +1578,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424 h1:hBwTReAElITu5uRvPEPy5vac2Kjr9ieByWD5lE9hp5U=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201 h1:qM3GpFTsEK5X45YmYsQBRqBFp7VnFsly9SrYP2F0zLc=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.78
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201
 	github.com/smartcontractkit/chainlink-data-streams v0.1.6
 	github.com/smartcontractkit/chainlink-deployments-framework v0.62.0
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1783,8 +1783,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424 h1:hBwTReAElITu5uRvPEPy5vac2Kjr9ieByWD5lE9hp5U=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251104231304-6cbcde243424/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201 h1:qM3GpFTsEK5X45YmYsQBRqBFp7VnFsly9SrYP2F0zLc=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251105200931-fdbfd5296201/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/CRE-545

Add a `CRESettings` job type, which acts as a no-op singleton for receiving CRE settings updates via job specs, and broadcasting to plugins.

Requires:
- https://github.com/smartcontractkit/capabilities/pull/350
- https://github.com/smartcontractkit/chainlink-common/pull/1684
- https://github.com/smartcontractkit/capabilities/pull/354