### PR TITLE
Record beholder config info metric periodically

### DIFF
--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -327,12 +327,11 @@ func (s *Shell) runNode(c *cli.Context) error {
 		ticker := time.NewTicker(1 * time.Hour)
 		defer ticker.Stop()
 
-		beholder.GetClient().RecordConfigMetric(ctx)
-
 		for {
+			beholder.GetClient().RecordConfigMetric(ctx)
+
 			select {
 			case <-ticker.C:
-				beholder.GetClient().RecordConfigMetric(ctx)
 			case <-ctx.Done():
 				return
 			}

--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -323,7 +323,7 @@ func (s *Shell) runNode(c *cli.Context) error {
 	lggr := logger.Sugared(s.Logger.Named("RunNode"))
 	lggr.Infow("configuration args", "config files", s.configFiles, "secret files", s.secretsFiles)
 
-	beholderConfigRecorder := beholderServices.NewConfigRecorder(1 * time.Hour)
+	beholderConfigRecorder := beholderServices.NewConfigRecorder(lggr, 1*time.Hour)
 	if err := beholderConfigRecorder.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start beholder config recorder service: %w", err)
 	}

--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -322,6 +322,23 @@ func (s *Shell) runNode(c *cli.Context) error {
 	lggr := logger.Sugared(s.Logger.Named("RunNode"))
 	lggr.Infow("configuration args", "config files", s.configFiles, "secret files", s.secretsFiles)
 
+	// Record beholder config periodically
+	go func() {
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+
+		beholder.GetClient().RecordConfigMetric(ctx)
+
+		for {
+			select {
+			case <-ticker.C:
+				beholder.GetClient().RecordConfigMetric(ctx)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
 	s.Config.LogConfiguration(lggr.Debugf, lggr.Warnf)
 
 	if err := s.Config.Validate(); err != nil {

--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/build"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	beholderServices "github.com/smartcontractkit/chainlink/v2/core/services/beholder"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
@@ -322,21 +323,11 @@ func (s *Shell) runNode(c *cli.Context) error {
 	lggr := logger.Sugared(s.Logger.Named("RunNode"))
 	lggr.Infow("configuration args", "config files", s.configFiles, "secret files", s.secretsFiles)
 
-	// Record beholder config periodically
-	go func() {
-		ticker := time.NewTicker(1 * time.Hour)
-		defer ticker.Stop()
-
-		for {
-			beholder.GetClient().RecordConfigMetric(ctx)
-
-			select {
-			case <-ticker.C:
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
+	beholderConfigRecorder := beholderServices.NewConfigRecorder(1 * time.Hour)
+	if err := beholderConfigRecorder.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start beholder config recorder service: %w", err)
+	}
+	defer beholderConfigRecorder.Close()
 
 	s.Config.LogConfiguration(lggr.Debugf, lggr.Warnf)
 

--- a/core/services/beholder/config_recorder.go
+++ b/core/services/beholder/config_recorder.go
@@ -15,18 +15,16 @@ type ConfigRecorder struct {
 	eng *services.Engine
 
 	interval time.Duration
-	logger   logger.Logger
 }
 
 func NewConfigRecorder(logger logger.Logger, interval time.Duration) *ConfigRecorder {
 	cr := &ConfigRecorder{
 		interval: interval,
-		logger:   logger.Named("BeholderConfigRecorder"),
 	}
 	cr.Service, cr.eng = services.Config{
 		Name:  "BeholderConfigRecorder",
 		Start: cr.start,
-	}.NewServiceEngine(cr.logger)
+	}.NewServiceEngine(logger)
 	return cr
 }
 
@@ -34,7 +32,7 @@ func (s *ConfigRecorder) start(ctx context.Context) error {
 	ticker := services.TickerConfig{}.NewTicker(s.interval)
 	s.eng.GoTick(ticker, func(ctx context.Context) {
 		if err := beholder.GetClient().RecordConfigMetric(ctx); err != nil {
-			s.logger.Errorf("failed to record beholder config metric: %v", err)
+			s.eng.Errorf("failed to record beholder config metric: %v", err)
 		}
 	})
 	return nil

--- a/core/services/beholder/config_recorder.go
+++ b/core/services/beholder/config_recorder.go
@@ -1,0 +1,57 @@
+package beholder
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+)
+
+// ConfigRecorder periodically records Beholder config info metric.
+type ConfigRecorder struct {
+	services.StateMachine
+	chStop   services.StopChan
+	wgDone   sync.WaitGroup
+	interval time.Duration
+}
+
+func NewConfigRecorder(interval time.Duration) *ConfigRecorder {
+	return &ConfigRecorder{
+		chStop:   make(services.StopChan),
+		interval: interval,
+	}
+}
+
+func (s *ConfigRecorder) Start(ctx context.Context) error {
+	return s.StartOnce("BeholderConfigRecorder", func() error {
+		s.wgDone.Add(1)
+		go s.run(ctx)
+		return nil
+	})
+}
+
+func (s *ConfigRecorder) Close() error {
+	return s.StopOnce("BeholderConfigRecorder", func() error {
+		close(s.chStop)
+		s.wgDone.Wait()
+		return nil
+	})
+}
+
+func (s *ConfigRecorder) run(ctx context.Context) {
+	defer s.wgDone.Done()
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		beholder.GetClient().RecordConfigMetric(ctx)
+		select {
+		case <-ticker.C:
+		case <-s.chStop:
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/core/services/beholder/config_recorder.go
+++ b/core/services/beholder/config_recorder.go
@@ -2,7 +2,6 @@ package beholder
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
@@ -12,51 +11,31 @@ import (
 
 // ConfigRecorder periodically records Beholder config info metric.
 type ConfigRecorder struct {
-	services.StateMachine
-	chStop   services.StopChan
-	wgDone   sync.WaitGroup
+	services.Service
+	eng *services.Engine
+
 	interval time.Duration
 	logger   logger.Logger
 }
 
 func NewConfigRecorder(logger logger.Logger, interval time.Duration) *ConfigRecorder {
-	return &ConfigRecorder{
-		chStop:   make(services.StopChan),
+	cr := &ConfigRecorder{
 		interval: interval,
 		logger:   logger,
 	}
+	cr.Service, cr.eng = services.Config{
+		Name:  "BeholderConfigRecorder",
+		Start: cr.start,
+	}.NewServiceEngine(logger)
+	return cr
 }
 
-func (s *ConfigRecorder) Start(ctx context.Context) error {
-	return s.StartOnce("BeholderConfigRecorder", func() error {
-		s.wgDone.Add(1)
-		go s.run(ctx)
-		return nil
-	})
-}
-
-func (s *ConfigRecorder) Close() error {
-	return s.StopOnce("BeholderConfigRecorder", func() error {
-		close(s.chStop)
-		s.wgDone.Wait()
-		return nil
-	})
-}
-
-func (s *ConfigRecorder) run(ctx context.Context) {
-	defer s.wgDone.Done()
-	ticker := time.NewTicker(s.interval)
-	defer ticker.Stop()
-	for {
+func (s *ConfigRecorder) start(ctx context.Context) error {
+	ticker := services.TickerConfig{}.NewTicker(s.interval)
+	s.eng.GoTick(ticker, func(ctx context.Context) {
 		if err := beholder.GetClient().RecordConfigMetric(ctx); err != nil {
 			s.logger.Errorf("failed to record beholder config metric: %v", err)
 		}
-		select {
-		case <-ticker.C:
-		case <-s.chStop:
-			return
-		case <-ctx.Done():
-			return
-		}
-	}
+	})
+	return nil
 }

--- a/core/services/beholder/config_recorder.go
+++ b/core/services/beholder/config_recorder.go
@@ -21,12 +21,12 @@ type ConfigRecorder struct {
 func NewConfigRecorder(logger logger.Logger, interval time.Duration) *ConfigRecorder {
 	cr := &ConfigRecorder{
 		interval: interval,
-		logger:   logger,
+		logger:   logger.Named("BeholderConfigRecorder"),
 	}
 	cr.Service, cr.eng = services.Config{
 		Name:  "BeholderConfigRecorder",
 		Start: cr.start,
-	}.NewServiceEngine(logger)
+	}.NewServiceEngine(cr.logger)
 	return cr
 }
 

--- a/core/services/beholder/config_recorder.go
+++ b/core/services/beholder/config_recorder.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 // ConfigRecorder periodically records Beholder config info metric.
@@ -15,12 +16,14 @@ type ConfigRecorder struct {
 	chStop   services.StopChan
 	wgDone   sync.WaitGroup
 	interval time.Duration
+	logger   logger.Logger
 }
 
-func NewConfigRecorder(interval time.Duration) *ConfigRecorder {
+func NewConfigRecorder(logger logger.Logger, interval time.Duration) *ConfigRecorder {
 	return &ConfigRecorder{
 		chStop:   make(services.StopChan),
 		interval: interval,
+		logger:   logger,
 	}
 }
 
@@ -45,7 +48,9 @@ func (s *ConfigRecorder) run(ctx context.Context) {
 	ticker := time.NewTicker(s.interval)
 	defer ticker.Stop()
 	for {
-		beholder.GetClient().RecordConfigMetric(ctx)
+		if err := beholder.GetClient().RecordConfigMetric(ctx); err != nil {
+			s.logger.Errorf("failed to record beholder config metric: %v", err)
+		}
 		select {
 		case <-ticker.C:
 		case <-s.chStop:


### PR DESCRIPTION
This introduces `beholder.config.info` metric that aggregates beholder settings as attributes and allows to track app configuration

Relates to: https://github.com/smartcontractkit/chainlink-common/pull/1769