### PR TITLE
Custom MCMS Proposal duration

### DIFF
--- a/deployment/common/proposalutils/propose.go
+++ b/deployment/common/proposalutils/propose.go
@@ -34,7 +34,7 @@ type TimelockConfig struct {
 	MCMSAction                types.TimelockAction `json:"mcmsAction"`
 	OverrideRoot              bool                 `json:"overrideRoot"`                        // if true, override the previous root with the new one.
 	TimelockQualifierPerChain map[uint64]string    `json:"timelockQualifierPerChain,omitempty"` // optional qualifier to fetch timelock address from datastore
-	ValidUntil                *time.Duration       `json:"validUntil" yaml:"validUntil"`
+	ValidDuration             *time.Duration       `json:"validDuration" yaml:"validDuration"`
 }
 
 func (tc *TimelockConfig) MCMBasedOnActionSolana(s state.MCMSWithTimelockStateSolana) (string, error) {
@@ -214,8 +214,8 @@ func BuildProposalFromBatchesV2(
 	}
 
 	proposalDuration := DefaultValidUntil
-	if mcmsCfg.ValidUntil != nil {
-		proposalDuration = *mcmsCfg.ValidUntil
+	if mcmsCfg.ValidDuration != nil {
+		proposalDuration = *mcmsCfg.ValidDuration
 	}
 	validUntil := time.Now().Add(proposalDuration).Unix()
 

--- a/deployment/common/proposalutils/propose.go
+++ b/deployment/common/proposalutils/propose.go
@@ -34,6 +34,7 @@ type TimelockConfig struct {
 	MCMSAction                types.TimelockAction `json:"mcmsAction"`
 	OverrideRoot              bool                 `json:"overrideRoot"`                        // if true, override the previous root with the new one.
 	TimelockQualifierPerChain map[uint64]string    `json:"timelockQualifierPerChain,omitempty"` // optional qualifier to fetch timelock address from datastore
+	ValidUntil                *time.Duration       `json:"validUntil" yaml:"validUntil"`
 }
 
 func (tc *TimelockConfig) MCMBasedOnActionSolana(s state.MCMSWithTimelockStateSolana) (string, error) {
@@ -212,7 +213,11 @@ func BuildProposalFromBatchesV2(
 		return nil, err
 	}
 
-	validUntil := time.Now().Unix() + int64(DefaultValidUntil.Seconds())
+	proposalDuration := DefaultValidUntil
+	if mcmsCfg.ValidUntil != nil {
+		proposalDuration = *mcmsCfg.ValidUntil
+	}
+	validUntil := time.Now().Add(proposalDuration).Unix()
 
 	builder := mcmslib.NewTimelockProposalBuilder()
 	builder.

--- a/deployment/cre/common/strategies/mcms_transaction_test.go
+++ b/deployment/cre/common/strategies/mcms_transaction_test.go
@@ -3,6 +3,7 @@ package strategies_test
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
@@ -200,5 +201,31 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 		metadata, ok := p.ChainMetadata[mcmstypes.ChainSelector(fixture.RegistrySelector)]
 		assert.True(t, ok)
 		assert.Equal(t, mcmsContracts.CancellerMcm.Address().String(), metadata.MCMAddress)
+	})
+
+	t.Run("uses custom ValidUntil value to set the proposal duration", func(t *testing.T) {
+		m := getMCMSTransaction(t, *fixture.Env)
+		validUntil := 2 * time.Second
+		cfg := contracts.MCMSConfig{
+			MinDelay: 0,
+			TimelockQualifierPerChain: map[uint64]string{
+				fixture.RegistrySelector: "",
+			},
+			ValidUntil: &validUntil,
+		}
+		mcmsContracts, err := strategies.GetMCMSContracts(*fixture.Env, fixture.RegistrySelector, cfg)
+		require.NoError(t, err)
+		m.Config = &cfg
+		m.MCMSContracts = mcmsContracts
+		m.ChainSel = fixture.RegistrySelector
+
+		op, err := proposalutils.BatchOperationForChain(m.ChainSel, m.Address.Hex(), []byte{0x01, 0x02, 0x03}, big.NewInt(0), "", nil)
+		require.NoError(t, err)
+
+		p, err := m.BuildProposal([]mcmstypes.BatchOperation{op})
+		require.NoError(t, err)
+
+		expectedValidUntil := time.Now().Add(validUntil).Unix()
+		assert.Equal(t, uint32(expectedValidUntil), p.ValidUntil) //nolint:gosec // G115
 	})
 }

--- a/deployment/cre/common/strategies/mcms_transaction_test.go
+++ b/deployment/cre/common/strategies/mcms_transaction_test.go
@@ -203,15 +203,15 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 		assert.Equal(t, mcmsContracts.CancellerMcm.Address().String(), metadata.MCMAddress)
 	})
 
-	t.Run("uses custom ValidUntil value to set the proposal duration", func(t *testing.T) {
+	t.Run("uses custom ValidDuration value to set the proposal duration", func(t *testing.T) {
 		m := getMCMSTransaction(t, *fixture.Env)
-		validUntil := 2 * time.Second
+		validDuration := 2 * time.Second
 		cfg := contracts.MCMSConfig{
 			MinDelay: 0,
 			TimelockQualifierPerChain: map[uint64]string{
 				fixture.RegistrySelector: "",
 			},
-			ValidUntil: &validUntil,
+			ValidDuration: &validDuration,
 		}
 		mcmsContracts, err := strategies.GetMCMSContracts(*fixture.Env, fixture.RegistrySelector, cfg)
 		require.NoError(t, err)
@@ -225,7 +225,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 		p, err := m.BuildProposal([]mcmstypes.BatchOperation{op})
 		require.NoError(t, err)
 
-		expectedValidUntil := time.Now().Add(validUntil).Unix()
+		expectedValidUntil := time.Now().Add(validDuration).Unix()
 		assert.Equal(t, uint32(expectedValidUntil), p.ValidUntil) //nolint:gosec // G115
 	})
 }

--- a/deployment/cre/common/strategies/mcms_transaction_test.go
+++ b/deployment/cre/common/strategies/mcms_transaction_test.go
@@ -226,6 +226,7 @@ func TestMCMSTransaction_BuildProposal(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedValidUntil := time.Now().Add(validDuration).Unix()
-		assert.Equal(t, uint32(expectedValidUntil), p.ValidUntil) //nolint:gosec // G115
+		// Using InDelta to allow for slight timing differences during test execution
+		assert.InDelta(t, uint32(expectedValidUntil), p.ValidUntil, 1, "ValidUntil should be within 1 second of expected value") //nolint:gosec // G115
 	})
 }

--- a/deployment/cre/contracts/contracts.go
+++ b/deployment/cre/contracts/contracts.go
@@ -7,15 +7,13 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
-	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
-
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
This addresses [CRE-1486](https://smartcontract-it.atlassian.net/browse/CRE-1486) by extending the MCMS Config struct to receive a	`ValidUntil` value which allows the caller to set any proposal duration, aside from the default of 72 hrs.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-1486]: https://smartcontract-it.atlassian.net/browse/CRE-1486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ