### PR TITLE
in http action, error when http method is not provide

### DIFF
--- a/.changeset/bitter-coats-swim.md
+++ b/.changeset/bitter-coats-swim.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix check http method

--- a/core/capabilities/fakes/http_action.go
+++ b/core/capabilities/fakes/http_action.go
@@ -3,6 +3,7 @@ package fakes
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -61,10 +62,10 @@ func (fh *DirectHTTPAction) SendRequest(ctx context.Context, metadata commonCap.
 		Timeout: timeout,
 	}
 
-	// Determine HTTP method (default to GET if not specified)
-	method := input.GetMethod()
+	// Return an error if no HTTP method is provided
+	method := strings.TrimSpace(input.GetMethod())
 	if method == "" {
-		method = "GET"
+		return nil, errors.New("http method cannot be empty")
 	}
 	method = strings.ToUpper(method)
 


### PR DESCRIPTION
```
2025-11-04T09:54:43Z [SIMULATION] Simulator Initialized

2025-11-04T09:54:43Z [SIMULATION] Running trigger trigger=cron-trigger@1.0.0
2025-11-04T09:54:43Z [USER LOG] msg="fetching por" url=https://api.real-time-reserves.verinumus.io/v1/chainlink/proof-of-reserves/TrueUSD evms="[{TokenAddress:0x4700A50d858Cb281847ca4Ee0938F80DEfB3F1dd ReserveManagerAddress:0x51933aD3A79c770cb6800585325649494120401a BalanceReaderAddress:0x4b0739c94C1389B55481cb7506c62430cA7211Cf MessageEmitterAddress:0x1d598672486ecB50685Da5497390571Ac4E93FDc ChainName:ethereum-testnet-sepolia GasLimit:1000000}]"
2025-11-04T09:54:43Z [USER LOG] msg="error fetching por" err="failed to execute capability: failed to execute capability: http method cannot be empty"
Workflow execution failed:
 failed to execute capability: failed to execute capability: http method cannot be empty
```