### PR TITLE
CRE Fix Chain Reads Tests in Response to Read Limits Enforcement 

### DIFF
--- a/go.md
+++ b/go.md
@@ -436,6 +436,7 @@ flowchart LR
 	chainlink/system-tests/tests --> chainlink/system-tests/tests/regression/cre/httpaction-negative
 	chainlink/system-tests/tests --> chainlink/system-tests/tests/smoke/cre/evm/evmread
 	chainlink/system-tests/tests --> chainlink/system-tests/tests/smoke/cre/evm/logtrigger
+	chainlink/system-tests/tests --> chainlink/system-tests/tests/smoke/cre/evmread
 	chainlink/system-tests/tests --> chainlink/system-tests/tests/smoke/cre/httpaction
 	click chainlink/system-tests/tests href "https://github.com/smartcontractkit/chainlink"
 	chainlink/system-tests/tests/regression/cre/consensus --> cre-sdk-go/capabilities/scheduler/cron
@@ -452,7 +453,8 @@ flowchart LR
 	chainlink/system-tests/tests/regression/cre/httpaction-negative --> cre-sdk-go/capabilities/networking/http
 	chainlink/system-tests/tests/regression/cre/httpaction-negative --> cre-sdk-go/capabilities/scheduler/cron
 	click chainlink/system-tests/tests/regression/cre/httpaction-negative href "https://github.com/smartcontractkit/chainlink"
-	chainlink/system-tests/tests/smoke/cre/evm/evmread --> chainlink/system-tests/tests/smoke/cre/evmread
+	chainlink/system-tests/tests/smoke/cre/evm/evmread --> cre-sdk-go/capabilities/blockchain/evm
+	chainlink/system-tests/tests/smoke/cre/evm/evmread --> cre-sdk-go/capabilities/scheduler/cron
 	click chainlink/system-tests/tests/smoke/cre/evm/evmread href "https://github.com/smartcontractkit/chainlink"
 	chainlink/system-tests/tests/smoke/cre/evm/logtrigger --> cre-sdk-go/capabilities/blockchain/evm
 	click chainlink/system-tests/tests/smoke/cre/evm/logtrigger href "https://github.com/smartcontractkit/chainlink"

--- a/system-tests/tests/smoke/cre/evm/evmread/config/config.go
+++ b/system-tests/tests/smoke/cre/evm/evmread/config/config.go
@@ -8,6 +8,7 @@ import (
 
 type Config struct {
 	ChainSelector    uint64
+	TestCaseName     string
 	ContractAddress  []byte
 	AccountAddress   []byte
 	ExpectedBalance  *big.Int

--- a/system-tests/tests/smoke/cre/evm/evmread/config/config.go
+++ b/system-tests/tests/smoke/cre/evm/evmread/config/config.go
@@ -44,10 +44,6 @@ func (tc TestCase) String() string {
 	}
 }
 
-func FormatSuccessMessage(workflowName string, tc TestCase) string {
-	return fmt.Sprintf("Test case %s passed for workflow %s", tc.String(), workflowName)
-}
-
 type Config struct {
 	ChainSelector    uint64
 	TestCase         TestCase

--- a/system-tests/tests/smoke/cre/evm/evmread/config/config.go
+++ b/system-tests/tests/smoke/cre/evm/evmread/config/config.go
@@ -1,14 +1,57 @@
 package config
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
+type TestCase int
+
+const (
+	TestCaseEVMReadBalance TestCase = iota
+	TestCaseEVMReadHeaders
+	TestCaseEVMReadEvents
+	TestCaseEVMReadCallContract
+	TestCaseEVMReadTransactionReceipt
+	TestCaseEVMReadBTx
+	TestCaseEVMEstimateGas
+	TestCaseEVMReadNotFoundTx
+	TestCaseLen
+)
+
+func (tc TestCase) String() string {
+	switch tc {
+	case TestCaseEVMReadBalance:
+		return "EVMReadBalance"
+	case TestCaseEVMReadHeaders:
+		return "EVMReadHeaders"
+	case TestCaseEVMReadEvents:
+		return "EVMReadEvents"
+	case TestCaseEVMReadCallContract:
+		return "EVMReadCallContract"
+	case TestCaseEVMReadTransactionReceipt:
+		return "EVMReadTransactionReceipt"
+	case TestCaseEVMReadBTx:
+		return "EVMReadBTx"
+	case TestCaseEVMEstimateGas:
+		return "EVMEstimateGas"
+	case TestCaseEVMReadNotFoundTx:
+		return "EVMReadNotFoundTx"
+	default:
+		return fmt.Sprintf("unknown TestCase: %d", tc)
+	}
+}
+
+func FormatSuccessMessage(workflowName string, tc TestCase) string {
+	return fmt.Sprintf("Test case %s passed for workflow %s", tc.String(), workflowName)
+}
+
 type Config struct {
 	ChainSelector    uint64
-	TestCaseName     string
+	TestCase         TestCase
+	WorkflowName     string
 	ContractAddress  []byte
 	AccountAddress   []byte
 	ExpectedBalance  *big.Int

--- a/system-tests/tests/smoke/cre/evm/evmread/go.mod
+++ b/system-tests/tests/smoke/cre/evm/evmread/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/ethereum/go-ethereum v1.16.4
 	github.com/google/go-cmp v0.7.0
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251021010742-3f8d3dba17d8
-	github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evmread v0.0.0-20250917232237-c4ecf802c6f8
 	github.com/smartcontractkit/cre-sdk-go v0.10.0
 	github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/evm v0.10.0
 	github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron v0.10.0

--- a/system-tests/tests/smoke/cre/evm/evmread/go.sum
+++ b/system-tests/tests/smoke/cre/evm/evmread/go.sum
@@ -214,8 +214,6 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251021010742-3f8d3dba17d8 h1:hPeEwcvRVtwhyNXH45qbzqmscqlbygu94cROwbjyzNQ=
 github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251021010742-3f8d3dba17d8/go.mod h1:jUC52kZzEnWF9tddHh85zolKybmLpbQ1oNA4FjOHt1Q=
-github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evmread v0.0.0-20250917232237-c4ecf802c6f8 h1:ZhpUCMDFATsyS1B+6YaAxWYfh/WsVx9WWtYSOkl5V0g=
-github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evmread v0.0.0-20250917232237-c4ecf802c6f8/go.mod h1:96T5PZe9IRPcuMTnS2I2VGAtyDdkL5U9aWUykLtAYb8=
 github.com/smartcontractkit/cre-sdk-go v0.10.0 h1:ZKQaTKa027R8Px30NezXauMaf0toUKeUiOEj+yc67Bg=
 github.com/smartcontractkit/cre-sdk-go v0.10.0/go.mod h1:CQY8hCISjctPmt8ViDVgFm4vMGLs5fYI198QhkBS++Y=
 github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/evm v0.10.0 h1:G0w0cLzHy/5m74IzSGz1Ynjffym4ZxLeUrRLp8EFP5w=

--- a/system-tests/tests/smoke/cre/evm/evmread/main.go
+++ b/system-tests/tests/smoke/cre/evm/evmread/main.go
@@ -25,8 +25,8 @@ import (
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values/pb"
 
-	"github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evmread/config"
-	"github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evmread/contracts"
+	"github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evm/evmread/config"
+	"github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evm/evmread/contracts"
 )
 
 func main() {
@@ -57,27 +57,28 @@ func onReadTrigger(cfg config.Config, runtime sdk.Runtime, payload *cron.Payload
 	}()
 	t := &T{Logger: runtime.Logger()}
 	client := evm.Client{ChainSelector: cfg.ChainSelector}
-	requireBalance(t, runtime, cfg, client)
-	runtime.Logger().Info("Successfully got balance")
+	switch cfg.TestCase {
+	case config.TestCaseEVMReadBalance:
+		requireBalance(t, runtime, cfg, client)
+	case config.TestCaseEVMReadHeaders:
+		requireHeaderByNumber(t, runtime, client)
+	case config.TestCaseEVMReadEvents:
+		requireEvent(t, cfg, runtime, client)
+	case config.TestCaseEVMReadCallContract:
+		requireContractCall(t, cfg, runtime, client)
+	case config.TestCaseEVMReadTransactionReceipt:
+		requireReceipt(t, runtime, cfg, client)
+	case config.TestCaseEVMReadBTx:
+		requireTx(t, runtime, cfg, client)
+	case config.TestCaseEVMEstimateGas:
+		requireEstimatedGas(t, runtime, cfg, client)
+	case config.TestCaseEVMReadNotFoundTx:
+		requireError(t, runtime, cfg, client)
+	default:
+		panic(fmt.Sprintf("unexpected test case: %s", cfg.TestCase))
+	}
 
-	latestHeadNumber := requireLatestBlockNumber(t, runtime, client)
-	runtime.Logger().Info("Successfully got latestHeadNumber")
-
-	requireEvent(t, cfg, runtime, latestHeadNumber, client)
-	runtime.Logger().Info("Successfully got event")
-	requireContractCall(t, cfg, runtime, client)
-	runtime.Logger().Info("Successfully called contract")
-	requireReceipt(t, runtime, cfg, client)
-	runtime.Logger().Info("Successfully got receipt")
-	var expectedTx types.Transaction
-	err = expectedTx.UnmarshalBinary(cfg.ExpectedBinaryTx)
-	require.NoError(t, err)
-	requireTx(t, runtime, &expectedTx, client)
-	runtime.Logger().Info("Successfully got transaction")
-	requireEstimatedGas(t, runtime, cfg, expectedTx.Data(), client)
-	runtime.Logger().Info("Successfully estimated gas")
-	requireError(t, runtime, cfg, client)
-	runtime.Logger().Info("Successfully got error for non-existing transaction")
+	runtime.Logger().Info("Read workflow test case passed", "testCase", cfg.TestCase.String(), "workflow", cfg.WorkflowName)
 	txHash := sendTx(t, runtime, cfg, client, "EVM read workflow executed successfully")
 	runtime.Logger().Info("Successfully sent transaction", "hash", common.Hash(txHash).String())
 	return
@@ -102,11 +103,15 @@ func requireError(t *T, runtime sdk.Runtime, cfg config.Config, client evm.Clien
 	runtime.Logger().Info("Successfully got error for non-existing transaction", "error", err)
 }
 
-func requireEstimatedGas(t *T, runtime sdk.Runtime, cfg config.Config, txData []byte, client evm.Client) {
+func requireEstimatedGas(t *T, runtime sdk.Runtime, cfg config.Config, client evm.Client) {
+	var tx types.Transaction
+	err := tx.UnmarshalBinary(cfg.ExpectedBinaryTx)
+	require.NoError(t, err)
+
 	estimatedGasReply, err := client.EstimateGas(runtime, &evm.EstimateGasRequest{
 		Msg: &evm.CallMsg{
 			To:   cfg.ContractAddress,
-			Data: txData,
+			Data: tx.Data(),
 		},
 	}).Await()
 	require.NoError(t, err, "failed to estimate gas")
@@ -114,7 +119,10 @@ func requireEstimatedGas(t *T, runtime sdk.Runtime, cfg config.Config, txData []
 	require.Greater(t, estimatedGasReply.Gas, uint64(0), "Estimated gas should greater than 0")
 }
 
-func requireTx(t *T, runtime sdk.Runtime, expectedTx *types.Transaction, client evm.Client) {
+func requireTx(t *T, runtime sdk.Runtime, cfg config.Config, client evm.Client) {
+	var expectedTx types.Transaction
+	err := expectedTx.UnmarshalBinary(cfg.ExpectedBinaryTx)
+	require.NoError(t, err)
 	txReply, err := client.GetTransactionByHash(runtime, &evm.GetTransactionByHashRequest{Hash: expectedTx.Hash().Bytes()}).Await()
 	require.NoError(t, err, "failed to get transaction by hash")
 	require.NotNil(t, txReply, "GetTransactionByHashReply should not be nil")
@@ -178,7 +186,7 @@ func requireContractCall(t *T, cfg config.Config, runtime sdk.Runtime, client ev
 	require.Equal(t, "getMessage returns: "+callArg, string(result))
 }
 
-func requireLatestBlockNumber(t *T, runtime sdk.Runtime, client evm.Client) int64 {
+func requireHeaderByNumber(t *T, runtime sdk.Runtime, client evm.Client) {
 	headerToFetch := []rpc.BlockNumber{rpc.FinalizedBlockNumber, rpc.SafeBlockNumber, rpc.LatestBlockNumber}
 	var prevHeaderNumber *big.Int
 	for _, headToFetch := range headerToFetch {
@@ -196,7 +204,6 @@ func requireLatestBlockNumber(t *T, runtime sdk.Runtime, client evm.Client) int6
 		}
 		prevHeaderNumber = headerNumber
 	}
-	return prevHeaderNumber.Int64()
 }
 
 func sendTx(t *T, runtime sdk.Runtime, cfg config.Config, client evm.Client, msg string) []byte {
@@ -218,8 +225,14 @@ func sendTx(t *T, runtime sdk.Runtime, cfg config.Config, client evm.Client, msg
 	require.NotNil(t, reportReply)
 	return reportReply.TxHash
 }
+func requireEvent(t *T, cfg config.Config, runtime sdk.Runtime, client evm.Client) {
+	headerReply, err := client.HeaderByNumber(runtime, &evm.HeaderByNumberRequest{BlockNumber: pb.NewBigIntFromInt(big.NewInt(rpc.LatestBlockNumber.Int64()))}).Await()
+	require.NoError(t, err)
+	require.NotNil(t, headerReply, "HeaderByNumberReply should not be nil")
+	require.NotNil(t, headerReply.Header, "Header should not be nil")
+	latestHeadNumber := pb.NewIntFromBigInt(headerReply.Header.BlockNumber).Int64()
+	runtime.Logger().Info("Fetched latest block", "blockNumber", latestHeadNumber)
 
-func requireEvent(t *T, cfg config.Config, runtime sdk.Runtime, latestHeadNumber int64, client evm.Client) {
 	const blocksStep = 100
 	foundEvent := false
 	for ; latestHeadNumber > 0; latestHeadNumber -= blocksStep {

--- a/system-tests/tests/smoke/cre/evm/evmread/main.go
+++ b/system-tests/tests/smoke/cre/evm/evmread/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
-	"runtime/debug"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -49,11 +48,11 @@ func RunReadWorkflow(cfg config.Config, logger *slog.Logger, secretsProvider sdk
 	}, nil
 }
 
-func onReadTrigger(cfg config.Config, runtime sdk.Runtime, payload *cron.Payload) (_ any, _ error) {
+func onReadTrigger(cfg config.Config, runtime sdk.Runtime, payload *cron.Payload) (_ any, err error) {
 	runtime.Logger().Info("onReadTrigger called", "payload", payload)
 	defer func() {
 		if r := recover(); r != nil {
-			runtime.Logger().Error("recovered from panic", "recovered", r, "stack", string(debug.Stack()))
+			err = fmt.Errorf("panic: %v", r)
 		}
 	}()
 	t := &T{Logger: runtime.Logger()}
@@ -71,7 +70,7 @@ func onReadTrigger(cfg config.Config, runtime sdk.Runtime, payload *cron.Payload
 	requireReceipt(t, runtime, cfg, client)
 	runtime.Logger().Info("Successfully got receipt")
 	var expectedTx types.Transaction
-	err := expectedTx.UnmarshalBinary(cfg.ExpectedBinaryTx)
+	err = expectedTx.UnmarshalBinary(cfg.ExpectedBinaryTx)
 	require.NoError(t, err)
 	requireTx(t, runtime, &expectedTx, client)
 	runtime.Logger().Info("Successfully got transaction")
@@ -247,14 +246,20 @@ func (t *T) Errorf(format string, args ...interface{}) {
 	// if the log was produced by require/assert we need to split it, as engine does not allow logs longer than 1k bytes
 	if len(args) > 0 {
 		if msg, ok := args[0].(string); ok && strings.Contains(msg, "Error:") && strings.Contains(msg, "Error Trace:") {
-			for _, line := range strings.Split(msg, "Error:") {
-				t.Logger.Error(line)
+			var out []string
+			for _, line := range strings.Split(msg, "\n") {
+				if strings.Contains(line, "Error Trace") {
+					continue
+				}
+
+				out = append(out, line)
 			}
+
+			t.Logger.Error(strings.Join(out, ";"))
 			return
 		}
 	}
 	t.Logger.Error(fmt.Sprintf(format, args...))
-	panic(fmt.Sprintf(format, args...)) // panic to stop execution
 }
 
 func (t *T) FailNow() {

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 	"math/rand"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -40,8 +39,7 @@ func ExecuteEVMReadTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 	listenerCtx, messageChan, _ := t_helpers.StartBeholder(t, lggr, testEnv)
 	go t_helpers.LogBeholderMessages(listenerCtx, lggr, messageChan)
 
-	var workflowsWg sync.WaitGroup
-	var successfulWorkflowRuns atomic.Int32
+	chainLock := sync.Mutex{}
 	for _, bcOutput := range testEnv.CreEnvironment.Blockchains {
 		chainID := bcOutput.CtfOutput().ChainID
 		if _, ok := enabledChains[chainID]; !ok {
@@ -49,27 +47,31 @@ func ExecuteEVMReadTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 			continue
 		}
 
-		lggr.Info().Msg("Creating EVM Read workflow configuration...")
-		require.IsType(t, &evm.Blockchain{}, bcOutput, "expected EVM blockchain type")
-		evmChain := bcOutput.(*evm.Blockchain)
-		workflowConfig := configureEVMReadWorkflow(t, lggr, evmChain)
-		workflowName := fmt.Sprintf("evm-read-workflow-%s-%04d", chainID, rand.Intn(10000))
-		t_helpers.CompileAndDeployWorkflow(t, testEnv, lggr, workflowName, &workflowConfig, workflowFileLocation)
+		for tc := range evm_config.TestCaseLen {
+			t.Run(fmt.Sprintf("Read %s on chain %s", tc.String(), chainID), func(t *testing.T) {
+				t.Parallel()
+				workflowName := fmt.Sprintf("evm-read-workflow-%s-%04d", chainID, rand.Intn(10000))
+				lggr.Info().
+					Str("workflow_name", workflowName).
+					Str("chain_id", chainID).
+					Str("test_case", tc.String()).
+					Msg("Creating EVM Read workflow configuration...")
+				require.IsType(t, &evm.Blockchain{}, bcOutput, "expected EVM blockchain type")
+				evmChain := bcOutput.(*evm.Blockchain)
+				// lock to avoid nonce issues
+				chainLock.Lock()
+				workflowConfig := configureEVMReadWorkflow(t, lggr, evmChain, tc, workflowName)
+				t_helpers.CompileAndDeployWorkflow(t, testEnv, lggr, workflowName, &workflowConfig, workflowFileLocation)
+				chainLock.Unlock()
 
-		workflowsWg.Add(1)
-		go func(evmChain *evm.Blockchain) {
-			defer workflowsWg.Done()
-			validateWorkflowExecution(t, lggr, testEnv, evmChain, workflowName, common.BytesToAddress(workflowConfig.ContractAddress), workflowConfig.ExpectedReceipt.BlockNumber.Uint64()) //nolint:testifylint // TODO: consider refactoring
-			successfulWorkflowRuns.Add(1)
-		}(evmChain)
+				validateWorkflowExecution(t, lggr, testEnv, evmChain, workflowName, common.BytesToAddress(workflowConfig.ContractAddress), workflowConfig.ExpectedReceipt.BlockNumber.Uint64())
+			})
+
+		}
 	}
-
-	// wait for all workflows to complete
-	workflowsWg.Wait()
-	require.Equal(t, len(enabledChains), int(successfulWorkflowRuns.Load()), "Not all workflows executed successfully")
 }
 
-func configureEVMReadWorkflow(t *testing.T, lggr zerolog.Logger, chain *evm.Blockchain) evm_config.Config {
+func configureEVMReadWorkflow(t *testing.T, lggr zerolog.Logger, chain *evm.Blockchain, testCase evm_config.TestCase, workflowName string) evm_config.Config {
 	t.Helper()
 
 	chainID := chain.CtfOutput().ChainID
@@ -106,6 +108,8 @@ func configureEVMReadWorkflow(t *testing.T, lggr zerolog.Logger, chain *evm.Bloc
 
 	accountAddress := addresses[0].Bytes()
 	return evm_config.Config{
+		TestCase:         testCase,
+		WorkflowName:     workflowName,
 		ContractAddress:  msgEmitterContractAddr.Bytes(),
 		ChainSelector:    chain.ChainSelector(),
 		AccountAddress:   accountAddress,
@@ -140,7 +144,7 @@ func validateWorkflowExecution(t *testing.T, lggr zerolog.Logger, testEnv *ttype
 
 		// if there are no more filtered reports, stop
 		return !isReportSubmittedByWorkflow(ctx, t, forwarderContract, msgEmitterAddr, startBlock)
-	}, timeout, tick, "workflow %s did not execute within the timeout %s", workflowName, timeout.String())
+	}, timeout, tick, "workflow %s did not execute within the timeout %s. Check logs of parent test.", workflowName, timeout.String())
 }
 
 // isReportSubmittedByWorkflow checks if a report has been submitted by the workflow by filtering the ReportProcessed events

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -66,7 +66,6 @@ func ExecuteEVMReadTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 
 				validateWorkflowExecution(t, lggr, testEnv, evmChain, workflowName, common.BytesToAddress(workflowConfig.ContractAddress), workflowConfig.ExpectedReceipt.BlockNumber.Uint64())
 			})
-
 		}
 	}
 }

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -37,6 +37,9 @@ func ExecuteEVMReadTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 	const workflowFileLocation = "./evm/evmread/main.go"
 	enabledChains := t_helpers.GetEVMEnabledChains(t, testEnv)
 
+	listenerCtx, messageChan, _ := t_helpers.StartBeholder(t, lggr, testEnv)
+	go t_helpers.LogBeholderMessages(listenerCtx, lggr, messageChan)
+
 	var workflowsWg sync.WaitGroup
 	var successfulWorkflowRuns atomic.Int32
 	for _, bcOutput := range testEnv.CreEnvironment.Blockchains {

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -304,17 +304,17 @@ func CreateAndFundAddresses(t *testing.T, testLogger zerolog.Logger, numberOfAdd
 // Register your workflow configuration types here
 type WorkflowConfig interface {
 	None |
-	portypes.WorkflowConfig |
-	crontypes.WorkflowConfig |
-	HTTPWorkflowConfig |
-	consensus_negative_config.Config |
-	evmread_config.Config |
-	logtrigger_config.Config |
-	evmread_negative_config.Config |
-	evmwrite_negative_config.Config |
-	http_config.Config |
-	httpaction_smoke_config.Config |
-	httpaction_negative_config.Config
+		portypes.WorkflowConfig |
+		crontypes.WorkflowConfig |
+		HTTPWorkflowConfig |
+		consensus_negative_config.Config |
+		evmread_config.Config |
+		logtrigger_config.Config |
+		evmread_negative_config.Config |
+		evmwrite_negative_config.Config |
+		http_config.Config |
+		httpaction_smoke_config.Config |
+		httpaction_negative_config.Config
 }
 
 // None represents an empty workflow configuration

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -240,6 +240,34 @@ func AssertBeholderMessage(ctx context.Context, t *testing.T, expectedLog string
 	return nil
 }
 
+func LogBeholderMessages(ctx context.Context, testLogger zerolog.Logger, messageChan <-chan proto.Message) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-messageChan:
+			// Process received messages
+			switch typedMsg := msg.(type) {
+			case *commonevents.BaseMessage:
+				l := testLogger.Info()
+				for labelKey, labelValue := range typedMsg.Labels {
+					l = l.Str(labelKey, labelValue)
+				}
+				l.Msg("➡️ Beholder Msg: " + typedMsg.Msg)
+			case *workflowevents.UserLogs:
+				l := testLogger.Info().
+					Str("execution_id", typedMsg.M.WorkflowExecutionID).
+					Str("workflow_name", typedMsg.M.WorkflowName)
+				for _, logLine := range typedMsg.LogLines {
+					l.Msg("➡️ Beholder user msg: " + logLine.Message)
+				}
+			default:
+				// ignore other message types
+			}
+		}
+	}
+}
+
 //////////////////////////////
 //      CRYPTO HELPERS      //
 //////////////////////////////
@@ -276,17 +304,17 @@ func CreateAndFundAddresses(t *testing.T, testLogger zerolog.Logger, numberOfAdd
 // Register your workflow configuration types here
 type WorkflowConfig interface {
 	None |
-		portypes.WorkflowConfig |
-		crontypes.WorkflowConfig |
-		HTTPWorkflowConfig |
-		consensus_negative_config.Config |
-		evmread_config.Config |
-		logtrigger_config.Config |
-		evmread_negative_config.Config |
-		evmwrite_negative_config.Config |
-		http_config.Config |
-		httpaction_smoke_config.Config |
-		httpaction_negative_config.Config
+	portypes.WorkflowConfig |
+	crontypes.WorkflowConfig |
+	HTTPWorkflowConfig |
+	consensus_negative_config.Config |
+	evmread_config.Config |
+	logtrigger_config.Config |
+	evmread_negative_config.Config |
+	evmwrite_negative_config.Config |
+	http_config.Config |
+	httpaction_smoke_config.Config |
+	httpaction_negative_config.Config
 }
 
 // None represents an empty workflow configuration


### PR DESCRIPTION
Chain Read limits enforcement broke the CRE EVM Read Tests. To fix them, the test was split into smaller parts, each tested separately.