### PR TITLE
[CRE-1775] Remove OracleFactoryConfig.TransmitterID

### DIFF
--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -1041,7 +1041,6 @@ type OracleFactoryConfig struct {
 	OCRContractAddress string                 `toml:"ocr_contract_address"`
 	OCRKeyBundleID     string                 `toml:"ocr_key_bundle_id"`
 	ChainID            string                 `toml:"chain_id"`
-	TransmitterID      string                 `toml:"transmitter_id"`
 	OnchainSigning     OnchainSigningStrategy `toml:"onchainSigningStrategy"`
 }
 

--- a/core/services/job/models_test.go
+++ b/core/services/job/models_test.go
@@ -39,7 +39,6 @@ func TestStandardCapabilitiesSpec_Deserialization(t *testing.T) {
 	ocr_contract_address = "0x2C84cff4cd5fA5a0c17dbc710fcCb8FC6A03dEEd"
 	ocr_key_bundle_id = "5fbb7d5dc1e592142a979b7014552e07a78cb89b1a8626c6412f12f2adfcb240"
 	chain_id = "11155111"
-	transmitter_id = "0x60042fBB756f736744C334c463BeBE1A72Add04F"
 	[oracle_factory.onchainSigningStrategy]
 	strategyName = "multi-chain"
 	[oracle_factory.onchainSigningStrategy.config]
@@ -58,7 +57,6 @@ func TestStandardCapabilitiesSpec_Deserialization(t *testing.T) {
 		"aptos": "7c2df2e806306383f9aa2bc7a3198cf0e1c626f873799992b2841240c6931733",
 		"evm":   "5fbb7d5dc1e592142a979b7014552e07a78cb89b1a8626c6412f12f2adfcb240",
 	}, spec.OracleFactory.OnchainSigning.Config)
-	assert.Equal(t, "0x60042fBB756f736744C334c463BeBE1A72Add04F", spec.OracleFactory.TransmitterID)
 	assert.Equal(t, "0x2C84cff4cd5fA5a0c17dbc710fcCb8FC6A03dEEd", spec.OracleFactory.OCRContractAddress)
 	assert.Equal(t, "5fbb7d5dc1e592142a979b7014552e07a78cb89b1a8626c6412f12f2adfcb240", spec.OracleFactory.OCRKeyBundleID)
 }

--- a/core/services/ocr2/plugins/generic/oraclefactory.go
+++ b/core/services/ocr2/plugins/generic/oraclefactory.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -98,14 +99,38 @@ func (of *oracleFactory) NewOracle(ctx context.Context, args core.OracleArgs) (c
 		return nil, fmt.Errorf("expected relayer to be of type relayerWrapper, got %T", relayer)
 	}
 
+	chainIDBigInt, ok := new(big.Int).SetString(of.config.ChainID, 10)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse chain ID %q", of.config.ChainID)
+	}
+
+	enabledKeys, err := of.ethKeystore.EnabledKeysForChain(ctx, chainIDBigInt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get enabled eth keys for chain %s: %w", of.config.ChainID, err)
+	}
+	if len(enabledKeys) == 0 {
+		return nil, fmt.Errorf("no enabled eth keys found for chain %s", of.config.ChainID)
+	}
+	if len(enabledKeys) > 1 {
+		of.lggr.Warnw("Multiple enabled eth keys found for chain, using first one", "chainID", of.config.ChainID)
+	}
+
+	transmitterID := enabledKeys[0].Address.Hex()
+	of.lggr.Infow("Using transmitter ID", "transmitterID", transmitterID, "chainID", of.config.ChainID)
+
+	sendingKeys := make([]string, len(enabledKeys))
+	for i, k := range enabledKeys {
+		sendingKeys[i] = k.Address.Hex()
+	}
+
 	var relayConfig = struct {
 		ChainID                string   `json:"chainID"`
 		EffectiveTransmitterID string   `json:"effectiveTransmitterID"`
 		SendingKeys            []string `json:"sendingKeys"`
 	}{
 		ChainID:                of.config.ChainID,
-		EffectiveTransmitterID: of.config.TransmitterID,
-		SendingKeys:            []string{of.config.TransmitterID},
+		EffectiveTransmitterID: transmitterID,
+		SendingKeys:            sendingKeys,
 	}
 	relayConfigBytes, err := json.Marshal(relayConfig)
 	if err != nil {
@@ -168,7 +193,7 @@ func (of *oracleFactory) NewOracle(ctx context.Context, args core.OracleArgs) (c
 		ContractConfigTracker:        configTracker,
 		OffchainConfigDigester:       configDigester,
 		LocalConfig:                  args.LocalConfig,
-		ContractTransmitter:          NewContractTransmitter(of.config.TransmitterID, args.ContractTransmitter),
+		ContractTransmitter:          NewContractTransmitter(transmitterID, args.ContractTransmitter),
 		ReportingPluginFactory:       args.ReportingPluginFactoryService,
 		BinaryNetworkEndpointFactory: of.peerWrapper.Peer2,
 		V2Bootstrappers:              bootstrapPeers,

--- a/core/services/standardcapabilities/delegate_test.go
+++ b/core/services/standardcapabilities/delegate_test.go
@@ -169,7 +169,6 @@ func Test_ValidatedStandardCapabilitiesSpec(t *testing.T) {
 			ocr_contract_address = "0x2C84cff4cd5fA5a0c17dbc710fcCb8FC6A03dEEd"
 			ocr_key_bundle_id = "5fbb7d5dc1e592142a979b7014552e07a78cb89b1a8626c6412f12f2adfcb240"
 			chain_id = "11155111"
-			transmitter_id = "0x60042fBB756f736744C334c463BeBE1A72Add04F"
 			[oracle_factory.onchainSigningStrategy]
 			strategyName = "multi-chain"
 			[oracle_factory.onchainSigningStrategy.config]
@@ -186,7 +185,6 @@ func Test_ValidatedStandardCapabilitiesSpec(t *testing.T) {
 					OCRContractAddress: "0x2C84cff4cd5fA5a0c17dbc710fcCb8FC6A03dEEd",
 					OCRKeyBundleID:     "5fbb7d5dc1e592142a979b7014552e07a78cb89b1a8626c6412f12f2adfcb240",
 					ChainID:            "11155111",
-					TransmitterID:      "0x60042fBB756f736744C334c463BeBE1A72Add04F",
 					OnchainSigning: job.OnchainSigningStrategy{
 						StrategyName: "multi-chain",
 						Config: map[string]string{


### PR DESCRIPTION
Simply use the first address associated with the desired chain.