### PR TITLE
core/services/gateway/network: fix race in TestWSConnectionWrapper_ClientReconnect

### DIFF
--- a/core/services/gateway/network/wsconnection_test.go
+++ b/core/services/gateway/network/wsconnection_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -47,22 +48,24 @@ func TestWSConnectionWrapper_ClientReconnect(t *testing.T) {
 	// connect, write a message, disconnect
 	conn, _, err := websocket.DefaultDialer.Dial(serverURL, nil)
 	require.NoError(t, err)
-	clientConnWrapper.Reset(conn)
-	writeErr := clientConnWrapper.Write(testutils.Context(t), websocket.TextMessage, []byte("hello"))
-	require.NoError(t, writeErr)
-	<-ssl.connWrapper.ReadChannel() // consumed by server
-	conn.Close()
+	func() {
+		defer func() { assert.NoError(t, conn.Close()) }()
+		clientConnWrapper.Reset(conn)
+		writeErr := clientConnWrapper.Write(testutils.Context(t), websocket.TextMessage, []byte("hello"))
+		require.NoError(t, writeErr)
+		<-ssl.connWrapper.ReadChannel() // consumed by server
+	}()
 
 	// try to write without a connection
-	writeErr = clientConnWrapper.Write(testutils.Context(t), websocket.TextMessage, []byte("failed send"))
+	writeErr := clientConnWrapper.Write(testutils.Context(t), websocket.TextMessage, []byte("failed send"))
 	require.Error(t, writeErr)
 
 	// re-connect, write another message, disconnect
 	conn, _, err = websocket.DefaultDialer.Dial(serverURL, nil)
 	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, conn.Close()) })
 	clientConnWrapper.Reset(conn)
 	writeErr = clientConnWrapper.Write(testutils.Context(t), websocket.TextMessage, []byte("hello again"))
 	require.NoError(t, writeErr)
 	<-ssl.connWrapper.ReadChannel() // consumed by server
-	conn.Close()
 }


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/actions/runs/19114178316/job/54618769971
https://github.com/smartcontractkit/chainlink/actions/runs/19114178006/job/54618773333
```
==================
WARNING: DATA RACE
Read at 0x00c0004358cb by goroutine 428:
  testing.(*common).destination()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1049 +0x96
  testing.(*outputWriter).Write()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1133 +0x9a
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1040 +0x164
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1191 +0x8e
  go.uber.org/zap/zaptest.TestingWriter.Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zaptest/logger.go:146 +0x119
  go.uber.org/zap/zaptest.(*TestingWriter).Write()
      <autogenerated>:1 +0x74
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/core.go:99 +0x18d
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/entry.go:253 +0x1ec
  go.uber.org/zap.(*SugaredLogger).log()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/sugar.go:355 +0x12c
  go.uber.org/zap.(*SugaredLogger).Errorw()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/sugar.go:269 +0xa4
  github.com/smartcontractkit/chainlink-common/pkg/logger.(*logger).Errorw()
      <autogenerated>:1 +0x1f
  github.com/smartcontractkit/chainlink/v2/core/services/gateway/network.(*wsConnectionWrapper).readPump()
      /home/runner/_work/chainlink/chainlink/core/services/gateway/network/wsconnection.go:176 +0x459
  github.com/smartcontractkit/chainlink/v2/core/services/gateway/network.(*wsConnectionWrapper).Reset.gowrap1()
      /home/runner/_work/chainlink/chainlink/core/services/gateway/network/wsconnection.go:111 +0x4f

Previous write at 0x00c0004358cb by goroutine 174:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1921 +0x904
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.25.3/x64/src/runtime/panic.go:589 +0x5d
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1997 +0x44

Goroutine 428 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/services/gateway/network.(*wsConnectionWrapper).Reset()
      /home/runner/_work/chainlink/chainlink/core/services/gateway/network/wsconnection.go:111 +0x179
  github.com/smartcontractkit/chainlink/v2/core/services/gateway/network_test.TestWSConnectionWrapper_ClientReconnect()
      /home/runner/_work/chainlink/chainlink/core/services/gateway/network/wsconnection_test.go:63 +0x97d
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1997 +0x44

Goroutine 174 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1997 +0x9d2
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:2477 +0x85
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1934 +0x21c
  testing.runTests()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:2475 +0x96c
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:2337 +0xed4
  main.main()
      _testmain.go:85 +0x164
==================
```