### PR TITLE
chore(ci): bump changed-modules-go

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -112,8 +112,8 @@ jobs:
           fi
 
       - name: Changed modules
-        uses: smartcontractkit/.github/actions/changed-modules-go@bc3f1be9389263eee8d2df57a1972bcca29423ce # 2025-11-24
-        continue-on-error: true # don't let this call affect the outcome of the job
+        uses: smartcontractkit/.github/actions/changed-modules-go@changed-modules-go/v1
+        continue-on-error: true # don't let this call affect the outcome of the job (during rollout)
         with:
           # when scheduled/workflow_dispatch, run against all modules
           no-change-behaviour: all


### PR DESCRIPTION
### Changes

* Pin to `changed-modules-go/v1` (https://github.com/smartcontractkit/.github/pull/1350) which fixes a bug which filtered out the root module.

### Notes

This is still part of the roll-out, so this doesn't change any existing functionality. This is only to verify behaviour.