### PR TITLE
Finalize release date for 2.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog Chainlink Core
 
-## 2.31.0
+## 2.31.0 - 2025-12-11
 
 ### Minor Changes
 


### PR DESCRIPTION
Finalize release date in CHANGELOG for v2.31.0. No code or dependency changes.