### PR TITLE
[CRE-1329] Avoid duplicate executions in Engine V2

### DIFF
--- a/core/services/workflows/store/store.go
+++ b/core/services/workflows/store/store.go
@@ -2,7 +2,11 @@ package store
 
 import (
 	"context"
+	"errors"
 )
+
+// ErrDuplicateExecution is returned by Add when the execution ID already exists.
+var ErrDuplicateExecution = errors.New("duplicate execution")
 
 type Store interface {
 	Add(ctx context.Context, steps map[string]*WorkflowExecutionStep,

--- a/core/services/workflows/store/store_memory.go
+++ b/core/services/workflows/store/store_memory.go
@@ -18,7 +18,7 @@ const (
 
 	// maximumExecutionAge is the default maximum age of an execution before it is considered expired and eligible for pruning
 	// regardless of its status
-	maximumExecutionAge = 1 * time.Hour
+	maximumExecutionAge = 24 * time.Hour
 )
 
 // InMemoryStore is an in-memory implementation of the Store interface used to store workflow execution states.
@@ -61,7 +61,7 @@ func (s *InMemoryStore) Add(ctx context.Context, steps map[string]*WorkflowExecu
 	defer s.mu.Unlock()
 	_, ok := s.idToExecution[executionID]
 	if ok {
-		return WorkflowExecution{}, fmt.Errorf("execution ID %s already exists in store", executionID)
+		return WorkflowExecution{}, fmt.Errorf("execution ID %s: %w", executionID, ErrDuplicateExecution)
 	}
 
 	now := s.clock.Now()

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -577,6 +577,27 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		return
 	}
 
+	// disallow duplicate executions
+	_, addErr := e.cfg.ExecutionsStore.Add(ctx, nil, executionID, e.cfg.WorkflowID, store.StatusStarted)
+	if addErr != nil {
+		if errors.Is(addErr, store.ErrDuplicateExecution) {
+			e.logger().Infow("Skipping duplicate execution", "executionID", executionID, "triggerID", wrappedTriggerEvent.triggerCapID, "triggerIndex", wrappedTriggerEvent.triggerIndex)
+			e.metrics.With(platform.KeyTriggerID, wrappedTriggerEvent.triggerCapID).IncrementWorkflowTriggerEventErrorCounter(ctx)
+			return
+		}
+		e.logger().Errorw("Failed to register execution in store, proceeding anyway", "executionID", executionID, "err", addErr)
+	}
+
+	var executionStatus string
+	defer func() {
+		if executionStatus == "" {
+			executionStatus = store.StatusErrored
+		}
+		if _, finishErr := e.cfg.ExecutionsStore.FinishExecution(ctx, executionID, executionStatus); finishErr != nil {
+			e.logger().Errorw("Failed to finish execution in store", "executionID", executionID, "status", executionStatus, "err", finishErr)
+		}
+	}()
+
 	// Fetch organization ID for this execution
 	organizationID := contexts.CREValue(ctx).Org
 	if e.cfg.OrgResolver != nil {
@@ -646,7 +667,6 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	executionLogger.Infow("Workflow execution starting ...")
 	_ = events.EmitExecutionStartedEvent(ctx, loggerLabels, triggerEvent.ID, executionID)
 	e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String()).IncrementWorkflowExecutionStartedCounter(ctx)
-	var executionStatus string // store.StatusStarted
 
 	var timeProvider TimeProvider = &types.LocalTimeProvider{}
 	if !e.cfg.UseLocalTimeProvider {

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -1047,7 +1047,7 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 		// Trigger the execution
 		mockTriggerEvent := capabilities.TriggerEvent{
 			TriggerType: "basic-trigger@1.0.0",
-			ID:          "metering_capability_test_2",
+			ID:          "metering_capability_test_4",
 			Payload:     nil,
 		}
 
@@ -1558,6 +1558,201 @@ func TestSecretsFetcher_Integration(t *testing.T) {
 
 	require.Equal(t, execID, <-executionFinishedCh)
 	require.NoError(t, engine.Close())
+}
+
+// TestEngine_DuplicateTriggerSameConfig verifies that the engine deduplicates executions
+// when a workflow subscribes to two instances of the same trigger with the same config
+// (e.g. two CRONs with an identical schedule). Both trigger registrations independently
+// fire events, so a single CRON tick produces two trigger events with the same event ID.
+// The engine must execute the workflow exactly once and silently drop the duplicate.
+func TestEngine_DuplicateTriggerSameConfig(t *testing.T) {
+	t.Parallel()
+
+	module := modulemocks.NewModuleV2(t)
+	module.EXPECT().Start()
+	module.EXPECT().Close()
+	capreg := regmocks.NewCapabilitiesRegistry(t)
+	capreg.EXPECT().LocalNode(matches.AnyContext).Return(newNode(t), nil)
+	billingClient := setupMockBillingClient(t)
+
+	initDoneCh := make(chan error)
+	subscribedToTriggersCh := make(chan []string, 1)
+	executionFinishedCh := make(chan string, 2)
+
+	cfg := defaultTestConfig(t, nil)
+	cfg.Module = module
+	cfg.CapRegistry = capreg
+	cfg.BillingClient = billingClient
+	cfg.Hooks = v2.LifecycleHooks{
+		OnInitialized: func(err error) {
+			initDoneCh <- err
+		},
+		OnSubscribedToTriggers: func(triggerIDs []string) {
+			subscribedToTriggersCh <- triggerIDs
+		},
+		OnExecutionFinished: func(executionID string, status string) {
+			executionFinishedCh <- executionID
+		},
+	}
+
+	engine, err := v2.NewEngine(cfg)
+	require.NoError(t, err)
+
+	// Two trigger subscriptions with the exact same trigger ID (same capability, same config)
+	sameTriggerID := "id_dup"
+	subs := newTriggerSubsSameID(2, sameTriggerID)
+	module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(subs, nil).Once()
+
+	trigger := capmocks.NewTriggerCapability(t)
+	capreg.EXPECT().GetTrigger(matches.AnyContext, sameTriggerID).Return(trigger, nil)
+
+	eventCh0 := make(chan capabilities.TriggerResponse, 1)
+	eventCh1 := make(chan capabilities.TriggerResponse, 1)
+	trigger.EXPECT().RegisterTrigger(matches.AnyContext, mock.Anything).Return(eventCh0, nil).Once()
+	trigger.EXPECT().RegisterTrigger(matches.AnyContext, mock.Anything).Return(eventCh1, nil).Once()
+	trigger.EXPECT().UnregisterTrigger(matches.AnyContext, mock.Anything).Return(nil)
+
+	// Only ONE execution should reach Module.Execute; the duplicate is dropped.
+	module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).
+		Return(nil, nil).
+		Once()
+
+	require.NoError(t, engine.Start(t.Context()))
+	require.NoError(t, <-initDoneCh)
+	require.Equal(t, []string{sameTriggerID, sameTriggerID}, <-subscribedToTriggersCh)
+
+	// Simulate the same CRON tick: both trigger registrations fire the same event.
+	sharedEventID := "cron_tick_12345"
+	sharedEvent := capabilities.TriggerResponse{
+		Event: capabilities.TriggerEvent{
+			TriggerType: sameTriggerID,
+			ID:          sharedEventID,
+		},
+	}
+	eventCh0 <- sharedEvent
+	eventCh1 <- sharedEvent
+
+	// Exactly one execution finishes.
+	wantExecID, err := workflowEvents.GenerateExecutionID(cfg.WorkflowID, sharedEventID)
+	require.NoError(t, err)
+
+	select {
+	case execID := <-executionFinishedCh:
+		require.Equal(t, wantExecID, execID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for execution to finish")
+	}
+
+	// Give the engine a brief window to see if a second (duplicate) execution fires.
+	// It should not.
+	select {
+	case execID := <-executionFinishedCh:
+		t.Fatalf("unexpected duplicate execution: %s", execID)
+	case <-time.After(200 * time.Millisecond):
+		// expected: no second execution
+	}
+
+	require.NoError(t, engine.Close())
+}
+
+func TestEngine_DeduplicatesSameEventID(t *testing.T) {
+	t.Parallel()
+
+	module := modulemocks.NewModuleV2(t)
+	module.EXPECT().Start()
+	module.EXPECT().Close()
+	capreg := regmocks.NewCapabilitiesRegistry(t)
+	capreg.EXPECT().LocalNode(matches.AnyContext).Return(newNode(t), nil)
+	billingClient := setupMockBillingClient(t)
+
+	initDoneCh := make(chan error)
+	subscribedToTriggersCh := make(chan []string, 1)
+	executionFinishedCh := make(chan string, 2)
+
+	cfg := defaultTestConfig(t, nil)
+	cfg.Module = module
+	cfg.CapRegistry = capreg
+	cfg.BillingClient = billingClient
+	cfg.Hooks = v2.LifecycleHooks{
+		OnInitialized: func(err error) {
+			initDoneCh <- err
+		},
+		OnSubscribedToTriggers: func(triggerIDs []string) {
+			subscribedToTriggersCh <- triggerIDs
+		},
+		OnExecutionFinished: func(executionID string, _ string) {
+			executionFinishedCh <- executionID
+		},
+	}
+
+	engine, err := v2.NewEngine(cfg)
+	require.NoError(t, err)
+
+	// Single trigger subscription.
+	module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(1), nil).Once()
+
+	trigger := capmocks.NewTriggerCapability(t)
+	capreg.EXPECT().GetTrigger(matches.AnyContext, "id_0").Return(trigger, nil)
+	eventCh := make(chan capabilities.TriggerResponse, 2)
+	trigger.EXPECT().RegisterTrigger(matches.AnyContext, mock.Anything).Return(eventCh, nil).Once()
+	trigger.EXPECT().UnregisterTrigger(matches.AnyContext, mock.Anything).Return(nil)
+
+	// Only ONE execution should reach Module.Execute.
+	module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).
+		Return(nil, nil).
+		Once()
+
+	require.NoError(t, engine.Start(t.Context()))
+	require.NoError(t, <-initDoneCh)
+	require.Equal(t, []string{"id_0"}, <-subscribedToTriggersCh)
+
+	// Send two events with the same ID through a single trigger channel.
+	duplicateEvent := capabilities.TriggerResponse{
+		Event: capabilities.TriggerEvent{
+			TriggerType: "basic-trigger@1.0.0",
+			ID:          "same_event_id",
+		},
+	}
+	eventCh <- duplicateEvent
+	eventCh <- duplicateEvent
+
+	wantExecID, err := workflowEvents.GenerateExecutionID(cfg.WorkflowID, "same_event_id")
+	require.NoError(t, err)
+
+	select {
+	case execID := <-executionFinishedCh:
+		require.Equal(t, wantExecID, execID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first execution to finish")
+	}
+
+	// No second execution should appear.
+	select {
+	case execID := <-executionFinishedCh:
+		t.Fatalf("unexpected duplicate execution: %s", execID)
+	case <-time.After(200 * time.Millisecond):
+		// expected
+	}
+
+	require.NoError(t, engine.Close())
+}
+
+// newTriggerSubsSameID creates n trigger subscriptions all referencing the same trigger ID.
+func newTriggerSubsSameID(n int, triggerID string) *sdkpb.ExecutionResult {
+	subs := make([]*sdkpb.TriggerSubscription, 0, n)
+	for range n {
+		subs = append(subs, &sdkpb.TriggerSubscription{
+			Id:     triggerID,
+			Method: "method",
+		})
+	}
+	return &sdkpb.ExecutionResult{
+		Result: &sdkpb.ExecutionResult_TriggerSubscriptions{
+			TriggerSubscriptions: &sdkpb.TriggerSubscriptionRequest{
+				Subscriptions: subs,
+			},
+		},
+	}
 }
 
 func TestEngine_HandleNewDON(t *testing.T) {


### PR DESCRIPTION
Store execution IDs for 24h. See https://smartcontract-it.atlassian.net/browse/CRE-1329
