### PR TITLE
Chore: Disable Sui zero receiver test

### DIFF
--- a/.github/integration-in-memory-tests.yml
+++ b/.github/integration-in-memory-tests.yml
@@ -800,19 +800,20 @@ runner-test-matrix:
   #   install_plugins_public: true
   #   free_disk_space: true
 
-  - id: smoke/ccip/ccip_sui_messaging_test.go:Test_CCIP_EVM2Sui_ZeroReceiver
-    path: integration-tests/smoke/ccip/ccip_sui_messaging_test.go
-    test_env_type: in-memory
-    runs_on: ubuntu-latest
-    triggers:
-      - PR Integration CCIP Tests
-      - Nightly Integration CCIP Tests
-    test_cmd: |
-      go test ./smoke/ccip -run "Test_CCIP_EVM2Sui_ZeroReceiver" -timeout 25m -test.parallel=1 -count=1 -json
-    test_go_project_path: integration-tests
-    sui_cli_version: mainnet-1.60.1
-    install_plugins_public: true
-    free_disk_space: true
+  # Skipping Sui zero receiver test due to flakiness
+  # - id: smoke/ccip/ccip_sui_messaging_test.go:Test_CCIP_EVM2Sui_ZeroReceiver
+  #   path: integration-tests/smoke/ccip/ccip_sui_messaging_test.go
+  #   test_env_type: in-memory
+  #   runs_on: ubuntu-latest
+  #   triggers:
+  #     - PR Integration CCIP Tests
+  #     - Nightly Integration CCIP Tests
+  #   test_cmd: |
+  #     go test ./smoke/ccip -run "Test_CCIP_EVM2Sui_ZeroReceiver" -timeout 25m -test.parallel=1 -count=1 -json
+  #   test_go_project_path: integration-tests
+  #   sui_cli_version: mainnet-1.60.1
+  #   install_plugins_public: true
+  #   free_disk_space: true
 
   - id: smoke/ccip/ccip_sui_token_transfer_test.go:Test_CCIPTokenTransfer_Sui2EVM_LockReleaseTokenPool
     path: integration-tests/smoke/ccip/ccip_sui_token_transfer_test.go

--- a/integration-tests/smoke/ccip/ccip_sui_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_sui_messaging_test.go
@@ -15,8 +15,9 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
-	module_fee_quoter "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip/fee_quoter"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
+
+	module_fee_quoter "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip/fee_quoter"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
@@ -545,6 +546,7 @@ func Test_CCIP_Messaging_EVM2Sui(t *testing.T) {
 }
 
 func Test_CCIP_EVM2Sui_ZeroReceiver(t *testing.T) {
+	t.Skip("Skipping Sui zero receiver test due to flakiness")
 	e, _, _ := testsetups.NewIntegrationEnvironment(
 		t,
 		testhelpers.WithNumOfChains(2),


### PR DESCRIPTION
This PR disables the the "ZeroReceiver" test case for Sui due to flakes and resource usage.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
