### PR TITLE
[PRODCRE-1614] allow multiple workflow DONs in the local CRE

### DIFF
--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
@@ -47,7 +47,7 @@
   supported_evm_chains = [1337, 2337]
 
   env_vars = { CL_EVM_CMD = "" }
-  capabilities = ["ocr3", "custom-compute", "web-api-trigger", "cron", "http-trigger", "consensus", "don-time"]
+  capabilities = ["ocr3", "custom-compute", "web-api-trigger", "cron", "http-action", "http-trigger", "consensus", "don-time"]
 
   [nodesets.chain_capabilities]
     # we want to write only to the home chain, so that we can test whether remote capabilities of the 'capabilities DON' are used

--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
@@ -47,7 +47,7 @@
   supported_evm_chains = [1337, 2337]
 
   env_vars = { CL_EVM_CMD = "" }
-  capabilities = ["ocr3", "custom-compute", "web-api-trigger", "cron", "http-action", "http-trigger", "consensus", "don-time"]
+  capabilities = ["ocr3", "custom-compute", "web-api-trigger", "cron", "http-trigger", "consensus", "don-time"]
 
   [nodesets.chain_capabilities]
     # we want to write only to the home chain, so that we can test whether remote capabilities of the 'capabilities DON' are used
@@ -82,7 +82,7 @@
   supported_evm_chains = [1337, 2337]
 
   env_vars = { CL_EVM_CMD = "" }
-  capabilities = ["web-api-target","vault"]
+  capabilities = ["web-api-target","vault","http-action"]
 
   [nodesets.chain_capabilities]
   write-evm = ["2337"]

--- a/core/scripts/cre/environment/configs/workflow-gateway-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-don.toml
@@ -66,37 +66,6 @@
       user_config_overrides = ""
 
 [[nodesets]]
-  nodes = 4
-  name = "shard1"
-  #is_shard = true # do not add to workflow registry?
-  don_types = ["workflow"]
-  override_mode = "all"
-  http_port_range_start = 10400
-
-  env_vars = { CL_EVM_CMD = "" }
-  capabilities = ["ocr3", "custom-compute", "web-api-target", "web-api-trigger", "cron", "consensus", "don-time"]
-
-   [nodesets.chain_capabilities]
-    write-evm = ["1337", "2337"]
-    read-contract = ["1337", "2337"]
-    evm = ["1337", "2337"]
-
-  # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
-
-  [nodesets.db]
-    image = "postgres:12.0"
-    port = 13400
-
-[[nodesets.node_specs]]
-    roles = ["plugin"]
-    [nodesets.node_specs.node]
-      docker_ctx = "../../../.."
-      docker_file = "core/chainlink.Dockerfile"
-      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
-      # image = "chainlink-tmp:latest"
-      user_config_overrides = ""
-
-[[nodesets]]
   nodes = 1
   name = "bootstrap-gateway"
   don_types = ["bootstrap", "gateway"]

--- a/core/scripts/cre/environment/configs/workflow-gateway-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-don.toml
@@ -66,6 +66,37 @@
       user_config_overrides = ""
 
 [[nodesets]]
+  nodes = 4
+  name = "shard1"
+  #is_shard = true # do not add to workflow registry?
+  don_types = ["workflow"]
+  override_mode = "all"
+  http_port_range_start = 10400
+
+  env_vars = { CL_EVM_CMD = "" }
+  capabilities = ["ocr3", "custom-compute", "web-api-target", "web-api-trigger", "cron", "consensus", "don-time"]
+
+   [nodesets.chain_capabilities]
+    write-evm = ["1337", "2337"]
+    read-contract = ["1337", "2337"]
+    evm = ["1337", "2337"]
+
+  # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
+
+  [nodesets.db]
+    image = "postgres:12.0"
+    port = 13400
+
+[[nodesets.node_specs]]
+    roles = ["plugin"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      # image = "chainlink-tmp:latest"
+      user_config_overrides = ""
+
+[[nodesets]]
   nodes = 1
   name = "bootstrap-gateway"
   don_types = ["bootstrap", "gateway"]

--- a/core/scripts/cre/environment/configs/workflow-gateway-sharded-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-sharded-don.toml
@@ -37,23 +37,18 @@
 
 [[nodesets]]
   nodes = 4
-  name = "workflow"
-  don_types = ["workflow"]
+  name = "shard0"
+  don_types = ["workflow", "shard"]
   override_mode = "all"
   http_port_range_start = 10100
 
-  # even though this DON is not using any capability for chain with ID 2337 we still need it to be connected to it,
-  # because bootstrap job for capability DON will be created on the boostrap node from this DON
-  supported_evm_chains = [1337, 2337]
-
   env_vars = { CL_EVM_CMD = "" }
-  capabilities = ["ocr3", "custom-compute", "web-api-trigger", "cron", "http-trigger", "consensus", "don-time"]
+  capabilities = ["ocr3", "custom-compute", "web-api-target", "web-api-trigger", "vault", "cron", "http-action", "http-trigger", "consensus", "don-time"]
 
-  [nodesets.chain_capabilities]
-    # we want to write only to the home chain, so that we can test whether remote capabilities of the 'capabilities DON' are used
-    write-evm = ["1337"]
-    read-contract = ["1337"]
-    evm = ["1337"]
+   [nodesets.chain_capabilities]
+    write-evm = ["1337", "2337"]
+    read-contract = ["1337", "2337"]
+    evm = ["1337", "2337"]
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 
@@ -61,7 +56,7 @@
     image = "postgres:12.0"
     port = 13000
 
- [[nodesets.node_specs]]
+[[nodesets.node_specs]]
     roles = ["plugin"]
     [nodesets.node_specs.node]
       docker_ctx = "../../../.."
@@ -72,29 +67,28 @@
 
 [[nodesets]]
   nodes = 4
-  name = "capabilities"
-  don_types = ["capabilities"]
-  exposes_remote_capabilities = true
+  name = "shard1"
+  don_types = ["workflow", "shard"]
+  shard_index = 1
   override_mode = "all"
-  http_port_range_start = 10200
-
-  # we need to have chain 1337 configured (even if no capability uses it), because we use node addresses on chain 1337
-  # to identify nodes in the gateway configuration (required by both web-api-target and vault capabilities)
-  supported_evm_chains = [1337, 2337]
+  http_port_range_start = 10400
 
   env_vars = { CL_EVM_CMD = "" }
-  capabilities = ["web-api-target", "vault"]
+  # add "vault", "http-action", "http-trigger", when gateway can support more than 1 DON per service
+  capabilities = ["ocr3", "custom-compute",  "web-api-target", "web-api-trigger", "cron", "consensus", "don-time"]
 
-  [nodesets.chain_capabilities]
-  write-evm = ["2337"]
-  read-contract = ["2337"]
-  evm = ["2337"]
+   [nodesets.chain_capabilities]
+    write-evm = ["1337", "2337"]
+    read-contract = ["1337", "2337"]
+    evm = ["1337", "2337"]
+
+  # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 
   [nodesets.db]
     image = "postgres:12.0"
-    port = 13100
+    port = 13400
 
-  [[nodesets.node_specs]]
+[[nodesets.node_specs]]
     roles = ["plugin"]
     [nodesets.node_specs.node]
       docker_ctx = "../../../.."

--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -24,12 +24,14 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
+
+	"github.com/spf13/cobra"
+
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	billingplatformservice "github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose/billing_platform_service"
 	chipingressset "github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose/chip_ingress_set"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/tracking"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/ptr"
-	"github.com/spf13/cobra"
 
 	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	cldlogger "github.com/smartcontractkit/chainlink/deployment/logger"

--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -1127,7 +1128,12 @@ func initLocalCREStageGen(in *envconfig.Config) *stagegen.StageGen {
 		stages++
 	}
 
-	// TODO: increment counter if sharding is enabled
+	for _, ns := range in.NodeSets {
+		if slices.Contains(ns.DONTypes, cre.ShardDON) {
+			stages++
+			break
+		}
+	}
 
 	return stagegen.NewStageGen(stages, "STAGE")
 }

--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -1127,5 +1127,7 @@ func initLocalCREStageGen(in *envconfig.Config) *stagegen.StageGen {
 		stages++
 	}
 
+	// TODO: increment counter if sharding is enabled
+
 	return stagegen.NewStageGen(stages, "STAGE")
 }

--- a/system-tests/lib/cre/contracts/keystone.go
+++ b/system-tests/lib/cre/contracts/keystone.go
@@ -82,6 +82,8 @@ func DeployKeystoneContracts(
 		return nil, errors.Wrap(err, "failed to merge datastore with Keystone contracts addresses")
 	}
 
+	// TODO: deploy shard contract if sharding is enabled
+
 	wfRegAddr := MustGetAddressFromMemoryDataStore(memoryDatastore, registryChainSelector, keystone_changeset.WorkflowRegistry.String(), input.ContractVersions[keystone_changeset.WorkflowRegistry.String()], "")
 	testLogger.Info().Msgf("Deployed Workflow Registry %s contract on chain %d at %s", input.ContractVersions[keystone_changeset.WorkflowRegistry.String()], registryChainSelector, wfRegAddr)
 
@@ -377,6 +379,13 @@ func toDons(input cre.ConfigureCapabilityRegistryInput) (*dons, error) {
 	}
 
 	return dons, nil
+}
+
+type ConfigureShardContractInput struct{}
+
+func ConfigureShardContract(input ConfigureShardContractInput) error {
+	// TODO: configure contract if sharding is enable
+	return nil
 }
 
 func ConfigureCapabilityRegistry(input cre.ConfigureCapabilityRegistryInput) (CapabilitiesRegistry, error) {

--- a/system-tests/lib/cre/contracts/keystone.go
+++ b/system-tests/lib/cre/contracts/keystone.go
@@ -82,8 +82,6 @@ func DeployKeystoneContracts(
 		return nil, errors.Wrap(err, "failed to merge datastore with Keystone contracts addresses")
 	}
 
-	// TODO: deploy shard contract if sharding is enabled
-
 	wfRegAddr := MustGetAddressFromMemoryDataStore(memoryDatastore, registryChainSelector, keystone_changeset.WorkflowRegistry.String(), input.ContractVersions[keystone_changeset.WorkflowRegistry.String()], "")
 	testLogger.Info().Msgf("Deployed Workflow Registry %s contract on chain %d at %s", input.ContractVersions[keystone_changeset.WorkflowRegistry.String()], registryChainSelector, wfRegAddr)
 
@@ -379,13 +377,6 @@ func toDons(input cre.ConfigureCapabilityRegistryInput) (*dons, error) {
 	}
 
 	return dons, nil
-}
-
-type ConfigureShardContractInput struct{}
-
-func ConfigureShardContract(input ConfigureShardContractInput) error {
-	// TODO: configure contract if sharding is enable
-	return nil
 }
 
 func ConfigureCapabilityRegistry(input cre.ConfigureCapabilityRegistryInput) (CapabilitiesRegistry, error) {

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -343,7 +343,7 @@ func SetupTestEnvironment(
 			ContractVersion: cldf.TypeAndVersion{Version: *wfRegVersion},
 			ChainSelector:   deployedBlockchains.RegistryChain().ChainSelector(),
 			CldEnv:          deployKeystoneContractsOutput.Env,
-			AllowedDonIDs:   []uint64{topology.WorkflowDONID},
+			AllowedDonIDs:   topology.WorkflowDONIDs,                                                                                    // TODO: this should be shard-aware
 			WorkflowOwners:  []common.Address{deployedBlockchains.RegistryChain().(*evm.Blockchain).SethClient.MustGetRootKeyAddress()}, // registry chain is always EVM
 		},
 	)

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -344,7 +344,7 @@ func SetupTestEnvironment(
 			ContractVersion: cldf.TypeAndVersion{Version: *wfRegVersion},
 			ChainSelector:   deployedBlockchains.RegistryChain().ChainSelector(),
 			CldEnv:          deployKeystoneContractsOutput.Env,
-			AllowedDonIDs:   topology.WorkflowDONIDs,                                                                                    // TODO: this should be shard-aware
+			AllowedDonIDs:   topology.WorkflowDONIDs,
 			WorkflowOwners:  []common.Address{deployedBlockchains.RegistryChain().(*evm.Blockchain).SethClient.MustGetRootKeyAddress()}, // registry chain is always EVM
 		},
 	)

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -36,6 +36,7 @@ import (
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/blockchains/evm"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/config"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/stagegen"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/sharding"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/workflow"
 	libformat "github.com/smartcontractkit/chainlink/system-tests/lib/format"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/infra"
@@ -403,12 +404,16 @@ func SetupTestEnvironment(
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.WrapAndNext("Workflow and Capability Registry contracts configured in %.2f seconds", input.StageGen.Elapsed().Seconds())))
 
 	if topology.DonsMetadata.ShardingEnabled() {
-		fmt.Print(libformat.PurpleText("%s", input.StageGen.Wrap("Configuring Shard contract")))
-		err := crecontracts.ConfigureShardContract(crecontracts.ConfigureShardContractInput{})
+		fmt.Print(libformat.PurpleText("%s", input.StageGen.Wrap("Setting up Sharding")))
+		err := sharding.SetupSharding(sharding.SetupShardingInput{
+			Logger:   testLogger,
+			CreEnv:   creEnvironment,
+			Topology: topology,
+		})
 		if err != nil {
-			return nil, pkgerrors.Wrap(err, "failed to configure Shard contract")
+			return nil, pkgerrors.Wrap(err, "failed to setup Sharding")
 		}
-		fmt.Print(libformat.PurpleText("%s", input.StageGen.WrapAndNext("Shard contract configured in %.2f seconds", input.StageGen.Elapsed().Seconds())))
+		fmt.Print(libformat.PurpleText("%s", input.StageGen.WrapAndNext("Sharding setup in %.2f seconds", input.StageGen.Elapsed().Seconds())))
 	}
 
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.Wrap("Applying Features after environment startup")))

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -401,6 +401,16 @@ func SetupTestEnvironment(
 	}
 
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.WrapAndNext("Workflow and Capability Registry contracts configured in %.2f seconds", input.StageGen.Elapsed().Seconds())))
+
+	if topology.DonsMetadata.ShardingEnabled() {
+		fmt.Print(libformat.PurpleText("%s", input.StageGen.Wrap("Configuring Shard contract")))
+		err := crecontracts.ConfigureShardContract(crecontracts.ConfigureShardContractInput{})
+		if err != nil {
+			return nil, pkgerrors.Wrap(err, "failed to configure Shard contract")
+		}
+		fmt.Print(libformat.PurpleText("%s", input.StageGen.WrapAndNext("Shard contract configured in %.2f seconds", input.StageGen.Elapsed().Seconds())))
+	}
+
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.Wrap("Applying Features after environment startup")))
 
 	for _, feature := range input.Features.List() {

--- a/system-tests/lib/cre/features/consensus/v1/consensus.go
+++ b/system-tests/lib/cre/features/consensus/v1/consensus.go
@@ -151,7 +151,7 @@ func createJobs(
 		Domain:      offchain.ProductLabel,
 		Environment: cre.EnvironmentName,
 		DONName:     bootstrap.DON.Name,
-		JobName:     "consensus-v1-bootstrap",
+		JobName:     "consensus-v1-bootstrap-" + don.Name,
 		ExtraLabels: map[string]string{cre.CapabilityLabelKey: flag},
 		DONFilters: []offchain.TargetDONFilter{
 			{Key: offchain.FilterKeyDONName, Value: bootstrap.DON.Name},

--- a/system-tests/lib/cre/features/consensus/v1/consensus.go
+++ b/system-tests/lib/cre/features/consensus/v1/consensus.go
@@ -51,7 +51,9 @@ func (c *Consensus) PreEnvStartup(
 			CapabilityType: 2, // CONSENSUS
 			ResponseType:   0, // REPORT
 		},
-		Config: &capabilitiespb.CapabilityConfig{},
+		Config: &capabilitiespb.CapabilityConfig{
+			LocalOnly: don.HasOnlyLocalCapabilities(),
+		},
 	}}
 
 	return &cre.PreEnvStartupOutput{

--- a/system-tests/lib/cre/features/consensus/v2/consensus.go
+++ b/system-tests/lib/cre/features/consensus/v2/consensus.go
@@ -177,7 +177,7 @@ func createJobs(
 		Domain:      offchain.ProductLabel,
 		Environment: cre.EnvironmentName,
 		DONName:     bootstrap.DON.Name,
-		JobName:     "consensus-v2-bootstrap",
+		JobName:     "consensus-v2-bootstrap-" + don.Name,
 		ExtraLabels: map[string]string{cre.CapabilityLabelKey: flag},
 		DONFilters: []offchain.TargetDONFilter{
 			{Key: offchain.FilterKeyDONName, Value: bootstrap.DON.Name},

--- a/system-tests/lib/cre/features/consensus/v2/consensus.go
+++ b/system-tests/lib/cre/features/consensus/v2/consensus.go
@@ -52,7 +52,9 @@ func (c *Consensus) PreEnvStartup(
 			CapabilityType: 2, // CONSENSUS
 			ResponseType:   0, // REPORT
 		},
-		Config: &capabilitiespb.CapabilityConfig{},
+		Config: &capabilitiespb.CapabilityConfig{
+			LocalOnly: don.HasOnlyLocalCapabilities(),
+		},
 	}}
 
 	return &cre.PreEnvStartupOutput{

--- a/system-tests/lib/cre/features/cron/cron.go
+++ b/system-tests/lib/cre/features/cron/cron.go
@@ -42,7 +42,9 @@ func (c *Cron) PreEnvStartup(
 			Version:        "1.0.0",
 			CapabilityType: 0, // TRIGGER
 		},
-		Config: &capabilitiespb.CapabilityConfig{},
+		Config: &capabilitiespb.CapabilityConfig{
+			LocalOnly: don.HasOnlyLocalCapabilities(),
+		},
 	}}
 
 	return &cre.PreEnvStartupOutput{

--- a/system-tests/lib/cre/features/custom_compute/custom_compute.go
+++ b/system-tests/lib/cre/features/custom_compute/custom_compute.go
@@ -66,7 +66,9 @@ func (o *CustomCompute) PreEnvStartup(
 			Version:        "1.0.0",
 			CapabilityType: 1, // ACTION
 		},
-		Config: &capabilitiespb.CapabilityConfig{},
+		Config: &capabilitiespb.CapabilityConfig{
+			LocalOnly: don.HasOnlyLocalCapabilities(),
+		},
 	}}
 
 	return &cre.PreEnvStartupOutput{

--- a/system-tests/lib/cre/features/evm/v1/evm.go
+++ b/system-tests/lib/cre/features/evm/v1/evm.go
@@ -113,7 +113,9 @@ func (o *EVM) PreEnvStartup(
 				CapabilityType: 3, // TARGET
 				ResponseType:   1, // OBSERVATION_IDENTICAL
 			},
-			Config: &capabilitiespb.CapabilityConfig{},
+			Config: &capabilitiespb.CapabilityConfig{
+				LocalOnly: don.HasOnlyLocalCapabilities(),
+			},
 		})
 	}
 

--- a/system-tests/lib/cre/features/evm/v2/evm.go
+++ b/system-tests/lib/cre/features/evm/v2/evm.go
@@ -362,7 +362,7 @@ func createJobs(
 			Domain:      offchain.ProductLabel,
 			Environment: cre.EnvironmentName,
 			DONName:     bootstrap.DON.Name,
-			JobName:     fmt.Sprintf("evm-v2-bootstrap-%d", chainID),
+			JobName:     fmt.Sprintf("evm-v2-bootstrap-%d-%s", chainID, don.Name),
 			ExtraLabels: map[string]string{cre.CapabilityLabelKey: flag},
 			DONFilters: []offchain.TargetDONFilter{
 				{Key: offchain.FilterKeyDONName, Value: bootstrap.DON.Name},

--- a/system-tests/lib/cre/features/evm/v2/evm.go
+++ b/system-tests/lib/cre/features/evm/v2/evm.go
@@ -125,6 +125,7 @@ func (o *EVM) PreEnvStartup(
 			},
 			Config: &capabilitiespb.CapabilityConfig{
 				MethodConfigs: evmMethodConfigs,
+				LocalOnly:     don.HasOnlyLocalCapabilities(),
 			},
 		})
 	}

--- a/system-tests/lib/cre/features/http_action/http_action.go
+++ b/system-tests/lib/cre/features/http_action/http_action.go
@@ -67,7 +67,9 @@ func (o *HTTPAction) PreEnvStartup(
 			Version:        "1.0.0-alpha",
 			CapabilityType: 1, // ACTION
 		},
-		Config: &capabilitiespb.CapabilityConfig{},
+		Config: &capabilitiespb.CapabilityConfig{
+			LocalOnly: don.HasOnlyLocalCapabilities(),
+		},
 	}}
 
 	return &cre.PreEnvStartupOutput{

--- a/system-tests/lib/cre/features/http_trigger/http_trigger.go
+++ b/system-tests/lib/cre/features/http_trigger/http_trigger.go
@@ -67,7 +67,9 @@ func (o *HTTPTrigger) PreEnvStartup(
 			Version:        "1.0.0-alpha",
 			CapabilityType: 0, // TRIGGER
 		},
-		Config: &capabilitiespb.CapabilityConfig{},
+		Config: &capabilitiespb.CapabilityConfig{
+			LocalOnly: don.HasOnlyLocalCapabilities(),
+		},
 	}}
 
 	return &cre.PreEnvStartupOutput{

--- a/system-tests/lib/cre/features/log_event_trigger/log_event_trigger.go
+++ b/system-tests/lib/cre/features/log_event_trigger/log_event_trigger.go
@@ -50,7 +50,9 @@ func (o *LogEventTrigger) PreEnvStartup(
 				CapabilityType: 0, // TRIGGER
 				ResponseType:   0, // REPORT
 			},
-			Config: &capabilitiespb.CapabilityConfig{},
+			Config: &capabilitiespb.CapabilityConfig{
+				LocalOnly: don.HasOnlyLocalCapabilities(),
+			},
 		})
 	}
 

--- a/system-tests/lib/cre/features/mock/mock.go
+++ b/system-tests/lib/cre/features/mock/mock.go
@@ -46,7 +46,9 @@ func (o *Mock) PreEnvStartup(
 			Version:        "1.0.0",
 			CapabilityType: 0, // TRIGGER
 		},
-		Config: &capabilitiespb.CapabilityConfig{},
+		Config: &capabilitiespb.CapabilityConfig{
+			LocalOnly: don.HasOnlyLocalCapabilities(),
+		},
 	}}
 
 	return &cre.PreEnvStartupOutput{

--- a/system-tests/lib/cre/features/read_contract/read_contract.go
+++ b/system-tests/lib/cre/features/read_contract/read_contract.go
@@ -48,7 +48,9 @@ func (o *ReadContract) PreEnvStartup(
 				Version:        "1.0.0",
 				CapabilityType: 1, // ACTION
 			},
-			Config: &capabilitiespb.CapabilityConfig{},
+			Config: &capabilitiespb.CapabilityConfig{
+				LocalOnly: don.HasOnlyLocalCapabilities(),
+			},
 		})
 	}
 

--- a/system-tests/lib/cre/features/solana/solana.go
+++ b/system-tests/lib/cre/features/solana/solana.go
@@ -102,7 +102,9 @@ func (o *Solana) PreEnvStartup(
 			CapabilityType: 3, // TARGET
 			ResponseType:   1, // OBSERVATION_IDENTICAL
 		},
-		Config: &capabilitiespb.CapabilityConfig{},
+		Config: &capabilitiespb.CapabilityConfig{
+			LocalOnly: don.HasOnlyLocalCapabilities(),
+		},
 	}}
 
 	return &cre.PreEnvStartupOutput{

--- a/system-tests/lib/cre/features/vault/vault.go
+++ b/system-tests/lib/cre/features/vault/vault.go
@@ -105,7 +105,9 @@ func (o *Vault) PreEnvStartup(
 			Version:        "1.0.0",
 			CapabilityType: 1, // ACTION
 		},
-		Config: &capabilitiespb.CapabilityConfig{},
+		Config: &capabilitiespb.CapabilityConfig{
+			LocalOnly: don.HasOnlyLocalCapabilities(),
+		},
 	}}
 
 	return &cre.PreEnvStartupOutput{

--- a/system-tests/lib/cre/features/vault/vault.go
+++ b/system-tests/lib/cre/features/vault/vault.go
@@ -261,7 +261,7 @@ func createJobs(
 		Domain:      offchain.ProductLabel,
 		Environment: cre.EnvironmentName,
 		DONName:     bootstrap.DON.Name,
-		JobName:     "vault-bootstrap",
+		JobName:     "vault-bootstrap-" + don.Name,
 		ExtraLabels: map[string]string{cre.CapabilityLabelKey: flag},
 		DONFilters: []offchain.TargetDONFilter{
 			{Key: offchain.FilterKeyDONName, Value: bootstrap.DON.Name},

--- a/system-tests/lib/cre/features/web_api_target/web_api_target.go
+++ b/system-tests/lib/cre/features/web_api_target/web_api_target.go
@@ -67,7 +67,9 @@ func (o *WebAPITarget) PreEnvStartup(
 			CapabilityType: 3, // TARGET
 			ResponseType:   1, // OBSERVATION_IDENTICAL
 		},
-		Config: &capabilitiespb.CapabilityConfig{},
+		Config: &capabilitiespb.CapabilityConfig{
+			LocalOnly: don.HasOnlyLocalCapabilities(),
+		},
 	}}
 
 	return &cre.PreEnvStartupOutput{

--- a/system-tests/lib/cre/features/web_api_trigger/web_api_trigger.go
+++ b/system-tests/lib/cre/features/web_api_trigger/web_api_trigger.go
@@ -62,7 +62,9 @@ func (o *WebAPITrigger) PreEnvStartup(
 			Version:        "1.0.0",
 			CapabilityType: 0, // TRIGGER
 		},
-		Config: &capabilitiespb.CapabilityConfig{},
+		Config: &capabilitiespb.CapabilityConfig{
+			LocalOnly: don.HasOnlyLocalCapabilities(),
+		},
 	}}
 
 	return &cre.PreEnvStartupOutput{

--- a/system-tests/lib/cre/sharding/sharding.go
+++ b/system-tests/lib/cre/sharding/sharding.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/rs/zerolog"
+
 	deployment_contracts "github.com/smartcontractkit/chainlink/deployment/cre/contracts"
 	shard_config_changeset "github.com/smartcontractkit/chainlink/deployment/cre/shard_config/v1/changeset"
+
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 	crecontracts "github.com/smartcontractkit/chainlink/system-tests/lib/cre/contracts"
 )

--- a/system-tests/lib/cre/sharding/sharding.go
+++ b/system-tests/lib/cre/sharding/sharding.go
@@ -1,0 +1,46 @@
+package sharding
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/rs/zerolog"
+	deployment_contracts "github.com/smartcontractkit/chainlink/deployment/cre/contracts"
+	shard_config_changeset "github.com/smartcontractkit/chainlink/deployment/cre/shard_config/v1/changeset"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
+	crecontracts "github.com/smartcontractkit/chainlink/system-tests/lib/cre/contracts"
+)
+
+type SetupShardingInput struct {
+	Logger   zerolog.Logger
+	CreEnv   *cre.Environment
+	Topology *cre.Topology
+}
+
+func SetupSharding(input SetupShardingInput) error {
+	deployInput := shard_config_changeset.DeployShardConfigInput{
+		ChainSelector:     input.CreEnv.RegistryChainSelector,
+		InitialShardCount: uint64(input.Topology.DonsMetadata.ShardCount()),
+	}
+
+	vErr := shard_config_changeset.DeployShardConfig{}.VerifyPreconditions(*input.CreEnv.CldfEnvironment, deployInput)
+	if vErr != nil {
+		return fmt.Errorf("preconditions verification for Shard Config contract failed: %w", vErr)
+	}
+
+	out, dErr := shard_config_changeset.DeployShardConfig{}.Apply(*input.CreEnv.CldfEnvironment, deployInput)
+	if dErr != nil {
+		return fmt.Errorf("failed to deploy Shard Config contract: %w", dErr)
+	}
+
+	crecontracts.MergeAllDataStores(input.CreEnv, out)
+
+	shardConfigAddr := crecontracts.MustGetAddressFromDataStore(input.CreEnv.CldfEnvironment.DataStore, input.CreEnv.RegistryChainSelector, deployment_contracts.ShardConfig.String(), semver.MustParse("1"), "")
+	input.Logger.Info().Msgf("Deployed Shard Config v1 contract on chain %d at %s", input.CreEnv.RegistryChainSelector, shardConfigAddr)
+
+	// once we have a changeset for job creation:
+	// get shard leader DON
+	// create job(s) on shard leader DON
+
+	return nil
+}

--- a/system-tests/lib/cre/topology.go
+++ b/system-tests/lib/cre/topology.go
@@ -18,7 +18,7 @@ const (
 )
 
 type Topology struct {
-	WorkflowDONID     uint64             `toml:"workflow_don_id" json:"workflow_don_id"`
+	WorkflowDONIDs    []uint64           `toml:"workflow_don_ids" json:"workflow_don_ids"`
 	DonsMetadata      *DonsMetadata      `toml:"dons_metadata" json:"dons_metadata"`
 	GatewayConfigs    []GatewayConfig    `toml:"gateway_configs" json:"gateway_configs"`
 	GatewayConnectors *GatewayConnectors `toml:"gateway_connectors" json:"gateway_connectors"`
@@ -41,18 +41,21 @@ func NewTopology(nodeSet []*NodeSet, provider infra.Provider) (*Topology, error)
 		return nil, fmt.Errorf("failed to create DONs metadata: %w", err)
 	}
 
-	wfDon, err := donsMetadata.WorkflowDON()
+	wfDONs, err := donsMetadata.WorkflowDONs()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get workflow DON: %w", err)
+		return nil, fmt.Errorf("failed to find any workflow DONs: %w", err)
 	}
 
 	topology := &Topology{
-		WorkflowDONID: wfDon.ID,
-		DonsMetadata:  donsMetadata,
-		GatewayConfigs: []GatewayConfig{{
-			Name:     wfDon.Name,
+		WorkflowDONIDs: make([]uint64, len(wfDONs)),
+		DonsMetadata:   donsMetadata,
+	}
+
+	for _, wfDON := range wfDONs {
+		topology.GatewayConfigs = append(topology.GatewayConfigs, GatewayConfig{
+			Name:     wfDON.Name,
 			Handlers: []string{pkg.GatewayHandlerTypeWebAPICapabilities},
-		}},
+		})
 	}
 
 	if donsMetadata.RequiresGateway() {

--- a/system-tests/lib/cre/topology.go
+++ b/system-tests/lib/cre/topology.go
@@ -47,7 +47,7 @@ func NewTopology(nodeSet []*NodeSet, provider infra.Provider) (*Topology, error)
 	}
 
 	topology := &Topology{
-		WorkflowDONIDs: make([]uint64, len(wfDONs)),
+		WorkflowDONIDs: []uint64{},
 		DonsMetadata:   donsMetadata,
 	}
 
@@ -56,6 +56,7 @@ func NewTopology(nodeSet []*NodeSet, provider infra.Provider) (*Topology, error)
 			Name:     wfDON.Name,
 			Handlers: []string{pkg.GatewayHandlerTypeWebAPICapabilities},
 		})
+		topology.WorkflowDONIDs = append(topology.WorkflowDONIDs, wfDON.ID)
 	}
 
 	if donsMetadata.RequiresGateway() {

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -598,7 +598,7 @@ func (m *DonMetadata) IsShardLeader() bool {
 }
 
 func (m *DonMetadata) HasOnlyLocalCapabilities() bool {
-	return m.ExposesRemoteCapabilities == false
+	return !m.ExposesRemoteCapabilities
 }
 
 // ConfigureForGatewayAccess adds gateway connector configuration to each node;s TOML config. It only adds connectors, if they are not already present.
@@ -846,7 +846,7 @@ func (m DonsMetadata) validate() error {
 
 		// Validate in a single pass: must start at 0, be sequential, and have no duplicates
 		for i, shardIdx := range shardIndexes {
-			expectedIdx := uint(i)
+			expectedIdx := uint(i) //nolint:gosec // disable G115 overflow is unrealistic
 
 			if shardIdx != expectedIdx {
 				if i > 0 && shardIdx == shardIndexes[i-1] {

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -48,6 +48,7 @@ const (
 	CapabilitiesDON CapabilityFlag = "capabilities"
 	GatewayDON      CapabilityFlag = "gateway"
 	BootstrapDON    CapabilityFlag = "bootstrap"
+	ShardDON        CapabilityFlag = "shard"
 )
 
 // Capabilities
@@ -457,10 +458,12 @@ func (g *GenerateConfigsInput) Validate() error {
 }
 
 type DonMetadata struct {
-	NodesMetadata []*NodeMetadata `toml:"nodes_metadata" json:"nodes_metadata"`
-	Flags         []string        `toml:"flags" json:"flags"`
-	ID            uint64          `toml:"id" json:"id"`
-	Name          string          `toml:"name" json:"name"`
+	NodesMetadata             []*NodeMetadata `toml:"nodes_metadata" json:"nodes_metadata"`
+	Flags                     []string        `toml:"flags" json:"flags"`
+	ID                        uint64          `toml:"id" json:"id"`
+	Name                      string          `toml:"name" json:"name"`
+	ExposesRemoteCapabilities bool            `toml:"exposes_remote_capabilities" json:"exposes_remote_capabilities"`
+	ShardIndex                uint            `toml:"shard_index" json:"shard_index"`
 
 	ns NodeSet // computed field, not serialized
 }
@@ -487,11 +490,13 @@ func NewDonMetadata(c *NodeSet, id uint64, provider infra.Provider) (*DonMetadat
 		return nil, fmt.Errorf("failed to create nodes metadata: %w", err)
 	}
 	out := &DonMetadata{
-		ID:            id,
-		Flags:         c.Flags(),
-		NodesMetadata: nodes,
-		Name:          c.Name,
-		ns:            *c,
+		ID:                        id,
+		Flags:                     c.Flags(),
+		NodesMetadata:             nodes,
+		Name:                      c.Name,
+		ns:                        *c,
+		ExposesRemoteCapabilities: c.ExposesRemoteCapabilities,
+		ShardIndex:                c.ShardIndex,
 	}
 
 	return out, nil
@@ -577,6 +582,23 @@ func (m *DonMetadata) IsWorkflowDON() bool {
 	}
 
 	return slices.Contains(m.Flags, WorkflowDON)
+}
+
+func (m *DonMetadata) IsShardDON() bool {
+	// is there a case where flags are not set yet?
+	if len(m.Flags) == 0 && len(m.ns.DONTypes) != 0 {
+		return slices.Contains(m.ns.DONTypes, ShardDON)
+	}
+
+	return slices.Contains(m.Flags, ShardDON)
+}
+
+func (m *DonMetadata) IsShardLeader() bool {
+	return m.ShardIndex == 0
+}
+
+func (m *DonMetadata) HasOnlyLocalCapabilities() bool {
+	return m.ExposesRemoteCapabilities == false
 }
 
 // ConfigureForGatewayAccess adds gateway connector configuration to each node;s TOML config. It only adds connectors, if they are not already present.
@@ -808,6 +830,18 @@ func (m DonsMetadata) validate() error {
 		return errors.New("at least one DON requires gateway due to its capabilities, but no DON had a node with role 'gateway'")
 	}
 
+	if m.ShardingEnabled() {
+		leadersFound := 0
+		for _, don := range m.dons {
+			if don.IsShardDON() && don.IsShardLeader() {
+				leadersFound++
+			}
+			if leadersFound > 1 {
+				return errors.New("only one shard leader DON is allowed. Please update your TOML config and make sure there is only one DON with 'shard_index' equal to 0")
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -845,6 +879,41 @@ func (m DonsMetadata) WorkflowDONs() ([]*DonMetadata, error) {
 	}
 
 	return dons, nil
+}
+
+func (m DonsMetadata) ShardingDONs() ([]*DonMetadata, error) {
+	// don't use flag b/c may not be set
+	var dons []*DonMetadata
+	for _, don := range m.dons {
+		if don.IsShardDON() {
+			dons = append(dons, don)
+		}
+	}
+
+	if len(dons) == 0 {
+		return nil, fmt.Errorf("no dons with flag %s found", ShardDON)
+	}
+
+	return dons, nil
+}
+
+func (m DonsMetadata) ShardLeaderDON() (*DonMetadata, error) {
+	for _, don := range m.dons {
+		if don.IsShardDON() && don.IsShardLeader() {
+			return don, nil
+		}
+	}
+
+	return nil, errors.New("no shard leader DON found")
+}
+
+func (m DonsMetadata) ShardingEnabled() bool {
+	for _, don := range m.dons {
+		if don.IsShardDON() {
+			return true
+		}
+	}
+	return false
 }
 
 func (m DonsMetadata) GatewayEnabled() bool {
@@ -961,6 +1030,9 @@ type NodeSet struct {
 	SupportedSolChains []string `toml:"supported_sol_chains"` // sol chain IDs that the DON supports
 	// Merged list of global and chain-specific capabilities. The latter ones are transformed to the format "capability-chainID", e.g. "evm-1337" for the evm capability on chain 1337.
 	ComputedCapabilities []string `toml:"computed_capabilities"`
+
+	ExposesRemoteCapabilities bool `toml:"exposes_remote_capabilities"`
+	ShardIndex                uint `toml:"shard_index"`
 }
 
 func (c *NodeSet) Flags() []string {

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -831,13 +831,31 @@ func (m DonsMetadata) validate() error {
 	}
 
 	if m.ShardingEnabled() {
-		leadersFound := 0
+		var shardIndexes []uint
 		for _, don := range m.dons {
-			if don.IsShardDON() && don.IsShardLeader() {
-				leadersFound++
+			if don.IsShardDON() {
+				shardIndexes = append(shardIndexes, don.ShardIndex)
 			}
-			if leadersFound > 1 {
-				return errors.New("only one shard leader DON is allowed. Please update your TOML config and make sure there is only one DON with 'shard_index' equal to 0")
+		}
+
+		if len(shardIndexes) == 0 {
+			return errors.New("sharding is enabled but no shard DONs found")
+		}
+
+		slices.Sort(shardIndexes)
+
+		// Validate in a single pass: must start at 0, be sequential, and have no duplicates
+		for i, shardIdx := range shardIndexes {
+			expectedIdx := uint(i)
+
+			if shardIdx != expectedIdx {
+				if i > 0 && shardIdx == shardIndexes[i-1] {
+					return fmt.Errorf("found duplicate shard index %d. Each shard index must be unique", shardIdx)
+				}
+				if expectedIdx == 0 {
+					return errors.New("no shard leader DON found. Please update your TOML config and make sure there is one DON with 'shard_index' equal to 0")
+				}
+				return fmt.Errorf("shard indexes must be sequential starting from 0, but found index %d at position %d", shardIdx, i)
 			}
 		}
 	}
@@ -895,6 +913,11 @@ func (m DonsMetadata) ShardingDONs() ([]*DonMetadata, error) {
 	}
 
 	return dons, nil
+}
+
+func (m DonsMetadata) ShardCount() uint {
+	dons, _ := m.ShardingDONs()
+	return uint(len(dons))
 }
 
 func (m DonsMetadata) ShardLeaderDON() (*DonMetadata, error) {

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -830,16 +830,21 @@ func (m DonsMetadata) Bootstrap() (*NodeMetadata, bool) {
 	return nil, false
 }
 
-// WorkflowDON returns the DON with the WorkflowDON flag. Returns an error if
-// there is not exactly one such DON. Currently, the WorkflowDON flag is required on exactly one DON.
-func (m DonsMetadata) WorkflowDON() (*DonMetadata, error) {
+// WorkflowDONs returns the DONs with the WorkflowDON flag
+func (m DonsMetadata) WorkflowDONs() ([]*DonMetadata, error) {
 	// don't use flag b/c may not be set
+	var dons []*DonMetadata
 	for _, don := range m.dons {
 		if don.IsWorkflowDON() {
-			return don, nil
+			dons = append(dons, don)
 		}
 	}
-	return nil, fmt.Errorf("no dons with flag %s found", WorkflowDON)
+
+	if len(dons) == 0 {
+		return nil, fmt.Errorf("no dons with flag %s found", WorkflowDON)
+	}
+
+	return dons, nil
 }
 
 func (m DonsMetadata) GatewayEnabled() bool {

--- a/system-tests/lib/cre/workflow/workflow.go
+++ b/system-tests/lib/cre/workflow/workflow.go
@@ -288,7 +288,7 @@ func registerWorkflowV1(sc *seth.Client, workflowRegistryAddr common.Address, do
 }
 
 // deleteAllWorkflowsV2 removes all workflows for v2 registry contracts.
-func deleteAllWorkflowsV2(ctx context.Context, sc *seth.Client, workflowRegistryAddr common.Address, version *semver.Version) error {
+func deleteAllWorkflowsV2(_ context.Context, sc *seth.Client, workflowRegistryAddr common.Address, version *semver.Version) error {
 	// Create registry instance once for all operations
 	registry, err := getRegistryV2Instance(sc, workflowRegistryAddr, version)
 	if err != nil {
@@ -317,7 +317,7 @@ func deleteAllWorkflowsV2(ctx context.Context, sc *seth.Client, workflowRegistry
 }
 
 // deleteAllWorkflowsV1 removes all workflows for v1 registry contracts.
-func deleteAllWorkflowsV1(ctx context.Context, sc *seth.Client, workflowRegistryAddr common.Address) error {
+func deleteAllWorkflowsV1(_ context.Context, sc *seth.Client, workflowRegistryAddr common.Address) error {
 	// Create registry instance once for all operations
 	registry, err := createRegistryV1Instance(sc, workflowRegistryAddr)
 	if err != nil {
@@ -436,6 +436,15 @@ func getRegistryV2Instance(sc *seth.Client, workflowRegistryAddr common.Address,
 	if err != nil {
 		return nil, errors.Wrapf(err, errCreateContractInstance, "WorkflowRegistry", version)
 	}
+
+	// add contract ABI to Seth, so that it can decode transaction errors
+	abi, aErr := workflow_registry_wrapper_v2.WorkflowRegistryMetaData.GetAbi()
+	if aErr != nil {
+		return nil, fmt.Errorf("failed to get WorkflowRegistryV2 ABI: %w", aErr)
+	}
+
+	sc.ABIFinder.ContractStore.AddABI("WorkflowRegistryV2", *abi)
+
 	return registry, nil
 }
 
@@ -445,6 +454,15 @@ func createRegistryV1Instance(sc *seth.Client, workflowRegistryAddr common.Addre
 	if err != nil {
 		return nil, errors.Wrap(err, errCreateRegistryInstance)
 	}
+
+	// add contract ABI to Seth, so that it can decode transaction errors
+	abi, aErr := workflow_registry_wrapper.WorkflowRegistryMetaData.GetAbi()
+	if aErr != nil {
+		return nil, fmt.Errorf("failed to get WorkflowRegistryV1 ABI: %w", aErr)
+	}
+
+	sc.ABIFinder.ContractStore.AddABI("WorkflowRegistryV1", *abi)
+
 	return registry, nil
 }
 


### PR DESCRIPTION
As a prerequisite for testing sharding I have removed the limitation of having only one workflow DON.

This PR also adds a new DON type `shard`, which can be mixed with all the other existing types. 

It also adds two new parameter to nodesets:
- `shard_index` -- we require that index starts with 0 and is sequential
- `exposes_remote_capabilities` -- when set to `true` adds capabilities to the capability registry contract as **public**

If sharding is enabled we deploy Shard Config contract with initial shard count set to the number of sharding DONs.

Last, but not least, I added the ABI of workflow registry contract to Seth's contract store, so that it can decode transaction errors.

I have added new topology `core/scripts/cre/environment/configs/workflow-gateway-sharded-don.toml`, which has two shards. I have tested them with consensus v2 workflow and made sure both workflows executed it.