### PR TITLE
fix(ci): disk space issues w/ aptos in-memory tests

### DIFF
--- a/.github/integration-in-memory-tests.yml
+++ b/.github/integration-in-memory-tests.yml
@@ -481,7 +481,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_messaging_test.go:Test_CCIP_Messaging_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_messaging_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -493,7 +493,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_messaging_test.go:Test_CCIP_Messaging_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_messaging_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -505,7 +505,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -517,7 +517,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -529,7 +529,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_BnM_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -541,7 +541,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_BnM_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -553,7 +553,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -565,7 +565,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -577,12 +577,11 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_without_TransferRef_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
     test_cmd: |
-      ./scripts/free-disk-space.sh
       echo "🚀 Starting CCIP Aptos LnR without TransferRef EVM2Aptos test..."
       go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_LnR_without_TransferRef_EVM2Aptos" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
@@ -592,7 +591,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_without_TransferRef_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -604,7 +603,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_msghasher_test.go:*
     path: integration-tests/smoke/ccip/ccip_aptos_msghasher_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -616,7 +615,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_regulated_token_transfer_test.go:Test_CCIP_RegulatedTokenTransfer_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_regulated_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -628,7 +627,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_regulated_token_transfer_test.go:Test_CCIP_RegulatedTokenTransfer_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_regulated_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -640,7 +639,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_BnM_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -652,7 +651,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_BnM_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -664,7 +663,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -676,7 +675,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -688,7 +687,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_without_TransferRef_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -700,7 +699,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_without_TransferRef_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -713,12 +712,11 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_ton_messaging_test.go:Test_CCIPMessaging_TON2EVM
     path: integration-tests/smoke/ccip/ccip_ton_messaging_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
     test_cmd: |
-      ./scripts/free-disk-space.sh
       echo "🚀 Starting CCIP TON2EVM test..."
       go test ./smoke/ccip -run "Test_CCIPMessaging_TON2EVM" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
@@ -727,12 +725,11 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_ton_messaging_test.go:Test_CCIPMessaging_EVM2TON
     path: integration-tests/smoke/ccip/ccip_ton_messaging_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
     test_cmd: |
-      ./scripts/free-disk-space.sh
       echo "🚀 Starting CCIP EVM2TON test..."
       go test ./smoke/ccip -run "Test_CCIPMessaging_EVM2TON" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
@@ -742,12 +739,11 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_sui_messaging_test.go:Test_CCIP_Messaging_Sui2EVM
     path: integration-tests/smoke/ccip/ccip_sui_messaging_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
     test_cmd: |
-      ./scripts/free-disk-space.sh
       echo "🚀 Starting CCIP Sui2EVM test..."
       go test ./smoke/ccip -run "Test_CCIP_Messaging_Sui2EVM" -timeout 10m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
@@ -757,12 +753,11 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_sui_messaging_test.go:Test_CCIP_Messaging_EVM2Sui
     path: integration-tests/smoke/ccip/ccip_sui_messaging_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
     test_cmd: |
-      ./scripts/free-disk-space.sh
       echo "🚀 Starting CCIP EVM2Sui test..."
       go test ./smoke/ccip -run "Test_CCIP_Messaging_EVM2Sui" -timeout 10m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
@@ -772,7 +767,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_sui_messaging_test.go:Test_CCIP_EVM2Sui_ZeroReceiver
     path: integration-tests/smoke/ccip/ccip_sui_messaging_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -784,12 +779,11 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_sui_token_transfer_test.go:Test_CCIPTokenTransfer_Sui2EVM_BurnMintTokenPool
     path: integration-tests/smoke/ccip/ccip_sui_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
     test_cmd: |
-      ./scripts/free-disk-space.sh
       echo "🚀 Starting CCIP Sui2EVM BurnMint token transfer test..."
       go test ./smoke/ccip -run "Test_CCIPTokenTransfer_Sui2EVM_BurnMintTokenPool" -timeout 10m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
@@ -799,12 +793,11 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_sui_token_transfer_test.go:Test_CCIPTokenTransfer_Sui2EVM_ManagedTokenPool
     path: integration-tests/smoke/ccip/ccip_sui_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
     test_cmd: |
-      ./scripts/free-disk-space.sh
       echo "🚀 Starting CCIP Sui2EVM ManagedTokenPool test..."
       go test ./smoke/ccip -run "Test_CCIPTokenTransfer_Sui2EVM_ManagedTokenPool" -timeout 15m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
@@ -814,12 +807,11 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_sui_token_transfer_test.go:Test_CCIPTokenTransfer_EVM2SUI_ManagedTokenPool
     path: integration-tests/smoke/ccip/ccip_sui_token_transfer_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
     test_cmd: |
-      ./scripts/free-disk-space.sh
       echo "🚀 Starting CCIP EVM2Sui ManagedTokenPool test..."
       go test ./smoke/ccip -run "Test_CCIPTokenTransfer_EVM2SUI_ManagedTokenPool" -timeout 10m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
@@ -829,7 +821,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_sui_upgrade_test.go:Test_CCIP_Upgrade_Sui2EVM
     path: integration-tests/smoke/ccip/ccip_sui_upgrade_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -841,7 +833,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_sui_upgrade_test.go:Test_CCIP_Upgrade_EVM2Sui
     path: integration-tests/smoke/ccip/ccip_sui_upgrade_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
@@ -849,16 +841,15 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     sui_cli_version: mainnet-1.60.1
     install_plugins_public: true
- 
+
   - id: smoke/ccip/ccip_sui_upgrade_test.go:Test_CCIP_Upgrade_CommonPkg_EVM2Sui
     path: integration-tests/smoke/ccip/ccip_sui_upgrade_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
     test_cmd: |
-      ./scripts/free-disk-space.sh
       echo "🚀 Starting CCIP Upgrade CommonPkg EVM2Sui test..."
       go test ./smoke/ccip -run "Test_CCIP_Upgrade_CommonPkg_EVM2Sui" -timeout 15m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
@@ -868,12 +859,11 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_sui_upgrade_test.go:Test_CCIP_Upgrade_NoBlock_EVM2Sui
     path: integration-tests/smoke/ccip/ccip_sui_upgrade_test.go
     test_env_type: in-memory
-    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
       - Nightly Integration CCIP Tests
     test_cmd: |
-      ./scripts/free-disk-space.sh
       echo "🚀 Starting CCIP Upgrade NoBlock EVM2Sui test..."
       go test ./smoke/ccip -run "Test_CCIP_Upgrade_NoBlock_EVM2Sui" -timeout 15m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
@@ -883,12 +873,11 @@ runner-test-matrix:
   # - id: smoke/ccip/ccip_sui_token_transfer_test.go:Test_CCIPPureTokenTransfer_EVM2SUI_BurnMintTokenPool
   #   path: integration-tests/smoke/ccip/ccip_sui_token_transfer_test.go
   #   test_env_type: in-memory
-  #   runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+  #   runs_on: ubuntu-latest
   #   triggers:
   #     - PR Integration CCIP Tests
   #     - Nightly Integration CCIP Tests
   #   test_cmd: |
-  #     ./scripts/free-disk-space.sh
   #     echo "🚀 Starting CCIP EVM2Sui Pure Token Transfer test..."
   #     go test ./smoke/ccip -run "Test_CCIPPureTokenTransfer_EVM2SUI_BurnMintTokenPool" -timeout 15m -test.parallel=1 -count=1 -json
   #   test_go_project_path: integration-tests
@@ -898,12 +887,11 @@ runner-test-matrix:
   # - id: smoke/ccip/ccip_sui_token_transfer_test.go:Test_CCIPProgrammableTokenTransfer_EVM2SUI_BurnMintTokenPool
   #   path: integration-tests/smoke/ccip/ccip_sui_token_transfer_test.go
   #   test_env_type: in-memory
-  #   runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+  #   runs_on: ubuntu-latest
   #   triggers:
   #     - PR Integration CCIP Tests
   #     - Nightly Integration CCIP Tests
   #   test_cmd: |
-  #     ./scripts/free-disk-space.sh
   #     echo "🚀 Starting CCIP EVM2Sui Programmable Token Transfer test..."
   #     go test ./smoke/ccip -run "Test_CCIPProgrammableTokenTransfer_EVM2SUI_BurnMintTokenPool" -timeout 20m -test.parallel=1 -count=1 -json
   #   test_go_project_path: integration-tests
@@ -913,12 +901,11 @@ runner-test-matrix:
   # - id: smoke/ccip/ccip_sui_token_transfer_test.go:Test_CCIPZeroGasLimitTokenTransfer_EVM2SUI_BurnMintTokenPool
   #   path: integration-tests/smoke/ccip/ccip_sui_token_transfer_test.go
   #   test_env_type: in-memory
-  #   runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+  #   runs_on: ubuntu-latest
   #   triggers:
   #     - PR Integration CCIP Tests
   #     - Nightly Integration CCIP Tests
   #   test_cmd: |
-  #     ./scripts/free-disk-space.sh
   #     echo "🚀 Starting CCIP EVM2Sui Zero Gas Limit Token Transfer test..."
   #     go test ./smoke/ccip -run "Test_CCIPZeroGasLimitTokenTransfer_EVM2SUI_BurnMintTokenPool" -timeout 10m -test.parallel=1 -count=1 -json
   #   test_go_project_path: integration-tests
@@ -928,12 +915,11 @@ runner-test-matrix:
   # - id: smoke/ccip/ccip_sui_token_transfer_test.go:Test_CCIPTokenTransfer_EVM2SUI_BurnMintTokenPool
   #   path: integration-tests/smoke/ccip/ccip_sui_token_transfer_test.go
   #   test_env_type: in-memory
-  #   runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+  #   runs_on: ubuntu-latest
   #   triggers:
   #     - PR Integration CCIP Tests
   #     - Nightly Integration CCIP Tests
   #   test_cmd: |
-  #     ./scripts/free-disk-space.sh
   #     echo "🚀 Starting CCIP EVM2Sui BurnMint Token Transfer test..."
   #     go test ./smoke/ccip -run "Test_CCIPTokenTransfer_EVM2SUI_BurnMintTokenPool" -timeout 15m -test.parallel=1 -count=1 -json
   #   test_go_project_path: integration-tests

--- a/.github/integration-in-memory-tests.yml
+++ b/.github/integration-in-memory-tests.yml
@@ -489,6 +489,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_messaging_test.go:Test_CCIP_Messaging_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_messaging_test.go
@@ -501,6 +502,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -513,6 +515,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -525,6 +528,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_BnM_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -537,6 +541,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_BnM_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -549,6 +554,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -561,6 +567,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -573,6 +580,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_without_TransferRef_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -587,6 +595,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_without_TransferRef_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -599,6 +608,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_msghasher_test.go:*
     path: integration-tests/smoke/ccip/ccip_aptos_msghasher_test.go
@@ -611,6 +621,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_regulated_token_transfer_test.go:Test_CCIP_RegulatedTokenTransfer_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_regulated_token_transfer_test.go
@@ -623,6 +634,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_regulated_token_transfer_test.go:Test_CCIP_RegulatedTokenTransfer_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_regulated_token_transfer_test.go
@@ -635,6 +647,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_BnM_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -647,6 +660,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_BnM_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -659,6 +673,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -671,6 +686,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -683,6 +699,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_without_TransferRef_EVM2Aptos
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -695,6 +712,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_aptos_token_transfer_test.go:Test_CCIP_TokenTransfer_LnR_without_TransferRef_Aptos2EVM
     path: integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -707,6 +725,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     aptos_cli_version: 7.10.0
     install_plugins_public: true
+    free_disk_space: true
 
   # TON tests
   - id: smoke/ccip/ccip_ton_messaging_test.go:Test_CCIPMessaging_TON2EVM
@@ -721,6 +740,7 @@ runner-test-matrix:
       go test ./smoke/ccip -run "Test_CCIPMessaging_TON2EVM" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_ton_messaging_test.go:Test_CCIPMessaging_EVM2TON
     path: integration-tests/smoke/ccip/ccip_ton_messaging_test.go
@@ -734,6 +754,7 @@ runner-test-matrix:
       go test ./smoke/ccip -run "Test_CCIPMessaging_EVM2TON" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
     install_plugins_public: true
+    free_disk_space: true
 
   # Sui tests
   - id: smoke/ccip/ccip_sui_messaging_test.go:Test_CCIP_Messaging_Sui2EVM
@@ -749,6 +770,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     sui_cli_version: mainnet-1.60.1
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_sui_messaging_test.go:Test_CCIP_Messaging_EVM2Sui
     path: integration-tests/smoke/ccip/ccip_sui_messaging_test.go
@@ -763,6 +785,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     sui_cli_version: mainnet-1.60.1
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_sui_messaging_test.go:Test_CCIP_EVM2Sui_ZeroReceiver
     path: integration-tests/smoke/ccip/ccip_sui_messaging_test.go
@@ -775,6 +798,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     sui_cli_version: mainnet-1.57.2
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_sui_token_transfer_test.go:Test_CCIPTokenTransfer_Sui2EVM_BurnMintTokenPool
     path: integration-tests/smoke/ccip/ccip_sui_token_transfer_test.go
@@ -789,6 +813,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     sui_cli_version: mainnet-1.60.1
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_sui_token_transfer_test.go:Test_CCIPTokenTransfer_Sui2EVM_ManagedTokenPool
     path: integration-tests/smoke/ccip/ccip_sui_token_transfer_test.go
@@ -803,6 +828,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     sui_cli_version: mainnet-1.60.1
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_sui_token_transfer_test.go:Test_CCIPTokenTransfer_EVM2SUI_ManagedTokenPool
     path: integration-tests/smoke/ccip/ccip_sui_token_transfer_test.go
@@ -817,6 +843,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     sui_cli_version: mainnet-1.60.1
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_sui_upgrade_test.go:Test_CCIP_Upgrade_Sui2EVM
     path: integration-tests/smoke/ccip/ccip_sui_upgrade_test.go
@@ -829,6 +856,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     sui_cli_version: mainnet-1.60.1
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_sui_upgrade_test.go:Test_CCIP_Upgrade_EVM2Sui
     path: integration-tests/smoke/ccip/ccip_sui_upgrade_test.go
@@ -841,6 +869,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     sui_cli_version: mainnet-1.60.1
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_sui_upgrade_test.go:Test_CCIP_Upgrade_CommonPkg_EVM2Sui
     path: integration-tests/smoke/ccip/ccip_sui_upgrade_test.go
@@ -855,6 +884,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     sui_cli_version: mainnet-1.60.1
     install_plugins_public: true
+    free_disk_space: true
 
   - id: smoke/ccip/ccip_sui_upgrade_test.go:Test_CCIP_Upgrade_NoBlock_EVM2Sui
     path: integration-tests/smoke/ccip/ccip_sui_upgrade_test.go
@@ -869,6 +899,7 @@ runner-test-matrix:
     test_go_project_path: integration-tests
     sui_cli_version: mainnet-1.60.1
     install_plugins_public: true
+    free_disk_space: true
 
   # - id: smoke/ccip/ccip_sui_token_transfer_test.go:Test_CCIPPureTokenTransfer_EVM2SUI_BurnMintTokenPool
   #   path: integration-tests/smoke/ccip/ccip_sui_token_transfer_test.go

--- a/.github/workflows/integration-in-memory-tests.yml
+++ b/.github/workflows/integration-in-memory-tests.yml
@@ -82,7 +82,7 @@ jobs:
       contents: read
     needs: changes
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@test/free-disk-space
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@9874c1f4ab4a4c70433df6d8f862044ca18456df # 2025-11-26
     with:
       workflow_name: Run CCIP Integration Tests For PR
       chainlink_version: ${{ inputs.cl_ref || github.sha }}
@@ -112,7 +112,7 @@ jobs:
       contents: read
     needs: changes
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@test/free-disk-space
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@9874c1f4ab4a4c70433df6d8f862044ca18456df # 2025-11-26
     with:
       workflow_name: Run CCIP Integration Tests For Merge Queue
       chainlink_version: ${{ inputs.cl_ref || github.sha }}

--- a/.github/workflows/integration-in-memory-tests.yml
+++ b/.github/workflows/integration-in-memory-tests.yml
@@ -82,7 +82,7 @@ jobs:
       contents: read
     needs: changes
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@a1273177bb5fc9577ec88364df09e95e102e87d1 # 2025-10-06
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@test/free-disk-space
     with:
       workflow_name: Run CCIP Integration Tests For PR
       chainlink_version: ${{ inputs.cl_ref || github.sha }}
@@ -90,6 +90,7 @@ jobs:
       test_trigger: PR Integration CCIP Tests
       skip_image_build: true # in-memory tests do not require an image
       use-self-hosted-runners: ${{ needs.changes.outputs.should_use_self_hosted_runner }}
+      free-disk-space: "true"
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -112,7 +113,7 @@ jobs:
       contents: read
     needs: changes
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@a1273177bb5fc9577ec88364df09e95e102e87d1 # 2025-10-06
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@test/free-disk-space
     with:
       workflow_name: Run CCIP Integration Tests For Merge Queue
       chainlink_version: ${{ inputs.cl_ref || github.sha }}
@@ -123,6 +124,7 @@ jobs:
       slack_notification_after_tests_name: CCIP Integration Tests In Merge Queue
       use-self-hosted-runners: ${{ needs.changes.outputs.should_use_self_hosted_runner }}
       skip_image_build: true # in-memory tests do not require an image
+      free-disk-space: "true"
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}

--- a/.github/workflows/integration-in-memory-tests.yml
+++ b/.github/workflows/integration-in-memory-tests.yml
@@ -90,8 +90,6 @@ jobs:
       test_trigger: PR Integration CCIP Tests
       skip_image_build: true # in-memory tests do not require an image
       use-self-hosted-runners: ${{ needs.changes.outputs.should_use_self_hosted_runner }}
-      collect_test_telemetry: true
-      free-disk-space: "true"
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -125,8 +123,6 @@ jobs:
       slack_notification_after_tests_name: CCIP Integration Tests In Merge Queue
       use-self-hosted-runners: ${{ needs.changes.outputs.should_use_self_hosted_runner }}
       skip_image_build: true # in-memory tests do not require an image
-      collect_test_telemetry: true
-      free-disk-space: "true"
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}

--- a/.github/workflows/integration-in-memory-tests.yml
+++ b/.github/workflows/integration-in-memory-tests.yml
@@ -90,6 +90,7 @@ jobs:
       test_trigger: PR Integration CCIP Tests
       skip_image_build: true # in-memory tests do not require an image
       use-self-hosted-runners: ${{ needs.changes.outputs.should_use_self_hosted_runner }}
+      collect_test_telemetry: true
       free-disk-space: "true"
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
@@ -124,6 +125,7 @@ jobs:
       slack_notification_after_tests_name: CCIP Integration Tests In Merge Queue
       use-self-hosted-runners: ${{ needs.changes.outputs.should_use_self_hosted_runner }}
       skip_image_build: true # in-memory tests do not require an image
+      collect_test_telemetry: true
       free-disk-space: "true"
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Changes

* Bump run-e2e-tests sha
* Change aptos tests back to `ubuntu-latest` runners
* Add `free_disk_space: true` test config parameter to those same tests

### Testing

Aptos tests pass with these changes:
- https://github.com/smartcontractkit/chainlink/actions/runs/19683949473?pr=20450
- https://github.com/smartcontractkit/chainlink/actions/runs/19713836030?pr=20450
- https://github.com/smartcontractkit/chainlink/actions/runs/19714705902?pr=20450

---

DX-2386