### PR TITLE
add .git and devenv/ to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git-together
+.git
 .DS_Store
 .envrc
 *.log
@@ -10,6 +11,7 @@ tmp/
 contracts/node_modules
 examples/
 
+devenv/
 deployment/
 integration/
 integration-scripts/


### PR DESCRIPTION
This change reduces the size of build context to around ~66 MB, down from up to 2 GB.