### PR TITLE
Bump version and update CHANGELOG for Core v2.30.0

### DIFF
--- a/.changeset/beige-icons-jam.md
+++ b/.changeset/beige-icons-jam.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#internal system-tests improvement

--- a/.changeset/beige-peaches-taste.md
+++ b/.changeset/beige-peaches-taste.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-Improved Solana LogPoller retry mechanism. #internal

--- a/.changeset/big-kids-retire.md
+++ b/.changeset/big-kids-retire.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated chain-selectors to v1.0.75

--- a/.changeset/big-plums-study.md
+++ b/.changeset/big-plums-study.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal changed vault request digest to use jsonrpc2 Digest method

--- a/.changeset/bitter-coats-swim.md
+++ b/.changeset/bitter-coats-swim.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix check http method

--- a/.changeset/cool-trees-laugh.md
+++ b/.changeset/cool-trees-laugh.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#added confidential-http to proposable job specs in chainlink/deployment

--- a/.changeset/dark-taxes-sing.md
+++ b/.changeset/dark-taxes-sing.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated Add ChIP ingress adapter for OTI telemetry

--- a/.changeset/dirty-spies-mate.md
+++ b/.changeset/dirty-spies-mate.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#added Add beholder logs streaming config params to control batching

--- a/.changeset/dry-buckets-lie.md
+++ b/.changeset/dry-buckets-lie.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix block number in fake evm cap

--- a/.changeset/dull-cycles-yell.md
+++ b/.changeset/dull-cycles-yell.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal exposes proposed jobs as nop view

--- a/.changeset/early-spiders-confess.md
+++ b/.changeset/early-spiders-confess.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal Use new getActiveAllowlistedRequestsReverse WR method

--- a/.changeset/eight-keys-cry.md
+++ b/.changeset/eight-keys-cry.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal adds human readable name to gateway spec

--- a/.changeset/fifty-clowns-taste.md
+++ b/.changeset/fifty-clowns-taste.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated chainlink-tron relayer

--- a/.changeset/fresh-cameras-hear.md
+++ b/.changeset/fresh-cameras-hear.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix #internal fixes log to use Warnw to properly display count

--- a/.changeset/full-socks-decide.md
+++ b/.changeset/full-socks-decide.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated chainlink-tron

--- a/.changeset/late-buttons-study.md
+++ b/.changeset/late-buttons-study.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated: add Telemetry LogLevel config option

--- a/.changeset/long-snakes-lie.md
+++ b/.changeset/long-snakes-lie.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal #bug_fix updates local node state on fetch of capability registry

--- a/.changeset/lucky-roses-lead.md
+++ b/.changeset/lucky-roses-lead.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Patch to bump version to fix release metadata

--- a/.changeset/mighty-trains-ask.md
+++ b/.changeset/mighty-trains-ask.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#added Bump chainlink-common to include beholder grpc metrics

--- a/.changeset/modern-buses-cheat.md
+++ b/.changeset/modern-buses-cheat.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal bump chainlink-sui repo version and update e2e tests

--- a/.changeset/open-papers-change.md
+++ b/.changeset/open-papers-change.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix logs a debug line of local node state in engine only if there is a config change

--- a/.changeset/popular-items-admire.md
+++ b/.changeset/popular-items-admire.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal add metric for workflow execution start

--- a/.changeset/quick-kiwis-tease.md
+++ b/.changeset/quick-kiwis-tease.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#internal LLO Observation loop

--- a/.changeset/ready-tigers-lose.md
+++ b/.changeset/ready-tigers-lose.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated bump common

--- a/.changeset/ripe-foxes-fix.md
+++ b/.changeset/ripe-foxes-fix.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix Fixing atomic core swapper after logger init

--- a/.changeset/shy-clowns-film.md
+++ b/.changeset/shy-clowns-film.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#updated operator ui version

--- a/.changeset/slick-badgers-behave.md
+++ b/.changeset/slick-badgers-behave.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#added Wire up OTel logs streaming, integrate chainlink logger with otel

--- a/.changeset/slick-pianos-warn.md
+++ b/.changeset/slick-pianos-warn.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix fix block number nil issue in fake evm

--- a/.changeset/slimy-guests-hide.md
+++ b/.changeset/slimy-guests-hide.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal remove the use of panic

--- a/.changeset/soft-ghosts-act.md
+++ b/.changeset/soft-ghosts-act.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated chain selectors

--- a/.changeset/soft-tips-go.md
+++ b/.changeset/soft-tips-go.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#fixed #bug update DKGRecipient keystore error to work correctly in shell_cmd.go for imports.

--- a/.changeset/thirty-ducks-greet.md
+++ b/.changeset/thirty-ducks-greet.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix bump chainlink-aptos to include Gas Limit Overhead handling (https://github.com/smartcontractkit/chainlink-aptos/pull/315)

--- a/.changeset/tricky-actors-run.md
+++ b/.changeset/tricky-actors-run.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#updated Wire up CHIP ingress client in telemetry manager

--- a/.changeset/twelve-socks-drop.md
+++ b/.changeset/twelve-socks-drop.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#added Sui keystore and relayer plugin basic integration

--- a/.changeset/wild-wombats-ring.md
+++ b/.changeset/wild-wombats-ring.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#added Mix and Max pipeline tasks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog Chainlink Core
 
+## 2.30.1 - 2025-11-18
+
+### Patch Changes
+
+- Metadata-only hotfix release to restore GitHub Release publishing capability after v2.30.0 Release object became immutable.
+
 ## 2.30.0 (UNRELEASED)
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 
 - [#19667](https://github.com/smartcontractkit/chainlink/pull/19667) [`535a014`](https://github.com/smartcontractkit/chainlink/commit/535a014bef3a6a007ecf7fe8c2d9f21907e4d127) - #added Add Workflow Registry Chain Selector to CRE v2 registry events.
 
-## 2.30.0
+## 2.30.0 (UNRELEASED)
 
 ### Minor Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Metadata-only hotfix release to restore GitHub Release publishing capability after v2.30.0 Release object became immutable.
 
-## 2.30.0 (UNRELEASED)
+## 2.30.0 - 2025-11-17
 
 ### Minor Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,57 +1,5 @@
 # Changelog Chainlink Core
 
-## 2.31.0
-
-### Minor Changes
-
-- [#19459](https://github.com/smartcontractkit/chainlink/pull/19459) [`f1ac655`](https://github.com/smartcontractkit/chainlink/commit/f1ac65512fc1896342440d929f06fb3237480bcb) - #added capability API controller
-
-- [#19628](https://github.com/smartcontractkit/chainlink/pull/19628) [`991564c`](https://github.com/smartcontractkit/chainlink/commit/991564cf26f6b399b28c7f0792ceb12bd3f29ee2) - #internal: Move CREv2 system-tests to one suite
-
-- [#19654](https://github.com/smartcontractkit/chainlink/pull/19654) [`bfc346d`](https://github.com/smartcontractkit/chainlink/commit/bfc346dec9512657dacd9b8977c99fc6a3c009f8) - #internal Add evm.getTransactionReceipts negative system tests
-
-- [#19723](https://github.com/smartcontractkit/chainlink/pull/19723) [`02b4069`](https://github.com/smartcontractkit/chainlink/commit/02b40693e4e8035fc474572bb4d80b0cd41bf6e1) - #internal Optimize beholder validator in system tests (part 2)
-
-- [#19553](https://github.com/smartcontractkit/chainlink/pull/19553) [`8091735`](https://github.com/smartcontractkit/chainlink/commit/80917356c02496456ef612554073afacdda5e947) - #internal Add flaky test detector and auto-quarantine to regression smoke-tests.
-
-- [#19713](https://github.com/smartcontractkit/chainlink/pull/19713) [`790ce70`](https://github.com/smartcontractkit/chainlink/commit/790ce7026c471f6793f8385d6847eb6eaebecbad) - #internal Add consensus negative system tests
-
-- [#19661](https://github.com/smartcontractkit/chainlink/pull/19661) [`0f908f9`](https://github.com/smartcontractkit/chainlink/commit/0f908f968222f93ebbbe2956ec6a1bad4df8771b) - #internal Bump cre-sdk-go in CREv2 workflows and system tests
-
-- [#19531](https://github.com/smartcontractkit/chainlink/pull/19531) [`550e7ce`](https://github.com/smartcontractkit/chainlink/commit/550e7ce59abb07c4244eb19a0e83c5a3a59636b7) - #internal Make CREv2 system tests to run with v2 contracts/registries
-
-- [#19723](https://github.com/smartcontractkit/chainlink/pull/19723) [`02b4069`](https://github.com/smartcontractkit/chainlink/commit/02b40693e4e8035fc474572bb4d80b0cd41bf6e1) - #internal Update PoR workflow to use chainlink BalanceReader bindings
-
-- [#19760](https://github.com/smartcontractkit/chainlink/pull/19760) [`e478a40`](https://github.com/smartcontractkit/chainlink/commit/e478a40e72570493235d14cc429b0b56cba59fa2) - Bump dependency of chainlink-evm #internal
-
-- [#19640](https://github.com/smartcontractkit/chainlink/pull/19640) [`0a7b72f`](https://github.com/smartcontractkit/chainlink/commit/0a7b72f6e85b641fbb7cb46accec5cdf0d2e41f6) - #internal Add topology to smoke tests names
-
-- [#19685](https://github.com/smartcontractkit/chainlink/pull/19685) [`ece61e7`](https://github.com/smartcontractkit/chainlink/commit/ece61e7dbbe4be9ff66b5cba465717ae76118eac) - #internal Add evm.WriteReport negative tests
-
-- [#19578](https://github.com/smartcontractkit/chainlink/pull/19578) [`4dc8682`](https://github.com/smartcontractkit/chainlink/commit/4dc8682150595d111a5e8b7c5c2b33b45a4642f7) - #internal Parallelize CRE regression system-tests
-
-- [#19657](https://github.com/smartcontractkit/chainlink/pull/19657) [`b9a1d97`](https://github.com/smartcontractkit/chainlink/commit/b9a1d973479dd9a4ba13daf014d0e7054c77abc4) - #internal Add negative system tests for evm.HeaderByNumber
-
-- [#19651](https://github.com/smartcontractkit/chainlink/pull/19651) [`93671be`](https://github.com/smartcontractkit/chainlink/commit/93671be2fd2778f12c8cd0c6960b1e9b9d7069f1) - #added coalesce pipeline task
-
-- [#19708](https://github.com/smartcontractkit/chainlink/pull/19708) [`fee5e30`](https://github.com/smartcontractkit/chainlink/commit/fee5e30eb00dfc1365beb734dd197975dfdb9064) - #internal Enable don2don topology for system tests
-
-### Patch Changes
-
-- [#19404](https://github.com/smartcontractkit/chainlink/pull/19404) [`84d34a5`](https://github.com/smartcontractkit/chainlink/commit/84d34a5f80f04fe029accbc3aa1317825f3bd91c) - #changed Support dynamic config updates in TriggerSubscriber
-
-- [#19320](https://github.com/smartcontractkit/chainlink/pull/19320) [`6f9d964`](https://github.com/smartcontractkit/chainlink/commit/6f9d964775c9cfbbcc060393fd611f6590073229) - #updated llo plugin data source and telemetry performance improvements
-
-- [#19548](https://github.com/smartcontractkit/chainlink/pull/19548) [`496d2d6`](https://github.com/smartcontractkit/chainlink/commit/496d2d6f28015f8b30e75ae91bf31a32f1353dd1) - #added versionTag build-time attribute with output of "git describe --always"
-
-- [#19610](https://github.com/smartcontractkit/chainlink/pull/19610) [`7c432e1`](https://github.com/smartcontractkit/chainlink/commit/7c432e13a5c46fd7d0788fa385c235d0f4f1fd2b) - #updated chain selectors
-
-- [#19475](https://github.com/smartcontractkit/chainlink/pull/19475) [`233bd59`](https://github.com/smartcontractkit/chainlink/commit/233bd5986b5c3caf08c9d09f4f795f9f15314cef) - #internal Quarantines flaky tests
-
-- [#19710](https://github.com/smartcontractkit/chainlink/pull/19710) [`5625fd0`](https://github.com/smartcontractkit/chainlink/commit/5625fd08dfcd03072efed15c50cd14518022483f) - #updated CCIP changesets to deploy v1.5.1 TokenPoolFactory instead of latest version
-
-- [#19667](https://github.com/smartcontractkit/chainlink/pull/19667) [`535a014`](https://github.com/smartcontractkit/chainlink/commit/535a014bef3a6a007ecf7fe8c2d9f21907e4d127) - #added Add Workflow Registry Chain Selector to CRE v2 registry events.
-
 ## 2.30.0 (UNRELEASED)
 
 ### Minor Changes

--- a/check_svr_inclusion.sh
+++ b/check_svr_inclusion.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Script to check if Chainlink Core version 2.29.0 includes all commits from 2.28.0-svr-2
+# Exits 0 if included, 1 if not included
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo "🔍 Checking if 2.29.0 includes 2.28.0-svr-2..."
+
+# Step 1: Fetch all tags from origin
+echo "📡 Fetching tags from origin..."
+git fetch --tags origin >/dev/null 2>&1 || true
+
+# Step 2: Get commit SHAs for the tags
+TAG_2290="v2.29.0"
+TAG_SVR="v2.28.0-svr-2"
+
+# Check if tags exist
+if ! git rev-parse --verify "$TAG_2290" >/dev/null 2>&1; then
+    echo -e "${RED}❌ Tag $TAG_2290 not found${NC}"
+    exit 1
+fi
+
+if ! git rev-parse --verify "$TAG_SVR" >/dev/null 2>&1; then
+    echo -e "${RED}❌ Tag $TAG_SVR not found${NC}"
+    exit 1
+fi
+
+# Get the commit SHAs
+COMMIT_2290=$(git rev-parse "$TAG_2290")
+COMMIT_SVR=$(git rev-parse "$TAG_SVR")
+
+echo "📍 $TAG_2290: $COMMIT_2290"
+echo "📍 $TAG_SVR: $COMMIT_SVR"
+
+# Step 3: Use git merge-base --is-ancestor to check if svr commit is an ancestor of 2.29.0
+if git merge-base --is-ancestor "$COMMIT_SVR" "$COMMIT_2290"; then
+    echo -e "${GREEN}✅ All svr fixes are included in 2.29.0${NC}"
+    exit 0
+else
+    echo -e "${RED}❌ svr fixes not included. Commits missing:${NC}"
+    echo ""
+    echo -e "${BLUE}📋 Recent commits in 2.29.0 since 2.28.0-svr-2:${NC}"
+    git log "$TAG_SVR".."$TAG_2290" --oneline --no-merges | head -n 10
+    exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -10,7 +10,7 @@ defaults:
 plugins:
   cron:
     - moduleURI: "github.com/smartcontractkit/capabilities/cron"
-      gitRef: "5f5cab3fe9fb8ab8c969d0c0fe77de70454ad86b"
+      gitRef: "7e6bdc6b1002f0151afd36b8c6ac8baf792901ab"
       installPath: "github.com/smartcontractkit/capabilities/cron"
       flags: "-tags timetzdata"
   kvstore:

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -41,7 +41,7 @@ plugins:
       installPath: "github.com/smartcontractkit/capabilities/http_trigger"
   evm:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
-      gitRef: "5f5cab3fe9fb8ab8c969d0c0fe77de70454ad86b"
+      gitRef: "1d2b9ed9b39ee04326fca636a0e9bce5af24b8d1"
       installPath: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
   mock:
     - moduleURI: "github.com/smartcontractkit/capabilities/mock"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -41,7 +41,7 @@ plugins:
       installPath: "github.com/smartcontractkit/capabilities/http_trigger"
   evm:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
-      gitRef: "1d2b9ed9b39ee04326fca636a0e9bce5af24b8d1"
+      gitRef: "5cb1d448c68379adaa9602b16f097756994ebce1"
       installPath: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
   mock:
     - moduleURI: "github.com/smartcontractkit/capabilities/mock"


### PR DESCRIPTION
(https://smartcontract-it.atlassian.net/browse/CRE-1381)[CRE-1381 ]

Port commits on  release/2.30.0-cre  to release/2.30.1-cre to handle broken core release of 2.30.0

 
