### PR TITLE
core/services/gateway/network: fix TestWSConnectionWrapper_ClientReconnect race

### DIFF
--- a/core/services/gateway/connector/connector.go
+++ b/core/services/gateway/connector/connector.go
@@ -264,7 +264,9 @@ func (c *gatewayConnector) reconnectLoop(gatewayState *gatewayState) {
 			c.lggr.Infow("connected successfully", "url", gatewayState.url)
 			closeCh := gatewayState.conn.Reset(conn)
 			gatewayState.signal()
-			<-closeCh
+			if closeCh != nil { // nil means already closed
+				<-closeCh
+			}
 			c.lggr.Infow("connection closed", "url", gatewayState.url)
 
 			// reset backoff


### PR DESCRIPTION
Ensuring connections were closed was not sufficient. We need to track read and write pump goroutines, and block until they shutdown from Close().