### PR TITLE
bump common & bump capabilities

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20251105200616-e158f436aa95
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957
 	github.com/smartcontractkit/chainlink-data-streams v0.1.6
 	github.com/smartcontractkit/chainlink-deployments-framework v0.68.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1622,8 +1622,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f h1:hEBIcL7s6gvCGiQWVOxaGkKiyS07zZnINVYNRn/VHuk=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f/go.mod h1:Xm4ZHLt7S2IXEYJkuJXGMgbAQUpXjHpXM7ZYuaVSIm8=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f h1:8yOwe2R/JhZz3en46ddZjzVjrDmAh2qwBXxCfZzw5QQ=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957 h1:IYdL23y6mOzTJurBaJvcNiq8uZ8BncsCAHV/fU11jG0=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957/go.mod h1:H99SdsDBkWi5FLm06DDyz6Up/EcbM+wqBwnuDwNqas8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20251105200616-e158f436aa95
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957
 	github.com/smartcontractkit/chainlink-deployments-framework v0.68.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1350,8 +1350,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f h1:hEBIcL7s6gvCGiQWVOxaGkKiyS07zZnINVYNRn/VHuk=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f/go.mod h1:Xm4ZHLt7S2IXEYJkuJXGMgbAQUpXjHpXM7ZYuaVSIm8=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f h1:8yOwe2R/JhZz3en46ddZjzVjrDmAh2qwBXxCfZzw5QQ=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957 h1:IYdL23y6mOzTJurBaJvcNiq8uZ8BncsCAHV/fU11jG0=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957/go.mod h1:H99SdsDBkWi5FLm06DDyz6Up/EcbM+wqBwnuDwNqas8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10
 	github.com/smartcontractkit/chainlink-data-streams v0.1.6
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f

--- a/go.sum
+++ b/go.sum
@@ -1120,8 +1120,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f h1:hEBIcL7s6gvCGiQWVOxaGkKiyS07zZnINVYNRn/VHuk=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f/go.mod h1:Xm4ZHLt7S2IXEYJkuJXGMgbAQUpXjHpXM7ZYuaVSIm8=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f h1:8yOwe2R/JhZz3en46ddZjzVjrDmAh2qwBXxCfZzw5QQ=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957 h1:IYdL23y6mOzTJurBaJvcNiq8uZ8BncsCAHV/fU11jG0=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957/go.mod h1:H99SdsDBkWi5FLm06DDyz6Up/EcbM+wqBwnuDwNqas8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20251105200616-e158f436aa95
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957
 	github.com/smartcontractkit/chainlink-deployments-framework v0.68.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1594,8 +1594,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f h1:hEBIcL7s6gvCGiQWVOxaGkKiyS07zZnINVYNRn/VHuk=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f/go.mod h1:Xm4ZHLt7S2IXEYJkuJXGMgbAQUpXjHpXM7ZYuaVSIm8=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f h1:8yOwe2R/JhZz3en46ddZjzVjrDmAh2qwBXxCfZzw5QQ=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957 h1:IYdL23y6mOzTJurBaJvcNiq8uZ8BncsCAHV/fU11jG0=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957/go.mod h1:H99SdsDBkWi5FLm06DDyz6Up/EcbM+wqBwnuDwNqas8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20251105200616-e158f436aa95
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957
 	github.com/smartcontractkit/chainlink-deployments-framework v0.68.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1573,8 +1573,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f h1:hEBIcL7s6gvCGiQWVOxaGkKiyS07zZnINVYNRn/VHuk=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f/go.mod h1:Xm4ZHLt7S2IXEYJkuJXGMgbAQUpXjHpXM7ZYuaVSIm8=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f h1:8yOwe2R/JhZz3en46ddZjzVjrDmAh2qwBXxCfZzw5QQ=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957 h1:IYdL23y6mOzTJurBaJvcNiq8uZ8BncsCAHV/fU11jG0=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957/go.mod h1:H99SdsDBkWi5FLm06DDyz6Up/EcbM+wqBwnuDwNqas8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -10,42 +10,42 @@ defaults:
 plugins:
   cron:
     - moduleURI: "github.com/smartcontractkit/capabilities/cron"
-      gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
+      gitRef: "b93d95f97f4c80d5cf778b92cccd90599f3fbbc4"
       installPath: "github.com/smartcontractkit/capabilities/cron"
       flags: "-tags timetzdata"
   kvstore:
     - enabled: false
       moduleURI: "github.com/smartcontractkit/capabilities/kvstore"
-      gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
+      gitRef: "b93d95f97f4c80d5cf778b92cccd90599f3fbbc4"
       installPath: "github.com/smartcontractkit/capabilities/kvstore"
   readcontract:
     - moduleURI: "github.com/smartcontractkit/capabilities/readcontract"
-      gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
+      gitRef: "b93d95f97f4c80d5cf778b92cccd90599f3fbbc4"
       installPath: "github.com/smartcontractkit/capabilities/readcontract"
   consensus:
     - moduleURI: "github.com/smartcontractkit/capabilities/consensus"
-      gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
+      gitRef: "b93d95f97f4c80d5cf778b92cccd90599f3fbbc4"
       installPath: "github.com/smartcontractkit/capabilities/consensus"
   workflowevent:
     - enabled: false
       moduleURI: "github.com/smartcontractkit/capabilities/workflowevent"
-      gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
+      gitRef: "b93d95f97f4c80d5cf778b92cccd90599f3fbbc4"
       installPath: "github.com/smartcontractkit/capabilities/workflowevent"
   httpaction:
     - moduleURI: "github.com/smartcontractkit/capabilities/http_action"
-      gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
+      gitRef: "b93d95f97f4c80d5cf778b92cccd90599f3fbbc4"
       installPath: "github.com/smartcontractkit/capabilities/http_action"
   httptrigger:
     - moduleURI: "github.com/smartcontractkit/capabilities/http_trigger"
-      gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
+      gitRef: "b93d95f97f4c80d5cf778b92cccd90599f3fbbc4"
       installPath: "github.com/smartcontractkit/capabilities/http_trigger"
   evm:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
-      gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
+      gitRef: "b93d95f97f4c80d5cf778b92cccd90599f3fbbc4"
       installPath: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
   mock:
     - moduleURI: "github.com/smartcontractkit/capabilities/mock"
-      gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
+      gitRef: "b93d95f97f4c80d5cf778b92cccd90599f3fbbc4"
       installPath: "github.com/smartcontractkit/capabilities/mock"
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/sethvargo/go-retry v0.3.0
 	github.com/smartcontractkit/chain-selectors v1.0.84
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957
 	github.com/smartcontractkit/chainlink-deployments-framework v0.68.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251029010119-b2ed6162042f
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1586,8 +1586,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f h1:hEBIcL7s6gvCGiQWVOxaGkKiyS07zZnINVYNRn/VHuk=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f/go.mod h1:Xm4ZHLt7S2IXEYJkuJXGMgbAQUpXjHpXM7ZYuaVSIm8=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f h1:8yOwe2R/JhZz3en46ddZjzVjrDmAh2qwBXxCfZzw5QQ=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957 h1:IYdL23y6mOzTJurBaJvcNiq8uZ8BncsCAHV/fU11jG0=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957/go.mod h1:H99SdsDBkWi5FLm06DDyz6Up/EcbM+wqBwnuDwNqas8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.84
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957
 	github.com/smartcontractkit/chainlink-data-streams v0.1.6
 	github.com/smartcontractkit/chainlink-deployments-framework v0.68.0
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1787,8 +1787,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f h1:hEBIcL7s6gvCGiQWVOxaGkKiyS07zZnINVYNRn/VHuk=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251119220244-0914730bcd0f/go.mod h1:Xm4ZHLt7S2IXEYJkuJXGMgbAQUpXjHpXM7ZYuaVSIm8=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f h1:8yOwe2R/JhZz3en46ddZjzVjrDmAh2qwBXxCfZzw5QQ=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20251118164938-731e805e0a2f/go.mod h1:AgiJcndCiWnUOVmCBX/K3PdST/fvrY1uCqSF65j960w=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957 h1:IYdL23y6mOzTJurBaJvcNiq8uZ8BncsCAHV/fU11jG0=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20251124121530-666e7c593957/go.mod h1:H99SdsDBkWi5FLm06DDyz6Up/EcbM+wqBwnuDwNqas8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=


### PR DESCRIPTION
This PR makes sure all modules are consistently using version 0.45.0 of the golang.org/x/crypto package.