### PR TITLE
fix: skips gateway connector startup if config is invalid

### DIFF
--- a/core/capabilities/gateway_connector/service_wrapper.go
+++ b/core/capabilities/gateway_connector/service_wrapper.go
@@ -2,6 +2,7 @@ package gatewayconnector
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jonboulle/clockwork"
@@ -67,7 +68,7 @@ func (e *ServiceWrapper) Start(ctx context.Context) error {
 		configuredNodeAddress := common.HexToAddress(nodeAddress)
 		err := e.keystore.CheckEnabled(ctx, configuredNodeAddress)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to start GatewayConnectorServiceWrapper: %w (node address: %s)", err, configuredNodeAddress)
 		}
 
 		translated := translateConfigs(conf)

--- a/core/config/capabilities_config.go
+++ b/core/config/capabilities_config.go
@@ -49,6 +49,7 @@ type GatewayConnector interface {
 	WSHandshakeTimeoutMillis() uint32
 	AuthMinChallengeLen() int
 	AuthTimestampToleranceSec() uint32
+	Valid() bool
 }
 
 type ConnectorGateway interface {

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -941,7 +941,7 @@ func newCREServices(
 	srvcs = append(srvcs, closerService{name: "WorkflowExecutionLimiter", Closer: workflowLimits})
 
 	var gatewayConnectorWrapper *gatewayconnector.ServiceWrapper
-	if capCfg.GatewayConnector().DonID() != "" {
+	if capCfg.GatewayConnector().Valid() {
 		globalLogger.Debugw("Creating GatewayConnector wrapper", "donID", capCfg.GatewayConnector().DonID())
 		chainID, ok := new(big.Int).SetString(capCfg.GatewayConnector().ChainIDForNodeKey(), 0)
 		if !ok {

--- a/core/services/chainlink/config_capabilities.go
+++ b/core/services/chainlink/config_capabilities.go
@@ -255,12 +255,17 @@ type gatewayConnector struct {
 func (c *gatewayConnector) ChainIDForNodeKey() string {
 	return *c.c.ChainIDForNodeKey
 }
+
 func (c *gatewayConnector) NodeAddress() string {
 	return *c.c.NodeAddress
 }
 
 func (c *gatewayConnector) DonID() string {
 	return *c.c.DonID
+}
+
+func (c *gatewayConnector) Valid() bool {
+	return c.ChainIDForNodeKey() != "" && c.NodeAddress() != "" && c.DonID() != ""
 }
 
 func (c *gatewayConnector) Gateways() []config.ConnectorGateway {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

it is currently possible to attempt to start the gateway connector service with an invalid config, which generally happens when starting without providing a valid `NodeAddress`.  this fails the node immediately with a cryptic message.  instead we will skip service startup if the config is invalid, which allows the node to boot and for operators to determine the node address.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
