### PR TITLE
chore: upgrade Go to 1.25.5 across repository

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -1,7 +1,7 @@
 ##
 # Build image: Chainlink binary with plugins.
 ##
-FROM golang:1.25.3-bookworm AS buildgo
+FROM golang:1.25.5-bookworm AS buildgo
 RUN go version
 RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
 

--- a/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251028192540-2ac3c24aa883

--- a/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251028192540-2ac3c24aa883

--- a/core/scripts/cre/environment/examples/workflows/v2/cron/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/cron/go.mod
@@ -2,7 +2,7 @@ module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/exampl
 
 go 1.24.5
 
-toolchain go1.25.3
+toolchain go1.25.5
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v0.8.0

--- a/core/scripts/cre/environment/examples/workflows/v2/http/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/http/go.mod
@@ -2,7 +2,7 @@ module main
 
 go 1.24.5
 
-toolchain go1.25.3
+toolchain go1.25.5
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v0.9.0

--- a/core/scripts/cre/environment/examples/workflows/v2/node-mode/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/node-mode/go.mod
@@ -2,7 +2,7 @@ module main
 
 go 1.24.5
 
-toolchain go1.25.3
+toolchain go1.25.5
 
 require (
 	github.com/google/uuid v1.6.0

--- a/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/ethereum/go-ethereum v1.16.2

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts
 
-go 1.25.3
+go 1.25.5
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../../

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/deployment
 
-go 1.25.3
+go 1.25.5
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/v2
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/BurntSushi/toml v1.4.0

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/integration-tests
 
-go 1.25.3
+go 1.25.5
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/load-tests
 
-go 1.25.3
+go 1.25.5
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../../

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -3,7 +3,7 @@
 # XXX: Experimental -- not to be used to build images for production use.
 # See: ../core/chainlink.Dockerfile for the production Dockerfile.
 ##
-FROM golang:1.25.3-bookworm AS buildgo
+FROM golang:1.25.5-bookworm AS buildgo
 RUN go version
 RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
 

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/lib
 
-go 1.25.3
+go 1.25.5
 
 // Using a separate `require` here to avoid surrounding line changes
 // creating potential merge conflicts.

--- a/system-tests/tests/canaries_sentinels/proof-of-reserve/cron-based/go.mod
+++ b/system-tests/tests/canaries_sentinels/proof-of-reserve/cron-based/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/ethereum/go-ethereum v1.16.2

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests
 
-go 1.25.3
+go 1.25.5
 
 // Using a separate `require` here to avoid surrounding line changes
 // creating potential merge conflicts.

--- a/system-tests/tests/regression/cre/consensus/go.mod
+++ b/system-tests/tests/regression/cre/consensus/go.mod
@@ -2,7 +2,7 @@ module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/c
 
 go 1.24.5
 
-toolchain go1.25.3
+toolchain go1.25.5
 
 require (
 	github.com/ethereum/go-ethereum v1.16.2

--- a/system-tests/tests/regression/cre/evm/evmread-negative/go.mod
+++ b/system-tests/tests/regression/cre/evm/evmread-negative/go.mod
@@ -2,7 +2,7 @@ module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/e
 
 go 1.24.5
 
-toolchain go1.25.3
+toolchain go1.25.5
 
 require (
 	github.com/ethereum/go-ethereum v1.16.4

--- a/system-tests/tests/regression/cre/evm/evmwrite-negative/go.mod
+++ b/system-tests/tests/regression/cre/evm/evmwrite-negative/go.mod
@@ -2,7 +2,7 @@ module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/e
 
 go 1.24.5
 
-toolchain go1.25.3
+toolchain go1.25.5
 
 require (
 	github.com/ethereum/go-ethereum v1.16.4

--- a/system-tests/tests/smoke/cre/evm/evmread/go.mod
+++ b/system-tests/tests/smoke/cre/evm/evmread/go.mod
@@ -2,7 +2,7 @@ module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evm/ev
 
 go 1.24.5
 
-toolchain go1.25.3
+toolchain go1.25.5
 
 require (
 	github.com/ethereum/go-ethereum v1.16.4


### PR DESCRIPTION
Upgrades the Go toolchain across all modules, submodules, system tests, integration tests, and build Dockerfiles. This aligns the entire repo with Go 1.25.5 before cutting release/2.31.0. All go.mod files and toolchain directives updated, Dockerfiles bumped, and tidy run where applicable.