### PR TITLE
chore: updates keystone solana tests to use new soltestutils package

### DIFF
--- a/deployment/internal/soltestutils/datastore.go
+++ b/deployment/internal/soltestutils/datastore.go
@@ -3,15 +3,46 @@ package soltestutils
 import (
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/require"
 
 	cldfsolana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 )
+
+// RegisterMCMSPrograms registers the MCMS programs in the datastore for a given selector.
+func RegisterMCMSPrograms(t *testing.T, selector uint64, ds *datastore.MemoryDataStore) {
+	t.Helper()
+
+	err := ds.AddressRefStore.Add(datastore.AddressRef{
+		Address:       directory[ProgMCM].ID,
+		ChainSelector: selector,
+		Type:          datastore.ContractType(commontypes.ManyChainMultisigProgram),
+		Version:       semver.MustParse("1.0.0"),
+	})
+	require.NoError(t, err)
+
+	err = ds.AddressRefStore.Add(datastore.AddressRef{
+		Address:       directory[ProgAccessController].ID,
+		ChainSelector: selector,
+		Type:          datastore.ContractType(commontypes.AccessControllerProgram),
+		Version:       semver.MustParse("1.0.0"),
+	})
+	require.NoError(t, err)
+
+	err = ds.AddressRefStore.Add(datastore.AddressRef{
+		Address:       directory[ProgTimelock].ID,
+		ChainSelector: selector,
+		Type:          datastore.ContractType(commontypes.RBACTimelockProgram),
+		Version:       semver.MustParse("1.0.0"),
+	})
+	require.NoError(t, err)
+}
 
 // PreloadAddressBookWithMCMSPrograms creates and returns an address book containing preloaded MCMS
 // Solana program addresses for the specified selector.
@@ -21,15 +52,15 @@ func PreloadAddressBookWithMCMSPrograms(t *testing.T, selector uint64) *cldf.Add
 	ab := cldf.NewMemoryAddressBook()
 
 	tv := cldf.NewTypeAndVersion(commontypes.ManyChainMultisigProgram, deployment.Version1_0_0)
-	err := ab.Save(selector, MCMSProgramIDs["mcm"], tv)
+	err := ab.Save(selector, directory[ProgMCM].ID, tv)
 	require.NoError(t, err)
 
 	tv = cldf.NewTypeAndVersion(commontypes.AccessControllerProgram, deployment.Version1_0_0)
-	err = ab.Save(selector, MCMSProgramIDs["access_controller"], tv)
+	err = ab.Save(selector, directory[ProgAccessController].ID, tv)
 	require.NoError(t, err)
 
 	tv = cldf.NewTypeAndVersion(commontypes.RBACTimelockProgram, deployment.Version1_0_0)
-	err = ab.Save(selector, MCMSProgramIDs["timelock"], tv)
+	err = ab.Save(selector, directory[ProgTimelock].ID, tv)
 	require.NoError(t, err)
 
 	return ab

--- a/deployment/internal/soltestutils/preload.go
+++ b/deployment/internal/soltestutils/preload.go
@@ -6,13 +6,45 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
+// LoadKeystonePrograms loads the Keystone and MCMS program artifacts into the given directory.
+//
+// Returns a map of program names to IDs.
+func LoadKeystonePrograms(t *testing.T, dir string) map[string]string {
+	t.Helper()
+
+	return directory.LoadKeystonePrograms(t, dir)
+}
+
+// LoadMCMSPrograms loads the MCMS program artifacts into the given directory.
+//
+// Returns the path to the temporary test directory and a map of program names to IDs.
+func LoadMCMSPrograms(t *testing.T, dir string) (string, map[string]string) {
+	t.Helper()
+
+	return dir, directory.LoadMCMSArtifacts(t, dir)
+}
+
+// LoadDataFeedsPrograms loads the Data Feeds and MCMS program artifacts into the given directory.
+//
+// Returns a map of program names to IDs.
+func LoadDataFeedsPrograms(t *testing.T, dir string) map[string]string {
+	t.Helper()
+
+	return directory.LoadDataFeedsPrograms(t, dir)
+}
+
 // PreloadMCMS provides a convenience function to preload the MCMS program artifacts and address
 // book for a given selector.
+//
+// TODO: Clean up this function to use the new LoadMCMSPrograms function.
 func PreloadMCMS(t *testing.T, selector uint64) (string, map[string]string, *cldf.AddressBookMap) {
 	t.Helper()
 
-	programsPath, programIDs := ProgramsForMCMS(t)
+	dir := t.TempDir()
+
+	programIDs := directory.LoadMCMSArtifacts(t, dir)
+
 	ab := PreloadAddressBookWithMCMSPrograms(t, selector)
 
-	return programsPath, programIDs, ab
+	return dir, programIDs, ab
 }

--- a/deployment/internal/soltestutils/programs.go
+++ b/deployment/internal/soltestutils/programs.go
@@ -2,6 +2,7 @@ package soltestutils
 
 import (
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,6 +14,27 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/utils/solutils"
 )
 
+// Program names
+const (
+	// Keystone Programs
+	ProgKeystoneForwarder = "keystone_forwarder"
+
+	// Data Feeds Programs
+	ProgDataFeedsCache = "data_feeds_cache"
+
+	// MCMS Programs
+	ProgMCM              = "mcm"
+	ProgTimelock         = "timelock"
+	ProgAccessController = "access_controller"
+)
+
+// Program names grouped by their usage.
+var (
+	MCMSProgramNames      = []string{ProgMCM, ProgTimelock, ProgAccessController}
+	KeystoneProgramNames  = []string{ProgKeystoneForwarder}
+	DataFeedsProgramNames = []string{ProgDataFeedsCache}
+)
+
 var (
 	// onceCCIP is used to ensure that the program artifacts from the chainlink-ccip repository are only downloaded once.
 	onceCCIP = &sync.Once{}
@@ -20,31 +42,93 @@ var (
 	onceSolana = &sync.Once{} //nolint:unused // Will be used once all tests are migrated to use this package
 )
 
-// MCMSProgramIDs is a map of predeployed MCMS Solana program IDs used in tests.
-var MCMSProgramIDs = map[string]string{
-	"mcm":               "5vNJx78mz7KVMjhuipyr9jKBKcMrKYGdjGkgE4LUmjKk",
-	"timelock":          "DoajfR5tK24xVw51fWcawUZWhAXD8yrBJVacc13neVQA",
-	"access_controller": "6KsN58MTnRQ8FfPaXHiFPPFGDRioikj9CdPvPxZJdCjb",
+// Repositories that contain the program artifacts.
+const (
+	repoCCIP   = "chainlink-ccip"
+	repoSolana = "chainlink-solana"
+)
+
+// ProgramEntry contains the information about a program.
+type ProgramEntry struct {
+	// ID is the program ID of the program.
+	ID string
+
+	// Repo is the repository name of where the program is located.
+	Repo string
 }
 
-// MCMSPrograms downloads the MCMS program artifacts and returns the path to the cached artifacts
-// and the map of program IDs to paths.
+// Programs maps the program name to the program information.
 //
-// This can be used to preload the MCMS program artifacts into a test environment as arguments to
-// the WithSolanaContainer function.
+// This is the source of truth for the program IDs and repositories.
+var directory = programDirectory{
+	// MCMS Programs
+	ProgMCM:              {ID: "5vNJx78mz7KVMjhuipyr9jKBKcMrKYGdjGkgE4LUmjKk", Repo: repoCCIP},
+	ProgTimelock:         {ID: "DoajfR5tK24xVw51fWcawUZWhAXD8yrBJVacc13neVQA", Repo: repoCCIP},
+	ProgAccessController: {ID: "6KsN58MTnRQ8FfPaXHiFPPFGDRioikj9CdPvPxZJdCjb", Repo: repoCCIP},
+
+	// Keystone Programs
+	ProgKeystoneForwarder: {ID: "whV7Q5pi17hPPyaPksToDw1nMx6Lh8qmNWKFaLRQ4wz", Repo: repoSolana},
+
+	// Data Feeds Programs
+	ProgDataFeedsCache: {ID: "3kX63udXtYcsdj2737Wi2KGd2PhqiKPgAFAxstrjtRUa", Repo: repoSolana},
+}
+
+// downloadFunc is a function type for downloading program artifacts
+type downloadFunc func(t *testing.T) string
+
+// programDirectory maps the program name to the program information.
+type programDirectory map[string]ProgramEntry
+
+// LoadMCMSArtifacts loads the MCMS program artifacts into the temporary test directory.
 //
-// TODO: Remove the dependency on the memory package by extracting the download logic into a
-// separate solutils package.
-func ProgramsForMCMS(t *testing.T) (string, map[string]string) {
+// Returns the map of program names to IDs.
+func (d programDirectory) LoadMCMSArtifacts(t *testing.T, dirPath string) map[string]string {
+	return d.loadProgramArtifacts(t, MCMSProgramNames, downloadChainlinkCCIPProgramArtifacts, dirPath)
+}
+
+// LoadKeystonePrograms loads the Keystone and MCMS program artifacts into the temporary test directory.
+//
+// Returns the map of program names to IDs.
+func (d programDirectory) LoadKeystonePrograms(t *testing.T, dirPath string) map[string]string {
+	keystoneProgIDs := d.loadProgramArtifacts(t, KeystoneProgramNames, downloadChainlinkSolanaProgramArtifacts, dirPath)
+	mcmsProgIDs := d.loadProgramArtifacts(t, MCMSProgramNames, downloadChainlinkCCIPProgramArtifacts, dirPath)
+
+	progIDs := make(map[string]string, len(keystoneProgIDs)+len(mcmsProgIDs))
+	maps.Copy(progIDs, keystoneProgIDs)
+	maps.Copy(progIDs, mcmsProgIDs)
+
+	return progIDs
+}
+
+// LoadDataFeedsPrograms loads the Data Feeds and MCMS program artifacts into the temporary test directory.
+//
+// Returns the map of program names to IDs.
+func (d programDirectory) LoadDataFeedsPrograms(t *testing.T, dirPath string) map[string]string {
+	dataFeedsProgIDs := d.loadProgramArtifacts(t, DataFeedsProgramNames, downloadChainlinkSolanaProgramArtifacts, dirPath)
+	mcmsProgIDs := d.loadProgramArtifacts(t, MCMSProgramNames, downloadChainlinkCCIPProgramArtifacts, dirPath)
+
+	progIDs := make(map[string]string, len(dataFeedsProgIDs)+len(mcmsProgIDs))
+	maps.Copy(progIDs, dataFeedsProgIDs)
+	maps.Copy(progIDs, mcmsProgIDs)
+
+	return progIDs
+}
+
+// loadProgramArtifacts is a helper function that loads program artifacts into a temporary test directory.
+// It downloads artifacts using the provided download function and copies the specified programs.
+//
+// Returns the map of program names to IDs.
+func (d programDirectory) loadProgramArtifacts(t *testing.T, programNames []string, downloadFn downloadFunc, targetDir string) map[string]string {
 	t.Helper()
 
-	targetDir := t.TempDir()
+	// Download the program artifacts using the provided download function
+	cachePath := downloadFn(t)
 
-	// Download the MCMS program artifacts
-	cachePath := downloadChainlinkCCIPProgramArtifacts(t)
+	// Get the program IDs for the specified programs
+	progIDs := d.ProgramIDs(programNames)
 
-	// Copy the specific artifacts to the path provided
-	for name := range MCMSProgramIDs {
+	// Copy the specific artifacts to the target directory
+	for name := range progIDs {
 		src := filepath.Join(cachePath, name+".so")
 		dst := filepath.Join(targetDir, name+".so")
 
@@ -62,15 +146,26 @@ func ProgramsForMCMS(t *testing.T) (string, map[string]string) {
 		dstFile.Close()
 	}
 
-	// Return the path to the cached artifacts and the map of program IDs to paths
-	return targetDir, MCMSProgramIDs
+	// Return the path to the cached artifacts and the map of program IDs
+	return progIDs
 }
 
-// downloadCLSolanaProgramArtifacts downloads the Chainlink Solana program artifacts.
+// ProgramIDs returns the map of program names to IDs.
+func (d programDirectory) ProgramIDs(names []string) map[string]string {
+	ids := make(map[string]string, len(names))
+
+	for _, name := range names {
+		ids[name] = d[name].ID
+	}
+
+	return ids
+}
+
+// downloadChainlinkSolanaProgramArtifacts downloads the Chainlink Solana program artifacts.
 //
 // The artifacts that are downloaded contain both the CCIP and MCMS program artifacts (even though
 // this is called "CCIP" program artifacts).
-func downloadCLSolanaProgramArtifacts(t *testing.T) string { //nolint:unused // Will be used once all tests are migrated to use this package
+func downloadChainlinkSolanaProgramArtifacts(t *testing.T) string {
 	t.Helper()
 
 	cachePath := programsCachePath()


### PR DESCRIPTION
This removes the dependency on the memory package.
