### PR TITLE
feat(deployment): Add sui view

### DIFF
--- a/deployment/ccip/shared/stateview/view.go
+++ b/deployment/ccip/shared/stateview/view.go
@@ -24,6 +24,7 @@ func ViewCCIP(e deployment.Environment) (json.Marshaler, error) {
 	allChains = append(allChains, e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))...)
 	allChains = append(allChains, e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyAptos))...)
 	allChains = append(allChains, e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyTon))...)
+	allChains = append(allChains, e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySui))...)
 	stateView, err := state.View(&e, allChains)
 	if err != nil {
 		return nil, err
@@ -37,6 +38,7 @@ func ViewCCIP(e deployment.Environment) (json.Marshaler, error) {
 		SolChains:   stateView.SolChains,
 		AptosChains: stateView.AptosChains,
 		TonChains:   stateView.TONChains,
+		SuiChains:   stateView.SuiChains,
 		Nops:        nopsView,
 	}, nil
 }

--- a/deployment/ccip/view/view.go
+++ b/deployment/ccip/view/view.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"sync"
 
+	suistate "github.com/smartcontractkit/chainlink-sui/deployment"
 	tonstate "github.com/smartcontractkit/chainlink-ton/deployment/state"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view/aptos"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view/shared"
@@ -167,6 +168,7 @@ type CCIPView struct {
 	SolChains   map[string]SolChainView          `json:"solChains,omitempty"`
 	AptosChains map[string]AptosChainView        `json:"aptosChains,omitempty"`
 	TonChains   map[string]tonstate.TONChainView `json:"tonChains,omitempty"`
+	SuiChains   map[string]suistate.SuiChainView `json:"suiChains,omitempty"`
 	Nops        map[string]view.NopView          `json:"nops,omitempty"`
 }
 


### PR DESCRIPTION
# Summary 
This PR adds SUI view to CCIP view.

# Features
- Extend CCIPView structure to have SUI view
- Call generate function for SUI chains

# Test
This PR can be tested on a workspace containing `chainlink-deployments` by:
1. from `domains/ccip/cmd`
2. call `state generate -e staging persist`