### PR TITLE
Fix 3rd party support for local CRE `RunSetup` function

### DIFF
--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -259,7 +259,7 @@ func startCmd() *cobra.Command {
 			}()
 
 			if doSetup {
-				setupErr := RunSetup(cmd.Context(), SetupConfig{ConfigPath: DefaultSetupConfigPath}, true, false, withBilling)
+				setupErr := RunSetup(cmd.Context(), SetupConfig{ConfigPath: DefaultSetupConfigPath}, true, false, withBilling, relativePathToRepoRoot)
 				if setupErr != nil {
 					return errors.Wrap(setupErr, "failed to run setup")
 				}

--- a/core/scripts/cre/environment/environment/setup.go
+++ b/core/scripts/cre/environment/environment/setup.go
@@ -44,7 +44,7 @@ func init() {
 		Short: "Setup the CRE environment prerequisites",
 		Long:  `Checks and sets up prerequisites for the CRE environment including Docker, AWS, Job Distributor, and CRE CLI`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return RunSetup(cmd.Context(), config, noPrompt, purge, withBilling)
+			return RunSetup(cmd.Context(), config, noPrompt, purge, withBilling, relativePathToRepoRoot)
 		},
 	}
 
@@ -381,7 +381,7 @@ func (c ImageConfig) Ensure(ctx context.Context, dockerClient *client.Client, aw
 }
 
 // RunSetup performs the setup for the CRE environment
-func RunSetup(ctx context.Context, config SetupConfig, noPrompt, purge, withBilling bool) (setupErr error) {
+func RunSetup(ctx context.Context, config SetupConfig, noPrompt, purge, withBilling bool, relativePathToRepoRoot string) (setupErr error) {
 	logger := framework.L
 	var localDXTracker tracking.Tracker
 	localDXTracker = &tracking.NoOpTracker{}


### PR DESCRIPTION
Currently, the `relativePathToRepoRoot` parameter to the `RunSetup` function is implicitly set to the [hardcoded one in swaps.go](https://github.com/smartcontractkit/chainlink/blob/develop/core/scripts/cre/environment/environment/swap.go#L33), which breaks 3rd party support. 

This PR fixes the issue.