### PR TITLE
feat(ci): use matrix-job-check in ci-core

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -168,14 +168,11 @@ jobs:
       actions: read
     steps:
       - name: Check matrix results
-        uses: smartcontractkit/.github/actions/matrix-job-check@matrix-job-check/0.0.0
+        uses: smartcontractkit/.github/actions/matrix-job-check@fix/matrix-job-check-github-token
         # allow this to fail if 'allow-lint-issues' label is present on the PR
         continue-on-error: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'allow-lint-issues') }}
         with:
           job-name-prefix: "GolangCI Lint"
-          assert-jobs-exist: "true"
-          assert-no-failures: "true"
-          assert-no-cancels: "true"
 
       - name: Check Golangci-lint Matrix Results
         env:
@@ -426,12 +423,9 @@ jobs:
       actions: read
     steps:
       - name: Check matrix results
-        uses: smartcontractkit/.github/actions/matrix-job-check@matrix-job-check/0.0.0
+        uses: smartcontractkit/.github/actions/matrix-job-check@fix/matrix-job-check-github-token
         with:
           job-name-prefix: "Core Tests"
-          assert-jobs-exist: "true"
-          assert-no-failures: "true"
-          assert-no-cancels: "true"
 
   core-scripts-tests:
     name: test-scripts

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -168,12 +168,13 @@ jobs:
       actions: read
     steps:
       - name: Check matrix results
-        uses: smartcontractkit/.github/actions/matrix-job-check@fix/matrix-job-check-github-token
-        # allow this to fail if 'allow-lint-issues' label is present on the PR
-        continue-on-error: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'allow-lint-issues') }}
+        uses: smartcontractkit/.github/actions/matrix-job-check@matrix-job-check/v1
         with:
           job-name-prefix: "GolangCI Lint"
+          # Allow for no jobs when no modules are affected
           assert-jobs-exist: ${{ needs.filter.outputs.affected-modules != '[]' }}
+          # Assert no failures unless "allow-lint-issues" label is present
+          assert-no-failures: ${{ !contains(join(github.event.pull_request.labels.*.name, ' '), 'allow-lint-issues') }}
 
       - name: Check Golangci-lint Matrix Results
         env:
@@ -245,7 +246,7 @@ jobs:
             setup-aptos: "true"
             install-loopps: "true"
             setup-sui: "true"
-            
+
     timeout-minutes: ${{ github.event_name == 'schedule' && 40 || 25 }} # 40 minute timeout for scheduled events (race tests)
     permissions:
       id-token: write
@@ -424,7 +425,7 @@ jobs:
       actions: read
     steps:
       - name: Check matrix results
-        uses: smartcontractkit/.github/actions/matrix-job-check@fix/matrix-job-check-github-token
+        uses: smartcontractkit/.github/actions/matrix-job-check@matrix-job-check/v1
         with:
           job-name-prefix: "Core Tests"
 

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -164,7 +164,19 @@ jobs:
     if: ${{ always() }}
     needs: [filter, golangci]
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
     steps:
+      - name: Check matrix results
+        uses: smartcontractkit/.github/actions/matrix-job-check@matrix-job-check/0.0.0
+        # allow this to fail if 'allow-lint-issues' label is present on the PR
+        continue-on-error: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'allow-lint-issues') }}
+        with:
+          job-name-prefix: "GolangCI Lint"
+          assert-jobs-exist: "true"
+          assert-no-failures: "true"
+          assert-no-cancels: "true"
+
       - name: Check Golangci-lint Matrix Results
         env:
           GOLANGCI_RESULT: ${{ needs.golangci.result }}
@@ -402,6 +414,24 @@ jobs:
           payload: |
             channel: ${{ secrets.SLACK_TOPIC_DATA_RACES_CHANNEL_ID}}
             text: "Race Tests Failed: <${{ format('https://github.com/{0}/actions/runs/{1}/job/{2}', github.repository, github.run_id, job.check_run_id) }}|Run>"
+
+  # Fails if any Core Tests matrix jobs fails and silently succeeds otherwise
+  # Consolidates the matrix results under one required check
+  core-matrix:
+    name: Core Tests Matrix Validation
+    if: ${{ always() }}
+    needs: [core]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Check matrix results
+        uses: smartcontractkit/.github/actions/matrix-job-check@matrix-job-check/0.0.0
+        with:
+          job-name-prefix: "Core Tests"
+          assert-jobs-exist: "true"
+          assert-no-failures: "true"
+          assert-no-cancels: "true"
 
   core-scripts-tests:
     name: test-scripts

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -173,6 +173,7 @@ jobs:
         continue-on-error: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'allow-lint-issues') }}
         with:
           job-name-prefix: "GolangCI Lint"
+          assert-jobs-exist: ${{ needs.filter.outputs.affected-modules != '[]' }}
 
       - name: Check Golangci-lint Matrix Results
         env:
@@ -206,10 +207,11 @@ jobs:
           fi
 
   core:
-    env:
-      # We explicitly have this env var not be "CL_DATABASE_URL" to avoid having it be used by core related tests
-      # when they should not be using it, while still allowing us to DRY up the setup
-      DB_URL: postgresql://postgres:postgres@localhost:5432/chainlink_test?sslmode=disable
+    name: Core Tests (${{ matrix.type.cmd }})
+    # We don't directly merge dependabot PRs, so let's not waste the resources
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    needs: [filter, run-frequency, runner-config]
+    runs-on: ${{ matrix.type.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -243,17 +245,16 @@ jobs:
             setup-aptos: "true"
             install-loopps: "true"
             setup-sui: "true"
-
-    name: Core Tests (${{ matrix.type.cmd }}) # Be careful modifying the job name, as it is used to fetch the job URL
-    # We don't directly merge dependabot PRs, so let's not waste the resources
-    if: ${{ github.actor != 'dependabot[bot]' }}
-    needs: [filter, run-frequency, runner-config]
+            
     timeout-minutes: ${{ github.event_name == 'schedule' && 40 || 25 }} # 40 minute timeout for scheduled events (race tests)
-    runs-on: ${{ matrix.type.os }}
     permissions:
       id-token: write
       contents: read
       actions: read
+    env:
+      # We explicitly have this env var not be "CL_DATABASE_URL" to avoid having it be used by core related tests
+      # when they should not be using it, while still allowing us to DRY up the setup
+      DB_URL: postgresql://postgres:postgres@localhost:5432/chainlink_test?sslmode=disable
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners
         # these env vars are set (and exposed) when it is a self-hosted runner with extras=s3-cache
@@ -415,7 +416,7 @@ jobs:
   # Fails if any Core Tests matrix jobs fails and silently succeeds otherwise
   # Consolidates the matrix results under one required check
   core-matrix:
-    name: Core Tests Matrix Validation
+    name: Matrix Validation (Core Tests)
     if: ${{ always() }}
     needs: [core]
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Changes

* Add references to new `matrix-job-check` action for linting and core tests matrix jobs

### Notes

* The original lint matix job validation is still in place, this has been added to test the functionality first
* The new `core-matrix` has been added but is non-blocking at the moment. Once validated, we can modify the required checks to use that instead of each individual matrix job
    * This is beneficial, because we should be able to fully skip unneeded matrix jobs, and simplify the required checks


### Testing

* https://github.com/smartcontractkit/chainlink/actions/runs/20247558027/job/58131526888?pr=20630
* https://github.com/smartcontractkit/chainlink/actions/runs/20249690509/job/58139566562?pr=20630
