### PR TITLE
docs: clarify OCR2 feed update cadence and DON reconfiguration notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> Note: In OCR2, update cadence depends on deviation thresholds and heartbeat parameters. 
+> DON membership or reconfiguration events may temporarily impact observed intervals.
 <br/>
 <p align="center">
 <a href="https://chain.link" target="_blank">


### PR DESCRIPTION
This PR adds a short note clarifying that OCR2 feed update cadence is a function of on-chain deviation thresholds and heartbeat settings, 
and that DON membership/reconfiguration events can temporarily affect observed update intervals. 
This helps integrators set expectations when consuming feed data across networks.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
