### PR TITLE
Set unreleased docker builds to use a more deterministic version tag

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -70,8 +70,10 @@ jobs:
         id: version-info
         run: |
           pkg_version=$(jq -r '.version' ./package.json)
+          # Sanitize package version for Docker tag compatibility (e.g., replace '+' with '-')
+          sanitized_pkg_version="${pkg_version//+/-}"
           short_sha=$(git rev-parse --short HEAD)
-          version_tag="${pkg_version}-${short_sha}"
+          version_tag="${sanitized_pkg_version}-${short_sha}"
           echo "version-tag=${version_tag}" | tee -a "$GITHUB_OUTPUT"
 
   docker-core:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -70,7 +70,7 @@ jobs:
         id: version-info
         run: |
           pkg_version=$(jq -r '.version' ./package.json)
-          version_tag="${sanitized_pkg_version}-dev"
+          version_tag="${pkg_version}-dev"
           echo "version-tag=${version_tag}" | tee -a "$GITHUB_OUTPUT"
 
   docker-core:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -69,7 +69,9 @@ jobs:
       - name: Version Info
         id: version-info
         run: |
-          version_tag=$( git describe --always )
+          pkg_version=$(jq -r '.version' ./package.json)
+          short_sha=$(git rev-parse --short HEAD)
+          version_tag="${pkg_version}-${short_sha}"
           echo "version-tag=${version_tag}" | tee -a "$GITHUB_OUTPUT"
 
   docker-core:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -70,10 +70,7 @@ jobs:
         id: version-info
         run: |
           pkg_version=$(jq -r '.version' ./package.json)
-          # Sanitize package version for Docker tag compatibility (e.g., replace '+' with '-')
-          sanitized_pkg_version="${pkg_version//+/-}"
-          short_sha=$(git rev-parse --short HEAD)
-          version_tag="${sanitized_pkg_version}-${short_sha}"
+          version_tag="${sanitized_pkg_version}-dev"
           echo "version-tag=${version_tag}" | tee -a "$GITHUB_OUTPUT"
 
   docker-core:


### PR DESCRIPTION
From the HEAD of `develop`, we have:

```
❯ git describe --always
v2.29.1-cre-beta.0-518-gc45c36fd99
```

This version string was being used for the image build's VERSION_TAG argument, which created version comparison issues downstream.

When attempting to upgrade an internal node on a DON from a previous version (e.g., v2.30.0) to an image built from develop, the upgrade would fail. The version was being parsed as v2.29.1 (based on the most recent ancestor tag), which is older than v2.30.0, even though develop is actually tracking 2.33.0 according to the package.json's version field.

Running `docker run -ti --rm --platform linux/amd64 --entrypoint chainlink public.ecr.aws/chainlink/chainlink:2.30.0` produces output like:

```
...
VERSION:
   2.30.0@ec74338ec78001939ed2d53c9c5e6b435f76b1d5
...
```