### PR TITLE
[local CRE] track topology used during environment startup

### DIFF
--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -136,6 +136,7 @@ var StartCmdRecoverHandlerFunc = func(p any, cleanupOnFailure bool, cleanupWait 
 			"success":  false,
 			"error":    errText,
 			"panicked": true,
+			"topology": os.Getenv("CTF_CONFIGS"),
 		})
 
 		if tracingErr != nil {
@@ -564,8 +565,9 @@ func setupDashboards(setupCfg SetupConfig) error {
 
 func trackStartup(success, hasBuiltDockerImage bool, infraType string, errorMessage *string, panicked *bool) error {
 	metadata := map[string]any{
-		"success": success,
-		"infra":   infraType,
+		"success":  success,
+		"infra":    infraType,
+		"topology": os.Getenv("CTF_CONFIGS"),
 	}
 
 	if errorMessage != nil {


### PR DESCRIPTION
<img width="717" height="399" alt="image" src="https://github.com/user-attachments/assets/3a54cb9f-4741-4ce6-a058-f012648afb33" />
