### PR TITLE
Sync 2.31.0 changeset + changelog into develop

### DIFF
--- a/.changeset/clean-foxes-clap.md
+++ b/.changeset/clean-foxes-clap.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Start 2.32.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog Chainlink Core
 
-## 2.31.0
+## 2.31.0 - UNRELEASED
 
 ### Minor Changes
 


### PR DESCRIPTION
Cherry-picks release bump commit so develop can progress to 2.32.x.