### PR TITLE
fix(ci): sui binary caching

### DIFF
--- a/.github/actions/setup-sui/action.yaml
+++ b/.github/actions/setup-sui/action.yaml
@@ -17,7 +17,7 @@ runs:
       name: Cache Sui CLI
       with:
         path: |
-          ~/.suiup/bin
+          ~/.local/bin/sui
         key: ${{ runner.os }}-suiup-${{ inputs.version }}
 
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
@@ -32,4 +32,5 @@ runs:
 
     - name: Export Sui CLI to PATH
       shell: bash
-      run: echo "PATH=$HOME/.suiup/bin:$HOME/.local/bin:$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
+      run: |
+        echo "PATH=$HOME/.local/bin:$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV


### PR DESCRIPTION
### Changes

* Fix the installation path for the sui binary so it can be cached

### Motivation

There were installation issues which were fixed in #20533, but it broke the SUI binary cache.

For example: https://github.com/smartcontractkit/chainlink/actions/runs/19968771608/job/57267681721#step:38:3
```
Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

### Testing

* Initial install due to no cache: https://github.com/smartcontractkit/chainlink/actions/runs/19972613226/job/57280908461?pr=20539#step:8:68 (30s)
* Use cache instead (re-run): https://github.com/smartcontractkit/chainlink/actions/runs/19972613226/job/57282089212?pr=20539#step:8:72 (1s)


