### PR TITLE
chore: bump Go version to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/v2
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
Updates the module Go version to 1.25.5, the latest stable release.

- go.mod updated
- no go.sum or dependency changes required
- local + CI toolchain will pick up 1.25.5 automatically
- required before cutting the release/2.31.0 branch and building the next beta image

This is a no-behavioral-change upgrade; only toolchain alignment.