### PR TITLE
DS-1850 - upgrading: chainlink-data-streams to avoid wrong timestamps in calculated streams

### DIFF
--- a/.changeset/violet-lamps-pay.md
+++ b/.changeset/violet-lamps-pay.md
@@ -2,4 +2,4 @@
 "chainlink": minor
 ---
 
-Upgrades plugin: chainlink-data-streams so that calculated streams do not generate wrong timestamps
+#bugfix Upgrades plugin: chainlink-data-streams so that calculated streams do not generate wrong timestamps

--- a/.changeset/violet-lamps-pay.md
+++ b/.changeset/violet-lamps-pay.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Upgrades plugin: chainlink-data-streams so that calculated streams do not generate wrong timestamps

--- a/.changeset/violet-lamps-pay.md
+++ b/.changeset/violet-lamps-pay.md
@@ -1,5 +1,5 @@
 ---
-"chainlink": minor
+"chainlink": patch
 ---
 
 #bugfix Upgrades plugin: chainlink-data-streams so that calculated streams do not generate wrong timestamps

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20251128020529-88d93b01d749
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4
-	github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f
+	github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19
 	github.com/smartcontractkit/chainlink-deployments-framework v0.70.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251208160518-8173bbd516d5
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1642,6 +1642,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f h1:SB1/gArhpTaItvde2ub6J5njc84ucw7/GLhAYCUpb3s=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
+github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 h1:gU4suSMid2uQVSxdtPhqGR9s9w3ViclcGtwkQaNbrtM=
+github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0 h1:wo2KL2viGZK/LhHLM8F88sRyhZF9wwWh+YDzW8hS00g=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0/go.mod h1:Cp7PuO7HUDugp7bWGP/TcDAvvvkFLdKOVrSm0zXlnhg=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251208160518-8173bbd516d5 h1:C1iBjGqdrju2sgsbUeaePmibmC+DRRFVTRKbTVBIWp0=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1640,8 +1640,6 @@ github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
-github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f h1:SB1/gArhpTaItvde2ub6J5njc84ucw7/GLhAYCUpb3s=
-github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 h1:gU4suSMid2uQVSxdtPhqGR9s9w3ViclcGtwkQaNbrtM=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0 h1:wo2KL2viGZK/LhHLM8F88sRyhZF9wwWh+YDzW8hS00g=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -416,7 +416,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e // indirect
 	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251208105135-980e1424951b // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
-	github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f // indirect
+	github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251021173435-e86785845942 // indirect

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1364,8 +1364,6 @@ github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
-github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f h1:SB1/gArhpTaItvde2ub6J5njc84ucw7/GLhAYCUpb3s=
-github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 h1:gU4suSMid2uQVSxdtPhqGR9s9w3ViclcGtwkQaNbrtM=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0 h1:wo2KL2viGZK/LhHLM8F88sRyhZF9wwWh+YDzW8hS00g=

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1366,6 +1366,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f h1:SB1/gArhpTaItvde2ub6J5njc84ucw7/GLhAYCUpb3s=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
+github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 h1:gU4suSMid2uQVSxdtPhqGR9s9w3ViclcGtwkQaNbrtM=
+github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0 h1:wo2KL2viGZK/LhHLM8F88sRyhZF9wwWh+YDzW8hS00g=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0/go.mod h1:Cp7PuO7HUDugp7bWGP/TcDAvvvkFLdKOVrSm0zXlnhg=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251208160518-8173bbd516d5 h1:C1iBjGqdrju2sgsbUeaePmibmC+DRRFVTRKbTVBIWp0=

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251208105135-980e1424951b
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10
-	github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f
+	github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251208160518-8173bbd516d5
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135

--- a/go.sum
+++ b/go.sum
@@ -1134,6 +1134,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f h1:SB1/gArhpTaItvde2ub6J5njc84ucw7/GLhAYCUpb3s=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
+github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 h1:gU4suSMid2uQVSxdtPhqGR9s9w3ViclcGtwkQaNbrtM=
+github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251208160518-8173bbd516d5 h1:C1iBjGqdrju2sgsbUeaePmibmC+DRRFVTRKbTVBIWp0=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251208160518-8173bbd516d5/go.mod h1:OQCmZCKnOiNp7LVbHAr6xZ9SThAU7jx5uI+aCvLOn1Q=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b h1:Dqhm/67Sb1ohgce8FW6tnK1CRXo2zoLCbV+EGyew5sg=

--- a/go.sum
+++ b/go.sum
@@ -1132,8 +1132,6 @@ github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
-github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f h1:SB1/gArhpTaItvde2ub6J5njc84ucw7/GLhAYCUpb3s=
-github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 h1:gU4suSMid2uQVSxdtPhqGR9s9w3ViclcGtwkQaNbrtM=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251208160518-8173bbd516d5 h1:C1iBjGqdrju2sgsbUeaePmibmC+DRRFVTRKbTVBIWp0=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -498,7 +498,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e // indirect
 	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251208105135-980e1424951b // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
-	github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f // indirect
+	github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251021173435-e86785845942 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1609,6 +1609,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f h1:SB1/gArhpTaItvde2ub6J5njc84ucw7/GLhAYCUpb3s=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
+github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 h1:gU4suSMid2uQVSxdtPhqGR9s9w3ViclcGtwkQaNbrtM=
+github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0 h1:wo2KL2viGZK/LhHLM8F88sRyhZF9wwWh+YDzW8hS00g=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0/go.mod h1:Cp7PuO7HUDugp7bWGP/TcDAvvvkFLdKOVrSm0zXlnhg=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251208160518-8173bbd516d5 h1:C1iBjGqdrju2sgsbUeaePmibmC+DRRFVTRKbTVBIWp0=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1607,8 +1607,6 @@ github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
-github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f h1:SB1/gArhpTaItvde2ub6J5njc84ucw7/GLhAYCUpb3s=
-github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 h1:gU4suSMid2uQVSxdtPhqGR9s9w3ViclcGtwkQaNbrtM=
 github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0 h1:wo2KL2viGZK/LhHLM8F88sRyhZF9wwWh+YDzW8hS00g=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -483,7 +483,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20251027185542-babb09e5363e // indirect
 	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251208105135-980e1424951b // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
-	github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f // indirect
+	github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251021173435-e86785845942 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1586,8 +1586,8 @@ github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
-github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f h1:SB1/gArhpTaItvde2ub6J5njc84ucw7/GLhAYCUpb3s=
-github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
+github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 h1:gU4suSMid2uQVSxdtPhqGR9s9w3ViclcGtwkQaNbrtM=
+github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0 h1:wo2KL2viGZK/LhHLM8F88sRyhZF9wwWh+YDzW8hS00g=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0/go.mod h1:Cp7PuO7HUDugp7bWGP/TcDAvvvkFLdKOVrSm0zXlnhg=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251208160518-8173bbd516d5 h1:C1iBjGqdrju2sgsbUeaePmibmC+DRRFVTRKbTVBIWp0=

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -45,7 +45,7 @@ plugins:
 
   streams:
     - moduleURI: "github.com/smartcontractkit/chainlink-data-streams"
-      gitRef: "v0.1.7-0.20251123170926-313d8827bd6f"
+      gitRef: "v0.1.7-0.20251209111830-ccd12a5b2a19"
       installPath: "./mercury/cmd/chainlink-mercury"
 
   ton:

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -457,7 +457,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5 // indirect
 	github.com/smartcontractkit/chainlink-ccv v0.0.0-20251208105135-980e1424951b // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
-	github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f // indirect
+	github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251021173435-e86785845942 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1603,8 +1603,8 @@ github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
-github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f h1:SB1/gArhpTaItvde2ub6J5njc84ucw7/GLhAYCUpb3s=
-github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
+github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 h1:gU4suSMid2uQVSxdtPhqGR9s9w3ViclcGtwkQaNbrtM=
+github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0 h1:wo2KL2viGZK/LhHLM8F88sRyhZF9wwWh+YDzW8hS00g=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0/go.mod h1:Cp7PuO7HUDugp7bWGP/TcDAvvvkFLdKOVrSm0zXlnhg=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251208160518-8173bbd516d5 h1:C1iBjGqdrju2sgsbUeaePmibmC+DRRFVTRKbTVBIWp0=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.85
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251125103916-0b41e73b80c4
-	github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f
+	github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19
 	github.com/smartcontractkit/chainlink-deployments-framework v0.70.0
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022075638-49d961001d1b
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251124151448-0448aefdaab9

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1800,8 +1800,8 @@ github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
-github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f h1:SB1/gArhpTaItvde2ub6J5njc84ucw7/GLhAYCUpb3s=
-github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251123170926-313d8827bd6f/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
+github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19 h1:gU4suSMid2uQVSxdtPhqGR9s9w3ViclcGtwkQaNbrtM=
+github.com/smartcontractkit/chainlink-data-streams v0.1.7-0.20251209111830-ccd12a5b2a19/go.mod h1:GPsn6PKJvPe1UfRYyVxsDzOWq6NILzBstiiLq/w+kG0=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0 h1:wo2KL2viGZK/LhHLM8F88sRyhZF9wwWh+YDzW8hS00g=
 github.com/smartcontractkit/chainlink-deployments-framework v0.70.0/go.mod h1:Cp7PuO7HUDugp7bWGP/TcDAvvvkFLdKOVrSm0zXlnhg=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20251208160518-8173bbd516d5 h1:C1iBjGqdrju2sgsbUeaePmibmC+DRRFVTRKbTVBIWp0=


### PR DESCRIPTION
[DS-1850](https://smartcontract-it.atlassian.net/browse/DS-1850)

This PR upgrades `chainlink-data-streams` so that include a fix for wrong timestamps in calculated streams . See related PR : https://github.com/smartcontractkit/chainlink-data-streams/pull/215

### Requires
- https://github.com/smartcontractkit/chainlink-data-streams/pull/215



[DS-1850]: https://smartcontract-it.atlassian.net/browse/DS-1850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ