### PR TITLE
core/services/workflows/types: add WorkflowID.String()

### DIFF
--- a/core/services/workflows/types/workflow_meta.go
+++ b/core/services/workflows/types/workflow_meta.go
@@ -44,6 +44,8 @@ func NewWorkflowName(userDefinedName string) (WorkflowName, error) {
 
 type WorkflowID [32]byte
 
+func (w WorkflowID) String() string { return w.Hex() }
+
 func (w WorkflowID) Hex() string {
 	return hex.EncodeToString(w[:])
 }


### PR DESCRIPTION
These log as raw bytes otherwise, which is spammy and unreadable.