### PR TITLE
[CRE-1188] Update platform.donVersion whenever there is a DON config change

### DIFF
--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -73,6 +73,29 @@ type enqueuedTriggerEvent struct {
 	event        capabilities.TriggerResponse
 }
 
+// buildLabels creates the label slice for the beholder logger based on config and localNode state.
+// This is used both during engine creation and when updating labels after a DON configuration change.
+func (e *Engine) buildLabels(localNode *capabilities.Node) []any {
+	return []any{
+		platform.KeyWorkflowID, e.cfg.WorkflowID,
+		platform.KeyWorkflowOwner, e.cfg.WorkflowOwner,
+		platform.KeyWorkflowName, e.cfg.WorkflowName.String(),
+		platform.KeyWorkflowVersion, platform.ValueWorkflowVersionV2,
+		platform.KeyDonID, strconv.Itoa(int(localNode.WorkflowDON.ID)),
+		platform.KeyDonF, strconv.Itoa(int(localNode.WorkflowDON.F)),
+		platform.KeyDonN, strconv.Itoa(len(localNode.WorkflowDON.Members)),
+		platform.KeyDonQ, strconv.Itoa(aggregation.ByzantineQuorum(
+			len(localNode.WorkflowDON.Members),
+			int(localNode.WorkflowDON.F),
+		)),
+		platform.KeyP2PID, localNode.PeerID.String(),
+		platform.WorkflowRegistryAddress, e.cfg.WorkflowRegistryAddress,
+		platform.WorkflowRegistryChainSelector, e.cfg.WorkflowRegistryChainSelector,
+		platform.EngineVersion, platform.ValueWorkflowVersionV2,
+		platform.DonVersion, strconv.FormatUint(uint64(localNode.WorkflowDON.ConfigVersion), 10),
+	}
+}
+
 func NewEngine(cfg *EngineConfig) (*Engine, error) {
 	err := cfg.Validate()
 	if err != nil {
@@ -92,24 +115,17 @@ func NewEngine(cfg *EngineConfig) (*Engine, error) {
 		return nil, fmt.Errorf("could not get local node state: %w", err)
 	}
 
-	labels := []any{
-		platform.KeyWorkflowID, cfg.WorkflowID,
-		platform.KeyWorkflowOwner, cfg.WorkflowOwner,
-		platform.KeyWorkflowName, cfg.WorkflowName.String(),
-		platform.KeyWorkflowVersion, platform.ValueWorkflowVersionV2,
-		platform.KeyDonID, strconv.Itoa(int(localNode.WorkflowDON.ID)),
-		platform.KeyDonF, strconv.Itoa(int(localNode.WorkflowDON.F)),
-		platform.KeyDonN, strconv.Itoa(len(localNode.WorkflowDON.Members)),
-		platform.KeyDonQ, strconv.Itoa(aggregation.ByzantineQuorum(
-			len(localNode.WorkflowDON.Members),
-			int(localNode.WorkflowDON.F),
-		)),
-		platform.KeyP2PID, localNode.PeerID.String(),
-		platform.WorkflowRegistryAddress, cfg.WorkflowRegistryAddress,
-		platform.WorkflowRegistryChainSelector, cfg.WorkflowRegistryChainSelector,
-		platform.EngineVersion, platform.ValueWorkflowVersionV2,
-		platform.DonVersion, strconv.FormatUint(uint64(localNode.WorkflowDON.ConfigVersion), 10),
+	// Create engine first so we can use the buildLabels method
+	engine := &Engine{
+		cfg:                     cfg,
+		triggers:                make(map[string]*triggerCapability),
+		allTriggerEventsQueueCh: cfg.LocalLimiters.TriggerEventQueue,
+		executionsSemaphore:     cfg.LocalLimiters.ExecutionConcurrency,
+		capCallsSemaphore:       cfg.LocalLimiters.CapabilityConcurrency,
 	}
+
+	// Build labels using the helper method
+	labels := engine.buildLabels(&localNode)
 
 	beholderLogger := logger.Sugared(custmsg.NewBeholderLogger(cfg.Lggr, cfg.BeholderEmitter).Named("WorkflowEngine").With(labels...))
 	metricsLabeler := monitoring.NewWorkflowsMetricLabeler(metrics.NewLabeler(), em).With(
@@ -125,16 +141,10 @@ func NewEngine(cfg *EngineConfig) (*Engine, error) {
 		beholderLogger.Errorw("WARNING: Debug mode is enabled, this is not suitable for production")
 	}
 
-	engine := &Engine{
-		cfg:                     cfg,
-		lggr:                    beholderLogger,
-		triggers:                make(map[string]*triggerCapability),
-		allTriggerEventsQueueCh: cfg.LocalLimiters.TriggerEventQueue,
-		executionsSemaphore:     cfg.LocalLimiters.ExecutionConcurrency,
-		capCallsSemaphore:       cfg.LocalLimiters.CapabilityConcurrency,
-		meterReports:            metering.NewReports(cfg.BillingClient, cfg.WorkflowOwner, cfg.WorkflowID, beholderLogger, labelsMap, metricsLabeler, cfg.WorkflowRegistryAddress, cfg.WorkflowRegistryChainSelector, metering.EngineVersionV2),
-		metrics:                 metricsLabeler,
-	}
+	// Store logger and other fields
+	engine.lggr = beholderLogger
+	engine.meterReports = metering.NewReports(cfg.BillingClient, cfg.WorkflowOwner, cfg.WorkflowID, beholderLogger, labelsMap, metricsLabeler, cfg.WorkflowRegistryAddress, cfg.WorkflowRegistryChainSelector, metering.EngineVersionV2)
+	engine.metrics = metricsLabeler
 	engine.loggerLabels.Store(&labelsMap)
 	engine.localNode.Store(&localNode)
 	engine.Service, engine.srvcEng = services.Config{
@@ -239,6 +249,23 @@ func (e *Engine) localNodeSync(ctx context.Context) {
 		"Workflow DON Families", localNode.WorkflowDON.Families,
 		"Workflow DON Config Version", localNode.WorkflowDON.ConfigVersion,
 	)
+
+	// Recreate the beholder logger with updated labels to reflect the new DON version
+	labels := e.buildLabels(&localNode)
+	newLogger := logger.Sugared(
+		custmsg.NewBeholderLogger(e.cfg.Lggr, e.cfg.BeholderEmitter).
+			Named("WorkflowEngine").
+			With(labels...),
+	)
+	e.lggr = newLogger
+
+	// Update loggerLabels map for metrics
+	labelsMap := make(map[string]string, len(labels)/2)
+	for i := 0; i < len(labels); i += 2 {
+		labelsMap[labels[i].(string)] = labels[i+1].(string)
+	}
+	e.loggerLabels.Store(&labelsMap)
+
 	e.cfg.Hooks.OnNodeSynced(localNode, nil)
 	e.localNode.Store(&localNode)
 }

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -41,8 +41,18 @@ type Engine struct {
 	services.Service
 	srvcEng *services.Engine
 
-	cfg          *EngineConfig
-	lggr         logger.SugaredLogger
+	cfg *EngineConfig
+
+	// lggr is the engine's logger. It is protected by lggrMu to allow safe updates when DON configuration changes.
+	// IMPORTANT: Do NOT access this field directly. Always use the logger() method to ensure thread-safety.
+	// Direct access will cause data races when the logger is updated in localNodeSync().
+	lggr logger.SugaredLogger
+
+	// lggrMu protects lggr during dynamic updates when DON configuration changes.
+	// Write access (Lock): Only in setLogger() called from localNodeSync()
+	// Read access (RLock): In logger() method called from everywhere else
+	lggrMu sync.RWMutex
+
 	loggerLabels atomic.Pointer[map[string]string]
 	localNode    atomic.Pointer[capabilities.Node]
 
@@ -96,6 +106,23 @@ func (e *Engine) buildLabels(localNode *capabilities.Node) []any {
 	}
 }
 
+// logger returns the current logger in a thread-safe manner.
+// This method should be used instead of accessing e.lggr directly to avoid race conditions
+// when the logger is dynamically updated (e.g., when DON configuration changes).
+func (e *Engine) logger() logger.SugaredLogger {
+	e.lggrMu.RLock()
+	defer e.lggrMu.RUnlock()
+	return e.lggr
+}
+
+// setLogger updates the logger in a thread-safe manner.
+// This is called when the DON configuration changes and we need to update the platform.DonVersion label.
+func (e *Engine) setLogger(lggr logger.SugaredLogger) {
+	e.lggrMu.Lock()
+	defer e.lggrMu.Unlock()
+	e.lggr = lggr
+}
+
 func NewEngine(cfg *EngineConfig) (*Engine, error) {
 	err := cfg.Validate()
 	if err != nil {
@@ -142,7 +169,7 @@ func NewEngine(cfg *EngineConfig) (*Engine, error) {
 	}
 
 	// Store logger and other fields
-	engine.lggr = beholderLogger
+	engine.setLogger(beholderLogger)
 	engine.meterReports = metering.NewReports(cfg.BillingClient, cfg.WorkflowOwner, cfg.WorkflowID, beholderLogger, labelsMap, metricsLabeler, cfg.WorkflowRegistryAddress, cfg.WorkflowRegistryChainSelector, metering.EngineVersionV2)
 	engine.metrics = metricsLabeler
 	engine.loggerLabels.Store(&labelsMap)
@@ -174,15 +201,15 @@ func (e *Engine) init(ctx context.Context) {
 		if errors.As(err, &errLimited) {
 			switch errLimited.Scope {
 			case settings.ScopeOwner:
-				e.lggr.Info("Per owner workflow count limit reached", "err", err)
+				e.logger().Info("Per owner workflow count limit reached", "err", err)
 				e.metrics.IncrementWorkflowLimitPerOwnerCounter(ctx)
 				e.cfg.Hooks.OnInitialized(types.ErrPerOwnerWorkflowCountLimitReached)
 			case settings.ScopeGlobal:
-				e.lggr.Info("Global workflow count limit reached", "err", err)
+				e.logger().Info("Global workflow count limit reached", "err", err)
 				e.metrics.IncrementWorkflowLimitGlobalCounter(ctx)
 				e.cfg.Hooks.OnInitialized(types.ErrGlobalWorkflowCountLimitReached)
 			default:
-				e.lggr.Errorw("Workflow count limit reached for unexpected scope", "scope", errLimited.Scope, "err", err)
+				e.logger().Errorw("Workflow count limit reached for unexpected scope", "scope", errLimited.Scope, "err", err)
 				e.cfg.Hooks.OnInitialized(err)
 			}
 		} else {
@@ -193,7 +220,7 @@ func (e *Engine) init(ctx context.Context) {
 
 	donSubCh, cleanup, err := e.cfg.DonSubscriber.Subscribe(ctx)
 	if err != nil {
-		e.lggr.Errorw("failed to subscribe to DON notifier", "error", err)
+		e.logger().Errorw("failed to subscribe to DON notifier", "error", err)
 		e.cfg.Hooks.OnInitialized(fmt.Errorf("failed to subscribe to DON notifier: %w", err))
 		return
 	}
@@ -217,12 +244,12 @@ func (e *Engine) init(ctx context.Context) {
 
 	err = e.runTriggerSubscriptionPhase(ctx)
 	if err != nil {
-		e.lggr.Errorw("Workflow Engine initialization failed", "err", err)
+		e.logger().Errorw("Workflow Engine initialization failed", "err", err)
 		e.cfg.Hooks.OnInitialized(err)
 		return
 	}
 
-	e.lggr.Info("Workflow Engine initialized")
+	e.logger().Info("Workflow Engine initialized")
 	e.metrics.IncrementWorkflowInitializationCounter(ctx)
 	e.cfg.Hooks.OnInitialized(nil)
 }
@@ -257,7 +284,7 @@ func (e *Engine) localNodeSync(ctx context.Context) {
 			Named("WorkflowEngine").
 			With(labels...),
 	)
-	e.lggr = newLogger
+	e.setLogger(newLogger)
 
 	// Update loggerLabels map for metrics
 	labelsMap := make(map[string]string, len(labels)/2)
@@ -290,7 +317,7 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 
 	var timeProvider TimeProvider = &types.LocalTimeProvider{}
 	if !e.cfg.UseLocalTimeProvider {
-		timeProvider = NewDonTimeProvider(e.cfg.DonTimeStore, e.cfg.WorkflowID, e.lggr)
+		timeProvider = NewDonTimeProvider(e.cfg.DonTimeStore, e.cfg.WorkflowID, e.logger())
 	}
 
 	moduleExecuteMaxResponseSizeBytes, err := e.cfg.LocalLimiters.ExecutionResponse.Limit(ctx)
@@ -304,7 +331,7 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 		Request:         &sdkpb.ExecuteRequest_Subscribe{},
 		MaxResponseSize: uint64(moduleExecuteMaxResponseSizeBytes), //nolint:gosec // G115
 		Config:          e.cfg.WorkflowConfig,
-	}, NewDisallowedExecutionHelper(e.lggr, userLogChan, timeProvider, e.secretsFetcher(e.cfg.WorkflowID)))
+	}, NewDisallowedExecutionHelper(e.logger(), userLogChan, timeProvider, e.secretsFetcher(e.cfg.WorkflowID)))
 	if err != nil {
 		return fmt.Errorf("failed to execute subscribe: %w", err)
 	}
@@ -343,7 +370,7 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 	for i, sub := range subs.Subscriptions {
 		triggerCap := triggers[i]
 		registrationID := fmt.Sprintf("trigger_reg_%s_%d", e.cfg.WorkflowID, i)
-		e.lggr.Debugw("Registering trigger", "triggerID", sub.Id, "method", sub.Method)
+		e.logger().Debugw("Registering trigger", "triggerID", sub.Id, "method", sub.Method)
 		triggerEventCh, err := triggerCap.RegisterTrigger(regCtx, capabilities.TriggerRegistrationRequest{
 			TriggerID: registrationID,
 			Metadata: capabilities.RequestMetadata{
@@ -365,7 +392,7 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 			// no Config needed - NoDAG uses Payload
 		})
 		if err != nil {
-			e.lggr.Errorw("One of trigger registrations failed - reverting all", "triggerID", sub.Id, "err", err)
+			e.logger().Errorw("One of trigger registrations failed - reverting all", "triggerID", sub.Id, "err", err)
 			e.metrics.With(platform.KeyTriggerID, sub.Id).IncrementRegisterTriggerFailureCounter(ctx)
 			e.unregisterAllTriggers(ctx)
 			return fmt.Errorf("failed to register trigger: %w", err)
@@ -391,7 +418,7 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 						return
 					}
 					if event.Err != nil {
-						e.lggr.Errorw("Received a trigger event with error, dropping", "triggerID", subs.Subscriptions[idx].Id, "err", event.Err)
+						e.logger().Errorw("Received a trigger event with error, dropping", "triggerID", subs.Subscriptions[idx].Id, "err", event.Err)
 						e.metrics.With(platform.KeyTriggerID, subs.Subscriptions[idx].Id).IncrementWorkflowTriggerEventErrorCounter(ctx)
 						continue
 					}
@@ -404,10 +431,10 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 						var errFull limits.ErrorQueueFull
 						if errors.As(err, &errFull) {
 							// queue full, drop the event
-							e.lggr.Errorw("Trigger event queue is full, dropping event", "triggerID", subs.Subscriptions[idx].Id, "triggerIndex", idx, "err", err)
+							e.logger().Errorw("Trigger event queue is full, dropping event", "triggerID", subs.Subscriptions[idx].Id, "triggerIndex", idx, "err", err)
 							e.metrics.With(platform.KeyTriggerID, subs.Subscriptions[idx].Id).IncrementWorkflowTriggerEventQueueFullCounter(ctx)
 						}
-						e.lggr.Errorw("Failed to enqueue trigger event", "triggerID", subs.Subscriptions[idx].Id, "triggerIndex", idx, "err", err)
+						e.logger().Errorw("Failed to enqueue trigger event", "triggerID", subs.Subscriptions[idx].Id, "triggerIndex", idx, "err", err)
 						e.metrics.With(platform.KeyTriggerID, subs.Subscriptions[idx].Id).IncrementWorkflowTriggerEventErrorCounter(ctx)
 						continue
 					}
@@ -415,7 +442,7 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 			}
 		})
 	}
-	e.lggr.Infow("All triggers registered successfully", "numTriggers", len(subs.Subscriptions), "triggerIDs", triggerCapIDs)
+	e.logger().Infow("All triggers registered successfully", "numTriggers", len(subs.Subscriptions), "triggerIDs", triggerCapIDs)
 	e.metrics.IncrementWorkflowRegisteredCounter(ctx)
 	e.cfg.Hooks.OnSubscribedToTriggers(triggerCapIDs)
 	return nil
@@ -430,16 +457,16 @@ func (e *Engine) handleAllTriggerEvents(ctx context.Context) {
 		eventAge := queueHead.timestamp.Sub(e.cfg.Clock.Now())
 		triggerEventMaxAge, err := e.cfg.LocalLimiters.TriggerEventQueueTime.Limit(ctx)
 		if err != nil {
-			e.lggr.Errorw("Failed to get trigger event queue time limit", "err", err)
+			e.logger().Errorw("Failed to get trigger event queue time limit", "err", err)
 			continue
 		}
 		if eventAge > triggerEventMaxAge {
-			e.lggr.Warnw("Trigger event is too old, skipping execution", "triggerID", queueHead.triggerCapID, "eventID", queueHead.event.Event.ID, "eventAgeMs", eventAge.Milliseconds())
+			e.logger().Warnw("Trigger event is too old, skipping execution", "triggerID", queueHead.triggerCapID, "eventID", queueHead.event.Event.ID, "eventAgeMs", eventAge.Milliseconds())
 			continue
 		}
 		free, err := e.executionsSemaphore.Wait(ctx, 1) // block if too many concurrent workflow executions
 		if err != nil {
-			e.lggr.Errorw("Failed to acquire executions semaphore", "err", err)
+			e.logger().Errorw("Failed to acquire executions semaphore", "err", err)
 			continue
 		}
 		e.srvcEng.GoCtx(context.WithoutCancel(ctx), func(ctx context.Context) {
@@ -454,7 +481,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	triggerEvent := wrappedTriggerEvent.event.Event
 	executionID, err := events.GenerateExecutionID(e.cfg.WorkflowID, triggerEvent.ID)
 	if err != nil {
-		e.lggr.Errorw("Failed to generate execution ID", "err", err, "triggerID", wrappedTriggerEvent.triggerCapID)
+		e.logger().Errorw("Failed to generate execution ID", "err", err, "triggerID", wrappedTriggerEvent.triggerCapID)
 		return
 	}
 
@@ -463,7 +490,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	if e.cfg.OrgResolver != nil {
 		orgID, gerr := e.cfg.OrgResolver.Get(ctx, e.cfg.WorkflowOwner)
 		if gerr != nil {
-			e.lggr.Warnw("Failed to resolve organization ID, continuing without it", "workflowOwner", e.cfg.WorkflowOwner, "err", gerr)
+			e.logger().Warnw("Failed to resolve organization ID, continuing without it", "workflowOwner", e.cfg.WorkflowOwner, "err", gerr)
 		} else {
 			organizationID = orgID
 		}
@@ -471,7 +498,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	loggerLabels := maps.Clone(*e.loggerLabels.Load())
 	loggerLabels[platform.KeyOrganizationID] = organizationID
 	e.loggerLabels.Store(&loggerLabels)
-	e.lggr.With(platform.KeyOrganizationID, organizationID)
+	e.logger().With(platform.KeyOrganizationID, organizationID)
 	creCtx := contexts.CREValue(ctx)
 	creCtx.Org = organizationID
 	ctx = contexts.WithCRE(ctx, creCtx)
@@ -483,14 +510,14 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 
 	meteringReport, meteringErr := e.meterReports.Start(ctx, executionID)
 	if meteringErr != nil {
-		e.lggr.Errorw("could start metering workflow execution. continuing without metering", "err", meteringErr)
+		e.logger().Errorw("could start metering workflow execution. continuing without metering", "err", meteringErr)
 	}
 
 	isMetering := meteringErr == nil
 	if isMetering {
 		mrErr := meteringReport.Reserve(ctx)
 		if mrErr != nil {
-			e.lggr.Errorw("could not reserve metering", "err", mrErr)
+			e.logger().Errorw("could not reserve metering", "err", mrErr)
 			return
 		}
 
@@ -499,15 +526,15 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 
 	execCtx, execCancel, err := e.cfg.LocalLimiters.ExecutionTime.WithTimeout(ctx)
 	if err != nil {
-		e.lggr.Errorw("Failed to get execution time limit", "err", err)
+		e.logger().Errorw("Failed to get execution time limit", "err", err)
 		return
 	}
 	defer execCancel()
-	executionLogger := logger.With(e.lggr, "executionID", executionID, "triggerID", wrappedTriggerEvent.triggerCapID, "triggerIndex", wrappedTriggerEvent.triggerIndex)
+	executionLogger := logger.With(e.logger(), "executionID", executionID, "triggerID", wrappedTriggerEvent.triggerCapID, "triggerIndex", wrappedTriggerEvent.triggerIndex)
 
 	maxUserLogEventsPerExecution, err := e.cfg.LocalLimiters.LogEvent.Limit(ctx)
 	if err != nil {
-		e.lggr.Errorw("Failed to get log event limit", "err", err)
+		e.logger().Errorw("Failed to get log event limit", "err", err)
 		return
 	}
 	userLogChan := make(chan *protoevents.LogLine, maxUserLogEventsPerExecution)
@@ -530,16 +557,16 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 
 	var timeProvider TimeProvider = &types.LocalTimeProvider{}
 	if !e.cfg.UseLocalTimeProvider {
-		timeProvider = NewDonTimeProvider(e.cfg.DonTimeStore, e.cfg.WorkflowID, e.lggr)
+		timeProvider = NewDonTimeProvider(e.cfg.DonTimeStore, e.cfg.WorkflowID, e.logger())
 	}
 
 	moduleExecuteMaxResponseSizeBytes, err := e.cfg.LocalLimiters.ExecutionResponse.Limit(ctx)
 	if err != nil {
-		e.lggr.Errorw("Failed to get execution response size limit", "err", err)
+		e.logger().Errorw("Failed to get execution response size limit", "err", err)
 		return
 	}
 	if moduleExecuteMaxResponseSizeBytes < 0 {
-		e.lggr.Errorf("invalid moduleExecuteMaxResponseSizeBytes; must not be negative: %d", moduleExecuteMaxResponseSizeBytes)
+		e.logger().Errorf("invalid moduleExecuteMaxResponseSizeBytes; must not be negative: %d", moduleExecuteMaxResponseSizeBytes)
 		return
 	}
 	execHelper := &ExecutionHelper{
@@ -574,11 +601,11 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 			},
 		)
 		if mrErr != nil {
-			e.lggr.Errorw("could not set metering for compute", "err", mrErr)
+			e.logger().Errorw("could not set metering for compute", "err", mrErr)
 		}
 		mrErr = e.meterReports.End(ctx, executionID)
 		if mrErr != nil {
-			e.lggr.Errorw("could not end metering report", "err", mrErr)
+			e.logger().Errorw("could not end metering report", "err", mrErr)
 		}
 	}
 
@@ -592,14 +619,14 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		}
 
 		executionLogger.Errorw("Workflow execution failed with module execution error", "status", executionStatus, "durationMs", executionDuration.Milliseconds(), "err", execErr)
-		_ = events.EmitExecutionFinishedEvent(ctx, loggerLabels, executionStatus, executionID, e.lggr)
+		_ = events.EmitExecutionFinishedEvent(ctx, loggerLabels, executionStatus, executionID, e.logger())
 		e.cfg.Hooks.OnExecutionFinished(executionID, executionStatus)
 		e.cfg.Hooks.OnExecutionError(execErr.Error())
 		return
 	}
 
 	if e.cfg.DebugMode {
-		e.lggr.Debugw("User workflow execution result", "result", result.GetValue(), "err", result.GetError())
+		e.logger().Debugw("User workflow execution result", "result", result.GetValue(), "err", result.GetError())
 	}
 
 	if len(result.GetError()) > 0 {
@@ -607,7 +634,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		e.metrics.UpdateWorkflowErrorDurationHistogram(ctx, int64(executionDuration.Seconds()))
 		e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String()).IncrementWorkflowExecutionFailedCounter(ctx)
 		executionLogger.Errorw("Workflow execution failed", "status", executionStatus, "durationMs", executionDuration.Milliseconds(), "error", result.GetError())
-		_ = events.EmitExecutionFinishedEvent(ctx, loggerLabels, executionStatus, executionID, e.lggr)
+		_ = events.EmitExecutionFinishedEvent(ctx, loggerLabels, executionStatus, executionID, e.logger())
 		e.cfg.Hooks.OnExecutionFinished(executionID, executionStatus)
 		e.cfg.Hooks.OnExecutionError(result.GetError())
 		return
@@ -615,7 +642,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 
 	executionStatus = store.StatusCompleted
 	executionLogger.Infow("Workflow execution finished successfully", "durationMs", executionDuration.Milliseconds())
-	_ = events.EmitExecutionFinishedEvent(ctx, loggerLabels, executionStatus, executionID, e.lggr)
+	_ = events.EmitExecutionFinishedEvent(ctx, loggerLabels, executionStatus, executionID, e.logger())
 	e.metrics.UpdateWorkflowCompletedDurationHistogram(ctx, int64(executionDuration.Seconds()))
 	e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String()).IncrementWorkflowExecutionSucceededCounter(ctx)
 	e.cfg.Hooks.OnResultReceived(result)
@@ -630,7 +657,7 @@ func (e *Engine) secretsFetcher(phaseID string) SecretsFetcher {
 	return NewSecretsFetcher(
 		e.metrics,
 		e.cfg.CapRegistry,
-		e.lggr,
+		e.logger(),
 		e.cfg.LocalLimiters.SecretsConcurrency,
 		e.cfg.WorkflowOwner,
 		e.cfg.WorkflowName.String(),
@@ -673,28 +700,28 @@ func (e *Engine) unregisterAllTriggers(ctx context.Context) {
 			Method:  trigger.method,
 		})
 		if err != nil {
-			e.lggr.Errorw("Failed to unregister trigger", "registrationId", registrationID, "err", err)
+			e.logger().Errorw("Failed to unregister trigger", "registrationId", registrationID, "err", err)
 			failCount++
 		}
 	}
-	e.lggr.Infow("All triggers unregistered", "numTriggers", len(e.triggers), "failed", failCount)
+	e.logger().Infow("All triggers unregistered", "numTriggers", len(e.triggers), "failed", failCount)
 	e.triggers = make(map[string]*triggerCapability)
 }
 
 func (e *Engine) heartbeatLoop(ctx context.Context) {
 	ticker := time.NewTicker(time.Duration(e.cfg.LocalLimits.HeartbeatFrequencyMs) * time.Millisecond)
 	defer ticker.Stop()
-	e.lggr.Info("Starting heartbeat loop")
+	e.logger().Info("Starting heartbeat loop")
 	e.metrics.EngineHeartbeatGauge(ctx, 1)
 
 	for {
 		select {
 		case <-ctx.Done():
 			e.metrics.EngineHeartbeatGauge(ctx, 0)
-			e.lggr.Info("Shutting down heartbeat")
+			e.logger().Info("Shutting down heartbeat")
 			return
 		case <-ticker.C:
-			e.lggr.Debugw("Engine heartbeat tick", "time", e.cfg.Clock.Now().Format(time.RFC3339))
+			e.logger().Debugw("Engine heartbeat tick", "time", e.cfg.Clock.Now().Format(time.RFC3339))
 			e.metrics.IncrementEngineHeartbeatCounter(ctx)
 		}
 	}
@@ -706,7 +733,7 @@ func (e *Engine) deductStandardBalances(ctx context.Context, meteringReport *met
 	ctxCancelPadding := (time.Millisecond * 1000).Milliseconds()
 	workflowExecutionTimeout, err := e.cfg.LocalLimiters.ExecutionTime.Limit(ctx)
 	if err != nil {
-		e.lggr.Errorw("Failed to get execution time limit", "err", err)
+		e.logger().Errorw("Failed to get execution time limit", "err", err)
 		return
 	}
 	compMs := decimal.NewFromInt(workflowExecutionTimeout.Milliseconds() + ctxCancelPadding)
@@ -716,15 +743,15 @@ func (e *Engine) deductStandardBalances(ctx context.Context, meteringReport *met
 		computeUnit,
 		metering.ByResource(computeUnit, "v2-standard-deduction-compute", compMs),
 	); err != nil {
-		e.lggr.Errorw("could not deduct balance for capability request", "capReq", "standard-deduction-compute", "err", err)
+		e.logger().Errorw("could not deduct balance for capability request", "capReq", "standard-deduction-compute", "err", err)
 	}
 }
 
 // separate call for each workflow execution
 func (e *Engine) emitUserLogs(ctx context.Context, userLogChan chan *protoevents.LogLine, executionID string, executionLabels map[string]string) {
-	e.lggr.Debugw("Listening for user logs ...")
+	e.logger().Debugw("Listening for user logs ...")
 	count := 0
-	defer func() { e.lggr.Debugw("Listening for user logs done.", "processedLogLines", count) }()
+	defer func() { e.logger().Debugw("Listening for user logs done.", "processedLogLines", count) }()
 	for {
 		select {
 		case <-ctx.Done():
@@ -734,21 +761,21 @@ func (e *Engine) emitUserLogs(ctx context.Context, userLogChan chan *protoevents
 				return
 			}
 			if e.cfg.DebugMode {
-				e.lggr.Debugf("User log: <<<%s>>>, local node timestamp: %s", logLine.Message, logLine.NodeTimestamp)
+				e.logger().Debugf("User log: <<<%s>>>, local node timestamp: %s", logLine.Message, logLine.NodeTimestamp)
 			}
 			err := e.cfg.LocalLimiters.LogEvent.Check(ctx, count)
 			if err != nil {
 				var errBoundLimited limits.ErrorBoundLimited[int]
 				if errors.As(err, &errBoundLimited) {
-					e.lggr.Warnw("Max user log events per execution reached, dropping event", "maxEvents", errBoundLimited.Limit)
+					e.logger().Warnw("Max user log events per execution reached, dropping event", "maxEvents", errBoundLimited.Limit)
 					return
 				}
-				e.lggr.Errorw("Failed to get user log event limit", "err", err)
+				e.logger().Errorw("Failed to get user log event limit", "err", err)
 				return
 			}
 			maxUserLogLength, err := e.cfg.LocalLimiters.LogLine.Limit(ctx)
 			if err != nil {
-				e.lggr.Errorw("Failed to get user log line limit", "err", err)
+				e.logger().Errorw("Failed to get user log line limit", "err", err)
 				return
 			}
 			if len(logLine.Message) > int(maxUserLogLength) {
@@ -756,7 +783,7 @@ func (e *Engine) emitUserLogs(ctx context.Context, userLogChan chan *protoevents
 			}
 
 			if err := events.EmitUserLogs(ctx, executionLabels, []*protoevents.LogLine{logLine}, executionID); err != nil {
-				e.lggr.Errorw("Failed to emit user logs", "err", err)
+				e.logger().Errorw("Failed to emit user logs", "err", err)
 			}
 			count++
 		}

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -1810,52 +1810,24 @@ func TestEngine_DonVersionLabelUpdate(t *testing.T) {
 	// Create a real DON notifier (this is what the engine uses)
 	donNotifier := coreCap.NewDonNotifier()
 
+	// Note: CreateLocalRegistry creates a DON with ConfigVersion=2 by default, but we need to start at 1
+	lr := v2.CreateLocalRegistry(t, peerID)
+
 	donID := uint32(1)
-	workflowDonNodes := []ragetypes.PeerID{peerID}
 
-	// Create initial DON with ConfigVersion = 1
-	don1 := capabilities.DON{
-		ID:               donID,
-		ConfigVersion:    1, // Initial version
-		F:                uint8(1),
-		IsPublic:         true,
-		AcceptsWorkflows: true,
-		Members:          workflowDonNodes,
-	}
+	// Update the DON to have ConfigVersion = 1 (initial state for this test)
+	don := lr.IDsToDONs[registrysyncer.DonID(donID)]
+	don.ConfigVersion = 1 // Start at version 1 so we can test the update to version 2
+	lr.IDsToDONs[registrysyncer.DonID(donID)] = don
 
-	// Create a real LocalRegistry with initial DON ConfigVersion = 1
-	dummyCapID := "test-capability"
-	dummyCap := registrysyncer.Capability{
-		ID:             dummyCapID,
-		CapabilityType: capabilities.CapabilityTypeTrigger,
-	}
-
-	lr := registrysyncer.NewLocalRegistry(
-		lggr,
-		func() (ragetypes.PeerID, error) { return peerID, nil },
-		map[registrysyncer.DonID]registrysyncer.DON{
-			registrysyncer.DonID(donID): {
-				DON:                      don1,
-				CapabilityConfigurations: map[string]registrysyncer.CapabilityConfiguration{},
-			},
-		},
-		map[ragetypes.PeerID]registrysyncer.NodeInfo{
-			peerID: {
-				NodeOperatorID:      1,
-				WorkflowDONId:       donID,
-				Signer:              coreCap.RandomUTF8BytesWord(),
-				P2pID:               peerID,
-				EncryptionPublicKey: coreCap.RandomUTF8BytesWord(),
-			},
-		},
-		map[string]registrysyncer.Capability{
-			dummyCapID: dummyCap,
-		},
-	)
-
+	// Wrap in updatableRegistry to allow thread-safe updates during testing
 	localRegistry := &updatableRegistry{
-		localRegistry: &lr,
+		localRegistry: lr,
 	}
+
+	// Create initial DON object for the notifier
+	don1 := don.DON
+	workflowDonNodes := don1.Members
 
 	// Set initial DON in the notifier
 	donNotifier.NotifyDonSet(don1)

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -48,6 +48,8 @@ import (
 	coreCap "github.com/smartcontractkit/chainlink/v2/core/capabilities"
 	capmocks "github.com/smartcontractkit/chainlink/v2/core/capabilities/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/wasmtest"
+	"github.com/smartcontractkit/chainlink/v2/core/platform"
+	"github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer"
 	workflowEvents "github.com/smartcontractkit/chainlink/v2/core/services/workflows/events"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/metering"
 	metmocks "github.com/smartcontractkit/chainlink/v2/core/services/workflows/metering/mocks"
@@ -1779,6 +1781,150 @@ func TestEngine_HandleNewDON(t *testing.T) {
 	})
 }
 
+// TestEngine_DonVersionLabelUpdate tests that when a DON's ConfigVersion changes,
+// the beholder logger labels should be updated to reflect the new version.
+//
+// This test creates a REAL engine with a REAL DON notifier and triggers a REAL DON update
+// to verify that the beholder logger labels are updated correctly.
+//
+// Test Flow:
+// 1. Create a real engine with DON ConfigVersion = 1
+// 2. Start the engine (which subscribes to DON updates)
+// 3. Trigger a real DON update via NotifyDonSet() with ConfigVersion = 2
+// 4. Verify that the beholder logger labels are updated to reflect ConfigVersion = 2
+func TestEngine_DonVersionLabelUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	lggr := logger.Test(t)
+
+	// Create a peer ID for our test node
+	peerID := ragetypes.PeerID{}
+	copy(peerID[:], "test-peer-id-1234567890abcdef")
+
+	// Create a tracking emitter to capture label changes
+	trackingEmitter := newTrackingBeholderEmitter()
+
+	// Create a real DON notifier (this is what the engine uses)
+	donNotifier := coreCap.NewDonNotifier()
+
+	donID := uint32(1)
+	workflowDonNodes := []ragetypes.PeerID{peerID}
+
+	// Create initial DON with ConfigVersion = 1
+	don1 := capabilities.DON{
+		ID:               donID,
+		ConfigVersion:    1, // Initial version
+		F:                uint8(1),
+		IsPublic:         true,
+		AcceptsWorkflows: true,
+		Members:          workflowDonNodes,
+	}
+
+	// Create a real LocalRegistry with initial DON ConfigVersion = 1
+	dummyCapID := "test-capability"
+	dummyCap := registrysyncer.Capability{
+		ID:             dummyCapID,
+		CapabilityType: capabilities.CapabilityTypeTrigger,
+	}
+
+	lr := registrysyncer.NewLocalRegistry(
+		lggr,
+		func() (ragetypes.PeerID, error) { return peerID, nil },
+		map[registrysyncer.DonID]registrysyncer.DON{
+			registrysyncer.DonID(donID): {
+				DON:                      don1,
+				CapabilityConfigurations: map[string]registrysyncer.CapabilityConfiguration{},
+			},
+		},
+		map[ragetypes.PeerID]registrysyncer.NodeInfo{
+			peerID: {
+				NodeOperatorID:      1,
+				WorkflowDONId:       donID,
+				Signer:              coreCap.RandomUTF8BytesWord(),
+				P2pID:               peerID,
+				EncryptionPublicKey: coreCap.RandomUTF8BytesWord(),
+			},
+		},
+		map[string]registrysyncer.Capability{
+			dummyCapID: dummyCap,
+		},
+	)
+
+	localRegistry := &updatableRegistry{
+		LocalRegistry: &lr,
+	}
+
+	// Set initial DON in the notifier
+	donNotifier.NotifyDonSet(don1)
+
+	// Create a real capabilities registry and set our updatable local registry
+	capRegistry := coreCap.NewRegistry(lggr)
+	capRegistry.SetLocalRegistry(localRegistry)
+
+	// Create a real engine configuration
+	engine, cfg := createTestEngineForDonVersionTest(t, ctx, lggr, capRegistry, donNotifier, trackingEmitter)
+
+	// Start the engine - this will subscribe to DON updates
+	err := engine.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, engine.Close())
+	}()
+
+	// Wait for initialization
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify initial labels
+	initialLabels := trackingEmitter.GetLatestLabels()
+	require.NotNil(t, initialLabels)
+	assert.Equal(t, "1", initialLabels[platform.DonVersion], "initial donVersion label should be 1")
+	t.Logf("✓ Initial labels: donVersion=%s", initialLabels[platform.DonVersion])
+
+	// NOW TRIGGER A REAL DON UPDATE
+	// This simulates what happens when the registry syncer detects a DON configuration change
+	don2 := capabilities.DON{
+		ID:               donID,
+		ConfigVersion:    2, // UPDATED VERSION
+		F:                uint8(1),
+		IsPublic:         true,
+		AcceptsWorkflows: true,
+		Members:          workflowDonNodes,
+	}
+
+	// Update the LocalRegistry (simulating what the registry syncer does)
+	localRegistry.UpdateDON(registrysyncer.DonID(donID), registrysyncer.DON{
+		DON:                      don2,
+		CapabilityConfigurations: map[string]registrysyncer.CapabilityConfiguration{},
+	})
+
+	// Notify the engine of the DON update
+	donNotifier.NotifyDonSet(don2)
+	t.Logf("✓ Triggered real DON update via NotifyDonSet()")
+
+	// Wait for the engine to process the update
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify the registry was updated
+	updatedNode, err := localRegistry.LocalNode(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), updatedNode.WorkflowDON.ConfigVersion, "DON ConfigVersion should now be 2")
+	t.Logf("✓ Registry updated: DON ConfigVersion is now %d", updatedNode.WorkflowDON.ConfigVersion)
+
+	// Check if the beholder logger labels were updated
+	currentLabels := trackingEmitter.GetLatestLabels()
+	donVersionLabel := currentLabels[platform.DonVersion]
+	t.Logf("After real DON update: donVersion label=%s (actual DON ConfigVersion=%d)",
+		donVersionLabel, updatedNode.WorkflowDON.ConfigVersion)
+	assert.Equal(t, "2", donVersionLabel,
+		"donVersion label should be updated to '2' when DON ConfigVersion changes. "+
+			"This test uses a REAL engine, REAL DON notifier, and triggers a REAL DON update.")
+
+	_ = cfg // Keep reference
+}
+
 // setupMockBillingClient creates a mock billing client with default expectations.
 func setupMockBillingClient(t *testing.T) *metmocks.BillingClient {
 	billingClient := metmocks.NewBillingClient(t)
@@ -1996,4 +2142,165 @@ func (c *TriggerCapabilityWrapper) Info(ctx context.Context) (capabilities.Capab
 		capabilities.CapabilityTypeTrigger,
 		"Mock of trigger capability for testing",
 	)
+}
+
+// updatableRegistry wraps LocalRegistry to allow thread-safe updates during testing
+// and implements the full CapabilitiesRegistry interface
+type updatableRegistry struct {
+	*registrysyncer.LocalRegistry
+	mu sync.RWMutex
+}
+
+func (r *updatableRegistry) LocalNode(ctx context.Context) (capabilities.Node, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.LocalRegistry.LocalNode(ctx)
+}
+
+func (r *updatableRegistry) UpdateDON(donID registrysyncer.DonID, don registrysyncer.DON) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.LocalRegistry.IDsToDONs[donID] = don
+}
+
+// Add implements the CapabilitiesRegistry interface (not used in this test)
+func (r *updatableRegistry) Add(ctx context.Context, cap capabilities.BaseCapability) error {
+	return nil
+}
+
+// createTestEngineForDonVersionTest creates a real V2 engine for testing DON version updates
+func createTestEngineForDonVersionTest(
+	t *testing.T,
+	_ context.Context,
+	lggr logger.Logger,
+	registry *coreCap.Registry,
+	donNotifier coreCap.DonNotifyWaitSubscriber,
+	emitter custmsg.MessageEmitter,
+) (*v2.Engine, *v2.EngineConfig) {
+	lf := limits.Factory{Logger: lggr}
+
+	name, err := types.NewWorkflowName("test-don-update-workflow")
+	require.NoError(t, err)
+
+	sLimiter, err := syncerlimiter.NewWorkflowLimits(lggr, syncerlimiter.Config{}, lf)
+	require.NoError(t, err)
+
+	// Use a mock WASM module (only mock we need!)
+	wasmModule := modulemocks.NewModuleV2(t)
+	wasmModule.On("Start").Return(nil)
+	wasmModule.On("Execute", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	wasmModule.On("Close").Return(nil)
+
+	cfg := &v2.EngineConfig{
+		Lggr:                              lggr,
+		Module:                            wasmModule,
+		CapRegistry:                       registry,
+		UseLocalTimeProvider:              true,
+		DonSubscriber:                     donNotifier,
+		ExecutionsStore:                   defaultTestConfig(t, nil).ExecutionsStore,
+		WorkflowID:                        "ffffaabbccddeeff00112233aabbccddeeff00112233aabbccddeeff00112233",
+		WorkflowOwner:                     "1234567890123456789012345678901234567890",
+		WorkflowName:                      name,
+		WorkflowTag:                       "test-tag",
+		WorkflowEncryptionKey:             defaultTestConfig(t, nil).WorkflowEncryptionKey,
+		LocalLimits:                       v2.EngineLimits{},
+		LocalLimiters:                     defaultTestConfig(t, nil).LocalLimiters,
+		GlobalExecutionConcurrencyLimiter: sLimiter,
+		GlobalExecutionRateLimiter:        defaultTestConfig(t, nil).GlobalExecutionRateLimiter,
+		BeholderEmitter:                   emitter,
+		WorkflowRegistryAddress:           "0xWorkflowRegistry",
+		WorkflowRegistryChainSelector:     "11155111",
+	}
+
+	engine, err := v2.NewEngine(cfg)
+	require.NoError(t, err)
+
+	return engine, cfg
+}
+
+// trackingBeholderEmitter is a test helper that tracks the labels set via With()
+// This helps us verify what labels the beholder logger would have at any point
+type trackingBeholderEmitter struct {
+	mu     sync.Mutex
+	labels map[string]string
+}
+
+func newTrackingBeholderEmitter() *trackingBeholderEmitter {
+	return &trackingBeholderEmitter{
+		labels: make(map[string]string),
+	}
+}
+
+func (t *trackingBeholderEmitter) With(keyValues ...string) custmsg.MessageEmitter {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Parse key-value pairs and store them
+	for i := 0; i < len(keyValues)-1; i += 2 {
+		key := keyValues[i]
+		value := keyValues[i+1]
+		t.labels[key] = value
+	}
+
+	return t
+}
+
+func (t *trackingBeholderEmitter) WithMapLabels(labels map[string]string) custmsg.MessageEmitter {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for k, v := range labels {
+		t.labels[k] = v
+	}
+
+	return t
+}
+
+func (t *trackingBeholderEmitter) Labels() map[string]string {
+	return t.GetLatestLabels()
+}
+
+func (t *trackingBeholderEmitter) Emit(_ context.Context, _ string) error {
+	// No-op for this test
+	return nil
+}
+
+func (t *trackingBeholderEmitter) Close() error {
+	return nil
+}
+
+func (t *trackingBeholderEmitter) GetLatestLabels() map[string]string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Return a copy to avoid race conditions
+	result := make(map[string]string, len(t.labels))
+	for k, v := range t.labels {
+		result[k] = v
+	}
+	return result
+}
+
+// HealthReport implements the custmsg.MessageEmitter interface
+func (t *trackingBeholderEmitter) HealthReport() map[string]error {
+	return nil
+}
+
+func (t *trackingBeholderEmitter) Name() string {
+	return "trackingBeholderEmitter"
+}
+
+func (t *trackingBeholderEmitter) Ready() error {
+	return nil
+}
+
+func (t *trackingBeholderEmitter) Start(context.Context) error {
+	return nil
+}
+
+// Helper function to pretty-print labels for debugging
+func (t *trackingBeholderEmitter) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return fmt.Sprintf("Labels: %v", t.labels)
 }

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -1854,7 +1854,7 @@ func TestEngine_DonVersionLabelUpdate(t *testing.T) {
 	)
 
 	localRegistry := &updatableRegistry{
-		LocalRegistry: &lr,
+		localRegistry: &lr,
 	}
 
 	// Set initial DON in the notifier
@@ -1865,7 +1865,7 @@ func TestEngine_DonVersionLabelUpdate(t *testing.T) {
 	capRegistry.SetLocalRegistry(localRegistry)
 
 	// Create a real engine configuration
-	engine, cfg := createTestEngineForDonVersionTest(t, ctx, lggr, capRegistry, donNotifier, trackingEmitter)
+	engine, cfg := createTestEngineForDonVersionTest(t, lggr, capRegistry, donNotifier, trackingEmitter)
 
 	// Start the engine - this will subscribe to DON updates
 	err := engine.Start(ctx)
@@ -2147,31 +2147,51 @@ func (c *TriggerCapabilityWrapper) Info(ctx context.Context) (capabilities.Capab
 // updatableRegistry wraps LocalRegistry to allow thread-safe updates during testing
 // and implements the full CapabilitiesRegistry interface
 type updatableRegistry struct {
-	*registrysyncer.LocalRegistry
-	mu sync.RWMutex
+	localRegistry *registrysyncer.LocalRegistry
+	mu            sync.RWMutex
 }
 
 func (r *updatableRegistry) LocalNode(ctx context.Context) (capabilities.Node, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.LocalRegistry.LocalNode(ctx)
+	return r.localRegistry.LocalNode(ctx)
 }
 
 func (r *updatableRegistry) UpdateDON(donID registrysyncer.DonID, don registrysyncer.DON) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.LocalRegistry.IDsToDONs[donID] = don
+	r.localRegistry.IDsToDONs[donID] = don
 }
 
 // Add implements the CapabilitiesRegistry interface (not used in this test)
-func (r *updatableRegistry) Add(ctx context.Context, cap capabilities.BaseCapability) error {
+func (r *updatableRegistry) Add(ctx context.Context, capability capabilities.BaseCapability) error {
 	return nil
+}
+
+// ConfigForCapability implements the CapabilitiesRegistryMetadata interface
+func (r *updatableRegistry) ConfigForCapability(ctx context.Context, capabilityID string, donID uint32) (capabilities.CapabilityConfiguration, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.localRegistry.ConfigForCapability(ctx, capabilityID, donID)
+}
+
+// DONsForCapability implements the CapabilitiesRegistryMetadata interface
+func (r *updatableRegistry) DONsForCapability(ctx context.Context, capabilityID string) ([]capabilities.DONWithNodes, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.localRegistry.DONsForCapability(ctx, capabilityID)
+}
+
+// NodeByPeerID implements the CapabilitiesRegistryMetadata interface
+func (r *updatableRegistry) NodeByPeerID(ctx context.Context, peerID ragetypes.PeerID) (capabilities.Node, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.localRegistry.NodeByPeerID(ctx, peerID)
 }
 
 // createTestEngineForDonVersionTest creates a real V2 engine for testing DON version updates
 func createTestEngineForDonVersionTest(
 	t *testing.T,
-	_ context.Context,
 	lggr logger.Logger,
 	registry *coreCap.Registry,
 	donNotifier coreCap.DonNotifyWaitSubscriber,


### PR DESCRIPTION
### Description

##### This is the current problem:
- When a workflow engine is created (v2/engine.go), the beholder logger is initialised once with initial labels including `platform.DonVersion` set to the current.
- The node periodically syncs with the capability registry (via registrysyncer)
- When the registry sync occurs, the local node's workflow DON information may be updated, including a new `ConfigVersion`
- The engine detects this change and updates its internal `localNode`
- However, the beholder logger was created with the initial labels and continues to use the old `DonVersion` value

##### The fix:
To keep it simple we create a new beholder logger instance whenever the workflow DON configuration changes, replacing the old logger in the engine.


[CRE-1188](https://smartcontract-it.atlassian.net/browse/CRE-1188)

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-1188]: https://smartcontract-it.atlassian.net/browse/CRE-1188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ