### PR TITLE
Merge back v2.30.1 hotfix (clean lineage)

### DIFF
--- a/.changeset/beige-icons-jam.md
+++ b/.changeset/beige-icons-jam.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#internal system-tests improvement

--- a/.changeset/beige-peaches-taste.md
+++ b/.changeset/beige-peaches-taste.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-Improved Solana LogPoller retry mechanism. #internal

--- a/.changeset/big-kids-retire.md
+++ b/.changeset/big-kids-retire.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated chain-selectors to v1.0.75

--- a/.changeset/big-plums-study.md
+++ b/.changeset/big-plums-study.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal changed vault request digest to use jsonrpc2 Digest method

--- a/.changeset/bitter-coats-swim.md
+++ b/.changeset/bitter-coats-swim.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix check http method

--- a/.changeset/cool-trees-laugh.md
+++ b/.changeset/cool-trees-laugh.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#added confidential-http to proposable job specs in chainlink/deployment

--- a/.changeset/dark-taxes-sing.md
+++ b/.changeset/dark-taxes-sing.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated Add ChIP ingress adapter for OTI telemetry

--- a/.changeset/dirty-spies-mate.md
+++ b/.changeset/dirty-spies-mate.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#added Add beholder logs streaming config params to control batching

--- a/.changeset/dry-buckets-lie.md
+++ b/.changeset/dry-buckets-lie.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix block number in fake evm cap

--- a/.changeset/dull-cycles-yell.md
+++ b/.changeset/dull-cycles-yell.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal exposes proposed jobs as nop view

--- a/.changeset/early-spiders-confess.md
+++ b/.changeset/early-spiders-confess.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal Use new getActiveAllowlistedRequestsReverse WR method

--- a/.changeset/eight-keys-cry.md
+++ b/.changeset/eight-keys-cry.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal adds human readable name to gateway spec

--- a/.changeset/fifty-clowns-taste.md
+++ b/.changeset/fifty-clowns-taste.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated chainlink-tron relayer

--- a/.changeset/fresh-cameras-hear.md
+++ b/.changeset/fresh-cameras-hear.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix #internal fixes log to use Warnw to properly display count

--- a/.changeset/full-socks-decide.md
+++ b/.changeset/full-socks-decide.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated chainlink-tron

--- a/.changeset/late-buttons-study.md
+++ b/.changeset/late-buttons-study.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated: add Telemetry LogLevel config option

--- a/.changeset/long-snakes-lie.md
+++ b/.changeset/long-snakes-lie.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal #bug_fix updates local node state on fetch of capability registry

--- a/.changeset/mighty-trains-ask.md
+++ b/.changeset/mighty-trains-ask.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#added Bump chainlink-common to include beholder grpc metrics

--- a/.changeset/modern-buses-cheat.md
+++ b/.changeset/modern-buses-cheat.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal bump chainlink-sui repo version and update e2e tests

--- a/.changeset/open-papers-change.md
+++ b/.changeset/open-papers-change.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix logs a debug line of local node state in engine only if there is a config change

--- a/.changeset/popular-items-admire.md
+++ b/.changeset/popular-items-admire.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal add metric for workflow execution start

--- a/.changeset/quick-kiwis-tease.md
+++ b/.changeset/quick-kiwis-tease.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#internal LLO Observation loop

--- a/.changeset/ready-tigers-lose.md
+++ b/.changeset/ready-tigers-lose.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated bump common

--- a/.changeset/ripe-foxes-fix.md
+++ b/.changeset/ripe-foxes-fix.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix Fixing atomic core swapper after logger init

--- a/.changeset/shy-clowns-film.md
+++ b/.changeset/shy-clowns-film.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#updated operator ui version

--- a/.changeset/slick-badgers-behave.md
+++ b/.changeset/slick-badgers-behave.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#added Wire up OTel logs streaming, integrate chainlink logger with otel

--- a/.changeset/slick-pianos-warn.md
+++ b/.changeset/slick-pianos-warn.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix fix block number nil issue in fake evm

--- a/.changeset/slimy-guests-hide.md
+++ b/.changeset/slimy-guests-hide.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal remove the use of panic

--- a/.changeset/soft-ghosts-act.md
+++ b/.changeset/soft-ghosts-act.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated chain selectors

--- a/.changeset/soft-tips-go.md
+++ b/.changeset/soft-tips-go.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#fixed #bug update DKGRecipient keystore error to work correctly in shell_cmd.go for imports.

--- a/.changeset/thirty-ducks-greet.md
+++ b/.changeset/thirty-ducks-greet.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix bump chainlink-aptos to include Gas Limit Overhead handling (https://github.com/smartcontractkit/chainlink-aptos/pull/315)

--- a/.changeset/tricky-actors-run.md
+++ b/.changeset/tricky-actors-run.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated Wire up CHIP ingress client in telemetry manager

--- a/.changeset/twelve-socks-drop.md
+++ b/.changeset/twelve-socks-drop.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#added Sui keystore and relayer plugin basic integration

--- a/.changeset/wild-wombats-ring.md
+++ b/.changeset/wild-wombats-ring.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#added Mix and Max pipeline tasks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog Chainlink Core
 
+<<<<<<< HEAD
 ## 2.30.1 - 2025-11-18
 
 ### Patch Changes
@@ -59,6 +60,9 @@
 - [#19667](https://github.com/smartcontractkit/chainlink/pull/19667) [`535a014`](https://github.com/smartcontractkit/chainlink/commit/535a014bef3a6a007ecf7fe8c2d9f21907e4d127) - #added Add Workflow Registry Chain Selector to CRE v2 registry events.
 
 ## 2.30.0 - 2025-11-17
+=======
+## 2.30.0 (UNRELEASED)
+>>>>>>> ec74338ec7 (Bump version and update CHANGELOG for Core v2.30.0)
 
 ### Minor Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog Chainlink Core
 
-<<<<<<< HEAD
 ## 2.30.1 - 2025-11-18
 
 ### Patch Changes
@@ -60,9 +59,6 @@
 - [#19667](https://github.com/smartcontractkit/chainlink/pull/19667) [`535a014`](https://github.com/smartcontractkit/chainlink/commit/535a014bef3a6a007ecf7fe8c2d9f21907e4d127) - #added Add Workflow Registry Chain Selector to CRE v2 registry events.
 
 ## 2.30.0 - 2025-11-17
-=======
-## 2.30.0 (UNRELEASED)
->>>>>>> ec74338ec7 (Bump version and update CHANGELOG for Core v2.30.0)
 
 ### Minor Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog Chainlink Core
 
+## 2.30.1 - 2025-11-18
+
+### Patch Changes
+
+- Metadata-only hotfix release to restore GitHub Release publishing capability after v2.30.0 Release object became immutable.
+
 ## 2.31.0
 
 ### Minor Changes

--- a/check_svr_inclusion.sh
+++ b/check_svr_inclusion.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Script to check if Chainlink Core version 2.29.0 includes all commits from 2.28.0-svr-2
+# Exits 0 if included, 1 if not included
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo "🔍 Checking if 2.29.0 includes 2.28.0-svr-2..."
+
+# Step 1: Fetch all tags from origin
+echo "📡 Fetching tags from origin..."
+git fetch --tags origin >/dev/null 2>&1 || true
+
+# Step 2: Get commit SHAs for the tags
+TAG_2290="v2.29.0"
+TAG_SVR="v2.28.0-svr-2"
+
+# Check if tags exist
+if ! git rev-parse --verify "$TAG_2290" >/dev/null 2>&1; then
+    echo -e "${RED}❌ Tag $TAG_2290 not found${NC}"
+    exit 1
+fi
+
+if ! git rev-parse --verify "$TAG_SVR" >/dev/null 2>&1; then
+    echo -e "${RED}❌ Tag $TAG_SVR not found${NC}"
+    exit 1
+fi
+
+# Get the commit SHAs
+COMMIT_2290=$(git rev-parse "$TAG_2290")
+COMMIT_SVR=$(git rev-parse "$TAG_SVR")
+
+echo "📍 $TAG_2290: $COMMIT_2290"
+echo "📍 $TAG_SVR: $COMMIT_SVR"
+
+# Step 3: Use git merge-base --is-ancestor to check if svr commit is an ancestor of 2.29.0
+if git merge-base --is-ancestor "$COMMIT_SVR" "$COMMIT_2290"; then
+    echo -e "${GREEN}✅ All svr fixes are included in 2.29.0${NC}"
+    exit 0
+else
+    echo -e "${RED}❌ svr fixes not included. Commits missing:${NC}"
+    echo ""
+    echo -e "${BLUE}📋 Recent commits in 2.29.0 since 2.28.0-svr-2:${NC}"
+    git log "$TAG_SVR".."$TAG_2290" --oneline --no-merges | head -n 10
+    exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.31.0",
+  "version": "2.30.1",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Rebased v2.30.1 hotfix onto develop; protected-branch restrictions prevented updating the original branch. This branch contains the correct metadata-only hotfix lineage.