### PR TITLE
[CRE] Local Secrets override

### DIFF
--- a/core/config/cre_config.go
+++ b/core/config/cre_config.go
@@ -9,6 +9,7 @@ type CRE interface {
 	UseLocalTimeProvider() bool
 	EnableDKGRecipient() bool
 	Linking() CRELinking
+	LocalSecrets() map[string]string
 }
 
 // WorkflowFetcher defines configuration for fetching workflow files

--- a/core/config/docs/secrets.toml
+++ b/core/config/docs/secrets.toml
@@ -69,3 +69,9 @@ ThresholdKeyShare = "A-Threshold-Decryption-Key-Share" # Example
 ApiKey = "streams-api-key" # Example
 # ApiSecret is the API secret used for authenticating with the CLL Data Streams SDK.
 ApiSecret = "streams-api-secret" # Example
+
+# LocalSecrets is a static map of secret ID to plaintext value.
+# When non-empty, all workflow secrets are served from this map instead of calling the vault capability.
+# Only use when the vault capability is not available.
+[CRE.LocalSecrets]
+# "my-secret-id" = "my-secret-value" # Example

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -2057,7 +2057,8 @@ type StreamsSecretConfig struct {
 }
 
 type CreSecrets struct {
-	Streams *StreamsSecretConfig `toml:",omitempty"`
+	Streams      *StreamsSecretConfig `toml:",omitempty"`
+	LocalSecrets map[string]string    `toml:",omitempty"`
 }
 
 func (c *CreSecrets) SetFrom(f *CreSecrets) (err error) {
@@ -2078,6 +2079,11 @@ func (c *CreSecrets) SetFrom(f *CreSecrets) (err error) {
 		}
 	}
 
+	if f.LocalSecrets != nil {
+		c.LocalSecrets = make(map[string]string, len(f.LocalSecrets))
+		maps.Copy(c.LocalSecrets, f.LocalSecrets)
+	}
+
 	return nil
 }
 
@@ -2089,6 +2095,9 @@ func (c *CreSecrets) validateMerge(f *CreSecrets) (err error) {
 		if c.Streams.APISecret != nil && f.Streams.APISecret != nil {
 			err = errors.Join(err, configutils.ErrOverride{Name: "Streams.APISecret"})
 		}
+	}
+	if len(c.LocalSecrets) > 0 && len(f.LocalSecrets) > 0 {
+		err = errors.Join(err, configutils.ErrOverride{Name: "LocalSecrets"})
 	}
 	return err
 }

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -1340,6 +1340,7 @@ func newCREServices(
 						syncerV2.WithBillingClient(opts.BillingClient),
 						syncerV2.WithWorkflowRegistry(capCfg.WorkflowRegistry().Address(), strconv.FormatUint(wrChainDetails.ChainSelector, 10)),
 						syncerV2.WithOrgResolver(orgResolver),
+						syncerV2.WithLocalSecrets(globalLogger, cfg.CRE().LocalSecrets()),
 					)
 					if err != nil {
 						return nil, fmt.Errorf("unable to create workflow registry event handler: %w", err)

--- a/core/services/chainlink/config_cre.go
+++ b/core/services/chainlink/config_cre.go
@@ -97,3 +97,7 @@ func (c *creConfig) Linking() config.CRELinking {
 
 	return &linkingConfig{url: url, tlsEnabled: tlsEnabled}
 }
+
+func (c *creConfig) LocalSecrets() map[string]string {
+	return c.s.LocalSecrets
+}

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -63,6 +63,7 @@ type eventHandler struct {
 	workflowDonSubscriber  capabilities.DonSubscriber
 	billingClient          metering.BillingClient
 	orgResolver            orgresolver.OrgResolver
+	secretsFetcher         v2.SecretsFetcher
 
 	// WorkflowRegistryAddress is the address of the workflow registry contract
 	workflowRegistryAddress string
@@ -112,6 +113,22 @@ func WithWorkflowRegistry(address, chainSelector string) func(*eventHandler) {
 func WithOrgResolver(orgResolver orgresolver.OrgResolver) func(*eventHandler) {
 	return func(e *eventHandler) {
 		e.orgResolver = orgResolver
+	}
+}
+
+func WithSecretsFetcher(sf v2.SecretsFetcher) func(*eventHandler) {
+	return func(e *eventHandler) {
+		e.secretsFetcher = sf
+	}
+}
+
+func WithLocalSecrets(lggr logger.Logger, secrets map[string]string) func(*eventHandler) {
+	return func(e *eventHandler) {
+		if len(secrets) == 0 {
+			return
+		}
+		lggr.Warnw("Local secrets override is active, vault capability will not be used for secrets", "numSecrets", len(secrets))
+		e.secretsFetcher = v2.NewLocalSecretsFetcher(secrets)
 	}
 }
 
@@ -547,6 +564,7 @@ func (h *eventHandler) engineFactoryFn(ctx context.Context, workflowID string, o
 		WorkflowRegistryAddress:       h.workflowRegistryAddress,
 		WorkflowRegistryChainSelector: h.workflowRegistryChainSelector,
 		OrgResolver:                   h.orgResolver,
+		SecretsFetcher:                h.secretsFetcher,
 	}
 
 	// Wire the initDone channel to the OnInitialized lifecycle hook.

--- a/core/services/workflows/v2/local_secrets_fetcher.go
+++ b/core/services/workflows/v2/local_secrets_fetcher.go
@@ -1,0 +1,44 @@
+package v2
+
+import (
+	"context"
+
+	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
+)
+
+type localSecretsFetcher struct {
+	secrets map[string]string
+}
+
+func NewLocalSecretsFetcher(secrets map[string]string) SecretsFetcher {
+	return &localSecretsFetcher{secrets: secrets}
+}
+
+func (f *localSecretsFetcher) GetSecrets(_ context.Context, request *sdkpb.GetSecretsRequest) ([]*sdkpb.SecretResponse, error) {
+	responses := make([]*sdkpb.SecretResponse, 0, len(request.Requests))
+	for _, req := range request.Requests {
+		value, ok := f.secrets[req.Id]
+		if !ok {
+			responses = append(responses, &sdkpb.SecretResponse{
+				Response: &sdkpb.SecretResponse_Error{
+					Error: &sdkpb.SecretError{
+						Id:    req.Id,
+						Error: "secret not found in local secrets",
+					},
+				},
+			})
+			continue
+		}
+
+		responses = append(responses, &sdkpb.SecretResponse{
+			Response: &sdkpb.SecretResponse_Secret{
+				Secret: &sdkpb.Secret{
+					Id:        req.Id,
+					Namespace: req.Namespace,
+					Value:     value,
+				},
+			},
+		})
+	}
+	return responses, nil
+}

--- a/core/services/workflows/v2/local_secrets_fetcher_test.go
+++ b/core/services/workflows/v2/local_secrets_fetcher_test.go
@@ -1,0 +1,82 @@
+package v2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
+)
+
+func TestLocalSecretsFetcher_GetSecrets(t *testing.T) {
+	secrets := map[string]string{
+		"api-key":     "sk-abc123",
+		"db-password": "hunter2",
+	}
+	fetcher := NewLocalSecretsFetcher(secrets)
+
+	t.Run("returns known secrets", func(t *testing.T) {
+		resp, err := fetcher.GetSecrets(context.Background(), &sdkpb.GetSecretsRequest{
+			Requests: []*sdkpb.SecretRequest{
+				{Id: "api-key", Namespace: "default"},
+				{Id: "db-password"},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp, 2)
+
+		s0 := resp[0].GetSecret()
+		require.NotNil(t, s0)
+		assert.Equal(t, "api-key", s0.Id)
+		assert.Equal(t, "default", s0.Namespace)
+		assert.Equal(t, "sk-abc123", s0.Value)
+
+		s1 := resp[1].GetSecret()
+		require.NotNil(t, s1)
+		assert.Equal(t, "db-password", s1.Id)
+		assert.Equal(t, "hunter2", s1.Value)
+	})
+
+	t.Run("returns error for unknown secret", func(t *testing.T) {
+		resp, err := fetcher.GetSecrets(context.Background(), &sdkpb.GetSecretsRequest{
+			Requests: []*sdkpb.SecretRequest{
+				{Id: "nonexistent"},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp, 1)
+
+		errResp := resp[0].GetError()
+		require.NotNil(t, errResp)
+		assert.Equal(t, "nonexistent", errResp.Id)
+		assert.Contains(t, errResp.Error, "not found")
+	})
+
+	t.Run("handles mixed known and unknown", func(t *testing.T) {
+		resp, err := fetcher.GetSecrets(context.Background(), &sdkpb.GetSecretsRequest{
+			Requests: []*sdkpb.SecretRequest{
+				{Id: "api-key"},
+				{Id: "missing"},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp, 2)
+
+		assert.NotNil(t, resp[0].GetSecret())
+		assert.NotNil(t, resp[1].GetError())
+	})
+
+	t.Run("empty map returns errors for all", func(t *testing.T) {
+		emptyFetcher := NewLocalSecretsFetcher(map[string]string{})
+		resp, err := emptyFetcher.GetSecrets(context.Background(), &sdkpb.GetSecretsRequest{
+			Requests: []*sdkpb.SecretRequest{
+				{Id: "anything"},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp, 1)
+		assert.NotNil(t, resp[0].GetError())
+	})
+}

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -212,3 +212,13 @@ ApiSecret = "streams-api-secret" # Example
 ```
 ApiSecret is the API secret used for authenticating with the CLL Data Streams SDK.
 
+## CRE.LocalSecrets
+```toml
+[CRE.LocalSecrets]
+```
+LocalSecrets is a static map of secret ID to plaintext value.
+When non-empty, all workflow secrets are served from this map instead of calling the vault capability.
+Only use when the vault capability is not available.
+
+"my-secret-id" = "my-secret-value" # Example
+


### PR DESCRIPTION
Adding CRE.LocalSecrets - a static map of secret ID to plaintext value.
When non-empty, all workflow secrets are served from this map instead of calling the vault capability.