### PR TITLE
[CRE-1291] print panics or 30 last log lines if test fails 

### DIFF
--- a/system-tests/lib/infra/docker.go
+++ b/system-tests/lib/infra/docker.go
@@ -1,15 +1,20 @@
 package infra
 
 import (
+	"bufio"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"maps"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/docker/docker/api/types/container"
+	dfilter "github.com/docker/docker/api/types/filters"
 	"github.com/rs/zerolog"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
@@ -27,7 +32,7 @@ func PrintFailedContainerLogs(logger zerolog.Logger, logLinesCount uint64) {
 		return
 	}
 
-	logger.Error().Msgf("Containers that failed to start: %s", strings.Join(slices.Collect(maps.Keys(logStream)), ", "))
+	logger.Error().Msgf("Containers that exited with non-zero codes: %s", strings.Join(slices.Collect(maps.Keys(logStream)), ", "))
 	for cName, ioReader := range logStream {
 		content := ""
 		header := make([]byte, 8) // Docker stream header is 8 bytes
@@ -62,4 +67,169 @@ func PrintFailedContainerLogs(logger zerolog.Logger, logLinesCount uint64) {
 		}
 		_ = ioReader.Close() // can't do much about the error here
 	}
+}
+
+// CheckContainersForPanics scans Docker container logs for panic-related patterns.
+// When a panic is detected, it displays the panic line and up to maxLinesAfterPanic lines following it.
+//
+// This is useful for debugging test failures where a Docker container may have panicked.
+// The function searches for common panic patterns including:
+//   - "panic:" - Standard Go panic
+//   - "runtime error:" - Runtime errors (nil pointer, index out of bounds, etc.)
+//   - "fatal error:" - Fatal errors
+//   - "goroutine N [running]" - Stack trace indicators
+//
+// The function scans all containers in parallel and stops as soon as the first panic is found.
+//
+// Parameters:
+//   - logger: zerolog.Logger for output
+//   - maxLinesAfterPanic: Maximum number of lines to show after the panic line (including stack trace).
+//     Recommended: 50-200 depending on how much context you want.
+//
+// Returns:
+//   - true if any panics were found in any container, false otherwise
+func CheckContainersForPanics(logger zerolog.Logger, maxLinesAfterPanic int) bool {
+	// Panic patterns to search for
+	panicPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)panic:`),                // Go panic
+		regexp.MustCompile(`(?i)runtime error:`),        // Runtime errors
+		regexp.MustCompile(`(?i)fatal error:`),          // Fatal errors
+		regexp.MustCompile(`goroutine \d+ \[running\]`), // Stack trace indicator
+	}
+
+	// List only Chainlink node containers
+	listOpts := container.ListOptions{
+		All: true,
+		Filters: dfilter.NewArgs(
+			dfilter.KeyValuePair{Key: "label", Value: "framework=ctf"},
+		),
+	}
+
+	logOpts := container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Timestamps: true, // Include timestamps for better debugging
+	}
+
+	logStream, err := framework.StreamContainerLogs(listOpts, logOpts)
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to stream container logs for panic detection")
+		return false
+	}
+
+	// Create context for early cancellation when first panic is found
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Channel to receive panic results
+	panicFoundChan := make(chan bool, len(logStream))
+	var wg sync.WaitGroup
+
+	// Scan all containers in parallel
+	for containerName, reader := range logStream {
+		wg.Add(1)
+		go func(name string, r io.ReadCloser) {
+			defer wg.Done()
+			defer r.Close()
+
+			panicFound := scanContainerForPanics(ctx, logger, name, r, panicPatterns, maxLinesAfterPanic)
+			if panicFound {
+				panicFoundChan <- true
+				cancel() // Signal other goroutines to stop
+			}
+		}(containerName, reader)
+	}
+
+	// Wait for all goroutines to finish in a separate goroutine
+	go func() {
+		wg.Wait()
+		close(panicFoundChan)
+	}()
+
+	// Check if any panic was found
+	for range panicFoundChan {
+		return true // Return as soon as first panic is found
+	}
+
+	return false
+}
+
+// scanContainerForPanics scans a single container's log stream for panic patterns
+// It checks the context for cancellation to enable early termination when another goroutine finds a panic
+func scanContainerForPanics(ctx context.Context, logger zerolog.Logger, containerName string, reader io.Reader, patterns []*regexp.Regexp, maxLinesAfter int) bool {
+	scanner := bufio.NewScanner(reader)
+	// Increase buffer size to handle large log lines
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	var logLines []string
+	lineNum := 0
+	panicLineNum := -1
+
+	// Read all lines and detect panic
+	for scanner.Scan() {
+		// Check if context is cancelled (another goroutine found a panic)
+		select {
+		case <-ctx.Done():
+			return false // Stop scanning, another container already found a panic
+		default:
+		}
+
+		line := scanner.Text()
+		lineNum++
+
+		// If we found a panic, collect remaining lines up to maxLinesAfter
+		if panicLineNum >= 0 {
+			logLines = append(logLines, line)
+			// Stop reading once we have enough context after the panic
+			if lineNum >= panicLineNum+maxLinesAfter+1 {
+				break
+			}
+			continue
+		}
+
+		// Still searching for panic - store all lines
+		logLines = append(logLines, line)
+
+		// Check if this line contains a panic pattern
+		for _, pattern := range patterns {
+			if pattern.MatchString(line) {
+				panicLineNum = lineNum - 1 // Store index (0-based)
+				break
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		logger.Error().Err(err).Str("Container", containerName).Msg("error reading container logs")
+		return false
+	}
+
+	// If panic was found, display it with context
+	if panicLineNum >= 0 {
+		logger.Error().
+			Str("Container", containerName).
+			Int("PanicLineNumber", panicLineNum+1).
+			Msgf("🔥 PANIC DETECTED in container logs")
+
+		// Calculate range to display
+		startLine := panicLineNum
+		endLine := min(len(logLines), panicLineNum+maxLinesAfter+1)
+
+		// Build the output
+		var output strings.Builder
+		output.WriteString(fmt.Sprintf("\n%s\n", strings.Repeat("=", 80)))
+		output.WriteString(fmt.Sprintf("PANIC FOUND IN CONTAINER: %s (showing %d lines from panic)\n", containerName, endLine-startLine))
+		output.WriteString(strings.Repeat("=", 80) + "\n")
+
+		for i := startLine; i < endLine; i++ {
+			output.WriteString(logLines[i] + "\n")
+		}
+
+		output.WriteString(strings.Repeat("=", 80))
+
+		fmt.Println(text.RedText("%s\n", output.String()))
+		return true
+	}
+
+	return false
 }

--- a/system-tests/lib/infra/docker.go
+++ b/system-tests/lib/infra/docker.go
@@ -90,11 +90,11 @@ func PrintFailedContainerLogs(logger zerolog.Logger, logLinesCount uint64) {
 //   - true if any panics were found in any container, false otherwise
 func CheckContainersForPanics(logger zerolog.Logger, maxLinesAfterPanic int) bool {
 	// Panic patterns to search for
-	panicPatterns := []*regexp.Regexp{
-		regexp.MustCompile(`(?i)panic:`),                // Go panic
-		regexp.MustCompile(`(?i)runtime error:`),        // Runtime errors
-		regexp.MustCompile(`(?i)fatal error:`),          // Fatal errors
-		regexp.MustCompile(`goroutine \d+ \[running\]`), // Stack trace indicator
+	panicPatterns := map[string]*regexp.Regexp{
+		"panic":         regexp.MustCompile(`(?i)panic:`),                // Go panic
+		"runtime error": regexp.MustCompile(`(?i)runtime error:`),        // Runtime errors
+		"fatal error":   regexp.MustCompile(`(?i)fatal error:`),          // Fatal errors
+		"stack trace":   regexp.MustCompile(`goroutine \d+ \[running\]`), // Stack trace indicator
 	}
 
 	// List only Chainlink node containers
@@ -156,7 +156,7 @@ func CheckContainersForPanics(logger zerolog.Logger, maxLinesAfterPanic int) boo
 
 // scanContainerForPanics scans a single container's log stream for panic patterns
 // It checks the context for cancellation to enable early termination when another goroutine finds a panic
-func scanContainerForPanics(ctx context.Context, logger zerolog.Logger, containerName string, reader io.Reader, patterns []*regexp.Regexp, maxLinesAfter int) bool {
+func scanContainerForPanics(ctx context.Context, logger zerolog.Logger, containerName string, reader io.Reader, patterns map[string]*regexp.Regexp, maxLinesAfter int) bool {
 	scanner := bufio.NewScanner(reader)
 	// Increase buffer size to handle large log lines
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
@@ -164,6 +164,7 @@ func scanContainerForPanics(ctx context.Context, logger zerolog.Logger, containe
 	var logLines []string
 	lineNum := 0
 	panicLineNum := -1
+	patternNameFound := ""
 
 	// Read all lines and detect panic
 	for scanner.Scan() {
@@ -191,8 +192,9 @@ func scanContainerForPanics(ctx context.Context, logger zerolog.Logger, containe
 		logLines = append(logLines, line)
 
 		// Check if this line contains a panic pattern
-		for _, pattern := range patterns {
+		for patternName, pattern := range patterns {
 			if pattern.MatchString(line) {
+				patternNameFound = patternName
 				panicLineNum = lineNum - 1 // Store index (0-based)
 				break
 			}
@@ -209,7 +211,7 @@ func scanContainerForPanics(ctx context.Context, logger zerolog.Logger, containe
 		logger.Error().
 			Str("Container", containerName).
 			Int("PanicLineNumber", panicLineNum+1).
-			Msgf("🔥 PANIC DETECTED in container logs")
+			Msgf("🔥 %s DETECTED in container logs", strings.ToUpper(patternNameFound))
 
 		// Calculate range to display
 		startLine := panicLineNum
@@ -218,7 +220,7 @@ func scanContainerForPanics(ctx context.Context, logger zerolog.Logger, containe
 		// Build the output
 		var output strings.Builder
 		output.WriteString(fmt.Sprintf("\n%s\n", strings.Repeat("=", 80)))
-		output.WriteString(fmt.Sprintf("PANIC FOUND IN CONTAINER: %s (showing %d lines from panic)\n", containerName, endLine-startLine))
+		output.WriteString(fmt.Sprintf("%s FOUND IN CONTAINER: %s (showing %d lines from panic)\n", strings.ToUpper(patternNameFound), containerName, endLine-startLine))
 		output.WriteString(strings.Repeat("=", 80) + "\n")
 
 		for i := startLine; i < endLine; i++ {


### PR DESCRIPTION
...and any container exited with non-zero code.

Example:
```
4:29PM ERR 🔥 PANIC DETECTED in container logs Container=/workflow-node3 PanicLineNumber=44680

================================================================================
PANIC FOUND IN CONTAINER: /workflow-node3 (showing 10 lines from panic)
================================================================================
g2025-11-05T15:24:00.116124632Z panic: runtime error: invalid memory address or nil pointer dereference
h2025-11-05T15:24:00.116268924Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x2d30044]
 2025-11-05T15:24:00.116272799Z 
:2025-11-05T15:24:00.116275882Z goroutine 70434 [running]:
�2025-11-05T15:24:00.116277590Z github.com/smartcontractkit/chainlink/v2/core/services/workflows/v2.(*ExecutionHelper).CallCapability(0x40043cb0e0, {0x75ecab8, 0x4007678dc0}, 0x40043cb380)
g2025-11-05T15:24:00.116280174Z 	/chainlink/core/services/workflows/v2/capability_executor.go:63 +0x144
�2025-11-05T15:24:00.116284257Z github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host.(*execution[...]).callCapAsync.func1()
�2025-11-05T15:24:00.116286965Z 	/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251030115044-5d80c1c62afd/pkg/workflows/wasm/host/execution.go:44 +0x44
�2025-11-05T15:24:00.116287882Z created by github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host.(*execution[...]).callCapAsync in goroutine 70357
�2025-11-05T15:24:00.116288715Z 	/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.9.6-0.20251030115044-5d80c1c62afd/pkg/workflows/wasm/host/execution.go:43 +0x13c
================================================================================
```

If no panic is found we will just print a tail of 30 log lines for each exited container.