### PR TITLE
LDAP / OIDC Auth: update DeleteAuthToken query based on table schema

### DIFF
--- a/core/sessions/ldapauth/ldap.go
+++ b/core/sessions/ldapauth/ldap.go
@@ -589,7 +589,7 @@ func (l *ldapAuthenticator) SetAuthToken(ctx context.Context, user *sessions.Use
 
 // DeleteAuthToken clears and disables the users Authentication Token.
 func (l *ldapAuthenticator) DeleteAuthToken(ctx context.Context, user *sessions.User) error {
-	_, err := l.ds.ExecContext(ctx, "DELETE FROM ldap_user_api_tokens WHERE email = $1")
+	_, err := l.ds.ExecContext(ctx, "DELETE FROM ldap_user_api_tokens WHERE user_email = $1", user.Email)
 	return err
 }
 

--- a/core/sessions/ldapauth/ldap_test.go
+++ b/core/sessions/ldapauth/ldap_test.go
@@ -254,6 +254,33 @@ func TestORM_FindUserByAPIToken_Expired(t *testing.T) {
 	require.Equal(t, sessions.ErrUserSessionExpired, err)
 }
 
+func TestORM_DeleteAuthToken(t *testing.T) {
+	ctx := testutils.Context(t)
+
+	// Initialize LDAP Authentication Provider with mock client
+	mockLdapClient := mocks.NewLDAPClient(t)
+	db, ldapAuthProvider := setupAuthenticationProvider(t, mockLdapClient)
+
+	// Create a token for a test user
+	testEmail := "test-delete@test.com"
+	apiToken := "delete-test-token"
+	_, err := db.Exec("INSERT INTO ldap_user_api_tokens values ($1, 'edit', false, $2, '', '', now())", testEmail, apiToken)
+	require.NoError(t, err)
+
+	// Verify token exists by finding user
+	user, err := ldapAuthProvider.FindUserByAPIToken(ctx, apiToken)
+	require.NoError(t, err)
+	require.Equal(t, testEmail, user.Email)
+
+	// Delete the auth token
+	err = ldapAuthProvider.DeleteAuthToken(ctx, &user)
+	require.NoError(t, err)
+
+	// Verify token is deleted - FindUserByAPIToken should fail
+	_, err = ldapAuthProvider.FindUserByAPIToken(ctx, apiToken)
+	require.Error(t, err)
+}
+
 func TestORM_ListUsers_Full(t *testing.T) {
 	t.Parallel()
 	ctx := testutils.Context(t)

--- a/core/sessions/oidcauth/oidc.go
+++ b/core/sessions/oidcauth/oidc.go
@@ -545,7 +545,7 @@ func (oi *oidcAuthenticator) SetAuthToken(ctx context.Context, user *clsessions.
 
 // DeleteAuthToken clears and disables the users Authentication Token.
 func (oi *oidcAuthenticator) DeleteAuthToken(ctx context.Context, user *clsessions.User) error {
-	_, err := oi.ds.ExecContext(ctx, "DELETE FROM oidc_user_api_tokens WHERE email = $1")
+	_, err := oi.ds.ExecContext(ctx, "DELETE FROM oidc_user_api_tokens WHERE user_email = $1", user.Email)
 	return err
 }
 

--- a/core/sessions/oidcauth/oidc_test.go
+++ b/core/sessions/oidcauth/oidc_test.go
@@ -100,6 +100,32 @@ func TestORM_FindUserByAPIToken_Expired(t *testing.T) {
 	require.Equal(t, sessions.ErrUserSessionExpired, err)
 }
 
+func TestORM_DeleteAuthToken(t *testing.T) {
+	ctx := testutils.Context(t)
+
+	// Init OIDC authenticator
+	db, oidcAuthProvider := setupAuthenticationProvider(t)
+
+	// Create a token for a test user
+	testEmail := "test-delete@test.com"
+	apiToken := "delete-test-token"
+	_, err := db.Exec("INSERT INTO oidc_user_api_tokens values ($1, 'edit', $2, '', '', now())", testEmail, apiToken)
+	require.NoError(t, err)
+
+	// Verify token exists by finding user
+	user, err := oidcAuthProvider.FindUserByAPIToken(ctx, apiToken)
+	require.NoError(t, err)
+	require.Equal(t, testEmail, user.Email)
+
+	// Delete the auth token
+	err = oidcAuthProvider.DeleteAuthToken(ctx, &user)
+	require.NoError(t, err)
+
+	// Verify token is deleted - FindUserByAPIToken should fail
+	_, err = oidcAuthProvider.FindUserByAPIToken(ctx, apiToken)
+	require.Error(t, err)
+}
+
 func TestORM_ListUsers(t *testing.T) {
 	ctx := testutils.Context(t)
 	// Init OIDC authenticator


### PR DESCRIPTION
- update query in LDAP and OIDC authentication driver
- add tests for `DeleteAuthToken`