### PR TITLE
feat: update standalone engine to take workflow limit settings

### DIFF
--- a/core/services/workflows/cmd/cre/main.go
+++ b/core/services/workflows/cmd/cre/main.go
@@ -10,6 +10,9 @@ import (
 
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/settings"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
+
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/cmd/cre/utils"
 )
@@ -23,6 +26,7 @@ func main() {
 		enableBeholder             bool
 		enableBilling              bool
 		enableStandardCapabilities bool
+		enableAllChains            bool
 	)
 
 	flag.StringVar(&wasmPath, "wasm", "", "Path to the WASM binary file")
@@ -32,6 +36,7 @@ func main() {
 	flag.BoolVar(&enableBeholder, "beholder", false, "Enable printing beholder messages to standard log")
 	flag.BoolVar(&enableBilling, "billing", false, "Enable to run a faked billing service that prints to the standard log.")
 	flag.BoolVar(&enableStandardCapabilities, "standardCapabilities", true, "Enable to use the latest production standard capability binaries for capabilities. The binaries must be available in local GOBIN.")
+	flag.BoolVar(&enableAllChains, "allChains", false, "Enable all chains in the workflow execution (for testing purposes).")
 	flag.Parse()
 
 	if wasmPath == "" {
@@ -81,5 +86,11 @@ func main() {
 		EnableBeholder:             enableBeholder,
 		EnableStandardCapabilities: enableStandardCapabilities,
 		Lggr:                       lggr,
+		WorkflowSettingsCfgFn: func(cfg *cresettings.Workflows) {
+			cfg.ChainAllowed = settings.PerChainSelector(
+				settings.Bool(enableAllChains),
+				map[string]bool{},
+			)
+		},
 	})
 }

--- a/core/services/workflows/cmd/cre/utils/runner.go
+++ b/core/services/workflows/cmd/cre/utils/runner.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
 	v2 "github.com/smartcontractkit/chainlink/v2/core/services/workflows/v2"
@@ -22,6 +23,7 @@ type RunnerConfig struct {
 	EnableStandardCapabilities bool
 	Lggr                       logger.Logger
 	LifecycleHooks             v2.LifecycleHooks
+	WorkflowSettingsCfgFn      func(*cresettings.Workflows)
 }
 
 type RunnerHooks struct {
@@ -148,7 +150,7 @@ func (r *Runner) Run(
 		billingAddress = "localhost:4319"
 	}
 
-	engine, triggerSub, err := NewStandaloneEngine(ctx, cfg.Lggr, registry, binary, config, secrets, billingAddress, cfg.LifecycleHooks, workflowName)
+	engine, triggerSub, err := NewStandaloneEngine(ctx, cfg.Lggr, registry, binary, config, secrets, billingAddress, cfg.LifecycleHooks, workflowName, cfg.WorkflowSettingsCfgFn)
 	if err != nil {
 		fmt.Printf("Failed to create engine: %v\n", err)
 		os.Exit(1)

--- a/core/services/workflows/cmd/cre/utils/standalone_engine.go
+++ b/core/services/workflows/cmd/cre/utils/standalone_engine.go
@@ -19,6 +19,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host"
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
@@ -60,6 +61,7 @@ func NewStandaloneEngine(
 	billingClientAddr string,
 	lifecycleHooks v2.LifecycleHooks,
 	workflowName string,
+	workflowSettingsCfgFn func(*cresettings.Workflows),
 ) (services.Service, []*sdkpb.TriggerSubscription, error) {
 	ctx = contexts.WithCRE(ctx, contexts.CRE{Owner: defaultOwner, Workflow: defaultWorkflowID})
 	labeler := custmsg.NewLabeler()
@@ -86,7 +88,7 @@ func NewStandaloneEngine(
 	}
 
 	lf := limits.Factory{Logger: logger.Named(lggr, "Limits")}
-	limiters, err := v2.NewLimiters(lf, nil)
+	limiters, err := v2.NewLimiters(lf, workflowSettingsCfgFn)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
[DEVSVCS-3469](https://smartcontract-it.atlassian.net/browse/DEVSVCS-3469)

This pull request adds support for enabling all chains during workflow execution using standalone engine. It introduces a new command-line flag and propagates the configuration through the workflow runner and engine setup, allowing the workflow to permit all chains when the flag is set. This is now required since https://github.com/smartcontractkit/chainlink/pull/20548

**Feature: Enable all chains for workflow execution**
- Added a new `--allChains` flag to the `cre` command-line tool, allowing users to enable all chains during workflow execution for testing purposes. [[1]](diffhunk://#diff-1e8e67df7dafe165bc749baf51eac07f67ead958be44e8abb3d00451fe2b1253R29) [[2]](diffhunk://#diff-1e8e67df7dafe165bc749baf51eac07f67ead958be44e8abb3d00451fe2b1253R39)
- Passed the new flag's value via the `WorkflowSettingsCfgFn` function through the runner and engine setup to configure per-chain settings accordingly. [[1]](diffhunk://#diff-1e8e67df7dafe165bc749baf51eac07f67ead958be44e8abb3d00451fe2b1253R89-R94) [[2]](diffhunk://#diff-a4bc79f41517e3b2dba5ba0a35e3140900689b79730fd356d2386cf964657577R26) [[3]](diffhunk://#diff-a4bc79f41517e3b2dba5ba0a35e3140900689b79730fd356d2386cf964657577L151-R153) [[4]](diffhunk://#diff-08ecf2c143679e5a797c13e6c7dafd2fdf8da89366c6d2f6a97794081f4c8ab5R64)
- Allow Standalone Engine to be instantiated with AllowedChains config as desired. Allows the simulator in cre-cli to continue to work with chainlink dep update.

**Internal: Dependency and configuration propagation**
- Updated imports to include `cresettings` and related settings packages in relevant files to support the new configuration logic. [[1]](diffhunk://#diff-1e8e67df7dafe165bc749baf51eac07f67ead958be44e8abb3d00451fe2b1253R13-R15) [[2]](diffhunk://#diff-a4bc79f41517e3b2dba5ba0a35e3140900689b79730fd356d2386cf964657577R10) [[3]](diffhunk://#diff-08ecf2c143679e5a797c13e6c7dafd2fdf8da89366c6d2f6a97794081f4c8ab5R22)
- Modified the engine initialization to accept and utilize the `WorkflowSettingsCfgFn` for setting up chain permissions, ensuring that the `--allChains` flag is respected during workflow execution.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
- https://github.com/smartcontractkit/cre-cli/pull/218


[DEVSVCS-3469]: https://smartcontract-it.atlassian.net/browse/DEVSVCS-3469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ