### PR TITLE
[DX-2749] don't use mutable tags for Chip images in the local CRE

### DIFF
--- a/core/scripts/cre/environment/README.md
+++ b/core/scripts/cre/environment/README.md
@@ -157,8 +157,12 @@ Refer to [this document](https://docs.google.com/document/d/1HtVLv2ipx2jvU15WYOi
 Environment can be setup by running `go run . env setup` inside `core/scripts/cre/environment` folder. Its configuration is defined in [configs/setup.toml](configs/setup.toml) file. It will make sure that:
 - you have AWS CLI installed and configured
 - you have GH CLI installed and authenticated
-- you have required Job Distributor and Chip Ingress (Beholder) images
+- you have required Job Distributor, Chip Ingress, and Chip Config images
 - install and copy all capability binaries to expected location
+
+**Image Versioning:**
+
+Docker images for Beholder services (chip-ingress, chip-config) use commit-based tags instead of mutable tags like `local-cre`. This ensures you always know which version is running and prevents hard-to-debug issues from version mismatches. The exact versions are defined in [configs/setup.toml](configs/setup.toml).
 
 Capability installation is two fold. Private and local plugins are compiled locally and then copied to the running Docker container. Public plugins are installed, when the Docker image is built. The reason is that capability developers need a way to quickly test capabilities they are working on, without having to push the code to remote repository, so that it could be installed in the Docker image (and that's because local capability code is usually located outside Docker build context and thus unavailable).
 
@@ -228,12 +232,28 @@ Once up and running you will be able to access [CRE topic view](http://localhost
 #### Filtering out heartbeats
 Heartbeat messages spam the topic, so it's highly recommended that you add a JavaScript filter that will exclude them using the following code: `return value.msg !== 'heartbeat';`.
 
-If environment is aready running you can start just the Beholder stack (and register protos) with:
+If environment is already running you can start just the Beholder stack (and register protos) with:
 ```bash
 go run . env beholder start
 ```
 
-> This assumes you have `chip-ingress:bbac3c825b061546980fa9d7dc0f3e8c34347bcf` Docker image on your local machine. Without it Beholder won't be able to start. If you do not, close the [Atlas](https://github.com/smartcontractkit/atlas) repository, and then in `atlas/chip-ingress` run `docker build -t chip-ingress:bbac3c825b061546980fa9d7dc0f3e8c34347bcf .`
+**Image Requirements:**
+
+Beholder requires `chip-ingress` and `chip-config` Docker images with specific versions defined in [configs/setup.toml](configs/setup.toml). The image tags use commit hashes for version tracking (e.g., `chip-ingress:da84cb72d3a160e02896247d46ab4b9806ebee2f`).
+
+When starting Beholder, the system will:
+- **In CI (`CI=true`)**: Skip image checks (docker-compose will pull at runtime)
+- **Interactive terminal**: Auto-build missing images from sources. If build fails and `AWS_ECR` is set, you'll be offered to pull from ECR instead
+- **Non-interactive (tests, scripts)**: Auto-pull from ECR if `AWS_ECR` is set, otherwise fail with instructions
+
+To manually ensure images are available, run:
+```bash
+# Build from sources
+go run . env setup
+
+# Or pull from ECR (requires AWS SSO access)
+AWS_ECR=<account-id>.dkr.ecr.us-west-2.amazonaws.com go run . env setup
+```
 
 ### Storage
 

--- a/core/scripts/cre/environment/configs/setup.toml
+++ b/core/scripts/cre/environment/configs/setup.toml
@@ -20,11 +20,11 @@ branch = "master"
 commit = "da84cb72d3a160e02896247d46ab4b9806ebee2f"
 dockerfile = "chip-ingress/Dockerfile"
 docker_ctx = "chip-ingress"
-local_image = "chip-ingress:local-cre"
+local_image = "chip-ingress:da84cb72d3a160e02896247d46ab4b9806ebee2f"
 pre_run = "pushd chip-ingress && go mod vendor && popd"
 
 [chip_ingress.pull_config]
-local_image = "chip-ingress:local-cre"
+local_image = "chip-ingress:da84cb72d3a160e02896247d46ab4b9806ebee2f"
 ecr_image = "{{.ECR}}/atlas-chip-ingress:da84cb72d3a160e02896247d46ab4b9806ebee2f"
 
 [chip_config.build_config]
@@ -33,11 +33,11 @@ branch = "master"
 commit = "7b4e9ee68fd1c737dd3480b5a3ced0188f29b969"
 dockerfile = "chip-config/Dockerfile"
 docker_ctx = "chip-config"
-local_image = "chip-config:local-cre"
+local_image = "chip-config:7b4e9ee68fd1c737dd3480b5a3ced0188f29b969"
 pre_run = "pushd chip-config && go mod vendor && popd"
 
 [chip_config.pull_config]
-local_image = "chip-config:local-cre"
+local_image = "chip-config:7b4e9ee68fd1c737dd3480b5a3ced0188f29b969"
 ecr_image = "{{.ECR}}/atlas-chip-config:7b4e9ee68fd1c737dd3480b5a3ced0188f29b969"
 
 [billing_platform_service.build_config]

--- a/core/scripts/cre/environment/environment/beholder.go
+++ b/core/scripts/cre/environment/environment/beholder.go
@@ -619,15 +619,18 @@ and make sure that the sink is pointing to correct upstream endpoint ('localhost
 		return errors.Wrap(err, "failed to ensure chip images exist")
 	}
 
-	// Set image version environment variables for docker-compose
-	if setupCfg.ChipIngress != nil {
-		if err := os.Setenv("CHIP_INGRESS_IMAGE", setupCfg.ChipIngress.BuildConfig.LocalImage); err != nil {
-			return fmt.Errorf("failed to set CHIP_INGRESS_IMAGE environment variable: %w", err)
+	// Don't set image version environment variables for CI environment, since we set them on the GHA workflow level
+	if os.Getenv("CI") != "true" {
+		// Set image version environment variables for docker-compose
+		if setupCfg.ChipIngress != nil {
+			if err := os.Setenv(chipingressset.ChipIngressImageEnvVar, setupCfg.ChipIngress.BuildConfig.LocalImage); err != nil {
+				return fmt.Errorf("failed to set CHIP_INGRESS_IMAGE environment variable: %w", err)
+			}
 		}
-	}
-	if setupCfg.ChipConfig != nil {
-		if err := os.Setenv("CHIP_CONFIG_IMAGE", setupCfg.ChipConfig.BuildConfig.LocalImage); err != nil {
-			return fmt.Errorf("failed to set CHIP_CONFIG_IMAGE environment variable: %w", err)
+		if setupCfg.ChipConfig != nil {
+			if err := os.Setenv(chipingressset.ChipConfigImageEnvVar, setupCfg.ChipConfig.BuildConfig.LocalImage); err != nil {
+				return fmt.Errorf("failed to set CHIP_CONFIG_IMAGE environment variable: %w", err)
+			}
 		}
 	}
 

--- a/core/scripts/cre/environment/environment/beholder.go
+++ b/core/scripts/cre/environment/environment/beholder.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"bufio"
 	"context"
 	"encoding/hex"
 	"encoding/json"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	retry "github.com/avast/retry-go/v4"
+	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -363,6 +365,207 @@ func isPortAvailable(addr string) bool {
 
 var protoRegistrationErrMsg = "proto registration failed"
 
+// MissingImage represents an image that needs to be built or pulled
+type MissingImage struct {
+	Name        string
+	Tag         string
+	FullImage   string
+	BuildConfig BuildConfig
+	PullConfig  PullConfig
+}
+
+// ensureChipImagesExist checks if required chip images exist and auto-builds them if missing.
+// In CI environments (CI=true), this check is skipped as images will be pulled at runtime.
+func ensureChipImagesExist(ctx context.Context, cfg *SetupConfigFile) error {
+	// Skip checks in CI environment - docker-compose will pull at runtime
+	if os.Getenv("CI") == "true" {
+		framework.L.Info().Msg("CI environment detected, skipping chip image pre-check")
+		return nil
+	}
+
+	dockerClient, err := client.NewClientWithOpts(client.WithAPIVersionNegotiation())
+	if err != nil {
+		return errors.Wrap(err, "failed to create Docker client")
+	}
+	defer dockerClient.Close()
+
+	// Check if Docker is running
+	_, err = dockerClient.Ping(ctx)
+	if err != nil {
+		return errors.Wrap(err, "Docker is not running")
+	}
+
+	// Collect required images
+	var requiredImages []MissingImage
+
+	if cfg.ChipIngress != nil {
+		requiredImages = append(requiredImages, MissingImage{
+			Name:        "chip-ingress",
+			Tag:         cfg.ChipIngress.BuildConfig.Commit,
+			FullImage:   cfg.ChipIngress.BuildConfig.LocalImage,
+			BuildConfig: cfg.ChipIngress.BuildConfig,
+			PullConfig:  cfg.ChipIngress.PullConfig,
+		})
+	}
+
+	if cfg.ChipConfig != nil {
+		requiredImages = append(requiredImages, MissingImage{
+			Name:        "chip-config",
+			Tag:         cfg.ChipConfig.BuildConfig.Commit,
+			FullImage:   cfg.ChipConfig.BuildConfig.LocalImage,
+			BuildConfig: cfg.ChipConfig.BuildConfig,
+			PullConfig:  cfg.ChipConfig.PullConfig,
+		})
+	}
+
+	// Find missing images
+	var missing []MissingImage
+	for _, img := range requiredImages {
+		_, err := dockerClient.ImageInspect(ctx, img.FullImage)
+		if err != nil {
+			framework.L.Info().Msgf("Image %s not found locally", img.FullImage)
+			missing = append(missing, img)
+		} else {
+			framework.L.Info().Msgf("✓ Image %s is available", img.FullImage)
+		}
+	}
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	ecrURL := os.Getenv("AWS_ECR")
+	interactive := isInteractiveTerminal()
+
+	// Non-interactive mode handling
+	if !interactive {
+		if ecrURL != "" {
+			// Non-interactive with AWS_ECR - pull images
+			framework.L.Info().Msgf("Non-interactive mode with AWS_ECR set. Pulling %d missing image(s) from ECR...", len(missing))
+			return pullAllImages(ctx, cfg, missing)
+		}
+		// Non-interactive without AWS_ECR - fail with instructions
+		framework.L.Error().Msgf("Missing %d required image(s) and AWS_ECR is not set:", len(missing))
+		for _, img := range missing {
+			framework.L.Error().Msgf("  - %s", img.FullImage)
+		}
+		printChipImagePullInstructions()
+		return errors.Errorf("missing %d required image(s). Set AWS_ECR to enable auto-pull or run 'go run . env setup' manually", len(missing))
+	}
+
+	// Interactive mode - try building first
+	framework.L.Info().Msgf("Building %d missing image(s) from sources...", len(missing))
+
+	var failedBuilds []MissingImage
+	var buildErrors []error
+
+	for _, img := range missing {
+		framework.L.Info().Msgf("🔨 Building %s from sources...", img.FullImage)
+
+		_, buildErr := img.BuildConfig.Build(ctx)
+		if buildErr != nil {
+			framework.L.Error().Msgf("Failed to build %s: %v", img.FullImage, buildErr)
+			failedBuilds = append(failedBuilds, img)
+			buildErrors = append(buildErrors, buildErr)
+		} else {
+			framework.L.Info().Msgf("✓ %s built successfully", img.FullImage)
+		}
+	}
+
+	// If all builds succeeded, we're done
+	if len(failedBuilds) == 0 {
+		return nil
+	}
+
+	// Some builds failed - offer to pull all failed images
+	return handleChipImageBuildFailures(ctx, cfg, failedBuilds, buildErrors)
+}
+
+// pullAllImages pulls all specified images from ECR
+func pullAllImages(ctx context.Context, cfg *SetupConfigFile, images []MissingImage) error {
+	for _, img := range images {
+		framework.L.Info().Msgf("Pulling %s from ECR...", img.Name)
+		_, pullErr := img.PullConfig.Pull(ctx, cfg.General.AWSProfile)
+		if pullErr != nil {
+			return errors.Wrapf(pullErr, "failed to pull %s", img.Name)
+		}
+		framework.L.Info().Msgf("✓ %s pulled successfully", img.FullImage)
+	}
+	return nil
+}
+
+// isInteractiveTerminal checks if stdin is connected to an interactive terminal
+func isInteractiveTerminal() bool {
+	fileInfo, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	// Check if stdin is a character device (terminal)
+	return (fileInfo.Mode() & os.ModeCharDevice) != 0
+}
+
+// handleChipImageBuildFailures handles build failures by offering to pull all failed images
+func handleChipImageBuildFailures(ctx context.Context, cfg *SetupConfigFile, failedImages []MissingImage, buildErrors []error) error {
+	// List all failed images
+	fmt.Println()
+	framework.L.Error().Msgf("Failed to build %d image(s):", len(failedImages))
+	for i, img := range failedImages {
+		framework.L.Error().Msgf("  - %s: %v", img.FullImage, buildErrors[i])
+	}
+
+	ecrURL := os.Getenv("AWS_ECR")
+	if ecrURL != "" {
+		shouldPull := false
+
+		if isInteractiveTerminal() {
+			// Interactive mode - ask user
+			fmt.Println()
+			fmt.Printf("AWS_ECR is set. Would you like to pull all %d failed image(s) from ECR instead? [Y/n] ", len(failedImages))
+
+			reader := bufio.NewReader(os.Stdin)
+			input, _ := reader.ReadString('\n')
+			input = strings.TrimSpace(strings.ToLower(input))
+
+			shouldPull = input == "" || input == "y" || input == "yes"
+		} else {
+			// Non-interactive mode (e.g., automated tests) - auto-pull
+			framework.L.Info().Msg("Non-interactive mode detected. Auto-pulling failed images from ECR...")
+			shouldPull = true
+		}
+
+		if shouldPull {
+			// Pull all failed images
+			for _, img := range failedImages {
+				framework.L.Info().Msgf("Pulling %s from ECR...", img.Name)
+				_, pullErr := img.PullConfig.Pull(ctx, cfg.General.AWSProfile)
+				if pullErr != nil {
+					return errors.Wrapf(pullErr, "failed to pull %s", img.Name)
+				}
+				framework.L.Info().Msgf("✓ %s pulled successfully", img.FullImage)
+			}
+			return nil
+		}
+	}
+
+	// Show manual instructions
+	printChipImagePullInstructions()
+	return errors.Errorf("failed to build %d image(s)", len(failedImages))
+}
+
+// printChipImagePullInstructions prints helpful instructions for pulling images manually
+func printChipImagePullInstructions() {
+	fmt.Println()
+	fmt.Println("────────────────────────────────────────────────────────────────")
+	fmt.Println("To pull pre-built images instead, run:")
+	fmt.Println()
+	fmt.Println("  AWS_ECR=<account-id>.dkr.ecr.us-west-2.amazonaws.com go run . env setup")
+	fmt.Println()
+	fmt.Println("Replace <account-id> with prod AWS account number.")
+	fmt.Println("See: https://smartcontract-it.atlassian.net/wiki/spaces/INFRA/pages/1045495923")
+	fmt.Println("────────────────────────────────────────────────────────────────")
+	fmt.Println()
+}
+
 func startBeholder(cmdContext context.Context, cleanupWait time.Duration, port int) (startupErr error) {
 	// just in case, remove the stack if it exists
 	_ = framework.RemoveTestStack(chipingressset.DEFAULT_STACK_NAME)
@@ -403,6 +606,29 @@ func startBeholder(cmdContext context.Context, cleanupWait time.Duration, port i
 		return fmt.Errorf(`port %d is already in use. Most probably an instance of ChIP Test Sink is already running.
 If you want to use both together start ChIP Ingress on a different port with '--grpc-port' flag
 and make sure that the sink is pointing to correct upstream endpoint ('localhost:<grpc-port>' in most cases)`, port)
+	}
+
+	// Load setup config to check for required images
+	setupCfg, setupCfgErr := ReadSetupConfig(DefaultSetupConfigPath)
+	if setupCfgErr != nil {
+		return errors.Wrap(setupCfgErr, "failed to read setup config")
+	}
+
+	// Ensure required chip images exist (auto-builds if missing, skipped in CI)
+	if err := ensureChipImagesExist(cmdContext, setupCfg); err != nil {
+		return errors.Wrap(err, "failed to ensure chip images exist")
+	}
+
+	// Set image version environment variables for docker-compose
+	if setupCfg.ChipIngress != nil {
+		if err := os.Setenv("CHIP_INGRESS_IMAGE", setupCfg.ChipIngress.BuildConfig.LocalImage); err != nil {
+			return fmt.Errorf("failed to set CHIP_INGRESS_IMAGE environment variable: %w", err)
+		}
+	}
+	if setupCfg.ChipConfig != nil {
+		if err := os.Setenv("CHIP_CONFIG_IMAGE", setupCfg.ChipConfig.BuildConfig.LocalImage); err != nil {
+			return fmt.Errorf("failed to set CHIP_CONFIG_IMAGE environment variable: %w", err)
+		}
 	}
 
 	// set both internal and external (host) ChIP Ingress GRPC port to the same value

--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -517,7 +517,7 @@ func startCmd() *cobra.Command {
 }
 
 func setupDashboards(ctx context.Context, setupCfg SetupConfig) error {
-	cfg, cfgErr := readConfig(setupCfg.ConfigPath)
+	cfg, cfgErr := ReadSetupConfig(setupCfg.ConfigPath)
 	if cfgErr != nil {
 		return errors.Wrap(cfgErr, "failed to read config")
 	}

--- a/core/scripts/cre/environment/environment/setup.go
+++ b/core/scripts/cre/environment/environment/setup.go
@@ -69,47 +69,55 @@ func init() {
 	EnvironmentCmd.AddCommand(BuildCapabilitiesCmd)
 }
 
-type config struct {
-	General        generalConfig         `toml:"general"`
-	JobDistributor jobDistributorConfig  `toml:"job_distributor"`
-	ChipIngress    *chipIngressConfig    `toml:"chip_ingress"`
-	ChipConfig     *chipConfigConfig     `toml:"chip_config"`
-	BillingService *billingServiceConfig `toml:"billing_platform_service"`
-	Capabilities   capabilitiesConfig    `toml:"capabilities"`
-	Observability  observabilityConfig   `toml:"observability"`
+// SetupConfigFile represents the full configuration loaded from setup.toml
+type SetupConfigFile struct {
+	General        GeneralConfig         `toml:"general"`
+	JobDistributor JobDistributorConfig  `toml:"job_distributor"`
+	ChipIngress    *ChipIngressConfig    `toml:"chip_ingress"`
+	ChipConfig     *ChipConfigConfig     `toml:"chip_config"`
+	BillingService *BillingServiceConfig `toml:"billing_platform_service"`
+	Capabilities   CapabilitiesConfig    `toml:"capabilities"`
+	Observability  ObservabilityConfig   `toml:"observability"`
 }
 
-type generalConfig struct {
+// GeneralConfig contains general setup configuration
+type GeneralConfig struct {
 	AWSProfile      string `toml:"aws_profile"`
 	MinGHCLIVersion string `toml:"min_gh_cli_version"`
 }
 
-type jobDistributorConfig struct {
+// JobDistributorConfig contains job distributor image configuration
+type JobDistributorConfig struct {
 	BuildConfig BuildConfig `toml:"build_config"`
 	PullConfig  PullConfig  `toml:"pull_config"`
 }
 
-type chipIngressConfig struct {
+// ChipIngressConfig contains chip ingress image configuration
+type ChipIngressConfig struct {
 	BuildConfig BuildConfig `toml:"build_config"`
 	PullConfig  PullConfig  `toml:"pull_config"`
 }
 
-type chipConfigConfig struct {
+// ChipConfigConfig contains chip config image configuration
+type ChipConfigConfig struct {
 	BuildConfig BuildConfig `toml:"build_config"`
 	PullConfig  PullConfig  `toml:"pull_config"`
 }
 
-type billingServiceConfig struct {
+// BillingServiceConfig contains billing service image configuration
+type BillingServiceConfig struct {
 	BuildConfig BuildConfig `toml:"build_config"`
 	PullConfig  PullConfig  `toml:"pull_config"`
 }
 
-type capabilitiesConfig struct {
+// CapabilitiesConfig contains capabilities build configuration
+type CapabilitiesConfig struct {
 	TargetPath   string   `toml:"target_path"`
 	MakeCommands []string `toml:"make_commands"`
 }
 
-type observabilityConfig struct {
+// ObservabilityConfig contains observability repository configuration
+type ObservabilityConfig struct {
 	RepoURL    string `toml:"repository"`
 	Branch     string `toml:"branch"`
 	TargetPath string `toml:"target_path"`
@@ -449,7 +457,7 @@ func RunSetup(ctx context.Context, config SetupConfig, noPrompt, purge, withBill
 		logger.Info().Msg("✓ AWS CLI is installed")
 	}
 
-	cfg, cfgErr := readConfig(config.ConfigPath)
+	cfg, cfgErr := ReadSetupConfig(config.ConfigPath)
 	if cfgErr != nil {
 		setupErr = errors.Wrap(cfgErr, "failed to read config")
 		return
@@ -616,7 +624,7 @@ func RunSetup(ctx context.Context, config SetupConfig, noPrompt, purge, withBill
 }
 
 func BuildCapabilities(ctx context.Context, config SetupConfig, noPrompt bool) error {
-	cfg, cfgErr := readConfig(config.ConfigPath)
+	cfg, cfgErr := ReadSetupConfig(config.ConfigPath)
 	if cfgErr != nil {
 		return errors.Wrap(cfgErr, "failed to read config")
 	}
@@ -674,7 +682,7 @@ func runGHSetupGit(ctx context.Context) error {
 	return nil
 }
 
-func makeCapabilities(ctx context.Context, capabilitiesConfig capabilitiesConfig, repoRootRelativePath string) ([]string, error) {
+func makeCapabilities(ctx context.Context, capabilitiesConfig CapabilitiesConfig, repoRootRelativePath string) ([]string, error) {
 	if len(capabilitiesConfig.MakeCommands) == 0 {
 		framework.L.Info().Msg("No make commands specified for capabilities. Skipping capabilities build.")
 		return nil, nil
@@ -753,8 +761,9 @@ func makeCapabilities(ctx context.Context, capabilitiesConfig capabilitiesConfig
 	return installedCapabilities, nil
 }
 
-func readConfig(configPath string) (*config, error) {
-	cfg := &config{}
+// ReadSetupConfig reads and parses the setup configuration from the given path
+func ReadSetupConfig(configPath string) (*SetupConfigFile, error) {
+	cfg := &SetupConfigFile{}
 
 	cfgBytes, err := os.ReadFile(configPath)
 	if err != nil {

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251124151448-0448aefdaab9
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204080016-11b6304dc841
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204092817-9352f89e16e7
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based v0.0.0-20251020210257-0a6ec41648b4

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251124151448-0448aefdaab9
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204103954-f8fb9ee775bb
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.20
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based v0.0.0-20251020210257-0a6ec41648b4

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251124151448-0448aefdaab9
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204092817-9352f89e16e7
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204103954-f8fb9ee775bb
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based v0.0.0-20251020210257-0a6ec41648b4

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251124151448-0448aefdaab9
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260203170017-cffa1e89a2fe
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based v0.0.0-20251020210257-0a6ec41648b4

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20251124151448-0448aefdaab9
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260203170017-cffa1e89a2fe
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204080016-11b6304dc841
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based v0.0.0-20251020210257-0a6ec41648b4

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1691,8 +1691,8 @@ github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260124000807-bff5e
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260124000807-bff5e296dfb7/go.mod h1:FbqbTFP9aBvE/2GDmfcFr/03HEWkzjP7OMmxdib26aY=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1 h1:JijOMT/94w/mt2q69vBQodliDlVfe+jqeaSTQJP3uxo=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1/go.mod h1:IQC7fXKDsFjD1vb0Jh83WWY4BCFhN1fkcn+z3oSuFIA=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204103954-f8fb9ee775bb h1:CR79GyxgVw8suQKQyMjyMNCJzmBdcmlRum2qob3fQdQ=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204103954-f8fb9ee775bb/go.mod h1:98jNYBOPuKWJw9a8x0LgQuudp5enrHhQQP5Hq0YwRB8=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.20 h1:8D2DUnn7mLUZOLhPDGGFKKvBrgU6LQd00tq2VOprvfI=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.20/go.mod h1:98jNYBOPuKWJw9a8x0LgQuudp5enrHhQQP5Hq0YwRB8=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5 h1:jARz/SWbmWoGJJGVcAnWwGMb8JuHRTQQsM3m6ZwrAGk=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1691,8 +1691,8 @@ github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260124000807-bff5e
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260124000807-bff5e296dfb7/go.mod h1:FbqbTFP9aBvE/2GDmfcFr/03HEWkzjP7OMmxdib26aY=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1 h1:JijOMT/94w/mt2q69vBQodliDlVfe+jqeaSTQJP3uxo=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1/go.mod h1:IQC7fXKDsFjD1vb0Jh83WWY4BCFhN1fkcn+z3oSuFIA=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19 h1:LFZkB/pc8SE+U13vsuCapnYqf1LPzeBsiWPUIQYiUkg=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19/go.mod h1:98jNYBOPuKWJw9a8x0LgQuudp5enrHhQQP5Hq0YwRB8=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260203170017-cffa1e89a2fe h1:/at0k3EjfzdzyC95FYLamx9g1Y3FT1/sydpC5xT5E44=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260203170017-cffa1e89a2fe/go.mod h1:98jNYBOPuKWJw9a8x0LgQuudp5enrHhQQP5Hq0YwRB8=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5 h1:jARz/SWbmWoGJJGVcAnWwGMb8JuHRTQQsM3m6ZwrAGk=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1691,8 +1691,8 @@ github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260124000807-bff5e
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260124000807-bff5e296dfb7/go.mod h1:FbqbTFP9aBvE/2GDmfcFr/03HEWkzjP7OMmxdib26aY=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1 h1:JijOMT/94w/mt2q69vBQodliDlVfe+jqeaSTQJP3uxo=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1/go.mod h1:IQC7fXKDsFjD1vb0Jh83WWY4BCFhN1fkcn+z3oSuFIA=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204092817-9352f89e16e7 h1:xCHj7gk2r8AJf0bXOj8B3R7T6Y3BIhU0BZ9jlchz6uM=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204092817-9352f89e16e7/go.mod h1:98jNYBOPuKWJw9a8x0LgQuudp5enrHhQQP5Hq0YwRB8=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204103954-f8fb9ee775bb h1:CR79GyxgVw8suQKQyMjyMNCJzmBdcmlRum2qob3fQdQ=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204103954-f8fb9ee775bb/go.mod h1:98jNYBOPuKWJw9a8x0LgQuudp5enrHhQQP5Hq0YwRB8=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5 h1:jARz/SWbmWoGJJGVcAnWwGMb8JuHRTQQsM3m6ZwrAGk=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1691,8 +1691,8 @@ github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260124000807-bff5e
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260124000807-bff5e296dfb7/go.mod h1:FbqbTFP9aBvE/2GDmfcFr/03HEWkzjP7OMmxdib26aY=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1 h1:JijOMT/94w/mt2q69vBQodliDlVfe+jqeaSTQJP3uxo=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1/go.mod h1:IQC7fXKDsFjD1vb0Jh83WWY4BCFhN1fkcn+z3oSuFIA=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204080016-11b6304dc841 h1:MxVoueUW0tRvFXDb5FJ8FODYYu7I01uFExVNAAxRhKE=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204080016-11b6304dc841/go.mod h1:98jNYBOPuKWJw9a8x0LgQuudp5enrHhQQP5Hq0YwRB8=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204092817-9352f89e16e7 h1:xCHj7gk2r8AJf0bXOj8B3R7T6Y3BIhU0BZ9jlchz6uM=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204092817-9352f89e16e7/go.mod h1:98jNYBOPuKWJw9a8x0LgQuudp5enrHhQQP5Hq0YwRB8=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5 h1:jARz/SWbmWoGJJGVcAnWwGMb8JuHRTQQsM3m6ZwrAGk=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1691,8 +1691,8 @@ github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260124000807-bff5e
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260124000807-bff5e296dfb7/go.mod h1:FbqbTFP9aBvE/2GDmfcFr/03HEWkzjP7OMmxdib26aY=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1 h1:JijOMT/94w/mt2q69vBQodliDlVfe+jqeaSTQJP3uxo=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1/go.mod h1:IQC7fXKDsFjD1vb0Jh83WWY4BCFhN1fkcn+z3oSuFIA=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260203170017-cffa1e89a2fe h1:/at0k3EjfzdzyC95FYLamx9g1Y3FT1/sydpC5xT5E44=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260203170017-cffa1e89a2fe/go.mod h1:98jNYBOPuKWJw9a8x0LgQuudp5enrHhQQP5Hq0YwRB8=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204080016-11b6304dc841 h1:MxVoueUW0tRvFXDb5FJ8FODYYu7I01uFExVNAAxRhKE=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.19-0.20260204080016-11b6304dc841/go.mod h1:98jNYBOPuKWJw9a8x0LgQuudp5enrHhQQP5Hq0YwRB8=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5 h1:jARz/SWbmWoGJJGVcAnWwGMb8JuHRTQQsM3m6ZwrAGk=

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -105,7 +105,6 @@ func GetEVMEnabledChains(t *testing.T, testEnv *ttypes.TestEnvironment) map[stri
 
 	enabledChains := map[string]struct{}{}
 	for _, nodeSet := range testEnv.Config.NodeSets {
-
 		enabledChainIDs, err := nodeSet.GetEnabledChainIDsForCapability(cre.EVMCapability)
 		require.NoError(t, err, "failed to get enabled chain IDs for EVM capability")
 


### PR DESCRIPTION
**Summary**
This PR fixes a versioning issue with Beholder Docker images (chip-ingress, chip-config) by replacing mutable local-cre tags with immutable commit-based tags. This prevents hard-to-debug issues caused by version mismatches when images are built from source or pulled images are removed.

**Problem**
Previously, images used a mutable local-cre tag that could point to any version. There was no way to verify if the locally available image matched what was defined in setup.toml, causing subtle bugs when:
* Images were built from different commits
* Pulled images were removed and re-pulled
* Multiple developers had different local versions

**Solution**
Commit-based image tags: Images now use commit hashes as tags (e.g., chip-ingress:da84cb72d3a160e02896247d46ab4b9806ebee2f)
Auto-build/pull on beholder start: When starting Beholder, the system checks if required images exist with correct versions:
* **CI** `(CI=true)`: Skips checks (docker-compose pulls at runtime)
* **Non-interactive + `AWS_ECR` set**: Auto-pulls from ECR
* **Non-interactive without `AWS_ECR`**: Fails with helpful instructions
* **Interactive terminal**: Builds from source, offers to pull if build fails
Environment variables for docker-compose: Sets `CHIP_INGRESS_IMAGE` and `CHIP_CONFIG_IMAGE` env vars for docker-compose to use

**Changes**
* `configs/setup.toml`: Use commit-based tags instead of local-cre
* `environment/setup.go`: Export config types for shared use
* `environment/beholder.go`: Add image verification, auto-build/pull logic
* `README.md`: Document new image handling behavior