### PR TITLE
fix(engine/v2): logs local node state only on update

### DIFF
--- a/.changeset/open-papers-change.md
+++ b/.changeset/open-papers-change.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix logs a debug line of local node state in engine only if there is a config change

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -229,6 +229,11 @@ func (e *Engine) localNodeSync(ctx context.Context) {
 		return
 	}
 
+	// ignore any reads that do not update the config version
+	if e.localNode.Load().WorkflowDON.ConfigVersion == localNode.WorkflowDON.ConfigVersion {
+		return
+	}
+
 	e.cfg.Lggr.Debugw("Setting local node state",
 		"Workflow DON ID", localNode.WorkflowDON.ID,
 		"Workflow DON Families", localNode.WorkflowDON.Families,

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -1680,7 +1680,6 @@ func TestEngine_HandleNewDON(t *testing.T) {
 		// assert that no log of the state was observed
 		require.Empty(t,
 			obs.FilterMessage("Setting local node state").All(),
-			0,
 			"logged local node state even though there was no change",
 		)
 	})

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -1632,6 +1632,57 @@ func TestEngine_HandleNewDON(t *testing.T) {
 		require.NoError(t, engine.Close())
 	})
 
+	t.Run("only logs set if state is new", func(t *testing.T) {
+		var (
+			lggr, obs  = logger.TestObserved(t, zapcore.DebugLevel)
+			initDoneCh = make(chan error)
+			donCh      = make(chan capabilities.DON)
+		)
+
+		// module mocks
+		module := modulemocks.NewModuleV2(t)
+		module.EXPECT().Start().Once()
+		module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(0), nil).Once()
+		module.EXPECT().Close().Once()
+
+		// capabilities registry mocks
+		capreg := regmocks.NewCapabilitiesRegistry(t)
+		initialNode := newNode(t, func(n *capabilities.Node) {
+			n.WorkflowDON.ConfigVersion = 1
+		})
+		capreg.EXPECT().LocalNode(matches.AnyContext).Return(initialNode, nil).Twice()
+
+		subscriberMock := capmocks.NewDonSubscriber(t)
+		subscriberMock.EXPECT().Subscribe(matches.AnyContext).Return(donCh, func() {}, nil)
+
+		// modify config for test
+		cfg := defaultTestConfig(t, nil)
+		cfg.Lggr = lggr
+		cfg.DonSubscriber = subscriberMock
+		cfg.Module = module
+		cfg.CapRegistry = capreg
+		cfg.Hooks = v2.LifecycleHooks{
+			OnInitialized: func(err error) {
+				initDoneCh <- err
+			},
+		}
+
+		// instantiate and run the engine
+		engine, err := v2.NewEngine(cfg)
+		require.NoError(t, err)
+		require.NoError(t, engine.Start(t.Context()))
+		require.NoError(t, <-initDoneCh)
+
+		// after initialization, signal a DON send to refetch local node
+		donCh <- capabilities.DON{}
+		require.Len(t,
+			obs.FilterMessage("Setting local node state").All(),
+			0,
+			"logged local node state even though there was no change",
+		)
+		require.NoError(t, engine.Close())
+	})
+
 	t.Run("fail to subscribe", func(t *testing.T) {
 		module := modulemocks.NewModuleV2(t)
 		module.EXPECT().Start().Once()

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -1675,12 +1675,14 @@ func TestEngine_HandleNewDON(t *testing.T) {
 
 		// after initialization, signal a DON send to refetch local node
 		donCh <- capabilities.DON{}
-		require.Len(t,
+		require.NoError(t, engine.Close())
+
+		// assert that no log of the state was observed
+		require.Empty(t,
 			obs.FilterMessage("Setting local node state").All(),
 			0,
 			"logged local node state even though there was no change",
 		)
-		require.NoError(t, engine.Close())
 	})
 
 	t.Run("fail to subscribe", func(t *testing.T) {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

logs an update to local node state only if the config version has changed.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
