### PR TITLE
Bump chainlink-common, update confidential http fake capability

### DIFF
--- a/core/capabilities/fakes/confidential_http_action.go
+++ b/core/capabilities/fakes/confidential_http_action.go
@@ -13,13 +13,10 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"sync"
 	"text/template"
 	"time"
 
 	"gopkg.in/yaml.v3"
-
-	"github.com/smartcontractkit/tdh2/go/tdh2/tdh2easy"
 
 	commonCap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
@@ -41,138 +38,11 @@ const ConfidentialHTTPActionServiceName = "ConfidentialHttpActionService"
 // This must match the constant in confidential-compute/types/types.go
 const AESGCMEncryptionKeyName = "san_marino_aes_gcm_encryption_key"
 
-// TDH2 test keys for threshold encryption when AES-GCM key is not provided.
-// These are lazily initialized on first use.
-var (
-	fakeTDH2InitOnce      sync.Once
-	fakeTDH2PublicKey     *tdh2easy.PublicKey
-	fakeTDH2PrivateShares []*tdh2easy.PrivateShare
-	errFakeTDH2Init       error
-)
-
-// FakeTDH2Threshold is the threshold for the fake TDH2 key setup (k of n).
-const FakeTDH2Threshold = 2
-
-// FakeTDH2TotalShares is the total number of shares for the fake TDH2 key setup.
-const FakeTDH2TotalShares = 3
-
-// initFakeTDH2Keys lazily initializes the fake TDH2 keys.
-func initFakeTDH2Keys() (*tdh2easy.PublicKey, []*tdh2easy.PrivateShare, error) {
-	fakeTDH2InitOnce.Do(func() {
-		_, pubKey, privShares, err := tdh2easy.GenerateKeys(FakeTDH2Threshold, FakeTDH2TotalShares)
-		if err != nil {
-			errFakeTDH2Init = fmt.Errorf("failed to generate fake TDH2 keys: %w", err)
-			return
-		}
-		fakeTDH2PublicKey = pubKey
-		fakeTDH2PrivateShares = privShares
-	})
-	return fakeTDH2PublicKey, fakeTDH2PrivateShares, errFakeTDH2Init
-}
-
-// GetFakeTDH2PublicKey returns the fake TDH2 public key used by this fake for encryption.
-// Tests can use this to verify that encryption occurred or to set up decryption.
-func GetFakeTDH2PublicKey() (*tdh2easy.PublicKey, error) {
-	pubKey, _, err := initFakeTDH2Keys()
-	return pubKey, err
-}
-
-// GetFakeTDH2PrivateShares returns the fake TDH2 private key shares used by this fake.
-// Tests can use these to decrypt responses encrypted with TDH2.
-func GetFakeTDH2PrivateShares() ([]*tdh2easy.PrivateShare, error) {
-	_, privShares, err := initFakeTDH2Keys()
-	return privShares, err
-}
-
-// DecryptFakeTDH2Ciphertext decrypts a TDH2 ciphertext that was encrypted by this fake.
-// This is a helper for tests that need to verify the decrypted content.
-func DecryptFakeTDH2Ciphertext(ciphertextBytes []byte) ([]byte, error) {
-	pubKey, privShares, err := initFakeTDH2Keys()
-	if err != nil {
-		return nil, err
-	}
-
-	ciphertext := &tdh2easy.Ciphertext{}
-	if unmarshalErr := ciphertext.UnmarshalVerify(ciphertextBytes, pubKey); unmarshalErr != nil {
-		return nil, fmt.Errorf("failed to unmarshal TDH2 ciphertext: %w", unmarshalErr)
-	}
-
-	// Create decryption shares using threshold number of private key shares
-	shares := make([]*tdh2easy.DecryptionShare, FakeTDH2Threshold)
-	for i := 0; i < FakeTDH2Threshold; i++ {
-		share, decryptErr := tdh2easy.Decrypt(ciphertext, privShares[i])
-		if decryptErr != nil {
-			return nil, fmt.Errorf("failed to create decryption share %d: %w", i, decryptErr)
-		}
-		shares[i] = share
-	}
-
-	// Aggregate shares to recover plaintext (n = total participants)
-	plaintext, err := tdh2easy.Aggregate(ciphertext, shares, FakeTDH2TotalShares)
-	if err != nil {
-		return nil, fmt.Errorf("failed to aggregate TDH2 shares: %w", err)
-	}
-
-	return plaintext, nil
-}
-
-// tdh2Encrypt encrypts plaintext using TDH2 with the fake public key.
-func tdh2Encrypt(plaintext []byte) ([]byte, error) {
-	pubKey, _, err := initFakeTDH2Keys()
-	if err != nil {
-		return nil, err
-	}
-
-	ciphertext, err := tdh2easy.Encrypt(pubKey, plaintext)
-	if err != nil {
-		return nil, fmt.Errorf("failed to TDH2 encrypt: %w", err)
-	}
-
-	ciphertextBytes, err := ciphertext.Marshal()
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal TDH2 ciphertext: %w", err)
-	}
-
-	return ciphertextBytes, nil
-}
-
 var directConfidentialHTTPActionInfo = commonCap.MustNewCapabilityInfo(
 	ConfidentialHTTPActionID,
 	commonCap.CapabilityTypeCombined,
 	"An action that makes a confidential HTTP request with secrets",
 )
-
-// AESGCMEncrypt encrypts plaintext using AES-GCM with the provided key.
-// Returns nonce || ciphertext || tag.
-func AESGCMEncrypt(plaintext []byte, key []byte) ([]byte, error) {
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-
-	nonce := make([]byte, gcm.NonceSize())
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return nil, err
-	}
-
-	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
-	return ciphertext, nil
-}
-
-// hasEncryptionSecret checks if the VaultDonSecrets contain the magic AES-GCM encryption key.
-func hasEncryptionSecret(secrets []*confidentialhttp.SecretIdentifier) bool {
-	for _, s := range secrets {
-		if s.GetKey() == AESGCMEncryptionKeyName {
-			return true
-		}
-	}
-	return false
-}
 
 type SecretsConfig struct {
 	SecretsNames map[string][]string `yaml:"secretsNames"`
@@ -351,15 +221,7 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 			respBody = encryptedBody
 			fh.eng.Infow("Response body encrypted with AES-GCM (fake key)", "encryptedSize", len(respBody))
 		} else {
-			// Priority 3: No AES key at all — use TDH2
-			fh.eng.Infow("Encrypting response body with fake TDH2 key", "originalSize", len(respBody))
-			encryptedBody, encErr := tdh2Encrypt(respBody)
-			if encErr != nil {
-				fh.eng.Errorw("Failed to encrypt response body with TDH2", "error", encErr)
-				return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to encrypt response body: %w", encErr), caperrors.Internal)
-			}
-			respBody = encryptedBody
-			fh.eng.Infow("Response body encrypted with TDH2", "encryptedSize", len(respBody))
+			fh.eng.Warn("encrypt_output is true but no encryption key found in secrets.yaml or vault DON secrets. Returning plaintext response.")
 		}
 	}
 
@@ -409,4 +271,36 @@ func (fh *DirectConfidentialHTTPAction) RegisterToWorkflow(ctx context.Context, 
 func (fh *DirectConfidentialHTTPAction) UnregisterFromWorkflow(ctx context.Context, request commonCap.UnregisterFromWorkflowRequest) error {
 	fh.eng.Infow("Unregistered from Direct Confidential Http Action", "workflowID", request.Metadata.WorkflowID)
 	return nil
+}
+
+// AESGCMEncrypt encrypts plaintext using AES-GCM with the provided key.
+// Returns nonce || ciphertext || tag.
+func AESGCMEncrypt(plaintext []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+	return ciphertext, nil
+}
+
+// hasEncryptionSecret checks if the VaultDonSecrets contain the magic AES-GCM encryption key.
+func hasEncryptionSecret(secrets []*confidentialhttp.SecretIdentifier) bool {
+	for _, s := range secrets {
+		if s.GetKey() == AESGCMEncryptionKeyName {
+			return true
+		}
+	}
+	return false
 }

--- a/core/capabilities/fakes/confidential_http_action.go
+++ b/core/capabilities/fakes/confidential_http_action.go
@@ -47,7 +47,7 @@ var (
 	fakeTDH2InitOnce      sync.Once
 	fakeTDH2PublicKey     *tdh2easy.PublicKey
 	fakeTDH2PrivateShares []*tdh2easy.PrivateShare
-	fakeTDH2InitErr       error
+	errFakeTDH2Init       error
 )
 
 // FakeTDH2Threshold is the threshold for the fake TDH2 key setup (k of n).
@@ -61,13 +61,13 @@ func initFakeTDH2Keys() (*tdh2easy.PublicKey, []*tdh2easy.PrivateShare, error) {
 	fakeTDH2InitOnce.Do(func() {
 		_, pubKey, privShares, err := tdh2easy.GenerateKeys(FakeTDH2Threshold, FakeTDH2TotalShares)
 		if err != nil {
-			fakeTDH2InitErr = fmt.Errorf("failed to generate fake TDH2 keys: %w", err)
+			errFakeTDH2Init = fmt.Errorf("failed to generate fake TDH2 keys: %w", err)
 			return
 		}
 		fakeTDH2PublicKey = pubKey
 		fakeTDH2PrivateShares = privShares
 	})
-	return fakeTDH2PublicKey, fakeTDH2PrivateShares, fakeTDH2InitErr
+	return fakeTDH2PublicKey, fakeTDH2PrivateShares, errFakeTDH2Init
 }
 
 // GetFakeTDH2PublicKey returns the fake TDH2 public key used by this fake for encryption.
@@ -93,16 +93,16 @@ func DecryptFakeTDH2Ciphertext(ciphertextBytes []byte) ([]byte, error) {
 	}
 
 	ciphertext := &tdh2easy.Ciphertext{}
-	if err := ciphertext.UnmarshalVerify(ciphertextBytes, pubKey); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal TDH2 ciphertext: %w", err)
+	if unmarshalErr := ciphertext.UnmarshalVerify(ciphertextBytes, pubKey); unmarshalErr != nil {
+		return nil, fmt.Errorf("failed to unmarshal TDH2 ciphertext: %w", unmarshalErr)
 	}
 
 	// Create decryption shares using threshold number of private key shares
 	shares := make([]*tdh2easy.DecryptionShare, FakeTDH2Threshold)
 	for i := 0; i < FakeTDH2Threshold; i++ {
-		share, err := tdh2easy.Decrypt(ciphertext, privShares[i])
-		if err != nil {
-			return nil, fmt.Errorf("failed to create decryption share %d: %w", i, err)
+		share, decryptErr := tdh2easy.Decrypt(ciphertext, privShares[i])
+		if decryptErr != nil {
+			return nil, fmt.Errorf("failed to create decryption share %d: %w", i, decryptErr)
 		}
 		shares[i] = share
 	}
@@ -199,8 +199,8 @@ func NewDirectConfidentialHTTPAction(lggr logger.Logger) *DirectConfidentialHTTP
 	}
 
 	if data, err := os.ReadFile(secretsFile); err == nil {
-		if err := yaml.Unmarshal(data, &fc.secretsConfig); err != nil {
-			lggr.Warnf("Failed to parse secrets file %s: %v", secretsFile, err)
+		if marshalErr := yaml.Unmarshal(data, &fc.secretsConfig); marshalErr != nil {
+			lggr.Warnf("Failed to parse secrets file %s: %v", secretsFile, marshalErr)
 		} else {
 			lggr.Infof("Loaded secrets from %s", secretsFile)
 		}
@@ -254,21 +254,22 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 	var httpReq *http.Request
 	var err error
 
-	if usesBody && bodyString != "" {
+	switch {
+	case usesBody && bodyString != "":
 		processedBody := &bytes.Buffer{}
 		bodyTmpl, err2 := template.New("body").Parse(bodyString)
 		if err2 != nil {
 			fh.eng.Errorf("error parsing body template: %v", err2)
-			return nil, caperrors.NewPublicUserError(fmt.Errorf("error parsing body template"), caperrors.InvalidArgument)
+			return nil, caperrors.NewPublicUserError(errors.New("error parsing body template"), caperrors.InvalidArgument)
 		}
 		if err2 = bodyTmpl.Execute(processedBody, templateData); err2 != nil {
 			fh.eng.Errorf("error executing body template: %v", err2)
-			return nil, caperrors.NewPublicUserError(fmt.Errorf("error executing body template"), caperrors.InvalidArgument)
+			return nil, caperrors.NewPublicUserError(errors.New("error executing body template"), caperrors.InvalidArgument)
 		}
 		httpReq, err = http.NewRequestWithContext(ctx, method, req.GetUrl(), processedBody)
-	} else if usesBody && len(bodyBytes) > 0 {
+	case usesBody && len(bodyBytes) > 0:
 		httpReq, err = http.NewRequestWithContext(ctx, method, req.GetUrl(), bytes.NewReader(bodyBytes))
-	} else {
+	default:
 		httpReq, err = http.NewRequestWithContext(ctx, method, req.GetUrl(), nil)
 	}
 
@@ -284,13 +285,13 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 				headerTmpl, tmplErr := template.New("header").Parse(value)
 				if tmplErr != nil {
 					fh.eng.Errorf("error parsing header template for %s: %v", name, tmplErr)
-					return nil, caperrors.NewPublicUserError(fmt.Errorf("error parsing header template"), caperrors.InvalidArgument)
+					return nil, caperrors.NewPublicUserError(errors.New("error parsing header template"), caperrors.InvalidArgument)
 				}
 
 				var processedHeader bytes.Buffer
 				if tmplErr = headerTmpl.Execute(&processedHeader, templateData); tmplErr != nil {
 					fh.eng.Errorf("error executing header template for %s: %v", name, tmplErr)
-					return nil, caperrors.NewPublicUserError(fmt.Errorf("error executing header template"), caperrors.InvalidArgument)
+					return nil, caperrors.NewPublicUserError(errors.New("error executing header template"), caperrors.InvalidArgument)
 				}
 
 				httpReq.Header.Add(name, processedHeader.String())

--- a/core/capabilities/fakes/confidential_http_action.go
+++ b/core/capabilities/fakes/confidential_http_action.go
@@ -11,7 +11,10 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
+
+	"github.com/smartcontractkit/tdh2/go/tdh2/tdh2easy"
 
 	commonCap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
@@ -36,7 +39,102 @@ const AESGCMEncryptionKeyName = "san_marino_aes_gcm_encryption_key"
 // FakeAESGCMEncryptionKey is a well-known 32-byte test key used by this fake for AES-256-GCM encryption.
 // This allows testing encrypt_output functionality without real VaultDON secrets.
 // WARNING: This key is for testing only and must not be used in production.
-var FakeAESGCMEncryptionKey = []byte("test-key-for-fake-encrypt-32-by") // exactly 32 bytes for AES-256
+var FakeAESGCMEncryptionKey = []byte("test-key-for-fake-encrypt-32-byt") // exactly 32 bytes for AES-256
+
+// TDH2 test keys for threshold encryption when AES-GCM key is not provided.
+// These are lazily initialized on first use.
+var (
+	fakeTDH2InitOnce      sync.Once
+	fakeTDH2PublicKey     *tdh2easy.PublicKey
+	fakeTDH2PrivateShares []*tdh2easy.PrivateShare
+	fakeTDH2InitErr       error
+)
+
+// FakeTDH2Threshold is the threshold for the fake TDH2 key setup (k of n).
+const FakeTDH2Threshold = 2
+
+// FakeTDH2TotalShares is the total number of shares for the fake TDH2 key setup.
+const FakeTDH2TotalShares = 3
+
+// initFakeTDH2Keys lazily initializes the fake TDH2 keys.
+func initFakeTDH2Keys() (*tdh2easy.PublicKey, []*tdh2easy.PrivateShare, error) {
+	fakeTDH2InitOnce.Do(func() {
+		_, pubKey, privShares, err := tdh2easy.GenerateKeys(FakeTDH2Threshold, FakeTDH2TotalShares)
+		if err != nil {
+			fakeTDH2InitErr = fmt.Errorf("failed to generate fake TDH2 keys: %w", err)
+			return
+		}
+		fakeTDH2PublicKey = pubKey
+		fakeTDH2PrivateShares = privShares
+	})
+	return fakeTDH2PublicKey, fakeTDH2PrivateShares, fakeTDH2InitErr
+}
+
+// GetFakeTDH2PublicKey returns the fake TDH2 public key used by this fake for encryption.
+// Tests can use this to verify that encryption occurred or to set up decryption.
+func GetFakeTDH2PublicKey() (*tdh2easy.PublicKey, error) {
+	pubKey, _, err := initFakeTDH2Keys()
+	return pubKey, err
+}
+
+// GetFakeTDH2PrivateShares returns the fake TDH2 private key shares used by this fake.
+// Tests can use these to decrypt responses encrypted with TDH2.
+func GetFakeTDH2PrivateShares() ([]*tdh2easy.PrivateShare, error) {
+	_, privShares, err := initFakeTDH2Keys()
+	return privShares, err
+}
+
+// DecryptFakeTDH2Ciphertext decrypts a TDH2 ciphertext that was encrypted by this fake.
+// This is a helper for tests that need to verify the decrypted content.
+func DecryptFakeTDH2Ciphertext(ciphertextBytes []byte) ([]byte, error) {
+	pubKey, privShares, err := initFakeTDH2Keys()
+	if err != nil {
+		return nil, err
+	}
+
+	ciphertext := &tdh2easy.Ciphertext{}
+	if err := ciphertext.UnmarshalVerify(ciphertextBytes, pubKey); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal TDH2 ciphertext: %w", err)
+	}
+
+	// Create decryption shares using threshold number of private key shares
+	shares := make([]*tdh2easy.DecryptionShare, FakeTDH2Threshold)
+	for i := 0; i < FakeTDH2Threshold; i++ {
+		share, err := tdh2easy.Decrypt(ciphertext, privShares[i])
+		if err != nil {
+			return nil, fmt.Errorf("failed to create decryption share %d: %w", i, err)
+		}
+		shares[i] = share
+	}
+
+	// Aggregate shares to recover plaintext (n = total participants)
+	plaintext, err := tdh2easy.Aggregate(ciphertext, shares, FakeTDH2TotalShares)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate TDH2 shares: %w", err)
+	}
+
+	return plaintext, nil
+}
+
+// tdh2Encrypt encrypts plaintext using TDH2 with the fake public key.
+func tdh2Encrypt(plaintext []byte) ([]byte, error) {
+	pubKey, _, err := initFakeTDH2Keys()
+	if err != nil {
+		return nil, err
+	}
+
+	ciphertext, err := tdh2easy.Encrypt(pubKey, plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to TDH2 encrypt: %w", err)
+	}
+
+	ciphertextBytes, err := ciphertext.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal TDH2 ciphertext: %w", err)
+	}
+
+	return ciphertextBytes, nil
+}
 
 var directConfidentialHTTPActionInfo = commonCap.MustNewCapabilityInfo(
 	ConfidentialHTTPActionID,
@@ -98,9 +196,13 @@ func NewDirectConfidentialHTTPAction(lggr logger.Logger) *DirectConfidentialHTTP
 func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadata commonCap.RequestMetadata, input *confidentialhttp.ConfidentialHTTPRequest) (*commonCap.ResponseAndMetadata[*confidentialhttp.HTTPResponse], caperrors.Error) {
 	fh.eng.Infow("Confidential HTTP Action SendRequest Started", "input", input, "secretsCount", len(input.GetVaultDonSecrets()))
 
-	// Warn if secrets are provided - this fake does not handle secret resolution
+	// Note: This fake does not resolve secrets from VaultDON.
+	// Template variables like {{.secretName}} will NOT be substituted.
+	// However, we DO check for the magic AES-GCM encryption key name to determine encryption mode.
 	if len(input.GetVaultDonSecrets()) > 0 {
-		fh.eng.Warnw("This fake does not handle secrets - VaultDonSecrets will be ignored. Template variables like {{.secretName}} will not be resolved.", "secretsCount", len(input.GetVaultDonSecrets()))
+		fh.eng.Infow("Secrets requested (template variables will NOT be resolved, but encryption key detection works)",
+			"secretsCount", len(input.GetVaultDonSecrets()),
+			"hasAESKey", hasEncryptionSecret(input.GetVaultDonSecrets()))
 	}
 
 	req := input.GetRequest()
@@ -162,18 +264,29 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 		return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to read response body: %w", err), caperrors.InvalidArgument)
 	}
 
-	// Encrypt response if encrypt_output is true and the magic secret is present
-	if input.GetEncryptOutput() && hasEncryptionSecret(input.GetVaultDonSecrets()) {
-		fh.eng.Infow("Encrypting response body with fake AES-GCM key", "originalSize", len(respBody))
-		encryptedBody, encErr := aesGCMEncrypt(respBody, FakeAESGCMEncryptionKey)
-		if encErr != nil {
-			fh.eng.Errorw("Failed to encrypt response body", "error", encErr)
-			return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to encrypt response body: %w", encErr), caperrors.Internal)
+	// Encrypt response if encrypt_output is true
+	if input.GetEncryptOutput() {
+		if hasEncryptionSecret(input.GetVaultDonSecrets()) {
+			// Use AES-GCM encryption with the magic key
+			fh.eng.Infow("Encrypting response body with fake AES-GCM key", "originalSize", len(respBody))
+			encryptedBody, encErr := aesGCMEncrypt(respBody, FakeAESGCMEncryptionKey)
+			if encErr != nil {
+				fh.eng.Errorw("Failed to encrypt response body with AES-GCM", "error", encErr)
+				return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to encrypt response body: %w", encErr), caperrors.Internal)
+			}
+			respBody = encryptedBody
+			fh.eng.Infow("Response body encrypted with AES-GCM", "encryptedSize", len(respBody))
+		} else {
+			// Use TDH2 encryption with the fake master public key (mimics real enclave behavior)
+			fh.eng.Infow("Encrypting response body with fake TDH2 key", "originalSize", len(respBody))
+			encryptedBody, encErr := tdh2Encrypt(respBody)
+			if encErr != nil {
+				fh.eng.Errorw("Failed to encrypt response body with TDH2", "error", encErr)
+				return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to encrypt response body: %w", encErr), caperrors.Internal)
+			}
+			respBody = encryptedBody
+			fh.eng.Infow("Response body encrypted with TDH2", "encryptedSize", len(respBody))
 		}
-		respBody = encryptedBody
-		fh.eng.Infow("Response body encrypted", "encryptedSize", len(respBody))
-	} else if input.GetEncryptOutput() {
-		fh.eng.Warnw("encrypt_output is true but no AES-GCM encryption secret found - response will not be encrypted. TDH2 encryption is not supported by this fake.", "secretsCount", len(input.GetVaultDonSecrets()))
 	}
 
 	// Convert response headers to map[string]*HeaderValues

--- a/core/capabilities/fakes/confidential_http_action.go
+++ b/core/capabilities/fakes/confidential_http_action.go
@@ -3,6 +3,9 @@ package fakes
 import (
 	"bytes"
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -26,11 +29,52 @@ var _ commonCap.ExecutableCapability = (*DirectConfidentialHTTPAction)(nil)
 const ConfidentialHTTPActionID = "confidential-http@1.0.0-alpha"
 const ConfidentialHTTPActionServiceName = "ConfidentialHttpActionService"
 
+// AESGCMEncryptionKeyName is the magic secret key name that triggers AES-GCM encryption.
+// This must match the constant in confidential-compute/types/types.go
+const AESGCMEncryptionKeyName = "san_marino_aes_gcm_encryption_key"
+
+// FakeAESGCMEncryptionKey is a well-known 32-byte test key used by this fake for AES-256-GCM encryption.
+// This allows testing encrypt_output functionality without real VaultDON secrets.
+// WARNING: This key is for testing only and must not be used in production.
+var FakeAESGCMEncryptionKey = []byte("test-key-for-fake-encrypt-32-by") // exactly 32 bytes for AES-256
+
 var directConfidentialHTTPActionInfo = commonCap.MustNewCapabilityInfo(
 	ConfidentialHTTPActionID,
 	commonCap.CapabilityTypeCombined,
 	"An action that makes a confidential HTTP request with secrets",
 )
+
+// aesGCMEncrypt encrypts plaintext using AES-GCM with the provided key.
+// Returns nonce || ciphertext || tag.
+func aesGCMEncrypt(plaintext []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+	return ciphertext, nil
+}
+
+// hasEncryptionSecret checks if the VaultDonSecrets contain the magic AES-GCM encryption key.
+func hasEncryptionSecret(secrets []*confidentialhttp.SecretIdentifier) bool {
+	for _, s := range secrets {
+		if s.GetKey() == AESGCMEncryptionKeyName {
+			return true
+		}
+	}
+	return false
+}
 
 type DirectConfidentialHTTPAction struct {
 	commonCap.CapabilityInfo
@@ -94,9 +138,13 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 		return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to create HTTP request: %w", err), caperrors.InvalidArgument)
 	}
 
-	// Add headers
-	for name, value := range req.GetHeaders() {
-		httpReq.Header.Set(name, value)
+	// Add headers from multi_headers (map[string]*HeaderValues)
+	for name, headerValues := range req.GetMultiHeaders() {
+		if headerValues != nil {
+			for _, value := range headerValues.GetValues() {
+				httpReq.Header.Add(name, value)
+			}
+		}
 	}
 
 	// Make the HTTP request
@@ -114,22 +162,33 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 		return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to read response body: %w", err), caperrors.InvalidArgument)
 	}
 
-	// Convert response headers to []*Header
-	var responseHeaders []*confidentialhttp.Header
+	// Encrypt response if encrypt_output is true and the magic secret is present
+	if input.GetEncryptOutput() && hasEncryptionSecret(input.GetVaultDonSecrets()) {
+		fh.eng.Infow("Encrypting response body with fake AES-GCM key", "originalSize", len(respBody))
+		encryptedBody, encErr := aesGCMEncrypt(respBody, FakeAESGCMEncryptionKey)
+		if encErr != nil {
+			fh.eng.Errorw("Failed to encrypt response body", "error", encErr)
+			return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to encrypt response body: %w", encErr), caperrors.Internal)
+		}
+		respBody = encryptedBody
+		fh.eng.Infow("Response body encrypted", "encryptedSize", len(respBody))
+	} else if input.GetEncryptOutput() {
+		fh.eng.Warnw("encrypt_output is true but no AES-GCM encryption secret found - response will not be encrypted. TDH2 encryption is not supported by this fake.", "secretsCount", len(input.GetVaultDonSecrets()))
+	}
+
+	// Convert response headers to map[string]*HeaderValues
+	responseHeaders := make(map[string]*confidentialhttp.HeaderValues)
 	for name, values := range resp.Header {
-		for _, value := range values {
-			responseHeaders = append(responseHeaders, &confidentialhttp.Header{
-				Name:  name,
-				Value: value,
-			})
+		responseHeaders[name] = &confidentialhttp.HeaderValues{
+			Values: values,
 		}
 	}
 
 	// Create response
 	response := &confidentialhttp.HTTPResponse{
-		StatusCode: uint32(resp.StatusCode), //nolint:gosec // HTTP status codes are always positive (100-599)
-		Body:       respBody,
-		Headers:    responseHeaders,
+		StatusCode:   uint32(resp.StatusCode), //nolint:gosec // HTTP status codes are always positive (100-599)
+		Body:         respBody,
+		MultiHeaders: responseHeaders,
 	}
 
 	responseAndMetadata := commonCap.ResponseAndMetadata[*confidentialhttp.HTTPResponse]{

--- a/core/capabilities/fakes/confidential_http_action.go
+++ b/core/capabilities/fakes/confidential_http_action.go
@@ -41,11 +41,6 @@ const ConfidentialHTTPActionServiceName = "ConfidentialHttpActionService"
 // This must match the constant in confidential-compute/types/types.go
 const AESGCMEncryptionKeyName = "san_marino_aes_gcm_encryption_key"
 
-// FakeAESGCMEncryptionKey is a well-known 32-byte test key used by this fake for AES-256-GCM encryption.
-// This allows testing encrypt_output functionality without real VaultDON secrets.
-// WARNING: This key is for testing only and must not be used in production.
-var FakeAESGCMEncryptionKey = []byte("test-key-for-fake-encrypt-32-byt") // exactly 32 bytes for AES-256
-
 // TDH2 test keys for threshold encryption when AES-GCM key is not provided.
 // These are lazily initialized on first use.
 var (
@@ -169,32 +164,6 @@ func AESGCMEncrypt(plaintext []byte, key []byte) ([]byte, error) {
 	return ciphertext, nil
 }
 
-// AESGCMDecrypt decrypts AES-GCM encrypted data (nonce || ciphertext || tag) with the provided key.
-func AESGCMDecrypt(blob []byte, key []byte) ([]byte, error) {
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-
-	nonceSize := gcm.NonceSize()
-	if len(blob) < nonceSize {
-		return nil, fmt.Errorf("ciphertext too short")
-	}
-
-	nonce, ciphertext := blob[:nonceSize], blob[nonceSize:]
-	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return plaintext, nil
-}
-
 // hasEncryptionSecret checks if the VaultDonSecrets contain the magic AES-GCM encryption key.
 func hasEncryptionSecret(secrets []*confidentialhttp.SecretIdentifier) bool {
 	for _, s := range secrets {
@@ -207,10 +176,6 @@ func hasEncryptionSecret(secrets []*confidentialhttp.SecretIdentifier) bool {
 
 type SecretsConfig struct {
 	SecretsNames map[string][]string `yaml:"secretsNames"`
-}
-
-type TemplateData struct {
-	Secrets map[string]interface{}
 }
 
 type DirectConfidentialHTTPAction struct {
@@ -273,14 +238,12 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 	method = strings.ToUpper(method)
 
 	// Prepare template data from loaded secrets
-	templateData := TemplateData{
-		Secrets: make(map[string]interface{}),
-	}
+	templateData := make(map[string]interface{})
 	for k, v := range fh.secretsConfig.SecretsNames {
 		if len(v) == 1 {
-			templateData.Secrets[k] = v[0]
+			templateData[k] = v[0]
 		} else {
-			templateData.Secrets[k] = v
+			templateData[k] = v
 		}
 	}
 
@@ -374,9 +337,12 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 			respBody = encryptedBody
 			fh.eng.Infow("Response body encrypted with AES-GCM (secrets.yaml key)", "encryptedSize", len(respBody))
 		} else if hasEncryptionSecret(input.GetVaultDonSecrets()) {
-			// Priority 2: AES key requested in VaultDonSecrets but not in secrets.yaml — use fake test key
-			fh.eng.Infow("Encrypting response body with fake AES-GCM key", "originalSize", len(respBody))
-			encryptedBody, encErr := AESGCMEncrypt(respBody, FakeAESGCMEncryptionKey)
+			secretHex := fh.secretsConfig.SecretsNames[AESGCMEncryptionKeyName][0]
+			secretKey, decErr := hex.DecodeString(secretHex)
+			if decErr != nil {
+				return nil, caperrors.NewPublicUserError(fmt.Errorf("could not decode secret key %w", decErr), caperrors.Internal)
+			}
+			encryptedBody, encErr := AESGCMEncrypt(respBody, secretKey)
 			if encErr != nil {
 				fh.eng.Errorw("Failed to encrypt response body with AES-GCM", "error", encErr)
 				return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to encrypt response body: %w", encErr), caperrors.Internal)

--- a/core/capabilities/fakes/confidential_http_action.go
+++ b/core/capabilities/fakes/confidential_http_action.go
@@ -6,13 +6,18 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/smartcontractkit/tdh2/go/tdh2/tdh2easy"
 
@@ -142,9 +147,9 @@ var directConfidentialHTTPActionInfo = commonCap.MustNewCapabilityInfo(
 	"An action that makes a confidential HTTP request with secrets",
 )
 
-// aesGCMEncrypt encrypts plaintext using AES-GCM with the provided key.
+// AESGCMEncrypt encrypts plaintext using AES-GCM with the provided key.
 // Returns nonce || ciphertext || tag.
-func aesGCMEncrypt(plaintext []byte, key []byte) ([]byte, error) {
+func AESGCMEncrypt(plaintext []byte, key []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
@@ -164,6 +169,32 @@ func aesGCMEncrypt(plaintext []byte, key []byte) ([]byte, error) {
 	return ciphertext, nil
 }
 
+// AESGCMDecrypt decrypts AES-GCM encrypted data (nonce || ciphertext || tag) with the provided key.
+func AESGCMDecrypt(blob []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(blob) < nonceSize {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, ciphertext := blob[:nonceSize], blob[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return plaintext, nil
+}
+
 // hasEncryptionSecret checks if the VaultDonSecrets contain the magic AES-GCM encryption key.
 func hasEncryptionSecret(secrets []*confidentialhttp.SecretIdentifier) bool {
 	for _, s := range secrets {
@@ -174,17 +205,42 @@ func hasEncryptionSecret(secrets []*confidentialhttp.SecretIdentifier) bool {
 	return false
 }
 
+type SecretsConfig struct {
+	SecretsNames map[string][]string `yaml:"secretsNames"`
+}
+
+type TemplateData struct {
+	Secrets map[string]interface{}
+}
+
 type DirectConfidentialHTTPAction struct {
 	commonCap.CapabilityInfo
 	services.Service
 	eng *services.Engine
 
-	lggr logger.Logger
+	secretsConfig SecretsConfig
+	lggr          logger.Logger
 }
 
 func NewDirectConfidentialHTTPAction(lggr logger.Logger) *DirectConfidentialHTTPAction {
 	fc := &DirectConfidentialHTTPAction{
 		lggr: lggr,
+	}
+
+	// Load secrets
+	secretsFile := "secrets.yaml"
+	if envFile := os.Getenv("SECRETS_FILE"); envFile != "" {
+		secretsFile = envFile
+	}
+
+	if data, err := os.ReadFile(secretsFile); err == nil {
+		if err := yaml.Unmarshal(data, &fc.secretsConfig); err != nil {
+			lggr.Warnf("Failed to parse secrets file %s: %v", secretsFile, err)
+		} else {
+			lggr.Infof("Loaded secrets from %s", secretsFile)
+		}
+	} else {
+		lggr.Infof("Could not read secrets file %s: %v. Continuing without local secrets.", secretsFile, err)
 	}
 
 	fc.Service, fc.eng = services.Config{
@@ -195,15 +251,6 @@ func NewDirectConfidentialHTTPAction(lggr logger.Logger) *DirectConfidentialHTTP
 
 func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadata commonCap.RequestMetadata, input *confidentialhttp.ConfidentialHTTPRequest) (*commonCap.ResponseAndMetadata[*confidentialhttp.HTTPResponse], caperrors.Error) {
 	fh.eng.Infow("Confidential HTTP Action SendRequest Started", "input", input, "secretsCount", len(input.GetVaultDonSecrets()))
-
-	// Note: This fake does not resolve secrets from VaultDON.
-	// Template variables like {{.secretName}} will NOT be substituted.
-	// However, we DO check for the magic AES-GCM encryption key name to determine encryption mode.
-	if len(input.GetVaultDonSecrets()) > 0 {
-		fh.eng.Infow("Secrets requested (template variables will NOT be resolved, but encryption key detection works)",
-			"secretsCount", len(input.GetVaultDonSecrets()),
-			"hasAESKey", hasEncryptionSecret(input.GetVaultDonSecrets()))
-	}
 
 	req := input.GetRequest()
 	if req == nil {
@@ -225,26 +272,65 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 	}
 	method = strings.ToUpper(method)
 
-	// Create request body
-	var body io.Reader
-	if bodyStr := req.GetBodyString(); bodyStr != "" {
-		body = bytes.NewReader([]byte(bodyStr))
-	} else if bodyBytes := req.GetBodyBytes(); len(bodyBytes) > 0 {
-		body = bytes.NewReader(bodyBytes)
+	// Prepare template data from loaded secrets
+	templateData := TemplateData{
+		Secrets: make(map[string]interface{}),
+	}
+	for k, v := range fh.secretsConfig.SecretsNames {
+		if len(v) == 1 {
+			templateData.Secrets[k] = v[0]
+		} else {
+			templateData.Secrets[k] = v
+		}
 	}
 
-	// Create the HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, method, req.GetUrl(), body)
+	usesBody := method == "POST" || method == "PUT" || method == "PATCH" || method == "DELETE"
+	bodyString := req.GetBodyString()
+	bodyBytes := req.GetBodyBytes()
+
+	var httpReq *http.Request
+	var err error
+
+	if usesBody && bodyString != "" {
+		processedBody := &bytes.Buffer{}
+		bodyTmpl, err2 := template.New("body").Parse(bodyString)
+		if err2 != nil {
+			fh.eng.Errorf("error parsing body template: %v", err2)
+			return nil, caperrors.NewPublicUserError(fmt.Errorf("error parsing body template"), caperrors.InvalidArgument)
+		}
+		if err2 = bodyTmpl.Execute(processedBody, templateData); err2 != nil {
+			fh.eng.Errorf("error executing body template: %v", err2)
+			return nil, caperrors.NewPublicUserError(fmt.Errorf("error executing body template"), caperrors.InvalidArgument)
+		}
+		httpReq, err = http.NewRequestWithContext(ctx, method, req.GetUrl(), processedBody)
+	} else if usesBody && len(bodyBytes) > 0 {
+		httpReq, err = http.NewRequestWithContext(ctx, method, req.GetUrl(), bytes.NewReader(bodyBytes))
+	} else {
+		httpReq, err = http.NewRequestWithContext(ctx, method, req.GetUrl(), nil)
+	}
+
 	if err != nil {
 		fh.eng.Errorw("Failed to create HTTP request", "error", err)
 		return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to create HTTP request: %w", err), caperrors.InvalidArgument)
 	}
 
-	// Add headers from multi_headers (map[string]*HeaderValues)
+	// Add headers with template processing
 	for name, headerValues := range req.GetMultiHeaders() {
 		if headerValues != nil {
 			for _, value := range headerValues.GetValues() {
-				httpReq.Header.Add(name, value)
+				headerTmpl, tmplErr := template.New("header").Parse(value)
+				if tmplErr != nil {
+					fh.eng.Errorf("error parsing header template for %s: %v", name, tmplErr)
+					return nil, caperrors.NewPublicUserError(fmt.Errorf("error parsing header template"), caperrors.InvalidArgument)
+				}
+
+				var processedHeader bytes.Buffer
+				if tmplErr = headerTmpl.Execute(&processedHeader, templateData); tmplErr != nil {
+					fh.eng.Errorf("error executing header template for %s: %v", name, tmplErr)
+					return nil, caperrors.NewPublicUserError(fmt.Errorf("error executing header template"), caperrors.InvalidArgument)
+				}
+
+				httpReq.Header.Add(name, processedHeader.String())
 			}
 		}
 	}
@@ -266,18 +352,39 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 
 	// Encrypt response if encrypt_output is true
 	if input.GetEncryptOutput() {
-		if hasEncryptionSecret(input.GetVaultDonSecrets()) {
-			// Use AES-GCM encryption with the magic key
-			fh.eng.Infow("Encrypting response body with fake AES-GCM key", "originalSize", len(respBody))
-			encryptedBody, encErr := aesGCMEncrypt(respBody, FakeAESGCMEncryptionKey)
+		// Priority 1: Use real AES key from secrets.yaml if available
+		if secretValues, exists := fh.secretsConfig.SecretsNames[AESGCMEncryptionKeyName]; exists && len(secretValues) > 0 {
+			secretKeyStr := secretValues[0]
+			var secretKey []byte
+
+			// Try hex decoding first
+			if decoded, decErr := hex.DecodeString(secretKeyStr); decErr == nil && len(decoded) == 32 {
+				secretKey = decoded
+			} else {
+				// Use as raw bytes
+				secretKey = []byte(secretKeyStr)
+			}
+
+			fh.eng.Infow("Encrypting response body with AES-GCM key from secrets.yaml", "originalSize", len(respBody))
+			encryptedBody, encErr := AESGCMEncrypt(respBody, secretKey)
 			if encErr != nil {
 				fh.eng.Errorw("Failed to encrypt response body with AES-GCM", "error", encErr)
 				return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to encrypt response body: %w", encErr), caperrors.Internal)
 			}
 			respBody = encryptedBody
-			fh.eng.Infow("Response body encrypted with AES-GCM", "encryptedSize", len(respBody))
+			fh.eng.Infow("Response body encrypted with AES-GCM (secrets.yaml key)", "encryptedSize", len(respBody))
+		} else if hasEncryptionSecret(input.GetVaultDonSecrets()) {
+			// Priority 2: AES key requested in VaultDonSecrets but not in secrets.yaml — use fake test key
+			fh.eng.Infow("Encrypting response body with fake AES-GCM key", "originalSize", len(respBody))
+			encryptedBody, encErr := AESGCMEncrypt(respBody, FakeAESGCMEncryptionKey)
+			if encErr != nil {
+				fh.eng.Errorw("Failed to encrypt response body with AES-GCM", "error", encErr)
+				return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to encrypt response body: %w", encErr), caperrors.Internal)
+			}
+			respBody = encryptedBody
+			fh.eng.Infow("Response body encrypted with AES-GCM (fake key)", "encryptedSize", len(respBody))
 		} else {
-			// Use TDH2 encryption with the fake master public key (mimics real enclave behavior)
+			// Priority 3: No AES key at all — use TDH2
 			fh.eng.Infow("Encrypting response body with fake TDH2 key", "originalSize", len(respBody))
 			encryptedBody, encErr := tdh2Encrypt(respBody)
 			if encErr != nil {

--- a/core/capabilities/fakes/confidential_http_action_test.go
+++ b/core/capabilities/fakes/confidential_http_action_test.go
@@ -1,9 +1,6 @@
 package fakes
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,13 +12,13 @@ import (
 func TestAESGCMEncryption(t *testing.T) {
 	plaintext := []byte("Hello, World! This is a test message.")
 
-	encrypted, err := aesGCMEncrypt(plaintext, FakeAESGCMEncryptionKey)
+	encrypted, err := AESGCMEncrypt(plaintext, FakeAESGCMEncryptionKey)
 	require.NoError(t, err)
 	assert.NotEqual(t, plaintext, encrypted)
 	assert.Greater(t, len(encrypted), len(plaintext)) // nonce + ciphertext + tag
 
 	// Verify we can decrypt it
-	decrypted, err := aesGCMDecrypt(encrypted, FakeAESGCMEncryptionKey)
+	decrypted, err := AESGCMDecrypt(encrypted, FakeAESGCMEncryptionKey)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, decrypted)
 }
@@ -112,23 +109,3 @@ func TestTDH2EncryptionEmptyMessage(t *testing.T) {
 	assert.Empty(t, decrypted) // Use Empty instead of Equal to handle nil vs []byte{}
 }
 
-// aesGCMDecrypt is a helper for testing - decrypts AES-GCM encrypted data
-func aesGCMDecrypt(ciphertext []byte, key []byte) ([]byte, error) {
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-
-	nonceSize := gcm.NonceSize()
-	if len(ciphertext) < nonceSize {
-		return nil, fmt.Errorf("ciphertext too short")
-	}
-
-	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
-	return gcm.Open(nil, nonce, ciphertext, nil)
-}

--- a/core/capabilities/fakes/confidential_http_action_test.go
+++ b/core/capabilities/fakes/confidential_http_action_test.go
@@ -1,0 +1,134 @@
+package fakes
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	confidentialhttp "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialhttp"
+)
+
+func TestAESGCMEncryption(t *testing.T) {
+	plaintext := []byte("Hello, World! This is a test message.")
+
+	encrypted, err := aesGCMEncrypt(plaintext, FakeAESGCMEncryptionKey)
+	require.NoError(t, err)
+	assert.NotEqual(t, plaintext, encrypted)
+	assert.Greater(t, len(encrypted), len(plaintext)) // nonce + ciphertext + tag
+
+	// Verify we can decrypt it
+	decrypted, err := aesGCMDecrypt(encrypted, FakeAESGCMEncryptionKey)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestTDH2Encryption(t *testing.T) {
+	plaintext := []byte("Hello, World! This is a TDH2 test message.")
+
+	// Encrypt using the fake TDH2 public key
+	encrypted, err := tdh2Encrypt(plaintext)
+	require.NoError(t, err)
+	assert.NotEqual(t, plaintext, encrypted)
+
+	// Decrypt using the helper function
+	decrypted, err := DecryptFakeTDH2Ciphertext(encrypted)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestTDH2KeysInitialization(t *testing.T) {
+	// Get public key
+	pubKey, err := GetFakeTDH2PublicKey()
+	require.NoError(t, err)
+	require.NotNil(t, pubKey)
+
+	// Get private shares
+	privShares, err := GetFakeTDH2PrivateShares()
+	require.NoError(t, err)
+	require.Len(t, privShares, FakeTDH2TotalShares)
+
+	// Verify keys are consistent across calls (lazy init)
+	pubKey2, err := GetFakeTDH2PublicKey()
+	require.NoError(t, err)
+	assert.Equal(t, pubKey, pubKey2)
+}
+
+func TestHasEncryptionSecret(t *testing.T) {
+	t.Run("returns true when magic key exists", func(t *testing.T) {
+		secrets := []*confidentialhttp.SecretIdentifier{
+			{Key: "other-key"},
+			{Key: AESGCMEncryptionKeyName},
+		}
+		assert.True(t, hasEncryptionSecret(secrets))
+	})
+
+	t.Run("returns false when magic key does not exist", func(t *testing.T) {
+		secrets := []*confidentialhttp.SecretIdentifier{
+			{Key: "other-key"},
+			{Key: "another-key"},
+		}
+		assert.False(t, hasEncryptionSecret(secrets))
+	})
+
+	t.Run("returns false for empty secrets", func(t *testing.T) {
+		assert.False(t, hasEncryptionSecret(nil))
+		assert.False(t, hasEncryptionSecret([]*confidentialhttp.SecretIdentifier{}))
+	})
+}
+
+func TestTDH2EncryptionRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name      string
+		plaintext []byte
+	}{
+		{"short message", []byte("Hi")},
+		{"medium message", []byte("This is a medium length test message for TDH2 encryption.")},
+		{"binary data", []byte{0x00, 0x01, 0x02, 0xFF, 0xFE, 0xFD}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			encrypted, err := tdh2Encrypt(tc.plaintext)
+			require.NoError(t, err)
+
+			decrypted, err := DecryptFakeTDH2Ciphertext(encrypted)
+			require.NoError(t, err)
+			assert.Equal(t, tc.plaintext, decrypted)
+		})
+	}
+}
+
+func TestTDH2EncryptionEmptyMessage(t *testing.T) {
+	// Empty messages are a special case - TDH2 may return nil instead of empty slice
+	encrypted, err := tdh2Encrypt([]byte{})
+	require.NoError(t, err)
+
+	decrypted, err := DecryptFakeTDH2Ciphertext(encrypted)
+	require.NoError(t, err)
+	assert.Empty(t, decrypted) // Use Empty instead of Equal to handle nil vs []byte{}
+}
+
+// aesGCMDecrypt is a helper for testing - decrypts AES-GCM encrypted data
+func aesGCMDecrypt(ciphertext []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
+	return gcm.Open(nil, nonce, ciphertext, nil)
+}

--- a/core/capabilities/fakes/confidential_http_action_test.go
+++ b/core/capabilities/fakes/confidential_http_action_test.go
@@ -9,20 +9,6 @@ import (
 	confidentialhttp "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialhttp"
 )
 
-func TestAESGCMEncryption(t *testing.T) {
-	plaintext := []byte("Hello, World! This is a test message.")
-
-	encrypted, err := AESGCMEncrypt(plaintext, FakeAESGCMEncryptionKey)
-	require.NoError(t, err)
-	assert.NotEqual(t, plaintext, encrypted)
-	assert.Greater(t, len(encrypted), len(plaintext)) // nonce + ciphertext + tag
-
-	// Verify we can decrypt it
-	decrypted, err := AESGCMDecrypt(encrypted, FakeAESGCMEncryptionKey)
-	require.NoError(t, err)
-	assert.Equal(t, plaintext, decrypted)
-}
-
 func TestTDH2Encryption(t *testing.T) {
 	plaintext := []byte("Hello, World! This is a TDH2 test message.")
 
@@ -108,4 +94,3 @@ func TestTDH2EncryptionEmptyMessage(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, decrypted) // Use Empty instead of Equal to handle nil vs []byte{}
 }
-

--- a/core/capabilities/fakes/confidential_http_action_test.go
+++ b/core/capabilities/fakes/confidential_http_action_test.go
@@ -4,41 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	confidentialhttp "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialhttp"
 )
-
-func TestTDH2Encryption(t *testing.T) {
-	plaintext := []byte("Hello, World! This is a TDH2 test message.")
-
-	// Encrypt using the fake TDH2 public key
-	encrypted, err := tdh2Encrypt(plaintext)
-	require.NoError(t, err)
-	assert.NotEqual(t, plaintext, encrypted)
-
-	// Decrypt using the helper function
-	decrypted, err := DecryptFakeTDH2Ciphertext(encrypted)
-	require.NoError(t, err)
-	assert.Equal(t, plaintext, decrypted)
-}
-
-func TestTDH2KeysInitialization(t *testing.T) {
-	// Get public key
-	pubKey, err := GetFakeTDH2PublicKey()
-	require.NoError(t, err)
-	require.NotNil(t, pubKey)
-
-	// Get private shares
-	privShares, err := GetFakeTDH2PrivateShares()
-	require.NoError(t, err)
-	require.Len(t, privShares, FakeTDH2TotalShares)
-
-	// Verify keys are consistent across calls (lazy init)
-	pubKey2, err := GetFakeTDH2PublicKey()
-	require.NoError(t, err)
-	assert.Equal(t, pubKey, pubKey2)
-}
 
 func TestHasEncryptionSecret(t *testing.T) {
 	t.Run("returns true when magic key exists", func(t *testing.T) {
@@ -61,36 +29,4 @@ func TestHasEncryptionSecret(t *testing.T) {
 		assert.False(t, hasEncryptionSecret(nil))
 		assert.False(t, hasEncryptionSecret([]*confidentialhttp.SecretIdentifier{}))
 	})
-}
-
-func TestTDH2EncryptionRoundTrip(t *testing.T) {
-	testCases := []struct {
-		name      string
-		plaintext []byte
-	}{
-		{"short message", []byte("Hi")},
-		{"medium message", []byte("This is a medium length test message for TDH2 encryption.")},
-		{"binary data", []byte{0x00, 0x01, 0x02, 0xFF, 0xFE, 0xFD}},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			encrypted, err := tdh2Encrypt(tc.plaintext)
-			require.NoError(t, err)
-
-			decrypted, err := DecryptFakeTDH2Ciphertext(encrypted)
-			require.NoError(t, err)
-			assert.Equal(t, tc.plaintext, decrypted)
-		})
-	}
-}
-
-func TestTDH2EncryptionEmptyMessage(t *testing.T) {
-	// Empty messages are a special case - TDH2 may return nil instead of empty slice
-	encrypted, err := tdh2Encrypt([]byte{})
-	require.NoError(t, err)
-
-	decrypted, err := DecryptFakeTDH2Ciphertext(encrypted)
-	require.NoError(t, err)
-	assert.Empty(t, decrypted) // Use Empty instead of Equal to handle nil vs []byte{}
 }

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -49,12 +49,12 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20260203202624-5101f4d33736
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d
 	github.com/smartcontractkit/chainlink-data-streams v0.1.11
 	github.com/smartcontractkit/chainlink-deployments-framework v0.78.1-0.20260130170219-7f3060452d15
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260203161436-cb489cf2896d
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.20

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1629,8 +1629,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a h1:5FxRKkjXvQvPlKx60ELXgOsn7NQIkBj/Au1Z6jpMfjM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a/go.mod h1:Xe0SH5IHtGkCW6sy/EdBRPKD5L+U52HgoGfl0KDP/lw=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43 h1:2Kp505f9fh2hYeoZl1LdsN7aohP7CXERCsV7Rr2sZsA=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43/go.mod h1:6FarqEpCt00pUn9cTRym+zzmrMUKQ4TW09oV5lD4tqA=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d h1:hNW4KXr9UPpZ2v+gbnalPKYIdoW04ReU59360quIQJo=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d/go.mod h1:Xj4eRsg1V/okUKOY7YSWoQKiSt40bZ3+mHw39VMHs6I=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4 h1:NOUsjsMzNecbjiPWUQGlRSRAutEvCFrqqyETDJeh5q4=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4/go.mod h1:Zpvul9sTcZNAZOVzt5vBl1XZGNvQebFpnpn3/KOQvOQ=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20251215152504-b1e41f508340 h1:PsjEI+5jZIz9AS4eOsLS5VpSWJINf38clXV3wryPyMk=
@@ -1663,8 +1663,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0 h1:+/0xWigvOxFLghyivyxiUCYGcky/7i8IxfGTdTeaXFg=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963 h1:DCLvEn4KkFzYbK/AYl4vJmf6EHaskPYvGDGdd0kOma0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0 h1:xHPmFDhff7QpeFxKsZfk+24j4AlnQiFjjRh5O87Peu4=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b h1:QuI6SmQFK/zyUlVWEf0GMkiUYBPY4lssn26nKSd/bOM=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -43,13 +43,13 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d
 	github.com/smartcontractkit/chainlink-deployments-framework v0.78.1-0.20260130170219-7f3060452d15
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260203161436-cb489cf2896d
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20251021173435-e86785845942
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.10.0
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260121103211-89fe83165431

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1366,8 +1366,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a h1:5FxRKkjXvQvPlKx60ELXgOsn7NQIkBj/Au1Z6jpMfjM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a/go.mod h1:Xe0SH5IHtGkCW6sy/EdBRPKD5L+U52HgoGfl0KDP/lw=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43 h1:2Kp505f9fh2hYeoZl1LdsN7aohP7CXERCsV7Rr2sZsA=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43/go.mod h1:6FarqEpCt00pUn9cTRym+zzmrMUKQ4TW09oV5lD4tqA=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d h1:hNW4KXr9UPpZ2v+gbnalPKYIdoW04ReU59360quIQJo=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d/go.mod h1:Xj4eRsg1V/okUKOY7YSWoQKiSt40bZ3+mHw39VMHs6I=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20251215152504-b1e41f508340 h1:PsjEI+5jZIz9AS4eOsLS5VpSWJINf38clXV3wryPyMk=
@@ -1400,8 +1400,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0 h1:+/0xWigvOxFLghyivyxiUCYGcky/7i8IxfGTdTeaXFg=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963 h1:DCLvEn4KkFzYbK/AYl4vJmf6EHaskPYvGDGdd0kOma0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0 h1:xHPmFDhff7QpeFxKsZfk+24j4AlnQiFjjRh5O87Peu4=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b h1:QuI6SmQFK/zyUlVWEf0GMkiUYBPY4lssn26nKSd/bOM=

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10
 	github.com/smartcontractkit/chainlink-data-streams v0.1.11
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260203161436-cb489cf2896d
@@ -99,7 +99,7 @@ require (
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251210101658-1c5c8e4c4f15
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20251021173435-e86785845942
 	github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.10.0
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260128151123-605e9540b706

--- a/go.sum
+++ b/go.sum
@@ -1180,8 +1180,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a h1:5FxRKkjXvQvPlKx60ELXgOsn7NQIkBj/Au1Z6jpMfjM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a/go.mod h1:Xe0SH5IHtGkCW6sy/EdBRPKD5L+U52HgoGfl0KDP/lw=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43 h1:2Kp505f9fh2hYeoZl1LdsN7aohP7CXERCsV7Rr2sZsA=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43/go.mod h1:6FarqEpCt00pUn9cTRym+zzmrMUKQ4TW09oV5lD4tqA=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d h1:hNW4KXr9UPpZ2v+gbnalPKYIdoW04ReU59360quIQJo=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d/go.mod h1:Xj4eRsg1V/okUKOY7YSWoQKiSt40bZ3+mHw39VMHs6I=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20251215152504-b1e41f508340 h1:PsjEI+5jZIz9AS4eOsLS5VpSWJINf38clXV3wryPyMk=
@@ -1212,8 +1212,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0 h1:+/0xWigvOxFLghyivyxiUCYGcky/7i8IxfGTdTeaXFg=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963 h1:DCLvEn4KkFzYbK/AYl4vJmf6EHaskPYvGDGdd0kOma0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b h1:QuI6SmQFK/zyUlVWEf0GMkiUYBPY4lssn26nKSd/bOM=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b/go.mod h1:qSTSwX3cBP3FKQwQacdjArqv0g6QnukjV4XuzO6UyoY=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.10.0 h1:0eroOyBwmdoGUwUdvMI0/J7m5wuzNnJDMglSOK1sfNY=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20260203202624-5101f4d33736
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d
 	github.com/smartcontractkit/chainlink-deployments-framework v0.78.1-0.20260130170219-7f3060452d15
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260203161436-cb489cf2896d
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
@@ -513,7 +513,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/committee-verifier v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d // indirect
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0 // indirect
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963 // indirect
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b // indirect
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.10.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260128151123-605e9540b706 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1610,8 +1610,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a h1:5FxRKkjXvQvPlKx60ELXgOsn7NQIkBj/Au1Z6jpMfjM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a/go.mod h1:Xe0SH5IHtGkCW6sy/EdBRPKD5L+U52HgoGfl0KDP/lw=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43 h1:2Kp505f9fh2hYeoZl1LdsN7aohP7CXERCsV7Rr2sZsA=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43/go.mod h1:6FarqEpCt00pUn9cTRym+zzmrMUKQ4TW09oV5lD4tqA=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d h1:hNW4KXr9UPpZ2v+gbnalPKYIdoW04ReU59360quIQJo=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d/go.mod h1:Xj4eRsg1V/okUKOY7YSWoQKiSt40bZ3+mHw39VMHs6I=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20251215152504-b1e41f508340 h1:PsjEI+5jZIz9AS4eOsLS5VpSWJINf38clXV3wryPyMk=
@@ -1644,8 +1644,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0 h1:+/0xWigvOxFLghyivyxiUCYGcky/7i8IxfGTdTeaXFg=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963 h1:DCLvEn4KkFzYbK/AYl4vJmf6EHaskPYvGDGdd0kOma0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0 h1:xHPmFDhff7QpeFxKsZfk+24j4AlnQiFjjRh5O87Peu4=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b h1:QuI6SmQFK/zyUlVWEf0GMkiUYBPY4lssn26nKSd/bOM=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20260203202624-5101f4d33736
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d
 	github.com/smartcontractkit/chainlink-deployments-framework v0.78.1-0.20260130170219-7f3060452d15
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260203161436-cb489cf2896d
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
@@ -498,7 +498,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/committee-verifier v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d // indirect
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0 // indirect
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963 // indirect
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b // indirect
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.10.0 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1588,8 +1588,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a h1:5FxRKkjXvQvPlKx60ELXgOsn7NQIkBj/Au1Z6jpMfjM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a/go.mod h1:Xe0SH5IHtGkCW6sy/EdBRPKD5L+U52HgoGfl0KDP/lw=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43 h1:2Kp505f9fh2hYeoZl1LdsN7aohP7CXERCsV7Rr2sZsA=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43/go.mod h1:6FarqEpCt00pUn9cTRym+zzmrMUKQ4TW09oV5lD4tqA=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d h1:hNW4KXr9UPpZ2v+gbnalPKYIdoW04ReU59360quIQJo=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d/go.mod h1:Xj4eRsg1V/okUKOY7YSWoQKiSt40bZ3+mHw39VMHs6I=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20251215152504-b1e41f508340 h1:PsjEI+5jZIz9AS4eOsLS5VpSWJINf38clXV3wryPyMk=
@@ -1622,8 +1622,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0 h1:+/0xWigvOxFLghyivyxiUCYGcky/7i8IxfGTdTeaXFg=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963 h1:DCLvEn4KkFzYbK/AYl4vJmf6EHaskPYvGDGdd0kOma0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0 h1:xHPmFDhff7QpeFxKsZfk+24j4AlnQiFjjRh5O87Peu4=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b h1:QuI6SmQFK/zyUlVWEf0GMkiUYBPY4lssn26nKSd/bOM=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -32,11 +32,11 @@ require (
 	github.com/sethvargo/go-retry v0.3.0
 	github.com/smartcontractkit/chain-selectors v1.0.91
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d
 	github.com/smartcontractkit/chainlink-deployments-framework v0.78.1-0.20260130170219-7f3060452d15
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260203161436-cb489cf2896d
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260106052706-6dd937cb5ec6
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260121103211-89fe83165431

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1593,8 +1593,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a h1:5FxRKkjXvQvPlKx60ELXgOsn7NQIkBj/Au1Z6jpMfjM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a/go.mod h1:Xe0SH5IHtGkCW6sy/EdBRPKD5L+U52HgoGfl0KDP/lw=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43 h1:2Kp505f9fh2hYeoZl1LdsN7aohP7CXERCsV7Rr2sZsA=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43/go.mod h1:6FarqEpCt00pUn9cTRym+zzmrMUKQ4TW09oV5lD4tqA=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d h1:hNW4KXr9UPpZ2v+gbnalPKYIdoW04ReU59360quIQJo=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d/go.mod h1:Xj4eRsg1V/okUKOY7YSWoQKiSt40bZ3+mHw39VMHs6I=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20251215152504-b1e41f508340 h1:PsjEI+5jZIz9AS4eOsLS5VpSWJINf38clXV3wryPyMk=
@@ -1627,8 +1627,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0 h1:+/0xWigvOxFLghyivyxiUCYGcky/7i8IxfGTdTeaXFg=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963 h1:DCLvEn4KkFzYbK/AYl4vJmf6EHaskPYvGDGdd0kOma0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0 h1:xHPmFDhff7QpeFxKsZfk+24j4AlnQiFjjRh5O87Peu4=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b h1:QuI6SmQFK/zyUlVWEf0GMkiUYBPY4lssn26nKSd/bOM=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -52,11 +52,11 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.91
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d
 	github.com/smartcontractkit/chainlink-data-streams v0.1.11
 	github.com/smartcontractkit/chainlink-deployments-framework v0.78.1-0.20260130170219-7f3060452d15
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260128151123-605e9540b706
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260106052706-6dd937cb5ec6

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1792,8 +1792,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a h1:5FxRKkjXvQvPlKx60ELXgOsn7NQIkBj/Au1Z6jpMfjM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a/go.mod h1:Xe0SH5IHtGkCW6sy/EdBRPKD5L+U52HgoGfl0KDP/lw=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43 h1:2Kp505f9fh2hYeoZl1LdsN7aohP7CXERCsV7Rr2sZsA=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43/go.mod h1:6FarqEpCt00pUn9cTRym+zzmrMUKQ4TW09oV5lD4tqA=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d h1:hNW4KXr9UPpZ2v+gbnalPKYIdoW04ReU59360quIQJo=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d/go.mod h1:Xj4eRsg1V/okUKOY7YSWoQKiSt40bZ3+mHw39VMHs6I=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4 h1:NOUsjsMzNecbjiPWUQGlRSRAutEvCFrqqyETDJeh5q4=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4/go.mod h1:Zpvul9sTcZNAZOVzt5vBl1XZGNvQebFpnpn3/KOQvOQ=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20251215152504-b1e41f508340 h1:PsjEI+5jZIz9AS4eOsLS5VpSWJINf38clXV3wryPyMk=
@@ -1826,8 +1826,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0 h1:+/0xWigvOxFLghyivyxiUCYGcky/7i8IxfGTdTeaXFg=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963 h1:DCLvEn4KkFzYbK/AYl4vJmf6EHaskPYvGDGdd0kOma0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0 h1:xHPmFDhff7QpeFxKsZfk+24j4AlnQiFjjRh5O87Peu4=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b h1:QuI6SmQFK/zyUlVWEf0GMkiUYBPY4lssn26nKSd/bOM=


### PR DESCRIPTION
  ## Summary                                                                                                                       
  - Bump chainlink-common for updated proto types (multi_headers, encrypt_output)                                                  
  - Update fake confidential HTTP action:                                                                                          
    - Replace `headers` (map[string]string) with `multi_headers` (map[string]*HeaderValues)                                        
    - Add `encrypt_output` field support with AES-GCM encryption from secrets.yaml                                                 
    - Add template/secret resolution from `secrets.yaml` (body and header template substitution via Go `text/template`)            
    - Load secrets via `SECRETS_FILE` env var (defaults to `secrets.yaml`)                                                         
    - Export `AESGCMEncrypt` helper  