### PR TITLE
DS-1992 - Add countNilsAsFaults flag to MedianTask

### DIFF
--- a/.changeset/empty-swans-crash.md
+++ b/.changeset/empty-swans-crash.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Add countNilsAsFaults flag to MedianTask. When enabled, nil values are counted toward allowedFaults and filtered out before median calculation, preventing nils from crashing the task while preserving fault

--- a/.changeset/empty-swans-crash.md
+++ b/.changeset/empty-swans-crash.md
@@ -2,4 +2,4 @@
 "chainlink": minor
 ---
 
-Add countNilsAsFaults flag to MedianTask. When enabled, nil values are counted toward allowedFaults and filtered out before median calculation, preventing nils from crashing the task while preserving fault
+#added Add countNilsAsFaults flag to MedianTask. When enabled, nil values are counted toward allowedFaults and filtered out before median calculation, preventing nils from crashing the task while preserving fault

--- a/core/services/pipeline/task.median.go
+++ b/core/services/pipeline/task.median.go
@@ -21,6 +21,9 @@ type MedianTask struct {
 	// Lax when disabled (default) will return an error if there are no values to medianize or if the input includes nil values.
 	// Lax when enabled will return nil with no error if there are no valid values to medianize. If the input includes nil values, they will be excluded from the median calculation and do not count as a fault.
 	Lax string
+	// CountNilsAsFaults when enabled treats nil values as faults (counted toward allowedFaults) but filters them out before median calculation.
+	// This is mutually exclusive with Lax.
+	CountNilsAsFaults string
 }
 
 var _ Task = (*MedianTask)(nil)
@@ -37,14 +40,20 @@ func (t *MedianTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs [
 		allowedFaults      int
 		faults             int
 		lax                BoolParam
+		countNilsAsFaults  BoolParam
 	)
 	err := stderrors.Join(
 		errors.Wrap(ResolveParam(&maybeAllowedFaults, From(t.AllowedFaults)), "allowedFaults"),
 		errors.Wrap(ResolveParam(&valuesAndErrs, From(VarExpr(t.Values, vars), JSONWithVarExprs(t.Values, vars, true), Inputs(inputs))), "values"),
 		errors.Wrap(ResolveParam(&lax, From(NonemptyString(t.Lax), false)), "lax"),
+		errors.Wrap(ResolveParam(&countNilsAsFaults, From(NonemptyString(t.CountNilsAsFaults), false)), "countNilsAsFaults"),
 	)
 	if err != nil {
 		return Result{Error: err}, runInfo
+	}
+
+	if bool(lax) && bool(countNilsAsFaults) {
+		return Result{Error: errors.New("lax and countNilsAsFaults cannot both be enabled")}, runInfo
 	}
 
 	// if lax is enabled, filter out nil values
@@ -60,9 +69,18 @@ func (t *MedianTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs [
 	}
 
 	values, faults := valuesAndErrs.FilterErrors()
+
+	// If countNilsAsFaults is enabled, filter nils AFTER fault counting
+	// so that nils are counted toward allowedFaults
+	if bool(countNilsAsFaults) {
+		var nilCount int
+		values, nilCount = values.FilterNils()
+		faults += nilCount
+	}
+
 	if faults > allowedFaults {
 		return Result{Error: errors.Wrapf(ErrTooManyErrors, "Number of faulty inputs %v to median task > number allowed faults %v", faults, allowedFaults)}, runInfo
-	} else if len(values) == 0 && bool(lax) {
+	} else if len(values) == 0 && (bool(lax) || bool(countNilsAsFaults)) {
 		return Result{}, runInfo // if lax is enabled, return nil result with no error
 	} else if len(values) == 0 {
 		return Result{Error: errors.Wrap(ErrWrongInputCardinality, "no values to medianize")}, runInfo

--- a/core/services/pipeline/task.median_test.go
+++ b/core/services/pipeline/task.median_test.go
@@ -142,6 +142,23 @@ func TestMedianTask(t *testing.T) {
 			"true",
 			pipeline.Result{Error: pipeline.ErrTooManyErrors},
 		},
+		{
+			// Replicates the holiday outage: expand-network returned HTTP 200 with valid schema
+			// but null numeric values. The nil passes through FilterErrors (it's not an error),
+			// then hits DecimalSliceParam.UnmarshalPipelineParam which fails hard on nil.
+			// The entire median task errors out even though 3 valid values were available,
+			// causing NOPs to stop producing observations on affected streams.
+			"(outage scenario) single nil from bridge returning null kills entire median",
+			[]pipeline.Result{
+				{},                           // expand-network returned HTTP 200 with null value
+				{Value: mustDecimal(t, "1")}, // 3 valid bridges — enough for a median
+				{Value: mustDecimal(t, "2")},
+				{Value: mustDecimal(t, "3")},
+			},
+			"3",
+			"",
+			pipeline.Result{Error: pipeline.ErrBadInput}, // nil poisons the entire batch
+		},
 	}
 
 	for _, test := range tests {
@@ -251,6 +268,154 @@ func TestMedianTask(t *testing.T) {
 	}
 }
 
+func TestMedianTask_CountNilsAsFaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		inputs            []pipeline.Result
+		allowedFaults     string
+		countNilsAsFaults string
+		want              pipeline.Result
+	}{
+		{
+			name: "holiday scenario: 1 nil + 7 errors exceeds allowedFaults",
+			inputs: []pipeline.Result{
+				{}, // nil
+				{Value: errors.New("e1")}, {Value: errors.New("e2")}, {Value: errors.New("e3")},
+				{Value: errors.New("e4")}, {Value: errors.New("e5")}, {Value: errors.New("e6")},
+				{Value: errors.New("e7")},
+			},
+			allowedFaults:     "7",
+			countNilsAsFaults: "true",
+			want:              pipeline.Result{Error: pipeline.ErrTooManyErrors},
+		},
+		{
+			// Same scenario as the holiday outage, but with countNilsAsFaults enabled.
+			// The nil is counted as a fault (1 fault total) which is within allowedFaults=3,
+			// then filtered out before decimal parsing. Median proceeds on the 3 valid values
+			// instead of crashing with ErrBadInput.
+			name: "(outage scenario) countNilsAsFaults prevents nil from killing median",
+			inputs: []pipeline.Result{
+				{},                           // expand-network returned HTTP 200 with null value
+				{Value: mustDecimal(t, "1")}, // 3 valid bridges
+				{Value: mustDecimal(t, "2")},
+				{Value: mustDecimal(t, "3")},
+			},
+			allowedFaults:     "3",
+			countNilsAsFaults: "true",
+			want:              pipeline.Result{Value: mustDecimal(t, "2")},
+		},
+		{
+			// Nils and errors are both counted as faults. Together they exceed allowedFaults,
+			// so the task correctly fails even though valid values exist.
+			name: "(outage scenario) combined nils and errors exceed allowedFaults",
+			inputs: []pipeline.Result{
+				{},                           // nil (1 fault)
+				{},                           // nil (2 faults)
+				{Value: errors.New("err1")},  // error (3 faults)
+				{Value: mustDecimal(t, "5")}, // valid
+			},
+			allowedFaults:     "2",
+			countNilsAsFaults: "true",
+			want:              pipeline.Result{Error: pipeline.ErrTooManyErrors}, // 3 faults > 2
+		},
+		{
+			name: "nils and errors within threshold returns valid median",
+			inputs: []pipeline.Result{
+				{},                          // nil (counted as fault)
+				{Value: errors.New("err")},  // error (counted as fault)
+				{Value: mustDecimal(t, "2")}, // valid
+				{Value: mustDecimal(t, "4")}, // valid
+			},
+			allowedFaults:     "2",
+			countNilsAsFaults: "true",
+			want:              pipeline.Result{Value: mustDecimal(t, "3")},
+		},
+		{
+			name:              "all nils exceed threshold",
+			inputs:            []pipeline.Result{{}, {}, {}},
+			allowedFaults:     "2",
+			countNilsAsFaults: "true",
+			want:              pipeline.Result{Error: pipeline.ErrTooManyErrors},
+		},
+		{
+			name:              "all nils within threshold returns empty result",
+			inputs:            []pipeline.Result{{}, {}},
+			allowedFaults:     "2",
+			countNilsAsFaults: "true",
+			want:              pipeline.Result{},
+		},
+		{
+			name: "no nils no errors returns normal median",
+			inputs: []pipeline.Result{
+				{Value: mustDecimal(t, "1")},
+				{Value: mustDecimal(t, "2")},
+				{Value: mustDecimal(t, "3")},
+			},
+			allowedFaults:     "1",
+			countNilsAsFaults: "true",
+			want:              pipeline.Result{Value: mustDecimal(t, "2")},
+		},
+		{
+			name: "only errors no nils behaves like default",
+			inputs: []pipeline.Result{
+				{Value: errors.New("e1")}, {Value: errors.New("e2")}, {Value: errors.New("e3")},
+				{Value: mustDecimal(t, "4")},
+			},
+			allowedFaults:     "2",
+			countNilsAsFaults: "true",
+			want:              pipeline.Result{Error: pipeline.ErrTooManyErrors},
+		},
+		{
+			name: "single nil with one valid value within threshold",
+			inputs: []pipeline.Result{
+				{},
+				{Value: mustDecimal(t, "42")},
+			},
+			allowedFaults:     "1",
+			countNilsAsFaults: "true",
+			want:              pipeline.Result{Value: mustDecimal(t, "42")},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			task := pipeline.MedianTask{
+				BaseTask:          pipeline.NewBaseTask(0, "task", nil, nil, 0),
+				AllowedFaults:     test.allowedFaults,
+				CountNilsAsFaults: test.countNilsAsFaults,
+			}
+			output, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), pipeline.NewVarsFrom(nil), test.inputs)
+			assert.False(t, runInfo.IsPending)
+			assert.False(t, runInfo.IsRetryable)
+			if output.Error != nil {
+				require.Equal(t, test.want.Error, errors.Cause(output.Error))
+				require.Nil(t, output.Value)
+			} else {
+				if test.want.Value == nil {
+					require.Nil(t, output.Value)
+				} else {
+					require.Equal(t, test.want.Value.(*decimal.Decimal).String(), output.Value.(decimal.Decimal).String())
+				}
+				require.NoError(t, output.Error)
+			}
+		})
+	}
+
+	t.Run("mutual exclusion: lax and countNilsAsFaults cannot both be enabled", func(t *testing.T) {
+		task := pipeline.MedianTask{
+			BaseTask:          pipeline.NewBaseTask(0, "task", nil, nil, 0),
+			AllowedFaults:     "1",
+			Lax:               "true",
+			CountNilsAsFaults: "true",
+		}
+		output, _ := task.Run(testutils.Context(t), logger.TestLogger(t), pipeline.NewVarsFrom(nil), []pipeline.Result{{Value: mustDecimal(t, "1")}})
+		require.Error(t, output.Error)
+		require.Contains(t, output.Error.Error(), "lax and countNilsAsFaults cannot both be enabled")
+	})
+}
+
 func TestMedianTask_AllowedFaultsAndLax_Unmarshal(t *testing.T) {
 	t.Parallel()
 
@@ -276,6 +441,31 @@ func TestMedianTask_AllowedFaultsAndLax_Unmarshal(t *testing.T) {
 		if task.Type() == pipeline.TaskTypeMedian {
 			require.Equal(t, "10", task.(*pipeline.MedianTask).AllowedFaults)
 			require.Equal(t, "true", task.(*pipeline.MedianTask).Lax)
+		}
+	}
+}
+
+func TestMedianTask_CountNilsAsFaults_Unmarshal(t *testing.T) {
+	t.Parallel()
+
+	p, err := pipeline.Parse(`
+	ds1          [type=bridge name=voter_turnout];
+	ds1_parse    [type=jsonparse path="one,two"];
+
+	ds2          [type=bridge name=voter_turnout2];
+	ds2_parse    [type=jsonparse path="three,four"];
+
+	ds1 -> ds1_parse -> answer1;
+	ds2 -> ds2_parse -> answer1;
+
+	answer1 [type=median index=0 allowedFaults=5 countNilsAsFaults=true];
+`)
+	require.NoError(t, err)
+	for _, task := range p.Tasks {
+		if task.Type() == pipeline.TaskTypeMedian {
+			require.Equal(t, "5", task.(*pipeline.MedianTask).AllowedFaults)
+			require.Equal(t, "true", task.(*pipeline.MedianTask).CountNilsAsFaults)
+			require.Equal(t, "", task.(*pipeline.MedianTask).Lax)
 		}
 	}
 }

--- a/core/services/pipeline/task.median_test.go
+++ b/core/services/pipeline/task.median_test.go
@@ -143,14 +143,13 @@ func TestMedianTask(t *testing.T) {
 			pipeline.Result{Error: pipeline.ErrTooManyErrors},
 		},
 		{
-			// Replicates the holiday outage: expand-network returned HTTP 200 with valid schema
-			// but null numeric values. The nil passes through FilterErrors (it's not an error),
-			// then hits DecimalSliceParam.UnmarshalPipelineParam which fails hard on nil.
-			// The entire median task errors out even though 3 valid values were available,
-			// causing NOPs to stop producing observations on affected streams.
-			"(outage scenario) single nil from bridge returning null kills entire median",
+			// A bridge returning HTTP 200 with null numeric values produces a nil result.
+			// The nil passes through FilterErrors (it's not an error), then hits
+			// DecimalSliceParam.UnmarshalPipelineParam which fails hard on nil.
+			// The entire median task errors out even though 3 valid values were available.
+			"single nil from bridge returning null kills entire median",
 			[]pipeline.Result{
-				{},                           // expand-network returned HTTP 200 with null value
+				{},                           // bridge returned HTTP 200 with null value
 				{Value: mustDecimal(t, "1")}, // 3 valid bridges — enough for a median
 				{Value: mustDecimal(t, "2")},
 				{Value: mustDecimal(t, "3")},
@@ -279,7 +278,7 @@ func TestMedianTask_CountNilsAsFaults(t *testing.T) {
 		want              pipeline.Result
 	}{
 		{
-			name: "holiday scenario: 1 nil + 7 errors exceeds allowedFaults",
+			name: "1 nil + 7 errors exceeds allowedFaults",
 			inputs: []pipeline.Result{
 				{}, // nil
 				{Value: errors.New("e1")}, {Value: errors.New("e2")}, {Value: errors.New("e3")},
@@ -291,13 +290,12 @@ func TestMedianTask_CountNilsAsFaults(t *testing.T) {
 			want:              pipeline.Result{Error: pipeline.ErrTooManyErrors},
 		},
 		{
-			// Same scenario as the holiday outage, but with countNilsAsFaults enabled.
-			// The nil is counted as a fault (1 fault total) which is within allowedFaults=3,
-			// then filtered out before decimal parsing. Median proceeds on the 3 valid values
-			// instead of crashing with ErrBadInput.
-			name: "(outage scenario) countNilsAsFaults prevents nil from killing median",
+			// With countNilsAsFaults enabled, the nil is counted as a fault (1 fault total)
+			// which is within allowedFaults=3, then filtered out before decimal parsing.
+			// Median proceeds on the 3 valid values instead of crashing with ErrBadInput.
+			name: "countNilsAsFaults prevents nil from killing median",
 			inputs: []pipeline.Result{
-				{},                           // expand-network returned HTTP 200 with null value
+				{},                           // bridge returned HTTP 200 with null value
 				{Value: mustDecimal(t, "1")}, // 3 valid bridges
 				{Value: mustDecimal(t, "2")},
 				{Value: mustDecimal(t, "3")},
@@ -309,7 +307,7 @@ func TestMedianTask_CountNilsAsFaults(t *testing.T) {
 		{
 			// Nils and errors are both counted as faults. Together they exceed allowedFaults,
 			// so the task correctly fails even though valid values exist.
-			name: "(outage scenario) combined nils and errors exceed allowedFaults",
+			name: "combined nils and errors exceed allowedFaults",
 			inputs: []pipeline.Result{
 				{},                           // nil (1 fault)
 				{},                           // nil (2 faults)

--- a/core/services/pipeline/task.median_test.go
+++ b/core/services/pipeline/task.median_test.go
@@ -321,8 +321,8 @@ func TestMedianTask_CountNilsAsFaults(t *testing.T) {
 		{
 			name: "nils and errors within threshold returns valid median",
 			inputs: []pipeline.Result{
-				{},                          // nil (counted as fault)
-				{Value: errors.New("err")},  // error (counted as fault)
+				{},                           // nil (counted as fault)
+				{Value: errors.New("err")},   // error (counted as fault)
 				{Value: mustDecimal(t, "2")}, // valid
 				{Value: mustDecimal(t, "4")}, // valid
 			},
@@ -463,7 +463,7 @@ func TestMedianTask_CountNilsAsFaults_Unmarshal(t *testing.T) {
 		if task.Type() == pipeline.TaskTypeMedian {
 			require.Equal(t, "5", task.(*pipeline.MedianTask).AllowedFaults)
 			require.Equal(t, "true", task.(*pipeline.MedianTask).CountNilsAsFaults)
-			require.Equal(t, "", task.(*pipeline.MedianTask).Lax)
+			require.Empty(t, task.(*pipeline.MedianTask).Lax)
 		}
 	}
 }


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

https://smartcontract-it.atlassian.net/browse/DS-1992

## What ? 

- This PR introduces a new flag available for the medianization task: `countNilsAsFaults`
- when `countNilsAsFaults` is enabled : 
   1. Nils are counted toward allowedFaults (alongside errors)
   2. Nils are filtered out after fault accounting, before decimal parsing.
   3. Median proceeds on remaining valid values

- This new flags allows for preserving fault tolerance while preventing nils from crashing a medianization task.

added tests for:
- checking the new flag does not conflict with lag
- to reproduce the issue that motivated the implementation of this flag (EA returning a valid schema response with nulls)
   - first test reproduces the issue 
   - second test checks that passing the implemented flag addresses the issue

## Why ?

This flag is intended to make streams medianization jobs more reliable by allowing better handle of nil values , which currently can cause observation outages even when there are enough values to compute a median ( see ticket incident ) 

### Problem

When a bridge returns HTTP 200 with a valid schema but null numeric values, the median task fails hard at decimal parsing (ErrBadInput), this happens **even** when enough valid values exist to compute a result. 
This cause an outage due to a single DP returning a payload with the right schema but with nulls in it.

The existing `lax` flag doesn't solve this well: it filters nils early and doesn't count them as faults. With a typical config of allowedFaults = N-1, this silently bypasses fault tolerance,  errors that would normally exceed the threshold slip through and the task can emit nil observations instead of failing.
