### PR TITLE
PLEX-2135: ensure an event gets emitted and picked up at some point

### DIFF
--- a/system-tests/tests/smoke/cre/evm/logtrigger/main.go
+++ b/system-tests/tests/smoke/cre/evm/logtrigger/main.go
@@ -135,7 +135,7 @@ func printDecodedData(t *T, runtime sdk.Runtime, eventABI string, eventName stri
 		first = false
 	}
 	decodedData := sb.String()
-	runtime.Logger().Info("Values formatted successfully:", "decodedData ", decodedData)
+	runtime.Logger().Info("Values formatted successfully")
 	return decodedData, nil
 }
 

--- a/system-tests/tests/smoke/cre/evm/logtrigger/main.go
+++ b/system-tests/tests/smoke/cre/evm/logtrigger/main.go
@@ -92,7 +92,6 @@ func toByteSlices(addresses []string) [][]byte {
 }
 
 func onTrigger(cfg logtrigger.Config, runtime sdk.Runtime, outputs *evm.Log) (string, error) {
-	//runtime.Logger().Info("Trigger OnTrigger called", "outputs", outputs)
 	runtime.Logger().With().Info(fmt.Sprintf("OnTrigger txHash: %s log index: %d", hex.EncodeToString(outputs.TxHash), outputs.Index))
 	t := &T{Logger: runtime.Logger()}
 	require.NotNil(t, outputs, "Log input should not be nil")

--- a/system-tests/tests/smoke/cre/evm/logtrigger/main.go
+++ b/system-tests/tests/smoke/cre/evm/logtrigger/main.go
@@ -92,7 +92,8 @@ func toByteSlices(addresses []string) [][]byte {
 }
 
 func onTrigger(cfg logtrigger.Config, runtime sdk.Runtime, outputs *evm.Log) (string, error) {
-	runtime.Logger().Info("Trigger OnTrigger called", "outputs", outputs)
+	//runtime.Logger().Info("Trigger OnTrigger called", "outputs", outputs)
+	runtime.Logger().With().Info(fmt.Sprintf("OnTrigger txHash: %s log index: %d", hex.EncodeToString(outputs.TxHash), outputs.Index))
 	t := &T{Logger: runtime.Logger()}
 	require.NotNil(t, outputs, "Log input should not be nil")
 

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -246,7 +246,7 @@ func ExecuteEVMLogTriggerTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 		time.Sleep(10 * time.Second)
 
 		message := "Data for log trigger"
-		//_ = emitEvent(t, lggr, chainID, bcOutput, msgEmitter, message, workflowConfig)
+		// _ = emitEvent(t, lggr, chainID, bcOutput, msgEmitter, message, workflowConfig)
 		// start background event emission every 10s while AssertBeholderMessage is running
 		ticker := time.NewTicker(10 * time.Second)
 		go func() {

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -246,7 +246,22 @@ func ExecuteEVMLogTriggerTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 		time.Sleep(10 * time.Second)
 
 		message := "Data for log trigger"
-		_ = emitEvent(t, lggr, chainID, bcOutput, msgEmitter, message, workflowConfig)
+		//_ = emitEvent(t, lggr, chainID, bcOutput, msgEmitter, message, workflowConfig)
+		// start background event emission every 10s while AssertBeholderMessage is running
+		ticker := time.NewTicker(10 * time.Second)
+		go func() {
+			defer ticker.Stop()
+			for {
+				select {
+				case <-listenerCtx.Done():
+					return
+				case <-ticker.C:
+					lggr.Info().Msgf("About to emit an event for chain %s", chainID)
+					blockNumber := emitEvent(t, lggr, chainID, bcOutput, msgEmitter, message, workflowConfig)
+					lggr.Info().Msgf("Event emitted for chain %s at blockNumber %d", chainID, blockNumber)
+				}
+			}
+		}()
 		expectedUserLog := "OnTrigger decoded message: message:" + message
 		err = t_helpers.AssertBeholderMessage(listenerCtx, t, expectedUserLog, lggr, messageChan, kafkaErrChan, 4*time.Minute)
 		require.NoError(t, err, "Expected user log test failed")

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -168,10 +168,18 @@ func emitEvent(t *testing.T, lggr zerolog.Logger, chainID string, bcOutput block
 	lggr.Info().Msgf("Emitting event to be picked up by workflow for chain '%s'", chainID)
 	sethClient := bcOutput.(*evm.Blockchain).SethClient
 	emittingTx, err := msgEmitter.EmitMessage(sethClient.NewTXOpts(), expectedUserLog)
-	require.NoError(t, err, "failed to emit message from contract '%s'", workflowConfig.Addresses[0])
+	// require.NoError(t, err, "failed to emit message from contract '%s'", workflowConfig.Addresses[0])
+	if err != nil {
+		lggr.Info().Msgf("Failed to emit transaction for chain '%s': %v", chainID, err)
+		return 0
+	}
 
 	emittingReceipt, err := sethClient.WaitMined(t.Context(), lggr, sethClient.Client, emittingTx)
-	require.NoError(t, err, "failed to get message emitter event tx")
+	// require.NoError(t, err, "failed to get message emitter event tx")
+	if err != nil {
+		lggr.Info().Msgf("Failed to emit receipt for chain '%s': %v", chainID, err)
+		return 0
+	}
 	lggr.Info().Msgf("Transaction for chain '%s' mined at '%d' with emitted message %q", chainID, emittingReceipt.BlockNumber.Uint64(), expectedUserLog)
 	return emittingReceipt.BlockNumber.Uint64()
 }

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -168,14 +168,12 @@ func emitEvent(t *testing.T, lggr zerolog.Logger, chainID string, bcOutput block
 	lggr.Info().Msgf("Emitting event to be picked up by workflow for chain '%s'", chainID)
 	sethClient := bcOutput.(*evm.Blockchain).SethClient
 	emittingTx, err := msgEmitter.EmitMessage(sethClient.NewTXOpts(), expectedUserLog)
-	// require.NoError(t, err, "failed to emit message from contract '%s'", workflowConfig.Addresses[0])
 	if err != nil {
 		lggr.Info().Msgf("Failed to emit transaction for chain '%s': %v", chainID, err)
 		return 0
 	}
 
 	emittingReceipt, err := sethClient.WaitMined(t.Context(), lggr, sethClient.Client, emittingTx)
-	// require.NoError(t, err, "failed to get message emitter event tx")
 	if err != nil {
 		lggr.Info().Msgf("Failed to emit receipt for chain '%s': %v", chainID, err)
 		return 0
@@ -250,12 +248,9 @@ func ExecuteEVMLogTriggerTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 		err := t_helpers.AssertBeholderMessage(listenerCtx, t, triggersUpAndRunning, lggr, messageChan, kafkaErrChan, 4*time.Minute)
 		require.NoError(t, err, "LogTrigger capability test failed, Beholder should not return an error")
 
-		// wait for trigger to be registered across the workflow engine of all workflow nodes
-		time.Sleep(10 * time.Second)
-
 		message := "Data for log trigger"
-		// _ = emitEvent(t, lggr, chainID, bcOutput, msgEmitter, message, workflowConfig)
-		// start background event emission every 10s while AssertBeholderMessage is running
+		// start background event emission every 10s while AssertBeholderMessage is running, so that the workflow has events to pick up eventually
+		var amountEmittedEvents int64 = 0
 		ticker := time.NewTicker(10 * time.Second)
 		go func() {
 			defer ticker.Stop()
@@ -264,9 +259,10 @@ func ExecuteEVMLogTriggerTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 				case <-listenerCtx.Done():
 					return
 				case <-ticker.C:
-					lggr.Info().Msgf("About to emit an event for chain %s", chainID)
+					lggr.Info().Msgf("About to emit an event %d for chain %s", amountEmittedEvents, chainID)
 					blockNumber := emitEvent(t, lggr, chainID, bcOutput, msgEmitter, message, workflowConfig)
 					lggr.Info().Msgf("Event emitted for chain %s at blockNumber %d", chainID, blockNumber)
+					amountEmittedEvents++
 				}
 			}
 		}()

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -250,7 +250,7 @@ func ExecuteEVMLogTriggerTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 
 		message := "Data for log trigger"
 		// start background event emission every 10s while AssertBeholderMessage is running, so that the workflow has events to pick up eventually
-		var amountEmittedEvents int64
+		var emittedEventCount int64
 		ticker := time.NewTicker(10 * time.Second)
 		go func() {
 			defer ticker.Stop()
@@ -259,10 +259,10 @@ func ExecuteEVMLogTriggerTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 				case <-listenerCtx.Done():
 					return
 				case <-ticker.C:
-					lggr.Info().Msgf("About to emit an event %d for chain %s", amountEmittedEvents, chainID)
+					lggr.Info().Msgf("About to emit event #%d for chain %s", emittedEventCount, chainID)
 					blockNumber := emitEvent(t, lggr, chainID, bcOutput, msgEmitter, message, workflowConfig)
 					lggr.Info().Msgf("Event emitted for chain %s at blockNumber %d", chainID, blockNumber)
-					amountEmittedEvents++
+					emittedEventCount++
 				}
 			}
 		}()

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -250,7 +250,7 @@ func ExecuteEVMLogTriggerTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 
 		message := "Data for log trigger"
 		// start background event emission every 10s while AssertBeholderMessage is running, so that the workflow has events to pick up eventually
-		var amountEmittedEvents int64 = 0
+		var amountEmittedEvents int64
 		ticker := time.NewTicker(10 * time.Second)
 		go func() {
 			defer ticker.Stop()


### PR DESCRIPTION
Jira https://smartcontract-it.atlassian.net/browse/PLEX-2135
Before this change, the test only emitted a single event and we checked if that event reached the WF.
As this is flaky, we are making it less strict so we are emitting an event every 10seconds, and if *any* event reachs the WF we will consider it good enough, finalizing the test successfully. 

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
