### PR TITLE
D2D trigger capability errors

### DIFF
--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -9,8 +9,11 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+
 	"github.com/smartcontractkit/libocr/ragep2p"
 	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/registry"
@@ -58,6 +61,7 @@ type launcher struct {
 	p2pStreamConfig     p2ptypes.StreamConfig
 	metrics             *launcherMetrics
 	localCapMgr         localcapmgr.LocalCapabilityManager
+	triggerRegistrationStatusUpdateTimeOut limits.TimeLimiter
 }
 
 // For V2 capabilities, shims are created once and their config is updated dynamically.
@@ -68,12 +72,6 @@ type cachedShims struct {
 	executableClients  map[string]executable.Client
 	executableServers  map[string]executable.Server
 }
-
-func shimKey(capID string, donID uint32, method string) string {
-	return fmt.Sprintf("%s:%d:%s", capID, donID, method)
-}
-
-// TODO: add metric handler and instrument all the internal log.Error calls
 
 // NewLauncher creates a new capabilities launcher.
 // If peerWrapper is nil, no p2p connections will be managed by the launcher.
@@ -86,6 +84,7 @@ func NewLauncher(
 	dispatcher remotetypes.Dispatcher,
 	registry *Registry,
 	workflowDonNotifier DonNotifier,
+	triggerRegistrationStatusUpdateTimeOut limits.TimeLimiter,
 ) (*launcher, error) {
 	p2pStreamConfig := defaultStreamConfig
 	if streamConfig != nil {
@@ -105,6 +104,7 @@ func NewLauncher(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create launcher metrics: %w", err)
 	}
+
 	return &launcher{
 		lggr:        logger.Sugared(lggr).Named("CapabilitiesLauncher"),
 		peerWrapper: peerWrapper,
@@ -116,13 +116,18 @@ func NewLauncher(
 			executableClients:  make(map[string]executable.Client),
 			executableServers:  make(map[string]executable.Server),
 		},
-		registry:            registry,
-		subServices:         []services.Service{},
-		workflowDonNotifier: workflowDonNotifier,
-		don2donSharedPeer:   don2donSharedPeer,
-		p2pStreamConfig:     p2pStreamConfig,
-		metrics:             metrics,
+		registry:                               registry,
+		subServices:                            []services.Service{},
+		workflowDonNotifier:                    workflowDonNotifier,
+		don2donSharedPeer:                      don2donSharedPeer,
+		p2pStreamConfig:                        p2pStreamConfig,
+		metrics:                                metrics,
+		triggerRegistrationStatusUpdateTimeOut: triggerRegistrationStatusUpdateTimeOut,
 	}, nil
+}
+
+func shimKey(capID string, donID uint32, method string) string {
+	return fmt.Sprintf("%s:%d:%s", capID, donID, method)
 }
 
 // Maintain only necessary Don2Don connections:
@@ -555,6 +560,7 @@ func (w *launcher) addRemoteCapability(ctx context.Context, cid string, capabili
 					"", // empty method name for v1
 					w.dispatcher,
 					w.lggr,
+					w.triggerRegistrationStatusUpdateTimeOut,
 				)
 				w.cachedShims.triggerSubscribers[shimKey] = triggerCap
 			}
@@ -938,7 +944,7 @@ func (w *launcher) addRemoteCapabilityV2(ctx context.Context, capID string, meth
 		if config.RemoteTriggerConfig != nil { // trigger
 			sub, alreadyExists := w.cachedShims.triggerSubscribers[shimKey]
 			if !alreadyExists {
-				sub = remote.NewTriggerSubscriber(capID, method, w.dispatcher, w.lggr)
+				sub = remote.NewTriggerSubscriber(capID, method, w.dispatcher, w.lggr, w.triggerRegistrationStatusUpdateTimeOut)
 				cc.SetTriggerSubscriber(method, sub)
 				// add to cachedShims later, only after startNewShim succeeds
 			}

--- a/core/capabilities/launcher_test.go
+++ b/core/capabilities/launcher_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
@@ -132,6 +133,7 @@ func TestLauncher(t *testing.T) {
 			dispatcher,
 			registry,
 			&mockDonNotifier{},
+			limits.NewTimeLimiter(0),
 		)
 		require.NoError(t, err)
 		require.NoError(t, launcher.Start(t.Context()))
@@ -181,6 +183,7 @@ func TestLauncher(t *testing.T) {
 			dispatcher,
 			registry,
 			&mockDonNotifier{},
+			limits.NewTimeLimiter(0),
 		)
 		require.NoError(t, err)
 		require.NoError(t, launcher.Start(t.Context()))
@@ -225,6 +228,7 @@ func TestLauncher(t *testing.T) {
 			dispatcher,
 			registry,
 			&mockDonNotifier{},
+			limits.NewTimeLimiter(0),
 		)
 		require.NoError(t, err)
 		require.NoError(t, launcher.Start(t.Context()))
@@ -248,6 +252,7 @@ func TestLauncher(t *testing.T) {
 			dispatcher,
 			registry,
 			&mockDonNotifier{},
+			limits.NewTimeLimiter(0),
 		)
 		require.NoError(t, err)
 		require.NoError(t, launcher.Start(t.Context()))
@@ -329,6 +334,7 @@ func TestLauncher_RemoteTriggerModeAggregatorShim(t *testing.T) {
 		dispatcher,
 		registry,
 		&mockDonNotifier{},
+		limits.NewTimeLimiter(0),
 	)
 	require.NoError(t, err)
 	require.NoError(t, launcher.Start(t.Context()))
@@ -372,7 +378,8 @@ func TestLauncher_RemoteTriggerModeAggregatorShim(t *testing.T) {
 		},
 	}
 	triggerEventCallbackCh, err := remoteTriggerSubscriber.RegisterTrigger(ctx, req)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, capabilities.ErrUnableToDetermineRegistrationStatus)
+
 	<-awaitRegistrationMessageCh
 
 	// Receive trigger event
@@ -425,6 +432,7 @@ func TestSyncer_IgnoresCapabilitiesForPrivateDON(t *testing.T) {
 		dispatcher,
 		registry,
 		&mockDonNotifier{},
+		limits.NewTimeLimiter(0),
 	)
 	require.NoError(t, err)
 	require.NoError(t, launcher.Start(t.Context()))
@@ -483,6 +491,7 @@ func TestLauncher_WiresUpClientsForPublicWorkflowDON(t *testing.T) {
 		dispatcher,
 		registry,
 		&mockDonNotifier{},
+		limits.NewTimeLimiter(0),
 	)
 	require.NoError(t, err)
 	require.NoError(t, launcher.Start(t.Context()))
@@ -544,6 +553,7 @@ func TestLauncher_WiresUpClientsForPublicWorkflowDONButIgnoresPrivateCapabilitie
 		dispatcher,
 		registry,
 		&mockDonNotifier{},
+		limits.NewTimeLimiter(0),
 	)
 	require.NoError(t, err)
 	require.NoError(t, launcher.Start(t.Context()))
@@ -614,6 +624,7 @@ func TestLauncher_SucceedsEvenIfDispatcherAlreadyHasReceiver(t *testing.T) {
 		dispatcher,
 		registry,
 		&mockDonNotifier{},
+		limits.NewTimeLimiter(0),
 	)
 	require.NoError(t, err)
 	require.NoError(t, launcher.Start(t.Context()))
@@ -677,6 +688,7 @@ func TestLauncher_SuccessfullyFilterDon2Don(t *testing.T) {
 		dispatcher,
 		registry,
 		&mockDonNotifier{},
+		limits.NewTimeLimiter(0),
 	)
 	require.NoError(t, err)
 	require.NoError(t, launcher.Start(t.Context()))
@@ -735,7 +747,7 @@ func TestLauncher_DonPairsToUpdate(t *testing.T) {
 	tt := NewTestTopology(pid, 4, 4)
 	wfDONID, capDONID, mixedDONID := registrysyncer.DonID(7), registrysyncer.DonID(12), registrysyncer.DonID(33)
 	localRegistry := tt.MakeLocalRegistry(uint32(wfDONID), uint32(capDONID), uint32(mixedDONID), RandomUTF8BytesWord(), fullTriggerCapID)
-	launcher, err := NewLauncher(logger.Test(t), nil, sharedPeer, nil, dispatcher, registry, &mockDonNotifier{})
+	launcher, err := NewLauncher(logger.Test(t), nil, sharedPeer, nil, dispatcher, registry, &mockDonNotifier{}, limits.NewTimeLimiter(0))
 	require.NoError(t, err)
 
 	sharedPeer.On("IsBootstrap").Return(false).Times(3)
@@ -817,7 +829,8 @@ func TestLauncher_DonPairsToUpdate_SkipsDifferentFamilies(t *testing.T) {
 	addDON(localRegistry, capDONZoneBID, uint32(0), uint8(1), true, false, capabilityDonNodesZoneB, []string{"zone-b"}, 1, [][32]byte{triggerCapID})
 	addCapabilityToDON(localRegistry, capDONZoneBID, fullTriggerCapID, capabilities.CapabilityTypeTrigger, nil)
 
-	launcher, err := NewLauncher(logger.Test(t), nil, sharedPeer, nil, dispatcher, registry, &mockDonNotifier{})
+	launcher, err := NewLauncher(logger.Test(t), nil, sharedPeer, nil, dispatcher, registry, &mockDonNotifier{},
+		limits.NewTimeLimiter(0))
 	require.NoError(t, err)
 
 	sharedPeer.On("IsBootstrap").Return(false).Once()
@@ -920,6 +933,7 @@ func TestLauncher_V2CapabilitiesAddViaCombinedClient(t *testing.T) {
 		dispatcher,
 		registry,
 		&mockDonNotifier{},
+		limits.NewTimeLimiter(0),
 	)
 	require.NoError(t, err)
 	launcher.p2pStreamConfig = customStreamConfig
@@ -1074,6 +1088,7 @@ func TestLauncher_V2CapabilitiesExposeRemotely(t *testing.T) {
 		dispatcher,
 		registry,
 		&mockDonNotifier{},
+		limits.NewTimeLimiter(0),
 	)
 	require.NoError(t, err)
 	require.NoError(t, launcher.Start(t.Context()))
@@ -1190,6 +1205,7 @@ func TestLauncher_OnNewRegistry_CallsLocalCapabilityManagerReconcile(t *testing.
 		dispatcher,
 		registry,
 		&mockDonNotifier{},
+		limits.NewTimeLimiter(0),
 	)
 	require.NoError(t, err)
 	launcher.SetLocalCapabilityManager(mockLCM)
@@ -1233,6 +1249,7 @@ func TestLauncher_OnNewRegistry_NilLocalCapabilityManager(t *testing.T) {
 		dispatcher,
 		registry,
 		&mockDonNotifier{},
+		limits.NewTimeLimiter(0),
 	)
 	require.NoError(t, err)
 	require.NoError(t, launcher.Start(t.Context()))

--- a/core/capabilities/remote/e2etesting/dispatcher.go
+++ b/core/capabilities/remote/e2etesting/dispatcher.go
@@ -1,0 +1,176 @@
+package e2etesting
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/mr-tron/base58"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	remotetypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
+)
+
+type TestAsyncMessageBroker struct {
+	services.Service
+	eng *services.Engine
+	t   *testing.T
+
+	nodes map[p2ptypes.PeerID]remotetypes.Receiver
+
+	sendCh chan *remotetypes.MessageBody
+
+	messageFilter atomic.Value // stores func(msg *remotetypes.MessageBody) bool
+}
+
+func NewTestAsyncMessageBroker(t *testing.T, sendChBufferSize int) *TestAsyncMessageBroker {
+	b := &TestAsyncMessageBroker{
+		t:      t,
+		nodes:  make(map[p2ptypes.PeerID]remotetypes.Receiver),
+		sendCh: make(chan *remotetypes.MessageBody, sendChBufferSize),
+	}
+	b.Service, b.eng = services.Config{
+		Name:  "TestAsyncMessageBroker",
+		Start: b.start,
+	}.NewServiceEngine(logger.Test(t))
+	return b
+}
+
+// SetMessageFilter sets the message filter function in a thread-safe way.
+func (a *TestAsyncMessageBroker) SetMessageFilter(filter func(msg *remotetypes.MessageBody) bool) {
+	a.messageFilter.Store(filter)
+}
+
+func (a *TestAsyncMessageBroker) start(ctx context.Context) error {
+	fmt.Print("TestAsyncMessageBroker started\n")
+	a.eng.Go(func(ctx context.Context) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg := <-a.sendCh:
+				receiverID := ToPeerID(msg.Receiver)
+
+				receiver, ok := a.nodes[receiverID]
+				if !ok {
+					panic("server not found for peer id")
+				}
+
+				receiver.Receive(a.t.Context(), msg)
+			}
+		}
+	})
+	return nil
+}
+
+func (a *TestAsyncMessageBroker) NewDispatcherForNode(nodePeerID p2ptypes.PeerID) remotetypes.Dispatcher {
+	return &nodeDispatcher{
+		callerPeerID: nodePeerID,
+		broker:       a,
+	}
+}
+
+func (a *TestAsyncMessageBroker) RegisterReceiverNode(nodePeerID p2ptypes.PeerID, node remotetypes.Receiver) {
+	if _, ok := a.nodes[nodePeerID]; ok {
+		panic("node already registered")
+	}
+
+	a.nodes[nodePeerID] = node
+}
+
+func (a *TestAsyncMessageBroker) Send(msg *remotetypes.MessageBody) {
+	filterVal := a.messageFilter.Load()
+	if filterVal != nil {
+		if filter := filterVal.(func(msg *remotetypes.MessageBody) bool); !filter(msg) {
+			// Drop the message
+			return
+		}
+	}
+
+	// Clone the message to simulate real behaviour when sent across the network
+	cloned := proto.Clone(msg).(*remotetypes.MessageBody)
+	a.sendCh <- cloned
+}
+
+func ToPeerID(id []byte) p2ptypes.PeerID {
+	return [32]byte(id)
+}
+
+type broker interface {
+	Send(msg *remotetypes.MessageBody)
+}
+
+type nodeDispatcher struct {
+	callerPeerID p2ptypes.PeerID
+	broker       broker
+}
+
+func (t *nodeDispatcher) Name() string {
+	return "nodeDispatcher"
+}
+
+func (t *nodeDispatcher) Start(ctx context.Context) error {
+	return nil
+}
+
+func (t *nodeDispatcher) Close() error {
+	return nil
+}
+
+func (t *nodeDispatcher) Ready() error {
+	return nil
+}
+
+func (t *nodeDispatcher) HealthReport() map[string]error {
+	return nil
+}
+
+func (t *nodeDispatcher) Send(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) error {
+	msgBody.Version = 1
+	msgBody.Sender = t.callerPeerID[:]
+	msgBody.Receiver = peerID[:]
+	msgBody.Timestamp = time.Now().UnixMilli()
+	t.broker.Send(msgBody)
+	return nil
+}
+
+func (t *nodeDispatcher) SetReceiver(capabilityID string, donID uint32, receiver remotetypes.Receiver) error {
+	return nil
+}
+func (t *nodeDispatcher) RemoveReceiver(capabilityID string, donID uint32) {}
+
+func (t *nodeDispatcher) SetReceiverForMethod(capabilityID string, donID uint32, methodName string, receiver remotetypes.Receiver) error {
+	return nil
+}
+func (t *nodeDispatcher) RemoveReceiverForMethod(capabilityID string, donID uint32, methodName string) {
+}
+
+func NewP2PPeerID(t *testing.T) p2ptypes.PeerID {
+	id := p2ptypes.PeerID{}
+	require.NoError(t, id.UnmarshalText([]byte(NewPeerID())))
+	return id
+}
+
+func NewPeerID() string {
+	var privKey [32]byte
+	_, err := rand.Read(privKey[:])
+	if err != nil {
+		panic(err)
+	}
+
+	peerID := append(libp2pMagic(), privKey[:]...)
+
+	return base58.Encode(peerID)
+}
+
+func libp2pMagic() []byte {
+	return []byte{0x00, 0x24, 0x08, 0x01, 0x12, 0x20}
+}

--- a/core/capabilities/remote/executable/client_test.go
+++ b/core/capabilities/remote/executable/client_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/e2etesting"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/executable"
@@ -24,7 +25,6 @@ import (
 )
 
 const (
-	stepReferenceID1     = "step1"
 	workflowID1          = "15c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0"
 	workflowID2          = "25c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce1"
 	workflowExecutionID1 = "95ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0abbadeed"
@@ -84,7 +84,6 @@ func Test_Client_DonTopologies(t *testing.T) {
 }
 
 func Test_Client_TransmissionSchedules(t *testing.T) {
-	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/DX-104")
 	ctx := testutils.Context(t)
 
 	responseTest := func(t *testing.T, response commoncap.CapabilityResponse, responseError error) {
@@ -202,7 +201,7 @@ func testClient(t *testing.T, numWorkflowPeers int, workflowNodeResponseTimeout 
 
 	capabilityPeers := make([]p2ptypes.PeerID, numCapabilityPeers)
 	for i := range numCapabilityPeers {
-		capabilityPeers[i] = NewP2PPeerID(t)
+		capabilityPeers[i] = e2etesting.NewP2PPeerID(t)
 	}
 
 	capDonInfo := commoncap.DON{
@@ -220,7 +219,7 @@ func testClient(t *testing.T, numWorkflowPeers int, workflowNodeResponseTimeout 
 
 	workflowPeers := make([]p2ptypes.PeerID, numWorkflowPeers)
 	for i := range numWorkflowPeers {
-		workflowPeers[i] = NewP2PPeerID(t)
+		workflowPeers[i] = e2etesting.NewP2PPeerID(t)
 	}
 
 	workflowDonInfo := commoncap.DON{
@@ -228,7 +227,7 @@ func testClient(t *testing.T, numWorkflowPeers int, workflowNodeResponseTimeout 
 		ID:      2,
 	}
 
-	broker := newTestAsyncMessageBroker(t, 100)
+	broker := e2etesting.NewTestAsyncMessageBroker(t, 100)
 
 	receivers := make([]remotetypes.Receiver, numCapabilityPeers)
 	for i := range numCapabilityPeers {
@@ -309,7 +308,7 @@ func (t *clientTestServer) Receive(ctx context.Context, msg *remotetypes.Message
 	t.mux.Lock()
 	defer t.mux.Unlock()
 
-	sender := toPeerID(msg.Sender)
+	sender := e2etesting.ToPeerID(msg.Sender)
 	messageID, err := executable.GetMessageID(msg)
 	if err != nil {
 		panic(err)
@@ -376,15 +375,15 @@ func TestClient_SetConfig(t *testing.T) {
 	capabilityID := "test_capability@1.0.0"
 
 	// Create broker and dispatcher like other tests
-	broker := newTestAsyncMessageBroker(t, 100)
-	peerID := NewP2PPeerID(t)
+	broker := e2etesting.NewTestAsyncMessageBroker(t, 100)
+	peerID := e2etesting.NewP2PPeerID(t)
 	dispatcher := broker.NewDispatcherForNode(peerID)
 	client := executable.NewClient(capabilityID, "execute", dispatcher, lggr)
 
 	// Create valid test data
 	validDonInfo := commoncap.DON{
 		ID:      1,
-		Members: []p2ptypes.PeerID{NewP2PPeerID(t)},
+		Members: []p2ptypes.PeerID{e2etesting.NewP2PPeerID(t)},
 		F:       0,
 	}
 
@@ -446,7 +445,7 @@ func TestClient_SetConfig(t *testing.T) {
 		newTimeout := 60 * time.Second
 		newDonInfo := commoncap.DON{
 			ID:      2,
-			Members: []p2ptypes.PeerID{NewP2PPeerID(t), NewP2PPeerID(t)},
+			Members: []p2ptypes.PeerID{e2etesting.NewP2PPeerID(t), e2etesting.NewP2PPeerID(t)},
 			F:       1,
 		}
 
@@ -466,14 +465,14 @@ func TestClient_SetConfig_StartClose(t *testing.T) {
 	capabilityID := "test_capability@1.0.0"
 
 	// Create broker and dispatcher like other tests
-	broker := newTestAsyncMessageBroker(t, 100)
-	peerID := NewP2PPeerID(t)
+	broker := e2etesting.NewTestAsyncMessageBroker(t, 100)
+	peerID := e2etesting.NewP2PPeerID(t)
 	dispatcher := broker.NewDispatcherForNode(peerID)
 	client := executable.NewClient(capabilityID, "execute", dispatcher, lggr)
 
 	validDonInfo := commoncap.DON{
 		ID:      1,
-		Members: []p2ptypes.PeerID{NewP2PPeerID(t)},
+		Members: []p2ptypes.PeerID{e2etesting.NewP2PPeerID(t)},
 		F:       0,
 	}
 

--- a/core/capabilities/remote/executable/client_test.go
+++ b/core/capabilities/remote/executable/client_test.go
@@ -12,8 +12,8 @@ import (
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/e2etesting"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/executable"
@@ -24,7 +24,6 @@ import (
 )
 
 const (
-	stepReferenceID1     = "step1"
 	workflowID1          = "15c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0"
 	workflowID2          = "25c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce1"
 	workflowExecutionID1 = "95ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0abbadeed"
@@ -84,7 +83,6 @@ func Test_Client_DonTopologies(t *testing.T) {
 }
 
 func Test_Client_TransmissionSchedules(t *testing.T) {
-	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/DX-104")
 	ctx := testutils.Context(t)
 
 	responseTest := func(t *testing.T, response commoncap.CapabilityResponse, responseError error) {
@@ -202,7 +200,7 @@ func testClient(t *testing.T, numWorkflowPeers int, workflowNodeResponseTimeout 
 
 	capabilityPeers := make([]p2ptypes.PeerID, numCapabilityPeers)
 	for i := range numCapabilityPeers {
-		capabilityPeers[i] = NewP2PPeerID(t)
+		capabilityPeers[i] = e2etesting.NewP2PPeerID(t)
 	}
 
 	capDonInfo := commoncap.DON{
@@ -220,7 +218,7 @@ func testClient(t *testing.T, numWorkflowPeers int, workflowNodeResponseTimeout 
 
 	workflowPeers := make([]p2ptypes.PeerID, numWorkflowPeers)
 	for i := range numWorkflowPeers {
-		workflowPeers[i] = NewP2PPeerID(t)
+		workflowPeers[i] = e2etesting.NewP2PPeerID(t)
 	}
 
 	workflowDonInfo := commoncap.DON{
@@ -228,7 +226,7 @@ func testClient(t *testing.T, numWorkflowPeers int, workflowNodeResponseTimeout 
 		ID:      2,
 	}
 
-	broker := newTestAsyncMessageBroker(t, 100)
+	broker := e2etesting.NewTestAsyncMessageBroker(t, 100)
 
 	receivers := make([]remotetypes.Receiver, numCapabilityPeers)
 	for i := range numCapabilityPeers {
@@ -309,7 +307,7 @@ func (t *clientTestServer) Receive(ctx context.Context, msg *remotetypes.Message
 	t.mux.Lock()
 	defer t.mux.Unlock()
 
-	sender := toPeerID(msg.Sender)
+	sender := e2etesting.ToPeerID(msg.Sender)
 	messageID, err := executable.GetMessageID(msg)
 	if err != nil {
 		panic(err)
@@ -376,15 +374,15 @@ func TestClient_SetConfig(t *testing.T) {
 	capabilityID := "test_capability@1.0.0"
 
 	// Create broker and dispatcher like other tests
-	broker := newTestAsyncMessageBroker(t, 100)
-	peerID := NewP2PPeerID(t)
+	broker := e2etesting.NewTestAsyncMessageBroker(t, 100)
+	peerID := e2etesting.NewP2PPeerID(t)
 	dispatcher := broker.NewDispatcherForNode(peerID)
 	client := executable.NewClient(capabilityID, "execute", dispatcher, lggr)
 
 	// Create valid test data
 	validDonInfo := commoncap.DON{
 		ID:      1,
-		Members: []p2ptypes.PeerID{NewP2PPeerID(t)},
+		Members: []p2ptypes.PeerID{e2etesting.NewP2PPeerID(t)},
 		F:       0,
 	}
 
@@ -446,7 +444,7 @@ func TestClient_SetConfig(t *testing.T) {
 		newTimeout := 60 * time.Second
 		newDonInfo := commoncap.DON{
 			ID:      2,
-			Members: []p2ptypes.PeerID{NewP2PPeerID(t), NewP2PPeerID(t)},
+			Members: []p2ptypes.PeerID{e2etesting.NewP2PPeerID(t), e2etesting.NewP2PPeerID(t)},
 			F:       1,
 		}
 
@@ -466,14 +464,14 @@ func TestClient_SetConfig_StartClose(t *testing.T) {
 	capabilityID := "test_capability@1.0.0"
 
 	// Create broker and dispatcher like other tests
-	broker := newTestAsyncMessageBroker(t, 100)
-	peerID := NewP2PPeerID(t)
+	broker := e2etesting.NewTestAsyncMessageBroker(t, 100)
+	peerID := e2etesting.NewP2PPeerID(t)
 	dispatcher := broker.NewDispatcherForNode(peerID)
 	client := executable.NewClient(capabilityID, "execute", dispatcher, lggr)
 
 	validDonInfo := commoncap.DON{
 		ID:      1,
-		Members: []p2ptypes.PeerID{NewP2PPeerID(t)},
+		Members: []p2ptypes.PeerID{e2etesting.NewP2PPeerID(t)},
 		F:       0,
 	}
 

--- a/core/capabilities/remote/executable/client_test.go
+++ b/core/capabilities/remote/executable/client_test.go
@@ -12,6 +12,7 @@ import (
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/e2etesting"
 

--- a/core/capabilities/remote/executable/endtoend_test.go
+++ b/core/capabilities/remote/executable/endtoend_test.go
@@ -2,7 +2,6 @@ package executable_test
 
 import (
 	"context"
-	"crypto/rand"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -10,16 +9,15 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/mr-tron/base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/e2etesting"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/executable"
 	remotetypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/transmission"
@@ -250,12 +248,12 @@ func testRemoteExecutableCapability(ctx context.Context, t *testing.T, underlyin
 	capabilityPeers := make([]p2ptypes.PeerID, numCapabilityPeers)
 	for i := range numCapabilityPeers {
 		capabilityPeerID := p2ptypes.PeerID{}
-		require.NoError(t, capabilityPeerID.UnmarshalText([]byte(NewPeerID())))
+		require.NoError(t, capabilityPeerID.UnmarshalText([]byte(e2etesting.NewPeerID())))
 		capabilityPeers[i] = capabilityPeerID
 	}
 
 	capabilityPeerID := p2ptypes.PeerID{}
-	require.NoError(t, capabilityPeerID.UnmarshalText([]byte(NewPeerID())))
+	require.NoError(t, capabilityPeerID.UnmarshalText([]byte(e2etesting.NewPeerID())))
 
 	capDonInfo := commoncap.DON{
 		ID:      2,
@@ -273,7 +271,7 @@ func testRemoteExecutableCapability(ctx context.Context, t *testing.T, underlyin
 	workflowPeers := make([]p2ptypes.PeerID, numWorkflowPeers)
 	for i := range numWorkflowPeers {
 		workflowPeerID := p2ptypes.PeerID{}
-		require.NoError(t, workflowPeerID.UnmarshalText([]byte(NewPeerID())))
+		require.NoError(t, workflowPeerID.UnmarshalText([]byte(e2etesting.NewPeerID())))
 		workflowPeers[i] = workflowPeerID
 	}
 
@@ -283,7 +281,7 @@ func testRemoteExecutableCapability(ctx context.Context, t *testing.T, underlyin
 		F:       workflowDonF,
 	}
 
-	broker := newTestAsyncMessageBroker(t, 1000)
+	broker := e2etesting.NewTestAsyncMessageBroker(t, 1000)
 
 	workflowDONs := map[uint32]commoncap.DON{
 		workflowDonInfo.ID: workflowDonInfo,
@@ -330,122 +328,6 @@ func testRemoteExecutableCapability(ctx context.Context, t *testing.T, underlyin
 	if waitForExecuteCalls {
 		wg.Wait()
 	}
-}
-
-type testAsyncMessageBroker struct {
-	services.Service
-	eng *services.Engine
-	t   *testing.T
-
-	nodes map[p2ptypes.PeerID]remotetypes.Receiver
-
-	sendCh chan *remotetypes.MessageBody
-}
-
-func newTestAsyncMessageBroker(t *testing.T, sendChBufferSize int) *testAsyncMessageBroker {
-	b := &testAsyncMessageBroker{
-		t:      t,
-		nodes:  make(map[p2ptypes.PeerID]remotetypes.Receiver),
-		sendCh: make(chan *remotetypes.MessageBody, sendChBufferSize),
-	}
-	b.Service, b.eng = services.Config{
-		Name:  "testAsyncMessageBroker",
-		Start: b.start,
-	}.NewServiceEngine(logger.Test(t))
-	return b
-}
-
-func (a *testAsyncMessageBroker) start(ctx context.Context) error {
-	a.eng.Go(func(ctx context.Context) {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case msg := <-a.sendCh:
-				receiverID := toPeerID(msg.Receiver)
-
-				receiver, ok := a.nodes[receiverID]
-				if !ok {
-					panic("server not found for peer id")
-				}
-
-				receiver.Receive(a.t.Context(), msg)
-			}
-		}
-	})
-	return nil
-}
-
-func (a *testAsyncMessageBroker) NewDispatcherForNode(nodePeerID p2ptypes.PeerID) remotetypes.Dispatcher {
-	return &nodeDispatcher{
-		callerPeerID: nodePeerID,
-		broker:       a,
-	}
-}
-
-func (a *testAsyncMessageBroker) RegisterReceiverNode(nodePeerID p2ptypes.PeerID, node remotetypes.Receiver) {
-	if _, ok := a.nodes[nodePeerID]; ok {
-		panic("node already registered")
-	}
-
-	a.nodes[nodePeerID] = node
-}
-
-func (a *testAsyncMessageBroker) Send(msg *remotetypes.MessageBody) {
-	a.sendCh <- msg
-}
-
-func toPeerID(id []byte) p2ptypes.PeerID {
-	return [32]byte(id)
-}
-
-type broker interface {
-	Send(msg *remotetypes.MessageBody)
-}
-
-type nodeDispatcher struct {
-	callerPeerID p2ptypes.PeerID
-	broker       broker
-}
-
-func (t *nodeDispatcher) Name() string {
-	return "nodeDispatcher"
-}
-
-func (t *nodeDispatcher) Start(ctx context.Context) error {
-	return nil
-}
-
-func (t *nodeDispatcher) Close() error {
-	return nil
-}
-
-func (t *nodeDispatcher) Ready() error {
-	return nil
-}
-
-func (t *nodeDispatcher) HealthReport() map[string]error {
-	return nil
-}
-
-func (t *nodeDispatcher) Send(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) error {
-	msgBody.Version = 1
-	msgBody.Sender = t.callerPeerID[:]
-	msgBody.Receiver = peerID[:]
-	msgBody.Timestamp = time.Now().UnixMilli()
-	t.broker.Send(msgBody)
-	return nil
-}
-
-func (t *nodeDispatcher) SetReceiver(capabilityID string, donID uint32, receiver remotetypes.Receiver) error {
-	return nil
-}
-func (t *nodeDispatcher) RemoveReceiver(capabilityID string, donID uint32) {}
-
-func (t *nodeDispatcher) SetReceiverForMethod(capabilityID string, donID uint32, methodName string, receiver remotetypes.Receiver) error {
-	return nil
-}
-func (t *nodeDispatcher) RemoveReceiverForMethod(capabilityID string, donID uint32, methodName string) {
 }
 
 type abstractTestCapability struct {
@@ -537,28 +419,6 @@ func (t TestRandomErrorCapability) RegisterToWorkflow(ctx context.Context, reque
 
 func (t TestRandomErrorCapability) UnregisterFromWorkflow(ctx context.Context, request commoncap.UnregisterFromWorkflowRequest) error {
 	return errors.New(uuid.New().String())
-}
-
-func NewP2PPeerID(t *testing.T) p2ptypes.PeerID {
-	id := p2ptypes.PeerID{}
-	require.NoError(t, id.UnmarshalText([]byte(NewPeerID())))
-	return id
-}
-
-func NewPeerID() string {
-	var privKey [32]byte
-	_, err := rand.Read(privKey[:])
-	if err != nil {
-		panic(err)
-	}
-
-	peerID := append(libp2pMagic(), privKey[:]...)
-
-	return base58.Encode(peerID)
-}
-
-func libp2pMagic() []byte {
-	return []byte{0x00, 0x24, 0x08, 0x01, 0x12, 0x20}
 }
 
 func executeCapability(ctx context.Context, t *testing.T, caller commoncap.ExecutableCapability, transmissionSchedule *values.Map, responseTest func(t *testing.T, response commoncap.CapabilityResponse, responseError error),

--- a/core/capabilities/remote/executable/server_test.go
+++ b/core/capabilities/remote/executable/server_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/e2etesting"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/executable"
 	remotetypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -325,7 +326,7 @@ func testRemoteExecutableCapabilityServer(ctx context.Context, t *testing.T,
 
 	capabilityPeers := make([]p2ptypes.PeerID, numCapabilityPeers)
 	for i := range numCapabilityPeers {
-		capabilityPeerID := NewP2PPeerID(t)
+		capabilityPeerID := e2etesting.NewP2PPeerID(t)
 		capabilityPeers[i] = capabilityPeerID
 	}
 
@@ -344,7 +345,7 @@ func testRemoteExecutableCapabilityServer(ctx context.Context, t *testing.T,
 
 	workflowPeers := make([]p2ptypes.PeerID, numWorkflowPeers)
 	for i := range numWorkflowPeers {
-		workflowPeers[i] = NewP2PPeerID(t)
+		workflowPeers[i] = e2etesting.NewP2PPeerID(t)
 	}
 
 	workflowDonInfo := commoncap.DON{
@@ -354,7 +355,7 @@ func testRemoteExecutableCapabilityServer(ctx context.Context, t *testing.T,
 	}
 
 	var srvcs []services.Service
-	broker := newTestAsyncMessageBroker(t, 1000)
+	broker := e2etesting.NewTestAsyncMessageBroker(t, 1000)
 	err := broker.Start(t.Context())
 	require.NoError(t, err)
 	srvcs = append(srvcs, broker)
@@ -445,10 +446,10 @@ func (r *serverTestClient) Execute(ctx context.Context, req commoncap.Capability
 
 func Test_Server_SetConfig(t *testing.T) {
 	lggr := logger.Test(t)
-	peerID := NewP2PPeerID(t)
+	peerID := e2etesting.NewP2PPeerID(t)
 
 	// Create broker and dispatcher
-	broker := newTestAsyncMessageBroker(t, 100)
+	broker := e2etesting.NewTestAsyncMessageBroker(t, 100)
 	dispatcher := broker.NewDispatcherForNode(peerID)
 
 	// Create server instance
@@ -470,7 +471,7 @@ func Test_Server_SetConfig(t *testing.T) {
 	workflowDONs := map[uint32]commoncap.DON{
 		2: {
 			ID:      2,
-			Members: []p2ptypes.PeerID{NewP2PPeerID(t)},
+			Members: []p2ptypes.PeerID{e2etesting.NewP2PPeerID(t)},
 			F:       0,
 		},
 	}
@@ -572,8 +573,8 @@ func Test_Server_SetConfig(t *testing.T) {
 
 func Test_Server_SetConfig_ConfigReplacement(t *testing.T) {
 	lggr := logger.Test(t)
-	peerID := NewP2PPeerID(t)
-	broker := newTestAsyncMessageBroker(t, 100)
+	peerID := e2etesting.NewP2PPeerID(t)
+	broker := e2etesting.NewTestAsyncMessageBroker(t, 100)
 	dispatcher := broker.NewDispatcherForNode(peerID)
 	server := executable.NewServer("test-capability-id", "test-method", peerID, dispatcher, lggr)
 
@@ -592,7 +593,7 @@ func Test_Server_SetConfig_ConfigReplacement(t *testing.T) {
 	workflowDONs := map[uint32]commoncap.DON{
 		2: {
 			ID:      2,
-			Members: []p2ptypes.PeerID{NewP2PPeerID(t)},
+			Members: []p2ptypes.PeerID{e2etesting.NewP2PPeerID(t)},
 			F:       0,
 		},
 	}
@@ -632,8 +633,8 @@ func Test_Server_SetConfig_StartValidation(t *testing.T) {
 
 	t.Run("Start without SetConfig should fail", func(t *testing.T) {
 		lggr := logger.Test(t)
-		peerID := NewP2PPeerID(t)
-		broker := newTestAsyncMessageBroker(t, 100)
+		peerID := e2etesting.NewP2PPeerID(t)
+		broker := e2etesting.NewTestAsyncMessageBroker(t, 100)
 		dispatcher := broker.NewDispatcherForNode(peerID)
 		server := executable.NewServer("test-capability-id", "test-method", peerID, dispatcher, lggr)
 
@@ -644,8 +645,8 @@ func Test_Server_SetConfig_StartValidation(t *testing.T) {
 
 	t.Run("Start with valid config should succeed", func(t *testing.T) {
 		lggr := logger.Test(t)
-		peerID := NewP2PPeerID(t)
-		broker := newTestAsyncMessageBroker(t, 100)
+		peerID := e2etesting.NewP2PPeerID(t)
+		broker := e2etesting.NewTestAsyncMessageBroker(t, 100)
 		dispatcher := broker.NewDispatcherForNode(peerID)
 		server := executable.NewServer("test-capability-id", "test-method", peerID, dispatcher, lggr)
 
@@ -665,7 +666,7 @@ func Test_Server_SetConfig_StartValidation(t *testing.T) {
 		workflowDONs := map[uint32]commoncap.DON{
 			2: {
 				ID:      2,
-				Members: []p2ptypes.PeerID{NewP2PPeerID(t)},
+				Members: []p2ptypes.PeerID{e2etesting.NewP2PPeerID(t)},
 				F:       0,
 			},
 		}
@@ -691,8 +692,8 @@ func Test_Server_SetConfig_StartValidation(t *testing.T) {
 func Test_Server_SetConfig_DONMembershipChange(t *testing.T) {
 	ctx := testutils.Context(t)
 	lggr := logger.Test(t)
-	peerID := NewP2PPeerID(t)
-	broker := newTestAsyncMessageBroker(t, 100)
+	peerID := e2etesting.NewP2PPeerID(t)
+	broker := e2etesting.NewTestAsyncMessageBroker(t, 100)
 	dispatcher := broker.NewDispatcherForNode(peerID)
 	server := executable.NewServer("test-capability-id", "test-method", peerID, dispatcher, lggr)
 
@@ -708,8 +709,8 @@ func Test_Server_SetConfig_DONMembershipChange(t *testing.T) {
 		F:       0,
 	}
 
-	workflowPeer1 := NewP2PPeerID(t)
-	workflowPeer2 := NewP2PPeerID(t)
+	workflowPeer1 := e2etesting.NewP2PPeerID(t)
+	workflowPeer2 := e2etesting.NewP2PPeerID(t)
 	workflowDONs := map[uint32]commoncap.DON{
 		2: {
 			ID:      2,
@@ -779,8 +780,8 @@ func Test_Server_SetConfig_DONMembershipChange(t *testing.T) {
 func Test_Server_SetConfig_ShutdownRaces(t *testing.T) {
 	ctx := testutils.Context(t)
 	lggr := logger.Test(t)
-	peerID := NewP2PPeerID(t)
-	broker := newTestAsyncMessageBroker(t, 100)
+	peerID := e2etesting.NewP2PPeerID(t)
+	broker := e2etesting.NewTestAsyncMessageBroker(t, 100)
 	dispatcher := broker.NewDispatcherForNode(peerID)
 	server := executable.NewServer("test-capability-id", "test-method", peerID, dispatcher, lggr)
 
@@ -799,7 +800,7 @@ func Test_Server_SetConfig_ShutdownRaces(t *testing.T) {
 	workflowDONs := map[uint32]commoncap.DON{
 		2: {
 			ID:      2,
-			Members: []p2ptypes.PeerID{NewP2PPeerID(t)},
+			Members: []p2ptypes.PeerID{e2etesting.NewP2PPeerID(t)},
 			F:       0,
 		},
 	}
@@ -846,7 +847,7 @@ func Test_Server_Execute_WithConcurrentSetConfig(t *testing.T) {
 	lggr := logger.Test(t)
 	numWorkflowPeers := 4
 
-	peerID := NewP2PPeerID(t)
+	peerID := e2etesting.NewP2PPeerID(t)
 	capabilityPeers := []p2ptypes.PeerID{peerID}
 
 	capDonInfo := commoncap.DON{
@@ -864,7 +865,7 @@ func Test_Server_Execute_WithConcurrentSetConfig(t *testing.T) {
 
 	workflowPeers := make([]p2ptypes.PeerID, numWorkflowPeers)
 	for i := range numWorkflowPeers {
-		workflowPeers[i] = NewP2PPeerID(t)
+		workflowPeers[i] = e2etesting.NewP2PPeerID(t)
 	}
 
 	workflowDonInfo := commoncap.DON{
@@ -873,7 +874,7 @@ func Test_Server_Execute_WithConcurrentSetConfig(t *testing.T) {
 		F:       1,
 	}
 
-	broker := newTestAsyncMessageBroker(t, 1000)
+	broker := e2etesting.NewTestAsyncMessageBroker(t, 1000)
 	err := broker.Start(t.Context())
 	require.NoError(t, err)
 	defer broker.Close()
@@ -1005,8 +1006,8 @@ func Test_Server_DuplicateRequestRemainsDedupedPastRequestTimeout(t *testing.T) 
 	ctx := testutils.Context(t)
 	lggr := logger.Test(t)
 
-	serverPeerID := NewP2PPeerID(t)
-	senderPeerID := NewP2PPeerID(t)
+	serverPeerID := e2etesting.NewP2PPeerID(t)
+	senderPeerID := e2etesting.NewP2PPeerID(t)
 
 	dispatcher := &noopDispatcher{}
 	server := executable.NewServer("cap_id@1.0.0", "", serverPeerID, dispatcher, lggr)

--- a/core/capabilities/remote/log/log.go
+++ b/core/capabilities/remote/log/log.go
@@ -1,0 +1,26 @@
+package log
+
+import (
+	"encoding/hex"
+	"unicode"
+)
+
+// TODO this is duplicated from utils to minimise the PR changeset - will be deduped later
+
+const (
+	maxLoggedStringLen = 256
+)
+
+func SanitizeLogString(s string) string {
+	tooLongSuffix := ""
+	if len(s) > maxLoggedStringLen {
+		s = s[:maxLoggedStringLen]
+		tooLongSuffix = " [TRUNCATED]"
+	}
+	for i := 0; i < len(s); i++ {
+		if !unicode.IsPrint(rune(s[i])) {
+			return "[UNPRINTABLE] " + hex.EncodeToString([]byte(s)) + tooLongSuffix
+		}
+	}
+	return s + tooLongSuffix
+}

--- a/core/capabilities/remote/messagecache/message_cache.go
+++ b/core/capabilities/remote/messagecache/message_cache.go
@@ -43,31 +43,33 @@ func (c *MessageCache[EventID, PeerID]) Insert(eventID EventID, peerID PeerID, t
 // received more recently than <minTimestamp>.
 // Return all messages that satisfy the above condition.
 // Ready() will return true at most once per event if <once> is true.
-func (c *MessageCache[EventID, PeerID]) Ready(eventID EventID, minCount uint32, minTimestamp int64, once bool) (bool, [][]byte) {
+func (c *MessageCache[EventID, PeerID]) Ready(eventID EventID, minCount uint32, minTimestamp int64, once bool) (bool, []PeerID, [][]byte) {
 	ev, ok := c.events[eventID]
 	if !ok {
-		return false, nil
+		return false, nil, nil
 	}
 	if ev.wasReady && once {
-		return false, nil
+		return false, nil, nil
 	}
 	//nolint:gosec // G115
 	if uint32(len(ev.peerMsgs)) < minCount {
-		return false, nil
+		return false, nil, nil
 	}
 	countAboveMinTimestamp := uint32(0)
+	var peers []PeerID
 	accPayloads := [][]byte{}
-	for _, msg := range ev.peerMsgs {
+	for peer, msg := range ev.peerMsgs {
 		if msg.timestamp >= minTimestamp {
 			countAboveMinTimestamp++
 			accPayloads = append(accPayloads, msg.payload)
+			peers = append(peers, peer)
 		}
 	}
 	if countAboveMinTimestamp >= minCount {
 		ev.wasReady = true
-		return true, accPayloads
+		return true, peers, accPayloads
 	}
-	return false, nil
+	return false, nil, nil
 }
 
 func (c *MessageCache[EventID, PeerID]) Delete(eventID EventID) {

--- a/core/capabilities/remote/messagecache/message_cache_test.go
+++ b/core/capabilities/remote/messagecache/message_cache_test.go
@@ -22,23 +22,26 @@ func TestMessageCache_InsertReady(t *testing.T) {
 	// not ready with one message
 	ts := cache.Insert(eventID1, peerID1, 100, []byte(payloadA))
 	require.Equal(t, int64(100), ts)
-	ready, _ := cache.Ready(eventID1, 2, 100, true)
+	ready, _, _ := cache.Ready(eventID1, 2, 100, true)
 	require.False(t, ready)
 
 	// not ready with two messages but only one fresh enough
 	ts = cache.Insert(eventID1, peerID2, 200, []byte(payloadA))
 	require.Equal(t, int64(100), ts)
-	ready, _ = cache.Ready(eventID1, 2, 150, true)
+	ready, _, _ = cache.Ready(eventID1, 2, 150, true)
 	require.False(t, ready)
 
 	// ready with two messages (once only)
-	ready, messages := cache.Ready(eventID1, 2, 100, true)
+	ready, peers, messages := cache.Ready(eventID1, 2, 100, true)
 	require.True(t, ready)
 	require.Equal(t, []byte(payloadA), messages[0])
 	require.Equal(t, []byte(payloadA), messages[1])
 
+	require.Contains(t, peers, peerID1)
+	require.Contains(t, peers, peerID2)
+
 	// not ready again for the same event ID
-	ready, _ = cache.Ready(eventID1, 2, 100, true)
+	ready, _, _ = cache.Ready(eventID1, 2, 100, true)
 	require.False(t, ready)
 }
 

--- a/core/capabilities/remote/trigger/registration/publisher_registration.go
+++ b/core/capabilities/remote/trigger/registration/publisher_registration.go
@@ -1,0 +1,254 @@
+package registration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
+)
+
+const messageCacheKey = "publisher_registration"
+
+type ID struct {
+	callerDonID uint32
+	workflowID  string
+	triggerID   string
+}
+
+func NewID(callerDonID uint32, workflowID, triggerID string) ID {
+	return ID{
+		callerDonID: callerDonID,
+		workflowID:  workflowID,
+		triggerID:   triggerID,
+	}
+}
+
+func (id *ID) String() string {
+	return fmt.Sprintf("callerDonID: %d, workflowID: %s, triggerID: %s", id.callerDonID, id.workflowID, id.triggerID)
+}
+
+func (id *ID) CallerDonID() uint32 {
+	return id.callerDonID
+}
+
+func (id *ID) WorkflowID() string {
+	return id.workflowID
+}
+
+func (id *ID) TriggerID() string {
+	return id.triggerID
+}
+
+type PublisherRegistration struct {
+	lggr            logger.Logger
+	id              ID
+	publishResponse func(registrationID ID, response commoncap.TriggerResponse)
+
+	wg     sync.WaitGroup
+	stopCh services.StopChan
+
+	dispatcher types.Dispatcher
+
+	capabilityID    string
+	capabilityDonID uint32
+	capMethodName   string
+
+	underlyingTrigger                    commoncap.TriggerCapability
+	underlyingTriggerRegistrationRequest *commoncap.TriggerRegistrationRequest
+
+	peerRequestsCache *messagecache.MessageCache[string, p2ptypes.PeerID]
+
+	registrationRequests map[p2ptypes.PeerID]uint32
+
+	registrationStatus       types.RegistrationStatus
+	registrationErrorMessage string
+
+	createdAt time.Time
+}
+
+func NewPublisherRegistration(lggr logger.Logger, id ID,
+	publishResponse func(registrationID ID, response commoncap.TriggerResponse),
+	underlying commoncap.TriggerCapability, // This is passed in and not read from dynamic config, reading from dynamic config introduces the possibility that
+	// the registration would register on a different underlying trigger than it unregisters from, this is a bug in the legacy code.
+	// If the underlying trigger changes, then this would take effect on a new registration only, that is to say the existing registration
+	// would need to be allowed to expire, this is the same behaviour as the legacy code.
+	capabilityID string,
+	capabilityDonID uint32,
+	capMethodName string,
+	dispatcher types.Dispatcher) *PublisherRegistration {
+	return &PublisherRegistration{
+		lggr:                 logger.With(lggr, "ID", id),
+		id:                   id,
+		publishResponse:      publishResponse,
+		stopCh:               make(services.StopChan),
+		underlyingTrigger:    underlying,
+		registrationRequests: make(map[p2ptypes.PeerID]uint32),
+		capabilityID:         capabilityID,
+		capabilityDonID:      capabilityDonID,
+		capMethodName:        capMethodName,
+		dispatcher:           dispatcher,
+		peerRequestsCache:    messagecache.NewMessageCache[string, p2ptypes.PeerID](),
+		createdAt:            time.Now(),
+		registrationStatus:   types.RegistrationStatus_UNREGISTERED,
+	}
+}
+
+// IsLive determines whether the publisher registration is considered live based on whether sufficient
+// registration requests have been received recently from peers in the caller DON.
+func (pr *PublisherRegistration) IsLive(registrationExpiry time.Duration, callerDon commoncap.DON) bool {
+	// If it's still unregistered after registrationExpiry from creation time, it is considered to be dead
+	if pr.registrationStatus == types.RegistrationStatus_UNREGISTERED {
+		if time.Since(pr.createdAt) > registrationExpiry {
+			return false
+		}
+	}
+
+	now := time.Now().UnixMilli()
+	ready, _, _ := pr.peerRequestsCache.Ready(messageCacheKey, uint32(2*callerDon.F+1), now-registrationExpiry.Milliseconds(), false)
+	return ready
+}
+
+func (pr *PublisherRegistration) AddRegistrationRequest(ctx context.Context, sender p2ptypes.PeerID, rawRequest []byte,
+	callerDon commoncap.DON, registrationExpiry time.Duration) {
+	nowMs := time.Now().UnixMilli()
+	// First remove any expired messages from the cache, the cache is not expected to be large so this is acceptable
+	// and uses no more resource that the ready call in this case so need to clean-up on a background goroutine.
+	pr.peerRequestsCache.DeleteOlderThan(nowMs - registrationExpiry.Milliseconds())
+
+	// Record the request to ensure liveness of the registration
+
+	pr.peerRequestsCache.Insert(messageCacheKey, sender, nowMs, rawRequest)
+
+	// If registration is already successful, send a status update immediately
+	if pr.registrationStatus == types.RegistrationStatus_REGISTERED {
+		pr.lggr.Debug("already registered on trigger")
+		pr.sendTriggerRegistrationStatus(sender)
+		return
+	}
+
+	// Retry registration if not yet successful - in the case where registration fails it means each request from each calling
+	// capability peer will result in a re-registration attempt (assuming sufficient requests have been received to aggregate)
+	// This is the same behaviour as the legacy code.  TODO Possible we may want limit this.
+
+	// NOTE: require 2F+1 by default, introduce different strategies later (KS-76)
+	minRequired := uint32(2*callerDon.F + 1)
+	ready, requestingPeers, payloads := pr.peerRequestsCache.Ready(messageCacheKey, minRequired, nowMs-registrationExpiry.Milliseconds(), false)
+	if !ready {
+		pr.lggr.Debugw("not ready to aggregate yet", "minRequired", minRequired)
+		return
+	}
+	aggregated, err := aggregation.AggregateModeRaw(payloads, uint32(callerDon.F+1))
+	if err != nil {
+		pr.lggr.Errorw("failed to aggregate trigger registrations", "err", err)
+		return
+	}
+	unmarshalled, err := pb.UnmarshalTriggerRegistrationRequest(aggregated)
+	if err != nil {
+		pr.lggr.Errorw("failed to unmarshal request", "err", err)
+		return
+	}
+
+	callbackCh, err := pr.underlyingTrigger.RegisterTrigger(ctx, unmarshalled)
+	pr.underlyingTriggerRegistrationRequest = &unmarshalled
+	registrationStatus := types.RegistrationStatus_REGISTERED
+	var errMsg string
+	if err != nil {
+		registrationStatus = types.RegistrationStatus_REGISTRATION_ERROR
+		var capErr caperrors.Error
+		if errors.As(err, &capErr) {
+			errMsg = capErr.SerializeToRemoteString()
+		} else {
+			errMsg = caperrors.NewPublicSystemError(err, caperrors.Unknown).SerializeToRemoteString()
+		}
+		pr.lggr.Warnw("failed to register trigger", "err", err)
+	} else {
+		pr.wg.Add(1)
+		go pr.triggerEventLoop(callbackCh)
+		pr.lggr.Debug("updated trigger registration")
+	}
+
+	// If transitioning from unregistered send the status update all peers who requested registration thus far to ensure
+	// a timely response on initial registration.
+	sendToAllPeers := pr.registrationStatus == types.RegistrationStatus_UNREGISTERED
+
+	pr.registrationStatus = registrationStatus
+	pr.registrationErrorMessage = errMsg
+
+	if sendToAllPeers {
+		for _, peerID := range requestingPeers {
+			pr.sendTriggerRegistrationStatus(peerID)
+		}
+	} else {
+		// Send registration status only to the current requester
+		// Other peers will get an updated registration status when they re-request registration.
+		// The alternative would be to send the status to all requesting peers every time,
+		// but that could lead to a lot of duplicate messages being sent if registration keeps failing.
+		pr.sendTriggerRegistrationStatus(sender)
+	}
+}
+
+func (pr *PublisherRegistration) triggerEventLoop(callbackCh <-chan commoncap.TriggerResponse) {
+	defer pr.wg.Done()
+	for {
+		select {
+		case <-pr.stopCh:
+			return
+		case response, ok := <-callbackCh:
+			if !ok {
+				pr.lggr.Infow("triggerEventLoop channel closed")
+				return
+			}
+
+			pr.publishResponse(pr.id, response)
+		}
+	}
+}
+
+func (pr *PublisherRegistration) Close(ctx context.Context) error {
+	close(pr.stopCh)
+	pr.wg.Wait()
+
+	if pr.registrationStatus == types.RegistrationStatus_REGISTERED {
+		unregisterErr := pr.underlyingTrigger.UnregisterTrigger(ctx, *pr.underlyingTriggerRegistrationRequest)
+		if unregisterErr != nil {
+			return fmt.Errorf("failed to unregister from underlying trigger, id %v: %w", pr.id, unregisterErr)
+		}
+	}
+
+	return nil
+}
+
+// sendTriggerRegistrationStatus sends a trigger registration response back to the caller DON with an optional error message
+func (pr *PublisherRegistration) sendTriggerRegistrationStatus(peerID p2ptypes.PeerID) {
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    pr.capabilityID,
+		CapabilityDonId: pr.capabilityDonID,
+		CallerDonId:     pr.id.callerDonID,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:         pr.id.TriggerID(),
+				WorkflowId:        pr.id.WorkflowID(),
+				RegistrationError: pr.registrationErrorMessage,
+				Status:            pr.registrationStatus,
+			},
+		},
+		CapabilityMethod: pr.capMethodName,
+	}
+	err := pr.dispatcher.Send(peerID, registrationResponseMessage)
+	if err != nil {
+		pr.lggr.Errorw("failed to send trigger registration response", "peerID", peerID, "err", err)
+	}
+}

--- a/core/capabilities/remote/trigger/registration/publisher_registration.go
+++ b/core/capabilities/remote/trigger/registration/publisher_registration.go
@@ -1,0 +1,254 @@
+package registration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
+)
+
+const messageCacheKey = "publisher_registration"
+
+type ID struct {
+	callerDonID uint32
+	workflowID  string
+	triggerID   string
+}
+
+func NewID(callerDonID uint32, workflowID, triggerID string) ID {
+	return ID{
+		callerDonID: callerDonID,
+		workflowID:  workflowID,
+		triggerID:   triggerID,
+	}
+}
+
+func (id *ID) String() string {
+	return fmt.Sprintf("callerDonID: %d, workflowID: %s, triggerID: %s", id.callerDonID, id.workflowID, id.triggerID)
+}
+
+func (id *ID) CallerDonID() uint32 {
+	return id.callerDonID
+}
+
+func (id *ID) WorkflowID() string {
+	return id.workflowID
+}
+
+func (id *ID) TriggerID() string {
+	return id.triggerID
+}
+
+type PublisherRegistration struct {
+	lggr            logger.Logger
+	id              ID
+	publishResponse func(registrationID ID, response commoncap.TriggerResponse)
+
+	wg     sync.WaitGroup
+	stopCh services.StopChan
+
+	dispatcher types.Dispatcher
+
+	capabilityID    string
+	capabilityDonID uint32
+	capMethodName   string
+
+	underlyingTrigger                    commoncap.TriggerCapability
+	underlyingTriggerRegistrationRequest *commoncap.TriggerRegistrationRequest
+
+	peerRequestsCache *messagecache.MessageCache[string, p2ptypes.PeerID]
+
+	registrationRequests map[p2ptypes.PeerID]uint32
+
+	registrationStatus       types.RegistrationStatus
+	registrationErrorMessage string
+
+	createdAt time.Time
+}
+
+func NewPublisherRegistration(lggr logger.Logger, id ID,
+	publishResponse func(registrationID ID, response commoncap.TriggerResponse),
+	underlying commoncap.TriggerCapability, // This is passed in and not read from dynamic config, reading from dynamic config introduces the possibility that
+	// the registration would register on a different underlying trigger than it unregisters from, this is a bug in the legacy code.
+	// If the underlying trigger changes, then this would take effect on a new registration only, that is to say the existing registration
+	// would need to be allowed to expire, this is the same behaviour as the legacy code.
+	capabilityID string,
+	capabilityDonID uint32,
+	capMethodName string,
+	dispatcher types.Dispatcher) *PublisherRegistration {
+	return &PublisherRegistration{
+		lggr:                 logger.With(lggr, "ID", id),
+		id:                   id,
+		publishResponse:      publishResponse,
+		stopCh:               make(services.StopChan),
+		underlyingTrigger:    underlying,
+		registrationRequests: make(map[p2ptypes.PeerID]uint32),
+		capabilityID:         capabilityID,
+		capabilityDonID:      capabilityDonID,
+		capMethodName:        capMethodName,
+		dispatcher:           dispatcher,
+		peerRequestsCache:    messagecache.NewMessageCache[string, p2ptypes.PeerID](),
+		createdAt:            time.Now(),
+		registrationStatus:   types.RegistrationStatus_UNREGISTERED,
+	}
+}
+
+// IsLive determines whether the publisher registration is considered live based on whether sufficient
+// registration requests have been received recently from peers in the caller DON.
+func (pr *PublisherRegistration) IsLive(registrationExpiry time.Duration, callerDon commoncap.DON) bool {
+	// If it's still unregistered after registrationExpiry from creation time, it is considered to be dead
+	if pr.registrationStatus == types.RegistrationStatus_UNREGISTERED {
+		if time.Since(pr.createdAt) > registrationExpiry {
+			return false
+		}
+	}
+
+	now := time.Now().UnixMilli()
+	ready, _, _ := pr.peerRequestsCache.Ready(messageCacheKey, uint32(2*callerDon.F+1), now-registrationExpiry.Milliseconds(), false)
+	return ready
+}
+
+func (pr *PublisherRegistration) AddRegistrationRequest(ctx context.Context, sender p2ptypes.PeerID, rawRequest []byte,
+	callerDon commoncap.DON, registrationExpiry time.Duration) {
+	nowMs := time.Now().UnixMilli()
+	// First remote any expired messages from the cache, the cache is not expected to be large so this is acceptable
+	// and uses no more resource that the ready call in this case so need to clean-up on a background goroutine.
+	pr.peerRequestsCache.DeleteOlderThan(nowMs - registrationExpiry.Milliseconds())
+
+	// Record the request to ensure liveness of the registration
+
+	pr.peerRequestsCache.Insert(messageCacheKey, sender, nowMs, rawRequest)
+
+	// If registration is already successful, send a status update immediately
+	if pr.registrationStatus == types.RegistrationStatus_REGISTERED {
+		pr.lggr.Debug("already registered on trigger")
+		pr.sendTriggerRegistrationStatus(sender)
+		return
+	}
+
+	// Retry registration if not yet successful - in the case where registration fails it means each request from each calling
+	// capability peer will result in a re-registration attempt (assuming sufficient requests have been received to aggregate)
+	// This is the same behaviour as the legacy code.  TODO Possible we may want limit this.
+
+	// NOTE: require 2F+1 by default, introduce different strategies later (KS-76)
+	minRequired := uint32(2*callerDon.F + 1)
+	ready, requestingPeers, payloads := pr.peerRequestsCache.Ready(messageCacheKey, minRequired, nowMs-registrationExpiry.Milliseconds(), false)
+	if !ready {
+		pr.lggr.Debugw("not ready to aggregate yet", "minRequired", minRequired)
+		return
+	}
+	aggregated, err := aggregation.AggregateModeRaw(payloads, uint32(callerDon.F+1))
+	if err != nil {
+		pr.lggr.Errorw("failed to aggregate trigger registrations", "err", err)
+		return
+	}
+	unmarshalled, err := pb.UnmarshalTriggerRegistrationRequest(aggregated)
+	if err != nil {
+		pr.lggr.Errorw("failed to unmarshal request", "err", err)
+		return
+	}
+
+	callbackCh, err := pr.underlyingTrigger.RegisterTrigger(ctx, unmarshalled)
+	pr.underlyingTriggerRegistrationRequest = &unmarshalled
+	registrationStatus := types.RegistrationStatus_REGISTERED
+	var errMsg string
+	if err != nil {
+		registrationStatus = types.RegistrationStatus_REGISTRATION_ERROR
+		var capErr caperrors.Error
+		if errors.As(err, &capErr) {
+			errMsg = capErr.SerializeToRemoteString()
+		} else {
+			errMsg = caperrors.NewPublicSystemError(err, caperrors.Unknown).SerializeToRemoteString()
+		}
+		pr.lggr.Warnw("failed to register trigger", "err", err)
+	} else {
+		pr.wg.Add(1)
+		go pr.triggerEventLoop(callbackCh)
+		pr.lggr.Debug("updated trigger registration")
+	}
+
+	// If transitioning from unregistered send the status update all peers who requested registration thus far to ensure
+	// a timely response on initial registration.
+	sendToAllPeers := pr.registrationStatus == types.RegistrationStatus_UNREGISTERED
+
+	pr.registrationStatus = registrationStatus
+	pr.registrationErrorMessage = errMsg
+
+	if sendToAllPeers {
+		for _, peerID := range requestingPeers {
+			pr.sendTriggerRegistrationStatus(peerID)
+		}
+	} else {
+		// Send registration status only to the current requester
+		// Other peers will get an updated registration status when they re-request registration.
+		// The alternative would be to send the status to all requesting peers every time,
+		// but that could lead to a lot of duplicate messages being sent if registration keeps failing.
+		pr.sendTriggerRegistrationStatus(sender)
+	}
+}
+
+func (pr *PublisherRegistration) triggerEventLoop(callbackCh <-chan commoncap.TriggerResponse) {
+	defer pr.wg.Done()
+	for {
+		select {
+		case <-pr.stopCh:
+			return
+		case response, ok := <-callbackCh:
+			if !ok {
+				pr.lggr.Infow("triggerEventLoop channel closed")
+				return
+			}
+
+			pr.publishResponse(pr.id, response)
+		}
+	}
+}
+
+func (pr *PublisherRegistration) Close(ctx context.Context) error {
+	close(pr.stopCh)
+	pr.wg.Wait()
+
+	if pr.registrationStatus == types.RegistrationStatus_REGISTERED {
+		unregisterErr := pr.underlyingTrigger.UnregisterTrigger(ctx, *pr.underlyingTriggerRegistrationRequest)
+		if unregisterErr != nil {
+			return fmt.Errorf("failed to unregister from underlying trigger, id %v: %w", pr.id, unregisterErr)
+		}
+	}
+
+	return nil
+}
+
+// sendTriggerRegistrationStatus sends a trigger registration response back to the caller DON with an optional error message
+func (pr *PublisherRegistration) sendTriggerRegistrationStatus(peerID p2ptypes.PeerID) {
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    pr.capabilityID,
+		CapabilityDonId: pr.capabilityDonID,
+		CallerDonId:     pr.id.callerDonID,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:         pr.id.TriggerID(),
+				WorkflowId:        pr.id.WorkflowID(),
+				RegistrationError: pr.registrationErrorMessage,
+				Status:            pr.registrationStatus,
+			},
+		},
+		CapabilityMethod: pr.capMethodName,
+	}
+	err := pr.dispatcher.Send(peerID, registrationResponseMessage)
+	if err != nil {
+		pr.lggr.Errorw("failed to send trigger registration response", "peerID", peerID, "err", err)
+	}
+}

--- a/core/capabilities/remote/trigger/registration/publisher_registration_test.go
+++ b/core/capabilities/remote/trigger/registration/publisher_registration_test.go
@@ -1,0 +1,482 @@
+package registration_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	p2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/trigger/registration"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+type testTriggerCapability struct {
+	t   *testing.T
+	err error
+}
+
+func (t *testTriggerCapability) AckEvent(ctx context.Context, triggerID string, eventID string, method string) error {
+	return nil
+}
+
+var _ commoncap.TriggerCapability = (*testTriggerCapability)(nil)
+
+func newTestTriggerCapability(t *testing.T, err error) *testTriggerCapability {
+	return &testTriggerCapability{t: t, err: err}
+}
+
+func (t *testTriggerCapability) Info(ctx context.Context) (commoncap.CapabilityInfo, error) {
+	return commoncap.CapabilityInfo{
+		ID: "test-capability",
+	}, nil
+}
+
+func (t *testTriggerCapability) RegisterTrigger(ctx context.Context, req commoncap.TriggerRegistrationRequest) (<-chan commoncap.TriggerResponse, error) {
+	require.NotNil(t.t, req)
+	ch := make(chan commoncap.TriggerResponse, 1)
+	return ch, t.err
+}
+
+func (t *testTriggerCapability) UnregisterTrigger(ctx context.Context, req commoncap.TriggerRegistrationRequest) error {
+	require.NotNil(t.t, req)
+	return nil
+}
+
+type sendCall struct {
+	peerID p2ptypes.PeerID
+	msg    *types.MessageBody
+}
+
+func TestMultipleAddedRequests_SuccessfulTriggerRegistration(t *testing.T) {
+	// Test that when multiple requests are added to a PublisherRegistration,
+	// they all receive the same registration status update when the trigger is registered.
+
+	// Setup
+	lggr := logger.TestLogger(t)
+	triggerID := "test-trigger"
+	workflowID := "test-workflow"
+	capabilityID := "test-capability"
+
+	dispatcher := &testDispatcher{}
+
+	pr := registration.NewPublisherRegistration(lggr,
+		registration.NewID(1, workflowID, triggerID), func(registrationID registration.ID, response commoncap.TriggerResponse) {}, newTestTriggerCapability(t, nil),
+		capabilityID, 1, "triggerCap", dispatcher,
+	)
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+
+	request := commoncap.TriggerRegistrationRequest{
+		TriggerID: triggerID,
+	}
+
+	rawRequest, err := pb.MarshalTriggerRegistrationRequest(request)
+	require.NoError(t, err)
+
+	// Add multiple requests
+	peerID1 := peers[0]
+	peerID2 := peers[1]
+
+	callerDon := commoncap.DON{
+		ID: 1,
+	}
+
+	registrationExpiry := 10 * time.Minute
+
+	pr.AddRegistrationRequest(context.Background(), peerID1, rawRequest, callerDon, registrationExpiry)
+	pr.AddRegistrationRequest(context.Background(), peerID2, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to each peer
+	require.Len(t, dispatcher.sendCalls, 2)
+
+	foundPeer1 := false
+	foundPeer2 := false
+	for _, call := range dispatcher.sendCalls {
+		require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+		meta := call.msg.GetTriggerRegistrationMetadata()
+		require.Equal(t, types.RegistrationStatus_REGISTERED, meta.Status)
+		require.Equal(t, triggerID, meta.TriggerId)
+		switch call.peerID {
+		case peerID1:
+			foundPeer1 = true
+		case peerID2:
+			foundPeer2 = true
+		}
+	}
+
+	require.True(t, foundPeer1, "did not find message sent to peerID1")
+	require.True(t, foundPeer2, "did not find message sent to peerID2")
+
+	// Send an additional registration request after trigger registration has already completed, expect to get immediate response to the new peer
+	peerID3 := peers[2]
+	pr.AddRegistrationRequest(context.Background(), peerID3, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to the new peer
+	require.Len(t, dispatcher.sendCalls, 3)
+
+	foundPeer3 := false
+	for _, call := range dispatcher.sendCalls {
+		if call.peerID == peerID3 {
+			foundPeer3 = true
+			require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+			meta := call.msg.GetTriggerRegistrationMetadata()
+			require.Equal(t, types.RegistrationStatus_REGISTERED, meta.Status)
+			require.Equal(t, triggerID, meta.TriggerId)
+		}
+	}
+
+	require.True(t, foundPeer3, "did not find message sent to peerID3")
+}
+
+func TestMultipleAddedRequests_TriggerRegistrationError(t *testing.T) {
+	// Test that when multiple requests are added to a PublisherRegistration,
+	// they all receive the same error response when the trigger registration fails.
+
+	// Setup
+	lggr := logger.TestLogger(t)
+	triggerID := "test-trigger"
+	workflowID := "test-workflow"
+	capabilityID := "test-capability"
+
+	dispatcher := &testDispatcher{}
+	pr := registration.NewPublisherRegistration(lggr,
+		registration.NewID(1, workflowID, triggerID), func(registrationID registration.ID, response commoncap.TriggerResponse) {},
+		newTestTriggerCapability(t, errors.New("its borken")),
+		capabilityID, 1, "triggerCap", dispatcher)
+
+	peers := make([]p2ptypes.PeerID, 4)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+
+	request := commoncap.TriggerRegistrationRequest{
+		TriggerID: triggerID,
+	}
+
+	rawRequest, err := pb.MarshalTriggerRegistrationRequest(request)
+	require.NoError(t, err)
+
+	// Add multiple requests
+	peerID1 := peers[0]
+	peerID2 := peers[1]
+
+	callerDon := commoncap.DON{
+		ID: 1,
+	}
+
+	registrationExpiry := 10 * time.Minute
+
+	pr.AddRegistrationRequest(context.Background(), peerID1, rawRequest, callerDon, registrationExpiry)
+	pr.AddRegistrationRequest(context.Background(), peerID2, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to each peer
+	require.Len(t, dispatcher.sendCalls, 2)
+
+	foundPeer1 := false
+	foundPeer2 := false
+	for _, call := range dispatcher.sendCalls {
+		require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+		meta := call.msg.GetTriggerRegistrationMetadata()
+		require.Equal(t, types.RegistrationStatus_REGISTRATION_ERROR, meta.Status)
+		require.Equal(t, triggerID, meta.TriggerId)
+		caperror := caperrors.DeserializeErrorFromString(meta.RegistrationError)
+		require.Equal(t, caperrors.Unknown, caperror.Code())
+		require.Equal(t, caperrors.OriginSystem, caperror.Origin())
+		require.Equal(t, caperrors.VisibilityPublic, caperror.Visibility())
+		require.Equal(t, "[2]Unknown: its borken", caperror.Error())
+		switch call.peerID {
+		case peerID1:
+			foundPeer1 = true
+		case peerID2:
+			foundPeer2 = true
+		}
+	}
+
+	require.True(t, foundPeer1, "did not find message sent to peerID1")
+	require.True(t, foundPeer2, "did not find message sent to peerID2")
+
+	// Send an additional registration request after trigger registration has already completed with error, expect to get immediate error response to the new peer
+	peerID3 := peers[2]
+
+	pr.AddRegistrationRequest(context.Background(), peerID3, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to the new peer
+	require.Len(t, dispatcher.sendCalls, 3)
+
+	foundPeer3 := false
+	for _, call := range dispatcher.sendCalls {
+		if call.peerID == peerID3 {
+			foundPeer3 = true
+			require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+			meta := call.msg.GetTriggerRegistrationMetadata()
+			require.Equal(t, types.RegistrationStatus_REGISTRATION_ERROR, meta.Status)
+			require.Equal(t, triggerID, meta.TriggerId)
+			caperror := caperrors.DeserializeErrorFromString(meta.RegistrationError)
+			require.Equal(t, caperrors.Unknown, caperror.Code())
+			require.Equal(t, caperrors.OriginSystem, caperror.Origin())
+			require.Equal(t, caperrors.VisibilityPublic, caperror.Visibility())
+			require.Equal(t, "[2]Unknown: its borken", caperror.Error())
+
+			require.Equal(t, triggerID, meta.TriggerId)
+		}
+	}
+
+	require.True(t, foundPeer3, "did not find message sent to peerID3")
+}
+
+func TestMultipleAddedRequests_TriggerRegistrationCapabilityUserError(t *testing.T) {
+	// Test that when multiple requests are added to a PublisherRegistration,
+	// they all receive the same error response when the trigger registration fails.
+
+	// Setup
+	lggr := logger.TestLogger(t)
+	triggerID := "test-trigger"
+	workflowID := "test-workflow"
+	capabilityID := "test-capability"
+
+	dispatcher := &testDispatcher{}
+	pr := registration.NewPublisherRegistration(lggr,
+		registration.NewID(1, workflowID, triggerID), func(registrationID registration.ID, response commoncap.TriggerResponse) {},
+		newTestTriggerCapability(t, caperrors.NewPublicUserError(errors.New("its borken"), caperrors.InvalidArgument)),
+		capabilityID, 1, "triggerCap",
+		dispatcher)
+
+	peers := make([]p2ptypes.PeerID, 4)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+
+	request := commoncap.TriggerRegistrationRequest{
+		TriggerID: triggerID,
+	}
+
+	rawRequest, err := pb.MarshalTriggerRegistrationRequest(request)
+	require.NoError(t, err)
+
+	// Add multiple requests
+	peerID1 := peers[0]
+	peerID2 := peers[1]
+
+	callerDon := commoncap.DON{
+		ID: 1,
+	}
+
+	registrationExpiry := 10 * time.Minute
+
+	pr.AddRegistrationRequest(context.Background(), peerID1, rawRequest, callerDon, registrationExpiry)
+	pr.AddRegistrationRequest(context.Background(), peerID2, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to each peer
+	require.Len(t, dispatcher.sendCalls, 2)
+
+	foundPeer1 := false
+	foundPeer2 := false
+	for _, call := range dispatcher.sendCalls {
+		require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+		meta := call.msg.GetTriggerRegistrationMetadata()
+		require.Equal(t, types.RegistrationStatus_REGISTRATION_ERROR, meta.Status)
+		require.Equal(t, triggerID, meta.TriggerId)
+		caperror := caperrors.DeserializeErrorFromString(meta.RegistrationError)
+		require.Equal(t, caperrors.InvalidArgument, caperror.Code())
+		require.Equal(t, caperrors.OriginUser, caperror.Origin())
+		require.Equal(t, caperrors.VisibilityPublic, caperror.Visibility())
+		require.Equal(t, "[3]InvalidArgument: its borken", caperror.Error())
+		switch call.peerID {
+		case peerID1:
+			foundPeer1 = true
+		case peerID2:
+			foundPeer2 = true
+		}
+	}
+
+	require.True(t, foundPeer1, "did not find message sent to peerID1")
+	require.True(t, foundPeer2, "did not find message sent to peerID2")
+
+	// Send an additional registration request after trigger registration has already completed with error, expect to get immediate error response to the new peer
+	peerID3 := peers[2]
+
+	pr.AddRegistrationRequest(context.Background(), peerID3, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to the new peer
+	require.Len(t, dispatcher.sendCalls, 3)
+
+	foundPeer3 := false
+	for _, call := range dispatcher.sendCalls {
+		if call.peerID == peerID3 {
+			foundPeer3 = true
+			require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+			meta := call.msg.GetTriggerRegistrationMetadata()
+			require.Equal(t, types.RegistrationStatus_REGISTRATION_ERROR, meta.Status)
+			require.Equal(t, triggerID, meta.TriggerId)
+			caperror := caperrors.DeserializeErrorFromString(meta.RegistrationError)
+			require.Equal(t, caperrors.InvalidArgument, caperror.Code())
+			require.Equal(t, caperrors.OriginUser, caperror.Origin())
+			require.Equal(t, caperrors.VisibilityPublic, caperror.Visibility())
+			require.Equal(t, "[3]InvalidArgument: its borken", caperror.Error())
+
+			require.Equal(t, triggerID, meta.TriggerId)
+		}
+	}
+
+	require.True(t, foundPeer3, "did not find message sent to peerID3")
+}
+
+func TestMultipleAddedRequests_TriggerRegistrationInitiallyErrorsThenRecovers(t *testing.T) {
+	// Test that when multiple requests are added to a PublisherRegistration,
+	// they all receive the same error response when the trigger registration fails.
+
+	// Setup
+	lggr := logger.TestLogger(t)
+	triggerID := "test-trigger"
+	workflowID := "test-workflow"
+	capabilityID := "test-capability"
+
+	dispatcher := &testDispatcher{}
+	testCapability := newTestTriggerCapability(t, errors.New("its borken"))
+	pr := registration.NewPublisherRegistration(lggr,
+		registration.NewID(1, workflowID, triggerID), func(registrationID registration.ID, response commoncap.TriggerResponse) {},
+		testCapability, capabilityID, 1,
+		"triggerCap", dispatcher)
+
+	peers := make([]p2ptypes.PeerID, 4)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+
+	request := commoncap.TriggerRegistrationRequest{
+		TriggerID: triggerID,
+	}
+
+	rawRequest, err := pb.MarshalTriggerRegistrationRequest(request)
+	require.NoError(t, err)
+
+	// Add multiple requests
+	peerID1 := peers[0]
+	peerID2 := peers[1]
+
+	callerDon := commoncap.DON{
+		ID: 1,
+	}
+
+	registrationExpiry := 10 * time.Minute
+
+	pr.AddRegistrationRequest(context.Background(), peerID1, rawRequest, callerDon, registrationExpiry)
+	pr.AddRegistrationRequest(context.Background(), peerID2, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to each peer
+	require.Len(t, dispatcher.sendCalls, 2)
+
+	foundPeer1 := false
+	foundPeer2 := false
+	for _, call := range dispatcher.sendCalls {
+		require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+		meta := call.msg.GetTriggerRegistrationMetadata()
+		require.Equal(t, types.RegistrationStatus_REGISTRATION_ERROR, meta.Status)
+		require.Equal(t, triggerID, meta.TriggerId)
+		caperror := caperrors.DeserializeErrorFromString(meta.RegistrationError)
+		require.Equal(t, caperrors.Unknown, caperror.Code())
+		require.Equal(t, caperrors.OriginSystem, caperror.Origin())
+		require.Equal(t, caperrors.VisibilityPublic, caperror.Visibility())
+		require.Equal(t, "[2]Unknown: its borken", caperror.Error())
+		switch call.peerID {
+		case peerID1:
+			foundPeer1 = true
+		case peerID2:
+			foundPeer2 = true
+		}
+	}
+
+	require.True(t, foundPeer1, "did not find message sent to peerID1")
+	require.True(t, foundPeer2, "did not find message sent to peerID2")
+
+	// Now update the test capability to succeed
+	testCapability.err = nil
+	// Send another registration request to trigger re-registration, expect it to return success
+	peerID3 := peers[2]
+
+	pr.AddRegistrationRequest(context.Background(), peerID3, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to the new peer
+	require.Len(t, dispatcher.sendCalls, 3)
+
+	foundPeer3 := false
+	for _, call := range dispatcher.sendCalls {
+		if call.peerID == peerID3 {
+			foundPeer3 = true
+			require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+			meta := call.msg.GetTriggerRegistrationMetadata()
+			require.Equal(t, types.RegistrationStatus_REGISTERED, meta.Status)
+			require.Empty(t, meta.RegistrationError)
+			require.Equal(t, triggerID, meta.TriggerId)
+		}
+	}
+
+	require.True(t, foundPeer3, "did not find message sent to peerID3")
+
+	// Resend a request from peerID1 to confirm it now also gets success response
+	pr.AddRegistrationRequest(context.Background(), peerID1, rawRequest, callerDon, registrationExpiry)
+
+	// Confirm a trigger response message was sent to peerID1 again
+	require.Len(t, dispatcher.sendCalls, 4)
+
+	call := dispatcher.sendCalls[3]
+	if call.peerID == peerID1 {
+		require.Equal(t, types.TriggerRegistrationStatus, call.msg.Method)
+		meta := call.msg.GetTriggerRegistrationMetadata()
+		require.Equal(t, types.RegistrationStatus_REGISTERED, meta.Status)
+		require.Empty(t, meta.RegistrationError)
+		require.Equal(t, triggerID, meta.TriggerId)
+	}
+}
+
+type testDispatcher struct {
+	services.StateMachine
+	sendCalls []sendCall
+}
+
+func (d *testDispatcher) Send(peerID p2ptypes.PeerID, msgBody *types.MessageBody) error {
+	d.sendCalls = append(d.sendCalls, sendCall{peerID, msgBody})
+	return nil
+}
+func (d *testDispatcher) SetReceiver(capabilityID string, donID uint32, receiver types.Receiver) error {
+	return nil
+}
+
+func (d *testDispatcher) RemoveReceiver(capabilityID string, donID uint32) {}
+
+func (d *testDispatcher) SetReceiverForMethod(capabilityID string, donID uint32, method string, receiver types.Receiver) error {
+	return nil
+}
+
+func (d *testDispatcher) RemoveReceiverForMethod(capabilityID string, donID uint32, method string) {}
+
+func (d *testDispatcher) Start(ctx context.Context) error {
+	return nil
+}
+
+func (d *testDispatcher) Close() error {
+	return nil
+}
+
+func (d *testDispatcher) Ready() error {
+	return nil
+}
+
+func (d *testDispatcher) HealthReport() map[string]error {
+	return nil
+}
+
+func (d *testDispatcher) Name() string {
+	return ""
+}

--- a/core/capabilities/remote/trigger/registration/subscriber_registration.go
+++ b/core/capabilities/remote/trigger/registration/subscriber_registration.go
@@ -1,0 +1,190 @@
+package registration
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	p2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
+
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/log"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+)
+
+const (
+	// This default is taken from the legacy code, it is the buffer size of the channel
+	sendChannelBufferSize = 1000
+)
+
+const registrationStatusUpdateCacheKey = "subscriber_registration"
+
+type SubscriberRegistration struct {
+	lggr              logger.Logger
+	triggerResponseCh chan commoncap.TriggerResponse
+	rawRequest        []byte
+
+	registrationStatusUpdateCache *messagecache.MessageCache[string, p2ptypes.PeerID]
+
+	statusMutex        sync.RWMutex
+	registrationStatus types.RegistrationStatus
+	registrationError  caperrors.Error
+
+	// Used to signal that this subscription is no longer waiting for the initial registration response
+	initialRegistrationResponseChan chan struct{}
+}
+
+func NewSubscriberRegistration(lggr logger.Logger, rawRequest []byte,
+	workflowID string, triggerID string) *SubscriberRegistration {
+	return &SubscriberRegistration{
+		lggr:                            logger.With(lggr, "WorkflowID", workflowID, "TriggerID", triggerID),
+		triggerResponseCh:               make(chan commoncap.TriggerResponse, sendChannelBufferSize),
+		rawRequest:                      rawRequest,
+		registrationStatusUpdateCache:   messagecache.NewMessageCache[string, p2ptypes.PeerID](),
+		initialRegistrationResponseChan: make(chan struct{}),
+	}
+}
+
+func (sr *SubscriberRegistration) HandleTriggerRegistrationStatusUpdate(sender p2ptypes.PeerID, msg *types.MessageBody, minResponseToAggregate uint32,
+	registrationExpiry time.Duration, publisherNodeCount int) {
+	nowMs := time.Now().UnixMilli()
+	// First remove any expired messages from the cache, the cache is not expected to be large so this is acceptable
+	// and uses no more resource that the ready call in this case so need to clean-up on a background goroutine.
+	sr.registrationStatusUpdateCache.DeleteOlderThan(nowMs - registrationExpiry.Milliseconds())
+
+	meta := msg.GetTriggerRegistrationMetadata()
+
+	if meta.Status == types.RegistrationStatus_REGISTRATION_ERROR {
+		sr.registrationStatusUpdateCache.Insert(registrationStatusUpdateCacheKey, sender, nowMs, []byte(meta.RegistrationError))
+	} else {
+		sr.registrationStatusUpdateCache.Insert(registrationStatusUpdateCacheKey, sender, nowMs, nil)
+	}
+
+	ready, _, registrationResponses := sr.registrationStatusUpdateCache.Ready(registrationStatusUpdateCacheKey, minResponseToAggregate, nowMs-registrationExpiry.Milliseconds(), false)
+
+	if ready {
+		var successfulRegistrationCount uint32
+		var totalErrorCount int
+
+		// aggregate errors by message
+		errorToCount := map[string]uint32{}
+		for _, responseError := range registrationResponses {
+			if len(responseError) > 0 {
+				errorStr := string(responseError)
+				errorToCount[errorStr]++
+				totalErrorCount++
+			} else {
+				successfulRegistrationCount++
+			}
+		}
+
+		if successfulRegistrationCount >= minResponseToAggregate {
+			// Successful registration
+			sr.lggr.Infow("successful trigger registration", "sender", sender)
+			sr.setRegistrationStatus(types.RegistrationStatus_REGISTERED, nil)
+		} else {
+			errStrs := make([]string, 0, len(errorToCount))
+			for errStr := range errorToCount {
+				errStrs = append(errStrs, errStr)
+			}
+			sort.Strings(errStrs)
+
+			// Registration failed - set error response
+			// Is there a consensus error?  if so set that
+			lastErr := ""
+
+			for _, errStr := range errStrs {
+				count := errorToCount[errStr]
+				if count >= minResponseToAggregate {
+					caperr := caperrors.DeserializeErrorFromString(errStr)
+					sr.setRegistrationStatus(types.RegistrationStatus_REGISTRATION_ERROR, caperr)
+					return
+				}
+
+				lastErr = errStr
+			}
+
+			// The check on when to give up waiting for minResponseToAggregate identical errors assumes that all received
+			// errors so far, and any future that will be received are and will be distinct.  It's the same logic
+			// used to aggregate errors for remote executable capabilities.  For the purposes of error handling it is
+			// sufficient.
+			if totalErrorCount >= publisherNodeCount-int(minResponseToAggregate)+1 {
+				// There is no consensus error, return a generic error message
+				sr.setRegistrationStatus(types.RegistrationStatus_REGISTRATION_ERROR,
+					caperrors.NewPublicSystemError(fmt.Errorf("received %d errors, last error %s : %s", totalErrorCount, msg.Error, log.SanitizeLogString(lastErr)), caperrors.ConsensusFailed))
+
+				// Log all the errors received to help diagnose why consensus failed.
+				// First sanitize the error messages and then log them in a single log line to ensure they are not interleaved with other log messages.
+				var sanitizedErrStrs []string
+				for _, errStr := range errStrs {
+					sanitizedErrStrs = append(sanitizedErrStrs, log.SanitizeLogString(errStr))
+				}
+				sr.lggr.Warnw("failed to achieve consensus on trigger registration errors", "errors", sanitizedErrStrs)
+			}
+		}
+	}
+}
+
+func (sr *SubscriberRegistration) GetTriggerResponseChannel() chan commoncap.TriggerResponse {
+	return sr.triggerResponseCh
+}
+
+// AwaitRegistration waits for the registration until the context is cancelled.  Returns nil if registration is
+// successful, returns a capability error if registration failed.
+// If the registration status is unable to be determined before the context is cancelled ErrUnableToDetermineRegistrationStatus is returned.
+func (sr *SubscriberRegistration) AwaitRegistration(ctx context.Context) error {
+	registrationStatus, registrationErr := sr.getRegistrationStatus()
+	switch registrationStatus {
+	case types.RegistrationStatus_REGISTERED:
+		return nil
+	case types.RegistrationStatus_REGISTRATION_ERROR:
+		return registrationErr
+	default:
+		// Wait for registration response or context cancellation
+		select {
+		case <-ctx.Done():
+			return commoncap.ErrUnableToDetermineRegistrationStatus
+		case <-sr.initialRegistrationResponseChan:
+			_, registrationErr = sr.getRegistrationStatus()
+			return registrationErr
+		}
+	}
+}
+
+func (sr *SubscriberRegistration) setRegistrationStatus(status types.RegistrationStatus, registrationError caperrors.Error) {
+	sr.statusMutex.Lock()
+	defer sr.statusMutex.Unlock()
+	if sr.registrationStatus == types.RegistrationStatus_UNREGISTERED && status != types.RegistrationStatus_UNREGISTERED {
+		// Signal that the initial registration response is ready
+		close(sr.initialRegistrationResponseChan)
+	}
+	sr.registrationStatus = status
+	sr.registrationError = registrationError
+}
+
+func (sr *SubscriberRegistration) getRegistrationStatus() (types.RegistrationStatus, caperrors.Error) {
+	sr.statusMutex.RLock()
+	defer sr.statusMutex.RUnlock()
+	return sr.registrationStatus, sr.registrationError
+}
+
+func (sr *SubscriberRegistration) UpdateRegistrationRequest(rawRequest []byte) {
+	sr.rawRequest = rawRequest
+}
+
+func (sr *SubscriberRegistration) GetRawRequest() []byte {
+	return sr.rawRequest
+}
+
+func (sr *SubscriberRegistration) SendAggregatedEvent(aggregatedEvent commoncap.TriggerResponse) {
+	sr.triggerResponseCh <- aggregatedEvent
+}
+
+func (sr *SubscriberRegistration) Close() {
+	close(sr.triggerResponseCh)
+}

--- a/core/capabilities/remote/trigger/registration/subscriber_registration.go
+++ b/core/capabilities/remote/trigger/registration/subscriber_registration.go
@@ -116,7 +116,7 @@ func (sr *SubscriberRegistration) HandleTriggerRegistrationStatusUpdate(sender p
 			if totalErrorCount >= publisherNodeCount-int(minResponseToAggregate)+1 {
 				// There is no consensus error, return a generic error message
 				sr.setRegistrationStatus(types.RegistrationStatus_REGISTRATION_ERROR,
-					caperrors.NewPublicSystemError(fmt.Errorf("received %d errors, last error %s : %s", totalErrorCount, msg.Error, log.SanitizeLogString(lastErr)), caperrors.Unknown))
+					caperrors.NewPublicSystemError(fmt.Errorf("received %d errors, last error %s : %s", totalErrorCount, msg.Error, log.SanitizeLogString(lastErr)), caperrors.ConsensusFailed))
 			}
 		}
 	}

--- a/core/capabilities/remote/trigger/registration/subscriber_registration.go
+++ b/core/capabilities/remote/trigger/registration/subscriber_registration.go
@@ -117,6 +117,14 @@ func (sr *SubscriberRegistration) HandleTriggerRegistrationStatusUpdate(sender p
 				// There is no consensus error, return a generic error message
 				sr.setRegistrationStatus(types.RegistrationStatus_REGISTRATION_ERROR,
 					caperrors.NewPublicSystemError(fmt.Errorf("received %d errors, last error %s : %s", totalErrorCount, msg.Error, log.SanitizeLogString(lastErr)), caperrors.ConsensusFailed))
+
+				// Log all the errors received to help diagnose why consensus failed.
+				// First sanitize the error messages and then log them in a single log line to ensure they are not interleaved with other log messages.
+				var sanitizedErrStrs []string
+				for _, errStr := range errStrs {
+					sanitizedErrStrs = append(sanitizedErrStrs, log.SanitizeLogString(errStr))
+				}
+				sr.lggr.Warnw("failed to achieve consensus on trigger registration errors", "errors", sanitizedErrStrs)
 			}
 		}
 	}

--- a/core/capabilities/remote/trigger/registration/subscriber_registration.go
+++ b/core/capabilities/remote/trigger/registration/subscriber_registration.go
@@ -58,10 +58,6 @@ func (sr *SubscriberRegistration) HandleTriggerRegistrationStatusUpdate(sender p
 	sr.registrationStatusUpdateCache.DeleteOlderThan(nowMs - registrationExpiry.Milliseconds())
 
 	meta := msg.GetTriggerRegistrationMetadata()
-	if meta == nil {
-		sr.lggr.Errorw("received trigger registration status update message with invalid trigger metadata", "sender", sender)
-		return
-	}
 
 	if meta.Status == types.RegistrationStatus_REGISTRATION_ERROR {
 		sr.registrationStatusUpdateCache.Insert(registrationStatusUpdateCacheKey, sender, nowMs, []byte(meta.RegistrationError))

--- a/core/capabilities/remote/trigger/registration/subscriber_registration.go
+++ b/core/capabilities/remote/trigger/registration/subscriber_registration.go
@@ -1,0 +1,186 @@
+package registration
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	p2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
+
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/log"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+)
+
+const (
+	// This default is taken from the legacy code, it is the buffer size of the channel
+	sendChannelBufferSize = 1000
+)
+
+const registrationStatusUpdateCacheKey = "subscriber_registration"
+
+type SubscriberRegistration struct {
+	lggr              logger.Logger
+	triggerResponseCh chan commoncap.TriggerResponse
+	rawRequest        []byte
+
+	registrationStatusUpdateCache *messagecache.MessageCache[string, p2ptypes.PeerID]
+
+	statusMutex        sync.RWMutex
+	registrationStatus types.RegistrationStatus
+	registrationError  caperrors.Error
+
+	// Used to signal that this subscription is no longer waiting for the initial registration response
+	initialRegistrationResponseChan chan struct{}
+}
+
+func NewSubscriberRegistration(lggr logger.Logger, rawRequest []byte,
+	workflowID string, triggerID string) *SubscriberRegistration {
+	return &SubscriberRegistration{
+		lggr:                            logger.With(lggr, "WorkflowID", workflowID, "TriggerID", triggerID),
+		triggerResponseCh:               make(chan commoncap.TriggerResponse, sendChannelBufferSize),
+		rawRequest:                      rawRequest,
+		registrationStatusUpdateCache:   messagecache.NewMessageCache[string, p2ptypes.PeerID](),
+		initialRegistrationResponseChan: make(chan struct{}),
+	}
+}
+
+func (sr *SubscriberRegistration) HandleTriggerRegistrationStatusUpdate(sender p2ptypes.PeerID, msg *types.MessageBody, minResponseToAggregate uint32,
+	registrationExpiry time.Duration, publisherNodeCount int) {
+	nowMs := time.Now().UnixMilli()
+	// First remove any expired messages from the cache, the cache is not expected to be large so this is acceptable
+	// and uses no more resource that the ready call in this case so need to clean-up on a background goroutine.
+	sr.registrationStatusUpdateCache.DeleteOlderThan(nowMs - registrationExpiry.Milliseconds())
+
+	meta := msg.GetTriggerRegistrationMetadata()
+	if meta == nil {
+		sr.lggr.Errorw("received trigger registration status update message with invalid trigger metadata", "sender", sender)
+		return
+	}
+
+	if meta.Status == types.RegistrationStatus_REGISTRATION_ERROR {
+		sr.registrationStatusUpdateCache.Insert(registrationStatusUpdateCacheKey, sender, nowMs, []byte(meta.RegistrationError))
+	} else {
+		sr.registrationStatusUpdateCache.Insert(registrationStatusUpdateCacheKey, sender, nowMs, nil)
+	}
+
+	ready, _, registrationResponses := sr.registrationStatusUpdateCache.Ready(registrationStatusUpdateCacheKey, minResponseToAggregate, nowMs-registrationExpiry.Milliseconds(), false)
+
+	if ready {
+		var successfulRegistrationCount uint32
+		var totalErrorCount int
+
+		// aggregate errors by message
+		errorToCount := map[string]uint32{}
+		for _, responseError := range registrationResponses {
+			if len(responseError) > 0 {
+				errorStr := string(responseError)
+				errorToCount[errorStr]++
+				totalErrorCount++
+			} else {
+				successfulRegistrationCount++
+			}
+		}
+
+		if successfulRegistrationCount >= minResponseToAggregate {
+			// Successful registration
+			sr.lggr.Infow("successful trigger registration", "sender", sender)
+			sr.setRegistrationStatus(types.RegistrationStatus_REGISTERED, nil)
+		} else {
+			errStrs := make([]string, 0, len(errorToCount))
+			for errStr := range errorToCount {
+				errStrs = append(errStrs, errStr)
+			}
+			sort.Strings(errStrs)
+
+			// Registration failed - set error response
+			// Is there a consensus error?  if so set that
+			lastErr := ""
+
+			for _, errStr := range errStrs {
+				count := errorToCount[errStr]
+				if count >= minResponseToAggregate {
+					caperr := caperrors.DeserializeErrorFromString(errStr)
+					sr.setRegistrationStatus(types.RegistrationStatus_REGISTRATION_ERROR, caperr)
+					return
+				}
+
+				lastErr = errStr
+			}
+
+			// The check on when to give up waiting for minResponseToAggregate identical errors assumes that all received
+			// errors so far, and any future that will be received are and will be distinct.  It's the same logic
+			// used to aggregate errors for remote executable capabilities.  For the purposes of error handling it is
+			// sufficient.
+			if totalErrorCount >= publisherNodeCount-int(minResponseToAggregate)+1 {
+				// There is no consensus error, return a generic error message
+				sr.setRegistrationStatus(types.RegistrationStatus_REGISTRATION_ERROR,
+					caperrors.NewPublicSystemError(fmt.Errorf("received %d errors, last error %s : %s", totalErrorCount, msg.Error, log.SanitizeLogString(lastErr)), caperrors.Unknown))
+			}
+		}
+	}
+}
+
+func (sr *SubscriberRegistration) GetTriggerResponseChannel() chan commoncap.TriggerResponse {
+	return sr.triggerResponseCh
+}
+
+// AwaitRegistration waits for the registration until the context is cancelled.  Returns nil if registration is
+// successful, returns a capability error if registration failed.
+// If the registration status is unable to be determined before the context is cancelled ErrUnableToDetermineRegistrationStatus is returned.
+func (sr *SubscriberRegistration) AwaitRegistration(ctx context.Context) error {
+	registrationStatus, registrationErr := sr.getRegistrationStatus()
+	switch registrationStatus {
+	case types.RegistrationStatus_REGISTERED:
+		return nil
+	case types.RegistrationStatus_REGISTRATION_ERROR:
+		return registrationErr
+	default:
+		// Wait for registration response or context cancellation
+		select {
+		case <-ctx.Done():
+			return commoncap.ErrUnableToDetermineRegistrationStatus
+		case <-sr.initialRegistrationResponseChan:
+			_, registrationErr = sr.getRegistrationStatus()
+			return registrationErr
+		}
+	}
+}
+
+func (sr *SubscriberRegistration) setRegistrationStatus(status types.RegistrationStatus, registrationError caperrors.Error) {
+	sr.statusMutex.Lock()
+	defer sr.statusMutex.Unlock()
+	if sr.registrationStatus == types.RegistrationStatus_UNREGISTERED && status != types.RegistrationStatus_UNREGISTERED {
+		// Signal that the initial registration response is ready
+		close(sr.initialRegistrationResponseChan)
+	}
+	sr.registrationStatus = status
+	sr.registrationError = registrationError
+}
+
+func (sr *SubscriberRegistration) getRegistrationStatus() (types.RegistrationStatus, caperrors.Error) {
+	sr.statusMutex.RLock()
+	defer sr.statusMutex.RUnlock()
+	return sr.registrationStatus, sr.registrationError
+}
+
+func (sr *SubscriberRegistration) UpdateRegistrationRequest(rawRequest []byte) {
+	sr.rawRequest = rawRequest
+}
+
+func (sr *SubscriberRegistration) GetRawRequest() []byte {
+	return sr.rawRequest
+}
+
+func (sr *SubscriberRegistration) SendAggregatedEvent(aggregatedEvent commoncap.TriggerResponse) {
+	sr.triggerResponseCh <- aggregatedEvent
+}
+
+func (sr *SubscriberRegistration) Close() {
+	close(sr.triggerResponseCh)
+}

--- a/core/capabilities/remote/trigger/registration/subscriber_registration_test.go
+++ b/core/capabilities/remote/trigger/registration/subscriber_registration_test.go
@@ -1,0 +1,299 @@
+package registration_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/trigger/registration"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+
+	p2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
+)
+
+const (
+	peerID1 = "12D3KooWF3dVeJ6YoT5HFnYhmwQWWMoEwVFzJQ5kKCMX3ZityxMC"
+	peerID2 = "12D3KooWQsmok6aD8PZqt3RnJhQRrNzKHLficq7zYFRp7kZ1hHP8"
+	peerID3 = "12D3KooWPumsXxg6mJ4hmRizjBD7oFMtN9vm3kTwN8BLEinyDPJS"
+	peerID4 = "12D3KooWNuumb38Jpw6DoRbgwejcZYwfsWbbzPU4fWy5imrW3dyD"
+)
+
+func TestSubscriberRegistration_SuccessfulRegistration(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"), "w1", "w1t1")
+
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:  "w1t1",
+				WorkflowId: "w1",
+				Status:     types.RegistrationStatus_REGISTERED,
+			},
+		},
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 1)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[1], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[2], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+	}()
+
+	err := reg.AwaitRegistration(ctx)
+	require.NoError(t, err)
+
+	// Ensure that the second wait for response returns immediately
+	err = reg.AwaitRegistration(ctx)
+	require.NoError(t, err)
+
+	require.NotNil(t, reg.GetTriggerResponseChannel())
+
+	wg.Wait()
+}
+
+func TestSubscriberRegistration_ZeroTimeout(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	// Zero timeout indicates the caller does not want to wait for a registration status update
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"), "w1", "w1t1")
+
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, 0)
+	defer cancel()
+
+	err := reg.AwaitRegistration(ctxWithTimeout)
+
+	require.ErrorIs(t, err, capabilities.ErrUnableToDetermineRegistrationStatus)
+}
+
+func TestSubscriberRegistration_UnsuccessfulRegistration_SameError(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"), "w1", "w1t1")
+
+	errMsg := "its broken"
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:         "w1t1",
+				WorkflowId:        "w1",
+				Status:            types.RegistrationStatus_REGISTRATION_ERROR,
+				RegistrationError: errMsg,
+			},
+		},
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 1)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[1], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[2], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+	}()
+
+	err := reg.AwaitRegistration(ctx)
+	require.Error(t, err)
+	require.Equal(t, "[2]Unknown: its broken", err.Error())
+
+	// Ensure that the second wait for response returns immediately
+	err = reg.AwaitRegistration(ctx)
+	require.Error(t, err)
+	require.Equal(t, "[2]Unknown: its broken", err.Error())
+	wg.Wait()
+}
+
+func TestSubscriberRegistration_UnsuccessfulRegistration_MixedErrors(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"), "w1", "w1t1")
+
+	errMsg1 := "its broken1"
+	errMsg2 := "its broken2"
+	errMsg3 := "its broken3"
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 2)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], createRegisterResponseMessageWithError(errMsg1), minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[1], createRegisterResponseMessageWithError(errMsg2), minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[2], createRegisterResponseMessageWithError(errMsg3), minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+	}()
+
+	err := reg.AwaitRegistration(ctx)
+	require.Error(t, err)
+	require.NotNil(t, reg.GetTriggerResponseChannel())
+	require.Contains(t, err.Error(), "[100]ConsensusFailed: received 3 errors, last error OK")
+
+	// Ensure that the second wait for response returns immediately
+	err = reg.AwaitRegistration(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "[100]ConsensusFailed: received 3 errors, last error OK")
+
+	wg.Wait()
+}
+
+func createRegisterResponseMessageWithError(errMsg1 string) *types.MessageBody {
+	return &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:         "w1t1",
+				WorkflowId:        "w1",
+				Status:            types.RegistrationStatus_REGISTRATION_ERROR,
+				RegistrationError: errMsg1,
+			},
+		},
+	}
+}
+
+func TestSubscriberRegistration_Timesout(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"), "w1", "w1t1")
+
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:  "w1t1",
+				WorkflowId: "w1",
+				Status:     types.RegistrationStatus_REGISTERED,
+			},
+		},
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 1)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+	}()
+
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, 1*time.Millisecond)
+	defer cancel()
+
+	err := reg.AwaitRegistration(ctxWithTimeout)
+	require.Error(t, err)
+	require.Equal(t, capabilities.ErrUnableToDetermineRegistrationStatus, err)
+	require.NotNil(t, reg.GetTriggerResponseChannel())
+
+	wg.Wait()
+}
+
+func TestSubscriberRegistration_InsufficientResponses(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"), "w1", "w1t1")
+
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:  "w1t1",
+				WorkflowId: "w1",
+				Status:     types.RegistrationStatus_REGISTERED,
+			},
+		},
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 1)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+
+		// Simulate insufficient responses by not sending the third response
+	}()
+
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	defer cancel()
+	err := reg.AwaitRegistration(ctxWithTimeout)
+	require.Equal(t, capabilities.ErrUnableToDetermineRegistrationStatus, err)
+
+	require.Error(t, err)
+	require.NotNil(t, reg.GetTriggerResponseChannel())
+
+	wg.Wait()
+}

--- a/core/capabilities/remote/trigger/registration/subscriber_registration_test.go
+++ b/core/capabilities/remote/trigger/registration/subscriber_registration_test.go
@@ -162,7 +162,7 @@ func TestSubscriberRegistration_UnsuccessfulRegistration_MixedErrors(t *testing.
 	go func() {
 		defer wg.Done()
 		capDonF := uint8(1)
-		minResponsesToAggregate := uint32(capDonF + 1)
+		minResponsesToAggregate := uint32(capDonF + 2)
 		numberOfCapabilityNodes := int(capDonF*2 + 1)
 		messageExpiry := 60000 * time.Millisecond
 		reg.HandleTriggerRegistrationStatusUpdate(peers[0], createRegisterResponseMessageWithError(errMsg1), minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)

--- a/core/capabilities/remote/trigger/registration/subscriber_registration_test.go
+++ b/core/capabilities/remote/trigger/registration/subscriber_registration_test.go
@@ -1,0 +1,299 @@
+package registration_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/trigger/registration"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+
+	p2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
+)
+
+const (
+	peerID1 = "12D3KooWF3dVeJ6YoT5HFnYhmwQWWMoEwVFzJQ5kKCMX3ZityxMC"
+	peerID2 = "12D3KooWQsmok6aD8PZqt3RnJhQRrNzKHLficq7zYFRp7kZ1hHP8"
+	peerID3 = "12D3KooWPumsXxg6mJ4hmRizjBD7oFMtN9vm3kTwN8BLEinyDPJS"
+	peerID4 = "12D3KooWNuumb38Jpw6DoRbgwejcZYwfsWbbzPU4fWy5imrW3dyD"
+)
+
+func TestSubscriberRegistration_SuccessfulRegistration(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"), "w1", "w1t1")
+
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:  "w1t1",
+				WorkflowId: "w1",
+				Status:     types.RegistrationStatus_REGISTERED,
+			},
+		},
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 1)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[1], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[2], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+	}()
+
+	err := reg.AwaitRegistration(ctx)
+	require.NoError(t, err)
+
+	// Ensure that the second wait for response returns immediately
+	err = reg.AwaitRegistration(ctx)
+	require.NoError(t, err)
+
+	require.NotNil(t, reg.GetTriggerResponseChannel())
+
+	wg.Wait()
+}
+
+func TestSubscriberRegistration_ZeroTimeout(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	// Zero timeout indicates the caller does not want to wait for a registration status update
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"), "w1", "w1t1")
+
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, 0)
+	defer cancel()
+
+	err := reg.AwaitRegistration(ctxWithTimeout)
+
+	require.ErrorIs(t, err, capabilities.ErrUnableToDetermineRegistrationStatus)
+}
+
+func TestSubscriberRegistration_UnsuccessfulRegistration_SameError(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"), "w1", "w1t1")
+
+	errMsg := "its broken"
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:         "w1t1",
+				WorkflowId:        "w1",
+				Status:            types.RegistrationStatus_REGISTRATION_ERROR,
+				RegistrationError: errMsg,
+			},
+		},
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 1)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[1], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[2], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+	}()
+
+	err := reg.AwaitRegistration(ctx)
+	require.Error(t, err)
+	require.Equal(t, "[2]Unknown: its broken", err.Error())
+
+	// Ensure that the second wait for response returns immediately
+	err = reg.AwaitRegistration(ctx)
+	require.Error(t, err)
+	require.Equal(t, "[2]Unknown: its broken", err.Error())
+	wg.Wait()
+}
+
+func TestSubscriberRegistration_UnsuccessfulRegistration_MixedErrors(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"), "w1", "w1t1")
+
+	errMsg1 := "its broken1"
+	errMsg2 := "its broken2"
+	errMsg3 := "its broken3"
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 1)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], createRegisterResponseMessageWithError(errMsg1), minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[1], createRegisterResponseMessageWithError(errMsg2), minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+		reg.HandleTriggerRegistrationStatusUpdate(peers[2], createRegisterResponseMessageWithError(errMsg3), minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+	}()
+
+	err := reg.AwaitRegistration(ctx)
+	require.Error(t, err)
+	require.NotNil(t, reg.GetTriggerResponseChannel())
+	require.Contains(t, err.Error(), "[2]Unknown: received 3 errors, last error OK")
+
+	// Ensure that the second wait for response returns immediately
+	err = reg.AwaitRegistration(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "[2]Unknown: received 3 errors, last error OK")
+
+	wg.Wait()
+}
+
+func createRegisterResponseMessageWithError(errMsg1 string) *types.MessageBody {
+	return &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:         "w1t1",
+				WorkflowId:        "w1",
+				Status:            types.RegistrationStatus_REGISTRATION_ERROR,
+				RegistrationError: errMsg1,
+			},
+		},
+	}
+}
+
+func TestSubscriberRegistration_Timesout(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"), "w1", "w1t1")
+
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:  "w1t1",
+				WorkflowId: "w1",
+				Status:     types.RegistrationStatus_REGISTERED,
+			},
+		},
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 1)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+	}()
+
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, 1*time.Millisecond)
+	defer cancel()
+
+	err := reg.AwaitRegistration(ctxWithTimeout)
+	require.Error(t, err)
+	require.Equal(t, capabilities.ErrUnableToDetermineRegistrationStatus, err)
+	require.NotNil(t, reg.GetTriggerResponseChannel())
+
+	wg.Wait()
+}
+
+func TestSubscriberRegistration_InsufficientResponses(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	peers := make([]p2ptypes.PeerID, 8)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+
+	reg := registration.NewSubscriberRegistration(lggr, []byte("rawRequest"), "w1", "w1t1")
+
+	registrationResponseMessage := &types.MessageBody{
+		CapabilityId:    "evm1",
+		CapabilityDonId: 2,
+		CallerDonId:     3,
+		Method:          types.TriggerRegistrationStatus,
+		Metadata: &types.MessageBody_TriggerRegistrationMetadata{
+			TriggerRegistrationMetadata: &types.TriggerRegistrationMetadata{
+				TriggerId:  "w1t1",
+				WorkflowId: "w1",
+				Status:     types.RegistrationStatus_REGISTERED,
+			},
+		},
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		capDonF := uint8(1)
+		minResponsesToAggregate := uint32(capDonF + 1)
+		numberOfCapabilityNodes := int(capDonF*2 + 1)
+		messageExpiry := 60000 * time.Millisecond
+		reg.HandleTriggerRegistrationStatusUpdate(peers[0], registrationResponseMessage, minResponsesToAggregate, messageExpiry, numberOfCapabilityNodes)
+
+		// Simulate insufficient responses by not sending the third response
+	}()
+
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	defer cancel()
+	err := reg.AwaitRegistration(ctxWithTimeout)
+	require.Equal(t, capabilities.ErrUnableToDetermineRegistrationStatus, err)
+
+	require.Error(t, err)
+	require.NotNil(t, reg.GetTriggerResponseChannel())
+
+	wg.Wait()
+}

--- a/core/capabilities/remote/trigger/registration/subscriber_registration_test.go
+++ b/core/capabilities/remote/trigger/registration/subscriber_registration_test.go
@@ -173,12 +173,12 @@ func TestSubscriberRegistration_UnsuccessfulRegistration_MixedErrors(t *testing.
 	err := reg.AwaitRegistration(ctx)
 	require.Error(t, err)
 	require.NotNil(t, reg.GetTriggerResponseChannel())
-	require.Contains(t, err.Error(), "[2]Unknown: received 3 errors, last error OK")
+	require.Contains(t, err.Error(), "[100]ConsensusFailed: received 3 errors, last error OK")
 
 	// Ensure that the second wait for response returns immediately
 	err = reg.AwaitRegistration(ctx)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "[2]Unknown: received 3 errors, last error OK")
+	require.Contains(t, err.Error(), "[100]ConsensusFailed: received 3 errors, last error OK")
 
 	wg.Wait()
 }

--- a/core/capabilities/remote/trigger_endtoend_test.go
+++ b/core/capabilities/remote/trigger_endtoend_test.go
@@ -1,0 +1,633 @@
+package remote_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/e2etesting"
+	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
+
+	"github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basictrigger"
+)
+
+func Test_RemoteTriggerCapability_EventForwarding(t *testing.T) {
+	ctx := t.Context()
+
+	var err error
+	numCapabilityPeers := 10
+	var underlyingTriggers []commoncap.TriggerCapability
+	broadcaster := NewTriggerBroadcaster(t, 100, nil)
+	underlyingTriggers, err = broadcaster.CreateTriggerCapabilities(numCapabilityPeers)
+	require.NoError(t, err)
+
+	f := uint8(4)
+	cfg := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Second,
+		RegistrationExpiry:      100 * time.Second,
+		MinResponsesToAggregate: uint32(f + 1),
+		MessageExpiry:           100 * time.Second,
+		MaxBatchSize:            1, // no batching
+		BatchCollectionPeriod:   time.Second,
+	}
+
+	clientTriggers, _, _ := setupRemoteTriggers(t, cfg, underlyingTriggers, 10, f, numCapabilityPeers, f)
+
+	req := commoncap.TriggerRegistrationRequest{
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+	result := registerOnAllTriggers(ctx, clientTriggers, req)
+	triggerRegistrations := result.GetAll()
+	for i, reg := range triggerRegistrations {
+		require.NoError(t, reg.err, "expected nil error for trigger registration at index %d", i)
+	}
+
+	payload := sendTriggerEvent(t, "Hello, ", broadcaster)
+
+	waitForEventFromAllTriggers(t, triggerRegistrations, payload)
+}
+
+func Test_RemoteTriggerCapability_EventForwarding_WithTriggerID(t *testing.T) {
+	ctx := t.Context()
+
+	var err error
+	numCapabilityPeers := 10
+	var underlyingTriggers []commoncap.TriggerCapability
+	broadcaster := NewTriggerBroadcaster(t, 100, nil)
+	underlyingTriggers, err = broadcaster.CreateTriggerCapabilities(numCapabilityPeers)
+	require.NoError(t, err)
+
+	f := uint8(4)
+	cfg := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Second,
+		RegistrationExpiry:      100 * time.Second,
+		MinResponsesToAggregate: uint32(f + 1),
+		MessageExpiry:           100 * time.Second,
+		MaxBatchSize:            1, // no batching
+		BatchCollectionPeriod:   time.Second,
+	}
+
+	clientTriggers, _, _ := setupRemoteTriggers(t, cfg, underlyingTriggers, 10, f, numCapabilityPeers, f)
+
+	req := commoncap.TriggerRegistrationRequest{
+		TriggerID: "custom-trigger-id-123",
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+	result := registerOnAllTriggers(ctx, clientTriggers, req)
+	triggerRegistrations := result.GetAll()
+	for i, reg := range triggerRegistrations {
+		require.NoError(t, reg.err, "expected nil error for trigger registration at index %d", i)
+	}
+
+	payload := sendTriggerEvent(t, "Hello, ", broadcaster)
+
+	waitForEventFromAllTriggers(t, triggerRegistrations, payload)
+}
+
+func Test_RemoteTriggerCapability_WaitForTriggerRegistration(t *testing.T) {
+	ctx := t.Context()
+
+	var err error
+	numCapabilityPeers := 10
+	var underlyingTriggers []commoncap.TriggerCapability
+	broadcaster := NewTriggerBroadcaster(t, 100, nil)
+	underlyingTriggers, err = broadcaster.CreateTriggerCapabilities(numCapabilityPeers)
+	require.NoError(t, err)
+
+	f := uint8(4)
+	cfg := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Second,
+		RegistrationExpiry:      100 * time.Second,
+		MinResponsesToAggregate: uint32(f + 1),
+		MessageExpiry:           100 * time.Second,
+		MaxBatchSize:            1, // no batching
+		BatchCollectionPeriod:   time.Second,
+	}
+
+	clientTriggers, _, _ := setupRemoteTriggers(t, cfg, underlyingTriggers, 10, f, numCapabilityPeers, f)
+
+	req := commoncap.TriggerRegistrationRequest{
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+	result := registerOnAllTriggers(ctx, clientTriggers, req)
+	triggerRegistrations := result.GetAll()
+	for i, reg := range triggerRegistrations {
+		require.NoError(t, reg.err, "expected nil error for trigger registration at index %d", i)
+	}
+
+	payload := sendTriggerEvent(t, "Hello, ", broadcaster)
+
+	waitForEventFromAllTriggers(t, triggerRegistrations, payload)
+}
+
+func Test_RemoteTriggerCapability_WaitForTriggerRegistrationCapabilityError(t *testing.T) {
+	ctx := t.Context()
+
+	capError := caperrors.NewPublicUserError(errors.New("some error"), caperrors.Unknown)
+
+	var err error
+	numCapabilityPeers := 10
+	var underlyingTriggers []commoncap.TriggerCapability
+	broadcaster := NewTriggerBroadcaster(t, 100, capError)
+	underlyingTriggers, err = broadcaster.CreateTriggerCapabilities(numCapabilityPeers)
+	require.NoError(t, err)
+
+	f := uint8(4)
+	cfg := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Second,
+		RegistrationExpiry:      100 * time.Second,
+		MinResponsesToAggregate: uint32(f + 1),
+		MessageExpiry:           100 * time.Second,
+		MaxBatchSize:            1, // no batching
+		BatchCollectionPeriod:   time.Second,
+	}
+
+	clientTriggers, _, _ := setupRemoteTriggers(t, cfg, underlyingTriggers, 10, f, numCapabilityPeers, f)
+
+	req := commoncap.TriggerRegistrationRequest{
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+	result := registerOnAllTriggers(ctx, clientTriggers, req)
+	triggerRegistrations := result.GetAll()
+	for i, reg := range triggerRegistrations {
+		require.Equal(t, capError, reg.err, "expected error for trigger registration at index %d", i)
+	}
+}
+
+func Test_RemoteTriggerCapability_WaitForTriggerRegistrationError(t *testing.T) {
+	ctx := t.Context()
+
+	regError := errors.New("some error")
+
+	var err error
+	numCapabilityPeers := 10
+	var underlyingTriggers []commoncap.TriggerCapability
+	broadcaster := NewTriggerBroadcaster(t, 100, regError)
+	underlyingTriggers, err = broadcaster.CreateTriggerCapabilities(numCapabilityPeers)
+	require.NoError(t, err)
+
+	f := uint8(4)
+	cfg := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Second,
+		RegistrationExpiry:      100 * time.Second,
+		MinResponsesToAggregate: uint32(f + 1),
+		MessageExpiry:           100 * time.Second,
+		MaxBatchSize:            1, // no batching
+		BatchCollectionPeriod:   time.Second,
+	}
+
+	clientTriggers, _, _ := setupRemoteTriggers(t, cfg, underlyingTriggers, 10, f, numCapabilityPeers, f)
+
+	req := commoncap.TriggerRegistrationRequest{
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+
+	expectedError := caperrors.NewPublicSystemError(regError, caperrors.Unknown)
+	result := registerOnAllTriggers(ctx, clientTriggers, req)
+	triggerRegistrations := result.GetAll()
+	for i, reg := range triggerRegistrations {
+		require.Equal(t, expectedError, reg.err, "expected error for trigger registration at index %d", i)
+	}
+}
+
+func Test_RemoteTriggerCapability_WaitForTriggerRegistrationTimeout(t *testing.T) {
+	ctx := t.Context()
+
+	var err error
+	numCapabilityPeers := 10
+	var underlyingTriggers []commoncap.TriggerCapability
+	broadcaster := NewTriggerBroadcaster(t, 100, nil)
+	underlyingTriggers, err = broadcaster.CreateTriggerCapabilities(numCapabilityPeers)
+	require.NoError(t, err)
+
+	f := uint8(4)
+	cfg := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Second,
+		RegistrationExpiry:      100 * time.Second,
+		MinResponsesToAggregate: uint32(f + 1),
+		MessageExpiry:           100 * time.Second,
+		MaxBatchSize:            1, // no batching
+		BatchCollectionPeriod:   time.Second,
+	}
+
+	subscribers, _, broker := setupRemoteTriggers(t, cfg, underlyingTriggers, 10, f, numCapabilityPeers, f)
+
+	// Block registration responses to simulate timeout when running against legacy don
+	broker.SetMessageFilter(func(msg *types.MessageBody) bool {
+		return msg.Method != types.TriggerRegistrationStatus
+	})
+
+	req := commoncap.TriggerRegistrationRequest{
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+
+	result := registerOnAllTriggers(ctx, subscribers, req)
+	triggerRegistrations := result.GetAll()
+	for i, reg := range triggerRegistrations {
+		require.ErrorIs(t, commoncap.ErrUnableToDetermineRegistrationStatus, reg.err, "expected error for trigger registration at index %d", i)
+	}
+}
+
+// Test that the underlying triggers unregister as expected when the trigger subscriber stops send registration requests.
+func Test_RemoteTriggerCapability_TriggerUnregisters(t *testing.T) {
+	ctx := t.Context()
+
+	var err error
+	numCapabilityPeers := 10
+	var underlyingTriggers []commoncap.TriggerCapability
+	broadcaster := NewTriggerBroadcaster(t, 100, nil)
+	underlyingTriggers, err = broadcaster.CreateTriggerCapabilities(numCapabilityPeers)
+	require.NoError(t, err)
+
+	f := uint8(4)
+	cfg := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Millisecond,
+		RegistrationExpiry:      100 * time.Millisecond,
+		MinResponsesToAggregate: uint32(f + 1),
+		MessageExpiry:           100 * time.Millisecond,
+		MaxBatchSize:            1, // no batching
+		BatchCollectionPeriod:   time.Second,
+	}
+
+	subscribers, _, broker := setupRemoteTriggers(t, cfg, underlyingTriggers, 10, f, numCapabilityPeers, f)
+
+	req := commoncap.TriggerRegistrationRequest{
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+
+	result := registerOnAllTriggers(ctx, subscribers, req)
+	triggerRegistrations := result.GetAll()
+	for i, reg := range triggerRegistrations {
+		require.NoError(t, reg.err, "expected error for trigger registration at index %d", i)
+	}
+
+	waitForTriggerRegistration(t, underlyingTriggers)
+
+	// Now block all trigger registration requests to simulate stopping the subscribers
+	broker.SetMessageFilter(func(msg *types.MessageBody) bool {
+		return msg.Method != types.MethodRegisterTrigger
+	})
+
+	// Verify that all underlying triggers unregister
+	waitForTriggersToUnregister(t, underlyingTriggers)
+}
+
+// Test that the underlying triggers unregister as expected when the trigger subscriber stops send registration requests.
+func Test_RemoteTriggerCapability_TriggerUnregisters_WithTriggerID(t *testing.T) {
+	ctx := t.Context()
+
+	var err error
+	numCapabilityPeers := 10
+	var underlyingTriggers []commoncap.TriggerCapability
+	broadcaster := NewTriggerBroadcaster(t, 100, nil)
+	underlyingTriggers, err = broadcaster.CreateTriggerCapabilities(numCapabilityPeers)
+	require.NoError(t, err)
+
+	f := uint8(4)
+	cfg := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Millisecond,
+		RegistrationExpiry:      100 * time.Millisecond,
+		MinResponsesToAggregate: uint32(f + 1),
+		MessageExpiry:           100 * time.Millisecond,
+		MaxBatchSize:            1, // no batching
+		BatchCollectionPeriod:   time.Second,
+	}
+
+	subscribers, _, broker := setupRemoteTriggers(t, cfg, underlyingTriggers, 10, f, numCapabilityPeers, f)
+
+	req := commoncap.TriggerRegistrationRequest{
+		TriggerID: "custom-trigger-id-123",
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+
+	result := registerOnAllTriggers(ctx, subscribers, req)
+	triggerRegistrations := result.GetAll()
+	for i, reg := range triggerRegistrations {
+		require.NoError(t, reg.err, "expected error for trigger registration at index %d", i)
+	}
+
+	waitForTriggerRegistration(t, underlyingTriggers)
+
+	// Now block all trigger registration requests to simulate stopping the subscribers
+	broker.SetMessageFilter(func(msg *types.MessageBody) bool {
+		return msg.Method != types.MethodRegisterTrigger
+	})
+
+	// Verify that all underlying triggers unregister
+	waitForTriggersToUnregister(t, underlyingTriggers)
+}
+
+func waitForTriggersToUnregister(t *testing.T, underlyingTriggers []commoncap.TriggerCapability) {
+	for i := 0; i < len(underlyingTriggers); i++ {
+		underlyingTrigger := underlyingTriggers[i].(*broadcasterTestTrigger)
+		require.Eventually(t, func() bool {
+			return !underlyingTrigger.IsTriggerRegistered()
+		}, 10*time.Second, 100*time.Millisecond, "underlying trigger did not have UnregisterTrigger called")
+	}
+}
+
+func waitForEventFromAllTriggers(t *testing.T, triggerRegistrations []registerTriggerResponse, payload *anypb.Any) {
+	for i := 0; i < len(triggerRegistrations); i++ {
+		triggerRegistration := triggerRegistrations[i]
+		require.Eventually(t, func() bool {
+			select {
+			case response := <-triggerRegistration.respCh:
+				return proto.Equal(response.Event.Payload, payload)
+			default:
+				return false
+			}
+		}, 10*time.Second, 100*time.Millisecond, "did not receive expected trigger response on client trigger %d", i)
+	}
+}
+
+func sendTriggerEvent(t *testing.T, payloadString string, broadcaster *triggerBroadcaster) *anypb.Any {
+	trigger := &basictrigger.Outputs{CoolOutput: payloadString}
+	payload, err := anypb.New(trigger)
+	require.NoError(t, err)
+
+	broadcaster.SendTriggerResponse(commoncap.TriggerResponse{
+		Event: commoncap.TriggerEvent{
+			TriggerType: "",
+			ID:          "",
+			Outputs:     nil,
+			Payload:     payload,
+			OCREvent:    nil,
+		},
+		Err: nil,
+	})
+	return payload
+}
+
+func waitForTriggerRegistration(t *testing.T, underlyingTriggers []commoncap.TriggerCapability) {
+	for i := 0; i < len(underlyingTriggers); i++ {
+		underlyingTrigger := underlyingTriggers[i].(*broadcasterTestTrigger)
+		require.Eventually(t, func() bool {
+			return underlyingTrigger.IsTriggerRegistered()
+		}, 10*time.Second, 100*time.Millisecond, "underlying trigger did not have RegisterTrigger called")
+	}
+}
+
+func registerOnAllTriggers(ctx context.Context, clientTriggers []triggerSubscriber, req commoncap.TriggerRegistrationRequest) *ThreadSafeSlice[registerTriggerResponse] {
+	result := &ThreadSafeSlice[registerTriggerResponse]{}
+	var wg sync.WaitGroup
+	for _, trigger := range clientTriggers {
+		wg.Add(1)
+		go func(trig commoncap.TriggerCapability) {
+			defer wg.Done()
+			respCh, err := trigger.RegisterTrigger(ctx, req)
+			result.Append(registerTriggerResponse{
+				respCh: respCh,
+				err:    err,
+			})
+		}(trigger)
+	}
+	wg.Wait()
+	return result
+}
+
+type ThreadSafeSlice[T any] struct {
+	mu    sync.Mutex
+	slice []T
+}
+
+func (s *ThreadSafeSlice[T]) Append(item T) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.slice = append(s.slice, item)
+}
+
+func (s *ThreadSafeSlice[T]) GetAll() []T {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make([]T, len(s.slice))
+	copy(result, s.slice)
+	return result
+}
+
+type triggerBroadcaster struct {
+	t               *testing.T
+	err             error
+	triggers        []*broadcasterTestTrigger
+	eventBufferSize int
+}
+
+func NewTriggerBroadcaster(t *testing.T, eventBufferSize int, err error) *triggerBroadcaster {
+	return &triggerBroadcaster{
+		t:               t,
+		err:             err,
+		eventBufferSize: eventBufferSize,
+	}
+}
+
+func (t *triggerBroadcaster) SetUnderlyingTriggerError(err error) {
+	for _, trigger := range t.triggers {
+		trigger.SetError(err)
+	}
+}
+
+func (t *triggerBroadcaster) CreateTriggerCapabilities(num int) ([]commoncap.TriggerCapability, error) {
+	var capabilities []commoncap.TriggerCapability
+	for i := 0; i < num; i++ {
+		capability, err := t.newTriggerCapability()
+		if err != nil {
+			return nil, err
+		}
+		capabilities = append(capabilities, capability)
+	}
+	return capabilities, nil
+}
+
+func (t *triggerBroadcaster) newTriggerCapability() (commoncap.TriggerCapability, error) {
+	trigger := &broadcasterTestTrigger{
+		t:   t.t,
+		err: t.err,
+		ch:  make(chan commoncap.TriggerResponse, t.eventBufferSize),
+	}
+	t.triggers = append(t.triggers, trigger)
+
+	return trigger, nil
+}
+
+func (t *triggerBroadcaster) SendTriggerResponse(resp commoncap.TriggerResponse) {
+	for _, trigger := range t.triggers {
+		trigger.ch <- resp
+	}
+}
+
+type broadcasterTestTrigger struct {
+	mu sync.Mutex
+
+	t   *testing.T
+	err error
+	ch  chan commoncap.TriggerResponse
+
+	registered atomic.Bool
+}
+
+func (t *broadcasterTestTrigger) SetError(err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.err = err
+}
+
+func (t *broadcasterTestTrigger) GetError() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.err
+}
+
+func (t *broadcasterTestTrigger) Info(ctx context.Context) (commoncap.CapabilityInfo, error) {
+	return commoncap.CapabilityInfo{
+		ID: "broadcast-trigger-capability",
+	}, nil
+}
+
+type registerTriggerResponse struct {
+	respCh <-chan commoncap.TriggerResponse
+	err    error
+}
+
+func (t *broadcasterTestTrigger) RegisterTrigger(ctx context.Context, req commoncap.TriggerRegistrationRequest) (<-chan commoncap.TriggerResponse, error) {
+	require.NotNil(t.t, req)
+	t.registered.Store(true)
+	return t.ch, t.GetError()
+}
+
+func (t *broadcasterTestTrigger) IsTriggerRegistered() bool {
+	return t.registered.Load()
+}
+
+func (t *broadcasterTestTrigger) UnregisterTrigger(ctx context.Context, req commoncap.TriggerRegistrationRequest) error {
+	require.NotNil(t.t, req)
+	t.registered.Store(false)
+	return nil
+}
+
+func (t *broadcasterTestTrigger) AckEvent(ctx context.Context, triggerID string, eventID string, method string) error {
+	return nil
+}
+
+type triggerSubscriber interface {
+	commoncap.TriggerCapability
+	Start(ctx context.Context) error
+	Close() error
+}
+
+type triggerPublisher interface {
+	Close() error
+}
+
+func setupRemoteTriggers(t *testing.T, cfg *commoncap.RemoteTriggerConfig, underlying []commoncap.TriggerCapability, numWorkflowPeers int, workflowDonF uint8,
+	numCapabilityPeers int, capabilityDonF uint8) ([]triggerSubscriber, []triggerPublisher, *e2etesting.TestAsyncMessageBroker) {
+	lggr := logger.Test(t)
+
+	capabilityPeers := make([]p2ptypes.PeerID, numCapabilityPeers)
+	for i := range numCapabilityPeers {
+		capabilityPeerID := p2ptypes.PeerID{}
+		require.NoError(t, capabilityPeerID.UnmarshalText([]byte(e2etesting.NewPeerID())))
+		capabilityPeers[i] = capabilityPeerID
+	}
+
+	capabilityPeerID := p2ptypes.PeerID{}
+	require.NoError(t, capabilityPeerID.UnmarshalText([]byte(e2etesting.NewPeerID())))
+
+	capDonInfo := commoncap.DON{
+		ID:      2,
+		Members: capabilityPeers,
+		F:       capabilityDonF,
+	}
+
+	capInfo := commoncap.CapabilityInfo{
+		ID:             "cap_id@1.0.0",
+		CapabilityType: commoncap.CapabilityTypeTrigger,
+		Description:    "Remote Target",
+		DON:            &capDonInfo,
+	}
+
+	workflowPeers := make([]p2ptypes.PeerID, numWorkflowPeers)
+	for i := range numWorkflowPeers {
+		workflowPeerID := p2ptypes.PeerID{}
+		require.NoError(t, workflowPeerID.UnmarshalText([]byte(e2etesting.NewPeerID())))
+		workflowPeers[i] = workflowPeerID
+	}
+
+	workflowDonInfo := commoncap.DON{
+		Members: workflowPeers,
+		ID:      1,
+		F:       workflowDonF,
+	}
+
+	broker := e2etesting.NewTestAsyncMessageBroker(t, 1000)
+
+	workflowDONs := map[uint32]commoncap.DON{
+		workflowDonInfo.ID: workflowDonInfo,
+	}
+
+	capabilityNodeTriggerPublishers := make([]triggerPublisher, numCapabilityPeers)
+
+	if len(underlying) != numCapabilityPeers {
+		t.Fatalf("expected %d underlying capability triggers, got %d", numCapabilityPeers, len(underlying))
+	}
+
+	for i := range numCapabilityPeers {
+		capabilityPeer := capabilityPeers[i]
+		capabilityDispatcher := broker.NewDispatcherForNode(capabilityPeer)
+		capabilityNode := remote.NewTriggerPublisher(capInfo.ID, "", capabilityDispatcher, lggr)
+		require.NoError(t, capabilityNode.SetConfig(cfg, underlying[i], capDonInfo, workflowDONs))
+		//	if runPublishers {
+		servicetest.Run(t, capabilityNode)
+		//	}
+		broker.RegisterReceiverNode(capabilityPeer, capabilityNode)
+		capabilityNodeTriggerPublishers[i] = capabilityNode
+	}
+
+	workflowNodeTriggerSubscribers := make([]triggerSubscriber, numWorkflowPeers)
+	for i := range numWorkflowPeers {
+		workflowPeerDispatcher := broker.NewDispatcherForNode(workflowPeers[i])
+		workflowNode := remote.NewTriggerSubscriber(capInfo.ID, "", workflowPeerDispatcher, lggr,
+			limits.NewTimeLimiter(60*time.Second))
+		agg := aggregation.NewDefaultModeAggregator(cfg.MinResponsesToAggregate)
+		err := workflowNode.SetConfig(cfg, capInfo, workflowDonInfo.ID, capDonInfo, agg)
+		require.NoError(t, err)
+		servicetest.Run(t, workflowNode)
+		broker.RegisterReceiverNode(workflowPeers[i], workflowNode)
+		workflowNodeTriggerSubscribers[i] = workflowNode
+	}
+
+	servicetest.Run(t, broker)
+
+	return workflowNodeTriggerSubscribers, capabilityNodeTriggerPublishers, broker
+}

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -13,9 +13,9 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
-
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/trigger/registration"
+
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/validation"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
@@ -33,11 +33,9 @@ type triggerPublisher struct {
 	dispatcher    types.Dispatcher
 	cfg           atomic.Pointer[dynamicPublisherConfig]
 
-	messageCache  *messagecache.MessageCache[registrationKey, p2ptypes.PeerID]
-	registrations map[registrationKey]*pubRegState
+	registrations map[registration.ID]*registration.PublisherRegistration
 	ackCache      *messagecache.MessageCache[ackKey, p2ptypes.PeerID]
 	mu            sync.RWMutex // protects messageCache, ackCache, and registrations
-
 	batchingQueue map[[32]byte]*batchedResponse
 	bqMu          sync.Mutex // protects batchingQueue
 	stopCh        services.StopChan
@@ -54,22 +52,10 @@ type dynamicPublisherConfig struct {
 	batchingEnabled bool
 }
 
-type registrationKey struct {
-	callerDonID uint32
-	workflowID  string
-	triggerID   string
-}
-
 type ackKey struct {
 	callerDonID    uint32
 	triggerEventID string
 	triggerID      string // triggerID contains the workflowID
-}
-
-type pubRegState struct {
-	callback <-chan commoncap.TriggerResponse
-	request  commoncap.TriggerRegistrationRequest
-	cancel   context.CancelFunc
 }
 
 type batchedResponse struct {
@@ -95,9 +81,8 @@ func NewTriggerPublisher(capabilityID string, capMethodName string, dispatcher t
 		capabilityID:  capabilityID,
 		capMethodName: capMethodName,
 		dispatcher:    dispatcher,
-		messageCache:  messagecache.NewMessageCache[registrationKey, p2ptypes.PeerID](),
 		ackCache:      messagecache.NewMessageCache[ackKey, p2ptypes.PeerID](),
-		registrations: make(map[registrationKey]*pubRegState),
+		registrations: make(map[registration.ID]*registration.PublisherRegistration),
 		batchingQueue: make(map[[32]byte]*batchedResponse),
 		stopCh:        make(services.StopChan),
 		lggr:          logger.With(logger.Named(lggr, "TriggerPublisher"), "capabilityID", capabilityID, "capMethodName", capMethodName),
@@ -211,48 +196,23 @@ func (p *triggerPublisher) Receive(_ context.Context, msg *types.MessageBody) {
 			return
 		}
 		p.lggr.Debugw("received trigger registration", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "sender", sender)
-		key := registrationKey{msg.CallerDonId, req.Metadata.WorkflowID, req.TriggerID}
-		nowMs := time.Now().UnixMilli()
+		regID := registration.NewID(msg.CallerDonId, req.Metadata.WorkflowID, req.TriggerID)
 		p.mu.Lock()
 		defer p.mu.Unlock()
-		p.messageCache.Insert(key, sender, nowMs, msg.Payload)
-		_, exists := p.registrations[key]
-		if exists {
-			p.lggr.Debugw("trigger registration already exists", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
-			return
-		}
-		// NOTE: require 2F+1 by default, introduce different strategies later (KS-76)
-		minRequired := uint32(2*callerDon.F + 1)
-		ready, payloads := p.messageCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), false)
-		if !ready {
-			p.lggr.Debugw("not ready to aggregate yet", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "minRequired", minRequired)
-			return
-		}
-		aggregated, err := aggregation.AggregateModeRaw(payloads, uint32(callerDon.F+1))
-		if err != nil {
-			p.lggr.Errorw("failed to aggregate trigger registrations", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", err)
-			return
-		}
-		unmarshaled, err := pb.UnmarshalTriggerRegistrationRequest(aggregated)
-		if err != nil {
-			p.lggr.Errorw("failed to unmarshal request", "err", err)
-			return
-		}
-		ctx, cancel := p.stopCh.NewCtx()
-		callbackCh, err := cfg.underlying.RegisterTrigger(ctx, unmarshaled)
-		if err == nil {
-			p.registrations[key] = &pubRegState{
-				callback: callbackCh,
-				request:  unmarshaled,
-				cancel:   cancel,
-			}
-			p.wg.Add(1)
-			go p.triggerEventLoop(callbackCh, key)
-			p.lggr.Debugw("updated trigger registration", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
+		reg, exists := p.registrations[regID]
+		if !exists {
+			p.lggr.Debugw("creating new trigger registration", "registrationID", regID)
+			reg = registration.NewPublisherRegistration(p.lggr, regID, p.publishResponse,
+				cfg.underlying,
+				p.capabilityID, cfg.capDonInfo.ID, p.capMethodName, p.dispatcher)
+
+			p.registrations[regID] = reg
 		} else {
-			cancel()
-			p.lggr.Errorw("failed to register trigger", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", err)
+			p.lggr.Debugw("using existing trigger registration already exists", "registrationID", regID)
 		}
+
+		ctx, _ := p.stopCh.NewCtx()
+		reg.AddRegistrationRequest(ctx, sender, msg.Payload, callerDon, cfg.remoteConfig.RegistrationExpiry)
 	case types.MethodTriggerEvent:
 		p.lggr.Errorw("trigger request failed with error",
 			"method", SanitizeLogString(msg.Method), "sender", sender, "errorMsg", SanitizeLogString(msg.ErrorMsg))
@@ -287,7 +247,7 @@ func (p *triggerPublisher) Receive(_ context.Context, msg *types.MessageBody) {
 		nowMs := time.Now().UnixMilli()
 		p.ackCache.Insert(key, sender, nowMs, msg.Payload)
 		minRequired := uint32(2*callerDon.F + 1)
-		ready, _ := p.ackCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.MessageExpiry.Milliseconds(), false)
+		ready, _, _ := p.ackCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.MessageExpiry.Milliseconds(), false)
 		if !ready {
 			p.lggr.Debugw("not ready to ACK trigger event yet", "triggerEventId", triggerEventID, "minRequired", minRequired)
 			return
@@ -333,19 +293,16 @@ func (p *triggerPublisher) cacheCleanupLoop() {
 			now := time.Now().UnixMilli()
 
 			p.mu.Lock()
-			for key, req := range p.registrations {
-				callerDon := cfg.workflowDONs[key.callerDonID]
-				ready, _ := p.messageCache.Ready(key, uint32(2*callerDon.F+1), now-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), false)
-				if !ready {
-					p.lggr.Infow("trigger registration expired", "callerDonID", key.callerDonID, "workflowId", key.workflowID, "triggerID", key.triggerID)
+			for regID, reg := range p.registrations {
+				callerDon := cfg.workflowDONs[regID.CallerDonID()]
+				if !reg.IsLive(cfg.remoteConfig.RegistrationExpiry, callerDon) {
+					p.lggr.Infow("trigger registration expired", "ID", regID)
 					ctx, cancel := p.stopCh.NewCtx()
-					err := cfg.underlying.UnregisterTrigger(ctx, req.request)
+					err := reg.Close(ctx)
 					cancel()
-					p.registrations[key].cancel() // Cancel context on register trigger
-					p.lggr.Infow("unregistered trigger", "callerDonID", key.callerDonID, "workflowId", key.workflowID, "triggerID", key.triggerID, "err", err)
+					p.lggr.Infow("unregistered trigger", "ID", regID, "err", err)
 					// after calling UnregisterTrigger, the underlying trigger will not send any more events to the channel
-					delete(p.registrations, key)
-					p.messageCache.Delete(key)
+					delete(p.registrations, regID)
 				}
 			}
 
@@ -359,47 +316,34 @@ func (p *triggerPublisher) cacheCleanupLoop() {
 	}
 }
 
-func (p *triggerPublisher) triggerEventLoop(callbackCh <-chan commoncap.TriggerResponse, key registrationKey) {
-	defer p.wg.Done()
-	for {
-		select {
-		case <-p.stopCh:
-			return
-		case response, ok := <-callbackCh:
-			if !ok {
-				p.lggr.Infow("triggerEventLoop channel closed", "workflowId", key.workflowID, "triggerID", key.triggerID)
-				return
-			}
+func (p *triggerPublisher) publishResponse(registrationID registration.ID, response commoncap.TriggerResponse) {
+	triggerEvent := response.Event
+	p.lggr.Debugw("received trigger event", "registrationID", registrationID, "triggerEventID", triggerEvent.ID)
+	marshaledResponse, err := pb.MarshalTriggerResponse(response)
+	if err != nil {
+		p.lggr.Debugw("can't marshal trigger event", "err", err)
+		return
+	}
 
-			triggerEvent := response.Event
-			p.lggr.Debugw("received trigger event", "workflowId", key.workflowID, "triggerID", key.triggerID, "triggerEventID", triggerEvent.ID)
-			marshaledResponse, err := pb.MarshalTriggerResponse(response)
-			if err != nil {
-				p.lggr.Debugw("can't marshal trigger event", "err", err)
-				break
-			}
-
-			cfg := p.cfg.Load()
-			if cfg.batchingEnabled {
-				p.enqueueForBatching(marshaledResponse, key, triggerEvent.ID)
-			} else {
-				// a single-element "batch"
-				p.sendBatch(&batchedResponse{
-					rawResponse:    marshaledResponse,
-					callerDonID:    key.callerDonID,
-					triggerEventID: triggerEvent.ID,
-					workflowIDs:    []string{key.workflowID},
-					triggerIDs:     []string{key.triggerID},
-				})
-			}
-		}
+	cfg := p.cfg.Load()
+	if cfg.batchingEnabled {
+		p.enqueueForBatching(marshaledResponse, registrationID, triggerEvent.ID)
+	} else {
+		// a single-element "batch"
+		p.sendBatch(&batchedResponse{
+			rawResponse:    marshaledResponse,
+			callerDonID:    registrationID.CallerDonID(),
+			triggerEventID: triggerEvent.ID,
+			workflowIDs:    []string{registrationID.WorkflowID()},
+			triggerIDs:     []string{registrationID.TriggerID()},
+		})
 	}
 }
 
-func (p *triggerPublisher) enqueueForBatching(rawResponse []byte, key registrationKey, triggerEventID string) {
+func (p *triggerPublisher) enqueueForBatching(rawResponse []byte, registrationID registration.ID, triggerEventID string) {
 	// put in batching queue, group by hash(callerDonId, triggerEventID, response)
 	combined := make([]byte, 4)
-	binary.LittleEndian.PutUint32(combined, key.callerDonID)
+	binary.LittleEndian.PutUint32(combined, registrationID.CallerDonID())
 	combined = append(combined, []byte(triggerEventID)...)
 	combined = append(combined, rawResponse...)
 	sha := sha256.Sum256(combined)
@@ -408,15 +352,15 @@ func (p *triggerPublisher) enqueueForBatching(rawResponse []byte, key registrati
 	if !exists {
 		elem = &batchedResponse{
 			rawResponse:    rawResponse,
-			callerDonID:    key.callerDonID,
+			callerDonID:    registrationID.CallerDonID(),
 			triggerEventID: triggerEventID,
-			workflowIDs:    []string{key.workflowID},
-			triggerIDs:     []string{key.triggerID},
+			workflowIDs:    []string{registrationID.WorkflowID()},
+			triggerIDs:     []string{registrationID.TriggerID()},
 		}
 		p.batchingQueue[sha] = elem
 	} else {
-		elem.workflowIDs = append(elem.workflowIDs, key.workflowID)
-		elem.triggerIDs = append(elem.triggerIDs, key.triggerID)
+		elem.workflowIDs = append(elem.workflowIDs, registrationID.WorkflowID())
+		elem.triggerIDs = append(elem.triggerIDs, registrationID.TriggerID())
 	}
 	p.bqMu.Unlock()
 }
@@ -548,6 +492,17 @@ func (p *triggerPublisher) batchingLoop() {
 func (p *triggerPublisher) Close() error {
 	close(p.stopCh)
 	p.wg.Wait()
+
+	// Close all registrations
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, reg := range p.registrations {
+		err := reg.Close(context.Background())
+		if err != nil {
+			p.lggr.Errorw("error closing registration", "err", err)
+		}
+	}
+
 	p.lggr.Info("TriggerPublisher closed")
 	return nil
 }

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -211,7 +211,7 @@ func (p *triggerPublisher) Receive(_ context.Context, msg *types.MessageBody) {
 			p.lggr.Debugw("using existing trigger registration already exists", "registrationID", regID)
 		}
 
-		ctx, _ := p.stopCh.NewCtx() // TODO why does existing code use this context and not that received by Receive?
+		ctx, _ := p.stopCh.NewCtx()
 		reg.AddRegistrationRequest(ctx, sender, msg.Payload, callerDon, cfg.remoteConfig.RegistrationExpiry)
 	case types.MethodTriggerEvent:
 		p.lggr.Errorw("trigger request failed with error",

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -13,9 +13,9 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
-
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/trigger/registration"
+
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/validation"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
@@ -33,11 +33,9 @@ type triggerPublisher struct {
 	dispatcher    types.Dispatcher
 	cfg           atomic.Pointer[dynamicPublisherConfig]
 
-	messageCache  *messagecache.MessageCache[registrationKey, p2ptypes.PeerID]
-	registrations map[registrationKey]*pubRegState
+	registrations map[registration.ID]*registration.PublisherRegistration
 	ackCache      *messagecache.MessageCache[ackKey, p2ptypes.PeerID]
 	mu            sync.RWMutex // protects messageCache, ackCache, and registrations
-
 	batchingQueue map[[32]byte]*batchedResponse
 	bqMu          sync.Mutex // protects batchingQueue
 	stopCh        services.StopChan
@@ -54,22 +52,10 @@ type dynamicPublisherConfig struct {
 	batchingEnabled bool
 }
 
-type registrationKey struct {
-	callerDonID uint32
-	workflowID  string
-	triggerID   string
-}
-
 type ackKey struct {
 	callerDonID    uint32
 	triggerEventID string
 	triggerID      string // triggerID contains the workflowID
-}
-
-type pubRegState struct {
-	callback <-chan commoncap.TriggerResponse
-	request  commoncap.TriggerRegistrationRequest
-	cancel   context.CancelFunc
 }
 
 type batchedResponse struct {
@@ -95,9 +81,8 @@ func NewTriggerPublisher(capabilityID string, capMethodName string, dispatcher t
 		capabilityID:  capabilityID,
 		capMethodName: capMethodName,
 		dispatcher:    dispatcher,
-		messageCache:  messagecache.NewMessageCache[registrationKey, p2ptypes.PeerID](),
 		ackCache:      messagecache.NewMessageCache[ackKey, p2ptypes.PeerID](),
-		registrations: make(map[registrationKey]*pubRegState),
+		registrations: make(map[registration.ID]*registration.PublisherRegistration),
 		batchingQueue: make(map[[32]byte]*batchedResponse),
 		stopCh:        make(services.StopChan),
 		lggr:          logger.With(logger.Named(lggr, "TriggerPublisher"), "capabilityID", capabilityID, "capMethodName", capMethodName),
@@ -211,48 +196,23 @@ func (p *triggerPublisher) Receive(_ context.Context, msg *types.MessageBody) {
 			return
 		}
 		p.lggr.Debugw("received trigger registration", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "sender", sender)
-		key := registrationKey{msg.CallerDonId, req.Metadata.WorkflowID, req.TriggerID}
-		nowMs := time.Now().UnixMilli()
+		regID := registration.NewID(msg.CallerDonId, req.Metadata.WorkflowID, req.TriggerID)
 		p.mu.Lock()
 		defer p.mu.Unlock()
-		p.messageCache.Insert(key, sender, nowMs, msg.Payload)
-		_, exists := p.registrations[key]
-		if exists {
-			p.lggr.Debugw("trigger registration already exists", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
-			return
-		}
-		// NOTE: require 2F+1 by default, introduce different strategies later (KS-76)
-		minRequired := uint32(2*callerDon.F + 1)
-		ready, payloads := p.messageCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), false)
-		if !ready {
-			p.lggr.Debugw("not ready to aggregate yet", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "minRequired", minRequired)
-			return
-		}
-		aggregated, err := aggregation.AggregateModeRaw(payloads, uint32(callerDon.F+1))
-		if err != nil {
-			p.lggr.Errorw("failed to aggregate trigger registrations", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", err)
-			return
-		}
-		unmarshaled, err := pb.UnmarshalTriggerRegistrationRequest(aggregated)
-		if err != nil {
-			p.lggr.Errorw("failed to unmarshal request", "err", err)
-			return
-		}
-		ctx, cancel := p.stopCh.NewCtx()
-		callbackCh, err := cfg.underlying.RegisterTrigger(ctx, unmarshaled)
-		if err == nil {
-			p.registrations[key] = &pubRegState{
-				callback: callbackCh,
-				request:  unmarshaled,
-				cancel:   cancel,
-			}
-			p.wg.Add(1)
-			go p.triggerEventLoop(callbackCh, key)
-			p.lggr.Debugw("updated trigger registration", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
+		reg, exists := p.registrations[regID]
+		if !exists {
+			p.lggr.Debugw("creating new trigger registration", "registrationID", regID)
+			reg = registration.NewPublisherRegistration(p.lggr, regID, p.publishResponse,
+				cfg.underlying,
+				p.capabilityID, cfg.capDonInfo.ID, p.capMethodName, p.dispatcher)
+
+			p.registrations[regID] = reg
 		} else {
-			cancel()
-			p.lggr.Errorw("failed to register trigger", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", err)
+			p.lggr.Debugw("using existing trigger registration already exists", "registrationID", regID)
 		}
+
+		ctx, _ := p.stopCh.NewCtx() // TODO why does existing code use this context and not that received by Receive?
+		reg.AddRegistrationRequest(ctx, sender, msg.Payload, callerDon, cfg.remoteConfig.RegistrationExpiry)
 	case types.MethodTriggerEvent:
 		p.lggr.Errorw("trigger request failed with error",
 			"method", SanitizeLogString(msg.Method), "sender", sender, "errorMsg", SanitizeLogString(msg.ErrorMsg))
@@ -287,7 +247,7 @@ func (p *triggerPublisher) Receive(_ context.Context, msg *types.MessageBody) {
 		nowMs := time.Now().UnixMilli()
 		p.ackCache.Insert(key, sender, nowMs, msg.Payload)
 		minRequired := uint32(2*callerDon.F + 1)
-		ready, _ := p.ackCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.MessageExpiry.Milliseconds(), false)
+		ready, _, _ := p.ackCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.MessageExpiry.Milliseconds(), false)
 		if !ready {
 			p.lggr.Debugw("not ready to ACK trigger event yet", "triggerEventId", triggerEventID, "minRequired", minRequired)
 			return
@@ -333,19 +293,16 @@ func (p *triggerPublisher) cacheCleanupLoop() {
 			now := time.Now().UnixMilli()
 
 			p.mu.Lock()
-			for key, req := range p.registrations {
-				callerDon := cfg.workflowDONs[key.callerDonID]
-				ready, _ := p.messageCache.Ready(key, uint32(2*callerDon.F+1), now-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), false)
-				if !ready {
-					p.lggr.Infow("trigger registration expired", "callerDonID", key.callerDonID, "workflowId", key.workflowID, "triggerID", key.triggerID)
+			for regID, reg := range p.registrations {
+				callerDon := cfg.workflowDONs[regID.CallerDonID()]
+				if !reg.IsLive(cfg.remoteConfig.RegistrationExpiry, callerDon) {
+					p.lggr.Infow("trigger registration expired", "ID", regID)
 					ctx, cancel := p.stopCh.NewCtx()
-					err := cfg.underlying.UnregisterTrigger(ctx, req.request)
+					err := reg.Close(ctx)
 					cancel()
-					p.registrations[key].cancel() // Cancel context on register trigger
-					p.lggr.Infow("unregistered trigger", "callerDonID", key.callerDonID, "workflowId", key.workflowID, "triggerID", key.triggerID, "err", err)
+					p.lggr.Infow("unregistered trigger", "ID", regID, "err", err)
 					// after calling UnregisterTrigger, the underlying trigger will not send any more events to the channel
-					delete(p.registrations, key)
-					p.messageCache.Delete(key)
+					delete(p.registrations, regID)
 				}
 			}
 
@@ -359,47 +316,34 @@ func (p *triggerPublisher) cacheCleanupLoop() {
 	}
 }
 
-func (p *triggerPublisher) triggerEventLoop(callbackCh <-chan commoncap.TriggerResponse, key registrationKey) {
-	defer p.wg.Done()
-	for {
-		select {
-		case <-p.stopCh:
-			return
-		case response, ok := <-callbackCh:
-			if !ok {
-				p.lggr.Infow("triggerEventLoop channel closed", "workflowId", key.workflowID, "triggerID", key.triggerID)
-				return
-			}
+func (p *triggerPublisher) publishResponse(registrationID registration.ID, response commoncap.TriggerResponse) {
+	triggerEvent := response.Event
+	p.lggr.Debugw("received trigger event", "registrationID", registrationID, "triggerEventID", triggerEvent.ID)
+	marshaledResponse, err := pb.MarshalTriggerResponse(response)
+	if err != nil {
+		p.lggr.Debugw("can't marshal trigger event", "err", err)
+		return
+	}
 
-			triggerEvent := response.Event
-			p.lggr.Debugw("received trigger event", "workflowId", key.workflowID, "triggerID", key.triggerID, "triggerEventID", triggerEvent.ID)
-			marshaledResponse, err := pb.MarshalTriggerResponse(response)
-			if err != nil {
-				p.lggr.Debugw("can't marshal trigger event", "err", err)
-				break
-			}
-
-			cfg := p.cfg.Load()
-			if cfg.batchingEnabled {
-				p.enqueueForBatching(marshaledResponse, key, triggerEvent.ID)
-			} else {
-				// a single-element "batch"
-				p.sendBatch(&batchedResponse{
-					rawResponse:    marshaledResponse,
-					callerDonID:    key.callerDonID,
-					triggerEventID: triggerEvent.ID,
-					workflowIDs:    []string{key.workflowID},
-					triggerIDs:     []string{key.triggerID},
-				})
-			}
-		}
+	cfg := p.cfg.Load()
+	if cfg.batchingEnabled {
+		p.enqueueForBatching(marshaledResponse, registrationID, triggerEvent.ID)
+	} else {
+		// a single-element "batch"
+		p.sendBatch(&batchedResponse{
+			rawResponse:    marshaledResponse,
+			callerDonID:    registrationID.CallerDonID(),
+			triggerEventID: triggerEvent.ID,
+			workflowIDs:    []string{registrationID.WorkflowID()},
+			triggerIDs:     []string{registrationID.TriggerID()},
+		})
 	}
 }
 
-func (p *triggerPublisher) enqueueForBatching(rawResponse []byte, key registrationKey, triggerEventID string) {
+func (p *triggerPublisher) enqueueForBatching(rawResponse []byte, registrationID registration.ID, triggerEventID string) {
 	// put in batching queue, group by hash(callerDonId, triggerEventID, response)
 	combined := make([]byte, 4)
-	binary.LittleEndian.PutUint32(combined, key.callerDonID)
+	binary.LittleEndian.PutUint32(combined, registrationID.CallerDonID())
 	combined = append(combined, []byte(triggerEventID)...)
 	combined = append(combined, rawResponse...)
 	sha := sha256.Sum256(combined)
@@ -408,15 +352,15 @@ func (p *triggerPublisher) enqueueForBatching(rawResponse []byte, key registrati
 	if !exists {
 		elem = &batchedResponse{
 			rawResponse:    rawResponse,
-			callerDonID:    key.callerDonID,
+			callerDonID:    registrationID.CallerDonID(),
 			triggerEventID: triggerEventID,
-			workflowIDs:    []string{key.workflowID},
-			triggerIDs:     []string{key.triggerID},
+			workflowIDs:    []string{registrationID.WorkflowID()},
+			triggerIDs:     []string{registrationID.TriggerID()},
 		}
 		p.batchingQueue[sha] = elem
 	} else {
-		elem.workflowIDs = append(elem.workflowIDs, key.workflowID)
-		elem.triggerIDs = append(elem.triggerIDs, key.triggerID)
+		elem.workflowIDs = append(elem.workflowIDs, registrationID.WorkflowID())
+		elem.triggerIDs = append(elem.triggerIDs, registrationID.TriggerID())
 	}
 	p.bqMu.Unlock()
 }
@@ -548,6 +492,17 @@ func (p *triggerPublisher) batchingLoop() {
 func (p *triggerPublisher) Close() error {
 	close(p.stopCh)
 	p.wg.Wait()
+
+	// Close all registrations
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, reg := range p.registrations {
+		err := reg.Close(context.Background())
+		if err != nil {
+			p.lggr.Errorw("error closing registration", "err", err)
+		}
+	}
+
 	p.lggr.Info("TriggerPublisher closed")
 	return nil
 }

--- a/core/capabilities/remote/trigger_publisher_test.go
+++ b/core/capabilities/remote/trigger_publisher_test.go
@@ -2,6 +2,7 @@ package remote_test
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
@@ -25,7 +27,7 @@ func TestTriggerPublisher_Register(t *testing.T) {
 	ctx := testutils.Context(t)
 	capabilityDONID, workflowDONID := uint32(1), uint32(2)
 
-	underlyingTriggerCap, publisher, _, peers := newServices(t, capabilityDONID, workflowDONID, 1)
+	underlyingTriggerCap, publisher, dispatcher, peers := newServices(t, capabilityDONID, workflowDONID, 1, 2, 0)
 
 	// invalid sender case - node 0 is not a member of the workflow DON, registration shoudn't happen
 	regEvent := newRegisterTriggerMessage(t, workflowDONID, peers[0])
@@ -33,6 +35,13 @@ func TestTriggerPublisher_Register(t *testing.T) {
 	require.Empty(t, underlyingTriggerCap.registrationsCh)
 
 	// valid registration
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Equal(t, peers[1], peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		require.Equal(t, remotetypes.Error_OK, msgBody.Error)
+		require.Empty(t, msgBody.ErrorMsg)
+	}).Return(nil)
+
 	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[1])
 	publisher.Receive(ctx, regEvent)
 	require.NotEmpty(t, underlyingTriggerCap.registrationsCh)
@@ -42,11 +51,140 @@ func TestTriggerPublisher_Register(t *testing.T) {
 	require.NoError(t, publisher.Close())
 }
 
+func TestTriggerPublisher_RegistrationResponse(t *testing.T) {
+	ctx := testutils.Context(t)
+	capabilityDONID, workflowDONID := uint32(1), uint32(2)
+
+	underlyingTriggerCap, publisher, dispatcher, peers := newServices(t, capabilityDONID, workflowDONID, 1, 8, 1)
+
+	// valid registration
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Contains(t, []p2ptypes.PeerID{peers[1], peers[3], peers[5]}, peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		require.Equal(t, remotetypes.Error_OK, msgBody.Error)
+		require.Empty(t, msgBody.ErrorMsg)
+	}).Return(nil).Once()
+
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Contains(t, []p2ptypes.PeerID{peers[1], peers[3], peers[5]}, peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		require.Equal(t, remotetypes.Error_OK, msgBody.Error)
+		require.Empty(t, msgBody.ErrorMsg)
+	}).Return(nil).Once()
+
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Contains(t, []p2ptypes.PeerID{peers[1], peers[3], peers[5]}, peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		require.Equal(t, remotetypes.Error_OK, msgBody.Error)
+		require.Empty(t, msgBody.ErrorMsg)
+	}).Return(nil).Once()
+
+	regEvent := newRegisterTriggerMessage(t, workflowDONID, peers[1])
+	publisher.Receive(ctx, regEvent)
+	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[3])
+	publisher.Receive(ctx, regEvent)
+	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[5])
+	publisher.Receive(ctx, regEvent)
+
+	require.NotEmpty(t, underlyingTriggerCap.registrationsCh)
+	forwarded := <-underlyingTriggerCap.registrationsCh
+	require.Equal(t, workflowID1, forwarded.Metadata.WorkflowID)
+
+	// Simulate late registration by another peer, should still result in it receiving a response
+	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[7])
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Equal(t, peers[7], peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		require.Equal(t, remotetypes.Error_OK, msgBody.Error)
+		require.Empty(t, msgBody.ErrorMsg)
+	}).Return(nil).Once()
+	publisher.Receive(ctx, regEvent)
+
+	require.NoError(t, publisher.Close())
+}
+
+func TestTriggerPublisher_RegistrationResponse_WhenTriggerRegistrationFails(t *testing.T) {
+	ctx := testutils.Context(t)
+	capabilityDONID, workflowDONID := uint32(1), uint32(2)
+
+	capInfo := commoncap.CapabilityInfo{
+		ID:             capID,
+		CapabilityType: commoncap.CapabilityTypeTrigger,
+		Description:    "Remote Trigger",
+	}
+
+	underlying := &testTrigger{
+		info:              capInfo,
+		registrationsCh:   make(chan commoncap.TriggerRegistrationRequest, 2),
+		eventCh:           make(chan commoncap.TriggerResponse, 2),
+		registrationError: errors.New("registration error"),
+	}
+
+	_, publisher, dispatcher, peers := newServicesWithTrigger(t, capabilityDONID, workflowDONID, 1, 8, 1,
+		underlying, capInfo)
+
+	// valid registration
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Contains(t, []p2ptypes.PeerID{peers[1], peers[3], peers[5]}, peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+
+		caperr := caperrors.DeserializeErrorFromString(msgBody.GetTriggerRegistrationMetadata().RegistrationError)
+		require.Equal(t, caperrors.Unknown, caperr.Code())
+		require.Equal(t, caperrors.OriginSystem, caperr.Origin())
+		require.Equal(t, caperrors.VisibilityPublic, caperr.Visibility())
+		require.Equal(t, "[2]Unknown: registration error", caperr.Error())
+	}).Return(nil).Once()
+
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Contains(t, []p2ptypes.PeerID{peers[1], peers[3], peers[5]}, peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		caperr := caperrors.DeserializeErrorFromString(msgBody.GetTriggerRegistrationMetadata().RegistrationError)
+		require.Equal(t, caperrors.Unknown, caperr.Code())
+		require.Equal(t, caperrors.OriginSystem, caperr.Origin())
+		require.Equal(t, caperrors.VisibilityPublic, caperr.Visibility())
+		require.Equal(t, "[2]Unknown: registration error", caperr.Error())
+	}).Return(nil).Once()
+
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Contains(t, []p2ptypes.PeerID{peers[1], peers[3], peers[5]}, peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		caperr := caperrors.DeserializeErrorFromString(msgBody.GetTriggerRegistrationMetadata().RegistrationError)
+		require.Equal(t, caperrors.Unknown, caperr.Code())
+		require.Equal(t, caperrors.OriginSystem, caperr.Origin())
+		require.Equal(t, caperrors.VisibilityPublic, caperr.Visibility())
+		require.Equal(t, "[2]Unknown: registration error", caperr.Error())
+	}).Return(nil).Once()
+
+	regEvent := newRegisterTriggerMessage(t, workflowDONID, peers[1])
+	publisher.Receive(ctx, regEvent)
+	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[3])
+	publisher.Receive(ctx, regEvent)
+	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[5])
+	publisher.Receive(ctx, regEvent)
+
+	// Simulate late registration by another peer, should still result in it receiving an error response
+	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[7])
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Run(func(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) {
+		require.Equal(t, peers[7], peerID)
+		require.Equal(t, capID, msgBody.CapabilityId)
+		caperr := caperrors.DeserializeErrorFromString(msgBody.GetTriggerRegistrationMetadata().RegistrationError)
+		require.Equal(t, caperrors.Unknown, caperr.Code())
+		require.Equal(t, caperrors.OriginSystem, caperr.Origin())
+		require.Equal(t, caperrors.VisibilityPublic, caperr.Visibility())
+		require.Equal(t, "[2]Unknown: registration error", caperr.Error())
+	}).Return(nil).Once()
+	publisher.Receive(ctx, regEvent)
+
+	require.NoError(t, publisher.Close())
+}
+
 func TestTriggerPublisher_ReceiveTriggerEvents_NoBatching(t *testing.T) {
 	ctx := testutils.Context(t)
 	capabilityDONID, workflowDONID := uint32(1), uint32(2)
 
-	underlyingTriggerCap, publisher, dispatcher, peers := newServices(t, capabilityDONID, workflowDONID, 1)
+	underlyingTriggerCap, publisher, dispatcher, peers := newServices(t, capabilityDONID, workflowDONID, 1, 2, 0)
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Return(nil).Once()
+
 	regEvent := newRegisterTriggerMessage(t, workflowDONID, peers[1])
 	publisher.Receive(ctx, regEvent)
 	require.NotEmpty(t, underlyingTriggerCap.registrationsCh)
@@ -66,8 +204,9 @@ func TestTriggerPublisher_ReceiveTriggerEvents_BatchingEnabled(t *testing.T) {
 	ctx := testutils.Context(t)
 	capabilityDONID, workflowDONID := uint32(1), uint32(2)
 
-	underlyingTriggerCap, publisher, dispatcher, peers := newServices(t, capabilityDONID, workflowDONID, 2)
+	underlyingTriggerCap, publisher, dispatcher, peers := newServices(t, capabilityDONID, workflowDONID, 2, 2, 0)
 	regEvent := newRegisterTriggerMessage(t, workflowDONID, peers[1])
+	dispatcher.EXPECT().Send(mock.Anything, mock.Anything).Return(nil).Once()
 	publisher.Receive(ctx, regEvent)
 	require.NotEmpty(t, underlyingTriggerCap.registrationsCh)
 
@@ -103,7 +242,7 @@ func TestTriggerPublisher_ReceiveTriggerEvents_BatchingEnabled(t *testing.T) {
 func TestTriggerPublisher_ReceiveTriggerEventAcks(t *testing.T) {
 	ctx := testutils.Context(t)
 	capabilityDONID, workflowDONID := uint32(1), uint32(2)
-	underlyingTriggerCap, publisher, _, peers := newServices(t, capabilityDONID, workflowDONID, 2)
+	underlyingTriggerCap, publisher, _, peers := newServices(t, capabilityDONID, workflowDONID, 2, 2, 0)
 	eventID := "123"
 	triggerID := "trigA"
 	regEvent := newAckEventMessage(t, eventID, triggerID, workflowDONID, peers[1])
@@ -218,26 +357,58 @@ func TestTriggerPublisher_SetConfig_Basic(t *testing.T) {
 	})
 }
 
-func newServices(t *testing.T, capabilityDONID uint32, workflowDONID uint32, maxBatchSize uint32) (*testTrigger, remotetypes.ReceiverService, *mocks.Dispatcher, []p2ptypes.PeerID) {
-	lggr := logger.Test(t)
-	ctx := testutils.Context(t)
+func newServices(t *testing.T, capabilityDONID uint32, workflowDONID uint32, maxBatchSize uint32,
+	peerCount int, f uint8) (*testTrigger, remotetypes.ReceiverService, *mocks.Dispatcher, []p2ptypes.PeerID) {
 	capInfo := commoncap.CapabilityInfo{
 		ID:             capID,
 		CapabilityType: commoncap.CapabilityTypeTrigger,
 		Description:    "Remote Trigger",
 	}
-	peers := make([]p2ptypes.PeerID, 2)
+
+	underlying := &testTrigger{
+		info:            capInfo,
+		registrationsCh: make(chan commoncap.TriggerRegistrationRequest, 2),
+		eventCh:         make(chan commoncap.TriggerResponse, 2),
+	}
+
+	return newServicesWithTrigger(t, capabilityDONID, workflowDONID, maxBatchSize, peerCount, f, underlying, capInfo)
+}
+
+func newServicesWithTrigger(t *testing.T, capabilityDONID uint32, workflowDONID uint32, maxBatchSize uint32,
+	peerCount int, f uint8, underlying *testTrigger, capInfo commoncap.CapabilityInfo) (*testTrigger, remotetypes.ReceiverService, *mocks.Dispatcher, []p2ptypes.PeerID,
+) {
+	lggr := logger.Test(t)
+	ctx := testutils.Context(t)
+	peers := make([]p2ptypes.PeerID, 8)
 	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
 	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte(peerID4)))
+	require.NoError(t, peers[4].UnmarshalText([]byte(peerID5)))
+	require.NoError(t, peers[5].UnmarshalText([]byte(peerID6)))
+	require.NoError(t, peers[6].UnmarshalText([]byte(peerID7)))
+	require.NoError(t, peers[7].UnmarshalText([]byte(peerID8)))
+
+	peers = peers[:peerCount]
+
+	// Split the peers between the capability DON and the workflow DON
+	capPeers := peers[:(peerCount+1)/2]
+	workflowPeers := peers[(peerCount+1)/2:]
+
+	for i := 0; i < (peerCount+1)/2; i += 2 {
+		capPeers[i] = peers[i]
+		workflowPeers[i] = peers[i+1]
+	}
+
 	capDonInfo := commoncap.DON{
 		ID:      capabilityDONID,
-		Members: []p2ptypes.PeerID{peers[0]}, // peer 0 is in the capability DON
-		F:       0,
+		Members: capPeers, // peer 0 is in the capability DON
+		F:       f,
 	}
 	workflowDonInfo := commoncap.DON{
 		ID:      workflowDONID,
-		Members: []p2ptypes.PeerID{peers[1]}, // peer 1 is in the workflow DON
-		F:       0,
+		Members: workflowPeers, // peer 1 is in the workflow DON
+		F:       f,
 	}
 
 	dispatcher := mocks.NewDispatcher(t)
@@ -252,11 +423,7 @@ func newServices(t *testing.T, capabilityDONID uint32, workflowDONID uint32, max
 	workflowDONs := map[uint32]commoncap.DON{
 		workflowDonInfo.ID: workflowDonInfo,
 	}
-	underlying := &testTrigger{
-		info:            capInfo,
-		registrationsCh: make(chan commoncap.TriggerRegistrationRequest, 2),
-		eventCh:         make(chan commoncap.TriggerResponse, 2),
-	}
+
 	publisher := remote.NewTriggerPublisher(capInfo.ID, "", dispatcher, lggr)
 	require.NoError(t, publisher.SetConfig(config, underlying, capDonInfo, workflowDONs))
 	require.NoError(t, publisher.Start(ctx))
@@ -295,10 +462,11 @@ func newAckEventMessage(t *testing.T, eventID string, triggerID string, callerDo
 }
 
 type testTrigger struct {
-	info            commoncap.CapabilityInfo
-	registrationsCh chan commoncap.TriggerRegistrationRequest
-	eventCh         chan commoncap.TriggerResponse
-	eventAckd       bool
+	info              commoncap.CapabilityInfo
+	registrationsCh   chan commoncap.TriggerRegistrationRequest
+	eventCh           chan commoncap.TriggerResponse
+	registrationError error
+	eventAckd         bool
 }
 
 func (tr *testTrigger) Info(_ context.Context) (commoncap.CapabilityInfo, error) {
@@ -306,6 +474,10 @@ func (tr *testTrigger) Info(_ context.Context) (commoncap.CapabilityInfo, error)
 }
 
 func (tr *testTrigger) RegisterTrigger(_ context.Context, request commoncap.TriggerRegistrationRequest) (<-chan commoncap.TriggerResponse, error) {
+	if tr.registrationError != nil {
+		return nil, tr.registrationError
+	}
+
 	tr.registrationsCh <- request
 	return tr.eventCh, nil
 }
@@ -362,6 +534,24 @@ func TestTriggerPublisher_MultipleTriggersSameWorkflow(t *testing.T) {
 	publisher := remote.NewTriggerPublisher(capInfo.ID, "", dispatcher, lggr)
 	require.NoError(t, publisher.SetConfig(config, underlying, capDonInfo, workflowDONs))
 	require.NoError(t, publisher.Start(ctx))
+
+	// Handle registration status update messages
+	dispatcher.On("Send", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		msg := args.Get(1).(*remotetypes.MessageBody)
+		require.Equal(t, capID, msg.CapabilityId)
+		require.Equal(t, remotetypes.TriggerRegistrationStatus, msg.Method)
+
+		metadata := msg.Metadata.(*remotetypes.MessageBody_TriggerRegistrationMetadata)
+		require.Equal(t, "trigger1", metadata.TriggerRegistrationMetadata.TriggerId)
+	}).Return(nil).Once()
+
+	dispatcher.On("Send", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		msg := args.Get(1).(*remotetypes.MessageBody)
+		require.Equal(t, capID, msg.CapabilityId)
+		require.Equal(t, remotetypes.TriggerRegistrationStatus, msg.Method)
+		metadata := msg.Metadata.(*remotetypes.MessageBody_TriggerRegistrationMetadata)
+		require.Equal(t, "trigger2", metadata.TriggerRegistrationMetadata.TriggerId)
+	}).Return(nil).Once()
 
 	// Register trigger1
 	regEvent1 := newRegisterTriggerMessageWithTriggerID(t, workflowDONID, peers[1], "trigger1")
@@ -456,13 +646,6 @@ func TestTriggerPublisher_ResendBehavior_MultiTriggerBatch(t *testing.T) {
 		require.NoError(t, publisher.Close())
 	}()
 
-	// Register two triggers
-	for _, trig := range []string{"triggerA", "triggerB"} {
-		reg := newRegisterTriggerMessageWithTriggerID(t, workflowDONID, peers[0], trig)
-		publisher.Receive(ctx, reg)
-		<-underlying.registrationsCh
-	}
-
 	var mu sync.Mutex
 	sendRecords := make([]struct {
 		peer       p2ptypes.PeerID
@@ -477,7 +660,12 @@ func TestTriggerPublisher_ResendBehavior_MultiTriggerBatch(t *testing.T) {
 
 		peer := args.Get(0).(p2ptypes.PeerID)
 		msg := args.Get(1).(*remotetypes.MessageBody)
-		meta := msg.Metadata.(*remotetypes.MessageBody_TriggerEventMetadata)
+
+		// Check if Metadata is of type *remotetypes.MessageBody_TriggerEventMetadata before using it
+		meta, ok := msg.Metadata.(*remotetypes.MessageBody_TriggerEventMetadata)
+		if !ok || meta.TriggerEventMetadata == nil {
+			return
+		}
 
 		sendRecords = append(sendRecords, struct {
 			peer       p2ptypes.PeerID
@@ -488,7 +676,14 @@ func TestTriggerPublisher_ResendBehavior_MultiTriggerBatch(t *testing.T) {
 		})
 
 		sendCh <- struct{}{}
-	}).Return(nil)
+	}).Maybe().Return(nil)
+
+	// Register two triggers
+	for _, trig := range []string{"triggerA", "triggerB"} {
+		reg := newRegisterTriggerMessageWithTriggerID(t, workflowDONID, peers[0], trig)
+		publisher.Receive(ctx, reg)
+		<-underlying.registrationsCh
+	}
 
 	t.Run("initial send to both peers with both triggerIDs", func(t *testing.T) {
 		mu.Lock()

--- a/core/capabilities/remote/trigger_subscriber.go
+++ b/core/capabilities/remote/trigger_subscriber.go
@@ -12,8 +12,10 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/trigger/registration"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 )
@@ -23,6 +25,7 @@ import (
 // Its responsibilities are:
 //  1. Periodically refresh all registrations for remote triggers.
 //  2. Collect trigger events from remote nodes and aggregate responses via a customizable aggregator.
+//  3. Track the registration status for each workflow.
 //
 // TriggerSubscriber communicates with corresponding TriggerReceivers on remote nodes.
 type triggerSubscriber struct {
@@ -37,11 +40,15 @@ type triggerSubscriber struct {
 	//   - Better logging and debugging.
 	//   - Easier migration.
 	// workflowID -> triggerID -> subRegState
-	registeredWorkflows map[string]map[string]*subRegState
+	registeredWorkflows map[string]map[string]*registration.SubscriberRegistration
 	mu                  sync.RWMutex // protects registeredWorkflows and messageCache
 	stopCh              services.StopChan
 	wg                  sync.WaitGroup
 	lggr                logger.Logger
+
+	// This channel is used to send initial registration requests immediately rather than waiting for the registration refresh cycle
+	initialRegistrationRequestCh           chan *registration.SubscriberRegistration
+	triggerRegistrationStatusUpdateTimeout limits.TimeLimiter
 }
 
 type dynamicConfig struct {
@@ -59,11 +66,6 @@ type triggerEventKey struct {
 	triggerID      string
 }
 
-type subRegState struct {
-	callback   chan commoncap.TriggerResponse
-	rawRequest []byte
-}
-
 type TriggerSubscriber interface {
 	commoncap.TriggerCapability
 	Receive(ctx context.Context, msg *types.MessageBody)
@@ -76,19 +78,21 @@ var _ services.Service = &triggerSubscriber{}
 
 const (
 	// Engine reads trigger events without blocking and applies its own limits
-	sendChannelBufferSize = 1000
 	maxBatchedWorkflowIDs = 1000
 )
 
-func NewTriggerSubscriber(capabilityID string, capMethodName string, dispatcher types.Dispatcher, lggr logger.Logger) *triggerSubscriber {
+func NewTriggerSubscriber(capabilityID string, capMethodName string, dispatcher types.Dispatcher, lggr logger.Logger,
+	triggerRegistrationStatusUpdateTimeout limits.TimeLimiter) *triggerSubscriber {
 	return &triggerSubscriber{
-		capabilityID:        capabilityID,
-		capMethodName:       capMethodName,
-		dispatcher:          dispatcher,
-		messageCache:        messagecache.NewMessageCache[triggerEventKey, p2ptypes.PeerID](),
-		registeredWorkflows: make(map[string]map[string]*subRegState),
-		stopCh:              make(services.StopChan),
-		lggr:                logger.With(logger.Named(lggr, "TriggerSubscriber"), "capabilityID", capabilityID, "capMethodName", capMethodName),
+		capabilityID:                           capabilityID,
+		capMethodName:                          capMethodName,
+		dispatcher:                             dispatcher,
+		messageCache:                           messagecache.NewMessageCache[triggerEventKey, p2ptypes.PeerID](),
+		registeredWorkflows:                    make(map[string]map[string]*registration.SubscriberRegistration),
+		stopCh:                                 make(services.StopChan),
+		lggr:                                   logger.With(logger.Named(lggr, "TriggerSubscriber"), "capabilityID", capabilityID, "capMethodName", capMethodName),
+		initialRegistrationRequestCh:           make(chan *registration.SubscriberRegistration),
+		triggerRegistrationStatusUpdateTimeout: triggerRegistrationStatusUpdateTimeout,
 	}
 }
 
@@ -175,26 +179,57 @@ func (s *triggerSubscriber) RegisterTrigger(ctx context.Context, request commonc
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.lggr.Infow("RegisterTrigger called", "donId", cfg.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID, "triggerID", request.TriggerID)
 	triggerMap, ok := s.registeredWorkflows[request.Metadata.WorkflowID]
 	if !ok {
-		triggerMap = make(map[string]*subRegState)
+		triggerMap = make(map[string]*registration.SubscriberRegistration)
 		s.registeredWorkflows[request.Metadata.WorkflowID] = triggerMap
 	}
-	regState, ok := triggerMap[request.TriggerID]
-	if !ok {
-		regState = &subRegState{
-			callback:   make(chan commoncap.TriggerResponse, sendChannelBufferSize),
-			rawRequest: rawRequest,
-		}
-		triggerMap[request.TriggerID] = regState
+	reg, existingRegistration := triggerMap[request.TriggerID]
+	if !existingRegistration {
+		reg = registration.NewSubscriberRegistration(s.lggr, rawRequest, request.Metadata.WorkflowID, request.TriggerID)
+		triggerMap[request.TriggerID] = reg
 	} else {
-		regState.rawRequest = rawRequest
+		reg.UpdateRegistrationRequest(rawRequest)
 		s.lggr.Warnw("RegisterTrigger re-registering trigger", "donId", cfg.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID, "triggerID", request.TriggerID)
 	}
+	s.mu.Unlock()
 
-	return regState.callback, nil
+	if existingRegistration {
+		return reg.GetTriggerResponseChannel(), nil
+	}
+
+	// Send the first registration request immediately, do not wait for the registration refresh cycle
+	s.initialRegistrationRequestCh <- reg
+
+	// Wait for the registration status with a timeout.
+	subCtx, subCancel, err := s.triggerRegistrationStatusUpdateTimeout.WithTimeout(ctx)
+	if err != nil {
+		s.lggr.Errorw("failed to create timeout context for trigger registration status update", "err", err)
+		return reg.GetTriggerResponseChannel(), commoncap.ErrUnableToDetermineRegistrationStatus
+	}
+	defer subCancel()
+
+	// Await registration with timeout - it is not guaranteed that registration status will be able to be determined
+	// as may be running against a legacy remote capability that does not support registration status updates.
+	start := time.Now()
+	s.lggr.Debug("Starting registration wait", "donId", cfg.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID, "triggerID", request.TriggerID)
+	regErr := reg.AwaitRegistration(subCtx)
+	s.lggr.Debugw("Finished registration wait", "donId", cfg.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID, "triggerID", request.TriggerID, "waitTime", time.Since(start).String(), "regErr", regErr)
+	if regErr == nil {
+		return reg.GetTriggerResponseChannel(), nil
+	}
+
+	// In the case that the error is ErrUnableToDetermineRegistrationStatus, the caller may choose to ignore the error
+	// and continue to wait for trigger events, this replicates the legacy behaviour to support remote nodes that do
+	// not provide registration status updates.
+	if errors.Is(regErr, commoncap.ErrUnableToDetermineRegistrationStatus) {
+		s.lggr.Warnw("unable to determine registration status", "donId", cfg.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID)
+		return reg.GetTriggerResponseChannel(), regErr
+	}
+
+	s.lggr.Errorw("registration error occurred", "donId", cfg.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID, "error", regErr)
+	return nil, regErr
 }
 
 func (s *triggerSubscriber) registrationLoop() {
@@ -207,6 +242,9 @@ func (s *triggerSubscriber) registrationLoop() {
 		select {
 		case <-s.stopCh:
 			return
+		case reg := <-s.initialRegistrationRequestCh:
+			cfg := s.cfg.Load()
+			s.sendRegistrationRequestToCapabilityDon(cfg, reg)
 		case <-ticker.C:
 			cfg := s.cfg.Load()
 			if cfg.remoteConfig.RegistrationRefresh != tickerDuration {
@@ -221,24 +259,28 @@ func (s *triggerSubscriber) registrationLoop() {
 			}
 
 			for _, regMap := range s.registeredWorkflows {
-				for _, registration := range regMap {
-					for _, peerID := range cfg.capDonInfo.Members {
-						m := &types.MessageBody{
-							CapabilityId:     cfg.capInfo.ID,
-							CapabilityDonId:  cfg.capDonInfo.ID,
-							CallerDonId:      cfg.localDonID,
-							Method:           types.MethodRegisterTrigger,
-							Payload:          registration.rawRequest, // triggerID is in the raw request
-							CapabilityMethod: s.capMethodName,
-						}
-						err := s.dispatcher.Send(peerID, m)
-						if err != nil {
-							s.lggr.Errorw("failed to send message", "donId", cfg.capDonInfo.ID, "peerId", peerID, "err", err)
-						}
-					}
+				for _, reg := range regMap {
+					s.sendRegistrationRequestToCapabilityDon(cfg, reg)
 				}
 			}
 			s.mu.RUnlock()
+		}
+	}
+}
+
+func (s *triggerSubscriber) sendRegistrationRequestToCapabilityDon(cfg *dynamicConfig, reg *registration.SubscriberRegistration) {
+	for _, peerID := range cfg.capDonInfo.Members {
+		m := &types.MessageBody{
+			CapabilityId:     cfg.capInfo.ID,
+			CapabilityDonId:  cfg.capDonInfo.ID,
+			CallerDonId:      cfg.localDonID,
+			Method:           types.MethodRegisterTrigger,
+			Payload:          reg.GetRawRequest(),
+			CapabilityMethod: s.capMethodName,
+		}
+		err := s.dispatcher.Send(peerID, m)
+		if err != nil {
+			s.lggr.Errorw("failed to send message", "donId", cfg.capDonInfo.ID, "peerId", peerID, "err", err)
 		}
 	}
 }
@@ -251,9 +293,9 @@ func (s *triggerSubscriber) UnregisterTrigger(ctx context.Context, request commo
 	if !ok {
 		return nil
 	}
-	state := triggerMap[request.TriggerID]
-	if state != nil && state.callback != nil {
-		close(state.callback)
+	reg := triggerMap[request.TriggerID]
+	if reg != nil {
+		reg.Close()
 	}
 	delete(triggerMap, request.TriggerID)
 	if len(triggerMap) == 0 {
@@ -297,7 +339,7 @@ func (s *triggerSubscriber) Receive(_ context.Context, msg *types.MessageBody) {
 			}
 			s.mu.RLock()
 			triggerMap, found := s.registeredWorkflows[workflowID]
-			var registration *subRegState
+			var registration *registration.SubscriberRegistration
 			if found {
 				if triggerID != "" {
 					// received a message from updated publisher, which provided a triggerID
@@ -326,7 +368,7 @@ func (s *triggerSubscriber) Receive(_ context.Context, msg *types.MessageBody) {
 			nowMs := time.Now().UnixMilli()
 			s.mu.Lock()
 			creationTs := s.messageCache.Insert(key, sender, nowMs, msg.Payload)
-			ready, payloads := s.messageCache.Ready(key, cfg.remoteConfig.MinResponsesToAggregate, nowMs-cfg.remoteConfig.MessageExpiry.Milliseconds(), true)
+			ready, _, payloads := s.messageCache.Ready(key, cfg.remoteConfig.MinResponsesToAggregate, nowMs-cfg.remoteConfig.MessageExpiry.Milliseconds(), true)
 			s.mu.Unlock()
 			s.lggr.Debugw("trigger event received", "triggerEventId", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID, "sender", sender, "ready", ready, "nowTs", nowMs, "creationTs", creationTs, "minResponsesToAggregate", cfg.remoteConfig.MinResponsesToAggregate)
 			if ready {
@@ -336,9 +378,32 @@ func (s *triggerSubscriber) Receive(_ context.Context, msg *types.MessageBody) {
 					continue
 				}
 				s.lggr.Infow("remote trigger event aggregated", "triggerEventID", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID)
-				registration.callback <- aggregatedResponse
+				registration.SendAggregatedEvent(aggregatedResponse)
 			}
 		}
+	} else if msg.Method == types.TriggerRegistrationStatus {
+		meta := msg.GetTriggerRegistrationMetadata()
+		if meta == nil {
+			s.lggr.Errorw("received trigger registration status message with nil trigger registration metadata", "sender", sender)
+			return
+		}
+		s.mu.Lock()
+
+		triggerMap, ok := s.registeredWorkflows[meta.WorkflowId]
+		if !ok {
+			triggerMap = make(map[string]*registration.SubscriberRegistration)
+			s.registeredWorkflows[meta.WorkflowId] = triggerMap
+		}
+		reg, found := triggerMap[meta.TriggerId]
+		s.mu.Unlock()
+
+		if !found {
+			s.lggr.Warnw("received trigger registration status message for unregistered workflow", "workflowID", SanitizeLogString(meta.WorkflowId), "triggerID", SanitizeLogString(meta.TriggerId), "sender", sender)
+			return
+		}
+
+		reg.HandleTriggerRegistrationStatusUpdate(sender, msg, cfg.remoteConfig.MinResponsesToAggregate, cfg.remoteConfig.MessageExpiry,
+			len(cfg.capDonInfo.Members))
 	} else {
 		s.lggr.Errorw("received trigger event with unknown method", "method", SanitizeLogString(msg.Method), "sender", sender, "err", SanitizeLogString(msg.ErrorMsg))
 	}

--- a/core/capabilities/remote/trigger_subscriber_test.go
+++ b/core/capabilities/remote/trigger_subscriber_test.go
@@ -11,6 +11,7 @@ import (
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
@@ -23,6 +24,12 @@ import (
 const (
 	peerID1     = "12D3KooWF3dVeJ6YoT5HFnYhmwQWWMoEwVFzJQ5kKCMX3ZityxMC"
 	peerID2     = "12D3KooWQsmok6aD8PZqt3RnJhQRrNzKHLficq7zYFRp7kZ1hHP8"
+	peerID3     = "12D3KooWPumsXxg6mJ4hmRizjBD7oFMtN9vm3kTwN8BLEinyDPJS"
+	peerID4     = "12D3KooWNuumb38Jpw6DoRbgwejcZYwfsWbbzPU4fWy5imrW3dyD"
+	peerID5     = "12D3KooWJNVGd4gur9H2uKMkRo6hvh17ktvg7dqvRx8YELTA4Bfo"
+	peerID6     = "12D3KooWPt1fVrGxeqG1FNZTvw6UNM85eGURr1PiNUsSAyFEvzQn"
+	peerID7     = "12D3KooWGG7xBVQZyBdXXCYemByedzey14KXEkVfLorX74p598qa"
+	peerID8     = "12D3KooWPH2jfCUd9rVh8TtvFeyQWfSosUnwmUdNN4iapMXSXs5d"
 	workflowID1 = "15c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0"
 )
 
@@ -50,7 +57,7 @@ func TestTriggerSubscriber_RegisterAndReceive(t *testing.T) {
 		MinResponsesToAggregate: 1,
 		MessageExpiry:           100 * time.Second,
 	}
-	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, limits.NewTimeLimiter(0))
 	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
 	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
 	require.NoError(t, subscriber.Start(t.Context()))
@@ -61,7 +68,7 @@ func TestTriggerSubscriber_RegisterAndReceive(t *testing.T) {
 		},
 	}
 	triggerEventCallbackCh, err := subscriber.RegisterTrigger(t.Context(), req)
-	require.NoError(t, err)
+
 	t.Cleanup(func() {
 		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), req))
 		// calling UnregisterTrigger repeatedly is safe
@@ -99,7 +106,7 @@ func TestTriggerSubscriber_CorrectEventExpiryCheck(t *testing.T) {
 		MinResponsesToAggregate: 2,
 		MessageExpiry:           10 * time.Second,
 	}
-	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, limits.NewTimeLimiter(0))
 	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
 	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
 
@@ -110,7 +117,6 @@ func TestTriggerSubscriber_CorrectEventExpiryCheck(t *testing.T) {
 		},
 	}
 	triggerEventCallbackCh, err := subscriber.RegisterTrigger(t.Context(), regReq)
-	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), regReq))
 		require.NoError(t, subscriber.Close())
@@ -152,7 +158,7 @@ func TestTriggerSubscriber_SetConfig_Basic(t *testing.T) {
 
 	t.Run("returns error when capability info ID doesn't match subscriber's ID", func(t *testing.T) {
 		dispatcher := remoteMocks.NewDispatcher(t)
-		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, limits.NewTimeLimiter(0))
 		config := &commoncap.RemoteTriggerConfig{}
 		mismatchedCapInfo := commoncap.CapabilityInfo{ID: "different_id", CapabilityType: commoncap.CapabilityTypeTrigger}
 		err := subscriber.SetConfig(config, mismatchedCapInfo, workflowDon.ID, capDon, agg)
@@ -164,7 +170,7 @@ func TestTriggerSubscriber_SetConfig_Basic(t *testing.T) {
 
 	t.Run("returns error when aggregator is nil", func(t *testing.T) {
 		dispatcher := remoteMocks.NewDispatcher(t)
-		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, limits.NewTimeLimiter(0))
 		config := &commoncap.RemoteTriggerConfig{}
 		err := subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, nil)
 		require.Error(t, err)
@@ -173,7 +179,7 @@ func TestTriggerSubscriber_SetConfig_Basic(t *testing.T) {
 
 	t.Run("updates existing config", func(t *testing.T) {
 		dispatcher := remoteMocks.NewDispatcher(t)
-		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, limits.NewTimeLimiter(0))
 		// Set initial config
 		initialConfig := &commoncap.RemoteTriggerConfig{
 			RegistrationRefresh:     100 * time.Millisecond,
@@ -198,7 +204,7 @@ func TestTriggerSubscriber_SetConfig_Basic(t *testing.T) {
 	})
 	t.Run("handles nil initial config", func(t *testing.T) {
 		dispatcher := remoteMocks.NewDispatcher(t)
-		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, limits.NewTimeLimiter(0))
 		// Set initial config as nil
 		err := subscriber.SetConfig(nil, capInfo, workflowDon.ID, capDon, agg)
 		require.NoError(t, err)
@@ -238,7 +244,7 @@ func TestTriggerSubscriber_RegistrationLoopWithConfigUpdate(t *testing.T) {
 		MinResponsesToAggregate: 1,
 		MessageExpiry:           100 * time.Second,
 	}
-	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, limits.NewTimeLimiter(0))
 	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
 
 	// Call SetConfig() with workflowDON ID = 1 and register trigger
@@ -250,7 +256,7 @@ func TestTriggerSubscriber_RegistrationLoopWithConfigUpdate(t *testing.T) {
 		},
 	}
 	_, err := subscriber.RegisterTrigger(t.Context(), req)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, commoncap.ErrUnableToDetermineRegistrationStatus)
 
 	// Wait for first registration message and validate CallerDonId = 1
 	<-registrationMessageCh
@@ -298,7 +304,7 @@ func TestTriggerSubscriber_MultipleTriggersSameWorkflow(t *testing.T) {
 		MinResponsesToAggregate: 1,
 		MessageExpiry:           100 * time.Second,
 	}
-	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, limits.NewTimeLimiter(0))
 	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
 	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
 	require.NoError(t, subscriber.Start(t.Context()))
@@ -318,9 +324,9 @@ func TestTriggerSubscriber_MultipleTriggersSameWorkflow(t *testing.T) {
 	}
 
 	callbackCh1, err := subscriber.RegisterTrigger(t.Context(), req1)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, commoncap.ErrUnableToDetermineRegistrationStatus)
 	callbackCh2, err := subscriber.RegisterTrigger(t.Context(), req2)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, commoncap.ErrUnableToDetermineRegistrationStatus)
 
 	t.Cleanup(func() {
 		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), req1))
@@ -377,7 +383,7 @@ func TestTriggerSubscriber_LegacyMessageWithoutTriggerID(t *testing.T) {
 		MinResponsesToAggregate: 1,
 		MessageExpiry:           100 * time.Second,
 	}
-	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, limits.NewTimeLimiter(0))
 	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
 	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
 	require.NoError(t, subscriber.Start(t.Context()))
@@ -391,7 +397,7 @@ func TestTriggerSubscriber_LegacyMessageWithoutTriggerID(t *testing.T) {
 	}
 
 	callbackCh, err := subscriber.RegisterTrigger(t.Context(), req)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, commoncap.ErrUnableToDetermineRegistrationStatus)
 
 	t.Cleanup(func() {
 		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), req))
@@ -426,7 +432,7 @@ func TestTriggerSubscriber_UnregisterOneTriggerKeepsOther(t *testing.T) {
 		MinResponsesToAggregate: 1,
 		MessageExpiry:           100 * time.Second,
 	}
-	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr, limits.NewTimeLimiter(0))
 	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
 	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
 	require.NoError(t, subscriber.Start(t.Context()))
@@ -446,9 +452,9 @@ func TestTriggerSubscriber_UnregisterOneTriggerKeepsOther(t *testing.T) {
 	}
 
 	_, err := subscriber.RegisterTrigger(t.Context(), req1)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, commoncap.ErrUnableToDetermineRegistrationStatus)
 	callbackCh2, err := subscriber.RegisterTrigger(t.Context(), req2)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, commoncap.ErrUnableToDetermineRegistrationStatus)
 
 	t.Cleanup(func() {
 		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), req2))

--- a/core/capabilities/remote/types/messages.pb.go
+++ b/core/capabilities/remote/types/messages.pb.go
@@ -79,6 +79,55 @@ func (Error) EnumDescriptor() ([]byte, []int) {
 	return file_core_capabilities_remote_types_messages_proto_rawDescGZIP(), []int{0}
 }
 
+type RegistrationStatus int32
+
+const (
+	RegistrationStatus_UNREGISTERED       RegistrationStatus = 0
+	RegistrationStatus_REGISTERED         RegistrationStatus = 1
+	RegistrationStatus_REGISTRATION_ERROR RegistrationStatus = 2
+)
+
+// Enum value maps for RegistrationStatus.
+var (
+	RegistrationStatus_name = map[int32]string{
+		0: "UNREGISTERED",
+		1: "REGISTERED",
+		2: "REGISTRATION_ERROR",
+	}
+	RegistrationStatus_value = map[string]int32{
+		"UNREGISTERED":       0,
+		"REGISTERED":         1,
+		"REGISTRATION_ERROR": 2,
+	}
+)
+
+func (x RegistrationStatus) Enum() *RegistrationStatus {
+	p := new(RegistrationStatus)
+	*p = x
+	return p
+}
+
+func (x RegistrationStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RegistrationStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_core_capabilities_remote_types_messages_proto_enumTypes[1].Descriptor()
+}
+
+func (RegistrationStatus) Type() protoreflect.EnumType {
+	return &file_core_capabilities_remote_types_messages_proto_enumTypes[1]
+}
+
+func (x RegistrationStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RegistrationStatus.Descriptor instead.
+func (RegistrationStatus) EnumDescriptor() ([]byte, []int) {
+	return file_core_capabilities_remote_types_messages_proto_rawDescGZIP(), []int{1}
+}
+
 type Message struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Signature     []byte                 `protobuf:"bytes,1,opt,name=signature,proto3" json:"signature,omitempty"`
@@ -321,6 +370,10 @@ func (*MessageBody_TriggerEventMetadata) isMessageBody_Metadata() {}
 type TriggerRegistrationMetadata struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	LastReceivedEventId string                 `protobuf:"bytes,1,opt,name=last_received_event_id,json=lastReceivedEventId,proto3" json:"last_received_event_id,omitempty"`
+	TriggerId           string                 `protobuf:"bytes,2,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
+	WorkflowId          string                 `protobuf:"bytes,3,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"`
+	Status              RegistrationStatus     `protobuf:"varint,4,opt,name=status,proto3,enum=remote.RegistrationStatus" json:"status,omitempty"`
+	RegistrationError   string                 `protobuf:"bytes,5,opt,name=registration_error,json=registrationError,proto3" json:"registration_error,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -358,6 +411,34 @@ func (*TriggerRegistrationMetadata) Descriptor() ([]byte, []int) {
 func (x *TriggerRegistrationMetadata) GetLastReceivedEventId() string {
 	if x != nil {
 		return x.LastReceivedEventId
+	}
+	return ""
+}
+
+func (x *TriggerRegistrationMetadata) GetTriggerId() string {
+	if x != nil {
+		return x.TriggerId
+	}
+	return ""
+}
+
+func (x *TriggerRegistrationMetadata) GetWorkflowId() string {
+	if x != nil {
+		return x.WorkflowId
+	}
+	return ""
+}
+
+func (x *TriggerRegistrationMetadata) GetStatus() RegistrationStatus {
+	if x != nil {
+		return x.Status
+	}
+	return RegistrationStatus_UNREGISTERED
+}
+
+func (x *TriggerRegistrationMetadata) GetRegistrationError() string {
+	if x != nil {
+		return x.RegistrationError
 	}
 	return ""
 }
@@ -449,9 +530,15 @@ const file_core_capabilities_remote_types_messages_proto_rawDesc = "" +
 	"\rcaller_don_id\x18\x10 \x01(\rR\vcallerDonId\x12+\n" +
 	"\x11capability_method\x18\x11 \x01(\tR\x10capabilityMethodB\n" +
 	"\n" +
-	"\bmetadataJ\x04\b\a\x10\bJ\x04\b\b\x10\t\"R\n" +
+	"\bmetadataJ\x04\b\a\x10\bJ\x04\b\b\x10\t\"\xf5\x01\n" +
 	"\x1bTriggerRegistrationMetadata\x123\n" +
-	"\x16last_received_event_id\x18\x01 \x01(\tR\x13lastReceivedEventId\"\x84\x01\n" +
+	"\x16last_received_event_id\x18\x01 \x01(\tR\x13lastReceivedEventId\x12\x1d\n" +
+	"\n" +
+	"trigger_id\x18\x02 \x01(\tR\ttriggerId\x12\x1f\n" +
+	"\vworkflow_id\x18\x03 \x01(\tR\n" +
+	"workflowId\x122\n" +
+	"\x06status\x18\x04 \x01(\x0e2\x1a.remote.RegistrationStatusR\x06status\x12-\n" +
+	"\x12registration_error\x18\x05 \x01(\tR\x11registrationError\"\x84\x01\n" +
 	"\x14TriggerEventMetadata\x12(\n" +
 	"\x10trigger_event_id\x18\x01 \x01(\tR\x0etriggerEventId\x12!\n" +
 	"\fworkflow_ids\x18\x02 \x03(\tR\vworkflowIds\x12\x1f\n" +
@@ -463,7 +550,12 @@ const file_core_capabilities_remote_types_messages_proto_rawDesc = "" +
 	"\x14CAPABILITY_NOT_FOUND\x10\x02\x12\x13\n" +
 	"\x0fINVALID_REQUEST\x10\x03\x12\v\n" +
 	"\aTIMEOUT\x10\x04\x12\x12\n" +
-	"\x0eINTERNAL_ERROR\x10\x05B Z\x1ecore/capabilities/remote/typesb\x06proto3"
+	"\x0eINTERNAL_ERROR\x10\x05*N\n" +
+	"\x12RegistrationStatus\x12\x10\n" +
+	"\fUNREGISTERED\x10\x00\x12\x0e\n" +
+	"\n" +
+	"REGISTERED\x10\x01\x12\x16\n" +
+	"\x12REGISTRATION_ERROR\x10\x02B Z\x1ecore/capabilities/remote/typesb\x06proto3"
 
 var (
 	file_core_capabilities_remote_types_messages_proto_rawDescOnce sync.Once
@@ -477,24 +569,26 @@ func file_core_capabilities_remote_types_messages_proto_rawDescGZIP() []byte {
 	return file_core_capabilities_remote_types_messages_proto_rawDescData
 }
 
-var file_core_capabilities_remote_types_messages_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_core_capabilities_remote_types_messages_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_core_capabilities_remote_types_messages_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_core_capabilities_remote_types_messages_proto_goTypes = []any{
 	(Error)(0),                          // 0: remote.Error
-	(*Message)(nil),                     // 1: remote.Message
-	(*MessageBody)(nil),                 // 2: remote.MessageBody
-	(*TriggerRegistrationMetadata)(nil), // 3: remote.TriggerRegistrationMetadata
-	(*TriggerEventMetadata)(nil),        // 4: remote.TriggerEventMetadata
+	(RegistrationStatus)(0),             // 1: remote.RegistrationStatus
+	(*Message)(nil),                     // 2: remote.Message
+	(*MessageBody)(nil),                 // 3: remote.MessageBody
+	(*TriggerRegistrationMetadata)(nil), // 4: remote.TriggerRegistrationMetadata
+	(*TriggerEventMetadata)(nil),        // 5: remote.TriggerEventMetadata
 }
 var file_core_capabilities_remote_types_messages_proto_depIdxs = []int32{
 	0, // 0: remote.MessageBody.error:type_name -> remote.Error
-	3, // 1: remote.MessageBody.trigger_registration_metadata:type_name -> remote.TriggerRegistrationMetadata
-	4, // 2: remote.MessageBody.trigger_event_metadata:type_name -> remote.TriggerEventMetadata
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	4, // 1: remote.MessageBody.trigger_registration_metadata:type_name -> remote.TriggerRegistrationMetadata
+	5, // 2: remote.MessageBody.trigger_event_metadata:type_name -> remote.TriggerEventMetadata
+	1, // 3: remote.TriggerRegistrationMetadata.status:type_name -> remote.RegistrationStatus
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_core_capabilities_remote_types_messages_proto_init() }
@@ -511,7 +605,7 @@ func file_core_capabilities_remote_types_messages_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_core_capabilities_remote_types_messages_proto_rawDesc), len(file_core_capabilities_remote_types_messages_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/core/capabilities/remote/types/messages.proto
+++ b/core/capabilities/remote/types/messages.proto
@@ -42,8 +42,18 @@ message MessageBody {
   string capability_method = 17; // method name defined by the capability (empty for legacy "v1" calls)
 }
 
+enum RegistrationStatus {
+  UNREGISTERED = 0;
+  REGISTERED = 1;
+  REGISTRATION_ERROR = 2;
+}
+
 message TriggerRegistrationMetadata {
   string last_received_event_id = 1;
+  string trigger_id =2;
+  string workflow_id = 3;
+  RegistrationStatus status = 4;
+  string registration_error = 5;
 }
 
 message TriggerEventMetadata {

--- a/core/capabilities/remote/types/types.go
+++ b/core/capabilities/remote/types/types.go
@@ -18,6 +18,8 @@ const (
 	MethodTriggerEvent      = "TriggerEvent"
 	MethodExecute           = "Execute"
 	MethodTriggerEventAck   = "TriggerEventACK"
+
+	TriggerRegistrationStatus = "TriggerRegistrationStatus"
 )
 
 type Dispatcher interface {

--- a/core/capabilities/streams/trigger_test.go
+++ b/core/capabilities/streams/trigger_test.go
@@ -8,9 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	ocrTypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types/mocks"
 
 	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
@@ -91,8 +96,13 @@ func TestStreamsTrigger(t *testing.T) {
 	config := &capabilities.RemoteTriggerConfig{
 		MinResponsesToAggregate: uint32(F + 1),
 	}
-	subscriber := remote.NewTriggerSubscriber(triggerID, "method", nil, lggr)
+	dispatcher := mocks.NewDispatcher(t)
+
+	dispatcher.On("Send", mock.Anything, mock.Anything).Return(nil).Maybe()
+	subscriber := remote.NewTriggerSubscriber(triggerID, "method", dispatcher, lggr,
+		limits.NewTimeLimiter(0))
 	require.NoError(t, subscriber.SetConfig(config, capInfo, 1, capDonInfo, agg))
+	servicetest.Run(t, subscriber)
 
 	// register trigger
 	req := capabilities.TriggerRegistrationRequest{
@@ -101,7 +111,7 @@ func TestStreamsTrigger(t *testing.T) {
 		},
 	}
 	triggerEventCallbackCh, err := subscriber.RegisterTrigger(ctx, req)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, capabilities.ErrUnableToDetermineRegistrationStatus)
 
 	// send and process all trigger events
 	startTs := time.Now().UnixMilli()

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 # Install Delve for debugging with cache mounts
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go install github.com/go-delve/delve/cmd/dlv@v1.24.2
+    go install github.com/go-delve/delve/cmd/dlv@v1.26.0
 
 # Flag to control installation of private plugins (default: true).
 ARG CL_INSTALL_PRIVATE_PLUGINS=true

--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
@@ -43,7 +43,7 @@
   # because bootstrap job for capability DON will be created on the boostrap node from this DON
   supported_evm_chains = [1337, 2337]
 
-  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node" }
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS_DEFAULT = "{\"TriggerRegistrationStatusUpdateTimeout\": \"30s\", \"PerWorkflow\": {\"TriggerRegistrationsTimeout\": \"60s\"}}" }
   capabilities = ["ocr3", "custom-compute", "web-api-trigger", "cron", "http-action", "http-trigger", "consensus", "don-time", "write-evm-1337", "read-contract-1337", "evm-1337"]
   registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
 

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/workflowkey"
 	"github.com/smartcontractkit/chainlink-common/pkg/billing"
@@ -207,6 +208,7 @@ func (s *Services) newSubservices(
 		ds,
 		opts,
 		dispatcherWrapper,
+		opts.LimitsFactory,
 	)
 	if err != nil {
 		return nil, err
@@ -362,6 +364,7 @@ func (s *Services) newRegistrySyncer(
 	ds sqlutil.DataSource,
 	opts Opts,
 	dispatcherWrapper *dispatcherWrapper,
+	lf limits.Factory,
 ) ([]commonsrv.Service, capabilities.DonNotifyWaitSubscriber, error) {
 	var srvcs []commonsrv.Service
 
@@ -392,6 +395,12 @@ func (s *Services) newRegistrySyncer(
 		return nil, nil, err
 	}
 
+	registrationStatusUpdateTimeout := cresettings.Default.TriggerRegistrationStatusUpdateTimeout
+	triggerRegistrationStatusUpdateTimeOut, err := lf.MakeTimeLimiter(registrationStatusUpdateTimeout)
+	if err != nil {
+		return nil, nil, errors.New("could not create trigger registration status update timeout limiter: " + err.Error())
+	}
+
 	wfLauncher, err := capabilities.NewLauncher(
 		lggr,
 		dispatcherWrapper.externalPeerWrapper,
@@ -400,6 +409,7 @@ func (s *Services) newRegistrySyncer(
 		dispatcherWrapper.dispatcher,
 		opts.CapabilitiesRegistry,
 		donNotifier,
+		triggerRegistrationStatusUpdateTimeOut,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not create workflow launcher: %w", err)

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -433,21 +433,29 @@ func (e *Engine) registerTrigger(ctx context.Context, t *triggerCapability, trig
 	}
 	eventsCh, err := t.trigger.RegisterTrigger(ctx, triggerRegRequest)
 	if err != nil {
-		e.metrics.With(platform.KeyTriggerID, triggerID).IncrementRegisterTriggerFailureCounter(ctx)
-		// It's confusing that t.ID is different from triggerID, but
-		// t.ID is the capability ID, and triggerID is the trigger ID.
-		//
-		// The capability ID is globally scoped, whereas the trigger ID
-		// is scoped to this workflow.
-		//
-		// For example, t.ID might be "streams-trigger:network=mainnet@1.0.0"
-		// and triggerID might be "wf_123_trigger_0"
-		return &workflowError{err: err, reason: fmt.Sprintf("failed to register trigger: %+v", triggerRegRequest),
-			labels: map[string]string{
-				platform.KeyWorkflowID:   e.workflow.id,
-				platform.KeyCapabilityID: t.ID,
-				platform.KeyTriggerID:    triggerID,
-			}}
+		// TODO This error type is temporarily required during migration of all DONS to support trigger registration status messages.
+		// TODO Jira to remove once migration completed https://smartcontract-it.atlassian.net/browse/CAPPL-1370
+		if !errors.Is(err, capabilities.ErrUnableToDetermineRegistrationStatus) {
+			e.metrics.With(platform.KeyTriggerID, triggerID).IncrementRegisterTriggerFailureCounter(ctx)
+			// It's confusing that t.ID is different from triggerID, but
+			// t.ID is the capability ID, and triggerID is the trigger ID.
+			//
+			// The capability ID is globally scoped, whereas the trigger ID
+			// is scoped to this workflow.
+			//
+			// For example, t.ID might be "streams-trigger:network=mainnet@1.0.0"
+			// and triggerID might be "wf_123_trigger_0"
+			return &workflowError{err: err, reason: fmt.Sprintf("failed to register trigger: %+v", triggerRegRequest),
+				labels: map[string]string{
+					platform.KeyWorkflowID:   e.workflow.id,
+					platform.KeyCapabilityID: t.ID,
+					platform.KeyTriggerID:    triggerID,
+				}}
+		}
+
+		// For backwards compatibility log a warning and ignore, may be running against an old capabilities DON
+		// Possible this may be made mandatory in the future once DON migration is complete.
+		e.logger.Warnw("unable to determine trigger registration status for trigger registration request", "triggerID", triggerID)
 	}
 
 	// mark the trigger as successfully registered

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -433,21 +433,27 @@ func (e *Engine) registerTrigger(ctx context.Context, t *triggerCapability, trig
 	}
 	eventsCh, err := t.trigger.RegisterTrigger(ctx, triggerRegRequest)
 	if err != nil {
-		e.metrics.With(platform.KeyTriggerID, triggerID).IncrementRegisterTriggerFailureCounter(ctx)
-		// It's confusing that t.ID is different from triggerID, but
-		// t.ID is the capability ID, and triggerID is the trigger ID.
-		//
-		// The capability ID is globally scoped, whereas the trigger ID
-		// is scoped to this workflow.
-		//
-		// For example, t.ID might be "streams-trigger:network=mainnet@1.0.0"
-		// and triggerID might be "wf_123_trigger_0"
-		return &workflowError{err: err, reason: fmt.Sprintf("failed to register trigger: %+v", triggerRegRequest),
-			labels: map[string]string{
-				platform.KeyWorkflowID:   e.workflow.id,
-				platform.KeyCapabilityID: t.ID,
-				platform.KeyTriggerID:    triggerID,
-			}}
+		if !errors.Is(err, capabilities.ErrUnableToDetermineRegistrationStatus) {
+			e.metrics.With(platform.KeyTriggerID, triggerID).IncrementRegisterTriggerFailureCounter(ctx)
+			// It's confusing that t.ID is different from triggerID, but
+			// t.ID is the capability ID, and triggerID is the trigger ID.
+			//
+			// The capability ID is globally scoped, whereas the trigger ID
+			// is scoped to this workflow.
+			//
+			// For example, t.ID might be "streams-trigger:network=mainnet@1.0.0"
+			// and triggerID might be "wf_123_trigger_0"
+			return &workflowError{err: err, reason: fmt.Sprintf("failed to register trigger: %+v", triggerRegRequest),
+				labels: map[string]string{
+					platform.KeyWorkflowID:   e.workflow.id,
+					platform.KeyCapabilityID: t.ID,
+					platform.KeyTriggerID:    triggerID,
+				}}
+		}
+
+		// For backwards compatibility log a warning and ignore, may be running against an old capabilities DON
+		// Possible this may be made mandatory in the future once DON migration is complete.
+		e.logger.Warnw("unable to determine trigger registration status for trigger registration request", "triggerID", triggerID)
 	}
 
 	// mark the trigger as successfully registered

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -433,6 +433,8 @@ func (e *Engine) registerTrigger(ctx context.Context, t *triggerCapability, trig
 	}
 	eventsCh, err := t.trigger.RegisterTrigger(ctx, triggerRegRequest)
 	if err != nil {
+		// TODO This error type is temporarily required during migration of all DONS to support trigger registration status messages.
+		// TODO Jira to remove once migration completed https://smartcontract-it.atlassian.net/browse/CAPPL-1370
 		if !errors.Is(err, capabilities.ErrUnableToDetermineRegistrationStatus) {
 			e.metrics.With(platform.KeyTriggerID, triggerID).IncrementRegisterTriggerFailureCounter(ctx)
 			// It's confusing that t.ID is different from triggerID, but

--- a/core/services/workflows/monitoring/monitoring.go
+++ b/core/services/workflows/monitoring/monitoring.go
@@ -16,23 +16,24 @@ import (
 // em AKA "engine metrics" is to locally scope these instruments to avoid
 // data races in testing
 type EngineMetrics struct {
-	registerTriggerFailureCounter            metric.Int64Counter
-	triggerWorkflowStarterErrorCounter       metric.Int64Counter
-	workflowsRunningGauge                    metric.Int64Gauge
-	capabilityInvocationCounter              metric.Int64Counter
-	capabilityFailureCounter                 metric.Int64Counter
-	capabilityUserErrorCounter               metric.Int64Counter
-	workflowRegisteredCounter                metric.Int64Counter
-	workflowUnregisteredCounter              metric.Int64Counter
-	workflowExecutionRateLimitGlobalCounter  metric.Int64Counter
-	workflowExecutionRateLimitPerUserCounter metric.Int64Counter
-	workflowLimitGlobalCounter               metric.Int64Counter
-	workflowLimitPerOwnerCounter             metric.Int64Counter
-	workflowExecutionLatencyGauge            metric.Int64Gauge // ms
-	workflowStepErrorCounter                 metric.Int64Counter
-	workflowInitializationCounter            metric.Int64Counter
-	workflowTriggerEventErrorCounter         metric.Int64Counter
-	workflowTriggerEventQueueFullCounter     metric.Int64Counter
+	registerTriggerFailureCounter               metric.Int64Counter
+	registerTriggerFailureDueToUserErrorCounter metric.Int64Counter
+	triggerWorkflowStarterErrorCounter          metric.Int64Counter
+	workflowsRunningGauge                       metric.Int64Gauge
+	capabilityInvocationCounter                 metric.Int64Counter
+	capabilityFailureCounter                    metric.Int64Counter
+	capabilityUserErrorCounter                  metric.Int64Counter
+	workflowRegisteredCounter                   metric.Int64Counter
+	workflowUnregisteredCounter                 metric.Int64Counter
+	workflowExecutionRateLimitGlobalCounter     metric.Int64Counter
+	workflowExecutionRateLimitPerUserCounter    metric.Int64Counter
+	workflowLimitGlobalCounter                  metric.Int64Counter
+	workflowLimitPerOwnerCounter                metric.Int64Counter
+	workflowExecutionLatencyGauge               metric.Int64Gauge // ms
+	workflowStepErrorCounter                    metric.Int64Counter
+	workflowInitializationCounter               metric.Int64Counter
+	workflowTriggerEventErrorCounter            metric.Int64Counter
+	workflowTriggerEventQueueFullCounter        metric.Int64Counter
 
 	// Deprecated: use the gauge instead
 	engineHeartbeatCounter metric.Int64Counter
@@ -85,6 +86,11 @@ func InitMonitoringResources() (em *EngineMetrics, err error) {
 	em.registerTriggerFailureCounter, err = beholder.GetMeter().Int64Counter("platform_engine_registertrigger_failures")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register trigger failure counter: %w", err)
+	}
+
+	em.registerTriggerFailureDueToUserErrorCounter, err = beholder.GetMeter().Int64Counter("platform_engine_registertrigger_user_error_failures")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register trigger failure due to user error counter: %w", err)
 	}
 
 	em.triggerWorkflowStarterErrorCounter, err = beholder.GetMeter().Int64Counter("platform_engine_triggerworkflow_starter_errors")
@@ -341,8 +347,13 @@ func (c WorkflowsMetricLabeler) IncrementWorkflowLimitPerOwnerCounter(ctx contex
 }
 
 func (c WorkflowsMetricLabeler) IncrementRegisterTriggerFailureCounter(ctx context.Context) {
-	otelLabels := monutils.KvMapToOtelAttributes(c.Labels)
+	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
 	c.em.registerTriggerFailureCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
+}
+
+func (c WorkflowsMetricLabeler) IncrementRegisterTriggerFailureDueToUserErrorCounter(ctx context.Context) {
+	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
+	c.em.registerTriggerFailureDueToUserErrorCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
 }
 
 func (c WorkflowsMetricLabeler) IncrementTriggerWorkflowStarterErrorCounter(ctx context.Context) {

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/aggregation"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/contexts"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
@@ -33,7 +34,6 @@ import (
 	billing "github.com/smartcontractkit/chainlink-protos/billing/go"
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 	protoevents "github.com/smartcontractkit/chainlink-protos/workflows/go/events"
-
 	"github.com/smartcontractkit/chainlink/v2/core/platform"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/events"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/metering"
@@ -473,9 +473,32 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 				// no Config needed - NoDAG uses Payload
 			})
 			if regErr != nil {
-				e.logger().Errorw("Trigger registration failed", "triggerID", sub.Id, "err", regErr)
-				e.metrics.With(platform.KeyTriggerID, sub.Id).IncrementRegisterTriggerFailureCounter(gCtx)
-				return fmt.Errorf("failed to register trigger %s: %w", sub.Id, regErr)
+				// This error type is required during migration of all DONS to support trigger registration status messages https://smartcontract-it.atlassian.net/browse/CAPPL-1370
+				if !errors.Is(regErr, capabilities.ErrUnableToDetermineRegistrationStatus) {
+					// TODO This error type is temporarily required during migration of all DONS to support trigger registration status messages.
+					// TODO Jira to remove once migration completed https://smartcontract-it.atlassian.net/browse/CAPPL-1370
+					var capErr caperrors.Error
+					if errors.As(regErr, &capErr) {
+						if capErr.Origin() == caperrors.OriginUser {
+							e.logger().Errorw("Trigger registration failed due to user error", "triggerID", sub.Id, "userErr", regErr)
+							e.metrics.With(platform.KeyTriggerID, sub.Id, platform.KeyCapabilityErrorCode, capErr.Code().String()).IncrementRegisterTriggerFailureDueToUserErrorCounter(gCtx)
+						} else {
+							e.logger().Errorw("Trigger registration failed due to system error", "triggerID", sub.Id, "systemErr", regErr)
+							e.metrics.With(platform.KeyTriggerID, sub.Id, platform.KeyCapabilityErrorCode, capErr.Code().String()).IncrementRegisterTriggerFailureCounter(gCtx)
+						}
+					} else {
+						e.logger().Errorw("Trigger registration failed", "triggerID", sub.Id, "err", regErr)
+						e.metrics.With(platform.KeyTriggerID, sub.Id).IncrementRegisterTriggerFailureCounter(gCtx)
+					}
+
+					return fmt.Errorf("failed to register trigger %s: %w", sub.Id, regErr)
+				}
+
+				// It's an ErrUnableToDetermineRegistrationStatus error, this could be due to the remote capability not
+				// supporting registration status messages, log a warning and ignore it for now whilst nodes are migrated
+				// to support registration update messages, once node migration is complete this error should be treated
+				// in the same way as any other registration error.
+				e.logger().Warnw("unable to determine trigger registration status for trigger registration request", "triggerID", sub.Id)
 			}
 			// Send successful result
 			resultsCh <- triggerRegResult{

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/aggregation"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/contexts"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
@@ -33,7 +34,6 @@ import (
 	billing "github.com/smartcontractkit/chainlink-protos/billing/go"
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 	protoevents "github.com/smartcontractkit/chainlink-protos/workflows/go/events"
-
 	"github.com/smartcontractkit/chainlink/v2/core/platform"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/events"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/metering"
@@ -473,9 +473,30 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 				// no Config needed - NoDAG uses Payload
 			})
 			if regErr != nil {
-				e.logger().Errorw("Trigger registration failed", "triggerID", sub.Id, "err", regErr)
-				e.metrics.With(platform.KeyTriggerID, sub.Id).IncrementRegisterTriggerFailureCounter(gCtx)
-				return fmt.Errorf("failed to register trigger %s: %w", sub.Id, regErr)
+				if !errors.Is(regErr, capabilities.ErrUnableToDetermineRegistrationStatus) {
+					// If the error is a capability error, further categorize it for metrics
+					var capErr caperrors.Error
+					if errors.As(regErr, &capErr) {
+						if capErr.Origin() == caperrors.OriginUser {
+							e.logger().Errorw("Trigger registration failed due to user error", "triggerID", sub.Id, "err", regErr)
+							e.metrics.With(platform.KeyTriggerID, sub.Id, platform.KeyCapabilityErrorCode, capErr.Code().String()).IncrementRegisterTriggerFailureDueToUserErrorCounter(gCtx)
+						} else {
+							e.logger().Errorw("Trigger registration failed due to system error", "triggerID", sub.Id, "err", regErr)
+							e.metrics.With(platform.KeyTriggerID, sub.Id, platform.KeyCapabilityErrorCode, capErr.Code().String()).IncrementRegisterTriggerFailureCounter(gCtx)
+						}
+					} else {
+						e.logger().Errorw("Trigger registration failed", "triggerID", sub.Id, "err", regErr)
+						e.metrics.With(platform.KeyTriggerID, sub.Id).IncrementRegisterTriggerFailureCounter(gCtx)
+					}
+
+					return fmt.Errorf("failed to register trigger %s: %w", sub.Id, regErr)
+				}
+
+				// It's an ErrUnableToDetermineRegistrationStatus error, this could be due to the remote capability not
+				// supporting registration status messages, log a warning and ignore it for now whilst nodes are migrated
+				// to support registration update messages, once node migration is complete this error should be treated
+				// in the same way as any other registration error.
+				e.logger().Warnw("unable to determine trigger registration status for trigger registration request", "triggerID", sub.Id)
 			}
 			// Send successful result
 			resultsCh <- triggerRegResult{

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -473,15 +473,17 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 				// no Config needed - NoDAG uses Payload
 			})
 			if regErr != nil {
+				// This error type is required during migration of all DONS to support trigger registration status messages https://smartcontract-it.atlassian.net/browse/CAPPL-1370
 				if !errors.Is(regErr, capabilities.ErrUnableToDetermineRegistrationStatus) {
-					// If the error is a capability error, further categorize it for metrics
+					// TODO This error type is temporarily required during migration of all DONS to support trigger registration status messages.
+					// TODO Jira to remove once migration completed https://smartcontract-it.atlassian.net/browse/CAPPL-1370
 					var capErr caperrors.Error
 					if errors.As(regErr, &capErr) {
 						if capErr.Origin() == caperrors.OriginUser {
-							e.logger().Errorw("Trigger registration failed due to user error", "triggerID", sub.Id, "err", regErr)
+							e.logger().Errorw("Trigger registration failed due to user error", "triggerID", sub.Id, "userErr", regErr)
 							e.metrics.With(platform.KeyTriggerID, sub.Id, platform.KeyCapabilityErrorCode, capErr.Code().String()).IncrementRegisterTriggerFailureDueToUserErrorCounter(gCtx)
 						} else {
-							e.logger().Errorw("Trigger registration failed due to system error", "triggerID", sub.Id, "err", regErr)
+							e.logger().Errorw("Trigger registration failed due to system error", "triggerID", sub.Id, "systemErr", regErr)
 							e.metrics.With(platform.KeyTriggerID, sub.Id, platform.KeyCapabilityErrorCode, capErr.Code().String()).IncrementRegisterTriggerFailureCounter(gCtx)
 						}
 					} else {

--- a/system-tests/tests/smoke/cre/cre_suite_test.go
+++ b/system-tests/tests/smoke/cre/cre_suite_test.go
@@ -209,6 +209,11 @@ func Test_CRE_V2_EVM_Write_LogTrigger(t *testing.T) {
 		testEnv := t_helpers.SetupTestEnvironmentWithPerTestKeys(t, t_helpers.GetDefaultTestConfig(t))
 		ExecuteEVMLogTriggerTest(t, testEnv)
 	})
+
+	t.Run("[v2] EVM LogTrigger User Error - "+topology, func(t *testing.T) {
+		testEnv := t_helpers.SetupTestEnvironmentWithPerTestKeys(t, t_helpers.GetDefaultTestConfig(t))
+		ExecuteEVMLogTriggerUserErrorTest(t, testEnv)
+	})
 }
 
 func Test_CRE_V2_EVM_Read_HeavyCalls(t *testing.T) {

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"strconv"
 	"strings"
 
 	"slices"
@@ -374,6 +375,63 @@ func snapshotTriggerStats(ctx context.Context, db *sql.DB) (tableStats, error) {
 		  WHERE relname = 'trigger_pending_events'`,
 	).Scan(&s.inserts, &s.deletes)
 	return s, err
+}
+
+// ExecuteEVMLogTriggerUserErrorTest purposefully causes a user error in the log trigger workflow and checks that the
+// error is found in the beholder logs with the correct visibility, origin and code. This ensures that user errors from
+// remote and local log trigger workflows are correctly reported.
+func ExecuteEVMLogTriggerUserErrorTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
+	const workflowFileLocation = "./evm/logtrigger/main.go"
+	lggr := framework.L
+
+	userLogsCh := make(chan *workflowevents.UserLogs, 1000)
+	baseMessageCh := make(chan *commonevents.BaseMessage, 1000)
+
+	server := t_helpers.StartChipTestSink(t, t_helpers.GetLoggingPublishFn(lggr, userLogsCh, baseMessageCh, "./logs/evm_log_trigger_user_err.log"))
+
+	t.Cleanup(func() {
+		server.Shutdown(t.Context())
+		close(userLogsCh)
+		close(baseMessageCh)
+	})
+
+	enabledChains := t_helpers.GetEVMEnabledChains(t, testEnv)
+	chainsToTest := make(map[string]blockchains.Blockchain)
+
+	for _, bcOutput := range testEnv.CreEnvironment.Blockchains {
+		chainID := bcOutput.CtfOutput().ChainID
+		if _, ok := enabledChains[chainID]; !ok {
+			lggr.Info().Msgf("Skipping chain %s as it is not enabled for EVM LogTrigger workflow test", chainID)
+			continue
+		}
+		chainsToTest[chainID] = bcOutput
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 4*time.Minute)
+	defer cancel()
+	for chainID, bcOutput := range chainsToTest {
+		lggr.Info().Msgf("Creating EVM LogTrigger workflow configuration for chain %s", chainID)
+		workflowConfig, _ := configureEVMLogTriggerWorkflow(t, lggr, bcOutput)
+
+		// Passing in empty addresses should cause the workflow to fail with a user error
+		workflowConfig.Addresses = nil
+
+		workflowName := fmt.Sprintf("evm-logTrigger-workflow-%s-%04d", chainID, rand.Intn(10000))
+		lggr.Info().Msgf("About to deploy Workflow %s on chain %s", workflowName, chainID)
+		t_helpers.CompileAndDeployWorkflow(t, testEnv, lggr, workflowName, &workflowConfig, workflowFileLocation)
+
+		// Wait for a beholder message containing the user error "no valid addresses provided (at least one address is required)"
+		expectedBeholderLog := "no valid addresses provided (at least one address is required)"
+
+		_, err := t_helpers.WaitForBaseMessageAndLabels(ctx, t, lggr, baseMessageCh, "Trigger registration failed due to user error", []string{"userErr", "triggerID"},
+			[]string{expectedBeholderLog, strconv.FormatUint(bcOutput.ChainSelector(), 10)})
+		if err != nil {
+			lggr.Error().Msgf("failed to find expected user log error message: %v", err)
+		}
+		require.NoError(t, err, "failed to find expected base message")
+	}
+
+	lggr.Info().Msg("EVM Trigger user error test completed successfully, found expected error message in beholder logs")
 }
 
 func ExecuteEVMLogTriggerTest(t *testing.T, testEnv *ttypes.TestEnvironment) {

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"strconv"
 	"strings"
 
 	"slices"
@@ -374,6 +375,63 @@ func snapshotTriggerStats(ctx context.Context, db *sql.DB) (tableStats, error) {
 		  WHERE relname = 'trigger_pending_events'`,
 	).Scan(&s.inserts, &s.deletes)
 	return s, err
+}
+
+// ExecuteEVMLogTriggerUserErrorTest purposefully causes a user error in the log trigger workflow and checks that the
+// error is found in the beholder logs with the correct visibility, origin and code. This ensures that user errors from
+// remote and local log trigger workflows are correctly reported.
+func ExecuteEVMLogTriggerUserErrorTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
+	const workflowFileLocation = "./evm/logtrigger/main.go"
+	lggr := framework.L
+
+	userLogsCh := make(chan *workflowevents.UserLogs, 1000)
+	baseMessageCh := make(chan *commonevents.BaseMessage, 1000)
+
+	server := t_helpers.StartChipTestSink(t, t_helpers.GetLoggingPublishFn(lggr, userLogsCh, baseMessageCh, "./logs/evm_log_trigger_user_err.log"))
+
+	t.Cleanup(func() {
+		server.Shutdown(t.Context())
+		close(userLogsCh)
+		close(baseMessageCh)
+	})
+
+	enabledChains := t_helpers.GetEVMEnabledChains(t, testEnv)
+	chainsToTest := make(map[string]blockchains.Blockchain)
+
+	for _, bcOutput := range testEnv.CreEnvironment.Blockchains {
+		chainID := bcOutput.CtfOutput().ChainID
+		if _, ok := enabledChains[chainID]; !ok {
+			lggr.Info().Msgf("Skipping chain %s as it is not enabled for EVM LogTrigger workflow test", chainID)
+			continue
+		}
+		chainsToTest[chainID] = bcOutput
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 4*time.Minute)
+	defer cancel()
+	for chainID, bcOutput := range chainsToTest {
+		lggr.Info().Msgf("Creating EVM LogTrigger workflow configuration for chain %s", chainID)
+		workflowConfig, _ := configureEVMLogTriggerWorkflow(t, lggr, bcOutput)
+
+		// Passing in empty addresses should cause the workflow to fail with a user error
+		workflowConfig.Addresses = nil
+
+		workflowName := fmt.Sprintf("evm-logTrigger-workflow-%s-%04d", chainID, rand.Intn(10000))
+		lggr.Info().Msgf("About to deploy Workflow %s on chain %s", workflowName, chainID)
+		t_helpers.CompileAndDeployWorkflow(t, testEnv, lggr, workflowName, &workflowConfig, workflowFileLocation)
+
+		// Wait for a beholder message containing the user error "no valid addresses provided (at least one address is required)"
+		expectedBeholderLog := "no valid addresses provided (at least one address is required)"
+
+		_, err := t_helpers.WaitForBaseMessageAndLabels(ctx, t, lggr, baseMessageCh, "Trigger registration failed due to user error", []string{"err", "triggerID"},
+			[]string{expectedBeholderLog, strconv.FormatUint(bcOutput.ChainSelector(), 10)})
+		if err != nil {
+			lggr.Error().Msgf("failed to find expected user log error message: %v", err)
+		}
+		require.NoError(t, err, "failed to find expected base message")
+	}
+
+	lggr.Info().Msg("EVM Trigger user error test completed successfully, found expected error message in beholder logs")
 }
 
 func ExecuteEVMLogTriggerTest(t *testing.T, testEnv *ttypes.TestEnvironment) {

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -423,7 +423,7 @@ func ExecuteEVMLogTriggerUserErrorTest(t *testing.T, testEnv *ttypes.TestEnviron
 		// Wait for a beholder message containing the user error "no valid addresses provided (at least one address is required)"
 		expectedBeholderLog := "no valid addresses provided (at least one address is required)"
 
-		_, err := t_helpers.WaitForBaseMessageAndLabels(ctx, t, lggr, baseMessageCh, "Trigger registration failed due to user error", []string{"err", "triggerID"},
+		_, err := t_helpers.WaitForBaseMessageAndLabels(ctx, t, lggr, baseMessageCh, "Trigger registration failed due to user error", []string{"userErr", "triggerID"},
 			[]string{expectedBeholderLog, strconv.FormatUint(bcOutput.ChainSelector(), 10)})
 		if err != nil {
 			lggr.Error().Msgf("failed to find expected user log error message: %v", err)

--- a/system-tests/tests/test-helpers/chip_testsink_helpers.go
+++ b/system-tests/tests/test-helpers/chip_testsink_helpers.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -607,6 +608,54 @@ func WaitForBaseMessage(
 				Str("expected_log", needle).
 				Str("found_message", strings.TrimSpace(msg.Msg)).
 				Msg("[soft assertion] Received BaseMessage message, but it does not match expected log")
+		}
+	}
+}
+
+func WaitForBaseMessageAndLabels(
+	ctx context.Context,
+	t *testing.T,
+	testLogger zerolog.Logger,
+	publishCh <-chan *commonevents.BaseMessage,
+	expectedMessage string,
+	labels []string,
+	needles []string,
+) (*commonevents.BaseMessage, error) {
+	require.Len(t, labels, len(needles))
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, context.Cause(ctx)
+		case msg := <-publishCh:
+
+			if strings.Contains(msg.Msg, "heartbeat") {
+				continue
+			}
+
+			if !strings.Contains(msg.Msg, expectedMessage) {
+				continue
+			}
+
+			allNeedlesPresent := true
+			for i, label := range labels {
+				if !strings.Contains(msg.Labels[label], needles[i]) {
+					allNeedlesPresent = false
+					break
+				}
+			}
+
+			if allNeedlesPresent {
+				return msg, nil
+			}
+
+			warnMsg := "[soft assertion] Received BaseMessage message without matching labels " + strings.Join(labels, ",")
+			testLogger.Warn().
+				Str("expected_labels", strings.Join(labels, ",")).
+				Str("expected_label_values", strings.Join(needles, ",")).
+				Str("found_labels", fmt.Sprintf("%v", msg.Labels)).
+				Str("found_message", strings.TrimSpace(msg.Msg)).
+				Msg(warnMsg)
 		}
 	}
 }


### PR DESCRIPTION
**Change overview:**

This change is to support the reporting of capability errors when a remote trigger is registered across the DON2DON (D2D) layer, no other changes required to handle the errors produced by trigger registration are included in this PR.

**Brief overview of the current situation (before this change) for context:**

On RegisterTrigger the TriggerSubscriber (TS) adds the registration to a list, this list is then polled at regular intervals and for each registration in the list a TriggerRegistration request is sent to the TriggerPublisher (TP).  The TS does not wait for any response from the TP, it assumes the registration was successful, thus there is currently no way to report registration errors to the workflow DON (where the TS sits).

On receipt of a TriggerRegistration request the TriggerPublisher will attempt to register to the underlying trigger (if it hasn't already), if an error occurs it will be logged but no indication of the error is sent back to the TS.  Note, the TS must send regular TriggerRegistration requests to the TP to keep the registration alive, failure to do so will result in the TP considering the registration to be dead and unregistering from the underlying trigger.

**Summary of the change in this PR**

_The change is subject to the following constraints:_

- Must be backwards compatible - that is a DON with this change must continue to work when communicating to a DON without this change.

- The D2D trigger communication mechanism has been proven in production, we want to avoid anything that fundamentally changes the behaviour. 

This change introduces the concept of a TriggerRegistrationStatus message (actually it sort of existed already but was unused) which is sent by the TP to the TS whenever the TP receives a TriggerRegistrationRequest from the TS.  The TriggerRegistrationStatus message includes the latest state of the registration on the underlying trigger including any registration error if one occurred.  As before, if the trigger is not currently successfully registered the receipt of the TriggerRegistrationRequest will cause the TP to attempt a new registration.  Also as before, the continued receipt of TriggerRegistrationRequests by the TP is necessary to keep a registration live.

On initial registration the TS can now (optionally) wait for TriggerRegistrationStatus messages from the TP, these can be used to determine if the initial registration attempt was successful.  Note, even though the TS will continue to send TriggerRegistrationRequests as part of polling, it does not (currently) have any code that deals with updates to the trigger registration status beyond the initial registration - this could be something to address in a future change, for now we are focussed on getting back the status on initial subscription so we can identify most errors, and in particular user errors.

Note, if the TS does not receive sufficient TriggerRegisrationStatus messages during the initial trigger registration phase it will return the events channel associated with the subscription along with an error indicating that registration status was unable to be determined.  Essentially this allows the code to behave in the current way (pre-this change) if running against old DON or for whatever other reason the status messages are not received.

It is expected that in most, if not all, cases initial trigger registration status will be returned, so will be a significant improvement over the current behaviour.  At some future point, perhaps after all DONs are migrated, it would be possible to make the wait for initial trigger registration status mandatory, tbd.

**Testing:**

In addition to additional system test, manual testing was carried out on staging zone b to ensure that there are no compatibility issue when running DONs with this change against DONs without this change and to confirm user registration errors are reported as expected, summarised here:

https://docs.google.com/spreadsheets/d/1-SP9lUCmjRQrY-xiufwioUbf5dnvz6zIgoZB-ZEi9GQ/edit?usp=sharing

**Deployment:**

Testing confirms that the change can de deployed in any order (i.e. workflow node followed by cap node, or vice versa) with no adverse impact.

Once both DONS are updated, the behaviour can be enabled by updating a setting, here is an example of a CLD PR that updates the setting, in this case to disable the behaviour, to enable the behaviour change the setting to '10s'

https://github.com/smartcontractkit/chainlink-deployments/pull/12204

