### PR TITLE
chore: bump package.json to 2.31.1-cre for CI gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.31.0",
+  "version": "2.31.1-cre",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Minimal patch bump to satisfy the version-file gate after tag creation. No functional changes.