### PR TITLE
chore(cre): bumps consensus capability version

### DIFF
--- a/.changeset/gold-dragons-melt.md
+++ b/.changeset/gold-dragons-melt.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal chore(cre): bumps consensus capability to include user error for too large observations

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -24,7 +24,7 @@ plugins:
       installPath: "."
   consensus:
     - moduleURI: "github.com/smartcontractkit/capabilities/consensus"
-      gitRef: "b0897990489fdbccb5cdc8892d786cacf64c3a1a"
+      gitRef: "0492b56b7b77c04b1078525fa89a7081949aace4"
       installPath: "."
   workflowevent:
     - enabled: false


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

bumps consensus capability to include new user error on too large observation size

https://github.com/smartcontractkit/capabilities/pull/412

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
