### PR TITLE
feat: set config per role

### DIFF
--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+
 	ccip "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/validate"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/fluxmonitorv2"
@@ -1518,11 +1519,12 @@ func (s *service) newChainConfigMsg(cfg ChainConfig) (*pb.ChainConfig, error) {
 			Id:   cfg.ChainID,
 			Type: protoChainType,
 		},
-		AccountAddress:    cfg.AccountAddress,
-		AdminAddress:      cfg.AdminAddress,
-		FluxMonitorConfig: s.newFluxMonitorConfigMsg(cfg.FluxMonitorConfig),
-		Ocr1Config:        ocr1Cfg,
-		Ocr2Config:        ocr2Cfg,
+		AccountAddress:          cfg.AccountAddress,
+		AdminAddress:            cfg.AdminAddress,
+		AccountAddressPublicKey: cfg.AccountAddressPublicKey.Ptr(),
+		FluxMonitorConfig:       s.newFluxMonitorConfigMsg(cfg.FluxMonitorConfig),
+		Ocr1Config:              ocr1Cfg,
+		Ocr2Config:              ocr2Cfg,
 	}
 
 	if cfg.AccountAddressPublicKey.Valid {

--- a/deployment/common/changeset/set_config_mcms.go
+++ b/deployment/common/changeset/set_config_mcms.go
@@ -28,9 +28,9 @@ import (
 )
 
 type ConfigPerRoleV2 struct {
-	Proposer  mcmstypes.Config
-	Canceller mcmstypes.Config
-	Bypasser  mcmstypes.Config
+	Proposer  *mcmstypes.Config
+	Canceller *mcmstypes.Config
+	Bypasser  *mcmstypes.Config
 }
 
 type MCMSConfigV2 struct {
@@ -52,6 +52,11 @@ func (cfg MCMSConfigV2) Validate(e cldf.Environment, selectors []uint64) error {
 	}
 
 	for chainSelector, c := range cfg.ConfigsPerChain {
+		// Ensure at least one config is provided
+		if c.Proposer == nil && c.Canceller == nil && c.Bypasser == nil {
+			return fmt.Errorf("at least one config (Proposer, Canceller, or Bypasser) must be provided for chain %d", chainSelector)
+		}
+
 		family, err := chain_selectors.GetSelectorFamily(chainSelector)
 		if err != nil {
 			return err
@@ -84,14 +89,20 @@ func (cfg MCMSConfigV2) Validate(e cldf.Environment, selectors []uint64) error {
 			}
 		}
 
-		if err := c.Proposer.Validate(); err != nil {
-			return err
+		if c.Proposer != nil {
+			if err := c.Proposer.Validate(); err != nil {
+				return err
+			}
 		}
-		if err := c.Canceller.Validate(); err != nil {
-			return err
+		if c.Canceller != nil {
+			if err := c.Canceller.Validate(); err != nil {
+				return err
+			}
 		}
-		if err := c.Bypasser.Validate(); err != nil {
-			return err
+		if c.Bypasser != nil {
+			if err := c.Bypasser.Validate(); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -130,20 +141,31 @@ type setConfigTxs struct {
 
 // setConfigPerRoleV2 sets the configuration for each of the MCMS contract roles on the mcmsState.
 func setConfigPerRoleV2(ctx context.Context, lggr logger.Logger, chain cldf_evm.Chain, cfg ConfigPerRoleV2, mcmsState *commonState.MCMSWithTimelockState, useMCMS bool) (setConfigTxs, error) {
-	// Proposer set config
-	proposerTx, err := setConfigOrTxDataV2(ctx, lggr, chain, cfg.Proposer, mcmsState.ProposerMcm, useMCMS)
-	if err != nil {
-		return setConfigTxs{}, err
+	var proposerTx, cancellerTx, bypasserTx *types.Transaction
+	var err error
+
+	// Proposer set config (only if provided)
+	if cfg.Proposer != nil {
+		proposerTx, err = setConfigOrTxDataV2(ctx, lggr, chain, *cfg.Proposer, mcmsState.ProposerMcm, useMCMS)
+		if err != nil {
+			return setConfigTxs{}, err
+		}
 	}
-	// Canceller set config
-	cancellerTx, err := setConfigOrTxDataV2(ctx, lggr, chain, cfg.Canceller, mcmsState.CancellerMcm, useMCMS)
-	if err != nil {
-		return setConfigTxs{}, err
+
+	// Canceller set config (only if provided)
+	if cfg.Canceller != nil {
+		cancellerTx, err = setConfigOrTxDataV2(ctx, lggr, chain, *cfg.Canceller, mcmsState.CancellerMcm, useMCMS)
+		if err != nil {
+			return setConfigTxs{}, err
+		}
 	}
-	// Bypasser set config
-	bypasserTx, err := setConfigOrTxDataV2(ctx, lggr, chain, cfg.Bypasser, mcmsState.BypasserMcm, useMCMS)
-	if err != nil {
-		return setConfigTxs{}, err
+
+	// Bypasser set config (only if provided)
+	if cfg.Bypasser != nil {
+		bypasserTx, err = setConfigOrTxDataV2(ctx, lggr, chain, *cfg.Bypasser, mcmsState.BypasserMcm, useMCMS)
+		if err != nil {
+			return setConfigTxs{}, err
+		}
 	}
 
 	return setConfigTxs{
@@ -236,16 +258,24 @@ func addTxsToProposalBatchV2(setConfigTxsChain setConfigTxs, chainSelector uint6
 		Transactions:  []mcmstypes.Transaction{},
 	}
 
-	result.Transactions = append(result.Transactions,
-		evm.NewTransaction(state.ProposerMcm.Address(),
-			setConfigTxsChain.proposerTx.Data(), big.NewInt(0), string(commontypes.ProposerManyChainMultisig), nil))
+	// Only add transactions for configs that were actually set
+	if setConfigTxsChain.proposerTx != nil {
+		result.Transactions = append(result.Transactions,
+			evm.NewTransaction(state.ProposerMcm.Address(),
+				setConfigTxsChain.proposerTx.Data(), big.NewInt(0), string(commontypes.ProposerManyChainMultisig), nil))
+	}
 
-	result.Transactions = append(result.Transactions, evm.NewTransaction(state.CancellerMcm.Address(),
-		setConfigTxsChain.cancellerTx.Data(), big.NewInt(0), string(commontypes.CancellerManyChainMultisig), nil))
+	if setConfigTxsChain.cancellerTx != nil {
+		result.Transactions = append(result.Transactions, evm.NewTransaction(state.CancellerMcm.Address(),
+			setConfigTxsChain.cancellerTx.Data(), big.NewInt(0), string(commontypes.CancellerManyChainMultisig), nil))
+	}
 
-	result.Transactions = append(result.Transactions,
-		evm.NewTransaction(state.BypasserMcm.Address(),
-			setConfigTxsChain.bypasserTx.Data(), big.NewInt(0), string(commontypes.BypasserManyChainMultisig), nil))
+	if setConfigTxsChain.bypasserTx != nil {
+		result.Transactions = append(result.Transactions,
+			evm.NewTransaction(state.BypasserMcm.Address(),
+				setConfigTxsChain.bypasserTx.Data(), big.NewInt(0), string(commontypes.BypasserManyChainMultisig), nil))
+	}
+
 	return result
 }
 
@@ -272,22 +302,31 @@ func setConfigSolana(
 
 	batches := []mcmstypes.BatchOperation{}
 	// broken into single batch per role (total 3 batches) due to size constraints on solana when all instructions were in the same single batch
-	proposerOps, err := setConfigForRole(e, chain, cfg.Proposer, proposerAddress, string(commontypes.ProposerManyChainMultisig), useMCMS, timelockSignerPDA)
-	if err != nil {
-		return nil, err
-	}
-	batches = append(batches, proposerOps)
 
-	cancellerOps, err := setConfigForRole(e, chain, cfg.Canceller, cancellerAddress, string(commontypes.CancellerManyChainMultisig), useMCMS, timelockSignerPDA)
-	if err != nil {
-		return nil, err
+	// Only set configs that are provided (non-nil)
+	if cfg.Proposer != nil {
+		proposerOps, err := setConfigForRole(e, chain, *cfg.Proposer, proposerAddress, string(commontypes.ProposerManyChainMultisig), useMCMS, timelockSignerPDA)
+		if err != nil {
+			return nil, err
+		}
+		batches = append(batches, proposerOps)
 	}
-	batches = append(batches, cancellerOps)
-	bypasserOps, err := setConfigForRole(e, chain, cfg.Bypasser, bypasserAddress, string(commontypes.BypasserManyChainMultisig), useMCMS, timelockSignerPDA)
-	if err != nil {
-		return nil, err
+
+	if cfg.Canceller != nil {
+		cancellerOps, err := setConfigForRole(e, chain, *cfg.Canceller, cancellerAddress, string(commontypes.CancellerManyChainMultisig), useMCMS, timelockSignerPDA)
+		if err != nil {
+			return nil, err
+		}
+		batches = append(batches, cancellerOps)
 	}
-	batches = append(batches, bypasserOps)
+
+	if cfg.Bypasser != nil {
+		bypasserOps, err := setConfigForRole(e, chain, *cfg.Bypasser, bypasserAddress, string(commontypes.BypasserManyChainMultisig), useMCMS, timelockSignerPDA)
+		if err != nil {
+			return nil, err
+		}
+		batches = append(batches, bypasserOps)
+	}
 
 	return batches, nil
 }

--- a/deployment/common/changeset/set_config_mcms_test.go
+++ b/deployment/common/changeset/set_config_mcms_test.go
@@ -77,9 +77,9 @@ func TestSetConfigMCMSV2EVM(t *testing.T) {
 						commonchangeset.MCMSConfigV2{
 							ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRoleV2{
 								chainSel: {
-									Proposer:  cfgProp,
-									Canceller: cfgCancel,
-									Bypasser:  cfgBypass,
+									Proposer:  &cfgProp,
+									Canceller: &cfgCancel,
+									Bypasser:  &cfgBypass,
 								},
 							},
 						},
@@ -107,9 +107,9 @@ func TestSetConfigMCMSV2EVM(t *testing.T) {
 							},
 							ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRoleV2{
 								chainSel: {
-									Proposer:  cfgProp,
-									Canceller: cfgCancel,
-									Bypasser:  cfgBypass,
+									Proposer:  &cfgProp,
+									Canceller: &cfgCancel,
+									Bypasser:  &cfgBypass,
 								},
 							},
 						},
@@ -238,9 +238,9 @@ func TestSetConfigMCMSV2Solana(t *testing.T) {
 				chainSelectorSolana,
 				map[uint64]commonchangeset.ConfigPerRoleV2{
 					chainSelectorSolana: {
-						Proposer:  newCfgProposer,
-						Canceller: newCfgCanceller,
-						Bypasser:  newCfgBypasser,
+						Proposer:  &newCfgProposer,
+						Canceller: &newCfgCanceller,
+						Bypasser:  &newCfgBypasser,
 					},
 				})
 			_, _, err = commonchangeset.ApplyChangesets(t, env, changesetsToApply)
@@ -292,14 +292,14 @@ func TestValidateV2(t *testing.T) {
 				},
 				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRoleV2{
 					chainSelector: {
-						Proposer:  cfg,
-						Canceller: cfg,
-						Bypasser:  cfg,
+						Proposer:  &cfg,
+						Canceller: &cfg,
+						Bypasser:  &cfg,
 					},
 					chainSelectorSolana: {
-						Proposer:  cfg,
-						Canceller: cfg,
-						Bypasser:  cfg,
+						Proposer:  &cfg,
+						Canceller: &cfg,
+						Bypasser:  &cfg,
 					},
 				},
 			},
@@ -309,14 +309,14 @@ func TestValidateV2(t *testing.T) {
 			cfg: commonchangeset.MCMSConfigV2{
 				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRoleV2{
 					chainSelector: {
-						Proposer:  cfg,
-						Canceller: cfg,
-						Bypasser:  cfg,
+						Proposer:  &cfg,
+						Canceller: &cfg,
+						Bypasser:  &cfg,
 					},
 					chainSelectorSolana: {
-						Proposer:  cfg,
-						Canceller: cfg,
-						Bypasser:  cfg,
+						Proposer:  &cfg,
+						Canceller: &cfg,
+						Bypasser:  &cfg,
 					},
 				},
 			},
@@ -333,9 +333,9 @@ func TestValidateV2(t *testing.T) {
 			cfg: commonchangeset.MCMSConfigV2{
 				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRoleV2{
 					123: {
-						Proposer:  cfg,
-						Canceller: cfg,
-						Bypasser:  cfg,
+						Proposer:  &cfg,
+						Canceller: &cfg,
+						Bypasser:  &cfg,
 					},
 				},
 			},
@@ -349,14 +349,14 @@ func TestValidateV2(t *testing.T) {
 				},
 				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRoleV2{
 					chainSelector: {
-						Proposer:  cfgInvalid,
-						Canceller: cfg,
-						Bypasser:  cfg,
+						Proposer:  &cfgInvalid,
+						Canceller: &cfg,
+						Bypasser:  &cfg,
 					},
 					chainSelectorSolana: {
-						Proposer:  cfg,
-						Canceller: cfg,
-						Bypasser:  cfg,
+						Proposer:  &cfg,
+						Canceller: &cfg,
+						Bypasser:  &cfg,
 					},
 				},
 			},
@@ -370,14 +370,14 @@ func TestValidateV2(t *testing.T) {
 				},
 				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRoleV2{
 					chainSelector: {
-						Proposer:  cfg,
-						Canceller: cfgInvalid,
-						Bypasser:  cfg,
+						Proposer:  &cfg,
+						Canceller: &cfgInvalid,
+						Bypasser:  &cfg,
 					},
 					chainSelectorSolana: {
-						Proposer:  cfg,
-						Canceller: cfg,
-						Bypasser:  cfg,
+						Proposer:  &cfg,
+						Canceller: &cfg,
+						Bypasser:  &cfg,
 					},
 				},
 			},
@@ -391,18 +391,55 @@ func TestValidateV2(t *testing.T) {
 				},
 				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRoleV2{
 					chainSelector: {
-						Proposer:  cfg,
-						Canceller: cfg,
-						Bypasser:  cfgInvalid,
+						Proposer:  &cfg,
+						Canceller: &cfg,
+						Bypasser:  &cfgInvalid,
 					},
 					chainSelectorSolana: {
-						Proposer:  cfg,
-						Canceller: cfg,
-						Bypasser:  cfg,
+						Proposer:  &cfg,
+						Canceller: &cfg,
+						Bypasser:  &cfg,
 					},
 				},
 			},
 			errorMsg: "invalid MCMS config: Quorum must be greater than 0",
+		},
+		{
+			name: "valid partial config - only proposer",
+			cfg: commonchangeset.MCMSConfigV2{
+				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRoleV2{
+					chainSelector: {
+						Proposer: &cfg,
+					},
+					chainSelectorSolana: {
+						Proposer: &cfg,
+					},
+				},
+			},
+		},
+		{
+			name: "valid partial config - only canceller and bypasser",
+			cfg: commonchangeset.MCMSConfigV2{
+				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRoleV2{
+					chainSelector: {
+						Canceller: &cfg,
+						Bypasser:  &cfg,
+					},
+					chainSelectorSolana: {
+						Canceller: &cfg,
+						Bypasser:  &cfg,
+					},
+				},
+			},
+		},
+		{
+			name: "invalid - no configs provided",
+			cfg: commonchangeset.MCMSConfigV2{
+				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRoleV2{
+					chainSelector: {},
+				},
+			},
+			errorMsg: "at least one config (Proposer, Canceller, or Bypasser) must be provided",
 		},
 	}
 
@@ -419,6 +456,60 @@ func TestValidateV2(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetConfigMCMSV2Partial(t *testing.T) {
+	t.Parallel()
+	env := setupSetConfigTestEnv(t)
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	chain := env.BlockChains.EVMChains()[chainSelector]
+	addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+	require.NoError(t, err)
+
+	mcmsState, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addrs)
+	require.NoError(t, err)
+
+	// Test setting only the proposer config
+	cfgProposer := proposalutils.SingleGroupMCMSV2(t)
+	cfgProposer.Signers = append(cfgProposer.Signers, mcmsState.Timelock.Address())
+	cfgProposer.Quorum = 2
+
+	_, _, err = commonchangeset.ApplyChangesets(t, env, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(
+			cldf.CreateLegacyChangeSet(commonchangeset.SetConfigMCMSV2),
+			commonchangeset.MCMSConfigV2{
+				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRoleV2{
+					chainSelector: {
+						Proposer: &cfgProposer, // Only setting proposer
+					},
+				},
+			},
+		),
+	})
+	require.NoError(t, err)
+
+	// Verify only the proposer config was changed
+	ctx := t.Context()
+	inspector := evm.NewInspector(chain.Client)
+
+	// Check proposer config was updated
+	newConf, err := inspector.GetConfig(ctx, mcmsState.ProposerMcm.Address().Hex())
+	require.NoError(t, err)
+	require.ElementsMatch(t, cfgProposer.Signers, newConf.Signers)
+	require.Equal(t, cfgProposer.Quorum, newConf.Quorum)
+
+	// Check canceller and bypasser configs were not changed (should still be original)
+	originalCfg := proposalutils.SingleGroupMCMSV2(t)
+
+	cancellerConf, err := inspector.GetConfig(ctx, mcmsState.CancellerMcm.Address().Hex())
+	require.NoError(t, err)
+	require.ElementsMatch(t, originalCfg.Signers, cancellerConf.Signers)
+	require.Equal(t, originalCfg.Quorum, cancellerConf.Quorum)
+
+	bypasserConf, err := inspector.GetConfig(ctx, mcmsState.BypasserMcm.Address().Hex())
+	require.NoError(t, err)
+	require.ElementsMatch(t, originalCfg.Signers, bypasserConf.Signers)
+	require.Equal(t, originalCfg.Quorum, bypasserConf.Quorum)
 }
 
 func fundSignerPDAs(


### PR DESCRIPTION
This pull request refactors the MCMS configuration logic to allow partial updates for individual contract roles (Proposer, Canceller, Bypasser), improves validation, and updates related tests to support this new flexibility. Previously, all three configs were required and always updated together; now, you can set any subset, and only the provided configs are updated. This makes configuration more robust and reduces unnecessary changes.

### Partial MCMS configuration support

* Changed `ConfigPerRoleV2` struct fields (`Proposer`, `Canceller`, `Bypasser`) from value types to pointers, allowing each to be optional.
* Updated logic in `setConfigPerRoleV2`, `addTxsToProposalBatchV2`, and `setConfigSolana` to only create and apply transactions for roles with non-nil configs, ensuring only the intended roles are updated. [[1]](diffhunk://#diff-ecdfdfd6b8bc7f6db4a05bc2c9d3dd611e386a586e1e52e8793c01b995e64843L133-R169) [[2]](diffhunk://#diff-ecdfdfd6b8bc7f6db4a05bc2c9d3dd611e386a586e1e52e8793c01b995e64843R261-R278) [[3]](diffhunk://#diff-ecdfdfd6b8bc7f6db4a05bc2c9d3dd611e386a586e1e52e8793c01b995e64843L275-R329)

### Validation improvements

* Enhanced `MCMSConfigV2.Validate` to require at least one config per chain and validate only provided configs, with clear error messages if none are set. [[1]](diffhunk://#diff-ecdfdfd6b8bc7f6db4a05bc2c9d3dd611e386a586e1e52e8793c01b995e64843R55-R59) [[2]](diffhunk://#diff-ecdfdfd6b8bc7f6db4a05bc2c9d3dd611e386a586e1e52e8793c01b995e64843R92-R107)

### Test suite updates

* Refactored all MCMS test cases to use pointers for configs, ensuring compatibility with the new partial config logic. [[1]](diffhunk://#diff-e3f80bb0b6390581acb24e8d44c8fab805923e427b3959dd5cb6a025d94b13d6L80-R82) [[2]](diffhunk://#diff-e3f80bb0b6390581acb24e8d44c8fab805923e427b3959dd5cb6a025d94b13d6L110-R112) [[3]](diffhunk://#diff-e3f80bb0b6390581acb24e8d44c8fab805923e427b3959dd5cb6a025d94b13d6L241-R243) [[4]](diffhunk://#diff-e3f80bb0b6390581acb24e8d44c8fab805923e427b3959dd5cb6a025d94b13d6L295-R302) [[5]](diffhunk://#diff-e3f80bb0b6390581acb24e8d44c8fab805923e427b3959dd5cb6a025d94b13d6L312-R319) [[6]](diffhunk://#diff-e3f80bb0b6390581acb24e8d44c8fab805923e427b3959dd5cb6a025d94b13d6L336-R338) [[7]](diffhunk://#diff-e3f80bb0b6390581acb24e8d44c8fab805923e427b3959dd5cb6a025d94b13d6L352-R359) [[8]](diffhunk://#diff-e3f80bb0b6390581acb24e8d44c8fab805923e427b3959dd5cb6a025d94b13d6L373-R380) [[9]](diffhunk://#diff-e3f80bb0b6390581acb24e8d44c8fab805923e427b3959dd5cb6a025d94b13d6L394-R443)
* Added new tests for partial config scenarios, including valid cases (single role or multiple roles) and invalid cases (no roles set), and verified that only the specified roles are updated. [[1]](diffhunk://#diff-e3f80bb0b6390581acb24e8d44c8fab805923e427b3959dd5cb6a025d94b13d6L394-R443) [[2]](diffhunk://#diff-e3f80bb0b6390581acb24e8d44c8fab805923e427b3959dd5cb6a025d94b13d6R461-R514)

### Minor protocol update

* Added support for `AccountAddressPublicKey` in the chain config message, enabling transmission of the account's public key.

### Import cleanups

* Minor import formatting change in `core/services/feeds/service.go`.