### PR TITLE
Add evm cap job spec deployment

### DIFF
--- a/deployment/cre/jobs/operations/propose_std_cap_job.go
+++ b/deployment/cre/jobs/operations/propose_std_cap_job.go
@@ -209,7 +209,7 @@ func resolveJob(job pkg.StandardCapabilityJob, setPerNodeCfg bool, nodeID string
 
 	spec, err := job.Resolve()
 	if err != nil {
-		return " ProposeStandardCapabilityJobOutput{}", fmt.Errorf("failed to resolve standard capability job for node %s: %w", nodeID, err)
+		return "", fmt.Errorf("failed to resolve standard capability job for node %s: %w", nodeID, err)
 	}
 
 	return spec, nil
@@ -231,7 +231,6 @@ func generateOracleFactory(cldEnv cldf.Environment, nodeInfo deployment.Node, jo
 		return &pkg.OracleFactory{}, fmt.Errorf("no evm ocr2 config for node %s", nodeInfo.NodeID)
 	}
 
-	addrRefKey.ChainSelector()
 	oracleFactory := &pkg.OracleFactory{
 		Enabled:            true,
 		BootstrapPeers:     job.BootstrapPeers,

--- a/deployment/cre/jobs/operations/propose_std_cap_job.go
+++ b/deployment/cre/jobs/operations/propose_std_cap_job.go
@@ -215,17 +215,22 @@ func resolveJob(job pkg.StandardCapabilityJob, setPerNodeCfg bool, nodeID string
 }
 
 func generateOracleFactory(cldEnv cldf.Environment, nodeInfo deployment.Node, job pkg.StandardCapabilityJob) (*pkg.OracleFactory, error) {
-	addrRefKey := pkg.GetOCR3CapabilityAddressRefKey(uint64(job.ChainSelectorEVM), job.ContractQualifier)
+	contractChainSelector := job.ChainSelectorEVM
+	if job.OCRChainSelector != 0 {
+		contractChainSelector = job.OCRChainSelector
+	}
+
+	addrRefKey := pkg.GetOCR3CapabilityAddressRefKey(uint64(contractChainSelector), job.ContractQualifier)
 	contractAddrRef, err := cldEnv.DataStore.Addresses().Get(addrRefKey)
 	if err != nil {
-		return &pkg.OracleFactory{}, fmt.Errorf("failed to get OCR3 contract address for chain selector %d and qualifier %s: %w", job.ChainSelectorEVM, job.ContractQualifier, err)
+		return &pkg.OracleFactory{}, fmt.Errorf("failed to get OCR3 contract address for chain selector %d and qualifier %s: %w", contractChainSelector, job.ContractQualifier, err)
 	}
 	contractChainID, err := chainsel.GetChainIDFromSelector(addrRefKey.ChainSelector())
 	if err != nil {
-		return &pkg.OracleFactory{}, fmt.Errorf("failed to get chainID for chain selector %d and qualifier %s: %w", job.ChainSelectorEVM, job.ContractQualifier, err)
+		return &pkg.OracleFactory{}, fmt.Errorf("failed to get chainID for chain selector %d and qualifier %s: %w", contractChainSelector, job.ContractQualifier, err)
 	}
 
-	evmOCRConfig, ok := nodeInfo.OCRConfigForChainSelector(uint64(job.ChainSelectorEVM))
+	evmOCRConfig, ok := nodeInfo.OCRConfigForChainSelector(uint64(contractChainSelector))
 	if !ok {
 		return &pkg.OracleFactory{}, fmt.Errorf("no evm ocr2 config for node %s", nodeInfo.NodeID)
 	}

--- a/deployment/cre/jobs/operations/propose_std_cap_job.go
+++ b/deployment/cre/jobs/operations/propose_std_cap_job.go
@@ -109,8 +109,8 @@ var ProposeStandardCapabilityJob = operations.NewSequence[
 			return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("no nodes info found for DON `%s` with filters %+v and node IDs %v", input.DONName, input.DONFilters, nodeIDs)
 		}
 
-		setPerNodeCfg := false
-		if input.NodeIDToConfig != nil && len(input.NodeIDToConfig) > 0 {
+		setPerNodeCfg := len(input.NodeIDToConfig) > 0
+		if setPerNodeCfg {
 			if len(input.NodeIDToConfig) != len(nodeInfos) {
 				return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("number of nodes found (%d) does not match number of configs provided (%d)", len(nodeInfos), len(input.NodeIDToConfig))
 			}
@@ -119,7 +119,6 @@ var ProposeStandardCapabilityJob = operations.NewSequence[
 					return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("node ID %s found in DON nodes but not in provided configs", n.NodeID)
 				}
 			}
-			setPerNodeCfg = true
 		}
 
 		shouldGenerateOracleFactory := input.Job.GenerateOracleFactory && input.Job.OracleFactory == nil

--- a/deployment/cre/jobs/operations/propose_std_cap_job.go
+++ b/deployment/cre/jobs/operations/propose_std_cap_job.go
@@ -235,6 +235,10 @@ func generateOracleFactory(cldEnv cldf.Environment, nodeInfo deployment.Node, jo
 		return &pkg.OracleFactory{}, fmt.Errorf("no evm ocr2 config for node %s", nodeInfo.NodeID)
 	}
 
+	if job.OCRSigningStrategy == "" {
+		job.OCRSigningStrategy = "multi-chain"
+	}
+
 	oracleFactory := &pkg.OracleFactory{
 		Enabled:            true,
 		BootstrapPeers:     job.BootstrapPeers,
@@ -243,7 +247,7 @@ func generateOracleFactory(cldEnv cldf.Environment, nodeInfo deployment.Node, jo
 		ChainID:            contractChainID,
 		TransmitterID:      string(evmOCRConfig.TransmitAccount),
 		OnchainSigningStrategy: pkg.OnchainSigningStrategy{
-			StrategyName: "multi-chain",
+			StrategyName: job.OCRSigningStrategy,
 			Config:       map[string]string{"evm": evmOCRConfig.KeyBundleID},
 		},
 	}

--- a/deployment/cre/jobs/operations/propose_std_cap_job.go
+++ b/deployment/cre/jobs/operations/propose_std_cap_job.go
@@ -32,6 +32,10 @@ type ProposeStandardCapabilityJobInput struct {
 	// If false, the OracleFactory field will be used as-is.
 	Job pkg.StandardCapabilityJob
 
+	// NodeIDToConfig is a map of node IDs to custom per node configs,
+	// throws an error if nodes from the map keys aren't an exact match with the DON nodes.
+	NodeIDToConfig map[string]string
+
 	DONFilters  []offchain.TargetDONFilter
 	ExtraLabels map[string]string
 }
@@ -105,14 +109,27 @@ var ProposeStandardCapabilityJob = operations.NewSequence[
 			return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("no nodes info found for DON `%s` with filters %+v and node IDs %v", input.DONName, input.DONFilters, nodeIDs)
 		}
 
-		generateOracleFactory := input.Job.GenerateOracleFactory && input.Job.OracleFactory == nil
-		if !generateOracleFactory {
+		setPerNodeCfg := false
+		if input.NodeIDToConfig != nil && len(input.NodeIDToConfig) > 0 {
+			if len(input.NodeIDToConfig) != len(nodeInfos) {
+				return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("number of nodes found (%d) does not match number of configs provided (%d)", len(nodes), len(input.NodeIDToConfig))
+			}
+			for _, n := range nodeInfos {
+				if _, ok := input.NodeIDToConfig[n.NodeID]; !ok {
+					return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("node ID %s found in DON nodes but not in provided configs", n.NodeID)
+				}
+			}
+			setPerNodeCfg = true
+		}
+
+		shouldGenerateOracleFactory := input.Job.GenerateOracleFactory && input.Job.OracleFactory == nil
+		if !shouldGenerateOracleFactory {
 			specs := make(map[string][]string)
 
 			for _, ni := range nodeInfos {
-				spec, err := input.Job.Resolve()
+				spec, err := resolveJob(input.Job, setPerNodeCfg, ni.NodeID, input.NodeIDToConfig)
 				if err != nil {
-					return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("failed to resolve standard capability job for node %s: %w", ni.NodeID, err)
+					return ProposeStandardCapabilityJobOutput{}, err
 				}
 
 				jobLabels := map[string]string{
@@ -141,62 +158,19 @@ var ProposeStandardCapabilityJob = operations.NewSequence[
 		}
 
 		// If no oracle factory is provided, we have to build it
-
-		addrRefKey := pkg.GetOCR3CapabilityAddressRefKey(uint64(input.Job.ChainSelectorEVM), input.Job.ContractQualifier)
-		contractAddrRef, err := deps.Env.DataStore.Addresses().Get(addrRefKey)
-		if err != nil {
-			return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("failed to get OCR3 contract address for chain selector %d and qualifier %s: %w", input.Job.ChainSelectorEVM, input.Job.ContractQualifier, err)
-		}
-
-		chainID, err := chainsel.GetChainIDFromSelector(uint64(input.Job.ChainSelectorEVM))
-		if err != nil {
-			return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("failed to get chain ID from selector: %w", err)
-		}
-
 		specs := make(map[string][]string)
 
 		for _, ni := range nodeInfos {
-			evmConfig, ok := ni.OCRConfigForChainSelector(uint64(input.Job.ChainSelectorEVM))
-			if !ok {
-				return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("no evm ocr2 config for node %s", ni.NodeID)
-			}
-
-			oracleFactory := &pkg.OracleFactory{
-				Enabled:            true,
-				BootstrapPeers:     input.Job.BootstrapPeers,
-				OCRContractAddress: contractAddrRef.Address,
-				OCRKeyBundleID:     evmConfig.KeyBundleID,
-				ChainID:            chainID,
-				TransmitterID:      string(evmConfig.TransmitAccount),
-				OnchainSigningStrategy: pkg.OnchainSigningStrategy{
-					StrategyName: "multi-chain",
-					Config:       map[string]string{"evm": evmConfig.KeyBundleID},
-				},
-			}
-
-			if input.Job.ChainSelectorAptos > 0 {
-				aptosConfig, ok := ni.OCRConfigForChainSelector(uint64(input.Job.ChainSelectorAptos))
-				if !ok {
-					return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("no aptos ocr2 config for node %s", ni.NodeID)
-				}
-
-				oracleFactory.OnchainSigningStrategy.Config["aptos"] = aptosConfig.KeyBundleID
-			}
-
-			if input.Job.ChainSelectorSolana > 0 {
-				solanaConfig, ok := ni.OCRConfigForChainSelector(uint64(input.Job.ChainSelectorSolana))
-				if !ok {
-					return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("no solana ocr2 config for node %s", ni.NodeID)
-				}
-
-				oracleFactory.OnchainSigningStrategy.Config["solana"] = solanaConfig.KeyBundleID
+			oracleFactory, err := generateOracleFactory(deps.Env, ni, input.Job)
+			if err != nil {
+				return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("failed to generate oracle factory for node %s: %w", ni.NodeID, err)
 			}
 
 			input.Job.OracleFactory = oracleFactory
 
-			spec, err := input.Job.Resolve()
+			spec, err := resolveJob(input.Job, setPerNodeCfg, ni.NodeID, input.NodeIDToConfig)
 			if err != nil {
-				return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("failed to resolve standard capability job for node %s: %w", ni.NodeID, err)
+				return ProposeStandardCapabilityJobOutput{}, err
 			}
 
 			jobLabels := map[string]string{
@@ -223,3 +197,71 @@ var ProposeStandardCapabilityJob = operations.NewSequence[
 
 		return ProposeStandardCapabilityJobOutput{Specs: specs}, nil
 	})
+
+func resolveJob(job pkg.StandardCapabilityJob, setPerNodeCfg bool, nodeID string, nodeIDToConfig map[string]string) (string, error) {
+	if setPerNodeCfg {
+		customCfg, ok := nodeIDToConfig[nodeID]
+		if !ok {
+			return "", fmt.Errorf("no custom config found for node ID %s", nodeID)
+		}
+		job.Config = customCfg
+	}
+
+	spec, err := job.Resolve()
+	if err != nil {
+		return " ProposeStandardCapabilityJobOutput{}", fmt.Errorf("failed to resolve standard capability job for node %s: %w", nodeID, err)
+	}
+
+	return spec, nil
+}
+
+func generateOracleFactory(cldEnv cldf.Environment, nodeInfo deployment.Node, job pkg.StandardCapabilityJob) (*pkg.OracleFactory, error) {
+	addrRefKey := pkg.GetOCR3CapabilityAddressRefKey(uint64(job.ChainSelectorEVM), job.ContractQualifier)
+	contractAddrRef, err := cldEnv.DataStore.Addresses().Get(addrRefKey)
+	if err != nil {
+		return &pkg.OracleFactory{}, fmt.Errorf("failed to get OCR3 contract address for chain selector %d and qualifier %s: %w", job.ChainSelectorEVM, job.ContractQualifier, err)
+	}
+	contractChainID, err := chainsel.GetChainIDFromSelector(addrRefKey.ChainSelector())
+	if err != nil {
+		return &pkg.OracleFactory{}, fmt.Errorf("failed to get chainID for chain selector %d and qualifier %s: %w", job.ChainSelectorEVM, job.ContractQualifier, err)
+	}
+
+	evmOCRConfig, ok := nodeInfo.OCRConfigForChainSelector(uint64(job.ChainSelectorEVM))
+	if !ok {
+		return &pkg.OracleFactory{}, fmt.Errorf("no evm ocr2 config for node %s", nodeInfo.NodeID)
+	}
+
+	addrRefKey.ChainSelector()
+	oracleFactory := &pkg.OracleFactory{
+		Enabled:            true,
+		BootstrapPeers:     job.BootstrapPeers,
+		OCRContractAddress: contractAddrRef.Address,
+		OCRKeyBundleID:     evmOCRConfig.KeyBundleID,
+		ChainID:            contractChainID,
+		TransmitterID:      string(evmOCRConfig.TransmitAccount),
+		OnchainSigningStrategy: pkg.OnchainSigningStrategy{
+			StrategyName: "multi-chain",
+			Config:       map[string]string{"evm": evmOCRConfig.KeyBundleID},
+		},
+	}
+
+	if job.ChainSelectorAptos > 0 {
+		aptosConfig, ok := nodeInfo.OCRConfigForChainSelector(uint64(job.ChainSelectorAptos))
+		if !ok {
+			return &pkg.OracleFactory{}, fmt.Errorf("no aptos ocr2 config for node %s", nodeInfo.NodeID)
+		}
+
+		oracleFactory.OnchainSigningStrategy.Config["aptos"] = aptosConfig.KeyBundleID
+	}
+
+	if job.ChainSelectorSolana > 0 {
+		solanaConfig, ok := nodeInfo.OCRConfigForChainSelector(uint64(job.ChainSelectorSolana))
+		if !ok {
+			return &pkg.OracleFactory{}, fmt.Errorf("no solana ocr2 config for node %s", nodeInfo.NodeID)
+		}
+
+		oracleFactory.OnchainSigningStrategy.Config["solana"] = solanaConfig.KeyBundleID
+	}
+
+	return oracleFactory, nil
+}

--- a/deployment/cre/jobs/operations/propose_std_cap_job.go
+++ b/deployment/cre/jobs/operations/propose_std_cap_job.go
@@ -225,6 +225,16 @@ func generateOracleFactory(cldEnv cldf.Environment, nodeInfo deployment.Node, jo
 	if err != nil {
 		return &pkg.OracleFactory{}, fmt.Errorf("failed to get OCR3 contract address for chain selector %d and qualifier %s: %w", contractChainSelector, job.ContractQualifier, err)
 	}
+
+	if addrRefKey.ChainSelector() != uint64(contractChainSelector) {
+		return &pkg.OracleFactory{}, fmt.Errorf(
+			"mismatched chain selector in address ref key for OCR3 contract %s: expected %d, got %d",
+			addrRefKey.String(),
+			contractChainSelector,
+			addrRefKey.ChainSelector(),
+		)
+	}
+
 	contractChainID, err := chainsel.GetChainIDFromSelector(addrRefKey.ChainSelector())
 	if err != nil {
 		return &pkg.OracleFactory{}, fmt.Errorf("failed to get chainID for chain selector %d and qualifier %s: %w", contractChainSelector, job.ContractQualifier, err)

--- a/deployment/cre/jobs/operations/propose_std_cap_job.go
+++ b/deployment/cre/jobs/operations/propose_std_cap_job.go
@@ -112,7 +112,7 @@ var ProposeStandardCapabilityJob = operations.NewSequence[
 		setPerNodeCfg := false
 		if input.NodeIDToConfig != nil && len(input.NodeIDToConfig) > 0 {
 			if len(input.NodeIDToConfig) != len(nodeInfos) {
-				return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("number of nodes found (%d) does not match number of configs provided (%d)", len(nodes), len(input.NodeIDToConfig))
+				return ProposeStandardCapabilityJobOutput{}, fmt.Errorf("number of nodes found (%d) does not match number of configs provided (%d)", len(nodeInfos), len(input.NodeIDToConfig))
 			}
 			for _, n := range nodeInfos {
 				if _, ok := input.NodeIDToConfig[n.NodeID]; !ok {

--- a/deployment/cre/jobs/pkg/addresses.go
+++ b/deployment/cre/jobs/pkg/addresses.go
@@ -14,3 +14,12 @@ func GetOCR3CapabilityAddressRefKey(chainSel uint64, qualifier string) datastore
 		qualifier,
 	)
 }
+
+func GetKeystoneForwarderCapabilityAddressRefKey(chainSel uint64, qualifier string) datastore.AddressRefKey {
+	return datastore.NewAddressRefKey(
+		chainSel,
+		"KeystoneForwarder",
+		semver.MustParse("1.0.0"),
+		qualifier,
+	)
+}

--- a/deployment/cre/jobs/pkg/std_cap.go
+++ b/deployment/cre/jobs/pkg/std_cap.go
@@ -27,12 +27,14 @@ type StandardCapabilityJob struct {
 
 	// Additional fields used to drive oracle factory creation/config
 	GenerateOracleFactory bool          // if true, an oracle factory will be generated using the fields below
-	ContractQualifier     string        `yaml:"contractQualifier"`   // used to fetch the OCR contract address
-	OCRChainSelector      ChainSelector `yaml:"ocrChainSelector"`    // OCR contract doesn't have to live on the same chain as the evm selector
-	ChainSelectorEVM      ChainSelector `yaml:"chainSelectorEVM"`    // used to fetch OCR EVM configs from nodes
-	ChainSelectorAptos    ChainSelector `yaml:"chainSelectorAptos"`  // used to fetch OCR Aptos configs from nodes - optional
-	ChainSelectorSolana   ChainSelector `yaml:"chainSelectorSolana"` // used to fetch OCR Solana configs from nodes - optional
-	BootstrapPeers        []string      `yaml:"bootstrapPeers"`      // set as value in the oracle factory
+	OCRSigningStrategy    string        `yaml:"ocrSigningStrategy"` // used to set the signing strategy in the oracle factory
+	ContractQualifier     string        `yaml:"contractQualifier"`  // used to fetch the OCR contract address
+	OCRChainSelector      ChainSelector `yaml:"ocrChainSelector"`   // OCR contract doesn't have to live on the same chain as the evm selector
+
+	ChainSelectorEVM    ChainSelector `yaml:"chainSelectorEVM"`    // used to fetch OCR EVM configs from nodes
+	ChainSelectorAptos  ChainSelector `yaml:"chainSelectorAptos"`  // used to fetch OCR Aptos configs from nodes - optional
+	ChainSelectorSolana ChainSelector `yaml:"chainSelectorSolana"` // used to fetch OCR Solana configs from nodes - optional
+	BootstrapPeers      []string      `yaml:"bootstrapPeers"`      // set as value in the oracle factory
 }
 
 func (s *StandardCapabilityJob) Resolve() (string, error) {

--- a/deployment/cre/jobs/pkg/std_cap.go
+++ b/deployment/cre/jobs/pkg/std_cap.go
@@ -28,6 +28,7 @@ type StandardCapabilityJob struct {
 	// Additional fields used to drive oracle factory creation/config
 	GenerateOracleFactory bool          // if true, an oracle factory will be generated using the fields below
 	ContractQualifier     string        `yaml:"contractQualifier"`   // used to fetch the OCR contract address
+	OCRChainSelector      ChainSelector `yaml:"ocrChainSelector"`    // OCR contract doesn't have to live on the same chain as the evm selector
 	ChainSelectorEVM      ChainSelector `yaml:"chainSelectorEVM"`    // used to fetch OCR EVM configs from nodes
 	ChainSelectorAptos    ChainSelector `yaml:"chainSelectorAptos"`  // used to fetch OCR Aptos configs from nodes - optional
 	ChainSelectorSolana   ChainSelector `yaml:"chainSelectorSolana"` // used to fetch OCR Solana configs from nodes - optional

--- a/deployment/cre/jobs/propose_evm_cap.go
+++ b/deployment/cre/jobs/propose_evm_cap.go
@@ -59,6 +59,7 @@ type ProposeEVMCapJobSpecInput struct {
 	ChainSelector        uint64               `json:"chainSelector" yaml:"chainSelector"`
 	BootstrapperOCR3Urls []string             `json:"bootstrapperOCR3Urls" yaml:"bootstrapperOCR3Urls"`
 	OCRContractQualifier string               `json:"ocrContractQualifier" yaml:"ocrContractQualifier"`
+	OCRChainSelector     uint64               `json:"ocrChainSelector" yaml:"ocrChainSelector"`
 	ForwardersQualifier  string               `json:"forwardersContractQualifier" yaml:"forwardersContractQualifier"`
 	EVMCapabilityInputs  []EVMCapabilityInput `json:"evmCapabilityInputs" yaml:"evmCapabilityInputs"`
 }
@@ -103,7 +104,7 @@ func (u ProposeEVMCapJobSpec) VerifyPreconditions(e cldf.Environment, input Prop
 		return fmt.Errorf("failed to get chainID from selector: %w", err)
 	}
 
-	ocrAddrRefKey := pkg.GetOCR3CapabilityAddressRefKey(input.ChainSelector, input.OCRContractQualifier)
+	ocrAddrRefKey := pkg.GetOCR3CapabilityAddressRefKey(input.OCRChainSelector, input.OCRContractQualifier)
 	if _, err := e.DataStore.Addresses().Get(ocrAddrRefKey); err != nil {
 		return fmt.Errorf("failed to get OCR contract address for ref key %s: %w", ocrAddrRefKey, err)
 	}
@@ -176,6 +177,7 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 		Command:               "/usr/local/bin/evm",
 		GenerateOracleFactory: true,
 		ContractQualifier:     input.OCRContractQualifier,
+		OCRChainSelector:      pkg.ChainSelector(input.OCRChainSelector),
 		ChainSelectorEVM:      pkg.ChainSelector(input.ChainSelector),
 		BootstrapPeers:        input.BootstrapperOCR3Urls,
 	}

--- a/deployment/cre/jobs/propose_evm_cap.go
+++ b/deployment/cre/jobs/propose_evm_cap.go
@@ -82,7 +82,14 @@ func (u ProposeEVMCapJobSpec) VerifyPreconditions(e cldf.Environment, input Prop
 	if input.ChainSelector == 0 {
 		return errors.New("chain selector is required")
 	}
-
+	if len(input.EVMCapabilityInputs) == 0 {
+		return errors.New("at least one evm capability input is required")
+	}
+	for i, evmCapInput := range input.EVMCapabilityInputs {
+		if evmCapInput.NodeID == "" {
+			return fmt.Errorf("nodeID is required for evm capability input at index %d", i)
+		}
+	}
 	if len(input.BootstrapperOCR3Urls) == 0 {
 		return errors.New("at least one bootstrapper OCR3 URL is required")
 	}
@@ -172,6 +179,7 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 		Command:               "/usr/local/bin/evm",
 		GenerateOracleFactory: true,
 		ContractQualifier:     input.OCRContractQualifier,
+		OCRSigningStrategy:    "single-chain",
 		OCRChainSelector:      pkg.ChainSelector(input.OCRChainSelector),
 		ChainSelectorEVM:      pkg.ChainSelector(input.ChainSelector),
 		BootstrapPeers:        input.BootstrapperOCR3Urls,
@@ -222,6 +230,7 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 			NodeIDToConfig: nodeIDToConfig,
 			Domain:         input.Domain,
 			DONName:        input.DONName,
+
 			DONFilters: []offchain.TargetDONFilter{
 				{Key: "product", Value: offchain.ProductLabel},
 				{Key: "environment", Value: input.Environment},

--- a/deployment/cre/jobs/propose_evm_cap.go
+++ b/deployment/cre/jobs/propose_evm_cap.go
@@ -1,16 +1,17 @@
 package jobs
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
 	"time"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
-	"gopkg.in/yaml.v3"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink/deployment"
 	operations2 "github.com/smartcontractkit/chainlink/deployment/cre/jobs/operations"
 	"github.com/smartcontractkit/chainlink/deployment/cre/jobs/pkg"
 
@@ -21,28 +22,28 @@ var _ cldf.ChangeSetV2[ProposeEVMCapJobSpecInput] = ProposeEVMCapJobSpec{}
 
 // Config defaults
 const (
-	logTriggerPollInterval        = 1500 * time.Millisecond
+	logTriggerPollInterval        = 1500000000
 	receiverGasMinimum     uint64 = 500
 	logTriggerSendChanBuf  uint64 = 3000
 	network                       = "evm"
 )
 
 type OverrideDefaultCfg struct {
-	ChainID                         uint64        `json:"chainID" yaml:"chainID"`
-	Network                         string        `json:"network" yaml:"network"`
-	LogTriggerPollInterval          time.Duration `json:"logTriggerPollInterval" yaml:"logTriggerPollInterval"`
-	LogTriggerSendChannelBufferSize uint64        `json:"logTriggerSendChannelBufferSize" yaml:"logTriggerSendChannelBufferSize"`
-	LogTriggerLimitQueryLogSize     uint64        `json:"logTriggerLimitQueryLogSize" yaml:"logTriggerLimitQueryLogSize"`
-	BlockDepth                      int64         `json:"blockDepth" yaml:"blockDepth"`
-	CREForwarderAddress             string        `json:"creForwarderAddress" yaml:"creForwarderAddress"`
-	// The minimum amount of gas that the receiver contract must get to process the forwarder report.
+	ChainID                         uint64 `json:"chainID,omitempty" yaml:"chainID,omitempty"`
+	Network                         string `json:"network,omitempty" yaml:"network,omitempty"`
+	LogTriggerPollInterval          uint64 `json:"logTriggerPollInterval,omitempty" yaml:"logTriggerPollInterval,omitempty"`
+	LogTriggerSendChannelBufferSize uint64 `json:"logTriggerSendChannelBufferSize,omitempty" yaml:"logTriggerSendChannelBufferSize,omitempty"`
+	LogTriggerLimitQueryLogSize     uint64 `json:"logTriggerLimitQueryLogSize,omitempty" yaml:"logTriggerLimitQueryLogSize,omitempty"`
+	BlockDepth                      int64  `json:"blockDepth,omitempty" yaml:"blockDepth,omitempty"`
+	CREForwarderAddress             string `json:"creForwarderAddress,omitempty" yaml:"creForwarderAddress,omitempty"`
+	// ReceiverGasMinimum is the minimum amount of gas that the receiver contract must get to process the forwarder report.
 	// This is the default value used when the user doesn't specify a gas limit when invoking WriteReport.
-	ReceiverGasMinimum            uint64        `json:"receiverGasMinimum" yaml:"receiverGasMinimum"`
-	NodeAddress                   string        `json:"nodeAddress" yaml:"nodeAddress"`
-	ObservationPollerWorkersCount uint          `json:"observationPollerWorkersCount" yaml:"observationPollerWorkersCount"`
-	ObservationPollPeriod         time.Duration `json:"observationPollPeriod" yaml:"observationPollPeriod"`
-	ChainHeightPollPeriod         time.Duration `json:"chainHeightPollPeriod" yaml:"chainHeightPollPeriod"`
-	UnknownRequestsTTL            time.Duration `json:"unknownRequestsTTL" yaml:"unknownRequestsTTL"`
+	ReceiverGasMinimum            uint64        `json:"receiverGasMinimum,omitempty" yaml:"receiverGasMinimum,omitempty"`
+	NodeAddress                   string        `json:"nodeAddress,omitempty" yaml:"nodeAddress,omitempty"`
+	ObservationPollerWorkersCount uint          `json:"observationPollerWorkersCount,omitempty" yaml:"observationPollerWorkersCount,omitempty"`
+	ObservationPollPeriod         time.Duration `json:"observationPollPeriod,omitempty" yaml:"observationPollPeriod,omitempty"`
+	ChainHeightPollPeriod         time.Duration `json:"chainHeightPollPeriod,omitempty" yaml:"chainHeightPollPeriod,omitempty"`
+	UnknownRequestsTTL            time.Duration `json:"unknownRequestsTTL,omitempty" yaml:"unknownRequestsTTL,omitempty"`
 }
 
 type EVMCapabilityInput struct {
@@ -150,7 +151,7 @@ func (u ProposeEVMCapJobSpec) VerifyPreconditions(e cldf.Environment, input Prop
 		}
 
 		if ov.LogTriggerPollInterval != 0 && ov.LogTriggerPollInterval < logTriggerPollInterval {
-			return fmt.Errorf("logTriggerPollInterval (%s) is below minimum (%s) for node %s",
+			return fmt.Errorf("logTriggerPollInterval (%d) is below minimum (%d) for node %s",
 				ov.LogTriggerPollInterval, logTriggerPollInterval, evmCapInput.NodeID)
 		}
 		if ov.ReceiverGasMinimum != 0 && ov.ReceiverGasMinimum < receiverGasMinimum {
@@ -172,8 +173,17 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get chain name from selector: %w", err)
 	}
 
-	jobName := fmt.Sprintf("evm-capabilities-v2-%s-%s", chainName, input.Zone)
+	chainIDStr, err := chainselectors.GetChainIDFromSelector(input.ChainSelector)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get chain ID from selector: %w", err)
+	}
 
+	chainID, err := strconv.ParseUint(chainIDStr, 10, 64)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to parse chain ID %s: %w", chainIDStr, err)
+	}
+
+	jobName := fmt.Sprintf("evm-capabilities-v2-%s-%s", chainName, input.Zone)
 	job := pkg.StandardCapabilityJob{
 		JobName:               jobName,
 		Command:               "/usr/local/bin/evm",
@@ -197,9 +207,20 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 			return cldf.ChangesetOutput{}, fmt.Errorf("duplicate nodeID %q in evmCapabilityInputs", evmCapInput.NodeID)
 		}
 
-		cfg := evmCapInput.OverrideDefaultCfg
+		nodeInfos, err := deployment.NodeInfo([]string{evmCapInput.NodeID}, e.Offchain)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get node info for node %s: %w", evmCapInput.NodeID, err)
+		}
 
+		evmOCRConfig, ok := nodeInfos[0].OCRConfigForChainSelector(input.OCRChainSelector)
+		if !ok {
+			return cldf.ChangesetOutput{}, fmt.Errorf("no evm ocr config for node %s and chain selector %d", evmCapInput.NodeID, input.OCRChainSelector)
+		}
+
+		cfg := evmCapInput.OverrideDefaultCfg
+		cfg.ChainID = chainID
 		cfg.Network = network
+		cfg.NodeAddress = string(evmOCRConfig.TransmitAccount)
 		cfg.CREForwarderAddress = fwdAddress.Address
 
 		// Apply defaults if unset (zero-values). Values provided and validated in VerifyPreconditions are preserved.
@@ -213,7 +234,7 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 			cfg.LogTriggerSendChannelBufferSize = logTriggerSendChanBuf
 		}
 
-		enc, err := yaml.Marshal(cfg)
+		enc, err := json.Marshal(cfg)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to marshal evm cap config: %w", err)
 		}

--- a/deployment/cre/jobs/propose_evm_cap.go
+++ b/deployment/cre/jobs/propose_evm_cap.go
@@ -19,6 +19,14 @@ import (
 
 var _ cldf.ChangeSetV2[ProposeEVMCapJobSpecInput] = ProposeEVMCapJobSpec{}
 
+// Config defaults
+const (
+	logTriggerPollInterval        = 1500 * time.Millisecond
+	receiverGasMinimum     uint64 = 500
+	logTriggerSendChanBuf  uint64 = 3000
+	network                       = "evm"
+)
+
 type OverrideDefaultCfg struct {
 	ChainID                         uint64        `json:"chainID" yaml:"chainID"`
 	Network                         string        `json:"network" yaml:"network"`
@@ -42,80 +50,117 @@ type EVMCapabilityInput struct {
 	OverrideDefaultCfg OverrideDefaultCfg `json:"overrideDefaultCfg" yaml:"overrideDefaultCfg"`
 }
 
-type RequiredDonInput struct {
-	Environment          string   `json:"environment" yaml:"environment"`
-	Zone                 string   `json:"zone" yaml:"zone"`
-	Domain               string   `json:"domain" yaml:"domain"`
-	DONName              string   `json:"donName" yaml:"donName"`
+type RequiredInput struct {
+	Environment string `json:"environment" yaml:"environment"`
+	Zone        string `json:"zone" yaml:"zone"`
+	Domain      string `json:"domain" yaml:"domain"`
+	DONName     string `json:"donName" yaml:"donName"`
+
 	ChainSelector        uint64   `json:"chainSelector" yaml:"chainSelector"`
 	BootstrapperOCR3Urls []string `json:"bootstrapperOCR3Urls" yaml:"bootstrapperOCR3Urls"`
 	OCRContractQualifier string   `json:"ocrContractQualifier" yaml:"ocrContractQualifier"`
 	ForwardersQualifier  string   `json:"forwardersContractQualifier" yaml:"forwardersContractQualifier"`
 }
+
 type ProposeEVMCapJobSpecInput struct {
-	RequiredDonInput    RequiredDonInput     `json:"requiredDonInput" yaml:"requiredDonInput"`
+	RequiredDonInput    RequiredInput        `json:"requiredDonInput" yaml:"requiredDonInput"`
 	EVMCapabilityInputs []EVMCapabilityInput `json:"evmCapabilityInputs" yaml:"evmCapabilityInputs"`
 }
 
 type ProposeEVMCapJobSpec struct{}
 
 func (u ProposeEVMCapJobSpec) VerifyPreconditions(e cldf.Environment, input ProposeEVMCapJobSpecInput) error {
-	requiredDonInput := input.RequiredDonInput
-	if requiredDonInput.Environment == "" {
+	required := input.RequiredDonInput
+	if required.Environment == "" {
 		return errors.New("environment is required")
 	}
-	if requiredDonInput.Domain == "" {
+	if required.Domain == "" {
 		return errors.New("domain is required")
 	}
-	if requiredDonInput.DONName == "" {
-		return errors.New("donName is required for node")
+	if required.Zone == "" {
+		return errors.New("zone is required")
 	}
-	if requiredDonInput.ChainSelector == 0 {
+	if required.DONName == "" {
+		return errors.New("donName is required")
+	}
+	if required.ChainSelector == 0 {
 		return errors.New("chain selector is required")
 	}
-	if input.EVMCapabilityInputs == nil || len(input.EVMCapabilityInputs) == 0 {
+	if len(input.EVMCapabilityInputs) == 0 {
 		return errors.New("at least one evm capability input is required")
 	}
-	if requiredDonInput.BootstrapperOCR3Urls == nil || len(requiredDonInput.BootstrapperOCR3Urls) == 0 {
+	if len(required.BootstrapperOCR3Urls) == 0 {
 		return errors.New("at least one bootstrapper OCR3 URL is required")
 	}
-	if requiredDonInput.OCRContractQualifier == "" {
+	for i, u := range required.BootstrapperOCR3Urls {
+		if u == "" {
+			return fmt.Errorf("bootstrapper OCR3 URL at index %d is empty", i)
+		}
+	}
+
+	if required.OCRContractQualifier == "" {
 		return errors.New("ocr contract qualifier is required")
 	}
-	if requiredDonInput.ForwardersQualifier == "" {
+	if required.ForwardersQualifier == "" {
 		return errors.New("cre forwarder qualifier is required")
 	}
 
-	chainID, err := chainselectors.GetChainIDFromSelector(requiredDonInput.ChainSelector)
+	chainIDStr, err := chainselectors.GetChainIDFromSelector(required.ChainSelector)
 	if err != nil {
 		return fmt.Errorf("failed to get chainID from selector: %w", err)
 	}
 
-	ocrAddrRefKey := pkg.GetOCR3CapabilityAddressRefKey(requiredDonInput.ChainSelector, requiredDonInput.OCRContractQualifier)
-	_, err = e.DataStore.Addresses().Get(ocrAddrRefKey)
-	if err != nil {
+	ocrAddrRefKey := pkg.GetOCR3CapabilityAddressRefKey(required.ChainSelector, required.OCRContractQualifier)
+	if _, err := e.DataStore.Addresses().Get(ocrAddrRefKey); err != nil {
 		return fmt.Errorf("failed to get OCR contract address for ref key %s: %w", ocrAddrRefKey, err)
 	}
 
-	fwdAddrRefKey := pkg.GetKeystoneForwarderCapabilityAddressRefKey(requiredDonInput.ChainSelector, requiredDonInput.ForwardersQualifier)
+	fwdAddrRefKey := pkg.GetKeystoneForwarderCapabilityAddressRefKey(required.ChainSelector, required.ForwardersQualifier)
 	fwdAddress, err := e.DataStore.Addresses().Get(fwdAddrRefKey)
 	if err != nil {
-		return fmt.Errorf("failed to get CRE forwarder address for chain selector %d and qualifier %s: %w", requiredDonInput.ChainSelector, requiredDonInput.ForwardersQualifier, err)
+		return fmt.Errorf("failed to get CRE forwarder address for chain selector %d and qualifier %s: %w", required.ChainSelector, required.ForwardersQualifier, err)
 	}
 
 	for _, evmCapInput := range input.EVMCapabilityInputs {
-		overrideDefaultCfg := evmCapInput.OverrideDefaultCfg
+		ov := evmCapInput.OverrideDefaultCfg
 		if evmCapInput.NodeID == "" {
-			return fmt.Errorf("nodeID in evm cap config is required")
+			return errors.New("nodeID in evm capability input is required")
 		}
-		if chainID != strconv.FormatUint(overrideDefaultCfg.ChainID, 10) {
-			return fmt.Errorf("chainID in override config (%d) does not match chainID from chain selector (%s) for node %s, this field gets auto generated from the qualifier and doesn't need to be filled out", overrideDefaultCfg.ChainID, chainID, evmCapInput.NodeID)
+
+		// If user provided ChainID, ensure it matches selector-derived chain id.
+		if ov.ChainID != 0 && chainIDStr != strconv.FormatUint(ov.ChainID, 10) {
+			return fmt.Errorf(
+				"chainID in override config (%d) does not match chainID from chain selector (%s) for node %s; "+
+					"this field is auto-populated and can be omitted",
+				ov.ChainID, chainIDStr, evmCapInput.NodeID,
+			)
 		}
-		if overrideDefaultCfg.Network != "evm" {
-			return fmt.Errorf("network in override config (%s) must be 'evm' for node %s, this field is auto generated and doesn't need to be filled out", overrideDefaultCfg.Network, evmCapInput.NodeID)
+
+		// If user set Network, it must be "evm".
+		if ov.Network != "" && ov.Network != network {
+			return fmt.Errorf("network in override config must be %q if set; got %q for node %s", network, ov.Network, evmCapInput.NodeID)
 		}
-		if fwdAddress.Address != overrideDefaultCfg.CREForwarderAddress {
-			return fmt.Errorf("CRE forwarder address in override config (%s) does not match address from data store (%s) for node %s, this field gets auto generated from the qualifier and doesn't need to be filled out", overrideDefaultCfg.CREForwarderAddress, fwdAddress.Address, evmCapInput.NodeID)
+
+		// If user set CREForwarderAddress, ensure it matches computed value.
+		if ov.CREForwarderAddress != "" && fwdAddress.Address != ov.CREForwarderAddress {
+			return fmt.Errorf(
+				"CRE forwarder address in override config (%s) does not match address from data store (%s) for node %s; "+
+					"this field is auto-populated and can be omitted",
+				ov.CREForwarderAddress, fwdAddress.Address, evmCapInput.NodeID,
+			)
+		}
+
+		if ov.LogTriggerPollInterval != 0 && ov.LogTriggerPollInterval < logTriggerPollInterval {
+			return fmt.Errorf("logTriggerPollInterval (%s) is below minimum (%s) for node %s",
+				ov.LogTriggerPollInterval, logTriggerPollInterval, evmCapInput.NodeID)
+		}
+		if ov.ReceiverGasMinimum != 0 && ov.ReceiverGasMinimum < receiverGasMinimum {
+			return fmt.Errorf("receiverGasMinimum (%d) is below minimum (%d) for node %s",
+				ov.ReceiverGasMinimum, receiverGasMinimum, evmCapInput.NodeID)
+		}
+		if ov.LogTriggerSendChannelBufferSize != 0 && ov.LogTriggerSendChannelBufferSize < logTriggerSendChanBuf {
+			return fmt.Errorf("logTriggerSendChannelBufferSize (%d) is below minimum (%d) for node %s",
+				ov.LogTriggerSendChannelBufferSize, logTriggerSendChanBuf, evmCapInput.NodeID)
 		}
 	}
 
@@ -123,9 +168,9 @@ func (u ProposeEVMCapJobSpec) VerifyPreconditions(e cldf.Environment, input Prop
 }
 
 func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSpecInput) (cldf.ChangesetOutput, error) {
-	requiredDonInput := input.RequiredDonInput
+	required := input.RequiredDonInput
 
-	chainName, err := chainselectors.GetChainNameFromSelector(requiredDonInput.ChainSelector)
+	chainName, err := chainselectors.GetChainNameFromSelector(required.ChainSelector)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get chain name from selector: %w", err)
 	}
@@ -135,47 +180,52 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to extract network env from chain name: %w", err)
 	}
 
-	jobName := fmt.Sprintf("evm-capabilities-v2-%s-%s-%s", chainName, networkEnv, requiredDonInput.Zone)
+	jobName := fmt.Sprintf("evm-capabilities-v2-%s-%s-%s", chainName, networkEnv, required.Zone)
 
 	job := pkg.StandardCapabilityJob{
-		JobName: jobName,
-		Command: "/usr/local/bin/evm",
-		// OCR
+		JobName:               jobName,
+		Command:               "/usr/local/bin/evm",
 		GenerateOracleFactory: true,
-		ContractQualifier:     requiredDonInput.OCRContractQualifier,
-		ChainSelectorEVM:      pkg.ChainSelector(requiredDonInput.ChainSelector),
-		BootstrapPeers:        requiredDonInput.BootstrapperOCR3Urls,
+		ContractQualifier:     required.OCRContractQualifier,
+		ChainSelectorEVM:      pkg.ChainSelector(required.ChainSelector),
+		BootstrapPeers:        required.BootstrapperOCR3Urls,
 	}
 
-	fwdAddrRefKey := pkg.GetKeystoneForwarderCapabilityAddressRefKey(requiredDonInput.ChainSelector, requiredDonInput.ForwardersQualifier)
+	fwdAddrRefKey := pkg.GetKeystoneForwarderCapabilityAddressRefKey(required.ChainSelector, required.ForwardersQualifier)
 	fwdAddress, err := e.DataStore.Addresses().Get(fwdAddrRefKey)
 	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get CRE forwarder address for chain selector %d and qualifier %s: %w", requiredDonInput.ChainSelector, requiredDonInput.ForwardersQualifier, err)
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get CRE forwarder address for chain selector %d and qualifier %s: %w", required.ChainSelector, required.ForwardersQualifier, err)
 	}
 
-	nodeIDToConfig := make(map[string]string)
+	nodeIDToConfig := make(map[string]string, len(input.EVMCapabilityInputs))
 	for _, evmCapInput := range input.EVMCapabilityInputs {
-		capConfig := evmCapInput.OverrideDefaultCfg
-		capConfig.Network = "evm"
-
-		// set EVM Config defaults
-		capConfig.CREForwarderAddress = fwdAddress.Address
-		if capConfig.LogTriggerPollInterval == 0 {
-			capConfig.LogTriggerPollInterval = 1500 * time.Millisecond
-		}
-		if capConfig.ReceiverGasMinimum == 0 {
-			capConfig.ReceiverGasMinimum = 500
-		}
-		if capConfig.LogTriggerSendChannelBufferSize == 0 {
-			capConfig.LogTriggerSendChannelBufferSize = 3000
+		if _, exists := nodeIDToConfig[evmCapInput.NodeID]; exists {
+			return cldf.ChangesetOutput{}, fmt.Errorf("duplicate nodeID %q in evmCapabilityInputs", evmCapInput.NodeID)
 		}
 
-		evmCapConfig, err := yaml.Marshal(capConfig)
+		cfg := evmCapInput.OverrideDefaultCfg
+
+		// Canonical values derived from inputs.
+		cfg.Network = network
+		cfg.CREForwarderAddress = fwdAddress.Address
+
+		// Apply defaults if unset (zero-values). Values provided and validated in VerifyPreconditions are preserved.
+		if cfg.LogTriggerPollInterval == 0 {
+			cfg.LogTriggerPollInterval = logTriggerPollInterval
+		}
+		if cfg.ReceiverGasMinimum == 0 {
+			cfg.ReceiverGasMinimum = receiverGasMinimum
+		}
+		if cfg.LogTriggerSendChannelBufferSize == 0 {
+			cfg.LogTriggerSendChannelBufferSize = logTriggerSendChanBuf
+		}
+
+		enc, err := yaml.Marshal(cfg)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to marshal evm cap config: %w", err)
 		}
 
-		nodeIDToConfig[evmCapInput.NodeID] = string(evmCapConfig)
+		nodeIDToConfig[evmCapInput.NodeID] = string(enc)
 	}
 
 	report, err := operations.ExecuteSequence(
@@ -185,26 +235,14 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 		operations2.ProposeStandardCapabilityJobInput{
 			Job:            job,
 			NodeIDToConfig: nodeIDToConfig,
-			Domain:         requiredDonInput.Domain,
-			DONName:        requiredDonInput.DONName,
+			Domain:         required.Domain,
+			DONName:        required.DONName,
 			DONFilters: []offchain.TargetDONFilter{
-				{
-					Key:   "product",
-					Value: offchain.ProductLabel,
-				},
-				{
-					Key:   "environment",
-					Value: requiredDonInput.Environment,
-				},
-				{
-					Key:   "zone",
-					Value: requiredDonInput.Zone,
-				},
-				// TODO? I think this is resolved in the sequence later
-				{
-					Key:   requiredDonInput.DONName,
-					Value: "",
-				},
+				{Key: "product", Value: offchain.ProductLabel},
+				{Key: "environment", Value: required.Environment},
+				{Key: "zone", Value: required.Zone},
+				// Preserved: sequence may handle this specially.
+				{Key: required.DONName, Value: ""},
 			},
 		},
 	)

--- a/deployment/cre/jobs/propose_evm_cap.go
+++ b/deployment/cre/jobs/propose_evm_cap.go
@@ -83,6 +83,9 @@ func (u ProposeEVMCapJobSpec) VerifyPreconditions(e cldf.Environment, input Prop
 	if input.ChainSelector == 0 {
 		return errors.New("chain selector is required")
 	}
+	if input.OCRChainSelector == 0 {
+		return errors.New("ocr chain selector is required")
+	}
 	if len(input.EVMCapabilityInputs) == 0 {
 		return errors.New("at least one evm capability input is required")
 	}
@@ -211,10 +214,13 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get node info for node %s: %w", evmCapInput.NodeID, err)
 		}
+		if len(nodeInfos) == 0 {
+			return cldf.ChangesetOutput{}, fmt.Errorf("no node info for node %s", evmCapInput.NodeID)
+		}
 
 		evmOCRConfig, ok := nodeInfos[0].OCRConfigForChainSelector(input.ChainSelector)
 		if !ok {
-			return cldf.ChangesetOutput{}, fmt.Errorf("no evm ocr config for node %s and chain selector %d", evmCapInput.NodeID, input.OCRChainSelector)
+			return cldf.ChangesetOutput{}, fmt.Errorf("no evm ocr config for node %s and chain selector %d", evmCapInput.NodeID, input.ChainSelector)
 		}
 
 		cfg := evmCapInput.OverrideDefaultCfg

--- a/deployment/cre/jobs/propose_evm_cap.go
+++ b/deployment/cre/jobs/propose_evm_cap.go
@@ -29,7 +29,7 @@ const (
 )
 
 type OverrideDefaultCfg struct {
-	ChainID                         uint64 `json:"chainID,omitempty" yaml:"chainID,omitempty"`
+	ChainID                         uint64 `json:"chainId,omitempty" yaml:"chainId,omitempty"`
 	Network                         string `json:"network,omitempty" yaml:"network,omitempty"`
 	LogTriggerPollInterval          uint64 `json:"logTriggerPollInterval,omitempty" yaml:"logTriggerPollInterval,omitempty"`
 	LogTriggerSendChannelBufferSize uint64 `json:"logTriggerSendChannelBufferSize,omitempty" yaml:"logTriggerSendChannelBufferSize,omitempty"`
@@ -212,7 +212,7 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get node info for node %s: %w", evmCapInput.NodeID, err)
 		}
 
-		evmOCRConfig, ok := nodeInfos[0].OCRConfigForChainSelector(input.OCRChainSelector)
+		evmOCRConfig, ok := nodeInfos[0].OCRConfigForChainSelector(input.ChainSelector)
 		if !ok {
 			return cldf.ChangesetOutput{}, fmt.Errorf("no evm ocr config for node %s and chain selector %d", evmCapInput.NodeID, input.OCRChainSelector)
 		}

--- a/deployment/cre/jobs/propose_evm_cap.go
+++ b/deployment/cre/jobs/propose_evm_cap.go
@@ -81,9 +81,7 @@ func (u ProposeEVMCapJobSpec) VerifyPreconditions(e cldf.Environment, input Prop
 	if input.ChainSelector == 0 {
 		return errors.New("chain selector is required")
 	}
-	if len(input.EVMCapabilityInputs) == 0 {
-		return errors.New("at least one evm capability input is required")
-	}
+
 	if len(input.BootstrapperOCR3Urls) == 0 {
 		return errors.New("at least one bootstrapper OCR3 URL is required")
 	}
@@ -231,7 +229,6 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 				{Key: "product", Value: offchain.ProductLabel},
 				{Key: "environment", Value: input.Environment},
 				{Key: "zone", Value: input.Zone},
-				// TODO
 			},
 		},
 	)

--- a/deployment/cre/jobs/propose_evm_cap.go
+++ b/deployment/cre/jobs/propose_evm_cap.go
@@ -14,7 +14,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment"
 	operations2 "github.com/smartcontractkit/chainlink/deployment/cre/jobs/operations"
 	"github.com/smartcontractkit/chainlink/deployment/cre/jobs/pkg"
-
 	"github.com/smartcontractkit/chainlink/deployment/cre/pkg/offchain"
 )
 
@@ -259,8 +258,6 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 			DONName:        input.DONName,
 
 			DONFilters: []offchain.TargetDONFilter{
-				{Key: "product", Value: offchain.ProductLabel},
-				{Key: "environment", Value: input.Environment},
 				{Key: "zone", Value: input.Zone},
 			},
 		},

--- a/deployment/cre/jobs/propose_evm_cap.go
+++ b/deployment/cre/jobs/propose_evm_cap.go
@@ -113,7 +113,7 @@ func (u ProposeEVMCapJobSpec) VerifyPreconditions(e cldf.Environment, input Prop
 	fwdAddrRefKey := pkg.GetKeystoneForwarderCapabilityAddressRefKey(input.ChainSelector, input.ForwardersQualifier)
 	fwdAddress, err := e.DataStore.Addresses().Get(fwdAddrRefKey)
 	if err != nil {
-		return fmt.Errorf("failed to get CRE forwarder address for chain selector %d and qualifier %s: %w", input.ChainSelector, input.ForwardersQualifier, err)
+		return fmt.Errorf("failed to get CRE forwarder address for ref key %q: %w", fwdAddrRefKey, err)
 	}
 
 	for _, evmCapInput := range input.EVMCapabilityInputs {
@@ -131,12 +131,10 @@ func (u ProposeEVMCapJobSpec) VerifyPreconditions(e cldf.Environment, input Prop
 			)
 		}
 
-		// If user set Network, it must be "evm".
 		if ov.Network != "" && ov.Network != network {
 			return fmt.Errorf("network in override config must be %q if set; got %q for node %s", network, ov.Network, evmCapInput.NodeID)
 		}
 
-		// If user set CREForwarderAddress, ensure it matches computed value.
 		if ov.CREForwarderAddress != "" && fwdAddress.Address != ov.CREForwarderAddress {
 			return fmt.Errorf(
 				"CRE forwarder address in override config (%s) does not match address from data store (%s) for node %s; "+
@@ -169,8 +167,8 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 	}
 
 	networkEnv, err := chainselectors.ExtractNetworkEnvName(chainName)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to extract network env from chain name: %w", err)
+	if err != nil && input.ChainSelector != chainselectors.TEST_90000001.Selector {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to extract network env from chain name %q: %w", chainName, err)
 	}
 
 	jobName := fmt.Sprintf("evm-capabilities-v2-%s-%s-%s", chainName, networkEnv, input.Zone)
@@ -187,7 +185,7 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 	fwdAddrRefKey := pkg.GetKeystoneForwarderCapabilityAddressRefKey(input.ChainSelector, input.ForwardersQualifier)
 	fwdAddress, err := e.DataStore.Addresses().Get(fwdAddrRefKey)
 	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get CRE forwarder address for chain selector %d and qualifier %s: %w", input.ChainSelector, input.ForwardersQualifier, err)
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get CRE forwarder address for chain selector %d and ref key %s: %w", input.ChainSelector, fwdAddrRefKey, err)
 	}
 
 	nodeIDToConfig := make(map[string]string, len(input.EVMCapabilityInputs))
@@ -198,7 +196,6 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 
 		cfg := evmCapInput.OverrideDefaultCfg
 
-		// Canonical values derived from inputs.
 		cfg.Network = network
 		cfg.CREForwarderAddress = fwdAddress.Address
 
@@ -234,8 +231,7 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 				{Key: "product", Value: offchain.ProductLabel},
 				{Key: "environment", Value: input.Environment},
 				{Key: "zone", Value: input.Zone},
-				// Preserved: sequence may handle this specially.
-				{Key: input.DONName, Value: ""},
+				// TODO
 			},
 		},
 	)

--- a/deployment/cre/jobs/propose_evm_cap.go
+++ b/deployment/cre/jobs/propose_evm_cap.go
@@ -165,12 +165,7 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get chain name from selector: %w", err)
 	}
 
-	networkEnv, err := chainselectors.ExtractNetworkEnvName(chainName)
-	if err != nil && input.ChainSelector != chainselectors.TEST_90000001.Selector {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to extract network env from chain name %q: %w", chainName, err)
-	}
-
-	jobName := fmt.Sprintf("evm-capabilities-v2-%s-%s-%s", chainName, networkEnv, input.Zone)
+	jobName := fmt.Sprintf("evm-capabilities-v2-%s-%s", chainName, input.Zone)
 
 	job := pkg.StandardCapabilityJob{
 		JobName:               jobName,

--- a/deployment/cre/jobs/propose_evm_cap.go
+++ b/deployment/cre/jobs/propose_evm_cap.go
@@ -50,75 +50,70 @@ type EVMCapabilityInput struct {
 	OverrideDefaultCfg OverrideDefaultCfg `json:"overrideDefaultCfg" yaml:"overrideDefaultCfg"`
 }
 
-type RequiredInput struct {
+type ProposeEVMCapJobSpecInput struct {
 	Environment string `json:"environment" yaml:"environment"`
 	Zone        string `json:"zone" yaml:"zone"`
 	Domain      string `json:"domain" yaml:"domain"`
 	DONName     string `json:"donName" yaml:"donName"`
 
-	ChainSelector        uint64   `json:"chainSelector" yaml:"chainSelector"`
-	BootstrapperOCR3Urls []string `json:"bootstrapperOCR3Urls" yaml:"bootstrapperOCR3Urls"`
-	OCRContractQualifier string   `json:"ocrContractQualifier" yaml:"ocrContractQualifier"`
-	ForwardersQualifier  string   `json:"forwardersContractQualifier" yaml:"forwardersContractQualifier"`
-}
-
-type ProposeEVMCapJobSpecInput struct {
-	RequiredDonInput    RequiredInput        `json:"requiredDonInput" yaml:"requiredDonInput"`
-	EVMCapabilityInputs []EVMCapabilityInput `json:"evmCapabilityInputs" yaml:"evmCapabilityInputs"`
+	ChainSelector        uint64               `json:"chainSelector" yaml:"chainSelector"`
+	BootstrapperOCR3Urls []string             `json:"bootstrapperOCR3Urls" yaml:"bootstrapperOCR3Urls"`
+	OCRContractQualifier string               `json:"ocrContractQualifier" yaml:"ocrContractQualifier"`
+	ForwardersQualifier  string               `json:"forwardersContractQualifier" yaml:"forwardersContractQualifier"`
+	EVMCapabilityInputs  []EVMCapabilityInput `json:"evmCapabilityInputs" yaml:"evmCapabilityInputs"`
 }
 
 type ProposeEVMCapJobSpec struct{}
 
 func (u ProposeEVMCapJobSpec) VerifyPreconditions(e cldf.Environment, input ProposeEVMCapJobSpecInput) error {
-	required := input.RequiredDonInput
-	if required.Environment == "" {
+	if input.Environment == "" {
 		return errors.New("environment is required")
 	}
-	if required.Domain == "" {
+	if input.Domain == "" {
 		return errors.New("domain is required")
 	}
-	if required.Zone == "" {
+	if input.Zone == "" {
 		return errors.New("zone is required")
 	}
-	if required.DONName == "" {
+	if input.DONName == "" {
 		return errors.New("donName is required")
 	}
-	if required.ChainSelector == 0 {
+	if input.ChainSelector == 0 {
 		return errors.New("chain selector is required")
 	}
 	if len(input.EVMCapabilityInputs) == 0 {
 		return errors.New("at least one evm capability input is required")
 	}
-	if len(required.BootstrapperOCR3Urls) == 0 {
+	if len(input.BootstrapperOCR3Urls) == 0 {
 		return errors.New("at least one bootstrapper OCR3 URL is required")
 	}
-	for i, u := range required.BootstrapperOCR3Urls {
+	for i, u := range input.BootstrapperOCR3Urls {
 		if u == "" {
 			return fmt.Errorf("bootstrapper OCR3 URL at index %d is empty", i)
 		}
 	}
 
-	if required.OCRContractQualifier == "" {
+	if input.OCRContractQualifier == "" {
 		return errors.New("ocr contract qualifier is required")
 	}
-	if required.ForwardersQualifier == "" {
+	if input.ForwardersQualifier == "" {
 		return errors.New("cre forwarder qualifier is required")
 	}
 
-	chainIDStr, err := chainselectors.GetChainIDFromSelector(required.ChainSelector)
+	chainIDStr, err := chainselectors.GetChainIDFromSelector(input.ChainSelector)
 	if err != nil {
 		return fmt.Errorf("failed to get chainID from selector: %w", err)
 	}
 
-	ocrAddrRefKey := pkg.GetOCR3CapabilityAddressRefKey(required.ChainSelector, required.OCRContractQualifier)
+	ocrAddrRefKey := pkg.GetOCR3CapabilityAddressRefKey(input.ChainSelector, input.OCRContractQualifier)
 	if _, err := e.DataStore.Addresses().Get(ocrAddrRefKey); err != nil {
 		return fmt.Errorf("failed to get OCR contract address for ref key %s: %w", ocrAddrRefKey, err)
 	}
 
-	fwdAddrRefKey := pkg.GetKeystoneForwarderCapabilityAddressRefKey(required.ChainSelector, required.ForwardersQualifier)
+	fwdAddrRefKey := pkg.GetKeystoneForwarderCapabilityAddressRefKey(input.ChainSelector, input.ForwardersQualifier)
 	fwdAddress, err := e.DataStore.Addresses().Get(fwdAddrRefKey)
 	if err != nil {
-		return fmt.Errorf("failed to get CRE forwarder address for chain selector %d and qualifier %s: %w", required.ChainSelector, required.ForwardersQualifier, err)
+		return fmt.Errorf("failed to get CRE forwarder address for chain selector %d and qualifier %s: %w", input.ChainSelector, input.ForwardersQualifier, err)
 	}
 
 	for _, evmCapInput := range input.EVMCapabilityInputs {
@@ -168,9 +163,7 @@ func (u ProposeEVMCapJobSpec) VerifyPreconditions(e cldf.Environment, input Prop
 }
 
 func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSpecInput) (cldf.ChangesetOutput, error) {
-	required := input.RequiredDonInput
-
-	chainName, err := chainselectors.GetChainNameFromSelector(required.ChainSelector)
+	chainName, err := chainselectors.GetChainNameFromSelector(input.ChainSelector)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get chain name from selector: %w", err)
 	}
@@ -180,21 +173,21 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to extract network env from chain name: %w", err)
 	}
 
-	jobName := fmt.Sprintf("evm-capabilities-v2-%s-%s-%s", chainName, networkEnv, required.Zone)
+	jobName := fmt.Sprintf("evm-capabilities-v2-%s-%s-%s", chainName, networkEnv, input.Zone)
 
 	job := pkg.StandardCapabilityJob{
 		JobName:               jobName,
 		Command:               "/usr/local/bin/evm",
 		GenerateOracleFactory: true,
-		ContractQualifier:     required.OCRContractQualifier,
-		ChainSelectorEVM:      pkg.ChainSelector(required.ChainSelector),
-		BootstrapPeers:        required.BootstrapperOCR3Urls,
+		ContractQualifier:     input.OCRContractQualifier,
+		ChainSelectorEVM:      pkg.ChainSelector(input.ChainSelector),
+		BootstrapPeers:        input.BootstrapperOCR3Urls,
 	}
 
-	fwdAddrRefKey := pkg.GetKeystoneForwarderCapabilityAddressRefKey(required.ChainSelector, required.ForwardersQualifier)
+	fwdAddrRefKey := pkg.GetKeystoneForwarderCapabilityAddressRefKey(input.ChainSelector, input.ForwardersQualifier)
 	fwdAddress, err := e.DataStore.Addresses().Get(fwdAddrRefKey)
 	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get CRE forwarder address for chain selector %d and qualifier %s: %w", required.ChainSelector, required.ForwardersQualifier, err)
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get CRE forwarder address for chain selector %d and qualifier %s: %w", input.ChainSelector, input.ForwardersQualifier, err)
 	}
 
 	nodeIDToConfig := make(map[string]string, len(input.EVMCapabilityInputs))
@@ -235,14 +228,14 @@ func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSp
 		operations2.ProposeStandardCapabilityJobInput{
 			Job:            job,
 			NodeIDToConfig: nodeIDToConfig,
-			Domain:         required.Domain,
-			DONName:        required.DONName,
+			Domain:         input.Domain,
+			DONName:        input.DONName,
 			DONFilters: []offchain.TargetDONFilter{
 				{Key: "product", Value: offchain.ProductLabel},
-				{Key: "environment", Value: required.Environment},
-				{Key: "zone", Value: required.Zone},
+				{Key: "environment", Value: input.Environment},
+				{Key: "zone", Value: input.Zone},
 				// Preserved: sequence may handle this specially.
-				{Key: required.DONName, Value: ""},
+				{Key: input.DONName, Value: ""},
 			},
 		},
 	)

--- a/deployment/cre/jobs/propose_evm_cap.go
+++ b/deployment/cre/jobs/propose_evm_cap.go
@@ -1,0 +1,218 @@
+package jobs
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+	"gopkg.in/yaml.v3"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	operations2 "github.com/smartcontractkit/chainlink/deployment/cre/jobs/operations"
+	"github.com/smartcontractkit/chainlink/deployment/cre/jobs/pkg"
+
+	"github.com/smartcontractkit/chainlink/deployment/cre/pkg/offchain"
+)
+
+var _ cldf.ChangeSetV2[ProposeEVMCapJobSpecInput] = ProposeEVMCapJobSpec{}
+
+type OverrideDefaultCfg struct {
+	ChainID                         uint64        `json:"chainID" yaml:"chainID"`
+	Network                         string        `json:"network" yaml:"network"`
+	LogTriggerPollInterval          time.Duration `json:"logTriggerPollInterval" yaml:"logTriggerPollInterval"`
+	LogTriggerSendChannelBufferSize uint64        `json:"logTriggerSendChannelBufferSize" yaml:"logTriggerSendChannelBufferSize"`
+	LogTriggerLimitQueryLogSize     uint64        `json:"logTriggerLimitQueryLogSize" yaml:"logTriggerLimitQueryLogSize"`
+	BlockDepth                      int64         `json:"blockDepth" yaml:"blockDepth"`
+	CREForwarderAddress             string        `json:"creForwarderAddress" yaml:"creForwarderAddress"`
+	// The minimum amount of gas that the receiver contract must get to process the forwarder report.
+	// This is the default value used when the user doesn't specify a gas limit when invoking WriteReport.
+	ReceiverGasMinimum            uint64        `json:"receiverGasMinimum" yaml:"receiverGasMinimum"`
+	NodeAddress                   string        `json:"nodeAddress" yaml:"nodeAddress"`
+	ObservationPollerWorkersCount uint          `json:"observationPollerWorkersCount" yaml:"observationPollerWorkersCount"`
+	ObservationPollPeriod         time.Duration `json:"observationPollPeriod" yaml:"observationPollPeriod"`
+	ChainHeightPollPeriod         time.Duration `json:"chainHeightPollPeriod" yaml:"chainHeightPollPeriod"`
+	UnknownRequestsTTL            time.Duration `json:"unknownRequestsTTL" yaml:"unknownRequestsTTL"`
+}
+
+type EVMCapabilityInput struct {
+	NodeID             string             `json:"nodeID" yaml:"nodeID"`
+	OverrideDefaultCfg OverrideDefaultCfg `json:"overrideDefaultCfg" yaml:"overrideDefaultCfg"`
+}
+
+type RequiredDonInput struct {
+	Environment          string   `json:"environment" yaml:"environment"`
+	Zone                 string   `json:"zone" yaml:"zone"`
+	Domain               string   `json:"domain" yaml:"domain"`
+	DONName              string   `json:"donName" yaml:"donName"`
+	ChainSelector        uint64   `json:"chainSelector" yaml:"chainSelector"`
+	BootstrapperOCR3Urls []string `json:"bootstrapperOCR3Urls" yaml:"bootstrapperOCR3Urls"`
+	OCRContractQualifier string   `json:"ocrContractQualifier" yaml:"ocrContractQualifier"`
+	ForwardersQualifier  string   `json:"forwardersContractQualifier" yaml:"forwardersContractQualifier"`
+}
+type ProposeEVMCapJobSpecInput struct {
+	RequiredDonInput    RequiredDonInput     `json:"requiredDonInput" yaml:"requiredDonInput"`
+	EVMCapabilityInputs []EVMCapabilityInput `json:"evmCapabilityInputs" yaml:"evmCapabilityInputs"`
+}
+
+type ProposeEVMCapJobSpec struct{}
+
+func (u ProposeEVMCapJobSpec) VerifyPreconditions(e cldf.Environment, input ProposeEVMCapJobSpecInput) error {
+	requiredDonInput := input.RequiredDonInput
+	if requiredDonInput.Environment == "" {
+		return errors.New("environment is required")
+	}
+	if requiredDonInput.Domain == "" {
+		return errors.New("domain is required")
+	}
+	if requiredDonInput.DONName == "" {
+		return errors.New("donName is required for node")
+	}
+	if requiredDonInput.ChainSelector == 0 {
+		return errors.New("chain selector is required")
+	}
+	if input.EVMCapabilityInputs == nil || len(input.EVMCapabilityInputs) == 0 {
+		return errors.New("at least one evm capability input is required")
+	}
+	if requiredDonInput.BootstrapperOCR3Urls == nil || len(requiredDonInput.BootstrapperOCR3Urls) == 0 {
+		return errors.New("at least one bootstrapper OCR3 URL is required")
+	}
+	if requiredDonInput.OCRContractQualifier == "" {
+		return errors.New("ocr contract qualifier is required")
+	}
+	if requiredDonInput.ForwardersQualifier == "" {
+		return errors.New("cre forwarder qualifier is required")
+	}
+
+	chainID, err := chainselectors.GetChainIDFromSelector(requiredDonInput.ChainSelector)
+	if err != nil {
+		return fmt.Errorf("failed to get chainID from selector: %w", err)
+	}
+
+	ocrAddrRefKey := pkg.GetOCR3CapabilityAddressRefKey(requiredDonInput.ChainSelector, requiredDonInput.OCRContractQualifier)
+	_, err = e.DataStore.Addresses().Get(ocrAddrRefKey)
+	if err != nil {
+		return fmt.Errorf("failed to get OCR contract address for ref key %s: %w", ocrAddrRefKey, err)
+	}
+
+	fwdAddrRefKey := pkg.GetKeystoneForwarderCapabilityAddressRefKey(requiredDonInput.ChainSelector, requiredDonInput.ForwardersQualifier)
+	fwdAddress, err := e.DataStore.Addresses().Get(fwdAddrRefKey)
+	if err != nil {
+		return fmt.Errorf("failed to get CRE forwarder address for chain selector %d and qualifier %s: %w", requiredDonInput.ChainSelector, requiredDonInput.ForwardersQualifier, err)
+	}
+
+	for _, evmCapInput := range input.EVMCapabilityInputs {
+		overrideDefaultCfg := evmCapInput.OverrideDefaultCfg
+		if evmCapInput.NodeID == "" {
+			return fmt.Errorf("nodeID in evm cap config is required")
+		}
+		if chainID != strconv.FormatUint(overrideDefaultCfg.ChainID, 10) {
+			return fmt.Errorf("chainID in override config (%d) does not match chainID from chain selector (%s) for node %s, this field gets auto generated from the qualifier and doesn't need to be filled out", overrideDefaultCfg.ChainID, chainID, evmCapInput.NodeID)
+		}
+		if overrideDefaultCfg.Network != "evm" {
+			return fmt.Errorf("network in override config (%s) must be 'evm' for node %s, this field is auto generated and doesn't need to be filled out", overrideDefaultCfg.Network, evmCapInput.NodeID)
+		}
+		if fwdAddress.Address != overrideDefaultCfg.CREForwarderAddress {
+			return fmt.Errorf("CRE forwarder address in override config (%s) does not match address from data store (%s) for node %s, this field gets auto generated from the qualifier and doesn't need to be filled out", overrideDefaultCfg.CREForwarderAddress, fwdAddress.Address, evmCapInput.NodeID)
+		}
+	}
+
+	return nil
+}
+
+func (u ProposeEVMCapJobSpec) Apply(e cldf.Environment, input ProposeEVMCapJobSpecInput) (cldf.ChangesetOutput, error) {
+	requiredDonInput := input.RequiredDonInput
+
+	chainName, err := chainselectors.GetChainNameFromSelector(requiredDonInput.ChainSelector)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get chain name from selector: %w", err)
+	}
+
+	networkEnv, err := chainselectors.ExtractNetworkEnvName(chainName)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to extract network env from chain name: %w", err)
+	}
+
+	jobName := fmt.Sprintf("evm-capabilities-v2-%s-%s-%s", chainName, networkEnv, requiredDonInput.Zone)
+
+	job := pkg.StandardCapabilityJob{
+		JobName: jobName,
+		Command: "/usr/local/bin/evm",
+		// OCR
+		GenerateOracleFactory: true,
+		ContractQualifier:     requiredDonInput.OCRContractQualifier,
+		ChainSelectorEVM:      pkg.ChainSelector(requiredDonInput.ChainSelector),
+		BootstrapPeers:        requiredDonInput.BootstrapperOCR3Urls,
+	}
+
+	fwdAddrRefKey := pkg.GetKeystoneForwarderCapabilityAddressRefKey(requiredDonInput.ChainSelector, requiredDonInput.ForwardersQualifier)
+	fwdAddress, err := e.DataStore.Addresses().Get(fwdAddrRefKey)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get CRE forwarder address for chain selector %d and qualifier %s: %w", requiredDonInput.ChainSelector, requiredDonInput.ForwardersQualifier, err)
+	}
+
+	nodeIDToConfig := make(map[string]string)
+	for _, evmCapInput := range input.EVMCapabilityInputs {
+		capConfig := evmCapInput.OverrideDefaultCfg
+		capConfig.Network = "evm"
+
+		// set EVM Config defaults
+		capConfig.CREForwarderAddress = fwdAddress.Address
+		if capConfig.LogTriggerPollInterval == 0 {
+			capConfig.LogTriggerPollInterval = 1500 * time.Millisecond
+		}
+		if capConfig.ReceiverGasMinimum == 0 {
+			capConfig.ReceiverGasMinimum = 500
+		}
+		if capConfig.LogTriggerSendChannelBufferSize == 0 {
+			capConfig.LogTriggerSendChannelBufferSize = 3000
+		}
+
+		evmCapConfig, err := yaml.Marshal(capConfig)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to marshal evm cap config: %w", err)
+		}
+
+		nodeIDToConfig[evmCapInput.NodeID] = string(evmCapConfig)
+	}
+
+	report, err := operations.ExecuteSequence(
+		e.OperationsBundle,
+		operations2.ProposeStandardCapabilityJob,
+		operations2.ProposeStandardCapabilityJobDeps{Env: e},
+		operations2.ProposeStandardCapabilityJobInput{
+			Job:            job,
+			NodeIDToConfig: nodeIDToConfig,
+			Domain:         requiredDonInput.Domain,
+			DONName:        requiredDonInput.DONName,
+			DONFilters: []offchain.TargetDONFilter{
+				{
+					Key:   "product",
+					Value: offchain.ProductLabel,
+				},
+				{
+					Key:   "environment",
+					Value: requiredDonInput.Environment,
+				},
+				{
+					Key:   "zone",
+					Value: requiredDonInput.Zone,
+				},
+				// TODO? I think this is resolved in the sequence later
+				{
+					Key:   requiredDonInput.DONName,
+					Value: "",
+				},
+			},
+		},
+	)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to propose standard capability job: %w", err)
+	}
+
+	return cldf.ChangesetOutput{
+		Reports: []operations.Report[any, any]{report.ToGenericReport()},
+	}, nil
+}

--- a/deployment/cre/jobs/propose_evm_cap_test.go
+++ b/deployment/cre/jobs/propose_evm_cap_test.go
@@ -235,7 +235,7 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_mismatchAndMinimums(t *testing
 
 		// Now set below-minimums independently each time
 		in = deepCloneInput(base)
-		//nolint:gosec // disable G115
+		//nolint:nolintlint,gosec // disable G115
 		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerPollInterval = uint64(1499 * time.Millisecond)
 		err := jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
 		require.Error(t, err)

--- a/deployment/cre/jobs/propose_evm_cap_test.go
+++ b/deployment/cre/jobs/propose_evm_cap_test.go
@@ -1,4 +1,4 @@
-package jobs
+package jobs_test
 
 import (
 	"strconv"
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
+	"github.com/smartcontractkit/chainlink/deployment/cre/jobs"
 
 	"github.com/smartcontractkit/chainlink/deployment/cre/test"
 
@@ -26,23 +27,23 @@ const (
 	testForwarderQualifier    = "forwarder-qualifier"
 )
 
-func minimalEVMCapInput(nodeID string) EVMCapabilityInput {
-	return EVMCapabilityInput{
+func minimalEVMCapInput(nodeID string) jobs.EVMCapabilityInput {
+	return jobs.EVMCapabilityInput{
 		NodeID:             nodeID,
-		OverrideDefaultCfg: OverrideDefaultCfg{},
+		OverrideDefaultCfg: jobs.OverrideDefaultCfg{},
 	}
 }
 
-func deepCloneInput(in ProposeEVMCapJobSpecInput) ProposeEVMCapJobSpecInput {
+func deepCloneInput(in jobs.ProposeEVMCapJobSpecInput) jobs.ProposeEVMCapJobSpecInput {
 	clone := in
 	if len(in.EVMCapabilityInputs) > 0 {
-		clone.EVMCapabilityInputs = append([]EVMCapabilityInput(nil), in.EVMCapabilityInputs...)
+		clone.EVMCapabilityInputs = append([]jobs.EVMCapabilityInput(nil), in.EVMCapabilityInputs...)
 	}
 	return clone
 }
 
-func freshBase(selector uint64) ProposeEVMCapJobSpecInput {
-	return ProposeEVMCapJobSpecInput{
+func freshBase(selector uint64) jobs.ProposeEVMCapJobSpecInput {
+	return jobs.ProposeEVMCapJobSpecInput{
 		Environment:          "test",
 		Zone:                 test.Zone,
 		Domain:               "cre",
@@ -52,7 +53,7 @@ func freshBase(selector uint64) ProposeEVMCapJobSpecInput {
 		BootstrapperOCR3Urls: []string{"12D3KooWxyz@127.0.0.1:5001"},
 		OCRContractQualifier: testOCRQualifier,
 		ForwardersQualifier:  testForwarderQualifier,
-		EVMCapabilityInputs:  []EVMCapabilityInput{minimalEVMCapInput("peer-1")},
+		EVMCapabilityInputs:  []jobs.EVMCapabilityInput{minimalEVMCapInput("peer-1")},
 	}
 }
 
@@ -84,7 +85,7 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_success(t *testing.T) {
 	seedAddressesForSelector(t, ds, chain.Selector, ocrAddr, fwdAddr)
 	env.DataStore = ds.Seal()
 
-	in := ProposeEVMCapJobSpecInput{
+	in := jobs.ProposeEVMCapJobSpecInput{
 		Environment:          "test",
 		Zone:                 test.Zone,
 		Domain:               "cre",
@@ -94,13 +95,13 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_success(t *testing.T) {
 		BootstrapperOCR3Urls: []string{"12D3KooWxyz@127.0.0.1:5001"},
 		OCRContractQualifier: testOCRQualifier,
 		ForwardersQualifier:  testForwarderQualifier,
-		EVMCapabilityInputs: []EVMCapabilityInput{
+		EVMCapabilityInputs: []jobs.EVMCapabilityInput{
 			minimalEVMCapInput("peer-1"),
 			minimalEVMCapInput("peer-2"),
 		},
 	}
 
-	err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+	err := jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
 	require.NoError(t, err)
 }
 
@@ -115,28 +116,28 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_requiredFields(t *testing.T) {
 
 	cases := []struct {
 		name    string
-		mutate  func(*ProposeEVMCapJobSpecInput)
+		mutate  func(*jobs.ProposeEVMCapJobSpecInput)
 		errFrag string
 	}{
-		{"missing environment", func(in *ProposeEVMCapJobSpecInput) { in.Environment = "" }, "environment is required"},
-		{"missing domain", func(in *ProposeEVMCapJobSpecInput) { in.Domain = "" }, "domain is required"},
-		{"missing don name", func(in *ProposeEVMCapJobSpecInput) { in.DONName = "" }, "donName is required"},
-		{"missing zone", func(in *ProposeEVMCapJobSpecInput) { in.Zone = "" }, "zone is required"},
-		{"missing chain selector", func(in *ProposeEVMCapJobSpecInput) { in.ChainSelector = 0 }, "chain selector is required"},
-		{"missing ocr chain selector", func(in *ProposeEVMCapJobSpecInput) { in.OCRChainSelector = 0 }, "ocr chain selector is required"},
-		{"missing evm inputs", func(in *ProposeEVMCapJobSpecInput) { in.EVMCapabilityInputs = nil }, "at least one evm capability input is required"},
-		{"missing bootstrapper urls", func(in *ProposeEVMCapJobSpecInput) { in.BootstrapperOCR3Urls = nil }, "at least one bootstrapper OCR3 URL is required"},
-		{"empty bootstrapper url element", func(in *ProposeEVMCapJobSpecInput) { in.BootstrapperOCR3Urls = []string{""} }, "bootstrapper OCR3 URL at index 0 is empty"},
-		{"missing OCR qualifier", func(in *ProposeEVMCapJobSpecInput) { in.OCRContractQualifier = "" }, "ocr contract qualifier is required"},
-		{"missing forwarder qualifier", func(in *ProposeEVMCapJobSpecInput) { in.ForwardersQualifier = "" }, "cre forwarder qualifier is required"},
-		{"missing node id", func(in *ProposeEVMCapJobSpecInput) { in.EVMCapabilityInputs[0].NodeID = "" }, "nodeID is required for evm capability input"},
+		{"missing environment", func(in *jobs.ProposeEVMCapJobSpecInput) { in.Environment = "" }, "environment is required"},
+		{"missing domain", func(in *jobs.ProposeEVMCapJobSpecInput) { in.Domain = "" }, "domain is required"},
+		{"missing don name", func(in *jobs.ProposeEVMCapJobSpecInput) { in.DONName = "" }, "donName is required"},
+		{"missing zone", func(in *jobs.ProposeEVMCapJobSpecInput) { in.Zone = "" }, "zone is required"},
+		{"missing chain selector", func(in *jobs.ProposeEVMCapJobSpecInput) { in.ChainSelector = 0 }, "chain selector is required"},
+		{"missing ocr chain selector", func(in *jobs.ProposeEVMCapJobSpecInput) { in.OCRChainSelector = 0 }, "ocr chain selector is required"},
+		{"missing evm inputs", func(in *jobs.ProposeEVMCapJobSpecInput) { in.EVMCapabilityInputs = nil }, "at least one evm capability input is required"},
+		{"missing bootstrapper urls", func(in *jobs.ProposeEVMCapJobSpecInput) { in.BootstrapperOCR3Urls = nil }, "at least one bootstrapper OCR3 URL is required"},
+		{"empty bootstrapper url element", func(in *jobs.ProposeEVMCapJobSpecInput) { in.BootstrapperOCR3Urls = []string{""} }, "bootstrapper OCR3 URL at index 0 is empty"},
+		{"missing OCR qualifier", func(in *jobs.ProposeEVMCapJobSpecInput) { in.OCRContractQualifier = "" }, "ocr contract qualifier is required"},
+		{"missing forwarder qualifier", func(in *jobs.ProposeEVMCapJobSpecInput) { in.ForwardersQualifier = "" }, "cre forwarder qualifier is required"},
+		{"missing node id", func(in *jobs.ProposeEVMCapJobSpecInput) { in.EVMCapabilityInputs[0].NodeID = "" }, "nodeID is required for evm capability input"},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			in := deepCloneInput(base)
 			tc.mutate(&in)
-			err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+			err := jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errFrag)
 		})
@@ -160,7 +161,7 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_missingAddresses(t *testing.T)
 	in := freshBase(selector)
 	in.OCRChainSelector = selector
 
-	err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+	err := jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get OCR contract address")
 
@@ -175,7 +176,7 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_missingAddresses(t *testing.T)
 	}))
 	env.DataStore = ds2.Seal()
 
-	err = ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+	err = jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get CRE forwarder address")
 }
@@ -200,7 +201,7 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_mismatchAndMinimums(t *testing
 		}
 		in.EVMCapabilityInputs[0].OverrideDefaultCfg.ChainID = wrong
 
-		err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+		err := jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "chainID in override config")
 	})
@@ -208,7 +209,7 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_mismatchAndMinimums(t *testing
 	t.Run("network must be evm if provided", func(t *testing.T) {
 		in := deepCloneInput(base)
 		in.EVMCapabilityInputs[0].OverrideDefaultCfg.Network = "solana"
-		err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+		err := jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "network in override config must be")
 	})
@@ -216,7 +217,7 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_mismatchAndMinimums(t *testing
 	t.Run("forwarder address mismatch when provided", func(t *testing.T) {
 		in := deepCloneInput(base)
 		in.EVMCapabilityInputs[0].OverrideDefaultCfg.CREForwarderAddress = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-		err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+		err := jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "CRE forwarder address in override config")
 	})
@@ -224,32 +225,32 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_mismatchAndMinimums(t *testing
 	t.Run("below-minimum values are rejected, zeros allowed because of defaults", func(t *testing.T) {
 		// Zeros OK (treated as "use defaults"), so verify passes:
 		in := deepCloneInput(base)
-		require.NoError(t, ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in))
+		require.NoError(t, jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in))
 
 		in = deepCloneInput(base)
 		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerPollInterval = 1500000000 // ns
 		in.EVMCapabilityInputs[0].OverrideDefaultCfg.ReceiverGasMinimum = 500
 		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerSendChannelBufferSize = 3000
-		require.NoError(t, ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in))
+		require.NoError(t, jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in))
 
 		// Now set below-minimums independently each time
 		in = deepCloneInput(base)
 		d := int64(1499 * time.Millisecond)
 		require.GreaterOrEqual(t, d, int64(0))
 		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerPollInterval = uint64(d)
-		err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+		err := jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "logTriggerPollInterval")
 
 		in = deepCloneInput(base)
 		in.EVMCapabilityInputs[0].OverrideDefaultCfg.ReceiverGasMinimum = 499
-		err = ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+		err = jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "receiverGasMinimum")
 
 		in = deepCloneInput(base)
 		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerSendChannelBufferSize = 2999
-		err = ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+		err = jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "logTriggerSendChannelBufferSize")
 	})
@@ -283,7 +284,7 @@ func TestProposeEVMCapJobSpec_Apply_success(t *testing.T) {
 
 	env.DataStore = ds.Seal()
 
-	input := ProposeEVMCapJobSpecInput{
+	input := jobs.ProposeEVMCapJobSpecInput{
 		Environment:          "test",
 		Zone:                 test.Zone,
 		Domain:               "cre",
@@ -293,7 +294,7 @@ func TestProposeEVMCapJobSpec_Apply_success(t *testing.T) {
 		BootstrapperOCR3Urls: []string{"12D3KooWabc@127.0.0.1:5001"},
 		OCRContractQualifier: testOCRQualifier,
 		ForwardersQualifier:  testForwarderQualifier,
-		EVMCapabilityInputs: []EVMCapabilityInput{
+		EVMCapabilityInputs: []jobs.EVMCapabilityInput{
 			// leave values zero to exercise defaults; Apply should fill them
 			minimalEVMCapInput("node_test-don-0"),
 			minimalEVMCapInput("node_test-don-1"),
@@ -303,10 +304,10 @@ func TestProposeEVMCapJobSpec_Apply_success(t *testing.T) {
 	}
 
 	// Verify should pass
-	require.NoError(t, ProposeEVMCapJobSpec{}.VerifyPreconditions(*env, input))
+	require.NoError(t, jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(*env, input))
 
 	// Apply should succeed and return one report
-	out, err := ProposeEVMCapJobSpec{}.Apply(*env, input)
+	out, err := jobs.ProposeEVMCapJobSpec{}.Apply(*env, input)
 	require.NoError(t, err)
 	assert.Len(t, out.Reports, 1)
 }
@@ -323,12 +324,12 @@ func TestProposeEVMCapJobSpec_Apply_duplicateNodeIDs(t *testing.T) {
 	input := freshBase(selector)
 	input.OCRChainSelector = selector
 	// duplicate
-	input.EVMCapabilityInputs = []EVMCapabilityInput{
+	input.EVMCapabilityInputs = []jobs.EVMCapabilityInput{
 		minimalEVMCapInput("node_test-don-0"),
 		minimalEVMCapInput("node_test-don-0"),
 	}
 
-	_, err := ProposeEVMCapJobSpec{}.Apply(*env, input)
+	_, err := jobs.ProposeEVMCapJobSpec{}.Apply(*env, input)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "duplicate nodeID")
 }

--- a/deployment/cre/jobs/propose_evm_cap_test.go
+++ b/deployment/cre/jobs/propose_evm_cap_test.go
@@ -235,9 +235,8 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_mismatchAndMinimums(t *testing
 
 		// Now set below-minimums independently each time
 		in = deepCloneInput(base)
-		d := int64(1499 * time.Millisecond)
-		require.GreaterOrEqual(t, d, int64(0))
-		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerPollInterval = uint64(d)
+		//nolint:gosec // disable G115
+		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerPollInterval = uint64(1499 * time.Millisecond)
 		err := jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "logTriggerPollInterval")

--- a/deployment/cre/jobs/propose_evm_cap_test.go
+++ b/deployment/cre/jobs/propose_evm_cap_test.go
@@ -21,15 +21,11 @@ import (
 )
 
 const (
-	// ⚠️ Adjust this if your pkg.GetKeystoneForwarderCapabilityAddressRefKey
-	// encodes a different ContractType in its key.
 	testForwarderContractType = datastore.ContractType("KeystoneForwarder")
-
-	testOCRQualifier       = "OCR3Capability"
-	testForwarderQualifier = "forwarder-qualifier"
+	testOCRQualifier          = "OCR3Capability"
+	testForwarderQualifier    = "forwarder-qualifier"
 )
 
-// helper to build a minimal valid input (no user overrides; Apply will fill defaults)
 func minimalEVMCapInput(nodeID string) EVMCapabilityInput {
 	return EVMCapabilityInput{
 		NodeID:             nodeID,
@@ -45,7 +41,6 @@ func deepCloneInput(in ProposeEVMCapJobSpecInput) ProposeEVMCapJobSpecInput {
 	return clone
 }
 
-// freshBase now also sets OCRChainSelector to selector (most tests need this)
 func freshBase(selector uint64) ProposeEVMCapJobSpecInput {
 	return ProposeEVMCapJobSpecInput{
 		Environment:          "test",
@@ -239,7 +234,9 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_mismatchAndMinimums(t *testing
 
 		// Now set below-minimums independently each time
 		in = deepCloneInput(base)
-		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerPollInterval = uint64((1499 * time.Millisecond).Nanoseconds()) // 1ms below min
+		d := int64(1499 * time.Millisecond)
+		require.GreaterOrEqual(t, d, int64(0))
+		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerPollInterval = uint64(d)
 		err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "logTriggerPollInterval")

--- a/deployment/cre/jobs/propose_evm_cap_test.go
+++ b/deployment/cre/jobs/propose_evm_cap_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -46,6 +45,7 @@ func deepCloneInput(in ProposeEVMCapJobSpecInput) ProposeEVMCapJobSpecInput {
 	return clone
 }
 
+// freshBase now also sets OCRChainSelector to selector (most tests need this)
 func freshBase(selector uint64) ProposeEVMCapJobSpecInput {
 	return ProposeEVMCapJobSpecInput{
 		Environment:          "test",
@@ -53,6 +53,7 @@ func freshBase(selector uint64) ProposeEVMCapJobSpecInput {
 		Domain:               "cre",
 		DONName:              test.DONName,
 		ChainSelector:        selector,
+		OCRChainSelector:     selector,
 		BootstrapperOCR3Urls: []string{"12D3KooWxyz@127.0.0.1:5001"},
 		OCRContractQualifier: testOCRQualifier,
 		ForwardersQualifier:  testForwarderQualifier,
@@ -94,6 +95,7 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_success(t *testing.T) {
 		Domain:               "cre",
 		DONName:              test.DONName,
 		ChainSelector:        chain.Selector,
+		OCRChainSelector:     chain.Selector,
 		BootstrapperOCR3Urls: []string{"12D3KooWxyz@127.0.0.1:5001"},
 		OCRContractQualifier: testOCRQualifier,
 		ForwardersQualifier:  testForwarderQualifier,
@@ -126,11 +128,13 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_requiredFields(t *testing.T) {
 		{"missing don name", func(in *ProposeEVMCapJobSpecInput) { in.DONName = "" }, "donName is required"},
 		{"missing zone", func(in *ProposeEVMCapJobSpecInput) { in.Zone = "" }, "zone is required"},
 		{"missing chain selector", func(in *ProposeEVMCapJobSpecInput) { in.ChainSelector = 0 }, "chain selector is required"},
+		{"missing ocr chain selector", func(in *ProposeEVMCapJobSpecInput) { in.OCRChainSelector = 0 }, "ocr chain selector is required"},
 		{"missing evm inputs", func(in *ProposeEVMCapJobSpecInput) { in.EVMCapabilityInputs = nil }, "at least one evm capability input is required"},
 		{"missing bootstrapper urls", func(in *ProposeEVMCapJobSpecInput) { in.BootstrapperOCR3Urls = nil }, "at least one bootstrapper OCR3 URL is required"},
+		{"empty bootstrapper url element", func(in *ProposeEVMCapJobSpecInput) { in.BootstrapperOCR3Urls = []string{""} }, "bootstrapper OCR3 URL at index 0 is empty"},
 		{"missing OCR qualifier", func(in *ProposeEVMCapJobSpecInput) { in.OCRContractQualifier = "" }, "ocr contract qualifier is required"},
 		{"missing forwarder qualifier", func(in *ProposeEVMCapJobSpecInput) { in.ForwardersQualifier = "" }, "cre forwarder qualifier is required"},
-		{"missing node id", func(in *ProposeEVMCapJobSpecInput) { in.EVMCapabilityInputs[0].NodeID = "" }, "nodeID in evm capability input is required"},
+		{"missing node id", func(in *ProposeEVMCapJobSpecInput) { in.EVMCapabilityInputs[0].NodeID = "" }, "nodeID is required for evm capability input"},
 	}
 
 	for _, tc := range cases {
@@ -142,6 +146,43 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_requiredFields(t *testing.T) {
 			assert.Contains(t, err.Error(), tc.errFrag)
 		})
 	}
+}
+
+func TestProposeEVMCapJobSpec_VerifyPreconditions_missingAddresses(t *testing.T) {
+	var env cldf.Environment
+	ds := datastore.NewMemoryDataStore()
+	selector := chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector
+	// Only seed forwarder so OCR lookup fails
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: selector,
+		Type:          testForwarderContractType,
+		Version:       semver.MustParse("1.0.0"),
+		Address:       "0x2222222222222222222222222222222222222222",
+		Qualifier:     testForwarderQualifier,
+	}))
+	env.DataStore = ds.Seal()
+
+	in := freshBase(selector)
+	in.OCRChainSelector = selector
+
+	err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get OCR contract address")
+
+	// Now seed OCR only and remove forwarder by using a fresh DS
+	ds2 := datastore.NewMemoryDataStore()
+	require.NoError(t, ds2.Addresses().Add(datastore.AddressRef{
+		ChainSelector: selector,
+		Type:          datastore.ContractType(ocr3.OCR3Capability),
+		Version:       semver.MustParse("1.0.0"),
+		Address:       "0x1111111111111111111111111111111111111111",
+		Qualifier:     testOCRQualifier,
+	}))
+	env.DataStore = ds2.Seal()
+
+	err = ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get CRE forwarder address")
 }
 
 func TestProposeEVMCapJobSpec_VerifyPreconditions_mismatchAndMinimums(t *testing.T) {
@@ -185,14 +226,20 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_mismatchAndMinimums(t *testing
 		assert.Contains(t, err.Error(), "CRE forwarder address in override config")
 	})
 
-	t.Run("below-minimum values are rejected, zeros allowed", func(t *testing.T) {
+	t.Run("below-minimum values are rejected, zeros allowed because of defaults", func(t *testing.T) {
 		// Zeros OK (treated as "use defaults"), so verify passes:
 		in := deepCloneInput(base)
 		require.NoError(t, ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in))
 
+		in = deepCloneInput(base)
+		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerPollInterval = 1500000000 // ns
+		in.EVMCapabilityInputs[0].OverrideDefaultCfg.ReceiverGasMinimum = 500
+		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerSendChannelBufferSize = 3000
+		require.NoError(t, ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in))
+
 		// Now set below-minimums independently each time
 		in = deepCloneInput(base)
-		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerPollInterval = 1499 * time.Millisecond // 1ms below min
+		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerPollInterval = uint64((1499 * time.Millisecond).Nanoseconds()) // 1ms below min
 		err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "logTriggerPollInterval")
@@ -215,14 +262,12 @@ func TestProposeEVMCapJobSpec_Apply_success(t *testing.T) {
 	testEnv := test.SetupEnvV2(t, false)
 	env := testEnv.Env
 
-	allNodes, err := testEnv.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
+	_, err := testEnv.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
 	require.NoError(t, err)
 
-	fmt.Println("allNodes:", allNodes)
 	selector := testEnv.RegistrySelector // use the test environment's selector
 	ds := datastore.NewMemoryDataStore()
 
-	fmt.Println("selector:", selector)
 	// Seed required addresses (OCR for VerifyPreconditions; forwarder for both Verify & Apply)
 	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
 		ChainSelector: selector,
@@ -247,6 +292,7 @@ func TestProposeEVMCapJobSpec_Apply_success(t *testing.T) {
 		Domain:               "cre",
 		DONName:              test.DONName,
 		ChainSelector:        selector,
+		OCRChainSelector:     selector,
 		BootstrapperOCR3Urls: []string{"12D3KooWabc@127.0.0.1:5001"},
 		OCRContractQualifier: testOCRQualifier,
 		ForwardersQualifier:  testForwarderQualifier,
@@ -266,6 +312,26 @@ func TestProposeEVMCapJobSpec_Apply_success(t *testing.T) {
 	out, err := ProposeEVMCapJobSpec{}.Apply(*env, input)
 	require.NoError(t, err)
 	assert.Len(t, out.Reports, 1)
+}
 
-	fmt.Println("out.Reports:", out.Reports)
+func TestProposeEVMCapJobSpec_Apply_duplicateNodeIDs(t *testing.T) {
+	testEnv := test.SetupEnvV2(t, false)
+	env := testEnv.Env
+
+	selector := testEnv.RegistrySelector
+	ds := datastore.NewMemoryDataStore()
+	seedAddressesForSelector(t, ds, selector, "0xocr...", "0xfwd...")
+	env.DataStore = ds.Seal()
+
+	input := freshBase(selector)
+	input.OCRChainSelector = selector
+	// duplicate
+	input.EVMCapabilityInputs = []EVMCapabilityInput{
+		minimalEVMCapInput("node_test-don-0"),
+		minimalEVMCapInput("node_test-don-0"),
+	}
+
+	_, err := ProposeEVMCapJobSpec{}.Apply(*env, input)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate nodeID")
 }

--- a/deployment/cre/jobs/propose_evm_cap_test.go
+++ b/deployment/cre/jobs/propose_evm_cap_test.go
@@ -1,0 +1,271 @@
+package jobs
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
+
+	"github.com/smartcontractkit/chainlink/deployment/cre/test"
+
+	"github.com/smartcontractkit/chainlink/deployment/cre/ocr3"
+)
+
+const (
+	// ⚠️ Adjust this if your pkg.GetKeystoneForwarderCapabilityAddressRefKey
+	// encodes a different ContractType in its key.
+	testForwarderContractType = datastore.ContractType("KeystoneForwarder")
+
+	testOCRQualifier       = "OCR3Capability"
+	testForwarderQualifier = "forwarder-qualifier"
+)
+
+// helper to build a minimal valid input (no user overrides; Apply will fill defaults)
+func minimalEVMCapInput(nodeID string) EVMCapabilityInput {
+	return EVMCapabilityInput{
+		NodeID:             nodeID,
+		OverrideDefaultCfg: OverrideDefaultCfg{},
+	}
+}
+
+func deepCloneInput(in ProposeEVMCapJobSpecInput) ProposeEVMCapJobSpecInput {
+	clone := in
+	if len(in.EVMCapabilityInputs) > 0 {
+		clone.EVMCapabilityInputs = append([]EVMCapabilityInput(nil), in.EVMCapabilityInputs...)
+	}
+	return clone
+}
+
+func freshBase(selector uint64) ProposeEVMCapJobSpecInput {
+	return ProposeEVMCapJobSpecInput{
+		Environment:          "test",
+		Zone:                 test.Zone,
+		Domain:               "cre",
+		DONName:              test.DONName,
+		ChainSelector:        selector,
+		BootstrapperOCR3Urls: []string{"12D3KooWxyz@127.0.0.1:5001"},
+		OCRContractQualifier: testOCRQualifier,
+		ForwardersQualifier:  testForwarderQualifier,
+		EVMCapabilityInputs:  []EVMCapabilityInput{minimalEVMCapInput("peer-1")},
+	}
+}
+
+func seedAddressesForSelector(t *testing.T, ds *datastore.MemoryDataStore, sel uint64, ocrAddr, fwdAddr string) {
+	t.Helper()
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: sel,
+		Type:          datastore.ContractType(ocr3.OCR3Capability),
+		Version:       semver.MustParse("1.0.0"),
+		Address:       ocrAddr,
+		Qualifier:     testOCRQualifier,
+	}))
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: sel,
+		Type:          testForwarderContractType,
+		Version:       semver.MustParse("1.0.0"),
+		Address:       fwdAddr,
+		Qualifier:     testForwarderQualifier,
+	}))
+}
+
+func TestProposeEVMCapJobSpec_VerifyPreconditions_success(t *testing.T) {
+	var env cldf.Environment
+
+	ds := datastore.NewMemoryDataStore()
+	chain := chainsel.ETHEREUM_TESTNET_SEPOLIA
+	ocrAddr := "0x1111111111111111111111111111111111111111"
+	fwdAddr := "0x2222222222222222222222222222222222222222"
+	seedAddressesForSelector(t, ds, chain.Selector, ocrAddr, fwdAddr)
+	env.DataStore = ds.Seal()
+
+	in := ProposeEVMCapJobSpecInput{
+		Environment:          "test",
+		Zone:                 test.Zone,
+		Domain:               "cre",
+		DONName:              test.DONName,
+		ChainSelector:        chain.Selector,
+		BootstrapperOCR3Urls: []string{"12D3KooWxyz@127.0.0.1:5001"},
+		OCRContractQualifier: testOCRQualifier,
+		ForwardersQualifier:  testForwarderQualifier,
+		EVMCapabilityInputs: []EVMCapabilityInput{
+			minimalEVMCapInput("peer-1"),
+			minimalEVMCapInput("peer-2"),
+		},
+	}
+
+	err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+	require.NoError(t, err)
+}
+
+func TestProposeEVMCapJobSpec_VerifyPreconditions_requiredFields(t *testing.T) {
+	var env cldf.Environment
+	ds := datastore.NewMemoryDataStore()
+	selector := chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector
+	seedAddressesForSelector(t, ds, selector, "0x1111111111111111111111111111111111111111", "0x2222222222222222222222222222222222222222")
+	env.DataStore = ds.Seal()
+
+	base := freshBase(selector)
+
+	cases := []struct {
+		name    string
+		mutate  func(*ProposeEVMCapJobSpecInput)
+		errFrag string
+	}{
+		{"missing environment", func(in *ProposeEVMCapJobSpecInput) { in.Environment = "" }, "environment is required"},
+		{"missing domain", func(in *ProposeEVMCapJobSpecInput) { in.Domain = "" }, "domain is required"},
+		{"missing don name", func(in *ProposeEVMCapJobSpecInput) { in.DONName = "" }, "donName is required"},
+		{"missing zone", func(in *ProposeEVMCapJobSpecInput) { in.Zone = "" }, "zone is required"},
+		{"missing chain selector", func(in *ProposeEVMCapJobSpecInput) { in.ChainSelector = 0 }, "chain selector is required"},
+		{"missing evm inputs", func(in *ProposeEVMCapJobSpecInput) { in.EVMCapabilityInputs = nil }, "at least one evm capability input is required"},
+		{"missing bootstrapper urls", func(in *ProposeEVMCapJobSpecInput) { in.BootstrapperOCR3Urls = nil }, "at least one bootstrapper OCR3 URL is required"},
+		{"missing OCR qualifier", func(in *ProposeEVMCapJobSpecInput) { in.OCRContractQualifier = "" }, "ocr contract qualifier is required"},
+		{"missing forwarder qualifier", func(in *ProposeEVMCapJobSpecInput) { in.ForwardersQualifier = "" }, "cre forwarder qualifier is required"},
+		{"missing node id", func(in *ProposeEVMCapJobSpecInput) { in.EVMCapabilityInputs[0].NodeID = "" }, "nodeID in evm capability input is required"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := deepCloneInput(base)
+			tc.mutate(&in)
+			err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errFrag)
+		})
+	}
+}
+
+func TestProposeEVMCapJobSpec_VerifyPreconditions_mismatchAndMinimums(t *testing.T) {
+	var env cldf.Environment
+	ds := datastore.NewMemoryDataStore()
+	chain := chainsel.ETHEREUM_TESTNET_SEPOLIA
+	seedAddressesForSelector(t, ds, chain.Selector, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	env.DataStore = ds.Seal()
+
+	chainIDStr, _ := chainsel.GetChainIDFromSelector(chain.Selector) // e.g., "11155111"
+
+	base := freshBase(chain.Selector)
+
+	t.Run("chainID mismatch when provided", func(t *testing.T) {
+		in := deepCloneInput(base)
+		// Provide a mismatching chainID (increment the parsed one)
+		var wrong uint64 = 1
+		if idNum, err := strconv.ParseUint(chainIDStr, 10, 64); err == nil {
+			wrong = idNum + 1
+		}
+		in.EVMCapabilityInputs[0].OverrideDefaultCfg.ChainID = wrong
+
+		err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "chainID in override config")
+	})
+
+	t.Run("network must be evm if provided", func(t *testing.T) {
+		in := deepCloneInput(base)
+		in.EVMCapabilityInputs[0].OverrideDefaultCfg.Network = "solana"
+		err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "network in override config must be")
+	})
+
+	t.Run("forwarder address mismatch when provided", func(t *testing.T) {
+		in := deepCloneInput(base)
+		in.EVMCapabilityInputs[0].OverrideDefaultCfg.CREForwarderAddress = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "CRE forwarder address in override config")
+	})
+
+	t.Run("below-minimum values are rejected, zeros allowed", func(t *testing.T) {
+		// Zeros OK (treated as "use defaults"), so verify passes:
+		in := deepCloneInput(base)
+		require.NoError(t, ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in))
+
+		// Now set below-minimums independently each time
+		in = deepCloneInput(base)
+		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerPollInterval = 1499 * time.Millisecond // 1ms below min
+		err := ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "logTriggerPollInterval")
+
+		in = deepCloneInput(base)
+		in.EVMCapabilityInputs[0].OverrideDefaultCfg.ReceiverGasMinimum = 499
+		err = ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "receiverGasMinimum")
+
+		in = deepCloneInput(base)
+		in.EVMCapabilityInputs[0].OverrideDefaultCfg.LogTriggerSendChannelBufferSize = 2999
+		err = ProposeEVMCapJobSpec{}.VerifyPreconditions(env, in)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "logTriggerSendChannelBufferSize")
+	})
+}
+
+func TestProposeEVMCapJobSpec_Apply_success(t *testing.T) {
+	testEnv := test.SetupEnvV2(t, false)
+	env := testEnv.Env
+
+	allNodes, err := testEnv.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
+	require.NoError(t, err)
+
+	fmt.Println("allNodes:", allNodes)
+	selector := testEnv.RegistrySelector // use the test environment's selector
+	ds := datastore.NewMemoryDataStore()
+
+	fmt.Println("selector:", selector)
+	// Seed required addresses (OCR for VerifyPreconditions; forwarder for both Verify & Apply)
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: selector,
+		Type:          datastore.ContractType(ocr3.OCR3Capability),
+		Version:       semver.MustParse("1.0.0"),
+		Address:       "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
+		Qualifier:     testOCRQualifier,
+	}))
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: selector,
+		Type:          testForwarderContractType,
+		Version:       semver.MustParse("1.0.0"),
+		Address:       "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
+		Qualifier:     testForwarderQualifier,
+	}))
+
+	env.DataStore = ds.Seal()
+
+	input := ProposeEVMCapJobSpecInput{
+		Environment:          "test",
+		Zone:                 test.Zone,
+		Domain:               "cre",
+		DONName:              test.DONName,
+		ChainSelector:        selector,
+		BootstrapperOCR3Urls: []string{"12D3KooWabc@127.0.0.1:5001"},
+		OCRContractQualifier: testOCRQualifier,
+		ForwardersQualifier:  testForwarderQualifier,
+		EVMCapabilityInputs: []EVMCapabilityInput{
+			// leave values zero to exercise defaults; Apply should fill them
+			minimalEVMCapInput("node_test-don-0"),
+			minimalEVMCapInput("node_test-don-1"),
+			minimalEVMCapInput("node_test-don-2"),
+			minimalEVMCapInput("node_test-don-3"),
+		},
+	}
+
+	// Verify should pass
+	require.NoError(t, ProposeEVMCapJobSpec{}.VerifyPreconditions(*env, input))
+
+	// Apply should succeed and return one report
+	out, err := ProposeEVMCapJobSpec{}.Apply(*env, input)
+	require.NoError(t, err)
+	assert.Len(t, out.Reports, 1)
+
+	fmt.Println("out.Reports:", out.Reports)
+}


### PR DESCRIPTION
Changed propose standard job cap sequence to accept optional nodeID to cap config mapping and added a new simplified job changeset to be used for evm job proposals

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
