### PR TITLE
.github: use fetch-depth: 0 for all checkouts

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
       - name: Check git tag type
         id: check-git-tag-type
@@ -140,6 +141,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Determine docker outputs

--- a/.github/workflows/changesets-preview-pr.yml
+++ b/.github/workflows/changesets-preview-pr.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         if: matrix.language == 'go'

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Go

--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -277,6 +277,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
           ref: ${{ env.GIT_HEAD_REF }}
 
@@ -406,6 +407,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
           ref: ${{ env.GIT_HEAD_REF }}
 

--- a/.github/workflows/operator-ui-ci.yml
+++ b/.github/workflows/operator-ui-ci.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Get operator-ui tag


### PR DESCRIPTION
We were burning ~5-10 minutes checking out the repo repeatedly. This change brings that down to 2 seconds.
<img width="1231" height="68" alt="Screenshot from 2025-12-09 17-02-24" src="https://github.com/user-attachments/assets/03de61c5-376e-4014-8093-df9aee7e700f" />
<img width="1231" height="68" alt="Screenshot from 2025-12-09 17-04-55" src="https://github.com/user-attachments/assets/3ee88fe4-0113-46b8-9c67-e54bdd0f69bb" />
