### PR TITLE
Fixes keystone state's nops grouping

### DIFF
--- a/deployment/keystone/changeset/view.go
+++ b/deployment/keystone/changeset/view.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -69,7 +70,40 @@ func ViewKeystoneV2(e deployment.Environment, previousView json.Marshaler) (json
 		viewErrs = errors.Join(viewErrs, err2)
 	}
 
-	nopsViewV2, err := commonview.GenerateNOPsViewV2(e.GetContext(), e.Logger, e.NodeIDs, e.Offchain, "keystone", nil)
+	remapper := func(nodeName string) string {
+		var nopName string
+
+		switch {
+		case strings.HasPrefix(nodeName, "cl-df-asset-don"):
+			nopName = "cl-df-asset-don"
+		case strings.HasPrefix(nodeName, "cl-keystone"):
+			nopName = "cl-keystone"
+		case strings.HasPrefix(nodeName, "clp-keystone"):
+			nopName = "clp-keystone"
+		case strings.HasPrefix(nodeName, "cl-mercury"):
+			nopName = "cl-mercury"
+		default:
+			parts := strings.Split(nodeName, "-")
+			if len(parts) > 0 {
+				lastPart := parts[len(parts)-1]
+				// if the last part is a number, we take the one before it, due to the following naming conventions in
+				// the mainnet state file:
+				// - bootstrap-<nop-name>-0
+				// - readwriter_2-node-<nop-name>
+				if _, err := strconv.Atoi(lastPart); err == nil && len(parts) > 1 {
+					nopName = parts[len(parts)-2]
+				} else {
+					nopName = lastPart
+				}
+			} else {
+				nopName = nodeName
+			}
+		}
+
+		return nopName
+	}
+
+	nopsViewV2, err := commonview.GenerateNOPsViewV2(e.GetContext(), e.Logger, e.NodeIDs, e.Offchain, "keystone", remapper)
 	if err != nil {
 		err2 := fmt.Errorf("failed to view nops v2: %w", err)
 		e.Logger.Error(err2)

--- a/deployment/keystone/changeset/view.go
+++ b/deployment/keystone/changeset/view.go
@@ -84,19 +84,16 @@ func ViewKeystoneV2(e deployment.Environment, previousView json.Marshaler) (json
 			nopName = "cl-mercury"
 		default:
 			parts := strings.Split(nodeName, "-")
-			if len(parts) > 0 {
-				lastPart := parts[len(parts)-1]
-				// if the last part is a number, we take the one before it, due to the following naming conventions in
-				// the mainnet state file:
-				// - bootstrap-<nop-name>-0
-				// - readwriter_2-node-<nop-name>
-				if _, err := strconv.Atoi(lastPart); err == nil && len(parts) > 1 {
-					nopName = parts[len(parts)-2]
-				} else {
-					nopName = lastPart
-				}
+			// strings.Split always returns at least one element
+			lastPart := parts[len(parts)-1]
+			// if the last part is a number, we take the one before it, due to the following naming conventions in
+			// the mainnet state file:
+			// - bootstrap-<nop-name>-0
+			// - readwriter_2-node-<nop-name>
+			if _, err := strconv.Atoi(lastPart); err == nil && len(parts) > 1 {
+				nopName = parts[len(parts)-2]
 			} else {
-				nopName = nodeName
+				nopName = lastPart
 			}
 		}
 


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
This PR helps addressing [CRE-1533](https://smartcontract-it.atlassian.net/browse/CRE-1533). It fixes the way NOPs are being grouped on the state v2.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
- <https://github.com/smartcontractkit/chainlink-deployments/pull/9506>

[CRE-1533]: https://smartcontract-it.atlassian.net/browse/CRE-1533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ