### PR TITLE
Add Cursor CI-fix skill and gh/git/go rules

### DIFF
--- a/.cursor/rules/gh-cli.mdc
+++ b/.cursor/rules/gh-cli.mdc
@@ -1,0 +1,131 @@
+---
+description: GitHub CLI (gh) usage patterns and safety rules for Chainlink work (PRs, checks, Actions runs, search, and GitHub API queries).
+alwaysApply: true
+---
+
+# GitHub CLI (`gh`) Rules
+
+Use `gh` as the default way to inspect PRs, CI failures, and repo history. If GitHub MCP calls fail, fall back to `gh`.
+
+## Auth / safety
+
+- If GitHub SSH auth prompts or appears stuck, **touch the YubiKey**. Never bypass signing/auth.
+- Treat `gh` as **read-only by default** unless the user explicitly confirms state-changing actions.
+  - OK (read-only): `gh pr view`, `gh pr checks`, `gh repo view`, `gh search prs`, `gh search code`, `gh api ...` (GET)
+  - Needs explicit confirmation: `gh pr create`, `gh pr merge`, `gh repo fork`, rerunning/dispatching workflows, or any other write operation
+
+## PR search (current repo vs cross-repo)
+
+Two main commands:
+- `gh pr list` (current repo)
+- `gh search prs` (across repos/orgs)
+
+Useful filters:
+- State: `--state open|closed|merged|all` (note: `gh pr list` supports `all`)
+- Sorting: `--sort updated|created|comments`
+
+Common patterns:
+
+```bash
+# Current repo PRs
+gh pr list --author <username> --state all --limit 50
+
+# Org-wide PR search
+gh search prs --owner smartcontractkit --author <username> --limit 50
+
+# Keyword search (org-wide)
+gh search prs --owner smartcontractkit "<keyword>" --author <username> --limit 50
+
+# Specific repo search
+gh search prs --repo smartcontractkit/<repo-name> --author <username> --limit 50
+```
+
+Defaults:
+- Always specify `--limit`
+- Prefer `--owner smartcontractkit` for org-wide searches
+
+## Repo browsing / cloning (when needed)
+
+Before cloning, check if it already exists under `~/repos/`. Prefer `gh repo clone` when cloning via GitHub.
+
+```bash
+gh repo clone smartcontractkit/chainlink ~/repos/chainlink
+```
+
+## Inspect a PR (metadata, diffs, checks)
+
+```bash
+# Core PR facts (branch/base/mergeability)
+gh pr view <pr> --json url,title,headRefName,baseRefName,mergeable,headRefOid \
+  --jq '{url,title,head:.headRefName,base:.baseRefName,mergeable,sha:.headRefOid}'
+
+# Required checks (and watch)
+gh pr checks <pr> --required
+gh pr checks <pr> --watch --fail-fast
+```
+
+## GitHub Actions runs (logs + reruns)
+
+```bash
+# Find recent PR runs for a head branch
+HEAD_BRANCH="$(gh pr view <pr> --json headRefName --jq .headRefName)"
+gh run list --branch "$HEAD_BRANCH" --event pull_request -L 10 \
+  --json databaseId,workflowName,status,conclusion,createdAt,url \
+  --jq '.[] | {id:.databaseId, workflow:.workflowName, status, conclusion, createdAt, url}'
+
+# View failing logs
+gh run view <run-id> --log-failed
+
+# Rerun only failed jobs (requires confirmation)
+gh run rerun <run-id> --failed
+
+# Rerun a specific job by databaseId (requires confirmation)
+gh run view <run-id> --json jobs --jq '.jobs[] | {name, databaseId, conclusion}'
+gh run rerun <run-id> --job <databaseId>
+```
+
+## GitHub API (`gh api`) for history and path-based investigation
+
+Use `gh api` with `--jq` for structured outputs.
+
+```bash
+# Recent commits touching a path (example time window: last 7 days, UTC; macOS date)
+gh api repos/smartcontractkit/chainlink/commits \
+  -f path="<path>" \
+  -f since="$(date -v-7d -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --jq '.[] | "\(.commit.committer.date) \(.sha[0:7]) \(.commit.message | split("\n")[0])"'
+
+# View commit details (files + message)
+gh api repos/smartcontractkit/chainlink/commits/<sha> \
+  --jq '{message: .commit.message, author: .commit.author.name, date: .commit.committer.date, files: [.files[].filename]}'
+```
+
+## Browsing paths without cloning
+
+For large repos, discover paths before cloning/sparse checkout:
+
+```bash
+gh api repos/smartcontractkit/<repo>/contents/path/to/check --jq '.[].path'
+gh browse -n smartcontractkit/<repo> -- path/to/subdir
+```
+
+## Wiki pages
+
+GitHub wikis are **not** available via `gh api` (REST/GraphQL). Practical options:
+
+- Print/open the wiki URL:
+
+```bash
+gh browse -n smartcontractkit/chainlink/wiki/Code-Style-Guide
+```
+
+- Fetch the wiki markdown via git (wiki repo):
+
+```bash
+git clone --depth 1 https://github.com/smartcontractkit/chainlink.wiki.git
+```
+
+## PR creation hygiene (if explicitly requested)
+
+- Draft title/body first; wait for explicit confirmation before running `gh pr create`.
+- Never include Cursor attribution in PR titles/descriptions (e.g. “Made with Cursor”).

--- a/.cursor/rules/git.mdc
+++ b/.cursor/rules/git.mdc
@@ -1,0 +1,54 @@
+---
+description: Git workflow and safety rules for working in smartcontractkit/chainlink (staging discipline, rebasing/conflict resolution, worktrees, and non-destructive defaults).
+alwaysApply: true
+---
+
+# Git Rules (Chainlink)
+
+## Safety + auth
+
+- If SSH auth or commit signing prompts/hangs, **touch the YubiKey**. Never bypass signing/auth.
+- Prefer non-destructive commands. Avoid rewriting history unless necessary.
+- Never run destructive commands (`git reset --hard`, `git clean -fd`, force push) unless the user explicitly confirms.
+
+## Repo hygiene
+
+- Before cloning anything, check `~/repos/` first.
+- Prefer `git worktree` over extra clones when juggling multiple branches.
+  - Naming convention: `~/repos/chainlink.wt/{branch-name}`
+
+## Keeping branches up to date (conflicts)
+
+- Prefer rebasing your feature branch onto the base branch (usually `develop`) when resolving merge conflicts:
+
+```bash
+git fetch origin develop
+git rebase origin/develop
+```
+
+- During conflicts:
+  - `git status` to list unmerged paths
+  - resolve conflict markers, keep intended behavior
+  - `git add <files>`
+  - `git rebase --continue`
+
+- If you must update a rebased branch on the remote, use `--force-with-lease` (never plain `--force`) and only with explicit confirmation.
+
+## Staging + commits
+
+- Always review:
+  - `git status`
+  - `git diff`
+  - `git diff --staged`
+- Stage **only** the files you intend to change:
+  - Prefer `git add <specific-file>` (never `git add .` / `git add -A` if there are pre-existing changes).
+- Do not create commits unless explicitly asked.
+  - When asked, propose a short commit title first; add a description only if requested.
+
+## Diffs / reporting
+
+- When showing diffs with stats, avoid truncated paths:
+
+```bash
+git diff --stat=200
+```

--- a/.cursor/rules/go.mdc
+++ b/.cursor/rules/go.mdc
@@ -1,0 +1,48 @@
+---
+description: Go (Golang) coding and testing guidelines for smartcontractkit/chainlink changes, optimized for CI-driven fixes (minimal diffs, explicit errors, gofmt, and targeted tests).
+alwaysApply: true
+---
+
+# Go Guidelines (Chainlink)
+
+## Style + correctness
+
+- Use idiomatic Go. Keep code simple and readable.
+- Keep functions small and focused.
+- Handle errors explicitly; wrap with context when returning.
+- Avoid global mutable state; pass dependencies explicitly.
+- Always format Go code with `gofmt` (and `goimports` when imports change).
+
+## Tests
+
+- Add the minimal tests needed for confidence:
+  - golden path first
+  - then common failure cases
+- Prefer deterministic tests; avoid sleeps/time-based flakiness.
+- When debugging CI, run targeted tests locally when possible:
+
+```bash
+go test ./path/to/pkg -run TestName -count=1
+```
+
+## Modules (Chainlink-specific)
+
+Chainlink has multiple Go modules (root, `integration-tests`, `core/scripts`). When CI errors mention `go.mod`/`go.sum` or dependency drift:
+
+- Prefer the repo helper to keep all modules tidy:
+
+```bash
+make gomodtidy
+```
+
+## Before pushing CI fixes
+
+- `git diff` should show only intended changes.
+- Go files should be formatted.
+- If you touched dependencies, `go.mod`/`go.sum` changes should be consistent across modules.
+
+## References
+
+- Chainlink wiki: [Code Style Guide](https://github.com/smartcontractkit/chainlink/wiki/Code-Style-Guide)
+- Go team: [CodeReviewComments](https://go.dev/wiki/CodeReviewComments)
+- Go team: [Effective Go](https://go.dev/doc/effective_go)

--- a/.cursor/skills/fix-chainlink-ci/SKILL.md
+++ b/.cursor/skills/fix-chainlink-ci/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: fix-chainlink-ci
+description: Triage and fix Chainlink GitHub Actions CI failures for pull requests (smartcontractkit/chainlink), focusing on merge conflicts/rebases, gofmt/gomod issues, failing Go tests, and flaky jobs. Use when the user mentions Chainlink CI, GitHub Actions, failing checks, merge conflicts, rebasing, flaky tests, or rerunning workflows.
+---
+
+# Fix Chainlink CI (GitHub Actions)
+
+## Goal
+
+Get a Chainlink PR to green by iterating: **inspect failing checks → classify cause → apply minimal fix → push → watch → rerun flakes**.
+
+This is optimized for Chainlink’s typical pain points (high-churn files + multiple Go modules), e.g. PR #20708 touches `core/config/toml/types.go`, `docs/CONFIG.md`, and multiple `go.mod`/`go.sum` files and is a good “conflict magnet” example.
+
+## Quick start
+
+1. Work in `~/repos/chainlink` (or use `-R smartcontractkit/chainlink` with `gh` commands).
+2. Collect facts:
+   - `gh pr view <pr> --json url,title,headRefName,baseRefName,mergeable --jq '{url,title,head:.headRefName,base:.baseRefName,mergeable}'`
+   - `gh pr checks <pr> --required`
+   - Optional (for local fixes): `gh pr checkout <pr>`
+3. For the first failure, prefer: `gh pr checks <pr> --watch --fail-fast`
+4. Fix by category (below), push, then watch again until green.
+
+## Workflow (loop until green)
+
+### 1) Snapshot: what’s failing?
+
+- Use `gh pr checks <pr> --required` to list required checks + links.
+- If you need logs, identify the workflow run for the current head SHA/branch, then:
+  - `gh run view <run-id> --log-failed`
+
+### 2) Classify and fix
+
+#### A) Merge conflict / PR not mergeable
+
+Signals:
+- `gh pr view <pr> --json mergeable --jq .mergeable` returns `CONFLICTING`, or UI says “has conflicts”.
+- A workflow that checks mergeability fails, or checkout of PR merge ref fails.
+
+Default fix (rebase onto base, usually `develop`):
+- `git fetch origin <base>`
+- `git rebase origin/<base>`
+- Resolve conflicts (repeat until rebase completes):
+  - `git status` → identify unmerged paths
+  - edit files, remove conflict markers, keep intended behavior
+  - `git add <files>`
+  - `git rebase --continue`
+- If the rebase requires rewriting history, push with `--force-with-lease` (never plain `--force`). If session rules require it, propose the exact command and wait for explicit confirmation.
+
+Chainlink-specific tips:
+- Conflicts commonly cluster in “high churn” files like `docs/CONFIG.md`, `core/config/toml/types.go`, and workflow syncer code under `core/services/workflows/...` (PR #20708 touches all of these).
+- If conflicts involve `go.mod`/`go.sum`, finish the merge, then run the module tidy step (see C).
+
+#### B) Lint / formatting
+
+Signals:
+- `gofmt`/`goimports` diffs, lint failures, or “files not formatted”.
+
+Fix:
+- Run the exact formatter/lint command shown in CI logs (preferred).
+- For Go formatting, ensure files are gofmt’d before committing.
+
+#### C) Go module / go.sum mismatch
+
+Signals:
+- CI complains `go.mod`/`go.sum` are dirty, `go list` errors, missing sums, or “tidy required”.
+
+Fix:
+- Chainlink has multiple Go modules; use the repo’s tidy helper when available:
+  - `make gomodtidy`
+- Otherwise run `go mod tidy` in each relevant module directory and commit resulting `go.mod`/`go.sum` updates.
+
+#### D) Deterministic test failure (unit/integration)
+
+Signals:
+- Same test fails consistently; stack trace/assertion points to code.
+
+Fix:
+- Use `gh run view <run-id> --log-failed` to get the failing package/test name.
+- Reproduce locally if feasible (copy the command from CI), otherwise make a minimal fix and rely on CI.
+- Run a targeted test locally when possible (e.g., `go test ./path/to/pkg -run TestName -count=1`).
+- When editing Go code, follow the repo Go guidelines (`.cursor/rules/go.mdc`): minimal diffs, explicit errors, gofmt/goimports, and minimal tests.
+
+#### E) Flake / CI infrastructure noise
+
+Signals (common):
+- timeouts, transient network errors, runner failures, Docker pull flakes, “connection reset”, “context deadline exceeded”.
+- A test that passes on rerun without code changes.
+
+Fix:
+- Don’t push “retry-only” commits.
+- Wait for the run to finish, then rerun failed jobs (state-changing; get explicit confirmation if required by session rules):
+  - `gh run rerun <run-id> --failed`
+- If only a single job is flaky, rerun just that job using its database ID:
+  - `gh run view <run-id> --json jobs --jq '.jobs[] | {name, databaseId, conclusion}'`
+  - `gh run rerun <run-id> --job <databaseId>`
+- After triggering a rerun, watch it:
+  - `gh run watch <run-id> --exit-status`
+
+### 3) Push + watch
+
+- After applying a real fix, push the branch (respect repo/session rules on committing and force-pushing).
+- Watch required checks:
+  - `gh pr checks <pr> --watch`
+- If you’re in a “conflict chain” (fix → new conflict → fix), repeat from snapshot.
+
+## Guardrails
+
+- Never bypass signing/hooks/auth (`--no-verify`, disabling GPG, etc.).
+- If git/SSH auth or signing prompts appear stuck, remind the user to touch the YubiKey.
+- Prefer minimal, mechanical fixes; avoid refactors while in “make CI green” mode.
+
+## Additional resources
+
+- Command cookbook: [reference.md](reference.md)
+- Worked example (PR #20708): [examples.md](examples.md)

--- a/.cursor/skills/fix-chainlink-ci/examples.md
+++ b/.cursor/skills/fix-chainlink-ci/examples.md
@@ -1,0 +1,77 @@
+# Examples
+
+## Example: PR #20708 (“Supporting Private Workflow Registry”)
+
+PR #20708 is a good stress-test example because it touches:
+- “high churn” config/docs (`core/config/toml/types.go`, `docs/CONFIG.md`)
+- workflow syncer code (`core/services/workflows/syncer/v2/...`)
+- multiple Go module files (`core/scripts/go.mod`, `system-tests/lib/go.mod`, `system-tests/lib/go.sum`, etc.)
+
+### 1) Triage failing checks
+
+```bash
+gh pr view 20708 --json url,title,headRefName,baseRefName,mergeable \
+  --jq '{url,title,head:.headRefName,base:.baseRefName,mergeable}'
+gh pr checks 20708 --required
+```
+
+If you want quick feedback:
+
+```bash
+gh pr checks 20708 --watch --fail-fast
+```
+
+### 2) Merge conflict loop (illustrative)
+
+If `mergeable` is `CONFLICTING` (or a mergeability check fails), rebase onto `develop`:
+
+```bash
+git fetch origin develop
+git checkout feat/multi-source-workflows
+git rebase origin/develop
+```
+
+Resolve conflicts in the most common hotspots for this PR:
+- `core/config/toml/types.go` (new `AdditionalWorkflowSource` TOML config)
+- `docs/CONFIG.md` / `core/config/docs/core.toml` (docs move a lot on `develop`)
+- `core/services/workflows/syncer/v2/workflow_registry.go` (large file, frequent churn)
+
+After conflict resolution:
+
+```bash
+git add <files>
+git rebase --continue
+```
+
+Then run module tidy (PR #20708 updates module files):
+
+```bash
+make gomodtidy
+```
+
+Push (rebase requires history rewrite):
+
+```bash
+git push --force-with-lease
+```
+
+### 3) Flake loop (illustrative)
+
+If a job flakes (timeouts/runner issues/transient network), rerun failed jobs instead of pushing a “retry” commit.
+
+Find the newest PR run for the head branch:
+
+```bash
+HEAD_BRANCH="$(gh pr view 20708 --json headRefName --jq .headRefName)"
+gh run list --branch "$HEAD_BRANCH" --event pull_request -L 3 \
+  --json databaseId,workflowName,status,conclusion,url \
+  --jq '.[] | {id:.databaseId, workflow:.workflowName, status, conclusion, url}'
+```
+
+View the failing logs and rerun:
+
+```bash
+gh run view <run-id> --log-failed
+gh run rerun <run-id> --failed
+gh run watch <run-id> --exit-status
+```

--- a/.cursor/skills/fix-chainlink-ci/reference.md
+++ b/.cursor/skills/fix-chainlink-ci/reference.md
@@ -1,0 +1,132 @@
+# Reference: Chainlink CI fix cookbook
+
+This file is intentionally “copy/paste friendly” for debugging Chainlink PR CI on GitHub Actions.
+
+## Work in the right repo
+
+```bash
+cd ~/repos/chainlink
+```
+
+If you’re not in the repo, pass `-R smartcontractkit/chainlink` to `gh` commands.
+
+## PR facts (mergeability + branches)
+
+```bash
+gh pr view <pr> --json url,title,headRefName,baseRefName,mergeable,headRefOid \
+  --jq '{url,title,head:.headRefName,base:.baseRefName,mergeable,sha:.headRefOid}'
+```
+
+## Checkout / diff (optional but handy)
+
+```bash
+gh pr checkout <pr>
+gh pr diff <pr>
+gh pr view <pr> --json files --jq '.files[].path'
+```
+
+## List required checks
+
+```bash
+gh pr checks <pr> --required
+```
+
+Watch until completion (fast feedback):
+
+```bash
+gh pr checks <pr> --watch --fail-fast
+```
+
+## Find the workflow run for a PR head branch
+
+```bash
+HEAD_BRANCH="$(gh pr view <pr> --json headRefName --jq .headRefName)"
+gh run list --branch "$HEAD_BRANCH" --event pull_request -L 10 \
+  --json databaseId,workflowName,status,conclusion,createdAt,url \
+  --jq '.[] | {id:.databaseId, workflow:.workflowName, status, conclusion, createdAt, url}'
+```
+
+## View failing logs
+
+```bash
+gh run view <run-id> --log-failed
+```
+
+If you need job-level drilldown:
+
+```bash
+gh run view <run-id> --json jobs --jq '.jobs[] | {name, databaseId, status, conclusion}'
+gh run view <run-id> --log-failed --job <databaseId>
+```
+
+## Rerun (flakes)
+
+Rerun only failed jobs:
+
+```bash
+gh run rerun <run-id> --failed
+```
+
+Rerun a specific job (note: must use `databaseId`, not the number from the URL):
+
+```bash
+gh run view <run-id> --json jobs --jq '.jobs[] | {name, databaseId, conclusion}'
+gh run rerun <run-id> --job <databaseId>
+```
+
+Watch:
+
+```bash
+gh run watch <run-id> --exit-status
+```
+
+## Merge conflict / rebase loop
+
+Fetch + rebase onto base (usually `develop`):
+
+```bash
+git fetch origin develop
+git rebase origin/develop
+```
+
+During conflicts:
+
+```bash
+git status
+git add <files>
+git rebase --continue
+```
+
+Abort if you need to restart:
+
+```bash
+git rebase --abort
+```
+
+After a rebase, update the PR branch (use `--force-with-lease`, never `--force`):
+
+```bash
+git push --force-with-lease
+```
+
+## Go module hygiene (Chainlink-specific)
+
+Chainlink has multiple Go modules. Prefer the repo helper:
+
+```bash
+make gomodtidy
+```
+
+## Local test quickies
+
+Run all Go tests:
+
+```bash
+go test ./...
+```
+
+Run a targeted package/test:
+
+```bash
+go test ./path/to/pkg -run TestName -count=1
+```

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,28 @@
+# Secrets / env
+.env
+.envrc
+.env.*
+.envrc.*
+!.env.example
+!.envrc.example
+!.github/actions/setup-postgres/.env
+.dbenv
+debug.env
+credentials.env
+secrets.toml
+
+# Credentials and keys
+*.pem
+*.key
+*.crt
+*.cert
+*.p12
+*.pfx
+
+# Cloud config that contains credentials
+.aws/
+.kube/config
+
+# Large dependency dirs / caches
+node_modules/
+.pnpm-store/


### PR DESCRIPTION
## Summary
- Add a Cursor skill to triage/fix Chainlink GitHub Actions CI failures (merge conflicts, gomod/gofmt, deterministic failures, flakes).
- Add project-local Cursor rules for `gh`, `git`, and Go style/testing references.
- Add `.cursorignore` baseline to avoid indexing secrets and heavy dependency dirs.

## Usage

If CI is red, you can use the Cursor command `/fix-chainlink-ci` with a PR link or failing job/run link to triage and suggest the minimal fix.

- **Prereqs**: authenticated `gh` CLI; local repo checkout (`~/repos/chainlink`)
- **Usage**: `/fix-chainlink-ci <PR URL | PR number | failing Actions job/run URL>`
- **Loop**: run → apply minimal fix (rebase / gofmt / gomod tidy / targeted test fix) → run again until green
- **Flakes**: prefer rerunning failed jobs; avoid “retry-only” commits

**Examples**
- `/fix-chainlink-ci https://github.com/smartcontractkit/chainlink/pull/20708`
- `/fix-chainlink-ci https://github.com/smartcontractkit/chainlink/actions/runs/<run-id>/job/<job-id>`