### PR TITLE
chore: bump Go version to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/v2
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
Bumps the module Go version from 1.25.3 → 1.25.5, aligning Core with the latest stable Go toolchain. This keeps the build environment consistent across local dev, CI, and release builds.

Details

Updated the go directive in go.mod to 1.25.5.

Ran go mod tidy to refresh module metadata.

No dependency or go.sum changes required.

No behavioral changes or code modifications included.

CI will automatically use the updated toolchain since it sources the version from go.mod.