### PR TITLE
core/logger: drop the slice storage of weak pointers

### DIFF
--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"os"
-	"slices"
 	"sync"
 	"time"
 	"weak"
@@ -21,7 +20,7 @@ const cleanupInterval = time.Minute * 5
 type AtomicCore struct {
 	mu          sync.RWMutex
 	core        zapcore.Core
-	children    []weak.Pointer[withCore]
+	children    map[weak.Pointer[withCore]]struct{}
 	stopCleanup chan struct{}
 	cleanupWg   sync.WaitGroup
 }
@@ -30,6 +29,7 @@ type AtomicCore struct {
 func NewAtomicCore() *AtomicCore {
 	ac := &AtomicCore{
 		core:        zapcore.NewNopCore(),
+		children:    make(map[weak.Pointer[withCore]]struct{}),
 		stopCleanup: make(chan struct{}),
 	}
 	ac.startPeriodicCleanup()
@@ -40,14 +40,14 @@ func (d *AtomicCore) Store(core zapcore.Core) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.core = core
-	d.children = slices.DeleteFunc(d.children, func(p weak.Pointer[withCore]) bool {
+	for p := range d.children {
 		c := p.Value()
 		if c == nil {
-			return true
+			delete(d.children, p)
+			continue
 		}
 		c.Store(d.core)
-		return false
-	})
+	}
 }
 
 func (d *AtomicCore) load() zapcore.Core {
@@ -62,8 +62,14 @@ func (d *AtomicCore) With(fs []zapcore.Field) zapcore.Core {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	coreWithFields := d.core.With(fs)
-	w := &withCore{fields: fs, AtomicCore: AtomicCore{core: coreWithFields}}
-	d.children = append(d.children, weak.Make(w))
+	w := &withCore{fields: fs, AtomicCore: AtomicCore{
+		core:     coreWithFields,
+		children: make(map[weak.Pointer[withCore]]struct{}),
+	}}
+	if d.children == nil {
+		d.children = make(map[weak.Pointer[withCore]]struct{})
+	}
+	d.children[weak.Make(w)] = struct{}{}
 	return w
 }
 
@@ -85,14 +91,14 @@ func (d *AtomicCore) cleanup() {
 	defer wg.Wait()
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	d.children = slices.DeleteFunc(d.children, func(p weak.Pointer[withCore]) bool {
+	for p := range d.children {
 		c := p.Value()
 		if c == nil {
-			return true
+			delete(d.children, p)
+			continue
 		}
-		wg.Go(c.cleanup)
-		return false
-	})
+		c.cleanup()
+	}
 }
 
 func (d *AtomicCore) startPeriodicCleanup() {
@@ -120,14 +126,9 @@ func (w *withCore) Store(core zapcore.Core) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.core = core.With(w.fields)
-	w.children = slices.DeleteFunc(w.children, func(p weak.Pointer[withCore]) bool {
-		c := p.Value()
-		if c == nil {
-			return true
-		}
-		c.Store(w.core)
-		return false
-	})
+	for p := range w.children {
+		p.Value().Store(w.core)
+	}
 }
 
 var _ Logger = &zapLogger{}

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -169,9 +169,11 @@ func (l *zapLogger) SetLogLevel(lvl zapcore.Level) {
 }
 
 func (l *zapLogger) With(args ...any) Logger {
+	fmt.Println("DEBUG zapLogger With", "initial length", len(l.fields))
 	newLogger := *l
 	newLogger.SugaredLogger = l.SugaredLogger.With(args...)
 	newLogger.fields = copyFields(l.fields, args...)
+	fmt.Println("DEBUG zapLogger With", "final length", len(newLogger.fields))
 	return &newLogger
 }
 

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -7,6 +7,7 @@ import (
 	"weak"
 
 	pkgerrors "github.com/pkg/errors"
+	"github.com/smartcontractkit/wsrpc/logger"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -42,11 +43,9 @@ func (d *AtomicCore) Store(core zapcore.Core) {
 	d.core = core
 	for p := range d.children {
 		c := p.Value()
-		if c == nil {
-			delete(d.children, p)
-			continue
+		if c != nil {
+			c.Store(d.core)
 		}
-		c.Store(d.core)
 	}
 }
 
@@ -91,6 +90,7 @@ func (d *AtomicCore) cleanup() {
 	defer wg.Wait()
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	initialChildrenCount := len(d.children)
 	for p := range d.children {
 		c := p.Value()
 		if c == nil {
@@ -99,6 +99,7 @@ func (d *AtomicCore) cleanup() {
 		}
 		c.cleanup()
 	}
+	logger.DefaultLogger.Debug("DEBUG AtomicCore cleanup", "deleted_children_count", initialChildrenCount-len(d.children))
 }
 
 func (d *AtomicCore) startPeriodicCleanup() {
@@ -128,11 +129,9 @@ func (w *withCore) Store(core zapcore.Core) {
 	w.core = core.With(w.fields)
 	for p := range w.children {
 		c := p.Value()
-		if c == nil {
-			delete(w.children, p)
-			continue
+		if c != nil {
+			c.Store(w.core)
 		}
-		c.Store(w.core)
 	}
 }
 

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -127,7 +127,12 @@ func (w *withCore) Store(core zapcore.Core) {
 	defer w.mu.Unlock()
 	w.core = core.With(w.fields)
 	for p := range w.children {
-		p.Value().Store(w.core)
+		c := p.Value()
+		if c == nil {
+			delete(w.children, p)
+			continue
+		}
+		c.Store(w.core)
 	}
 }
 

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -1,13 +1,13 @@
 package logger
 
 import (
+	"fmt"
 	"os"
 	"sync"
 	"time"
 	"weak"
 
 	pkgerrors "github.com/pkg/errors"
-	"github.com/smartcontractkit/wsrpc/logger"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -34,6 +34,7 @@ func NewAtomicCore() *AtomicCore {
 		stopCleanup: make(chan struct{}),
 	}
 	ac.startPeriodicCleanup()
+	fmt.Println("DEBUG AtomicCore cleanup", "step", "new")
 	return ac
 }
 
@@ -86,12 +87,12 @@ func (d *AtomicCore) Close() {
 }
 
 func (d *AtomicCore) cleanup() {
-	logger.DefaultLogger.Error("DEBUG AtomicCore cleanup", "step", "enter")
+	fmt.Println("DEBUG AtomicCore cleanup", "step", "enter")
 	var wg sync.WaitGroup
 	defer wg.Wait()
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	logger.DefaultLogger.Error("DEBUG AtomicCore cleanup", "step", "init loop")
+	fmt.Println("DEBUG AtomicCore cleanup", "step", "init loop")
 	initialChildrenCount := len(d.children)
 	for p := range d.children {
 		c := p.Value()
@@ -101,7 +102,7 @@ func (d *AtomicCore) cleanup() {
 		}
 		go c.cleanup()
 	}
-	logger.DefaultLogger.Error("DEBUG AtomicCore cleanup", "deleted_children_count", initialChildrenCount-len(d.children))
+	fmt.Println("DEBUG AtomicCore cleanup", "deleted_children_count", initialChildrenCount-len(d.children))
 }
 
 func (d *AtomicCore) startPeriodicCleanup() {
@@ -112,7 +113,7 @@ func (d *AtomicCore) startPeriodicCleanup() {
 		for {
 			select {
 			case <-ticker.C:
-				logger.DefaultLogger.Error("DEBUG AtomicCore cleanup", "step", "trigger")
+				fmt.Println("DEBUG AtomicCore cleanup", "step", "trigger")
 				d.cleanup()
 			case <-d.stopCleanup:
 				return

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"sync"
 	"time"
 	"weak"
@@ -87,20 +88,23 @@ func (d *AtomicCore) Close() {
 }
 
 func (d *AtomicCore) cleanup() {
+	// Explicitly call GC and wait
+	runtime.GC()
+	time.Sleep(10 * time.Second)
 	fmt.Println("DEBUG AtomicCore cleanup", "step", "enter")
 	var wg sync.WaitGroup
 	defer wg.Wait()
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	fmt.Println("DEBUG AtomicCore cleanup", "step", "init loop")
 	initialChildrenCount := len(d.children)
+	fmt.Println("DEBUG AtomicCore cleanup", "step", "init loop", "start_children_count", initialChildrenCount)
 	for p := range d.children {
 		c := p.Value()
 		if c == nil {
 			delete(d.children, p)
 			continue
 		}
-		go c.cleanup()
+		wg.Go(c.cleanup)
 	}
 	fmt.Println("DEBUG AtomicCore cleanup", "deleted_children_count", initialChildrenCount-len(d.children))
 }

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -86,10 +86,12 @@ func (d *AtomicCore) Close() {
 }
 
 func (d *AtomicCore) cleanup() {
+	logger.DefaultLogger.Error("DEBUG AtomicCore cleanup", "step", "enter")
 	var wg sync.WaitGroup
 	defer wg.Wait()
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	logger.DefaultLogger.Error("DEBUG AtomicCore cleanup", "step", "init loop")
 	initialChildrenCount := len(d.children)
 	for p := range d.children {
 		c := p.Value()
@@ -97,9 +99,9 @@ func (d *AtomicCore) cleanup() {
 			delete(d.children, p)
 			continue
 		}
-		c.cleanup()
+		go c.cleanup()
 	}
-	logger.DefaultLogger.Debug("DEBUG AtomicCore cleanup", "deleted_children_count", initialChildrenCount-len(d.children))
+	logger.DefaultLogger.Error("DEBUG AtomicCore cleanup", "deleted_children_count", initialChildrenCount-len(d.children))
 }
 
 func (d *AtomicCore) startPeriodicCleanup() {
@@ -110,6 +112,7 @@ func (d *AtomicCore) startPeriodicCleanup() {
 		for {
 			select {
 			case <-ticker.C:
+				logger.DefaultLogger.Error("DEBUG AtomicCore cleanup", "step", "trigger")
 				d.cleanup()
 			case <-d.stopCleanup:
 				return

--- a/core/services/llo/mercurytransmitter/queue.go
+++ b/core/services/llo/mercurytransmitter/queue.go
@@ -2,7 +2,6 @@ package mercurytransmitter
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"strconv"
@@ -109,7 +108,6 @@ func (tq *transmitQueue) Push(t *Transmission) (ok bool) {
 			lggr := tq.lggr
 			if removed, ok := removed.(*Transmission); ok {
 				hash := removed.Hash()
-				lggr = lggr.With("transmissionHash", hex.EncodeToString(hash[:]))
 				tq.asyncDeleter.AsyncDelete(hash)
 			}
 			lggr.Criticalw(fmt.Sprintf("Transmit queue is full; dropping oldest transmission (reached max length of %d)", tq.maxlen), "transmission", removed)

--- a/core/services/llo/mercurytransmitter/queue.go
+++ b/core/services/llo/mercurytransmitter/queue.go
@@ -2,6 +2,7 @@ package mercurytransmitter
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strconv"
@@ -108,6 +109,8 @@ func (tq *transmitQueue) Push(t *Transmission) (ok bool) {
 			lggr := tq.lggr
 			if removed, ok := removed.(*Transmission); ok {
 				hash := removed.Hash()
+				// TODO(brunotm): drop this log
+				lggr = lggr.With("transmissionHash", hex.EncodeToString(hash[:]))
 				tq.asyncDeleter.AsyncDelete(hash)
 			}
 			lggr.Criticalw(fmt.Sprintf("Transmit queue is full; dropping oldest transmission (reached max length of %d)", tq.maxlen), "transmission", removed)


### PR DESCRIPTION
The slices.DeleteFunc modifies the slice in place and does not reclaim the allocated capacity of the slice storage.

This change fixes the logger memory leak by replacing the slice storage with a map which can be grown/shrink by the Go runtime without additional manual memory management.