### PR TITLE
chore: move node test utils from memory package to utils package

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -54,6 +54,7 @@ import (
 	ccipseq "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm/v1_6"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+	"github.com/smartcontractkit/chainlink/deployment/utils/nodetestutils"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	ccipocr3common "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
@@ -146,7 +147,7 @@ type TestConfigs struct {
 
 	// CLNodeConfigOpts are the config options to be passed to the chainlink node.
 	// Only used in memory mode.
-	CLNodeConfigOpts []memory.ConfigOpt
+	CLNodeConfigOpts []nodetestutils.ConfigOpt
 
 	// RoleDONTopology is the chain-node topology of the role DON.
 	// Only used in memory mode.
@@ -221,7 +222,7 @@ func WithExtraConfigTomls(extraTomls []string) TestOps {
 	}
 }
 
-func WithCLNodeConfigOpts(opts ...memory.ConfigOpt) TestOps {
+func WithCLNodeConfigOpts(opts ...nodetestutils.ConfigOpt) TestOps {
 	return func(testCfg *TestConfigs) {
 		testCfg.CLNodeConfigOpts = opts
 	}
@@ -407,7 +408,7 @@ func (d *DeployedEnv) SetupJobs(t *testing.T) {
 
 type MemoryEnvironment struct {
 	DeployedEnv
-	nodes       map[string]memory.Node
+	nodes       map[string]nodetestutils.Node
 	TestConfig  *TestConfigs
 	Chains      map[uint64]cldf_evm.Chain
 	SolChains   map[uint64]cldf_solana.Chain
@@ -521,7 +522,7 @@ func (m *MemoryEnvironment) StartNodes(t *testing.T, crConfig deployment.Capabil
 	require.NotNil(t, m.Chains, "start chains first, chains are empty")
 	require.NotNil(t, m.DeployedEnv, "start chains and initiate deployed env first before starting nodes")
 	tc := m.TestConfig
-	c := memory.NewNodesConfig{
+	c := nodetestutils.NewNodesConfig{
 		LogLevel:       zapcore.InfoLevel,
 		BlockChains:    m.Env.BlockChains,
 		NumNodes:       tc.Nodes,
@@ -529,7 +530,7 @@ func (m *MemoryEnvironment) StartNodes(t *testing.T, crConfig deployment.Capabil
 		RegistryConfig: crConfig,
 		CustomDBSetup:  nil,
 	}
-	nodes := memory.NewNodes(t, c, tc.CLNodeConfigOpts...)
+	nodes := nodetestutils.NewNodes(t, c, tc.CLNodeConfigOpts...)
 	ctx := testcontext.Get(t)
 	lggr := logger.Test(t)
 	for _, node := range nodes {

--- a/deployment/environment/memory/aptos_chains.go
+++ b/deployment/environment/memory/aptos_chains.go
@@ -12,7 +12,6 @@ import (
 	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
 	cldf_aptos_provider "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos/provider"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
-	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
 
 func getTestAptosChainSelectors() []uint64 {
@@ -48,23 +47,6 @@ func generateChainsAptos(t *testing.T, numChains int) []cldf_chain.BlockChain {
 	return chains
 }
 
-func createAptosChainConfig(chainID string, chain cldf_aptos.Chain) chainlink.RawConfig {
-	chainConfig := chainlink.RawConfig{}
-
-	chainConfig["Enabled"] = true
-	chainConfig["ChainID"] = chainID
-	chainConfig["NetworkName"] = "localnet"
-	chainConfig["NetworkNameFull"] = "aptos-localnet"
-	chainConfig["Nodes"] = []any{
-		map[string]any{
-			"Name": "primary",
-			"URL":  chain.URL,
-		},
-	}
-
-	return chainConfig
-}
-
 func migrateAccountToFA(t *testing.T, signer aptos.TransactionSigner, client aptos.AptosRpcClient) error {
 	// Migrate APT Coin to FA, required for CCIP
 	payload := aptos.TransactionPayload{
@@ -96,18 +78,6 @@ func migrateAccountToFA(t *testing.T, signer aptos.TransactionSigner, client apt
 	accountAddress := signer.AccountAddress()
 	logger.TestLogger(t).Infof("Migrated account %v to Fungible Asset APT", accountAddress.StringLong())
 	return err
-}
-
-func fundNodesAptos(t *testing.T, aptosChain cldf_aptos.Chain, nodes []*Node) {
-	for _, node := range nodes {
-		aptoskeys, err := node.App.GetKeyStore().Aptos().GetAll()
-		require.NoError(t, err)
-		require.Len(t, aptoskeys, 1)
-		transmitter := aptoskeys[0]
-		transmitterAccountAddress := aptos.AccountAddress{}
-		require.NoError(t, transmitterAccountAddress.ParseStringRelaxed(transmitter.Account()))
-		FundAptosAccount(t, aptosChain.DeployerSigner, transmitterAccountAddress, 100*1e8, aptosChain.Client)
-	}
 }
 
 func FundAptosAccount(t *testing.T, signer aptos.TransactionSigner, to aptos.AccountAddress, amount uint64, client aptos.AptosRpcClient) {

--- a/deployment/environment/memory/evm_chains.go
+++ b/deployment/environment/memory/evm_chains.go
@@ -1,28 +1,16 @@
 package memory
 
 import (
-	"math/big"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient/simulated"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm_provider "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider"
 )
-
-type EVMChain struct {
-	Backend     *simulated.Backend
-	DeployerKey *bind.TransactOpts
-	Users       []*bind.TransactOpts
-}
 
 // evmTestChainSelectors returns the selectors for the test EVM chains. We arbitrarily
 // start this from the EVM test selector TEST_90000001 and limit the number of chains you can load
@@ -85,25 +73,4 @@ func generateChainsEVMWithIDs(t *testing.T, chainIDs []uint64, numUsers int) []c
 	}
 
 	return chains
-}
-
-// funcAddress funds to an EVM address using a given transaction options.
-func fundAddress(t *testing.T, from *bind.TransactOpts, to common.Address, amount *big.Int, backend *simulated.Backend) {
-	ctx := t.Context()
-	nonce, err := backend.Client().PendingNonceAt(ctx, from.From)
-	require.NoError(t, err)
-	gp, err := backend.Client().SuggestGasPrice(ctx)
-	require.NoError(t, err)
-	rawTx := types.NewTx(&types.LegacyTx{
-		Nonce:    nonce,
-		GasPrice: gp,
-		Gas:      21000,
-		To:       &to,
-		Value:    amount,
-	})
-	signedTx, err := from.Signer(from.From, rawTx)
-	require.NoError(t, err)
-	err = backend.Client().SendTransaction(ctx, signedTx)
-	require.NoError(t, err)
-	backend.Commit()
 }

--- a/deployment/environment/memory/job_service_client.go
+++ b/deployment/environment/memory/job_service_client.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/test"
+	"github.com/smartcontractkit/chainlink/deployment/utils/nodetestutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/feeds"
 )
 
@@ -16,7 +17,7 @@ type JobApprover interface {
 }
 
 type autoApprovalNode struct {
-	*Node
+	*nodetestutils.Node
 }
 
 var _ JobApprover = &autoApprovalNode{}
@@ -62,10 +63,10 @@ var errNoExist = errors.New("does not exist")
 
 // nodeStore is an interface for storing nodes.
 type nodeStore interface {
-	put(nodeID string, node *Node) error
-	get(nodeID string) (*Node, error)
-	list() []*Node
-	asMap() map[string]*Node
+	put(nodeID string, node *nodetestutils.Node) error
+	get(nodeID string) (*nodetestutils.Node, error)
+	list() []*nodetestutils.Node
+	asMap() map[string]*nodetestutils.Node
 	delete(nodeID string) error
 }
 
@@ -73,24 +74,24 @@ var _ nodeStore = &mapNodeStore{}
 
 type mapNodeStore struct {
 	mu    sync.Mutex
-	nodes map[string]*Node
+	nodes map[string]*nodetestutils.Node
 }
 
-func newMapNodeStore(n map[string]*Node) *mapNodeStore {
+func newMapNodeStore(n map[string]*nodetestutils.Node) *mapNodeStore {
 	return &mapNodeStore{
 		nodes: n,
 	}
 }
-func (m *mapNodeStore) put(nodeID string, node *Node) error {
+func (m *mapNodeStore) put(nodeID string, node *nodetestutils.Node) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.nodes == nil {
-		m.nodes = make(map[string]*Node)
+		m.nodes = make(map[string]*nodetestutils.Node)
 	}
 	m.nodes[nodeID] = node
 	return nil
 }
-func (m *mapNodeStore) get(nodeID string) (*Node, error) {
+func (m *mapNodeStore) get(nodeID string) (*nodetestutils.Node, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.nodes == nil {
@@ -102,13 +103,13 @@ func (m *mapNodeStore) get(nodeID string) (*Node, error) {
 	}
 	return node, nil
 }
-func (m *mapNodeStore) list() []*Node {
+func (m *mapNodeStore) list() []*nodetestutils.Node {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.nodes == nil {
 		return nil
 	}
-	nodes := make([]*Node, 0)
+	nodes := make([]*nodetestutils.Node, 0)
 	for _, node := range m.nodes {
 		nodes = append(nodes, node)
 	}
@@ -128,13 +129,13 @@ func (m *mapNodeStore) delete(nodeID string) error {
 	return nil
 }
 
-func (m *mapNodeStore) asMap() map[string]*Node {
+func (m *mapNodeStore) asMap() map[string]*nodetestutils.Node {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.nodes == nil {
 		return nil
 	}
-	nodes := make(map[string]*Node)
+	nodes := make(map[string]*nodetestutils.Node)
 	maps.Copy(nodes, m.nodes)
 	return nodes
 }

--- a/deployment/environment/memory/job_service_client_test.go
+++ b/deployment/environment/memory/job_service_client_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
+	"github.com/smartcontractkit/chainlink/deployment/utils/nodetestutils"
 )
 
 func TestJobClientProposeJob(t *testing.T) {
@@ -28,7 +29,7 @@ func TestJobClientProposeJob(t *testing.T) {
 
 	blockchains := cldf_chain.NewBlockChainsFromSlice(bc)
 	ports := freeport.GetN(t, 1)
-	c := NewNodeConfig{
+	c := nodetestutils.NewNodeConfig{
 		Port:           ports[0],
 		BlockChains:    blockchains,
 		LogLevel:       zapcore.DebugLevel,
@@ -36,11 +37,11 @@ func TestJobClientProposeJob(t *testing.T) {
 		RegistryConfig: deployment.CapabilityRegistryConfig{},
 		CustomDBSetup:  nil,
 	}
-	testNode := NewNode(t, c)
+	testNode := nodetestutils.NewNode(t, c)
 
 	// Set up the JobClient with a mock node
 	nodeID := "node-1"
-	nodes := map[string]Node{
+	nodes := map[string]nodetestutils.Node{
 		nodeID: *testNode,
 	}
 	jobClient := NewMemoryJobClient(nodes)
@@ -133,7 +134,7 @@ func TestJobClientJobAPI(t *testing.T) {
 
 	blockchains := cldf_chain.NewBlockChainsFromSlice(bc)
 	ports := freeport.GetN(t, 1)
-	c := NewNodeConfig{
+	c := nodetestutils.NewNodeConfig{
 		Port:           ports[0],
 		BlockChains:    blockchains,
 		LogLevel:       zapcore.DebugLevel,
@@ -141,14 +142,14 @@ func TestJobClientJobAPI(t *testing.T) {
 		RegistryConfig: deployment.CapabilityRegistryConfig{},
 		CustomDBSetup:  nil,
 	}
-	testNode := NewNode(t, c)
+	testNode := nodetestutils.NewNode(t, c)
 
 	// Set up the JobClient with a mock node
 	nodeID := "node-1"
 	externalJobID := "f1ac5211-ab79-4c31-ba1c-0997b72db466"
 
 	jobSpecToml := testJobProposalTOML(t, externalJobID)
-	nodes := map[string]Node{
+	nodes := map[string]nodetestutils.Node{
 		nodeID: *testNode,
 	}
 	jobClient := NewMemoryJobClient(nodes)

--- a/deployment/environment/memory/node_service_client.go
+++ b/deployment/environment/memory/node_service_client.go
@@ -10,6 +10,7 @@ import (
 	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
+	"github.com/smartcontractkit/chainlink/deployment/utils/nodetestutils"
 )
 
 func (j JobClient) EnableNode(ctx context.Context, in *nodev1.EnableNodeRequest, opts ...grpc.CallOption) (*nodev1.EnableNodeResponse, error) {
@@ -31,7 +32,7 @@ func (j *JobClient) RegisterNode(ctx context.Context, in *nodev1.RegisterNodeReq
 		return nil, fmt.Errorf("node with Public Key %s is already registered", in.GetPublicKey())
 	}
 
-	var foundNode *Node
+	var foundNode *nodetestutils.Node
 	for _, node := range j.nodeStore.list() {
 		if node.Keys.CSA.ID() == in.GetPublicKey() {
 			foundNode = node

--- a/deployment/environment/memory/offchain_client.go
+++ b/deployment/environment/memory/offchain_client.go
@@ -14,25 +14,26 @@ import (
 	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/test"
+	"github.com/smartcontractkit/chainlink/deployment/utils/nodetestutils"
 )
 
 var _ cldf_offchain.Client = &JobClient{}
 
 type JobClient struct {
-	RegisteredNodes map[string]Node
+	RegisteredNodes map[string]nodetestutils.Node
 	nodeStore
 	*test.JobServiceClient
 }
 
-func NewMemoryJobClient(nodesByPeerID map[string]Node) *JobClient {
-	m := make(map[string]*Node)
+func NewMemoryJobClient(nodesByPeerID map[string]nodetestutils.Node) *JobClient {
+	m := make(map[string]*nodetestutils.Node)
 	for id, node := range nodesByPeerID {
 		m[id] = &node
 	}
 	ns := newMapNodeStore(m)
 	jg := &jobApproverGetter{s: ns}
 	return &JobClient{
-		RegisteredNodes:  make(map[string]Node),
+		RegisteredNodes:  make(map[string]nodetestutils.Node),
 		JobServiceClient: test.NewJobServiceClient(jg),
 		nodeStore:        ns,
 	}

--- a/deployment/environment/memory/solana_chains.go
+++ b/deployment/environment/memory/solana_chains.go
@@ -19,7 +19,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	cldf_solana_provider "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana/provider"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
@@ -243,18 +242,6 @@ func generateChainsSol(t *testing.T, numChains int, commitSha string) []cldf_cha
 	}
 
 	return chains
-}
-
-func fundNodesSol(t *testing.T, solChain cldf_solana.Chain, nodes []*Node) {
-	for _, node := range nodes {
-		solkeys, err := node.App.GetKeyStore().Solana().GetAll()
-		require.NoError(t, err)
-		require.Len(t, solkeys, 1)
-		transmitter := solkeys[0]
-		_, err = solChain.Client.RequestAirdrop(t.Context(), transmitter.PublicKey(), 1000*solana.LAMPORTS_PER_SOL, solRpc.CommitmentConfirmed)
-		require.NoError(t, err)
-		// we don't wait for confirmation so we don't block the tests, it'll take a while before nodes start transmitting
-	}
 }
 
 // chainlink-ccip has dynamic resolution which does not work across repos

--- a/deployment/environment/memory/sui_chains.go
+++ b/deployment/environment/memory/sui_chains.go
@@ -7,18 +7,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/block-vision/sui-go-sdk/models"
-	"github.com/go-resty/resty/v2"
 	"github.com/stretchr/testify/require"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-	cldf_sui "github.com/smartcontractkit/chainlink-deployments-framework/chain/sui"
 	cldf_sui_provider "github.com/smartcontractkit/chainlink-deployments-framework/chain/sui/provider"
-	"github.com/smartcontractkit/chainlink-testing-framework/framework"
-
-	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
 
 func getTestSuiChainSelectors() []uint64 {
@@ -63,37 +57,4 @@ func GenerateChainsSui(t *testing.T, numChains int) []cldf_chain.BlockChain {
 
 	t.Logf("Created %d Sui chains: %+v", len(chains), chains)
 	return chains
-}
-
-func createSuiChainConfig(chainID string, chain cldf_sui.Chain) chainlink.RawConfig {
-	chainConfig := chainlink.RawConfig{}
-
-	chainConfig["Enabled"] = true
-	chainConfig["ChainID"] = chainID
-	chainConfig["NetworkName"] = "sui-localnet"
-	chainConfig["NetworkNameFull"] = "sui-localnet"
-	chainConfig["Nodes"] = []any{
-		map[string]any{
-			"Name": "primary",
-			"URL":  chain.URL,
-		},
-	}
-
-	return chainConfig
-}
-
-func FundSuiAccount(url string, address string) error {
-	r := resty.New().SetBaseURL(url)
-	b := &models.FaucetRequest{
-		FixedAmountRequest: &models.FaucetFixedAmountRequest{
-			Recipient: address,
-		},
-	}
-	resp, err := r.R().SetBody(b).SetHeader("Content-Type", "application/json").Post("/gas")
-	if err != nil {
-		return err
-	}
-	framework.L.Info().Any("Resp", resp).Msg("Address is funded!")
-
-	return nil
 }

--- a/deployment/environment/memory/ton_chains.go
+++ b/deployment/environment/memory/ton_chains.go
@@ -15,18 +15,14 @@ import (
 	"github.com/xssnick/tonutils-go/tlb"
 	"golang.org/x/mod/modfile"
 
-	"github.com/xssnick/tonutils-go/ton/wallet"
-
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_ton "github.com/smartcontractkit/chainlink-deployments-framework/chain/ton"
 	cldf_ton_provider "github.com/smartcontractkit/chainlink-deployments-framework/chain/ton/provider"
 	"github.com/smartcontractkit/chainlink-ton/deployment/utils"
-	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
 
 var (
-	deployerFundAmount    = tlb.MustFromTON("1000")
-	transmitterFundAmount = tlb.MustFromTON("200")
+	deployerFundAmount = tlb.MustFromTON("1000")
 )
 
 func getTestTonChainSelectors() []uint64 {
@@ -104,38 +100,6 @@ func generateChainsTon(t *testing.T, numChains int) []cldf_chain.BlockChain {
 	}
 
 	return chains
-}
-
-func createTonChainConfig(chainID string, chain cldf_ton.Chain) chainlink.RawConfig {
-	chainConfig := chainlink.RawConfig{}
-
-	chainConfig["Enabled"] = true
-	chainConfig["ChainID"] = chainID
-	chainConfig["NetworkName"] = "ton-local"
-	chainConfig["NetworkNameFull"] = "ton-local"
-	chainConfig["Nodes"] = []any{
-		map[string]any{
-			"Name": "primary",
-			"URL":  chain.URL,
-		},
-	}
-
-	return chainConfig
-}
-
-func fundNodesTon(t *testing.T, tonChain cldf_ton.Chain, nodes []*Node) {
-	messages := make([]*wallet.Message, 0, len(nodes))
-	for _, node := range nodes {
-		tonkeys, err := node.App.GetKeyStore().TON().GetAll()
-		require.NoError(t, err)
-		require.Len(t, tonkeys, 1)
-		transmitter := tonkeys[0].PubkeyToAddress()
-		msg, err := tonChain.Wallet.BuildTransfer(transmitter, transmitterFundAmount, false, "")
-		require.NoError(t, err)
-		messages = append(messages, msg)
-	}
-	_, _, err := tonChain.Wallet.SendManyWaitTransaction(t.Context(), messages)
-	require.NoError(t, err)
 }
 
 func getModFilePath() (string, error) {

--- a/deployment/environment/memory/tron_chains.go
+++ b/deployment/environment/memory/tron_chains.go
@@ -7,10 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-	cldf_tron "github.com/smartcontractkit/chainlink-deployments-framework/chain/tron"
 	cldf_tron_provider "github.com/smartcontractkit/chainlink-deployments-framework/chain/tron/provider"
-
-	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
 
 func getTestTronChainSelectors() []uint64 {
@@ -44,21 +41,4 @@ func generateChainsTron(t *testing.T, numChains int) []cldf_chain.BlockChain {
 	}
 
 	return chains
-}
-
-func createTronChainConfig(chainID string, chain cldf_tron.Chain) chainlink.RawConfig {
-	chainConfig := chainlink.RawConfig{}
-
-	chainConfig["Enabled"] = true
-	chainConfig["ChainID"] = chainID
-	chainConfig["NetworkName"] = "tron-local"
-	chainConfig["NetworkNameFull"] = "tron-local"
-	chainConfig["Nodes"] = []any{
-		map[string]any{
-			"Name": "primary",
-			"URL":  chain.URL,
-		},
-	}
-
-	return chainConfig
 }

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/consul/sdk v0.16.2
 	github.com/mr-tron/base58 v1.2.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pelletier/go-toml/v2 v2.2.4
@@ -276,7 +277,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026 // indirect
-	github.com/hashicorp/consul/sdk v0.16.2 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-envparse v0.1.0 // indirect

--- a/deployment/internal/aptostestutils/fund.go
+++ b/deployment/internal/aptostestutils/fund.go
@@ -1,0 +1,35 @@
+package aptostestutils
+
+import (
+	"testing"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/bcs"
+	"github.com/stretchr/testify/require"
+)
+
+// FundAccount funds an Aptos account with the given amount of APT.
+func FundAccount(t *testing.T, signer aptos.TransactionSigner, to aptos.AccountAddress, amount uint64, client aptos.AptosRpcClient) {
+	toBytes, err := bcs.Serialize(&to)
+	require.NoError(t, err)
+	amountBytes, err := bcs.SerializeU64(amount)
+	require.NoError(t, err)
+	payload := aptos.TransactionPayload{Payload: &aptos.EntryFunction{
+		Module: aptos.ModuleId{
+			Address: aptos.AccountOne,
+			Name:    "aptos_account",
+		},
+		Function: "transfer",
+		Args: [][]byte{
+			toBytes,
+			amountBytes,
+		},
+	}}
+	tx, err := client.BuildSignAndSubmitTransaction(signer, payload)
+	require.NoError(t, err)
+	res, err := client.WaitForTransaction(tx.Hash)
+	require.NoError(t, err)
+	require.True(t, res.Success, res.VmStatus)
+	sender := signer.AccountAddress()
+	t.Logf("Funded account %s from %s with %f APT", to.StringLong(), sender.StringLong(), float64(amount)/1e8)
+}

--- a/deployment/internal/evmtestutils/fund.go
+++ b/deployment/internal/evmtestutils/fund.go
@@ -1,0 +1,33 @@
+package evmtestutils
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient/simulated"
+	"github.com/stretchr/testify/require"
+)
+
+// FundAddress funds to an EVM address using a given transaction options.
+func FundAddress(t *testing.T, from *bind.TransactOpts, to common.Address, amount *big.Int, backend *simulated.Backend) {
+	ctx := t.Context()
+	nonce, err := backend.Client().PendingNonceAt(ctx, from.From)
+	require.NoError(t, err)
+	gp, err := backend.Client().SuggestGasPrice(ctx)
+	require.NoError(t, err)
+	rawTx := types.NewTx(&types.LegacyTx{
+		Nonce:    nonce,
+		GasPrice: gp,
+		Gas:      21000,
+		To:       &to,
+		Value:    amount,
+	})
+	signedTx, err := from.Signer(from.From, rawTx)
+	require.NoError(t, err)
+	err = backend.Client().SendTransaction(ctx, signedTx)
+	require.NoError(t, err)
+	backend.Commit()
+}

--- a/deployment/internal/nodetestutils/node.go
+++ b/deployment/internal/nodetestutils/node.go
@@ -1,1 +1,0 @@
-package nodetestutils

--- a/deployment/internal/suitestutils/fund.go
+++ b/deployment/internal/suitestutils/fund.go
@@ -1,0 +1,25 @@
+package suitestutils
+
+import (
+	"github.com/block-vision/sui-go-sdk/models"
+	"github.com/go-resty/resty/v2"
+
+	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+)
+
+// FundAccount funds a Sui account with the given amount of SUI.
+func FundAccount(url string, address string) error {
+	r := resty.New().SetBaseURL(url)
+	b := &models.FaucetRequest{
+		FixedAmountRequest: &models.FaucetFixedAmountRequest{
+			Recipient: address,
+		},
+	}
+	resp, err := r.R().SetBody(b).SetHeader("Content-Type", "application/json").Post("/gas")
+	if err != nil {
+		return err
+	}
+	framework.L.Info().Any("Resp", resp).Msg("Address is funded!")
+
+	return nil
+}

--- a/deployment/keystone/changeset/test/dons.go
+++ b/deployment/keystone/changeset/test/dons.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/deployment/utils/nodetestutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 )
 
@@ -22,10 +22,10 @@ var _ testDon = (*memoryDon)(nil)
 // memoryDon is backed by in-memory nodes running the full chainlink Application
 type memoryDon struct {
 	name string
-	m    map[string]memory.Node
+	m    map[string]nodetestutils.Node
 }
 
-func newMemoryDon(name string, m map[string]memory.Node) *memoryDon {
+func newMemoryDon(name string, m map[string]nodetestutils.Node) *memoryDon {
 	return &memoryDon{name: name, m: m}
 }
 
@@ -133,8 +133,8 @@ func (d *memoryDons) P2PIDs() P2PIDs {
 	return out.Unique()
 }
 
-func (d *memoryDons) AllNodes() map[string]memory.Node {
-	out := make(map[string]memory.Node)
+func (d *memoryDons) AllNodes() map[string]nodetestutils.Node {
+	out := make(map[string]nodetestutils.Node)
 	for _, d := range d.dons {
 		maps.Copy(out, d.m)
 	}

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -32,6 +32,7 @@ import (
 	envtest "github.com/smartcontractkit/chainlink/deployment/environment/test"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
+	"github.com/smartcontractkit/chainlink/deployment/utils/nodetestutils"
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	forwarder "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/forwarder_1_0_0"
@@ -478,7 +479,7 @@ func setupMemoryNodeTest(
 
 	wfChains := map[uint64]cldf_evm.Chain{}
 	wfChains[registryChainSel] = blockchains.EVMChains()[registryChainSel]
-	wfConf := memory.NewNodesConfig{
+	wfConf := nodetestutils.NewNodesConfig{
 		LogLevel:       zapcore.InfoLevel,
 		BlockChains:    blockchains,
 		NumNodes:       c.WFDonConfig.N,
@@ -486,10 +487,10 @@ func setupMemoryNodeTest(
 		RegistryConfig: crConfig,
 		CustomDBSetup:  nil,
 	}
-	wfNodes := memory.NewNodes(t, wfConf)
+	wfNodes := nodetestutils.NewNodes(t, wfConf)
 	require.Len(t, wfNodes, c.WFDonConfig.N)
 
-	cwConf := memory.NewNodesConfig{
+	cwConf := nodetestutils.NewNodesConfig{
 		LogLevel:       zapcore.InfoLevel,
 		BlockChains:    blockchains,
 		NumNodes:       c.WriterDonConfig.N,
@@ -497,12 +498,12 @@ func setupMemoryNodeTest(
 		RegistryConfig: crConfig,
 		CustomDBSetup:  nil,
 	}
-	cwNodes := memory.NewNodes(t, cwConf)
+	cwNodes := nodetestutils.NewNodes(t, cwConf)
 	require.Len(t, cwNodes, c.WriterDonConfig.N)
 
 	assetChains := map[uint64]cldf_evm.Chain{}
 	assetChains[registryChainSel] = blockchains.EVMChains()[registryChainSel]
-	assetCfg := memory.NewNodesConfig{
+	assetCfg := nodetestutils.NewNodesConfig{
 		LogLevel:       zapcore.InfoLevel,
 		BlockChains:    blockchains,
 		NumNodes:       c.AssetDonConfig.N,
@@ -510,7 +511,7 @@ func setupMemoryNodeTest(
 		RegistryConfig: crConfig,
 		CustomDBSetup:  nil,
 	}
-	assetNodes := memory.NewNodes(t, assetCfg)
+	assetNodes := nodetestutils.NewNodes(t, assetCfg)
 	require.Len(t, assetNodes, c.AssetDonConfig.N)
 
 	dons := newMemoryDons()

--- a/deployment/utils/nodetestutils/chain_configs.go
+++ b/deployment/utils/nodetestutils/chain_configs.go
@@ -1,0 +1,81 @@
+package nodetestutils
+
+import (
+	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
+	cldf_sui "github.com/smartcontractkit/chainlink-deployments-framework/chain/sui"
+	cldf_ton "github.com/smartcontractkit/chainlink-deployments-framework/chain/ton"
+	cldf_tron "github.com/smartcontractkit/chainlink-deployments-framework/chain/tron"
+	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
+)
+
+// createSuiChainConfig creates a Chainlink node defined Sui chain configuration.
+func createSuiChainConfig(chainID string, chain cldf_sui.Chain) chainlink.RawConfig {
+	chainConfig := chainlink.RawConfig{}
+
+	chainConfig["Enabled"] = true
+	chainConfig["ChainID"] = chainID
+	chainConfig["NetworkName"] = "sui-localnet"
+	chainConfig["NetworkNameFull"] = "sui-localnet"
+	chainConfig["Nodes"] = []any{
+		map[string]any{
+			"Name": "primary",
+			"URL":  chain.URL,
+		},
+	}
+
+	return chainConfig
+}
+
+// createTonChainConfig creates a Chainlink node defined Ton chain configuration.
+func createTonChainConfig(chainID string, chain cldf_ton.Chain) chainlink.RawConfig {
+	chainConfig := chainlink.RawConfig{}
+
+	chainConfig["Enabled"] = true
+	chainConfig["ChainID"] = chainID
+	chainConfig["NetworkName"] = "ton-local"
+	chainConfig["NetworkNameFull"] = "ton-local"
+	chainConfig["Nodes"] = []any{
+		map[string]any{
+			"Name": "primary",
+			"URL":  chain.URL,
+		},
+	}
+
+	return chainConfig
+}
+
+// createTronChainConfig creates a Chainlink node defined Tron chain configuration.
+func createTronChainConfig(chainID string, chain cldf_tron.Chain) chainlink.RawConfig {
+	chainConfig := chainlink.RawConfig{}
+
+	chainConfig["Enabled"] = true
+	chainConfig["ChainID"] = chainID
+	chainConfig["NetworkName"] = "tron-local"
+	chainConfig["NetworkNameFull"] = "tron-local"
+	chainConfig["Nodes"] = []any{
+		map[string]any{
+			"Name": "primary",
+			"URL":  chain.URL,
+		},
+	}
+
+	return chainConfig
+}
+
+// createAptosChainConfig creates a Chainlink node defined Aptos chain configuration.
+func createAptosChainConfig(chainID string, chain cldf_aptos.Chain) chainlink.RawConfig {
+	chainConfig := chainlink.RawConfig{}
+
+	chainConfig["Enabled"] = true
+	chainConfig["ChainID"] = chainID
+	chainConfig["NetworkName"] = "localnet"
+	chainConfig["NetworkNameFull"] = "aptos-localnet"
+	chainConfig["Nodes"] = []any{
+		map[string]any{
+			"Name": "primary",
+			"URL":  chain.URL,
+		},
+	}
+
+	return chainConfig
+}

--- a/deployment/utils/nodetestutils/fund.go
+++ b/deployment/utils/nodetestutils/fund.go
@@ -1,0 +1,65 @@
+package nodetestutils
+
+import (
+	"testing"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/gagliardetto/solana-go"
+	solRpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/stretchr/testify/require"
+	"github.com/xssnick/tonutils-go/tlb"
+	"github.com/xssnick/tonutils-go/ton/wallet"
+
+	"github.com/smartcontractkit/chainlink/deployment/internal/aptostestutils"
+
+	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	cldf_ton "github.com/smartcontractkit/chainlink-deployments-framework/chain/ton"
+)
+
+var (
+	// tonTransmitterFundAmount is the amount of TON to fund the transmitter address.
+	tonTransmitterFundAmount = tlb.MustFromTON("200")
+)
+
+// fundNodesTon funds the given nodes with the given amount of TON.
+func fundNodesTon(t *testing.T, tonChain cldf_ton.Chain, nodes []*Node) {
+	messages := make([]*wallet.Message, 0, len(nodes))
+	for _, node := range nodes {
+		tonkeys, err := node.App.GetKeyStore().TON().GetAll()
+		require.NoError(t, err)
+		require.Len(t, tonkeys, 1)
+		transmitter := tonkeys[0].PubkeyToAddress()
+		msg, err := tonChain.Wallet.BuildTransfer(transmitter, tonTransmitterFundAmount, false, "")
+		require.NoError(t, err)
+		messages = append(messages, msg)
+	}
+	_, _, err := tonChain.Wallet.SendManyWaitTransaction(t.Context(), messages)
+	require.NoError(t, err)
+}
+
+// fundNodesAptos funds the given nodes with the given amount of APT.
+func fundNodesAptos(t *testing.T, aptosChain cldf_aptos.Chain, nodes []*Node) {
+	for _, node := range nodes {
+		aptoskeys, err := node.App.GetKeyStore().Aptos().GetAll()
+		require.NoError(t, err)
+		require.Len(t, aptoskeys, 1)
+		transmitter := aptoskeys[0]
+		transmitterAccountAddress := aptos.AccountAddress{}
+		require.NoError(t, transmitterAccountAddress.ParseStringRelaxed(transmitter.Account()))
+		aptostestutils.FundAccount(t, aptosChain.DeployerSigner, transmitterAccountAddress, 100*1e8, aptosChain.Client)
+	}
+}
+
+// fundNodesSol funds the given nodes with the given amount of SOL.
+func fundNodesSol(t *testing.T, solChain cldf_solana.Chain, nodes []*Node) {
+	for _, node := range nodes {
+		solkeys, err := node.App.GetKeyStore().Solana().GetAll()
+		require.NoError(t, err)
+		require.Len(t, solkeys, 1)
+		transmitter := solkeys[0]
+		_, err = solChain.Client.RequestAirdrop(t.Context(), transmitter.PublicKey(), 1000*solana.LAMPORTS_PER_SOL, solRpc.CommitmentConfirmed)
+		require.NoError(t, err)
+		// we don't wait for confirmation so we don't block the tests, it'll take a while before nodes start transmitting
+	}
+}

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/manualexechelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/deployment/utils/nodetestutils"
 	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
 	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
@@ -54,7 +54,7 @@ func Test_CCIPMessaging_EVM2EVM(t *testing.T) {
 	e, _, _ := testsetups.NewIntegrationEnvironment(
 		t,
 		testhelpers.WithChainIDs(chainIDs),
-		testhelpers.WithCLNodeConfigOpts(memory.WithFinalityDepths(map[uint64]uint32{
+		testhelpers.WithCLNodeConfigOpts(nodetestutils.WithFinalityDepths(map[uint64]uint32{
 			chains[1].EvmChainID: 30, // make dest chain finality depth 30 so we can observe exec behavior
 		})),
 	)


### PR DESCRIPTION
This moves the common code to bring up nodes in tests to the utils package and updates all references to it. This is a refactor to prepare for the final removal of the memory package.
