### PR TITLE
Change Release version to 2.30.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.30.1-cre",
+  "version": "2.30.1",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The version 2.30.1-cre is treated as older than 2.30.1, thus staging nodes refuse to upgrade.
Reverting the version to unblock staging nodes.
