### PR TITLE
Bump chainlink-deployments-framework to v0.64.0

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20251105200616-e158f436aa95
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251107130345-a71a2d557176
 	github.com/smartcontractkit/chainlink-data-streams v0.1.6
-	github.com/smartcontractkit/chainlink-deployments-framework v0.62.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.64.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251021010742-3f8d3dba17d8

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1621,8 +1621,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.6 h1:B3cwmJrVYoJVAjPOyQWTNaGD+V30HI1vFHhC2dQpWDo=
 github.com/smartcontractkit/chainlink-data-streams v0.1.6/go.mod h1:e9jETTzrVO8iu9Zp5gDuTCmBVhSJwUOk6K4Q/VFrJ6o=
-github.com/smartcontractkit/chainlink-deployments-framework v0.62.0 h1:/vfXc1kjdXA9qeos05rQ0WLGwnchc3nZ9TWSQVNHNqM=
-github.com/smartcontractkit/chainlink-deployments-framework v0.62.0/go.mod h1:y39Mr9YAElrLEhA3/Wx3c0cT7bark3aiSg4RQXf9WpI=
+github.com/smartcontractkit/chainlink-deployments-framework v0.64.0 h1:QZCVEBENiyF/FvlaMuT/XlD4SCGib+ecRhmT3HojMCU=
+github.com/smartcontractkit/chainlink-deployments-framework v0.64.0/go.mod h1:wo/aaK/nHhvvwG0IHgEpQUgYCaCqOrNy4KCAkrHc3jQ=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f h1:XXeZ5ChjN13kDgl8eZVSyrN7ZUlLan2p3dzmtgkMG00=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f/go.mod h1:6Zh4cDsZ5fa3k2t3ShnzEKAE+fp/KwtaWCZOrGoMWjg=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b h1:Dqhm/67Sb1ohgce8FW6tnK1CRXo2zoLCbV+EGyew5sg=

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -172,31 +172,12 @@ func (n Node) AllOCRConfigs() map[chain_selectors.ChainDetails]OCRConfig {
 }
 
 func (n Node) OCRConfigForChainSelector(chainSel uint64) (OCRConfig, bool) {
-	fam, err := chain_selectors.GetSelectorFamily(chainSel)
-	if err != nil {
-		return OCRConfig{}, false
-	}
-
-	id, err := chain_selectors.GetChainIDFromSelector(chainSel)
-	if err != nil {
-		return OCRConfig{}, false
-	}
-
-	want, err := chain_selectors.GetChainDetailsByChainIDAndFamily(id, fam)
-	if err != nil {
-		return OCRConfig{}, false
-	}
-	// only applicable for test related simulated chains, the chains don't have a name
-	if want.ChainName == "" {
-		want.ChainName = strconv.FormatUint(want.ChainSelector, 10)
-	}
-
 	chainSelToConfig := make(map[uint64]OCRConfig, len(n.SelToOCRConfig))
 	for details, config := range n.SelToOCRConfig {
 		chainSelToConfig[details.ChainSelector] = config
 	}
 
-	c, ok := chainSelToConfig[want.ChainSelector]
+	c, ok := chainSelToConfig[chainSel]
 	return c, ok
 }
 

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -191,12 +191,12 @@ func (n Node) OCRConfigForChainSelector(chainSel uint64) (OCRConfig, bool) {
 		want.ChainName = strconv.FormatUint(want.ChainSelector, 10)
 	}
 
-	chainIdToConfig := make(map[uint64]OCRConfig, len(n.SelToOCRConfig))
+	chainSelToConfig := make(map[uint64]OCRConfig, len(n.SelToOCRConfig))
 	for details, config := range n.SelToOCRConfig {
-		chainIdToConfig[details.ChainSelector] = config
+		chainSelToConfig[details.ChainSelector] = config
 	}
 
-	c, ok := chainIdToConfig[want.ChainSelector]
+	c, ok := chainSelToConfig[want.ChainSelector]
 	return c, ok
 }
 

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -191,7 +191,12 @@ func (n Node) OCRConfigForChainSelector(chainSel uint64) (OCRConfig, bool) {
 		want.ChainName = strconv.FormatUint(want.ChainSelector, 10)
 	}
 
-	c, ok := n.SelToOCRConfig[want]
+	chainIdToConfig := make(map[uint64]OCRConfig, len(n.SelToOCRConfig))
+	for details, config := range n.SelToOCRConfig {
+		chainIdToConfig[details.ChainSelector] = config
+	}
+
+	c, ok := chainIdToConfig[want.ChainSelector]
 	return c, ok
 }
 

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251107130345-a71a2d557176
-	github.com/smartcontractkit/chainlink-deployments-framework v0.62.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.64.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20251021173435-e86785845942

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1345,8 +1345,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.6 h1:B3cwmJrVYoJVAjPOyQWTNaGD+V30HI1vFHhC2dQpWDo=
 github.com/smartcontractkit/chainlink-data-streams v0.1.6/go.mod h1:e9jETTzrVO8iu9Zp5gDuTCmBVhSJwUOk6K4Q/VFrJ6o=
-github.com/smartcontractkit/chainlink-deployments-framework v0.62.0 h1:/vfXc1kjdXA9qeos05rQ0WLGwnchc3nZ9TWSQVNHNqM=
-github.com/smartcontractkit/chainlink-deployments-framework v0.62.0/go.mod h1:y39Mr9YAElrLEhA3/Wx3c0cT7bark3aiSg4RQXf9WpI=
+github.com/smartcontractkit/chainlink-deployments-framework v0.64.0 h1:QZCVEBENiyF/FvlaMuT/XlD4SCGib+ecRhmT3HojMCU=
+github.com/smartcontractkit/chainlink-deployments-framework v0.64.0/go.mod h1:wo/aaK/nHhvvwG0IHgEpQUgYCaCqOrNy4KCAkrHc3jQ=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f h1:XXeZ5ChjN13kDgl8eZVSyrN7ZUlLan2p3dzmtgkMG00=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f/go.mod h1:6Zh4cDsZ5fa3k2t3ShnzEKAE+fp/KwtaWCZOrGoMWjg=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b h1:Dqhm/67Sb1ohgce8FW6tnK1CRXo2zoLCbV+EGyew5sg=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251107130345-a71a2d557176
-	github.com/smartcontractkit/chainlink-deployments-framework v0.62.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.64.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1589,8 +1589,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.6 h1:B3cwmJrVYoJVAjPOyQWTNaGD+V30HI1vFHhC2dQpWDo=
 github.com/smartcontractkit/chainlink-data-streams v0.1.6/go.mod h1:e9jETTzrVO8iu9Zp5gDuTCmBVhSJwUOk6K4Q/VFrJ6o=
-github.com/smartcontractkit/chainlink-deployments-framework v0.62.0 h1:/vfXc1kjdXA9qeos05rQ0WLGwnchc3nZ9TWSQVNHNqM=
-github.com/smartcontractkit/chainlink-deployments-framework v0.62.0/go.mod h1:y39Mr9YAElrLEhA3/Wx3c0cT7bark3aiSg4RQXf9WpI=
+github.com/smartcontractkit/chainlink-deployments-framework v0.64.0 h1:QZCVEBENiyF/FvlaMuT/XlD4SCGib+ecRhmT3HojMCU=
+github.com/smartcontractkit/chainlink-deployments-framework v0.64.0/go.mod h1:wo/aaK/nHhvvwG0IHgEpQUgYCaCqOrNy4KCAkrHc3jQ=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f h1:XXeZ5ChjN13kDgl8eZVSyrN7ZUlLan2p3dzmtgkMG00=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f/go.mod h1:6Zh4cDsZ5fa3k2t3ShnzEKAE+fp/KwtaWCZOrGoMWjg=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b h1:Dqhm/67Sb1ohgce8FW6tnK1CRXo2zoLCbV+EGyew5sg=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251107130345-a71a2d557176
-	github.com/smartcontractkit/chainlink-deployments-framework v0.62.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.64.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.11.7

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1568,8 +1568,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.6 h1:B3cwmJrVYoJVAjPOyQWTNaGD+V30HI1vFHhC2dQpWDo=
 github.com/smartcontractkit/chainlink-data-streams v0.1.6/go.mod h1:e9jETTzrVO8iu9Zp5gDuTCmBVhSJwUOk6K4Q/VFrJ6o=
-github.com/smartcontractkit/chainlink-deployments-framework v0.62.0 h1:/vfXc1kjdXA9qeos05rQ0WLGwnchc3nZ9TWSQVNHNqM=
-github.com/smartcontractkit/chainlink-deployments-framework v0.62.0/go.mod h1:y39Mr9YAElrLEhA3/Wx3c0cT7bark3aiSg4RQXf9WpI=
+github.com/smartcontractkit/chainlink-deployments-framework v0.64.0 h1:QZCVEBENiyF/FvlaMuT/XlD4SCGib+ecRhmT3HojMCU=
+github.com/smartcontractkit/chainlink-deployments-framework v0.64.0/go.mod h1:wo/aaK/nHhvvwG0IHgEpQUgYCaCqOrNy4KCAkrHc3jQ=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f h1:XXeZ5ChjN13kDgl8eZVSyrN7ZUlLan2p3dzmtgkMG00=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f/go.mod h1:6Zh4cDsZ5fa3k2t3ShnzEKAE+fp/KwtaWCZOrGoMWjg=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b h1:Dqhm/67Sb1ohgce8FW6tnK1CRXo2zoLCbV+EGyew5sg=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.78
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251107130345-a71a2d557176
-	github.com/smartcontractkit/chainlink-deployments-framework v0.62.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.64.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251021010742-3f8d3dba17d8

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1586,8 +1586,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.6 h1:B3cwmJrVYoJVAjPOyQWTNaGD+V30HI1vFHhC2dQpWDo=
 github.com/smartcontractkit/chainlink-data-streams v0.1.6/go.mod h1:e9jETTzrVO8iu9Zp5gDuTCmBVhSJwUOk6K4Q/VFrJ6o=
-github.com/smartcontractkit/chainlink-deployments-framework v0.62.0 h1:/vfXc1kjdXA9qeos05rQ0WLGwnchc3nZ9TWSQVNHNqM=
-github.com/smartcontractkit/chainlink-deployments-framework v0.62.0/go.mod h1:y39Mr9YAElrLEhA3/Wx3c0cT7bark3aiSg4RQXf9WpI=
+github.com/smartcontractkit/chainlink-deployments-framework v0.64.0 h1:QZCVEBENiyF/FvlaMuT/XlD4SCGib+ecRhmT3HojMCU=
+github.com/smartcontractkit/chainlink-deployments-framework v0.64.0/go.mod h1:wo/aaK/nHhvvwG0IHgEpQUgYCaCqOrNy4KCAkrHc3jQ=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f h1:XXeZ5ChjN13kDgl8eZVSyrN7ZUlLan2p3dzmtgkMG00=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f/go.mod h1:6Zh4cDsZ5fa3k2t3ShnzEKAE+fp/KwtaWCZOrGoMWjg=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b h1:Dqhm/67Sb1ohgce8FW6tnK1CRXo2zoLCbV+EGyew5sg=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.78
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251107130345-a71a2d557176
 	github.com/smartcontractkit/chainlink-data-streams v0.1.6
-	github.com/smartcontractkit/chainlink-deployments-framework v0.62.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.64.0
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251021010742-3f8d3dba17d8
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1791,8 +1791,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.6 h1:B3cwmJrVYoJVAjPOyQWTNaGD+V30HI1vFHhC2dQpWDo=
 github.com/smartcontractkit/chainlink-data-streams v0.1.6/go.mod h1:e9jETTzrVO8iu9Zp5gDuTCmBVhSJwUOk6K4Q/VFrJ6o=
-github.com/smartcontractkit/chainlink-deployments-framework v0.62.0 h1:/vfXc1kjdXA9qeos05rQ0WLGwnchc3nZ9TWSQVNHNqM=
-github.com/smartcontractkit/chainlink-deployments-framework v0.62.0/go.mod h1:y39Mr9YAElrLEhA3/Wx3c0cT7bark3aiSg4RQXf9WpI=
+github.com/smartcontractkit/chainlink-deployments-framework v0.64.0 h1:QZCVEBENiyF/FvlaMuT/XlD4SCGib+ecRhmT3HojMCU=
+github.com/smartcontractkit/chainlink-deployments-framework v0.64.0/go.mod h1:wo/aaK/nHhvvwG0IHgEpQUgYCaCqOrNy4KCAkrHc3jQ=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f h1:XXeZ5ChjN13kDgl8eZVSyrN7ZUlLan2p3dzmtgkMG00=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f/go.mod h1:6Zh4cDsZ5fa3k2t3ShnzEKAE+fp/KwtaWCZOrGoMWjg=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b h1:Dqhm/67Sb1ohgce8FW6tnK1CRXo2zoLCbV+EGyew5sg=


### PR DESCRIPTION
Contains a fix for CCIP types `suibindings.NewCCIPEntrypointArgEncoder`