### PR TITLE
Resolve secrets using envars in the fake confidential HTTP capability

### DIFF
--- a/core/capabilities/fakes/confidential_http_action.go
+++ b/core/capabilities/fakes/confidential_http_action.go
@@ -57,13 +57,13 @@ type DirectConfidentialHTTPAction struct {
 	lggr          logger.Logger
 }
 
-func NewDirectConfidentialHTTPAction(lggr logger.Logger) *DirectConfidentialHTTPAction {
+func NewDirectConfidentialHTTPAction(lggr logger.Logger, secretsPath string) *DirectConfidentialHTTPAction {
 	fc := &DirectConfidentialHTTPAction{
 		lggr: lggr,
 	}
 
 	// Load secrets
-	secretsFile := "secrets.yaml"
+	secretsFile := secretsPath
 	if envFile := os.Getenv("SECRETS_FILE"); envFile != "" {
 		secretsFile = envFile
 	}

--- a/core/capabilities/fakes/confidential_http_action.go
+++ b/core/capabilities/fakes/confidential_http_action.go
@@ -75,13 +75,15 @@ func NewDirectConfidentialHTTPAction(lggr logger.Logger, secretsPath string) *Di
 			lggr.Infof("Loaded secrets from %s", secretsFile)
 			// Resolve environment variables
 			for key, val := range fc.secretsConfig.SecretsNames {
-				for i, v := range val {
+				secrets := val
+				for i, v := range secrets {
 					if envVal := os.Getenv(v); envVal != "" {
-						fc.secretsConfig.SecretsNames[key][i] = envVal
+						secrets[i] = envVal
 					} else {
 						lggr.Warnf("Secret environment variable %s not set", v)
 					}
 				}
+				fc.secretsConfig.SecretsNames[key] = secrets
 			}
 		}
 	} else {

--- a/core/capabilities/fakes/confidential_http_action.go
+++ b/core/capabilities/fakes/confidential_http_action.go
@@ -73,6 +73,16 @@ func NewDirectConfidentialHTTPAction(lggr logger.Logger) *DirectConfidentialHTTP
 			lggr.Warnf("Failed to parse secrets file %s: %v", secretsFile, marshalErr)
 		} else {
 			lggr.Infof("Loaded secrets from %s", secretsFile)
+			// Resolve environment variables
+			for key, val := range fc.secretsConfig.SecretsNames {
+				for i, v := range val {
+					if envVal := os.Getenv(v); envVal != "" {
+						fc.secretsConfig.SecretsNames[key][i] = envVal
+					} else {
+						lggr.Warnf("Secret environment variable %s not set", v)
+					}
+				}
+			}
 		}
 	} else {
 		lggr.Infof("Could not read secrets file %s: %v. Continuing without local secrets.", secretsFile, err)

--- a/core/capabilities/fakes/confidential_http_action_test.go
+++ b/core/capabilities/fakes/confidential_http_action_test.go
@@ -49,11 +49,10 @@ secretsNames:
 	defer func() { require.NoError(t, os.Remove(secretsFile)) }()
 
 	// Set environment variables
-	t.Setenv("SECRETS_FILE", secretsFile)
 	t.Setenv("API_KEY_ALL", "resolved-api-key")
 
 	lggr := logger.Test(t)
-	action := NewDirectConfidentialHTTPAction(lggr)
+	action := NewDirectConfidentialHTTPAction(lggr, secretsFile)
 
 	// Verify secrets were resolved
 	secrets, ok := action.secretsConfig.SecretsNames["API_KEY"]

--- a/core/capabilities/fakes/confidential_http_action_test.go
+++ b/core/capabilities/fakes/confidential_http_action_test.go
@@ -60,3 +60,26 @@ secretsNames:
 	require.Len(t, secrets, 1)
 	assert.Equal(t, "resolved-api-key", secrets[0])
 }
+
+func TestDirectConfidentialHTTPAction_SecretsLoading_MissingEnv(t *testing.T) {
+	// Create a temporary secrets.yaml
+	tmpDir := t.TempDir()
+	secretsFile := filepath.Join(tmpDir, "secrets.yaml")
+	secretsContent := `
+secretsNames:
+  API_KEY:
+    - MISSING_ENV_VAR
+`
+	err := os.WriteFile(secretsFile, []byte(secretsContent), 0600)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.Remove(secretsFile)) }()
+
+	lggr := logger.Test(t)
+	action := NewDirectConfidentialHTTPAction(lggr, secretsFile)
+
+	// Verify secret remains as the placeholder when env var is missing
+	secrets, ok := action.secretsConfig.SecretsNames["API_KEY"]
+	require.True(t, ok)
+	require.Len(t, secrets, 1)
+	assert.Equal(t, "MISSING_ENV_VAR", secrets[0])
+}

--- a/core/capabilities/fakes/confidential_http_action_test.go
+++ b/core/capabilities/fakes/confidential_http_action_test.go
@@ -1,11 +1,15 @@
 package fakes
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	confidentialhttp "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialhttp"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 func TestHasEncryptionSecret(t *testing.T) {
@@ -29,4 +33,31 @@ func TestHasEncryptionSecret(t *testing.T) {
 		assert.False(t, hasEncryptionSecret(nil))
 		assert.False(t, hasEncryptionSecret([]*confidentialhttp.SecretIdentifier{}))
 	})
+}
+
+func TestDirectConfidentialHTTPAction_SecretsLoading(t *testing.T) {
+	// Create a temporary secrets.yaml
+	tmpDir := t.TempDir()
+	secretsFile := filepath.Join(tmpDir, "secrets.yaml")
+	secretsContent := `
+secretsNames:
+  CMC_API_KEY:
+    - CMC_API_KEY_ALL
+`
+	err := os.WriteFile(secretsFile, []byte(secretsContent), 0600)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.Remove(secretsFile)) }()
+
+	// Set environment variables
+	t.Setenv("SECRETS_FILE", secretsFile)
+	t.Setenv("CMC_API_KEY_ALL", "resolved-api-key")
+
+	lggr := logger.Test(t)
+	action := NewDirectConfidentialHTTPAction(lggr)
+
+	// Verify secrets were resolved
+	secrets, ok := action.secretsConfig.SecretsNames["CMC_API_KEY"]
+	require.True(t, ok)
+	require.Len(t, secrets, 1)
+	assert.Equal(t, "resolved-api-key", secrets[0])
 }

--- a/core/capabilities/fakes/confidential_http_action_test.go
+++ b/core/capabilities/fakes/confidential_http_action_test.go
@@ -41,8 +41,8 @@ func TestDirectConfidentialHTTPAction_SecretsLoading(t *testing.T) {
 	secretsFile := filepath.Join(tmpDir, "secrets.yaml")
 	secretsContent := `
 secretsNames:
-  CMC_API_KEY:
-    - CMC_API_KEY_ALL
+  API_KEY:
+    - API_KEY_ALL
 `
 	err := os.WriteFile(secretsFile, []byte(secretsContent), 0600)
 	require.NoError(t, err)
@@ -50,13 +50,13 @@ secretsNames:
 
 	// Set environment variables
 	t.Setenv("SECRETS_FILE", secretsFile)
-	t.Setenv("CMC_API_KEY_ALL", "resolved-api-key")
+	t.Setenv("API_KEY_ALL", "resolved-api-key")
 
 	lggr := logger.Test(t)
 	action := NewDirectConfidentialHTTPAction(lggr)
 
 	// Verify secrets were resolved
-	secrets, ok := action.secretsConfig.SecretsNames["CMC_API_KEY"]
+	secrets, ok := action.secretsConfig.SecretsNames["API_KEY"]
 	require.True(t, ok)
 	require.Len(t, secrets, 1)
 	assert.Equal(t, "resolved-api-key", secrets[0])


### PR DESCRIPTION
Also validated dowm in CLI simulator tests: github.com/smartcontractkit/cre-cli/pull/257