### PR TITLE
Avoid closing nil WS connection

### DIFF
--- a/core/services/gateway/network/wsserver.go
+++ b/core/services/gateway/network/wsserver.go
@@ -123,7 +123,9 @@ func (s *webSocketServer) handleRequest(w http.ResponseWriter, r *http.Request) 
 	conn, err := s.upgrader.Upgrade(w, r, hdr)
 	if err != nil {
 		s.lggr.Errorw("failed websocket upgrade", "err", err)
-		conn.Close()
+		if conn != nil {
+			conn.Close()
+		}
 		s.acceptor.AbortHandshake(attemptId)
 		return
 	}


### PR DESCRIPTION
When a Websocket connection upgrade fails, `conn` can be `nil`. Closing on it might cause a panic on nil dereference.