### PR TITLE
tiny formatting and function visibility changes

### DIFF
--- a/system-tests/lib/cre/crib/crib.go
+++ b/system-tests/lib/cre/crib/crib.go
@@ -151,7 +151,7 @@ func DeployDons(ctx context.Context, input *DeployCribDonsInput) ([]*cre.NodeSet
 		}
 
 		for nodeIdx, nodeMetadata := range donMetadata.NodesMetadata {
-			configToml, secrets, confSecretsErr := getConfigAndSecretsForNode(nodeMetadata, donIdx, input, donMetadata)
+			configToml, secrets, confSecretsErr := getConfigAndSecretsForNode(nodeMetadata, donIdx, input)
 			if confSecretsErr != nil {
 				return nil, confSecretsErr
 			}
@@ -225,7 +225,7 @@ func DeployDons(ctx context.Context, input *DeployCribDonsInput) ([]*cre.NodeSet
 	return input.NodeSet, nil
 }
 
-func getConfigAndSecretsForNode(nodeMetadata *cre.NodeMetadata, donIndex int, input *DeployCribDonsInput, donMetadata *cre.DonMetadata) (*string, *string, error) {
+func getConfigAndSecretsForNode(nodeMetadata *cre.NodeMetadata, donIndex int, input *DeployCribDonsInput) (*string, *string, error) {
 	nodeSpec := input.NodeSet[donIndex].NodeSpecs[nodeMetadata.Index]
 
 	cleanedToml, tomlErr := cleanToml(nodeSpec.Node.TestConfigOverrides)

--- a/system-tests/lib/cre/don.go
+++ b/system-tests/lib/cre/don.go
@@ -272,7 +272,7 @@ func NewDON(ctx context.Context, donMetadata *DonMetadata, ctfNodes []*clnode.Ou
 	return don, nil
 }
 
-func RegisterWithJD(ctx context.Context, d *Don, supportedChains []blockchains.Blockchain, cldfEnv *cldf.Environment) error {
+func registerWithJD(ctx context.Context, d *Don, supportedChains []blockchains.Blockchain, cldfEnv *cldf.Environment) error {
 	mu := &sync.Mutex{}
 
 	jd, ok := cldfEnv.Offchain.(*jd.JobDistributor)
@@ -284,7 +284,7 @@ func RegisterWithJD(ctx context.Context, d *Don, supportedChains []blockchains.B
 	for idx, node := range d.Nodes {
 		errgroup.Go(func() error {
 			// Set up Job distributor in node and register node with the job distributor
-			setupErr := node.SetUpAndLinkJobDistributor(ctx, cldfEnv)
+			setupErr := node.setUpAndLinkJobDistributor(ctx, cldfEnv)
 			if setupErr != nil {
 				return fmt.Errorf("failed to set up job distributor in node %s: %w", node.Name, setupErr)
 			}
@@ -292,7 +292,7 @@ func RegisterWithJD(ctx context.Context, d *Don, supportedChains []blockchains.B
 			for _, role := range node.Roles {
 				switch role {
 				case RoleWorker, RoleBootstrap:
-					if err := CreateJDChainConfigs(ctx, node, supportedChains, jd); err != nil {
+					if err := createJDChainConfigs(ctx, node, supportedChains, jd); err != nil {
 						return fmt.Errorf("failed to create supported chains in node %s: %w", node.Name, err)
 					}
 				case RoleGateway:
@@ -450,7 +450,7 @@ type JDChainConfigInput struct {
 	ChainType string
 }
 
-func CreateJDChainConfigs(ctx context.Context, n *Node, supportedChains []blockchains.Blockchain, jd *jd.JobDistributor) error {
+func createJDChainConfigs(ctx context.Context, n *Node, supportedChains []blockchains.Blockchain, jd *jd.JobDistributor) error {
 	for _, chain := range supportedChains {
 		var account string
 		chainIDStr := strconv.FormatUint(chain.ChainID(), 10)
@@ -675,9 +675,9 @@ func (n *Node) CreateJobDistributor(ctx context.Context, jd *jd.JobDistributor) 
 	})
 }
 
-// SetUpAndLinkJobDistributor sets up the job distributor in the node and registers the node with the job distributor
+// setUpAndLinkJobDistributor sets up the job distributor in the node and registers the node with the job distributor
 // it sets the job distributor id for node
-func (n *Node) SetUpAndLinkJobDistributor(ctx context.Context, cldfEnv *cldf.Environment) error {
+func (n *Node) setUpAndLinkJobDistributor(ctx context.Context, cldfEnv *cldf.Environment) error {
 	err := n.RegisterNodeToJobDistributor(ctx, cldfEnv)
 	if err != nil {
 		return err
@@ -775,12 +775,12 @@ func LinkToJobDistributor(ctx context.Context, input *LinkDonsToJDInput) error {
 	var nodeIDs []string
 
 	for idx, don := range input.Dons.List() {
-		supportedChains, schErr := FindDONsSupportedChains(input.Topology.DonsMetadata.List()[idx], input.Blockchains)
+		supportedChains, schErr := findDonSupportedChains(input.Topology.DonsMetadata.List()[idx], input.Blockchains)
 		if schErr != nil {
 			return errors.Wrap(schErr, "failed to find supported chains for DON")
 		}
 
-		if err := RegisterWithJD(ctx, don, supportedChains, input.CldfEnvironment); err != nil {
+		if err := registerWithJD(ctx, don, supportedChains, input.CldfEnvironment); err != nil {
 			return fmt.Errorf("failed to register DON with JD: %w", err)
 		}
 		nodeIDs = append(nodeIDs, don.JDNodeIDs()...)
@@ -806,7 +806,7 @@ func HasFlag(values []string, capability string) bool {
 	return false
 }
 
-func FindDONsSupportedChains(donMetadata *DonMetadata, bcs []blockchains.Blockchain) ([]blockchains.Blockchain, error) {
+func findDonSupportedChains(donMetadata *DonMetadata, bcs []blockchains.Blockchain) ([]blockchains.Blockchain, error) {
 	chains := make([]blockchains.Blockchain, 0)
 
 	for _, bc := range bcs {

--- a/system-tests/lib/cre/environment/dons.go
+++ b/system-tests/lib/cre/environment/dons.go
@@ -58,7 +58,6 @@ func StartDONs(
 	nodeSets []*cre.NodeSet,
 ) (*StartedDONs, error) {
 	if infraInput.Type == infra.CRIB {
-		lggr.Info().Msg("Saving node configs and secret overrides")
 		deployCribDonsInput := &crib.DeployCribDonsInput{
 			Topology:       topology,
 			NodeSet:        nodeSets,

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -356,7 +356,6 @@ func SetupTestEnvironment(
 			WorkflowOwners:  []common.Address{deployedBlockchains.RegistryChain().(*evm.Blockchain).SethClient.MustGetRootKeyAddress()}, // registry chain is always EVM
 		},
 	)
-
 	if wfErr != nil {
 		return nil, pkgerrors.Wrap(wfErr, "failed to configure workflow registry")
 	}
@@ -402,9 +401,7 @@ func SetupTestEnvironment(
 		configFn := capability.CapabilityRegistryV1ConfigFn()
 		capRegInput.CapabilityRegistryConfigFns = append(capRegInput.CapabilityRegistryConfigFns, configFn)
 	}
-
 	capRegInput.CapabilityRegistryConfigFns = append(capRegInput.CapabilityRegistryConfigFns, input.CapabilitiesContractFactoryFunctions...)
-
 	maps.Copy(capRegInput.DONCapabilityWithConfigs, donsCapabilities)
 
 	_, capRegErr := crecontracts.ConfigureCapabilityRegistry(capRegInput)
@@ -413,8 +410,8 @@ func SetupTestEnvironment(
 	}
 
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.WrapAndNext("Workflow and Capability Registry contracts configured in %.2f seconds", input.StageGen.Elapsed().Seconds())))
-
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.Wrap("Applying Features after environment startup")))
+
 	for _, feature := range input.Features.List() {
 		for _, don := range dons.DonsWithFlag(feature.Flag()) {
 			testLogger.Info().Msgf("Executing PostEnvStartup for feature %s for don '%s'", feature.Flag(), don.Name)


### PR DESCRIPTION
This pull request mainly refactors several functions and methods in the `system-tests/lib/cre/don.go` and related files to follow Go naming conventions (lowerCamelCase for unexported functions), simplifies function signatures, and removes some unnecessary lines. These changes improve code consistency and readability without affecting functionality.

### Refactoring for naming consistency

* Renamed multiple functions and methods from exported (PascalCase) to unexported (lowerCamelCase) style, such as `RegisterWithJD` → `registerWithJD`, `CreateJDChainConfigs` → `createJDChainConfigs`, `SetUpAndLinkJobDistributor` → `setUpAndLinkJobDistributor`, and `FindDONsSupportedChains` → `findDonSupportedChains`. This aligns with Go's convention for unexported identifiers. [[1]](diffhunk://#diff-69d5f33765f277b7df4625b004cf6f4befb5d74fb1bd772c78af72fb6f24d3e0L275-R275) [[2]](diffhunk://#diff-69d5f33765f277b7df4625b004cf6f4befb5d74fb1bd772c78af72fb6f24d3e0L453-R453) [[3]](diffhunk://#diff-69d5f33765f277b7df4625b004cf6f4befb5d74fb1bd772c78af72fb6f24d3e0L678-R680) [[4]](diffhunk://#diff-69d5f33765f277b7df4625b004cf6f4befb5d74fb1bd772c78af72fb6f24d3e0L809-R809)

* Updated all call sites to use the new function and method names, ensuring consistency throughout the codebase. [[1]](diffhunk://#diff-69d5f33765f277b7df4625b004cf6f4befb5d74fb1bd772c78af72fb6f24d3e0L287-R295) [[2]](diffhunk://#diff-69d5f33765f277b7df4625b004cf6f4befb5d74fb1bd772c78af72fb6f24d3e0L778-R783)

### Simplifying function signatures

* Removed the unnecessary `donMetadata` parameter from `getConfigAndSecretsForNode`, simplifying its signature and usage. [[1]](diffhunk://#diff-23d2436bcf4cd2710cc9a70f7cc0345dcb5d8a2115bcc11c10ec5c9df434ca7dL154-R154) [[2]](diffhunk://#diff-23d2436bcf4cd2710cc9a70f7cc0345dcb5d8a2115bcc11c10ec5c9df434ca7dL228-R228)

### Minor code cleanup

* Removed an unnecessary log message from `StartDONs` in `dons.go` to reduce verbosity.

* Deleted extraneous blank lines in `environment.go` to improve code clarity. [[1]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L359) [[2]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L405-L407) [[3]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L416-R414)