### PR TITLE
[PRODCRE-1746] Extract keystore models into its own package

### DIFF
--- a/core/services/keystore/eth.go
+++ b/core/services/keystore/eth.go
@@ -271,7 +271,7 @@ func (ks *eth) addKey(ctx context.Context, ds sqlutil.DataSource, address common
 		return errors.Wrap(err, "failed to insert key_state")
 	}
 	// consider: do we really need a cache of the keystates?
-	ks.keyStates.add(state)
+	ks.keyStates.Add(state)
 	return nil
 }
 
@@ -296,9 +296,9 @@ func (ks *eth) enable(ctx context.Context, address common.Address, chainID *big.
 	}
 
 	if state.CreatedAt.Equal(state.UpdatedAt) {
-		ks.keyStates.add(state)
+		ks.keyStates.Add(state)
 	} else {
-		ks.keyStates.enable(address, chainID, state.UpdatedAt)
+		ks.keyStates.Enable(address, chainID, state.UpdatedAt)
 	}
 	return nil
 }
@@ -323,9 +323,9 @@ func (ks *eth) disable(ctx context.Context, address common.Address, chainID *big
 	}
 
 	if state.CreatedAt.Equal(state.UpdatedAt) {
-		ks.keyStates.add(state)
+		ks.keyStates.Add(state)
 	} else {
-		ks.keyStates.disable(address, chainID, state.UpdatedAt)
+		ks.keyStates.Disable(address, chainID, state.UpdatedAt)
 	}
 	return nil
 }
@@ -347,7 +347,7 @@ func (ks *eth) Delete(ctx context.Context, id string) (ethkey.KeyV2, error) {
 	if err != nil {
 		return ethkey.KeyV2{}, errors.Wrap(err, "unable to remove eth key")
 	}
-	ks.keyStates.delete(key.Address)
+	ks.keyStates.Delete(key.Address)
 	return key, nil
 }
 

--- a/core/services/keystore/helpers_test.go
+++ b/core/services/keystore/helpers_test.go
@@ -4,19 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/smartcontractkit/chainlink-common/keystore"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/models"
 )
-
-func mustNewEthKey(t *testing.T) *ethkey.KeyV2 {
-	key, err := ethkey.NewV2()
-	require.NoError(t, err)
-	return &key
-}
 
 func ExposedNewMaster(t *testing.T, ds sqlutil.DataSource) *master {
 	return newMaster(ds, keystore.FastScryptParams, logger.Test(t).Infof)
@@ -29,8 +21,8 @@ func (m *master) ExportedSave(ctx context.Context) error {
 }
 
 func (m *master) ResetXXXTestOnly() {
-	m.keyRing = newKeyRing()
-	m.keyStates = newKeyStates()
+	m.keyRing = models.NewKeyRing()
+	m.keyStates = models.NewKeyStates()
 	m.password = ""
 }
 

--- a/core/services/keystore/keys/models/legacy_key.go
+++ b/core/services/keystore/keys/models/legacy_key.go
@@ -1,4 +1,4 @@
-package keystore
+package models
 
 import (
 	"encoding/json"
@@ -37,7 +37,7 @@ func (rlk *rawLegacyKeys) hasValueInField(fieldName, value string) bool {
 // StoreUnsupported will store the raw keys that no longer have support in the node
 // it will check if raw json contains keys that have not been added to the key ring
 // and stores them internally
-func (k *LegacyKeyStorage) StoreUnsupported(allRawKeysJson []byte, keyRing *keyRing) error {
+func (k *LegacyKeyStorage) StoreUnsupported(allRawKeysJson []byte, keyRing *KeyRing) error {
 	if keyRing == nil {
 		return errors.New("keyring is nil")
 	}

--- a/core/services/keystore/keys/models/legacy_key.go
+++ b/core/services/keystore/keys/models/legacy_key.go
@@ -37,7 +37,7 @@ func (rlk *rawLegacyKeys) hasValueInField(fieldName, value string) bool {
 // StoreUnsupported will store the raw keys that no longer have support in the node
 // it will check if raw json contains keys that have not been added to the key ring
 // and stores them internally
-func (k *LegacyKeyStorage) StoreUnsupported(allRawKeysJson []byte, keyRing *KeyRing) error {
+func (k *LegacyKeyStorage) StoreUnsupported(allRawKeysJSON []byte, keyRing *KeyRing) error {
 	if keyRing == nil {
 		return errors.New("keyring is nil")
 	}
@@ -51,7 +51,7 @@ func (k *LegacyKeyStorage) StoreUnsupported(allRawKeysJson []byte, keyRing *KeyR
 		supportedKeys = rawLegacyKeys{}
 	)
 
-	err = json.Unmarshal(allRawKeysJson, &allKeys)
+	err = json.Unmarshal(allRawKeysJSON, &allKeys)
 	if err != nil {
 		return err
 	}

--- a/core/services/keystore/keys/models/models.go
+++ b/core/services/keystore/keys/models/models.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 	"math/big"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/keystore"
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/aptoskey"

--- a/core/services/keystore/keys/models/models.go
+++ b/core/services/keystore/keys/models/models.go
@@ -31,14 +31,14 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/workflowkey"
 )
 
-type encryptedKeyRing struct {
+type EncryptedKeyRing struct {
 	UpdatedAt     time.Time
 	EncryptedKeys []byte
 }
 
-func (ekr encryptedKeyRing) Decrypt(password string) (*keyRing, error) {
+func (ekr EncryptedKeyRing) Decrypt(password string) (*KeyRing, error) {
 	if len(ekr.EncryptedKeys) == 0 {
-		return newKeyRing(), nil
+		return NewKeyRing(), nil
 	}
 	var cryptoJSON gethkeystore.CryptoJSON
 	err := json.Unmarshal(ekr.EncryptedKeys, &cryptoJSON)
@@ -68,7 +68,7 @@ func (ekr encryptedKeyRing) Decrypt(password string) (*keyRing, error) {
 	return ring, nil
 }
 
-type keyStates struct {
+type KeyStates struct {
 	// Key ID => chain ID => state
 	KeyIDChainID map[string]map[string]*ethkey.State
 	// Chain ID => Key ID => state
@@ -76,8 +76,8 @@ type keyStates struct {
 	All          []*ethkey.State
 }
 
-func newKeyStates() *keyStates {
-	return &keyStates{
+func NewKeyStates() *KeyStates {
+	return &KeyStates{
 		KeyIDChainID: make(map[string]map[string]*ethkey.State),
 		ChainIDKeyID: make(map[string]map[string]*ethkey.State),
 	}
@@ -85,7 +85,7 @@ func newKeyStates() *keyStates {
 
 // warning: not thread-safe! caller must sync
 // adds or replaces a state
-func (ks *keyStates) add(state *ethkey.State) {
+func (ks *KeyStates) Add(state *ethkey.State) {
 	cid := state.EVMChainID.String()
 	kid := state.KeyID()
 
@@ -117,7 +117,7 @@ func (ks *keyStates) add(state *ethkey.State) {
 }
 
 // warning: not thread-safe! caller must sync
-func (ks *keyStates) get(addr common.Address, chainID *big.Int) *ethkey.State {
+func (ks *KeyStates) Get(addr common.Address, chainID *big.Int) *ethkey.State {
 	chainStates, exists := ks.KeyIDChainID[addr.Hex()]
 	if !exists {
 		return nil
@@ -126,21 +126,21 @@ func (ks *keyStates) get(addr common.Address, chainID *big.Int) *ethkey.State {
 }
 
 // warning: not thread-safe! caller must sync
-func (ks *keyStates) disable(addr common.Address, chainID *big.Int, updatedAt time.Time) {
-	state := ks.get(addr, chainID)
+func (ks *KeyStates) Disable(addr common.Address, chainID *big.Int, updatedAt time.Time) {
+	state := ks.Get(addr, chainID)
 	state.Disabled = true
 	state.UpdatedAt = updatedAt
 }
 
 // warning: not thread-safe! caller must sync
-func (ks *keyStates) enable(addr common.Address, chainID *big.Int, updatedAt time.Time) {
-	state := ks.get(addr, chainID)
+func (ks *KeyStates) Enable(addr common.Address, chainID *big.Int, updatedAt time.Time) {
+	state := ks.Get(addr, chainID)
 	state.Disabled = false
 	state.UpdatedAt = updatedAt
 }
 
 // warning: not thread-safe! caller must sync
-func (ks *keyStates) delete(addr common.Address) {
+func (ks *KeyStates) Delete(addr common.Address) {
 	var chainIDs []*big.Int
 	for i := len(ks.All) - 1; i >= 0; i-- {
 		if ks.All[i].Address.Address() == addr {
@@ -154,7 +154,7 @@ func (ks *keyStates) delete(addr common.Address) {
 	}
 }
 
-type keyRing struct {
+type KeyRing struct {
 	CSA          map[string]csakey.KeyV2
 	Eth          map[string]ethkey.KeyV2
 	OCR          map[string]ocrkey.KeyV2
@@ -173,8 +173,8 @@ type keyRing struct {
 	LegacyKeys   LegacyKeyStorage
 }
 
-func newKeyRing() *keyRing {
-	return &keyRing{
+func NewKeyRing() *KeyRing {
+	return &KeyRing{
 		CSA:          make(map[string]csakey.KeyV2),
 		Eth:          make(map[string]ethkey.KeyV2),
 		OCR:          make(map[string]ocrkey.KeyV2),
@@ -193,7 +193,7 @@ func newKeyRing() *keyRing {
 	}
 }
 
-func (kr *keyRing) Encrypt(password string, scryptParams keystore.ScryptParams) (ekr encryptedKeyRing, err error) {
+func (kr *KeyRing) Encrypt(password string, scryptParams keystore.ScryptParams) (ekr EncryptedKeyRing, err error) {
 	marshalledRawKeyRingJson, err := json.Marshal(kr.raw())
 	if err != nil {
 		return ekr, err
@@ -201,7 +201,7 @@ func (kr *keyRing) Encrypt(password string, scryptParams keystore.ScryptParams) 
 
 	marshalledRawKeyRingJson, err = kr.LegacyKeys.UnloadUnsupported(marshalledRawKeyRingJson)
 	if err != nil {
-		return encryptedKeyRing{}, err
+		return EncryptedKeyRing{}, err
 	}
 
 	cryptoJSON, err := gethkeystore.EncryptDataV3(
@@ -217,12 +217,12 @@ func (kr *keyRing) Encrypt(password string, scryptParams keystore.ScryptParams) 
 	if err != nil {
 		return ekr, errors.Wrapf(err, "could not encode cryptoJSON")
 	}
-	return encryptedKeyRing{
+	return EncryptedKeyRing{
 		EncryptedKeys: encryptedKeys,
 	}, nil
 }
 
-func (kr *keyRing) raw() (rawKeys rawKeyRing) {
+func (kr *KeyRing) raw() (rawKeys rawKeyRing) {
 	for _, csaKey := range kr.CSA {
 		rawKeys.CSA = append(rawKeys.CSA, internal.RawBytes(csaKey))
 	}
@@ -271,7 +271,7 @@ func (kr *keyRing) raw() (rawKeys rawKeyRing) {
 	return rawKeys
 }
 
-func (kr *keyRing) logPubKeys(lggr logger.Logger) {
+func (kr *KeyRing) logPubKeys(lggr logger.Logger) {
 	lggr = logger.Named(lggr, "KeyRing")
 	var csaIDs []string
 	for _, CSAKey := range kr.CSA {
@@ -407,8 +407,8 @@ type rawKeyRing struct {
 	LegacyKeys   LegacyKeyStorage `json:"-"`
 }
 
-func (rawKeys rawKeyRing) keys() (*keyRing, error) {
-	keyRing := newKeyRing()
+func (rawKeys rawKeyRing) keys() (*KeyRing, error) {
+	keyRing := NewKeyRing()
 	for _, rawCSAKey := range rawKeys.CSA {
 		csaKey := csakey.KeyFor(internal.NewRaw(rawCSAKey))
 		keyRing.CSA[csaKey.ID()] = csaKey

--- a/core/services/keystore/keys/models/models.go
+++ b/core/services/keystore/keys/models/models.go
@@ -1,4 +1,4 @@
-package keystore
+package models
 
 import (
 	"encoding/json"
@@ -271,121 +271,7 @@ func (kr *KeyRing) raw() (rawKeys rawKeyRing) {
 	return rawKeys
 }
 
-func (kr *KeyRing) logPubKeys(lggr logger.Logger) {
-	lggr = logger.Named(lggr, "KeyRing")
-	var csaIDs []string
-	for _, CSAKey := range kr.CSA {
-		csaIDs = append(csaIDs, CSAKey.ID())
-	}
-	var ethIDs []string
-	for _, ETHKey := range kr.Eth {
-		ethIDs = append(ethIDs, ETHKey.ID())
-	}
-	var ocrIDs []string
-	for _, OCRKey := range kr.OCR {
-		ocrIDs = append(ocrIDs, OCRKey.ID())
-	}
-	var ocr2IDs []string
-	for _, OCR2Key := range kr.OCR2 {
-		ocr2IDs = append(ocr2IDs, OCR2Key.ID())
-	}
-	var p2pIDs []string
-	for _, P2PKey := range kr.P2P {
-		p2pIDs = append(p2pIDs, P2PKey.ID())
-	}
-	var cosmosIDs []string
-	for _, cosmosKey := range kr.Cosmos {
-		cosmosIDs = append(cosmosIDs, cosmosKey.ID())
-	}
-	var solanaIDs []string
-	for _, solanaKey := range kr.Solana {
-		solanaIDs = append(solanaIDs, solanaKey.ID())
-	}
-	var starknetIDs []string
-	for _, starkkey := range kr.StarkNet {
-		starknetIDs = append(starknetIDs, starkkey.ID())
-	}
-	var aptosIDs []string
-	for _, aptosKey := range kr.Aptos {
-		aptosIDs = append(aptosIDs, aptosKey.ID())
-	}
-	tronIDs := []string{}
-	for _, tronKey := range kr.Tron {
-		tronIDs = append(tronIDs, tronKey.ID())
-	}
-	tonIDs := []string{}
-	for _, tonKey := range kr.TON {
-		tonIDs = append(tonIDs, tonKey.ID())
-	}
-	suiIDs := []string{}
-	for _, suiKey := range kr.Sui {
-		suiIDs = append(suiIDs, suiKey.ID())
-	}
-	var vrfIDs []string
-	for _, VRFKey := range kr.VRF {
-		vrfIDs = append(vrfIDs, VRFKey.ID())
-	}
-	dkgRecipientIDs := []string{}
-	for _, dkgRecipientKey := range kr.DKGRecipient {
-		dkgRecipientIDs = append(dkgRecipientIDs, dkgRecipientKey.ID())
-	}
-	workflowIDs := make([]string, len(kr.Workflow))
-	i := 0
-	for _, workflowKey := range kr.Workflow {
-		workflowIDs[i] = workflowKey.ID()
-		i++
-	}
-	if len(csaIDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d CSA keys", len(csaIDs)), "keys", csaIDs)
-	}
-	if len(ethIDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d ETH keys", len(ethIDs)), "keys", ethIDs)
-	}
-	if len(ocrIDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d OCR keys", len(ocrIDs)), "keys", ocrIDs)
-	}
-	if len(ocr2IDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d OCR2 keys", len(ocr2IDs)), "keys", ocr2IDs)
-	}
-	if len(p2pIDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d P2P keys", len(p2pIDs)), "keys", p2pIDs)
-	}
-	if len(cosmosIDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d Cosmos keys", len(cosmosIDs)), "keys", cosmosIDs)
-	}
-	if len(solanaIDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d Solana keys", len(solanaIDs)), "keys", solanaIDs)
-	}
-	if len(starknetIDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d StarkNet keys", len(starknetIDs)), "keys", starknetIDs)
-	}
-	if len(aptosIDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d Aptos keys", len(aptosIDs)), "keys", aptosIDs)
-	}
-	if len(tronIDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d Tron keys", len(tronIDs)), "keys", tronIDs)
-	}
-	if len(tonIDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d TON keys", len(tonIDs)), "keys", tonIDs)
-	}
-	if len(suiIDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d Sui keys", len(suiIDs)), "keys", suiIDs)
-	}
-	if len(vrfIDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d VRF keys", len(vrfIDs)), "keys", vrfIDs)
-	}
-	if len(dkgRecipientIDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d DKGRecipient keys", len(dkgRecipientIDs)), "keys", dkgRecipientIDs)
-	}
-	if len(workflowIDs) > 0 {
-		lggr.Infow(fmt.Sprintf("Unlocked %d Workflow keys", len(workflowIDs)), "keys", workflowIDs)
-	}
-	if len(kr.LegacyKeys.legacyRawKeys) > 0 {
-		lggr.Infow(fmt.Sprintf("%d keys stored in legacy system", kr.LegacyKeys.legacyRawKeys.len()))
-	}
-}
-
-// rawKeyRing is an intermediate struct for encrypting / decrypting keyRing
+// rawKeyRing is an intermediate struct for encrypting / decrypting KeyRing
 // it holds only the essential key information to avoid adding unnecessary data
 // (like public keys) to the database
 type rawKeyRing struct {

--- a/core/services/keystore/keys/models/models_test.go
+++ b/core/services/keystore/keys/models/models_test.go
@@ -1,4 +1,4 @@
-package keystore
+package models
 
 import (
 	"crypto/rand"
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/cosmoskey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/csakey"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocrkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
@@ -161,4 +162,10 @@ func TestKeyRing_Encrypt_Decrypt(t *testing.T) {
 		_, err = originalKeyRing.LegacyKeys.UnloadUnsupported(nil)
 		require.Error(t, err)
 	})
+}
+
+func mustNewEthKey(t *testing.T) *ethkey.KeyV2 {
+	key, err := ethkey.NewV2()
+	require.NoError(t, err)
+	return &key
 }

--- a/core/services/keystore/keystoretest.go
+++ b/core/services/keystore/keystoretest.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/keystore"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/models"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 // memoryORM is an in-memory version of the keystore. This is
@@ -16,7 +18,7 @@ import (
 // Note: we store `q` on the struct since `saveEncryptedKeyRing` needs
 // to support DB callbacks.
 type memoryORM struct {
-	keyRing *encryptedKeyRing
+	keyRing *models.EncryptedKeyRing
 	ds      sqlutil.DataSource
 	mu      sync.RWMutex
 }
@@ -25,7 +27,7 @@ func (o *memoryORM) isEmpty(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func (o *memoryORM) saveEncryptedKeyRing(ctx context.Context, kr *encryptedKeyRing, callbacks ...func(sqlutil.DataSource) error) (err error) {
+func (o *memoryORM) saveEncryptedKeyRing(ctx context.Context, kr *models.EncryptedKeyRing, callbacks ...func(sqlutil.DataSource) error) (err error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.keyRing = kr
@@ -35,11 +37,11 @@ func (o *memoryORM) saveEncryptedKeyRing(ctx context.Context, kr *encryptedKeyRi
 	return
 }
 
-func (o *memoryORM) getEncryptedKeyRing(ctx context.Context) (encryptedKeyRing, error) {
+func (o *memoryORM) getEncryptedKeyRing(ctx context.Context) (models.EncryptedKeyRing, error) {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
 	if o.keyRing == nil {
-		return encryptedKeyRing{}, nil
+		return models.EncryptedKeyRing{}, nil
 	}
 	return *o.keyRing, nil
 }

--- a/core/services/keystore/keystoretest.go
+++ b/core/services/keystore/keystoretest.go
@@ -8,7 +8,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/keystore"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/models"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 // memoryORM is an in-memory version of the keystore. This is

--- a/core/services/keystore/master.go
+++ b/core/services/keystore/master.go
@@ -28,7 +28,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/tronkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/vrfkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/workflowkey"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 var (

--- a/core/services/keystore/master.go
+++ b/core/services/keystore/master.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/csakey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/dkgrecipientkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/models"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocrkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
@@ -27,6 +28,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/tronkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/vrfkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/workflowkey"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 var (
@@ -175,20 +177,20 @@ func (ks *master) DKGRecipient() DKGRecipient {
 
 type ORM interface {
 	isEmpty(context.Context) (bool, error)
-	saveEncryptedKeyRing(context.Context, *encryptedKeyRing, ...func(sqlutil.DataSource) error) error
-	getEncryptedKeyRing(context.Context) (encryptedKeyRing, error)
+	saveEncryptedKeyRing(context.Context, *models.EncryptedKeyRing, ...func(sqlutil.DataSource) error) error
+	getEncryptedKeyRing(context.Context) (models.EncryptedKeyRing, error)
 }
 
 type keystateORM interface {
-	loadKeyStates(context.Context) (*keyStates, error)
+	loadKeyStates(context.Context) (*models.KeyStates, error)
 }
 
 type keyManager struct {
 	orm          ORM
 	keystateORM  keystateORM
 	scryptParams keystore.ScryptParams
-	keyRing      *keyRing
-	keyStates    *keyStates
+	keyRing      *models.KeyRing
+	keyStates    *models.KeyStates
 	lock         *sync.RWMutex
 	password     string
 	announce     func(Key)

--- a/core/services/keystore/orm.go
+++ b/core/services/keystore/orm.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/models"
 )
 
 func NewORM(ds sqlutil.DataSource) ksORM {
@@ -29,7 +30,7 @@ func (orm ksORM) isEmpty(ctx context.Context) (bool, error) {
 	return count == 0, nil
 }
 
-func (orm ksORM) saveEncryptedKeyRing(ctx context.Context, kr *encryptedKeyRing, callbacks ...func(sqlutil.DataSource) error) error {
+func (orm ksORM) saveEncryptedKeyRing(ctx context.Context, kr *models.EncryptedKeyRing, callbacks ...func(sqlutil.DataSource) error) error {
 	return sqlutil.TransactDataSource(ctx, orm.ds, nil, func(tx sqlutil.DataSource) error {
 		_, err := tx.ExecContext(ctx, `
 		UPDATE encrypted_key_rings
@@ -48,7 +49,7 @@ func (orm ksORM) saveEncryptedKeyRing(ctx context.Context, kr *encryptedKeyRing,
 	})
 }
 
-func (orm ksORM) getEncryptedKeyRing(ctx context.Context) (kr encryptedKeyRing, err error) {
+func (orm ksORM) getEncryptedKeyRing(ctx context.Context) (kr models.EncryptedKeyRing, err error) {
 	err = orm.ds.GetContext(ctx, &kr, `SELECT * FROM encrypted_key_rings LIMIT 1`)
 	if errors.Is(err, sql.ErrNoRows) {
 		sql := `INSERT INTO encrypted_key_rings (encrypted_keys, updated_at) VALUES (NULL, NOW()) RETURNING *;`
@@ -63,14 +64,14 @@ func (orm ksORM) getEncryptedKeyRing(ctx context.Context) (kr encryptedKeyRing, 
 	return kr, nil
 }
 
-func (orm ksORM) loadKeyStates(ctx context.Context) (*keyStates, error) {
-	ks := newKeyStates()
+func (orm ksORM) loadKeyStates(ctx context.Context) (*models.KeyStates, error) {
+	ks := models.NewKeyStates()
 	var ethkeystates []*ethkey.State
 	if err := orm.ds.SelectContext(ctx, &ethkeystates, `SELECT id, address, evm_chain_id, disabled, created_at, updated_at FROM evm.key_states`); err != nil {
 		return ks, errors.Wrap(err, "error loading evm.key_states from DB")
 	}
 	for _, state := range ethkeystates {
-		ks.add(state)
+		ks.Add(state)
 	}
 	return ks, nil
 }


### PR DESCRIPTION
Models is the only external place where `internal` is used outside of `keys`, so I am moving it inside `keys` so that later we move it the whole `keys` folder to common/keystore/corekeys.

In this move we also make `EncryptedKeyRing`, `KeyStates`, and `KeyRing` public. Note that `rawKeyRing` with raw key bytes stays private.