### PR TITLE
tune according to last runs

### DIFF
--- a/devenv/tests/ocr2/load_test.go
+++ b/devenv/tests/ocr2/load_test.go
@@ -141,14 +141,14 @@ func TestLoad(t *testing.T) {
 			require.NoError(t, err)
 			errs := l.Check(&leak.CLNodesCheck{
 				// since the test is stable we assert absolute values
-				// no more than 30% CPU and 200Mb (last 5m)
+				// no more than 25% CPU and 350Mb (last 5m)
 				ComparisonMode:  leak.ComparisonModeAbsolute,
 				NumNodes:        in.NodeSets[0].Nodes,
 				Start:           start,
 				End:             time.Now(),
 				WarmUpDuration:  30 * time.Minute,
-				CPUThreshold:    30.0,
-				MemoryThreshold: 200.0,
+				CPUThreshold:    25.0,
+				MemoryThreshold: 350.0,
 			})
 			require.NoError(t, errs)
 		})


### PR DESCRIPTION
Adjusting thresholds for the last 4 CI runs to 25% CPU and 350Mb.
```bash
Node0: [148.51953125 Mb -> 151.125 Mb]
Node1: [289.33984375 Mb -> 328.107421875 Mb]
Node2: [288.203125 Mb -> 323.609375 Mb]
Node3: [313.5390625 Mb -> 332.5 Mb]

Node0: [118.23828125 Mb -> 145.904296875 Mb]
Node1: [290.04296875 Mb -> 320.8203125 Mb]
Node2: [299.109375 Mb -> 319.65625 Mb]
Node3: [310.98046875 Mb -> 327.078125 Mb]

Node0: [114.0625 Mb -> 145.99609375 Mb]
Node1: [308.453125 Mb -> 329.091796875 Mb]
Node2: [289.78515625 Mb -> 330.21875 Mb]
Node3: [307.80859375 Mb -> 334.681640625 Mb]

Node0: [145.9765625 Mb -> 147.57421875 Mb]
Node1: [290.3984375 Mb -> 320.9609375 Mb]
Node2: [308.30859375 Mb -> 332.53125 Mb]
Node3: [317.3984375 Mb -> 318.42578125 Mb]
```