### PR TITLE
Implement job uuid lookup for evm cap jobs with the same name

### DIFF
--- a/deployment/common/view/nops.go
+++ b/deployment/common/view/nops.go
@@ -81,7 +81,7 @@ func GenerateNopsView(lggr logger.Logger, nodeIDs []string, oc cldf_offchain.Cli
 		}
 		return nil
 	}
-	jobspecs, proposedSpecs, err := approvedJobspecs(context.Background(), lggr, nodeIDs, oc)
+	jobspecs, proposedSpecs, err := ApprovedJobspecs(context.Background(), lggr, nodeIDs, oc)
 	if err != nil {
 		// best effort on job specs
 		lggr.Warnf("Failed to get approved jobspecs: %v", err)
@@ -133,7 +133,7 @@ func GenerateNopsView(lggr logger.Logger, nodeIDs []string, oc cldf_offchain.Cli
 	return nv, nil
 }
 
-func approvedJobspecs(ctx context.Context, lggr logger.Logger, nodeIDs []string, oc cldf_offchain.Client) (nodeJobsView map[string]map[string]JobView, proposedJobsView map[string]map[string]JobView, verr error) {
+func ApprovedJobspecs(ctx context.Context, lggr logger.Logger, nodeIDs []string, oc cldf_offchain.Client) (nodeJobsView map[string]map[string]JobView, proposedJobsView map[string]map[string]JobView, verr error) {
 	nodeJobsView = make(map[string]map[string]JobView)
 	proposedJobsView = make(map[string]map[string]JobView)
 

--- a/deployment/cre/jobs/operations/propose_std_cap_job.go
+++ b/deployment/cre/jobs/operations/propose_std_cap_job.go
@@ -211,11 +211,11 @@ func resolveJob(ctx context.Context, lggr logger.Logger, job pkg.StandardCapabil
 		job.Config = customCfg
 	}
 
-	externalJobID, found, err := GetEVMExternalJobIDByName(ctx, lggr, job.JobName, nodeID, oc)
+	externalJobID, err := getEVMExternalJobIDByName(ctx, lggr, job.JobName, nodeID, oc)
 	if err != nil {
 		return "", err
 	}
-	if found {
+	if externalJobID != "" {
 		job.ExternalJobID = externalJobID
 	}
 
@@ -227,37 +227,39 @@ func resolveJob(ctx context.Context, lggr logger.Logger, job pkg.StandardCapabil
 	return spec, nil
 }
 
-func GetEVMExternalJobIDByName(ctx context.Context, lggr logger.Logger, jobName, nodeID string, oc cldf_offchain.Client) (string, bool, error) {
+// getEVMExternalJobIDByName returns an empty string if id is not found.
+func getEVMExternalJobIDByName(ctx context.Context, lggr logger.Logger, jobName, nodeID string, oc cldf_offchain.Client) (string, error) {
 	if !strings.Contains(jobName, "evm-capabilities-v2") {
-		return "", false, nil
+		return "", nil
 	}
 
 	nodesJobs, _, err := view.ApprovedJobspecs(ctx, lggr, []string{nodeID}, oc)
 	if err != nil {
-		return "", false, fmt.Errorf("failed to fetch approved jobs for node %s: %w", nodeID, err)
+		return "", fmt.Errorf("failed to fetch approved jobs for node %s: %w", nodeID, err)
 	}
 
 	nodeJobs, ok := nodesJobs[nodeID]
-	if !ok {
-		return "", false, nil
+	if !ok || len(nodeJobs) == 0 {
+		return "", nil
 	}
 
+	specFormattedJobName := `name = "` + jobName + `"`
 	for _, j := range nodeJobs {
-		if !strings.Contains(j.Spec, `name = "`+jobName+`"`) {
+		if !strings.Contains(j.Spec, specFormattedJobName) {
 			continue
 		}
 
 		ji := make(job_types.JobSpecInput)
 		if err = toml.Unmarshal([]byte(j.Spec), &ji); err != nil {
-			return "", false, fmt.Errorf("failed to unmarshal job spec toml for job %s on node %s: %w", jobName, nodeID, err)
+			return "", fmt.Errorf("failed to unmarshal job spec toml for job %s on node %s: %w", jobName, nodeID, err)
 		}
 
-		if s, ok := ji["externalJobID"].(string); ok {
-			return s, true, nil
+		if s, _ := ji["externalJobID"].(string); s != "" {
+			return s, nil
 		}
 	}
 
-	return "", false, nil
+	return "", nil
 }
 
 func generateOracleFactory(cldEnv cldf.Environment, nodeInfo deployment.Node, job pkg.StandardCapabilityJob) (*pkg.OracleFactory, error) {

--- a/deployment/cre/jobs/operations/propose_std_cap_job.go
+++ b/deployment/cre/jobs/operations/propose_std_cap_job.go
@@ -1,20 +1,25 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 	"maps"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
-
+	"github.com/pelletier/go-toml/v2"
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
-
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/view"
 	"github.com/smartcontractkit/chainlink/deployment/cre/jobs/pkg"
+	job_types "github.com/smartcontractkit/chainlink/deployment/cre/jobs/types"
 	"github.com/smartcontractkit/chainlink/deployment/cre/pkg/offchain"
 	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 )
@@ -126,7 +131,7 @@ var ProposeStandardCapabilityJob = operations.NewSequence[
 			specs := make(map[string][]string)
 
 			for _, ni := range nodeInfos {
-				spec, err := resolveJob(input.Job, setPerNodeCfg, ni.NodeID, input.NodeIDToConfig)
+				spec, err := resolveJob(b.GetContext(), deps.Env.Logger, input.Job, setPerNodeCfg, ni.NodeID, input.NodeIDToConfig, deps.Env.Offchain)
 				if err != nil {
 					return ProposeStandardCapabilityJobOutput{}, err
 				}
@@ -167,7 +172,7 @@ var ProposeStandardCapabilityJob = operations.NewSequence[
 
 			input.Job.OracleFactory = oracleFactory
 
-			spec, err := resolveJob(input.Job, setPerNodeCfg, ni.NodeID, input.NodeIDToConfig)
+			spec, err := resolveJob(b.GetContext(), deps.Env.Logger, input.Job, setPerNodeCfg, ni.NodeID, input.NodeIDToConfig, deps.Env.Offchain)
 			if err != nil {
 				return ProposeStandardCapabilityJobOutput{}, err
 			}
@@ -197,7 +202,7 @@ var ProposeStandardCapabilityJob = operations.NewSequence[
 		return ProposeStandardCapabilityJobOutput{Specs: specs}, nil
 	})
 
-func resolveJob(job pkg.StandardCapabilityJob, setPerNodeCfg bool, nodeID string, nodeIDToConfig map[string]string) (string, error) {
+func resolveJob(ctx context.Context, lggr logger.Logger, job pkg.StandardCapabilityJob, setPerNodeCfg bool, nodeID string, nodeIDToConfig map[string]string, oc cldf_offchain.Client) (string, error) {
 	if setPerNodeCfg {
 		customCfg, ok := nodeIDToConfig[nodeID]
 		if !ok {
@@ -206,12 +211,53 @@ func resolveJob(job pkg.StandardCapabilityJob, setPerNodeCfg bool, nodeID string
 		job.Config = customCfg
 	}
 
+	uuid, found, err := GetEVMJobUIIDByName(ctx, lggr, job.JobName, nodeID, oc)
+	if err != nil {
+		return "", err
+	}
+	if found {
+		job.ExternalJobID = uuid
+	}
+
 	spec, err := job.Resolve()
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve standard capability job for node %s: %w", nodeID, err)
 	}
 
 	return spec, nil
+}
+
+func GetEVMJobUIIDByName(ctx context.Context, lggr logger.Logger, jobName, nodeID string, oc cldf_offchain.Client) (string, bool, error) {
+	if !strings.Contains(jobName, "evm-capabilities-v2") {
+		return "", false, nil
+	}
+
+	nodesJobs, _, err := view.ApprovedJobspecs(ctx, lggr, []string{nodeID}, oc)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to fetch approved jobs for node %s: %w", nodeID, err)
+	}
+
+	nodeJobs, ok := nodesJobs[nodeID]
+	if !ok {
+		return "", false, nil
+	}
+
+	for _, j := range nodeJobs {
+		if !strings.Contains(j.Spec, `name = "`+jobName+`"`) {
+			continue
+		}
+
+		ji := make(job_types.JobSpecInput)
+		if err = toml.Unmarshal([]byte(j.Spec), &ji); err != nil {
+			return "", false, fmt.Errorf("failed to unmarshal job spec toml for job %s on node %s: %w", jobName, nodeID, err)
+		}
+
+		if s, ok := ji["externalJobID"].(string); ok {
+			return s, true, nil
+		}
+	}
+
+	return "", false, nil
 }
 
 func generateOracleFactory(cldEnv cldf.Environment, nodeInfo deployment.Node, job pkg.StandardCapabilityJob) (*pkg.OracleFactory, error) {

--- a/deployment/cre/jobs/operations/propose_std_cap_job.go
+++ b/deployment/cre/jobs/operations/propose_std_cap_job.go
@@ -211,12 +211,12 @@ func resolveJob(ctx context.Context, lggr logger.Logger, job pkg.StandardCapabil
 		job.Config = customCfg
 	}
 
-	uuid, found, err := GetEVMJobUIIDByName(ctx, lggr, job.JobName, nodeID, oc)
+	externalJobID, found, err := GetEVMExternalJobIDByName(ctx, lggr, job.JobName, nodeID, oc)
 	if err != nil {
 		return "", err
 	}
 	if found {
-		job.ExternalJobID = uuid
+		job.ExternalJobID = externalJobID
 	}
 
 	spec, err := job.Resolve()
@@ -227,7 +227,7 @@ func resolveJob(ctx context.Context, lggr logger.Logger, job pkg.StandardCapabil
 	return spec, nil
 }
 
-func GetEVMJobUIIDByName(ctx context.Context, lggr logger.Logger, jobName, nodeID string, oc cldf_offchain.Client) (string, bool, error) {
+func GetEVMExternalJobIDByName(ctx context.Context, lggr logger.Logger, jobName, nodeID string, oc cldf_offchain.Client) (string, bool, error) {
 	if !strings.Contains(jobName, "evm-capabilities-v2") {
 		return "", false, nil
 	}

--- a/deployment/cre/jobs/propose_evm_cap_test.go
+++ b/deployment/cre/jobs/propose_evm_cap_test.go
@@ -11,13 +11,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	tenv "github.com/smartcontractkit/chainlink/deployment/environment/test"
+
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	csav1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/csa"
+	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 	"github.com/smartcontractkit/chainlink/deployment/cre/jobs"
-
 	"github.com/smartcontractkit/chainlink/deployment/cre/test"
 
 	"github.com/smartcontractkit/chainlink/deployment/cre/ocr3"
@@ -267,22 +270,7 @@ func TestProposeEVMCapJobSpec_Apply_success(t *testing.T) {
 	selector := testEnv.RegistrySelector // use the test environment's selector
 	ds := datastore.NewMemoryDataStore()
 
-	// Seed required addresses (OCR for VerifyPreconditions; forwarder for both Verify & Apply)
-	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
-		ChainSelector: selector,
-		Type:          datastore.ContractType(ocr3.OCR3Capability),
-		Version:       semver.MustParse("1.0.0"),
-		Address:       "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
-		Qualifier:     testOCRQualifier,
-	}))
-	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
-		ChainSelector: selector,
-		Type:          testForwarderContractType,
-		Version:       semver.MustParse("1.0.0"),
-		Address:       "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
-		Qualifier:     testForwarderQualifier,
-	}))
-
+	seedAddressesForSelector(t, ds, selector, "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B", "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0")
 	env.DataStore = ds.Seal()
 
 	const (
@@ -348,4 +336,88 @@ func TestProposeEVMCapJobSpec_Apply_duplicateNodeIDs(t *testing.T) {
 	_, err := jobs.ProposeEVMCapJobSpec{}.Apply(*env, input)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "duplicate nodeID")
+}
+
+func TestProposeStandardCapabilityJob_ReusesUUIDForEvmCapabilitiesV2(t *testing.T) {
+	testEnv := test.SetupEnvV2(t, false)
+
+	selector := testEnv.RegistrySelector
+	ds := datastore.NewMemoryDataStore()
+	seedAddressesForSelector(t, ds, selector, "0xocr...", "0xfwd...")
+	env := testEnv.Env
+	env.DataStore = ds.Seal()
+
+	nodes, err := testEnv.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
+	require.NoError(t, err)
+
+	var nodeIDs []string
+	var evmCapInputs []jobs.EVMCapabilityInput
+	mockGetter := &tenv.MockJobApproverGetter{JobApprovers: make(map[string]*tenv.MockJobApprover)}
+	for _, n := range nodes.GetNodes() {
+		if strings.Contains(n.Id, "bootstrap") {
+			continue
+		}
+		nodeIDs = append(nodeIDs, n.Id)
+		mockGetter.JobApprovers[n.Id] = &tenv.MockJobApprover{}
+		evmCapInputs = append(evmCapInputs, minimalEVMCapInput(n.Id))
+	}
+
+	client := tenv.NewJobServiceClient(mockGetter)
+
+	testEnv.TestJD.JobServiceClient = client
+
+	env.Offchain = struct {
+		jobv1.JobServiceClient
+		node.NodeServiceClient
+		csav1.CSAServiceClient
+	}{
+		JobServiceClient:  client,
+		NodeServiceClient: env.Offchain,
+		CSAServiceClient:  env.Offchain,
+	}
+
+	input := jobs.ProposeEVMCapJobSpecInput{
+		Environment:             "test",
+		Zone:                    test.Zone,
+		Domain:                  "cre",
+		DONName:                 test.DONName,
+		ChainSelector:           selector,
+		OCRChainSelector:        selector,
+		BootstrapperOCR3Urls:    []string{"12D3KooWabc@127.0.0.1:5001"},
+		OCRContractQualifier:    testOCRQualifier,
+		ForwardersQualifier:     testForwarderQualifier,
+		ForwarderLookbackBlocks: 123,
+		EVMCapabilityInputs:     evmCapInputs,
+	}
+	_, err = jobs.ProposeEVMCapJobSpec{}.Apply(*env, input)
+	require.NoError(t, err)
+
+	// verify that the jobs have been distributed and accepted
+	verifyJobProposal := func(revision int64) {
+		jobProposals, err := env.Offchain.ListProposals(t.Context(), &jobv1.ListProposalsRequest{})
+
+		require.NoError(t, err)
+
+		jobsList, err := env.Offchain.ListJobs(t.Context(), &jobv1.ListJobsRequest{Filter: &jobv1.ListJobsRequest_Filter{NodeIds: nodeIDs}})
+		require.NoError(t, err)
+
+		proposalsAtRevision := 0
+		for _, jp := range jobProposals.GetProposals() {
+			require.Equal(t, jobv1.ProposalStatus_PROPOSAL_STATUS_APPROVED, jp.Status)
+			if revision == jp.Revision {
+				proposalsAtRevision++
+			}
+		}
+
+		require.Len(t, jobsList.GetJobs(), len(nodeIDs))
+		require.Len(t, jobProposals.GetProposals(), len(nodeIDs)*int(revision))
+		require.Equal(t, len(nodeIDs), proposalsAtRevision)
+	}
+	verifyJobProposal(1)
+
+	// different config generates different uuid, but evm cap jobs should lookup the old id and reuse it
+	input.ForwarderLookbackBlocks = 999
+	_, err = jobs.ProposeEVMCapJobSpec{}.Apply(*env, input)
+	require.NoError(t, err)
+	verifyJobProposal(2)
 }

--- a/deployment/cre/jobs/propose_std_cap_test.go
+++ b/deployment/cre/jobs/propose_std_cap_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
 	"github.com/smartcontractkit/chainlink/deployment/cre/jobs"
 	"github.com/smartcontractkit/chainlink/deployment/cre/pkg/offchain"
 	"github.com/smartcontractkit/chainlink/deployment/cre/test"

--- a/deployment/environment/test/jd.go
+++ b/deployment/environment/test/jd.go
@@ -28,13 +28,14 @@ var _ csav1.CSAServiceClient = (*JDNodeService)(nil)
 type JDNodeService struct {
 	mu    sync.RWMutex
 	store *store
-	*UnimplementedJobServiceClient
+	jobv1.JobServiceClient
 	*UnimplementedCSAServiceClient
 }
 
 func NewJDService(nodes []deployment.Node) *JDNodeService {
 	return &JDNodeService{
-		store: newStore(nodes),
+		store:            newStore(nodes),
+		JobServiceClient: &UnimplementedJobServiceClient{},
 	}
 }
 

--- a/deployment/environment/test/job_service_client.go
+++ b/deployment/environment/test/job_service_client.go
@@ -226,7 +226,7 @@ func (j *JobServiceClient) ProposeJob(ctx context.Context, in *jobv1.ProposeJobR
 			job.ProposalIds = append(job.ProposalIds, storeProposalID)
 		}
 
-		// the jobs with same id overwrite each-other but there is a nodeID mapping that is maintained
+		// Jobs are keyed by external job ID in this store. Multiple nodes can have jobs with the same external job ID; the NodeId field records which node this particular job instance belongs to
 		job.NodeId = in.NodeId
 		storeErr = j.jobStore.put(extractor.ExternalJobID, job)
 		if storeErr != nil {
@@ -404,13 +404,22 @@ func (m *mapJobStore) list(filter *jobv1.ListJobsRequest_Filter) ([]*jobv1.Job, 
 			if !ok {
 				continue
 			}
+			idSet := make(map[string]struct{}, len(jobIDs)) // adjust type as needed
+			for _, id := range jobIDs {
+				idSet[id] = struct{}{}
+			}
+
 			for _, j := range m.jobs {
-				for _, jobID := range jobIDs {
-					if j.Id == jobID && matchesSelectors(filter.Selectors, j) {
-						j.NodeId = nodeID
-						jobs = append(jobs, j)
-					}
+				if _, ok := idSet[j.Id]; !ok {
+					continue
 				}
+
+				if !matchesSelectors(filter.Selectors, j) {
+					continue
+				}
+
+				j.NodeId = nodeID
+				jobs = append(jobs, j)
 			}
 		}
 	case filter.Uuids != nil:

--- a/deployment/environment/test/job_service_client.go
+++ b/deployment/environment/test/job_service_client.go
@@ -225,6 +225,9 @@ func (j *JobServiceClient) ProposeJob(ctx context.Context, in *jobv1.ProposeJobR
 		} else {
 			job.ProposalIds = append(job.ProposalIds, storeProposalID)
 		}
+
+		// the jobs with same id overwrite each-other but there is a nodeID mapping that is maintained
+		job.NodeId = in.NodeId
 		storeErr = j.jobStore.put(extractor.ExternalJobID, job)
 		if storeErr != nil {
 			return nil, fmt.Errorf("failed to save job: %w", storeErr)
@@ -332,10 +335,12 @@ func (m *mapJobStore) put(jobID string, job *jobv1.Job) error {
 		m.uuidToJobIDs = make(map[string][]string)
 	}
 	m.jobs[jobID] = job
-	if _, ok := m.nodesToJobIDs[job.NodeId]; !ok {
-		m.nodesToJobIDs[job.NodeId] = make([]string, 0)
+	if !slices.Contains(m.nodesToJobIDs[job.NodeId], jobID) {
+		if _, ok := m.nodesToJobIDs[job.NodeId]; !ok {
+			m.nodesToJobIDs[job.NodeId] = make([]string, 0)
+		}
+		m.nodesToJobIDs[job.NodeId] = append(m.nodesToJobIDs[job.NodeId], jobID)
 	}
-	m.nodesToJobIDs[job.NodeId] = append(m.nodesToJobIDs[job.NodeId], jobID)
 	if _, ok := m.uuidToJobIDs[job.Uuid]; !ok {
 		m.uuidToJobIDs[job.Uuid] = make([]string, 0)
 	}
@@ -399,8 +404,13 @@ func (m *mapJobStore) list(filter *jobv1.ListJobsRequest_Filter) ([]*jobv1.Job, 
 			if !ok {
 				continue
 			}
-			for _, jobID := range jobIDs {
-				wantedJobIDs[jobID] = struct{}{}
+			for _, j := range m.jobs {
+				for _, jobID := range jobIDs {
+					if j.Id == jobID && matchesSelectors(filter.Selectors, j) {
+						j.NodeId = nodeID
+						jobs = append(jobs, j)
+					}
+				}
 			}
 		}
 	case filter.Uuids != nil:
@@ -586,4 +596,29 @@ func (m *mapProposalStore) delete(proposalID string) error {
 
 	delete(m.proposals, proposalID)
 	return nil
+}
+
+// MockJobApprover is a mock implementation of the JobApprover interface
+type MockJobApprover struct {
+	shouldFail bool
+}
+
+func (m *MockJobApprover) AutoApproveJob(ctx context.Context, p *feeds.ProposeJobArgs) error {
+	if m.shouldFail {
+		return errors.New("mock approval failure")
+	}
+	return nil
+}
+
+// MockJobApproverGetter is a mock implementation of the getter[JobApprover] interface
+type MockJobApproverGetter struct {
+	JobApprovers map[string]*MockJobApprover
+}
+
+func (m *MockJobApproverGetter) Get(id string) (JobApprover, error) {
+	approver, ok := m.JobApprovers[id]
+	if !ok {
+		return nil, errors.New("job approver not found")
+	}
+	return approver, nil
 }

--- a/deployment/environment/test/job_service_client.go
+++ b/deployment/environment/test/job_service_client.go
@@ -404,7 +404,7 @@ func (m *mapJobStore) list(filter *jobv1.ListJobsRequest_Filter) ([]*jobv1.Job, 
 			if !ok {
 				continue
 			}
-			idSet := make(map[string]struct{}, len(jobIDs)) // adjust type as needed
+			idSet := make(map[string]struct{}, len(jobIDs))
 			for _, id := range jobIDs {
 				idSet[id] = struct{}{}
 			}

--- a/deployment/environment/test/job_service_client_test.go
+++ b/deployment/environment/test/job_service_client_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -14,17 +13,16 @@ import (
 	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 
 	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
-	"github.com/smartcontractkit/chainlink/v2/core/services/feeds"
 )
 
 func TestNewJobServiceClient(t *testing.T) {
 	t.Parallel()
 
 	// Create a mock JobApprover getter
-	mockGetter := &mockJobApproverGetter{
-		jobApprovers: make(map[string]*mockJobApprover),
+	mockGetter := &MockJobApproverGetter{
+		JobApprovers: make(map[string]*MockJobApprover),
 	}
-	mockGetter.jobApprovers["node-1"] = &mockJobApprover{}
+	mockGetter.JobApprovers["node-1"] = &MockJobApprover{}
 
 	// Create a new JobServiceClient
 	client := NewJobServiceClient(mockGetter)
@@ -44,11 +42,11 @@ func TestBatchProposeJob(t *testing.T) {
 	ctx := t.Context()
 
 	// Create mock job approvers
-	mockGetter := &mockJobApproverGetter{
-		jobApprovers: make(map[string]*mockJobApprover),
+	mockGetter := &MockJobApproverGetter{
+		JobApprovers: make(map[string]*MockJobApprover),
 	}
-	mockGetter.jobApprovers["node-1"] = &mockJobApprover{}
-	mockGetter.jobApprovers["node-2"] = &mockJobApprover{}
+	mockGetter.JobApprovers["node-1"] = &MockJobApprover{}
+	mockGetter.JobApprovers["node-2"] = &MockJobApprover{}
 
 	client := NewJobServiceClient(mockGetter)
 
@@ -74,7 +72,7 @@ func TestBatchProposeJob(t *testing.T) {
 	})
 
 	t.Run("one node fails", func(t *testing.T) {
-		mockGetter.jobApprovers["node-2"].shouldFail = true
+		mockGetter.JobApprovers["node-2"].shouldFail = true
 
 		req := &jobv1.BatchProposeJobRequest{
 			NodeIds: []string{"node-1", "node-2"},
@@ -91,7 +89,7 @@ func TestBatchProposeJob(t *testing.T) {
 		require.Contains(t, resp.FailedResponses, "node-2")
 
 		// Reset for next tests
-		mockGetter.jobApprovers["node-2"].shouldFail = false
+		mockGetter.JobApprovers["node-2"].shouldFail = false
 	})
 
 	t.Run("node not found", func(t *testing.T) {
@@ -124,10 +122,10 @@ func TestProposeJob(t *testing.T) {
 	ctx := context.Background()
 
 	// Create mock job approvers
-	mockGetter := &mockJobApproverGetter{
-		jobApprovers: make(map[string]*mockJobApprover),
+	mockGetter := &MockJobApproverGetter{
+		JobApprovers: make(map[string]*MockJobApprover),
 	}
-	mockGetter.jobApprovers["node-1"] = &mockJobApprover{}
+	mockGetter.JobApprovers["node-1"] = &MockJobApprover{}
 
 	client := NewJobServiceClient(mockGetter)
 
@@ -217,7 +215,7 @@ name = "Test Job"
 	})
 
 	t.Run("approval failure", func(t *testing.T) {
-		mockGetter.jobApprovers["node-1"].shouldFail = true
+		mockGetter.JobApprovers["node-1"].shouldFail = true
 
 		externalJobID := uuid.NewString()
 		jobSpec := createValidJobSpec(externalJobID)
@@ -233,17 +231,17 @@ name = "Test Job"
 		require.Contains(t, err.Error(), "failed to auto approve job")
 
 		// Reset for next tests
-		mockGetter.jobApprovers["node-1"].shouldFail = false
+		mockGetter.JobApprovers["node-1"].shouldFail = false
 	})
 }
 
 func TestRevokeJob(t *testing.T) {
 	t.Parallel()
 
-	mockGetter := &mockJobApproverGetter{
-		jobApprovers: make(map[string]*mockJobApprover),
+	mockGetter := &MockJobApproverGetter{
+		JobApprovers: make(map[string]*MockJobApprover),
 	}
-	mockGetter.jobApprovers["node-1"] = &mockJobApprover{}
+	mockGetter.JobApprovers["node-1"] = &MockJobApprover{}
 	client := NewJobServiceClient(mockGetter)
 
 	proposeJob := func(autoApprove bool) *jobv1.Proposal {
@@ -319,10 +317,10 @@ func TestGetJob(t *testing.T) {
 	ctx := context.Background()
 
 	// Create mock job approvers
-	mockGetter := &mockJobApproverGetter{
-		jobApprovers: make(map[string]*mockJobApprover),
+	mockGetter := &MockJobApproverGetter{
+		JobApprovers: make(map[string]*MockJobApprover),
 	}
-	mockGetter.jobApprovers["node-1"] = &mockJobApprover{}
+	mockGetter.JobApprovers["node-1"] = &MockJobApprover{}
 
 	client := NewJobServiceClient(mockGetter)
 
@@ -372,10 +370,10 @@ func TestGetProposal(t *testing.T) {
 	ctx := context.Background()
 
 	// Create mock job approvers
-	mockGetter := &mockJobApproverGetter{
-		jobApprovers: make(map[string]*mockJobApprover),
+	mockGetter := &MockJobApproverGetter{
+		JobApprovers: make(map[string]*MockJobApprover),
 	}
-	mockGetter.jobApprovers["node-1"] = &mockJobApprover{}
+	mockGetter.JobApprovers["node-1"] = &MockJobApprover{}
 
 	client := NewJobServiceClient(mockGetter)
 
@@ -424,11 +422,11 @@ func TestListJobs(t *testing.T) {
 	ctx := context.Background()
 
 	// Create mock job approvers
-	mockGetter := &mockJobApproverGetter{
-		jobApprovers: make(map[string]*mockJobApprover),
+	mockGetter := &MockJobApproverGetter{
+		JobApprovers: make(map[string]*MockJobApprover),
 	}
-	mockGetter.jobApprovers["node-1"] = &mockJobApprover{}
-	mockGetter.jobApprovers["node-2"] = &mockJobApprover{}
+	mockGetter.JobApprovers["node-1"] = &MockJobApprover{}
+	mockGetter.JobApprovers["node-2"] = &MockJobApprover{}
 
 	client := NewJobServiceClient(mockGetter)
 
@@ -536,10 +534,10 @@ func TestListProposals(t *testing.T) {
 	ctx := context.Background()
 
 	// Create mock job approvers
-	mockGetter := &mockJobApproverGetter{
-		jobApprovers: make(map[string]*mockJobApprover),
+	mockGetter := &MockJobApproverGetter{
+		JobApprovers: make(map[string]*MockJobApprover),
 	}
-	mockGetter.jobApprovers["node-1"] = &mockJobApprover{}
+	mockGetter.JobApprovers["node-1"] = &MockJobApprover{}
 
 	client := NewJobServiceClient(mockGetter)
 
@@ -1066,29 +1064,4 @@ command = "/home/capabilities/nowhere"
 config = ""
 `
 	return fmt.Sprintf(tomlString, externalJobID, externalJobID)
-}
-
-// mockJobApprover is a mock implementation of the JobApprover interface
-type mockJobApprover struct {
-	shouldFail bool
-}
-
-func (m *mockJobApprover) AutoApproveJob(ctx context.Context, p *feeds.ProposeJobArgs) error {
-	if m.shouldFail {
-		return errors.New("mock approval failure")
-	}
-	return nil
-}
-
-// mockJobApproverGetter is a mock implementation of the getter[JobApprover] interface
-type mockJobApproverGetter struct {
-	jobApprovers map[string]*mockJobApprover
-}
-
-func (m *mockJobApproverGetter) Get(id string) (JobApprover, error) {
-	approver, ok := m.jobApprovers[id]
-	if !ok {
-		return nil, errors.New("job approver not found")
-	}
-	return approver, nil
 }


### PR DESCRIPTION
There is an issue with distributing job specs where every distributed job with a different config is not a job update but a completely new job. Because of this NOPs have to cancel the old job and reaccept the new one which could be error prone.

Implement a feature for evm cap job pipeline so that jobs with same names copy the existing UUID if it exists