### PR TITLE
Remove validation

### DIFF
--- a/deployment/ccip/changeset/solana_v0_1_1/self_serve.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/self_serve.go
@@ -73,9 +73,6 @@ func (cfg OnboardTokenPoolsForSelfServeConfig) Validate(e cldf.Environment, chai
 		if registerTokenConfig.ProposedOwner.IsZero() {
 			return errors.New("token admin registry admin is required")
 		}
-		if err := chainState.CommonValidation(e, cfg.ChainSelector, tokenMint); err != nil {
-			return err
-		}
 		tokenAdminRegistryPDA, _, err := solState.FindTokenAdminRegistryPDA(tokenMint, routerProgramAddress)
 		if err != nil {
 			return fmt.Errorf("failed to find token admin registry pda (mint: %s, router: %s): %w",


### PR DESCRIPTION
Remove validation that checks that the token mint exists in the state, as it failed when running the migration. The tests worked as they deployed the tokens and store the mint in the data store.