### PR TITLE
chore: bump go to 1.25.7 across modules

### DIFF
--- a/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20251028192540-2ac3c24aa883

--- a/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260107095648-223976d2b9f1

--- a/core/scripts/cre/environment/examples/workflows/v2/cron/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/cron/go.mod
@@ -1,8 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/cron
 
-go 1.25.3
-
-toolchain go1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18

--- a/core/scripts/cre/environment/examples/workflows/v2/http/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/http/go.mod
@@ -1,8 +1,6 @@
 module main
 
-go 1.25.3
-
-toolchain go1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18

--- a/core/scripts/cre/environment/examples/workflows/v2/http_simple/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/http_simple/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.25.3
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18

--- a/core/scripts/cre/environment/examples/workflows/v2/node-mode/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/node-mode/go.mod
@@ -1,8 +1,6 @@
 module main
 
-go 1.25.3
-
-toolchain go1.25.5
+go 1.25.7
 
 require (
 	github.com/google/uuid v1.6.0

--- a/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/core/scripts/cre/environment/examples/workflows/v2/time/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/time/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.25.3
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18

--- a/core/scripts/cre/environment/examples/workflows/v2/time_consensus/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/time_consensus/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.25.3
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts
 
-go 1.25.5
+go 1.25.7
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../../

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/deployment
 
-go 1.25.5
+go 1.25.7
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/v2
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/BurntSushi/toml v1.5.0

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/integration-tests
 
-go 1.25.5
+go 1.25.7
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/load-tests
 
-go 1.25.5
+go 1.25.7
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../../

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/lib
 
-go 1.25.5
+go 1.25.7
 
 // Using a separate `require` here to avoid surrounding line changes
 // creating potential merge conflicts.

--- a/system-tests/tests/canaries_sentinels/proof-of-reserve/cron-based/go.mod
+++ b/system-tests/tests/canaries_sentinels/proof-of-reserve/cron-based/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.2

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests
 
-go 1.25.5
+go 1.25.7
 
 // Using a separate `require` here to avoid surrounding line changes
 // creating potential merge conflicts.

--- a/system-tests/tests/regression/cre/consensus/go.mod
+++ b/system-tests/tests/regression/cre/consensus/go.mod
@@ -1,8 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/consensus
 
-go 1.25.3
-
-toolchain go1.25.5
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/system-tests/tests/regression/cre/evm/evmread-negative/go.mod
+++ b/system-tests/tests/regression/cre/evm/evmread-negative/go.mod
@@ -1,8 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/evm/evmread-negative
 
-go 1.25.3
-
-toolchain go1.25.5
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/system-tests/tests/regression/cre/evm/evmwrite-negative/go.mod
+++ b/system-tests/tests/regression/cre/evm/evmwrite-negative/go.mod
@@ -1,8 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/evm/evmwrite-negative
 
-go 1.25.3
-
-toolchain go1.25.5
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/system-tests/tests/regression/cre/http/go.mod
+++ b/system-tests/tests/regression/cre/http/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/http
 
-go 1.25.3
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18

--- a/system-tests/tests/regression/cre/httpaction-negative/go.mod
+++ b/system-tests/tests/regression/cre/httpaction-negative/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/httpaction-negative
 
-go 1.25.3
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18

--- a/system-tests/tests/smoke/cre/evm/evmread/go.mod
+++ b/system-tests/tests/smoke/cre/evm/evmread/go.mod
@@ -1,8 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evm/evmread
 
-go 1.25.3
-
-toolchain go1.25.5
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/system-tests/tests/smoke/cre/evm/logtrigger/go.mod
+++ b/system-tests/tests/smoke/cre/evm/logtrigger/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evm/logtrigger
 
-go 1.25.3
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/system-tests/tests/smoke/cre/httpaction/go.mod
+++ b/system-tests/tests/smoke/cre/httpaction/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/httpaction
 
-go 1.25.3
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18


### PR DESCRIPTION
Bump Go patch version to 1.25.7 across all modules. Patch-level upgrade only