### PR TITLE
Remove FromAddress config dependency for v2 evm capability

### DIFF
--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -227,8 +227,9 @@ func NewRelayer(lggr logger.Logger, chain legacyevm.Chain, opts RelayerOpts) (*R
 		mercuryCfg:            opts.MercuryConfig,
 		capabilitiesRegistry:  opts.CapabilitiesRegistry,
 		evmService: evmService{
-			chain:  chain,
-			logger: sugared,
+			addressLister: opts.EVMKeystore,
+			chain:         chain,
+			logger:        sugared,
 		},
 	}, nil
 }

--- a/core/services/relay/evm/evm_service.go
+++ b/core/services/relay/evm/evm_service.go
@@ -20,6 +20,7 @@ import (
 	evmprimitives "github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives/evm"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/retry"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
+	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmtxmgr "github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
@@ -28,8 +29,9 @@ import (
 )
 
 type evmService struct {
-	chain  legacyevm.Chain
-	logger logger.Logger
+	addressLister keys.AddressLister
+	chain         legacyevm.Chain
+	logger        logger.Logger
 }
 
 // Direct RPC
@@ -201,11 +203,29 @@ func (e *evmService) GetTransactionStatus(ctx context.Context, transactionID com
 func (e *evmService) SubmitTransaction(ctx context.Context, txRequest evm.SubmitTransactionRequest) (*evm.TransactionResult, error) {
 	config := e.chain.Config()
 
-	fromAddress := config.EVM().Workflow().FromAddress().Address()
 	var gasLimit uint64
 	if txRequest.GasConfig != nil && txRequest.GasConfig.GasLimit != nil {
 		gasLimit = *txRequest.GasConfig.GasLimit
 	}
+	if e.addressLister == nil {
+		return nil, errors.New("address lister is not initialized")
+	}
+
+	addresses, err := e.addressLister.EnabledAddresses(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get enabled addresses: %w", err)
+	}
+
+	if len(addresses) == 0 {
+		return nil, errors.New("no enabled addresses available")
+	}
+
+	// Find address with highest balance
+	fromAddress, err := e.getAddressWithHighestBalance(ctx, addresses)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine FromAddress for SubmitTransaction: %w", err)
+	}
+	e.logger.Debugw("Using fromAddress", "address", fromAddress.Hex())
 
 	id, err := uuid.NewUUID()
 	if err != nil {
@@ -282,6 +302,45 @@ func (e *evmService) SubmitTransaction(ctx context.Context, txRequest evm.Submit
 		TxHash:           (*receipt).GetTxHash(),
 		TxIdempotencyKey: txID,
 	}, nil
+}
+
+// getAddressWithHighestBalance returns the address with the highest ETH balance
+func (e *evmService) getAddressWithHighestBalance(ctx context.Context, addresses []common.Address) (common.Address, error) {
+	if len(addresses) == 0 {
+		return common.Address{}, errors.New("no addresses provided")
+	}
+	if len(addresses) == 1 {
+		e.logger.Debugw("only one enabled fromAddress for chain", "address", addresses[0].Hex())
+		return addresses[0], nil
+	}
+
+	var highestBalance *big.Int
+	var selectedAddress common.Address
+
+	for _, addr := range addresses {
+		balance, err := e.chain.Client().BalanceAt(ctx, addr, nil) // nil = latest block
+		if err != nil {
+			e.logger.Warnw("failed to get balance for address, skipping", "address", addr.Hex(), "error", err)
+			continue
+		}
+
+		if highestBalance == nil || balance.Cmp(highestBalance) > 0 {
+			highestBalance = balance
+			selectedAddress = addr
+		}
+	}
+
+	if highestBalance == nil {
+		// Fallback to first address if all balance queries failed
+		return addresses[0], nil
+	}
+
+	e.logger.Debugw("selected fromAddress with highest balance for chain",
+		"address", selectedAddress.Hex(),
+		"balance", highestBalance.String(),
+		"totalAddresses", len(addresses))
+
+	return selectedAddress, nil
 }
 
 func (e *evmService) CalculateTransactionFee(ctx context.Context, receipt evm.ReceiptGasInfo) (*evm.TransactionFee, error) {

--- a/core/services/relay/evm/evm_service_test.go
+++ b/core/services/relay/evm/evm_service_test.go
@@ -1,6 +1,7 @@
 package evm
 
 import (
+	"context"
 	"errors"
 	"math"
 	"math/big"
@@ -23,11 +24,13 @@ import (
 	configmocks "github.com/smartcontractkit/chainlink-evm/pkg/config/mocks"
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads/headstest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
+	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	evmmocks "github.com/smartcontractkit/chainlink/v2/common/chains/mocks"
 	lpmocks "github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
 	txmmocks "github.com/smartcontractkit/chainlink/v2/common/txmgr/mocks"
+	keystoremocks "github.com/smartcontractkit/chainlink/v2/core/services/keystore/mocks"
 )
 
 const ExpectedTxHash = "0xabcd"
@@ -42,6 +45,7 @@ type Mocks struct {
 	Poller        *lpmocks.LogPoller
 	HeaderTracker *headstest.Tracker[*types.Head, common.Hash]
 	Relayer       *Relayer
+	KeyStoreMock  keyStoreMock
 }
 
 type returnedStatusAndReceipts struct {
@@ -59,6 +63,15 @@ func createMockReceipt(t *testing.T) *txmgr.ChainReceipt {
 	return &receipt
 }
 
+type keyStoreMock struct {
+	chainID *big.Int
+	*keystoremocks.Eth
+}
+
+func (_m keyStoreMock) EnabledAddresses(ctx context.Context) ([]common.Address, error) {
+	return _m.EnabledAddressesForChain(ctx, _m.chainID)
+}
+
 func setupMocksAndRelayer(t *testing.T) (*Mocks, *Relayer) {
 	chain := evmmocks.NewChain(t)
 	txManager := txmmocks.NewMockEvmTxManager(t)
@@ -68,7 +81,9 @@ func setupMocksAndRelayer(t *testing.T) (*Mocks, *Relayer) {
 	evmClient := clienttest.NewClient(t)
 	poller := lpmocks.NewLogPoller(t)
 	ht := headstest.NewTracker[*types.Head](t)
-
+	ksMock := keyStoreMock{chainID: evmtestutils.FixtureChainID, Eth: keystoremocks.NewEth(t)}
+	ksMock.Eth.EXPECT().EnabledAddressesForChain(mock.Anything, mock.Anything).Return([]common.Address{createFromAddress().Address()}, nil).Maybe()
+	mockEVM.EXPECT().ConfirmationTimeout().Return(2 * time.Second).Maybe()
 	chain.On("TxManager").Return(txManager).Maybe()
 	chain.On("LogPoller").Return(poller).Maybe()
 	chain.On("HeadTracker").Return(ht).Maybe()
@@ -76,12 +91,11 @@ func setupMocksAndRelayer(t *testing.T) (*Mocks, *Relayer) {
 	chain.EXPECT().Config().Return(mockConfig).Maybe()
 	mockConfig.EXPECT().EVM().Return(mockEVM).Maybe()
 	mockEVM.EXPECT().Workflow().Return(mockWorkflow).Maybe()
-
 	lggr, err := logger.New()
 	require.NoError(t, err)
 	relayer := &Relayer{
 		chain:      chain,
-		evmService: evmService{chain: chain, logger: lggr},
+		evmService: evmService{addressLister: ksMock, chain: chain, logger: lggr},
 	}
 
 	return &Mocks{
@@ -93,6 +107,7 @@ func setupMocksAndRelayer(t *testing.T) (*Mocks, *Relayer) {
 		EvmClient:     evmClient,
 		Poller:        poller,
 		HeaderTracker: ht,
+		KeyStoreMock:  ksMock,
 	}, relayer
 }
 
@@ -110,8 +125,6 @@ func runSubmitTransactionTest(t *testing.T, tc SubmitTransactionTestCase) {
 	if tc.SetupMocks != nil {
 		tc.SetupMocks(mocks, ctx)
 	}
-
-	setCommonSubmitTransactionMocks(mocks)
 
 	receiver := createToAddress()
 	gasLimit := uint64(1000)
@@ -132,12 +145,6 @@ func runSubmitTransactionTest(t *testing.T, tc SubmitTransactionTestCase) {
 		result.TxIdempotencyKey = ""
 		require.Equal(t, tc.ExpectedResult, result)
 	}
-}
-
-func setCommonSubmitTransactionMocks(m *Mocks) {
-	fromAddress := createFromAddress()
-	m.Workflow.EXPECT().FromAddress().Return(&fromAddress)
-	m.EVM.EXPECT().ConfirmationTimeout().Return(2 * time.Second)
 }
 
 func createFromAddress() types.EIP55Address {
@@ -343,6 +350,61 @@ func TestEVMService(t *testing.T) {
 				TxHash:   common.Hash{},
 				TxStatus: evm.TxFatal,
 			},
+		},
+		{
+			Name: "Fails with failed to get enabled addresses",
+			SetupMocks: func(m *Mocks, ctx any) {
+				// Clear the default expectation first
+				m.KeyStoreMock.Eth.EXPECT().EnabledAddressesForChain(mock.Anything, mock.Anything).Unset()
+				// Set new expectation
+				m.KeyStoreMock.EXPECT().EnabledAddressesForChain(mock.Anything, mock.Anything).Return([]common.Address{}, errors.New("some error")).Once()
+			},
+			ExpectedError: "failed to get enabled addresses: some error",
+		},
+		{
+			Name: "Fails with no enabled addresses",
+			SetupMocks: func(m *Mocks, ctx any) {
+				// Clear the default expectation first
+				m.KeyStoreMock.Eth.EXPECT().EnabledAddressesForChain(mock.Anything, mock.Anything).Unset()
+				// Set new expectation
+				m.KeyStoreMock.Eth.EXPECT().EnabledAddressesForChain(mock.Anything, mock.Anything).Return([]common.Address{}, nil).Once()
+			},
+			ExpectedError: "no enabled addresses available",
+		},
+		{
+			Name: "Selects address with highest balance when multiple addresses available",
+			SetupMocks: func(m *Mocks, ctx any) {
+				highBalanceAddr := createFromAddress().Address()
+				lowBalanceAddr := common.HexToAddress("0x333")
+
+				// Clear the default expectation and return multiple addresses
+				m.KeyStoreMock.Eth.EXPECT().EnabledAddressesForChain(mock.Anything, mock.Anything).Unset()
+				m.KeyStoreMock.Eth.EXPECT().EnabledAddressesForChain(mock.Anything, mock.Anything).Return(
+					[]common.Address{lowBalanceAddr, highBalanceAddr}, nil,
+				).Once()
+
+				// Mock BalanceAt: lowBalanceAddr has 0, highBalanceAddr has 1000
+				m.EvmClient.EXPECT().BalanceAt(mock.Anything, lowBalanceAddr, (*big.Int)(nil)).Return(big.NewInt(0), nil).Once()
+				m.EvmClient.EXPECT().BalanceAt(mock.Anything, highBalanceAddr, (*big.Int)(nil)).Return(big.NewInt(1000), nil).Once()
+
+				// Expect transaction to be created with the high balance address
+				expectedTxRequest := txmgr.TxRequest{
+					FromAddress:    highBalanceAddr,
+					ToAddress:      createToAddress(),
+					EncodedPayload: createPayload(),
+				}
+				m.TxManager.EXPECT().CreateTransaction(ctx, mock.MatchedBy(func(txRequest txmgr.TxRequest) bool {
+					return txRequest.FromAddress == expectedTxRequest.FromAddress &&
+						txRequest.ToAddress == expectedTxRequest.ToAddress &&
+						slices.Equal(txRequest.EncodedPayload, expectedTxRequest.EncodedPayload)
+				})).Return(txmgr.Tx{}, nil).Once()
+
+				m.TxManager.EXPECT().GetTransactionStatus(mock.Anything, mock.Anything).Return(commontypes.Finalized, nil).Once()
+				txHash := common.HexToHash(ExpectedTxHash)
+				mockReceipt := NewChainReceipt(txHash, t)
+				m.TxManager.EXPECT().GetTransactionReceipt(mock.Anything, mock.Anything).Return(&mockReceipt, nil).Once()
+			},
+			ExpectedResult: &evm.TransactionResult{TxStatus: evm.TxSuccess, TxHash: common.HexToHash(ExpectedTxHash)},
 		},
 	}
 

--- a/system-tests/lib/cre/features/evm/v2/evm.go
+++ b/system-tests/lib/cre/features/evm/v2/evm.go
@@ -12,7 +12,6 @@ import (
 	"dario.cat/mergo"
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pelletier/go-toml/v2"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -20,7 +19,6 @@ import (
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
-	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/ptr"
 	"github.com/smartcontractkit/chainlink/deployment/cre/common/strategies"
@@ -31,12 +29,10 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/cre/pkg/offchain"
 	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	ks_contracts_op "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/operations/contracts"
-	corechainlink "github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	libc "github.com/smartcontractkit/chainlink/system-tests/lib/conversions"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/contracts"
 	credon "github.com/smartcontractkit/chainlink/system-tests/lib/cre/don"
@@ -98,12 +94,8 @@ func (o *EVM) PreEnvStartup(
 	}
 	for _, workerNode := range workerNodes {
 		currentConfig := don.NodeSets().NodeSpecs[workerNode.Index].Node.TestConfigOverrides
-		updatedConfig, updErr := updateNodeConfig(workerNode, don.NodeSets(), currentConfig)
-		if updErr != nil {
-			return nil, errors.Wrapf(updErr, "failed to update node config for node index %d", workerNode.Index)
-		}
-
-		don.NodeSets().NodeSpecs[workerNode.Index].Node.TestConfigOverrides = *updatedConfig
+		currentConfigPtr := ptr.Ptr(currentConfig)
+		don.NodeSets().NodeSpecs[workerNode.Index].Node.TestConfigOverrides = *currentConfigPtr
 	}
 
 	capabilities := []keystone_changeset.DONCapabilityWithConfig{}
@@ -133,43 +125,6 @@ func (o *EVM) PreEnvStartup(
 	return &cre.PreEnvStartupOutput{
 		DONCapabilityWithConfig: capabilities,
 	}, nil
-}
-
-func updateNodeConfig(workerNode *cre.NodeMetadata, nodeSet *cre.NodeSet, currentConfig string) (*string, error) {
-	chainsFromAddress, err := findNodeAddressPerChain(nodeSet, workerNode)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get chains with from address")
-	}
-
-	var typedConfig corechainlink.Config
-	unmarshallErr := toml.Unmarshal([]byte(currentConfig), &typedConfig)
-	if unmarshallErr != nil {
-		return nil, errors.Wrapf(unmarshallErr, "failed to unmarshal config for node index %d", workerNode.Index)
-	}
-
-	if len(typedConfig.EVM) < len(chainsFromAddress) {
-		return nil, fmt.Errorf("not enough EVM chains configured in node index %d to add evm config. Expected at least %d chains, but found %d", workerNode.Index, len(chainsFromAddress), len(typedConfig.EVM))
-	}
-
-	for idx, evmChain := range typedConfig.EVM {
-		chainID := libc.MustSafeUint64(evmChain.ChainID.Int64())
-		addr, ok := chainsFromAddress[chainID]
-		if ok {
-			// if present means we need fromAddress for this chain
-			address, err := types.NewEIP55Address(addr.Hex())
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to convert fromAddress to EIP55Address for chain %d", chainID)
-			}
-			typedConfig.EVM[idx].Workflow.FromAddress = &address
-		}
-	}
-
-	stringifiedConfig, mErr := toml.Marshal(typedConfig)
-	if mErr != nil {
-		return nil, errors.Wrapf(mErr, "failed to marshal config for node index %d", workerNode.Index)
-	}
-
-	return ptr.Ptr(string(stringifiedConfig)), nil
 }
 
 func (o *EVM) PostEnvStartup(


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/PLEX-2173

V2 Tests will pass with the following Node TOML

```
[EVM.Workflow]
FromAddress = '0x0000000000000000000000000000000000000000'
ForwarderAddress = '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0'
GasLimitDefault = 400000
TxAcceptanceState = 2
PollPeriod = '2s'
AcceptanceTimeout = '30s'

[EVM.Workflow]
FromAddress = '0x0000000000000000000000000000000000000000'
ForwarderAddress = '0x0000000000000000000000000000000000000000'
GasLimitDefault = 400000
TxAcceptanceState = 2
PollPeriod = '2s'
AcceptanceTimeout = '30s'

```

Local CRE Logs
<img width="1594" height="446" alt="image" src="https://github.com/user-attachments/assets/ab9fcd6d-8e4f-4b98-a9a7-0706f491ad31" />