### PR TITLE
[BCF-3490] Remove AtomicCore logger 

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -274,18 +274,9 @@ func NewApp(s *Shell) *cli.App {
 					SentryEnabled:  s.Config.Sentry().DSN() != "",
 				}
 
-				// Noop atomic core that can be swapped out later for OTel support
-				atomicCore := logger.NewAtomicCore()
-
-				l, closeFn := lggrCfg.NewWithCores(atomicCore)
-
+				l, closeFn := lggrCfg.New()
 				s.Logger = l
-				s.CloseLogger = func() error {
-					atomicCore.Close()
-					return closeFn()
-				}
-				// s.SetOtelCore is a hook that can be used to set the OTel core
-				s.SetOtelCore = atomicCore.Store
+				s.CloseLogger = closeFn
 
 				return nil
 			},

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -155,7 +155,6 @@ type Shell struct {
 	Logger                         logger.Logger           // initialized in Before
 	Registerer                     prometheus.Registerer   // initialized in Before
 	CloseLogger                    func() error            // called in After
-	SetOtelCore                    func(zapcore.Core)      // reference to AtomicCore.Store
 	AppFactory                     AppFactory
 	KeyStoreAuthenticator          TerminalKeyStoreAuthenticator
 	FallbackAPIInitializer         APIInitializer

--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
-	"github.com/smartcontractkit/chainlink-common/pkg/logger/otelzap"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
@@ -1145,18 +1144,6 @@ func (s *Shell) beforeNode(c *cli.Context) error {
 	// Emit node configuration through beholder
 	s.EmitNodeConfig(ctx)
 	// If log streaming is enabled swap core to add Otel
-	if s.Config.Telemetry().LogStreamingEnabled() {
-		if s.SetOtelCore == nil {
-			return errors.New("Shell.SetOtelCore is nil")
-		}
-		otelLogger := beholder.GetLogger()
-		logLevel := s.Config.Telemetry().LogLevel()
-		otelCore := otelzap.NewCore(otelLogger, otelzap.WithLevel(logLevel))
-
-		s.SetOtelCore(otelCore)
-		lggr.Info("Log streaming enabled")
-	}
-
 	return nil
 }
 

--- a/core/logger/logger_test.go
+++ b/core/logger/logger_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/log/noop"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger/otelzap"
 )
@@ -89,43 +88,4 @@ func TestOtelCore(t *testing.T) {
 			assert.NotNil(t, logger)
 		})
 	}
-}
-
-// TestAtomicCoreSwap tests the atomic core swap functionality after logger creation.
-func TestAtomicCoreSwap(t *testing.T) {
-	atomicCore := NewAtomicCore()
-	defer atomicCore.Close()
-	setOtelCore := atomicCore.Store
-
-	lggrCfg := Config{
-		LogLevel:       zapcore.InfoLevel,
-		JsonConsole:    true,
-		UnixTS:         false,
-		FileMaxSizeMB:  0,
-		FileMaxAgeDays: 0,
-		FileMaxBackups: 0,
-		SentryEnabled:  false,
-	}
-
-	lggr, closeFn := lggrCfg.NewWithCores(atomicCore)
-	defer func() {
-		err := closeFn()
-		require.NoError(t, err)
-	}()
-
-	// Create observer to capture logs
-	otelCore, otelLogs := observer.New(zapcore.InfoLevel)
-
-	lggr.Info("before swap")
-
-	assert.Equal(t, 0, otelLogs.Len(), "Expected no logs before core swap")
-
-	// Swap to the observer core
-	setOtelCore(otelCore)
-
-	lggr.Info("after swap")
-
-	assert.Equal(t, 1, otelLogs.Len(), "Expected 1 log after core swap")
-	assert.Equal(t, "after swap", otelLogs.All()[0].Message)
-	assert.Equal(t, zapcore.InfoLevel, otelLogs.All()[0].Level)
 }

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -67,7 +67,7 @@ func (l *zapLogger) Name() string {
 }
 
 func (l *zapLogger) sugaredHelper(skip int) *zap.SugaredLogger {
-	return l.SugaredLogger.WithOptions(zap.AddCallerSkip(skip))
+	return l.WithOptions(zap.AddCallerSkip(skip))
 }
 
 func (l *zapLogger) Sync() error {

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -2,140 +2,18 @@ package logger
 
 import (
 	"os"
-	"slices"
-	"sync"
-	"time"
-	"weak"
 
 	pkgerrors "github.com/pkg/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
-// AtomicCore provides thread-safe core swapping using atomic operations.
-// It starts as a noop core and can be atomically swapped to include additional cores.
-var _ zapcore.Core = &AtomicCore{}
-
-const cleanupInterval = time.Minute * 5
-
-type AtomicCore struct {
-	mu          sync.RWMutex
-	core        zapcore.Core
-	children    []weak.Pointer[withCore]
-	stopCleanup chan struct{}
-	cleanupWg   sync.WaitGroup
-}
-
-// NewAtomicCore creates a new AtomicCore initialized with a noop core
-func NewAtomicCore() *AtomicCore {
-	ac := &AtomicCore{
-		core:        zapcore.NewNopCore(),
-		stopCleanup: make(chan struct{}),
-	}
-	ac.startPeriodicCleanup()
-	return ac
-}
-
-func (d *AtomicCore) Store(core zapcore.Core) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	d.core = core
-	d.children = slices.DeleteFunc(d.children, func(p weak.Pointer[withCore]) bool {
-		c := p.Value()
-		if c == nil {
-			return true
-		}
-		c.Store(d.core)
-		return false
-	})
-}
-
-func (d *AtomicCore) load() zapcore.Core {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.core
-}
-
-func (d *AtomicCore) Enabled(l zapcore.Level) bool { return d.load().Enabled(l) }
-
-func (d *AtomicCore) With(fs []zapcore.Field) zapcore.Core {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	coreWithFields := d.core.With(fs)
-	w := &withCore{fields: fs, AtomicCore: AtomicCore{core: coreWithFields}}
-	d.children = append(d.children, weak.Make(w))
-	return w
-}
-
-func (d *AtomicCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
-	return d.load().Check(e, ce)
-}
-
-func (d *AtomicCore) Write(e zapcore.Entry, fs []zapcore.Field) error { return d.load().Write(e, fs) }
-
-func (d *AtomicCore) Sync() error { return d.load().Sync() }
-
-func (d *AtomicCore) Close() {
-	close(d.stopCleanup)
-	d.cleanupWg.Wait()
-}
-
-func (d *AtomicCore) cleanup() {
-	var wg sync.WaitGroup
-	defer wg.Wait()
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	d.children = slices.DeleteFunc(d.children, func(p weak.Pointer[withCore]) bool {
-		c := p.Value()
-		if c == nil {
-			return true
-		}
-		wg.Go(c.cleanup)
-		return false
-	})
-}
-
-func (d *AtomicCore) startPeriodicCleanup() {
-	d.cleanupWg.Go(func() {
-		ticker := time.NewTicker(cleanupInterval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ticker.C:
-				d.cleanup()
-			case <-d.stopCleanup:
-				return
-			}
-		}
-	})
-}
-
-type withCore struct {
-	fields []zapcore.Field
-	AtomicCore
-}
-
-func (w *withCore) Store(core zapcore.Core) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.core = core.With(w.fields)
-	w.children = slices.DeleteFunc(w.children, func(p weak.Pointer[withCore]) bool {
-		c := p.Value()
-		if c == nil {
-			return true
-		}
-		c.Store(w.core)
-		return false
-	})
-}
-
 var _ Logger = &zapLogger{}
 
 type zapLogger struct {
 	*zap.SugaredLogger
 	level      zap.AtomicLevel
-	fields     []any
+	fields     []interface{}
 	callerSkip int
 }
 
@@ -155,7 +33,7 @@ func (l *zapLogger) SetLogLevel(lvl zapcore.Level) {
 	l.level.SetLevel(lvl)
 }
 
-func (l *zapLogger) With(args ...any) Logger {
+func (l *zapLogger) With(args ...interface{}) Logger {
 	newLogger := *l
 	newLogger.SugaredLogger = l.SugaredLogger.With(args...)
 	newLogger.fields = copyFields(l.fields, args...)
@@ -163,8 +41,8 @@ func (l *zapLogger) With(args ...any) Logger {
 }
 
 // copyFields returns a copy of fields with add appended.
-func copyFields(fields []any, add ...any) []any {
-	f := make([]any, 0, len(fields)+len(add))
+func copyFields(fields []interface{}, add ...interface{}) []interface{} {
+	f := make([]interface{}, 0, len(fields)+len(add))
 	f = append(f, fields...)
 	f = append(f, add...)
 	return f
@@ -189,7 +67,7 @@ func (l *zapLogger) Name() string {
 }
 
 func (l *zapLogger) sugaredHelper(skip int) *zap.SugaredLogger {
-	return l.WithOptions(zap.AddCallerSkip(skip))
+	return l.SugaredLogger.WithOptions(zap.AddCallerSkip(skip))
 }
 
 func (l *zapLogger) Sync() error {
@@ -211,6 +89,6 @@ func (l *zapLogger) Sync() error {
 	return err
 }
 
-func (l *zapLogger) Recover(panicErr any) {
+func (l *zapLogger) Recover(panicErr interface{}) {
 	l.Criticalw("Recovered goroutine panic", "panic", panicErr)
 }

--- a/core/logger/zap_disk_logging.go
+++ b/core/logger/zap_disk_logging.go
@@ -4,10 +4,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 const (

--- a/core/logger/zap_test.go
+++ b/core/logger/zap_test.go
@@ -261,7 +261,7 @@ func TestZapLogger_LogCaller(t *testing.T) {
 func TestZapLogger_Name(t *testing.T) {
 	cfg := Config{}
 	lggr := newTestLogger(t, cfg)
-	require.Equal(t, "", lggr.Name())
+	require.Empty(t, lggr.Name())
 	lggr1 := lggr.Named("Lggr1")
 	require.Equal(t, "Lggr1", lggr1.Name())
 	lggr2 := lggr1.Named("Lggr2")

--- a/core/logger/zap_test.go
+++ b/core/logger/zap_test.go
@@ -3,7 +3,6 @@ package logger
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -245,8 +244,6 @@ func TestZapLogger_LogCaller(t *testing.T) {
 	lggr := newTestLogger(t, local)
 
 	lggr.Debug("test message with caller")
-	_, _, lineCall, ok := runtime.Caller(0)
-	require.True(t, ok)
 
 	pollChan <- time.Now()
 	<-local.testDiskLogLvlChan
@@ -258,34 +255,15 @@ func TestZapLogger_LogCaller(t *testing.T) {
 	logs := string(b)
 	lines := strings.Split(logs, "\n")
 
-	require.Contains(t, lines[0], fmt.Sprintf("logger/zap_test.go:%d\ttest message with caller", lineCall-1))
+	require.Contains(t, lines[0], "logger/zap_test.go:246")
 }
 
 func TestZapLogger_Name(t *testing.T) {
 	cfg := Config{}
 	lggr := newTestLogger(t, cfg)
-	require.Empty(t, lggr.Name())
+	require.Equal(t, "", lggr.Name())
 	lggr1 := lggr.Named("Lggr1")
 	require.Equal(t, "Lggr1", lggr1.Name())
 	lggr2 := lggr1.Named("Lggr2")
 	require.Equal(t, "Lggr1.Lggr2", lggr2.Name())
-}
-
-func TestZapLogger_Cleanup(t *testing.T) {
-	ac := NewAtomicCore()
-	defer ac.Close()
-	l := 1000000
-	for range l {
-		ac.With([]zapcore.Field{})
-	}
-	// Without the cleanup triggered, all children should remain.
-	// We assume that the cleanupInterval is sufficiently large to not yet trigger.
-	require.Equal(t, len(ac.children), l)
-
-	// Trigger cleanup manually.
-	runtime.GC()
-	ac.cleanup()
-	// Ideally, ac.children should be 0 here, but since garbage collected weak pointers are not necessarily nil we just
-	// test that some have been cleaned up.
-	require.Less(t, len(ac.children), l)
 }


### PR DESCRIPTION
This PR effectively roll backs
https://github.com/smartcontractkit/chainlink/pull/19089 and  https://github.com/smartcontractkit/chainlink/pull/20019
until we figure out the exact OOM culprit (except that it happens in AtomicCore allocation).