### PR TITLE
Update Justfile to handle optional registry parameter for build and p…

### DIFF
--- a/devenv/Justfile
+++ b/devenv/Justfile
@@ -7,7 +7,7 @@ default:
 clean:
     rm -rf compose/ blockscout/
 
-build-fakes registry platform="linux/amd64":
+build-fakes registry="" platform="linux/amd64":
     just fakes/build {{registry}}
 
 push-fakes registry:

--- a/devenv/fakes/Justfile
+++ b/devenv/fakes/Justfile
@@ -3,9 +3,12 @@ IMAGE_NAME := "ocr2-fakes"
 run:
     docker run --rm -it -v $(pwd):/app -p 9111:9111 {{IMAGE_NAME}}:latest
 
-build registry platform="linux/amd64":
+build registry="" platform="linux/amd64":
     docker build --platform {{platform}} -f Dockerfile -t {{IMAGE_NAME}}:latest .
-    docker tag {{IMAGE_NAME}}:latest {{registry}}/{{IMAGE_NAME}}
+    # Only tag with registry if provided
+    if [ -n "{{registry}}" ]; then \
+        docker tag {{IMAGE_NAME}}:latest {{registry}}/{{IMAGE_NAME}}; \
+    fi
 
 push registry:
     aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin {{registry}}


### PR DESCRIPTION
This pull request updates the build scripts for Docker images, making the registry parameter optional and ensuring images are only tagged with a registry if one is provided. This improves flexibility when building images locally or for different registries.

**Build script improvements:**

* Made the `registry` parameter optional in both the main `Justfile` and the `fakes/Justfile`, allowing builds without specifying a registry. [[1]](diffhunk://#diff-124cf544512a6421321a3f775843f8eafd6f5f2b8bb751fc643dd40c59f29da0L10-R10) [[2]](diffhunk://#diff-c3dcf6de03293425ceca893340800a632e5bad8adc76a21b88206c6be3674928L6-R11)
* Updated the Docker build process in `fakes/Justfile` to only tag the image with a registry if the `registry` parameter is set, preventing unnecessary or invalid tags.…ush commands

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
