### PR TITLE
ci: fix permissions for prerelease slack notifications

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -125,6 +125,8 @@ jobs:
   # Notify Slack channel for new git tags associated with pre-releases.
   # Final release notifications originate from the release coordinator repo.
   slack-notify-prereleases:
+    permissions:
+      contents: read
     if: always() && (needs.docker-core.result == 'success' || needs.docker-ccip.result == 'success') && needs.checks.outputs.is-pre-release == 'true'
     needs: [checks, docker-core, docker-ccip]
     uses: ./.github/workflows/release-notifications.yml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.32.0-streams",
+  "version": "2.32.0",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.32.0",
+  "version": "2.32.0-streams",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes GitHub Actions permission mismatch blocking prerelease Slack notifications. Required to unblock datastreams beta for INCIDENT-2208.