### PR TITLE
[CRE] Fix context reuse in HTTP handler

### DIFF
--- a/core/services/gateway/handlers/capabilities/v2/http_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_handler.go
@@ -39,6 +39,7 @@ const (
 	internalErrorMessage                 = "Internal server error occurred while processing the request"
 	defaultOutboundRequestCacheTTLMs     = 1000 * 60 * 10      // 10 minutes
 	defaultJWTReplayPeriodMs             = 1000 * 60 * 60 * 24 // 24 hours
+	defaultSendResponseTimeoutMs         = 1000 * 5            // 5 seconds
 )
 
 type gatewayHandler struct {
@@ -339,20 +340,22 @@ func (h *gatewayHandler) makeOutgoingRequest(ctx context.Context, resp *jsonrpc.
 		Timeout:          timeout,
 	}
 
+	sendResponseTimeout := time.Duration(defaultSendResponseTimeoutMs) * time.Millisecond
+
 	// send response to node async
 	h.wg.Add(1)
 	go func() {
 		defer h.wg.Done()
 		// not cancelled when parent is cancelled to ensure the goroutine can finish
-		newCtx := context.WithoutCancel(ctx)
-		newCtx, cancel := context.WithTimeout(newCtx, timeout)
-		defer cancel()
+		baseCtx := context.WithoutCancel(ctx)
+		httpCtx, httpCancel := context.WithTimeout(baseCtx, timeout)
+		defer httpCancel()
 		l := logger.With(h.lggr, "requestID", requestID, "method", req.Method, "timeout", req.TimeoutMs)
 		var outboundResp gateway_common.OutboundHTTPResponse
-		callback := h.createHTTPRequestCallback(newCtx, requestID, httpReq, req)
+		callback := h.createHTTPRequestCallback(httpCtx, requestID, httpReq, req)
 		if req.CacheSettings.MaxAgeMs > 0 {
 			h.metrics.IncrementCacheReadCount(ctx, h.lggr)
-			outboundResp = h.responseCache.Fetch(ctx, workflowID, req, callback, req.CacheSettings.Store)
+			outboundResp = h.responseCache.Fetch(httpCtx, workflowID, req, callback, req.CacheSettings.Store)
 		} else {
 			outboundResp = callback()
 			if req.CacheSettings.Store {
@@ -360,7 +363,11 @@ func (h *gatewayHandler) makeOutgoingRequest(ctx context.Context, resp *jsonrpc.
 			}
 		}
 		h.metrics.IncrementActionCapabilityRequestCount(ctx, nodeAddr, h.lggr)
-		err := h.sendResponseToNode(newCtx, requestID, outboundResp, nodeAddr)
+		// Use a separate context for sending the response to the node so that an
+		// expired HTTP request timeout does not prevent delivering the result.
+		sendCtx, sendCancel := context.WithTimeout(baseCtx, sendResponseTimeout)
+		defer sendCancel()
+		err := h.sendResponseToNode(sendCtx, requestID, outboundResp, nodeAddr)
 		if err != nil {
 			l.Errorw("error sending response to node", "err", err, "nodeAddr", nodeAddr, "requestID", requestID)
 			h.metrics.IncrementActionCapabilityFailures(ctx, nodeAddr, h.lggr)

--- a/core/services/gateway/handlers/capabilities/v2/http_handler_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_handler_test.go
@@ -700,6 +700,47 @@ func TestCreateHTTPRequestCallback(t *testing.T) {
 	})
 }
 
+func TestMakeOutgoingRequest_SendResponseUsesIndependentContext(t *testing.T) {
+	handler := createTestHandler(t)
+	mockDon := handler.don.(*handlermocks.DON)
+	mockHTTPClient := handler.httpClient.(*httpmocks.HTTPClient)
+
+	outboundReq := gateway_common.OutboundHTTPRequest{
+		Method:    "GET",
+		URL:       "https://slow-endpoint.com/api",
+		TimeoutMs: 50, // very short timeout so the HTTP context expires quickly
+	}
+	reqBytes, err := json.Marshal(outboundReq)
+	require.NoError(t, err)
+
+	id := fmt.Sprintf("%s/%s", gateway_common.MethodHTTPAction, uuid.New().String())
+	rawRequest := json.RawMessage(reqBytes)
+	resp := &jsonrpc.Response[json.RawMessage]{
+		ID:     id,
+		Result: &rawRequest,
+	}
+
+	// Simulate a slow HTTP endpoint that blocks until the context deadline expires.
+	mockHTTPClient.EXPECT().Send(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, req network.HTTPRequest) (*network.HTTPResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	)
+
+	// The critical assertion: SendToNode must receive a non-expired context.
+	// Before the fix, the same context was shared between the HTTP call and
+	// sendResponseToNode, so an expired HTTP timeout would also prevent
+	// delivering the response back to the node.
+	mockDon.EXPECT().SendToNode(mock.MatchedBy(func(ctx context.Context) bool {
+		return ctx.Err() == nil
+	}), "node1", mock.Anything).Return(nil)
+
+	err = handler.HandleNodeMessage(testutils.Context(t), resp, "node1")
+	require.NoError(t, err)
+	handler.wg.Wait()
+}
+
 // TestMakeOutgoingRequestCachingBehavior tests the specific caching logic in makeOutgoingRequest
 func TestMakeOutgoingRequestCachingBehavior(t *testing.T) {
 	t.Run("MaxAgeMs=0 and Store=true calls Set", func(t *testing.T) {


### PR DESCRIPTION
A context that expires when making an HTTP call is later re-used when sending errors responses back to nodes and failing immediately.

