### PR TITLE
(feat): Ensure workflow registry syncer deletes before creations

### DIFF
--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -303,14 +303,19 @@ func (w *workflowRegistry) generateReconciliationEvents(_ context.Context, pendi
 			toDeletedEvent := WorkflowDeletedEvent{
 				WorkflowID: engine.WorkflowID,
 			}
-			events = append(events, &reconciliationEvent{
-				Event: Event{
-					Data: toDeletedEvent,
-					Name: WorkflowDeleted,
+			events = append(
+				[]*reconciliationEvent{
+					{
+						Event: Event{
+							Data: toDeletedEvent,
+							Name: WorkflowDeleted,
+						},
+						signature: signature,
+						id:        id,
+					},
 				},
-				signature: signature,
-				id:        id,
-			})
+				events...,
+			)
 		}
 	}
 

--- a/core/services/workflows/syncer/v2/workflow_registry_test.go
+++ b/core/services/workflows/syncer/v2/workflow_registry_test.go
@@ -581,4 +581,65 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 		require.Empty(t, pendingEvents)
 		require.Empty(t, events)
 	})
+
+	t.Run("delete events are handled before any other events", func(t *testing.T) {
+		lggr := logger.TestLogger(t)
+		ctx := testutils.Context(t)
+		workflowDonNotifier := capabilities.NewDonNotifier()
+		// Engine already in the workflow registry
+		er := NewEngineRegistry()
+		wfID := [32]byte{1}
+		owner := []byte{1}
+		wfName := "wf name 1"
+		err := er.Add(wfID, &mockService{})
+		require.NoError(t, err)
+		wr, err := NewWorkflowRegistry(
+			lggr,
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
+				return nil, nil
+			},
+			"",
+			Config{
+				QueryCount:   20,
+				SyncStrategy: SyncStrategyReconciliation,
+			},
+			&eventHandler{},
+			workflowDonNotifier,
+			er,
+		)
+		fakeClock := clockwork.NewFakeClock()
+		wr.clock = fakeClock
+		require.NoError(t, err)
+
+		// The workflow gets a new version with updated metadata, which changes the workflow ID
+		wfID2 := [32]byte{2}
+		binaryURL := "b1"
+		configURL := "c1"
+		createdAt := uint64(1000000)
+		tag := "tag1"
+		attributes := []byte{}
+		donFamily := "A"
+		metadata := []WorkflowMetadataView{
+			{
+				WorkflowID:   wfID2,
+				Owner:        owner,
+				CreatedAt:    createdAt,
+				Status:       WorkflowStatusActive,
+				WorkflowName: wfName,
+				BinaryURL:    binaryURL,
+				ConfigURL:    configURL,
+				Tag:          tag,
+				Attributes:   attributes,
+				DonFamily:    donFamily,
+			},
+		}
+
+		pendingEvents := map[string]*reconciliationEvent{}
+		events, err := wr.generateReconciliationEvents(ctx, pendingEvents, metadata)
+		require.NoError(t, err)
+
+		// Delete event happens before create event
+		require.Equal(t, events[0].Name, WorkflowDeleted)
+		require.Equal(t, events[1].Name, WorkflowRegistered)
+	})
 }


### PR DESCRIPTION
name: Sync develop from smartcontractkit/chainlink

on:
  schedule:
    # * is a special character in YAML so you have to quote this string
    - cron: '*/30 * * * *'

jobs:
  sync:
    name: Sync
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
        with:
          persist-credentials: false
          ref: develop
        if: env.GITHUB_REPOSITORY != 'smartcontractkit/chainlink'
      - name: Sync
        run: |
          git remote add upstream "https://github.com/smartcontractkit/chainlink.git"
          COMMIT_HASH_UPSTREAM=$(git ls-remote upstream develop | grep -P '^[0-9a-f]{40}\trefs/heads/develop$' | cut -f 1)
          COMMIT_HASH_ORIGIN=$(git ls-remote origin develop | grep -P '^[0-9a-f]{40}\trefs/heads/develop$' | cut -f 1)
          if [ "$COMMIT_HASH_UPSTREAM" = "$COMMIT_HASH_ORIGIN" ]; then
            echo "Both remotes have develop at $COMMIT_HASH_UPSTREAM. No need to sync."
          else
            echo "upstream has develop at $COMMIT_HASH_UPSTREAM. origin has develop at $COMMIT_HASH_ORIGIN. Syncing..."
            git fetch upstream
            git push origin upstream/develop:develop
          fi
        if: env.GITHUB_REPOSITORY != 'smartcontractkit/chainlink'


