### PR TITLE
Update SendRequestEVM to be compatible with 1.5 onramps

### DIFF
--- a/.changeset/orange-nights-allow.md
+++ b/.changeset/orange-nights-allow.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-Added logic to handle ABI version mismatches in the SendRequestEVM function in testhelpers
+#bugfix Added logic to handle ABI version mismatches in the SendRequestEVM function in testhelpers

--- a/.changeset/orange-nights-allow.md
+++ b/.changeset/orange-nights-allow.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-#bugfix Added logic to handle ABI version mismatches in the SendRequestEVM function in testhelpers
+#bugfix Fixed SendRequestEVM to parse CCIP events directly from transaction receipts instead of using blockchain filtering, making it compatible with both OnRamp v1.5 (CCIPSendRequested) and v1.6 (CCIPMessageSent) events

--- a/.changeset/orange-nights-allow.md
+++ b/.changeset/orange-nights-allow.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Added logic to handle ABI version mismatches in the SendRequestEVM function in testhelpers

--- a/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
@@ -585,8 +585,9 @@ func SendRequestEVM(
 			return nil, fmt.Errorf("failed to get transaction receipt: %w", err)
 		}
 
-		onRampAddr := state.MustGetEVMChainState(cfg.SourceChain).OnRamp.Address()
-		onRamp := state.MustGetEVMChainState(cfg.SourceChain).OnRamp
+		evmChainState := state.MustGetEVMChainState(cfg.SourceChain)
+		onRampAddr := evmChainState.OnRamp.Address()
+		onRamp := evmChainState.OnRamp
 
 		for _, log := range receipt.Logs {
 			if log.Address == onRampAddr && len(log.Topics) > 0 {

--- a/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
@@ -557,58 +557,36 @@ func SendRequestEVM(
 		return nil, err
 	}
 
-	// Try the standard event filtering approach first
-	it, err := state.MustGetEVMChainState(cfg.SourceChain).OnRamp.FilterCCIPMessageSent(&bind.FilterOpts{
-		Start:   blockNum,
-		End:     &blockNum,
-		Context: context.Background(),
-	}, []uint64{cfg.DestChain}, []uint64{})
+	// Get transaction receipt and parse events directly from logs
+	receipt, err := e.BlockChains.EVMChains()[cfg.SourceChain].Client.TransactionReceipt(context.Background(), tx.Hash())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get transaction receipt: %w", err)
 	}
 
+	evmChainState := state.MustGetEVMChainState(cfg.SourceChain)
+	onRampAddr := evmChainState.OnRamp.Address()
+	onRamp := evmChainState.OnRamp
+
 	var msgSentEvent *ccipclient.AnyMsgSentEvent
-
-	// If standard filtering works, use it
-	if it.Next() {
-		msgSentEvent = &ccipclient.AnyMsgSentEvent{
-			SequenceNumber: it.Event.SequenceNumber,
-			RawEvent:       it.Event,
-		}
-	} else {
-		// Fallback: If filtering didn't find the event (likely onRamp ABI version mismatch),
-		// parse directly from transaction receipt logs
-		e.Logger.Warnf("Standard event filtering found no events, falling back to receipt log parsing (likely ABI version mismatch)")
-
-		receipt, err := e.BlockChains.EVMChains()[cfg.SourceChain].Client.TransactionReceipt(context.Background(), tx.Hash())
-		if err != nil {
-			return nil, fmt.Errorf("failed to get transaction receipt: %w", err)
-		}
-
-		evmChainState := state.MustGetEVMChainState(cfg.SourceChain)
-		onRampAddr := evmChainState.OnRamp.Address()
-		onRamp := evmChainState.OnRamp
-
-		for _, log := range receipt.Logs {
-			if log.Address == onRampAddr && len(log.Topics) > 0 {
-				event, err := onRamp.ParseCCIPMessageSent(*log)
-				if err == nil {
-					msgSentEvent = &ccipclient.AnyMsgSentEvent{
-						SequenceNumber: event.SequenceNumber,
-						RawEvent:       event,
-					}
-					break
+	for _, log := range receipt.Logs {
+		if log.Address == onRampAddr && len(log.Topics) > 0 {
+			// ParseCCIPMessageSent works for both v1.5 (CCIPSendRequested) and v1.6 (CCIPMessageSent)
+			// because the v1.6 binding includes both event signatures for backward compatibility
+			event, err := onRamp.ParseCCIPMessageSent(*log)
+			if err == nil {
+				msgSentEvent = &ccipclient.AnyMsgSentEvent{
+					SequenceNumber: event.SequenceNumber,
+					RawEvent:       event,
 				}
+				break
 			}
 		}
 	}
 
 	if msgSentEvent == nil {
-		return nil, fmt.Errorf("no CCIP message sent event found for tx %s in block %d (tried both filtering and receipt parsing)",
-			tx.Hash().String(), blockNum)
+		return nil, fmt.Errorf("no CCIP message sent event found for tx %s in block %d", tx.Hash().String(), blockNum)
 	}
 
-	// Log the successful message send
 	event := msgSentEvent.RawEvent.(*onramp.OnRampCCIPMessageSent)
 	e.Logger.Infof("CCIP message (id %s) sent from chain selector %d to chain selector %d tx %s seqNum %d nonce %d sender %s testRouterEnabled %t",
 		common.Bytes2Hex(event.Message.Header.MessageId[:]),
@@ -620,7 +598,6 @@ func SendRequestEVM(
 		event.Message.Sender.String(),
 		cfg.IsTestRouter,
 	)
-
 	return msgSentEvent, nil
 }
 

--- a/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
@@ -557,6 +557,7 @@ func SendRequestEVM(
 		return nil, err
 	}
 
+	// Try the standard event filtering approach first
 	it, err := state.MustGetEVMChainState(cfg.SourceChain).OnRamp.FilterCCIPMessageSent(&bind.FilterOpts{
 		Start:   blockNum,
 		End:     &blockNum,
@@ -566,24 +567,60 @@ func SendRequestEVM(
 		return nil, err
 	}
 
-	if !it.Next() {
-		return nil, errors.New("no CCIP message sent event found")
+	var msgSentEvent *ccipclient.AnyMsgSentEvent
+
+	// If standard filtering works, use it
+	if it.Next() {
+		msgSentEvent = &ccipclient.AnyMsgSentEvent{
+			SequenceNumber: it.Event.SequenceNumber,
+			RawEvent:       it.Event,
+		}
+	} else {
+		// Fallback: If filtering didn't find the event (likely onRamp ABI version mismatch),
+		// parse directly from transaction receipt logs
+		e.Logger.Warnf("Standard event filtering found no events, falling back to receipt log parsing (likely ABI version mismatch)")
+		
+		receipt, err := e.BlockChains.EVMChains()[cfg.SourceChain].Client.TransactionReceipt(context.Background(), tx.Hash())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get transaction receipt: %w", err)
+		}
+		
+		onRampAddr := state.MustGetEVMChainState(cfg.SourceChain).OnRamp.Address()
+		onRamp := state.MustGetEVMChainState(cfg.SourceChain).OnRamp
+		
+		for _, log := range receipt.Logs {
+			if log.Address == onRampAddr && len(log.Topics) > 0 {
+				event, err := onRamp.ParseCCIPMessageSent(*log)
+				if err == nil {
+					msgSentEvent = &ccipclient.AnyMsgSentEvent{
+						SequenceNumber: event.SequenceNumber,
+						RawEvent:       event,
+					}
+					break
+				}
+			}
+		}
 	}
 
+	if msgSentEvent == nil {
+		return nil, fmt.Errorf("no CCIP message sent event found for tx %s in block %d (tried both filtering and receipt parsing)", 
+			tx.Hash().String(), blockNum)
+	}
+
+	// Log the successful message send
+	event := msgSentEvent.RawEvent.(*onramp.OnRampCCIPMessageSent)
 	e.Logger.Infof("CCIP message (id %s) sent from chain selector %d to chain selector %d tx %s seqNum %d nonce %d sender %s testRouterEnabled %t",
-		common.Bytes2Hex(it.Event.Message.Header.MessageId[:]),
+		common.Bytes2Hex(event.Message.Header.MessageId[:]),
 		cfg.SourceChain,
 		cfg.DestChain,
 		tx.Hash().String(),
-		it.Event.SequenceNumber,
-		it.Event.Message.Header.Nonce,
-		it.Event.Message.Sender.String(),
+		msgSentEvent.SequenceNumber,
+		event.Message.Header.Nonce,
+		event.Message.Sender.String(),
 		cfg.IsTestRouter,
 	)
-	return &ccipclient.AnyMsgSentEvent{
-		SequenceNumber: it.Event.SequenceNumber,
-		RawEvent:       it.Event,
-	}, nil
+
+	return msgSentEvent, nil
 }
 
 func SendRequestSui(

--- a/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
@@ -579,15 +579,15 @@ func SendRequestEVM(
 		// Fallback: If filtering didn't find the event (likely onRamp ABI version mismatch),
 		// parse directly from transaction receipt logs
 		e.Logger.Warnf("Standard event filtering found no events, falling back to receipt log parsing (likely ABI version mismatch)")
-		
+
 		receipt, err := e.BlockChains.EVMChains()[cfg.SourceChain].Client.TransactionReceipt(context.Background(), tx.Hash())
 		if err != nil {
 			return nil, fmt.Errorf("failed to get transaction receipt: %w", err)
 		}
-		
+
 		onRampAddr := state.MustGetEVMChainState(cfg.SourceChain).OnRamp.Address()
 		onRamp := state.MustGetEVMChainState(cfg.SourceChain).OnRamp
-		
+
 		for _, log := range receipt.Logs {
 			if log.Address == onRampAddr && len(log.Topics) > 0 {
 				event, err := onRamp.ParseCCIPMessageSent(*log)
@@ -603,7 +603,7 @@ func SendRequestEVM(
 	}
 
 	if msgSentEvent == nil {
-		return nil, fmt.Errorf("no CCIP message sent event found for tx %s in block %d (tried both filtering and receipt parsing)", 
+		return nil, fmt.Errorf("no CCIP message sent event found for tx %s in block %d (tried both filtering and receipt parsing)",
 			tx.Hash().String(), blockNum)
 	}
 


### PR DESCRIPTION
**Problem:**
Smoke/load tests were failing with "no CCIP message sent event found" on chains using v1.5 OnRamp, even though transactions were successful and events were emitted on-chain. 

The filtering approach would fail when the emitted event signature didn't match the expected signature in the ABI (on-chain emitting v1.5's 0x192442a2... while the v1.6 ABI expects 0x419ed275...)

**Solution:**
Changed SendRequestEVM to parse events directly from transaction receipt logs using ParseCCIPMessageSent. 

This works because the v1.6 OnRamp binding includes both v1.5 (CCIPSendRequested) and v1.6 (CCIPMessageSent) event signatures for backward compatibility, allowing it to successfully parse events from both contract versions.
