### PR TITLE
[Local CRE] Remove OCR bootstrap job specs

### DIFF
--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -280,6 +280,15 @@ func (w *launcher) donPairsToUpdate(myID ragetypes.PeerID, localRegistry *regist
 			}
 		}
 	}
+	if isBootstrap {
+		// Add self-pairs [A,A] for all DONs to make sure that isolated DONs can still discover their own members and run OCR.
+		// This is only useful for environments without don2don connectivity (e.g. single-DON Local CRE) or temporary
+		// isolated DONs (e.g. first DON in a new DON family).
+		for _, id := range allDONIds {
+			don := localRegistry.IDsToDONs[id]
+			donPairs = append(donPairs, p2ptypes.DonPair{don.DON, don.DON})
+		}
+	}
 	return donPairs
 }
 

--- a/core/capabilities/launcher_test.go
+++ b/core/capabilities/launcher_test.go
@@ -749,23 +749,29 @@ func TestLauncher_DonPairsToUpdate(t *testing.T) {
 	// peer (not bootstrap) that doesn't belong to any DON connects to nobody
 	require.Empty(t, launcher.donPairsToUpdate(other, localRegistry))
 
-	// bootstrap node adds all 3 DON pairs
+	// bootstrap node adds all 3 DON pairs + 3 self-pairs
 	sharedPeer.On("IsBootstrap").Return(true).Once()
 	res = launcher.donPairsToUpdate(pid, localRegistry)
-	require.Len(t, res, 3)
+	require.Len(t, res, 6)
 	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[wfDONID].DON, localRegistry.IDsToDONs[capDONID].DON}, res[0])
 	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[wfDONID].DON, localRegistry.IDsToDONs[mixedDONID].DON}, res[1])
 	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[capDONID].DON, localRegistry.IDsToDONs[mixedDONID].DON}, res[2])
+	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[wfDONID].DON, localRegistry.IDsToDONs[wfDONID].DON}, res[3])
+	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[capDONID].DON, localRegistry.IDsToDONs[capDONID].DON}, res[4])
+	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[mixedDONID].DON, localRegistry.IDsToDONs[mixedDONID].DON}, res[5])
 
-	// bootstrap node adds only allowed DON pairs
+	// bootstrap node adds only allowed DON pairs + 3 self-pairs
 	mixedDON := localRegistry.IDsToDONs[mixedDONID]
 	mixedDON.AcceptsWorkflows = false
 	localRegistry.IDsToDONs[mixedDONID] = mixedDON
 	sharedPeer.On("IsBootstrap").Return(true).Once()
 	res = launcher.donPairsToUpdate(pid, localRegistry)
-	require.Len(t, res, 2)
+	require.Len(t, res, 5)
 	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[wfDONID].DON, localRegistry.IDsToDONs[capDONID].DON}, res[0])
 	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[wfDONID].DON, localRegistry.IDsToDONs[mixedDONID].DON}, res[1])
+	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[wfDONID].DON, localRegistry.IDsToDONs[wfDONID].DON}, res[2])
+	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[capDONID].DON, localRegistry.IDsToDONs[capDONID].DON}, res[3])
+	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[mixedDONID].DON, localRegistry.IDsToDONs[mixedDONID].DON}, res[4])
 }
 
 func TestLauncher_DonPairsToUpdate_SkipsDifferentFamilies(t *testing.T) {
@@ -815,11 +821,14 @@ func TestLauncher_DonPairsToUpdate_SkipsDifferentFamilies(t *testing.T) {
 	require.Len(t, res, 1, "expected only one DON pair (zone-a workflow to zone-a capability)")
 	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[registrysyncer.DonID(wfDONID)].DON, localRegistry.IDsToDONs[registrysyncer.DonID(capDONZoneAID)].DON}, res[0])
 
-	// Bootstrap node should still respect family boundaries
+	// Bootstrap node should still respect family boundaries, plus add self-pairs for all DONs
 	sharedPeer.On("IsBootstrap").Return(true).Once()
 	res = launcher.donPairsToUpdate(pid, localRegistry)
-	require.Len(t, res, 1, "bootstrap should also filter based on families")
+	require.Len(t, res, 4, "bootstrap should also filter based on families but add self-pairs")
 	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[registrysyncer.DonID(wfDONID)].DON, localRegistry.IDsToDONs[registrysyncer.DonID(capDONZoneAID)].DON}, res[0])
+	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[registrysyncer.DonID(wfDONID)].DON, localRegistry.IDsToDONs[registrysyncer.DonID(wfDONID)].DON}, res[1])
+	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[registrysyncer.DonID(capDONZoneAID)].DON, localRegistry.IDsToDONs[registrysyncer.DonID(capDONZoneAID)].DON}, res[2])
+	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[registrysyncer.DonID(capDONZoneBID)].DON, localRegistry.IDsToDONs[registrysyncer.DonID(capDONZoneBID)].DON}, res[3])
 }
 
 func TestLauncher_V2CapabilitiesAddViaCombinedClient(t *testing.T) {

--- a/system-tests/lib/cre/features/consensus/v1/consensus.go
+++ b/system-tests/lib/cre/features/consensus/v1/consensus.go
@@ -149,43 +149,7 @@ func createJobs(
 		return errors.New("could not find bootstrap node in topology, exactly one bootstrap node is required")
 	}
 
-	bootInput := cre_jobs.ProposeJobSpecInput{
-		Domain:      offchain.ProductLabel,
-		Environment: cre.EnvironmentName,
-		DONName:     bootstrap.DON.Name,
-		JobName:     "consensus-v1-bootstrap-" + don.Name,
-		ExtraLabels: map[string]string{cre.CapabilityLabelKey: flag},
-		DONFilters: []offchain.TargetDONFilter{
-			{Key: offchain.FilterKeyDONName, Value: bootstrap.DON.Name},
-		},
-		Template: job_types.BootstrapOCR3,
-		Inputs: job_types.JobSpecInput{
-			"chainSelector":     creEnv.RegistryChainSelector,
-			"contractQualifier": ContractQualifier,
-		},
-	}
-
-	bootVerErr := cre_jobs.ProposeJobSpec{}.VerifyPreconditions(*creEnv.CldfEnvironment, bootInput)
-	if bootVerErr != nil {
-		return fmt.Errorf("precondition verification failed for Consensus v1 bootstrap job: %w", bootVerErr)
-	}
-
-	bootReport, bootErr := cre_jobs.ProposeJobSpec{}.Apply(*creEnv.CldfEnvironment, bootInput)
-	if bootErr != nil {
-		return fmt.Errorf("failed to propose Consensus v1 bootstrap job spec: %w", bootErr)
-	}
-
 	specs := make(map[string][]string)
-	for _, r := range bootReport.Reports {
-		out, ok := r.Output.(cre_jobs_ops.ProposeOCR3BootstrapJobOutput)
-		if !ok {
-			return fmt.Errorf("unable to cast to ProposeOCR3BootstrapJobOutput, actual type: %T", r.Output)
-		}
-		mErr := mergo.Merge(&specs, out.Specs, mergo.WithAppendSlice)
-		if mErr != nil {
-			return fmt.Errorf("failed to merge bootstrap job specs: %w", mErr)
-		}
-	}
 
 	_, ocrPeeringCfg, err := cre.PeeringCfgs(bootstrap)
 	if err != nil {

--- a/system-tests/lib/cre/features/consensus/v2/consensus.go
+++ b/system-tests/lib/cre/features/consensus/v2/consensus.go
@@ -188,13 +188,6 @@ func createJobs(
 
 	specs := make(map[string][]string)
 
-	// Create bootstrap job
-	if bootSpecs, err := proposeBootstrapJob(creEnv, bootstrap, don); err != nil {
-		return err
-	} else if err := mergo.Merge(&specs, bootSpecs, mergo.WithAppendSlice); err != nil {
-		return fmt.Errorf("failed to merge bootstrap job specs: %w", err)
-	}
-
 	// Create node job
 	if nodeSpecs, err := proposeNodeJob(creEnv, don, command, []string{formatBootstrapPeer(bootstrap)}, configStr); err != nil {
 		return err

--- a/system-tests/lib/cre/features/evm/v2/evm.go
+++ b/system-tests/lib/cre/features/evm/v2/evm.go
@@ -309,43 +309,6 @@ func createJobs(
 			return errors.Wrapf(err, "failed to get contract address for key %s and chainID %d", ocr3Key, chainID)
 		}
 
-		bootInput := cre_jobs.ProposeJobSpecInput{
-			Domain:      offchain.ProductLabel,
-			Environment: cre.EnvironmentName,
-			DONName:     bootstrap.DON.Name,
-			JobName:     fmt.Sprintf("evm-v2-bootstrap-%d-%s", chainID, don.Name),
-			ExtraLabels: map[string]string{cre.CapabilityLabelKey: flag},
-			DONFilters: []offchain.TargetDONFilter{
-				{Key: offchain.FilterKeyDONName, Value: bootstrap.DON.Name},
-			},
-			Template: job_types.BootstrapOCR3,
-			Inputs: job_types.JobSpecInput{
-				"chainSelector":     chainSelector,
-				"contractQualifier": qualifier,
-			},
-		}
-
-		bootVerErr := cre_jobs.ProposeJobSpec{}.VerifyPreconditions(*creEnv.CldfEnvironment, bootInput)
-		if bootVerErr != nil {
-			return fmt.Errorf("precondition verification failed for EVM v2 bootstrap job for chainID %d: %w", chainID, bootVerErr)
-		}
-
-		bootReport, bootErr := cre_jobs.ProposeJobSpec{}.Apply(*creEnv.CldfEnvironment, bootInput)
-		if bootErr != nil {
-			return fmt.Errorf("failed to propose EVM v2 bootstrap job spec for chainID %d: %w", chainID, bootErr)
-		}
-
-		for _, r := range bootReport.Reports {
-			out, ok := r.Output.(cre_jobs_ops.ProposeOCR3BootstrapJobOutput)
-			if !ok {
-				return fmt.Errorf("unable to cast to ProposeOCR3BootstrapJobOutput, actual type: %T", r.Output)
-			}
-			mErr := mergo.Merge(&specs, out.Specs, mergo.WithAppendSlice)
-			if mErr != nil {
-				return fmt.Errorf("failed to merge bootstrap job specs: %w", mErr)
-			}
-		}
-
 		capabilityConfig, resolveErr := cre.ResolveCapabilityConfig(nodeSet, flag, cre.ChainCapabilityScope(chainID))
 		if resolveErr != nil {
 			return fmt.Errorf("could not resolve capability config for '%s' on chain %d: %w", flag, chainID, resolveErr)

--- a/system-tests/lib/cre/features/vault/vault.go
+++ b/system-tests/lib/cre/features/vault/vault.go
@@ -33,7 +33,6 @@ import (
 	cre_jobs "github.com/smartcontractkit/chainlink/deployment/cre/jobs"
 	cre_jobs_ops "github.com/smartcontractkit/chainlink/deployment/cre/jobs/operations"
 	"github.com/smartcontractkit/chainlink/deployment/cre/jobs/pkg"
-	cre_jobs_seq "github.com/smartcontractkit/chainlink/deployment/cre/jobs/sequences"
 	job_types "github.com/smartcontractkit/chainlink/deployment/cre/jobs/types"
 	creseq "github.com/smartcontractkit/chainlink/deployment/cre/ocr3/v2/changeset/sequences"
 	"github.com/smartcontractkit/chainlink/deployment/cre/pkg/offchain"
@@ -278,43 +277,7 @@ func createJobs(
 		return errors.New("could not find bootstrap node in topology, exactly one bootstrap node is required")
 	}
 
-	bootInput := cre_jobs.ProposeJobSpecInput{
-		Domain:      offchain.ProductLabel,
-		Environment: cre.EnvironmentName,
-		DONName:     bootstrap.DON.Name,
-		JobName:     "vault-bootstrap-" + don.Name,
-		ExtraLabels: map[string]string{cre.CapabilityLabelKey: flag},
-		DONFilters: []offchain.TargetDONFilter{
-			{Key: offchain.FilterKeyDONName, Value: bootstrap.DON.Name},
-		},
-		Template: job_types.BootstrapVault,
-		Inputs: job_types.JobSpecInput{
-			"chainSelector":           creEnv.RegistryChainSelector,
-			"contractQualifierPrefix": ContractQualifier,
-		},
-	}
-
-	bootVerErr := cre_jobs.ProposeJobSpec{}.VerifyPreconditions(*creEnv.CldfEnvironment, bootInput)
-	if bootVerErr != nil {
-		return fmt.Errorf("precondition verification failed for Vault bootstrap job: %w", bootVerErr)
-	}
-
-	bootReport, bootErr := cre_jobs.ProposeJobSpec{}.Apply(*creEnv.CldfEnvironment, bootInput)
-	if bootErr != nil {
-		return fmt.Errorf("failed to propose Vault bootstrap job spec: %w", bootErr)
-	}
-
 	specs := make(map[string][]string)
-	for _, r := range bootReport.Reports {
-		out, ok := r.Output.(cre_jobs_seq.ProposeVaultBootstrapJobsOutput)
-		if !ok {
-			return fmt.Errorf("unable to cast to ProposeVaultBootstrapJobsOutput, actual type: %T", r.Output)
-		}
-		mErr := mergo.Merge(&specs, out.Specs, mergo.WithAppendSlice)
-		if mErr != nil {
-			return fmt.Errorf("failed to merge bootstrap job specs: %w", mErr)
-		}
-	}
 
 	_, ocrPeeringCfg, err := cre.PeeringCfgs(bootstrap)
 	if err != nil {


### PR DESCRIPTION
Individual OCR bootstrap job specs are not needed any more. Global bootstraps cover all nodes in the environment.