### PR TITLE
feat(heartbeat): add EVM RPC node domain labels to beholder metrics

### DIFF
--- a/core/services/chainlink/heartbeat.go
+++ b/core/services/chainlink/heartbeat.go
@@ -34,7 +34,7 @@ type HeartbeatConfig struct {
 	P2P          string
 	AppID        string
 	CSAPublicKey string
-	EVMNodeURLs  map[string]string // Maps chainID_WSURL/chainID_HTTPURL to comma-separated domains
+	EVMNodeURLs  map[string]string // Maps WSURL_chainID/HTTPURL_chainID to comma-separated domains
 }
 
 func NewHeartbeatConfig(cfg ApplicationOpts) HeartbeatConfig {

--- a/core/services/chainlink/heartbeat.go
+++ b/core/services/chainlink/heartbeat.go
@@ -183,8 +183,9 @@ func (h *Heartbeat) GetBeat() time.Duration {
 	return h.beat
 }
 
-// ExtractDomainFromURLString parses a URL string and returns only the host (domain).
+// ExtractDomainFromURLString parses a URL string and returns only the hostname (domain).
 // This ensures sensitive information like API keys in URL paths are not exposed.
+// The port is stripped to avoid formatting issues.
 func ExtractDomainFromURLString(rawURL string) string {
 	if rawURL == "" {
 		return ""
@@ -193,5 +194,5 @@ func ExtractDomainFromURLString(rawURL string) string {
 	if err != nil {
 		return ""
 	}
-	return u.Host
+	return u.Hostname()
 }

--- a/core/services/chainlink/heartbeat.go
+++ b/core/services/chainlink/heartbeat.go
@@ -3,6 +3,8 @@ package chainlink
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/metric"
@@ -32,6 +34,7 @@ type HeartbeatConfig struct {
 	P2P          string
 	AppID        string
 	CSAPublicKey string
+	EVMNodeURLs  map[string]string // Maps chainID_WSURL/chainID_HTTPURL to comma-separated domains
 }
 
 func NewHeartbeatConfig(cfg ApplicationOpts) HeartbeatConfig {
@@ -47,12 +50,42 @@ func NewHeartbeatConfig(cfg ApplicationOpts) HeartbeatConfig {
 		cfg.Logger.Warn("no CSA key found for heartbeat")
 	}
 
+	evmNodeURLs := make(map[string]string)
+	if cfg.Config.EVMEnabled() {
+		for _, evmCfg := range cfg.Config.EVMConfigs() {
+			if evmCfg.ChainID == nil || !evmCfg.IsEnabled() {
+				continue
+			}
+			chainID := evmCfg.ChainID.String()
+			var wsDomains, httpDomains []string
+			for _, node := range evmCfg.Nodes {
+				if node.WSURL != nil {
+					if domain := ExtractDomainFromURLString(node.WSURL.String()); domain != "" {
+						wsDomains = append(wsDomains, domain)
+					}
+				}
+				if node.HTTPURL != nil {
+					if domain := ExtractDomainFromURLString(node.HTTPURL.String()); domain != "" {
+						httpDomains = append(httpDomains, domain)
+					}
+				}
+			}
+			if len(wsDomains) > 0 {
+				evmNodeURLs["WSURL_"+chainID] = strings.Join(wsDomains, ",")
+			}
+			if len(httpDomains) > 0 {
+				evmNodeURLs["HTTPURL_"+chainID] = strings.Join(httpDomains, ",")
+			}
+		}
+	}
+
 	return HeartbeatConfig{
 		Beat:         cfg.Config.Telemetry().HeartbeatInterval(),
 		Lggr:         cfg.Logger,
 		P2P:          cfg.Config.P2P().PeerID().String(),
 		AppID:        cfg.Config.AppID().String(),
 		CSAPublicKey: csaKey,
+		EVMNodeURLs:  evmNodeURLs,
 	}
 }
 
@@ -60,7 +93,12 @@ func NewHeartbeatConfig(cfg ApplicationOpts) HeartbeatConfig {
 func NewHeartbeat(cfg HeartbeatConfig, opts ...HeartbeatOpt) Heartbeat {
 	// setup default emitter and meter
 	cme := custmsg.NewLabeler()
-	labels := map[string]string{"system": "Application", "version": static.Version, "commit": static.Sha}
+	labels := map[string]string{
+		"system":      "Application",
+		"version":     static.Version,
+		"commit":      static.Sha,
+		"version_tag": static.VersionTag,
+	}
 	if cfg.P2P != "" {
 		labels["peer_id"] = cfg.P2P
 	}
@@ -69,6 +107,9 @@ func NewHeartbeat(cfg HeartbeatConfig, opts ...HeartbeatOpt) Heartbeat {
 	}
 	if cfg.CSAPublicKey != "" {
 		labels["csa_key"] = cfg.CSAPublicKey
+	}
+	for k, v := range cfg.EVMNodeURLs {
+		labels[k] = v
 	}
 
 	cme.WithMapLabels(labels)
@@ -140,4 +181,17 @@ func (h *Heartbeat) start(_ context.Context) error {
 
 func (h *Heartbeat) GetBeat() time.Duration {
 	return h.beat
+}
+
+// ExtractDomainFromURLString parses a URL string and returns only the host (domain).
+// This ensures sensitive information like API keys in URL paths are not exposed.
+func ExtractDomainFromURLString(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
 }

--- a/core/services/chainlink/heartbeat_test.go
+++ b/core/services/chainlink/heartbeat_test.go
@@ -148,3 +148,128 @@ func (bc *byteCollector) String() string {
 	defer bc.mu.Unlock()
 	return bc.buffer.String()
 }
+
+func TestExtractDomainFromURLString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rawURL   string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			rawURL:   "",
+			expected: "",
+		},
+		{
+			name:     "simple https URL",
+			rawURL:   "https://eth-mainnet.example.com",
+			expected: "eth-mainnet.example.com",
+		},
+		{
+			name:     "https URL with path",
+			rawURL:   "https://eth-mainnet.infura.io/v3/abc123secretkey",
+			expected: "eth-mainnet.infura.io",
+		},
+		{
+			name:     "https URL with port",
+			rawURL:   "https://localhost:8545",
+			expected: "localhost:8545",
+		},
+		{
+			name:     "wss URL",
+			rawURL:   "wss://eth-mainnet.example.com/ws",
+			expected: "eth-mainnet.example.com",
+		},
+		{
+			name:     "wss URL with API key in path",
+			rawURL:   "wss://mainnet.infura.io/ws/v3/abc123secretkey",
+			expected: "mainnet.infura.io",
+		},
+		{
+			name:     "URL with query params (should be stripped)",
+			rawURL:   "https://api.example.com/rpc?apikey=secret",
+			expected: "api.example.com",
+		},
+		{
+			name:     "URL with user info (should be stripped)",
+			rawURL:   "https://user:pass@api.example.com/rpc",
+			expected: "api.example.com",
+		},
+		{
+			name:     "invalid URL",
+			rawURL:   "://invalid",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := chainlink.ExtractDomainFromURLString(tt.rawURL)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewHeartbeat_WithEVMNodeURLs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		evmNodeURLs map[string]string
+	}{
+		{
+			name:        "no EVM node URLs",
+			evmNodeURLs: nil,
+		},
+		{
+			name: "single chain with both URLs",
+			evmNodeURLs: map[string]string{
+				"WSURL_1":   "eth-mainnet.example.com",
+				"HTTPURL_1": "eth-mainnet.infura.io",
+			},
+		},
+		{
+			name: "multiple chains",
+			evmNodeURLs: map[string]string{
+				"WSURL_1":     "eth-mainnet.example.com",
+				"HTTPURL_1":   "eth-mainnet.infura.io",
+				"WSURL_137":   "polygon-mainnet.example.com",
+				"HTTPURL_137": "polygon-mainnet.infura.io",
+			},
+		},
+		{
+			name: "chain with multiple nodes (comma-separated domains)",
+			evmNodeURLs: map[string]string{
+				"WSURL_1":   "node1.example.com,node2.example.com",
+				"HTTPURL_1": "rpc1.infura.io,rpc2.alchemy.com",
+			},
+		},
+		{
+			name: "chain with only HTTPURL",
+			evmNodeURLs: map[string]string{
+				"HTTPURL_42161": "arb-mainnet.g.alchemy.com",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lggr := logger.TestLogger(t)
+
+			c := chainlink.HeartbeatConfig{
+				Beat:        1 * time.Second,
+				Lggr:        lggr,
+				P2P:         "peer-id",
+				AppID:       "app-id",
+				EVMNodeURLs: tt.evmNodeURLs,
+			}
+
+			heartbeat := chainlink.NewHeartbeat(c)
+
+			// Verify heartbeat was created successfully
+			assert.Equal(t, 1*time.Second, heartbeat.GetBeat())
+		})
+	}
+}

--- a/core/services/chainlink/heartbeat_test.go
+++ b/core/services/chainlink/heartbeat_test.go
@@ -175,7 +175,7 @@ func TestExtractDomainFromURLString(t *testing.T) {
 		{
 			name:     "https URL with port",
 			rawURL:   "https://localhost:8545",
-			expected: "localhost:8545",
+			expected: "localhost",
 		},
 		{
 			name:     "wss URL",


### PR DESCRIPTION
Add WSURL_{chainID} and HTTPURL_{chainID} labels to heartbeat metrics to enable RPC visibility via Beholder. 

For privacy and security, only the domain (host) is extracted from node URLs, stripping API keys and other sensitive path information.

Changes:
- Add EVMNodeURLs field to HeartbeatConfig
- Extract domains from EVM node WSURL and HTTPURL in NewHeartbeatConfig
- Add ExtractDomainFromURLString helper function
- Add labels to heartbeat emitter for each chain's RPC endpoints
- Add comprehensive tests for domain extraction and config handling


