### PR TITLE
Make dependabot to track cre-sdk-go dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,3 +68,14 @@ updates:
     labels:
       - "dependencies"
       - "ctf"
+  - package-ecosystem: gomod
+    directories:
+      - "**/*"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "cre-sdk-go"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "tests"


### PR DESCRIPTION
It is necessary to track that dependency to be updated to ensure the compatibility with the latest `cre-sdk-go`