### PR TITLE
Fixes MCMS Strategy to be `Action` aware

### DIFF
--- a/deployment/cre/common/strategies/mcms_transaction.go
+++ b/deployment/cre/common/strategies/mcms_transaction.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/mcms/sdk"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
@@ -22,7 +23,7 @@ import (
 // MCMSTransaction executes a transaction through MCMS timelock
 type MCMSTransaction struct {
 	Env           cldf.Environment
-	ChainSel      uint64
+	Chain         cldf_evm.Chain
 	Description   string
 	Address       common.Address
 	Config        *contracts.MCMSConfig
@@ -37,7 +38,7 @@ func (m *MCMSTransaction) Apply(callFn func(opts *bind.TransactOpts) (*types.Tra
 		return nil, nil, err
 	}
 
-	op, err := proposalutils.BatchOperationForChain(m.ChainSel, m.Address.Hex(), tx.Data(), big.NewInt(0), "", nil)
+	op, err := proposalutils.BatchOperationForChain(m.Chain.ChainSelector(), m.Address.Hex(), tx.Data(), big.NewInt(0), "", nil)
 	if err != nil {
 		return nil, tx, err
 	}
@@ -64,17 +65,17 @@ func (m *MCMSTransaction) BuildProposal(operations []mcmstypes.BatchOperation) (
 	}
 
 	timelocksPerChain := map[uint64]string{
-		m.ChainSel: m.MCMSContracts.Timelock.Address().Hex(),
+		m.Chain.ChainSelector(): m.MCMSContracts.Timelock.Address().Hex(),
 	}
 	mcmsAddressesPerChain := map[uint64]string{
-		m.ChainSel: mcmContract.Address().Hex(),
+		m.Chain.ChainSelector(): mcmContract.Address().Hex(),
 	}
-	inspector, err := proposalutils.McmsInspectorForChain(m.Env, m.ChainSel)
+	inspector, err := proposalutils.McmsInspectorForChain(m.Env, m.Chain.ChainSelector())
 	if err != nil {
 		return nil, err
 	}
 	inspectorPerChain := map[uint64]sdk.Inspector{
-		m.ChainSel: inspector,
+		m.Chain.ChainSelector(): inspector,
 	}
 
 	return proposalutils.BuildProposalFromBatchesV2(

--- a/deployment/cre/common/strategies/mcms_transaction.go
+++ b/deployment/cre/common/strategies/mcms_transaction.go
@@ -12,7 +12,6 @@ import (
 	"github.com/smartcontractkit/mcms/sdk"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
-	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
@@ -23,7 +22,7 @@ import (
 // MCMSTransaction executes a transaction through MCMS timelock
 type MCMSTransaction struct {
 	Env           cldf.Environment
-	Chain         cldf_evm.Chain
+	ChainSel      uint64
 	Description   string
 	Address       common.Address
 	Config        *contracts.MCMSConfig
@@ -38,7 +37,7 @@ func (m *MCMSTransaction) Apply(callFn func(opts *bind.TransactOpts) (*types.Tra
 		return nil, nil, err
 	}
 
-	op, err := proposalutils.BatchOperationForChain(m.Chain.ChainSelector(), m.Address.Hex(), tx.Data(), big.NewInt(0), "", nil)
+	op, err := proposalutils.BatchOperationForChain(m.ChainSel, m.Address.Hex(), tx.Data(), big.NewInt(0), "", nil)
 	if err != nil {
 		return nil, tx, err
 	}
@@ -65,17 +64,17 @@ func (m *MCMSTransaction) BuildProposal(operations []mcmstypes.BatchOperation) (
 	}
 
 	timelocksPerChain := map[uint64]string{
-		m.Chain.ChainSelector(): m.MCMSContracts.Timelock.Address().Hex(),
+		m.ChainSel: m.MCMSContracts.Timelock.Address().Hex(),
 	}
 	mcmsAddressesPerChain := map[uint64]string{
-		m.Chain.ChainSelector(): mcmContract.Address().Hex(),
+		m.ChainSel: mcmContract.Address().Hex(),
 	}
-	inspector, err := proposalutils.McmsInspectorForChain(m.Env, m.Chain.ChainSelector())
+	inspector, err := proposalutils.McmsInspectorForChain(m.Env, m.ChainSel)
 	if err != nil {
 		return nil, err
 	}
 	inspectorPerChain := map[uint64]sdk.Inspector{
-		m.Chain.ChainSelector(): inspector,
+		m.ChainSel: inspector,
 	}
 
 	return proposalutils.BuildProposalFromBatchesV2(

--- a/deployment/cre/common/strategies/mcms_transaction.go
+++ b/deployment/cre/common/strategies/mcms_transaction.go
@@ -60,11 +60,7 @@ func (m *MCMSTransaction) BuildProposal(operations []mcmstypes.BatchOperation) (
 
 	mcmContract, err := m.Config.MCMBasedOnAction(*m.MCMSContracts)
 	if err != nil {
-		action := m.Config.MCMSAction
-		if action == "" {
-			action = mcmstypes.TimelockActionSchedule
-		}
-		return nil, fmt.Errorf("error building MCM contract based on Action: %s, error: %w", action, err)
+		return nil, fmt.Errorf("failed to get mcms contract by action '%s' for config %v : %w", m.Config.MCMSAction, m.Config, err)
 	}
 
 	timelocksPerChain := map[uint64]string{

--- a/deployment/cre/common/strategies/mcms_transaction.go
+++ b/deployment/cre/common/strategies/mcms_transaction.go
@@ -2,6 +2,7 @@ package strategies
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -57,11 +58,20 @@ func (m *MCMSTransaction) BuildProposal(operations []mcmstypes.BatchOperation) (
 		return nil, errors.New("no operations provided to build proposal")
 	}
 
+	mcmContract, err := m.Config.MCMBasedOnAction(*m.MCMSContracts)
+	if err != nil {
+		action := m.Config.MCMSAction
+		if action == "" {
+			action = mcmstypes.TimelockActionSchedule
+		}
+		return nil, fmt.Errorf("error building MCM contract based on Action: %s, error: %v", action, err)
+	}
+
 	timelocksPerChain := map[uint64]string{
 		m.ChainSel: m.MCMSContracts.Timelock.Address().Hex(),
 	}
-	proposerMCMSes := map[uint64]string{
-		m.ChainSel: m.MCMSContracts.ProposerMcm.Address().Hex(),
+	mcmsAddressesPerChain := map[uint64]string{
+		m.ChainSel: mcmContract.Address().Hex(),
 	}
 	inspector, err := proposalutils.McmsInspectorForChain(m.Env, m.ChainSel)
 	if err != nil {
@@ -74,7 +84,7 @@ func (m *MCMSTransaction) BuildProposal(operations []mcmstypes.BatchOperation) (
 	return proposalutils.BuildProposalFromBatchesV2(
 		m.Env,
 		timelocksPerChain,
-		proposerMCMSes,
+		mcmsAddressesPerChain,
 		inspectorPerChain,
 		operations,
 		m.Description,

--- a/deployment/cre/common/strategies/mcms_transaction.go
+++ b/deployment/cre/common/strategies/mcms_transaction.go
@@ -64,7 +64,7 @@ func (m *MCMSTransaction) BuildProposal(operations []mcmstypes.BatchOperation) (
 		if action == "" {
 			action = mcmstypes.TimelockActionSchedule
 		}
-		return nil, fmt.Errorf("error building MCM contract based on Action: %s, error: %v", action, err)
+		return nil, fmt.Errorf("error building MCM contract based on Action: %s, error: %w", action, err)
 	}
 
 	timelocksPerChain := map[uint64]string{

--- a/deployment/cre/common/strategies/mcms_transaction_test.go
+++ b/deployment/cre/common/strategies/mcms_transaction_test.go
@@ -1,0 +1,204 @@
+package strategies_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
+	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	"github.com/smartcontractkit/chainlink/deployment/cre/common/strategies"
+	"github.com/smartcontractkit/chainlink/deployment/cre/contracts"
+	"github.com/smartcontractkit/chainlink/deployment/cre/test"
+)
+
+func getMCMSTransaction(t *testing.T, env deployment.Environment) *strategies.MCMSTransaction {
+	t.Helper()
+
+	return &strategies.MCMSTransaction{
+		Env:           env,
+		ChainSel:      1,
+		Description:   "test",
+		Config:        &contracts.MCMSConfig{},
+		Address:       common.HexToAddress("0x1"),
+		MCMSContracts: &commonchangeset.MCMSWithTimelockState{},
+	}
+}
+
+func TestMCMSTransaction_BuildProposal(t *testing.T) {
+	t.Parallel()
+
+	fixture := test.SetupEnvV2(t, true)
+
+	t.Run("no config", func(t *testing.T) {
+		m := getMCMSTransaction(t, *fixture.Env)
+		m.Config = nil
+
+		_, err := m.BuildProposal([]mcmstypes.BatchOperation{})
+		require.Error(t, err)
+		assert.Equal(t, "MCMS configuration or contracts are not provided", err.Error())
+	})
+
+	t.Run("no contracts", func(t *testing.T) {
+		m := getMCMSTransaction(t, *fixture.Env)
+		m.MCMSContracts = nil
+
+		_, err := m.BuildProposal([]mcmstypes.BatchOperation{})
+		require.Error(t, err)
+		assert.Equal(t, "MCMS configuration or contracts are not provided", err.Error())
+	})
+
+	t.Run("no timelock", func(t *testing.T) {
+		m := getMCMSTransaction(t, *fixture.Env)
+		cfg := contracts.MCMSConfig{
+			MinDelay: 0,
+			TimelockQualifierPerChain: map[uint64]string{
+				fixture.RegistrySelector: "",
+			},
+		}
+		mcmsContracts, err := strategies.GetMCMSContracts(*fixture.Env, fixture.RegistrySelector, cfg)
+		require.NoError(t, err)
+		m.MCMSContracts = mcmsContracts
+		m.MCMSContracts.Timelock = nil
+
+		_, err = m.BuildProposal([]mcmstypes.BatchOperation{})
+		require.Error(t, err)
+		assert.Equal(t, "MCMS contracts are not properly initialized, missing Timelock or Proposer", err.Error())
+	})
+
+	t.Run("no proposer", func(t *testing.T) {
+		m := getMCMSTransaction(t, *fixture.Env)
+		cfg := contracts.MCMSConfig{
+			MinDelay: 0,
+			TimelockQualifierPerChain: map[uint64]string{
+				fixture.RegistrySelector: "",
+			},
+		}
+		mcmsContracts, err := strategies.GetMCMSContracts(*fixture.Env, fixture.RegistrySelector, cfg)
+		require.NoError(t, err)
+		m.MCMSContracts = mcmsContracts
+		m.MCMSContracts.ProposerMcm = nil
+
+		_, err = m.BuildProposal([]mcmstypes.BatchOperation{})
+		require.Error(t, err)
+		assert.Equal(t, "MCMS contracts are not properly initialized, missing Timelock or Proposer", err.Error())
+	})
+
+	t.Run("no operations", func(t *testing.T) {
+		m := getMCMSTransaction(t, *fixture.Env)
+		cfg := contracts.MCMSConfig{
+			MinDelay: 0,
+			TimelockQualifierPerChain: map[uint64]string{
+				fixture.RegistrySelector: "",
+			},
+		}
+		mcmsContracts, err := strategies.GetMCMSContracts(*fixture.Env, fixture.RegistrySelector, cfg)
+		require.NoError(t, err)
+		m.MCMSContracts = mcmsContracts
+
+		_, err = m.BuildProposal([]mcmstypes.BatchOperation{})
+		require.Error(t, err)
+		assert.Equal(t, "no operations provided to build proposal", err.Error())
+	})
+
+	t.Run("MCMBasedOnAction fails", func(t *testing.T) {
+		m := getMCMSTransaction(t, *fixture.Env)
+		cfg := contracts.MCMSConfig{
+			MinDelay: 0,
+			TimelockQualifierPerChain: map[uint64]string{
+				fixture.RegistrySelector: "",
+			},
+		}
+		mcmsContracts, err := strategies.GetMCMSContracts(*fixture.Env, fixture.RegistrySelector, cfg)
+		require.NoError(t, err)
+		m.MCMSContracts = mcmsContracts
+		m.Config.MCMSAction = "invalid"
+
+		_, err = m.BuildProposal([]mcmstypes.BatchOperation{{}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get mcms contract by action 'invalid'")
+	})
+
+	t.Run("uses Proposer when not specifying an action (defaults to `schedule`)", func(t *testing.T) {
+		m := getMCMSTransaction(t, *fixture.Env)
+		cfg := contracts.MCMSConfig{
+			MinDelay: 0,
+			TimelockQualifierPerChain: map[uint64]string{
+				fixture.RegistrySelector: "",
+			},
+		}
+		mcmsContracts, err := strategies.GetMCMSContracts(*fixture.Env, fixture.RegistrySelector, cfg)
+		require.NoError(t, err)
+		m.Config = &cfg
+		m.MCMSContracts = mcmsContracts
+		m.ChainSel = fixture.RegistrySelector
+
+		op, err := proposalutils.BatchOperationForChain(m.ChainSel, m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
+		require.NoError(t, err)
+
+		p, err := m.BuildProposal([]mcmstypes.BatchOperation{op})
+		require.NoError(t, err)
+
+		metadata, ok := p.ChainMetadata[mcmstypes.ChainSelector(fixture.RegistrySelector)]
+		assert.True(t, ok)
+		assert.Equal(t, mcmsContracts.ProposerMcm.Address().String(), metadata.MCMAddress)
+	})
+
+	t.Run("uses Bypasser when specified", func(t *testing.T) {
+		m := getMCMSTransaction(t, *fixture.Env)
+		cfg := contracts.MCMSConfig{
+			MinDelay:   0,
+			MCMSAction: mcmstypes.TimelockActionBypass,
+			TimelockQualifierPerChain: map[uint64]string{
+				fixture.RegistrySelector: "",
+			},
+		}
+		mcmsContracts, err := strategies.GetMCMSContracts(*fixture.Env, fixture.RegistrySelector, cfg)
+		require.NoError(t, err)
+		m.Config = &cfg
+		m.MCMSContracts = mcmsContracts
+		m.ChainSel = fixture.RegistrySelector
+
+		op, err := proposalutils.BatchOperationForChain(m.ChainSel, m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
+		require.NoError(t, err)
+
+		p, err := m.BuildProposal([]mcmstypes.BatchOperation{op})
+		require.NoError(t, err)
+
+		metadata, ok := p.ChainMetadata[mcmstypes.ChainSelector(fixture.RegistrySelector)]
+		assert.True(t, ok)
+		assert.Equal(t, mcmsContracts.BypasserMcm.Address().String(), metadata.MCMAddress)
+	})
+
+	t.Run("uses Canceller when specified", func(t *testing.T) {
+		m := getMCMSTransaction(t, *fixture.Env)
+		cfg := contracts.MCMSConfig{
+			MinDelay:   0,
+			MCMSAction: mcmstypes.TimelockActionCancel,
+			TimelockQualifierPerChain: map[uint64]string{
+				fixture.RegistrySelector: "",
+			},
+		}
+		mcmsContracts, err := strategies.GetMCMSContracts(*fixture.Env, fixture.RegistrySelector, cfg)
+		require.NoError(t, err)
+		m.Config = &cfg
+		m.MCMSContracts = mcmsContracts
+		m.ChainSel = fixture.RegistrySelector
+
+		op, err := proposalutils.BatchOperationForChain(m.ChainSel, m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
+		require.NoError(t, err)
+
+		p, err := m.BuildProposal([]mcmstypes.BatchOperation{op})
+		require.NoError(t, err)
+
+		metadata, ok := p.ChainMetadata[mcmstypes.ChainSelector(fixture.RegistrySelector)]
+		assert.True(t, ok)
+		assert.Equal(t, mcmsContracts.CancellerMcm.Address().String(), metadata.MCMAddress)
+	})
+}

--- a/deployment/cre/common/strategies/mcms_transaction_test.go
+++ b/deployment/cre/common/strategies/mcms_transaction_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,12 +19,12 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/cre/test"
 )
 
-func getMCMSTransaction(t *testing.T, env deployment.Environment) *strategies.MCMSTransaction {
+func getMCMSTransaction(t *testing.T, env deployment.Environment, chain cldf_evm.Chain) *strategies.MCMSTransaction {
 	t.Helper()
 
 	return &strategies.MCMSTransaction{
 		Env:           env,
-		ChainSel:      1,
+		Chain:         chain,
 		Description:   "test",
 		Config:        &contracts.MCMSConfig{},
 		Address:       common.HexToAddress("0x1"),
@@ -35,9 +36,10 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	t.Parallel()
 
 	fixture := test.SetupEnvV2(t, true)
+	chain := fixture.Env.BlockChains.EVMChains()[fixture.RegistrySelector]
 
 	t.Run("no config", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env)
+		m := getMCMSTransaction(t, *fixture.Env, chain)
 		m.Config = nil
 
 		_, err := m.BuildProposal([]mcmstypes.BatchOperation{})
@@ -46,7 +48,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("no contracts", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env)
+		m := getMCMSTransaction(t, *fixture.Env, chain)
 		m.MCMSContracts = nil
 
 		_, err := m.BuildProposal([]mcmstypes.BatchOperation{})
@@ -55,7 +57,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("no timelock", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env)
+		m := getMCMSTransaction(t, *fixture.Env, chain)
 		cfg := contracts.MCMSConfig{
 			MinDelay: 0,
 			TimelockQualifierPerChain: map[uint64]string{
@@ -73,7 +75,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("no proposer", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env)
+		m := getMCMSTransaction(t, *fixture.Env, chain)
 		cfg := contracts.MCMSConfig{
 			MinDelay: 0,
 			TimelockQualifierPerChain: map[uint64]string{
@@ -91,7 +93,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("no operations", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env)
+		m := getMCMSTransaction(t, *fixture.Env, chain)
 		cfg := contracts.MCMSConfig{
 			MinDelay: 0,
 			TimelockQualifierPerChain: map[uint64]string{
@@ -108,7 +110,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("MCMBasedOnAction fails", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env)
+		m := getMCMSTransaction(t, *fixture.Env, chain)
 		cfg := contracts.MCMSConfig{
 			MinDelay: 0,
 			TimelockQualifierPerChain: map[uint64]string{
@@ -126,7 +128,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("uses Proposer when not specifying an action (defaults to `schedule`)", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env)
+		m := getMCMSTransaction(t, *fixture.Env, chain)
 		cfg := contracts.MCMSConfig{
 			MinDelay: 0,
 			TimelockQualifierPerChain: map[uint64]string{
@@ -137,9 +139,8 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 		require.NoError(t, err)
 		m.Config = &cfg
 		m.MCMSContracts = mcmsContracts
-		m.ChainSel = fixture.RegistrySelector
 
-		op, err := proposalutils.BatchOperationForChain(m.ChainSel, m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
+		op, err := proposalutils.BatchOperationForChain(m.Chain.ChainSelector(), m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
 		require.NoError(t, err)
 
 		p, err := m.BuildProposal([]mcmstypes.BatchOperation{op})
@@ -151,7 +152,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("uses Bypasser when specified", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env)
+		m := getMCMSTransaction(t, *fixture.Env, chain)
 		cfg := contracts.MCMSConfig{
 			MinDelay:   0,
 			MCMSAction: mcmstypes.TimelockActionBypass,
@@ -163,9 +164,8 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 		require.NoError(t, err)
 		m.Config = &cfg
 		m.MCMSContracts = mcmsContracts
-		m.ChainSel = fixture.RegistrySelector
 
-		op, err := proposalutils.BatchOperationForChain(m.ChainSel, m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
+		op, err := proposalutils.BatchOperationForChain(m.Chain.ChainSelector(), m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
 		require.NoError(t, err)
 
 		p, err := m.BuildProposal([]mcmstypes.BatchOperation{op})
@@ -177,7 +177,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("uses Canceller when specified", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env)
+		m := getMCMSTransaction(t, *fixture.Env, chain)
 		cfg := contracts.MCMSConfig{
 			MinDelay:   0,
 			MCMSAction: mcmstypes.TimelockActionCancel,
@@ -189,9 +189,8 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 		require.NoError(t, err)
 		m.Config = &cfg
 		m.MCMSContracts = mcmsContracts
-		m.ChainSel = fixture.RegistrySelector
 
-		op, err := proposalutils.BatchOperationForChain(m.ChainSel, m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
+		op, err := proposalutils.BatchOperationForChain(m.Chain.ChainSelector(), m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
 		require.NoError(t, err)
 
 		p, err := m.BuildProposal([]mcmstypes.BatchOperation{op})

--- a/deployment/cre/common/strategies/mcms_transaction_test.go
+++ b/deployment/cre/common/strategies/mcms_transaction_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,12 +18,12 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/cre/test"
 )
 
-func getMCMSTransaction(t *testing.T, env deployment.Environment, chain cldf_evm.Chain) *strategies.MCMSTransaction {
+func getMCMSTransaction(t *testing.T, env deployment.Environment) *strategies.MCMSTransaction {
 	t.Helper()
 
 	return &strategies.MCMSTransaction{
 		Env:           env,
-		Chain:         chain,
+		ChainSel:      1,
 		Description:   "test",
 		Config:        &contracts.MCMSConfig{},
 		Address:       common.HexToAddress("0x1"),
@@ -36,10 +35,9 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	t.Parallel()
 
 	fixture := test.SetupEnvV2(t, true)
-	chain := fixture.Env.BlockChains.EVMChains()[fixture.RegistrySelector]
 
 	t.Run("no config", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env, chain)
+		m := getMCMSTransaction(t, *fixture.Env)
 		m.Config = nil
 
 		_, err := m.BuildProposal([]mcmstypes.BatchOperation{})
@@ -48,7 +46,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("no contracts", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env, chain)
+		m := getMCMSTransaction(t, *fixture.Env)
 		m.MCMSContracts = nil
 
 		_, err := m.BuildProposal([]mcmstypes.BatchOperation{})
@@ -57,7 +55,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("no timelock", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env, chain)
+		m := getMCMSTransaction(t, *fixture.Env)
 		cfg := contracts.MCMSConfig{
 			MinDelay: 0,
 			TimelockQualifierPerChain: map[uint64]string{
@@ -75,7 +73,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("no proposer", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env, chain)
+		m := getMCMSTransaction(t, *fixture.Env)
 		cfg := contracts.MCMSConfig{
 			MinDelay: 0,
 			TimelockQualifierPerChain: map[uint64]string{
@@ -93,7 +91,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("no operations", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env, chain)
+		m := getMCMSTransaction(t, *fixture.Env)
 		cfg := contracts.MCMSConfig{
 			MinDelay: 0,
 			TimelockQualifierPerChain: map[uint64]string{
@@ -110,7 +108,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("MCMBasedOnAction fails", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env, chain)
+		m := getMCMSTransaction(t, *fixture.Env)
 		cfg := contracts.MCMSConfig{
 			MinDelay: 0,
 			TimelockQualifierPerChain: map[uint64]string{
@@ -128,7 +126,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("uses Proposer when not specifying an action (defaults to `schedule`)", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env, chain)
+		m := getMCMSTransaction(t, *fixture.Env)
 		cfg := contracts.MCMSConfig{
 			MinDelay: 0,
 			TimelockQualifierPerChain: map[uint64]string{
@@ -139,8 +137,9 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 		require.NoError(t, err)
 		m.Config = &cfg
 		m.MCMSContracts = mcmsContracts
+		m.ChainSel = fixture.RegistrySelector
 
-		op, err := proposalutils.BatchOperationForChain(m.Chain.ChainSelector(), m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
+		op, err := proposalutils.BatchOperationForChain(m.ChainSel, m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
 		require.NoError(t, err)
 
 		p, err := m.BuildProposal([]mcmstypes.BatchOperation{op})
@@ -152,7 +151,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("uses Bypasser when specified", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env, chain)
+		m := getMCMSTransaction(t, *fixture.Env)
 		cfg := contracts.MCMSConfig{
 			MinDelay:   0,
 			MCMSAction: mcmstypes.TimelockActionBypass,
@@ -164,8 +163,9 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 		require.NoError(t, err)
 		m.Config = &cfg
 		m.MCMSContracts = mcmsContracts
+		m.ChainSel = fixture.RegistrySelector
 
-		op, err := proposalutils.BatchOperationForChain(m.Chain.ChainSelector(), m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
+		op, err := proposalutils.BatchOperationForChain(m.ChainSel, m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
 		require.NoError(t, err)
 
 		p, err := m.BuildProposal([]mcmstypes.BatchOperation{op})
@@ -177,7 +177,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 	})
 
 	t.Run("uses Canceller when specified", func(t *testing.T) {
-		m := getMCMSTransaction(t, *fixture.Env, chain)
+		m := getMCMSTransaction(t, *fixture.Env)
 		cfg := contracts.MCMSConfig{
 			MinDelay:   0,
 			MCMSAction: mcmstypes.TimelockActionCancel,
@@ -189,8 +189,9 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 		require.NoError(t, err)
 		m.Config = &cfg
 		m.MCMSContracts = mcmsContracts
+		m.ChainSel = fixture.RegistrySelector
 
-		op, err := proposalutils.BatchOperationForChain(m.Chain.ChainSelector(), m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
+		op, err := proposalutils.BatchOperationForChain(m.ChainSel, m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
 		require.NoError(t, err)
 
 		p, err := m.BuildProposal([]mcmstypes.BatchOperation{op})

--- a/deployment/cre/common/strategies/strategies.go
+++ b/deployment/cre/common/strategies/strategies.go
@@ -53,7 +53,7 @@ func CreateStrategy(
 			Config:        mcmsConfig,
 			Description:   description,
 			Address:       targetAddress,
-			Chain:         chain,
+			ChainSel:      chain.ChainSelector(),
 			MCMSContracts: mcmsContracts,
 			Env:           env,
 		}, nil

--- a/deployment/cre/common/strategies/strategies.go
+++ b/deployment/cre/common/strategies/strategies.go
@@ -44,11 +44,16 @@ func CreateStrategy(
 			return nil, errors.New("MCMS contracts are required when mcmsConfig is not nil")
 		}
 
+		err := mcmsConfig.Validate(chain, *mcmsContracts)
+		if err != nil {
+			return nil, fmt.Errorf("invalid MCMS configuration: %w", err)
+		}
+
 		return &MCMSTransaction{
 			Config:        mcmsConfig,
 			Description:   description,
 			Address:       targetAddress,
-			ChainSel:      chain.Selector,
+			Chain:         chain,
 			MCMSContracts: mcmsContracts,
 			Env:           env,
 		}, nil


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
This PR addresses [CRE-1441](https://smartcontract-it.atlassian.net/browse/CRE-1441) by fixing the MCMS Strategy so it knows which MCM address to use based on the `Action` specified.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-1441]: https://smartcontract-it.atlassian.net/browse/CRE-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ