### PR TITLE
[chore] bump confidential-compute capability git ref

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -49,6 +49,6 @@ plugins:
       installPath: "github.com/smartcontractkit/capabilities/mock"
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "5002f9ffb9b1d7647619c6b7577ec42117b89995"
+      gitRef: "7564d88034ea22038f11fe2cfc972494263fb99e"
       installPath: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
 

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -49,6 +49,6 @@ plugins:
       installPath: "github.com/smartcontractkit/capabilities/mock"
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "c519f08284afe2f97fa5927f490dd801b8585e4c"
+      gitRef: "e3e526d8ea27ed50c7ff822a6b7762cc30a31722"
       installPath: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
 

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -49,6 +49,6 @@ plugins:
       installPath: "github.com/smartcontractkit/capabilities/mock"
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "e3e526d8ea27ed50c7ff822a6b7762cc30a31722"
+      gitRef: "6a3c6bca2bb0dca9d6d493308ed1afd6b4888d5c"
       installPath: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
 

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -49,6 +49,6 @@ plugins:
       installPath: "github.com/smartcontractkit/capabilities/mock"
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "7564d88034ea22038f11fe2cfc972494263fb99e"
+      gitRef: "c519f08284afe2f97fa5927f490dd801b8585e4c"
       installPath: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
 


### PR DESCRIPTION
## Summary

Bumps the `confidential-compute` capability git ref in `plugins/plugins.private.yaml`.
