### PR TITLE
Bump chainlink-common, update confidential-http fake capability

### DIFF
--- a/core/capabilities/fakes/confidential_http_action.go
+++ b/core/capabilities/fakes/confidential_http_action.go
@@ -3,12 +3,20 @@ package fakes
 import (
 	"bytes"
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
+	"text/template"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	commonCap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
@@ -25,6 +33,7 @@ var _ commonCap.ExecutableCapability = (*DirectConfidentialHTTPAction)(nil)
 
 const ConfidentialHTTPActionID = "confidential-http@1.0.0-alpha"
 const ConfidentialHTTPActionServiceName = "ConfidentialHttpActionService"
+const AESGCMEncryptionKey = "san_marino_aes_gcm_encryption_key"
 
 var directConfidentialHTTPActionInfo = commonCap.MustNewCapabilityInfo(
 	ConfidentialHTTPActionID,
@@ -37,12 +46,37 @@ type DirectConfidentialHTTPAction struct {
 	services.Service
 	eng *services.Engine
 
-	lggr logger.Logger
+	secretsConfig SecretsConfig
+	lggr          logger.Logger
+}
+
+type SecretsConfig struct {
+	SecretsNames map[string][]string `yaml:"secretsNames"`
+}
+
+type TemplateData struct {
+	Secrets map[string]interface{}
 }
 
 func NewDirectConfidentialHTTPAction(lggr logger.Logger) *DirectConfidentialHTTPAction {
 	fc := &DirectConfidentialHTTPAction{
 		lggr: lggr,
+	}
+
+	// Load secrets
+	secretsFile := "secrets.yaml"
+	if envFile := os.Getenv("SECRETS_FILE"); envFile != "" {
+		secretsFile = envFile
+	}
+
+	if data, err := os.ReadFile(secretsFile); err == nil {
+		if err := yaml.Unmarshal(data, &fc.secretsConfig); err != nil {
+			lggr.Warnf("Failed to parse secrets file %s: %v", secretsFile, err)
+		} else {
+			lggr.Infof("Loaded secrets from %s", secretsFile)
+		}
+	} else {
+		lggr.Infof("Could not read secrets file %s: %v. Continuing without local secrets.", secretsFile, err)
 	}
 
 	fc.Service, fc.eng = services.Config{
@@ -54,9 +88,8 @@ func NewDirectConfidentialHTTPAction(lggr logger.Logger) *DirectConfidentialHTTP
 func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadata commonCap.RequestMetadata, input *confidentialhttp.ConfidentialHTTPRequest) (*commonCap.ResponseAndMetadata[*confidentialhttp.HTTPResponse], caperrors.Error) {
 	fh.eng.Infow("Confidential HTTP Action SendRequest Started", "input", input, "secretsCount", len(input.GetVaultDonSecrets()))
 
-	// Warn if secrets are provided - this fake does not handle secret resolution
 	if len(input.GetVaultDonSecrets()) > 0 {
-		fh.eng.Warnw("This fake does not handle secrets - VaultDonSecrets will be ignored. Template variables like {{.secretName}} will not be resolved.", "secretsCount", len(input.GetVaultDonSecrets()))
+
 	}
 
 	req := input.GetRequest()
@@ -79,24 +112,65 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 	}
 	method = strings.ToUpper(method)
 
-	// Create request body
-	var body io.Reader
-	if bodyStr := req.GetBodyString(); bodyStr != "" {
-		body = bytes.NewReader([]byte(bodyStr))
-	} else if bodyBytes := req.GetBodyBytes(); len(bodyBytes) > 0 {
-		body = bytes.NewReader(bodyBytes)
+	// Prepare template data
+	templateData := TemplateData{
+		Secrets: make(map[string]interface{}),
+	}
+	for k, v := range fh.secretsConfig.SecretsNames {
+		if len(v) == 1 {
+			templateData.Secrets[k] = v[0]
+		} else {
+			templateData.Secrets[k] = v
+		}
 	}
 
-	// Create the HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, method, req.GetUrl(), body)
+	usesBody := method == "POST" || method == "PUT" || method == "PATCH" || method == "DELETE"
+	bodyString := req.GetBodyString()
+	bodyBytes := req.GetBodyBytes()
+
+	var httpReq *http.Request
+	var err error
+
+	if usesBody && bodyString != "" {
+		processedBody := &bytes.Buffer{}
+		bodyTmpl, err2 := template.New("body").Parse(bodyString)
+		if err2 != nil {
+			fh.eng.Errorf("error parsing body template: %v", err2)
+			return nil, caperrors.NewPublicUserError(fmt.Errorf("error parsing body template"), caperrors.InvalidArgument)
+		}
+		if err2 = bodyTmpl.Execute(processedBody, templateData); err2 != nil {
+			fh.eng.Errorf("error executing body template: %v", err2)
+			return nil, caperrors.NewPublicUserError(fmt.Errorf("error executing body template"), caperrors.InvalidArgument)
+		}
+		httpReq, err = http.NewRequestWithContext(ctx, method, req.GetUrl(), processedBody)
+	} else if usesBody && len(bodyBytes) > 0 {
+		httpReq, err = http.NewRequestWithContext(ctx, method, req.GetUrl(), bytes.NewReader(bodyBytes))
+	} else {
+		httpReq, err = http.NewRequestWithContext(ctx, method, req.GetUrl(), nil)
+	}
+
 	if err != nil {
 		fh.eng.Errorw("Failed to create HTTP request", "error", err)
 		return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to create HTTP request: %w", err), caperrors.InvalidArgument)
 	}
 
 	// Add headers
-	for name, value := range req.GetHeaders() {
-		httpReq.Header.Set(name, value)
+	for name, values := range req.GetMultiHeaders() {
+		for _, value := range values.Values {
+			headerTmpl, err := template.New("header").Parse(value)
+			if err != nil {
+				fh.eng.Errorf("error parsing header template for %s: %v", name, err)
+				return nil, caperrors.NewPublicUserError(fmt.Errorf("error parsing header template"), caperrors.InvalidArgument)
+			}
+
+			var processedHeader bytes.Buffer
+			if err := headerTmpl.Execute(&processedHeader, templateData); err != nil {
+				fh.eng.Errorf("error executing header template for %s: %v", name, err)
+				return nil, caperrors.NewPublicUserError(fmt.Errorf("error executing header template"), caperrors.InvalidArgument)
+			}
+
+			httpReq.Header.Add(name, processedHeader.String())
+		}
 	}
 
 	// Make the HTTP request
@@ -114,22 +188,41 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 		return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to read response body: %w", err), caperrors.InvalidArgument)
 	}
 
+	// Encrypt response body if AESGCMEncryptionKey is present in secrets
+	if secretValues, exists := fh.secretsConfig.SecretsNames[AESGCMEncryptionKey]; exists && len(secretValues) > 0 {
+		secretKeyStr := secretValues[0]
+		var secretKey []byte
+
+		// Try hex decoding first
+		if decoded, err := hex.DecodeString(secretKeyStr); err == nil && len(decoded) == 32 {
+			secretKey = decoded
+		} else {
+			// Use as raw bytes
+			secretKey = []byte(secretKeyStr)
+		}
+
+		encryptedBody, err := AESGCMEncrypt(respBody, secretKey)
+		if err != nil {
+			fh.eng.Errorw("Failed to encrypt response body", "error", err)
+			return nil, caperrors.NewPublicUserError(fmt.Errorf("failed to encrypt response body: %w", err), caperrors.InvalidArgument)
+		}
+		respBody = encryptedBody
+		fh.eng.Infow("Encrypted response body", "bodySize", len(respBody))
+	}
+
 	// Convert response headers to []*Header
-	var responseHeaders []*confidentialhttp.Header
+	responseHeaders := make(map[string]*confidentialhttp.HeaderValues)
 	for name, values := range resp.Header {
-		for _, value := range values {
-			responseHeaders = append(responseHeaders, &confidentialhttp.Header{
-				Name:  name,
-				Value: value,
-			})
+		responseHeaders[name] = &confidentialhttp.HeaderValues{
+			Values: values,
 		}
 	}
 
 	// Create response
 	response := &confidentialhttp.HTTPResponse{
-		StatusCode: uint32(resp.StatusCode), //nolint:gosec // HTTP status codes are always positive (100-599)
-		Body:       respBody,
-		Headers:    responseHeaders,
+		StatusCode:   uint32(resp.StatusCode), //nolint:gosec // HTTP status codes are always positive (100-599)
+		Body:         respBody,
+		MultiHeaders: responseHeaders,
 	}
 
 	responseAndMetadata := commonCap.ResponseAndMetadata[*confidentialhttp.HTTPResponse]{
@@ -163,4 +256,60 @@ func (fh *DirectConfidentialHTTPAction) RegisterToWorkflow(ctx context.Context, 
 func (fh *DirectConfidentialHTTPAction) UnregisterFromWorkflow(ctx context.Context, request commonCap.UnregisterFromWorkflowRequest) error {
 	fh.eng.Infow("Unregistered from Direct Confidential Http Action", "workflowID", request.Metadata.WorkflowID)
 	return nil
+}
+
+func AESGCMEncrypt(plaintext []byte, key []byte) ([]byte, error) {
+	// Create AES cipher
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create GCM mode
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate random nonce
+	nonce := make([]byte, gcm.NonceSize()) // 12 bytes for GCM
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	// Encrypt and authenticate
+	// Seal appends: nonce || ciphertext || tag
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+
+	return ciphertext, nil
+}
+
+func AESGCMDecrypt(blob []byte, key []byte) ([]byte, error) {
+	// Create AES cipher
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create GCM mode
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(blob) < nonceSize {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+
+	// Split nonce and ciphertext+tag
+	nonce, ciphertext := blob[:nonceSize], blob[nonceSize:]
+
+	// Decrypt and verify
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return plaintext, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a
-	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43
+	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10
 	github.com/smartcontractkit/chainlink-data-streams v0.1.11
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717
@@ -99,7 +99,7 @@ require (
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251210101658-1c5c8e4c4f15
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20251021173435-e86785845942
 	github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.10.0
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260128151123-605e9540b706

--- a/go.sum
+++ b/go.sum
@@ -1180,8 +1180,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a h1:5FxRKkjXvQvPlKx60ELXgOsn7NQIkBj/Au1Z6jpMfjM=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260122132406-0ada7a3fe04a/go.mod h1:Xe0SH5IHtGkCW6sy/EdBRPKD5L+U52HgoGfl0KDP/lw=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43 h1:2Kp505f9fh2hYeoZl1LdsN7aohP7CXERCsV7Rr2sZsA=
-github.com/smartcontractkit/chainlink-common v0.9.6-0.20260204232850-c7d66f2dab43/go.mod h1:6FarqEpCt00pUn9cTRym+zzmrMUKQ4TW09oV5lD4tqA=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d h1:hNW4KXr9UPpZ2v+gbnalPKYIdoW04ReU59360quIQJo=
+github.com/smartcontractkit/chainlink-common v0.9.6-0.20260206011444-ed1fb0284e5d/go.mod h1:Xj4eRsg1V/okUKOY7YSWoQKiSt40bZ3+mHw39VMHs6I=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20251215152504-b1e41f508340 h1:PsjEI+5jZIz9AS4eOsLS5VpSWJINf38clXV3wryPyMk=
@@ -1212,8 +1212,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0 h1:+/0xWigvOxFLghyivyxiUCYGcky/7i8IxfGTdTeaXFg=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260204211151-e87a8bf189b0/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963 h1:DCLvEn4KkFzYbK/AYl4vJmf6EHaskPYvGDGdd0kOma0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260206000552-087e235a7963/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b h1:QuI6SmQFK/zyUlVWEf0GMkiUYBPY4lssn26nKSd/bOM=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b/go.mod h1:qSTSwX3cBP3FKQwQacdjArqv0g6QnukjV4XuzO6UyoY=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.10.0 h1:0eroOyBwmdoGUwUdvMI0/J7m5wuzNnJDMglSOK1sfNY=


### PR DESCRIPTION
## Summary

Bumps `chainlink-common` and rewrites the `confidential-http` fake capability action (`core/capabilities/fakes/confidential_http_action.go`) to match the updated common types. (Closed.)
