### PR TITLE
chore: updates codeowners for deployment package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,17 +84,16 @@ core/scripts/gateway @smartcontractkit/dev-services
 /integration-tests/**/*ccip* @smartcontractkit/ccip-offchain @smartcontractkit/core @smartcontractkit/ccip
 
 # Deployment tooling
-/deployment @smartcontractkit/ccip-tooling @smartcontractkit/ccip-offchain @smartcontractkit/keystone @smartcontractkit/core @smartcontractkit/cld-team
-/deployment/common @smartcontractkit/devex-tooling
-/deployment/ccip @smartcontractkit/ccip-tooling @smartcontractkit/ccip-offchain @smartcontractkit/core @smartcontractkit/cld-team
+/deployment @smartcontractkit/ccip-tooling @smartcontractkit/ccip-offchain @smartcontractkit/keystone @smartcontractkit/operations-platform @smartcontractkit/core
+/deployment/ccip @smartcontractkit/ccip-tooling @smartcontractkit/ccip-offchain @smartcontractkit/operations-platform @smartcontractkit/core
 /deployment/ccip/changeset/globals @smartcontractkit/ccip-offchain
-/deployment/crib @smartcontractkit/ccip-offchain
-/deployment/ccip/changeset/ton @smartcontractkit/bix-build @smartcontractkit/core @smartcontractkit/cld-team
-/deployment/keystone @smartcontractkit/keystone @smartcontractkit/core @smartcontractkit/cld-team
-/deployment/data-feeds @smartcontractkit/data-feeds-engineers @smartcontractkit/core @smartcontractkit/cld-team
-/deployment/data-streams @smartcontractkit/data-streams-engineers @smartcontractkit/core @smartcontractkit/cld-team
-/deployment/vault @smartcontractkit/cld-vault @smartcontractkit/core @smartcontractkit/cld-team
-# TODO: As more products add their deployment logic here, add the team as an owner
+/deployment/ccip/changeset/ton @smartcontractkit/bix-build @smartcontractkit/operations-platform @smartcontractkit/core
+/deployment/common @smartcontractkit/operations-platform
+/deployment/cre @smartcontractkit/keystone @smartcontractkit/operations-platform
+/deployment/data-feeds @smartcontractkit/data-feeds-engineers @smartcontractkit/operations-platform @smartcontractkit/core
+/deployment/data-streams @smartcontractkit/data-streams-engineers @smartcontractkit/operations-platform @smartcontractkit/core
+/deployment/keystone @smartcontractkit/keystone @smartcontractkit/operations-platform @smartcontractkit/core
+/deployment/vault @smartcontractkit/cld-vault @smartcontractkit/operations-platform @smartcontractkit/core
 
 # CI/CD
 /.github/** @smartcontractkit/devex-cicd @smartcontractkit/devex-tooling @smartcontractkit/core


### PR DESCRIPTION
This updates the codeowners for the deployment package to replace the `cld-team` with `operations-platform`. The `cld-team` is a subset of this parent team, with the additional engineers now providing more coverage across timezones for reviews.
