### PR TITLE
[PRODCRE-1746] Make keys folder self-contained.

### DIFF
--- a/core/cmd/ocr2_keys_commands.go
+++ b/core/cmd/ocr2_keys_commands.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
 	cutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
-	"github.com/smartcontractkit/chainlink/v2/core/store/models"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
@@ -168,7 +168,7 @@ func (s *Shell) DeleteOCR2KeyBundle(c *cli.Context) error {
 	if !c.Args().Present() {
 		return s.errorOut(errors.New("Must pass the key ID to be deleted"))
 	}
-	id, err := models.Sha256HashFromHex(c.Args().Get(0))
+	id, err := keys.Sha256HashFromHex(c.Args().Get(0))
 	if err != nil {
 		return s.errorOut(err)
 	}

--- a/core/cmd/ocr_keys_commands.go
+++ b/core/cmd/ocr_keys_commands.go
@@ -12,7 +12,7 @@ import (
 	"github.com/urfave/cli"
 
 	cutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
-	"github.com/smartcontractkit/chainlink/v2/core/store/models"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
@@ -160,7 +160,7 @@ func (s *Shell) DeleteOCRKeyBundle(c *cli.Context) error {
 	if !c.Args().Present() {
 		return s.errorOut(errors.New("Must pass the key ID to be deleted"))
 	}
-	id, err := models.Sha256HashFromHex(c.Args().Get(0))
+	id, err := keys.Sha256HashFromHex(c.Args().Get(0))
 	if err != nil {
 		return s.errorOut(err)
 	}

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -21,6 +21,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/build"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/config/parse"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 	"github.com/smartcontractkit/chainlink/v2/core/sessions"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
@@ -1347,7 +1348,7 @@ type OCR2 struct {
 	ContractSubscribeInterval          *commonconfig.Duration
 	ContractTransmitterTransmitTimeout *commonconfig.Duration
 	DatabaseTimeout                    *commonconfig.Duration
-	KeyBundleID                        *models.Sha256Hash
+	KeyBundleID                        *keys.Sha256Hash
 	CaptureEATelemetry                 *bool
 	CaptureAutomationCustomTelemetry   *bool
 	AllowNoBootstrappers               *bool
@@ -1417,7 +1418,7 @@ type OCR struct {
 	ContractSubscribeInterval    *commonconfig.Duration
 	DefaultTransactionQueueDepth *uint32
 	// Optional
-	KeyBundleID          *models.Sha256Hash
+	KeyBundleID          *keys.Sha256Hash
 	SimulateTransactions *bool
 	TransmitterAddress   *types.EIP55Address
 	CaptureEATelemetry   *bool

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -17,7 +17,6 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
@@ -25,12 +24,14 @@ import (
 	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/core/auth"
+	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keeper"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
@@ -194,7 +195,7 @@ func MustInsertHead(t *testing.T, ds sqlutil.DataSource, number int64) *evmtypes
 func MustInsertOffchainreportingOracleSpec(t *testing.T, db *sqlx.DB, transmitterAddress evmtypes.EIP55Address) job.OCROracleSpec {
 	t.Helper()
 
-	ocrKeyID := models.MustSha256HashFromHex(DefaultOCRKeyBundleID)
+	ocrKeyID := keys.MustSha256HashFromHex(DefaultOCRKeyBundleID)
 	spec := job.OCROracleSpec{}
 	require.NoError(t, db.Get(&spec, `INSERT INTO ocr_oracle_specs (created_at, updated_at, contract_address, p2pv2_bootstrappers, is_bootstrap_peer, encrypted_ocr_key_bundle_id, transmitter_address, observation_timeout, blockchain_timeout, contract_config_tracker_subscribe_interval, contract_config_tracker_poll_interval, contract_config_confirmations, database_timeout, observation_grace_period, contract_transmitter_transmit_timeout, evm_chain_id) VALUES (
 NOW(),NOW(),$1,'{}',false,$2,$3,0,0,0,0,0,0,0,0,0

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -14,16 +14,16 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+	evmcfg "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	solcfg "github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 
-	evmcfg "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
 	coreconfig "github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/config/env"
 	"github.com/smartcontractkit/chainlink/v2/core/config/parse"
 	v2 "github.com/smartcontractkit/chainlink/v2/core/config/toml"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
-	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
@@ -603,4 +603,4 @@ func (g *generalConfig) LOOPP() coreconfig.LOOPP {
 	return &looppConfig{l: g.c.LOOPP}
 }
 
-var zeroSha256Hash = models.Sha256Hash{}
+var zeroSha256Hash = keys.Sha256Hash{}

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/config/toml"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
@@ -431,7 +432,7 @@ func TestConfig_Marshal(t *testing.T) {
 		ContractSubscribeInterval:          commoncfg.MustNewDuration(time.Minute),
 		ContractTransmitterTransmitTimeout: commoncfg.MustNewDuration(time.Minute),
 		DatabaseTimeout:                    commoncfg.MustNewDuration(8 * time.Second),
-		KeyBundleID:                        ptr(models.MustSha256HashFromHex("7a5f66bbe6594259325bf2b4f5b1a9c9")),
+		KeyBundleID:                        ptr(keys.MustSha256HashFromHex("7a5f66bbe6594259325bf2b4f5b1a9c9")),
 		CaptureEATelemetry:                 ptr(false),
 		CaptureAutomationCustomTelemetry:   ptr(true),
 		AllowNoBootstrappers:               ptr(true),
@@ -448,7 +449,7 @@ func TestConfig_Marshal(t *testing.T) {
 		ContractPollInterval:         commoncfg.MustNewDuration(time.Hour),
 		ContractSubscribeInterval:    commoncfg.MustNewDuration(time.Minute),
 		DefaultTransactionQueueDepth: ptr[uint32](12),
-		KeyBundleID:                  ptr(models.MustSha256HashFromHex("acdd42797a8b921b2910497badc50006")),
+		KeyBundleID:                  ptr(keys.MustSha256HashFromHex("acdd42797a8b921b2910497badc50006")),
 		SimulateTransactions:         ptr(true),
 		TransmitterAddress:           ptr(types.MustEIP55Address("0xa0788FC17B1dEe36f057c42B6F373A34B014687e")),
 		CaptureEATelemetry:           ptr(false),

--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -28,6 +28,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	clnull "github.com/smartcontractkit/chainlink/v2/core/null"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 	"github.com/smartcontractkit/chainlink/v2/core/services/signatures/secp256k1"
@@ -296,7 +297,7 @@ type OCROracleSpec struct {
 	ContractAddress                        evmtypes.EIP55Address  `toml:"contractAddress"`
 	P2PV2Bootstrappers                     pq.StringArray         `toml:"p2pv2Bootstrappers" db:"p2pv2_bootstrappers"`
 	IsBootstrapPeer                        bool                   `toml:"isBootstrapPeer"`
-	EncryptedOCRKeyBundleID                *models.Sha256Hash     `toml:"keyBundleID"`
+	EncryptedOCRKeyBundleID                *keys.Sha256Hash       `toml:"keyBundleID"`
 	TransmitterAddress                     *evmtypes.EIP55Address `toml:"transmitterAddress"`
 	ObservationTimeout                     sqlutil.Interval       `toml:"observationTimeout"`
 	BlockchainTimeout                      sqlutil.Interval       `toml:"blockchainTimeout"`

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -28,10 +28,10 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/null"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	medianconfig "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/median/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
-	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 )
 
 var (
@@ -1027,7 +1027,7 @@ func LoadConfigVarsOCR(evmOcrCfg evmconfig.OCR, ocrCfg OCRConfig, os OCROracleSp
 		if err != nil {
 			return nil, err
 		}
-		encryptedOCRKeyBundleID, err := models.Sha256HashFromHex(kb)
+		encryptedOCRKeyBundleID, err := keys.Sha256HashFromHex(kb)
 		if err != nil {
 			return nil, err
 		}

--- a/core/services/job/runner_integration_test.go
+++ b/core/services/job/runner_integration_test.go
@@ -41,13 +41,13 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/validate"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/v2/core/services/telemetry"
 	"github.com/smartcontractkit/chainlink/v2/core/services/webhook"
-	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 	"github.com/smartcontractkit/chainlink/v2/core/web"
 )
 
@@ -67,7 +67,7 @@ func TestRunner(t *testing.T) {
 		c.P2P.V2.ListenAddresses = &[]string{fmt.Sprintf("127.0.0.1:%d", freeport.GetOne(t))}
 		kb, err := keyStore.OCR().Create(ctx)
 		require.NoError(t, err)
-		kbid := models.MustSha256HashFromHex(kb.ID())
+		kbid := keys.MustSha256HashFromHex(kb.ID())
 		c.OCR.KeyBundleID = &kbid
 		taddress := types.EIP55AddressFromAddress(transmitterAddress)
 		c.OCR.TransmitterAddress = &taddress

--- a/core/services/keystore/aptos_test.go
+++ b/core/services/keystore/aptos_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/aptoskey"
 )
 
@@ -48,7 +49,7 @@ func Test_AptosKeyStore_E2E(t *testing.T) {
 		require.NoError(t, err)
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, key, retrievedKey)
+		keys.RequireEqualKeys(t, key, retrievedKey)
 	})
 
 	t.Run("imports and exports a key", func(t *testing.T) {
@@ -73,7 +74,7 @@ func Test_AptosKeyStore_E2E(t *testing.T) {
 		require.Equal(t, key.ID(), importedKey.ID())
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, importedKey, retrievedKey)
+		keys.RequireEqualKeys(t, importedKey, retrievedKey)
 	})
 
 	t.Run("adds an externally created key / deletes a key", func(t *testing.T) {

--- a/core/services/keystore/cosmos_test.go
+++ b/core/services/keystore/cosmos_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/cosmoskey"
 )
 
@@ -48,7 +49,7 @@ func Test_CosmosKeyStore_E2E(t *testing.T) {
 		require.NoError(t, err)
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, key, retrievedKey)
+		keys.RequireEqualKeys(t, key, retrievedKey)
 	})
 
 	t.Run("imports and exports a key", func(t *testing.T) {
@@ -73,7 +74,7 @@ func Test_CosmosKeyStore_E2E(t *testing.T) {
 		require.Equal(t, key.ID(), importedKey.ID())
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, importedKey, retrievedKey)
+		keys.RequireEqualKeys(t, importedKey, retrievedKey)
 	})
 
 	t.Run("adds an externally created key / deletes a key", func(t *testing.T) {

--- a/core/services/keystore/dkgrecipient_test.go
+++ b/core/services/keystore/dkgrecipient_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/dkgrecipientkey"
 )
 
@@ -49,7 +50,7 @@ func Test_DKGRecipientKeyStore_E2E(t *testing.T) {
 		require.NoError(t, err)
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, key, retrievedKey)
+		keys.RequireEqualKeys(t, key, retrievedKey)
 
 		t.Run("prevents creating more than one key", func(t *testing.T) {
 			ctx := testutils.Context(t)
@@ -77,7 +78,7 @@ func Test_DKGRecipientKeyStore_E2E(t *testing.T) {
 		require.Equal(t, key.ID(), importedKey.ID())
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, importedKey, retrievedKey)
+		keys.RequireEqualKeys(t, importedKey, retrievedKey)
 
 		t.Run("prevents importing more than one key", func(t *testing.T) {
 			k, err2 := ks.Import(testutils.Context(t), exportJSON, cltest.Password)

--- a/core/services/keystore/eth_test.go
+++ b/core/services/keystore/eth_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr/txmgrtest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -52,7 +53,7 @@ func Test_EthKeyStore(t *testing.T) {
 		require.Equal(t, key.Address, retrievedKeys[0].Address)
 		foundKey, err := ethKeyStore.Get(ctx, key.Address.Hex())
 		require.NoError(t, err)
-		requireEqualKeys(t, key, foundKey)
+		keys.RequireEqualKeys(t, key, foundKey)
 		// adds ethkey.State
 		cltest.AssertCount(t, db, statesTableName, 1)
 		var state ethkey.State
@@ -90,7 +91,7 @@ func Test_EthKeyStore(t *testing.T) {
 		sort.Slice(keys, func(i, j int) bool { return keys[i].Cmp(keys[j]) < 0 })
 
 		for i := range keys {
-			requireEqualKeys(t, keys[i], retrievedKeys[i])
+			keys.RequireEqualKeys(t, keys[i], retrievedKeys[i])
 		}
 	})
 
@@ -145,7 +146,7 @@ func Test_EthKeyStore(t *testing.T) {
 
 		require.Len(t, sendingKeys2, 1)
 		for i := range sendingKeys1 {
-			requireEqualKeys(t, sendingKeys1[i], sendingKeys2[i])
+			keys.RequireEqualKeys(t, sendingKeys1[i], sendingKeys2[i])
 		}
 	})
 
@@ -160,12 +161,12 @@ func Test_EthKeyStore(t *testing.T) {
 		keys, err := ethKeyStore.EnabledKeysForChain(ctx, testutils.FixtureChainID)
 		require.NoError(t, err)
 		require.Len(t, keys, 1)
-		requireEqualKeys(t, key, keys[0])
+		keys.RequireEqualKeys(t, key, keys[0])
 
 		keys, err = ethKeyStore.EnabledKeysForChain(ctx, big.NewInt(1337))
 		require.NoError(t, err)
 		require.Len(t, keys, 1)
-		requireEqualKeys(t, key2, keys[0])
+		keys.RequireEqualKeys(t, key2, keys[0])
 
 		_, err = ethKeyStore.EnabledKeysForChain(ctx, nil)
 		assert.Error(t, err)
@@ -183,12 +184,12 @@ func Test_EthKeyStore(t *testing.T) {
 		keys, err := ethKeyStore.ListKeys(ctx, testutils.FixtureChainID, nil)
 		require.NoError(t, err)
 		require.Len(t, keys, 1)
-		requireEqualKeys(t, key, keys[0])
+		keys.RequireEqualKeys(t, key, keys[0])
 
 		keys, err = ethKeyStore.ListKeys(ctx, big.NewInt(1337), nil)
 		require.NoError(t, err)
 		require.Len(t, keys, 1)
-		requireEqualKeys(t, key2, keys[0])
+		keys.RequireEqualKeys(t, key2, keys[0])
 
 		_, err = ethKeyStore.ListKeys(ctx, nil, nil)
 		require.Error(t, err)
@@ -283,9 +284,9 @@ func Test_EthKeyStore_ListKeys(t *testing.T) {
 		require.Len(t, keys, 3)
 
 		// Verify ordering matches State.ID order
-		requireEqualKeys(t, key1, keys[0])
-		requireEqualKeys(t, key2, keys[1])
-		requireEqualKeys(t, key3, keys[2])
+		keys.RequireEqualKeys(t, key1, keys[0])
+		keys.RequireEqualKeys(t, key2, keys[1])
+		keys.RequireEqualKeys(t, key3, keys[2])
 	})
 
 	t.Run("excludes disabled keys", func(t *testing.T) {
@@ -304,8 +305,8 @@ func Test_EthKeyStore_ListKeys(t *testing.T) {
 		keys, err := ethKeyStore.ListKeys(ctx, testutils.FixtureChainID, nil)
 		require.NoError(t, err)
 		require.Len(t, keys, 2)
-		requireEqualKeys(t, key1, keys[0])
-		requireEqualKeys(t, key3, keys[1])
+		keys.RequireEqualKeys(t, key1, keys[0])
+		keys.RequireEqualKeys(t, key3, keys[1])
 
 		// Verify key2 is not in the list
 		for _, k := range keys {
@@ -359,8 +360,8 @@ func Test_EthKeyStore_ListKeys(t *testing.T) {
 		require.Len(t, keys3, 3)
 
 		for i := range keys1 {
-			requireEqualKeys(t, keys1[i], keys2[i])
-			requireEqualKeys(t, keys1[i], keys3[i])
+			keys.RequireEqualKeys(t, keys1[i], keys2[i])
+			keys.RequireEqualKeys(t, keys1[i], keys3[i])
 		}
 	})
 	t.Run("handles keys enabled for multiple chains correctly", func(t *testing.T) {
@@ -391,7 +392,7 @@ func Test_EthKeyStore_ListKeys(t *testing.T) {
 		keysSimulated, err := ethKeyStore.ListKeys(ctx, testutils.SimulatedChainID, nil)
 		require.NoError(t, err)
 		require.Len(t, keysSimulated, 1)
-		requireEqualKeys(t, key1, keysSimulated[0])
+		keys.RequireEqualKeys(t, key1, keysSimulated[0])
 	})
 
 	t.Run("errors on nil chainID", func(t *testing.T) {

--- a/core/services/keystore/eth_test.go
+++ b/core/services/keystore/eth_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr/txmgrtest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
+	keystorekeys "github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -53,7 +53,7 @@ func Test_EthKeyStore(t *testing.T) {
 		require.Equal(t, key.Address, retrievedKeys[0].Address)
 		foundKey, err := ethKeyStore.Get(ctx, key.Address.Hex())
 		require.NoError(t, err)
-		keys.RequireEqualKeys(t, key, foundKey)
+		keystorekeys.RequireEqualKeys(t, key, foundKey)
 		// adds ethkey.State
 		cltest.AssertCount(t, db, statesTableName, 1)
 		var state ethkey.State
@@ -91,7 +91,7 @@ func Test_EthKeyStore(t *testing.T) {
 		sort.Slice(keys, func(i, j int) bool { return keys[i].Cmp(keys[j]) < 0 })
 
 		for i := range keys {
-			keys.RequireEqualKeys(t, keys[i], retrievedKeys[i])
+			keystorekeys.RequireEqualKeys(t, keys[i], retrievedKeys[i])
 		}
 	})
 
@@ -146,7 +146,7 @@ func Test_EthKeyStore(t *testing.T) {
 
 		require.Len(t, sendingKeys2, 1)
 		for i := range sendingKeys1 {
-			keys.RequireEqualKeys(t, sendingKeys1[i], sendingKeys2[i])
+			keystorekeys.RequireEqualKeys(t, sendingKeys1[i], sendingKeys2[i])
 		}
 	})
 
@@ -161,12 +161,12 @@ func Test_EthKeyStore(t *testing.T) {
 		keys, err := ethKeyStore.EnabledKeysForChain(ctx, testutils.FixtureChainID)
 		require.NoError(t, err)
 		require.Len(t, keys, 1)
-		keys.RequireEqualKeys(t, key, keys[0])
+		keystorekeys.RequireEqualKeys(t, key, keys[0])
 
 		keys, err = ethKeyStore.EnabledKeysForChain(ctx, big.NewInt(1337))
 		require.NoError(t, err)
 		require.Len(t, keys, 1)
-		keys.RequireEqualKeys(t, key2, keys[0])
+		keystorekeys.RequireEqualKeys(t, key2, keys[0])
 
 		_, err = ethKeyStore.EnabledKeysForChain(ctx, nil)
 		assert.Error(t, err)
@@ -184,12 +184,12 @@ func Test_EthKeyStore(t *testing.T) {
 		keys, err := ethKeyStore.ListKeys(ctx, testutils.FixtureChainID, nil)
 		require.NoError(t, err)
 		require.Len(t, keys, 1)
-		keys.RequireEqualKeys(t, key, keys[0])
+		keystorekeys.RequireEqualKeys(t, key, keys[0])
 
 		keys, err = ethKeyStore.ListKeys(ctx, big.NewInt(1337), nil)
 		require.NoError(t, err)
 		require.Len(t, keys, 1)
-		keys.RequireEqualKeys(t, key2, keys[0])
+		keystorekeys.RequireEqualKeys(t, key2, keys[0])
 
 		_, err = ethKeyStore.ListKeys(ctx, nil, nil)
 		require.Error(t, err)
@@ -284,9 +284,9 @@ func Test_EthKeyStore_ListKeys(t *testing.T) {
 		require.Len(t, keys, 3)
 
 		// Verify ordering matches State.ID order
-		keys.RequireEqualKeys(t, key1, keys[0])
-		keys.RequireEqualKeys(t, key2, keys[1])
-		keys.RequireEqualKeys(t, key3, keys[2])
+		keystorekeys.RequireEqualKeys(t, key1, keys[0])
+		keystorekeys.RequireEqualKeys(t, key2, keys[1])
+		keystorekeys.RequireEqualKeys(t, key3, keys[2])
 	})
 
 	t.Run("excludes disabled keys", func(t *testing.T) {
@@ -305,8 +305,8 @@ func Test_EthKeyStore_ListKeys(t *testing.T) {
 		keys, err := ethKeyStore.ListKeys(ctx, testutils.FixtureChainID, nil)
 		require.NoError(t, err)
 		require.Len(t, keys, 2)
-		keys.RequireEqualKeys(t, key1, keys[0])
-		keys.RequireEqualKeys(t, key3, keys[1])
+		keystorekeys.RequireEqualKeys(t, key1, keys[0])
+		keystorekeys.RequireEqualKeys(t, key3, keys[1])
 
 		// Verify key2 is not in the list
 		for _, k := range keys {
@@ -360,8 +360,8 @@ func Test_EthKeyStore_ListKeys(t *testing.T) {
 		require.Len(t, keys3, 3)
 
 		for i := range keys1 {
-			keys.RequireEqualKeys(t, keys1[i], keys2[i])
-			keys.RequireEqualKeys(t, keys1[i], keys3[i])
+			keystorekeys.RequireEqualKeys(t, keys1[i], keys2[i])
+			keystorekeys.RequireEqualKeys(t, keys1[i], keys3[i])
 		}
 	})
 	t.Run("handles keys enabled for multiple chains correctly", func(t *testing.T) {
@@ -392,7 +392,7 @@ func Test_EthKeyStore_ListKeys(t *testing.T) {
 		keysSimulated, err := ethKeyStore.ListKeys(ctx, testutils.SimulatedChainID, nil)
 		require.NoError(t, err)
 		require.Len(t, keysSimulated, 1)
-		keys.RequireEqualKeys(t, key1, keysSimulated[0])
+		keystorekeys.RequireEqualKeys(t, key1, keysSimulated[0])
 	})
 
 	t.Run("errors on nil chainID", func(t *testing.T) {

--- a/core/services/keystore/eth_test.go
+++ b/core/services/keystore/eth_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr/txmgrtest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
-	keystorekeys "github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	keystorekeys "github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
 )
 

--- a/core/services/keystore/keys/exporttestutils.go
+++ b/core/services/keystore/keys/exporttestutils.go
@@ -39,3 +39,13 @@ func RunKeyExportImportTestcase(t *testing.T, createKey CreateKeyFunc, decrypt D
 	require.Equal(t, key.ID(), imported.ID())
 	require.Equal(t, internal.RawBytes(key), internal.RawBytes(imported))
 }
+
+func RequireEqualKeys(t *testing.T, a, b interface {
+	ID() string
+	Raw() internal.Raw
+}) {
+	t.Helper()
+	require.Equal(t, a.ID(), b.ID(), "ids be equal")
+	require.Equal(t, a.Raw(), b.Raw(), "raw bytes must be equal")
+	require.EqualExportedValues(t, a, b)
+}

--- a/core/services/keystore/keys/ocr2key/cosmos_keyring.go
+++ b/core/services/keystore/keys/ocr2key/cosmos_keyring.go
@@ -9,8 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/blake2s"
 
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
-
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/chains/evmutil"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -66,7 +64,7 @@ func (ckr *cosmosKeyring) Sign3(digest types.ConfigDigest, seqNr uint64, r ocrty
 func (ckr *cosmosKeyring) SignBlob(b []byte) ([]byte, error) {
 	signedMsg := ed25519.Sign(ckr.privKey(), b)
 	// match on-chain parsing (first 32 bytes are for pubkey, remaining are for signature)
-	return utils.ConcatBytes(ckr.PublicKey(), signedMsg), nil
+	return concatBytes(ckr.PublicKey(), signedMsg), nil
 }
 
 func (ckr *cosmosKeyring) Verify(publicKey ocrtypes.OnchainPublicKey, reportCtx ocrtypes.ReportContext, report ocrtypes.Report, signature []byte) bool {

--- a/core/services/keystore/keys/ocr2key/ed25519_keyring.go
+++ b/core/services/keystore/keys/ocr2key/ed25519_keyring.go
@@ -9,8 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/blake2b"
 
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
-
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/chains/evmutil"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -80,7 +78,7 @@ func (akr *ed25519Keyring) Sign3(digest types.ConfigDigest, seqNr uint64, r ocrt
 func (akr *ed25519Keyring) SignBlob(b []byte) ([]byte, error) {
 	signedMsg := ed25519.Sign(akr.privKey(), b)
 	// match on-chain parsing (first 32 bytes are for pubkey, remaining are for signature)
-	return utils.ConcatBytes(akr.PublicKey(), signedMsg), nil
+	return concatBytes(akr.PublicKey(), signedMsg), nil
 }
 
 func (akr *ed25519Keyring) Verify(publicKey ocrtypes.OnchainPublicKey, reportCtx ocrtypes.ReportContext, report ocrtypes.Report, signature []byte) bool {
@@ -136,4 +134,8 @@ func (akr *ed25519Keyring) Unmarshal(in []byte) error {
 	}
 	akr.pubKey = pubKey
 	return nil
+}
+
+func concatBytes(bufs ...[]byte) []byte {
+	return bytes.Join(bufs, []byte{})
 }

--- a/core/services/keystore/keys/ocr2key/evm_keyring_test.go
+++ b/core/services/keystore/keys/ocr2key/evm_keyring_test.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 )
 
 func TestEVMKeyring_SignVerify(t *testing.T) {
@@ -54,10 +52,10 @@ func TestEVMKeyring_Sign3Verify3(t *testing.T) {
 	kr2, err := newEVMKeyring(cryptorand.Reader)
 	require.NoError(t, err)
 
-	digest, err := types.BytesToConfigDigest(testutils.MustRandBytes(32))
+	digest, err := types.BytesToConfigDigest(mustRandBytes(32))
 	require.NoError(t, err)
 	seqNr := rand.Uint64()
-	r := ocrtypes.Report(testutils.MustRandBytes(rand.Intn(1024)))
+	r := ocrtypes.Report(mustRandBytes(rand.Intn(1024)))
 
 	t.Run("can verify", func(t *testing.T) {
 		sig, err := kr1.Sign3(digest, seqNr, r)
@@ -159,4 +157,13 @@ func TestRawReportContext3(t *testing.T) {
 			assert.Equal(t, tc.expected, actual, "unexpected result")
 		})
 	}
+}
+
+func mustRandBytes(n int) (b []byte) {
+	b = make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	return
 }

--- a/core/services/keystore/keys/ocr2key/evm_keyring_test.go
+++ b/core/services/keystore/keys/ocr2key/evm_keyring_test.go
@@ -161,7 +161,7 @@ func TestRawReportContext3(t *testing.T) {
 
 func mustRandBytes(n int) (b []byte) {
 	b = make([]byte, n)
-	_, err := rand.Read(b)
+	_, err := cryptorand.Read(b)
 	if err != nil {
 		panic(err)
 	}

--- a/core/services/keystore/keys/ocr2key/generic_key_bundle.go
+++ b/core/services/keystore/keys/ocr2key/generic_key_bundle.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
-	"github.com/smartcontractkit/chainlink/v2/core/store/models"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 )
 
 type (
@@ -34,7 +34,7 @@ type (
 		ChainType       corekeys.ChainType
 		OffchainKeyring []byte
 		Keyring         []byte
-		ID              models.Sha256Hash // tracked to preserve bundle ID in case of migrations
+		ID              keys.Sha256Hash // tracked to preserve bundle ID in case of migrations
 
 		// old chain specific format for migrating
 		EVMKeyring    []byte `json:",omitempty"`
@@ -183,7 +183,7 @@ func (kbraw *keyBundleRawData) Migrate(b []byte) error {
 
 	// if key does not have an ID associated with it (old formats),
 	// derive the key ID and preserve it
-	if bytes.Equal(kbraw.ID[:], models.EmptySha256Hash[:]) {
+	if bytes.Equal(kbraw.ID[:], keys.EmptySha256Hash[:]) {
 		kbraw.ID = sha256.Sum256(b)
 	}
 

--- a/core/services/keystore/keys/ocr2key/generic_key_bundle.go
+++ b/core/services/keystore/keys/ocr2key/generic_key_bundle.go
@@ -14,8 +14,11 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
-	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 )
+
+type Sha256Hash [32]byte
+
+var EmptySha256Hash = new(Sha256Hash)
 
 type (
 	keyring interface {
@@ -34,7 +37,7 @@ type (
 		ChainType       corekeys.ChainType
 		OffchainKeyring []byte
 		Keyring         []byte
-		ID              models.Sha256Hash // tracked to preserve bundle ID in case of migrations
+		ID              Sha256Hash // tracked to preserve bundle ID in case of migrations
 
 		// old chain specific format for migrating
 		EVMKeyring    []byte `json:",omitempty"`
@@ -183,7 +186,7 @@ func (kbraw *keyBundleRawData) Migrate(b []byte) error {
 
 	// if key does not have an ID associated with it (old formats),
 	// derive the key ID and preserve it
-	if bytes.Equal(kbraw.ID[:], models.EmptySha256Hash[:]) {
+	if bytes.Equal(kbraw.ID[:], EmptySha256Hash[:]) {
 		kbraw.ID = sha256.Sum256(b)
 	}
 

--- a/core/services/keystore/keys/ocr2key/generic_key_bundle.go
+++ b/core/services/keystore/keys/ocr2key/generic_key_bundle.go
@@ -14,11 +14,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
+	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 )
-
-type Sha256Hash [32]byte
-
-var EmptySha256Hash = new(Sha256Hash)
 
 type (
 	keyring interface {
@@ -37,7 +34,7 @@ type (
 		ChainType       corekeys.ChainType
 		OffchainKeyring []byte
 		Keyring         []byte
-		ID              Sha256Hash // tracked to preserve bundle ID in case of migrations
+		ID              models.Sha256Hash // tracked to preserve bundle ID in case of migrations
 
 		// old chain specific format for migrating
 		EVMKeyring    []byte `json:",omitempty"`
@@ -186,7 +183,7 @@ func (kbraw *keyBundleRawData) Migrate(b []byte) error {
 
 	// if key does not have an ID associated with it (old formats),
 	// derive the key ID and preserve it
-	if bytes.Equal(kbraw.ID[:], EmptySha256Hash[:]) {
+	if bytes.Equal(kbraw.ID[:], models.EmptySha256Hash[:]) {
 		kbraw.ID = sha256.Sum256(b)
 	}
 

--- a/core/services/keystore/keys/ocr2key/key_bundle.go
+++ b/core/services/keystore/keys/ocr2key/key_bundle.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/starkkey"
-	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 )
 
 type OCR3SignerVerifier interface {
@@ -99,7 +99,7 @@ func MustNewInsecure(reader io.Reader, chainType corekeys.ChainType) KeyBundle {
 
 type keyBundleBase struct {
 	offchainKeyring
-	id        models.Sha256Hash
+	id        keys.Sha256Hash
 	chainType corekeys.ChainType
 }
 

--- a/core/services/keystore/keys/ocr2key/key_bundle.go
+++ b/core/services/keystore/keys/ocr2key/key_bundle.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/starkkey"
+	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 )
 
 type OCR3SignerVerifier interface {
@@ -98,7 +99,7 @@ func MustNewInsecure(reader io.Reader, chainType corekeys.ChainType) KeyBundle {
 
 type keyBundleBase struct {
 	offchainKeyring
-	id        Sha256Hash
+	id        models.Sha256Hash
 	chainType corekeys.ChainType
 }
 

--- a/core/services/keystore/keys/ocr2key/key_bundle.go
+++ b/core/services/keystore/keys/ocr2key/key_bundle.go
@@ -12,7 +12,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/starkkey"
-	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 )
 
 type OCR3SignerVerifier interface {
@@ -99,7 +98,7 @@ func MustNewInsecure(reader io.Reader, chainType corekeys.ChainType) KeyBundle {
 
 type keyBundleBase struct {
 	offchainKeyring
-	id        models.Sha256Hash
+	id        Sha256Hash
 	chainType corekeys.ChainType
 }
 

--- a/core/services/keystore/keys/ocr2key/ton_keyring.go
+++ b/core/services/keystore/keys/ocr2key/ton_keyring.go
@@ -9,8 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/xssnick/tonutils-go/tvm/cell"
 
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
-
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/chains/evmutil"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -74,7 +72,7 @@ func (tkr *tonKeyring) reportToSigData3(digest types.ConfigDigest, seqNr uint64,
 
 func (tkr *tonKeyring) SignBlob(b []byte) ([]byte, error) {
 	sig := ed25519.Sign(tkr.privKey(), b)
-	return utils.ConcatBytes(tkr.PublicKey(), sig), nil
+	return concatBytes(tkr.PublicKey(), sig), nil
 }
 
 func (tkr *tonKeyring) Verify(publicKey ocrtypes.OnchainPublicKey, reportCtx ocrtypes.ReportContext, report ocrtypes.Report, signature []byte) bool {

--- a/core/services/keystore/keys/sha256.go
+++ b/core/services/keystore/keys/sha256.go
@@ -1,0 +1,85 @@
+package keys
+
+import (
+	"database/sql/driver"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+// Explicit type indicating a 32-byte sha256 hash
+type Sha256Hash [32]byte
+
+var EmptySha256Hash = new(Sha256Hash)
+
+// MarshalJSON converts a Sha256Hash to a JSON byte slice.
+func (s Sha256Hash) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+// UnmarshalJSON converts a bytes slice of JSON to a TaskType.
+func (s *Sha256Hash) UnmarshalJSON(input []byte) error {
+	var shaHash string
+	if err := json.Unmarshal(input, &shaHash); err != nil {
+		return err
+	}
+
+	sha, err := Sha256HashFromHex(shaHash)
+	if err != nil {
+		return err
+	}
+
+	*s = sha
+	return nil
+}
+
+func Sha256HashFromHex(x string) (Sha256Hash, error) {
+	bs, err := hex.DecodeString(x)
+	if err != nil {
+		return Sha256Hash{}, err
+	}
+	var hash Sha256Hash
+	copy(hash[:], bs)
+	return hash, nil
+}
+
+func MustSha256HashFromHex(x string) Sha256Hash {
+	bs, err := hex.DecodeString(x)
+	if err != nil {
+		panic(err)
+	}
+	var hash Sha256Hash
+	copy(hash[:], bs)
+	return hash
+}
+
+func (s Sha256Hash) String() string {
+	return hex.EncodeToString(s[:])
+}
+
+func (s *Sha256Hash) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+func (s *Sha256Hash) UnmarshalText(bs []byte) (err error) {
+	*s, err = Sha256HashFromHex(string(bs))
+	return
+}
+
+func (s *Sha256Hash) Scan(value any) error {
+	bytes, ok := value.([]byte)
+	if !ok {
+		return fmt.Errorf("Failed to unmarshal Sha256Hash value: %v", value)
+	}
+	if s == nil {
+		*s = Sha256Hash{}
+	}
+	copy((*s)[:], bytes)
+	return nil
+}
+
+func (s Sha256Hash) Value() (driver.Value, error) {
+	b := make([]byte, 32)
+	copy(b, s[:])
+	return b, nil
+}

--- a/core/services/keystore/keys/sha256.go
+++ b/core/services/keystore/keys/sha256.go
@@ -69,7 +69,7 @@ func (s *Sha256Hash) UnmarshalText(bs []byte) (err error) {
 func (s *Sha256Hash) Scan(value any) error {
 	bytes, ok := value.([]byte)
 	if !ok {
-		return fmt.Errorf("Failed to unmarshal Sha256Hash value: %v", value)
+		return fmt.Errorf("failed to unmarshal Sha256Hash value: %v", value)
 	}
 	if s == nil {
 		*s = Sha256Hash{}

--- a/core/services/keystore/keys/sha256_test.go
+++ b/core/services/keystore/keys/sha256_test.go
@@ -1,0 +1,59 @@
+package keys_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
+)
+
+func TestSha256Hash_MarshalJSON_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	hash := keys.MustSha256HashFromHex("f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5")
+	json, err := hash.MarshalJSON()
+	require.NoError(t, err)
+	require.NotEmpty(t, json)
+
+	var newHash keys.Sha256Hash
+	err = newHash.UnmarshalJSON(json)
+	require.NoError(t, err)
+
+	require.Equal(t, hash, newHash)
+}
+
+func TestSha256Hash_Sha256HashFromHex(t *testing.T) {
+	t.Parallel()
+
+	_, err := keys.Sha256HashFromHex("abczzz")
+	require.Error(t, err)
+
+	_, err = keys.Sha256HashFromHex("f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5")
+	require.NoError(t, err)
+
+	_, err = keys.Sha256HashFromHex("f5bf259689b26f1374e6")
+	require.NoError(t, err)
+}
+
+func TestSha256Hash_String(t *testing.T) {
+	t.Parallel()
+
+	hash := keys.MustSha256HashFromHex("f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5")
+	assert.Equal(t, "f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5", hash.String())
+}
+
+func TestSha256Hash_Scan_Value(t *testing.T) {
+	t.Parallel()
+
+	hash := keys.MustSha256HashFromHex("f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5")
+	val, err := hash.Value()
+	require.NoError(t, err)
+
+	var newHash keys.Sha256Hash
+	err = newHash.Scan(val)
+	require.NoError(t, err)
+
+	require.Equal(t, hash, newHash)
+}

--- a/core/services/keystore/master_test.go
+++ b/core/services/keystore/master_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
 
 func TestMasterKeystore_Unlock_Save(t *testing.T) {
@@ -63,14 +62,4 @@ func TestMasterKeystore_Unlock_Save(t *testing.T) {
 		keyStore.ResetXXXTestOnly()
 		require.NoError(t, keyStore.Unlock(ctx, cltest.Password))
 	})
-}
-
-func requireEqualKeys(t *testing.T, a, b interface {
-	ID() string
-	Raw() internal.Raw
-}) {
-	t.Helper()
-	require.Equal(t, a.ID(), b.ID(), "ids be equal")
-	require.Equal(t, a.Raw(), b.Raw(), "raw bytes must be equal")
-	require.EqualExportedValues(t, a, b)
 }

--- a/core/services/keystore/solana_test.go
+++ b/core/services/keystore/solana_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/solkey"
 )
 
@@ -48,7 +49,7 @@ func Test_SolanaKeyStore_E2E(t *testing.T) {
 		require.NoError(t, err)
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, key, retrievedKey)
+		keys.RequireEqualKeys(t, key, retrievedKey)
 	})
 
 	t.Run("imports and exports a key", func(t *testing.T) {
@@ -73,7 +74,7 @@ func Test_SolanaKeyStore_E2E(t *testing.T) {
 		require.Equal(t, key.ID(), importedKey.ID())
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, importedKey, retrievedKey)
+		keys.RequireEqualKeys(t, importedKey, retrievedKey)
 	})
 
 	t.Run("adds an externally created key / deletes a key", func(t *testing.T) {

--- a/core/services/keystore/starknet_test.go
+++ b/core/services/keystore/starknet_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/starkkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/mocks"
 )
@@ -52,7 +53,7 @@ func Test_StarkNetKeyStore_E2E(t *testing.T) {
 		require.NoError(t, err)
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, key, retrievedKey)
+		keys.RequireEqualKeys(t, key, retrievedKey)
 	})
 
 	t.Run("imports and exports a key", func(t *testing.T) {
@@ -71,7 +72,7 @@ func Test_StarkNetKeyStore_E2E(t *testing.T) {
 		require.Equal(t, key.ID(), importedKey.ID())
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, importedKey, retrievedKey)
+		keys.RequireEqualKeys(t, importedKey, retrievedKey)
 	})
 
 	t.Run("adds an externally created key / deletes a key", func(t *testing.T) {

--- a/core/services/keystore/sui_test.go
+++ b/core/services/keystore/sui_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/suikey"
 )
 
@@ -48,7 +49,7 @@ func Test_SuiKeyStore_E2E(t *testing.T) {
 		require.NoError(t, err)
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, key, retrievedKey)
+		keys.RequireEqualKeys(t, key, retrievedKey)
 	})
 
 	t.Run("imports and exports a key", func(t *testing.T) {
@@ -73,7 +74,7 @@ func Test_SuiKeyStore_E2E(t *testing.T) {
 		require.Equal(t, key.ID(), importedKey.ID())
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, importedKey, retrievedKey)
+		keys.RequireEqualKeys(t, importedKey, retrievedKey)
 	})
 
 	t.Run("adds an externally created key / deletes a key", func(t *testing.T) {

--- a/core/services/keystore/ton_test.go
+++ b/core/services/keystore/ton_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/tonkey"
 )
 
@@ -48,7 +49,7 @@ func Test_TONKeyStore_E2E(t *testing.T) {
 		require.NoError(t, err)
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, key, retrievedKey)
+		keys.RequireEqualKeys(t, key, retrievedKey)
 	})
 
 	t.Run("imports and exports a key", func(t *testing.T) {
@@ -73,7 +74,7 @@ func Test_TONKeyStore_E2E(t *testing.T) {
 		require.Equal(t, key.ID(), importedKey.ID())
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, importedKey, retrievedKey)
+		keys.RequireEqualKeys(t, importedKey, retrievedKey)
 	})
 
 	t.Run("adds an externally created key / deletes a key", func(t *testing.T) {

--- a/core/services/keystore/tron_test.go
+++ b/core/services/keystore/tron_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/tronkey"
 )
 
@@ -50,7 +51,7 @@ func Test_TronKeyStore_E2E(t *testing.T) {
 		require.NoError(t, err)
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, key, retrievedKey)
+		keys.RequireEqualKeys(t, key, retrievedKey)
 	})
 
 	t.Run("imports and exports a key", func(t *testing.T) {
@@ -75,7 +76,7 @@ func Test_TronKeyStore_E2E(t *testing.T) {
 		require.Equal(t, key.ID(), importedKey.ID())
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, importedKey, retrievedKey)
+		keys.RequireEqualKeys(t, importedKey, retrievedKey)
 	})
 
 	t.Run("adds an externally created key / deletes a key", func(t *testing.T) {

--- a/core/services/keystore/workflow_test.go
+++ b/core/services/keystore/workflow_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/workflowkey"
 )
 
@@ -49,7 +50,7 @@ func Test_EncryptionKeyStore_E2E(t *testing.T) {
 		require.NoError(t, err)
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, key, retrievedKey)
+		keys.RequireEqualKeys(t, key, retrievedKey)
 
 		t.Run("prevents creating more than one key", func(t *testing.T) {
 			ctx := testutils.Context(t)
@@ -77,7 +78,7 @@ func Test_EncryptionKeyStore_E2E(t *testing.T) {
 		require.Equal(t, key.ID(), importedKey.ID())
 		retrievedKey, err := ks.Get(key.ID())
 		require.NoError(t, err)
-		requireEqualKeys(t, importedKey, retrievedKey)
+		keys.RequireEqualKeys(t, importedKey, retrievedKey)
 
 		t.Run("prevents importing more than one key", func(t *testing.T) {
 			k, err2 := ks.Import(testutils.Context(t), exportJSON, cltest.Password)

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -3,7 +3,6 @@ package models
 import (
 	"bytes"
 	"database/sql/driver"
-	"encoding/hex"
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
@@ -270,83 +269,6 @@ func Merge(inputs ...JSON) (JSON, error) {
 	}
 
 	return JSON{Result: gjson.ParseBytes(bytes)}, nil
-}
-
-// Explicit type indicating a 32-byte sha256 hash
-type Sha256Hash [32]byte
-
-var EmptySha256Hash = new(Sha256Hash)
-
-// MarshalJSON converts a Sha256Hash to a JSON byte slice.
-func (s Sha256Hash) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.String())
-}
-
-// UnmarshalJSON converts a bytes slice of JSON to a TaskType.
-func (s *Sha256Hash) UnmarshalJSON(input []byte) error {
-	var shaHash string
-	if err := json.Unmarshal(input, &shaHash); err != nil {
-		return err
-	}
-
-	sha, err := Sha256HashFromHex(shaHash)
-	if err != nil {
-		return err
-	}
-
-	*s = sha
-	return nil
-}
-
-func Sha256HashFromHex(x string) (Sha256Hash, error) {
-	bs, err := hex.DecodeString(x)
-	if err != nil {
-		return Sha256Hash{}, err
-	}
-	var hash Sha256Hash
-	copy(hash[:], bs)
-	return hash, nil
-}
-
-func MustSha256HashFromHex(x string) Sha256Hash {
-	bs, err := hex.DecodeString(x)
-	if err != nil {
-		panic(err)
-	}
-	var hash Sha256Hash
-	copy(hash[:], bs)
-	return hash
-}
-
-func (s Sha256Hash) String() string {
-	return hex.EncodeToString(s[:])
-}
-
-func (s *Sha256Hash) MarshalText() ([]byte, error) {
-	return []byte(s.String()), nil
-}
-
-func (s *Sha256Hash) UnmarshalText(bs []byte) (err error) {
-	*s, err = Sha256HashFromHex(string(bs))
-	return
-}
-
-func (s *Sha256Hash) Scan(value any) error {
-	bytes, ok := value.([]byte)
-	if !ok {
-		return errors.Errorf("Failed to unmarshal Sha256Hash value: %v", value)
-	}
-	if s == nil {
-		*s = Sha256Hash{}
-	}
-	copy((*s)[:], bytes)
-	return nil
-}
-
-func (s Sha256Hash) Value() (driver.Value, error) {
-	b := make([]byte, 32)
-	copy(b, s[:])
-	return b, nil
 }
 
 // ServiceHeader is an HTTP header to include in POST to log service.

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -275,6 +275,8 @@ func Merge(inputs ...JSON) (JSON, error) {
 // Explicit type indicating a 32-byte sha256 hash
 type Sha256Hash [32]byte
 
+var EmptySha256Hash = new(Sha256Hash)
+
 // MarshalJSON converts a Sha256Hash to a JSON byte slice.
 func (s Sha256Hash) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.String())

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -275,8 +275,6 @@ func Merge(inputs ...JSON) (JSON, error) {
 // Explicit type indicating a 32-byte sha256 hash
 type Sha256Hash [32]byte
 
-var EmptySha256Hash = new(Sha256Hash)
-
 // MarshalJSON converts a Sha256Hash to a JSON byte slice.
 func (s Sha256Hash) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.String())

--- a/core/store/models/common_test.go
+++ b/core/store/models/common_test.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/v2/core/store/models"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 )
 
 func TestJSON_Merge(t *testing.T) {
@@ -224,55 +224,6 @@ func TestCron_UnmarshalJSON_Invalid(t *testing.T) {
 			assert.EqualError(t, err, test.wantError)
 		})
 	}
-}
-
-func TestSha256Hash_MarshalJSON_UnmarshalJSON(t *testing.T) {
-	t.Parallel()
-
-	hash := models.MustSha256HashFromHex("f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5")
-	json, err := hash.MarshalJSON()
-	require.NoError(t, err)
-	require.NotEmpty(t, json)
-
-	var newHash models.Sha256Hash
-	err = newHash.UnmarshalJSON(json)
-	require.NoError(t, err)
-
-	require.Equal(t, hash, newHash)
-}
-
-func TestSha256Hash_Sha256HashFromHex(t *testing.T) {
-	t.Parallel()
-
-	_, err := models.Sha256HashFromHex("abczzz")
-	require.Error(t, err)
-
-	_, err = models.Sha256HashFromHex("f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5")
-	require.NoError(t, err)
-
-	_, err = models.Sha256HashFromHex("f5bf259689b26f1374e6")
-	require.NoError(t, err)
-}
-
-func TestSha256Hash_String(t *testing.T) {
-	t.Parallel()
-
-	hash := models.MustSha256HashFromHex("f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5")
-	assert.Equal(t, "f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5", hash.String())
-}
-
-func TestSha256Hash_Scan_Value(t *testing.T) {
-	t.Parallel()
-
-	hash := models.MustSha256HashFromHex("f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5")
-	val, err := hash.Value()
-	require.NoError(t, err)
-
-	var newHash models.Sha256Hash
-	err = newHash.Scan(val)
-	require.NoError(t, err)
-
-	require.Equal(t, hash, newHash)
 }
 
 func TestAddressCollection_Scan_Value(t *testing.T) {

--- a/core/web/presenters/job.go
+++ b/core/web/presenters/job.go
@@ -16,6 +16,7 @@ import (
 
 	clnull "github.com/smartcontractkit/chainlink/v2/core/null"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/v2/core/services/signatures/secp256k1"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
@@ -129,7 +130,7 @@ type OffChainReportingSpec struct {
 	ContractAddress                        types.EIP55Address  `json:"contractAddress"`
 	P2PV2Bootstrappers                     pq.StringArray      `json:"p2pv2Bootstrappers"`
 	IsBootstrapPeer                        bool                `json:"isBootstrapPeer"`
-	EncryptedOCRKeyBundleID                *models.Sha256Hash  `json:"keyBundleID"`
+	EncryptedOCRKeyBundleID                *keys.Sha256Hash    `json:"keyBundleID"`
 	TransmitterAddress                     *types.EIP55Address `json:"transmitterAddress"`
 	ObservationTimeout                     sqlutil.Interval    `json:"observationTimeout"`
 	BlockchainTimeout                      sqlutil.Interval    `json:"blockchainTimeout"`

--- a/core/web/presenters/job_test.go
+++ b/core/web/presenters/job_test.go
@@ -20,9 +20,9 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	clnull "github.com/smartcontractkit/chainlink/v2/core/null"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/v2/core/services/signatures/secp256k1"
-	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
 
@@ -38,7 +38,7 @@ func TestJob(t *testing.T) {
 
 	// Used in OCR tests
 	var ocrKeyBundleID = "f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5"
-	ocrKeyID := models.MustSha256HashFromHex(ocrKeyBundleID)
+	ocrKeyID := keys.MustSha256HashFromHex(ocrKeyBundleID)
 	transmitterAddress, err := types.NewEIP55Address("0x27548a32b9aD5D64c5945EaE9Da5337bc3169D15")
 	require.NoError(t, err)
 

--- a/core/web/resolver/spec_test.go
+++ b/core/web/resolver/spec_test.go
@@ -15,6 +15,7 @@ import (
 	commonassets "github.com/smartcontractkit/chainlink-common/pkg/assets"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
@@ -368,7 +369,7 @@ func TestResolver_OCRSpec(t *testing.T) {
 	transmitterAddress, err := evmtypes.NewEIP55Address("0x3cCad4715152693fE3BC4460591e3D3Fbd071b42")
 	require.NoError(t, err)
 
-	keyBundleID := models.MustSha256HashFromHex("f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5")
+	keyBundleID := keys.MustSha256HashFromHex("f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5")
 
 	testCases := []GQLTestCase{
 		{
@@ -465,7 +466,7 @@ func TestResolver_OCR2Spec(t *testing.T) {
 	transmitterAddress, err := evmtypes.NewEIP55Address("0x3cCad4715152693fE3BC4460591e3D3Fbd071b42")
 	require.NoError(t, err)
 
-	keyBundleID := models.MustSha256HashFromHex("f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5")
+	keyBundleID := keys.MustSha256HashFromHex("f5bf259689b26f1374efb3c9a9868796953a0f814bb2d39b968d0e61b58620a5")
 
 	relayConfig := map[string]any{
 		"chainID": 1337,


### PR DESCRIPTION
- Move RequireEqualKeys to exporttestutils (last non-keys usage of internal.Raw)
- Inlined concatBytes into ocr2key
- Inlined mustRandBytes into evm_keyring_test
- Extracted type Sha256Hash into a separate sha256 file.