### PR TITLE
[PRIV-322] Add better observability to the Vault plugin

### DIFF
--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -86,6 +86,7 @@ import (
 	ringconfig "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ring/config"
 	vaultocrplugin "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/vault"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/validate"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr3_1/beholderwrapper"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
@@ -803,7 +804,12 @@ func (d *Delegate) newServicesVaultPlugin(
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate vault plugin: failed to create reporting plugin factory: %w", err)
 	}
-	oracleArgs.ReportingPluginFactory = rpf
+	wrappedRpf := beholderwrapper.NewReportingPluginFactory(
+		rpf,
+		lggr,
+		"vault",
+	)
+	oracleArgs.ReportingPluginFactory = wrappedRpf
 
 	oracle, err := libocr2.NewOracle(oracleArgs)
 	if err != nil {

--- a/core/services/ocr3_1/beholderwrapper/factory.go
+++ b/core/services/ocr3_1/beholderwrapper/factory.go
@@ -1,0 +1,50 @@
+package beholderwrapper
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+)
+
+var _ ocr3_1types.ReportingPluginFactory[any] = &ReportingPluginFactory[any]{}
+
+type ReportingPluginFactory[RI any] struct {
+	wrapped ocr3_1types.ReportingPluginFactory[RI]
+	lggr    logger.Logger
+	plugin  string
+}
+
+func NewReportingPluginFactory[RI any](
+	wrapped ocr3_1types.ReportingPluginFactory[RI],
+	lggr logger.Logger,
+	plugin string,
+) *ReportingPluginFactory[RI] {
+	return &ReportingPluginFactory[RI]{
+		wrapped: wrapped,
+		lggr:    lggr,
+		plugin:  plugin,
+	}
+}
+
+func (r ReportingPluginFactory[RI]) NewReportingPlugin(ctx context.Context, config ocr3types.ReportingPluginConfig, fetcher ocr3_1types.BlobBroadcastFetcher) (ocr3_1types.ReportingPlugin[RI], ocr3_1types.ReportingPluginInfo, error) {
+	plugin, info, err := r.wrapped.NewReportingPlugin(ctx, config, fetcher)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	metrics, err := newPluginMetrics(r.plugin, config.ConfigDigest.String())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create plugin metrics: %w", err)
+	}
+
+	r.lggr.Infow("Wrapping OCR3_1 ReportingPlugin with beholder metrics reporter",
+		"configDigest", config.ConfigDigest,
+	)
+
+	wrappedPlugin := newReportingPlugin(plugin, metrics)
+	return wrappedPlugin, info, nil
+}

--- a/core/services/ocr3_1/beholderwrapper/factory_test.go
+++ b/core/services/ocr3_1/beholderwrapper/factory_test.go
@@ -1,0 +1,48 @@
+package beholderwrapper
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func Test_WrapperFactory(t *testing.T) {
+	validFactory := NewReportingPluginFactory(
+		&fakeFactory[uint]{},
+		logger.TestLogger(t),
+		"plugin",
+	)
+	failingFactory := NewReportingPluginFactory(
+		&fakeFactory[uint]{err: errors.New("error")},
+		logger.TestLogger(t),
+		"plugin",
+	)
+
+	plugin, _, err := validFactory.NewReportingPlugin(t.Context(), ocr3types.ReportingPluginConfig{}, nil)
+	require.NoError(t, err)
+
+	_, err = plugin.StateTransition(t.Context(), 1, ocrtypes.AttributedQuery{}, nil, nil, nil)
+	require.NoError(t, err)
+
+	_, _, err = failingFactory.NewReportingPlugin(t.Context(), ocr3types.ReportingPluginConfig{}, nil)
+	require.Error(t, err)
+}
+
+type fakeFactory[RI any] struct {
+	err error
+}
+
+func (f *fakeFactory[RI]) NewReportingPlugin(context.Context, ocr3types.ReportingPluginConfig, ocr3_1types.BlobBroadcastFetcher) (ocr3_1types.ReportingPlugin[RI], ocr3_1types.ReportingPluginInfo, error) {
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+	return &fakePlugin[RI]{}, ocr3_1types.ReportingPluginInfo1{}, nil
+}

--- a/core/services/ocr3_1/beholderwrapper/plugin.go
+++ b/core/services/ocr3_1/beholderwrapper/plugin.go
@@ -1,0 +1,127 @@
+package beholderwrapper
+
+import (
+	"context"
+	"time"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+)
+
+var _ ocr3_1types.ReportingPlugin[any] = &reportingPlugin[any]{}
+
+type reportingPlugin[RI any] struct {
+	ocr3_1types.ReportingPlugin[RI]
+	metrics *pluginMetrics
+}
+
+func newReportingPlugin[RI any](
+	origin ocr3_1types.ReportingPlugin[RI],
+	metrics *pluginMetrics,
+) *reportingPlugin[RI] {
+	return &reportingPlugin[RI]{
+		ReportingPlugin: origin,
+		metrics:         metrics,
+	}
+}
+
+func (p *reportingPlugin[RI]) Query(ctx context.Context, seqNr uint64, keyValueReader ocr3_1types.KeyValueStateReader, blobBroadcastFetcher ocr3_1types.BlobBroadcastFetcher) (ocrtypes.Query, error) {
+	return withObservedExecution(ctx, p.metrics, query, func() (ocrtypes.Query, error) {
+		return p.ReportingPlugin.Query(ctx, seqNr, keyValueReader, blobBroadcastFetcher)
+	})
+}
+
+func (p *reportingPlugin[RI]) Observation(ctx context.Context, seqNr uint64, aq ocrtypes.AttributedQuery, keyValueReader ocr3_1types.KeyValueStateReader, blobBroadcastFetcher ocr3_1types.BlobBroadcastFetcher) (ocrtypes.Observation, error) {
+	result, err := withObservedExecution(ctx, p.metrics, observation, func() (ocrtypes.Observation, error) {
+		return p.ReportingPlugin.Observation(ctx, seqNr, aq, keyValueReader, blobBroadcastFetcher)
+	})
+	if err == nil {
+		p.metrics.trackSize(ctx, observation, len(result))
+	}
+	return result, err
+}
+
+func (p *reportingPlugin[RI]) ValidateObservation(ctx context.Context, seqNr uint64, aq ocrtypes.AttributedQuery, ao ocrtypes.AttributedObservation, keyValueReader ocr3_1types.KeyValueStateReader, blobFetcher ocr3_1types.BlobFetcher) error {
+	_, err := withObservedExecution(ctx, p.metrics, validateObservation, func() (any, error) {
+		err := p.ReportingPlugin.ValidateObservation(ctx, seqNr, aq, ao, keyValueReader, blobFetcher)
+		return nil, err
+	})
+	return err
+}
+
+func (p *reportingPlugin[RI]) ObservationQuorum(ctx context.Context, seqNr uint64, aq ocrtypes.AttributedQuery, aos []ocrtypes.AttributedObservation, keyValueReader ocr3_1types.KeyValueStateReader, blobFetcher ocr3_1types.BlobFetcher) (bool, error) {
+	return withObservedExecution(ctx, p.metrics, observationQuorum, func() (bool, error) {
+		return p.ReportingPlugin.ObservationQuorum(ctx, seqNr, aq, aos, keyValueReader, blobFetcher)
+	})
+}
+
+func (p *reportingPlugin[RI]) StateTransition(ctx context.Context, seqNr uint64, aq ocrtypes.AttributedQuery, aos []ocrtypes.AttributedObservation, keyValueReadWriter ocr3_1types.KeyValueStateReadWriter, blobFetcher ocr3_1types.BlobFetcher) (ocr3_1types.ReportsPlusPrecursor, error) {
+	result, err := withObservedExecution(ctx, p.metrics, stateTransition, func() (ocr3_1types.ReportsPlusPrecursor, error) {
+		return p.ReportingPlugin.StateTransition(ctx, seqNr, aq, aos, keyValueReadWriter, blobFetcher)
+	})
+	if err == nil {
+		p.metrics.trackSize(ctx, stateTransition, len(result))
+	}
+	return result, err
+}
+
+func (p *reportingPlugin[RI]) Committed(ctx context.Context, seqNr uint64, keyValueReader ocr3_1types.KeyValueStateReader) error {
+	_, err := withObservedExecution(ctx, p.metrics, committed, func() (any, error) {
+		err := p.ReportingPlugin.Committed(ctx, seqNr, keyValueReader)
+		return nil, err
+	})
+	return err
+}
+
+func (p *reportingPlugin[RI]) Reports(ctx context.Context, seqNr uint64, reportsPlusPrecursor ocr3_1types.ReportsPlusPrecursor) ([]ocr3types.ReportPlus[RI], error) {
+	result, err := withObservedExecution(ctx, p.metrics, reports, func() ([]ocr3types.ReportPlus[RI], error) {
+		return p.ReportingPlugin.Reports(ctx, seqNr, reportsPlusPrecursor)
+	})
+	p.metrics.trackReports(ctx, reports, len(result))
+	return result, err
+}
+
+func (p *reportingPlugin[RI]) ShouldAcceptAttestedReport(ctx context.Context, seqNr uint64, reportWithInfo ocr3types.ReportWithInfo[RI]) (bool, error) {
+	result, err := withObservedExecution(ctx, p.metrics, shouldAccept, func() (bool, error) {
+		return p.ReportingPlugin.ShouldAcceptAttestedReport(ctx, seqNr, reportWithInfo)
+	})
+	p.metrics.trackReports(ctx, shouldAccept, boolToInt(result))
+	return result, err
+}
+
+func (p *reportingPlugin[RI]) ShouldTransmitAcceptedReport(ctx context.Context, seqNr uint64, reportWithInfo ocr3types.ReportWithInfo[RI]) (bool, error) {
+	result, err := withObservedExecution(ctx, p.metrics, shouldTransmit, func() (bool, error) {
+		return p.ReportingPlugin.ShouldTransmitAcceptedReport(ctx, seqNr, reportWithInfo)
+	})
+	p.metrics.trackReports(ctx, shouldTransmit, boolToInt(result))
+	return result, err
+}
+
+func (p *reportingPlugin[RI]) Close() error {
+	p.metrics.updateStatus(context.Background(), false)
+	return p.ReportingPlugin.Close()
+}
+
+func boolToInt(arg bool) int {
+	if arg {
+		return 1
+	}
+	return 0
+}
+
+func withObservedExecution[R any](
+	ctx context.Context,
+	metrics *pluginMetrics,
+	function functionType,
+	exec func() (R, error),
+) (R, error) {
+	start := time.Now()
+	result, err := exec()
+
+	success := err == nil
+	metrics.recordDuration(ctx, function, time.Since(start), success)
+	metrics.updateStatus(ctx, true)
+
+	return result, err
+}

--- a/core/services/ocr3_1/beholderwrapper/plugin_test.go
+++ b/core/services/ocr3_1/beholderwrapper/plugin_test.go
@@ -1,0 +1,178 @@
+package beholderwrapper
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+)
+
+func Test_ReportingPlugin_WrapsAllMethods(t *testing.T) {
+	metrics, err := newPluginMetrics("test", "abc")
+	require.NoError(t, err)
+
+	plugin := newReportingPlugin(
+		&fakePlugin[uint]{reports: make([]ocr3types.ReportPlus[uint], 2), observationSize: 5, stateTransitionSize: 3},
+		metrics,
+	)
+
+	// Test Query
+	_, err = plugin.Query(t.Context(), 1, nil, nil)
+	require.NoError(t, err)
+
+	// Test Observation
+	obs, err := plugin.Observation(t.Context(), 1, ocrtypes.AttributedQuery{}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, obs, 5)
+
+	// Test ValidateObservation
+	err = plugin.ValidateObservation(t.Context(), 1, ocrtypes.AttributedQuery{}, ocrtypes.AttributedObservation{}, nil, nil)
+	require.NoError(t, err)
+
+	// Test ObservationQuorum
+	quorum, err := plugin.ObservationQuorum(t.Context(), 1, ocrtypes.AttributedQuery{}, nil, nil, nil)
+	require.NoError(t, err)
+	require.True(t, quorum)
+
+	// Test StateTransition
+	st, err := plugin.StateTransition(t.Context(), 1, ocrtypes.AttributedQuery{}, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, st, 3)
+
+	// Test Committed
+	err = plugin.Committed(t.Context(), 1, nil)
+	require.NoError(t, err)
+
+	// Test Reports
+	reports, err := plugin.Reports(t.Context(), 1, nil)
+	require.NoError(t, err)
+	require.Len(t, reports, 2)
+
+	// Test ShouldAcceptAttestedReport
+	accept, err := plugin.ShouldAcceptAttestedReport(t.Context(), 1, ocr3types.ReportWithInfo[uint]{})
+	require.NoError(t, err)
+	require.True(t, accept)
+
+	// Test ShouldTransmitAcceptedReport
+	transmit, err := plugin.ShouldTransmitAcceptedReport(t.Context(), 1, ocr3types.ReportWithInfo[uint]{})
+	require.NoError(t, err)
+	require.True(t, transmit)
+
+	// Test Close
+	err = plugin.Close()
+	require.NoError(t, err)
+}
+
+func Test_ReportingPlugin_PropagatesErrors(t *testing.T) {
+	metrics, err := newPluginMetrics("test", "abc")
+	require.NoError(t, err)
+
+	expectedErr := errors.New("test error")
+	plugin := newReportingPlugin(
+		&fakePlugin[uint]{err: expectedErr},
+		metrics,
+	)
+
+	_, err = plugin.Query(t.Context(), 1, nil, nil)
+	require.ErrorIs(t, err, expectedErr)
+
+	_, err = plugin.Observation(t.Context(), 1, ocrtypes.AttributedQuery{}, nil, nil)
+	require.ErrorIs(t, err, expectedErr)
+
+	err = plugin.ValidateObservation(t.Context(), 1, ocrtypes.AttributedQuery{}, ocrtypes.AttributedObservation{}, nil, nil)
+	require.ErrorIs(t, err, expectedErr)
+
+	_, err = plugin.ObservationQuorum(t.Context(), 1, ocrtypes.AttributedQuery{}, nil, nil, nil)
+	require.ErrorIs(t, err, expectedErr)
+
+	_, err = plugin.StateTransition(t.Context(), 1, ocrtypes.AttributedQuery{}, nil, nil, nil)
+	require.ErrorIs(t, err, expectedErr)
+
+	err = plugin.Committed(t.Context(), 1, nil)
+	require.ErrorIs(t, err, expectedErr)
+
+	_, err = plugin.Reports(t.Context(), 1, nil)
+	require.ErrorIs(t, err, expectedErr)
+
+	_, err = plugin.ShouldAcceptAttestedReport(t.Context(), 1, ocr3types.ReportWithInfo[uint]{})
+	require.ErrorIs(t, err, expectedErr)
+
+	_, err = plugin.ShouldTransmitAcceptedReport(t.Context(), 1, ocr3types.ReportWithInfo[uint]{})
+	require.ErrorIs(t, err, expectedErr)
+
+	err = plugin.Close()
+	require.ErrorIs(t, err, expectedErr)
+}
+
+type fakePlugin[RI any] struct {
+	reports             []ocr3types.ReportPlus[RI]
+	observationSize     int
+	stateTransitionSize int
+	err                 error
+}
+
+func (f *fakePlugin[RI]) Query(context.Context, uint64, ocr3_1types.KeyValueStateReader, ocr3_1types.BlobBroadcastFetcher) (ocrtypes.Query, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return ocrtypes.Query{}, nil
+}
+
+func (f *fakePlugin[RI]) Observation(context.Context, uint64, ocrtypes.AttributedQuery, ocr3_1types.KeyValueStateReader, ocr3_1types.BlobBroadcastFetcher) (ocrtypes.Observation, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return make([]byte, f.observationSize), nil
+}
+
+func (f *fakePlugin[RI]) ValidateObservation(context.Context, uint64, ocrtypes.AttributedQuery, ocrtypes.AttributedObservation, ocr3_1types.KeyValueStateReader, ocr3_1types.BlobFetcher) error {
+	return f.err
+}
+
+func (f *fakePlugin[RI]) ObservationQuorum(context.Context, uint64, ocrtypes.AttributedQuery, []ocrtypes.AttributedObservation, ocr3_1types.KeyValueStateReader, ocr3_1types.BlobFetcher) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	return true, nil
+}
+
+func (f *fakePlugin[RI]) StateTransition(context.Context, uint64, ocrtypes.AttributedQuery, []ocrtypes.AttributedObservation, ocr3_1types.KeyValueStateReadWriter, ocr3_1types.BlobFetcher) (ocr3_1types.ReportsPlusPrecursor, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return make([]byte, f.stateTransitionSize), nil
+}
+
+func (f *fakePlugin[RI]) Committed(context.Context, uint64, ocr3_1types.KeyValueStateReader) error {
+	return f.err
+}
+
+func (f *fakePlugin[RI]) Reports(context.Context, uint64, ocr3_1types.ReportsPlusPrecursor) ([]ocr3types.ReportPlus[RI], error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.reports, nil
+}
+
+func (f *fakePlugin[RI]) ShouldAcceptAttestedReport(context.Context, uint64, ocr3types.ReportWithInfo[RI]) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	return true, nil
+}
+
+func (f *fakePlugin[RI]) ShouldTransmitAcceptedReport(context.Context, uint64, ocr3types.ReportWithInfo[RI]) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	return true, nil
+}
+
+func (f *fakePlugin[RI]) Close() error {
+	return f.err
+}

--- a/core/services/ocr3_1/beholderwrapper/types.go
+++ b/core/services/ocr3_1/beholderwrapper/types.go
@@ -1,0 +1,104 @@
+package beholderwrapper
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+)
+
+type functionType string
+
+const (
+	query               functionType = "query"
+	observation         functionType = "observation"
+	validateObservation functionType = "validateObservation"
+	observationQuorum   functionType = "observationQuorum"
+	stateTransition     functionType = "stateTransition"
+	committed           functionType = "committed"
+	reports             functionType = "reports"
+	shouldAccept        functionType = "shouldAccept"
+	shouldTransmit      functionType = "shouldTransmit"
+)
+
+type pluginMetrics struct {
+	plugin       string
+	configDigest string
+
+	durations        metric.Int64Histogram
+	reportsGenerated metric.Int64Counter
+	sizes            metric.Int64Counter
+	status           metric.Int64Gauge
+}
+
+func newPluginMetrics(plugin, configDigest string) (*pluginMetrics, error) {
+	durations, err := beholder.GetMeter().Int64Histogram("platform_ocr3_1_reporting_plugin_duration_ms")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create duration histogram: %w", err)
+	}
+
+	reportsGenerated, err := beholder.GetMeter().Int64Counter("platform_ocr3_1_reporting_plugin_reports_processed")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create reports counter: %w", err)
+	}
+
+	sizes, err := beholder.GetMeter().Int64Counter("platform_ocr3_1_reporting_plugin_data_sizes")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create sizes counter: %w", err)
+	}
+
+	status, err := beholder.GetMeter().Int64Gauge("platform_ocr3_1_reporting_plugin_status")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create status gauge: %w", err)
+	}
+
+	return &pluginMetrics{
+		plugin:           plugin,
+		configDigest:     configDigest,
+		durations:        durations,
+		reportsGenerated: reportsGenerated,
+		sizes:            sizes,
+		status:           status,
+	}, nil
+}
+
+func (m *pluginMetrics) recordDuration(ctx context.Context, function functionType, d time.Duration, success bool) {
+	m.durations.Record(ctx, d.Milliseconds(), metric.WithAttributes(
+		attribute.String("plugin", m.plugin),
+		attribute.String("function", string(function)),
+		attribute.String("success", strconv.FormatBool(success)),
+		attribute.String("configDigest", m.configDigest),
+	))
+}
+
+func (m *pluginMetrics) trackReports(ctx context.Context, function functionType, count int) {
+	m.reportsGenerated.Add(ctx, int64(count), metric.WithAttributes(
+		attribute.String("plugin", m.plugin),
+		attribute.String("function", string(function)),
+		attribute.String("configDigest", m.configDigest),
+	))
+}
+
+func (m *pluginMetrics) trackSize(ctx context.Context, function functionType, size int) {
+	m.sizes.Add(ctx, int64(size), metric.WithAttributes(
+		attribute.String("plugin", m.plugin),
+		attribute.String("function", string(function)),
+		attribute.String("configDigest", m.configDigest),
+	))
+}
+
+func (m *pluginMetrics) updateStatus(ctx context.Context, up bool) {
+	val := int64(0)
+	if up {
+		val = 1
+	}
+	m.status.Record(ctx, val, metric.WithAttributes(
+		attribute.String("plugin", m.plugin),
+		attribute.String("configDigest", m.configDigest),
+	))
+}


### PR DESCRIPTION
Add a ocr3_1/beholderwrapper package that wraps an OCR3_1 RP implementation and emits beholder logs for it.

Wire this up to the Vault plugin so we can benefit from observations on eg. plugin size.

 