### PR TITLE
Add chain selector validation for configured chains

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -341,6 +341,13 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 		return nil, fmt.Errorf("failed to initialize relayer chain interoperators: %w", err)
 	}
 
+	// Validate that all configured chains have valid chain selectors
+	// This ensures the node crashes early if TOML configs contain chains that aren't
+	// recognized by the chain-selectors library, preventing silent failures in CCIP and other capabilities
+	if err := validateChainSelectorsForConfiguredChains(globalLogger, relayChainInterops); err != nil {
+		return nil, fmt.Errorf("FATAL: Chain configuration validation failed: %w", err)
+	}
+
 	var billingClient metering.BillingClient
 
 	signer, CSAPubKey, err := keystore.BuildNodeAuth(ctx, csaKeystore)
@@ -1722,3 +1729,61 @@ func (c closerService) Ready() error { return nil }
 func (c closerService) HealthReport() map[string]error { return map[string]error{c.Name(): nil} }
 
 func (c closerService) Name() string { return c.name }
+
+// This function ensures that all chains configured in TOML files have valid chain selectors at runtime.
+// We should never really have a case where a chain is in TOML config but not in chain-selectors.
+// This prevents silent failures later when CCIP plugins or other capabilities try to use chain selectors that don't exist.
+// This validation makes such misconfigurations fail fast at startup and it only affects node bootup
+func validateChainSelectorsForConfiguredChains(
+	lggr logger.Logger,
+	relayChainInterops *CoreRelayerChainInteroperators,
+) error {
+	lggr.Info("Validating chain selector mappings for all configured chains...")
+
+	allRelayers := relayChainInterops.GetIDToRelayerMap()
+	if len(allRelayers) == 0 {
+		lggr.Warn("No relayers configured - skipping chain selector validation")
+		return nil
+	}
+
+	validatedCount := 0
+
+	for relayID := range allRelayers {
+		if relayID.Network == "dummy" {
+			continue
+		}
+
+		chainDetails, err := chainselectors.GetChainDetailsByChainIDAndFamily(
+			relayID.ChainID,
+			relayID.Network,
+		)
+
+		if err != nil {
+			return fmt.Errorf(
+				"invalid chain configuration for %s (network=%s, chainID=%s): "+
+					"chain not recognized by chain-selectors library. "+
+					"Please verify: (1) ChainID in TOML is correct, "+
+					"(2) chain is supported in github.com/smartcontractkit/chain-selectors, "+
+					"(3) you're using a compatible version of chain-selectors. "+
+					"Error: %w",
+				relayID.Name(),
+				relayID.Network,
+				relayID.ChainID,
+				err,
+			)
+		}
+
+		lggr.Debugw("Validated chain configuration",
+			"network", relayID.Network,
+			"chainID", relayID.ChainID,
+			"chainSelector", chainDetails.ChainSelector,
+			"chainName", chainDetails.ChainName,
+		)
+		validatedCount++
+	}
+
+	lggr.Infow("Successfully validated chain selector mappings",
+		"validatedChains", validatedCount,
+	)
+	return nil
+}

--- a/core/services/chainlink/chain_selector_validation_test.go
+++ b/core/services/chainlink/chain_selector_validation_test.go
@@ -1,0 +1,113 @@
+package chainlink
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
+
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func Test_validateChainSelectorsForConfiguredChains(t *testing.T) {
+	t.Parallel()
+
+	lggr := logger.TestLogger(t)
+
+	t.Run("succeeds with no relayers configured", func(t *testing.T) {
+		t.Parallel()
+
+		relayChainInterops := &CoreRelayerChainInteroperators{
+			loopRelayers: make(map[commontypes.RelayID]loop.Relayer),
+		}
+
+		err := validateChainSelectorsForConfiguredChains(lggr, relayChainInterops)
+		require.NoError(t, err)
+	})
+
+	t.Run("succeeds with valid chains", func(t *testing.T) {
+		t.Parallel()
+
+		relayChainInterops := &CoreRelayerChainInteroperators{
+			loopRelayers: map[commontypes.RelayID]loop.Relayer{
+				// EVM chains
+				{Network: "evm", ChainID: "1"}:        nil, // Ethereum Mainnet
+				{Network: "evm", ChainID: "11155111"}: nil, // Sepolia
+				{Network: "evm", ChainID: "42161"}:    nil, // Arbitrum One
+				// Solana chains
+				{Network: "solana", ChainID: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d"}: nil, // Mainnet
+				{Network: "solana", ChainID: "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"}: nil, // Devnet
+			},
+		}
+
+		err := validateChainSelectorsForConfiguredChains(lggr, relayChainInterops)
+		require.NoError(t, err)
+	})
+
+	t.Run("skips dummy relayers", func(t *testing.T) {
+		t.Parallel()
+
+		relayChainInterops := &CoreRelayerChainInteroperators{
+			loopRelayers: map[commontypes.RelayID]loop.Relayer{
+				// Valid chain
+				{Network: "evm", ChainID: "1"}: nil,
+				// Dummy relayers should be skipped
+				{Network: "dummy", ChainID: "test-chain-1"}: nil,
+				{Network: "dummy", ChainID: "test-chain-2"}: nil,
+			},
+		}
+
+		err := validateChainSelectorsForConfiguredChains(lggr, relayChainInterops)
+		require.NoError(t, err)
+	})
+
+	t.Run("fails with invalid EVM chain ID", func(t *testing.T) {
+		t.Parallel()
+
+		relayChainInterops := &CoreRelayerChainInteroperators{
+			loopRelayers: map[commontypes.RelayID]loop.Relayer{
+				{Network: "evm", ChainID: "999999999999999"}: nil,
+			},
+		}
+
+		err := validateChainSelectorsForConfiguredChains(lggr, relayChainInterops)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid chain configuration")
+		assert.Contains(t, err.Error(), "999999999999999")
+		assert.Contains(t, err.Error(), "not recognized")
+	})
+
+	t.Run("fails with invalid Solana chain ID", func(t *testing.T) {
+		t.Parallel()
+
+		relayChainInterops := &CoreRelayerChainInteroperators{
+			loopRelayers: map[commontypes.RelayID]loop.Relayer{
+				{Network: "solana", ChainID: "invalid-solana-genesis-hash"}: nil,
+			},
+		}
+
+		err := validateChainSelectorsForConfiguredChains(lggr, relayChainInterops)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid chain configuration")
+		assert.Contains(t, err.Error(), "solana")
+		assert.Contains(t, err.Error(), "invalid-solana-genesis-hash")
+	})
+
+	t.Run("fails with typo in chain ID", func(t *testing.T) {
+		t.Parallel()
+
+		relayChainInterops := &CoreRelayerChainInteroperators{
+			loopRelayers: map[commontypes.RelayID]loop.Relayer{
+				{Network: "evm", ChainID: "1115511"}: nil, //Sepolia mistyped
+			},
+		}
+
+		err := validateChainSelectorsForConfiguredChains(lggr, relayChainInterops)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "1115511")
+		assert.Contains(t, err.Error(), "ChainID in TOML is correct")
+	})
+}


### PR DESCRIPTION
**Problem**
Currently, if a chain is configured in TOML with a ChainID that doesn't have a corresponding ChainSelector in the chain-selectors library, the Chainlink node boots up without issues but can experience silent failures in the CCIP plugin which boots up (and reloads) asynchronously.  When the CCIP plugin fails, it essentially kills the entire CCIP network silently. 
This wasn't a big issue in the past since our workflows always required bumping the CS version in the Chainlink go.mod but it became more problematic since the introduction of extra-selectors which allows adding new selectors at runtime bypassing CS version bumps.


**Solution**
This change implements fail-fast chain-selector<>chain config validation in application.go that runs before any jobs or services start, and fails (crashes) the node at startup with a clear error message if any chain has an invalid ChainID → ChainSelector mapping,

The impact is minimal as the node will fail to boot if it has invalid config but it will not affect any further plugins downstream.