### PR TITLE
Fix CLD state generation: handle v1_6_1 token pool types and skip failing pools

### DIFF
--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -766,7 +766,8 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			jobCh <- func() error {
 				tokenPoolView, err := v1_5.GenerateTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
-					return fmt.Errorf("failed to generate burn mint token pool view for %s: %w", tokenPool.Address().String(), err)
+					lggr.Warnw("failed to generate burn mint token pool view, skipping", "tokenPool", tokenPool.Address().Hex(), "chain", chain, "error", err)
+					return nil
 				}
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), v1_5_1.PoolView{
 					TokenPoolView: tokenPoolView,
@@ -781,7 +782,8 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			jobCh <- func() error {
 				tokenPoolView, err := v1_5_1.GenerateTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
-					return fmt.Errorf("failed to generate burn mint token pool view for %s: %w", tokenPool.Address().String(), err)
+					lggr.Warnw("failed to generate burn mint token pool view, skipping", "tokenPool", tokenPool.Address().Hex(), "chain", chain, "error", err)
+					return nil
 				}
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), v1_5_1.PoolView{
 					TokenPoolView: tokenPoolView,
@@ -796,7 +798,8 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			jobCh <- func() error {
 				tokenPoolView, err := v1_5_1.GenerateTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
-					return fmt.Errorf("failed to generate burn mint token pool view for %s: %w", tokenPool.Address().String(), err)
+					lggr.Warnw("failed to generate burn mint token pool view, skipping", "tokenPool", tokenPool.Address().Hex(), "chain", chain, "error", err)
+					return nil
 				}
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), v1_5_1.PoolView{
 					TokenPoolView: tokenPoolView,
@@ -811,7 +814,8 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			jobCh <- func() error {
 				tokenPoolView, err := v1_5_1.GenerateTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
-					return fmt.Errorf("failed to generate burn mint token pool view for %s: %w", tokenPool.Address().String(), err)
+					lggr.Warnw("failed to generate burn with from mint token pool view, skipping", "tokenPool", tokenPool.Address().Hex(), "chain", chain, "error", err)
+					return nil
 				}
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), v1_5_1.PoolView{
 					TokenPoolView: tokenPoolView,
@@ -826,7 +830,8 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			jobCh <- func() error {
 				tokenPoolView, err := v1_5_1.GenerateTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
-					return fmt.Errorf("failed to generate burn mint token pool view for %s: %w", tokenPool.Address().String(), err)
+					lggr.Warnw("failed to generate burn from mint token pool view, skipping", "tokenPool", tokenPool.Address().Hex(), "chain", chain, "error", err)
+					return nil
 				}
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), v1_5_1.PoolView{
 					TokenPoolView: tokenPoolView,
@@ -841,7 +846,8 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			jobCh <- func() error {
 				tokenPoolView, err := v1_5_1.GenerateLockReleaseTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
-					return fmt.Errorf("failed to generate lock release token pool view for %s: %w", tokenPool.Address().String(), err)
+					lggr.Warnw("failed to generate lock release token pool view, skipping", "tokenPool", tokenPool.Address().Hex(), "chain", chain, "error", err)
+					return nil
 				}
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), tokenPoolView)
 				lggr.Infow("generated lock release token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
@@ -854,7 +860,8 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			jobCh <- func() error {
 				tokenPoolView, err := v1_6_1.GenerateLockReleaseTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
-					return fmt.Errorf("failed to generate lock release token pool view for %s: %w", tokenPool.Address().String(), err)
+					lggr.Warnw("failed to generate lock release token pool view, skipping", "tokenPool", tokenPool.Address().Hex(), "chain", chain, "error", err)
+					return nil
 				}
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), tokenPoolView)
 				lggr.Infow("generated lock release token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
@@ -867,7 +874,8 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		jobCh <- func() error {
 			tokenPoolView, err := v1_5_1.GenerateUSDCTokenPoolView(pool)
 			if err != nil {
-				return fmt.Errorf("failed to generate USDC token pool view for %s: %w", pool.Address().String(), err)
+				lggr.Warnw("failed to generate USDC token pool view, skipping", "tokenPool", pool.Address().Hex(), "chain", chain, "error", err)
+				return nil
 			}
 			chainView.UpdateTokenPool(string(shared.USDCSymbol), pool.Address().Hex(), tokenPoolView)
 			lggr.Infow("generated USDC token pool view", "tokenPool", pool.Address().Hex(), "chain", chain)

--- a/deployment/ccip/view/v1_5_1/token_pool.go
+++ b/deployment/ccip/view/v1_5_1/token_pool.go
@@ -13,6 +13,8 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/lock_release_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/usdc_token_pool"
+	burn_mint_token_pool_v1_6_1 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_1/burn_mint_token_pool"
+	lock_release_token_pool_v1_6_1 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_1/lock_release_token_pool"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view/shared"
 	"github.com/smartcontractkit/chainlink/deployment/common/view/types"
@@ -47,6 +49,12 @@ func GetCurrentInboundRateLimiterState(t TokenPoolContract, remoteChainSelector 
 	case *usdc_token_pool.USDCTokenPool:
 		state, err := v.GetCurrentInboundRateLimiterState(nil, remoteChainSelector)
 		return token_pool.RateLimiterTokenBucket(state), err
+	case *burn_mint_token_pool_v1_6_1.BurnMintTokenPool:
+		state, err := v.GetCurrentInboundRateLimiterState(nil, remoteChainSelector)
+		return token_pool.RateLimiterTokenBucket(state), err
+	case *lock_release_token_pool_v1_6_1.LockReleaseTokenPool:
+		state, err := v.GetCurrentInboundRateLimiterState(nil, remoteChainSelector)
+		return token_pool.RateLimiterTokenBucket(state), err
 	default:
 		return token_pool.RateLimiterTokenBucket{}, fmt.Errorf("unknown type %T", t)
 	}
@@ -67,6 +75,12 @@ func GetCurrentOutboundRateLimiterState(t TokenPoolContract, remoteChainSelector
 		state, err := v.GetCurrentOutboundRateLimiterState(nil, remoteChainSelector)
 		return token_pool.RateLimiterTokenBucket(state), err
 	case *usdc_token_pool.USDCTokenPool:
+		state, err := v.GetCurrentOutboundRateLimiterState(nil, remoteChainSelector)
+		return token_pool.RateLimiterTokenBucket(state), err
+	case *burn_mint_token_pool_v1_6_1.BurnMintTokenPool:
+		state, err := v.GetCurrentOutboundRateLimiterState(nil, remoteChainSelector)
+		return token_pool.RateLimiterTokenBucket(state), err
+	case *lock_release_token_pool_v1_6_1.LockReleaseTokenPool:
 		state, err := v.GetCurrentOutboundRateLimiterState(nil, remoteChainSelector)
 		return token_pool.RateLimiterTokenBucket(state), err
 	default:


### PR DESCRIPTION
## Summary

- Add v1_6_1 `BurnMintTokenPool` and `LockReleaseTokenPool` type handling to `GetCurrentInboundRateLimiterState` and `GetCurrentOutboundRateLimiterState` functions in `v1_5_1/token_pool.go`
- Change token pool view generation in `state.go` to log warnings and continue instead of failing when individual pools error (e.g., due to on-chain reverts like uninitialized pools)

## Problem

State generation in `chainlink-deployments` was failing with:
1. `unknown type *burn_mint_token_pool.BurnMintTokenPool` - when v1_6_1 token pools were passed to v1_5_1 view functions
2. `execution reverted` - when certain token pools (e.g., MARA pool on ethereum-mainnet) failed on-chain calls like `CanAcceptLiquidity()`

## Solution

1. Added explicit type switch cases for v1_6_1 pool types in the v1_5_1 rate limiter state functions
2. Changed error handling in token pool view generation to log warnings and skip problematic pools instead of failing the entire state generation