### PR TITLE
ci: backport tag signature bypass for 2.32.0 beta

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -55,11 +55,6 @@ jobs:
         uses: ./.github/actions/version-file-bump
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check Tag Signature
-        uses: smartcontractkit/.github/actions/check-if-verified@6319f88a06e307c360dff43c3ac25d0581894a75 # check-if-verified@1.0.0
-        with:
-          tag: ${{ github.ref_name }}
-          assert: true
 
   docker-core:
     needs: [checks]


### PR DESCRIPTION
Backport of #20750 (merge 5c2b0fb) to unblock 2.32.0 beta image build. Approved by Security in #20750.