### PR TITLE
[fix] Update confidential-http gitref

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -49,6 +49,6 @@ plugins:
       installPath: "github.com/smartcontractkit/capabilities/mock"
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "6a3c6bca2bb0dca9d6d493308ed1afd6b4888d5c"
-      installPath: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
+      gitRef: "b485e01d79c160354d23154d73f0ee753e2d4397"
+      installPath: "./cmd/confidential-http"
 


### PR DESCRIPTION
Updates our install path such that the binary name is not vaguely set to `capability` but rather `confidential-http`