### PR TITLE
Fix: correct v2.30.1 CHANGELOG date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Metadata-only hotfix release to restore GitHub Release publishing capability after v2.30.0 Release object became immutable.
 
-## 2.30.0 (UNRELEASED)
+## 2.30.0 - 2025-11-17
 
 ### Minor Changes
 


### PR DESCRIPTION
Tiny patch to correct the v2.30.1 release date. No code changes.