### PR TITLE
Update confidential-http capability to v0.0.2

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -49,6 +49,6 @@ plugins:
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "b485e01d79c160354d23154d73f0ee753e2d4397"
+      gitRef: "2c7c8e0282e350136a37f4aae518225797c3551a"
       installPath: "./cmd/confidential-http"
 


### PR DESCRIPTION
## Summary
Update confidential-http capability gitRef to v0.0.2 release.

- gitRef: `2c7c8e0282e350136a37f4aae518225797c3551a`
- Release: https://github.com/smartcontractkit/confidential-compute/releases/tag/v0.0.2

## Changes
- `plugins/plugins.private.yaml`: Update confidential-http gitRef