### PR TITLE
[CRE-1748] make sharding configurable and backwards compatible

### DIFF
--- a/core/config/docs/core.toml
+++ b/core/config/docs/core.toml
@@ -919,6 +919,10 @@ EnableDKGRecipient = false # Default
 
 # Sharding holds settings for node sharding configuration.
 [Sharding]
+# ShardingEnabled enables workflow sharding across multiple nodes.
+# When false (default), all workflows are processed by this node (backwards compatible mode).
+# When true, workflows are distributed across shards based on ShardIndex and shard orchestrator mappings.
+ShardingEnabled = false # Default
 # ArbiterPort is the port the Arbiter gRPC server listens on.
 ArbiterPort = 9876 # Default
 # ArbiterPollInterval is how often to poll the ShardConfig contract.
@@ -932,4 +936,5 @@ ShardIndex = 0 # Default
 # When a ring OCR job is created, the shard orchestrator server is spun up on this port.
 ShardOrchestratorPort = 50051 # Default
 # ShardOrchestratorAddress is the URL that the shard orchestration client will try to connect to.
+# Required when ShardingEnabled=true and ShardIndex > 0.
 ShardOrchestratorAddress = '' # Default

--- a/core/config/sharding_config.go
+++ b/core/config/sharding_config.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Sharding interface {
+	ShardingEnabled() bool
 	ArbiterPort() uint16
 	ArbiterPollInterval() time.Duration
 	ArbiterRetryInterval() time.Duration

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -2757,6 +2757,7 @@ func (jd *JobDistributor) setFrom(f *JobDistributor) {
 }
 
 type Sharding struct {
+	ShardingEnabled          *bool
 	ArbiterPort              *uint16
 	ArbiterPollInterval      *commonconfig.Duration
 	ArbiterRetryInterval     *commonconfig.Duration
@@ -2766,6 +2767,10 @@ type Sharding struct {
 }
 
 func (s *Sharding) setFrom(f *Sharding) {
+	if f.ShardingEnabled != nil {
+		s.ShardingEnabled = f.ShardingEnabled
+	}
+
 	if f.ArbiterPort != nil {
 		s.ArbiterPort = f.ArbiterPort
 	}
@@ -2792,14 +2797,16 @@ func (s *Sharding) setFrom(f *Sharding) {
 }
 
 func (s *Sharding) ValidateConfig() (err error) {
-	// If ShardIndex > 0, ShardOrchestratorAddress must be specified
-	if s.ShardIndex != nil && *s.ShardIndex > 0 {
-		if s.ShardOrchestratorAddress == nil || s.ShardOrchestratorAddress.URL() == nil {
-			err = errors.Join(err, configutils.ErrInvalid{
-				Name:  "ShardOrchestratorAddress",
-				Value: s.ShardOrchestratorAddress,
-				Msg:   "must be specified when ShardIndex > 0",
-			})
+	// If sharding is enabled and ShardIndex > 0, ShardOrchestratorAddress must be specified
+	if s.ShardingEnabled != nil && *s.ShardingEnabled {
+		if s.ShardIndex != nil && *s.ShardIndex > 0 {
+			if s.ShardOrchestratorAddress == nil || s.ShardOrchestratorAddress.URL() == nil {
+				err = errors.Join(err, configutils.ErrInvalid{
+					Name:  "ShardOrchestratorAddress",
+					Value: s.ShardOrchestratorAddress,
+					Msg:   "must be specified when ShardingEnabled is true and ShardIndex > 0",
+				})
+			}
 		}
 	}
 	return err

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -271,32 +271,37 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 		opts.DonTimeStore = dontime.NewStore(dontime.DefaultRequestTimeout)
 	}
 
+	// Initialize sharding components only if sharding is explicitly enabled
 	var shardOrchestratorClient *shardorchestrator.Client
-	shardIdx := cfg.Sharding().ShardIndex()
+	if cfg.Sharding().ShardingEnabled() {
+		shardIdx := cfg.Sharding().ShardIndex()
+		shardOrchestratorAddr := cfg.Sharding().ShardOrchestratorAddress()
 
-	shardID := shardIdx // TODO: confirm these are the same or if its going to be derived from it + CSAKey
-	// Shard 1+ runs the gRPC client
+		var address string
+		if shardIdx == 0 {
+			// TODO: REMOVE THIS currently Shard 0 connects to its own gRPC server
+			address = "127.0.0.1:50051" // default address for shard 0 server
+		} else {
+			// Shard > 0 connects to shard 0's server
+			if shardOrchestratorAddr == nil {
+				return nil, fmt.Errorf("shard %d requires ShardOrchestratorAddress when sharding is enabled", shardIdx)
+			}
+			address = shardOrchestratorAddr.String()
+		}
 
-	// TODO: this requires attention and a proper fix!
-	var address string
-	if shardID == 0 {
-		address = "127.0.0.1:50051" // default address for shard 0 server
+		client, err := shardorchestrator.NewClient(
+			ctx,
+			address,
+			globalLogger.Named("ShardOrchestratorClient"),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create ShardOrchestrator gRPC client: %w", err)
+		}
+		shardOrchestratorClient = client
+		globalLogger.Infow("ShardOrchestrator gRPC client created", "shardID", shardIdx, "serverAddress", address)
 	} else {
-		address = cfg.Sharding().ShardOrchestratorAddress().String()
+		globalLogger.Debug("Sharding not enabled, running without shard orchestrator client")
 	}
-	//if address == nil {
-	//	return nil, fmt.Errorf("shard %d requires ShardOrchestratorAddress configuration", shardID)
-	//}
-	client, err := shardorchestrator.NewClient(
-		ctx,
-		address,
-		globalLogger.Named("ShardOrchestratorClient"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create ShardOrchestrator gRPC client: %w", err)
-	}
-	shardOrchestratorClient = client
-	globalLogger.Infow("ShardOrchestrator gRPC client created", "shardID", shardID, "serverAddress", address)
 
 	creSettingsTOML, err := toml.Marshal(commoncresettings.Default)
 	if err != nil {
@@ -1330,30 +1335,45 @@ func newCREServices(
 						return nil, fmt.Errorf("unable to create workflow registry event handler: %w", err)
 					}
 
-					workflowRegistrySyncerV2, err = syncerV2.NewWorkflowRegistry(
-						lggr,
-						crFactory,
-						capCfg.WorkflowRegistry().Address(),
-						syncerV2.Config{
-							QueryCount:   100,
-							SyncStrategy: syncerV2.SyncStrategy(capCfg.WorkflowRegistry().SyncStrategy()),
-						},
-						eventHandler,
-						workflowDonNotifier,
-						engineRegistry,
-						// TODO: make this configurable and backwards compatible
-						syncerV2.WithShardEnabled(true),
-						syncerV2.WithShardOrchestratorClient(opts.ShardOrchestratorClient),
-						syncerV2.WithShardID(uint32(cfg.Sharding().ShardIndex())),
-					)
-
+					// Build sharding options if sharding is enabled
+					if cfg.Sharding().ShardingEnabled() && opts.ShardOrchestratorClient != nil {
+						workflowRegistrySyncerV2, err = syncerV2.NewWorkflowRegistry(
+							lggr,
+							crFactory,
+							capCfg.WorkflowRegistry().Address(),
+							syncerV2.Config{
+								QueryCount:   100,
+								SyncStrategy: syncerV2.SyncStrategy(capCfg.WorkflowRegistry().SyncStrategy()),
+							},
+							eventHandler,
+							workflowDonNotifier,
+							engineRegistry,
+							syncerV2.WithShardEnabled(true),
+							syncerV2.WithShardOrchestratorClient(opts.ShardOrchestratorClient),
+							syncerV2.WithShardID(uint32(cfg.Sharding().ShardIndex())),
+						)
+					} else {
+						// Sharding is disabled (backwards compatible mode)
+						workflowRegistrySyncerV2, err = syncerV2.NewWorkflowRegistry(
+							lggr,
+							crFactory,
+							capCfg.WorkflowRegistry().Address(),
+							syncerV2.Config{
+								QueryCount:   100,
+								SyncStrategy: syncerV2.SyncStrategy(capCfg.WorkflowRegistry().SyncStrategy()),
+							},
+							eventHandler,
+							workflowDonNotifier,
+							engineRegistry,
+							syncerV2.WithShardEnabled(false),
+						)
+					}
 					if err != nil {
 						return nil, fmt.Errorf("unable to create workflow registry syncer: %w", err)
 					}
 
 					srvcs = append(srvcs, workflowRegistrySyncerV2)
 					globalLogger.Debugw("Created WorkflowRegistrySyncer V2")
-
 				default:
 					return nil, fmt.Errorf("unsupported WorkflowRegistry contract version %s", wrVersion)
 				}

--- a/core/services/chainlink/config_sharding.go
+++ b/core/services/chainlink/config_sharding.go
@@ -14,6 +14,13 @@ type shardingConfig struct {
 	s toml.Sharding
 }
 
+func (s *shardingConfig) ShardingEnabled() bool {
+	if s.s.ShardingEnabled == nil {
+		return false
+	}
+	return *s.s.ShardingEnabled
+}
+
 func (s *shardingConfig) ArbiterPort() uint16 {
 	return *s.s.ArbiterPort
 }

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -652,6 +652,7 @@ func TestConfig_Marshal(t *testing.T) {
 		IgnoreJoblessBridges: ptr(false),
 	}
 	full.Sharding = toml.Sharding{
+		ShardingEnabled:          ptr(false),
 		ArbiterPort:              ptr[uint16](9876),
 		ArbiterPollInterval:      commoncfg.MustNewDuration(12 * time.Second),
 		ArbiterRetryInterval:     commoncfg.MustNewDuration(12 * time.Second),

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -393,6 +393,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -410,6 +410,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -393,6 +393,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -774,6 +774,12 @@ func (w *workflowRegistry) filterWorkflowsByShard(ctx context.Context, allWorkfl
 		return allWorkflows, nil
 	}
 
+	// If sharding is not enabled or client is not configured, return all workflows (backwards compatible)
+	if !w.shardingEnabled || w.shardOrchestratorClient == nil {
+		w.lggr.Debugw("Sharding not enabled, processing all workflows", "count", len(allWorkflows))
+		return allWorkflows, nil
+	}
+
 	w.lggr.Debugw("Shard filtering workflows", "count", len(allWorkflows))
 
 	workflowIDs := make([]string, 0, len(allWorkflows))

--- a/core/web/resolver/testdata/config-empty-effective.toml
+++ b/core/web/resolver/testdata/config-empty-effective.toml
@@ -393,6 +393,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -410,6 +410,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -393,6 +393,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -2614,6 +2614,7 @@ EnableDKGRecipient should be set to true if the DON runs a capability that uses 
 ## Sharding
 ```toml
 [Sharding]
+ShardingEnabled = false # Default
 ArbiterPort = 9876 # Default
 ArbiterPollInterval = '12s' # Default
 ArbiterRetryInterval = '12s' # Default
@@ -2622,6 +2623,14 @@ ShardOrchestratorPort = 50051 # Default
 ShardOrchestratorAddress = '' # Default
 ```
 Sharding holds settings for node sharding configuration.
+
+### ShardingEnabled
+```toml
+ShardingEnabled = false # Default
+```
+ShardingEnabled enables workflow sharding across multiple nodes.
+When false (default), all workflows are processed by this node (backwards compatible mode).
+When true, workflows are distributed across shards based on ShardIndex and shard orchestrator mappings.
 
 ### ArbiterPort
 ```toml
@@ -2660,6 +2669,7 @@ When a ring OCR job is created, the shard orchestrator server is spun up on this
 ShardOrchestratorAddress = '' # Default
 ```
 ShardOrchestratorAddress is the URL that the shard orchestration client will try to connect to.
+Required when ShardingEnabled=true and ShardIndex > 0.
 
 ## EVM
 EVM defaults depend on ChainID:

--- a/system-tests/lib/cre/don/config/config.go
+++ b/system-tests/lib/cre/don/config/config.go
@@ -443,6 +443,7 @@ func addWorkerNodeConfig(
 	}
 
 	if donMetadata.IsShardDON() {
+		existingConfig.Sharding.ShardingEnabled = ptr.Ptr(true)
 		existingConfig.Sharding.ShardIndex = ptr.Ptr(uint16(donMetadata.ShardIndex)) //nolint:gosec // disable G115 overflow is unrealistic
 
 		// all shards apart from the leader need to connect to shard orchestrators running on shard leader DON (shard0)

--- a/testdata/scripts/config/merge_raw_configs.txtar
+++ b/testdata/scripts/config/merge_raw_configs.txtar
@@ -540,6 +540,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/testdata/scripts/node/validate/default.txtar
+++ b/testdata/scripts/node/validate/default.txtar
@@ -405,6 +405,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/testdata/scripts/node/validate/defaults-override.txtar
+++ b/testdata/scripts/node/validate/defaults-override.txtar
@@ -466,6 +466,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
@@ -449,6 +449,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
@@ -449,6 +449,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/testdata/scripts/node/validate/disk-based-logging.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging.txtar
@@ -449,6 +449,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/testdata/scripts/node/validate/fallback-override.txtar
+++ b/testdata/scripts/node/validate/fallback-override.txtar
@@ -547,6 +547,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
+++ b/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
@@ -434,6 +434,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/testdata/scripts/node/validate/invalid.txtar
+++ b/testdata/scripts/node/validate/invalid.txtar
@@ -445,6 +445,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/testdata/scripts/node/validate/valid.txtar
+++ b/testdata/scripts/node/validate/valid.txtar
@@ -446,6 +446,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'

--- a/testdata/scripts/node/validate/warnings.txtar
+++ b/testdata/scripts/node/validate/warnings.txtar
@@ -428,6 +428,7 @@ IgnoreInvalidBridges = true
 IgnoreJoblessBridges = false
 
 [Sharding]
+ShardingEnabled = false
 ArbiterPort = 9876
 ArbiterPollInterval = '12s'
 ArbiterRetryInterval = '12s'


### PR DESCRIPTION
### Description

The changes introduced on this pr aims to make the changes on CRE-1714 backwards compatible.
This is meant to be merged against [cre-1714-ring-test-real-workflows](https://github.com/smartcontractkit/chainlink/tree/cre-1714-ring-test-real-workflows) 
[CRE-1748](https://smartcontract-it.atlassian.net/browse/CRE-1748) not `main` given there are gaps/shortcuts pending to be addressed.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-1748]: https://smartcontract-it.atlassian.net/browse/CRE-1748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ