### PR TITLE
llo/datasource: update observation cache atomically for each iteration

### DIFF
--- a/core/services/llo/observation/cache.go
+++ b/core/services/llo/observation/cache.go
@@ -103,10 +103,21 @@ func (c *Cache) add(id llotypes.StreamID, value llo.StreamValue, ttl time.Durati
 	c.values[id] = item{value: value, expiresAt: expiresAt}
 }
 
+func (c *Cache) GetMany(streamValues llo.StreamValues) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for id := range streamValues {
+		streamValues[id], _ = c.get(id)
+	}
+}
+
 func (c *Cache) Get(id llotypes.StreamID) (llo.StreamValue, time.Time) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+	return c.get(id)
+}
 
+func (c *Cache) get(id llotypes.StreamID) (llo.StreamValue, time.Time) {
 	label := strconv.FormatUint(uint64(id), 10)
 	item, ok := c.values[id]
 	if !ok {

--- a/core/services/llo/observation/cache.go
+++ b/core/services/llo/observation/cache.go
@@ -82,13 +82,24 @@ func NewCache(cleanupInterval time.Duration) *Cache {
 
 // Add adds a stream value to the cache.
 func (c *Cache) Add(id llotypes.StreamID, value llo.StreamValue, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.add(id, value, ttl)
+}
+
+func (c *Cache) AddMany(values map[llotypes.StreamID]llo.StreamValue, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for id, value := range values {
+		c.add(id, value, ttl)
+	}
+}
+
+func (c *Cache) add(id llotypes.StreamID, value llo.StreamValue, ttl time.Duration) {
 	var expiresAt time.Time
 	if ttl > 0 {
 		expiresAt = time.Now().Add(ttl)
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.values[id] = item{value: value, expiresAt: expiresAt}
 }
 

--- a/core/services/llo/observation/cache.go
+++ b/core/services/llo/observation/cache.go
@@ -103,6 +103,7 @@ func (c *Cache) add(id llotypes.StreamID, value llo.StreamValue, ttl time.Durati
 	c.values[id] = item{value: value, expiresAt: expiresAt}
 }
 
+//nolint:revive // GetMany mutates streamValues in-place for zero-allocation reads.
 func (c *Cache) GetMany(streamValues llo.StreamValues) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/core/services/llo/observation/cache_test.go
+++ b/core/services/llo/observation/cache_test.go
@@ -120,6 +120,63 @@ func TestCache_AddMany(t *testing.T) {
 	})
 }
 
+func TestCache_GetMany(t *testing.T) {
+	t.Run("fills map with cached values", func(t *testing.T) {
+		cache := NewCache(0)
+		cache.AddMany(map[llotypes.StreamID]llo.StreamValue{
+			1: &mockStreamValue{value: []byte{1}},
+			2: &mockStreamValue{value: []byte{2}},
+			3: &mockStreamValue{value: []byte{3}},
+		}, time.Second)
+
+		streamValues := llo.StreamValues{1: nil, 2: nil, 3: nil}
+		cache.GetMany(streamValues)
+
+		assert.Equal(t, &mockStreamValue{value: []byte{1}}, streamValues[1])
+		assert.Equal(t, &mockStreamValue{value: []byte{2}}, streamValues[2])
+		assert.Equal(t, &mockStreamValue{value: []byte{3}}, streamValues[3])
+	})
+
+	t.Run("misses remain nil", func(t *testing.T) {
+		cache := NewCache(0)
+		cache.Add(1, &mockStreamValue{value: []byte{1}}, time.Second)
+
+		streamValues := llo.StreamValues{1: nil, 2: nil, 99: nil}
+		cache.GetMany(streamValues)
+
+		assert.Equal(t, &mockStreamValue{value: []byte{1}}, streamValues[1])
+		assert.Nil(t, streamValues[2])
+		assert.Nil(t, streamValues[99])
+	})
+
+	t.Run("empty map is a no-op", func(t *testing.T) {
+		cache := NewCache(0)
+		cache.Add(1, &mockStreamValue{value: []byte{1}}, time.Second)
+		streamValues := llo.StreamValues{}
+		cache.GetMany(streamValues)
+		assert.Empty(t, streamValues)
+	})
+
+	t.Run("expired entries are filled with nil", func(t *testing.T) {
+		cache := NewCache(0)
+		cache.Add(1, &mockStreamValue{value: []byte{1}}, time.Nanosecond*100)
+		time.Sleep(time.Millisecond)
+
+		streamValues := llo.StreamValues{1: nil}
+		cache.GetMany(streamValues)
+		assert.Nil(t, streamValues[1])
+	})
+
+	t.Run("overwrites existing values in map", func(t *testing.T) {
+		cache := NewCache(0)
+		cache.Add(1, &mockStreamValue{value: []byte{100}}, time.Second)
+
+		streamValues := llo.StreamValues{1: &mockStreamValue{value: []byte{0}}}
+		cache.GetMany(streamValues)
+		assert.Equal(t, &mockStreamValue{value: []byte{100}}, streamValues[1])
+	})
+}
+
 func TestCache_Add_Get(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/core/services/llo/observation/cache_test.go
+++ b/core/services/llo/observation/cache_test.go
@@ -76,6 +76,50 @@ func TestNewCache(t *testing.T) {
 	}
 }
 
+func TestCache_AddMany(t *testing.T) {
+	t.Run("adds multiple values with same TTL", func(t *testing.T) {
+		cache := NewCache(0)
+		ttl := time.Second
+		values := map[llotypes.StreamID]llo.StreamValue{
+			1: &mockStreamValue{value: []byte{1}},
+			2: &mockStreamValue{value: []byte{2}},
+			3: &mockStreamValue{value: []byte{3}},
+		}
+		cache.AddMany(values, ttl)
+
+		for id, want := range values {
+			got, _ := cache.Get(id)
+			assert.Equal(t, want, got)
+		}
+	})
+
+	t.Run("empty map is a no-op", func(t *testing.T) {
+		cache := NewCache(0)
+		cache.AddMany(map[llotypes.StreamID]llo.StreamValue{}, time.Second)
+		val, _ := cache.Get(1)
+		assert.Nil(t, val)
+	})
+
+	t.Run("single entry", func(t *testing.T) {
+		cache := NewCache(0)
+		cache.AddMany(map[llotypes.StreamID]llo.StreamValue{
+			42: &mockStreamValue{value: []byte{42}},
+		}, time.Minute)
+		got, _ := cache.Get(42)
+		assert.Equal(t, &mockStreamValue{value: []byte{42}}, got)
+	})
+
+	t.Run("overwrites existing entries", func(t *testing.T) {
+		cache := NewCache(0)
+		cache.Add(1, &mockStreamValue{value: []byte{0}}, time.Second)
+		cache.AddMany(map[llotypes.StreamID]llo.StreamValue{
+			1: &mockStreamValue{value: []byte{100}},
+		}, time.Second)
+		got, _ := cache.Get(1)
+		assert.Equal(t, &mockStreamValue{value: []byte{100}}, got)
+	})
+}
+
 func TestCache_Add_Get(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/core/services/llo/observation/data_source.go
+++ b/core/services/llo/observation/data_source.go
@@ -206,6 +206,7 @@ func (d *dataSource) startObservationLoop(loopStartedCh chan struct{}) {
 
 			var mu sync.Mutex
 			successfulStreamIDs := make([]streams.StreamID, 0, len(osv.streamValues))
+			observedValues := make(map[streams.StreamID]llo.StreamValue, len(osv.streamValues))
 			var errs []ErrObservationFailed
 
 			var wg sync.WaitGroup
@@ -239,10 +240,8 @@ func (d *dataSource) startObservationLoop(loopStartedCh chan struct{}) {
 						return
 					}
 
-					// cache the observed value
-					d.cache.Add(streamID, val, 4*osv.observationTimeout)
-
 					mu.Lock()
+					observedValues[streamID] = val
 					successfulStreamIDs = append(successfulStreamIDs, streamID)
 					mu.Unlock()
 				}(streamID)
@@ -250,6 +249,8 @@ func (d *dataSource) startObservationLoop(loopStartedCh chan struct{}) {
 
 			wg.Wait()
 			elapsed = time.Since(startTS)
+
+			d.cache.AddMany(observedValues, 4*osv.observationTimeout)
 
 			// notify the caller that we've completed our first round of observations.
 			if loopStarting {

--- a/core/services/llo/observation/data_source.go
+++ b/core/services/llo/observation/data_source.go
@@ -126,9 +126,7 @@ func (d *dataSource) Observe(ctx context.Context, streamValues llo.StreamValues,
 	}
 
 	// Fetch the cached observations for all streams.
-	for streamID := range streamValues {
-		streamValues[streamID], _ = d.cache.Get(streamID)
-	}
+	d.cache.GetMany(streamValues)
 
 	return nil
 }


### PR DESCRIPTION
…ration

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
