### PR TITLE
core/utils: fix CronTicker.Stop() race

### DIFF
--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -383,7 +383,8 @@ func (t *CronTicker) Start() bool {
 func (t *CronTicker) Stop() bool {
 	if t.Cron != nil {
 		if t.beenRun.CompareAndSwap(true, false) {
-			t.Cron.Stop()
+			ctx := t.Cron.Stop()
+			<-ctx.Done() // Wait for background routines
 			return true
 		}
 	}


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/actions/runs/19200578016/job/54887836018
```
==================
WARNING: DATA RACE
Write at 0x00c000a010d8 by goroutine 9765:
  runtime.racewrite()
      <autogenerated>:1 +0x1e
  github.com/robfig/cron/v3.(*Cron).Stop.func1()
      /home/runner/go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:332 +0x3b

Previous read at 0x00c000a010d8 by goroutine 9767:
  runtime.raceread()
      <autogenerated>:1 +0x1e
  github.com/robfig/cron/v3.(*Cron).startJob()
      /home/runner/go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:309 +0x44
  github.com/robfig/cron/v3.(*Cron).run()
      /home/runner/go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:273 +0x18b5
  github.com/robfig/cron/v3.(*Cron).Start.gowrap2()
      /home/runner/go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:222 +0x33

Goroutine 9765 (running) created at:
  github.com/robfig/cron/v3.(*Cron).Stop()
      /home/runner/go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:331 +0x1dc
  github.com/smartcontractkit/chainlink/v2/core/utils.(*CronTicker).Stop()
      /home/runner/_work/chainlink/chainlink/core/utils/utils.go:386 +0x71
  github.com/smartcontractkit/chainlink/v2/core/utils_test.TestCronTicker()
      /home/runner/_work/chainlink/chainlink/core/utils/utils_test.go:440 +0x275
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1997 +0x44

Goroutine 9767 (running) created at:
  github.com/robfig/cron/v3.(*Cron).Start()
      /home/runner/go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:222 +0x124
  github.com/smartcontractkit/chainlink/v2/core/utils.(*CronTicker).Start()
      /home/runner/_work/chainlink/chainlink/core/utils/utils.go:375 +0x71
  github.com/smartcontractkit/chainlink/v2/core/utils_test.TestCronTicker()
      /home/runner/_work/chainlink/chainlink/core/utils/utils_test.go:443 +0x2dc
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1997 +0x44
==================
```