### PR TITLE
[CRE-1287] pass GATI's GH token to Beholder

### DIFF
--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -220,6 +220,16 @@ jobs:
             exit $exit_code
           fi
 
+      - name: Setup GitHub token using GATI
+        id: github-token
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/1.0.0
+        with:
+          aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+          aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
+          aws-region: us-west-2
+          aws-role-duration-seconds: "1800"
+          set-git-config: "true"
+
       - name: Run CRE${{ matrix.tests.cre_version }} Smoke system tests
         id: run-tests
         shell: bash
@@ -230,6 +240,7 @@ jobs:
           TEST_TIMEOUT: 30m
           RUN_QUARANTINED_TESTS: "true" # always run quarantined tests in CI
           TOPOLOGY_NAME: ${{ matrix.tests.topology }}
+          GITHUB_TOKEN: ${{ steps.github-token.outputs.access-token || '' }} # to avoid rate limiting when downloading protobuf files from GitHub
         run: |
           echo "Starting test: '${TEST_NAME}'"
           gotestsum \


### PR DESCRIPTION
Very rarely starting Beholder in CI fails with:
```
Error: failed to start Beholder: failed to register protos: proto registration failedfailed to fetch and register protos: failed to fetch protos from https://github.com/smartcontractkit/chainlink-protos: bad status from GitHub for workflows/workflows/v2/capability_execution_finished.proto: 429
```

In this PR we add setting `GITHUB_TOKEN` so that we are not rate limited.