### PR TITLE
Improves keystone state generation

### DIFF
--- a/deployment/cre/state/view.go
+++ b/deployment/cre/state/view.go
@@ -18,7 +18,9 @@ var _ deployment.ViewStateV2 = ViewCREV2
 func ViewCRE(e deployment.Environment, previousView json.Marshaler) (json.Marshaler, error) {
 	chainViews, viewErrs := generateCREChainsViews(e, previousView)
 	if viewErrs != nil {
-		return nil, fmt.Errorf("failed to generate CRE chain views: %w", viewErrs)
+		err2 := fmt.Errorf("failed to generate CRE chain views: %w", viewErrs)
+		e.Logger.Error(err2)
+		viewErrs = errors.Join(viewErrs, err2)
 	}
 	nopsView, err := commonview.GenerateNopsView(e.Logger, e.NodeIDs, e.Offchain)
 	if err != nil {
@@ -35,7 +37,9 @@ func ViewCRE(e deployment.Environment, previousView json.Marshaler) (json.Marsha
 func ViewCREV2(e deployment.Environment, previousView json.Marshaler) (json.Marshaler, error) {
 	chainViews, viewErrs := generateCREChainsViews(e, previousView)
 	if viewErrs != nil {
-		return nil, fmt.Errorf("failed to generate CRE chain views: %w", viewErrs)
+		err2 := fmt.Errorf("failed to generate CRE chain views: %w", viewErrs)
+		e.Logger.Error(err2)
+		viewErrs = errors.Join(viewErrs, err2)
 	}
 
 	// keeping the old NOPs view for backwards compatibility

--- a/deployment/keystone/changeset/view.go
+++ b/deployment/keystone/changeset/view.go
@@ -35,7 +35,9 @@ type viewContracts struct {
 func ViewKeystone(e deployment.Environment, previousView json.Marshaler) (json.Marshaler, error) {
 	chainViews, viewErrs := generateKeystoneChainsViews(e, previousView)
 	if viewErrs != nil {
-		return nil, fmt.Errorf("failed to generate Keystone chain views: %w", viewErrs)
+		err2 := fmt.Errorf("failed to generate Keystone chain views: %w", viewErrs)
+		e.Logger.Error(err2)
+		viewErrs = errors.Join(viewErrs, err2)
 	}
 
 	nopsView, err := commonview.GenerateNopsView(e.Logger, e.NodeIDs, e.Offchain)
@@ -44,6 +46,7 @@ func ViewKeystone(e deployment.Environment, previousView json.Marshaler) (json.M
 		e.Logger.Error(err2)
 		viewErrs = errors.Join(viewErrs, err2)
 	}
+
 	return &KeystoneView{
 		Chains: chainViews,
 		Nops:   nopsView,
@@ -53,18 +56,30 @@ func ViewKeystone(e deployment.Environment, previousView json.Marshaler) (json.M
 func ViewKeystoneV2(e deployment.Environment, previousView json.Marshaler) (json.Marshaler, error) {
 	chainViews, viewErrs := generateKeystoneChainsViews(e, previousView)
 	if viewErrs != nil {
-		return nil, fmt.Errorf("failed to generate Keystone chain views: %w", viewErrs)
+		err2 := fmt.Errorf("failed to generate Keystone chain views: %w", viewErrs)
+		e.Logger.Error(err2)
+		viewErrs = errors.Join(viewErrs, err2)
 	}
 
-	nopsView, err := commonview.GenerateNOPsViewV2(e.GetContext(), e.Logger, e.NodeIDs, e.Offchain, "keystone", nil)
+	// keeping the old NOPs view for backwards compatibility
+	nopsView, err := commonview.GenerateNopsView(e.Logger, e.NodeIDs, e.Offchain)
 	if err != nil {
 		err2 := fmt.Errorf("failed to view nops: %w", err)
 		e.Logger.Error(err2)
 		viewErrs = errors.Join(viewErrs, err2)
 	}
+
+	nopsViewV2, err := commonview.GenerateNOPsViewV2(e.GetContext(), e.Logger, e.NodeIDs, e.Offchain, "keystone", nil)
+	if err != nil {
+		err2 := fmt.Errorf("failed to view nops v2: %w", err)
+		e.Logger.Error(err2)
+		viewErrs = errors.Join(viewErrs, err2)
+	}
+
 	return &KeystoneViewV2{
 		Chains: chainViews,
 		Nops:   nopsView,
+		NopsV2: nopsViewV2,
 	}, viewErrs
 }
 

--- a/deployment/keystone/changeset/view_contracts.go
+++ b/deployment/keystone/changeset/view_contracts.go
@@ -35,12 +35,13 @@ type KeystoneChainView struct {
 }
 
 type ForwarderView struct {
-	DonID         uint32   `json:"donId"`
-	ConfigVersion uint32   `json:"configVersion"`
-	F             uint8    `json:"f"`
-	Signers       []string `json:"signers"`
-	TxHash        string   `json:"txHash,omitempty"`
-	BlockNumber   uint64   `json:"blockNumber,omitempty"`
+	DonID                   uint32   `json:"donId"`
+	ConfigVersion           uint32   `json:"configVersion"`
+	F                       uint8    `json:"f"`
+	Signers                 []string `json:"signers"`
+	TxHash                  string   `json:"txHash,omitempty"`
+	BlockNumber             uint64   `json:"blockNumber,omitempty"`
+	LatestViewedBlockNumber uint64   `json:"latestViewedBlockNumber,omitempty"`
 }
 
 var (
@@ -218,11 +219,18 @@ func GenerateForwarderView(ctx context.Context, f *forwarder.KeystoneForwarder, 
 	if len(prevViews) > 0 {
 		// Sort `prevViews` by block number in ascending order, we make sure the last item has the highest block number
 		sort.Slice(prevViews, func(i, j int) bool {
+			// having `LatestViewedBlockNumber` means all prev views have it, so we use it for sorting
+			if prevViews[i].LatestViewedBlockNumber > 0 {
+				return prevViews[i].LatestViewedBlockNumber < prevViews[j].LatestViewedBlockNumber
+			}
 			return prevViews[i].BlockNumber < prevViews[j].BlockNumber
 		})
 
 		// If we have previous views, we will start from the last block number +1 of the previous views
 		startBlock = prevViews[len(prevViews)-1].BlockNumber + 1
+		if prevViews[len(prevViews)-1].LatestViewedBlockNumber > 0 {
+			startBlock = prevViews[len(prevViews)-1].LatestViewedBlockNumber + 1
+		}
 	} else {
 		// If we don't have previous views, we will start from the deployment block number
 		// which is stored in the forwarder's type and version labels.
@@ -293,30 +301,38 @@ func GenerateForwarderView(ctx context.Context, f *forwarder.KeystoneForwarder, 
 			configSets = append(configSets, configIterator.Event)
 		}
 	}
+	updatedPrevViews := make([]ForwarderView, 0, len(prevViews)+len(configSets))
+	for _, prevView := range prevViews {
+		// Let's set the LatestViewedBlockNumber to the previous views
+		prevView.LatestViewedBlockNumber = latestBlock
+		updatedPrevViews = append(updatedPrevViews, prevView)
+	}
+
 	if len(configSets) == 0 {
 		// Forwarder is not configured only if we don't have any previous configuration events.
-		if len(prevViews) == 0 {
+		if len(updatedPrevViews) == 0 {
 			return nil, ErrForwarderNotConfigured
 		}
 
 		// If we don't have any new config sets, we return the previous views as is.
-		return prevViews, nil
+		return updatedPrevViews, nil
 	}
 
 	// We now create a slice with all previous views and the new views, so they get all added to the final view.
-	forwarderViews := append([]ForwarderView{}, prevViews...)
+	forwarderViews := updatedPrevViews
 	for _, configSet := range configSets {
 		var readableSigners []string
 		for _, s := range configSet.Signers {
 			readableSigners = append(readableSigners, s.String())
 		}
 		forwarderViews = append(forwarderViews, ForwarderView{
-			DonID:         configSet.DonId,
-			ConfigVersion: configSet.ConfigVersion,
-			F:             configSet.F,
-			Signers:       readableSigners,
-			TxHash:        configSet.Raw.TxHash.String(),
-			BlockNumber:   configSet.Raw.BlockNumber,
+			DonID:                   configSet.DonId,
+			ConfigVersion:           configSet.ConfigVersion,
+			F:                       configSet.F,
+			Signers:                 readableSigners,
+			TxHash:                  configSet.Raw.TxHash.String(),
+			BlockNumber:             configSet.Raw.BlockNumber,
+			LatestViewedBlockNumber: latestBlock,
 		})
 	}
 
@@ -345,7 +361,13 @@ func (v KeystoneView) MarshalJSON() ([]byte, error) {
 
 type KeystoneViewV2 struct {
 	Chains map[string]KeystoneChainView `json:"chains,omitempty"`
-	Nops   map[string]view.NopViewV2    `json:"nops,omitempty"`
+
+	// Nops will be DEPRECATED, but needs to stay here so we don't break downstream consumers, as tracking all the
+	// consumers is not straightforward. We would need to list them for the rdd monster Kafka topic and BQ table, but
+	// also list all the consumers who read the state.json file directly (are there any? we don't know).
+	// The best way to go about it is to add a `nops_v2` entry and announce depreciation of the `nops` entry.
+	Nops   map[string]view.NopView   `json:"nops,omitempty"`
+	NopsV2 map[string]view.NopViewV2 `json:"nops_v2,omitempty"`
 }
 
 func (v KeystoneViewV2) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
This helps addressing [CRE-1533](https://smartcontract-it.atlassian.net/browse/CRE-1533) by improving the Keystone state generation in a way in can catch up faster when it gets behind by too many blocks (Forwarders).

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
- <https://github.com/smartcontractkit/chainlink-deployments/pull/9475>


[CRE-1533]: https://smartcontract-it.atlassian.net/browse/CRE-1533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ