### PR TITLE
Bump Aptos CLI Version to v8.1.0

### DIFF
--- a/.github/integration-in-memory-tests.yml
+++ b/.github/integration-in-memory-tests.yml
@@ -320,7 +320,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go -run "^TestRMNCurseUncurseAptos$" -timeout 20m -test.parallel=4 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
 
   - id: smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go:TestRMNCurseMCMS
     path: integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -511,7 +511,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_Messaging_EVM2Aptos" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -524,7 +524,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_Messaging_Aptos2EVM" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -537,7 +537,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_Aptos2EVM" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -550,7 +550,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_EVM2Aptos" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -563,7 +563,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_BnM_Aptos2EVM" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -576,7 +576,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_BnM_EVM2Aptos" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -589,7 +589,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_LnR_Aptos2EVM" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -602,7 +602,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_LnR_EVM2Aptos" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -617,7 +617,7 @@ runner-test-matrix:
       echo "🚀 Starting CCIP Aptos LnR without TransferRef EVM2Aptos test..."
       go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_LnR_without_TransferRef_EVM2Aptos" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -630,7 +630,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_LnR_without_TransferRef_Aptos2EVM" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -643,7 +643,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_AptosMessageHasher" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -656,7 +656,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_RegulatedTokenTransfer_EVM2Aptos" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -669,7 +669,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_RegulatedTokenTransfer_Aptos2EVM" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -682,7 +682,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_BnM_Aptos2EVM" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -695,7 +695,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_BnM_EVM2Aptos" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -708,7 +708,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_LnR_Aptos2EVM" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -721,7 +721,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_LnR_EVM2Aptos" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -734,7 +734,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_LnR_without_TransferRef_EVM2Aptos" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 
@@ -747,7 +747,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test ./smoke/ccip -run "Test_CCIP_TokenTransfer_LnR_without_TransferRef_Aptos2EVM" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
-    aptos_cli_version: 7.13.0
+    aptos_cli_version: 8.1.0
     install_plugins_public: true
     free_disk_space: true
 

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -275,7 +275,7 @@ jobs:
         if: ${{ matrix.type.should-run == 'true' && matrix.type.setup-aptos == 'true' }}
         uses: aptos-labs/actions/install-aptos-cli@63740b290d839b87ecfafbcf75ed03a36a54a29f # jan 15, 2025
         with:
-          CLI_VERSION: 7.13.0
+          CLI_VERSION: 8.1.0
 
       - name: Setup Sui CLI v1.61.2
         if: ${{ matrix.type.should-run == 'true' && matrix.type.setup-sui == 'true' }}


### PR DESCRIPTION
Bump the Aptos CLI version to: https://github.com/aptos-labs/aptos-core/releases/tag/aptos-cli-v8.1.0