### PR TITLE
plugins: use relative install paths

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -11,44 +11,44 @@ plugins:
   cron:
     - moduleURI: "github.com/smartcontractkit/capabilities/cron"
       gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
-      installPath: "github.com/smartcontractkit/capabilities/cron"
+      installPath: "."
       flags: "-tags timetzdata"
   kvstore:
     - enabled: false
       moduleURI: "github.com/smartcontractkit/capabilities/kvstore"
       gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
-      installPath: "github.com/smartcontractkit/capabilities/kvstore"
+      installPath: "."
   readcontract:
     - moduleURI: "github.com/smartcontractkit/capabilities/readcontract"
       gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
-      installPath: "github.com/smartcontractkit/capabilities/readcontract"
+      installPath: "."
   consensus:
     - moduleURI: "github.com/smartcontractkit/capabilities/consensus"
       gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
-      installPath: "github.com/smartcontractkit/capabilities/consensus"
+      installPath: "."
   workflowevent:
     - enabled: false
       moduleURI: "github.com/smartcontractkit/capabilities/workflowevent"
       gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
-      installPath: "github.com/smartcontractkit/capabilities/workflowevent"
+      installPath: "."
   httpaction:
     - moduleURI: "github.com/smartcontractkit/capabilities/http_action"
       gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
-      installPath: "github.com/smartcontractkit/capabilities/http_action"
+      installPath: "."
   httptrigger:
     - moduleURI: "github.com/smartcontractkit/capabilities/http_trigger"
       gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
-      installPath: "github.com/smartcontractkit/capabilities/http_trigger"
+      installPath: "."
   evm:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
       gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
-      installPath: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
+      installPath: "."
   mock:
     - moduleURI: "github.com/smartcontractkit/capabilities/mock"
       gitRef: "cb1309df43755c7280ed5da3f0d79810bf2ff7f6"
-      installPath: "github.com/smartcontractkit/capabilities/mock"
+      installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
       gitRef: "6a3c6bca2bb0dca9d6d493308ed1afd6b4888d5c"
-      installPath: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
+      installPath: "."
 

--- a/plugins/plugins.testing.yaml
+++ b/plugins/plugins.testing.yaml
@@ -13,10 +13,10 @@ plugins:
     - enabled: true
       moduleURI: "github.com/smartcontractkit/capabilities/mock"
       gitRef: "02cb745cabad2979034e6f96ebb47c9322df24ba"
-      installPath: "github.com/smartcontractkit/capabilities/mock"
+      installPath: "."
   capabilitywatcher:
     - enabled: true
       moduleURI: "github.com/smartcontractkit/capabilities/capabilitywatcher"
       gitRef: "3d44e5711b322b57854a17de92277cdb8f383609"
-      installPath: "github.com/smartcontractkit/capabilities/capabilitywatcher"
+      installPath: "."
 


### PR DESCRIPTION
We were only using these in the `plugins.public.yaml`