### PR TITLE
[CRE-491] Extract EVM relay specific config for functions.

### DIFF
--- a/core/services/ocr2/plugins/functions/config/config.go
+++ b/core/services/ocr2/plugins/functions/config/config.go
@@ -16,19 +16,14 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/functions/allowlist"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/functions/subscriptions"
 	s4PluginConfig "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/s4"
+	relayConfig "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/functions/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/s4"
 )
 
 // This config is part of the job spec and is loaded only once on node boot/job creation.
 type PluginConfig struct {
+	relayConfig.RelayConfig
 	EnableRequestSignatureCheck              bool                                      `json:"enableRequestSignatureCheck"`
-	DONID                                    string                                    `json:"donID"`
-	ContractVersion                          uint32                                    `json:"contractVersion"`
-	MinRequestConfirmations                  uint32                                    `json:"minRequestConfirmations"`
-	MinResponseConfirmations                 uint32                                    `json:"minResponseConfirmations"`
-	MinIncomingConfirmations                 uint32                                    `json:"minIncomingConfirmations"`
-	PastBlocksToPoll                         uint32                                    `json:"pastBlocksToPoll"`
-	LogPollerCacheDurationSec                uint32                                    `json:"logPollerCacheDurationSec"` // Duration to cache previously detected request or response logs such that they can be filtered when calling logpoller_wrapper.LatestEvents()
 	RequestTimeoutSec                        uint32                                    `json:"requestTimeoutSec"`
 	RequestTimeoutCheckFrequencySec          uint32                                    `json:"requestTimeoutCheckFrequencySec"`
 	RequestTimeoutBatchLookupSize            uint32                                    `json:"requestTimeoutBatchLookupSize"`
@@ -37,7 +32,6 @@ type PluginConfig struct {
 	PruneBatchSize                           uint32                                    `json:"pruneBatchSize"`
 	ListenerEventHandlerTimeoutSec           uint32                                    `json:"listenerEventHandlerTimeoutSec"`
 	ListenerEventsCheckFrequencyMillis       uint32                                    `json:"listenerEventsCheckFrequencyMillis"`
-	ContractUpdateCheckFrequencySec          uint32                                    `json:"contractUpdateCheckFrequencySec"`
 	MaxRequestSizeBytes                      uint32                                    `json:"maxRequestSizeBytes"`
 	MaxRequestSizesList                      []uint32                                  `json:"maxRequestSizesList"`
 	MaxSecretsSizesList                      []uint32                                  `json:"maxSecretsSizesList"`

--- a/core/services/relay/evm/functions.go
+++ b/core/services/relay/evm/functions.go
@@ -20,8 +20,8 @@ import (
 	txm "github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/functions/config"
-	functionsRelay "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/functions"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/functions"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/functions/config"
 )
 
 type functionsProvider struct {
@@ -80,7 +80,7 @@ func (p *functionsProvider) Codec() commontypes.Codec {
 	return nil
 }
 
-func NewFunctionsProvider(ctx context.Context, chain legacyevm.Chain, rargs commontypes.RelayArgs, pargs commontypes.PluginArgs, lggr logger.Logger, ethKeystore keys.Store, pluginType functionsRelay.FunctionsPluginType) (evmconfig.FunctionsProvider, error) {
+func NewFunctionsProvider(ctx context.Context, chain legacyevm.Chain, rargs commontypes.RelayArgs, pargs commontypes.PluginArgs, lggr logger.Logger, ethKeystore keys.Store, pluginType functions.FunctionsPluginType) (evmconfig.FunctionsProvider, error) {
 	relayOpts := evmconfig.NewRelayOpts(rargs)
 	relayConfig, err := relayOpts.RelayConfig()
 	if err != nil {
@@ -96,12 +96,12 @@ func NewFunctionsProvider(ctx context.Context, chain legacyevm.Chain, rargs comm
 	if !common.IsHexAddress(rargs.ContractID) {
 		return nil, errors.Errorf("invalid contractID, expected hex address")
 	}
-	var pluginConfig config.PluginConfig
-	if err2 := json.Unmarshal(pargs.PluginConfig, &pluginConfig); err2 != nil {
+	var relayFunctionsConfig config.RelayConfig
+	if err2 := json.Unmarshal(pargs.PluginConfig, &relayFunctionsConfig); err2 != nil {
 		return nil, err2
 	}
 	routerContractAddress := common.HexToAddress(rargs.ContractID)
-	logPollerWrapper, err := functionsRelay.NewLogPollerWrapper(routerContractAddress, pluginConfig, chain.Client(), chain.LogPoller(), lggr)
+	logPollerWrapper, err := functions.NewLogPollerWrapper(routerContractAddress, relayFunctionsConfig, chain.Client(), chain.LogPoller(), lggr)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func NewFunctionsProvider(ctx context.Context, chain legacyevm.Chain, rargs comm
 	}
 	var contractTransmitter transmitter.ContractTransmitter
 	if relayConfig.SendingKeys != nil {
-		contractTransmitter, err = newFunctionsContractTransmitter(ctx, pluginConfig.ContractVersion, rargs, pargs.TransmitterID, configWatcher, ethKeystore, logPollerWrapper, lggr)
+		contractTransmitter, err = newFunctionsContractTransmitter(ctx, relayFunctionsConfig.ContractVersion, rargs, pargs.TransmitterID, configWatcher, ethKeystore, logPollerWrapper, lggr)
 		if err != nil {
 			return nil, err
 		}
@@ -121,20 +121,20 @@ func NewFunctionsProvider(ctx context.Context, chain legacyevm.Chain, rargs comm
 	return newFunctionsProvider(lggr, configWatcher, contractTransmitter, logPollerWrapper), nil
 }
 
-func newFunctionsConfigProvider(ctx context.Context, pluginType functionsRelay.FunctionsPluginType, chain legacyevm.Chain, args commontypes.RelayArgs, fromBlock uint64, logPollerWrapper evmconfig.LogPollerWrapper, lggr logger.Logger) (*configWatcher, error) {
+func newFunctionsConfigProvider(ctx context.Context, pluginType functions.FunctionsPluginType, chain legacyevm.Chain, args commontypes.RelayArgs, fromBlock uint64, logPollerWrapper evmconfig.LogPollerWrapper, lggr logger.Logger) (*configWatcher, error) {
 	if !common.IsHexAddress(args.ContractID) {
 		return nil, errors.Errorf("invalid contractID, expected hex address")
 	}
 
 	routerContractAddress := common.HexToAddress(args.ContractID)
 
-	cp, err := functionsRelay.NewFunctionsConfigPoller(pluginType, chain.LogPoller(), lggr)
+	cp, err := functions.NewFunctionsConfigPoller(pluginType, chain.LogPoller(), lggr)
 	if err != nil {
 		return nil, err
 	}
 	logPollerWrapper.SubscribeToUpdates(ctx, "FunctionsConfigPoller", cp)
 
-	offchainConfigDigester := functionsRelay.NewFunctionsOffchainConfigDigester(pluginType, chain.ID().Uint64())
+	offchainConfigDigester := functions.NewFunctionsOffchainConfigDigester(pluginType, chain.ID().Uint64())
 	logPollerWrapper.SubscribeToUpdates(ctx, "FunctionsOffchainConfigDigester", offchainConfigDigester)
 
 	return newConfigWatcher(lggr, routerContractAddress, offchainConfigDigester, cp, chain, fromBlock, args.New), nil
@@ -182,7 +182,7 @@ func newFunctionsContractTransmitter(ctx context.Context, contractVersion uint32
 		gasLimit = uint64(*ocr2Limit)
 	}
 
-	functionsTransmitter, err := functionsRelay.NewFunctionsContractTransmitter(
+	functionsTransmitter, err := functions.NewFunctionsContractTransmitter(
 		configWatcher.chain.Client(),
 		OCR2AggregatorTransmissionContractABI,
 		configWatcher.chain.LogPoller(),

--- a/core/services/relay/evm/functions/config/config.go
+++ b/core/services/relay/evm/functions/config/config.go
@@ -1,0 +1,12 @@
+package config
+
+type RelayConfig struct {
+	MinIncomingConfirmations        uint32 `json:"minIncomingConfirmations"`
+	MinRequestConfirmations         uint32 `json:"minRequestConfirmations"`
+	MinResponseConfirmations        uint32 `json:"minResponseConfirmations"`
+	LogPollerCacheDurationSec       uint32 `json:"logPollerCacheDurationSec"` // Duration to cache previously detected request or response logs such that they can be filtered when calling logpoller_wrapper.LatestEvents()
+	PastBlocksToPoll                uint32 `json:"pastBlocksToPoll"`
+	DONID                           string `json:"donID"`
+	ContractVersion                 uint32 `json:"contractVersion"`
+	ContractUpdateCheckFrequencySec uint32 `json:"contractUpdateCheckFrequencySec"`
+}

--- a/core/services/relay/evm/functions/config_poller.go
+++ b/core/services/relay/evm/functions/config_poller.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config"
-
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 )
 

--- a/core/services/relay/evm/functions/logpoller_wrapper.go
+++ b/core/services/relay/evm/functions/logpoller_wrapper.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
-	evmconfig "github.com/smartcontractkit/chainlink-evm/pkg/config"
-
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/functions/generated/functions_coordinator"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/functions/generated/functions_router"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
+	evmconfig "github.com/smartcontractkit/chainlink-evm/pkg/config"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/functions/config"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/functions/config"
 )
 
 type logPollerWrapper struct {
@@ -26,7 +26,7 @@ type logPollerWrapper struct {
 	eng *services.Engine
 
 	routerContract            *functions_router.FunctionsRouter
-	pluginConfig              config.PluginConfig
+	relayConfig               config.RelayConfig
 	client                    client.Client
 	logPoller                 logpoller.LogPoller
 	subscribers               map[string]evmconfig.RouteUpdateSubscriber
@@ -57,44 +57,44 @@ const maxLogsToProcess = 1000
 
 var _ evmconfig.LogPollerWrapper = &logPollerWrapper{}
 
-func NewLogPollerWrapper(routerContractAddress common.Address, pluginConfig config.PluginConfig, client client.Client, logPoller logpoller.LogPoller, lggr logger.Logger) (evmconfig.LogPollerWrapper, error) {
+func NewLogPollerWrapper(routerContractAddress common.Address, relayConfig config.RelayConfig, client client.Client, logPoller logpoller.LogPoller, lggr logger.Logger) (evmconfig.LogPollerWrapper, error) {
 	routerContract, err := functions_router.NewFunctionsRouter(routerContractAddress, client)
 	if err != nil {
 		return nil, err
 	}
-	blockOffset := int64(pluginConfig.MinIncomingConfirmations) - 1
+	blockOffset := int64(relayConfig.MinIncomingConfirmations) - 1
 	if blockOffset < 0 {
-		lggr.Warnw("invalid minIncomingConfirmations, using 1 instead", "minIncomingConfirmations", pluginConfig.MinIncomingConfirmations)
+		lggr.Warnw("invalid minIncomingConfirmations, using 1 instead", "minIncomingConfirmations", relayConfig.MinIncomingConfirmations)
 		blockOffset = 0
 	}
-	requestBlockOffset := int64(pluginConfig.MinRequestConfirmations) - 1
+	requestBlockOffset := int64(relayConfig.MinRequestConfirmations) - 1
 	if requestBlockOffset < 0 {
-		lggr.Warnw("invalid minRequestConfirmations, using minIncomingConfirmations instead", "minRequestConfirmations", pluginConfig.MinRequestConfirmations)
+		lggr.Warnw("invalid minRequestConfirmations, using minIncomingConfirmations instead", "minRequestConfirmations", relayConfig.MinRequestConfirmations)
 		requestBlockOffset = blockOffset
 	}
-	responseBlockOffset := int64(pluginConfig.MinResponseConfirmations) - 1
+	responseBlockOffset := int64(relayConfig.MinResponseConfirmations) - 1
 	if responseBlockOffset < 0 {
-		lggr.Warnw("invalid minResponseConfirmations, using minIncomingConfirmations instead", "minResponseConfirmations", pluginConfig.MinResponseConfirmations)
+		lggr.Warnw("invalid minResponseConfirmations, using minIncomingConfirmations instead", "minResponseConfirmations", relayConfig.MinResponseConfirmations)
 		responseBlockOffset = blockOffset
 	}
-	logPollerCacheDurationSec := int64(pluginConfig.LogPollerCacheDurationSec)
+	logPollerCacheDurationSec := int64(relayConfig.LogPollerCacheDurationSec)
 	if logPollerCacheDurationSec <= 0 {
 		lggr.Warnw("invalid logPollerCacheDuration, using 300 instead", "logPollerCacheDurationSec", logPollerCacheDurationSec)
 		logPollerCacheDurationSec = logPollerCacheDurationSecDefault
 	}
-	pastBlocksToPoll := int64(pluginConfig.PastBlocksToPoll)
+	pastBlocksToPoll := int64(relayConfig.PastBlocksToPoll)
 	if pastBlocksToPoll <= 0 {
 		lggr.Warnw("invalid pastBlocksToPoll, using 50 instead", "pastBlocksToPoll", pastBlocksToPoll)
 		pastBlocksToPoll = pastBlocksToPollDefault
 	}
 	if blockOffset >= pastBlocksToPoll || requestBlockOffset >= pastBlocksToPoll || responseBlockOffset >= pastBlocksToPoll {
-		lggr.Errorw("invalid config: number of required confirmation blocks >= pastBlocksToPoll", "pastBlocksToPoll", pastBlocksToPoll, "minIncomingConfirmations", pluginConfig.MinIncomingConfirmations, "minRequestConfirmations", pluginConfig.MinRequestConfirmations, "minResponseConfirmations", pluginConfig.MinResponseConfirmations)
+		lggr.Errorw("invalid config: number of required confirmation blocks >= pastBlocksToPoll", "pastBlocksToPoll", pastBlocksToPoll, "minIncomingConfirmations", relayConfig.MinIncomingConfirmations, "minRequestConfirmations", relayConfig.MinRequestConfirmations, "minResponseConfirmations", relayConfig.MinResponseConfirmations)
 		return nil, errors.Errorf("invalid config: number of required confirmation blocks >= pastBlocksToPoll")
 	}
 
 	w := &logPollerWrapper{
 		routerContract:            routerContract,
-		pluginConfig:              pluginConfig,
+		relayConfig:               relayConfig,
 		requestBlockOffset:        requestBlockOffset,
 		responseBlockOffset:       responseBlockOffset,
 		pastBlocksToPoll:          pastBlocksToPoll,
@@ -113,10 +113,10 @@ func NewLogPollerWrapper(routerContractAddress common.Address, pluginConfig conf
 }
 
 func (l *logPollerWrapper) start(context.Context) error {
-	l.eng.Infow("starting LogPollerWrapper", "routerContract", l.routerContract.Address().Hex(), "contractVersion", l.pluginConfig.ContractVersion)
+	l.eng.Infow("starting LogPollerWrapper", "routerContract", l.routerContract.Address().Hex(), "contractVersion", l.relayConfig.ContractVersion)
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.pluginConfig.ContractVersion != 1 {
+	if l.relayConfig.ContractVersion != 1 {
 		return errors.New("only contract version 1 is supported")
 	}
 	l.eng.Go(l.checkForRouteUpdates)
@@ -296,7 +296,7 @@ func (l *logPollerWrapper) filterPreviouslyDetectedEvents(logs []logpoller.Log, 
 
 // "internal" method called only by EVM relayer components
 func (l *logPollerWrapper) SubscribeToUpdates(ctx context.Context, subscriberName string, subscriber evmconfig.RouteUpdateSubscriber) {
-	switch l.pluginConfig.ContractVersion {
+	switch l.relayConfig.ContractVersion {
 	case 0:
 		// in V0, immediately set contract address to Oracle contract and never update again
 		if err := subscriber.UpdateRoutes(ctx, l.routerContract.Address(), l.routerContract.Address()); err != nil {
@@ -310,7 +310,7 @@ func (l *logPollerWrapper) SubscribeToUpdates(ctx context.Context, subscriberNam
 }
 
 func (l *logPollerWrapper) checkForRouteUpdates(ctx context.Context) {
-	freqSec := l.pluginConfig.ContractUpdateCheckFrequencySec
+	freqSec := l.relayConfig.ContractUpdateCheckFrequencySec
 	if freqSec == 0 {
 		l.eng.Errorw("LogPollerWrapper: ContractUpdateCheckFrequencySec is zero - route update checks disabled")
 		return
@@ -318,7 +318,7 @@ func (l *logPollerWrapper) checkForRouteUpdates(ctx context.Context) {
 
 	updateOnce := func(ctx context.Context) {
 		// NOTE: timeout == frequency here, could be changed to a separate config value
-		timeout := time.Duration(l.pluginConfig.ContractUpdateCheckFrequencySec) * time.Second
+		timeout := time.Duration(l.relayConfig.ContractUpdateCheckFrequencySec) * time.Second
 		ctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 		active, proposed, err := l.getCurrentCoordinators(ctx)
@@ -344,11 +344,11 @@ func (l *logPollerWrapper) checkForRouteUpdates(ctx context.Context) {
 }
 
 func (l *logPollerWrapper) getCurrentCoordinators(ctx context.Context) (common.Address, common.Address, error) {
-	if l.pluginConfig.ContractVersion == 0 {
+	if l.relayConfig.ContractVersion == 0 {
 		return l.routerContract.Address(), l.routerContract.Address(), nil
 	}
 	var donId [32]byte
-	copy(donId[:], []byte(l.pluginConfig.DONID))
+	copy(donId[:], []byte(l.relayConfig.DONID))
 
 	activeCoordinator, err := l.routerContract.GetContractById(&bind.CallOpts{
 		Pending: false,
@@ -417,7 +417,7 @@ func (l *logPollerWrapper) handleRouteUpdate(ctx context.Context, activeCoordina
 }
 
 func (l *logPollerWrapper) filterPrefix() string {
-	return "FunctionsLogPollerWrapper:" + l.pluginConfig.DONID
+	return "FunctionsLogPollerWrapper:" + l.relayConfig.DONID
 }
 
 func (l *logPollerWrapper) filterName(addr common.Address) string {

--- a/core/services/relay/evm/functions/logpoller_wrapper_test.go
+++ b/core/services/relay/evm/functions/logpoller_wrapper_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	lpmocks "github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/functions/config"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/functions/config"
 )
 
 type subscriber struct {
@@ -57,7 +57,7 @@ func setUp(t *testing.T, updateFrequencySec uint32) (*lpmocks.LogPoller, evmconf
 	lggr := logger.Test(t)
 	client := clienttest.NewClient(t)
 	lp := lpmocks.NewLogPoller(t)
-	config := config.PluginConfig{
+	config := config.RelayConfig{
 		ContractUpdateCheckFrequencySec: updateFrequencySec,
 		ContractVersion:                 1,
 	}


### PR DESCRIPTION
This extraction is needed to be able to move relay/evm/functions to the chainlink-evm repository.