### PR TITLE
core/services/gateway/network: fix TestWSConnectionWrapper_ClientReconnect race

### DIFF
--- a/core/services/gateway/network/wsconnection_test.go
+++ b/core/services/gateway/network/wsconnection_test.go
@@ -35,8 +35,9 @@ func TestWSConnectionWrapper_ClientReconnect(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	// server
-	ssl := &serverSideLogic{connWrapper: network.NewWSConnectionWrapper(lggr)}
-	servicetest.Run(t, ssl.connWrapper)
+	wsConn := network.NewWSConnectionWrapper(lggr)
+	servicetest.Run(t, wsConn)
+	ssl := &serverSideLogic{connWrapper: wsConn}
 	s := httptest.NewServer(http.HandlerFunc(ssl.wsHandler))
 	serverURL := "ws" + strings.TrimPrefix(s.URL, "http")
 	defer s.Close()


### PR DESCRIPTION
Follow up from #20258
https://github.com/smartcontractkit/chainlink/actions/runs/19121841542/job/54643806646
```
==================
WARNING: DATA RACE
Read at 0x00c0003ffc4b by goroutine 449:
  testing.(*common).destination()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1049 +0x96
  testing.(*outputWriter).Write()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1133 +0x9a
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1040 +0x164
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1191 +0x8e
  go.uber.org/zap/zaptest.TestingWriter.Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zaptest/logger.go:146 +0x119
  go.uber.org/zap/zaptest.(*TestingWriter).Write()
      <autogenerated>:1 +0x74
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/core.go:99 +0x18d
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/entry.go:253 +0x1ec
  go.uber.org/zap.(*SugaredLogger).log()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/sugar.go:355 +0x12c
  go.uber.org/zap.(*SugaredLogger).Errorw()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/sugar.go:269 +0xa4
  github.com/smartcontractkit/chainlink-common/pkg/logger.(*logger).Errorw()
      <autogenerated>:1 +0x1f
  github.com/smartcontractkit/chainlink/v2/core/services/gateway/network.(*wsConnectionWrapper).readPump()
      /home/runner/_work/chainlink/chainlink/core/services/gateway/network/wsconnection.go:176 +0x459
  github.com/smartcontractkit/chainlink/v2/core/services/gateway/network.(*wsConnectionWrapper).Reset.gowrap1()
      /home/runner/_work/chainlink/chainlink/core/services/gateway/network/wsconnection.go:111 +0x4f

Previous write at 0x00c0003ffc4b by goroutine 178:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1921 +0x904
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.25.3/x64/src/runtime/panic.go:589 +0x5d
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1997 +0x44

Goroutine 449 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/services/gateway/network.(*wsConnectionWrapper).Reset()
      /home/runner/_work/chainlink/chainlink/core/services/gateway/network/wsconnection.go:111 +0x179
  github.com/smartcontractkit/chainlink/v2/core/services/gateway/network_test.(*serverSideLogic).wsHandler()
      /home/runner/_work/chainlink/chainlink/core/services/gateway/network/wsconnection_test.go:31 +0x84
  github.com/smartcontractkit/chainlink/v2/core/services/gateway/network_test.(*serverSideLogic).wsHandler-fm()
      <autogenerated>:1 +0x51
  net/http.HandlerFunc.ServeHTTP()
      /opt/hostedtoolcache/go/1.25.3/x64/src/net/http/server.go:2322 +0x47
  net/http.serverHandler.ServeHTTP()
      /opt/hostedtoolcache/go/1.25.3/x64/src/net/http/server.go:3340 +0x2a1
  net/http.(*conn).serve()
      /opt/hostedtoolcache/go/1.25.3/x64/src/net/http/server.go:2109 +0xda4
  net/http.(*Server).Serve.gowrap3()
      /opt/hostedtoolcache/go/1.25.3/x64/src/net/http/server.go:3493 +0x4f

Goroutine 178 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1997 +0x9d2
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:2477 +0x85
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1934 +0x21c
  testing.runTests()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:2475 +0x96c
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:2337 +0xed4
  main.main()
      _testmain.go:87 +0x164
==================
```