### PR TITLE
CCIP-7920 Defensive CCIP Oracle creation 

### DIFF
--- a/core/capabilities/ccip/launcher/launcher.go
+++ b/core/capabilities/ccip/launcher/launcher.go
@@ -254,10 +254,10 @@ func (l *launcher) processAdded(ctx context.Context, added map[registrysyncer.Do
 			configs,
 		)
 		if err != nil {
-			return fmt.Errorf("processAdded: call createDON %d: %w", donID, err)
+			l.lggr.Errorw("Some oracles failed to be created", "donID", donID, "err", err)
 		}
 		if len(newPlugins) == 0 {
-			// not a member of this DON.
+			// not a member of this DON or no oracles could be created
 			continue
 		}
 

--- a/core/capabilities/ccip/launcher/launcher.go
+++ b/core/capabilities/ccip/launcher/launcher.go
@@ -217,9 +217,10 @@ func (l *launcher) processUpdate(ctx context.Context, updated map[registrysyncer
 		)
 		if err != nil {
 			l.lggr.Errorw("Some oracles failed to be created", "donID", donID, "err", err)
+			continue
 		}
 		if len(newPlugins) == 0 {
-			// not a member of this DON or no oracles could be created
+			// not a member of this DON.
 			continue
 		}
 
@@ -256,9 +257,10 @@ func (l *launcher) processAdded(ctx context.Context, added map[registrysyncer.Do
 		)
 		if err != nil {
 			l.lggr.Errorw("Some oracles failed to be created", "donID", donID, "err", err)
+			continue
 		}
 		if len(newPlugins) == 0 {
-			// not a member of this DON or no oracles could be created
+			// not a member of this DON.
 			continue
 		}
 
@@ -326,7 +328,7 @@ func updateDON(
 		if _, ok := prevPlugins[digest]; !ok {
 			oracle, err := oracleCreator.Create(ctx, don.ID, cctypes.OCR3ConfigWithMeta(c))
 			if err != nil {
-				return nil, fmt.Errorf("failed to create CCIP oracle: %w for digest %x", err, digest)
+				return nil, fmt.Errorf("failed to create CCIP oracle: %w for digest %x", err, digest[:])
 			}
 
 			newP[digest] = oracle
@@ -339,9 +341,7 @@ func updateDON(
 }
 
 // createDON is a pure function that handles the case where a new DON is added to the capability registry.
-// It returns up to 4 plugins that are later started. It can create a partial state in which some oracles are properly
-// created and stored in the map, while others failed to be created. The caller is responsible for deciding what to do
-// in that situation.
+// It returns up to 4 plugins that are later started.
 func createDON(
 	ctx context.Context,
 	lggr logger.Logger,
@@ -354,25 +354,21 @@ func createDON(
 		lggr.Infow("Not a member of this DON and not a bootstrap node either, skipping", "donID", don.ID, "p2pID", p2pID.String())
 		return nil, nil
 	}
-	var aggErr error
 	p := make(pluginRegistry)
-
 	for _, config := range configs {
 		digest, err := ocrtypes.BytesToConfigDigest(config.ConfigDigest[:])
 		if err != nil {
-			aggErr = errors.Join(aggErr, fmt.Errorf("digest does not match type %w", err))
-			continue
+			return nil, fmt.Errorf("digest does not match type %w", err)
 		}
 
 		oracle, err := oracleCreator.Create(ctx, don.ID, cctypes.OCR3ConfigWithMeta(config))
 		if err != nil {
-			aggErr = errors.Join(aggErr, fmt.Errorf("failed to create CCIP oracle: %w for digest %x", err, digest))
-			continue
+			return nil, fmt.Errorf("failed to create CCIP oracle: %w for digest %x", err, digest[:])
 		}
 
 		p[digest] = oracle
 	}
-	return p, aggErr
+	return p, nil
 }
 
 func getConfigsForDon(

--- a/core/capabilities/ccip/launcher/launcher.go
+++ b/core/capabilities/ccip/launcher/launcher.go
@@ -213,12 +213,13 @@ func (l *launcher) processUpdate(ctx context.Context, updated map[registrysyncer
 			prevPlugins,
 			don,
 			l.oracleCreator,
-			latestConfigs)
+			latestConfigs,
+		)
 		if err != nil {
-			return err
+			l.lggr.Errorw("Some oracles failed to be created", "donID", donID, "err", err)
 		}
 		if len(newPlugins) == 0 {
-			// not a member of this DON.
+			// not a member of this DON or no oracles could be created
 			continue
 		}
 

--- a/core/capabilities/ccip/launcher/launcher.go
+++ b/core/capabilities/ccip/launcher/launcher.go
@@ -338,7 +338,9 @@ func updateDON(
 }
 
 // createDON is a pure function that handles the case where a new DON is added to the capability registry.
-// It returns up to 4 plugins that are later started.
+// It returns up to 4 plugins that are later started. It can create a partial state in which some oracles are properly
+// created and stored in the map, while others failed to be created. The caller is responsible for deciding what to do
+// in that situation.
 func createDON(
 	ctx context.Context,
 	lggr logger.Logger,
@@ -351,21 +353,25 @@ func createDON(
 		lggr.Infow("Not a member of this DON and not a bootstrap node either, skipping", "donID", don.ID, "p2pID", p2pID.String())
 		return nil, nil
 	}
+	var aggErr error
 	p := make(pluginRegistry)
+
 	for _, config := range configs {
 		digest, err := ocrtypes.BytesToConfigDigest(config.ConfigDigest[:])
 		if err != nil {
-			return nil, fmt.Errorf("digest does not match type %w", err)
+			aggErr = errors.Join(aggErr, fmt.Errorf("digest does not match type %w", err))
+			continue
 		}
 
 		oracle, err := oracleCreator.Create(ctx, don.ID, cctypes.OCR3ConfigWithMeta(config))
 		if err != nil {
-			return nil, fmt.Errorf("failed to create CCIP oracle: %w for digest %x", err, digest)
+			aggErr = errors.Join(aggErr, fmt.Errorf("failed to create CCIP oracle: %w for digest %x", err, digest))
+			continue
 		}
 
 		p[digest] = oracle
 	}
-	return p, nil
+	return p, aggErr
 }
 
 func getConfigsForDon(

--- a/core/capabilities/ccip/launcher/launcher_test.go
+++ b/core/capabilities/ccip/launcher/launcher_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	ragep2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
 	ccipreaderpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
@@ -253,8 +254,9 @@ func Test_createDON_withFailures(t *testing.T) {
 	oracleCreator := mocks.NewOracleCreator(t)
 	homeChainReader := mocks.NewHomeChainReader(t)
 
-	config1 := utils.RandomBytes32()
-	config2 := utils.RandomBytes32()
+	var config1, config2 ocrtypes.ConfigDigest
+	config1 = utils.RandomBytes32()
+	config2 = utils.RandomBytes32()
 
 	homeChainReader.
 		On("GetOCRConfigs", mock.Anything, uint32(1), uint8(cctypes.PluginTypeCCIPCommit)).

--- a/core/capabilities/ccip/launcher/launcher_test.go
+++ b/core/capabilities/ccip/launcher/launcher_test.go
@@ -1,6 +1,8 @@
 package launcher
 
 import (
+	"bytes"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -241,6 +243,70 @@ func Test_createDON(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_createDON_withFailures(t *testing.T) {
+	lggr := logger.Test(t)
+	p2pID := p2pID1
+	ctx := testutils.Context(t)
+	don := defaultRegistryDon
+	oracleCreator := mocks.NewOracleCreator(t)
+	homeChainReader := mocks.NewHomeChainReader(t)
+
+	config1 := utils.RandomBytes32()
+	config2 := utils.RandomBytes32()
+
+	homeChainReader.
+		On("GetOCRConfigs", mock.Anything, uint32(1), uint8(cctypes.PluginTypeCCIPCommit)).
+		Return(ccipreaderpkg.ActiveAndCandidate{
+			ActiveConfig: ccipreaderpkg.OCR3ConfigWithMeta{},
+			CandidateConfig: ccipreaderpkg.OCR3ConfigWithMeta{
+				Config: ccipreaderpkg.OCR3Config{
+					PluginType: uint8(cctypes.PluginTypeCCIPCommit),
+					Nodes:      getOCR3Nodes(3, 4),
+				},
+				ConfigDigest: config1,
+			},
+		}, nil)
+
+	homeChainReader.
+		On("GetOCRConfigs", mock.Anything, uint32(1), uint8(cctypes.PluginTypeCCIPExec)).
+		Return(ccipreaderpkg.ActiveAndCandidate{
+			ActiveConfig: ccipreaderpkg.OCR3ConfigWithMeta{},
+			CandidateConfig: ccipreaderpkg.OCR3ConfigWithMeta{
+				Config: ccipreaderpkg.OCR3Config{
+					PluginType: uint8(cctypes.PluginTypeCCIPExec),
+					Nodes:      getOCR3Nodes(3, 4),
+				},
+				ConfigDigest: config2,
+			},
+		}, nil)
+
+	// First create fails, second succeeds
+	oracleCreator.EXPECT().
+		Create(mock.Anything, don.ID, mock.MatchedBy(func(cfg cctypes.OCR3ConfigWithMeta) bool {
+			return bytes.Equal(cfg.ConfigDigest[:], config1[:])
+		})).
+		Return(nil, fmt.Errorf("fail on first")).
+		Maybe()
+
+	oracleCreator.EXPECT().
+		Create(mock.Anything, don.ID, mock.MatchedBy(func(cfg cctypes.OCR3ConfigWithMeta) bool {
+			return bytes.Equal(cfg.ConfigDigest[:], config2[:])
+		})).
+		Return(mocks.NewCCIPOracle(t), nil).
+		Maybe()
+
+	latestConfigs, err := getConfigsForDon(ctx, homeChainReader, don)
+	require.NoError(t, err)
+
+	pluginReg, err := createDON(ctx, lggr, p2pID, don, oracleCreator, latestConfigs)
+	require.Error(t, err)
+
+	require.Len(t, pluginReg, 1)
+
+	require.NotContains(t, pluginReg, config1)
+	require.Contains(t, pluginReg, config2)
 }
 
 func Test_updateDON(t *testing.T) {

--- a/core/capabilities/ccip/launcher/launcher_test.go
+++ b/core/capabilities/ccip/launcher/launcher_test.go
@@ -792,6 +792,79 @@ func Test_launcher_processDiff(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"single oracle fails to create without impacting others",
+			fields{
+				lggr:  logger.Test(t),
+				p2pID: p2pID1,
+				homeChainReader: newMock(t, func(t *testing.T) *mocks.HomeChainReader {
+					return mocks.NewHomeChainReader(t)
+				}, func(m *mocks.HomeChainReader) {
+					m.On("GetOCRConfigs", mock.Anything, uint32(1), uint8(cctypes.PluginTypeCCIPCommit)).
+						Return(ccipreaderpkg.ActiveAndCandidate{
+							ActiveConfig: ccipreaderpkg.OCR3ConfigWithMeta{},
+							CandidateConfig: ccipreaderpkg.OCR3ConfigWithMeta{
+								Config: ccipreaderpkg.OCR3Config{
+									PluginType: uint8(cctypes.PluginTypeCCIPCommit),
+									Nodes:      getOCR3Nodes(3, 4),
+								},
+								ConfigDigest: digest1,
+							},
+						}, nil)
+					m.On("GetOCRConfigs", mock.Anything, uint32(1), uint8(cctypes.PluginTypeCCIPExec)).
+						Return(ccipreaderpkg.ActiveAndCandidate{
+							ActiveConfig: ccipreaderpkg.OCR3ConfigWithMeta{},
+							CandidateConfig: ccipreaderpkg.OCR3ConfigWithMeta{
+								Config: ccipreaderpkg.OCR3Config{
+									PluginType: uint8(cctypes.PluginTypeCCIPExec),
+									Nodes:      getOCR3Nodes(3, 4),
+								},
+								ConfigDigest: digest2,
+							},
+						}, nil)
+				}),
+				oracleCreator: newMock(t, func(t *testing.T) *mocks.OracleCreator {
+					return mocks.NewOracleCreator(t)
+				}, func(m *mocks.OracleCreator) {
+					commitOracle := mocks.NewCCIPOracle(t)
+					commitOracle.On("Start").Return(nil).Maybe()
+					execOracle := mocks.NewCCIPOracle(t)
+					execOracle.On("Start").Return(nil).Maybe()
+					m.EXPECT().Create(mock.Anything, mock.Anything, mock.MatchedBy(func(cfg cctypes.OCR3ConfigWithMeta) bool {
+						return cfg.Config.PluginType == uint8(cctypes.PluginTypeCCIPCommit)
+					})).
+						Return(nil, errors.New("fail on commit"))
+					m.EXPECT().Create(mock.Anything, mock.Anything, mock.MatchedBy(func(cfg cctypes.OCR3ConfigWithMeta) bool {
+						return cfg.Config.PluginType == uint8(cctypes.PluginTypeCCIPExec)
+					})).
+						Return(execOracle, nil)
+				}),
+				instances: map[registrysyncer.DonID]pluginRegistry{},
+				regState: registrysyncer.LocalRegistry{
+					IDsToDONs: map[registrysyncer.DonID]registrysyncer.DON{},
+				},
+			},
+			args{
+				diff: diffResult{
+					added: map[registrysyncer.DonID]registrysyncer.DON{
+						1: defaultRegistryDon,
+					},
+				},
+			},
+			func(t *testing.T, l *launcher) {
+				require.Len(t, l.instances, 1)
+				pluginReg := l.instances[1]
+
+				var configDigest1, configDigest2 ocrtypes.ConfigDigest
+				configDigest1 = digest1
+				configDigest2 = digest2
+
+				require.NotContains(t, pluginReg, configDigest1)
+				require.Contains(t, pluginReg, configDigest2)
+				require.Len(t, l.regState.IDsToDONs, 1)
+			},
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/core/capabilities/ccip/launcher/launcher_test.go
+++ b/core/capabilities/ccip/launcher/launcher_test.go
@@ -1,7 +1,6 @@
 package launcher
 
 import (
-	"bytes"
 	"errors"
 	"math/big"
 	"testing"
@@ -244,71 +243,6 @@ func Test_createDON(t *testing.T) {
 			}
 		})
 	}
-}
-
-func Test_createDON_withFailures(t *testing.T) {
-	lggr := logger.Test(t)
-	p2pID := p2pID1
-	ctx := testutils.Context(t)
-	don := defaultRegistryDon
-	oracleCreator := mocks.NewOracleCreator(t)
-	homeChainReader := mocks.NewHomeChainReader(t)
-
-	var config1, config2 ocrtypes.ConfigDigest
-	config1 = utils.RandomBytes32()
-	config2 = utils.RandomBytes32()
-
-	homeChainReader.
-		On("GetOCRConfigs", mock.Anything, uint32(1), uint8(cctypes.PluginTypeCCIPCommit)).
-		Return(ccipreaderpkg.ActiveAndCandidate{
-			ActiveConfig: ccipreaderpkg.OCR3ConfigWithMeta{},
-			CandidateConfig: ccipreaderpkg.OCR3ConfigWithMeta{
-				Config: ccipreaderpkg.OCR3Config{
-					PluginType: uint8(cctypes.PluginTypeCCIPCommit),
-					Nodes:      getOCR3Nodes(3, 4),
-				},
-				ConfigDigest: config1,
-			},
-		}, nil)
-
-	homeChainReader.
-		On("GetOCRConfigs", mock.Anything, uint32(1), uint8(cctypes.PluginTypeCCIPExec)).
-		Return(ccipreaderpkg.ActiveAndCandidate{
-			ActiveConfig: ccipreaderpkg.OCR3ConfigWithMeta{},
-			CandidateConfig: ccipreaderpkg.OCR3ConfigWithMeta{
-				Config: ccipreaderpkg.OCR3Config{
-					PluginType: uint8(cctypes.PluginTypeCCIPExec),
-					Nodes:      getOCR3Nodes(3, 4),
-				},
-				ConfigDigest: config2,
-			},
-		}, nil)
-
-	// First create fails, second succeeds
-	oracleCreator.EXPECT().
-		Create(mock.Anything, don.ID, mock.MatchedBy(func(cfg cctypes.OCR3ConfigWithMeta) bool {
-			return bytes.Equal(cfg.ConfigDigest[:], config1[:])
-		})).
-		Return(nil, errors.New("fail on first")).
-		Maybe()
-
-	oracleCreator.EXPECT().
-		Create(mock.Anything, don.ID, mock.MatchedBy(func(cfg cctypes.OCR3ConfigWithMeta) bool {
-			return bytes.Equal(cfg.ConfigDigest[:], config2[:])
-		})).
-		Return(mocks.NewCCIPOracle(t), nil).
-		Maybe()
-
-	latestConfigs, err := getConfigsForDon(ctx, homeChainReader, don)
-	require.NoError(t, err)
-
-	pluginReg, err := createDON(ctx, lggr, p2pID, don, oracleCreator, latestConfigs)
-	require.Error(t, err)
-
-	require.Len(t, pluginReg, 1)
-
-	require.NotContains(t, pluginReg, config1)
-	require.Contains(t, pluginReg, config2)
 }
 
 func Test_updateDON(t *testing.T) {
@@ -800,7 +734,7 @@ func Test_launcher_processDiff(t *testing.T) {
 				homeChainReader: newMock(t, func(t *testing.T) *mocks.HomeChainReader {
 					return mocks.NewHomeChainReader(t)
 				}, func(m *mocks.HomeChainReader) {
-					m.On("GetOCRConfigs", mock.Anything, uint32(1), uint8(cctypes.PluginTypeCCIPCommit)).
+					m.On("GetOCRConfigs", mock.Anything, mock.Anything, uint8(cctypes.PluginTypeCCIPCommit)).
 						Return(ccipreaderpkg.ActiveAndCandidate{
 							ActiveConfig: ccipreaderpkg.OCR3ConfigWithMeta{},
 							CandidateConfig: ccipreaderpkg.OCR3ConfigWithMeta{
@@ -811,7 +745,7 @@ func Test_launcher_processDiff(t *testing.T) {
 								ConfigDigest: digest1,
 							},
 						}, nil)
-					m.On("GetOCRConfigs", mock.Anything, uint32(1), uint8(cctypes.PluginTypeCCIPExec)).
+					m.On("GetOCRConfigs", mock.Anything, mock.Anything, uint8(cctypes.PluginTypeCCIPExec)).
 						Return(ccipreaderpkg.ActiveAndCandidate{
 							ActiveConfig: ccipreaderpkg.OCR3ConfigWithMeta{},
 							CandidateConfig: ccipreaderpkg.OCR3ConfigWithMeta{
@@ -830,13 +764,9 @@ func Test_launcher_processDiff(t *testing.T) {
 					commitOracle.On("Start").Return(nil).Maybe()
 					execOracle := mocks.NewCCIPOracle(t)
 					execOracle.On("Start").Return(nil).Maybe()
-					m.EXPECT().Create(mock.Anything, mock.Anything, mock.MatchedBy(func(cfg cctypes.OCR3ConfigWithMeta) bool {
-						return cfg.Config.PluginType == uint8(cctypes.PluginTypeCCIPCommit)
-					})).
+					m.EXPECT().Create(mock.Anything, uint32(1), mock.Anything).
 						Return(nil, errors.New("fail on commit"))
-					m.EXPECT().Create(mock.Anything, mock.Anything, mock.MatchedBy(func(cfg cctypes.OCR3ConfigWithMeta) bool {
-						return cfg.Config.PluginType == uint8(cctypes.PluginTypeCCIPExec)
-					})).
+					m.EXPECT().Create(mock.Anything, uint32(2), mock.Anything).
 						Return(execOracle, nil)
 				}),
 				instances: map[registrysyncer.DonID]pluginRegistry{},
@@ -848,20 +778,27 @@ func Test_launcher_processDiff(t *testing.T) {
 				diff: diffResult{
 					added: map[registrysyncer.DonID]registrysyncer.DON{
 						1: defaultRegistryDon,
+						2: secondaryRegistryDon,
 					},
 				},
 			},
 			func(t *testing.T, l *launcher) {
 				require.Len(t, l.instances, 1)
-				pluginReg := l.instances[1]
+				pluginReg, ok := l.instances[2]
+				require.True(t, ok)
 
 				var configDigest1, configDigest2 ocrtypes.ConfigDigest
 				configDigest1 = digest1
 				configDigest2 = digest2
 
-				require.NotContains(t, pluginReg, configDigest1)
+				require.Contains(t, pluginReg, configDigest1)
 				require.Contains(t, pluginReg, configDigest2)
+
 				require.Len(t, l.regState.IDsToDONs, 1)
+				_, ok1 := l.regState.IDsToDONs[1]
+				require.False(t, ok1)
+				_, ok2 := l.regState.IDsToDONs[2]
+				require.True(t, ok2)
 			},
 			false,
 		},

--- a/core/capabilities/ccip/launcher/launcher_test.go
+++ b/core/capabilities/ccip/launcher/launcher_test.go
@@ -2,7 +2,7 @@ package launcher
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"math/big"
 	"testing"
 
@@ -289,7 +289,7 @@ func Test_createDON_withFailures(t *testing.T) {
 		Create(mock.Anything, don.ID, mock.MatchedBy(func(cfg cctypes.OCR3ConfigWithMeta) bool {
 			return bytes.Equal(cfg.ConfigDigest[:], config1[:])
 		})).
-		Return(nil, fmt.Errorf("fail on first")).
+		Return(nil, errors.New("fail on first")).
 		Maybe()
 
 	oracleCreator.EXPECT().

--- a/core/capabilities/ccip/launcher/test_helpers.go
+++ b/core/capabilities/ccip/launcher/test_helpers.go
@@ -32,6 +32,10 @@ var (
 		DON:                      getDON(1, []ragep2ptypes.PeerID{p2pID1}, 0),
 		CapabilityConfigurations: defaultCapCfgs,
 	}
+	secondaryRegistryDon = registrysyncer.DON{
+		DON:                      getDON(2, []ragep2ptypes.PeerID{p2pID1}, 0),
+		CapabilityConfigurations: defaultCapCfgs,
+	}
 )
 
 func getP2PID(id uint32) ragep2ptypes.PeerID {


### PR DESCRIPTION
More defensive approach to creating CCIP Oracles. So far, a single oracle creation failure has bubbled up and stopped the entire process. Therefore single faulty definition of a job or an invalid configuration impacted the entire node by bringing down all the oracles.

Right now, the approach is more defensive / best-effort. We try to create as many oracles as possible without interrupting the process on error. Launcher ticks in intervals, which will take care of the retries. If the config is faulty, it would keep erroring on the log level without impacting other oracles. 

