### PR TITLE
Fix package.json version after 2.30.0 merge-back

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This bumps package.json from 2.30.0 to 2.31.0 to restore the upgrade_version test and align develop with the merge-back. No other changes included.