### PR TITLE
Bump version and update CHANGELOG for core v2.32.0

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -49,6 +49,6 @@ plugins:
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "b485e01d79c160354d23154d73f0ee753e2d4397"
+      gitRef: "2c7c8e0282e350136a37f4aae518225797c3551a"
       installPath: "./cmd/confidential-http"
 


### PR DESCRIPTION
Update gitRef to 2c7c8e0282e350136a37f4aae518225797c3551a

Release: https://github.com/smartcontractkit/confidential-compute/releases/tag/v0.0.2
