### PR TITLE
CCIP Solana: execute revert test

### DIFF
--- a/.github/integration-in-memory-tests.yml
+++ b/.github/integration-in-memory-tests.yml
@@ -89,6 +89,20 @@ runner-test-matrix:
     test_env_vars:
       CL_SOLANA_CMD: chainlink-solana
 
+  - id: smoke/ccip/ccip_messaging_test.go:Test_CCIPMessaging_Revert_EVM2Solana_LOOPP
+    path: integration-tests/smoke/ccip/ccip_messaging_test.go
+    test_env_type: in-memory
+    runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    triggers:
+      - PR Integration CCIP Tests
+      - Nightly Integration CCIP Tests
+    test_cmd: cd smoke/ccip && go test -run "Test_CCIPMessaging_Revert_EVM2Solana" -timeout 18m -test.parallel=4 -count=1 -json
+    test_go_project_path: integration-tests
+    install_plugins_public: true
+    test_env_vars:
+      CL_SOLANA_CMD: chainlink-solana
+
   - id: smoke/ccip/ccip_messaging_test.go:Test_CCIPMessaging_MultiExecReports_EVM2Solana
     path: integration-tests/smoke/ccip/ccip_messaging_test.go
     test_env_type: in-memory

--- a/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
@@ -9,10 +9,11 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"github.com/xssnick/tonutils-go/address"
 	"github.com/xssnick/tonutils-go/tvm/cell"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	solconfig "github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/config"
@@ -107,9 +108,10 @@ const (
 )
 
 type TestCaseOutput struct {
-	Replayed     bool
-	Nonce        uint64
-	MsgSentEvent *ccipclient.AnyMsgSentEvent
+	Replayed         bool
+	Nonce            uint64
+	MsgSentEvent     *ccipclient.AnyMsgSentEvent
+	AllMsgSentEvents []*ccipclient.AnyMsgSentEvent
 }
 
 func getLatestNonce(tc TestCase) uint64 {
@@ -329,6 +331,8 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 			msgSentEvents[i] = msgSentEventLocal
 		}
 	}
+	// return all message sent events.
+	out.AllMsgSentEvents = msgSentEvents
 
 	// HACK: if the node booted or the logpoller filters got registered after ccipSend,
 	// we need to replay missed logs

--- a/deployment/ccip/changeset/testhelpers/test_assertions.go
+++ b/deployment/ccip/changeset/testhelpers/test_assertions.go
@@ -580,7 +580,8 @@ type EventWithTxn[T any] struct {
 	Txn   *solrpc.GetTransactionResult
 }
 
-// Scan for events referencing address
+// SolEventEmitter listens for events of type T emitted by the Solana program at the given address. Failed transactions
+// can be included by setting the includeFailed flag to true.
 func SolEventEmitter[T any](ctx context.Context, client *solrpc.Client, address solana.PublicKey, eventType string, startSlot uint64, done chan any, ticker *time.Ticker, includeFailed bool) (<-chan EventWithTxn[T], <-chan error) {
 	ch := make(chan EventWithTxn[T])
 	errorCh := make(chan error)
@@ -1052,6 +1053,10 @@ type MessageStateEvent struct {
 	State          ccip_offramp.MessageExecutionState
 }
 
+// GetMessageStatesWithSeqNrsSol waits for execution state changes on the destination Solana chain with the expected
+// sequence numbers. The timeout is configurable.
+// If "inProgress" is true, and there are unexecutable messages, it will continue to watch for additional "InProgress"
+// states for the entire timeoutDuration.
 func GetMessageStatesWithSeqNrsSol(
 	t *testing.T,
 	timeoutDuration time.Duration,
@@ -1121,6 +1126,9 @@ func GetMessageStatesWithSeqNrsSol(
 	}
 }
 
+// ConfirmExecWithSeqNrsSol waits for an execution state change on the destination Solana chain with the expected
+// sequence numbers. The timeout is automatically set to 30 seconds or 90% of the test timeout (if there is one).
+// This is a wrapper around the more general GetMessageStatesWithSeqNrsSol.
 func ConfirmExecWithSeqNrsSol(
 	t *testing.T,
 	srcSelector uint64,

--- a/deployment/ccip/changeset/testhelpers/test_assertions.go
+++ b/deployment/ccip/changeset/testhelpers/test_assertions.go
@@ -581,7 +581,7 @@ type EventWithTxn[T any] struct {
 }
 
 // Scan for events referencing address
-func SolEventEmitter[T any](ctx context.Context, client *solrpc.Client, address solana.PublicKey, eventType string, startSlot uint64, done chan any, ticker *time.Ticker) (<-chan EventWithTxn[T], <-chan error) {
+func SolEventEmitter[T any](ctx context.Context, client *solrpc.Client, address solana.PublicKey, eventType string, startSlot uint64, done chan any, ticker *time.Ticker, includeFailed bool) (<-chan EventWithTxn[T], <-chan error) {
 	ch := make(chan EventWithTxn[T])
 	errorCh := make(chan error)
 	go func() {
@@ -612,7 +612,7 @@ func SolEventEmitter[T any](ctx context.Context, client *solrpc.Client, address 
 
 				// values are returned ordered newest to oldest, so we replay them backwards
 				for _, txSig := range slices.Backward(txSigs) {
-					if txSig.Err != nil {
+					if txSig.Err != nil && !includeFailed {
 						// We're not interested in failed transactions.
 						continue
 					}
@@ -677,7 +677,7 @@ func ConfirmCommitWithExpectedSeqNumRangeSol(
 
 	done := make(chan any)
 	defer close(done)
-	sink, errCh := SolEventEmitter[solcommon.EventCommitReportAccepted](t.Context(), dest.Client, offrampAddress, consts.EventNameCommitReportAccepted, startSlot, done, time.NewTicker(2*time.Second))
+	sink, errCh := SolEventEmitter[solcommon.EventCommitReportAccepted](t.Context(), dest.Client, offrampAddress, consts.EventNameCommitReportAccepted, startSlot, done, time.NewTicker(2*time.Second), false)
 
 	timeout := time.NewTimer(tests.WaitTimeout(t))
 	defer timeout.Stop()
@@ -1046,28 +1046,38 @@ func ConfirmExecWithSeqNrs(
 	}
 }
 
-func ConfirmExecWithSeqNrsSol(
+type MessageStateEvent struct {
+	SequenceNumber uint64
+	Block          uint64
+	State          ccip_offramp.MessageExecutionState
+}
+
+func GetMessageStatesWithSeqNrsSol(
 	t *testing.T,
+	timeoutDuration time.Duration,
 	srcSelector uint64,
 	dest cldf_solana.Chain,
 	offrampAddress solana.PublicKey,
 	startSlot uint64,
 	expectedSeqNrs []uint64,
-) (executionStates map[uint64]int, err error) {
+	inProgress bool,
+) (executionStates map[uint64][]MessageStateEvent, err error) {
 	// TODO: share with EVM
 	// some state to efficiently track the execution states
 	// of all the expected sequence numbers.
-	executionStates = make(map[uint64]int)
+	executionStates = make(map[uint64][]MessageStateEvent)
+	seqNrsInProgress := make(map[uint64]struct{})
 	seqNrsToWatch := make(map[uint64]struct{})
 	for _, seqNr := range expectedSeqNrs {
 		seqNrsToWatch[seqNr] = struct{}{}
+		seqNrsInProgress[seqNr] = struct{}{}
 	}
 
 	done := make(chan any)
 	defer close(done)
-	sink, errCh := SolEventEmitter[solccip.EventExecutionStateChanged](t.Context(), dest.Client, offrampAddress, consts.EventNameExecutionStateChanged, startSlot, done, time.NewTicker(2*time.Second))
+	sink, errCh := SolEventEmitter[solccip.EventExecutionStateChanged](t.Context(), dest.Client, offrampAddress, consts.EventNameExecutionStateChanged, startSlot, done, time.NewTicker(2*time.Second), inProgress)
 
-	timeout := time.NewTimer(tests.WaitTimeout(t))
+	timeout := time.NewTimer(timeoutDuration)
 	defer timeout.Stop()
 
 	for {
@@ -1079,12 +1089,20 @@ func ConfirmExecWithSeqNrsSol(
 			if found && execEvent.SourceChainSelector == srcSelector {
 				t.Logf("Received ExecutionStateChanged (state %s) on chain %d (offramp %s) from chain %d with expected sequence number %d",
 					execEvent.State.String(), dest.Selector, offrampAddress.String(), srcSelector, execEvent.SequenceNumber)
+
+				executionStates[execEvent.SequenceNumber] = append(executionStates[execEvent.SequenceNumber],
+					MessageStateEvent{
+						SequenceNumber: execEvent.SequenceNumber,
+						Block:          eventWithTxn.Txn.Slot,
+						State:          execEvent.State,
+					})
 				if execEvent.State == ccip_offramp.InProgress_MessageExecutionState {
-					// skip the in progress state, executed event should follow
+					delete(seqNrsInProgress, execEvent.SequenceNumber)
+					// continue watching for final state or timeout
 					continue
 				}
-				executionStates[execEvent.SequenceNumber] = int(execEvent.State)
 				delete(seqNrsToWatch, execEvent.SequenceNumber)
+				delete(seqNrsInProgress, execEvent.SequenceNumber)
 				if len(seqNrsToWatch) == 0 {
 					return executionStates, nil
 				}
@@ -1092,10 +1110,47 @@ func ConfirmExecWithSeqNrsSol(
 		case err := <-errCh:
 			require.NoError(t, err)
 		case <-timeout.C:
+			// If we have some status for every seqNr, return what we have instead of an error.
+			if len(seqNrsInProgress) == 0 {
+				return executionStates, nil
+			}
+			// Otherwise return a timeout error.
 			return nil, fmt.Errorf("timed out waiting for ExecutionStateChanged on chain %d (offramp %s) from chain %d with expected sequence numbers %+v",
 				dest.Selector, offrampAddress.String(), srcSelector, expectedSeqNrs)
 		}
 	}
+}
+
+func ConfirmExecWithSeqNrsSol(
+	t *testing.T,
+	srcSelector uint64,
+	dest cldf_solana.Chain,
+	offrampAddress solana.PublicKey,
+	startSlot uint64,
+	expectedSeqNrs []uint64,
+) (executionStates map[uint64]int, err error) {
+	timeout := tests.WaitTimeout(t)
+	states, err := GetMessageStatesWithSeqNrsSol(t, timeout, srcSelector, dest, offrampAddress, startSlot, expectedSeqNrs, false)
+	if err != nil {
+		return nil, err
+	}
+
+	executionStates = make(map[uint64]int)
+
+	for seqNr, stateList := range states {
+		if len(stateList) == 0 {
+			return nil, fmt.Errorf("no execution states found for seqNr %d", seqNr)
+		}
+		// check that the final state is either success or failure
+		state := stateList[len(stateList)-1].State
+		if state != ccip_offramp.Success_MessageExecutionState && state != ccip_offramp.Failure_MessageExecutionState {
+			return nil, fmt.Errorf("expected final execution state for seqNr %d, got %s", seqNr, state.String())
+		}
+
+		executionStates[seqNr] = int(state)
+	}
+
+	return executionStates, nil
 }
 
 func ConfirmExecWithExpectedSeqNrsAptos(

--- a/integration-tests/load/ccip/sol_helpers.go
+++ b/integration-tests/load/ccip/sol_helpers.go
@@ -60,7 +60,7 @@ func subscribeSolTransmitEvents(
 	}
 
 	done := make(chan any)
-	sink, errCh := testhelpers.SolEventEmitter[solccip.EventCCIPMessageSent](ctx, client, onrampAddress, ccipconsts.EventNameCCIPMessageSent, startSlot, done, time.NewTicker(2*time.Second))
+	sink, errCh := testhelpers.SolEventEmitter[solccip.EventCCIPMessageSent](ctx, client, onrampAddress, ccipconsts.EventNameCCIPMessageSent, startSlot, done, time.NewTicker(2*time.Second), false)
 	defer close(done)
 	for {
 		select {
@@ -162,7 +162,7 @@ func subscribeSolCommitEvents(
 	}
 
 	done := make(chan any)
-	sink, errCh := testhelpers.SolEventEmitter[solcommon.EventCommitReportAccepted](ctx, client, offrampAddress, ccipconsts.EventNameCommitReportAccepted, startSlot, done, time.NewTicker(2*time.Second))
+	sink, errCh := testhelpers.SolEventEmitter[solcommon.EventCommitReportAccepted](ctx, client, offrampAddress, ccipconsts.EventNameCommitReportAccepted, startSlot, done, time.NewTicker(2*time.Second), false)
 	defer close(done)
 
 	ticker := time.NewTicker(tickerDuration)
@@ -285,7 +285,7 @@ func subscribeSolExecutionEvents(
 		completedSrcChains[srcChain] = false
 	}
 	done := make(chan any)
-	sink, errCh := testhelpers.SolEventEmitter[solccip.EventExecutionStateChanged](ctx, client, offrampAddress, ccipconsts.EventNameExecutionStateChanged, startSlot, done, time.NewTicker(2*time.Second))
+	sink, errCh := testhelpers.SolEventEmitter[solccip.EventExecutionStateChanged](ctx, client, offrampAddress, ccipconsts.EventNameExecutionStateChanged, startSlot, done, time.NewTicker(2*time.Second), false)
 	defer close(done)
 
 	ticker := time.NewTicker(tickerDuration)

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -686,7 +686,7 @@ func Test_CCIPMessaging_Solana2EVM(t *testing.T) {
 // CCIPReceiver to reject all messages. The in-flight cache is designed to prevent re-execution during OCR transmission.
 // The main assertion is that there is only a single "in progress" event; this indicates that there was only one
 // execution.
-func Test_CCIPMessaging_EVM2Solana_Revert(t *testing.T) {
+func Test_CCIPMessaging_Revert_EVM2Solana(t *testing.T) {
 	inflightDuration := 30 * time.Second
 
 	// Setup 2 chains (EVM and Solana) and a single lane.

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -14,14 +14,13 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	soltestutils "github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/testutils"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/ccip_offramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/test_ccip_receiver"
-
-	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 
 	solconfig "github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/config"
 	solccip "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/ccip"
@@ -223,7 +222,7 @@ func Test_CCIPMessaging_MultiExecReports_EVM2Solana(t *testing.T) {
 	e, _, _ := testsetups.NewIntegrationEnvironment(t,
 		testhelpers.WithSolChains(1),
 		testhelpers.WithOCRConfigOverride(func(params v1_6.CCIPOCRParams) v1_6.CCIPOCRParams {
-			params.ExecuteOffChainConfig.InflightCacheExpiry = *config.MustNewDuration(1 * time.Hour)
+			params.ExecuteOffChainConfig.InflightCacheExpiry = *config.MustNewDuration(time.Minute)
 			params.ExecuteOffChainConfig.MessageVisibilityInterval = *config.MustNewDuration(1 * time.Hour)
 			params.ExecuteOffChainConfig.MultipleReportsEnabled = true
 			params.ExecuteOffChainConfig.MaxReportMessages = 1
@@ -359,7 +358,7 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 		testhelpers.WithMultiCall3(),
 		testhelpers.WithSolChains(1),
 		testhelpers.WithOCRConfigOverride(func(params v1_6.CCIPOCRParams) v1_6.CCIPOCRParams {
-			params.ExecuteOffChainConfig.InflightCacheExpiry = *config.MustNewDuration(1 * time.Hour)
+			params.ExecuteOffChainConfig.InflightCacheExpiry = *config.MustNewDuration(time.Minute)
 			params.ExecuteOffChainConfig.MessageVisibilityInterval = *config.MustNewDuration(1 * time.Hour)
 			params.ExecuteOffChainConfig.MultipleReportsEnabled = true
 			params.ExecuteOffChainConfig.MaxReportMessages = 1
@@ -683,8 +682,12 @@ func Test_CCIPMessaging_Solana2EVM(t *testing.T) {
 	})
 }
 
+// Test that messages that revert on Solana side only execute once. This is done by setting a flag in the Solana
+// CCIPReceiver to reject all messages. The in-flight cache is designed to prevent re-execution during OCR transmission.
+// The main assertion is that there is only a single "in progress" event; this indicates that there was only one
+// execution.
 func Test_CCIPMessaging_EVM2Solana_Revert(t *testing.T) {
-	inflightDuration := time.Minute
+	inflightDuration := 30 * time.Second
 
 	// Setup 2 chains (EVM and Solana) and a single lane.
 	e, _, _ := testsetups.NewIntegrationEnvironment(t,
@@ -735,31 +738,29 @@ func Test_CCIPMessaging_EVM2Solana_Revert(t *testing.T) {
 		)
 	)
 
-	fmt.Println("Waiting for event filter...")
 	// Wait for filter registration for CCIPMessageSent (onramp), CommitReportAccepted (offramp), and ExecutionStateChanged (offramp)
 	testhelpers.WaitForEventFilterRegistrationOnLane(t, state, e.Env.Offchain, sourceChain, destChain)
-	fmt.Println("Done: Waiting for event filter...")
 
 	receiverProgram := state.SolChains[destChain].Receiver
 	receiver := receiverProgram.Bytes()
 	receiverTargetAccountPDA, _, _ := solana.FindProgramAddress([][]byte{[]byte("counter")}, receiverProgram)
 	receiverExternalExecutionConfigPDA, _, _ := solana.FindProgramAddress([][]byte{[]byte("external_execution_config")}, receiverProgram)
 
-	/////////////////////////////////////////////////////////////////////////////////
-	// This is the point where the env diverges from Test_CCIPMessaging_EVM2Solana //
-	/////////////////////////////////////////////////////////////////////////////////
-
-	// Set reject all flag in receiver to force reverts
 	ctx := testhelpers.Context(t)
 	solChains := e.Env.BlockChains.SolanaChains()
-	deployer := solChains[destChain].DeployerKey
-	ix, err := test_ccip_receiver.NewSetRejectAllInstruction(true, receiverTargetAccountPDA, deployer.PublicKey()).ValidateAndBuild()
-	require.NoError(t, err)
-	ixData, err := ix.Data()
-	require.NoError(t, err)
-	rejectAllIx := solana.NewInstruction(receiverProgram, ix.Accounts(), ixData)
-	res := soltestutils.SendAndConfirm(ctx, t, solChains[destChain].Client, []solana.Instruction{rejectAllIx}, *deployer, solconfig.DefaultCommitment)
-	require.Nil(t, res.Meta.Err)
+	{
+		//////////////////////////////////////////////////////
+		// Set reject all flag in receiver to force reverts //
+		//////////////////////////////////////////////////////
+		deployer := solChains[destChain].DeployerKey
+		ix, err := test_ccip_receiver.NewSetRejectAllInstruction(true, receiverTargetAccountPDA, deployer.PublicKey()).ValidateAndBuild()
+		require.NoError(t, err)
+		ixData, err := ix.Data()
+		require.NoError(t, err)
+		rejectAllIx := solana.NewInstruction(receiverProgram, ix.Accounts(), ixData)
+		res := soltestutils.SendAndConfirm(ctx, t, solChains[destChain].Client, []solana.Instruction{rejectAllIx}, *deployer, solconfig.DefaultCommitment)
+		require.Nil(t, res.Meta.Err)
+	}
 
 	t.Run("failed messages should only execute once", func(t *testing.T) {
 		accounts := [][32]byte{
@@ -802,11 +803,10 @@ func Test_CCIPMessaging_EVM2Solana_Revert(t *testing.T) {
 
 		// This test works by waiting for an extra long duration and checking that
 		// no re-execution happens for the failed message.
-
-		fmt.Println("Checking for states.")
 		states, err := testhelpers.GetMessageStatesWithSeqNrsSol(
 			t,
-			2*time.Minute, // timeout
+			// timeout must be large enough for inflight cache to expire and an additional ocr round.
+			inflightDuration+time.Minute,
 			sourceChain,
 			e.Env.BlockChains.SolanaChains()[destChain],
 			state.SolChains[destChain].OffRamp,
@@ -818,11 +818,6 @@ func Test_CCIPMessaging_EVM2Solana_Revert(t *testing.T) {
 		if err != nil {
 			t.Logf("Error getting message states: %v", err)
 		}
-		//else {
-		//	if states[seqNrs[0]] == testhelpers.EXECUTION_STATE_INPROGRESS {
-		//		assert.Fail(t, "An additional in progress event is detected.")
-		//	}
-		//}
 
 		fmt.Println(states)
 		_, ok := states[seqNrs[0]]
@@ -832,59 +827,6 @@ func Test_CCIPMessaging_EVM2Solana_Revert(t *testing.T) {
 		assert.Len(t, states[seqNrs[0]], 1)
 		// And it is in progress.
 		assert.Equal(t, int(states[seqNrs[0]][0].State), int(ccip_offramp.InProgress_MessageExecutionState))
-
-		/*
-			// We need to find an in progress state.
-			looking := true
-			for looking {
-				states, err := testhelpers.GetMessageStateWithSeqNrsSol(
-					t,
-					sourceChain,
-					e.Env.BlockChains.SolanaChains()[destChain],
-					state.SolChains[destChain].OffRamp,
-					blockH,
-					seqNrs,
-					true,
-				)
-				if err != nil {
-					t.Logf("Error getting message states: %v", err)
-				} else {
-					if states[seqNrs[0]] == testhelpers.EXECUTION_STATE_INPROGRESS {
-						// We see the message is "in progress", as expected
-						looking = false
-					}
-				}
-				// Wait a bit before trying again
-				if looking {
-					time.Sleep(5 * time.Second)
-				}
-			}
-			// Update the blockH, we'll continue searching for events from here.
-			blockH, err = e.Env.BlockChains.SolanaChains()[destChain].Client.GetBlockHeight(t.Context(), rpc.CommitmentFinalized)
-			if err != nil {
-				t.Fatalf("failed to get latest block height: %v", err)
-			}
-			// Wait for the in-flight duration to expire to ensure no re-execution happens.
-			time.Sleep(inflightDuration * 2)
-			// There should be no more in progress events.
-			states, err := testhelpers.GetMessageStatesWithSeqNrsSol(
-				t,
-				sourceChain,
-				e.Env.BlockChains.SolanaChains()[destChain],
-				state.SolChains[destChain].OffRamp,
-				blockH,
-				seqNrs,
-				true,
-			)
-			if err != nil {
-				t.Logf("Error getting message states: %v", err)
-			} else {
-				if states[seqNrs[0]] == testhelpers.EXECUTION_STATE_INPROGRESS {
-					assert.Fail(t, "An additional in progress event is detected.")
-				}
-			}
-		*/
-		fmt.Println("done")
 	})
 
 	_ = out

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
+
 	soltestutils "github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/testutils"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/ccip_offramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/test_ccip_receiver"

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -12,7 +12,14 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/stretchr/testify/assert"
+
 	chainsel "github.com/smartcontractkit/chain-selectors"
+	soltestutils "github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/testutils"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/ccip_offramp"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/test_ccip_receiver"
+
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
@@ -308,7 +315,7 @@ func Test_CCIPMessaging_MultiExecReports_EVM2Solana(t *testing.T) {
 	done := make(chan any)
 	defer close(done)
 	offrampAddress := state.SolChains[destChain].OffRamp
-	sink, errCh := testhelpers.SolEventEmitter[solccip.EventTransmitted](ctx, solChains[destChain].Client, offrampAddress, "Transmitted", 0, done, time.NewTicker(2*time.Second))
+	sink, errCh := testhelpers.SolEventEmitter[solccip.EventTransmitted](ctx, solChains[destChain].Client, offrampAddress, "Transmitted", 0, done, time.NewTicker(2*time.Second), false)
 	timeout := time.NewTimer(tests.WaitTimeout(t) - 5*time.Second) // 5 seconds buffer for cleanup
 	defer timeout.Stop()
 
@@ -676,6 +683,214 @@ func Test_CCIPMessaging_Solana2EVM(t *testing.T) {
 
 		_ = out // avoid unused error
 	})
+}
+
+func Test_CCIPMessaging_EVM2Solana_Revert(t *testing.T) {
+	inflightDuration := time.Millisecond
+
+	// Setup 2 chains (EVM and Solana) and a single lane.
+	e, _, _ := testsetups.NewIntegrationEnvironment(t,
+		testhelpers.WithMultiCall3(),
+		testhelpers.WithSolChains(1),
+		testhelpers.WithOCRConfigOverride(func(params v1_6.CCIPOCRParams) v1_6.CCIPOCRParams {
+			params.ExecuteOffChainConfig.InflightCacheExpiry = *config.MustNewDuration(inflightDuration)
+			params.ExecuteOffChainConfig.MessageVisibilityInterval = *config.MustNewDuration(1 * time.Hour)
+			params.ExecuteOffChainConfig.MultipleReportsEnabled = true
+			params.ExecuteOffChainConfig.MaxReportMessages = 1
+			params.ExecuteOffChainConfig.MaxSingleChainReports = 1
+			params.ExecuteOffChainConfig.SolanaChainWriterConfigVersion = &cctypes.SolanaChainWriterExecuteConfigVersionV2
+			return params
+		}),
+	)
+
+	// TODO: do this as part of setup
+	testhelpers.DeploySolanaCcipReceiver(t, e.Env)
+
+	state, err := stateview.LoadOnchainState(e.Env)
+	require.NoError(t, err)
+
+	allChainSelectors := e.Env.BlockChains.ListChainSelectors(chain.WithFamily(chainsel.FamilyEVM))
+	allSolChainSelectors := e.Env.BlockChains.ListChainSelectors(chain.WithFamily(chainsel.FamilySolana))
+	sourceChain := allChainSelectors[0]
+	destChain := allSolChainSelectors[0]
+	t.Log("All chain selectors:", allChainSelectors,
+		", sol chain selectors:", allSolChainSelectors,
+		", home chain selector:", e.HomeChainSel,
+		", feed chain selector:", e.FeedChainSel,
+		", source chain selector:", sourceChain,
+		", dest chain selector:", destChain,
+	)
+	// connect a single lane, source to dest
+	testhelpers.AddLaneWithEnforceOutOfOrder(t, &e, state, sourceChain, destChain, false)
+
+	var (
+		// nonce    uint64 // Nonce not used as Solana check is skipped
+		sender = common.LeftPadBytes(e.Env.BlockChains.EVMChains()[sourceChain].DeployerKey.From.Bytes(), 32)
+		out    mt.TestCaseOutput
+		setup  = mt.NewTestSetupWithDeployedEnv(
+			t,
+			e,
+			state,
+			sourceChain,
+			destChain,
+			sender,
+			false, // testRouter
+		)
+	)
+
+	fmt.Println("Waiting for event filter...")
+	// Wait for filter registration for CCIPMessageSent (onramp), CommitReportAccepted (offramp), and ExecutionStateChanged (offramp)
+	testhelpers.WaitForEventFilterRegistrationOnLane(t, state, e.Env.Offchain, sourceChain, destChain)
+	fmt.Println("Done: Waiting for event filter...")
+
+	receiverProgram := state.SolChains[destChain].Receiver
+	receiver := receiverProgram.Bytes()
+	receiverTargetAccountPDA, _, _ := solana.FindProgramAddress([][]byte{[]byte("counter")}, receiverProgram)
+	receiverExternalExecutionConfigPDA, _, _ := solana.FindProgramAddress([][]byte{[]byte("external_execution_config")}, receiverProgram)
+
+	/////////////////////////////////////////////////////////////////////////////////
+	// This is the point where the env diverges from Test_CCIPMessaging_EVM2Solana //
+	/////////////////////////////////////////////////////////////////////////////////
+
+	// Set reject all flag in receiver to force reverts
+	ctx := testhelpers.Context(t)
+	solChains := e.Env.BlockChains.SolanaChains()
+	deployer := solChains[destChain].DeployerKey
+	ix, err := test_ccip_receiver.NewSetRejectAllInstruction(true, receiverTargetAccountPDA, deployer.PublicKey()).ValidateAndBuild()
+	require.NoError(t, err)
+	ixData, err := ix.Data()
+	require.NoError(t, err)
+	rejectAllIx := solana.NewInstruction(receiverProgram, ix.Accounts(), ixData)
+	res := soltestutils.SendAndConfirm(ctx, t, solChains[destChain].Client, []solana.Instruction{rejectAllIx}, *deployer, solconfig.DefaultCommitment)
+	require.Nil(t, res.Meta.Err)
+
+	t.Run("failed messages should only execute once", func(t *testing.T) {
+		accounts := [][32]byte{
+			receiverExternalExecutionConfigPDA,
+			receiverTargetAccountPDA,
+			solana.SystemProgramID,
+		}
+
+		extraArgs, err := ccipevm.SerializeClientSVMExtraArgsV1(msg_hasher163.ClientSVMExtraArgsV1{
+			AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes([]int{0, 1}),
+			Accounts:                 accounts,
+			ComputeUnits:             1_000_000,
+			AllowOutOfOrderExecution: true,
+		})
+		require.NoError(t, err)
+
+		blockH, err := e.Env.BlockChains.SolanaChains()[destChain].Client.GetBlockHeight(t.Context(), rpc.CommitmentFinalized)
+		if err != nil {
+			t.Fatalf("failed to get latest block height: %v", err)
+		}
+
+		out = mt.Run(
+			t,
+			mt.TestCase{
+				ValidationType:   mt.ValidationTypeCommit,
+				TestSetup:        setup,
+				Nonce:            nil, // Solana nonce check is skipped
+				Receiver:         receiver,
+				MsgData:          bytes.Repeat([]byte("a"), 1),
+				ExtraArgs:        extraArgs,
+				NumberOfMessages: 1,
+				UseMulticall3:    true,
+			},
+		)
+
+		var seqNrs []uint64
+		for _, msgEvent := range out.AllMsgSentEvents {
+			seqNrs = append(seqNrs, msgEvent.SequenceNumber)
+		}
+
+		// This test works by waiting for an extra long duration and checking that
+		// no re-execution happens for the failed message.
+
+		fmt.Println("Checking for states.")
+		states, err := testhelpers.GetMessageStatesWithSeqNrsSol(
+			t,
+			2*time.Minute, // timeout
+			sourceChain,
+			e.Env.BlockChains.SolanaChains()[destChain],
+			state.SolChains[destChain].OffRamp,
+			blockH,
+			seqNrs,
+			true,
+		)
+		fmt.Println("Done checking for states.")
+		if err != nil {
+			t.Logf("Error getting message states: %v", err)
+		}
+		//else {
+		//	if states[seqNrs[0]] == testhelpers.EXECUTION_STATE_INPROGRESS {
+		//		assert.Fail(t, "An additional in progress event is detected.")
+		//	}
+		//}
+
+		fmt.Println(states)
+		_, ok := states[seqNrs[0]]
+		assert.True(t, ok, "status returned for seqNr")
+
+		// Only 1 event
+		assert.Len(t, states[seqNrs[0]], 1)
+		// And it is in progress.
+		assert.Equal(t, int(states[seqNrs[0]][0].State), int(ccip_offramp.InProgress_MessageExecutionState))
+
+		/*
+			// We need to find an in progress state.
+			looking := true
+			for looking {
+				states, err := testhelpers.GetMessageStateWithSeqNrsSol(
+					t,
+					sourceChain,
+					e.Env.BlockChains.SolanaChains()[destChain],
+					state.SolChains[destChain].OffRamp,
+					blockH,
+					seqNrs,
+					true,
+				)
+				if err != nil {
+					t.Logf("Error getting message states: %v", err)
+				} else {
+					if states[seqNrs[0]] == testhelpers.EXECUTION_STATE_INPROGRESS {
+						// We see the message is "in progress", as expected
+						looking = false
+					}
+				}
+				// Wait a bit before trying again
+				if looking {
+					time.Sleep(5 * time.Second)
+				}
+			}
+			// Update the blockH, we'll continue searching for events from here.
+			blockH, err = e.Env.BlockChains.SolanaChains()[destChain].Client.GetBlockHeight(t.Context(), rpc.CommitmentFinalized)
+			if err != nil {
+				t.Fatalf("failed to get latest block height: %v", err)
+			}
+			// Wait for the in-flight duration to expire to ensure no re-execution happens.
+			time.Sleep(inflightDuration * 2)
+			// There should be no more in progress events.
+			states, err := testhelpers.GetMessageStatesWithSeqNrsSol(
+				t,
+				sourceChain,
+				e.Env.BlockChains.SolanaChains()[destChain],
+				state.SolChains[destChain].OffRamp,
+				blockH,
+				seqNrs,
+				true,
+			)
+			if err != nil {
+				t.Logf("Error getting message states: %v", err)
+			} else {
+				if states[seqNrs[0]] == testhelpers.EXECUTION_STATE_INPROGRESS {
+					assert.Fail(t, "An additional in progress event is detected.")
+				}
+			}
+		*/
+		fmt.Println("done")
+	})
+
+	_ = out
 }
 
 type monitorState struct {

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -228,7 +228,6 @@ func Test_CCIPMessaging_MultiExecReports_EVM2Solana(t *testing.T) {
 			params.ExecuteOffChainConfig.MultipleReportsEnabled = true
 			params.ExecuteOffChainConfig.MaxReportMessages = 1
 			params.ExecuteOffChainConfig.MaxSingleChainReports = 1
-			params.ExecuteOffChainConfig.SolanaChainWriterConfigVersion = &cctypes.SolanaChainWriterExecuteConfigVersionV2
 			return params
 		}),
 	)
@@ -365,7 +364,6 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 			params.ExecuteOffChainConfig.MultipleReportsEnabled = true
 			params.ExecuteOffChainConfig.MaxReportMessages = 1
 			params.ExecuteOffChainConfig.MaxSingleChainReports = 1
-			params.ExecuteOffChainConfig.SolanaChainWriterConfigVersion = &cctypes.SolanaChainWriterExecuteConfigVersionV2
 			return params
 		}),
 	)
@@ -686,7 +684,7 @@ func Test_CCIPMessaging_Solana2EVM(t *testing.T) {
 }
 
 func Test_CCIPMessaging_EVM2Solana_Revert(t *testing.T) {
-	inflightDuration := time.Millisecond
+	inflightDuration := time.Minute
 
 	// Setup 2 chains (EVM and Solana) and a single lane.
 	e, _, _ := testsetups.NewIntegrationEnvironment(t,
@@ -698,7 +696,6 @@ func Test_CCIPMessaging_EVM2Solana_Revert(t *testing.T) {
 			params.ExecuteOffChainConfig.MultipleReportsEnabled = true
 			params.ExecuteOffChainConfig.MaxReportMessages = 1
 			params.ExecuteOffChainConfig.MaxSingleChainReports = 1
-			params.ExecuteOffChainConfig.SolanaChainWriterConfigVersion = &cctypes.SolanaChainWriterExecuteConfigVersionV2
 			return params
 		}),
 	)


### PR DESCRIPTION
Add a CCIP integration test to ensure only one execution attempt is made when an execution attempt on Solana is reverted.