### PR TITLE
[CRE][Don2Don] Support multiple trigger subscriptions of the same type

### DIFF
--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -55,6 +55,7 @@ type dynamicPublisherConfig struct {
 type registrationKey struct {
 	callerDonID uint32
 	workflowID  string
+	triggerID   string
 }
 
 type pubRegState struct {
@@ -68,6 +69,7 @@ type batchedResponse struct {
 	callerDonID    uint32
 	triggerEventID string
 	workflowIDs    []string
+	triggerIDs     []string
 }
 
 type TriggerPublisher interface {
@@ -199,27 +201,27 @@ func (p *triggerPublisher) Receive(_ context.Context, msg *types.MessageBody) {
 			p.lggr.Errorw("received trigger request with invalid workflow ID", "workflowId", SanitizeLogString(req.Metadata.WorkflowID), "err", err)
 			return
 		}
-		p.lggr.Debugw("received trigger registration", "workflowId", req.Metadata.WorkflowID, "sender", sender)
-		key := registrationKey{msg.CallerDonId, req.Metadata.WorkflowID}
+		p.lggr.Debugw("received trigger registration", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "sender", sender)
+		key := registrationKey{msg.CallerDonId, req.Metadata.WorkflowID, req.TriggerID}
 		nowMs := time.Now().UnixMilli()
 		p.mu.Lock()
 		defer p.mu.Unlock()
 		p.messageCache.Insert(key, sender, nowMs, msg.Payload)
 		_, exists := p.registrations[key]
 		if exists {
-			p.lggr.Debugw("trigger registration already exists", "workflowId", req.Metadata.WorkflowID)
+			p.lggr.Debugw("trigger registration already exists", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
 			return
 		}
 		// NOTE: require 2F+1 by default, introduce different strategies later (KS-76)
 		minRequired := uint32(2*callerDon.F + 1)
 		ready, payloads := p.messageCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), false)
 		if !ready {
-			p.lggr.Debugw("not ready to aggregate yet", "workflowId", req.Metadata.WorkflowID, "minRequired", minRequired)
+			p.lggr.Debugw("not ready to aggregate yet", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "minRequired", minRequired)
 			return
 		}
 		aggregated, err := aggregation.AggregateModeRaw(payloads, uint32(callerDon.F+1))
 		if err != nil {
-			p.lggr.Errorw("failed to aggregate trigger registrations", "workflowId", req.Metadata.WorkflowID, "err", err)
+			p.lggr.Errorw("failed to aggregate trigger registrations", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", err)
 			return
 		}
 		unmarshaled, err := pb.UnmarshalTriggerRegistrationRequest(aggregated)
@@ -237,10 +239,10 @@ func (p *triggerPublisher) Receive(_ context.Context, msg *types.MessageBody) {
 			}
 			p.wg.Add(1)
 			go p.triggerEventLoop(callbackCh, key)
-			p.lggr.Debugw("updated trigger registration", "workflowId", req.Metadata.WorkflowID)
+			p.lggr.Debugw("updated trigger registration", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
 		} else {
 			cancel()
-			p.lggr.Errorw("failed to register trigger", "workflowId", req.Metadata.WorkflowID, "err", err)
+			p.lggr.Errorw("failed to register trigger", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", err)
 		}
 	case types.MethodTriggerEvent:
 		p.lggr.Errorw("trigger request failed with error",
@@ -281,12 +283,12 @@ func (p *triggerPublisher) registrationCleanupLoop() {
 				callerDon := cfg.workflowDONs[key.callerDonID]
 				ready, _ := p.messageCache.Ready(key, uint32(2*callerDon.F+1), now-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), false)
 				if !ready {
-					p.lggr.Infow("trigger registration expired", "callerDonID", key.callerDonID, "workflowId", key.workflowID)
+					p.lggr.Infow("trigger registration expired", "callerDonID", key.callerDonID, "workflowId", key.workflowID, "triggerID", key.triggerID)
 					ctx, cancel := p.stopCh.NewCtx()
 					err := cfg.underlying.UnregisterTrigger(ctx, req.request)
 					cancel()
 					p.registrations[key].cancel() // Cancel context on register trigger
-					p.lggr.Infow("unregistered trigger", "callerDonID", key.callerDonID, "workflowId", key.workflowID, "err", err)
+					p.lggr.Infow("unregistered trigger", "callerDonID", key.callerDonID, "workflowId", key.workflowID, "triggerID", key.triggerID, "err", err)
 					// after calling UnregisterTrigger, the underlying trigger will not send any more events to the channel
 					delete(p.registrations, key)
 					p.messageCache.Delete(key)
@@ -305,12 +307,12 @@ func (p *triggerPublisher) triggerEventLoop(callbackCh <-chan commoncap.TriggerR
 			return
 		case response, ok := <-callbackCh:
 			if !ok {
-				p.lggr.Infow("triggerEventLoop channel closed", "workflowId", key.workflowID)
+				p.lggr.Infow("triggerEventLoop channel closed", "workflowId", key.workflowID, "triggerID", key.triggerID)
 				return
 			}
 
 			triggerEvent := response.Event
-			p.lggr.Debugw("received trigger event", "workflowId", key.workflowID, "triggerEventID", triggerEvent.ID)
+			p.lggr.Debugw("received trigger event", "workflowId", key.workflowID, "triggerID", key.triggerID, "triggerEventID", triggerEvent.ID)
 			marshaledResponse, err := pb.MarshalTriggerResponse(response)
 			if err != nil {
 				p.lggr.Debugw("can't marshal trigger event", "err", err)
@@ -327,6 +329,7 @@ func (p *triggerPublisher) triggerEventLoop(callbackCh <-chan commoncap.TriggerR
 					callerDonID:    key.callerDonID,
 					triggerEventID: triggerEvent.ID,
 					workflowIDs:    []string{key.workflowID},
+					triggerIDs:     []string{key.triggerID},
 				})
 			}
 		}
@@ -348,10 +351,12 @@ func (p *triggerPublisher) enqueueForBatching(rawResponse []byte, key registrati
 			callerDonID:    key.callerDonID,
 			triggerEventID: triggerEventID,
 			workflowIDs:    []string{key.workflowID},
+			triggerIDs:     []string{key.triggerID},
 		}
 		p.batchingQueue[sha] = elem
 	} else {
 		elem.workflowIDs = append(elem.workflowIDs, key.workflowID)
+		elem.triggerIDs = append(elem.triggerIDs, key.triggerID)
 	}
 	p.bqMu.Unlock()
 }
@@ -364,12 +369,16 @@ func (p *triggerPublisher) sendBatch(resp *batchedResponse) {
 	}
 
 	for len(resp.workflowIDs) > 0 {
-		idBatch := resp.workflowIDs
-		if cfg.batchingEnabled && int64(len(idBatch)) > int64(cfg.remoteConfig.MaxBatchSize) {
-			idBatch = idBatch[:cfg.remoteConfig.MaxBatchSize]
+		workflowBatch := resp.workflowIDs
+		triggerBatch := resp.triggerIDs
+		if cfg.batchingEnabled && int64(len(workflowBatch)) > int64(cfg.remoteConfig.MaxBatchSize) {
+			workflowBatch = workflowBatch[:cfg.remoteConfig.MaxBatchSize]
+			triggerBatch = triggerBatch[:cfg.remoteConfig.MaxBatchSize]
 			resp.workflowIDs = resp.workflowIDs[cfg.remoteConfig.MaxBatchSize:]
+			resp.triggerIDs = resp.triggerIDs[cfg.remoteConfig.MaxBatchSize:]
 		} else {
 			resp.workflowIDs = nil
+			resp.triggerIDs = nil
 		}
 		msg := &types.MessageBody{
 			CapabilityId:    p.capabilityID,
@@ -379,7 +388,8 @@ func (p *triggerPublisher) sendBatch(resp *batchedResponse) {
 			Payload:         resp.rawResponse,
 			Metadata: &types.MessageBody_TriggerEventMetadata{
 				TriggerEventMetadata: &types.TriggerEventMetadata{
-					WorkflowIds:    idBatch,
+					WorkflowIds:    workflowBatch,
+					TriggerIds:     triggerBatch,
 					TriggerEventId: resp.triggerEventID,
 				},
 			},

--- a/core/capabilities/remote/trigger_publisher_test.go
+++ b/core/capabilities/remote/trigger_publisher_test.go
@@ -2,6 +2,7 @@ package remote_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -283,4 +284,160 @@ func (tr *testTrigger) RegisterTrigger(_ context.Context, request commoncap.Trig
 
 func (tr *testTrigger) UnregisterTrigger(_ context.Context, request commoncap.TriggerRegistrationRequest) error {
 	return nil
+}
+
+func TestTriggerPublisher_MultipleTriggersSameWorkflow(t *testing.T) {
+	ctx := testutils.Context(t)
+	lggr := logger.Test(t)
+	capabilityDONID, workflowDONID := uint32(1), uint32(2)
+
+	capInfo := commoncap.CapabilityInfo{
+		ID:             capID,
+		CapabilityType: commoncap.CapabilityTypeTrigger,
+		Description:    "Remote Trigger",
+	}
+	peers := make([]p2ptypes.PeerID, 2)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	capDonInfo := commoncap.DON{
+		ID:      capabilityDONID,
+		Members: []p2ptypes.PeerID{peers[0]},
+		F:       0,
+	}
+	workflowDonInfo := commoncap.DON{
+		ID:      workflowDONID,
+		Members: []p2ptypes.PeerID{peers[1]},
+		F:       0,
+	}
+	workflowDONs := map[uint32]commoncap.DON{
+		workflowDonInfo.ID: workflowDonInfo,
+	}
+
+	// Create a trigger that tracks registrations by triggerID
+	underlying := newMultiTrigger(capInfo)
+
+	dispatcher := mocks.NewDispatcher(t)
+	config := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Millisecond,
+		RegistrationExpiry:      100 * time.Second,
+		MinResponsesToAggregate: 1,
+		MessageExpiry:           100 * time.Second,
+		MaxBatchSize:            1, // no batching
+		BatchCollectionPeriod:   time.Second,
+	}
+
+	publisher := remote.NewTriggerPublisher(capInfo.ID, "", dispatcher, lggr)
+	require.NoError(t, publisher.SetConfig(config, underlying, capDonInfo, workflowDONs))
+	require.NoError(t, publisher.Start(ctx))
+
+	// Register trigger1
+	regEvent1 := newRegisterTriggerMessageWithTriggerID(t, workflowDONID, peers[1], "trigger1")
+	publisher.Receive(ctx, regEvent1)
+	reg1 := <-underlying.registrationsCh
+	require.Equal(t, "trigger1", reg1.TriggerID)
+	require.Equal(t, workflowID1, reg1.Metadata.WorkflowID)
+
+	// Register trigger2 for the same workflow
+	regEvent2 := newRegisterTriggerMessageWithTriggerID(t, workflowDONID, peers[1], "trigger2")
+	publisher.Receive(ctx, regEvent2)
+	reg2 := <-underlying.registrationsCh
+	require.Equal(t, "trigger2", reg2.TriggerID)
+	require.Equal(t, workflowID1, reg2.Metadata.WorkflowID) // same workflowID
+
+	trigger1EventReceived := make(chan struct{})
+	trigger2EventReceived := make(chan struct{})
+
+	dispatcher.On("Send", peers[1], mock.Anything).Run(func(args mock.Arguments) {
+		msg := args.Get(1).(*remotetypes.MessageBody)
+		require.Equal(t, capID, msg.CapabilityId)
+		require.Equal(t, remotetypes.MethodTriggerEvent, msg.Method)
+		metadata := msg.Metadata.(*remotetypes.MessageBody_TriggerEventMetadata)
+		require.Len(t, metadata.TriggerEventMetadata.WorkflowIds, 1)
+		require.Len(t, metadata.TriggerEventMetadata.TriggerIds, 1)
+		triggerID := metadata.TriggerEventMetadata.TriggerIds[0]
+		eventID := metadata.TriggerEventMetadata.TriggerEventId
+		if triggerID == "trigger1" && eventID == "event1" {
+			close(trigger1EventReceived)
+		} else if triggerID == "trigger2" && eventID == "event2" {
+			close(trigger2EventReceived)
+		}
+	}).Return(nil)
+
+	// Send both events and expect them to be delivered separately
+	underlying.SendEvent("trigger1", commoncap.TriggerResponse{
+		Event: commoncap.TriggerEvent{ID: "event1"},
+	})
+	underlying.SendEvent("trigger2", commoncap.TriggerResponse{
+		Event: commoncap.TriggerEvent{ID: "event2"},
+	})
+
+	<-trigger1EventReceived
+	<-trigger2EventReceived
+
+	require.NoError(t, publisher.Close())
+}
+
+func newRegisterTriggerMessageWithTriggerID(t *testing.T, callerDonID uint32, sender p2ptypes.PeerID, triggerID string) *remotetypes.MessageBody {
+	triggerRequest := commoncap.TriggerRegistrationRequest{
+		TriggerID: triggerID,
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+	marshaled, err := pb.MarshalTriggerRegistrationRequest(triggerRequest)
+	require.NoError(t, err)
+	return &remotetypes.MessageBody{
+		Sender:      sender[:],
+		Method:      remotetypes.MethodRegisterTrigger,
+		CallerDonId: callerDonID,
+		Payload:     marshaled,
+	}
+}
+
+// multiTrigger is a test trigger that supports multiple trigger registrations
+// and can send events to specific triggers by triggerID
+type multiTrigger struct {
+	info            commoncap.CapabilityInfo
+	registrationsCh chan commoncap.TriggerRegistrationRequest
+	eventChans      map[string]chan commoncap.TriggerResponse
+	mu              sync.Mutex
+}
+
+func newMultiTrigger(info commoncap.CapabilityInfo) *multiTrigger {
+	return &multiTrigger{
+		info:            info,
+		registrationsCh: make(chan commoncap.TriggerRegistrationRequest, 10),
+		eventChans:      make(map[string]chan commoncap.TriggerResponse),
+	}
+}
+
+func (tr *multiTrigger) Info(_ context.Context) (commoncap.CapabilityInfo, error) {
+	return tr.info, nil
+}
+
+func (tr *multiTrigger) RegisterTrigger(_ context.Context, request commoncap.TriggerRegistrationRequest) (<-chan commoncap.TriggerResponse, error) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	ch := make(chan commoncap.TriggerResponse, 10)
+	tr.eventChans[request.TriggerID] = ch
+	tr.registrationsCh <- request
+	return ch, nil
+}
+
+func (tr *multiTrigger) UnregisterTrigger(_ context.Context, request commoncap.TriggerRegistrationRequest) error {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if ch, ok := tr.eventChans[request.TriggerID]; ok {
+		close(ch)
+		delete(tr.eventChans, request.TriggerID)
+	}
+	return nil
+}
+
+func (tr *multiTrigger) SendEvent(triggerID string, event commoncap.TriggerResponse) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if ch, ok := tr.eventChans[triggerID]; ok {
+		ch <- event
+	}
 }

--- a/core/capabilities/remote/trigger_subscriber.go
+++ b/core/capabilities/remote/trigger_subscriber.go
@@ -30,9 +30,14 @@ type triggerSubscriber struct {
 	capMethodName string
 	dispatcher    types.Dispatcher
 	cfg           atomic.Pointer[dynamicConfig]
-
-	messageCache        *messagecache.MessageCache[triggerEventKey, p2ptypes.PeerID]
-	registeredWorkflows map[string]*subRegState
+	messageCache  *messagecache.MessageCache[triggerEventKey, p2ptypes.PeerID]
+	// In theory we could identify all trigger registrations only by TriggerID (Workflow Engine
+	// already includes WorkflowID inside TriggerID). However, keeping the workflowID has some benefits:
+	//   - Protection against changes to Engine's logic.
+	//   - Better logging and debugging.
+	//   - Easier migration.
+	// workflowID -> triggerID -> subRegState
+	registeredWorkflows map[string]map[string]*subRegState
 	mu                  sync.RWMutex // protects registeredWorkflows and messageCache
 	stopCh              services.StopChan
 	wg                  sync.WaitGroup
@@ -51,6 +56,7 @@ type dynamicConfig struct {
 type triggerEventKey struct {
 	triggerEventID string
 	workflowID     string
+	triggerID      string
 }
 
 type subRegState struct {
@@ -80,7 +86,7 @@ func NewTriggerSubscriber(capabilityID string, capMethodName string, dispatcher 
 		capMethodName:       capMethodName,
 		dispatcher:          dispatcher,
 		messageCache:        messagecache.NewMessageCache[triggerEventKey, p2ptypes.PeerID](),
-		registeredWorkflows: make(map[string]*subRegState),
+		registeredWorkflows: make(map[string]map[string]*subRegState),
 		stopCh:              make(services.StopChan),
 		lggr:                logger.With(logger.Named(lggr, "TriggerSubscriber"), "capabilityID", capabilityID, "capMethodName", capMethodName),
 	}
@@ -145,17 +151,22 @@ func (s *triggerSubscriber) RegisterTrigger(ctx context.Context, request commonc
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.lggr.Infow("RegisterTrigger called", "donId", cfg.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID)
-	regState, ok := s.registeredWorkflows[request.Metadata.WorkflowID]
+	s.lggr.Infow("RegisterTrigger called", "donId", cfg.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID, "triggerID", request.TriggerID)
+	triggerMap, ok := s.registeredWorkflows[request.Metadata.WorkflowID]
+	if !ok {
+		triggerMap = make(map[string]*subRegState)
+		s.registeredWorkflows[request.Metadata.WorkflowID] = triggerMap
+	}
+	regState, ok := triggerMap[request.TriggerID]
 	if !ok {
 		regState = &subRegState{
 			callback:   make(chan commoncap.TriggerResponse, sendChannelBufferSize),
 			rawRequest: rawRequest,
 		}
-		s.registeredWorkflows[request.Metadata.WorkflowID] = regState
+		triggerMap[request.TriggerID] = regState
 	} else {
 		regState.rawRequest = rawRequest
-		s.lggr.Warnw("RegisterTrigger re-registering trigger", "donId", cfg.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID)
+		s.lggr.Warnw("RegisterTrigger re-registering trigger", "donId", cfg.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID, "triggerID", request.TriggerID)
 	}
 
 	return regState.callback, nil
@@ -184,19 +195,21 @@ func (s *triggerSubscriber) registrationLoop() {
 				s.lggr.Infow("no workflows to register")
 			}
 
-			for _, registration := range s.registeredWorkflows {
-				for _, peerID := range cfg.capDonInfo.Members {
-					m := &types.MessageBody{
-						CapabilityId:     cfg.capInfo.ID,
-						CapabilityDonId:  cfg.capDonInfo.ID,
-						CallerDonId:      cfg.localDonID,
-						Method:           types.MethodRegisterTrigger,
-						Payload:          registration.rawRequest,
-						CapabilityMethod: s.capMethodName,
-					}
-					err := s.dispatcher.Send(peerID, m)
-					if err != nil {
-						s.lggr.Errorw("failed to send message", "donId", cfg.capDonInfo.ID, "peerId", peerID, "err", err)
+			for _, regMap := range s.registeredWorkflows {
+				for _, registration := range regMap {
+					for _, peerID := range cfg.capDonInfo.Members {
+						m := &types.MessageBody{
+							CapabilityId:     cfg.capInfo.ID,
+							CapabilityDonId:  cfg.capDonInfo.ID,
+							CallerDonId:      cfg.localDonID,
+							Method:           types.MethodRegisterTrigger,
+							Payload:          registration.rawRequest, // triggerID is in the raw request
+							CapabilityMethod: s.capMethodName,
+						}
+						err := s.dispatcher.Send(peerID, m)
+						if err != nil {
+							s.lggr.Errorw("failed to send message", "donId", cfg.capDonInfo.ID, "peerId", peerID, "err", err)
+						}
 					}
 				}
 			}
@@ -209,11 +222,18 @@ func (s *triggerSubscriber) UnregisterTrigger(ctx context.Context, request commo
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	state := s.registeredWorkflows[request.Metadata.WorkflowID]
+	triggerMap, ok := s.registeredWorkflows[request.Metadata.WorkflowID]
+	if !ok {
+		return nil
+	}
+	state := triggerMap[request.TriggerID]
 	if state != nil && state.callback != nil {
 		close(state.callback)
 	}
-	delete(s.registeredWorkflows, request.Metadata.WorkflowID)
+	delete(triggerMap, request.TriggerID)
+	if len(triggerMap) == 0 {
+		delete(s.registeredWorkflows, request.Metadata.WorkflowID)
+	}
 	// Registrations will quickly expire on all remote nodes.
 	// Alternatively, we could send UnregisterTrigger messages right away.
 	return nil
@@ -245,31 +265,52 @@ func (s *triggerSubscriber) Receive(_ context.Context, msg *types.MessageBody) {
 			s.lggr.Errorw("received message with too many workflow IDs - truncating", "nWorkflows", len(meta.WorkflowIds), "sender", sender)
 			meta.WorkflowIds = meta.WorkflowIds[:maxBatchedWorkflowIDs]
 		}
-		for _, workflowID := range meta.WorkflowIds {
+		for idx, workflowID := range meta.WorkflowIds {
+			var triggerID string
+			if idx < len(meta.TriggerIds) {
+				triggerID = meta.TriggerIds[idx]
+			}
 			s.mu.RLock()
-			registration, found := s.registeredWorkflows[workflowID]
+			triggerMap, found := s.registeredWorkflows[workflowID]
+			var registration *subRegState
+			if found {
+				if triggerID != "" {
+					// received a message from updated publisher, which provided a triggerID
+					registration = triggerMap[triggerID]
+				} else {
+					// legacy flow, expect there to be only a single trigger of each type per workflow
+					for _, reg := range triggerMap {
+						registration = reg
+						break
+					}
+					if len(triggerMap) > 1 {
+						s.lggr.Errorw("received message without triggerID but workflow has multiple trigger - picking a random one", "workflowID", SanitizeLogString(workflowID), "sender", sender)
+					}
+				}
+			}
 			s.mu.RUnlock()
-			if !found {
-				s.lggr.Errorw("received message for unregistered workflow", "workflowID", SanitizeLogString(workflowID), "sender", sender)
+			if registration == nil {
+				s.lggr.Errorw("received message for unregistered workflow/trigger", "workflowID", SanitizeLogString(workflowID), "triggerID", triggerID, "sender", sender)
 				continue
 			}
 			key := triggerEventKey{
 				triggerEventID: meta.TriggerEventId,
 				workflowID:     workflowID,
+				triggerID:      triggerID,
 			}
 			nowMs := time.Now().UnixMilli()
 			s.mu.Lock()
 			creationTs := s.messageCache.Insert(key, sender, nowMs, msg.Payload)
 			ready, payloads := s.messageCache.Ready(key, cfg.remoteConfig.MinResponsesToAggregate, nowMs-cfg.remoteConfig.MessageExpiry.Milliseconds(), true)
 			s.mu.Unlock()
-			s.lggr.Debugw("trigger event received", "triggerEventId", meta.TriggerEventId, "workflowId", workflowID, "sender", sender, "ready", ready, "nowTs", nowMs, "creationTs", creationTs, "minResponsesToAggregate", cfg.remoteConfig.MinResponsesToAggregate)
+			s.lggr.Debugw("trigger event received", "triggerEventId", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID, "sender", sender, "ready", ready, "nowTs", nowMs, "creationTs", creationTs, "minResponsesToAggregate", cfg.remoteConfig.MinResponsesToAggregate)
 			if ready {
 				aggregatedResponse, err := cfg.aggregator.Aggregate(meta.TriggerEventId, payloads)
 				if err != nil {
-					s.lggr.Errorw("failed to aggregate responses", "triggerEventID", meta.TriggerEventId, "workflowId", workflowID, "err", err)
+					s.lggr.Errorw("failed to aggregate responses", "triggerEventID", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID, "err", err)
 					continue
 				}
-				s.lggr.Infow("remote trigger event aggregated", "triggerEventID", meta.TriggerEventId, "workflowId", workflowID)
+				s.lggr.Infow("remote trigger event aggregated", "triggerEventID", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID)
 				registration.callback <- aggregatedResponse
 			}
 		}

--- a/core/capabilities/remote/trigger_subscriber_test.go
+++ b/core/capabilities/remote/trigger_subscriber_test.go
@@ -279,6 +279,194 @@ func TestTriggerSubscriber_RegistrationLoopWithConfigUpdate(t *testing.T) {
 	require.NoError(t, subscriber.Close())
 }
 
+func TestTriggerSubscriber_MultipleTriggersSameWorkflow(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+	capInfo, capDon, workflowDon := buildTwoTestDONs(t, 1, 1)
+	dispatcher := remoteMocks.NewDispatcher(t)
+	awaitRegistrationMessageCh := make(chan struct{}, 10)
+	dispatcher.On("Send", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		select {
+		case awaitRegistrationMessageCh <- struct{}{}:
+		default:
+		}
+	})
+
+	config := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Millisecond,
+		RegistrationExpiry:      100 * time.Second,
+		MinResponsesToAggregate: 1,
+		MessageExpiry:           100 * time.Second,
+	}
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
+	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
+	require.NoError(t, subscriber.Start(t.Context()))
+
+	// Register two triggers for the same workflow with different triggerIDs
+	req1 := commoncap.TriggerRegistrationRequest{
+		TriggerID: "trigger1",
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+	req2 := commoncap.TriggerRegistrationRequest{
+		TriggerID: "trigger2",
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+
+	callbackCh1, err := subscriber.RegisterTrigger(t.Context(), req1)
+	require.NoError(t, err)
+	callbackCh2, err := subscriber.RegisterTrigger(t.Context(), req2)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), req1))
+		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), req2))
+		require.NoError(t, subscriber.Close())
+	})
+	<-awaitRegistrationMessageCh
+
+	// Send message for trigger1 - should only go to callbackCh1
+	triggerEvent1Msg := buildTriggerEventWithTriggerID(t, capDon.Members[0][:], workflowID1, "trigger1", "event1")
+	subscriber.Receive(t.Context(), triggerEvent1Msg)
+
+	resp := <-callbackCh1
+	require.NotNil(t, resp.Event.Outputs)
+
+	select {
+	case <-callbackCh2:
+		t.Fatal("did not expect message on callbackCh2")
+	default:
+		// expected - no message on callbackCh2
+	}
+
+	// Send message for trigger2 - should only go to callbackCh2
+	triggerEvent2Msg := buildTriggerEventWithTriggerID(t, capDon.Members[0][:], workflowID1, "trigger2", "event2")
+	subscriber.Receive(t.Context(), triggerEvent2Msg)
+
+	resp = <-callbackCh2
+	require.NotNil(t, resp.Event.Outputs)
+
+	select {
+	case <-callbackCh1:
+		t.Fatal("did not expect another message on callbackCh1")
+	default:
+		// expected - no message on callbackCh1
+	}
+}
+
+func TestTriggerSubscriber_LegacyMessageWithoutTriggerID(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+	capInfo, capDon, workflowDon := buildTwoTestDONs(t, 1, 1)
+	dispatcher := remoteMocks.NewDispatcher(t)
+	awaitRegistrationMessageCh := make(chan struct{}, 10)
+	dispatcher.On("Send", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		select {
+		case awaitRegistrationMessageCh <- struct{}{}:
+		default:
+		}
+	})
+
+	config := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Millisecond,
+		RegistrationExpiry:      100 * time.Second,
+		MinResponsesToAggregate: 1,
+		MessageExpiry:           100 * time.Second,
+	}
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
+	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
+	require.NoError(t, subscriber.Start(t.Context()))
+
+	// Register single trigger (legacy style, with triggerID but receiving messages without it)
+	req := commoncap.TriggerRegistrationRequest{
+		TriggerID: "trigger1",
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+
+	callbackCh, err := subscriber.RegisterTrigger(t.Context(), req)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), req))
+		require.NoError(t, subscriber.Close())
+	})
+	<-awaitRegistrationMessageCh
+
+	// Send legacy message without triggerID - should still route to the single registered trigger
+	legacyMsg := buildTriggerEvent(t, capDon.Members[0][:])
+	subscriber.Receive(t.Context(), legacyMsg)
+
+	resp := <-callbackCh
+	require.NotNil(t, resp.Event.Outputs)
+}
+
+func TestTriggerSubscriber_UnregisterOneTriggerKeepsOther(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+	capInfo, capDon, workflowDon := buildTwoTestDONs(t, 1, 1)
+	dispatcher := remoteMocks.NewDispatcher(t)
+	awaitRegistrationMessageCh := make(chan struct{}, 10)
+	dispatcher.On("Send", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		select {
+		case awaitRegistrationMessageCh <- struct{}{}:
+		default:
+		}
+	})
+
+	config := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Millisecond,
+		RegistrationExpiry:      100 * time.Second,
+		MinResponsesToAggregate: 1,
+		MessageExpiry:           100 * time.Second,
+	}
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
+	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
+	require.NoError(t, subscriber.Start(t.Context()))
+
+	// Register two triggers
+	req1 := commoncap.TriggerRegistrationRequest{
+		TriggerID: "trigger1",
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+	req2 := commoncap.TriggerRegistrationRequest{
+		TriggerID: "trigger2",
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+
+	_, err := subscriber.RegisterTrigger(t.Context(), req1)
+	require.NoError(t, err)
+	callbackCh2, err := subscriber.RegisterTrigger(t.Context(), req2)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), req2))
+		require.NoError(t, subscriber.Close())
+	})
+	<-awaitRegistrationMessageCh
+
+	// Unregister trigger1
+	require.NoError(t, subscriber.UnregisterTrigger(t.Context(), req1))
+
+	// trigger2 should still work
+	triggerEvent2Msg := buildTriggerEventWithTriggerID(t, capDon.Members[0][:], workflowID1, "trigger2", "event2")
+	subscriber.Receive(t.Context(), triggerEvent2Msg)
+
+	resp := <-callbackCh2
+	require.NotNil(t, resp.Event.Outputs)
+}
+
 func buildTwoTestDONs(t *testing.T, capDonSize int, workflowDonSize int) (commoncap.CapabilityInfo, commoncap.DON, commoncap.DON) {
 	capInfo := commoncap.CapabilityInfo{
 		ID:             "cap_id@1",
@@ -330,6 +518,33 @@ func buildTriggerEvent(t *testing.T, sender []byte) *remotetypes.MessageBody {
 		Metadata: &remotetypes.MessageBody_TriggerEventMetadata{
 			TriggerEventMetadata: &remotetypes.TriggerEventMetadata{
 				WorkflowIds: []string{workflowID1},
+			},
+		},
+		Payload: marshaled,
+	}
+}
+
+func buildTriggerEventWithTriggerID(t *testing.T, sender []byte, workflowID, triggerID, eventID string) *remotetypes.MessageBody {
+	triggerEventValue, err := values.NewMap(triggerEvent1)
+	require.NoError(t, err)
+	capResponse := commoncap.TriggerResponse{
+		Event: commoncap.TriggerEvent{
+			ID:      eventID,
+			Outputs: triggerEventValue,
+		},
+		Err: nil,
+	}
+	marshaled, err := pb.MarshalTriggerResponse(capResponse)
+	require.NoError(t, err)
+
+	return &remotetypes.MessageBody{
+		Sender: sender,
+		Method: remotetypes.MethodTriggerEvent,
+		Metadata: &remotetypes.MessageBody_TriggerEventMetadata{
+			TriggerEventMetadata: &remotetypes.TriggerEventMetadata{
+				TriggerEventId: eventID,
+				WorkflowIds:    []string{workflowID},
+				TriggerIds:     []string{triggerID},
 			},
 		},
 		Payload: marshaled,

--- a/core/capabilities/remote/types/messages.pb.go
+++ b/core/capabilities/remote/types/messages.pb.go
@@ -366,6 +366,7 @@ type TriggerEventMetadata struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	TriggerEventId string                 `protobuf:"bytes,1,opt,name=trigger_event_id,json=triggerEventId,proto3" json:"trigger_event_id,omitempty"`
 	WorkflowIds    []string               `protobuf:"bytes,2,rep,name=workflow_ids,json=workflowIds,proto3" json:"workflow_ids,omitempty"`
+	TriggerIds     []string               `protobuf:"bytes,3,rep,name=trigger_ids,json=triggerIds,proto3" json:"trigger_ids,omitempty"` // must be equal length to workflow_ids (or empty if not supported)
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -414,6 +415,13 @@ func (x *TriggerEventMetadata) GetWorkflowIds() []string {
 	return nil
 }
 
+func (x *TriggerEventMetadata) GetTriggerIds() []string {
+	if x != nil {
+		return x.TriggerIds
+	}
+	return nil
+}
+
 var File_core_capabilities_remote_types_messages_proto protoreflect.FileDescriptor
 
 const file_core_capabilities_remote_types_messages_proto_rawDesc = "" +
@@ -443,10 +451,12 @@ const file_core_capabilities_remote_types_messages_proto_rawDesc = "" +
 	"\n" +
 	"\bmetadataJ\x04\b\a\x10\bJ\x04\b\b\x10\t\"R\n" +
 	"\x1bTriggerRegistrationMetadata\x123\n" +
-	"\x16last_received_event_id\x18\x01 \x01(\tR\x13lastReceivedEventId\"c\n" +
+	"\x16last_received_event_id\x18\x01 \x01(\tR\x13lastReceivedEventId\"\x84\x01\n" +
 	"\x14TriggerEventMetadata\x12(\n" +
 	"\x10trigger_event_id\x18\x01 \x01(\tR\x0etriggerEventId\x12!\n" +
-	"\fworkflow_ids\x18\x02 \x03(\tR\vworkflowIds*v\n" +
+	"\fworkflow_ids\x18\x02 \x03(\tR\vworkflowIds\x12\x1f\n" +
+	"\vtrigger_ids\x18\x03 \x03(\tR\n" +
+	"triggerIds*v\n" +
 	"\x05Error\x12\x06\n" +
 	"\x02OK\x10\x00\x12\x15\n" +
 	"\x11VALIDATION_FAILED\x10\x01\x12\x18\n" +

--- a/core/capabilities/remote/types/messages.proto
+++ b/core/capabilities/remote/types/messages.proto
@@ -49,4 +49,5 @@ message TriggerRegistrationMetadata {
 message TriggerEventMetadata {
   string trigger_event_id = 1;
   repeated string workflow_ids = 2;
+  repeated string trigger_ids = 3; // must be equal length to workflow_ids (or empty if not supported)
 }


### PR DESCRIPTION
Instead of routing don2don messages by workflowID, route them by (workflowID, triggerID) pairs. See inline comments for more details.