### PR TITLE
trigger registrations concurrent + sync to handler. trigger subscript…

### DIFF
--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -684,7 +684,7 @@ func (h *eventHandler) tryEngineCreate(ctx context.Context, spec *job.WorkflowSp
 	}
 
 	// Wait for the engine to complete initialization (including trigger subscriptions).
-	// This ensures we don't emit workflowActivated events before triggers are actually subscribed.
+	// This ensures we don't emit workflowActivated events before the engine initializes successfully.
 	select {
 	case <-ctx.Done():
 		// Context cancelled while waiting for initialization
@@ -695,7 +695,7 @@ func (h *eventHandler) tryEngineCreate(ctx context.Context, spec *job.WorkflowSp
 	case initErr := <-initDone:
 		if initErr != nil {
 			// Engine initialization failed (e.g., trigger subscription failed)
-			// TODO (patrickhuie19) add logic to mark a deployment as failed to avoid churn.
+			// TODO (cre-1482) add logic to mark a deployment as failed to avoid churn.
 			// Currently, failed deployments will be retried on each poll cycle (with exponential backoff).
 			// If the failure is due to user error (e.g., invalid trigger config), this causes unnecessary retries.
 			// Consider marking the workflow spec as "failed" in the database and requiring workflow redeployment.

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -75,6 +75,8 @@ func WithEngineRegistry(er *EngineRegistry) func(*eventHandler) {
 	}
 }
 
+// WithEngineFactoryFn allows for overriding the engine factory function.
+// if in doubt, close initDone channel immediately in tests to prevent deadlocks.
 func WithEngineFactoryFn(efn engineFactoryFn) func(*eventHandler) {
 	return func(e *eventHandler) {
 		e.engineFactory = efn

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -37,7 +37,11 @@ type ORM interface {
 	artifacts.WorkflowSpecsDS
 }
 
-type engineFactoryFn func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte) (services.Service, error)
+// engineFactoryFn creates a workflow engine. The initDone channel is used to signal when the engine
+// has completed initialization (including trigger subscriptions). For v2 engines, this is wired to
+// the OnInitialized lifecycle hook. For v1 legacy DAG engines, nil is sent immediately after engine
+// creation since they don't support async initialization hooks.
+type engineFactoryFn func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error)
 
 // eventHandler is a handler for WorkflowRegistryEvent events.  Each event type has a corresponding method that handles the event.
 type eventHandler struct {
@@ -79,7 +83,11 @@ func WithEngineFactoryFn(efn engineFactoryFn) func(*eventHandler) {
 
 func WithStaticEngine(engine services.Service) func(*eventHandler) {
 	return func(e *eventHandler) {
-		e.engineFactory = func(_ context.Context, _ string, _ string, _ types.WorkflowName, _ string, _ []byte, _ []byte) (services.Service, error) {
+		e.engineFactory = func(_ context.Context, _ string, _ string, _ types.WorkflowName, _ string, _ []byte, _ []byte, initDone chan<- error) (services.Service, error) {
+			// For static engines (used in tests), signal immediate initialization success
+			if initDone != nil {
+				initDone <- nil
+			}
 			return engine, nil
 		}
 	}
@@ -458,7 +466,7 @@ func (h *eventHandler) fetchOrganizationID(ctx context.Context, workflowOwner st
 	return organizationID, nil
 }
 
-func (h *eventHandler) engineFactoryFn(ctx context.Context, workflowID string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte) (services.Service, error) {
+func (h *eventHandler) engineFactoryFn(ctx context.Context, workflowID string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
 	lggr := h.lggr.Named("WorkflowEngine.Module").With("workflowID", workflowID, "workflowName", name, "workflowOwner", owner)
 	moduleConfig := &host.ModuleConfig{
 		Logger:                       lggr,
@@ -534,6 +542,22 @@ func (h *eventHandler) engineFactoryFn(ctx context.Context, workflowID string, o
 		WorkflowRegistryChainSelector: h.workflowRegistryChainSelector,
 		OrgResolver:                   h.orgResolver,
 	}
+
+	// Wire the initDone channel to the OnInitialized lifecycle hook.
+	// This will be called when the engine completes initialization (including trigger subscriptions).
+	// We compose with any existing hook to avoid overwriting test hooks or other user-provided hooks.
+	if initDone != nil {
+		existingHook := cfg.Hooks.OnInitialized
+		cfg.Hooks.OnInitialized = func(err error) {
+			// Signal completion to the handler first
+			initDone <- err
+			// Then call any existing hook (e.g., from tests)
+			if existingHook != nil {
+				existingHook(err)
+			}
+		}
+	}
+
 	return v2.NewEngine(cfg)
 }
 
@@ -592,7 +616,9 @@ func (h *eventHandler) tryEngineCleanup(workflowID types.WorkflowID) error {
 	return nil
 }
 
-// tryEngineCreate attempts to create a new workflow engine, start it, and register it with the engine registry
+// tryEngineCreate attempts to create a new workflow engine, start it, and register it with the engine registry.
+// This function waits for the engine to complete initialization (including trigger subscriptions) before returning,
+// ensuring that the workflowActivated event accurately reflects the deployment status including trigger registration.
 func (h *eventHandler) tryEngineCreate(ctx context.Context, spec *job.WorkflowSpec) error {
 	// Ensure the capabilities registry is ready before creating any Engine instances.
 	// This should be guaranteed by the Workflow Registry Syncer.
@@ -631,6 +657,12 @@ func (h *eventHandler) tryEngineCreate(ctx context.Context, spec *job.WorkflowSp
 	if err != nil {
 		return fmt.Errorf("invalid workflow name: %w", err)
 	}
+
+	// Create a channel to receive the initialization result.
+	// This allows us to wait for the engine to complete initialization (including trigger subscriptions)
+	// before emitting the workflowActivated event, ensuring the event accurately reflects deployment status.
+	initDone := make(chan error, 1)
+
 	engine, err := h.engineFactory(
 		ctx,
 		spec.WorkflowID,
@@ -639,6 +671,7 @@ func (h *eventHandler) tryEngineCreate(ctx context.Context, spec *job.WorkflowSp
 		spec.WorkflowTag,
 		[]byte(spec.Config),
 		decodedBinary,
+		initDone,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create workflow engine: %w", err)
@@ -648,6 +681,30 @@ func (h *eventHandler) tryEngineCreate(ctx context.Context, spec *job.WorkflowSp
 		return fmt.Errorf("failed to start workflow engine: %w", err)
 	}
 
+	// Wait for the engine to complete initialization (including trigger subscriptions).
+	// This ensures we don't emit workflowActivated events before triggers are actually subscribed.
+	select {
+	case <-ctx.Done():
+		// Context cancelled while waiting for initialization
+		if closeErr := engine.Close(); closeErr != nil {
+			h.lggr.Errorw("failed to close engine after context cancellation", "error", closeErr, "workflowID", spec.WorkflowID)
+		}
+		return fmt.Errorf("context cancelled while waiting for engine initialization: %w", ctx.Err())
+	case initErr := <-initDone:
+		if initErr != nil {
+			// Engine initialization failed (e.g., trigger subscription failed)
+			// TODO (patrickhuie19) add logic to mark a deployment as failed to avoid churn.
+			// Currently, failed deployments will be retried on each poll cycle (with exponential backoff).
+			// If the failure is due to user error (e.g., invalid trigger config), this causes unnecessary retries.
+			// Consider marking the workflow spec as "failed" in the database and requiring workflow redeployment.
+			if closeErr := engine.Close(); closeErr != nil {
+				h.lggr.Errorw("failed to close engine after initialization failure", "error", closeErr, "workflowID", spec.WorkflowID)
+			}
+			return fmt.Errorf("engine initialization failed: %w", initErr)
+		}
+	}
+
+	// Engine is fully initialized, add to registry
 	if err := h.engineRegistry.Add(wid, engine); err != nil {
 		if closeErr := engine.Close(); closeErr != nil {
 			return fmt.Errorf("failed to close workflow engine: %w during invariant violation: %w", closeErr, err)

--- a/core/services/workflows/syncer/v2/handler_test.go
+++ b/core/services/workflows/syncer/v2/handler_test.go
@@ -213,7 +213,10 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					signedConfigURL:                      {Body: config, Err: nil},
 				})
 			},
-			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte) (services.Service, error) {
+			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
+				if initDone != nil {
+					initDone <- nil
+				}
 				return &mockEngine{}, nil
 			},
 			GiveConfig:       config,
@@ -248,13 +251,16 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					signedConfigURL:                      {Body: config, Err: nil},
 				})
 			},
-			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte) (services.Service, error) {
+			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
 				if _, err := hex.DecodeString(name.Hex()); err != nil {
 					return nil, fmt.Errorf("invalid workflow name: %w", err)
 				}
 				want := hex.EncodeToString([]byte(pkgworkflows.HashTruncateName(name.String())))
 				if want != name.Hex() {
 					return nil, fmt.Errorf("invalid workflow name: doesn't match, got %s, want %s", name.Hex(), want)
+				}
+				if initDone != nil {
+					initDone <- nil
 				}
 				return &mockEngine{}, nil
 			},
@@ -289,7 +295,10 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					signedConfigURL:                      {Body: config, Err: nil},
 				})
 			},
-			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte) (services.Service, error) {
+			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
+				if initDone != nil {
+					initDone <- nil
+				}
 				return &mockEngine{StartErr: assert.AnError}, nil
 			},
 			GiveConfig:       config,
@@ -606,7 +615,7 @@ type testCase struct {
 	fetcherFactory   func(wfID []byte) *mockFetcher
 	Event            func(wfID []byte) WorkflowRegisteredEvent
 	validationFn     func(t *testing.T, ctx context.Context, event WorkflowRegisteredEvent, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID types.WorkflowID, fetcher *mockFetcher, binaryURL string, configURL string)
-	engineFactoryFn  func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte) (services.Service, error)
+	engineFactoryFn  func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error)
 }
 
 func testRunningWorkflow(t *testing.T, tc testCase) {
@@ -1037,7 +1046,10 @@ func Test_Handler_OrganizationID(t *testing.T) {
 
 	h, err := NewEventHandler(lggr, store, nil, true, registry, er, emitter, limiters, rl, workflowLimits, artifactStore, workflowEncryptionKey, &testDonNotifier{},
 		WithEngineRegistry(er),
-		WithEngineFactoryFn(func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte) (services.Service, error) {
+		WithEngineFactoryFn(func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
+			if initDone != nil {
+				initDone <- nil
+			}
 			return &mockEngine{}, nil
 		}),
 		WithOrgResolver(orgResolver),
@@ -1106,7 +1118,10 @@ func Test_Handler_OrganizationID(t *testing.T) {
 
 		hDelete, err := NewEventHandler(lggr, store, nil, true, registry, er, deleteEmitter, limiters, rl, workflowLimits, deleteArtifactStore, workflowEncryptionKey, &testDonNotifier{},
 			WithEngineRegistry(er),
-			WithEngineFactoryFn(func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte) (services.Service, error) {
+			WithEngineFactoryFn(func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
+				if initDone != nil {
+					initDone <- nil
+				}
 				return &mockEngine{}, nil
 			}),
 			WithOrgResolver(orgResolver),

--- a/core/services/workflows/syncer/v2/handler_test.go
+++ b/core/services/workflows/syncer/v2/handler_test.go
@@ -105,6 +105,15 @@ func (m *mockEngine) HealthReport() map[string]error { return nil }
 
 func (m *mockEngine) Name() string { return "mockEngine" }
 
+// mockEngineFactory returns a standard mock engine factory for tests.
+// It sends nil to initDone to signal successful initialization.
+func mockEngineFactory(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
+	if initDone != nil {
+		initDone <- nil
+	}
+	return &mockEngine{}, nil
+}
+
 func Test_Handler(t *testing.T) {
 	t.Run("fails with unsupported event type", func(t *testing.T) {
 		lggr := logger.TestLogger(t)
@@ -213,12 +222,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					signedConfigURL:                      {Body: config, Err: nil},
 				})
 			},
-			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
-				if initDone != nil {
-					initDone <- nil
-				}
-				return &mockEngine{}, nil
-			},
+			engineFactoryFn:  mockEngineFactory,
 			GiveConfig:       config,
 			ConfigURLFactory: configURLFactory,
 			BinaryURLFactory: binaryURLFactory,
@@ -391,12 +395,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					ConfigURL:     configURLFactory(hex.EncodeToString(wfID)),
 				}
 			},
-			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
-				if initDone != nil {
-					initDone <- nil
-				}
-				return &mockEngine{}, nil
-			},
+			engineFactoryFn: mockEngineFactory,
 			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredEvent, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID types.WorkflowID, fetcher *mockFetcher, binaryURL string, configURL string) {
 				me := &mockEngine{}
 				oldWfIDBytes := [32]byte{0, 1, 2, 3, 5}
@@ -485,12 +484,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					ConfigURL:     configURLFactory(hex.EncodeToString(wfID)),
 				}
 			},
-			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
-				if initDone != nil {
-					initDone <- nil
-				}
-				return &mockEngine{}, nil
-			},
+			engineFactoryFn: mockEngineFactory,
 			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredEvent, h *eventHandler,
 				s *artifacts.Store, wfOwner []byte, wfName string, wfID types.WorkflowID, fetcher *mockFetcher, binaryURL string, configURL string,
 			) {
@@ -540,12 +534,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					signedBinaryURL:                      {Body: encodedBinary, Err: nil},
 				})
 			},
-			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
-				if initDone != nil {
-					initDone <- nil
-				}
-				return &mockEngine{}, nil
-			},
+			engineFactoryFn: mockEngineFactory,
 			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredEvent, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID types.WorkflowID, fetcher *mockFetcher, binaryURL string, configURL string) {
 				defaultValidationFn(t, ctx, event, h, s, wfOwner, wfName, wfID, fetcher)
 
@@ -582,12 +571,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					signedConfigURL:                      {Body: config, Err: nil},
 				})
 			},
-			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
-				if initDone != nil {
-					initDone <- nil
-				}
-				return &mockEngine{}, nil
-			},
+			engineFactoryFn: mockEngineFactory,
 			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredEvent, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID types.WorkflowID, fetcher *mockFetcher, binaryURL string, configURL string) {
 				// Create the record in the database
 				entry := &job.WorkflowSpec{
@@ -796,12 +780,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 
 		h, err := NewEventHandler(lggr, store, nil, true, registry, NewEngineRegistry(), emitter, limiters, rl, workflowLimits, artifactStore, workflowEncryptionKey, &testDonNotifier{},
 			WithEngineRegistry(er),
-			WithEngineFactoryFn(func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
-				if initDone != nil {
-					initDone <- nil
-				}
-				return &mockEngine{}, nil
-			}),
+			WithEngineFactoryFn(mockEngineFactory),
 		)
 		require.NoError(t, err)
 		ctx = contexts.WithCRE(ctx, contexts.CRE{Owner: hex.EncodeToString(wfOwner), Workflow: wfIDString})
@@ -951,12 +930,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 
 		h, err := NewEventHandler(lggr, store, nil, true, registry, NewEngineRegistry(), emitter, limiters, rl, workflowLimits, mockAS, workflowEncryptionKey, &testDonNotifier{},
 			WithEngineRegistry(er),
-			WithEngineFactoryFn(func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
-				if initDone != nil {
-					initDone <- nil
-				}
-				return &mockEngine{}, nil
-			}),
+			WithEngineFactoryFn(mockEngineFactory),
 		)
 		require.NoError(t, err)
 		ctx = contexts.WithCRE(ctx, contexts.CRE{Owner: hex.EncodeToString(wfOwner), Workflow: wfIDString})
@@ -1086,12 +1060,7 @@ func Test_Handler_OrganizationID(t *testing.T) {
 
 	h, err := NewEventHandler(lggr, store, nil, true, registry, er, emitter, limiters, rl, workflowLimits, artifactStore, workflowEncryptionKey, &testDonNotifier{},
 		WithEngineRegistry(er),
-		WithEngineFactoryFn(func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
-			if initDone != nil {
-				initDone <- nil
-			}
-			return &mockEngine{}, nil
-		}),
+		WithEngineFactoryFn(mockEngineFactory),
 		WithOrgResolver(orgResolver),
 	)
 	require.NoError(t, err)
@@ -1158,12 +1127,7 @@ func Test_Handler_OrganizationID(t *testing.T) {
 
 		hDelete, err := NewEventHandler(lggr, store, nil, true, registry, er, deleteEmitter, limiters, rl, workflowLimits, deleteArtifactStore, workflowEncryptionKey, &testDonNotifier{},
 			WithEngineRegistry(er),
-			WithEngineFactoryFn(func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
-				if initDone != nil {
-					initDone <- nil
-				}
-				return &mockEngine{}, nil
-			}),
+			WithEngineFactoryFn(mockEngineFactory),
 			WithOrgResolver(orgResolver),
 		)
 		require.NoError(t, err)

--- a/core/services/workflows/syncer/v2/handler_test.go
+++ b/core/services/workflows/syncer/v2/handler_test.go
@@ -391,6 +391,12 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					ConfigURL:     configURLFactory(hex.EncodeToString(wfID)),
 				}
 			},
+			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
+				if initDone != nil {
+					initDone <- nil
+				}
+				return &mockEngine{}, nil
+			},
 			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredEvent, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID types.WorkflowID, fetcher *mockFetcher, binaryURL string, configURL string) {
 				me := &mockEngine{}
 				oldWfIDBytes := [32]byte{0, 1, 2, 3, 5}
@@ -479,6 +485,12 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					ConfigURL:     configURLFactory(hex.EncodeToString(wfID)),
 				}
 			},
+			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
+				if initDone != nil {
+					initDone <- nil
+				}
+				return &mockEngine{}, nil
+			},
 			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredEvent, h *eventHandler,
 				s *artifacts.Store, wfOwner []byte, wfName string, wfID types.WorkflowID, fetcher *mockFetcher, binaryURL string, configURL string,
 			) {
@@ -528,6 +540,12 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					signedBinaryURL:                      {Body: encodedBinary, Err: nil},
 				})
 			},
+			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
+				if initDone != nil {
+					initDone <- nil
+				}
+				return &mockEngine{}, nil
+			},
 			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredEvent, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID types.WorkflowID, fetcher *mockFetcher, binaryURL string, configURL string) {
 				defaultValidationFn(t, ctx, event, h, s, wfOwner, wfName, wfID, fetcher)
 
@@ -563,6 +581,12 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					signedBinaryURL:                      {Body: encodedBinary, Err: nil},
 					signedConfigURL:                      {Body: config, Err: nil},
 				})
+			},
+			engineFactoryFn: func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
+				if initDone != nil {
+					initDone <- nil
+				}
+				return &mockEngine{}, nil
 			},
 			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredEvent, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID types.WorkflowID, fetcher *mockFetcher, binaryURL string, configURL string) {
 				// Create the record in the database
@@ -770,7 +794,15 @@ func Test_workflowDeletedHandler(t *testing.T) {
 		}))
 		require.NoError(t, err)
 
-		h, err := NewEventHandler(lggr, store, nil, true, registry, NewEngineRegistry(), emitter, limiters, rl, workflowLimits, artifactStore, workflowEncryptionKey, &testDonNotifier{}, WithEngineRegistry(er))
+		h, err := NewEventHandler(lggr, store, nil, true, registry, NewEngineRegistry(), emitter, limiters, rl, workflowLimits, artifactStore, workflowEncryptionKey, &testDonNotifier{},
+			WithEngineRegistry(er),
+			WithEngineFactoryFn(func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
+				if initDone != nil {
+					initDone <- nil
+				}
+				return &mockEngine{}, nil
+			}),
+		)
 		require.NoError(t, err)
 		ctx = contexts.WithCRE(ctx, contexts.CRE{Owner: hex.EncodeToString(wfOwner), Workflow: wfIDString})
 		err = h.workflowRegisteredEvent(ctx, active)
@@ -917,7 +949,15 @@ func Test_workflowDeletedHandler(t *testing.T) {
 
 		mockAS := newMockArtifactStore(artifactStore, errors.New(failWith))
 
-		h, err := NewEventHandler(lggr, store, nil, true, registry, NewEngineRegistry(), emitter, limiters, rl, workflowLimits, mockAS, workflowEncryptionKey, &testDonNotifier{}, WithEngineRegistry(er))
+		h, err := NewEventHandler(lggr, store, nil, true, registry, NewEngineRegistry(), emitter, limiters, rl, workflowLimits, mockAS, workflowEncryptionKey, &testDonNotifier{},
+			WithEngineRegistry(er),
+			WithEngineFactoryFn(func(ctx context.Context, wfid string, owner string, name types.WorkflowName, tag string, config []byte, binary []byte, initDone chan<- error) (services.Service, error) {
+				if initDone != nil {
+					initDone <- nil
+				}
+				return &mockEngine{}, nil
+			}),
+		)
 		require.NoError(t, err)
 		ctx = contexts.WithCRE(ctx, contexts.CRE{Owner: hex.EncodeToString(wfOwner), Workflow: wfIDString})
 		err = h.workflowRegisteredEvent(ctx, active)

--- a/core/services/workflows/v2/config.go
+++ b/core/services/workflows/v2/config.go
@@ -222,6 +222,8 @@ type EngineLimits struct {
 }
 
 type LifecycleHooks struct {
+	// OnInitialized is used to emit a workflowActivated event after the engine
+	// has completed initialization. It is also helpful for testing.
 	OnInitialized          func(err error)
 	OnSubscribedToTriggers func(triggerIDs []string)
 	OnExecutionFinished    func(executionID string, status string)

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -424,7 +424,8 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 		})
 	}
 
-	// Wait for all registrations to complete (or first error)
+	// wait for all registrations to complete.
+	// returns first non-nil error.
 	registrationErr := g.Wait()
 	close(resultsCh)
 
@@ -435,6 +436,14 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 	eventChans := make([]<-chan capabilities.TriggerResponse, len(subs.Subscriptions))
 	triggerCapIDs := make([]string, len(subs.Subscriptions))
 
+	// If any registration failed, unregister successful ones and return error
+	if registrationErr != nil {
+		e.logger().Errorw("One or more trigger registrations failed - reverting all", "err", registrationErr)
+		e.unregisterAllTriggers(ctx) // needs to be called under e.triggersRegMu lock
+		return registrationErr
+	}
+
+	// collect successful registrations
 	for result := range resultsCh {
 		e.triggers[result.registrationID] = &triggerCapability{
 			TriggerCapability: result.triggerCap,
@@ -443,13 +452,6 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 		}
 		eventChans[result.index] = result.eventCh
 		triggerCapIDs[result.index] = result.triggerCapID
-	}
-
-	// If any registration failed, unregister successful ones and return error
-	if registrationErr != nil {
-		e.logger().Errorw("One or more trigger registrations failed - reverting all", "err", registrationErr)
-		e.unregisterAllTriggers(ctx)
-		return registrationErr
 	}
 
 	// start listening for trigger events only if all registrations succeeded

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -429,21 +429,13 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 	registrationErr := g.Wait()
 	close(resultsCh)
 
-	// Collect results
+	// Collect results into e.triggers map
 	e.triggersRegMu.Lock()
 	defer e.triggersRegMu.Unlock()
 
 	eventChans := make([]<-chan capabilities.TriggerResponse, len(subs.Subscriptions))
 	triggerCapIDs := make([]string, len(subs.Subscriptions))
 
-	// If any registration failed, unregister successful ones and return error
-	if registrationErr != nil {
-		e.logger().Errorw("One or more trigger registrations failed - reverting all", "err", registrationErr)
-		e.unregisterAllTriggers(ctx) // needs to be called under e.triggersRegMu lock
-		return registrationErr
-	}
-
-	// collect successful registrations
 	for result := range resultsCh {
 		e.triggers[result.registrationID] = &triggerCapability{
 			TriggerCapability: result.triggerCap,
@@ -452,6 +444,13 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 		}
 		eventChans[result.index] = result.eventCh
 		triggerCapIDs[result.index] = result.triggerCapID
+	}
+
+	// If any registration failed, unregister successful ones and return error
+	if registrationErr != nil {
+		e.logger().Errorw("One or more trigger registrations failed - reverting all", "err", registrationErr)
+		e.unregisterAllTriggers(ctx) // needs to be called under e.triggersRegMu lock
+		return registrationErr
 	}
 
 	// start listening for trigger events only if all registrations succeeded

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/aggregation"
@@ -357,53 +358,98 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 		triggers = append(triggers, triggerCap)
 	}
 
-	// register to all triggers
+	// register to all triggers concurrently
 	regCtx, regCancel, err := e.cfg.LocalLimiters.TriggerRegistrationsTime.WithTimeout(ctx)
 	if err != nil {
 		return err
 	}
 	defer regCancel()
-	e.triggersRegMu.Lock()
-	defer e.triggersRegMu.Unlock()
-	eventChans := make([]<-chan capabilities.TriggerResponse, len(subs.Subscriptions))
-	triggerCapIDs := make([]string, len(subs.Subscriptions))
+
+	// trigger registration results for use in concurrent trigger subscriptions
+	type triggerRegResult struct {
+		index          int
+		registrationID string
+		triggerCap     capabilities.TriggerCapability
+		eventCh        <-chan capabilities.TriggerResponse
+		payload        *anypb.Any
+		method         string
+		triggerCapID   string
+	}
+
+	resultsCh := make(chan triggerRegResult, len(subs.Subscriptions))
+	g, gCtx := errgroup.WithContext(regCtx)
+
+	// Launch concurrent trigger registrations
 	for i, sub := range subs.Subscriptions {
 		triggerCap := triggers[i]
-		registrationID := fmt.Sprintf("trigger_reg_%s_%d", e.cfg.WorkflowID, i)
-		e.logger().Debugw("Registering trigger", "triggerID", sub.Id, "method", sub.Method)
-		triggerEventCh, err := triggerCap.RegisterTrigger(regCtx, capabilities.TriggerRegistrationRequest{
-			TriggerID: registrationID,
-			Metadata: capabilities.RequestMetadata{
-				WorkflowID:                    e.cfg.WorkflowID,
-				WorkflowOwner:                 e.cfg.WorkflowOwner,
-				WorkflowName:                  e.cfg.WorkflowName.Hex(),
-				WorkflowTag:                   e.cfg.WorkflowTag,
-				DecodedWorkflowName:           e.cfg.WorkflowName.String(),
-				WorkflowDonID:                 e.localNode.Load().WorkflowDON.ID,
-				WorkflowDonConfigVersion:      e.localNode.Load().WorkflowDON.ConfigVersion,
-				ReferenceID:                   fmt.Sprintf("trigger_%d", i),
-				WorkflowRegistryChainSelector: e.cfg.WorkflowRegistryChainSelector,
-				WorkflowRegistryAddress:       e.cfg.WorkflowRegistryAddress,
-				EngineVersion:                 platform.ValueWorkflowVersionV2,
-				// no WorkflowExecutionID needed (or available at this stage)
-			},
-			Payload: sub.Payload,
-			Method:  sub.Method,
-			// no Config needed - NoDAG uses Payload
+		g.Go(func() error {
+			registrationID := fmt.Sprintf("trigger_reg_%s_%d", e.cfg.WorkflowID, i)
+			e.logger().Debugw("Registering trigger", "triggerID", sub.Id, "method", sub.Method)
+			triggerEventCh, regErr := triggerCap.RegisterTrigger(gCtx, capabilities.TriggerRegistrationRequest{
+				TriggerID: registrationID,
+				Metadata: capabilities.RequestMetadata{
+					WorkflowID:                    e.cfg.WorkflowID,
+					WorkflowOwner:                 e.cfg.WorkflowOwner,
+					WorkflowName:                  e.cfg.WorkflowName.Hex(),
+					WorkflowTag:                   e.cfg.WorkflowTag,
+					DecodedWorkflowName:           e.cfg.WorkflowName.String(),
+					WorkflowDonID:                 e.localNode.Load().WorkflowDON.ID,
+					WorkflowDonConfigVersion:      e.localNode.Load().WorkflowDON.ConfigVersion,
+					ReferenceID:                   fmt.Sprintf("trigger_%d", i),
+					WorkflowRegistryChainSelector: e.cfg.WorkflowRegistryChainSelector,
+					WorkflowRegistryAddress:       e.cfg.WorkflowRegistryAddress,
+					EngineVersion:                 platform.ValueWorkflowVersionV2,
+					// no WorkflowExecutionID needed (or available at this stage)
+				},
+				Payload: sub.Payload,
+				Method:  sub.Method,
+				// no Config needed - NoDAG uses Payload
+			})
+			if regErr != nil {
+				e.logger().Errorw("Trigger registration failed", "triggerID", sub.Id, "err", regErr)
+				e.metrics.With(platform.KeyTriggerID, sub.Id).IncrementRegisterTriggerFailureCounter(gCtx)
+				return fmt.Errorf("failed to register trigger %s: %w", sub.Id, regErr)
+			}
+			// Send successful result
+			resultsCh <- triggerRegResult{
+				index:          i,
+				registrationID: registrationID,
+				triggerCap:     triggerCap,
+				eventCh:        triggerEventCh,
+				payload:        sub.Payload,
+				method:         sub.Method,
+				triggerCapID:   sub.Id,
+			}
+			return nil
 		})
-		if err != nil {
-			e.logger().Errorw("One of trigger registrations failed - reverting all", "triggerID", sub.Id, "err", err)
-			e.metrics.With(platform.KeyTriggerID, sub.Id).IncrementRegisterTriggerFailureCounter(ctx)
-			e.unregisterAllTriggers(ctx)
-			return fmt.Errorf("failed to register trigger: %w", err)
+	}
+
+	// Wait for all registrations to complete (or first error)
+	registrationErr := g.Wait()
+	close(resultsCh)
+
+	// Collect results
+	e.triggersRegMu.Lock()
+	defer e.triggersRegMu.Unlock()
+
+	eventChans := make([]<-chan capabilities.TriggerResponse, len(subs.Subscriptions))
+	triggerCapIDs := make([]string, len(subs.Subscriptions))
+
+	for result := range resultsCh {
+		e.triggers[result.registrationID] = &triggerCapability{
+			TriggerCapability: result.triggerCap,
+			payload:           result.payload,
+			method:            result.method,
 		}
-		e.triggers[registrationID] = &triggerCapability{
-			TriggerCapability: triggerCap,
-			payload:           sub.Payload,
-			method:            sub.Method,
-		}
-		eventChans[i] = triggerEventCh
-		triggerCapIDs[i] = sub.Id
+		eventChans[result.index] = result.eventCh
+		triggerCapIDs[result.index] = result.triggerCapID
+	}
+
+	// If any registration failed, unregister successful ones and return error
+	if registrationErr != nil {
+		e.logger().Errorw("One or more trigger registrations failed - reverting all", "err", registrationErr)
+		e.unregisterAllTriggers(ctx)
+		return registrationErr
 	}
 
 	// start listening for trigger events only if all registrations succeeded

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -254,7 +254,7 @@ func TestEngine_TriggerSubscriptions(t *testing.T) {
 		trigger1.EXPECT().RegisterTrigger(matches.AnyContext, mock.Anything).Return(nil, errors.New("failure ABC")).Once()
 		trigger0.EXPECT().UnregisterTrigger(matches.AnyContext, mock.Anything).Return(nil).Once()
 		servicetest.Run(t, engine)
-		require.ErrorContains(t, <-initDoneCh, "failed to register trigger: failure ABC")
+		require.ErrorContains(t, <-initDoneCh, "failed to register trigger id_1: failure ABC")
 	})
 }
 


### PR DESCRIPTION
CRE-1173

Trigger subscriptions happened async to `tryEngineCreate`, meaning that any errors with trigger subscriptions would not flow through to the UI. For now, we want to treat all of engine init successful as meaning a healthy deployment. This means I had a few options:
* Start emitting a new event, like `TriggerSubscriptionsComplete` after the trigger subscription phase in engine init is complete. requires updates across the stack to handle appropriately in the UI (only `WorkflowActivated` event is no longer sufficient)
* Pass a callback to the engineFactoryFn to emit an activated event after the trigger subscriptions were complete. Means that consumers writing in the trigger subscription logic are now responsible for deployment/UI concerns, which I found undesirable.
* The current implemented solution: make the handler sync to trigger subscriptions. Since we allow multiple trigger subscriptions, and they are currently handled serially, these could lead to a lot of latency. To help alleviate that, i've added concurrency for the trigger subscriptions.

(note, about half of this diagram is chopped for confidentiality)
<img width="941" height="598" alt="image" src="https://github.com/user-attachments/assets/d1cd9a85-dbbc-48c2-b347-2b27d7d6d64d" />

