### PR TITLE
[BCF-3490] Add AtomicCore time based cleanup.

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -280,7 +280,10 @@ func NewApp(s *Shell) *cli.App {
 				l, closeFn := lggrCfg.NewWithCores(atomicCore)
 
 				s.Logger = l
-				s.CloseLogger = closeFn
+				s.CloseLogger = func() error {
+					atomicCore.Close()
+					return closeFn()
+				}
 				// s.SetOtelCore is a hook that can be used to set the OTel core
 				s.SetOtelCore = atomicCore.Store
 

--- a/core/logger/logger_test.go
+++ b/core/logger/logger_test.go
@@ -94,6 +94,7 @@ func TestOtelCore(t *testing.T) {
 // TestAtomicCoreSwap tests the atomic core swap functionality after logger creation.
 func TestAtomicCoreSwap(t *testing.T) {
 	atomicCore := NewAtomicCore()
+	defer atomicCore.Close()
 	setOtelCore := atomicCore.Store
 
 	lggrCfg := Config{

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -23,6 +23,7 @@ type AtomicCore struct {
 	core        zapcore.Core
 	children    []weak.Pointer[withCore]
 	stopCleanup chan struct{}
+	cleanupWg   sync.WaitGroup
 }
 
 // NewAtomicCore creates a new AtomicCore initialized with a noop core
@@ -76,6 +77,7 @@ func (d *AtomicCore) Sync() error { return d.load().Sync() }
 
 func (d *AtomicCore) Close() {
 	close(d.stopCleanup)
+	d.cleanupWg.Wait()
 }
 
 func (d *AtomicCore) cleanup() {
@@ -92,7 +94,9 @@ func (d *AtomicCore) cleanup() {
 }
 
 func (d *AtomicCore) startPeriodicCleanup() {
+	d.cleanupWg.Add(1)
 	go func() {
+		defer d.cleanupWg.Done()
 		ticker := time.NewTicker(cleanupInterval)
 		defer ticker.Stop()
 

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -81,6 +81,8 @@ func (d *AtomicCore) Close() {
 }
 
 func (d *AtomicCore) cleanup() {
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.children = slices.DeleteFunc(d.children, func(p weak.Pointer[withCore]) bool {
@@ -88,7 +90,7 @@ func (d *AtomicCore) cleanup() {
 		if c == nil {
 			return true
 		}
-		c.cleanup()
+		wg.Go(c.cleanup)
 		return false
 	})
 }

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"slices"
 	"sync"
+	"time"
 	"weak"
 
 	pkgerrors "github.com/pkg/errors"
@@ -15,15 +16,23 @@ import (
 // It starts as a noop core and can be atomically swapped to include additional cores.
 var _ zapcore.Core = &AtomicCore{}
 
+const cleanupInterval = time.Minute * 5
+
 type AtomicCore struct {
-	mu       sync.RWMutex
-	core     zapcore.Core
-	children []weak.Pointer[withCore]
+	mu          sync.RWMutex
+	core        zapcore.Core
+	children    []weak.Pointer[withCore]
+	stopCleanup chan struct{}
 }
 
 // NewAtomicCore creates a new AtomicCore initialized with a noop core
 func NewAtomicCore() *AtomicCore {
-	return &AtomicCore{core: zapcore.NewNopCore()}
+	ac := &AtomicCore{
+		core:        zapcore.NewNopCore(),
+		stopCleanup: make(chan struct{}),
+	}
+	ac.startPeriodicCleanup()
+	return ac
 }
 
 func (d *AtomicCore) Store(core zapcore.Core) {
@@ -64,6 +73,39 @@ func (d *AtomicCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.C
 func (d *AtomicCore) Write(e zapcore.Entry, fs []zapcore.Field) error { return d.load().Write(e, fs) }
 
 func (d *AtomicCore) Sync() error { return d.load().Sync() }
+
+func (d *AtomicCore) Close() {
+	close(d.stopCleanup)
+}
+
+func (d *AtomicCore) cleanup() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.children = slices.DeleteFunc(d.children, func(p weak.Pointer[withCore]) bool {
+		c := p.Value()
+		if c == nil {
+			return true
+		}
+		c.cleanup()
+		return false
+	})
+}
+
+func (d *AtomicCore) startPeriodicCleanup() {
+	go func() {
+		ticker := time.NewTicker(cleanupInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				d.cleanup()
+			case <-d.stopCleanup:
+				return
+			}
+		}
+	}()
+}
 
 type withCore struct {
 	fields []zapcore.Field

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -96,9 +96,7 @@ func (d *AtomicCore) cleanup() {
 }
 
 func (d *AtomicCore) startPeriodicCleanup() {
-	d.cleanupWg.Add(1)
-	go func() {
-		defer d.cleanupWg.Done()
+	d.cleanupWg.Go(func() {
 		ticker := time.NewTicker(cleanupInterval)
 		defer ticker.Stop()
 
@@ -110,7 +108,7 @@ func (d *AtomicCore) startPeriodicCleanup() {
 				return
 			}
 		}
-	}()
+	})
 }
 
 type withCore struct {

--- a/core/logger/zap_test.go
+++ b/core/logger/zap_test.go
@@ -256,7 +256,7 @@ func TestZapLogger_LogCaller(t *testing.T) {
 	logs := string(b)
 	lines := strings.Split(logs, "\n")
 
-	require.Contains(t, lines[0], "logger/zap_test.go:246")
+	require.Contains(t, lines[0], "logger/zap_test.go:247")
 }
 
 func TestZapLogger_Name(t *testing.T) {

--- a/core/logger/zap_test.go
+++ b/core/logger/zap_test.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -266,4 +267,24 @@ func TestZapLogger_Name(t *testing.T) {
 	require.Equal(t, "Lggr1", lggr1.Name())
 	lggr2 := lggr1.Named("Lggr2")
 	require.Equal(t, "Lggr1.Lggr2", lggr2.Name())
+}
+
+func TestZapLogger_Cleanup(t *testing.T) {
+	ac := NewAtomicCore()
+	defer ac.Close()
+	l := 1000000
+	for range l {
+		ac.With([]zapcore.Field{})
+	}
+	// Without the cleanup triggered, all children should remain.
+	// (We assume that the cleanupInterval is sufficiently large to not yet trigger.)
+	require.Equal(t, len(ac.children), l)
+
+	// Trigger cleanup manually
+	runtime.GC()
+	ac.cleanup()
+	ac.With([]zapcore.Field{})
+	// Ideally, a.children should be 1 here, but since garbage collected weak pointers are not necessary nil we just
+	// test that some have been cleaned up.
+	require.Less(t, len(ac.children), l)
 }

--- a/core/logger/zap_test.go
+++ b/core/logger/zap_test.go
@@ -285,8 +285,7 @@ func TestZapLogger_Cleanup(t *testing.T) {
 	// Trigger cleanup manually.
 	runtime.GC()
 	ac.cleanup()
-	ac.With([]zapcore.Field{})
-	// Ideally, ac.children should be 1 here, but since garbage collected weak pointers are not necessarily nil we just
+	// Ideally, ac.children should be 0 here, but since garbage collected weak pointers are not necessarily nil we just
 	// test that some have been cleaned up.
 	require.Less(t, len(ac.children), l)
 }

--- a/core/logger/zap_test.go
+++ b/core/logger/zap_test.go
@@ -277,14 +277,14 @@ func TestZapLogger_Cleanup(t *testing.T) {
 		ac.With([]zapcore.Field{})
 	}
 	// Without the cleanup triggered, all children should remain.
-	// (We assume that the cleanupInterval is sufficiently large to not yet trigger.)
+	// We assume that the cleanupInterval is sufficiently large to not yet trigger.
 	require.Equal(t, len(ac.children), l)
 
-	// Trigger cleanup manually
+	// Trigger cleanup manually.
 	runtime.GC()
 	ac.cleanup()
 	ac.With([]zapcore.Field{})
-	// Ideally, a.children should be 1 here, but since garbage collected weak pointers are not necessary nil we just
+	// Ideally, ac.children should be 1 here, but since garbage collected weak pointers are not necessary nil we just
 	// test that some have been cleaned up.
 	require.Less(t, len(ac.children), l)
 }

--- a/core/logger/zap_test.go
+++ b/core/logger/zap_test.go
@@ -245,6 +245,8 @@ func TestZapLogger_LogCaller(t *testing.T) {
 	lggr := newTestLogger(t, local)
 
 	lggr.Debug("test message with caller")
+	_, _, lineCall, ok := runtime.Caller(0)
+	require.True(t, ok)
 
 	pollChan <- time.Now()
 	<-local.testDiskLogLvlChan
@@ -256,7 +258,7 @@ func TestZapLogger_LogCaller(t *testing.T) {
 	logs := string(b)
 	lines := strings.Split(logs, "\n")
 
-	require.Contains(t, lines[0], "logger/zap_test.go:247")
+	require.Contains(t, lines[0], fmt.Sprintf("logger/zap_test.go:%d\ttest message with caller", lineCall-1))
 }
 
 func TestZapLogger_Name(t *testing.T) {
@@ -284,7 +286,7 @@ func TestZapLogger_Cleanup(t *testing.T) {
 	runtime.GC()
 	ac.cleanup()
 	ac.With([]zapcore.Field{})
-	// Ideally, ac.children should be 1 here, but since garbage collected weak pointers are not necessary nil we just
+	// Ideally, ac.children should be 1 here, but since garbage collected weak pointers are not necessarily nil we just
 	// test that some have been cleaned up.
 	require.Less(t, len(ac.children), l)
 }


### PR DESCRIPTION
Before this PR `d.children` could grow indefinitely. After this PR we introduce a regular goroutine that will remove garbage collected entries from `d.children` periodically.