### PR TITLE
chore: bump ccv version

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -492,7 +492,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/ccv/chains/evm v0.0.0-20251127040717-30244f57ea7a // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5 // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5 // indirect
-	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b // indirect
+	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1634,6 +1634,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b h1:+GnP8VoRndysmH3JYLUveeDmNTNrfhyUhfAeOs6WHPI=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
+github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa h1:uaGuM0IbTf8ihBPegBIDH6ShwpOyjG5oyaeg3dtbqLM=
+github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4 h1:2LHrlWAStA2oRcDKrJ9lKOShC9an2Pkis2BwY8J7gDw=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4/go.mod h1:uRnGLHKo56QYaPk93z0NRAIgv115lh72rzG40CiE1Mk=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1632,8 +1632,6 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
-github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b h1:+GnP8VoRndysmH3JYLUveeDmNTNrfhyUhfAeOs6WHPI=
-github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa h1:uaGuM0IbTf8ihBPegBIDH6ShwpOyjG5oyaeg3dtbqLM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4 h1:2LHrlWAStA2oRcDKrJ9lKOShC9an2Pkis2BwY8J7gDw=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -414,7 +414,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
 	github.com/smartcontractkit/chainlink-ccip/ccv/chains/evm v0.0.0-20251127040717-30244f57ea7a // indirect
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e // indirect
-	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b // indirect
+	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.6 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1358,6 +1358,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b h1:+GnP8VoRndysmH3JYLUveeDmNTNrfhyUhfAeOs6WHPI=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
+github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa h1:uaGuM0IbTf8ihBPegBIDH6ShwpOyjG5oyaeg3dtbqLM=
+github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4 h1:2LHrlWAStA2oRcDKrJ9lKOShC9an2Pkis2BwY8J7gDw=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4/go.mod h1:uRnGLHKo56QYaPk93z0NRAIgv115lh72rzG40CiE1Mk=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1356,8 +1356,6 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
-github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b h1:+GnP8VoRndysmH3JYLUveeDmNTNrfhyUhfAeOs6WHPI=
-github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa h1:uaGuM0IbTf8ihBPegBIDH6ShwpOyjG5oyaeg3dtbqLM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4 h1:2LHrlWAStA2oRcDKrJ9lKOShC9an2Pkis2BwY8J7gDw=

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20251128020529-88d93b01d749
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b
+	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10
 	github.com/smartcontractkit/chainlink-data-streams v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -1124,8 +1124,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-f
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:Ve1xD71bl193YIZQEoJMmBqLGQJdNs29bwbuObwvbhQ=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5 h1:Z4t2ZY+ZyGWxtcXvPr11y4o3CGqhg3frJB5jXkCSvWA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b h1:+GnP8VoRndysmH3JYLUveeDmNTNrfhyUhfAeOs6WHPI=
-github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
+github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa h1:uaGuM0IbTf8ihBPegBIDH6ShwpOyjG5oyaeg3dtbqLM=
+github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4 h1:2LHrlWAStA2oRcDKrJ9lKOShC9an2Pkis2BwY8J7gDw=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4/go.mod h1:uRnGLHKo56QYaPk93z0NRAIgv115lh72rzG40CiE1Mk=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -496,7 +496,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
 	github.com/smartcontractkit/chainlink-ccip/ccv/chains/evm v0.0.0-20251127040717-30244f57ea7a // indirect
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e // indirect
-	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b // indirect
+	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.6 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1599,8 +1599,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
-github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b h1:+GnP8VoRndysmH3JYLUveeDmNTNrfhyUhfAeOs6WHPI=
-github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
+github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa h1:uaGuM0IbTf8ihBPegBIDH6ShwpOyjG5oyaeg3dtbqLM=
+github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4 h1:2LHrlWAStA2oRcDKrJ9lKOShC9an2Pkis2BwY8J7gDw=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4/go.mod h1:uRnGLHKo56QYaPk93z0NRAIgv115lh72rzG40CiE1Mk=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -481,7 +481,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
 	github.com/smartcontractkit/chainlink-ccip/ccv/chains/evm v0.0.0-20251127040717-30244f57ea7a // indirect
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e // indirect
-	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b // indirect
+	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.6 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1578,8 +1578,6 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
-github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b h1:+GnP8VoRndysmH3JYLUveeDmNTNrfhyUhfAeOs6WHPI=
-github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa h1:uaGuM0IbTf8ihBPegBIDH6ShwpOyjG5oyaeg3dtbqLM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4 h1:2LHrlWAStA2oRcDKrJ9lKOShC9an2Pkis2BwY8J7gDw=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1580,6 +1580,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b h1:+GnP8VoRndysmH3JYLUveeDmNTNrfhyUhfAeOs6WHPI=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
+github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa h1:uaGuM0IbTf8ihBPegBIDH6ShwpOyjG5oyaeg3dtbqLM=
+github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4 h1:2LHrlWAStA2oRcDKrJ9lKOShC9an2Pkis2BwY8J7gDw=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4/go.mod h1:uRnGLHKo56QYaPk93z0NRAIgv115lh72rzG40CiE1Mk=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -455,7 +455,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20251128020529-88d93b01d749 // indirect
 	github.com/smartcontractkit/chainlink-ccip/ccv/chains/evm v0.0.0-20251127040717-30244f57ea7a // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5 // indirect
-	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b // indirect
+	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.6 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1595,8 +1595,6 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
-github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b h1:+GnP8VoRndysmH3JYLUveeDmNTNrfhyUhfAeOs6WHPI=
-github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa h1:uaGuM0IbTf8ihBPegBIDH6ShwpOyjG5oyaeg3dtbqLM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4 h1:2LHrlWAStA2oRcDKrJ9lKOShC9an2Pkis2BwY8J7gDw=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1597,6 +1597,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b h1:+GnP8VoRndysmH3JYLUveeDmNTNrfhyUhfAeOs6WHPI=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
+github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa h1:uaGuM0IbTf8ihBPegBIDH6ShwpOyjG5oyaeg3dtbqLM=
+github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4 h1:2LHrlWAStA2oRcDKrJ9lKOShC9an2Pkis2BwY8J7gDw=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4/go.mod h1:uRnGLHKo56QYaPk93z0NRAIgv115lh72rzG40CiE1Mk=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/influxdata/tdigest v0.0.2-0.20210216194612-fc98d27c9e8b // indirect
 	github.com/smartcontractkit/chainlink-ccip/ccv/chains/evm v0.0.0-20251127040717-30244f57ea7a // indirect
-	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b // indirect
+	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/go v0.0.0-20251126123859-d079d6815edb // indirect
 )
 

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1792,8 +1792,6 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e h1:hQEOz6nRQgIQf0HS3EsjS22cAwejLa6q4nCyFGYrb/s=
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
-github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b h1:+GnP8VoRndysmH3JYLUveeDmNTNrfhyUhfAeOs6WHPI=
-github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa h1:uaGuM0IbTf8ihBPegBIDH6ShwpOyjG5oyaeg3dtbqLM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4 h1:2LHrlWAStA2oRcDKrJ9lKOShC9an2Pkis2BwY8J7gDw=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1794,6 +1794,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e/go.mod h1:IaoLCQE1miX3iUlQNxOPcVrXrshcO/YsFpxnFuhG9DM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b h1:+GnP8VoRndysmH3JYLUveeDmNTNrfhyUhfAeOs6WHPI=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205143623-4948c857101b/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
+github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa h1:uaGuM0IbTf8ihBPegBIDH6ShwpOyjG5oyaeg3dtbqLM=
+github.com/smartcontractkit/chainlink-ccv v0.0.0-20251205222258-2f17e4b865fa/go.mod h1:Ysd/qkofD0bepk29RS7Q4ZlVDd4yAHXucYsp5gAy6AE=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4 h1:2LHrlWAStA2oRcDKrJ9lKOShC9an2Pkis2BwY8J7gDw=
 github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4/go.mod h1:uRnGLHKo56QYaPk93z0NRAIgv115lh72rzG40CiE1Mk=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=


### PR DESCRIPTION
Closed due to: https://github.com/smartcontractkit/chainlink/pull/20550