### PR TITLE
Don2don trigger capability errors spike

### DIFF
--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -522,6 +522,7 @@ func (w *launcher) addRemoteCapability(ctx context.Context, cid string, capabili
 					"", // empty method name for v1
 					w.dispatcher,
 					w.lggr,
+					0, // Increase this to enable registration response handling
 				)
 				w.cachedShims.triggerSubscribers[shimKey] = triggerCap
 			}
@@ -905,7 +906,8 @@ func (w *launcher) addRemoteCapabilityV2(ctx context.Context, capID string, meth
 		if config.RemoteTriggerConfig != nil { // trigger
 			sub, alreadyExists := w.cachedShims.triggerSubscribers[shimKey]
 			if !alreadyExists {
-				sub = remote.NewTriggerSubscriber(capID, method, w.dispatcher, w.lggr)
+				sub = remote.NewTriggerSubscriber(capID, method, w.dispatcher, w.lggr,
+					0) // Increase this to enable registration response handling
 				cc.SetTriggerSubscriber(method, sub)
 				// add to cachedShims later, only after startNewShim succeeds
 			}

--- a/core/capabilities/remote/log/log.go
+++ b/core/capabilities/remote/log/log.go
@@ -1,0 +1,26 @@
+package log
+
+import (
+	"encoding/hex"
+	"unicode"
+)
+
+// TODO this is duplicated from utils to minimise the PR changeset - will be deduped later
+
+const (
+	maxLoggedStringLen = 256
+)
+
+func SanitizeLogString(s string) string {
+	tooLongSuffix := ""
+	if len(s) > maxLoggedStringLen {
+		s = s[:maxLoggedStringLen]
+		tooLongSuffix = " [TRUNCATED]"
+	}
+	for i := 0; i < len(s); i++ {
+		if !unicode.IsPrint(rune(s[i])) {
+			return "[UNPRINTABLE] " + hex.EncodeToString([]byte(s)) + tooLongSuffix
+		}
+	}
+	return s + tooLongSuffix
+}

--- a/core/capabilities/remote/messagecache/message_cache.go
+++ b/core/capabilities/remote/messagecache/message_cache.go
@@ -43,31 +43,33 @@ func (c *MessageCache[EventID, PeerID]) Insert(eventID EventID, peerID PeerID, t
 // received more recently than <minTimestamp>.
 // Return all messages that satisfy the above condition.
 // Ready() will return true at most once per event if <once> is true.
-func (c *MessageCache[EventID, PeerID]) Ready(eventID EventID, minCount uint32, minTimestamp int64, once bool) (bool, [][]byte) {
+func (c *MessageCache[EventID, PeerID]) Ready(eventID EventID, minCount uint32, minTimestamp int64, once bool) (bool, []PeerID, [][]byte) {
 	ev, ok := c.events[eventID]
 	if !ok {
-		return false, nil
+		return false, nil, nil
 	}
 	if ev.wasReady && once {
-		return false, nil
+		return false, nil, nil
 	}
 	//nolint:gosec // G115
 	if uint32(len(ev.peerMsgs)) < minCount {
-		return false, nil
+		return false, nil, nil
 	}
 	countAboveMinTimestamp := uint32(0)
+	var peers []PeerID
 	accPayloads := [][]byte{}
-	for _, msg := range ev.peerMsgs {
+	for peer, msg := range ev.peerMsgs {
 		if msg.timestamp >= minTimestamp {
 			countAboveMinTimestamp++
 			accPayloads = append(accPayloads, msg.payload)
+			peers = append(peers, peer)
 		}
 	}
 	if countAboveMinTimestamp >= minCount {
 		ev.wasReady = true
-		return true, accPayloads
+		return true, peers, accPayloads
 	}
-	return false, nil
+	return false, nil, nil
 }
 
 func (c *MessageCache[EventID, PeerID]) Delete(eventID EventID) {

--- a/core/capabilities/remote/messagecache/message_cache_test.go
+++ b/core/capabilities/remote/messagecache/message_cache_test.go
@@ -22,24 +22,26 @@ func TestMessageCache_InsertReady(t *testing.T) {
 	// not ready with one message
 	ts := cache.Insert(eventID1, peerID1, 100, []byte(payloadA))
 	require.Equal(t, int64(100), ts)
-	ready, _ := cache.Ready(eventID1, 2, 100, true)
+	ready, _, _ := cache.Ready(eventID1, 2, 100, true)
 	require.False(t, ready)
 
 	// not ready with two messages but only one fresh enough
 	ts = cache.Insert(eventID1, peerID2, 200, []byte(payloadA))
 	require.Equal(t, int64(100), ts)
-	ready, _ = cache.Ready(eventID1, 2, 150, true)
+	ready, _, _ = cache.Ready(eventID1, 2, 150, true)
 	require.False(t, ready)
 
 	// ready with two messages (once only)
-	ready, messages := cache.Ready(eventID1, 2, 100, true)
+	ready, _, messages := cache.Ready(eventID1, 2, 100, true)
 	require.True(t, ready)
 	require.Equal(t, []byte(payloadA), messages[0])
 	require.Equal(t, []byte(payloadA), messages[1])
 
 	// not ready again for the same event ID
-	ready, _ = cache.Ready(eventID1, 2, 100, true)
+	ready, _, _ = cache.Ready(eventID1, 2, 100, true)
 	require.False(t, ready)
+	
+	// TODO add peers check here
 }
 
 func TestMessageCache_DeleteOlderThan(t *testing.T) {

--- a/core/capabilities/remote/trigger/registration/publisher_registration.go
+++ b/core/capabilities/remote/trigger/registration/publisher_registration.go
@@ -1,0 +1,233 @@
+package registration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+
+	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
+)
+
+const messageCacheKey = "publisher_registration"
+
+type PublisherRegistration struct {
+	lggr logger.Logger
+
+	wg     sync.WaitGroup
+	stopCh services.StopChan
+
+	sendToDispatcher func(peerID p2ptypes.PeerID, msgBody *types.MessageBody) error
+
+	triggerID       string
+	workflowID      string
+	capabilityID    string
+	capabilityDonID uint32
+
+	underlyingTrigger commoncap.TriggerCapability
+
+	eventForwardingChannel               chan commoncap.TriggerResponse
+	underlyingTriggerRegistrationRequest commoncap.TriggerRegistrationRequest
+
+	peerRequestsCache *messagecache.MessageCache[string, p2ptypes.PeerID]
+
+	registrationRequests map[p2ptypes.PeerID]uint32
+
+	registrationStatus       types.RegistrationStatus
+	registrationErrorMessage string
+
+	createdAt time.Time
+}
+
+func NewPublisherRegistration(lggr logger.Logger,
+	underlying commoncap.TriggerCapability, // This is passed in and not read from dynamic config, reading from dynamic config introduces the possibility that
+// the registration would register on a different underlying trigger than it unregisters from, this is a bug in the legacy code.
+// If the underlying trigger changes, then this would take effect on a new registration only, that is to say the existing registration
+// would need to be allowed to expire, this is the same behaviour as the legacy code.
+	triggerID string,
+	workflowID string,
+	capabilityID string,
+	sendToDispatcher func(peerID p2ptypes.PeerID, msgBody *types.MessageBody) error) *PublisherRegistration {
+
+	return &PublisherRegistration{
+		lggr:                   lggr,
+		stopCh:                 make(services.StopChan),
+		underlyingTrigger:      underlying,
+		registrationRequests:   make(map[p2ptypes.PeerID]uint32),
+		triggerID:              triggerID,
+		workflowID:             workflowID,
+		capabilityID:           capabilityID,
+		sendToDispatcher:       sendToDispatcher,
+		peerRequestsCache:      messagecache.NewMessageCache[string, p2ptypes.PeerID](),
+		eventForwardingChannel: make(chan commoncap.TriggerResponse),
+		createdAt:              time.Now(),
+		registrationStatus:     types.RegistrationStatus_UNREGISTERED,
+	}
+}
+
+func (pr *PublisherRegistration) EventChannel() <-chan commoncap.TriggerResponse {
+	return pr.eventForwardingChannel
+}
+
+// IsLive determines whether the publisher registration is considered live based on whether sufficient
+// registration requests have been received recently from peers in the caller DON.
+func (pr *PublisherRegistration) IsLive(registrationExpiry time.Duration, callerDon commoncap.DON) bool {
+
+	// If it's still unregistered after registrationExpiry from creation time, it is considered to be dead
+	if pr.registrationStatus == types.RegistrationStatus_UNREGISTERED {
+		if time.Since(pr.createdAt) > registrationExpiry {
+			return false
+		}
+	}
+
+	now := time.Now().UnixMilli()
+	ready, _, _ := pr.peerRequestsCache.Ready(messageCacheKey, uint32(2*callerDon.F+1), now-registrationExpiry.Milliseconds(), false)
+	return ready
+}
+
+func (pr *PublisherRegistration) AddRegistrationRequest(ctx context.Context, sender p2ptypes.PeerID, rawRequest []byte,
+	callerDon commoncap.DON, registrationExpiry time.Duration) {
+	nowMs := time.Now().UnixMilli()
+	// First remote any expired messages from the cache, the cache is not expected to be large so this is acceptable
+	// and uses no more resource that the ready call in this case so need to clean-up on a background goroutine.
+	pr.peerRequestsCache.DeleteOlderThan(nowMs - registrationExpiry.Milliseconds())
+
+	// Record the request to ensure liveness of the registration
+
+	pr.peerRequestsCache.Insert(messageCacheKey, sender, nowMs, rawRequest)
+
+	// If registration is already successful, send a status update immediately
+	if pr.registrationStatus == types.RegistrationStatus_REGISTERED {
+		pr.lggr.Debugw("already registered on trigger", "workflowId", pr.workflowID)
+		pr.sendTriggerRegistrationStatus(sender, callerDon.ID)
+		return
+	}
+
+	// Retry registration if not yet successful - in the case where registration fails it means each request from each calling
+	// capability peer will result in a re-registration attempt (assuming sufficient requests have been received to aggregate)
+	// This is the same behaviour as the legacy code.  TODO Possible we may want limit this.
+
+	// NOTE: require 2F+1 by default, introduce different strategies later (KS-76)
+	minRequired := uint32(2*callerDon.F + 1)
+	ready, requestingPeers, payloads := pr.peerRequestsCache.Ready(messageCacheKey, minRequired, nowMs-registrationExpiry.Milliseconds(), false)
+	if !ready {
+		pr.lggr.Debugw("not ready to aggregate yet", "workflowId", pr.workflowID, "minRequired", minRequired)
+		return
+	}
+	aggregated, err := aggregation.AggregateModeRaw(payloads, uint32(callerDon.F+1))
+	if err != nil {
+		pr.lggr.Errorw("failed to aggregate trigger registrations", "workflowId", pr.workflowID, "err", err)
+		return
+	}
+	unmarshalled, err := pb.UnmarshalTriggerRegistrationRequest(aggregated)
+	if err != nil {
+		pr.lggr.Errorw("failed to unmarshal request", "err", err)
+		return
+	}
+
+	callbackCh, err := pr.underlyingTrigger.RegisterTrigger(ctx, unmarshalled)
+	registrationStatus := types.RegistrationStatus_REGISTERED
+	var errMsg string
+	if err != nil {
+		registrationStatus = types.RegistrationStatus_REGISTRATION_ERROR
+		var capErr caperrors.Error
+		if errors.As(err, &capErr) {
+			errMsg = capErr.SerializeToRemoteString()
+		} else {
+			errMsg = caperrors.NewPublicSystemError(err, caperrors.Unknown).SerializeToRemoteString()
+		}
+		pr.lggr.Warnw("failed to register trigger", "workflowId", pr.workflowID, "err", err)
+	} else {
+		pr.forwardEvents(callbackCh)
+		pr.lggr.Debugw("updated trigger registration", "workflowId", pr.workflowID)
+	}
+
+	// If transitioning from unregistered send the status update all peers who requested registration thus far to ensure
+	// a timely response on initial registration.
+	sendToAllPeers := pr.registrationStatus == types.RegistrationStatus_UNREGISTERED
+
+	pr.registrationStatus = registrationStatus
+	pr.registrationErrorMessage = errMsg
+
+	if sendToAllPeers {
+		for _, peerID := range requestingPeers {
+			pr.sendTriggerRegistrationStatus(peerID, callerDon.ID)
+		}
+	} else {
+		// Send registration status only to the current requester
+		// Other peers will get an updated registration status when they re-request registration.
+		// The alternative would be to send the status to all requesting peers every time,
+		// but that could lead to a lot of duplicate messages being sent if registration keeps failing.
+		pr.sendTriggerRegistrationStatus(sender, callerDon.ID)
+	}
+}
+
+func (pr *PublisherRegistration) forwardEvents(eventsCh <-chan commoncap.TriggerResponse) {
+	pr.wg.Add(1)
+	go func() {
+		defer pr.wg.Done()
+		for {
+			select {
+			case <-pr.stopCh:
+				return
+			case event, ok := <-eventsCh:
+				if !ok {
+					close(pr.eventForwardingChannel)
+					return
+				}
+				select {
+				case pr.eventForwardingChannel <- event:
+				case <-pr.stopCh:
+					return
+				}
+			}
+		}
+	}()
+}
+
+func (pr *PublisherRegistration) Close(ctx context.Context) error {
+	close(pr.stopCh)
+	pr.wg.Wait()
+
+	if pr.registrationStatus == types.RegistrationStatus_REGISTERED {
+		unregisterErr := pr.underlyingTrigger.UnregisterTrigger(ctx, pr.underlyingTriggerRegistrationRequest)
+		if unregisterErr != nil {
+			return fmt.Errorf("failed to unregister from underlying trigger, workflow ID %s, trigger ID %s: %w",
+				pr.workflowID, pr.triggerID, unregisterErr)
+		}
+	}
+
+	return nil
+}
+
+// sendTriggerRegistrationStatus sends a trigger registration response back to the caller DON with an optional error message
+func (pr *PublisherRegistration) sendTriggerRegistrationStatus(peerID p2ptypes.PeerID, callerDonID uint32) {
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    pr.capabilityID,
+		CapabilityDonId: pr.capabilityDonID,
+		CallerDonId:     callerDonID,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:         pr.triggerID,
+				WorkflowId:        pr.workflowID,
+				RegistrationError: pr.registrationErrorMessage,
+				Status:            pr.registrationStatus,
+			},
+		},
+	}
+	err := pr.sendToDispatcher(peerID, registrationResponseMessage)
+	if err != nil {
+		pr.lggr.Errorw("failed to send trigger registration response", "peerID", peerID, "err", err)
+	}
+}

--- a/core/capabilities/remote/trigger/registration/publisher_registration_test.go
+++ b/core/capabilities/remote/trigger/registration/publisher_registration_test.go
@@ -1,0 +1,425 @@
+package registration_test
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	//"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/trigger/registration"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	p2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
+)
+
+type testTriggerCapability struct {
+	err error
+}
+
+var _ commoncap.TriggerCapability = (*testTriggerCapability)(nil)
+
+func (t *testTriggerCapability) Info(ctx context.Context) (commoncap.CapabilityInfo, error) {
+	return commoncap.CapabilityInfo{
+		ID: "test-capability",
+	}, nil
+}
+
+func (t *testTriggerCapability) RegisterTrigger(ctx context.Context, req commoncap.TriggerRegistrationRequest) (<-chan commoncap.TriggerResponse, error) {
+	ch := make(chan commoncap.TriggerResponse, 1)
+	return ch, t.err
+}
+
+func (t *testTriggerCapability) UnregisterTrigger(ctx context.Context, req commoncap.TriggerRegistrationRequest) error {
+	return nil
+}
+
+type sendCall struct {
+	peerID p2ptypes.PeerID
+	msg    *types.MessageBody
+}
+
+func TestMultipleAddedRequests_SuccessfulTriggerRegistration(t *testing.T) {
+	// Test that when multiple requests are added to a PublisherRegistration,
+	// they all receive the same registration status update when the trigger is registered.
+
+	// Setup
+	lggr := logger.TestLogger(t)
+	triggerID := "test-trigger"
+	workflowID := "test-workflow"
+	capabilityID := "test-capability"
+
+	var sendCalls []sendCall
+	pr := registration.NewPublisherRegistration(lggr, &testTriggerCapability{err: nil}, triggerID, workflowID, capabilityID, func(peerID p2ptypes.PeerID, msgBody *types.MessageBody) error {
+		sendCalls = append(sendCalls, sendCall{peerID, msgBody})
+		return nil
+	})
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+
+	request := commoncap.TriggerRegistrationRequest{
+		TriggerID: triggerID,
+	}
+
+	rawRequest, err := pb.MarshalTriggerRegistrationRequest(request)
+	require.NoError(t, err)
+
+	// Add multiple requests
+	peerID1 := peers[0]
+	peerID2 := peers[1]
+
+	callerDon := commoncap.DON{
+		ID: 1,
+	}
+
+	registrationExpiry := 10 * time.Minute
+
+	pr.AddRegistrationRequest(context.Background(), peerID1, rawRequest, callerDon, registrationExpiry)
+	pr.AddRegistrationRequest(context.Background(), peerID2, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to each peer
+	require.Len(t, sendCalls, 2)
+
+	foundPeer1 := false
+	foundPeer2 := false
+	for _, call := range sendCalls {
+		require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+		meta := call.msg.GetTriggerRegistrationMetadata()
+		require.Equal(t, types.RegistrationStatus_REGISTERED, meta.Status)
+		require.Equal(t, triggerID, meta.TriggerId)
+		if call.peerID == peerID1 {
+			foundPeer1 = true
+		} else if call.peerID == peerID2 {
+			foundPeer2 = true
+		}
+	}
+
+	require.True(t, foundPeer1, "did not find message sent to peerID1")
+	require.True(t, foundPeer2, "did not find message sent to peerID2")
+
+	// Send an additional registration request after trigger registration has already completed, expect to get immediate response to the new peer
+	peerID3 := peers[2]
+	pr.AddRegistrationRequest(context.Background(), peerID3, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to the new peer
+	require.Len(t, sendCalls, 3)
+
+	foundPeer3 := false
+	for _, call := range sendCalls {
+		if call.peerID == peerID3 {
+			foundPeer3 = true
+			require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+			meta := call.msg.GetTriggerRegistrationMetadata()
+			require.Equal(t, types.RegistrationStatus_REGISTERED, meta.Status)
+			require.Equal(t, triggerID, meta.TriggerId)
+		}
+	}
+
+	require.True(t, foundPeer3, "did not find message sent to peerID3")
+}
+
+func TestMultipleAddedRequests_TriggerRegistrationError(t *testing.T) {
+	// Test that when multiple requests are added to a PublisherRegistration,
+	// they all receive the same error response when the trigger registration fails.
+
+	// Setup
+	lggr := logger.TestLogger(t)
+	triggerID := "test-trigger"
+	workflowID := "test-workflow"
+	capabilityID := "test-capability"
+
+	var sendCalls []sendCall
+
+	pr := registration.NewPublisherRegistration(lggr, &testTriggerCapability{err: errors.New("its borken")}, triggerID, workflowID, capabilityID, func(peerID p2ptypes.PeerID, msgBody *types.MessageBody) error {
+		sendCalls = append(sendCalls, sendCall{peerID, msgBody})
+		return nil
+	})
+
+	peers := make([]p2ptypes.PeerID, 4)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+
+	request := commoncap.TriggerRegistrationRequest{
+		TriggerID: triggerID,
+	}
+
+	rawRequest, err := pb.MarshalTriggerRegistrationRequest(request)
+	require.NoError(t, err)
+
+	// Add multiple requests
+	peerID1 := peers[0]
+	peerID2 := peers[1]
+
+	callerDon := commoncap.DON{
+		ID: 1,
+	}
+
+	registrationExpiry := 10 * time.Minute
+
+	pr.AddRegistrationRequest(context.Background(), peerID1, rawRequest, callerDon, registrationExpiry)
+	pr.AddRegistrationRequest(context.Background(), peerID2, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to each peer
+	require.Len(t, sendCalls, 2)
+
+	foundPeer1 := false
+	foundPeer2 := false
+	for _, call := range sendCalls {
+		require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+		meta := call.msg.GetTriggerRegistrationMetadata()
+		require.Equal(t, types.RegistrationStatus_REGISTRATION_ERROR, meta.Status)
+		require.Equal(t, triggerID, meta.TriggerId)
+		caperror := caperrors.DeserializeErrorFromString(meta.RegistrationError)
+		require.Equal(t, caperrors.Unknown, caperror.Code())
+		require.Equal(t, caperrors.OriginSystem, caperror.Origin())
+		require.Equal(t, caperrors.VisibilityPublic, caperror.Visibility())
+		require.Equal(t, "[2]Unknown: its borken", caperror.Error())
+		if call.peerID == peerID1 {
+			foundPeer1 = true
+		} else if call.peerID == peerID2 {
+			foundPeer2 = true
+		}
+	}
+
+	require.True(t, foundPeer1, "did not find message sent to peerID1")
+	require.True(t, foundPeer2, "did not find message sent to peerID2")
+
+	// Send an additional registration request after trigger registration has already completed with error, expect to get immediate error response to the new peer
+	peerID3 := peers[2]
+
+	pr.AddRegistrationRequest(context.Background(), peerID3, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to the new peer
+	require.Len(t, sendCalls, 3)
+
+	foundPeer3 := false
+	for _, call := range sendCalls {
+		if call.peerID == peerID3 {
+			foundPeer3 = true
+			require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+			meta := call.msg.GetTriggerRegistrationMetadata()
+			require.Equal(t, types.RegistrationStatus_REGISTRATION_ERROR, meta.Status)
+			require.Equal(t, triggerID, meta.TriggerId)
+			caperror := caperrors.DeserializeErrorFromString(meta.RegistrationError)
+			require.Equal(t, caperrors.Unknown, caperror.Code())
+			require.Equal(t, caperrors.OriginSystem, caperror.Origin())
+			require.Equal(t, caperrors.VisibilityPublic, caperror.Visibility())
+			require.Equal(t, "[2]Unknown: its borken", caperror.Error())
+
+			require.Equal(t, triggerID, meta.TriggerId)
+		}
+	}
+
+	require.True(t, foundPeer3, "did not find message sent to peerID3")
+}
+
+func TestMultipleAddedRequests_TriggerRegistrationCapabilityUserError(t *testing.T) {
+	// Test that when multiple requests are added to a PublisherRegistration,
+	// they all receive the same error response when the trigger registration fails.
+
+	// Setup
+	lggr := logger.TestLogger(t)
+	triggerID := "test-trigger"
+	workflowID := "test-workflow"
+	capabilityID := "test-capability"
+
+	var sendCalls []sendCall
+
+	pr := registration.NewPublisherRegistration(lggr, &testTriggerCapability{err: caperrors.NewPublicUserError(errors.New("its borken"), caperrors.InvalidArgument)}, triggerID, workflowID, capabilityID, func(peerID p2ptypes.PeerID, msgBody *types.MessageBody) error {
+		sendCalls = append(sendCalls, sendCall{peerID, msgBody})
+		return nil
+	})
+
+	peers := make([]p2ptypes.PeerID, 4)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+
+	request := commoncap.TriggerRegistrationRequest{
+		TriggerID: triggerID,
+	}
+
+	rawRequest, err := pb.MarshalTriggerRegistrationRequest(request)
+	require.NoError(t, err)
+
+	// Add multiple requests
+	peerID1 := peers[0]
+	peerID2 := peers[1]
+
+	callerDon := commoncap.DON{
+		ID: 1,
+	}
+
+	registrationExpiry := 10 * time.Minute
+
+	pr.AddRegistrationRequest(context.Background(), peerID1, rawRequest, callerDon, registrationExpiry)
+	pr.AddRegistrationRequest(context.Background(), peerID2, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to each peer
+	require.Len(t, sendCalls, 2)
+
+	foundPeer1 := false
+	foundPeer2 := false
+	for _, call := range sendCalls {
+		require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+		meta := call.msg.GetTriggerRegistrationMetadata()
+		require.Equal(t, types.RegistrationStatus_REGISTRATION_ERROR, meta.Status)
+		require.Equal(t, triggerID, meta.TriggerId)
+		caperror := caperrors.DeserializeErrorFromString(meta.RegistrationError)
+		require.Equal(t, caperrors.InvalidArgument, caperror.Code())
+		require.Equal(t, caperrors.OriginUser, caperror.Origin())
+		require.Equal(t, caperrors.VisibilityPublic, caperror.Visibility())
+		require.Equal(t, "[3]InvalidArgument: its borken", caperror.Error())
+		if call.peerID == peerID1 {
+			foundPeer1 = true
+		} else if call.peerID == peerID2 {
+			foundPeer2 = true
+		}
+	}
+
+	require.True(t, foundPeer1, "did not find message sent to peerID1")
+	require.True(t, foundPeer2, "did not find message sent to peerID2")
+
+	// Send an additional registration request after trigger registration has already completed with error, expect to get immediate error response to the new peer
+	peerID3 := peers[2]
+
+	pr.AddRegistrationRequest(context.Background(), peerID3, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to the new peer
+	require.Len(t, sendCalls, 3)
+
+	foundPeer3 := false
+	for _, call := range sendCalls {
+		if call.peerID == peerID3 {
+			foundPeer3 = true
+			require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+			meta := call.msg.GetTriggerRegistrationMetadata()
+			require.Equal(t, types.RegistrationStatus_REGISTRATION_ERROR, meta.Status)
+			require.Equal(t, triggerID, meta.TriggerId)
+			caperror := caperrors.DeserializeErrorFromString(meta.RegistrationError)
+			require.Equal(t, caperrors.InvalidArgument, caperror.Code())
+			require.Equal(t, caperrors.OriginUser, caperror.Origin())
+			require.Equal(t, caperrors.VisibilityPublic, caperror.Visibility())
+			require.Equal(t, "[3]InvalidArgument: its borken", caperror.Error())
+
+			require.Equal(t, triggerID, meta.TriggerId)
+		}
+	}
+
+	require.True(t, foundPeer3, "did not find message sent to peerID3")
+}
+
+func TestMultipleAddedRequests_TriggerRegistrationInitiallyErrorsThenRecovers(t *testing.T) {
+	// Test that when multiple requests are added to a PublisherRegistration,
+	// they all receive the same error response when the trigger registration fails.
+
+	// Setup
+	lggr := logger.TestLogger(t)
+	triggerID := "test-trigger"
+	workflowID := "test-workflow"
+	capabilityID := "test-capability"
+
+	var sendCalls []sendCall
+
+	testCapability := &testTriggerCapability{err: errors.New("its borken")}
+	pr := registration.NewPublisherRegistration(lggr, testCapability, triggerID, workflowID, capabilityID, func(peerID p2ptypes.PeerID, msgBody *types.MessageBody) error {
+		sendCalls = append(sendCalls, sendCall{peerID, msgBody})
+		return nil
+	})
+
+	peers := make([]p2ptypes.PeerID, 4)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+
+	request := commoncap.TriggerRegistrationRequest{
+		TriggerID: triggerID,
+	}
+
+	rawRequest, err := pb.MarshalTriggerRegistrationRequest(request)
+	require.NoError(t, err)
+
+	// Add multiple requests
+	peerID1 := peers[0]
+	peerID2 := peers[1]
+
+	callerDon := commoncap.DON{
+		ID: 1,
+	}
+
+	registrationExpiry := 10 * time.Minute
+
+	pr.AddRegistrationRequest(context.Background(), peerID1, rawRequest, callerDon, registrationExpiry)
+	pr.AddRegistrationRequest(context.Background(), peerID2, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to each peer
+	require.Len(t, sendCalls, 2)
+
+	foundPeer1 := false
+	foundPeer2 := false
+	for _, call := range sendCalls {
+		require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+		meta := call.msg.GetTriggerRegistrationMetadata()
+		require.Equal(t, types.RegistrationStatus_REGISTRATION_ERROR, meta.Status)
+		require.Equal(t, triggerID, meta.TriggerId)
+		caperror := caperrors.DeserializeErrorFromString(meta.RegistrationError)
+		require.Equal(t, caperrors.Unknown, caperror.Code())
+		require.Equal(t, caperrors.OriginSystem, caperror.Origin())
+		require.Equal(t, caperrors.VisibilityPublic, caperror.Visibility())
+		require.Equal(t, "[2]Unknown: its borken", caperror.Error())
+		if call.peerID == peerID1 {
+			foundPeer1 = true
+		} else if call.peerID == peerID2 {
+			foundPeer2 = true
+		}
+	}
+
+	require.True(t, foundPeer1, "did not find message sent to peerID1")
+	require.True(t, foundPeer2, "did not find message sent to peerID2")
+
+	// Now update the test capability to succeed
+	testCapability.err = nil
+	// Send another registration request to trigger re-registration, expect it to return success
+	peerID3 := peers[2]
+
+	pr.AddRegistrationRequest(context.Background(), peerID3, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to the new peer
+	require.Len(t, sendCalls, 3)
+
+	foundPeer3 := false
+	for _, call := range sendCalls {
+		if call.peerID == peerID3 {
+			foundPeer3 = true
+			require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+			meta := call.msg.GetTriggerRegistrationMetadata()
+			require.Equal(t, types.RegistrationStatus_REGISTERED, meta.Status)
+			require.Equal(t, "", meta.RegistrationError)
+			require.Equal(t, triggerID, meta.TriggerId)
+		}
+	}
+
+	require.True(t, foundPeer3, "did not find message sent to peerID3")
+
+	// Resend a request from peerID1 to confirm it now also gets success response
+	pr.AddRegistrationRequest(context.Background(), peerID1, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to peerID1 again
+	require.Len(t, sendCalls, 4)
+
+	call := sendCalls[3]
+	if call.peerID == peerID1 {
+		require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+		meta := call.msg.GetTriggerRegistrationMetadata()
+		require.Equal(t, types.RegistrationStatus_REGISTERED, meta.Status)
+		require.Equal(t, "", meta.RegistrationError)
+		require.Equal(t, triggerID, meta.TriggerId)
+	}
+}

--- a/core/capabilities/remote/trigger/registration/subscriber_registration.go
+++ b/core/capabilities/remote/trigger/registration/subscriber_registration.go
@@ -1,0 +1,191 @@
+package registration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/log"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	p2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
+)
+
+const (
+	// This default is taken from the legacy code, it is the buffer size of the channel
+	sendChannelBufferSize = 1000
+)
+
+const registrationStatusUpdateCacheKey = "publisher_registration"
+
+type SubscriberRegistration struct {
+	lggr              logger.Logger
+	triggerResponseCh chan commoncap.TriggerResponse
+	rawRequest        []byte
+
+	registrationStatusUpdateCache *messagecache.MessageCache[string, p2ptypes.PeerID]
+
+	statusMutex        sync.RWMutex
+	registrationStatus types.RegistrationStatus
+	registrationError  caperrors.Error
+
+	// Used to signal that this subscription is no longer waiting for the initial registration response
+	initialRegistrationResponseChan chan struct{}
+}
+
+func NewSubscriberRegistration(lggr logger.Logger, rawRequest []byte) *SubscriberRegistration {
+	return &SubscriberRegistration{
+		lggr:                            lggr,
+		triggerResponseCh:               make(chan commoncap.TriggerResponse, sendChannelBufferSize),
+		rawRequest:                      rawRequest,
+		registrationStatusUpdateCache:   messagecache.NewMessageCache[string, p2ptypes.PeerID](),
+		initialRegistrationResponseChan: make(chan struct{}),
+	}
+}
+
+func (sr *SubscriberRegistration) HandleTriggerRegistrationStatusUpdate(sender p2ptypes.PeerID, msg *types.MessageBody, minResponseToAggregate uint32,
+	registrationExpiry time.Duration, publisherNodeCount int) {
+	nowMs := time.Now().UnixMilli()
+	// First remove any expired messages from the cache, the cache is not expected to be large so this is acceptable
+	// and uses no more resource that the ready call in this case so need to clean-up on a background goroutine.
+	sr.registrationStatusUpdateCache.DeleteOlderThan(nowMs - registrationExpiry.Milliseconds())
+
+	meta := msg.GetTriggerRegistrationMetadata()
+	if meta == nil {
+		sr.lggr.Errorw("received trigger registration status update message with invalid trigger metadata", "sender", sender)
+		return
+	}
+
+	if meta.Status == types.RegistrationStatus_REGISTRATION_ERROR {
+		sr.registrationStatusUpdateCache.Insert(registrationStatusUpdateCacheKey, sender, nowMs, []byte(meta.RegistrationError))
+	} else {
+		sr.registrationStatusUpdateCache.Insert(registrationStatusUpdateCacheKey, sender, nowMs, nil)
+	}
+
+	ready, _, registrationResponses := sr.registrationStatusUpdateCache.Ready(registrationStatusUpdateCacheKey, minResponseToAggregate, nowMs-registrationExpiry.Milliseconds(), false)
+
+	if ready {
+		var successfulRegistrationCount uint32
+		var totalErrorCount int
+
+		// aggregate errors by message
+		errorToCount := map[string]int{}
+		for _, responseError := range registrationResponses {
+			if len(responseError) > 0 {
+				errorStr := string(responseError)
+				errorToCount[errorStr] = errorToCount[errorStr] + 1
+				totalErrorCount++
+			} else {
+				successfulRegistrationCount++
+			}
+		}
+
+		if successfulRegistrationCount >= minResponseToAggregate {
+			// Successful registration
+			sr.lggr.Infow("successful trigger registration", "triggerID", meta.TriggerId, "sender", sender)
+			sr.setRegistrationStatus(types.RegistrationStatus_REGISTERED, nil)
+		} else {
+
+			errStrs := make([]string, 0, len(errorToCount))
+			for errStr := range errorToCount {
+				errStrs = append(errStrs, errStr)
+			}
+			sort.Strings(errStrs)
+
+			// Registration failed - set error response
+			// Is there a consensus error?  if so set that
+			lastErr := ""
+
+			for _, errStr := range errStrs {
+				count := errorToCount[errStr]
+				if uint32(count) >= minResponseToAggregate {
+					caperr := caperrors.DeserializeErrorFromString(errStr)
+					sr.setRegistrationStatus(types.RegistrationStatus_REGISTRATION_ERROR, caperr)
+					return
+				}
+
+				lastErr = errStr
+			}
+
+			// The check on when to give up waiting for minResponseToAggregate identical errors assumes that all received
+			// errors so far, and any future that will be received are and will be distinct.  It's the same logic
+			// used to aggregate errors for remote executable capabilities.  For the purposes of error handling it is
+			// sufficient.
+			if totalErrorCount >= publisherNodeCount-int(minResponseToAggregate)+1 {
+				// There is no consensus error, return a generic error message
+				sr.setRegistrationStatus(types.RegistrationStatus_REGISTRATION_ERROR,
+					caperrors.NewPublicSystemError(fmt.Errorf("received %d errors, last error %s : %s", totalErrorCount, msg.Error, log.SanitizeLogString(lastErr)), caperrors.Unknown))
+			}
+		}
+	}
+}
+
+func (sr *SubscriberRegistration) GetTriggerResponseChannel() chan commoncap.TriggerResponse {
+	return sr.triggerResponseCh
+}
+
+// TerminatedBeforeRegistrationUpdate is returned when the call terminates before registration status update.
+var TerminatedBeforeRegistrationUpdate = errors.New("terminated before before registration status update")
+
+// AwaitRegistration waits for the registration until the context is cancelled.  Returns nil if registration is
+// successful, returns a capability error if registration failed.
+// If the context is done before registration completes, TerminatedBeforeRegistrationUpdate is returned.
+func (sr *SubscriberRegistration) AwaitRegistration(ctx context.Context, maxWaitTime time.Duration) error {
+	ctx, cancelFn := context.WithTimeout(ctx, maxWaitTime)
+	defer cancelFn()
+
+	registrationStatus, registrationErr := sr.getRegistrationStatus()
+	if registrationStatus == types.RegistrationStatus_REGISTERED {
+		return nil
+	} else if registrationStatus == types.RegistrationStatus_REGISTRATION_ERROR {
+		return registrationErr
+	} else {
+		// Wait for registration to complete
+		select {
+		case <-ctx.Done():
+			return TerminatedBeforeRegistrationUpdate
+		case <-sr.initialRegistrationResponseChan:
+			_, registrationErr = sr.getRegistrationStatus()
+			return registrationErr
+		}
+	}
+}
+
+func (sr *SubscriberRegistration) setRegistrationStatus(status types.RegistrationStatus, registrationError caperrors.Error) {
+	sr.statusMutex.Lock()
+	defer sr.statusMutex.Unlock()
+	if sr.registrationStatus == types.RegistrationStatus_UNREGISTERED && status != types.RegistrationStatus_UNREGISTERED {
+		// Signal that the initial registration response is ready
+		close(sr.initialRegistrationResponseChan)
+	}
+	sr.registrationStatus = status
+	sr.registrationError = registrationError
+}
+
+func (sr *SubscriberRegistration) getRegistrationStatus() (types.RegistrationStatus, caperrors.Error) {
+	sr.statusMutex.RLock()
+	defer sr.statusMutex.RUnlock()
+	return sr.registrationStatus, sr.registrationError
+}
+
+func (sr *SubscriberRegistration) UpdateRegistrationRequest(rawRequest []byte) {
+	sr.rawRequest = rawRequest
+}
+
+func (sr *SubscriberRegistration) GetRawRequest() []byte {
+	return sr.rawRequest
+}
+
+func (sr *SubscriberRegistration) SendAggregatedEvent(aggregatedEvent commoncap.TriggerResponse) {
+	sr.triggerResponseCh <- aggregatedEvent
+}
+
+func (sr *SubscriberRegistration) Close() {
+	close(sr.triggerResponseCh)
+}

--- a/core/capabilities/remote/trigger/registration/subscriber_registration_test.go
+++ b/core/capabilities/remote/trigger/registration/subscriber_registration_test.go
@@ -1,0 +1,268 @@
+package registration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/trigger/registration"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	p2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
+)
+
+const (
+	peerID1 = "12D3KooWF3dVeJ6YoT5HFnYhmwQWWMoEwVFzJQ5kKCMX3ZityxMC"
+	peerID2 = "12D3KooWQsmok6aD8PZqt3RnJhQRrNzKHLficq7zYFRp7kZ1hHP8"
+	peerID3 = "12D3KooWPumsXxg6mJ4hmRizjBD7oFMtN9vm3kTwN8BLEinyDPJS"
+	peerID4 = "12D3KooWNuumb38Jpw6DoRbgwejcZYwfsWbbzPU4fWy5imrW3dyD"
+)
+
+func TestSubscriberRegistration_SuccessfulRegistration(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"))
+
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:  "w1t1",
+				WorkflowId: "w1",
+				Status:     types.RegistrationStatus_REGISTERED,
+			},
+		},
+	}
+
+	go func() {
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 1)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[1], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[2], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+	}()
+
+	err := reg.AwaitRegistration(ctx, 10*time.Minute)
+	require.NoError(t, err)
+
+	// Ensure that the second wait for response returns immediately
+	err = reg.AwaitRegistration(ctx, 10*time.Minute)
+	require.NoError(t, err)
+
+	require.NotNil(t, reg.GetTriggerResponseChannel())
+}
+
+func TestSubscriberRegistration_ZeroTimeout(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	// Zero timeout indicates the caller does not want to wait for a registration status update
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"))
+
+	err := reg.AwaitRegistration(ctx, 0)
+
+	require.ErrorIs(t, err, registration.TerminatedBeforeRegistrationUpdate)
+}
+
+func TestSubscriberRegistration_UnsuccessfulRegistration_SameError(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"))
+
+	errMsg := "its broken"
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:         "w1t1",
+				WorkflowId:        "w1",
+				Status:            types.RegistrationStatus_REGISTRATION_ERROR,
+				RegistrationError: errMsg,
+			},
+		},
+	}
+
+	go func() {
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 1)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[1], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[2], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+	}()
+
+	err := reg.AwaitRegistration(ctx, 10*time.Minute)
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "[2]Unknown: its broken")
+
+	// Ensure that the second wait for response returns immediately
+	err = reg.AwaitRegistration(ctx, 10*time.Minute)
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "[2]Unknown: its broken")
+}
+
+func TestSubscriberRegistration_UnsuccessfulRegistration_MixedErrors(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"))
+
+	errMsg1 := "its broken1"
+	errMsg2 := "its broken2"
+	errMsg3 := "its broken3"
+
+	go func() {
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 1)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], createRegisterResponseMessageWithError(errMsg1), minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[1], createRegisterResponseMessageWithError(errMsg2), minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[2], createRegisterResponseMessageWithError(errMsg3), minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+	}()
+
+	err := reg.AwaitRegistration(ctx, 10*time.Minute)
+	require.Error(t, err)
+	require.NotNil(t, reg.GetTriggerResponseChannel())
+	require.Contains(t, err.Error(), "[2]Unknown: received 3 errors, last error OK : its broken3")
+
+	// Ensure that the second wait for response returns immediately
+	err = reg.AwaitRegistration(ctx, 10*time.Minute)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "[2]Unknown: received 3 errors, last error OK : its broken3")
+}
+
+func createRegisterResponseMessageWithError(errMsg1 string) *types.MessageBody {
+	return &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:         "w1t1",
+				WorkflowId:        "w1",
+				Status:            types.RegistrationStatus_REGISTRATION_ERROR,
+				RegistrationError: errMsg1,
+			},
+		},
+	}
+}
+
+func TestSubscriberRegistration_Timesout(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"))
+
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:  "w1t1",
+				WorkflowId: "w1",
+				Status:     types.RegistrationStatus_REGISTERED,
+			},
+		},
+	}
+
+	go func() {
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 1)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+	}()
+
+	err := reg.AwaitRegistration(ctx, 1*time.Millisecond)
+	require.Error(t, err)
+	require.Equal(t, registration.TerminatedBeforeRegistrationUpdate, err)
+	require.NotNil(t, reg.GetTriggerResponseChannel())
+}
+
+func TestSubscriberRegistration_InsufficientResponses(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"))
+
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:  "w1t1",
+				WorkflowId: "w1",
+				Status:     types.RegistrationStatus_REGISTERED,
+			},
+		},
+	}
+
+	ctxWithCancel, cancel := context.WithCancel(ctx)
+
+	go func() {
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 1)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+
+		// Simulate insufficient responses by not sending the third response
+		// Cancel the context to simulate timeout or cancellation
+		cancel()
+	}()
+
+	err := reg.AwaitRegistration(ctxWithCancel, 10*time.Minute)
+	require.Equal(t, registration.TerminatedBeforeRegistrationUpdate, err)
+
+	require.Error(t, err)
+	require.NotNil(t, reg.GetTriggerResponseChannel())
+}

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -13,9 +13,8 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/trigger/registration"
 
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/validation"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
@@ -33,8 +32,7 @@ type triggerPublisher struct {
 	dispatcher    types.Dispatcher
 	cfg           atomic.Pointer[dynamicPublisherConfig]
 
-	messageCache  *messagecache.MessageCache[registrationKey, p2ptypes.PeerID]
-	registrations map[registrationKey]*pubRegState
+	registrations map[registrationKey]*registration.PublisherRegistration
 	mu            sync.RWMutex // protects messageCache and registrations
 	batchingQueue map[[32]byte]*batchedResponse
 	bqMu          sync.Mutex // protects batchingQueue
@@ -56,12 +54,6 @@ type registrationKey struct {
 	callerDonID uint32
 	workflowID  string
 	triggerID   string
-}
-
-type pubRegState struct {
-	callback <-chan commoncap.TriggerResponse
-	request  commoncap.TriggerRegistrationRequest
-	cancel   context.CancelFunc
 }
 
 type batchedResponse struct {
@@ -87,8 +79,7 @@ func NewTriggerPublisher(capabilityID string, capMethodName string, dispatcher t
 		capabilityID:  capabilityID,
 		capMethodName: capMethodName,
 		dispatcher:    dispatcher,
-		messageCache:  messagecache.NewMessageCache[registrationKey, p2ptypes.PeerID](),
-		registrations: make(map[registrationKey]*pubRegState),
+		registrations: make(map[registrationKey]*registration.PublisherRegistration),
 		batchingQueue: make(map[[32]byte]*batchedResponse),
 		stopCh:        make(services.StopChan),
 		lggr:          logger.With(logger.Named(lggr, "TriggerPublisher"), "capabilityID", capabilityID, "capMethodName", capMethodName),
@@ -203,47 +194,25 @@ func (p *triggerPublisher) Receive(_ context.Context, msg *types.MessageBody) {
 		}
 		p.lggr.Debugw("received trigger registration", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "sender", sender)
 		key := registrationKey{msg.CallerDonId, req.Metadata.WorkflowID, req.TriggerID}
-		nowMs := time.Now().UnixMilli()
 		p.mu.Lock()
 		defer p.mu.Unlock()
-		p.messageCache.Insert(key, sender, nowMs, msg.Payload)
-		_, exists := p.registrations[key]
-		if exists {
-			p.lggr.Debugw("trigger registration already exists", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
-			return
-		}
-		// NOTE: require 2F+1 by default, introduce different strategies later (KS-76)
-		minRequired := uint32(2*callerDon.F + 1)
-		ready, payloads := p.messageCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), false)
-		if !ready {
-			p.lggr.Debugw("not ready to aggregate yet", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "minRequired", minRequired)
-			return
-		}
-		aggregated, err := aggregation.AggregateModeRaw(payloads, uint32(callerDon.F+1))
-		if err != nil {
-			p.lggr.Errorw("failed to aggregate trigger registrations", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", err)
-			return
-		}
-		unmarshaled, err := pb.UnmarshalTriggerRegistrationRequest(aggregated)
-		if err != nil {
-			p.lggr.Errorw("failed to unmarshal request", "err", err)
-			return
-		}
-		ctx, cancel := p.stopCh.NewCtx()
-		callbackCh, err := cfg.underlying.RegisterTrigger(ctx, unmarshaled)
-		if err == nil {
-			p.registrations[key] = &pubRegState{
-				callback: callbackCh,
-				request:  unmarshaled,
-				cancel:   cancel,
-			}
+		reg, exists := p.registrations[key]
+		if !exists {
+			p.lggr.Debugw("creating new trigger registration", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
+			reg = registration.NewPublisherRegistration(p.lggr,
+				cfg.underlying,
+				req.TriggerID, req.Metadata.WorkflowID,
+				p.capabilityID, p.dispatcher.Send)
+
+			p.registrations[key] = reg
 			p.wg.Add(1)
-			go p.triggerEventLoop(callbackCh, key)
-			p.lggr.Debugw("updated trigger registration", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
+			go p.triggerEventLoop(reg.EventChannel(), key)
 		} else {
-			cancel()
-			p.lggr.Errorw("failed to register trigger", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", err)
+			p.lggr.Debugw("using existing trigger registration already exists", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
 		}
+
+		ctx, _ := p.stopCh.NewCtx() // TODO why does existing code use this context and not that received by Receive?
+		reg.AddRegistrationRequest(ctx, sender, msg.Payload, callerDon, cfg.remoteConfig.RegistrationExpiry)
 	case types.MethodTriggerEvent:
 		p.lggr.Errorw("trigger request failed with error",
 			"method", SanitizeLogString(msg.Method), "sender", sender, "errorMsg", SanitizeLogString(msg.ErrorMsg))
@@ -276,22 +245,18 @@ func (p *triggerPublisher) registrationCleanupLoop() {
 				cleanupInterval = cfg.remoteConfig.MessageExpiry
 				ticker.Reset(cleanupInterval)
 			}
-			now := time.Now().UnixMilli()
 
 			p.mu.Lock()
-			for key, req := range p.registrations {
+			for key, reg := range p.registrations {
 				callerDon := cfg.workflowDONs[key.callerDonID]
-				ready, _ := p.messageCache.Ready(key, uint32(2*callerDon.F+1), now-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), false)
-				if !ready {
+				if !reg.IsLive(cfg.remoteConfig.RegistrationExpiry, callerDon) {
 					p.lggr.Infow("trigger registration expired", "callerDonID", key.callerDonID, "workflowId", key.workflowID, "triggerID", key.triggerID)
 					ctx, cancel := p.stopCh.NewCtx()
-					err := cfg.underlying.UnregisterTrigger(ctx, req.request)
+					err := reg.Close(ctx)
 					cancel()
-					p.registrations[key].cancel() // Cancel context on register trigger
 					p.lggr.Infow("unregistered trigger", "callerDonID", key.callerDonID, "workflowId", key.workflowID, "triggerID", key.triggerID, "err", err)
 					// after calling UnregisterTrigger, the underlying trigger will not send any more events to the channel
 					delete(p.registrations, key)
-					p.messageCache.Delete(key)
 				}
 			}
 			p.mu.Unlock()
@@ -445,6 +410,17 @@ func (p *triggerPublisher) batchingLoop() {
 func (p *triggerPublisher) Close() error {
 	close(p.stopCh)
 	p.wg.Wait()
+
+	// Close all registrations
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, reg := range p.registrations {
+		err := reg.Close(context.Background())
+		if err != nil {
+			p.lggr.Errorw("error closing registration", "err", err)
+		}
+	}
+
 	p.lggr.Info("TriggerPublisher closed")
 	return nil
 }

--- a/core/capabilities/remote/trigger_publisher_test.go
+++ b/core/capabilities/remote/trigger_publisher_test.go
@@ -2,6 +2,7 @@ package remote_test
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
@@ -25,7 +27,7 @@ func TestTriggerPublisher_Register(t *testing.T) {
 	ctx := testutils.Context(t)
 	capabilityDONID, workflowDONID := uint32(1), uint32(2)
 
-	underlyingTriggerCap, publisher, _, peers := newServices(t, capabilityDONID, workflowDONID, 1)
+	underlyingTriggerCap, publisher, dispatcher, peers := newServices(t, capabilityDONID, workflowDONID, 1, 2, 0)
 
 	// invalid sender case - node 0 is not a member of the workflow DON, registration shoudn't happen
 	regEvent := newRegisterTriggerMessage(t, workflowDONID, peers[0])
@@ -33,6 +35,13 @@ func TestTriggerPublisher_Register(t *testing.T) {
 	require.Empty(t, underlyingTriggerCap.registrationsCh)
 
 	// valid registration
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Equal(t, peers[1], peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		require.Equal(t, remotetypes.Error_OK, msgBody.Error)
+		require.Equal(t, "", msgBody.ErrorMsg)
+	}).Return(nil)
+
 	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[1])
 	publisher.Receive(ctx, regEvent)
 	require.NotEmpty(t, underlyingTriggerCap.registrationsCh)
@@ -42,11 +51,140 @@ func TestTriggerPublisher_Register(t *testing.T) {
 	require.NoError(t, publisher.Close())
 }
 
+func TestTriggerPublisher_RegistrationResponse(t *testing.T) {
+	ctx := testutils.Context(t)
+	capabilityDONID, workflowDONID := uint32(1), uint32(2)
+
+	underlyingTriggerCap, publisher, dispatcher, peers := newServices(t, capabilityDONID, workflowDONID, 1, 8, 1)
+
+	// valid registration
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Equal(t, peers[1], peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		require.Equal(t, remotetypes.Error_OK, msgBody.Error)
+		require.Equal(t, "", msgBody.ErrorMsg)
+	}).Return(nil).Once()
+
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Equal(t, peers[3], peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		require.Equal(t, remotetypes.Error_OK, msgBody.Error)
+		require.Equal(t, "", msgBody.ErrorMsg)
+	}).Return(nil).Once()
+
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Equal(t, peers[5], peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		require.Equal(t, remotetypes.Error_OK, msgBody.Error)
+		require.Equal(t, "", msgBody.ErrorMsg)
+	}).Return(nil).Once()
+
+	regEvent := newRegisterTriggerMessage(t, workflowDONID, peers[1])
+	publisher.Receive(ctx, regEvent)
+	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[3])
+	publisher.Receive(ctx, regEvent)
+	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[5])
+	publisher.Receive(ctx, regEvent)
+
+	require.NotEmpty(t, underlyingTriggerCap.registrationsCh)
+	forwarded := <-underlyingTriggerCap.registrationsCh
+	require.Equal(t, workflowID1, forwarded.Metadata.WorkflowID)
+
+	// Simulate late registration by another peer, should still result in it receiving a response
+	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[7])
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Equal(t, peers[7], peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		require.Equal(t, remotetypes.Error_OK, msgBody.Error)
+		require.Equal(t, "", msgBody.ErrorMsg)
+	}).Return(nil).Once()
+	publisher.Receive(ctx, regEvent)
+
+	require.NoError(t, publisher.Close())
+}
+
+func TestTriggerPublisher_RegistrationResponse_WhenTriggerRegistrationFails(t *testing.T) {
+	ctx := testutils.Context(t)
+	capabilityDONID, workflowDONID := uint32(1), uint32(2)
+
+	capInfo := commoncap.CapabilityInfo{
+		ID:             capID,
+		CapabilityType: commoncap.CapabilityTypeTrigger,
+		Description:    "Remote Trigger",
+	}
+
+	underlying := &testTrigger{
+		info:              capInfo,
+		registrationsCh:   make(chan commoncap.TriggerRegistrationRequest, 2),
+		eventCh:           make(chan commoncap.TriggerResponse, 2),
+		registrationError: errors.New("registration error"),
+	}
+
+	_, publisher, dispatcher, peers := newServicesWithTrigger(t, capabilityDONID, workflowDONID, 1, 8, 1,
+		underlying, capInfo)
+
+	// valid registration
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Contains(t, []p2ptypes.PeerID{peers[1], peers[3], peers[5]}, peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+
+		caperr := caperrors.DeserializeErrorFromString(msgBody.GetTriggerRegistrationMetadata().RegistrationError)
+		require.Equal(t, caperrors.Unknown, caperr.Code())
+		require.Equal(t, caperrors.OriginSystem, caperr.Origin())
+		require.Equal(t, caperrors.VisibilityPublic, caperr.Visibility())
+		require.Equal(t, "[2]Unknown: registration error", caperr.Error())
+	}).Return(nil).Once()
+
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Contains(t, []p2ptypes.PeerID{peers[1], peers[3], peers[5]}, peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		caperr := caperrors.DeserializeErrorFromString(msgBody.GetTriggerRegistrationMetadata().RegistrationError)
+		require.Equal(t, caperrors.Unknown, caperr.Code())
+		require.Equal(t, caperrors.OriginSystem, caperr.Origin())
+		require.Equal(t, caperrors.VisibilityPublic, caperr.Visibility())
+		require.Equal(t, "[2]Unknown: registration error", caperr.Error())
+	}).Return(nil).Once()
+
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Contains(t, []p2ptypes.PeerID{peers[1], peers[3], peers[5]}, peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		caperr := caperrors.DeserializeErrorFromString(msgBody.GetTriggerRegistrationMetadata().RegistrationError)
+		require.Equal(t, caperrors.Unknown, caperr.Code())
+		require.Equal(t, caperrors.OriginSystem, caperr.Origin())
+		require.Equal(t, caperrors.VisibilityPublic, caperr.Visibility())
+		require.Equal(t, "[2]Unknown: registration error", caperr.Error())
+	}).Return(nil).Once()
+
+	regEvent := newRegisterTriggerMessage(t, workflowDONID, peers[1])
+	publisher.Receive(ctx, regEvent)
+	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[3])
+	publisher.Receive(ctx, regEvent)
+	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[5])
+	publisher.Receive(ctx, regEvent)
+
+	// Simulate late registration by another peer, should still result in it receiving an error response
+	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[7])
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Equal(t, peers[7], peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		caperr := caperrors.DeserializeErrorFromString(msgBody.GetTriggerRegistrationMetadata().RegistrationError)
+		require.Equal(t, caperrors.Unknown, caperr.Code())
+		require.Equal(t, caperrors.OriginSystem, caperr.Origin())
+		require.Equal(t, caperrors.VisibilityPublic, caperr.Visibility())
+		require.Equal(t, "[2]Unknown: registration error", caperr.Error())
+	}).Return(nil).Once()
+	publisher.Receive(ctx, regEvent)
+
+	require.NoError(t, publisher.Close())
+}
+
 func TestTriggerPublisher_ReceiveTriggerEvents_NoBatching(t *testing.T) {
 	ctx := testutils.Context(t)
 	capabilityDONID, workflowDONID := uint32(1), uint32(2)
 
-	underlyingTriggerCap, publisher, dispatcher, peers := newServices(t, capabilityDONID, workflowDONID, 1)
+	underlyingTriggerCap, publisher, dispatcher, peers := newServices(t, capabilityDONID, workflowDONID, 1, 2, 0)
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Return(nil).Once()
+
 	regEvent := newRegisterTriggerMessage(t, workflowDONID, peers[1])
 	publisher.Receive(ctx, regEvent)
 	require.NotEmpty(t, underlyingTriggerCap.registrationsCh)
@@ -66,8 +204,9 @@ func TestTriggerPublisher_ReceiveTriggerEvents_BatchingEnabled(t *testing.T) {
 	ctx := testutils.Context(t)
 	capabilityDONID, workflowDONID := uint32(1), uint32(2)
 
-	underlyingTriggerCap, publisher, dispatcher, peers := newServices(t, capabilityDONID, workflowDONID, 2)
+	underlyingTriggerCap, publisher, dispatcher, peers := newServices(t, capabilityDONID, workflowDONID, 2, 2, 0)
 	regEvent := newRegisterTriggerMessage(t, workflowDONID, peers[1])
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Return(nil).Once()
 	publisher.Receive(ctx, regEvent)
 	require.NotEmpty(t, underlyingTriggerCap.registrationsCh)
 
@@ -205,26 +344,59 @@ func TestTriggerPublisher_SetConfig_Basic(t *testing.T) {
 	})
 }
 
-func newServices(t *testing.T, capabilityDONID uint32, workflowDONID uint32, maxBatchSize uint32) (*testTrigger, remotetypes.ReceiverService, *mocks.Dispatcher, []p2ptypes.PeerID) {
-	lggr := logger.Test(t)
-	ctx := testutils.Context(t)
+func newServices(t *testing.T, capabilityDONID uint32, workflowDONID uint32, maxBatchSize uint32,
+	peerCount int, f uint8) (*testTrigger, remotetypes.ReceiverService, *mocks.Dispatcher, []p2ptypes.PeerID) {
+
 	capInfo := commoncap.CapabilityInfo{
 		ID:             capID,
 		CapabilityType: commoncap.CapabilityTypeTrigger,
 		Description:    "Remote Trigger",
 	}
-	peers := make([]p2ptypes.PeerID, 2)
+
+	underlying := &testTrigger{
+		info:            capInfo,
+		registrationsCh: make(chan commoncap.TriggerRegistrationRequest, 2),
+		eventCh:         make(chan commoncap.TriggerResponse, 2),
+	}
+
+	return newServicesWithTrigger(t, capabilityDONID, workflowDONID, maxBatchSize, peerCount, f, underlying, capInfo)
+}
+
+func newServicesWithTrigger(t *testing.T, capabilityDONID uint32, workflowDONID uint32, maxBatchSize uint32,
+	peerCount int, f uint8, underlying *testTrigger, capInfo commoncap.CapabilityInfo) (*testTrigger, remotetypes.ReceiverService, *mocks.Dispatcher, []p2ptypes.PeerID,
+) {
+	lggr := logger.Test(t)
+	ctx := testutils.Context(t)
+	peers := make([]p2ptypes.PeerID, 8)
 	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
 	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+	require.NoError(t, peers[4].UnmarshalText([]byte(peerID5)))
+	require.NoError(t, peers[5].UnmarshalText([]byte(peerID6)))
+	require.NoError(t, peers[6].UnmarshalText([]byte(peerID7)))
+	require.NoError(t, peers[7].UnmarshalText([]byte(peerID8)))
+
+	peers = peers[:peerCount]
+
+	// Split the peers between the capability DON and the workflow DON
+	capPeers := peers[:(peerCount+1)/2]
+	workflowPeers := peers[(peerCount+1)/2:]
+
+	for i := 0; i < (peerCount+1)/2; i = i + 2 {
+		capPeers[i] = peers[i]
+		workflowPeers[i] = peers[i+1]
+	}
+
 	capDonInfo := commoncap.DON{
 		ID:      capabilityDONID,
-		Members: []p2ptypes.PeerID{peers[0]}, // peer 0 is in the capability DON
-		F:       0,
+		Members: capPeers, // peer 0 is in the capability DON
+		F:       f,
 	}
 	workflowDonInfo := commoncap.DON{
 		ID:      workflowDONID,
-		Members: []p2ptypes.PeerID{peers[1]}, // peer 1 is in the workflow DON
-		F:       0,
+		Members: workflowPeers, // peer 1 is in the workflow DON
+		F:       f,
 	}
 
 	dispatcher := mocks.NewDispatcher(t)
@@ -239,11 +411,7 @@ func newServices(t *testing.T, capabilityDONID uint32, workflowDONID uint32, max
 	workflowDONs := map[uint32]commoncap.DON{
 		workflowDonInfo.ID: workflowDonInfo,
 	}
-	underlying := &testTrigger{
-		info:            capInfo,
-		registrationsCh: make(chan commoncap.TriggerRegistrationRequest, 2),
-		eventCh:         make(chan commoncap.TriggerResponse, 2),
-	}
+
 	publisher := remote.NewTriggerPublisher(capInfo.ID, "", dispatcher, lggr)
 	require.NoError(t, publisher.SetConfig(config, underlying, capDonInfo, workflowDONs))
 	require.NoError(t, publisher.Start(ctx))
@@ -268,9 +436,10 @@ func newRegisterTriggerMessage(t *testing.T, callerDonID uint32, sender p2ptypes
 }
 
 type testTrigger struct {
-	info            commoncap.CapabilityInfo
-	registrationsCh chan commoncap.TriggerRegistrationRequest
-	eventCh         chan commoncap.TriggerResponse
+	info              commoncap.CapabilityInfo
+	registrationsCh   chan commoncap.TriggerRegistrationRequest
+	eventCh           chan commoncap.TriggerResponse
+	registrationError error
 }
 
 func (tr *testTrigger) Info(_ context.Context) (commoncap.CapabilityInfo, error) {
@@ -278,6 +447,10 @@ func (tr *testTrigger) Info(_ context.Context) (commoncap.CapabilityInfo, error)
 }
 
 func (tr *testTrigger) RegisterTrigger(_ context.Context, request commoncap.TriggerRegistrationRequest) (<-chan commoncap.TriggerResponse, error) {
+	if tr.registrationError != nil {
+		return nil, tr.registrationError
+	}
+
 	tr.registrationsCh <- request
 	return tr.eventCh, nil
 }
@@ -329,6 +502,24 @@ func TestTriggerPublisher_MultipleTriggersSameWorkflow(t *testing.T) {
 	publisher := remote.NewTriggerPublisher(capInfo.ID, "", dispatcher, lggr)
 	require.NoError(t, publisher.SetConfig(config, underlying, capDonInfo, workflowDONs))
 	require.NoError(t, publisher.Start(ctx))
+
+	// Handle registration status update messages
+	dispatcher.On("Send", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		msg := args.Get(1).(*remotetypes.MessageBody)
+		require.Equal(t, capID, msg.CapabilityId)
+		require.Equal(t, remotetypes.TriggerRegistrationStatus, msg.Method)
+
+		metadata := msg.Metadata.(*remotetypes.MessageBody_TriggerRegistrationMetadata)
+		require.Equal(t, "trigger1", metadata.TriggerRegistrationMetadata.TriggerId)
+	}).Return(nil).Once()
+
+	dispatcher.On("Send", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		msg := args.Get(1).(*remotetypes.MessageBody)
+		require.Equal(t, capID, msg.CapabilityId)
+		require.Equal(t, remotetypes.TriggerRegistrationStatus, msg.Method)
+		metadata := msg.Metadata.(*remotetypes.MessageBody_TriggerRegistrationMetadata)
+		require.Equal(t, "trigger2", metadata.TriggerRegistrationMetadata.TriggerId)
+	}).Return(nil).Once()
 
 	// Register trigger1
 	regEvent1 := newRegisterTriggerMessageWithTriggerID(t, workflowDONID, peers[1], "trigger1")

--- a/core/capabilities/remote/trigger_subscriber.go
+++ b/core/capabilities/remote/trigger_subscriber.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/trigger/registration"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 )
@@ -23,6 +24,7 @@ import (
 // Its responsibilities are:
 //  1. Periodically refresh all registrations for remote triggers.
 //  2. Collect trigger events from remote nodes and aggregate responses via a customizable aggregator.
+//  3. Track the registration status for each workflow.
 //
 // TriggerSubscriber communicates with corresponding TriggerReceivers on remote nodes.
 type triggerSubscriber struct {
@@ -37,11 +39,16 @@ type triggerSubscriber struct {
 	//   - Better logging and debugging.
 	//   - Easier migration.
 	// workflowID -> triggerID -> subRegState
-	registeredWorkflows map[string]map[string]*subRegState
+	registeredWorkflows map[string]map[string]*registration.SubscriberRegistration
 	mu                  sync.RWMutex // protects registeredWorkflows and messageCache
 	stopCh              services.StopChan
 	wg                  sync.WaitGroup
 	lggr                logger.Logger
+
+	// How long to wait for registration status updates after initial registration
+	registrationStatusUpdateWaitTime time.Duration
+	// This channel is used to send initial registration requests immediately rather than waiting for the registration refresh cycle
+	initialRegistrationRequestCh chan *registration.SubscriberRegistration
 }
 
 type dynamicConfig struct {
@@ -59,11 +66,6 @@ type triggerEventKey struct {
 	triggerID      string
 }
 
-type subRegState struct {
-	callback   chan commoncap.TriggerResponse
-	rawRequest []byte
-}
-
 type TriggerSubscriber interface {
 	commoncap.TriggerCapability
 	Receive(ctx context.Context, msg *types.MessageBody)
@@ -76,19 +78,21 @@ var _ services.Service = &triggerSubscriber{}
 
 const (
 	// Engine reads trigger events without blocking and applies its own limits
-	sendChannelBufferSize = 1000
 	maxBatchedWorkflowIDs = 1000
 )
 
-func NewTriggerSubscriber(capabilityID string, capMethodName string, dispatcher types.Dispatcher, lggr logger.Logger) *triggerSubscriber {
+func NewTriggerSubscriber(capabilityID string, capMethodName string, dispatcher types.Dispatcher, lggr logger.Logger,
+	registrationStatusUpdateTimeout time.Duration) *triggerSubscriber {
 	return &triggerSubscriber{
-		capabilityID:        capabilityID,
-		capMethodName:       capMethodName,
-		dispatcher:          dispatcher,
-		messageCache:        messagecache.NewMessageCache[triggerEventKey, p2ptypes.PeerID](),
-		registeredWorkflows: make(map[string]map[string]*subRegState),
-		stopCh:              make(services.StopChan),
-		lggr:                logger.With(logger.Named(lggr, "TriggerSubscriber"), "capabilityID", capabilityID, "capMethodName", capMethodName),
+		capabilityID:                     capabilityID,
+		capMethodName:                    capMethodName,
+		dispatcher:                       dispatcher,
+		messageCache:                     messagecache.NewMessageCache[triggerEventKey, p2ptypes.PeerID](),
+		registrationStatusUpdateWaitTime: registrationStatusUpdateTimeout,
+		registeredWorkflows:              make(map[string]map[string]*registration.SubscriberRegistration),
+		stopCh:                           make(services.StopChan),
+		lggr:                             logger.With(logger.Named(lggr, "TriggerSubscriber"), "capabilityID", capabilityID, "capMethodName", capMethodName),
+		initialRegistrationRequestCh:     make(chan *registration.SubscriberRegistration),
 	}
 }
 
@@ -150,26 +154,47 @@ func (s *triggerSubscriber) RegisterTrigger(ctx context.Context, request commonc
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.lggr.Infow("RegisterTrigger called", "donId", cfg.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID, "triggerID", request.TriggerID)
 	triggerMap, ok := s.registeredWorkflows[request.Metadata.WorkflowID]
 	if !ok {
-		triggerMap = make(map[string]*subRegState)
+		triggerMap = make(map[string]*registration.SubscriberRegistration)
 		s.registeredWorkflows[request.Metadata.WorkflowID] = triggerMap
 	}
-	regState, ok := triggerMap[request.TriggerID]
-	if !ok {
-		regState = &subRegState{
-			callback:   make(chan commoncap.TriggerResponse, sendChannelBufferSize),
-			rawRequest: rawRequest,
-		}
-		triggerMap[request.TriggerID] = regState
+	reg, existingRegistration := triggerMap[request.TriggerID]
+	if !existingRegistration {
+		reg = registration.NewSubscriberRegistration(s.lggr, rawRequest)
+		triggerMap[request.TriggerID] = reg
 	} else {
-		regState.rawRequest = rawRequest
+		reg.UpdateRegistrationRequest(rawRequest)
 		s.lggr.Warnw("RegisterTrigger re-registering trigger", "donId", cfg.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID, "triggerID", request.TriggerID)
 	}
+	s.mu.Unlock()
 
-	return regState.callback, nil
+	if existingRegistration {
+		return reg.GetTriggerResponseChannel(), nil
+	} else {
+		// Send the first registration request immediately, do not wait for the registration refresh cycle
+		s.initialRegistrationRequestCh <- reg
+
+		// Await registration with timeout - it is not guaranteed that registration will complete
+		// as may be running against a legacy remote capability that does not support registration status updates.
+		regErr := reg.AwaitRegistration(ctx, s.registrationStatusUpdateWaitTime)
+
+		if errors.Is(regErr, registration.TerminatedBeforeRegistrationUpdate) {
+			// AwaitRegistration returned before registration completed, could be running against a legacy remote capability
+			// that does not support registration status updates.  Just return the response channel and nil error.
+			s.lggr.Warnw("no registration update received after wait, returning response channel anyway", "registrationStatusUpdateWaitTime", s.registrationStatusUpdateWaitTime, "donId", cfg.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID)
+			return reg.GetTriggerResponseChannel(), nil
+		}
+
+		// Return the response channel even if the error is non nil, the caller
+		// can still read from the channel to get any events that may come in later if the registration eventually succeeds.
+		// The caller has the option to handle the error as they see fit.  (for example a user capability error may be reason
+		// to terminate the workflow as the trigger will never work, but a transient network error may be retried later, or
+		// it may just be that different errors stats are updated to better differentiate alerts).
+		return reg.GetTriggerResponseChannel(), regErr
+	}
+
 }
 
 func (s *triggerSubscriber) registrationLoop() {
@@ -182,6 +207,9 @@ func (s *triggerSubscriber) registrationLoop() {
 		select {
 		case <-s.stopCh:
 			return
+		case reg := <-s.initialRegistrationRequestCh:
+			cfg := s.cfg.Load()
+			s.sendRegistrationRequestToCapabilityDon(cfg, reg)
 		case <-ticker.C:
 			cfg := s.cfg.Load()
 			if cfg.remoteConfig.RegistrationRefresh != tickerDuration {
@@ -196,24 +224,28 @@ func (s *triggerSubscriber) registrationLoop() {
 			}
 
 			for _, regMap := range s.registeredWorkflows {
-				for _, registration := range regMap {
-					for _, peerID := range cfg.capDonInfo.Members {
-						m := &types.MessageBody{
-							CapabilityId:     cfg.capInfo.ID,
-							CapabilityDonId:  cfg.capDonInfo.ID,
-							CallerDonId:      cfg.localDonID,
-							Method:           types.MethodRegisterTrigger,
-							Payload:          registration.rawRequest, // triggerID is in the raw request
-							CapabilityMethod: s.capMethodName,
-						}
-						err := s.dispatcher.Send(peerID, m)
-						if err != nil {
-							s.lggr.Errorw("failed to send message", "donId", cfg.capDonInfo.ID, "peerId", peerID, "err", err)
-						}
-					}
+				for _, reg := range regMap {
+					s.sendRegistrationRequestToCapabilityDon(cfg, reg)
 				}
 			}
 			s.mu.RUnlock()
+		}
+	}
+}
+
+func (s *triggerSubscriber) sendRegistrationRequestToCapabilityDon(cfg *dynamicConfig, reg *registration.SubscriberRegistration) {
+	for _, peerID := range cfg.capDonInfo.Members {
+		m := &types.MessageBody{
+			CapabilityId:     cfg.capInfo.ID,
+			CapabilityDonId:  cfg.capDonInfo.ID,
+			CallerDonId:      cfg.localDonID,
+			Method:           types.MethodRegisterTrigger,
+			Payload:          reg.GetRawRequest(),
+			CapabilityMethod: s.capMethodName,
+		}
+		err := s.dispatcher.Send(peerID, m)
+		if err != nil {
+			s.lggr.Errorw("failed to send message", "donId", cfg.capDonInfo.ID, "peerId", peerID, "err", err)
 		}
 	}
 }
@@ -226,9 +258,9 @@ func (s *triggerSubscriber) UnregisterTrigger(ctx context.Context, request commo
 	if !ok {
 		return nil
 	}
-	state := triggerMap[request.TriggerID]
-	if state != nil && state.callback != nil {
-		close(state.callback)
+	reg := triggerMap[request.TriggerID]
+	if reg != nil {
+		reg.Close()
 	}
 	delete(triggerMap, request.TriggerID)
 	if len(triggerMap) == 0 {
@@ -272,7 +304,7 @@ func (s *triggerSubscriber) Receive(_ context.Context, msg *types.MessageBody) {
 			}
 			s.mu.RLock()
 			triggerMap, found := s.registeredWorkflows[workflowID]
-			var registration *subRegState
+			var registration *registration.SubscriberRegistration
 			if found {
 				if triggerID != "" {
 					// received a message from updated publisher, which provided a triggerID
@@ -301,7 +333,7 @@ func (s *triggerSubscriber) Receive(_ context.Context, msg *types.MessageBody) {
 			nowMs := time.Now().UnixMilli()
 			s.mu.Lock()
 			creationTs := s.messageCache.Insert(key, sender, nowMs, msg.Payload)
-			ready, payloads := s.messageCache.Ready(key, cfg.remoteConfig.MinResponsesToAggregate, nowMs-cfg.remoteConfig.MessageExpiry.Milliseconds(), true)
+			ready, _, payloads := s.messageCache.Ready(key, cfg.remoteConfig.MinResponsesToAggregate, nowMs-cfg.remoteConfig.MessageExpiry.Milliseconds(), true)
 			s.mu.Unlock()
 			s.lggr.Debugw("trigger event received", "triggerEventId", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID, "sender", sender, "ready", ready, "nowTs", nowMs, "creationTs", creationTs, "minResponsesToAggregate", cfg.remoteConfig.MinResponsesToAggregate)
 			if ready {
@@ -311,9 +343,32 @@ func (s *triggerSubscriber) Receive(_ context.Context, msg *types.MessageBody) {
 					continue
 				}
 				s.lggr.Infow("remote trigger event aggregated", "triggerEventID", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID)
-				registration.callback <- aggregatedResponse
+				registration.SendAggregatedEvent(aggregatedResponse)
 			}
 		}
+	} else if msg.Method == types.TriggerRegistrationStatus {
+		meta := msg.GetTriggerRegistrationMetadata()
+		if meta == nil {
+			s.lggr.Errorw("received trigger registration status message with nil trigger registration metadata", "sender", sender)
+			return
+		}
+		s.mu.RLock()
+
+		triggerMap, ok := s.registeredWorkflows[meta.WorkflowId]
+		if !ok {
+			triggerMap = make(map[string]*registration.SubscriberRegistration)
+			s.registeredWorkflows[meta.WorkflowId] = triggerMap
+		}
+		reg, found := triggerMap[meta.TriggerId]
+		s.mu.RUnlock()
+
+		if !found {
+			s.lggr.Warnw("received trigger registration status message for unregistered workflow", "workflowID", SanitizeLogString(meta.WorkflowId), "triggerID", SanitizeLogString(meta.TriggerId), "sender", sender)
+			return
+		}
+
+		reg.HandleTriggerRegistrationStatusUpdate(sender, msg, cfg.remoteConfig.MinResponsesToAggregate, cfg.remoteConfig.MessageExpiry,
+			len(cfg.capDonInfo.Members))
 	} else {
 		s.lggr.Errorw("received trigger event with unknown method", "method", SanitizeLogString(msg.Method), "sender", sender, "err", SanitizeLogString(msg.ErrorMsg))
 	}

--- a/core/capabilities/remote/trigger_subscriber_test.go
+++ b/core/capabilities/remote/trigger_subscriber_test.go
@@ -23,6 +23,12 @@ import (
 const (
 	peerID1     = "12D3KooWF3dVeJ6YoT5HFnYhmwQWWMoEwVFzJQ5kKCMX3ZityxMC"
 	peerID2     = "12D3KooWQsmok6aD8PZqt3RnJhQRrNzKHLficq7zYFRp7kZ1hHP8"
+	peerID3     = "12D3KooWPumsXxg6mJ4hmRizjBD7oFMtN9vm3kTwN8BLEinyDPJS"
+	peerID4     = "12D3KooWNuumb38Jpw6DoRbgwejcZYwfsWbbzPU4fWy5imrW3dyD"
+	peerID5     = "12D3KooWJNVGd4gur9H2uKMkRo6hvh17ktvg7dqvRx8YELTA4Bfo"
+	peerID6     = "12D3KooWPt1fVrGxeqG1FNZTvw6UNM85eGURr1PiNUsSAyFEvzQn"
+	peerID7     = "12D3KooWGG7xBVQZyBdXXCYemByedzey14KXEkVfLorX74p598qa"
+	peerID8     = "12D3KooWPH2jfCUd9rVh8TtvFeyQWfSosUnwmUdNN4iapMXSXs5d"
 	workflowID1 = "15c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0"
 )
 
@@ -50,7 +56,7 @@ func TestTriggerSubscriber_RegisterAndReceive(t *testing.T) {
 		MinResponsesToAggregate: 1,
 		MessageExpiry:           100 * time.Second,
 	}
-	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, 0)
 	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
 	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
 	require.NoError(t, subscriber.Start(t.Context()))
@@ -61,7 +67,7 @@ func TestTriggerSubscriber_RegisterAndReceive(t *testing.T) {
 		},
 	}
 	triggerEventCallbackCh, err := subscriber.RegisterTrigger(t.Context(), req)
-	require.NoError(t, err)
+
 	t.Cleanup(func() {
 		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), req))
 		// calling UnregisterTrigger repeatedly is safe
@@ -99,7 +105,7 @@ func TestTriggerSubscriber_CorrectEventExpiryCheck(t *testing.T) {
 		MinResponsesToAggregate: 2,
 		MessageExpiry:           10 * time.Second,
 	}
-	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, 0)
 	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
 	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
 
@@ -110,7 +116,6 @@ func TestTriggerSubscriber_CorrectEventExpiryCheck(t *testing.T) {
 		},
 	}
 	triggerEventCallbackCh, err := subscriber.RegisterTrigger(t.Context(), regReq)
-	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), regReq))
 		require.NoError(t, subscriber.Close())
@@ -152,7 +157,7 @@ func TestTriggerSubscriber_SetConfig_Basic(t *testing.T) {
 
 	t.Run("returns error when capability info ID doesn't match subscriber's ID", func(t *testing.T) {
 		dispatcher := remoteMocks.NewDispatcher(t)
-		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, 0)
 		config := &commoncap.RemoteTriggerConfig{}
 		mismatchedCapInfo := commoncap.CapabilityInfo{ID: "different_id", CapabilityType: commoncap.CapabilityTypeTrigger}
 		err := subscriber.SetConfig(config, mismatchedCapInfo, workflowDon.ID, capDon, agg)
@@ -164,7 +169,7 @@ func TestTriggerSubscriber_SetConfig_Basic(t *testing.T) {
 
 	t.Run("returns error when aggregator is nil", func(t *testing.T) {
 		dispatcher := remoteMocks.NewDispatcher(t)
-		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, 0)
 		config := &commoncap.RemoteTriggerConfig{}
 		err := subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, nil)
 		require.Error(t, err)
@@ -173,7 +178,7 @@ func TestTriggerSubscriber_SetConfig_Basic(t *testing.T) {
 
 	t.Run("updates existing config", func(t *testing.T) {
 		dispatcher := remoteMocks.NewDispatcher(t)
-		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, 0)
 		// Set initial config
 		initialConfig := &commoncap.RemoteTriggerConfig{
 			RegistrationRefresh:     100 * time.Millisecond,
@@ -198,7 +203,7 @@ func TestTriggerSubscriber_SetConfig_Basic(t *testing.T) {
 	})
 	t.Run("handles nil initial config", func(t *testing.T) {
 		dispatcher := remoteMocks.NewDispatcher(t)
-		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, 0)
 		// Set initial config as nil
 		err := subscriber.SetConfig(nil, capInfo, workflowDon.ID, capDon, agg)
 		require.NoError(t, err)
@@ -238,7 +243,7 @@ func TestTriggerSubscriber_RegistrationLoopWithConfigUpdate(t *testing.T) {
 		MinResponsesToAggregate: 1,
 		MessageExpiry:           100 * time.Second,
 	}
-	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, 0)
 	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
 
 	// Call SetConfig() with workflowDON ID = 1 and register trigger
@@ -279,6 +284,55 @@ func TestTriggerSubscriber_RegistrationLoopWithConfigUpdate(t *testing.T) {
 	require.NoError(t, subscriber.Close())
 }
 
+func TestTriggerSubscriber_RegisterAndReceiveHappensImmediatelyOnFirstRegistration(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+	capInfo, capDon, workflowDon := buildTwoTestDONs(t, 1, 1)
+	dispatcher := remoteMocks.NewDispatcher(t)
+	awaitRegistrationMessageCh := make(chan struct{})
+	dispatcher.On("Send", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		select {
+		case awaitRegistrationMessageCh <- struct{}{}:
+		default:
+		}
+	})
+
+	// register trigger
+	config := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Minute, // Set high to avoid refresh during test
+		RegistrationExpiry:      100 * time.Second,
+		MinResponsesToAggregate: 1,
+		MessageExpiry:           100 * time.Second,
+	}
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, 0)
+	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
+	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
+	require.NoError(t, subscriber.Start(t.Context()))
+
+	req := commoncap.TriggerRegistrationRequest{
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+	triggerEventCallbackCh, err := subscriber.RegisterTrigger(t.Context(), req)
+
+	t.Cleanup(func() {
+		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), req))
+		// calling UnregisterTrigger repeatedly is safe
+		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), req))
+		require.NoError(t, subscriber.Close())
+	})
+	<-awaitRegistrationMessageCh
+
+	// receive trigger event
+	triggerEventValue, err := values.NewMap(triggerEvent1)
+	require.NoError(t, err)
+	triggerEvent := buildTriggerEvent(t, capDon.Members[0][:])
+	subscriber.Receive(t.Context(), triggerEvent)
+	response := <-triggerEventCallbackCh
+	require.Equal(t, response.Event.Outputs, triggerEventValue)
+}
+
 func TestTriggerSubscriber_MultipleTriggersSameWorkflow(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
@@ -298,7 +352,7 @@ func TestTriggerSubscriber_MultipleTriggersSameWorkflow(t *testing.T) {
 		MinResponsesToAggregate: 1,
 		MessageExpiry:           100 * time.Second,
 	}
-	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, 0)
 	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
 	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
 	require.NoError(t, subscriber.Start(t.Context()))
@@ -377,7 +431,7 @@ func TestTriggerSubscriber_LegacyMessageWithoutTriggerID(t *testing.T) {
 		MinResponsesToAggregate: 1,
 		MessageExpiry:           100 * time.Second,
 	}
-	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, 0)
 	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
 	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
 	require.NoError(t, subscriber.Start(t.Context()))
@@ -426,7 +480,7 @@ func TestTriggerSubscriber_UnregisterOneTriggerKeepsOther(t *testing.T) {
 		MinResponsesToAggregate: 1,
 		MessageExpiry:           100 * time.Second,
 	}
-	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, 0)
 	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
 	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
 	require.NoError(t, subscriber.Start(t.Context()))

--- a/core/capabilities/remote/types/messages.pb.go
+++ b/core/capabilities/remote/types/messages.pb.go
@@ -79,6 +79,55 @@ func (Error) EnumDescriptor() ([]byte, []int) {
 	return file_core_capabilities_remote_types_messages_proto_rawDescGZIP(), []int{0}
 }
 
+type RegistrationStatus int32
+
+const (
+	RegistrationStatus_UNREGISTERED       RegistrationStatus = 0
+	RegistrationStatus_REGISTERED         RegistrationStatus = 1
+	RegistrationStatus_REGISTRATION_ERROR RegistrationStatus = 2
+)
+
+// Enum value maps for RegistrationStatus.
+var (
+	RegistrationStatus_name = map[int32]string{
+		0: "UNREGISTERED",
+		1: "REGISTERED",
+		2: "REGISTRATION_ERROR",
+	}
+	RegistrationStatus_value = map[string]int32{
+		"UNREGISTERED":       0,
+		"REGISTERED":         1,
+		"REGISTRATION_ERROR": 2,
+	}
+)
+
+func (x RegistrationStatus) Enum() *RegistrationStatus {
+	p := new(RegistrationStatus)
+	*p = x
+	return p
+}
+
+func (x RegistrationStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RegistrationStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_core_capabilities_remote_types_messages_proto_enumTypes[1].Descriptor()
+}
+
+func (RegistrationStatus) Type() protoreflect.EnumType {
+	return &file_core_capabilities_remote_types_messages_proto_enumTypes[1]
+}
+
+func (x RegistrationStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RegistrationStatus.Descriptor instead.
+func (RegistrationStatus) EnumDescriptor() ([]byte, []int) {
+	return file_core_capabilities_remote_types_messages_proto_rawDescGZIP(), []int{1}
+}
+
 type Message struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Signature     []byte                 `protobuf:"bytes,1,opt,name=signature,proto3" json:"signature,omitempty"`
@@ -321,6 +370,10 @@ func (*MessageBody_TriggerEventMetadata) isMessageBody_Metadata() {}
 type TriggerRegistrationMetadata struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	LastReceivedEventId string                 `protobuf:"bytes,1,opt,name=last_received_event_id,json=lastReceivedEventId,proto3" json:"last_received_event_id,omitempty"`
+	TriggerId           string                 `protobuf:"bytes,2,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
+	WorkflowId          string                 `protobuf:"bytes,3,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"`
+	Status              RegistrationStatus     `protobuf:"varint,4,opt,name=status,proto3,enum=remote.RegistrationStatus" json:"status,omitempty"`
+	RegistrationError   string                 `protobuf:"bytes,5,opt,name=registration_error,json=registrationError,proto3" json:"registration_error,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -358,6 +411,34 @@ func (*TriggerRegistrationMetadata) Descriptor() ([]byte, []int) {
 func (x *TriggerRegistrationMetadata) GetLastReceivedEventId() string {
 	if x != nil {
 		return x.LastReceivedEventId
+	}
+	return ""
+}
+
+func (x *TriggerRegistrationMetadata) GetTriggerId() string {
+	if x != nil {
+		return x.TriggerId
+	}
+	return ""
+}
+
+func (x *TriggerRegistrationMetadata) GetWorkflowId() string {
+	if x != nil {
+		return x.WorkflowId
+	}
+	return ""
+}
+
+func (x *TriggerRegistrationMetadata) GetStatus() RegistrationStatus {
+	if x != nil {
+		return x.Status
+	}
+	return RegistrationStatus_UNREGISTERED
+}
+
+func (x *TriggerRegistrationMetadata) GetRegistrationError() string {
+	if x != nil {
+		return x.RegistrationError
 	}
 	return ""
 }
@@ -449,9 +530,15 @@ const file_core_capabilities_remote_types_messages_proto_rawDesc = "" +
 	"\rcaller_don_id\x18\x10 \x01(\rR\vcallerDonId\x12+\n" +
 	"\x11capability_method\x18\x11 \x01(\tR\x10capabilityMethodB\n" +
 	"\n" +
-	"\bmetadataJ\x04\b\a\x10\bJ\x04\b\b\x10\t\"R\n" +
+	"\bmetadataJ\x04\b\a\x10\bJ\x04\b\b\x10\t\"\xf5\x01\n" +
 	"\x1bTriggerRegistrationMetadata\x123\n" +
-	"\x16last_received_event_id\x18\x01 \x01(\tR\x13lastReceivedEventId\"\x84\x01\n" +
+	"\x16last_received_event_id\x18\x01 \x01(\tR\x13lastReceivedEventId\x12\x1d\n" +
+	"\n" +
+	"trigger_id\x18\x02 \x01(\tR\ttriggerId\x12\x1f\n" +
+	"\vworkflow_id\x18\x03 \x01(\tR\n" +
+	"workflowId\x122\n" +
+	"\x06status\x18\x04 \x01(\x0e2\x1a.remote.RegistrationStatusR\x06status\x12-\n" +
+	"\x12registration_error\x18\x05 \x01(\tR\x11registrationError\"\x84\x01\n" +
 	"\x14TriggerEventMetadata\x12(\n" +
 	"\x10trigger_event_id\x18\x01 \x01(\tR\x0etriggerEventId\x12!\n" +
 	"\fworkflow_ids\x18\x02 \x03(\tR\vworkflowIds\x12\x1f\n" +
@@ -463,7 +550,12 @@ const file_core_capabilities_remote_types_messages_proto_rawDesc = "" +
 	"\x14CAPABILITY_NOT_FOUND\x10\x02\x12\x13\n" +
 	"\x0fINVALID_REQUEST\x10\x03\x12\v\n" +
 	"\aTIMEOUT\x10\x04\x12\x12\n" +
-	"\x0eINTERNAL_ERROR\x10\x05B Z\x1ecore/capabilities/remote/typesb\x06proto3"
+	"\x0eINTERNAL_ERROR\x10\x05*N\n" +
+	"\x12RegistrationStatus\x12\x10\n" +
+	"\fUNREGISTERED\x10\x00\x12\x0e\n" +
+	"\n" +
+	"REGISTERED\x10\x01\x12\x16\n" +
+	"\x12REGISTRATION_ERROR\x10\x02B Z\x1ecore/capabilities/remote/typesb\x06proto3"
 
 var (
 	file_core_capabilities_remote_types_messages_proto_rawDescOnce sync.Once
@@ -477,24 +569,26 @@ func file_core_capabilities_remote_types_messages_proto_rawDescGZIP() []byte {
 	return file_core_capabilities_remote_types_messages_proto_rawDescData
 }
 
-var file_core_capabilities_remote_types_messages_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_core_capabilities_remote_types_messages_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_core_capabilities_remote_types_messages_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_core_capabilities_remote_types_messages_proto_goTypes = []any{
 	(Error)(0),                          // 0: remote.Error
-	(*Message)(nil),                     // 1: remote.Message
-	(*MessageBody)(nil),                 // 2: remote.MessageBody
-	(*TriggerRegistrationMetadata)(nil), // 3: remote.TriggerRegistrationMetadata
-	(*TriggerEventMetadata)(nil),        // 4: remote.TriggerEventMetadata
+	(RegistrationStatus)(0),             // 1: remote.RegistrationStatus
+	(*Message)(nil),                     // 2: remote.Message
+	(*MessageBody)(nil),                 // 3: remote.MessageBody
+	(*TriggerRegistrationMetadata)(nil), // 4: remote.TriggerRegistrationMetadata
+	(*TriggerEventMetadata)(nil),        // 5: remote.TriggerEventMetadata
 }
 var file_core_capabilities_remote_types_messages_proto_depIdxs = []int32{
 	0, // 0: remote.MessageBody.error:type_name -> remote.Error
-	3, // 1: remote.MessageBody.trigger_registration_metadata:type_name -> remote.TriggerRegistrationMetadata
-	4, // 2: remote.MessageBody.trigger_event_metadata:type_name -> remote.TriggerEventMetadata
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	4, // 1: remote.MessageBody.trigger_registration_metadata:type_name -> remote.TriggerRegistrationMetadata
+	5, // 2: remote.MessageBody.trigger_event_metadata:type_name -> remote.TriggerEventMetadata
+	1, // 3: remote.TriggerRegistrationMetadata.status:type_name -> remote.RegistrationStatus
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_core_capabilities_remote_types_messages_proto_init() }
@@ -511,7 +605,7 @@ func file_core_capabilities_remote_types_messages_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_core_capabilities_remote_types_messages_proto_rawDesc), len(file_core_capabilities_remote_types_messages_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/core/capabilities/remote/types/messages.proto
+++ b/core/capabilities/remote/types/messages.proto
@@ -42,8 +42,18 @@ message MessageBody {
   string capability_method = 17; // method name defined by the capability (empty for legacy "v1" calls)
 }
 
+enum RegistrationStatus {
+  UNREGISTERED = 0;
+  REGISTERED = 1;
+  REGISTRATION_ERROR = 2;
+}
+
 message TriggerRegistrationMetadata {
   string last_received_event_id = 1;
+  string trigger_id =2;
+  string workflow_id = 3;
+  RegistrationStatus status = 4;
+  string registration_error = 5;
 }
 
 message TriggerEventMetadata {

--- a/core/capabilities/remote/types/types.go
+++ b/core/capabilities/remote/types/types.go
@@ -17,6 +17,8 @@ const (
 	MethodUnRegisterTrigger = "UnregisterTrigger"
 	MethodTriggerEvent      = "TriggerEvent"
 	MethodExecute           = "Execute"
+
+	TriggerRegistrationStatus = "TriggerRegistrationStatus"
 )
 
 type Dispatcher interface {

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -444,6 +444,16 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 				// no Config needed - NoDAG uses Payload
 			})
 			if regErr != nil {
+				// TODO: distinguish user vs system errors here
+				//var capabilityError caperrors.Error
+				//if errors.As(err, &capabilityError) {
+				// Determine what to do based on type of error, i.e. different metrics for user vs system errors
+				// Ideally would report user errors to the workflow in some way.
+				//}
+
+				// TODO also, to maintain compatibility we could ignore trigger.ErrRegistrationResponseTimeout error, or alternatively
+				// set the registrationResponseTimeout to 0
+
 				e.logger().Errorw("Trigger registration failed", "triggerID", sub.Id, "err", regErr)
 				e.metrics.With(platform.KeyTriggerID, sub.Id).IncrementRegisterTriggerFailureCounter(gCtx)
 				return fmt.Errorf("failed to register trigger %s: %w", sub.Id, regErr)


### PR DESCRIPTION
A spike to flesh out a possible solution to handling user v system errors on trigger registration in the DON2DON layer (still very much a WIP - ignore implementation snafus, interested in thoughts on the overall approach)

Summary:

Currently trigger registration in the DON2DON shim does not return the remote capabilities error message when initial trigger registration occurs, this limits how we can handle errors from remote triggers, i.e. we would like to distinguish errors that are due to user error (e.g. invalid args) from system errors (which may be transient and can be handled differently, this would improve the UX and improve supportability.

The solution spiked here waits for trigger response messages on the initial trigger subscription in the remote client shim.  

The solution is backwards compatible, if the capability node does not support registrationResponse messages the workflow node will wait a configurable period of time (can be set to 0) and continue as before.  Similarly if the capability node sends registrationResponse message to an old version of the workflow node they will be ignored (logged with a warning).

