### PR TITLE
.github/workflows: restore git diff --stat

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -561,7 +561,7 @@ jobs:
       - name: Ensure clean after generate
         run: |
           git add --all
-          git diff --minimal --cached --exit-code
+          git diff --stat --cached --exit-code
       - run: make gomodtidy
       - name: Ensure clean after tidy
         run: |


### PR DESCRIPTION
Stat was chosen because --minimal often logs more than 75 thousand lines.
