### PR TITLE
[CRE-1773] LocalCapabilityManager to launch std caps without job specs

### DIFF
--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/localcapmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/executable"
@@ -56,6 +57,7 @@ type launcher struct {
 	don2donSharedPeer   p2ptypes.SharedPeer
 	p2pStreamConfig     p2ptypes.StreamConfig
 	metrics             *launcherMetrics
+	localCapMgr         localcapmgr.LocalCapabilityManager
 }
 
 // For V2 capabilities, shims are created once and their config is updated dynamically.
@@ -244,6 +246,11 @@ func (w *launcher) Close() error {
 	return nil
 }
 
+// LocalCapabilityManager is initialized after the Launcher is created
+func (w *launcher) SetLocalCapabilityManager(lcm localcapmgr.LocalCapabilityManager) {
+	w.localCapMgr = lcm
+}
+
 func (w *launcher) Ready() error {
 	return nil
 }
@@ -363,6 +370,16 @@ func (w *launcher) OnNewRegistry(ctx context.Context, localRegistry *registrysyn
 	} else {
 		// legacy / Keystone setting
 		w.lggr.Debug("My node doesn't belong to any DON families. No filtering will be applied.")
+	}
+
+	// Reconcile local capabilities: start/stop/restart capabilities based on registry state.
+	if w.localCapMgr != nil {
+		myDONs := make([]registrysyncer.DON, 0, len(myCapabilityDONs)+len(myWorkflowDONs))
+		myDONs = append(myDONs, myCapabilityDONs...)
+		myDONs = append(myDONs, myWorkflowDONs...)
+		if err := w.localCapMgr.Reconcile(ctx, myDONs); err != nil {
+			w.lggr.Errorw("Failed to reconcile local capabilities", "error", err)
+		}
 	}
 
 	belongsToAWorkflowDON := len(myWorkflowDONs) > 0

--- a/core/capabilities/launcher_test.go
+++ b/core/capabilities/launcher_test.go
@@ -1121,3 +1121,120 @@ func addCapabilityToDON(registry *registrysyncer.LocalRegistry, donID uint32, ca
 		CapabilityType: capabilityType,
 	}
 }
+
+func TestLauncher_OnNewRegistry_CallsLocalCapabilityManagerReconcile(t *testing.T) {
+	lggr := logger.Test(t)
+	registry := NewRegistry(lggr)
+	dispatcher := remoteMocks.NewDispatcher(t)
+
+	capabilityDonNodes := newNodes(4)
+	peer := mocks.NewPeer(t)
+	peer.On("UpdateConnections", mock.Anything).Return(nil)
+	peer.On("ID").Return(capabilityDonNodes[0])
+	peer.On("IsBootstrap").Return(false)
+	wrapper := mocks.NewPeerWrapper(t)
+	wrapper.On("GetPeer").Return(peer)
+
+	fullTriggerCapID := "streams-trigger@1.0.0"
+	mt := newMockTrigger(capabilities.MustNewCapabilityInfo(
+		fullTriggerCapID,
+		capabilities.CapabilityTypeTrigger,
+		"streams trigger",
+	))
+	require.NoError(t, registry.Add(t.Context(), mt))
+
+	triggerCapIDHash := RandomUTF8BytesWord()
+	capDonID := uint32(1)
+
+	localRegistry := buildLocalRegistry()
+	addDON(localRegistry, capDonID, uint32(0), uint8(1), true, false, capabilityDonNodes, []string{"zone-a"}, 1, [][32]byte{triggerCapIDHash})
+	addCapabilityToDON(localRegistry, capDonID, fullTriggerCapID, capabilities.CapabilityTypeTrigger, nil)
+
+	reconcileCalled := make(chan struct{}, 1)
+	mockLCM := &mockLocalCapabilityManager{
+		reconcileFn: func(ctx context.Context, dons []registrysyncer.DON) error {
+			assert.Len(t, dons, 1, "should pass all DONs")
+			assert.Equal(t, capDonID, dons[0].ID)
+			reconcileCalled <- struct{}{}
+			return nil
+		},
+	}
+
+	dispatcher.On("SetReceiver", fullTriggerCapID, capDonID, mock.Anything).Return(nil)
+
+	launcher, err := NewLauncher(
+		lggr,
+		wrapper,
+		nil,
+		nil,
+		dispatcher,
+		registry,
+		&mockDonNotifier{},
+	)
+	require.NoError(t, err)
+	launcher.SetLocalCapabilityManager(mockLCM)
+	require.NoError(t, launcher.Start(t.Context()))
+	defer launcher.Close()
+
+	err = launcher.OnNewRegistry(t.Context(), localRegistry)
+	require.NoError(t, err)
+
+	select {
+	case <-reconcileCalled:
+		// success
+	default:
+		t.Fatal("Reconcile was not called on LocalCapabilityManager")
+	}
+}
+
+func TestLauncher_OnNewRegistry_NilLocalCapabilityManager(t *testing.T) {
+	lggr := logger.Test(t)
+	registry := NewRegistry(lggr)
+	dispatcher := remoteMocks.NewDispatcher(t)
+
+	nodes := newNodes(4)
+	peer := mocks.NewPeer(t)
+	peer.On("UpdateConnections", mock.Anything).Return(nil)
+	peer.On("ID").Return(nodes[0])
+	peer.On("IsBootstrap").Return(false)
+	wrapper := mocks.NewPeerWrapper(t)
+	wrapper.On("GetPeer").Return(peer)
+
+	localRegistry := buildLocalRegistry()
+	dID := uint32(1)
+	addDON(localRegistry, dID, uint32(0), uint8(1), true, true, nodes, []string{"zone-a"}, 1, nil)
+
+	// Don't set localCapMgr - should not panic.
+	launcher, err := NewLauncher(
+		lggr,
+		wrapper,
+		nil,
+		nil,
+		dispatcher,
+		registry,
+		&mockDonNotifier{},
+	)
+	require.NoError(t, err)
+	require.NoError(t, launcher.Start(t.Context()))
+	defer launcher.Close()
+
+	err = launcher.OnNewRegistry(t.Context(), localRegistry)
+	require.NoError(t, err)
+}
+
+// mockLocalCapabilityManager is a test mock that records calls to Reconcile.
+type mockLocalCapabilityManager struct {
+	reconcileFn func(ctx context.Context, dons []registrysyncer.DON) error
+}
+
+func (m *mockLocalCapabilityManager) Start(context.Context) error    { return nil }
+func (m *mockLocalCapabilityManager) Close() error                   { return nil }
+func (m *mockLocalCapabilityManager) Ready() error                   { return nil }
+func (m *mockLocalCapabilityManager) HealthReport() map[string]error { return nil }
+func (m *mockLocalCapabilityManager) Name() string                   { return "mockLocalCapMgr" }
+func (m *mockLocalCapabilityManager) Reconcile(ctx context.Context, dons []registrysyncer.DON) error {
+	if m.reconcileFn != nil {
+		return m.reconcileFn(ctx, dons)
+	}
+	return nil
+}

--- a/core/capabilities/localcapmgr/manager.go
+++ b/core/capabilities/localcapmgr/manager.go
@@ -1,0 +1,305 @@
+package localcapmgr
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"sync"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+
+	"github.com/smartcontractkit/chainlink/v2/core/config"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	"github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer"
+	"github.com/smartcontractkit/chainlink/v2/core/services/standardcapabilities/conversions"
+)
+
+// LocalCapabilityManager handles the full lifecycle of capabilities this node hosts.
+// It starts, stops, and reconfigures local capabilities based on the on-chain registry state.
+// It depends on standardcapabilities/delegate.go to build all dependencies for the capabilities.
+type LocalCapabilityManager interface {
+	services.Service
+
+	// Called by Launcher.OnNewRegistry() for each registry update.
+	Reconcile(ctx context.Context, allMyDONs []registrysyncer.DON) error
+}
+
+// runningCapability tracks a started capability.
+type runningCapability struct {
+	capID      string
+	donID      uint32
+	services   []job.ServiceCtx
+	configHash string
+}
+
+// capabilityInfo describes a capability that should be running.
+type capabilityInfo struct {
+	capID      string
+	donID      uint32
+	config     registrysyncer.CapabilityConfiguration
+	configHash string
+}
+
+func runningKey(capID string, donID uint32) string {
+	return fmt.Sprintf("%s:%d", capID, donID)
+}
+
+type localCapabilityManager struct {
+	services.StateMachine
+	lggr logger.Logger
+
+	localCfg      config.LocalCapabilities
+	newServicesFn NewServicesFn
+
+	runningCapabilities map[string]*runningCapability
+	mu                  sync.RWMutex
+
+	metrics *metrics
+}
+
+// Wraps standardcapabilities.Delegate.NewServices to avoid direct dependency on the Delegate.
+type NewServicesFn func(ctx context.Context, capID string, command string, configJSON string) ([]job.ServiceCtx, error)
+
+func NewLocalCapabilityManager(lggr logger.Logger, localCfg config.LocalCapabilities, newServicesFn NewServicesFn) (LocalCapabilityManager, error) {
+	metrics, err := newMetrics()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create local capability manager metrics: %w", err)
+	}
+	return &localCapabilityManager{
+		lggr:                logger.Named(lggr, "LocalCapabilityManager"),
+		localCfg:            localCfg,
+		newServicesFn:       newServicesFn,
+		runningCapabilities: make(map[string]*runningCapability),
+		metrics:             metrics,
+	}, nil
+}
+
+func (m *localCapabilityManager) Start(ctx context.Context) error {
+	return m.StartOnce("LocalCapabilityManager", func() error {
+		m.lggr.Info("LocalCapabilityManager started")
+		return nil
+	})
+}
+
+func (m *localCapabilityManager) Close() error {
+	return m.StopOnce("LocalCapabilityManager", func() error {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		var errs []error
+		for key, rc := range m.runningCapabilities {
+			m.lggr.Infow("Stopping capability on shutdown", "capID", rc.capID, "donID", rc.donID)
+			if err := m.closeServices(rc); err != nil {
+				m.lggr.Errorw("Failed to stop capability on shutdown", "key", key, "error", err)
+				errs = append(errs, err)
+			}
+		}
+		m.runningCapabilities = make(map[string]*runningCapability)
+		m.lggr.Info("LocalCapabilityManager stopped")
+		return errors.Join(errs...)
+	})
+}
+
+func (m *localCapabilityManager) Ready() error {
+	return m.StateMachine.Ready()
+}
+
+func (m *localCapabilityManager) HealthReport() map[string]error {
+	return map[string]error{m.Name(): m.Ready()}
+}
+
+func (m *localCapabilityManager) Name() string {
+	return m.lggr.Name()
+}
+
+// Reconcile compares running capabilities against the desired state from the registry.
+// It starts new capabilities, stops removed ones, and restarts those with changed config.
+func (m *localCapabilityManager) Reconcile(
+	ctx context.Context,
+	allMyDONs []registrysyncer.DON,
+) error {
+	desired := m.buildDesiredState(allMyDONs)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Stop capabilities that should no longer be running.
+	for key, rc := range m.runningCapabilities {
+		if _, ok := desired[key]; !ok {
+			m.lggr.Infow("Stopping removed capability", "capID", rc.capID, "donID", rc.donID)
+			if err := m.closeServices(rc); err != nil {
+				m.lggr.Errorw("Failed to stop removed capability", "capID", rc.capID, "donID", rc.donID, "error", err)
+			}
+			m.metrics.recordStop(ctx, rc.capID)
+			delete(m.runningCapabilities, key)
+		}
+	}
+
+	// Start new capabilities or restart those with changed config.
+	for key, info := range desired {
+		existing, ok := m.runningCapabilities[key]
+		if ok && existing.configHash == info.configHash {
+			continue // already running with same config
+		}
+
+		if ok {
+			// Config changed - stop old instance first.
+			m.lggr.Infow("Restarting capability due to config change",
+				"capID", info.capID, "donID", info.donID,
+				"oldHash", existing.configHash, "newHash", info.configHash)
+			if err := m.closeServices(existing); err != nil {
+				m.lggr.Errorw("Failed to stop capability for config update", "capID", info.capID, "error", err)
+			}
+			m.metrics.recordConfigUpdate(ctx, info.capID)
+			delete(m.runningCapabilities, key)
+		}
+
+		// Start new capability.
+		rc, err := m.startCapability(ctx, info)
+		if err != nil {
+			m.lggr.Errorw("Failed to start capability", "capID", info.capID, "donID", info.donID, "error", err)
+			continue
+		}
+		m.runningCapabilities[key] = rc
+	}
+
+	m.metrics.recordRunning(ctx, int64(len(m.runningCapabilities)))
+	return nil
+}
+
+// buildDesiredState extracts capabilities that should be running from DON configs.
+// Only includes capabilities that are in the RegistryBasedLaunchAllowlist.
+func (m *localCapabilityManager) buildDesiredState(myCapabilityDONs []registrysyncer.DON) map[string]*capabilityInfo {
+	desired := make(map[string]*capabilityInfo)
+	for _, don := range myCapabilityDONs {
+		for capID, capCfg := range don.CapabilityConfigurations {
+			if m.localCfg == nil || !m.localCfg.IsAllowlisted(capID) {
+				continue
+			}
+
+			key := runningKey(capID, don.ID)
+			desired[key] = &capabilityInfo{
+				capID:      capID,
+				donID:      don.ID,
+				config:     capCfg,
+				configHash: configHash(capCfg.Config),
+			}
+		}
+	}
+	return desired
+}
+
+func (m *localCapabilityManager) startCapability(ctx context.Context, info *capabilityInfo) (*runningCapability, error) {
+	start := time.Now()
+
+	command := m.resolveCapabilityBinary(info.capID)
+	if command == "" {
+		return nil, fmt.Errorf("could not resolve capability binary for %s", info.capID)
+	}
+	configJSON, err := m.buildConfigJSON(info)
+	if err != nil {
+		return nil, fmt.Errorf("build config for %s: %w", info.capID, err)
+	}
+
+	// TODO(CRE-1775): pass also Ocr3Configs and OracleFactoryConfigs if present onchain
+	svcs, err := m.newServicesFn(ctx, info.capID, command, configJSON)
+	if err != nil {
+		return nil, fmt.Errorf("build services for %s: %w", info.capID, err)
+	}
+
+	for i, svc := range svcs {
+		if err := svc.Start(ctx); err != nil {
+			for j := i - 1; j >= 0; j-- {
+				if closeErr := svcs[j].Close(); closeErr != nil {
+					m.lggr.Errorw("Failed to close service during rollback", "capID", info.capID, "serviceIndex", j, "error", closeErr)
+				}
+			}
+			return nil, fmt.Errorf("start service %d for %s: %w", i, info.capID, err)
+		}
+	}
+
+	duration := time.Since(start)
+	m.metrics.recordLaunch(ctx, info.capID, duration)
+	m.lggr.Infow("Started capability",
+		"capID", info.capID, "donID", info.donID,
+		"duration", duration, "configHash", info.configHash)
+
+	return &runningCapability{
+		capID:      info.capID,
+		donID:      info.donID,
+		services:   svcs,
+		configHash: info.configHash,
+	}, nil
+}
+
+func (m *localCapabilityManager) resolveCapabilityBinary(capID string) string {
+	if m.localCfg != nil {
+		capCfg := m.localCfg.GetCapabilityConfig(capID)
+		if capCfg != nil && capCfg.BinaryPathOverride() != "" {
+			m.lggr.Debugw("Using binary path override from TOML", "capID", capID, "path", capCfg.BinaryPathOverride())
+			return capCfg.BinaryPathOverride()
+		}
+	}
+
+	// fall back to default command based on capability ID
+	return conversions.GetCommandFromCapabilityID(capID)
+}
+
+// buildConfigJSON merges the node-local TOML config with the onchain SpecConfig
+// into a flat JSON object. Onchain values take precedence over local ones.
+func (m *localCapabilityManager) buildConfigJSON(info *capabilityInfo) (string, error) {
+	merged := make(map[string]any)
+
+	if m.localCfg != nil {
+		capCfg := m.localCfg.GetCapabilityConfig(info.capID)
+		if capCfg != nil {
+			for k, v := range capCfg.Config() {
+				merged[k] = v
+			}
+		}
+	}
+
+	if len(info.config.Config) > 0 {
+		capCfg, err := info.config.Unmarshal()
+		if err != nil {
+			m.lggr.Warnw("Failed to unmarshal onchain config, using local config only",
+				"capID", info.capID, "error", err)
+		} else if capCfg.SpecConfig != nil {
+			unwrapped, err := capCfg.SpecConfig.Unwrap()
+			if err != nil {
+				return "", fmt.Errorf("unwrap onchain spec config for %s: %w", info.capID, err)
+			}
+			if onchain, ok := unwrapped.(map[string]any); ok {
+				maps.Copy(merged, onchain)
+			}
+		}
+	}
+
+	if len(merged) == 0 {
+		return "{}", nil
+	}
+
+	b, err := json.Marshal(merged)
+	if err != nil {
+		return "", fmt.Errorf("marshal merged config for %s: %w", info.capID, err)
+	}
+	return string(b), nil
+}
+
+func (m *localCapabilityManager) closeServices(rc *runningCapability) error {
+	return services.MultiCloser(rc.services).Close()
+}
+
+func configHash(configBytes []byte) string {
+	if len(configBytes) == 0 {
+		return ""
+	}
+	h := sha256.Sum256(configBytes)
+	return hex.EncodeToString(h[:])
+}

--- a/core/capabilities/localcapmgr/manager_test.go
+++ b/core/capabilities/localcapmgr/manager_test.go
@@ -1,0 +1,518 @@
+package localcapmgr
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	valuespb "github.com/smartcontractkit/chainlink-protos/cre/go/values/pb"
+
+	"github.com/smartcontractkit/chainlink/v2/core/config"
+	corelogger "github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	"github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer"
+)
+
+func TestConfigHash(t *testing.T) {
+	t.Run("empty config returns empty string", func(t *testing.T) {
+		assert.Empty(t, configHash(nil))
+		assert.Empty(t, configHash([]byte{}))
+	})
+
+	t.Run("same config produces same hash", func(t *testing.T) {
+		cfg := []byte(`{"key": "value"}`)
+		h1 := configHash(cfg)
+		h2 := configHash(cfg)
+		assert.Equal(t, h1, h2)
+		assert.NotEmpty(t, h1)
+	})
+
+	t.Run("different config produces different hash", func(t *testing.T) {
+		h1 := configHash([]byte(`{"key": "value1"}`))
+		h2 := configHash([]byte(`{"key": "value2"}`))
+		assert.NotEqual(t, h1, h2)
+	})
+}
+
+func TestRunningKey(t *testing.T) {
+	assert.Equal(t, "cron@1.0.0:1", runningKey("cron@1.0.0", 1))
+	assert.Equal(t, "consensus@1.0.0:42", runningKey("consensus@1.0.0", 42))
+}
+
+func testLogger(t *testing.T) corelogger.Logger {
+	return corelogger.TestLogger(t)
+}
+
+func TestBuildDesiredState(t *testing.T) {
+	lggr := testLogger(t)
+	mgr := &localCapabilityManager{
+		lggr:     lggr,
+		localCfg: &testLocalCapabilities{allowlisted: map[string]bool{"cron@1.0.0": true, "consensus@1.0.0": true}},
+	}
+
+	dons := []registrysyncer.DON{
+		{
+			DON: capabilities.DON{ID: 1},
+			CapabilityConfigurations: map[string]registrysyncer.CapabilityConfiguration{
+				"cron@1.0.0":      {Config: []byte(`{"interval": 60}`)},
+				"consensus@1.0.0": {Config: []byte(`{"key": "evm"}`)},
+				"unknown@1.0.0":   {Config: []byte(`{}`)}, // not allowlisted
+			},
+		},
+		{
+			DON: capabilities.DON{ID: 2},
+			CapabilityConfigurations: map[string]registrysyncer.CapabilityConfiguration{
+				"cron@1.0.0": {Config: []byte(`{"interval": 30}`)},
+			},
+		},
+	}
+
+	desired := mgr.buildDesiredState(dons)
+
+	assert.Len(t, desired, 3)
+	assert.Contains(t, desired, "cron@1.0.0:1")
+	assert.Contains(t, desired, "consensus@1.0.0:1")
+	assert.Contains(t, desired, "cron@1.0.0:2")
+	assert.NotContains(t, desired, "unknown@1.0.0:1")
+}
+
+func TestBuildDesiredState_NilLocalConfig(t *testing.T) {
+	lggr := testLogger(t)
+	mgr := &localCapabilityManager{
+		lggr:     lggr,
+		localCfg: nil,
+	}
+
+	dons := []registrysyncer.DON{
+		{
+			DON: capabilities.DON{ID: 1},
+			CapabilityConfigurations: map[string]registrysyncer.CapabilityConfiguration{
+				"cron@1.0.0": {Config: []byte(`{}`)},
+			},
+		},
+	}
+
+	desired := mgr.buildDesiredState(dons)
+	assert.Empty(t, desired, "nil config should not allow any capabilities")
+}
+
+func noopServiceBuilder(_ context.Context, _ string, _ string, _ string) ([]job.ServiceCtx, error) {
+	return []job.ServiceCtx{&mockService{}}, nil
+}
+
+func failingServiceBuilder(_ context.Context, _ string, _ string, _ string) ([]job.ServiceCtx, error) {
+	return nil, assert.AnError
+}
+
+func TestReconcile_StartsNewCapabilities(t *testing.T) {
+	ctx := context.Background()
+	lggr := testLogger(t)
+	metrics, err := newMetrics()
+	require.NoError(t, err)
+
+	mgr := &localCapabilityManager{
+		lggr: lggr,
+		localCfg: &testLocalCapabilities{
+			allowlisted: map[string]bool{"test-cap@1.0.0": true},
+			configs: map[string]*testCapabilityNodeConfig{
+				"test-cap@1.0.0": {binaryPath: "/bin/test-cap"},
+			},
+		},
+		newServicesFn:       noopServiceBuilder,
+		runningCapabilities: make(map[string]*runningCapability),
+		metrics:             metrics,
+	}
+
+	onchainCfg := mustMarshalCapConfig(t, map[string]string{"test": "true"})
+	dons := []registrysyncer.DON{
+		{
+			DON: capabilities.DON{ID: 1},
+			CapabilityConfigurations: map[string]registrysyncer.CapabilityConfiguration{
+				"test-cap@1.0.0": {Config: onchainCfg},
+			},
+		},
+	}
+
+	err = mgr.Reconcile(ctx, dons)
+	require.NoError(t, err)
+
+	assert.Len(t, mgr.runningCapabilities, 1)
+	assert.Contains(t, mgr.runningCapabilities, "test-cap@1.0.0:1")
+}
+
+func TestReconcile_StopsRemovedCapabilities(t *testing.T) {
+	ctx := context.Background()
+	lggr := testLogger(t)
+	metrics, err := newMetrics()
+	require.NoError(t, err)
+
+	emptyCfg := mustMarshalCapConfig(t, nil)
+	mockSvc := &mockService{}
+	mgr := &localCapabilityManager{
+		lggr: lggr,
+		localCfg: &testLocalCapabilities{
+			allowlisted: map[string]bool{"test-cap@1.0.0": true},
+			configs: map[string]*testCapabilityNodeConfig{
+				"test-cap@1.0.0": {binaryPath: "/bin/test-cap"},
+			},
+		},
+		newServicesFn: noopServiceBuilder,
+		runningCapabilities: map[string]*runningCapability{
+			"test-cap@1.0.0:1": {
+				capID:      "test-cap@1.0.0",
+				donID:      1,
+				services:   []job.ServiceCtx{mockSvc},
+				configHash: configHash(emptyCfg),
+			},
+			"removed-cap@1.0.0:1": {
+				capID:    "removed-cap@1.0.0",
+				donID:    1,
+				services: []job.ServiceCtx{&mockService{}},
+			},
+		},
+		metrics: metrics,
+	}
+
+	// Only test-cap@1.0.0 is in the desired state.
+	dons := []registrysyncer.DON{
+		{
+			DON: capabilities.DON{ID: 1},
+			CapabilityConfigurations: map[string]registrysyncer.CapabilityConfiguration{
+				"test-cap@1.0.0": {Config: emptyCfg},
+			},
+		},
+	}
+
+	err = mgr.Reconcile(ctx, dons)
+	require.NoError(t, err)
+
+	// removed-cap should be stopped and removed.
+	assert.Len(t, mgr.runningCapabilities, 1)
+	assert.Contains(t, mgr.runningCapabilities, "test-cap@1.0.0:1")
+	assert.NotContains(t, mgr.runningCapabilities, "removed-cap@1.0.0:1")
+}
+
+func TestReconcile_DetectsConfigChange(t *testing.T) {
+	ctx := context.Background()
+	lggr := testLogger(t)
+	metrics, err := newMetrics()
+	require.NoError(t, err)
+
+	oldCfg := mustMarshalCapConfig(t, map[string]string{"version": "1"})
+	newCfg := mustMarshalCapConfig(t, map[string]string{"version": "2"})
+
+	mockSvc := &mockService{}
+	mgr := &localCapabilityManager{
+		lggr: lggr,
+		localCfg: &testLocalCapabilities{
+			allowlisted: map[string]bool{"test-cap@1.0.0": true},
+			configs: map[string]*testCapabilityNodeConfig{
+				"test-cap@1.0.0": {binaryPath: "/bin/test-cap"},
+			},
+		},
+		newServicesFn: noopServiceBuilder,
+		runningCapabilities: map[string]*runningCapability{
+			"test-cap@1.0.0:1": {
+				capID:      "test-cap@1.0.0",
+				donID:      1,
+				services:   []job.ServiceCtx{mockSvc},
+				configHash: configHash(oldCfg),
+			},
+		},
+		metrics: metrics,
+	}
+
+	dons := []registrysyncer.DON{
+		{
+			DON: capabilities.DON{ID: 1},
+			CapabilityConfigurations: map[string]registrysyncer.CapabilityConfiguration{
+				"test-cap@1.0.0": {Config: newCfg},
+			},
+		},
+	}
+
+	err = mgr.Reconcile(ctx, dons)
+	require.NoError(t, err)
+
+	// Old capability closed, new one started.
+	assert.True(t, mockSvc.closed, "old capability should be closed on config change")
+	assert.Len(t, mgr.runningCapabilities, 1)
+	assert.Contains(t, mgr.runningCapabilities, "test-cap@1.0.0:1")
+
+	// Verify new hash.
+	rc := mgr.runningCapabilities["test-cap@1.0.0:1"]
+	assert.Equal(t, configHash(newCfg), rc.configHash)
+}
+
+func TestReconcile_ContinuesOnStartFailure(t *testing.T) {
+	ctx := context.Background()
+	lggr := testLogger(t)
+	metrics, err := newMetrics()
+	require.NoError(t, err)
+
+	emptyCfg := mustMarshalCapConfig(t, nil)
+	mgr := &localCapabilityManager{
+		lggr: lggr,
+		localCfg: &testLocalCapabilities{
+			allowlisted: map[string]bool{"failing-cap@1.0.0": true, "good-cap@1.0.0": true},
+			configs: map[string]*testCapabilityNodeConfig{
+				"failing-cap@1.0.0": {binaryPath: "/bin/failing"},
+				"good-cap@1.0.0":    {binaryPath: "/bin/good"},
+			},
+		},
+		newServicesFn:       failingServiceBuilder,
+		runningCapabilities: make(map[string]*runningCapability),
+		metrics:             metrics,
+	}
+
+	dons := []registrysyncer.DON{
+		{
+			DON: capabilities.DON{ID: 1},
+			CapabilityConfigurations: map[string]registrysyncer.CapabilityConfiguration{
+				"failing-cap@1.0.0": {Config: emptyCfg},
+				"good-cap@1.0.0":    {Config: emptyCfg},
+			},
+		},
+	}
+
+	err = mgr.Reconcile(ctx, dons)
+	require.NoError(t, err) // Reconcile is best-effort, doesn't return errors for individual caps.
+
+	// Both failed since we use failingServiceBuilder.
+	assert.Empty(t, mgr.runningCapabilities)
+}
+
+func TestResolveCapabilityBinary(t *testing.T) {
+	lggr := testLogger(t)
+
+	t.Run("uses TOML override when set", func(t *testing.T) {
+		override := "/opt/chainlink/binaries/cron"
+		mgr := &localCapabilityManager{
+			lggr: lggr,
+			localCfg: &testLocalCapabilities{
+				allowlisted: map[string]bool{"cron@1.0.0": true},
+				configs: map[string]*testCapabilityNodeConfig{
+					"cron@1.0.0": {binaryPath: override},
+				},
+			},
+		}
+		path := mgr.resolveCapabilityBinary("cron@1.0.0")
+		assert.Equal(t, override, path)
+	})
+
+	t.Run("falls back to command from capID when no override", func(t *testing.T) {
+		mgr := &localCapabilityManager{
+			lggr: lggr,
+			localCfg: &testLocalCapabilities{
+				allowlisted: map[string]bool{"cron-trigger@1.0.0": true},
+			},
+		}
+		path := mgr.resolveCapabilityBinary("cron-trigger@1.0.0")
+		assert.Equal(t, "cron", path)
+	})
+
+	t.Run("returns empty for unrecognized capID with nil config", func(t *testing.T) {
+		mgr := &localCapabilityManager{
+			lggr:     lggr,
+			localCfg: nil,
+		}
+		path := mgr.resolveCapabilityBinary("unknown@1.0.0")
+		assert.Empty(t, path)
+	})
+}
+
+func TestClose_StopsAllRunningCapabilities(t *testing.T) {
+	lggr := testLogger(t)
+	metrics, err := newMetrics()
+	require.NoError(t, err)
+
+	svc1 := &mockService{}
+	svc2 := &mockService{}
+	mgr := &localCapabilityManager{
+		lggr: lggr,
+		runningCapabilities: map[string]*runningCapability{
+			"cap1@1.0.0:1": {capID: "cap1@1.0.0", donID: 1, services: []job.ServiceCtx{svc1}},
+			"cap2@1.0.0:2": {capID: "cap2@1.0.0", donID: 2, services: []job.ServiceCtx{svc2}},
+		},
+		metrics: metrics,
+	}
+
+	// Start it first so Close works.
+	require.NoError(t, mgr.Start(context.Background()))
+	require.NoError(t, mgr.Close())
+
+	assert.True(t, svc1.closed)
+	assert.True(t, svc2.closed)
+	assert.Empty(t, mgr.runningCapabilities)
+}
+
+// --- Test helpers ---
+
+type mockService struct {
+	started bool
+	closed  bool
+}
+
+func (m *mockService) Start(context.Context) error { m.started = true; return nil }
+func (m *mockService) Close() error                { m.closed = true; return nil }
+
+// testLocalCapabilities implements config.LocalCapabilities for testing.
+type testLocalCapabilities struct {
+	allowlisted map[string]bool
+	configs     map[string]*testCapabilityNodeConfig
+}
+
+func (t *testLocalCapabilities) RegistryBasedLaunchAllowlist() []string {
+	result := make([]string, 0, len(t.allowlisted))
+	for k := range t.allowlisted {
+		result = append(result, k)
+	}
+	return result
+}
+
+func (t *testLocalCapabilities) Capabilities() map[string]config.CapabilityNodeConfig {
+	return nil
+}
+
+func (t *testLocalCapabilities) IsAllowlisted(capabilityID string) bool {
+	return t.allowlisted[capabilityID]
+}
+
+func (t *testLocalCapabilities) GetCapabilityConfig(capabilityID string) config.CapabilityNodeConfig {
+	if t.configs == nil {
+		return nil
+	}
+	c, ok := t.configs[capabilityID]
+	if !ok {
+		return nil
+	}
+	return c
+}
+
+type testCapabilityNodeConfig struct {
+	binaryPath string
+	cfg        map[string]string
+}
+
+func (c *testCapabilityNodeConfig) BinaryPathOverride() string { return c.binaryPath }
+func (c *testCapabilityNodeConfig) Config() map[string]string  { return c.cfg }
+
+// mustMarshalCapConfig creates proto-encoded CapabilityConfig bytes with a DefaultConfig map.
+func mustMarshalCapConfig(t *testing.T, kv map[string]string) []byte {
+	t.Helper()
+	fields := make(map[string]*valuespb.Value, len(kv))
+	for k, v := range kv {
+		fields[k] = valuespb.NewStringValue(v)
+	}
+	cfg := &capabilitiespb.CapabilityConfig{
+		SpecConfig: &valuespb.Map{Fields: fields},
+	}
+	b, err := proto.Marshal(cfg)
+	require.NoError(t, err)
+	return b
+}
+
+func TestBuildConfigJSON(t *testing.T) {
+	lggr := testLogger(t)
+
+	t.Run("local config only", func(t *testing.T) {
+		mgr := &localCapabilityManager{
+			lggr: lggr,
+			localCfg: &testLocalCapabilities{
+				allowlisted: map[string]bool{"cap@1.0.0": true},
+				configs: map[string]*testCapabilityNodeConfig{
+					"cap@1.0.0": {cfg: map[string]string{"key1": "local1"}},
+				},
+			},
+		}
+		info := &capabilityInfo{capID: "cap@1.0.0", config: registrysyncer.CapabilityConfiguration{}}
+		result, err := mgr.buildConfigJSON(info)
+		require.NoError(t, err)
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result), &got))
+		assert.Equal(t, "local1", got["key1"])
+	})
+
+	t.Run("onchain config only", func(t *testing.T) {
+		mgr := &localCapabilityManager{
+			lggr:     lggr,
+			localCfg: &testLocalCapabilities{allowlisted: map[string]bool{"cap@1.0.0": true}},
+		}
+		onchainBytes := mustMarshalCapConfig(t, map[string]string{"chainId": "42"})
+		info := &capabilityInfo{
+			capID:  "cap@1.0.0",
+			config: registrysyncer.CapabilityConfiguration{Config: onchainBytes},
+		}
+		result, err := mgr.buildConfigJSON(info)
+		require.NoError(t, err)
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result), &got))
+		assert.Equal(t, "42", got["chainId"])
+	})
+
+	t.Run("onchain overrides local", func(t *testing.T) {
+		mgr := &localCapabilityManager{
+			lggr: lggr,
+			localCfg: &testLocalCapabilities{
+				allowlisted: map[string]bool{"cap@1.0.0": true},
+				configs: map[string]*testCapabilityNodeConfig{
+					"cap@1.0.0": {cfg: map[string]string{"chainId": "99", "localOnly": "yes"}},
+				},
+			},
+		}
+		onchainBytes := mustMarshalCapConfig(t, map[string]string{"chainId": "42", "onchainOnly": "true"})
+		info := &capabilityInfo{
+			capID:  "cap@1.0.0",
+			config: registrysyncer.CapabilityConfiguration{Config: onchainBytes},
+		}
+		result, err := mgr.buildConfigJSON(info)
+		require.NoError(t, err)
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result), &got))
+		assert.Equal(t, "42", got["chainId"], "onchain should override local")
+		assert.Equal(t, "true", got["onchainOnly"], "onchain-only keys preserved")
+		assert.Equal(t, "yes", got["localOnly"], "local-only keys included")
+	})
+
+	t.Run("empty config returns empty JSON object", func(t *testing.T) {
+		mgr := &localCapabilityManager{
+			lggr:     lggr,
+			localCfg: &testLocalCapabilities{allowlisted: map[string]bool{"cap@1.0.0": true}},
+		}
+		info := &capabilityInfo{capID: "cap@1.0.0", config: registrysyncer.CapabilityConfiguration{}}
+		result, err := mgr.buildConfigJSON(info)
+		require.NoError(t, err)
+		assert.Equal(t, "{}", result)
+	})
+
+	t.Run("invalid onchain proto falls back to local config", func(t *testing.T) {
+		mgr := &localCapabilityManager{
+			lggr: lggr,
+			localCfg: &testLocalCapabilities{
+				allowlisted: map[string]bool{"cap@1.0.0": true},
+				configs: map[string]*testCapabilityNodeConfig{
+					"cap@1.0.0": {cfg: map[string]string{"fallback": "ok"}},
+				},
+			},
+		}
+		info := &capabilityInfo{
+			capID:  "cap@1.0.0",
+			config: registrysyncer.CapabilityConfiguration{Config: []byte("not-valid-proto")},
+		}
+		result, err := mgr.buildConfigJSON(info)
+		require.NoError(t, err)
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result), &got))
+		assert.Equal(t, "ok", got["fallback"])
+	})
+}

--- a/core/capabilities/localcapmgr/metrics.go
+++ b/core/capabilities/localcapmgr/metrics.go
@@ -1,0 +1,83 @@
+package localcapmgr
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+)
+
+const keyCapabilityID = "capability_id"
+
+type metrics struct {
+	launchesTotal  metric.Int64Counter
+	stopsTotal     metric.Int64Counter
+	configUpdates  metric.Int64Counter
+	launchDuration metric.Float64Histogram
+	runningGauge   metric.Int64Gauge
+}
+
+func newMetrics() (*metrics, error) {
+	meter := beholder.GetMeter()
+
+	launchesTotal, err := meter.Int64Counter("platform_capability_launches_total",
+		metric.WithDescription("Total capabilities started via registry"))
+	if err != nil {
+		return nil, err
+	}
+
+	stopsTotal, err := meter.Int64Counter("platform_capability_stops_total",
+		metric.WithDescription("Total capabilities stopped via registry"))
+	if err != nil {
+		return nil, err
+	}
+
+	configUpdates, err := meter.Int64Counter("platform_capability_config_updates_total",
+		metric.WithDescription("Total config updates received"))
+	if err != nil {
+		return nil, err
+	}
+
+	launchDuration, err := meter.Float64Histogram("platform_capability_launch_duration_seconds",
+		metric.WithDescription("Time to start a capability"))
+	if err != nil {
+		return nil, err
+	}
+
+	runningGauge, err := meter.Int64Gauge("platform_capability_running",
+		metric.WithDescription("Currently running capabilities"))
+	if err != nil {
+		return nil, err
+	}
+
+	return &metrics{
+		launchesTotal:  launchesTotal,
+		stopsTotal:     stopsTotal,
+		configUpdates:  configUpdates,
+		launchDuration: launchDuration,
+		runningGauge:   runningGauge,
+	}, nil
+}
+
+func (m *metrics) recordLaunch(ctx context.Context, capID string, duration time.Duration) {
+	attrs := metric.WithAttributes(attribute.String(keyCapabilityID, capID))
+	m.launchesTotal.Add(ctx, 1, attrs)
+	m.launchDuration.Record(ctx, duration.Seconds(), attrs)
+}
+
+func (m *metrics) recordStop(ctx context.Context, capID string) {
+	attrs := metric.WithAttributes(attribute.String(keyCapabilityID, capID))
+	m.stopsTotal.Add(ctx, 1, attrs)
+}
+
+func (m *metrics) recordConfigUpdate(ctx context.Context, capID string) {
+	attrs := metric.WithAttributes(attribute.String(keyCapabilityID, capID))
+	m.configUpdates.Add(ctx, 1, attrs)
+}
+
+func (m *metrics) recordRunning(ctx context.Context, count int64) {
+	m.runningGauge.Record(ctx, count)
+}

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -615,7 +615,7 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 	delegates[job.CRESettings] = cresettings.NewDelegate(globalLogger, atomicSettings)
 
 	// If peer wrapper is initialized, Oracle Factory dependency will be available to standard capabilities
-	delegates[job.StandardCapabilities] = standardcapabilities.NewDelegate(
+	stdcapDelegate := standardcapabilities.NewDelegate(
 		globalLogger,
 		opts.DS, jobORM,
 		opts.CapabilitiesRegistry,
@@ -632,7 +632,15 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 		creServices.OrgResolver,
 		atomicSettings,
 		creServices.OCRConfigService,
+		cfg.Capabilities().Local(),
 	)
+	delegates[job.StandardCapabilities] = stdcapDelegate
+	if creServices.SetDelegatesDeps != nil {
+		err = creServices.SetDelegatesDeps(stdcapDelegate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set CRE delegates dependencies: %w", err)
+		}
+	}
 
 	if cfg.OCR().Enabled() {
 		delegates[job.OffchainReporting] = ocr.NewDelegate(

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
 	"google.golang.org/grpc/credentials"
 
@@ -32,9 +33,11 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/compute"
 	gatewayconnector "github.com/smartcontractkit/chainlink/v2/core/capabilities/gateway_connector"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/localcapmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
 	remotetypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr/capregconfig"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
@@ -44,6 +47,7 @@ import (
 	registrysyncerV1 "github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer"
 	registrysyncerV2 "github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer/v2"
 	"github.com/smartcontractkit/chainlink/v2/core/services/shardorchestrator"
+	"github.com/smartcontractkit/chainlink/v2/core/services/standardcapabilities"
 	artifactsV1 "github.com/smartcontractkit/chainlink/v2/core/services/workflows/artifacts"
 	artifactsV2 "github.com/smartcontractkit/chainlink/v2/core/services/workflows/artifacts/v2"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/metering"
@@ -107,6 +111,9 @@ type Services struct {
 	OrgResolver orgresolver.OrgResolver
 
 	OCRConfigService capregconfig.OCRConfigService
+
+	// callback to wire Delegates into CRE services (e.g. Launcher) when ready
+	SetDelegatesDeps func(*standardcapabilities.Delegate) error
 }
 
 func (s *Services) close() error {
@@ -191,7 +198,7 @@ func (s *Services) newSubservices(
 		return srvs, nil
 	}
 
-	registrySyncerServices, donNotifier, ocrConfigService, err := newRegistrySyncer(
+	registrySyncerServices, donNotifier, err := s.newRegistrySyncer(
 		lggr,
 		cfg,
 		relayerChainInterops,
@@ -202,7 +209,6 @@ func (s *Services) newSubservices(
 	if err != nil {
 		return nil, err
 	}
-	s.OCRConfigService = ocrConfigService
 	srvs = append(srvs, registrySyncerServices...)
 
 	if capCfg.WorkflowRegistry().Address() == "" {
@@ -304,26 +310,9 @@ func newRegistrySyncerV1(
 	registryAddress string,
 	ds sqlutil.DataSource,
 	externalPeerWrapper p2ptypes.PeerWrapper,
-	don2donSharedPeer p2ptypes.SharedPeer,
-	streamConfig config.StreamConfig,
-	dispatcher remotetypes.Dispatcher,
-	capabilitiesRegistry *capabilities.Registry,
-	donNotifier capabilities.DonNotifier,
 	ocrConfigService capregconfig.OCRConfigService,
+	wfLauncher registrysyncerV1.Listener,
 ) ([]commonsrv.Service, error) {
-	wfLauncher, err := capabilities.NewLauncher(
-		lggr,
-		externalPeerWrapper,
-		don2donSharedPeer,
-		streamConfig,
-		dispatcher,
-		capabilitiesRegistry,
-		donNotifier,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("could not create workflow launcher: %w", err)
-	}
-
 	registrySyncer, err := registrysyncerV1.New(
 		lggr,
 		getPeerID,
@@ -336,7 +325,7 @@ func newRegistrySyncerV1(
 	}
 
 	registrySyncer.AddListener(wfLauncher, ocrConfigService)
-	return []commonsrv.Service{wfLauncher, registrySyncer, ocrConfigService}, nil
+	return []commonsrv.Service{registrySyncer, ocrConfigService}, nil
 }
 
 func newRegistrySyncerV2(
@@ -345,27 +334,9 @@ func newRegistrySyncerV2(
 	relayer loop.Relayer,
 	registryAddress string,
 	ds sqlutil.DataSource,
-	don2donSharedPeer p2ptypes.SharedPeer,
-	externalPeerWrapper p2ptypes.PeerWrapper,
-	streamConfig config.StreamConfig,
-	dispatcher remotetypes.Dispatcher,
-	capabilitiesRegistry *capabilities.Registry,
-	donNotifier capabilities.DonNotifier,
 	ocrConfigService capregconfig.OCRConfigService,
+	wfLauncher registrysyncerV1.Listener,
 ) ([]commonsrv.Service, error) {
-	wfLauncher, err := capabilities.NewLauncher(
-		lggr,
-		externalPeerWrapper,
-		don2donSharedPeer,
-		streamConfig,
-		dispatcher,
-		capabilitiesRegistry,
-		donNotifier,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("could not create workflow launcher: %w", err)
-	}
-
 	registrySyncer, err := registrysyncerV2.New(
 		lggr,
 		getPeerID,
@@ -378,18 +349,18 @@ func newRegistrySyncerV2(
 	}
 
 	registrySyncer.AddListener(wfLauncher, ocrConfigService)
-	return []commonsrv.Service{wfLauncher, registrySyncer, ocrConfigService}, nil
+	return []commonsrv.Service{registrySyncer, ocrConfigService}, nil
 }
 
 // newRegistrySyncer creates a registry syncer based on the external registry version
-func newRegistrySyncer(
+func (s *Services) newRegistrySyncer(
 	lggr logger.Logger,
 	cfg Config,
 	relayerChainInterops RelayerChainInterops,
 	ds sqlutil.DataSource,
 	opts Opts,
 	dispatcherWrapper *dispatcherWrapper,
-) ([]commonsrv.Service, capabilities.DonNotifyWaitSubscriber, capregconfig.OCRConfigService, error) {
+) ([]commonsrv.Service, capabilities.DonNotifyWaitSubscriber, error) {
 	var srvcs []commonsrv.Service
 
 	capCfg := cfg.Capabilities()
@@ -398,7 +369,7 @@ func newRegistrySyncer(
 	registryAddress := capCfg.ExternalRegistry().Address()
 	relayer, err := relayerChainInterops.Get(rid)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("could not fetch relayer %s configured for capabilities registry: %w", rid, err)
+		return nil, nil, fmt.Errorf("could not fetch relayer %s configured for capabilities registry: %w", rid, err)
 	}
 
 	var streamConfig config.StreamConfig
@@ -410,12 +381,46 @@ func newRegistrySyncer(
 
 	ocrConfigService, ocrErr := newOCRConfigService(lggr, rid, registryAddress, dispatcherWrapper)
 	if ocrErr != nil {
-		return nil, nil, nil, ocrErr
+		return nil, nil, ocrErr
 	}
+	s.OCRConfigService = ocrConfigService
 
 	externalRegistryVersion, err := semver.NewVersion(capCfg.ExternalRegistry().ContractVersion())
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
+	}
+
+	wfLauncher, err := capabilities.NewLauncher(
+		lggr,
+		dispatcherWrapper.externalPeerWrapper,
+		dispatcherWrapper.don2DonSharedPeer,
+		streamConfig,
+		dispatcherWrapper.dispatcher,
+		opts.CapabilitiesRegistry,
+		donNotifier,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not create workflow launcher: %w", err)
+	}
+	srvcs = append(srvcs, wfLauncher)
+
+	// callback to wire LocalCapabilityManager into the launcher if local capabilities are configured.
+	localCfg := cfg.Capabilities().Local()
+	if localCfg != nil && len(localCfg.RegistryBasedLaunchAllowlist()) > 0 {
+		// will be called when the Delegate is ready
+		s.SetDelegatesDeps = func(stdcapDelegate *standardcapabilities.Delegate) error {
+			// abstraction for the Delegate
+			newServicesFn := func(ctx context.Context, capID string, command string, configJSON string) ([]job.ServiceCtx, error) {
+				return stdcapDelegate.NewServices(ctx, command, configJSON, 0, capID, uuid.New(), job.OracleFactoryConfig{})
+			}
+			localCapMgr, lcmErr := localcapmgr.NewLocalCapabilityManager(lggr, localCfg, newServicesFn)
+			if lcmErr != nil {
+				return fmt.Errorf("could not create local capability manager: %w", lcmErr)
+			}
+			wfLauncher.SetLocalCapabilityManager(localCapMgr)
+			srvcs = append(srvcs, localCapMgr) // srvcs is still valid when the callback is called
+			return nil
+		}
 	}
 
 	switch externalRegistryVersion.Major() {
@@ -427,18 +432,14 @@ func newRegistrySyncer(
 			registryAddress,
 			ds,
 			dispatcherWrapper.externalPeerWrapper,
-			dispatcherWrapper.don2DonSharedPeer,
-			streamConfig,
-			dispatcherWrapper.dispatcher,
-			opts.CapabilitiesRegistry,
-			donNotifier,
 			ocrConfigService,
+			wfLauncher,
 		)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 		srvcs = append(srvcs, srvs...)
-		return srvcs, donNotifier, ocrConfigService, nil
+		return srvcs, donNotifier, nil
 	case 2:
 		srvs, err := newRegistrySyncerV2(
 			lggr,
@@ -446,22 +447,17 @@ func newRegistrySyncer(
 			relayer,
 			registryAddress,
 			ds,
-			dispatcherWrapper.don2DonSharedPeer,
-			dispatcherWrapper.externalPeerWrapper,
-			streamConfig,
-			dispatcherWrapper.dispatcher,
-			opts.CapabilitiesRegistry,
-			donNotifier,
 			ocrConfigService,
+			wfLauncher,
 		)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 		srvcs = append(srvcs, srvs...)
-		return srvcs, donNotifier, ocrConfigService, nil
+		return srvcs, donNotifier, nil
 	}
 
-	return nil, nil, nil, fmt.Errorf("could not configure capability registry syncer with version: %d", externalRegistryVersion.Major())
+	return nil, nil, fmt.Errorf("could not configure capability registry syncer with version: %d", externalRegistryVersion.Major())
 }
 
 func newOCRConfigService(

--- a/core/services/registrysyncer/local_registry.go
+++ b/core/services/registrysyncer/local_registry.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/smartcontractkit/libocr/ragep2p/types"
 	"google.golang.org/protobuf/proto"
 
@@ -104,6 +106,53 @@ func (c CapabilityConfiguration) Unmarshal() (capabilities.CapabilityConfigurati
 		}
 	}
 
+	var ocr3Configs map[string]ocrtypes.ContractConfig
+	if cconf.Ocr3Configs != nil {
+		ocr3Configs = make(map[string]ocrtypes.ContractConfig, len(cconf.Ocr3Configs))
+		for name, pbCfg := range cconf.Ocr3Configs {
+			signers := make([]ocrtypes.OnchainPublicKey, len(pbCfg.Signers))
+			for i, s := range pbCfg.Signers {
+				signers[i] = s
+			}
+			transmitters := make([]ocrtypes.Account, len(pbCfg.Transmitters))
+			for i, t := range pbCfg.Transmitters {
+				transmitters[i] = ocrtypes.Account(t)
+			}
+			if pbCfg.F > math.MaxUint8 {
+				return capabilities.CapabilityConfiguration{}, fmt.Errorf("OCR3Config %q: F value %d exceeds uint8 max", name, pbCfg.F)
+			}
+			ocr3Configs[name] = ocrtypes.ContractConfig{
+				ConfigCount:           pbCfg.ConfigCount,
+				Signers:               signers,
+				Transmitters:          transmitters,
+				F:                     uint8(pbCfg.F), //#nosec G115 - bounds checked above
+				OnchainConfig:         pbCfg.OnchainConfig,
+				OffchainConfigVersion: pbCfg.OffchainConfigVersion,
+				OffchainConfig:        pbCfg.OffchainConfig,
+			}
+		}
+	}
+
+	var oracleFactoryConfigs map[string]values.Map
+	if cconf.OracleFactoryConfigs != nil {
+		oracleFactoryConfigs = make(map[string]values.Map, len(cconf.OracleFactoryConfigs))
+		for name, pbMap := range cconf.OracleFactoryConfigs {
+			var m *values.Map
+			m, err = values.FromMapValueProto(pbMap)
+			if err != nil {
+				return capabilities.CapabilityConfiguration{}, fmt.Errorf("failed to unmarshal oracle factory config %q: %w", name, err)
+			}
+			if m != nil {
+				oracleFactoryConfigs[name] = *m
+			}
+		}
+	}
+
+	sc, err := values.FromMapValueProto(cconf.SpecConfig)
+	if err != nil {
+		return capabilities.CapabilityConfiguration{}, fmt.Errorf("failed to unmarshal capability configuration: %w", err)
+	}
+
 	return capabilities.CapabilityConfiguration{
 		DefaultConfig:          dc,
 		RestrictedKeys:         cconf.RestrictedKeys,
@@ -112,6 +161,9 @@ func (c CapabilityConfiguration) Unmarshal() (capabilities.CapabilityConfigurati
 		RemoteTargetConfig:     remoteTargetConfig,
 		CapabilityMethodConfig: methodConfigs,
 		LocalOnly:              cconf.LocalOnly,
+		Ocr3Configs:            ocr3Configs,
+		OracleFactoryConfigs:   oracleFactoryConfigs,
+		SpecConfig:             sc,
 	}, nil
 }
 

--- a/core/services/registrysyncer/local_registry_test.go
+++ b/core/services/registrysyncer/local_registry_test.go
@@ -3,12 +3,16 @@ package registrysyncer
 import (
 	"testing"
 
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/smartcontractkit/libocr/ragep2p/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	valuespb "github.com/smartcontractkit/chainlink-protos/cre/go/values/pb"
 )
 
 func TestLocalRegistry_DONsForCapability(t *testing.T) {
@@ -28,7 +32,7 @@ func TestLocalRegistry_DONsForCapability(t *testing.T) {
 				},
 			},
 			CapabilityConfigurations: map[string]CapabilityConfiguration{
-				"capabilityID@1.0.0": CapabilityConfiguration{},
+				"capabilityID@1.0.0": {},
 			},
 		},
 		2: {
@@ -42,7 +46,7 @@ func TestLocalRegistry_DONsForCapability(t *testing.T) {
 				},
 			},
 			CapabilityConfigurations: map[string]CapabilityConfiguration{
-				"secondCapabilityID@1.0.0": CapabilityConfiguration{},
+				"secondCapabilityID@1.0.0": {},
 			},
 		},
 		3: {
@@ -56,7 +60,7 @@ func TestLocalRegistry_DONsForCapability(t *testing.T) {
 				},
 			},
 			CapabilityConfigurations: map[string]CapabilityConfiguration{
-				"thirdCapabilityID@1.0.0": CapabilityConfiguration{},
+				"thirdCapabilityID@1.0.0": {},
 			},
 		},
 	}
@@ -104,4 +108,170 @@ func TestLocalRegistry_DONsForCapability(t *testing.T) {
 	// thirdCapability is on a DON with invalid peers
 	_, err = lr.DONsForCapability(t.Context(), "thirdCapabilityID@1.0.0")
 	require.ErrorContains(t, err, "could not find node for peerID")
+}
+
+func mustMarshalProto(t *testing.T, msg proto.Message) []byte {
+	t.Helper()
+	b, err := proto.Marshal(msg)
+	require.NoError(t, err)
+	return b
+}
+
+func makeStringMap(kv map[string]string) *valuespb.Map {
+	fields := make(map[string]*valuespb.Value, len(kv))
+	for k, v := range kv {
+		fields[k] = valuespb.NewStringValue(v)
+	}
+	return &valuespb.Map{Fields: fields}
+}
+
+func TestCapabilityConfiguration_Unmarshal(t *testing.T) {
+	t.Run("empty config", func(t *testing.T) {
+		raw := mustMarshalProto(t, &capabilitiespb.CapabilityConfig{})
+		cc := CapabilityConfiguration{Config: raw}
+
+		got, err := cc.Unmarshal()
+		require.NoError(t, err)
+		assert.Nil(t, got.DefaultConfig)
+		assert.Nil(t, got.SpecConfig)
+		assert.Nil(t, got.RestrictedConfig)
+		assert.Nil(t, got.Ocr3Configs)
+		assert.Nil(t, got.OracleFactoryConfigs)
+	})
+
+	t.Run("invalid proto returns error", func(t *testing.T) {
+		cc := CapabilityConfiguration{Config: []byte("not-valid-proto")}
+		_, err := cc.Unmarshal()
+		require.ErrorContains(t, err, "failed to unmarshal capability configuration")
+	})
+
+	t.Run("DefaultConfig and RestrictedConfig", func(t *testing.T) {
+		raw := mustMarshalProto(t, &capabilitiespb.CapabilityConfig{
+			DefaultConfig:    makeStringMap(map[string]string{"key": "val"}),
+			RestrictedConfig: makeStringMap(map[string]string{"secret": "hidden"}),
+			RestrictedKeys:   []string{"secret"},
+		})
+		cc := CapabilityConfiguration{Config: raw}
+
+		got, err := cc.Unmarshal()
+		require.NoError(t, err)
+
+		require.NotNil(t, got.DefaultConfig)
+		unwrapped, err := got.DefaultConfig.Unwrap()
+		require.NoError(t, err)
+		assert.Equal(t, "val", unwrapped.(map[string]any)["key"])
+
+		require.NotNil(t, got.RestrictedConfig)
+		unwrappedRC, err := got.RestrictedConfig.Unwrap()
+		require.NoError(t, err)
+		assert.Equal(t, "hidden", unwrappedRC.(map[string]any)["secret"])
+
+		assert.Equal(t, []string{"secret"}, got.RestrictedKeys)
+	})
+
+	t.Run("SpecConfig", func(t *testing.T) {
+		raw := mustMarshalProto(t, &capabilitiespb.CapabilityConfig{
+			SpecConfig: makeStringMap(map[string]string{"interval": "60"}),
+		})
+		cc := CapabilityConfiguration{Config: raw}
+
+		got, err := cc.Unmarshal()
+		require.NoError(t, err)
+
+		require.NotNil(t, got.SpecConfig)
+		unwrapped, err := got.SpecConfig.Unwrap()
+		require.NoError(t, err)
+		assert.Equal(t, "60", unwrapped.(map[string]any)["interval"])
+	})
+
+	t.Run("Ocr3Configs", func(t *testing.T) {
+		signer := []byte{0x01, 0x02, 0x03}
+		transmitter := []byte("0xabc")
+
+		raw := mustMarshalProto(t, &capabilitiespb.CapabilityConfig{
+			Ocr3Configs: map[string]*capabilitiespb.OCR3Config{
+				"__default__": {
+					Signers:               [][]byte{signer},
+					Transmitters:          [][]byte{transmitter},
+					F:                     2,
+					OnchainConfig:         []byte("onchain"),
+					OffchainConfigVersion: 5,
+					OffchainConfig:        []byte("offchain"),
+					ConfigCount:           3,
+				},
+			},
+		})
+		cc := CapabilityConfiguration{Config: raw}
+
+		got, err := cc.Unmarshal()
+		require.NoError(t, err)
+
+		require.Contains(t, got.Ocr3Configs, "__default__")
+		cfg := got.Ocr3Configs["__default__"]
+		assert.Equal(t, []ocrtypes.OnchainPublicKey{signer}, cfg.Signers)
+		assert.Equal(t, []ocrtypes.Account{ocrtypes.Account(transmitter)}, cfg.Transmitters)
+		assert.Equal(t, uint8(2), cfg.F)
+		assert.Equal(t, []byte("onchain"), cfg.OnchainConfig)
+		assert.Equal(t, uint64(5), cfg.OffchainConfigVersion)
+		assert.Equal(t, []byte("offchain"), cfg.OffchainConfig)
+		assert.Equal(t, uint64(3), cfg.ConfigCount)
+	})
+
+	t.Run("OracleFactoryConfigs", func(t *testing.T) {
+		raw := mustMarshalProto(t, &capabilitiespb.CapabilityConfig{
+			OracleFactoryConfigs: map[string]*valuespb.Map{
+				"blue": makeStringMap(map[string]string{"mode": "blue"}),
+			},
+		})
+		cc := CapabilityConfiguration{Config: raw}
+
+		got, err := cc.Unmarshal()
+		require.NoError(t, err)
+
+		require.Contains(t, got.OracleFactoryConfigs, "blue")
+		blueMap := got.OracleFactoryConfigs["blue"]
+		unwrapped, err := blueMap.Unwrap()
+		require.NoError(t, err)
+		assert.Equal(t, "blue", unwrapped.(map[string]any)["mode"])
+	})
+
+	t.Run("LocalOnly flag", func(t *testing.T) {
+		raw := mustMarshalProto(t, &capabilitiespb.CapabilityConfig{
+			LocalOnly: true,
+		})
+		cc := CapabilityConfiguration{Config: raw}
+
+		got, err := cc.Unmarshal()
+		require.NoError(t, err)
+		assert.True(t, got.LocalOnly)
+	})
+
+	t.Run("all fields together", func(t *testing.T) {
+		raw := mustMarshalProto(t, &capabilitiespb.CapabilityConfig{
+			DefaultConfig: makeStringMap(map[string]string{"dc": "1"}),
+			SpecConfig:    makeStringMap(map[string]string{"sc": "2"}),
+			Ocr3Configs: map[string]*capabilitiespb.OCR3Config{
+				"__default__": {
+					Signers:      [][]byte{{0xAA}},
+					Transmitters: [][]byte{[]byte("tx1")},
+					F:            1,
+					ConfigCount:  7,
+				},
+			},
+			OracleFactoryConfigs: map[string]*valuespb.Map{
+				"green": makeStringMap(map[string]string{"x": "y"}),
+			},
+			LocalOnly: true,
+		})
+		cc := CapabilityConfiguration{Config: raw}
+
+		got, err := cc.Unmarshal()
+		require.NoError(t, err)
+
+		assert.NotNil(t, got.DefaultConfig)
+		assert.NotNil(t, got.SpecConfig)
+		assert.Len(t, got.Ocr3Configs, 1)
+		assert.Len(t, got.OracleFactoryConfigs, 1)
+		assert.True(t, got.LocalOnly)
+	})
 }

--- a/core/services/standardcapabilities/conversions/conversions.go
+++ b/core/services/standardcapabilities/conversions/conversions.go
@@ -1,0 +1,58 @@
+package conversions
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+)
+
+// WARNING: Hacky and brittle - used only during migration to map job specs to capability IDs
+// before executing the LOOPP. When std cap job specs are deprecated, capability IDs will be known upfront.
+func GetCapabilityIDFromCommand(command string, config string) string {
+	switch filepath.Base(command) {
+	case "evm":
+		var cfg struct {
+			ChainID uint64 `json:"chainId"`
+		}
+		if err := json.Unmarshal([]byte(config), &cfg); err != nil {
+			return ""
+		}
+		selector, err := chainselectors.SelectorFromChainId(cfg.ChainID)
+		if err != nil {
+			return ""
+		}
+		return "evm:ChainSelector:" + strconv.FormatUint(selector, 10) + "@1.0.0"
+	case "consensus":
+		return "consensus@1.0.0-alpha"
+	case "cron":
+		return "cron-trigger@1.0.0"
+	case "http_trigger":
+		return "http-trigger@1.0.0-alpha"
+	case "http_action":
+		return "http-actions@1.0.0-alpha" // plural "actions"
+	default:
+		return ""
+	}
+}
+
+// GetCommandFromCapabilityID is the inverse of GetCapabilityIDFromCommand: it maps a capability ID
+// back to the base command name (e.g. "evm", "consensus"). Returns "" for unrecognized IDs.
+func GetCommandFromCapabilityID(capabilityID string) string {
+	switch {
+	case strings.HasPrefix(capabilityID, "evm"):
+		return "evm"
+	case strings.HasPrefix(capabilityID, "consensus"):
+		return "consensus"
+	case strings.HasPrefix(capabilityID, "cron-trigger"):
+		return "cron"
+	case strings.HasPrefix(capabilityID, "http-trigger"):
+		return "http_trigger"
+	case strings.HasPrefix(capabilityID, "http-actions"):
+		return "http_action"
+	default:
+		return ""
+	}
+}

--- a/core/services/standardcapabilities/conversions/conversions_test.go
+++ b/core/services/standardcapabilities/conversions/conversions_test.go
@@ -1,0 +1,210 @@
+package conversions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetCapabilityIDFromCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		config   string
+		expected string
+	}{
+		{
+			name:     "consensus command",
+			command:  "consensus",
+			config:   "",
+			expected: "consensus@1.0.0-alpha",
+		},
+		{
+			name:     "evm command with valid config - mainnet",
+			command:  "/usr/local/bin/evm",
+			config:   `{"chainId": 1}`,
+			expected: "evm:ChainSelector:5009297550715157269@1.0.0",
+		},
+		{
+			name:     "evm command with valid config - sepolia",
+			command:  "/usr/local/bin/evm",
+			config:   `{"chainId": 11155111}`,
+			expected: "evm:ChainSelector:16015286601757825753@1.0.0",
+		},
+		{
+			name:     "evm command with valid config - arbitrum",
+			command:  "/usr/local/bin/evm",
+			config:   `{"chainId": 42161}`,
+			expected: "evm:ChainSelector:4949039107694359620@1.0.0",
+		},
+		{
+			name:     "evm command with additional config fields",
+			command:  "/usr/local/bin/evm",
+			config:   `{"chainId": 1, "network": "mainnet", "otherField": "value"}`,
+			expected: "evm:ChainSelector:5009297550715157269@1.0.0",
+		},
+		{
+			name:     "evm command with invalid JSON",
+			command:  "/usr/local/bin/evm",
+			config:   `{invalid json}`,
+			expected: "",
+		},
+		{
+			name:     "evm command with missing chainId",
+			command:  "/usr/local/bin/evm",
+			config:   `{"network": "mainnet"}`,
+			expected: "", // chainId defaults to 0, which is invalid
+		},
+		{
+			name:     "evm command with zero chain ID",
+			command:  "/usr/local/bin/evm",
+			config:   `{"chainId": 0}`,
+			expected: "",
+		},
+		{
+			name:     "evm command with empty config",
+			command:  "/usr/local/bin/evm",
+			config:   "",
+			expected: "",
+		},
+		{
+			name:     "cron command",
+			command:  "cron",
+			config:   "",
+			expected: "cron-trigger@1.0.0",
+		},
+		{
+			name:     "http_trigger command",
+			command:  "/opt/bin/http_trigger",
+			config:   "",
+			expected: "http-trigger@1.0.0-alpha",
+		},
+		{
+			name:     "http_action command",
+			command:  "http_action",
+			config:   "",
+			expected: "http-actions@1.0.0-alpha",
+		},
+		{
+			name:     "unknown command",
+			command:  "/usr/local/bin/unknown",
+			config:   "",
+			expected: "",
+		},
+		{
+			name:     "empty command",
+			command:  "",
+			config:   "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetCapabilityIDFromCommand(tt.command, tt.config)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_GetCommandFromCapabilityID(t *testing.T) {
+	tests := []struct {
+		name         string
+		capabilityID string
+		expected     string
+	}{
+		{
+			name:         "consensus capability - exact",
+			capabilityID: "consensus@1.0.0-alpha",
+			expected:     "consensus",
+		},
+		{
+			name:         "consensus capability - different version",
+			capabilityID: "consensus@2.0.0",
+			expected:     "consensus",
+		},
+		{
+			name:         "cron trigger capability - exact",
+			capabilityID: "cron-trigger@1.0.0",
+			expected:     "cron",
+		},
+		{
+			name:         "cron trigger capability - different version",
+			capabilityID: "cron-trigger@2.0.0",
+			expected:     "cron",
+		},
+		{
+			name:         "http trigger capability - exact",
+			capabilityID: "http-trigger@1.0.0-alpha",
+			expected:     "http_trigger",
+		},
+		{
+			name:         "http trigger capability - different version",
+			capabilityID: "http-trigger@3.0.0",
+			expected:     "http_trigger",
+		},
+		{
+			name:         "http action capability - exact",
+			capabilityID: "http-actions@1.0.0-alpha",
+			expected:     "http_action",
+		},
+		{
+			name:         "http action capability - different version",
+			capabilityID: "http-actions@2.0.0",
+			expected:     "http_action",
+		},
+		{
+			name:         "evm mainnet capability",
+			capabilityID: "evm:ChainSelector:5009297550715157269@1.0.0",
+			expected:     "evm",
+		},
+		{
+			name:         "evm sepolia capability",
+			capabilityID: "evm:ChainSelector:16015286601757825753@1.0.0",
+			expected:     "evm",
+		},
+		{
+			name:         "evm arbitrum capability",
+			capabilityID: "evm:ChainSelector:4949039107694359620@1.0.0",
+			expected:     "evm",
+		},
+		{
+			name:         "evm capability - different version",
+			capabilityID: "evm:ChainSelector:5009297550715157269@2.0.0",
+			expected:     "evm",
+		},
+		{
+			name:         "unknown capability",
+			capabilityID: "unknown@1.0.0",
+			expected:     "",
+		},
+		{
+			name:         "empty capability ID",
+			capabilityID: "",
+			expected:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetCommandFromCapabilityID(tt.capabilityID)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_roundTrip(t *testing.T) {
+	commands := []string{"consensus", "cron", "http_trigger", "http_action"}
+	for _, cmd := range commands {
+		t.Run(cmd, func(t *testing.T) {
+			capID := GetCapabilityIDFromCommand(cmd, "")
+			assert.NotEmpty(t, capID)
+			got := GetCommandFromCapabilityID(capID)
+			assert.Equal(t, cmd, got)
+		})
+	}
+
+	// EVM round-trip: command base name is preserved
+	evmCapID := GetCapabilityIDFromCommand("/usr/local/bin/evm", `{"chainId": 1}`)
+	assert.Equal(t, "evm", GetCommandFromCapabilityID(evmCapID))
+}

--- a/core/services/standardcapabilities/delegate.go
+++ b/core/services/standardcapabilities/delegate.go
@@ -3,16 +3,12 @@ package standardcapabilities
 import (
 	"context"
 	"crypto"
-	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"strconv"
 
 	"github.com/google/uuid"
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
-
-	chainselectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/ocr2key"
@@ -28,6 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/webapi"
 	webapitarget "github.com/smartcontractkit/chainlink/v2/core/capabilities/webapi/target"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/webapi/trigger"
+	coreconfig "github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/connector"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities"
@@ -38,6 +35,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
+	"github.com/smartcontractkit/chainlink/v2/core/services/standardcapabilities/conversions"
 	"github.com/smartcontractkit/chainlink/v2/core/services/telemetry"
 	"github.com/smartcontractkit/chainlink/v2/plugins"
 )
@@ -66,6 +64,7 @@ type Delegate struct {
 	orgResolver             orgresolver.OrgResolver
 	creSettings             core.SettingsBroadcaster
 	ocrConfigService        capregconfig.OCRConfigService
+	localCfg                coreconfig.LocalCapabilities
 
 	isNewlyCreatedJob bool
 }
@@ -75,29 +74,6 @@ const (
 	commandOverrideForWebAPITarget        = "__builtin_web-api-target"
 	commandOverrideForCustomComputeAction = "__builtin_custom-compute-action"
 )
-
-// WARNING: Hacky and brittle - used only during migration to map job specs to capability IDs
-// before executing the LOOPP. When std cap job specs are deprecated, capability IDs will be known upfront.
-func getCapabilityID(command string, config string) string {
-	switch filepath.Base(command) {
-	case "evm":
-		var cfg struct {
-			ChainID uint64 `json:"chainId"`
-		}
-		if err := json.Unmarshal([]byte(config), &cfg); err != nil {
-			return ""
-		}
-		selector, err := chainselectors.SelectorFromChainId(cfg.ChainID)
-		if err != nil {
-			return ""
-		}
-		return "evm:ChainSelector:" + strconv.FormatUint(selector, 10) + "@1.0.0"
-	case "consensus":
-		return "consensus@1.0.0-alpha"
-	default:
-		return ""
-	}
-}
 
 type NewOracleFactoryFn func(generic.OracleFactoryParams) (core.OracleFactory, error)
 
@@ -119,6 +95,7 @@ func NewDelegate(
 	orgResolver orgresolver.OrgResolver,
 	creSettings core.SettingsBroadcaster,
 	ocrConfigService capregconfig.OCRConfigService,
+	localCfg coreconfig.LocalCapabilities,
 	opts ...func(*gateway.RoundRobinSelector),
 ) *Delegate {
 	return &Delegate{
@@ -140,6 +117,7 @@ func NewDelegate(
 		orgResolver:             orgResolver,
 		creSettings:             creSettings,
 		ocrConfigService:        ocrConfigService,
+		localCfg:                localCfg,
 		selectorOpts:            opts,
 	}
 }
@@ -154,7 +132,21 @@ func (d *Delegate) BeforeJobCreated(job job.Job) {
 }
 
 func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.ServiceCtx, error) {
-	return d.NewServices(ctx, spec.StandardCapabilitiesSpec.Command, spec.StandardCapabilitiesSpec.Config, spec.ID, spec.Name.ValueOrZero(), spec.ExternalJobID, spec.StandardCapabilitiesSpec.OracleFactory)
+	command := spec.StandardCapabilitiesSpec.Command
+	configJSON := spec.StandardCapabilitiesSpec.Config
+
+	if d.localCfg != nil {
+		capabilityID := conversions.GetCapabilityIDFromCommand(command, configJSON)
+		if capabilityID != "" && d.localCfg.IsAllowlisted(capabilityID) {
+			return nil, fmt.Errorf(
+				"capability %q is in the RegistryBasedLaunchAllowlist and will be started from the on-chain registry; "+
+					"remove the job spec and let the LocalCapabilityManager handle it via [Capabilities.Local] TOML config",
+				capabilityID,
+			)
+		}
+	}
+
+	return d.NewServices(ctx, command, configJSON, spec.ID, spec.Name.ValueOrZero(), spec.ExternalJobID, spec.StandardCapabilitiesSpec.OracleFactory)
 }
 
 func (d *Delegate) NewServices(
@@ -222,7 +214,7 @@ func (d *Delegate) NewServices(
 		ocrEvmKeyBundle = ocrEvmKeyBundles[0]
 	}
 
-	capabilityID := getCapabilityID(command, configJSON)
+	capabilityID := conversions.GetCapabilityIDFromCommand(command, configJSON)
 	if d.ocrConfigService != nil && capabilityID == "" {
 		log.Warnw("No capability ID mapping for command, using legacy config only",
 			"command", command)

--- a/core/services/standardcapabilities/delegate_test.go
+++ b/core/services/standardcapabilities/delegate_test.go
@@ -1,96 +1,16 @@
 package standardcapabilities
 
 import (
+	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 )
-
-func Test_getCapabilityID(t *testing.T) {
-	tests := []struct {
-		name     string
-		command  string
-		config   string
-		expected string
-	}{
-		{
-			name:     "consensus command",
-			command:  "consensus",
-			config:   "",
-			expected: "consensus@1.0.0-alpha",
-		},
-		{
-			name:     "evm command with valid config - mainnet",
-			command:  "/usr/local/bin/evm",
-			config:   `{"chainId": 1}`,
-			expected: "evm:ChainSelector:5009297550715157269@1.0.0",
-		},
-		{
-			name:     "evm command with valid config - sepolia",
-			command:  "/usr/local/bin/evm",
-			config:   `{"chainId": 11155111}`,
-			expected: "evm:ChainSelector:16015286601757825753@1.0.0",
-		},
-		{
-			name:     "evm command with valid config - arbitrum",
-			command:  "/usr/local/bin/evm",
-			config:   `{"chainId": 42161}`,
-			expected: "evm:ChainSelector:4949039107694359620@1.0.0",
-		},
-		{
-			name:     "evm command with additional config fields",
-			command:  "/usr/local/bin/evm",
-			config:   `{"chainId": 1, "network": "mainnet", "otherField": "value"}`,
-			expected: "evm:ChainSelector:5009297550715157269@1.0.0",
-		},
-		{
-			name:     "evm command with invalid JSON",
-			command:  "/usr/local/bin/evm",
-			config:   `{invalid json}`,
-			expected: "",
-		},
-		{
-			name:     "evm command with missing chainId",
-			command:  "/usr/local/bin/evm",
-			config:   `{"network": "mainnet"}`,
-			expected: "", // chainId defaults to 0, which is invalid
-		},
-		{
-			name:     "evm command with zero chain ID",
-			command:  "/usr/local/bin/evm",
-			config:   `{"chainId": 0}`,
-			expected: "",
-		},
-		{
-			name:     "evm command with empty config",
-			command:  "/usr/local/bin/evm",
-			config:   "",
-			expected: "",
-		},
-		{
-			name:     "unknown command",
-			command:  "/usr/local/bin/unknown",
-			config:   "",
-			expected: "",
-		},
-		{
-			name:     "empty command",
-			command:  "",
-			config:   "",
-			expected: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := getCapabilityID(tt.command, tt.config)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
 
 func Test_ValidatedStandardCapabilitiesSpec(t *testing.T) {
 	type testCase struct {
@@ -214,4 +134,104 @@ func Test_ValidatedStandardCapabilitiesSpec(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_ServicesForSpec_AllowlistEnforcement(t *testing.T) {
+	t.Run("allowlisted consensus capability is rejected", func(t *testing.T) {
+		d := &Delegate{
+			localCfg: &stubLocalCapabilities{allowlisted: map[string]bool{"consensus@1.0.0-alpha": true}},
+		}
+		spec := job.Job{
+			ExternalJobID:            uuid.New(),
+			StandardCapabilitiesSpec: &job.StandardCapabilitiesSpec{Command: "consensus"},
+		}
+		_, err := d.ServicesForSpec(context.Background(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "RegistryBasedLaunchAllowlist")
+		assert.Contains(t, err.Error(), "LocalCapabilityManager")
+		assert.Contains(t, err.Error(), "consensus@1.0.0-alpha")
+	})
+
+	t.Run("allowlisted cron trigger is rejected", func(t *testing.T) {
+		d := &Delegate{
+			localCfg: &stubLocalCapabilities{allowlisted: map[string]bool{"cron-trigger@1.0.0": true}},
+		}
+		spec := job.Job{
+			ExternalJobID:            uuid.New(),
+			StandardCapabilitiesSpec: &job.StandardCapabilitiesSpec{Command: "cron"},
+		}
+		_, err := d.ServicesForSpec(context.Background(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "RegistryBasedLaunchAllowlist")
+		assert.Contains(t, err.Error(), "cron-trigger@1.0.0")
+	})
+
+	t.Run("allowlisted http trigger is rejected", func(t *testing.T) {
+		d := &Delegate{
+			localCfg: &stubLocalCapabilities{allowlisted: map[string]bool{"http-trigger@1.0.0-alpha": true}},
+		}
+		spec := job.Job{
+			ExternalJobID:            uuid.New(),
+			StandardCapabilitiesSpec: &job.StandardCapabilitiesSpec{Command: "http_trigger"},
+		}
+		_, err := d.ServicesForSpec(context.Background(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "RegistryBasedLaunchAllowlist")
+	})
+
+	t.Run("non-allowlisted capability passes through", func(t *testing.T) {
+		d := &Delegate{
+			localCfg: &stubLocalCapabilities{allowlisted: map[string]bool{}},
+		}
+		spec := job.Job{
+			ExternalJobID:            uuid.New(),
+			StandardCapabilitiesSpec: &job.StandardCapabilitiesSpec{Command: "consensus"},
+		}
+		// The allowlist check should pass; the call will panic deeper in NewServices due to
+		// nil dependencies. A panic (not an allowlist error) proves the check passed.
+		assert.Panics(t, func() {
+			_, _ = d.ServicesForSpec(context.Background(), spec)
+		})
+	})
+
+	t.Run("nil localCfg allows all capabilities", func(t *testing.T) {
+		d := &Delegate{}
+		spec := job.Job{
+			ExternalJobID:            uuid.New(),
+			StandardCapabilitiesSpec: &job.StandardCapabilitiesSpec{Command: "consensus"},
+		}
+		assert.Panics(t, func() {
+			_, _ = d.ServicesForSpec(context.Background(), spec)
+		})
+	})
+
+	t.Run("unknown command bypasses allowlist check", func(t *testing.T) {
+		d := &Delegate{
+			localCfg: &stubLocalCapabilities{allowlisted: map[string]bool{"consensus@1.0.0-alpha": true}},
+		}
+		spec := job.Job{
+			ExternalJobID:            uuid.New(),
+			StandardCapabilitiesSpec: &job.StandardCapabilitiesSpec{Command: "unknown-binary"},
+		}
+		// Unknown commands have no capability ID mapping, so the allowlist check is skipped.
+		assert.Panics(t, func() {
+			_, _ = d.ServicesForSpec(context.Background(), spec)
+		})
+	})
+}
+
+// stubLocalCapabilities is a minimal test implementation of config.LocalCapabilities.
+type stubLocalCapabilities struct {
+	allowlisted map[string]bool
+}
+
+func (s *stubLocalCapabilities) RegistryBasedLaunchAllowlist() []string { return nil }
+func (s *stubLocalCapabilities) Capabilities() map[string]config.CapabilityNodeConfig {
+	return nil
+}
+func (s *stubLocalCapabilities) IsAllowlisted(capabilityID string) bool {
+	return s.allowlisted[capabilityID]
+}
+func (s *stubLocalCapabilities) GetCapabilityConfig(string) config.CapabilityNodeConfig {
+	return nil
 }


### PR DESCRIPTION
1. Add LocalCapabilityManager to start/stop capabilities based on CapReg entries and plug it into Launcher.
2. Accept config from TOML and from the contract (merge if both are present).
3. Apply TOML allowlist in LocalCapabilityManager and also in the existing Delegate.