### PR TITLE
[PRODCRE-1746] Use moved bigInt from chainlink-common

### DIFF
--- a/core/capabilities/ccip/ccip_integration_tests/usdcreader/usdcreader_test.go
+++ b/core/capabilities/ccip/ccip_integration_tests/usdcreader/usdcreader_test.go
@@ -32,11 +32,11 @@ import (
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads/headstest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	evmconfig "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/configs/evm"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
@@ -337,7 +337,7 @@ func populateDatabase(b *testing.B,
 
 		// Create log entry
 		logs = append(logs, logpoller.Log{
-			EVMChainID:     ubig.New(new(big.Int).SetUint64(uint64(source))),
+			EVMChainID:     sqlutil.New(new(big.Int).SetUint64(uint64(source))),
 			LogIndex:       int64(i + 1),
 			BlockHash:      utils.NewHash(),
 			BlockNumber:    int64(i + 1),

--- a/core/cmd/blocks_commands_test.go
+++ b/core/cmd/blocks_commands_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
 
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
@@ -17,7 +17,7 @@ func Test_ReplayFromBlock(t *testing.T) {
 	t.Parallel()
 
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-		c.EVM[0].ChainID = (*ubig.Big)(big.NewInt(5))
+		c.EVM[0].ChainID = (*sqlutil.Big)(big.NewInt(5))
 		c.EVM[0].Enabled = ptr(true)
 
 		solCfg := &config.TOMLConfig{
@@ -74,7 +74,7 @@ func Test_FindLCA(t *testing.T) {
 
 	// ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(42), nil)
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-		c.EVM[0].ChainID = (*ubig.Big)(big.NewInt(5))
+		c.EVM[0].ChainID = (*sqlutil.Big)(big.NewInt(5))
 		c.EVM[0].Enabled = ptr(true)
 	})
 

--- a/core/cmd/chains_commands_test.go
+++ b/core/cmd/chains_commands_test.go
@@ -9,8 +9,8 @@ import (
 
 	solcfg "github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	client2 "github.com/smartcontractkit/chainlink-evm/pkg/client"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/cmd"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -18,8 +18,8 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
 
-func newRandChainID() *big.Big {
-	return big.New(testutils.NewRandomEVMChainID())
+func newRandChainID() *sqlutil.Big {
+	return sqlutil.New(testutils.NewRandomEVMChainID())
 }
 
 func TestShell_IndexEVMChains(t *testing.T) {

--- a/core/cmd/eth_keys_commands_test.go
+++ b/core/cmd/eth_keys_commands_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/urfave/cli"
 
 	commonassets "github.com/smartcontractkit/chainlink-common/pkg/assets"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/cmd"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -40,7 +40,7 @@ func TestEthKeysPresenter_RenderTable(t *testing.T) {
 		isDisabled     = true
 		createdAt      = time.Now()
 		updatedAt      = time.Now().Add(time.Second)
-		maxGasPriceWei = ubig.NewI(12345)
+		maxGasPriceWei = sqlutil.NewI(12345)
 		bundleID       = cltest.DefaultOCRKeyBundleID
 		buffer         = bytes.NewBufferString("")
 		r              = cmd.RendererTable{Writer: buffer}

--- a/core/cmd/evm_transaction_commands.go
+++ b/core/cmd/evm_transaction_commands.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/urfave/cli"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 	"github.com/smartcontractkit/chainlink/v2/core/utils/stringutils"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
@@ -186,7 +186,7 @@ func (s *Shell) SendEther(c *cli.Context) (err error) {
 		DestinationAddress: destinationAddress,
 		FromAddress:        fromAddress,
 		Amount:             amount,
-		EVMChainID:         (*ubig.Big)(evmChainID),
+		EVMChainID:         (*sqlutil.Big)(evmChainID),
 		AllowHigherAmounts: c.IsSet("force"),
 	}
 

--- a/core/cmd/forwarders_commands.go
+++ b/core/cmd/forwarders_commands.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/web"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
@@ -136,7 +136,7 @@ func (s *Shell) TrackForwarder(c *cli.Context) (err error) {
 	}
 
 	request, err := json.Marshal(web.TrackEVMForwarderRequest{
-		EVMChainID: (*ubig.Big)(chainID),
+		EVMChainID: (*sqlutil.Big)(chainID),
 		Address:    address,
 	})
 	if err != nil {

--- a/core/cmd/forwarders_commands_test.go
+++ b/core/cmd/forwarders_commands_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/cmd"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
@@ -24,7 +24,7 @@ func TestEVMForwarderPresenter_RenderTable(t *testing.T) {
 	var (
 		id         = "ID:"
 		address    = utils.RandomAddress()
-		evmChainID = big.NewI(4)
+		evmChainID = sqlutil.NewI(4)
 		createdAt  = time.Now()
 		updatedAt  = time.Now().Add(time.Second)
 		buffer     = bytes.NewBufferString("")

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -55,7 +55,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/core/auth"
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
@@ -258,10 +257,10 @@ func NewApplicationWithConfigAndKey(t testing.TB, c chainlink.GeneralConfig, fla
 	ctx := testutils.Context(t)
 	app := NewApplicationWithConfig(t, c, flagsAndDeps...)
 
-	chainID := *ubig.New(&FixtureChainID)
+	chainID := *sqlutil.New(&FixtureChainID)
 	for _, dep := range flagsAndDeps {
 		switch v := dep.(type) {
-		case *ubig.Big:
+		case *sqlutil.Big:
 			chainID = *v
 		}
 	}
@@ -1164,12 +1163,12 @@ func AssertEthTxAttemptCountStays(t testing.TB, txStore txmgr.TestEvmTxStore, wa
 
 // Head return a new head with the given number.
 func Head(num int64) *evmtypes.Head {
-	h := evmtypes.NewHead(big.NewInt(num), evmutils.NewHash(), evmutils.NewHash(), ubig.New(&FixtureChainID))
+	h := evmtypes.NewHead(big.NewInt(num), evmutils.NewHash(), evmutils.NewHash(), sqlutil.New(&FixtureChainID))
 	return &h
 }
 
 func HeadWithHash(n int64, hash common.Hash) *evmtypes.Head {
-	h := evmtypes.NewHead(big.NewInt(n), hash, evmutils.NewHash(), ubig.New(&FixtureChainID))
+	h := evmtypes.NewHead(big.NewInt(n), hash, evmutils.NewHash(), sqlutil.New(&FixtureChainID))
 	return &h
 }
 

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -21,7 +21,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/core/auth"
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
@@ -130,14 +129,14 @@ type RandomKey struct {
 	Nonce    int64
 	Disabled bool
 
-	chainIDs []ubig.Big // nil: Fixture, set empty for none
+	chainIDs []sqlutil.Big // nil: Fixture, set empty for none
 }
 
 func (r RandomKey) MustInsert(t testing.TB, keystore keystore.Eth) (ethkey.KeyV2, common.Address) {
 	ctx := testutils.Context(t)
 	chainIDs := r.chainIDs
 	if chainIDs == nil {
-		chainIDs = []ubig.Big{*ubig.New(&FixtureChainID)}
+		chainIDs = []sqlutil.Big{*sqlutil.New(&FixtureChainID)}
 	}
 
 	key := MustGenerateRandomKey(t)
@@ -165,7 +164,7 @@ func (r RandomKey) MustInsertWithState(t testing.TB, keystore keystore.Eth) (eth
 // MustInsertRandomKey inserts a randomly generated (not cryptographically secure) key for testing.
 // By default, it is enabled for the fixture chain. Pass chainIDs to override.
 // Use MustInsertRandomKeyNoChains for a key associate with no chains.
-func MustInsertRandomKey(t testing.TB, keystore keystore.Eth, chainIDs ...ubig.Big) (ethkey.KeyV2, common.Address) {
+func MustInsertRandomKey(t testing.TB, keystore keystore.Eth, chainIDs ...sqlutil.Big) (ethkey.KeyV2, common.Address) {
 	r := RandomKey{}
 	if len(chainIDs) > 0 {
 		r.chainIDs = chainIDs
@@ -174,7 +173,7 @@ func MustInsertRandomKey(t testing.TB, keystore keystore.Eth, chainIDs ...ubig.B
 }
 
 func MustInsertRandomKeyNoChains(t testing.TB, keystore keystore.Eth) (ethkey.KeyV2, common.Address) {
-	return RandomKey{chainIDs: []ubig.Big{}}.MustInsert(t, keystore)
+	return RandomKey{chainIDs: []sqlutil.Big{}}.MustInsert(t, keystore)
 }
 
 func MustGenerateRandomKey(t testing.TB) ethkey.KeyV2 {
@@ -184,7 +183,7 @@ func MustGenerateRandomKey(t testing.TB) ethkey.KeyV2 {
 }
 
 func MustInsertHead(t *testing.T, ds sqlutil.DataSource, number int64) *evmtypes.Head {
-	h := evmtypes.NewHead(big.NewInt(number), evmutils.NewHash(), evmutils.NewHash(), ubig.New(&FixtureChainID))
+	h := evmtypes.NewHead(big.NewInt(number), evmutils.NewHash(), evmutils.NewHash(), sqlutil.New(&FixtureChainID))
 	horm := heads.NewORM(FixtureChainID, ds, 0)
 
 	err := horm.IdempotentInsertHead(testutils.Context(t), &h)
@@ -205,7 +204,7 @@ NOW(),NOW(),$1,'{}',false,$2,$3,0,0,0,0,0,0,0,0,0
 
 func MakeDirectRequestJobSpec(t *testing.T) *job.Job {
 	t.Helper()
-	drs := &job.DirectRequestSpec{EVMChainID: (*ubig.Big)(testutils.FixtureChainID)}
+	drs := &job.DirectRequestSpec{EVMChainID: (*sqlutil.Big)(testutils.FixtureChainID)}
 	spec := &job.Job{
 		Type:              job.DirectRequest,
 		SchemaVersion:     1,
@@ -253,7 +252,7 @@ func MustInsertKeeperJob(t *testing.T, db *sqlx.DB, korm *keeper.ORM, from evmty
 func MustInsertKeeperRegistry(t *testing.T, db *sqlx.DB, korm *keeper.ORM, ethKeyStore keystore.Eth, keeperIndex, numKeepers, blockCountPerTurn int32) (keeper.Registry, job.Job) {
 	t.Helper()
 	ctx := testutils.Context(t)
-	key, _ := MustInsertRandomKey(t, ethKeyStore, *ubig.New(testutils.SimulatedChainID))
+	key, _ := MustInsertRandomKey(t, ethKeyStore, *sqlutil.New(testutils.SimulatedChainID))
 	from := key.EIP55Address
 	contractAddress := NewEIP55Address()
 	jb := MustInsertKeeperJob(t, db, korm, from, contractAddress)
@@ -277,7 +276,7 @@ func MustInsertKeeperRegistry(t *testing.T, db *sqlx.DB, korm *keeper.ORM, ethKe
 func MustInsertUpkeepForRegistry(t *testing.T, db *sqlx.DB, registry keeper.Registry) keeper.UpkeepRegistration {
 	ctx := testutils.Context(t)
 	korm := keeper.NewORM(db, logger.TestLogger(t))
-	upkeepID := ubig.NewI(int64(mathrand.Uint32()))
+	upkeepID := sqlutil.NewI(int64(mathrand.Uint32()))
 	upkeep := keeper.UpkeepRegistration{
 		UpkeepID:   upkeepID,
 		ExecuteGas: uint32(150_000),

--- a/core/internal/cltest/simulated_backend.go
+++ b/core/internal/cltest/simulated_backend.go
@@ -10,9 +10,9 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient/simulated"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -54,7 +54,7 @@ func NewApplicationWithConfigV2OnSimulatedBlockchain(
 	}
 
 	require.Zero(t, evmtest.MustGetDefaultChainID(t, cfg.EVMConfigs()).Cmp(testutils.SimulatedChainID))
-	chainID := big.New(testutils.SimulatedChainID)
+	chainID := sqlutil.New(testutils.SimulatedChainID)
 	client := client.NewSimulatedBackendClient(t, backend, testutils.SimulatedChainID)
 
 	flagsAndDeps = append(flagsAndDeps, client, chainID)
@@ -80,7 +80,7 @@ func NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(
 	}
 
 	require.Zero(t, evmtest.MustGetDefaultChainID(t, cfg.EVMConfigs()).Cmp(testutils.SimulatedChainID))
-	chainID := big.New(testutils.SimulatedChainID)
+	chainID := sqlutil.New(testutils.SimulatedChainID)
 	client := client.NewSimulatedBackendClient(t, backend, testutils.SimulatedChainID)
 
 	flagsAndDeps = append(flagsAndDeps, client, chainID)

--- a/core/internal/features/features_test.go
+++ b/core/internal/features/features_test.go
@@ -42,8 +42,8 @@ import (
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
-	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/consumer_wrapper"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/flags_wrapper"
@@ -53,11 +53,11 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/operatorforwarder/generated/operator"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
+	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/forwarders"
 	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/auth"
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
@@ -796,7 +796,7 @@ func setupForwarderEnabledNode(t *testing.T, owner *bind.TransactOpts, portV2 in
 	forwarderORM := forwarders.NewORM(app.GetDB())
 	chainID, err := b.Client().ChainID(testutils.Context(t))
 	require.NoError(t, err)
-	_, err = forwarderORM.CreateForwarder(testutils.Context(t), forwarder, ubig.Big(*chainID))
+	_, err = forwarderORM.CreateForwarder(testutils.Context(t), forwarder, sqlutil.Big(*chainID))
 	require.NoError(t, err)
 
 	return app, p2pKey.PeerID().Raw(), transmitter, forwarder, key
@@ -1315,7 +1315,7 @@ func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 		Transactions: cltest.LegacyTransactionsFromGasPrices(48_000_000_000, 49_000_000_000, 31_000_000_000),
 	}
 
-	evmChainID := ubig.New(evmtest.MustGetDefaultChainID(t, cfg.EVMConfigs()))
+	evmChainID := sqlutil.New(evmtest.MustGetDefaultChainID(t, cfg.EVMConfigs()))
 	h40 := types.Head{Hash: evmutils.NewHash(), Number: 40, EVMChainID: evmChainID}
 	h41 := types.Head{Hash: b41.Hash, ParentHash: h40.Hash, Number: 41, EVMChainID: evmChainID}
 	h42 := types.Head{Hash: b42.Hash, ParentHash: h41.Hash, Number: 42, EVMChainID: evmChainID}

--- a/core/internal/features/ocr2/features_ocr2_helper.go
+++ b/core/internal/features/ocr2/features_ocr2_helper.go
@@ -37,6 +37,7 @@ import (
 	ocrtypes2 "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/link_token_interface"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/operatorforwarder/generated/authorized_forwarder"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
@@ -45,7 +46,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
 	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	"github.com/smartcontractkit/chainlink-evm/pkg/transmitter"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
@@ -200,7 +200,7 @@ func SetupNodeOCR2(
 		forwarderORM := forwarders.NewORM(app.GetDB())
 		chainID, err := b.Client().ChainID(testutils.Context(t))
 		require.NoError(t, err)
-		_, err2 = forwarderORM.CreateForwarder(testutils.Context(t), faddr, ubig.Big(*chainID))
+		_, err2 = forwarderORM.CreateForwarder(testutils.Context(t), faddr, sqlutil.Big(*chainID))
 		require.NoError(t, err2)
 
 		effectiveTransmitter = faddr

--- a/core/internal/testutils/configtest/general_config.go
+++ b/core/internal/testutils/configtest/general_config.go
@@ -1,6 +1,7 @@
 package configtest
 
 import (
+	"math/big"
 	"net"
 	"testing"
 	"time"
@@ -8,12 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	pgcommon "github.com/smartcontractkit/chainlink-common/pkg/sqlutil/pg"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
 	evmclient "github.com/smartcontractkit/chainlink-evm/pkg/client"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
@@ -70,7 +71,7 @@ func overrides(c *chainlink.Config, s *chainlink.Secrets) {
 	c.WebServer.ListenIP = &testIP
 	c.WebServer.TLS.ListenIP = &testIP
 
-	chainID := big.NewI(evmclient.NullClientChainID)
+	chainID := sqlutil.NewI(evmclient.NullClientChainID)
 
 	chainCfg := toml.Defaults(chainID)
 	chainCfg.LogPollInterval = commonconfig.MustNewDuration(1 * time.Second) // speed it up from the standard 15s for tests
@@ -106,7 +107,7 @@ func NewGeneralConfigSimulated(t testing.TB, overrideFn func(*chainlink.Config, 
 // simulated is a config override func that appends the simulated EVM chain (testutils.SimulatedChainID),
 // or replaces the null chain (client.NullClientChainID) if that is the only entry.
 func simulated(c *chainlink.Config, s *chainlink.Secrets) {
-	chainID := big.New(testutils.SimulatedChainID)
+	chainID := sqlutil.New(testutils.SimulatedChainID)
 	enabled := true
 	cfg := toml.EVMConfig{
 		ChainID: chainID,
@@ -114,7 +115,7 @@ func simulated(c *chainlink.Config, s *chainlink.Secrets) {
 		Enabled: &enabled,
 		Nodes:   toml.EVMNodes{&validTestNode},
 	}
-	if len(c.EVM) == 1 && c.EVM[0].ChainID.Cmp(big.NewI(client.NullClientChainID)) == 0 {
+	if len(c.EVM) == 1 && c.EVM[0].ChainID.ToInt().Cmp(big.NewInt(client.NullClientChainID)) == 0 {
 		c.EVM[0] = &cfg // replace null, if only entry
 	} else {
 		c.EVM = append(c.EVM, &cfg)

--- a/core/internal/testutils/evmtest/evmtest.go
+++ b/core/internal/testutils/evmtest/evmtest.go
@@ -29,7 +29,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -42,7 +41,7 @@ func NewChainScopedConfig(t testing.TB, cfg configtoml.HasEVMConfigs) evmconfig.
 	if len(cfg.EVMConfigs()) > 0 {
 		evmCfg = cfg.EVMConfigs()[0]
 	} else {
-		var chainID = (*ubig.Big)(testutils.FixtureChainID)
+		var chainID = (*sqlutil.Big)(testutils.FixtureChainID)
 		evmCfg = &configtoml.EVMConfig{
 			ChainID: chainID,
 			Chain:   configtoml.Defaults(chainID),
@@ -268,7 +267,7 @@ func (mo *TestConfigs) NodeStatusesPaged(offset int, limit int, chainIDs ...stri
 	return
 }
 
-func legacyNode(n *configtoml.Node, chainID *ubig.Big) (v2 evmtypes.Node) {
+func legacyNode(n *configtoml.Node, chainID *sqlutil.Big) (v2 evmtypes.Node) {
 	v2.Name = *n.Name
 	v2.EVMChainID = *chainID
 	if n.HTTPURL != nil {

--- a/core/scripts/functions/src/fetching.go
+++ b/core/scripts/functions/src/fetching.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/urfave/cli"
 
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
@@ -114,7 +114,7 @@ func findEvmOCR2Bundle(ocr2Bundles []ocr2Bundle) int {
 
 func findFirstGoodEthKeyAddress(chainID int64, ethKeys []presenters.ETHKeyResource) (string, error) {
 	for _, ethKey := range ethKeys {
-		if ethKey.EVMChainID.Equal(ubig.NewI(chainID)) && !ethKey.Disabled {
+		if ethKey.EVMChainID.ToInt().Cmp(big.NewInt(chainID)) == 0 && !ethKey.Disabled {
 			if ethKey.EthBalance.IsZero() {
 				fmt.Println("WARN: selected ETH address has zero balance", ethKey.Address)
 			}

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -46,11 +46,11 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20260203202624-5101f4d33736
-	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-data-streams v0.1.11
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260210221717-2546aed27ebe
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20260203202624-5101f4d33736
-	github.com/smartcontractkit/chainlink-common v0.10.0
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-data-streams v0.1.11
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-data-streams v0.1.11
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260210221717-2546aed27ebe
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1612,8 +1612,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856 h1:e/L0oKHTwXjqIf66vw8NWYvXecCq5tybGwHm7YK9wuo=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856/go.mod h1:wLN3X89JoiWr951CX+lALwmDirEm1KzP0n+gGFblwxw=
-github.com/smartcontractkit/chainlink-common v0.10.0 h1:d90b9UPJecrIryzhl43F1oQwkJQoug3TaANlJ1xLHyI=
-github.com/smartcontractkit/chainlink-common v0.10.0/go.mod h1:13YN2kb3Vqpw2S7d4IwhX/578WPGC0JHN5JrOnAEsOc=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3 h1:kKYwuaUklodjRTIz8uyjjFg/A+QC8a4VQ7jzIs684Ok=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3/go.mod h1:Xkgene5cOdtOYKxZsJfdQbhxSyomfzMDxyuQDAi0ecQ=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9 h1:dWqd2lOW3GbwtgZEeDSDI1b1X175MPOlCU6GDQQVBjk=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9/go.mod h1:SMegDBf3KDs2tuKApmTRyO2xQthMu3gV2J+IuHEs0Y0=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4 h1:NOUsjsMzNecbjiPWUQGlRSRAutEvCFrqqyETDJeh5q4=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1612,8 +1612,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856 h1:e/L0oKHTwXjqIf66vw8NWYvXecCq5tybGwHm7YK9wuo=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856/go.mod h1:wLN3X89JoiWr951CX+lALwmDirEm1KzP0n+gGFblwxw=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3 h1:kKYwuaUklodjRTIz8uyjjFg/A+QC8a4VQ7jzIs684Ok=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3/go.mod h1:Xkgene5cOdtOYKxZsJfdQbhxSyomfzMDxyuQDAi0ecQ=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6 h1:bkKoQ7jW25iHtbbriRj5YPHokalaFH2ImBtiKm3QmKU=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6/go.mod h1:13YN2kb3Vqpw2S7d4IwhX/578WPGC0JHN5JrOnAEsOc=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9 h1:dWqd2lOW3GbwtgZEeDSDI1b1X175MPOlCU6GDQQVBjk=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9/go.mod h1:SMegDBf3KDs2tuKApmTRyO2xQthMu3gV2J+IuHEs0Y0=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4 h1:NOUsjsMzNecbjiPWUQGlRSRAutEvCFrqqyETDJeh5q4=
@@ -1624,8 +1624,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.11 h1:yBzjU0Cu8AcfuM858G
 github.com/smartcontractkit/chainlink-data-streams v0.1.11/go.mod h1:8rUcGhjeXBoTFx2MynWgXiBWzVSB+LXd9JR6m8y2FfQ=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6 h1:wVGho+uL3UEqhzMtAXmtZDUQ14J1Fmm7PkqJDuJWd1c=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6/go.mod h1:0EzSyjHDLYSNqo3Bp9lSQs53CTaGbXHB5ovCa6BoOOM=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 h1:vG3FwU52KCZq74Tq7elg+Gm/Eyx3rE2P7hOnJ8NrQzc=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440/go.mod h1:Nhvp2f+FW4SCaWJtDFc59vRAFoWistXNLmxk2i879Cw=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848 h1:B2ns2U3nZs8Wk0coMobIzO0ZI8/BmPLJzki/DHZfPEo=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848/go.mod h1:L5v6d4KEG8+WkxBE34WhjC4AsDzSB6fqF5WpeSyGJKw=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1624,8 +1624,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.11 h1:yBzjU0Cu8AcfuM858G
 github.com/smartcontractkit/chainlink-data-streams v0.1.11/go.mod h1:8rUcGhjeXBoTFx2MynWgXiBWzVSB+LXd9JR6m8y2FfQ=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6 h1:wVGho+uL3UEqhzMtAXmtZDUQ14J1Fmm7PkqJDuJWd1c=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6/go.mod h1:0EzSyjHDLYSNqo3Bp9lSQs53CTaGbXHB5ovCa6BoOOM=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717 h1:OiR/E3lq1jMlA6B9mqhom0f2JeNJOCIxbbyktBlR+Fg=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717/go.mod h1:jBZMFIz1C3sq/YyuTgk5MCu12SdHP+PcujdojZsSk6g=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 h1:vG3FwU52KCZq74Tq7elg+Gm/Eyx3rE2P7hOnJ8NrQzc=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440/go.mod h1:Nhvp2f+FW4SCaWJtDFc59vRAFoWistXNLmxk2i879Cw=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=

--- a/core/scripts/keystone/src/02_provision_crib.go
+++ b/core/scripts/keystone/src/02_provision_crib.go
@@ -10,9 +10,9 @@ import (
 
 	ocrcommontypes "github.com/smartcontractkit/libocr/commontypes"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	evmcfg "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
 	"github.com/smartcontractkit/chainlink/v2/core/config/toml"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
@@ -234,7 +234,7 @@ func generateOverridesToml(
 	nodeSetName string,
 ) string {
 	evmConfig := &evmcfg.EVMConfig{
-		ChainID: big.NewI(chainID),
+		ChainID: sqlutil.NewI(chainID),
 		Nodes:   nil, // We have the rpc nodes set globally
 	}
 

--- a/core/scripts/keystone/src/99_fetch_keys.go
+++ b/core/scripts/keystone/src/99_fetch_keys.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"strings"
 
 	"github.com/urfave/cli"
 
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
 	"github.com/smartcontractkit/chainlink/v2/core/cmd"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
@@ -277,7 +277,7 @@ func findFirstCSAPublicKey(csaKeyResources []presenters.CSAKeyResource) (string,
 
 func findFirstGoodEthKeyAddress(chainID int64, ethKeys []presenters.ETHKeyResource) (string, error) {
 	for _, ethKey := range ethKeys {
-		if ethKey.EVMChainID.Equal(ubig.NewI(chainID)) && !ethKey.Disabled {
+		if ethKey.EVMChainID.ToInt().Cmp(big.NewInt(chainID)) == 0 && !ethKey.Disabled {
 			return ethKey.Address, nil
 		}
 	}

--- a/core/services/blockhashstore/delegate_test.go
+++ b/core/services/blockhashstore/delegate_test.go
@@ -11,10 +11,10 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	lpmocks "github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -98,7 +98,7 @@ func TestDelegate_ServicesForSpec(t *testing.T) {
 	defaultWaitBlocks := (int32)(finalityDepth)
 
 	t.Run("happy", func(t *testing.T) {
-		spec := job.Job{BlockhashStoreSpec: &job.BlockhashStoreSpec{WaitBlocks: defaultWaitBlocks, EVMChainID: (*big.Big)(testutils.FixtureChainID)}}
+		spec := job.Job{BlockhashStoreSpec: &job.BlockhashStoreSpec{WaitBlocks: defaultWaitBlocks, EVMChainID: (*sqlutil.Big)(testutils.FixtureChainID)}}
 		services, err := delegate.ServicesForSpec(testutils.Context(t), spec)
 
 		require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestDelegate_ServicesForSpec(t *testing.T) {
 			CoordinatorV1Address:     &coordinatorV1,
 			CoordinatorV2Address:     &coordinatorV2,
 			CoordinatorV2PlusAddress: &coordinatorV2Plus,
-			EVMChainID:               (*big.Big)(testutils.FixtureChainID),
+			EVMChainID:               (*sqlutil.Big)(testutils.FixtureChainID),
 		}}
 		services, err := delegate.ServicesForSpec(testutils.Context(t), spec)
 
@@ -131,7 +131,7 @@ func TestDelegate_ServicesForSpec(t *testing.T) {
 
 	t.Run("wrong EVMChainID", func(t *testing.T) {
 		spec := job.Job{BlockhashStoreSpec: &job.BlockhashStoreSpec{
-			EVMChainID: big.NewI(123),
+			EVMChainID: sqlutil.NewI(123),
 		}}
 		_, err := delegate.ServicesForSpec(testutils.Context(t), spec)
 		assert.Error(t, err)
@@ -168,7 +168,7 @@ func TestDelegate_StartStop(t *testing.T) {
 		WaitBlocks: defaultWaitBlocks,
 		PollPeriod: time.Second,
 		RunTimeout: testutils.WaitTimeout(t),
-		EVMChainID: (*big.Big)(testutils.FixtureChainID),
+		EVMChainID: (*sqlutil.Big)(testutils.FixtureChainID),
 	}}
 	services, err := delegate.ServicesForSpec(testutils.Context(t), spec)
 

--- a/core/services/blockhashstore/validate_test.go
+++ b/core/services/blockhashstore/validate_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 )
 
@@ -49,7 +49,7 @@ fromAddresses = ["0x469aA2CD13e037DC5236320783dCfd0e641c0559"]`,
 					os.BlockhashStoreSpec.BlockhashStoreAddress)
 				require.Equal(t, 23*time.Second, os.BlockhashStoreSpec.PollPeriod)
 				require.Equal(t, 7*time.Second, os.BlockhashStoreSpec.RunTimeout)
-				require.Equal(t, big.NewI(4), os.BlockhashStoreSpec.EVMChainID)
+				require.Equal(t, sqlutil.NewI(4), os.BlockhashStoreSpec.EVMChainID)
 				require.Equal(t, fromAddresses,
 					os.BlockhashStoreSpec.FromAddresses)
 			},

--- a/core/services/blockheaderfeeder/validate.go
+++ b/core/services/blockheaderfeeder/validate.go
@@ -52,7 +52,7 @@ func ValidatedSpec(tomlString string) (job.Job, error) {
 		return jb, notSet("evmChainID")
 	}
 
-	err = validateChainID(spec.EVMChainID.Int64())
+	err = validateChainID(spec.EVMChainID.ToInt().Int64())
 	if err != nil {
 		return jb, err
 	}

--- a/core/services/blockheaderfeeder/validate_test.go
+++ b/core/services/blockheaderfeeder/validate_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 )
 
@@ -59,7 +59,7 @@ storeBlockhashesBatchSize = 10
 					os.BlockHeaderFeederSpec.BatchBlockhashStoreAddress)
 				require.Equal(t, 23*time.Second, os.BlockHeaderFeederSpec.PollPeriod)
 				require.Equal(t, 7*time.Second, os.BlockHeaderFeederSpec.RunTimeout)
-				require.Equal(t, big.NewI(4), os.BlockHeaderFeederSpec.EVMChainID)
+				require.Equal(t, sqlutil.NewI(4), os.BlockHeaderFeederSpec.EVMChainID)
 				require.Equal(t, fromAddresses,
 					os.BlockHeaderFeederSpec.FromAddresses)
 				require.Equal(t, uint16(20),
@@ -86,7 +86,7 @@ fromAddresses = ["0x469aA2CD13e037DC5236320783dCfd0e641c0559"]
 				require.Equal(t, int32(256), os.BlockHeaderFeederSpec.WaitBlocks)
 				require.Equal(t, 15*time.Second, os.BlockHeaderFeederSpec.PollPeriod)
 				require.Equal(t, 30*time.Second, os.BlockHeaderFeederSpec.RunTimeout)
-				require.Equal(t, big.NewI(4), os.BlockHeaderFeederSpec.EVMChainID)
+				require.Equal(t, sqlutil.NewI(4), os.BlockHeaderFeederSpec.EVMChainID)
 				require.Equal(t, fromAddresses,
 					os.BlockHeaderFeederSpec.FromAddresses)
 				require.Equal(t, uint16(100),

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -21,6 +21,7 @@ import (
 	commonassets "github.com/smartcontractkit/chainlink-common/pkg/assets"
 	commoncfg "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/config/configtest"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/hex"
 	"github.com/smartcontractkit/chainlink-framework/multinode"
@@ -31,7 +32,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/chaintype"
 	evmcfg "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/config/toml"
@@ -110,7 +110,7 @@ var (
 		},
 		EVM: []*evmcfg.EVMConfig{
 			{
-				ChainID: ubig.NewI(1),
+				ChainID: sqlutil.NewI(1),
 				Chain: evmcfg.Chain{
 					FinalityDepth:        ptr[uint32](26),
 					SafeDepth:            ptr[uint32](0),
@@ -130,7 +130,7 @@ var (
 					},
 				}},
 			{
-				ChainID: ubig.NewI(42),
+				ChainID: sqlutil.NewI(42),
 				Chain: evmcfg.Chain{
 					GasEstimator: evmcfg.GasEstimator{
 						PriceDefault: assets.NewWeiI(math.MaxInt64),
@@ -143,7 +143,7 @@ var (
 					},
 				}},
 			{
-				ChainID: ubig.NewI(137),
+				ChainID: sqlutil.NewI(137),
 				Chain: evmcfg.Chain{
 					GasEstimator: evmcfg.GasEstimator{
 						Mode: ptr("FixedPrice"),
@@ -688,7 +688,7 @@ func TestConfig_Marshal(t *testing.T) {
 	}
 	full.EVM = []*evmcfg.EVMConfig{
 		{
-			ChainID: ubig.NewI(1),
+			ChainID: sqlutil.NewI(1),
 			Enabled: ptr(false),
 			Chain: evmcfg.Chain{
 				AutoCreateKey: ptr(false),
@@ -1916,7 +1916,7 @@ func assertValidationError(t *testing.T, invalid interface{ Validate() error }, 
 
 func TestConfig_setDefaults(t *testing.T) {
 	var c Config
-	c.EVM = evmcfg.EVMConfigs{{ChainID: ubig.NewI(99999133712345)}}
+	c.EVM = evmcfg.EVMConfigs{{ChainID: sqlutil.NewI(99999133712345)}}
 	c.Cosmos = RawConfigs{{"ChainID": ptr("unknown cosmos chain")}}
 	c.Solana = solcfg.TOMLConfigs{{ChainID: ptr("unknown solana chain")}}
 	c.Starknet = RawConfigs{{"ChainID": ptr("unknown starknet chain")}}

--- a/core/services/chainlink/relayer_chain_interoperators_test.go
+++ b/core/services/chainlink/relayer_chain_interoperators_test.go
@@ -10,6 +10,7 @@ import (
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	sqlutil "github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mailbox"
 
@@ -19,7 +20,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
@@ -33,7 +33,7 @@ import (
 )
 
 func TestCoreRelayerChainInteroperators(t *testing.T) {
-	evmChainID1, evmChainID2 := ubig.New(big.NewInt(1)), ubig.New(big.NewInt(2))
+	evmChainID1, evmChainID2 := sqlutil.New(big.NewInt(1)), sqlutil.New(big.NewInt(2))
 	solanaChainID1, solanaChainID2 := "solana-id-1", "solana-id-2"
 
 	newConfig := func() chainlink.GeneralConfig {
@@ -68,7 +68,7 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 				Chain:   toml.Defaults(evmChainID1),
 				Nodes:   toml.EVMNodes{&node1_1, &node1_2},
 			}
-			id2 := ubig.New(big.NewInt(2))
+			id2 := sqlutil.New(big.NewInt(2))
 			c.EVM = append(c.EVM, &toml.EVMConfig{
 				ChainID: evmChainID2,
 				Chain:   toml.Defaults(id2),

--- a/core/services/directrequest/delegate_test.go
+++ b/core/services/directrequest/delegate_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/operatorforwarder/generated/operator"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/log"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	log_mocks "github.com/smartcontractkit/chainlink/v2/common/log/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
@@ -69,7 +68,7 @@ func TestDelegate_ServicesForSpec(t *testing.T) {
 	})
 
 	t.Run("Spec with DirectRequestSpec", func(t *testing.T) {
-		spec := job.Job{DirectRequestSpec: &job.DirectRequestSpec{EVMChainID: (*ubig.Big)(testutils.FixtureChainID)}, PipelineSpec: &pipeline.Spec{}}
+		spec := job.Job{DirectRequestSpec: &job.DirectRequestSpec{EVMChainID: (*sqlutil.Big)(testutils.FixtureChainID)}, PipelineSpec: &pipeline.Spec{}}
 		services, err := delegate.ServicesForSpec(testutils.Context(t), spec)
 		require.NoError(t, err)
 		assert.Len(t, services, 1)

--- a/core/services/directrequest/validate.go
+++ b/core/services/directrequest/validate.go
@@ -5,8 +5,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/assets"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/null"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
@@ -16,7 +16,7 @@ type DirectRequestToml struct {
 	ContractAddress          types.EIP55Address       `toml:"contractAddress"`
 	Requesters               models.AddressCollection `toml:"requesters"`
 	MinContractPayment       *assets.Link             `toml:"minContractPaymentLinkJuels"`
-	EVMChainID               *big.Big                 `toml:"evmChainID"`
+	EVMChainID               *sqlutil.Big             `toml:"evmChainID"`
 	MinIncomingConfirmations null.Uint32              `toml:"minIncomingConfirmations"`
 }
 

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	ccip "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/validate"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ccv/ccvcommitteeverifier"
@@ -1431,7 +1430,7 @@ func findExistingJobForOCR2(ctx context.Context, j *job.Job, tx job.ORM) (int32,
 // findExistingJobForOCRFlux looks for existing job for OCR or flux
 func findExistingJobForOCRFlux(ctx context.Context, j *job.Job, tx job.ORM) (int32, error) {
 	var address types.EIP55Address
-	var evmChainID *big.Big
+	var evmChainID *sqlutil.Big
 
 	switch j.Type {
 	case job.OffchainReporting:

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -26,12 +26,12 @@ import (
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	proto "github.com/smartcontractkit/chainlink-protos/orchestrator/feedsmanager"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	evmbig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -2537,7 +2537,7 @@ func Test_Service_ListSpecsByJobProposalIDs(t *testing.T) {
 }
 
 func Test_Service_ApproveSpec(t *testing.T) {
-	var evmChainID *evmbig.Big
+	var evmChainID *sqlutil.Big
 	address := types.EIP55AddressFromAddress(common.Address{})
 	externalJobID := uuid.New()
 	now := time.Now()

--- a/core/services/fluxmonitorv2/orm_test.go
+++ b/core/services/fluxmonitorv2/orm_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/jsonserializable"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	txmmocks "github.com/smartcontractkit/chainlink/v2/common/txmgr/mocks"
 	commontxmmocks "github.com/smartcontractkit/chainlink/v2/common/txmgr/types/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
@@ -163,7 +163,7 @@ func makeJob(t *testing.T) *job.Job {
 			IdleTimerDisabled: false,
 			CreatedAt:         time.Now(),
 			UpdatedAt:         time.Now(),
-			EVMChainID:        (*big.Big)(testutils.FixtureChainID),
+			EVMChainID:        (*sqlutil.Big)(testutils.FixtureChainID),
 		},
 	}
 }

--- a/core/services/headreporter/head_reporter_test.go
+++ b/core/services/headreporter/head_reporter_test.go
@@ -9,15 +9,15 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func NewHead() evmtypes.Head {
-	return evmtypes.Head{Number: 42, EVMChainID: ubig.New(testutils.FixtureChainID)}
+	return evmtypes.Head{Number: 42, EVMChainID: sqlutil.New(testutils.FixtureChainID)}
 }
 
 func Test_HeadReporterService(t *testing.T) {

--- a/core/services/headreporter/telemetry_reporter.go
+++ b/core/services/headreporter/telemetry_reporter.go
@@ -39,7 +39,7 @@ func NewLegacyEVMTelemetryReporter(monitoringEndpointGen telemetry.MonitoringEnd
 func (t *legacyEVMTelemetryReporter) ReportNewHead(ctx context.Context, head *evmtypes.Head) error {
 	monitoringEndpoint := t.endpoints[head.EVMChainID.ToInt().Uint64()]
 	if monitoringEndpoint == nil {
-		return fmt.Errorf("No monitoring endpoint provided chain_id=%d", head.EVMChainID.Int64())
+		return fmt.Errorf("No monitoring endpoint provided chain_id=%d", head.EVMChainID.ToInt().Int64())
 	}
 	var finalized *telem.Block
 	latestFinalizedHead := head.LatestFinalizedHead()
@@ -65,7 +65,7 @@ func (t *legacyEVMTelemetryReporter) ReportNewHead(ctx context.Context, head *ev
 	}
 	monitoringEndpoint.SendLog(bytes)
 	if finalized == nil {
-		t.lggr.Infow("No finalized block was found", "chainID", head.EVMChainID.Int64(),
+		t.lggr.Infow("No finalized block was found", "chainID", head.EVMChainID.ToInt().Int64(),
 			"head.number", head.Number, "chainLength", head.ChainLength())
 	}
 	return nil

--- a/core/services/headreporter/telemetry_reporter_test.go
+++ b/core/services/headreporter/telemetry_reporter_test.go
@@ -14,10 +14,10 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	mocks2 "github.com/smartcontractkit/chainlink/v2/common/types/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -33,7 +33,7 @@ import (
 func Test_EVMTelemetryReporter_NewHead(t *testing.T) {
 	head := evmtypes.Head{
 		Number:     42,
-		EVMChainID: ubig.NewI(100),
+		EVMChainID: sqlutil.NewI(100),
 		Hash:       common.HexToHash("0x1010"),
 		Timestamp:  time.UnixMilli(1000),
 	}
@@ -75,7 +75,7 @@ func Test_EVMTelemetryReporter_NewHead(t *testing.T) {
 func Test_EVMTelemetryReporter_NewHeadMissingFinalized(t *testing.T) {
 	head := evmtypes.Head{
 		Number:     42,
-		EVMChainID: ubig.NewI(100),
+		EVMChainID: sqlutil.NewI(100),
 		Hash:       common.HexToHash("0x1010"),
 		Timestamp:  time.UnixMilli(1000),
 	}
@@ -110,7 +110,7 @@ func Test_EVMTelemetryReporter_NewHead_MissingEndpoint(t *testing.T) {
 
 	reporter := headreporter.NewLegacyEVMTelemetryReporter(monitoringEndpointGen, logger.TestLogger(t), big.NewInt(100))
 
-	head := evmtypes.Head{Number: 42, EVMChainID: ubig.NewI(100)}
+	head := evmtypes.Head{Number: 42, EVMChainID: sqlutil.NewI(100)}
 
 	err := reporter.ReportNewHead(testutils.Context(t), &head)
 	assert.Errorf(t, err, "No monitoring endpoint provided chain_id=100")

--- a/core/services/job/helpers_test.go
+++ b/core/services/job/helpers_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
-	chainlinkevmbig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest"
@@ -204,7 +203,7 @@ func makeMinimalHTTPOracleSpec(t *testing.T, db *sqlx.DB, cfg chainlink.GeneralC
 		ContractConfigTrackerSubscribeInterval: sqlutil.Interval(2 * time.Minute),
 		ContractConfigTrackerPollInterval:      sqlutil.Interval(1 * time.Minute),
 		ContractConfigConfirmations:            uint16(3),
-		EVMChainID:                             chainlinkevmbig.New(testutils.FixtureChainID),
+		EVMChainID:                             sqlutil.New(testutils.FixtureChainID),
 	}
 	var os = job.Job{
 		Name:          null.NewString("a job", true),

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -28,7 +28,6 @@ import (
 	configtoml "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
@@ -814,7 +813,7 @@ func TestORM_CreateJob_EVMChainID_Validation(t *testing.T) {
 
 func TestORM_CreateJob_OCR_DuplicatedContractAddress(t *testing.T) {
 	ctx := testutils.Context(t)
-	customChainID := big.New(testutils.NewRandomEVMChainID())
+	customChainID := sqlutil.New(testutils.NewRandomEVMChainID())
 
 	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		enabled := true
@@ -891,7 +890,7 @@ func TestORM_CreateJob_OCR_DuplicatedContractAddress(t *testing.T) {
 
 func TestORM_CreateJob_OCR2_DuplicatedContractAddress(t *testing.T) {
 	ctx := testutils.Context(t)
-	customChainID := big.New(testutils.NewRandomEVMChainID())
+	customChainID := sqlutil.New(testutils.NewRandomEVMChainID())
 
 	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		enabled := true
@@ -944,7 +943,7 @@ func TestORM_CreateJob_OCR2_DuplicatedContractAddress(t *testing.T) {
 	require.NoError(t, err)
 	jb3.Name = null.StringFrom("Job with different chain id & same contract address")
 	jb3.OCR2OracleSpec.TransmitterID = null.StringFrom(address.String())
-	jb3.OCR2OracleSpec.RelayConfig["chainID"] = customChainID.Int64()
+	jb3.OCR2OracleSpec.RelayConfig["chainID"] = customChainID.ToInt().Int64()
 	jb3.OCR2OracleSpec.PluginConfig["juelsPerFeeCoinSource"] = juelsPerFeeCoinSource
 
 	err = jobORM.CreateJob(ctx, &jb3)
@@ -953,7 +952,7 @@ func TestORM_CreateJob_OCR2_DuplicatedContractAddress(t *testing.T) {
 
 func TestORM_CreateJob_OCR2_Sending_Keys_Transmitter_Keys_Validations(t *testing.T) {
 	ctx := testutils.Context(t)
-	customChainID := big.New(testutils.NewRandomEVMChainID())
+	customChainID := sqlutil.New(testutils.NewRandomEVMChainID())
 
 	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		enabled := true
@@ -1206,8 +1205,8 @@ func Test_FindJob(t *testing.T) {
 	// Create a config with multiple EVM chains. The test fixtures already load 1337
 	// Additional chains will need additional fixture statements to add a chain to evm_chains.
 	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-		chainID1Big := big.NewI(chainID1)
-		chainID2Big := big.NewI(chainID2)
+		chainID1Big := sqlutil.NewI(chainID1)
+		chainID2Big := sqlutil.NewI(chainID2)
 		enabled := true
 		c.EVM = append(c.EVM, &configtoml.EVMConfig{
 			ChainID: chainID1Big,
@@ -1264,7 +1263,7 @@ func Test_FindJob(t *testing.T) {
 			JobID:              uuid.New().String(),
 			TransmitterAddress: address.Hex(),
 			Name:               "ocr spec dup addr",
-			EVMChainID:         big.NewI(chainID1).String(),
+			EVMChainID:         sqlutil.NewI(chainID1).String(),
 			DS1BridgeName:      bridge.Name.String(),
 			DS2BridgeName:      bridge2.Name.String(),
 		}).Toml(),
@@ -1376,7 +1375,7 @@ func Test_FindJob(t *testing.T) {
 
 		assert.Equal(t, job.ID, jbID)
 
-		_, err2 = orm.FindJobIDByAddress(ctx, "not-existing", big.NewI(0))
+		_, err2 = orm.FindJobIDByAddress(ctx, "not-existing", sqlutil.NewI(0))
 		require.Error(t, err2)
 		require.ErrorIs(t, err2, sql.ErrNoRows)
 	})
@@ -1456,7 +1455,7 @@ func Test_FindJobsByPipelineSpecIDs(t *testing.T) {
 
 	jb, err := directrequest.ValidatedDirectRequestSpec(testspecs.GetDirectRequestSpec())
 	require.NoError(t, err)
-	jb.DirectRequestSpec.EVMChainID = big.NewI(0)
+	jb.DirectRequestSpec.EVMChainID = sqlutil.NewI(0)
 
 	err = orm.CreateJob(testutils.Context(t), &jb)
 	require.NoError(t, err)
@@ -2225,7 +2224,7 @@ func mustInsertPipelineRun(t *testing.T, orm pipeline.ORM, j job.Job) pipeline.R
 
 func TestORM_CreateJob_OCR2_With_DualTransmission(t *testing.T) {
 	ctx := testutils.Context(t)
-	customChainID := big.New(testutils.NewRandomEVMChainID())
+	customChainID := sqlutil.New(testutils.NewRandomEVMChainID())
 
 	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		enabled := true
@@ -2306,7 +2305,7 @@ func TestORM_CreateJob_OCR2_With_DualTransmission(t *testing.T) {
 
 func TestORM_CreateJob_KeyLocking(t *testing.T) {
 	ctx := testutils.Context(t)
-	customChainID := big.New(testutils.NewRandomEVMChainID())
+	customChainID := sqlutil.New(testutils.NewRandomEVMChainID())
 
 	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		enabled := true

--- a/core/services/job/mocks/orm.go
+++ b/core/services/job/mocks/orm.go
@@ -3,10 +3,9 @@
 package mocks
 
 import (
-	common "github.com/ethereum/go-ethereum/common"
-	big "github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-
 	context "context"
+
+	common "github.com/ethereum/go-ethereum/common"
 
 	job "github.com/smartcontractkit/chainlink/v2/core/services/job"
 
@@ -544,7 +543,7 @@ func (_c *ORM_FindJobByExternalJobID_Call) RunAndReturn(run func(context.Context
 }
 
 // FindJobIDByAddress provides a mock function with given fields: ctx, address, evmChainID
-func (_m *ORM) FindJobIDByAddress(ctx context.Context, address types.EIP55Address, evmChainID *big.Big) (int32, error) {
+func (_m *ORM) FindJobIDByAddress(ctx context.Context, address types.EIP55Address, evmChainID *sqlutil.Big) (int32, error) {
 	ret := _m.Called(ctx, address, evmChainID)
 
 	if len(ret) == 0 {
@@ -553,16 +552,16 @@ func (_m *ORM) FindJobIDByAddress(ctx context.Context, address types.EIP55Addres
 
 	var r0 int32
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.EIP55Address, *big.Big) (int32, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.EIP55Address, *sqlutil.Big) (int32, error)); ok {
 		return rf(ctx, address, evmChainID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, types.EIP55Address, *big.Big) int32); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.EIP55Address, *sqlutil.Big) int32); ok {
 		r0 = rf(ctx, address, evmChainID)
 	} else {
 		r0 = ret.Get(0).(int32)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, types.EIP55Address, *big.Big) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, types.EIP55Address, *sqlutil.Big) error); ok {
 		r1 = rf(ctx, address, evmChainID)
 	} else {
 		r1 = ret.Error(1)
@@ -579,14 +578,14 @@ type ORM_FindJobIDByAddress_Call struct {
 // FindJobIDByAddress is a helper method to define mock.On call
 //   - ctx context.Context
 //   - address types.EIP55Address
-//   - evmChainID *big.Big
+//   - evmChainID *sqlutil.Big
 func (_e *ORM_Expecter) FindJobIDByAddress(ctx interface{}, address interface{}, evmChainID interface{}) *ORM_FindJobIDByAddress_Call {
 	return &ORM_FindJobIDByAddress_Call{Call: _e.mock.On("FindJobIDByAddress", ctx, address, evmChainID)}
 }
 
-func (_c *ORM_FindJobIDByAddress_Call) Run(run func(ctx context.Context, address types.EIP55Address, evmChainID *big.Big)) *ORM_FindJobIDByAddress_Call {
+func (_c *ORM_FindJobIDByAddress_Call) Run(run func(ctx context.Context, address types.EIP55Address, evmChainID *sqlutil.Big)) *ORM_FindJobIDByAddress_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(types.EIP55Address), args[2].(*big.Big))
+		run(args[0].(context.Context), args[1].(types.EIP55Address), args[2].(*sqlutil.Big))
 	})
 	return _c
 }
@@ -596,7 +595,7 @@ func (_c *ORM_FindJobIDByAddress_Call) Return(_a0 int32, _a1 error) *ORM_FindJob
 	return _c
 }
 
-func (_c *ORM_FindJobIDByAddress_Call) RunAndReturn(run func(context.Context, types.EIP55Address, *big.Big) (int32, error)) *ORM_FindJobIDByAddress_Call {
+func (_c *ORM_FindJobIDByAddress_Call) RunAndReturn(run func(context.Context, types.EIP55Address, *sqlutil.Big) (int32, error)) *ORM_FindJobIDByAddress_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/services/job/mocks/orm.go
+++ b/core/services/job/mocks/orm.go
@@ -4,7 +4,7 @@ package mocks
 
 import (
 	common "github.com/ethereum/go-ethereum/common"
-	big "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	big "github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
 	context "context"
 

--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -25,7 +25,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	clnull "github.com/smartcontractkit/chainlink/v2/core/null"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
@@ -304,7 +303,7 @@ type OCROracleSpec struct {
 	ContractConfigTrackerSubscribeInterval sqlutil.Interval       `toml:"contractConfigTrackerSubscribeInterval"`
 	ContractConfigTrackerPollInterval      sqlutil.Interval       `toml:"contractConfigTrackerPollInterval"`
 	ContractConfigConfirmations            uint16                 `toml:"contractConfigConfirmations"`
-	EVMChainID                             *big.Big               `toml:"evmChainID" db:"evm_chain_id"`
+	EVMChainID                             *sqlutil.Big           `toml:"evmChainID" db:"evm_chain_id"`
 	DatabaseTimeout                        *sqlutil.Interval      `toml:"databaseTimeout"`
 	ObservationGracePeriod                 *sqlutil.Interval      `toml:"observationGracePeriod"`
 	ContractTransmitterTransmitTimeout     *sqlutil.Interval      `toml:"contractTransmitterTransmitTimeout"`
@@ -513,17 +512,17 @@ type DirectRequestSpec struct {
 	MinIncomingConfirmations clnull.Uint32            `toml:"minIncomingConfirmations"`
 	Requesters               models.AddressCollection `toml:"requesters"`
 	MinContractPayment       *commonassets.Link       `toml:"minContractPaymentLinkJuels"`
-	EVMChainID               *big.Big                 `toml:"evmChainID"`
+	EVMChainID               *sqlutil.Big             `toml:"evmChainID"`
 	CreatedAt                time.Time                `toml:"-"`
 	UpdatedAt                time.Time                `toml:"-"`
 }
 
 type CronSpec struct {
-	ID           int32     `toml:"-"`
-	CronSchedule string    `toml:"schedule"`
-	EVMChainID   *big.Big  `toml:"evmChainID"`
-	CreatedAt    time.Time `toml:"-"`
-	UpdatedAt    time.Time `toml:"-"`
+	ID           int32        `toml:"-"`
+	CronSchedule string       `toml:"schedule"`
+	EVMChainID   *sqlutil.Big `toml:"evmChainID"`
+	CreatedAt    time.Time    `toml:"-"`
+	UpdatedAt    time.Time    `toml:"-"`
 }
 
 func (s CronSpec) GetID() string {
@@ -555,9 +554,9 @@ type FluxMonitorSpec struct {
 	DrumbeatRandomDelay time.Duration
 	DrumbeatEnabled     bool
 	MinPayment          *commonassets.Link
-	EVMChainID          *big.Big  `toml:"evmChainID"`
-	CreatedAt           time.Time `toml:"-"`
-	UpdatedAt           time.Time `toml:"-"`
+	EVMChainID          *sqlutil.Big `toml:"evmChainID"`
+	CreatedAt           time.Time    `toml:"-"`
+	UpdatedAt           time.Time    `toml:"-"`
 }
 
 type KeeperSpec struct {
@@ -565,7 +564,7 @@ type KeeperSpec struct {
 	ContractAddress          evmtypes.EIP55Address `toml:"contractAddress"`
 	MinIncomingConfirmations *uint32               `toml:"minIncomingConfirmations"`
 	FromAddress              evmtypes.EIP55Address `toml:"fromAddress"`
-	EVMChainID               *big.Big              `toml:"evmChainID"`
+	EVMChainID               *sqlutil.Big          `toml:"evmChainID"`
 	CreatedAt                time.Time             `toml:"-"`
 	UpdatedAt                time.Time             `toml:"-"`
 }
@@ -595,7 +594,7 @@ type VRFSpec struct {
 	CoordinatorAddress       evmtypes.EIP55Address   `toml:"coordinatorAddress"`
 	PublicKey                secp256k1.PublicKey     `toml:"publicKey"`
 	MinIncomingConfirmations uint32                  `toml:"minIncomingConfirmations"`
-	EVMChainID               *big.Big                `toml:"evmChainID"`
+	EVMChainID               *sqlutil.Big            `toml:"evmChainID"`
 	FromAddresses            []evmtypes.EIP55Address `toml:"fromAddresses"`
 	PollPeriod               time.Duration           `toml:"pollPeriod"`          // For v2 jobs
 	RequestedConfsDelay      int64                   `toml:"requestedConfsDelay"` // For v2 jobs. Optional, defaults to 0 if not provided.
@@ -669,7 +668,7 @@ type BlockhashStoreSpec struct {
 	RunTimeout time.Duration `toml:"runTimeout"`
 
 	// EVMChainID defines the chain ID for monitoring and storing of blockhashes.
-	EVMChainID *big.Big `toml:"evmChainID"`
+	EVMChainID *sqlutil.Big `toml:"evmChainID"`
 
 	// FromAddress is the sender address that should be used to store blockhashes.
 	FromAddresses []evmtypes.EIP55Address `toml:"fromAddresses"`
@@ -718,7 +717,7 @@ type BlockHeaderFeederSpec struct {
 	RunTimeout time.Duration `toml:"runTimeout"`
 
 	// EVMChainID defines the chain ID for monitoring and storing of blockhashes.
-	EVMChainID *big.Big `toml:"evmChainID"`
+	EVMChainID *sqlutil.Big `toml:"evmChainID"`
 
 	// FromAddress is the sender address that should be used to store blockhashes.
 	FromAddresses []evmtypes.EIP55Address `toml:"fromAddresses"`
@@ -745,11 +744,11 @@ type LegacyGasStationServerSpec struct {
 	ForwarderAddress evmtypes.EIP55Address `toml:"forwarderAddress"`
 
 	// EVMChainID defines the chain ID from which the meta-transaction request originates.
-	EVMChainID *big.Big `toml:"evmChainID"`
+	EVMChainID *sqlutil.Big `toml:"evmChainID"`
 
 	// CCIPChainSelector is the CCIP chain selector that corresponds to EVMChainID param.
 	// This selector is equivalent to (source) chainID specified in SendTransaction request
-	CCIPChainSelector *big.Big `toml:"ccipChainSelector"`
+	CCIPChainSelector *sqlutil.Big `toml:"ccipChainSelector"`
 
 	// FromAddress is the sender address that should be used to send meta-transactions
 	FromAddresses []evmtypes.EIP55Address `toml:"fromAddresses"`
@@ -782,10 +781,10 @@ type LegacyGasStationSidecarSpec struct {
 	RunTimeout time.Duration `toml:"runTimeout"`
 
 	// EVMChainID defines the chain ID for the on-chain events tracked by sidecar
-	EVMChainID *big.Big `toml:"evmChainID"`
+	EVMChainID *sqlutil.Big `toml:"evmChainID"`
 
 	// CCIPChainSelector is the CCIP chain selector that corresponds to EVMChainID param
-	CCIPChainSelector *big.Big `toml:"ccipChainSelector"`
+	CCIPChainSelector *sqlutil.Big `toml:"ccipChainSelector"`
 
 	// CreatedAt is the time this job was created.
 	CreatedAt time.Time `toml:"-"`
@@ -871,7 +870,7 @@ type EALSpec struct {
 	ForwarderAddress evmtypes.EIP55Address `toml:"forwarderAddress"`
 
 	// EVMChainID defines the chain ID from which the meta-transaction request originates.
-	EVMChainID *big.Big `toml:"evmChainID"`
+	EVMChainID *sqlutil.Big `toml:"evmChainID"`
 
 	// FromAddress is the sender address that should be used to send meta-transactions
 	FromAddresses []evmtypes.EIP55Address `toml:"fromAddresses"`

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	big "github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	evmconfig "github.com/smartcontractkit/chainlink-evm/pkg/config"
 	evmkeystore "github.com/smartcontractkit/chainlink-evm/pkg/keys"
@@ -48,7 +47,7 @@ type ORM interface {
 	FindJobs(ctx context.Context, offset, limit int) ([]Job, int, error)
 	FindJob(ctx context.Context, id int32) (Job, error)
 	FindJobByExternalJobID(ctx context.Context, uuid uuid.UUID) (Job, error)
-	FindJobIDByAddress(ctx context.Context, address evmtypes.EIP55Address, evmChainID *big.Big) (int32, error)
+	FindJobIDByAddress(ctx context.Context, address evmtypes.EIP55Address, evmChainID *sqlutil.Big) (int32, error)
 	FindOCR2JobIDByAddress(ctx context.Context, relay string, chainID int64, contractID string, feedID *common.Hash) (int32, error)
 	FindJobIDsWithBridge(ctx context.Context, name string) ([]int32, error)
 	DeleteJob(ctx context.Context, id int32, jobType Type) error
@@ -1081,7 +1080,7 @@ func (o *orm) FindJobByExternalJobID(ctx context.Context, externalJobID uuid.UUI
 }
 
 // FindJobIDByAddress - finds a job id by contract address. Currently only OCR and FM jobs are supported
-func (o *orm) FindJobIDByAddress(ctx context.Context, address evmtypes.EIP55Address, evmChainID *big.Big) (jobID int32, err error) {
+func (o *orm) FindJobIDByAddress(ctx context.Context, address evmtypes.EIP55Address, evmChainID *sqlutil.Big) (jobID int32, err error) {
 	stmt := `
 SELECT jobs.id
 FROM jobs

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -18,11 +18,11 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+	big "github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	evmconfig "github.com/smartcontractkit/chainlink-evm/pkg/config"
 	evmkeystore "github.com/smartcontractkit/chainlink-evm/pkg/keys"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"

--- a/core/services/keeper/integration_test.go
+++ b/core/services/keeper/integration_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/smartcontractkit/quarantine"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
-	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/basic_upkeep_contract"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/keeper_registry_logic1_3"
@@ -29,11 +29,11 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/mock_v3_aggregator_contract"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/operatorforwarder/generated/authorized_forwarder"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
+	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
 	"github.com/smartcontractkit/chainlink-evm/pkg/forwarders"
 	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -414,7 +414,7 @@ func TestKeeperForwarderEthIntegration(t *testing.T) {
 			c.EVM[0].MinIncomingConfirmations = ptr[uint32](1)    // disable reorg protection for this test
 			c.EVM[0].HeadTracker.MaxBufferSize = ptr[uint32](100) // helps prevent missed heads
 			c.EVM[0].Transactions.ForwardersEnabled = ptr(true)   // Enable Operator Forwarder flow
-			c.EVM[0].ChainID = (*ubig.Big)(testutils.SimulatedChainID)
+			c.EVM[0].ChainID = (*sqlutil.Big)(testutils.SimulatedChainID)
 		})
 		korm := keeper.NewORM(db, logger.TestLogger(t))
 
@@ -422,7 +422,7 @@ func TestKeeperForwarderEthIntegration(t *testing.T) {
 		require.NoError(t, app.Start(ctx))
 
 		forwarderORM := forwarders.NewORM(db)
-		chainID := ubig.Big(*backend.ConfiguredChainID())
+		chainID := sqlutil.Big(*backend.ConfiguredChainID())
 		_, err = forwarderORM.CreateForwarder(ctx, fwdrAddress, chainID)
 		require.NoError(t, err)
 
@@ -441,7 +441,7 @@ func TestKeeperForwarderEthIntegration(t *testing.T) {
 			KeeperSpec: &job.KeeperSpec{
 				FromAddress:     nodeAddressEIP55,
 				ContractAddress: regAddrEIP55,
-				EVMChainID:      (*ubig.Big)(testutils.SimulatedChainID),
+				EVMChainID:      (*sqlutil.Big)(testutils.SimulatedChainID),
 			},
 			SchemaVersion:     1,
 			ForwardingAllowed: true,

--- a/core/services/keeper/models.go
+++ b/core/services/keeper/models.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/null"
 )
 
@@ -35,7 +35,7 @@ type UpkeepRegistration struct {
 	LastRunBlockHeight  int64
 	RegistryID          int64
 	Registry            Registry
-	UpkeepID            *big.Big
+	UpkeepID            *sqlutil.Big
 	LastKeeperIndex     null.Int64
 	PositioningConstant int32
 }
@@ -61,16 +61,16 @@ func (upkeep UpkeepRegistration) PrettyID() string {
 	return NewUpkeepIdentifier(upkeep.UpkeepID).String()
 }
 
-func NewUpkeepIdentifier(i *big.Big) *UpkeepIdentifier {
+func NewUpkeepIdentifier(i *sqlutil.Big) *UpkeepIdentifier {
 	val := UpkeepIdentifier(*i)
 	return &val
 }
 
-type UpkeepIdentifier big.Big
+type UpkeepIdentifier sqlutil.Big
 
 // String produces a hex encoded value, zero padded, prefixed with UpkeepPrefix
 func (ui UpkeepIdentifier) String() string {
-	val := big.Big(ui)
+	val := sqlutil.Big(ui)
 	result, err := utils.Uint256ToBytes(val.ToInt())
 	if err != nil {
 		panic(errors.Wrap(err, "invariant, invalid upkeepID"))

--- a/core/services/keeper/models_test.go
+++ b/core/services/keeper/models_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 )
 
 func TestUpkeepIdentifer_String(t *testing.T) {
@@ -26,7 +26,7 @@ func TestUpkeepIdentifer_String(t *testing.T) {
 				return
 			}
 
-			result := NewUpkeepIdentifier(ubig.New(o)).String()
+			result := NewUpkeepIdentifier(sqlutil.New(o)).String()
 			require.Equal(t, test.hex, result)
 		})
 	}

--- a/core/services/keeper/orm.go
+++ b/core/services/keeper/orm.go
@@ -10,7 +10,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
@@ -95,7 +94,7 @@ RETURNING *
 }
 
 // UpdateUpkeepLastKeeperIndex updates the last keeper index for an upkeep
-func (o *ORM) UpdateUpkeepLastKeeperIndex(ctx context.Context, jobID int32, upkeepID *big.Big, fromAddress types.EIP55Address) error {
+func (o *ORM) UpdateUpkeepLastKeeperIndex(ctx context.Context, jobID int32, upkeepID *sqlutil.Big, fromAddress types.EIP55Address) error {
 	_, err := o.ds.ExecContext(ctx, `
 	UPDATE upkeep_registrations
 	SET
@@ -107,7 +106,7 @@ func (o *ORM) UpdateUpkeepLastKeeperIndex(ctx context.Context, jobID int32, upke
 }
 
 // BatchDeleteUpkeepsForJob deletes all upkeeps by the given IDs for the job with the given ID
-func (o *ORM) BatchDeleteUpkeepsForJob(ctx context.Context, jobID int32, upkeepIDs []big.Big) (int64, error) {
+func (o *ORM) BatchDeleteUpkeepsForJob(ctx context.Context, jobID int32, upkeepIDs []sqlutil.Big) (int64, error) {
 	strIds := []string{}
 	for _, upkeepID := range upkeepIDs {
 		strIds = append(strIds, upkeepID.String())
@@ -211,7 +210,7 @@ func (o *ORM) loadUpkeepsRegistry(ctx context.Context, upkeeps []UpkeepRegistrat
 	return nil
 }
 
-func (o *ORM) AllUpkeepIDsForRegistry(ctx context.Context, regID int64) (upkeeps []big.Big, err error) {
+func (o *ORM) AllUpkeepIDsForRegistry(ctx context.Context, regID int64) (upkeeps []sqlutil.Big, err error) {
 	err = o.ds.SelectContext(ctx, &upkeeps, `
 SELECT upkeep_id
 FROM upkeep_registrations
@@ -221,7 +220,7 @@ WHERE registry_id = $1
 }
 
 // SetLastRunInfoForUpkeepOnJob sets the last run block height and the associated keeper index only if the new block height is greater than the previous.
-func (o *ORM) SetLastRunInfoForUpkeepOnJob(ctx context.Context, jobID int32, upkeepID *big.Big, height int64, fromAddress types.EIP55Address) (int64, error) {
+func (o *ORM) SetLastRunInfoForUpkeepOnJob(ctx context.Context, jobID int32, upkeepID *sqlutil.Big, height int64, fromAddress types.EIP55Address) (int64, error) {
 	res, err := o.ds.ExecContext(ctx, `
 	UPDATE upkeep_registrations
 	SET last_run_block_height = $1,

--- a/core/services/keeper/orm_test.go
+++ b/core/services/keeper/orm_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	bigmath "github.com/smartcontractkit/chainlink-common/pkg/utils/big_math"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -45,7 +45,7 @@ func setupKeeperDB(t *testing.T) (
 
 func newUpkeep(registry keeper.Registry, upkeepID int64) keeper.UpkeepRegistration {
 	return keeper.UpkeepRegistration{
-		UpkeepID:   ubig.NewI(upkeepID),
+		UpkeepID:   sqlutil.NewI(upkeepID),
 		ExecuteGas: executeGas,
 		Registry:   registry,
 		RegistryID: registry.ID,
@@ -106,7 +106,7 @@ func TestKeeperDB_UpsertUpkeep(t *testing.T) {
 
 	registry, _ := cltest.MustInsertKeeperRegistry(t, db, orm, ethKeyStore, 0, 1, 20)
 	upkeep := keeper.UpkeepRegistration{
-		UpkeepID:            ubig.NewI(0),
+		UpkeepID:            sqlutil.NewI(0),
 		ExecuteGas:          executeGas,
 		Registry:            registry,
 		RegistryID:          registry.ID,
@@ -143,7 +143,7 @@ func TestKeeperDB_BatchDeleteUpkeepsForJob(t *testing.T) {
 	registry, job := cltest.MustInsertKeeperRegistry(t, db, orm, ethKeyStore, 0, 1, 20)
 
 	expectedUpkeepID := cltest.MustInsertUpkeepForRegistry(t, db, registry).UpkeepID
-	var upkeepIDs []ubig.Big
+	var upkeepIDs []sqlutil.Big
 	for range 2 {
 		upkeep := cltest.MustInsertUpkeepForRegistry(t, db, registry)
 		upkeepIDs = append(upkeepIDs, *upkeep.UpkeepID)
@@ -185,7 +185,7 @@ func TestKeeperDB_EligibleUpkeeps_Shuffle(t *testing.T) {
 	assert.NoError(t, err)
 
 	require.Len(t, eligibleUpkeeps, 100)
-	shuffled := [100]*ubig.Big{}
+	shuffled := [100]*sqlutil.Big{}
 	for i := range 100 {
 		shuffled[i] = eligibleUpkeeps[i].UpkeepID
 	}
@@ -247,16 +247,16 @@ func TestKeeperDB_EligibleUpkeeps_TurnsRandom(t *testing.T) {
 
 	// sort before compare
 	sort.Slice(list1, func(i, j int) bool {
-		return list1[i].UpkeepID.Cmp(list1[j].UpkeepID) == -1
+		return list1[i].UpkeepID.ToInt().Cmp(list1[j].UpkeepID.ToInt()) == -1
 	})
 	sort.Slice(list2, func(i, j int) bool {
-		return list2[i].UpkeepID.Cmp(list2[j].UpkeepID) == -1
+		return list2[i].UpkeepID.ToInt().Cmp(list2[j].UpkeepID.ToInt()) == -1
 	})
 	sort.Slice(list3, func(i, j int) bool {
-		return list3[i].UpkeepID.Cmp(list3[j].UpkeepID) == -1
+		return list3[i].UpkeepID.ToInt().Cmp(list3[j].UpkeepID.ToInt()) == -1
 	})
 	sort.Slice(list4, func(i, j int) bool {
-		return list4[i].UpkeepID.Cmp(list4[j].UpkeepID) == -1
+		return list4[i].UpkeepID.ToInt().Cmp(list4[j].UpkeepID.ToInt()) == -1
 	})
 
 	assert.NotEqual(t, list1, list2, "list1 vs list2")
@@ -384,8 +384,8 @@ func TestKeeperDB_AllUpkeepIDsForRegistry(t *testing.T) {
 	require.NoError(t, err)
 	// No upkeeps returned
 	require.Len(t, upkeepIDs, 2)
-	require.Contains(t, upkeepIDs, *ubig.New(big.NewInt(3)))
-	require.Contains(t, upkeepIDs, *ubig.New(big.NewInt(8)))
+	require.Contains(t, upkeepIDs, *sqlutil.New(big.NewInt(3)))
+	require.Contains(t, upkeepIDs, *sqlutil.New(big.NewInt(8)))
 }
 
 func TestKeeperDB_UpdateUpkeepLastKeeperIndex(t *testing.T) {

--- a/core/services/keeper/registry1_1_synchronizer_test.go
+++ b/core/services/keeper/registry1_1_synchronizer_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
 	registry1_1 "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/keeper_registry_wrapper1_1"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	logmocks "github.com/smartcontractkit/chainlink/v2/common/log/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -121,7 +121,7 @@ func Test_RegistrySynchronizer1_1_Start(t *testing.T) {
 func Test_RegistrySynchronizer_CalcPositioningConstant(t *testing.T) {
 	t.Parallel()
 	for _, upkeepID := range []int64{0, 1, 100, 10_000} {
-		_, err := keeper.CalcPositioningConstant(ubig.NewI(upkeepID), cltest.NewEIP55Address())
+		_, err := keeper.CalcPositioningConstant(sqlutil.NewI(upkeepID), cltest.NewEIP55Address())
 		require.NoError(t, err)
 	}
 }

--- a/core/services/keeper/registry1_3_synchronizer_test.go
+++ b/core/services/keeper/registry1_3_synchronizer_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
 	registry1_3 "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/keeper_registry_wrapper1_3"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	logmocks "github.com/smartcontractkit/chainlink/v2/common/log/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -651,7 +651,7 @@ func Test_RegistrySynchronizer1_3_UpkeepPausedLog_UpkeepUnpausedLog(t *testing.T
 
 	cltest.WaitForCount(t, db, "upkeep_registrations", 3)
 	var upkeep keeper.UpkeepRegistration
-	err := db.Get(&upkeep, `SELECT * FROM upkeep_registrations WHERE upkeep_id = $1`, ubig.New(upkeepId))
+	err := db.Get(&upkeep, `SELECT * FROM upkeep_registrations WHERE upkeep_id = $1`, sqlutil.New(upkeepId))
 	require.NoError(t, err)
 
 	require.Equal(t, upkeepId.String(), upkeep.UpkeepID.String())
@@ -711,7 +711,7 @@ func Test_RegistrySynchronizer1_3_UpkeepCheckDataUpdatedLog(t *testing.T) {
 
 	g.Eventually(func() []byte {
 		var upkeep keeper.UpkeepRegistration
-		err := db.Get(&upkeep, `SELECT * FROM upkeep_registrations WHERE upkeep_id = $1`, ubig.New(upkeepId))
+		err := db.Get(&upkeep, `SELECT * FROM upkeep_registrations WHERE upkeep_id = $1`, sqlutil.New(upkeepId))
 		require.NoError(t, err)
 		return upkeep.CheckData
 	}, testutils.WaitTimeout(t), cltest.DBPollingInterval).Should(gomega.Equal(newCheckData))

--- a/core/services/keeper/registry_synchronizer_process_logs.go
+++ b/core/services/keeper/registry_synchronizer_process_logs.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	registry1_1 "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/keeper_registry_wrapper1_1"
 	registry1_2 "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/keeper_registry_wrapper1_2"
 	registry1_3 "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/keeper_registry_wrapper1_3"
 	"github.com/smartcontractkit/chainlink-evm/pkg/log"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 )
 
 func (rs *RegistrySynchronizer) processLogs(ctx context.Context) {
@@ -113,7 +113,7 @@ func (rs *RegistrySynchronizer) handleUpkeepCancelled(ctx context.Context, broad
 		return errors.Wrap(err, "Unable to fetch cancelled upkeep ID from log")
 	}
 
-	affected, err := rs.orm.BatchDeleteUpkeepsForJob(ctx, rs.job.ID, []big.Big{*big.New(cancelledID)})
+	affected, err := rs.orm.BatchDeleteUpkeepsForJob(ctx, rs.job.ID, []sqlutil.Big{*sqlutil.New(cancelledID)})
 	if err != nil {
 		return errors.Wrap(err, "unable to batch delete upkeeps")
 	}
@@ -134,7 +134,7 @@ func (rs *RegistrySynchronizer) handleUpkeepRegistered(ctx context.Context, broa
 		return errors.Wrap(err, "Unable to fetch upkeep ID from registration log")
 	}
 
-	err = rs.syncUpkeep(ctx, &rs.registryWrapper, registry, big.New(upkeepID))
+	err = rs.syncUpkeep(ctx, &rs.registryWrapper, registry, sqlutil.New(upkeepID))
 	if err != nil {
 		return errors.Wrapf(err, "failed to sync upkeep, log: %v", broadcast.String())
 	}
@@ -148,7 +148,7 @@ func (rs *RegistrySynchronizer) handleUpkeepPerformed(ctx context.Context, broad
 	if err != nil {
 		return errors.Wrap(err, "Unable to fetch upkeep ID from performed log")
 	}
-	rowsAffected, err := rs.orm.SetLastRunInfoForUpkeepOnJob(ctx, rs.job.ID, big.New(log.UpkeepID), int64(broadcast.RawLog().BlockNumber), types.EIP55AddressFromAddress(log.FromKeeper))
+	rowsAffected, err := rs.orm.SetLastRunInfoForUpkeepOnJob(ctx, rs.job.ID, sqlutil.New(log.UpkeepID), int64(broadcast.RawLog().BlockNumber), types.EIP55AddressFromAddress(log.FromKeeper))
 	if err != nil {
 		return errors.Wrap(err, "failed to set last run to 0")
 	}
@@ -175,7 +175,7 @@ func (rs *RegistrySynchronizer) handleUpkeepGasLimitSet(ctx context.Context, bro
 		return errors.Wrap(err, "Unable to fetch upkeep ID from gas limit set log")
 	}
 
-	err = rs.syncUpkeep(ctx, &rs.registryWrapper, registry, big.New(upkeepID))
+	err = rs.syncUpkeep(ctx, &rs.registryWrapper, registry, sqlutil.New(upkeepID))
 	if err != nil {
 		return errors.Wrapf(err, "failed to sync upkeep, log: %v", broadcast.String())
 	}
@@ -195,7 +195,7 @@ func (rs *RegistrySynchronizer) handleUpkeepReceived(ctx context.Context, broadc
 		return errors.Wrap(err, "Unable to fetch upkeep ID from received log")
 	}
 
-	err = rs.syncUpkeep(ctx, &rs.registryWrapper, registry, big.New(upkeepID))
+	err = rs.syncUpkeep(ctx, &rs.registryWrapper, registry, sqlutil.New(upkeepID))
 	if err != nil {
 		return errors.Wrapf(err, "failed to sync upkeep, log: %v", broadcast.String())
 	}
@@ -210,7 +210,7 @@ func (rs *RegistrySynchronizer) handleUpkeepMigrated(ctx context.Context, broadc
 		return errors.Wrap(err, "Unable to fetch migrated upkeep ID from log")
 	}
 
-	affected, err := rs.orm.BatchDeleteUpkeepsForJob(ctx, rs.job.ID, []big.Big{*big.New(migratedID)})
+	affected, err := rs.orm.BatchDeleteUpkeepsForJob(ctx, rs.job.ID, []sqlutil.Big{*sqlutil.New(migratedID)})
 	if err != nil {
 		return errors.Wrap(err, "unable to batch delete upkeeps")
 	}
@@ -226,7 +226,7 @@ func (rs *RegistrySynchronizer) handleUpkeepPaused(ctx context.Context, broadcas
 		return errors.Wrap(err, "Unable to fetch upkeep ID from upkeep paused log")
 	}
 
-	_, err = rs.orm.BatchDeleteUpkeepsForJob(ctx, rs.job.ID, []big.Big{*big.New(pausedUpkeepId)})
+	_, err = rs.orm.BatchDeleteUpkeepsForJob(ctx, rs.job.ID, []sqlutil.Big{*sqlutil.New(pausedUpkeepId)})
 	if err != nil {
 		return errors.Wrap(err, "unable to batch delete upkeeps")
 	}
@@ -247,7 +247,7 @@ func (rs *RegistrySynchronizer) handleUpkeepUnpaused(ctx context.Context, broadc
 		return errors.Wrap(err, "Unable to fetch upkeep ID from upkeep unpaused log")
 	}
 
-	err = rs.syncUpkeep(ctx, &rs.registryWrapper, registry, big.New(unpausedUpkeepId))
+	err = rs.syncUpkeep(ctx, &rs.registryWrapper, registry, sqlutil.New(unpausedUpkeepId))
 	if err != nil {
 		return errors.Wrapf(err, "failed to sync upkeep, log: %s", broadcast.String())
 	}
@@ -268,7 +268,7 @@ func (rs *RegistrySynchronizer) handleUpkeepCheckDataUpdated(ctx context.Context
 		return errors.Wrap(err, "Unable to parse update log from upkeep check data updated log")
 	}
 
-	err = rs.syncUpkeep(ctx, &rs.registryWrapper, registry, big.New(updateLog.UpkeepID))
+	err = rs.syncUpkeep(ctx, &rs.registryWrapper, registry, sqlutil.New(updateLog.UpkeepID))
 	if err != nil {
 		return errors.Wrapf(err, "unable to update check data for upkeep %s", updateLog.UpkeepID.String())
 	}

--- a/core/services/keeper/registry_synchronizer_sync.go
+++ b/core/services/keeper/registry_synchronizer_sync.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"encoding/binary"
 	"math"
+	"math/big"
 	"sync"
 
 	"github.com/pkg/errors"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/big_math"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 )
 
 func (rs *RegistrySynchronizer) fullSync(ctx context.Context) {
@@ -55,15 +57,15 @@ func (rs *RegistrySynchronizer) fullSyncUpkeeps(ctx context.Context, reg Registr
 	}
 
 	activeSet := make(map[string]bool)
-	allActiveUpkeeps := make([]big.Big, 0)
+	allActiveUpkeeps := make([]sqlutil.Big, 0)
 	for _, upkeepID := range activeUpkeepIDs {
 		activeSet[upkeepID.String()] = true
-		allActiveUpkeeps = append(allActiveUpkeeps, *big.New(upkeepID))
+		allActiveUpkeeps = append(allActiveUpkeeps, *sqlutil.New(upkeepID))
 	}
 	rs.batchSyncUpkeepsOnRegistry(ctx, reg, allActiveUpkeeps)
 
 	// All upkeeps in existingUpkeepIDs, not in activeUpkeepIDs should be deleted
-	canceled := make([]big.Big, 0)
+	canceled := make([]sqlutil.Big, 0)
 	for _, upkeepID := range existingUpkeepIDs {
 		if _, found := activeSet[upkeepID.ToInt().String()]; !found {
 			canceled = append(canceled, upkeepID)
@@ -77,7 +79,7 @@ func (rs *RegistrySynchronizer) fullSyncUpkeeps(ctx context.Context, reg Registr
 
 // batchSyncUpkeepsOnRegistry syncs <syncUpkeepQueueSize> upkeeps at a time in parallel
 // for all the IDs within newUpkeeps slice
-func (rs *RegistrySynchronizer) batchSyncUpkeepsOnRegistry(ctx context.Context, reg Registry, newUpkeeps []big.Big) {
+func (rs *RegistrySynchronizer) batchSyncUpkeepsOnRegistry(ctx context.Context, reg Registry, newUpkeeps []sqlutil.Big) {
 	wg := sync.WaitGroup{}
 	chSyncUpkeepQueue := make(chan struct{}, rs.syncUpkeepQueueSize)
 
@@ -94,7 +96,7 @@ func (rs *RegistrySynchronizer) batchSyncUpkeepsOnRegistry(ctx context.Context, 
 	wg.Wait()
 }
 
-func (rs *RegistrySynchronizer) syncUpkeepWithCallback(ctx context.Context, getter upkeepGetter, registry Registry, upkeepID *big.Big, doneCallback func()) {
+func (rs *RegistrySynchronizer) syncUpkeepWithCallback(ctx context.Context, getter upkeepGetter, registry Registry, upkeepID *sqlutil.Big, doneCallback func()) {
 	defer doneCallback()
 
 	if err := rs.syncUpkeep(ctx, getter, registry, upkeepID); err != nil {
@@ -105,7 +107,7 @@ func (rs *RegistrySynchronizer) syncUpkeepWithCallback(ctx context.Context, gett
 	}
 }
 
-func (rs *RegistrySynchronizer) syncUpkeep(ctx context.Context, getter upkeepGetter, registry Registry, upkeepID *big.Big) error {
+func (rs *RegistrySynchronizer) syncUpkeep(ctx context.Context, getter upkeepGetter, registry Registry, upkeepID *sqlutil.Big) error {
 	upkeep, err := getter.GetUpkeep(nil, upkeepID.ToInt())
 	if err != nil {
 		return errors.Wrap(err, "failed to get upkeep config")
@@ -174,9 +176,9 @@ func (rs *RegistrySynchronizer) newRegistryFromChain(ctx context.Context) (Regis
 
 // CalcPositioningConstant calculates a positioning constant.
 // The positioning constant is fixed because upkeepID and registryAddress are immutable
-func CalcPositioningConstant(upkeepID *big.Big, registryAddress types.EIP55Address) (int32, error) {
+func CalcPositioningConstant(upkeepID *sqlutil.Big, registryAddress types.EIP55Address) (int32, error) {
 	upkeepBytes := make([]byte, binary.MaxVarintLen64)
-	binary.PutVarint(upkeepBytes, upkeepID.Mod(big.NewI(math.MaxInt64)).Int64())
+	binary.PutVarint(upkeepBytes, bigmath.Mod(upkeepID.ToInt(), big.NewInt(math.MaxInt64)).Int64())
 	bytesToHash := utils.ConcatBytes(upkeepBytes, registryAddress.Bytes())
 	checksum, err := utils.Keccak256(bytesToHash)
 	if err != nil {

--- a/core/services/keeper/registry_synchronizer_sync.go
+++ b/core/services/keeper/registry_synchronizer_sync.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/big_math"
+	bigmath "github.com/smartcontractkit/chainlink-common/pkg/utils/big_math"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 )

--- a/core/services/keeper/registry_synchronizer_sync_test.go
+++ b/core/services/keeper/registry_synchronizer_sync_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
@@ -43,7 +43,7 @@ func TestSyncUpkeepWithCallback_UpkeepNotFound(t *testing.T) {
 		t.FailNow()
 	}
 
-	id := ubig.New(o)
+	id := sqlutil.New(o)
 	count := 0
 	doneFunc := func() {
 		count++

--- a/core/services/keeper/upkeep_executer_test.go
+++ b/core/services/keeper/upkeep_executer_test.go
@@ -16,13 +16,13 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	txmmocks "github.com/smartcontractkit/chainlink/v2/common/txmgr/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
@@ -38,7 +38,7 @@ import (
 )
 
 func newHead() evmtypes.Head {
-	return evmtypes.NewHead(big.NewInt(20), utils.NewHash(), utils.NewHash(), ubig.NewI(0))
+	return evmtypes.NewHead(big.NewInt(20), utils.NewHash(), utils.NewHash(), sqlutil.NewI(0))
 }
 
 func setup(t *testing.T, overrideFn func(c *chainlink.Config, s *chainlink.Secrets)) (
@@ -125,7 +125,7 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 	t.Run("runs upkeep on triggering block number", func(t *testing.T) {
 		db, config, ethMock, executer, registry, upkeep, job, jpv2, txm, _, _, _ := setup(t,
 			func(c *chainlink.Config, s *chainlink.Secrets) {
-				c.EVM[0].ChainID = (*ubig.Big)(testutils.SimulatedChainID)
+				c.EVM[0].ChainID = (*sqlutil.Big)(testutils.SimulatedChainID)
 			})
 
 		gasLimit := uint64(5_000_000 + config.Keeper().Registry().PerformGasOverhead())
@@ -170,7 +170,7 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 		runTest := func(t *testing.T, eip1559 bool) {
 			db, config, ethMock, executer, registry, upkeep, job, jpv2, txm, _, _, _ := setup(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 				c.EVM[0].GasEstimator.EIP1559DynamicFees = &eip1559
-				c.EVM[0].ChainID = (*ubig.Big)(testutils.SimulatedChainID)
+				c.EVM[0].ChainID = (*sqlutil.Big)(testutils.SimulatedChainID)
 			})
 
 			gasLimit := uint64(5_000_000 + config.Keeper().Registry().PerformGasOverhead())
@@ -224,7 +224,7 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 	t.Run("errors if submission key not found", func(t *testing.T) {
 		ctx := testutils.Context(t)
 		_, _, ethMock, executer, registry, _, job, jpv2, _, keyStore, _, _ := setup(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-			c.EVM[0].ChainID = (*ubig.Big)(testutils.SimulatedChainID)
+			c.EVM[0].ChainID = (*sqlutil.Big)(testutils.SimulatedChainID)
 		})
 
 		// replace expected key with random one
@@ -261,7 +261,7 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 
 		registry, jb := cltest.MustInsertKeeperRegistry(t, db, orm, keyStore.Eth(), 0, 1, 20)
 		// change chain ID to non-configured chain
-		jb.KeeperSpec.EVMChainID = (*ubig.Big)(big.NewInt(999))
+		jb.KeeperSpec.EVMChainID = (*sqlutil.Big)(big.NewInt(999))
 		cltest.MustInsertUpkeepForRegistry(t, db, registry)
 		lggr := logger.TestLogger(t)
 		executer := keeper.NewUpkeepExecuter(jb, orm, jpv2.Pr, ethMock, ch.HeadBroadcaster(), ch.GasEstimator(), lggr, cfg.Keeper(), jb.KeeperSpec.FromAddress.Address())
@@ -276,7 +276,7 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 
 	t.Run("triggers if heads are skipped but later heads arrive within range", func(t *testing.T) {
 		db, config, ethMock, executer, registry, upkeep, job, jpv2, txm, _, _, _ := setup(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-			c.EVM[0].ChainID = (*ubig.Big)(testutils.SimulatedChainID)
+			c.EVM[0].ChainID = (*sqlutil.Big)(testutils.SimulatedChainID)
 		})
 
 		etxs := []cltest.Awaiter{
@@ -319,7 +319,7 @@ func Test_UpkeepExecuter_PerformsUpkeep_Error(t *testing.T) {
 
 	db, _, ethMock, executer, registry, _, _, _, _, _, _, _ := setup(t,
 		func(c *chainlink.Config, s *chainlink.Secrets) {
-			c.EVM[0].ChainID = (*ubig.Big)(testutils.SimulatedChainID)
+			c.EVM[0].ChainID = (*sqlutil.Big)(testutils.SimulatedChainID)
 		})
 
 	var wasCalled atomic.Bool

--- a/core/services/keeper/upkeep_executer_unit_test.go
+++ b/core/services/keeper/upkeep_executer_unit_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
@@ -34,7 +34,7 @@ func TestBuildJobSpec(t *testing.T) {
 			ContractAddress: contract,
 		}}
 
-	upkeepID := big.NewI(4)
+	upkeepID := sqlutil.NewI(4)
 	upkeep := UpkeepRegistration{
 		Registry: Registry{
 			FromAddress:     from,

--- a/core/services/keystore/eth_test.go
+++ b/core/services/keystore/eth_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	commonutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr/txmgrtest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -786,7 +786,7 @@ func Test_EthKeyStore_Delete(t *testing.T) {
 
 	_, addr1 := cltest.MustInsertRandomKey(t, ks)
 	_, addr2 := cltest.MustInsertRandomKey(t, ks)
-	cltest.MustInsertRandomKey(t, ks, *ubig.New(testutils.SimulatedChainID))
+	cltest.MustInsertRandomKey(t, ks, *sqlutil.New(testutils.SimulatedChainID))
 	require.NoError(t, ks.Add(ctx, addr1, testutils.SimulatedChainID))
 	require.NoError(t, ks.Enable(ctx, addr1, testutils.SimulatedChainID))
 

--- a/core/services/keystore/keys/ethkey/models.go
+++ b/core/services/keystore/keys/ethkey/models.go
@@ -3,14 +3,14 @@ package ethkey
 import (
 	"time"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 )
 
 type State struct {
 	ID         int32
 	Address    types.EIP55Address
-	EVMChainID big.Big
+	EVMChainID sqlutil.Big
 	Disabled   bool
 	CreatedAt  time.Time
 	UpdatedAt  time.Time

--- a/core/services/ocr/database.go
+++ b/core/services/ocr/database.go
@@ -15,7 +15,6 @@ import (
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
@@ -163,7 +162,7 @@ func (d *db) WriteConfig(ctx context.Context, c ocrtypes.ContractConfig) error {
 }
 
 func (d *db) StorePendingTransmission(ctx context.Context, k ocrtypes.ReportTimestamp, p ocrtypes.PendingTransmission) error {
-	median := big.New(p.Median)
+	median := sqlutil.New(p.Median)
 	var rs [][]byte
 	var ss [][]byte
 	// Note: p.Rs and p.Ss are of type [][32]byte.
@@ -233,7 +232,7 @@ WHERE ocr_oracle_spec_id = $1 AND config_digest = $2
 		k := ocrtypes.ReportTimestamp{}
 		p := ocrtypes.PendingTransmission{}
 
-		var median big.Big
+		var median sqlutil.Big
 		var rs [][]byte
 		var ss [][]byte
 		var vs []byte

--- a/core/services/ocr2/delegate_test.go
+++ b/core/services/ocr2/delegate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
@@ -17,7 +18,6 @@ import (
 	evmrelayer "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	txmmocks "github.com/smartcontractkit/chainlink/v2/common/txmgr/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
@@ -34,7 +34,7 @@ import (
 )
 
 func TestGetEVMEffectiveTransmitterID(t *testing.T) {
-	customChainID := big.New(testutils.NewRandomEVMChainID())
+	customChainID := sqlutil.New(testutils.NewRandomEVMChainID())
 
 	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		enabled := true

--- a/core/services/ocr2/plugins/ccip/internal/cache/commit_roots_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/cache/commit_roots_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	commit_store_1_2_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/commit_store"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
@@ -313,6 +313,6 @@ func createReportAcceptedLog(t testing.TB, chainID *big.Int, address common.Addr
 		EventSig:       topic0,
 		Address:        address,
 		TxHash:         utils.RandomBytes32(),
-		EVMChainID:     ubig.New(chainID),
+		EVMChainID:     sqlutil.New(chainID),
 	}
 }

--- a/core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go
@@ -37,6 +37,7 @@ import (
 	commonkeystore "github.com/smartcontractkit/chainlink-common/keystore"
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
 	pb "github.com/smartcontractkit/chainlink-protos/orchestrator/feedsmanager"
 
@@ -45,7 +46,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	evmUtils "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	price_registry_1_2_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/price_registry"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/commit_store"
@@ -514,7 +514,7 @@ func createConfigV2Chain(chainID *big.Int, finalityDepth uint32) *toml.EVMConfig
 	defaultGasLimit := uint64(5000000)
 	tr := true
 
-	sourceC := toml.Defaults((*evmUtils.Big)(chainID))
+	sourceC := toml.Defaults((*sqlutil.Big)(chainID))
 	sourceC.GasEstimator.LimitDefault = &defaultGasLimit
 	fixedPrice := "FixedPrice"
 	sourceC.GasEstimator.Mode = &fixedPrice
@@ -522,7 +522,7 @@ func createConfigV2Chain(chainID *big.Int, finalityDepth uint32) *toml.EVMConfig
 	sourceC.LogPollInterval = &d
 	sourceC.FinalityDepth = &finalityDepth
 	return &toml.EVMConfig{
-		ChainID: (*evmUtils.Big)(chainID),
+		ChainID: (*sqlutil.Big)(chainID),
 		Enabled: &tr,
 		Chain:   sourceC,
 		Nodes:   toml.EVMNodes{&toml.Node{}},

--- a/core/services/ocr2/plugins/ccip/testhelpers/testhelpers_1_4_0/chainlink.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/testhelpers_1_4_0/chainlink.go
@@ -36,6 +36,7 @@ import (
 	commonkeystore "github.com/smartcontractkit/chainlink-common/keystore"
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
 	pb "github.com/smartcontractkit/chainlink-protos/orchestrator/feedsmanager"
 
@@ -44,7 +45,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	evmUtils "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	commit_store_1_2_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/commit_store"
 	evm_2_evm_offramp_1_2_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/evm_2_evm_offramp"
@@ -516,7 +516,7 @@ func createConfigV2Chain(chainID *big.Int) *toml.EVMConfig {
 	defaultGasLimit := uint64(5000000)
 	tr := true
 
-	sourceC := toml.Defaults((*evmUtils.Big)(chainID))
+	sourceC := toml.Defaults((*sqlutil.Big)(chainID))
 	sourceC.GasEstimator.LimitDefault = &defaultGasLimit
 	fixedPrice := "FixedPrice"
 	sourceC.GasEstimator.Mode = &fixedPrice
@@ -525,7 +525,7 @@ func createConfigV2Chain(chainID *big.Int) *toml.EVMConfig {
 	fd := uint32(2)
 	sourceC.FinalityDepth = &fd
 	return &toml.EVMConfig{
-		ChainID: (*evmUtils.Big)(chainID),
+		ChainID: (*sqlutil.Big)(chainID),
 		Enabled: &tr,
 		Chain:   sourceC,
 		Nodes:   toml.EVMNodes{&toml.Node{}},

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
 	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 	datastreamsllo "github.com/smartcontractkit/chainlink-data-streams/llo"
@@ -53,7 +54,6 @@ import (
 	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/config/toml"
@@ -752,8 +752,8 @@ lloConfigMode = "bluegreen"
 			return encoded
 		}
 
-		standardMultiplier := ubig.NewI(1e18)
-		millisToNanosMultiplier := ubig.NewI(1e6)
+		standardMultiplier := sqlutil.NewI(1e18)
+		millisToNanosMultiplier := sqlutil.NewI(1e6)
 
 		const simpleStreamlinedChannelID = 5
 		const complexStreamlinedChannelID = 6
@@ -945,8 +945,8 @@ lloConfigMode = "bluegreen"
 				Opts: mustEncodeOpts(&lloevm.ReportFormatEVMStreamlinedOpts{
 					ABI: []lloevm.ABIEncoder{
 						newSingleABIEncoder("int192", standardMultiplier),
-						newSingleABIEncoder("int8", ubig.NewI(1)),
-						newSingleABIEncoder("uint64", ubig.NewI(100)),
+						newSingleABIEncoder("int8", sqlutil.NewI(1)),
+						newSingleABIEncoder("uint64", sqlutil.NewI(100)),
 					},
 				}),
 			},
@@ -2758,7 +2758,7 @@ func pad32bytes(d uint32) [32]byte {
 	return result
 }
 
-func newSingleABIEncoder(typ string, multiplier *ubig.Big) (enc lloevm.ABIEncoder) {
+func newSingleABIEncoder(typ string, multiplier *sqlutil.Big) (enc lloevm.ABIEncoder) {
 	if multiplier == nil {
 		err := json.Unmarshal(fmt.Appendf(nil, `{"type":"%s"}`, typ), &enc)
 		if err != nil {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry_test.go
@@ -12,10 +12,10 @@ import (
 
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v2"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads/headstest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -177,8 +177,8 @@ func TestPollLogs(t *testing.T) {
 				InputStart: 250,
 				InputEnd:   500,
 				OutputLogs: []logpoller.Log{
-					{EVMChainID: ubig.New(big.NewInt(5)), LogIndex: 1},
-					{EVMChainID: ubig.New(big.NewInt(6)), LogIndex: 2},
+					{EVMChainID: sqlutil.New(big.NewInt(5)), LogIndex: 1},
+					{EVMChainID: sqlutil.New(big.NewInt(6)), LogIndex: 2},
 				},
 				OutputErr: nil,
 			},

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	autotypes "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	lpmocks "github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -1022,7 +1022,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 				LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
 					return []logpoller.Log{
 						{
-							EVMChainID:     ubig.New(big.NewInt(1)),
+							EVMChainID:     sqlutil.New(big.NewInt(1)),
 							LogIndex:       3,
 							BlockHash:      [32]byte{1},
 							BlockNumber:    80,

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_test.go
@@ -16,12 +16,12 @@ import (
 
 	autotypes "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 
 	evmheads "github.com/smartcontractkit/chainlink-evm/pkg/heads"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated"
 	ac "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/automation_compatible_utils"
@@ -178,8 +178,8 @@ func TestPollLogs(t *testing.T) {
 				InputStart: 250,
 				InputEnd:   500,
 				OutputLogs: []logpoller.Log{
-					{EVMChainID: ubig.New(big.NewInt(5)), LogIndex: 1},
-					{EVMChainID: ubig.New(big.NewInt(6)), LogIndex: 2},
+					{EVMChainID: sqlutil.New(big.NewInt(5)), LogIndex: 1},
+					{EVMChainID: sqlutil.New(big.NewInt(6)), LogIndex: 2},
 				},
 				OutputErr: nil,
 			},

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/orm.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/orm.go
@@ -8,16 +8,15 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 )
 
 type orm struct {
-	chainID *ubig.Big
+	chainID *sqlutil.Big
 	ds      sqlutil.DataSource
 }
 
 type persistedStateRecord struct {
-	UpkeepID            *ubig.Big
+	UpkeepID            *sqlutil.Big
 	WorkID              string
 	CompletionState     uint8
 	BlockNumber         int64
@@ -28,7 +27,7 @@ type persistedStateRecord struct {
 // NewORM creates an ORM scoped to chainID.
 func NewORM(chainID *big.Int, ds sqlutil.DataSource) *orm {
 	return &orm{
-		chainID: ubig.New(chainID),
+		chainID: sqlutil.New(chainID),
 		ds:      ds,
 	}
 }
@@ -40,12 +39,12 @@ func (o *orm) BatchInsertRecords(ctx context.Context, state []persistedStateReco
 	}
 
 	type row struct {
-		EvmChainId          *ubig.Big
+		EvmChainId          *sqlutil.Big
 		WorkId              string
 		CompletionState     uint8
 		BlockNumber         int64
 		InsertedAt          time.Time
-		UpkeepId            *ubig.Big
+		UpkeepId            *sqlutil.Big
 		IneligibilityReason uint8
 	}
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/orm_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/orm_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 )
@@ -21,7 +21,7 @@ func TestInsertSelectDelete(t *testing.T) {
 
 	inserted := []persistedStateRecord{
 		{
-			UpkeepID:            ubig.New(big.NewInt(2)),
+			UpkeepID:            sqlutil.New(big.NewInt(2)),
 			WorkID:              "0x1",
 			CompletionState:     100,
 			BlockNumber:         2,

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/store.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/store.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
@@ -222,7 +221,7 @@ func (u *upkeepStateStore) upsertStateRecord(ctx context.Context, workID string,
 	u.cache[workID] = record
 
 	u.pendingRecords = append(u.pendingRecords, persistedStateRecord{
-		UpkeepID:            ubig.New(upkeepID),
+		UpkeepID:            sqlutil.New(upkeepID),
 		WorkID:              record.workID,
 		CompletionState:     uint8(record.state),
 		IneligibilityReason: reason,

--- a/core/services/ocr2/plugins/ocr2keeper/integration_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/integration_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/basic_upkeep_contract"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/keeper_registry_logic2_0"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/keeper_registry_wrapper2_0"
@@ -45,7 +46,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/config/toml"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -450,7 +450,7 @@ func setupForwarderForNode(
 	forwarderORM := forwarders.NewORM(app.GetDB())
 	chainID, err := backend.Client().ChainID(testutils.Context(t))
 	require.NoError(t, err)
-	_, err = forwarderORM.CreateForwarder(ctx, faddr, ubig.Big(*chainID))
+	_, err = forwarderORM.CreateForwarder(ctx, faddr, sqlutil.Big(*chainID))
 	require.NoError(t, err)
 
 	chainService, err := app.GetRelayers().LegacyEVMChains().Get(chainID.String())

--- a/core/services/ocr2/plugins/s4/integration_test.go
+++ b/core/services/ocr2/plugins/s4/integration_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
@@ -222,7 +222,7 @@ func TestS4Integration_WrongSignature(t *testing.T) {
 	originSnapshot, err := don.orms[0].GetSnapshot(ctx, s4_svc.NewFullAddressRange())
 	require.NoError(t, err)
 	originSnapshot = filter(originSnapshot, func(row *s4_svc.SnapshotRow) bool {
-		return row.Address.Cmp(rows[0].Address) != 0 || row.SlotId != rows[0].SlotId
+		return row.Address.ToInt().Cmp(rows[0].Address.ToInt()) != 0 || row.SlotId != rows[0].SlotId
 	})
 	require.Len(t, originSnapshot, len(rows)-1)
 
@@ -356,14 +356,14 @@ func TestS4Integration_RandomState(t *testing.T) {
 
 	type user struct {
 		privateKey *ecdsa.PrivateKey
-		address    *big.Big
+		address    *sqlutil.Big
 	}
 
 	nUsers := 100
 	users := make([]user, nUsers)
 	for i := range nUsers {
 		pk, addr := testutils.NewPrivateKeyAndAddress(t)
-		users[i] = user{pk, big.New(addr.Big())}
+		users[i] = user{pk, sqlutil.New(addr.Big())}
 	}
 
 	// generating test records
@@ -379,7 +379,7 @@ func TestS4Integration_RandomState(t *testing.T) {
 				Payload:    cltest.MustRandomBytes(t, 64),
 			}
 			env := &s4_svc.Envelope{
-				Address:    common.BytesToAddress(user.address.Bytes()).Bytes(),
+				Address:    common.BytesToAddress(user.address.ToInt().Bytes()).Bytes(),
 				SlotID:     row.SlotId,
 				Version:    row.Version,
 				Expiration: row.Expiration,

--- a/core/services/ocr2/plugins/s4/messages.go
+++ b/core/services/ocr2/plugins/s4/messages.go
@@ -7,15 +7,15 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"google.golang.org/protobuf/proto"
 
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/services/s4"
 )
 
 func MarshalQuery(rows []*SnapshotRow, addressRange *s4.AddressRange) ([]byte, error) {
 	rr := &Query{
 		AddressRange: &AddressRange{
-			MinAddress: addressRange.MinAddress.Bytes(),
-			MaxAddress: addressRange.MaxAddress.Bytes(),
+			MinAddress: addressRange.MinAddress.ToInt().Bytes(),
+			MaxAddress: addressRange.MaxAddress.ToInt().Bytes(),
 		},
 		Rows: rows,
 	}
@@ -58,8 +58,8 @@ func UnmarshalRows(data []byte) ([]*Row, error) {
 	return rows.Rows, nil
 }
 
-func UnmarshalAddress(address []byte) *ubig.Big {
-	return ubig.New(new(big.Int).SetBytes(address))
+func UnmarshalAddress(address []byte) *sqlutil.Big {
+	return sqlutil.New(new(big.Int).SetBytes(address))
 }
 
 func (row *Row) VerifySignature() error {

--- a/core/services/ocr2/plugins/s4/messages_test.go
+++ b/core/services/ocr2/plugins/s4/messages_test.go
@@ -42,7 +42,7 @@ func Test_MarshalUnmarshalQuery(t *testing.T) {
 	snapshot := make([]*s4.SnapshotRow, len(ormVersions))
 	for i, v := range ormVersions {
 		snapshot[i] = &s4.SnapshotRow{
-			Address: v.Address.Bytes(),
+			Address: v.Address.ToInt().Bytes(),
 			Slotid:  uint32(v.SlotId),
 			Version: v.Version,
 		}

--- a/core/services/ocr2/plugins/s4/plugin.go
+++ b/core/services/ocr2/plugins/s4/plugin.go
@@ -11,7 +11,7 @@ import (
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/services/s4"
 )
 
@@ -77,7 +77,7 @@ func (c *plugin) Query(ctx context.Context, ts types.ReportTimestamp) (types.Que
 	rows := make([]*SnapshotRow, len(snapshot))
 	for i, v := range snapshot {
 		rows[i] = &SnapshotRow{
-			Address: v.Address.Bytes(),
+			Address: v.Address.ToInt().Bytes(),
 			Slotid:  uint32(v.SlotId),
 			Version: v.Version,
 		}
@@ -142,7 +142,7 @@ func (c *plugin) Observation(ctx context.Context, ts types.ReportTimestamp, quer
 			c.logger.Error("ORM GetSnapshot error", commontypes.LogFields{"err": err})
 		} else {
 			type rkey struct {
-				address *big.Big
+				address *sqlutil.Big
 				slotID  uint
 			}
 
@@ -310,7 +310,7 @@ func (c *plugin) Close() error {
 
 func convertRow(from *s4.Row) *Row {
 	return &Row{
-		Address:    from.Address.Bytes(),
+		Address:    from.Address.ToInt().Bytes(),
 		Slotid:     uint32(from.SlotId),
 		Version:    from.Version,
 		Expiration: from.Expiration,

--- a/core/services/ocr2/plugins/s4/plugin_test.go
+++ b/core/services/ocr2/plugins/s4/plugin_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -37,7 +37,7 @@ func generateTestRows(t *testing.T, n int, ttl time.Duration) []*s4.Row {
 	rows := make([]*s4.Row, n)
 	for i := range n {
 		rows[i] = &s4.Row{
-			Address:    ormRows[i].Address.Bytes(),
+			Address:    ormRows[i].Address.ToInt().Bytes(),
 			Slotid:     uint32(ormRows[i].SlotId),
 			Version:    ormRows[i].Version,
 			Expiration: ormRows[i].Expiration,
@@ -51,7 +51,7 @@ func generateTestRows(t *testing.T, n int, ttl time.Duration) []*s4.Row {
 func generateTestOrmRow(t *testing.T, ttl time.Duration, version uint64, confimed bool) *s4_svc.Row {
 	priv, addr := testutils.NewPrivateKeyAndAddress(t)
 	row := &s4_svc.Row{
-		Address:    big.New(addr.Big()),
+		Address:    sqlutil.New(addr.Big()),
 		SlotId:     0,
 		Version:    version,
 		Confirmed:  confimed,
@@ -90,7 +90,7 @@ func generateConfirmedTestOrmRows(t *testing.T, n int, ttl time.Duration) []*s4_
 func compareRows(t *testing.T, protoRows []*s4.Row, ormRows []*s4_svc.Row) {
 	assert.Len(t, protoRows, len(ormRows))
 	for i, row := range protoRows {
-		assert.Equal(t, row.Address, ormRows[i].Address.Bytes())
+		assert.Equal(t, row.Address, ormRows[i].Address.ToInt().Bytes())
 		assert.Equal(t, row.Version, ormRows[i].Version)
 		assert.Equal(t, row.Expiration, ormRows[i].Expiration)
 		assert.Equal(t, row.Payload, ormRows[i].Payload)
@@ -101,7 +101,7 @@ func compareRows(t *testing.T, protoRows []*s4.Row, ormRows []*s4_svc.Row) {
 func compareSnapshotRows(t *testing.T, snapshot []*s4.SnapshotRow, ormVersions []*s4_svc.SnapshotRow) {
 	assert.Len(t, snapshot, len(ormVersions))
 	for i, row := range snapshot {
-		assert.Equal(t, row.Address, ormVersions[i].Address.Bytes())
+		assert.Equal(t, row.Address, ormVersions[i].Address.ToInt().Bytes())
 		assert.Equal(t, row.Slotid, uint32(ormVersions[i].SlotId))
 		assert.Equal(t, row.Version, ormVersions[i].Version)
 	}
@@ -295,7 +295,7 @@ func TestPlugin_Query(t *testing.T) {
 		for i := range 256 {
 			var thisAddress common.Address
 			thisAddress[0] = byte(i)
-			ormRows[i].Address = big.New(thisAddress.Big())
+			ormRows[i].Address = sqlutil.New(thisAddress.Big())
 		}
 		versions := rowsToShapshotRows(ormRows)
 
@@ -380,7 +380,7 @@ func TestPlugin_Observation(t *testing.T) {
 		numHigherVersion := 2
 		for i, v := range snapshotRows {
 			query.Rows[i] = &s4.SnapshotRow{
-				Address: v.Address.Bytes(),
+				Address: v.Address.ToInt().Bytes(),
 				Slotid:  uint32(v.SlotId),
 				Version: v.Version,
 			}
@@ -432,12 +432,12 @@ func TestPlugin_Observation(t *testing.T) {
 		query := &s4.Query{
 			Rows: []*s4.SnapshotRow{
 				&s4.SnapshotRow{
-					Address: snapshot[0].Address.Bytes(),
+					Address: snapshot[0].Address.ToInt().Bytes(),
 					Slotid:  uint32(snapshot[0].SlotId),
 					Version: vHigh,
 				},
 				&s4.SnapshotRow{
-					Address: snapshot[1].Address.Bytes(),
+					Address: snapshot[1].Address.ToInt().Bytes(),
 					Slotid:  uint32(snapshot[1].SlotId),
 					Version: vLow,
 				},

--- a/core/services/ocrcommon/data_source.go
+++ b/core/services/ocrcommon/data_source.go
@@ -14,8 +14,8 @@ import (
 	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
-	serializablebig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
@@ -290,8 +290,8 @@ func (ds *inMemoryDataSourceCache) updater() {
 }
 
 type ResultTimePair struct {
-	Result serializablebig.Big `json:"result"`
-	Time   time.Time           `json:"time"`
+	Result sqlutil.Big `json:"result"`
+	Time   time.Time   `json:"time"`
 }
 
 func (ds *inMemoryDataSourceCache) updateCache(ctx context.Context) error {
@@ -322,7 +322,7 @@ func (ds *inMemoryDataSourceCache) updateCache(ctx context.Context) error {
 	ds.latestUpdateErr = nil
 
 	// backup in case data source fails continuously and node gets rebooted
-	timePairBytes, err := json.Marshal(&ResultTimePair{Result: *serializablebig.New(value), Time: time.Now()})
+	timePairBytes, err := json.Marshal(&ResultTimePair{Result: *sqlutil.New(value), Time: time.Now()})
 	if err != nil {
 		return fmt.Errorf("failed to marshal result time pair, err: %w", err)
 	}

--- a/core/services/ocrcommon/data_source_test.go
+++ b/core/services/ocrcommon/data_source_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	serializablebig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
@@ -107,7 +106,7 @@ func Test_CachedInMemoryDataSourceErrHandling(t *testing.T) {
 		ds := ocrcommon.NewInMemoryDataSource(runner, job.Job{}, pipeline.Spec{}, logger.TestLogger(t))
 
 		mockKVStore := mocks.KVStore{}
-		persistedVal := serializablebig.NewI(1337)
+		persistedVal := sqlutil.NewI(1337)
 
 		result, err := json.Marshal(&ocrcommon.ResultTimePair{Result: *persistedVal, Time: time.Now()})
 		assert.NoError(t, err)

--- a/core/services/ocrcommon/telemetry_test.go
+++ b/core/services/ocrcommon/telemetry_test.go
@@ -16,13 +16,13 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/mercury"
 	mercuryv1 "github.com/smartcontractkit/chainlink-common/pkg/types/mercury/v1"
 	mercuryv2 "github.com/smartcontractkit/chainlink-common/pkg/types/mercury/v2"
 	mercuryv4 "github.com/smartcontractkit/chainlink-common/pkg/types/mercury/v4"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
@@ -152,7 +152,7 @@ func TestGetChainID(t *testing.T) {
 	}
 
 	j.Type = job.Type(pipeline.OffchainReportingJobType)
-	j.OCROracleSpec.EVMChainID = (*ubig.Big)(big.NewInt(1234567890))
+	j.OCROracleSpec.EVMChainID = (*sqlutil.Big)(big.NewInt(1234567890))
 	assert.Equal(t, "1234567890", e.getChainID())
 
 	j.Type = job.Type(pipeline.OffchainReporting2JobType)
@@ -303,7 +303,7 @@ func TestSendEATelemetry(t *testing.T) {
 		OCROracleSpec: &job.OCROracleSpec{
 			ContractAddress:    evmtypes.EIP55AddressFromAddress(feedAddress),
 			CaptureEATelemetry: true,
-			EVMChainID:         (*ubig.Big)(big.NewInt(9)),
+			EVMChainID:         (*sqlutil.Big)(big.NewInt(9)),
 		},
 	}
 

--- a/core/services/pipeline/orm_test.go
+++ b/core/services/pipeline/orm_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/hex"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/jsonserializable"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
-
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -158,7 +156,7 @@ answer2 [type=bridge name=election_winner index=1];
 		MaxTaskDuration: sqlutil.Interval(1 * time.Minute),
 		DirectRequestSpec: &job.DirectRequestSpec{
 			ContractAddress: cltest.NewEIP55Address(),
-			EVMChainID:      (*big.Big)(&cltest.FixtureChainID),
+			EVMChainID:      (*sqlutil.Big)(&cltest.FixtureChainID),
 		},
 		PipelineSpec: &pipeline.Spec{
 			DotDagSource: s,
@@ -260,7 +258,7 @@ answer2 [type=bridge name=election_winner index=1];
 		MaxTaskDuration: sqlutil.Interval(1 * time.Minute),
 		DirectRequestSpec: &job.DirectRequestSpec{
 			ContractAddress: cltest.NewEIP55Address(),
-			EVMChainID:      (*big.Big)(&cltest.FixtureChainID),
+			EVMChainID:      (*sqlutil.Big)(&cltest.FixtureChainID),
 		},
 		PipelineSpec: &pipeline.Spec{
 			DotDagSource: s,
@@ -667,7 +665,7 @@ func Test_GetUnfinishedRuns_Keepers(t *testing.T) {
 			FromAddress:     cltest.NewEIP55Address(),
 			CreatedAt:       timestamp,
 			UpdatedAt:       timestamp,
-			EVMChainID:      (*big.Big)(&cltest.FixtureChainID),
+			EVMChainID:      (*sqlutil.Big)(&cltest.FixtureChainID),
 		},
 		ExternalJobID: uuid.MustParse("0EEC7E1D-D0D2-476C-A1A8-72DFB6633F46"),
 		PipelineSpec: &pipeline.Spec{
@@ -769,7 +767,7 @@ func Test_GetUnfinishedRuns_DirectRequest(t *testing.T) {
 			ContractAddress: cltest.NewEIP55Address(),
 			CreatedAt:       timestamp,
 			UpdatedAt:       timestamp,
-			EVMChainID:      (*big.Big)(&cltest.FixtureChainID),
+			EVMChainID:      (*sqlutil.Big)(&cltest.FixtureChainID),
 		},
 		ExternalJobID: uuid.MustParse("0EEC7E1D-D0D2-476C-A1A8-72DFB6633F46"),
 		PipelineSpec: &pipeline.Spec{

--- a/core/services/relay/evm/median_test.go
+++ b/core/services/relay/evm/median_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/common/chains/mocks"
 )
@@ -37,7 +37,7 @@ func TestNewMedianProvider(t *testing.T) {
 	})
 
 	t.Run("invalid contractID", func(t *testing.T) {
-		relayConfig := config.RelayConfig{ChainID: big.New(chainID)}
+		relayConfig := config.RelayConfig{ChainID: sqlutil.New(chainID)}
 		rc, err2 := json.Marshal(&relayConfig)
 		require.NoError(t, err2)
 		rargsBadContractID := commontypes.RelayArgs{ContractID: "NotAContractID", RelayConfig: rc}

--- a/core/services/s4/address_range.go
+++ b/core/services/s4/address_range.go
@@ -7,21 +7,22 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/big_math"
 )
 
 // AddressRange represents a range of Ethereum addresses.
 type AddressRange struct {
 	// MinAddress (inclusive).
-	MinAddress *ubig.Big
+	MinAddress *sqlutil.Big
 	// MaxAddress (inclusive).
-	MaxAddress *ubig.Big
+	MaxAddress *sqlutil.Big
 }
 
 var (
 	ErrInvalidIntervals = errors.New("invalid intervals value")
-	MinAddress          = ubig.New(common.BytesToAddress(bytes.Repeat([]byte{0x00}, common.AddressLength)).Big())
-	MaxAddress          = ubig.New(common.BytesToAddress(bytes.Repeat([]byte{0xff}, common.AddressLength)).Big())
+	MinAddress          = sqlutil.New(common.BytesToAddress(bytes.Repeat([]byte{0x00}, common.AddressLength)).Big())
+	MaxAddress          = sqlutil.New(common.BytesToAddress(bytes.Repeat([]byte{0xff}, common.AddressLength)).Big())
 )
 
 // NewFullAddressRange creates AddressRange for all address space: 0x00..-0xFF..
@@ -33,8 +34,8 @@ func NewFullAddressRange() *AddressRange {
 }
 
 // NewSingleAddressRange creates AddressRange for a single address.
-func NewSingleAddressRange(address *ubig.Big) (*AddressRange, error) {
-	if address == nil || address.Cmp(MinAddress) < 0 || address.Cmp(MaxAddress) > 0 {
+func NewSingleAddressRange(address *sqlutil.Big) (*AddressRange, error) {
+	if address == nil || address.ToInt().Cmp(MinAddress.ToInt()) < 0 || address.ToInt().Cmp(MaxAddress.ToInt()) > 0 {
 		return nil, errors.New("invalid address")
 	}
 	return &AddressRange{
@@ -56,12 +57,12 @@ func NewInitialAddressRangeForIntervals(intervals uint) (*AddressRange, error) {
 	}
 
 	divisor := big.NewInt(int64(intervals))
-	maxPlusOne := MaxAddress.Add(ubig.NewI(1))
-	interval := ubig.New(new(big.Int).Div(maxPlusOne.ToInt(), divisor))
+	maxPlusOne := bigmath.Add(MaxAddress.ToInt(), big.NewInt(1))
+	interval := bigmath.Div(maxPlusOne, divisor)
 
 	return &AddressRange{
 		MinAddress: MinAddress,
-		MaxAddress: MinAddress.Add(interval).Sub(ubig.NewI(1)),
+		MaxAddress: sqlutil.New(bigmath.Sub(bigmath.Add(MinAddress.ToInt(), interval), big.NewInt(1))),
 	}, nil
 }
 
@@ -75,31 +76,31 @@ func (r *AddressRange) Advance() {
 
 	interval := r.Interval()
 
-	r.MinAddress = r.MinAddress.Add(interval)
-	r.MaxAddress = r.MaxAddress.Add(interval)
+	r.MinAddress = sqlutil.New(bigmath.Add(r.MinAddress.ToInt(), interval.ToInt()))
+	r.MaxAddress = sqlutil.New(bigmath.Add(r.MaxAddress.ToInt(), interval.ToInt()))
 
-	if r.MinAddress.Cmp(MaxAddress) >= 0 {
+	if r.MinAddress.ToInt().Cmp(MaxAddress.ToInt()) >= 0 {
 		r.MinAddress = MinAddress
-		r.MaxAddress = MinAddress.Add(interval).Sub(ubig.NewI(1))
+		r.MaxAddress = sqlutil.New(bigmath.Sub(bigmath.Add(MinAddress.ToInt(), interval.ToInt()), big.NewInt(1)))
 	}
 
-	if r.MaxAddress.Cmp(MaxAddress) > 0 {
+	if r.MaxAddress.ToInt().Cmp(MaxAddress.ToInt()) > 0 {
 		r.MaxAddress = MaxAddress
 	}
 }
 
 // Contains returns true if the given address belongs to the range.
-func (r *AddressRange) Contains(address *ubig.Big) bool {
+func (r *AddressRange) Contains(address *sqlutil.Big) bool {
 	if r == nil {
 		return false
 	}
-	return r.MinAddress.Cmp(address) <= 0 && r.MaxAddress.Cmp(address) >= 0
+	return r.MinAddress.ToInt().Cmp(address.ToInt()) <= 0 && r.MaxAddress.ToInt().Cmp(address.ToInt()) >= 0
 }
 
 // Interval returns the interval between max and min address plus one.
-func (r *AddressRange) Interval() *ubig.Big {
+func (r *AddressRange) Interval() *sqlutil.Big {
 	if r == nil {
 		return nil
 	}
-	return r.MaxAddress.Sub(r.MinAddress).Add(ubig.NewI(1))
+	return sqlutil.New(bigmath.Add(bigmath.Sub(r.MaxAddress.ToInt(), r.MinAddress.ToInt()), big.NewInt(1)))
 }

--- a/core/services/s4/address_range.go
+++ b/core/services/s4/address_range.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/big_math"
+	bigmath "github.com/smartcontractkit/chainlink-common/pkg/utils/big_math"
 )
 
 // AddressRange represents a range of Ethereum addresses.
@@ -62,7 +62,7 @@ func NewInitialAddressRangeForIntervals(intervals uint) (*AddressRange, error) {
 
 	return &AddressRange{
 		MinAddress: MinAddress,
-		MaxAddress: sqlutil.New(bigmath.Sub(bigmath.Add(MinAddress.ToInt(), interval), big.NewInt(1))),
+		MaxAddress: sub(add(MinAddress, sqlutil.New(interval)), sqlutil.NewI(1)),
 	}, nil
 }
 
@@ -76,12 +76,12 @@ func (r *AddressRange) Advance() {
 
 	interval := r.Interval()
 
-	r.MinAddress = sqlutil.New(bigmath.Add(r.MinAddress.ToInt(), interval.ToInt()))
-	r.MaxAddress = sqlutil.New(bigmath.Add(r.MaxAddress.ToInt(), interval.ToInt()))
+	r.MinAddress = add(r.MinAddress, interval)
+	r.MaxAddress = add(r.MaxAddress, interval)
 
 	if r.MinAddress.ToInt().Cmp(MaxAddress.ToInt()) >= 0 {
 		r.MinAddress = MinAddress
-		r.MaxAddress = sqlutil.New(bigmath.Sub(bigmath.Add(MinAddress.ToInt(), interval.ToInt()), big.NewInt(1)))
+		r.MaxAddress = sub(add(MinAddress, interval), sqlutil.NewI(1))
 	}
 
 	if r.MaxAddress.ToInt().Cmp(MaxAddress.ToInt()) > 0 {
@@ -102,5 +102,13 @@ func (r *AddressRange) Interval() *sqlutil.Big {
 	if r == nil {
 		return nil
 	}
-	return sqlutil.New(bigmath.Add(bigmath.Sub(r.MaxAddress.ToInt(), r.MinAddress.ToInt()), big.NewInt(1)))
+	return sub(add(r.MaxAddress, r.MinAddress), sqlutil.NewI(1))
+}
+
+func sub(a, b *sqlutil.Big) *sqlutil.Big {
+	return sqlutil.New(bigmath.Sub(a.ToInt(), b.ToInt()))
+}
+
+func add(a, b *sqlutil.Big) *sqlutil.Big {
+	return sqlutil.New(bigmath.Add(a.ToInt(), b.ToInt()))
 }

--- a/core/services/s4/address_range.go
+++ b/core/services/s4/address_range.go
@@ -102,7 +102,7 @@ func (r *AddressRange) Interval() *sqlutil.Big {
 	if r == nil {
 		return nil
 	}
-	return sub(add(r.MaxAddress, r.MinAddress), sqlutil.NewI(1))
+	return add(sub(r.MaxAddress, r.MinAddress), sqlutil.NewI(1))
 }
 
 func sub(a, b *sqlutil.Big) *sqlutil.Big {

--- a/core/services/s4/address_range_test.go
+++ b/core/services/s4/address_range_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
@@ -61,8 +62,8 @@ func TestAddressRange_NewInitialAddressRangeForIntervals(t *testing.T) {
 	t.Run("initial range for 256 intervals", func(t *testing.T) {
 		r, err := s4.NewInitialAddressRangeForIntervals(256)
 		assert.NoError(t, err)
-		assert.Equal(t, "0x0", r.MinAddress.Hex())
-		assert.Equal(t, "0xffffffffffffffffffffffffffffffffffffff", r.MaxAddress.Hex())
+		assert.Equal(t, "0x0", hex(r.MinAddress))
+		assert.Equal(t, "0xffffffffffffffffffffffffffffffffffffff", hex(r.MaxAddress))
 	})
 
 	t.Run("advance for 256 intervals", func(t *testing.T) {
@@ -70,23 +71,23 @@ func TestAddressRange_NewInitialAddressRangeForIntervals(t *testing.T) {
 		assert.NoError(t, err)
 
 		r.Advance()
-		assert.Equal(t, "0x100000000000000000000000000000000000000", r.MinAddress.Hex())
-		assert.Equal(t, "0x1ffffffffffffffffffffffffffffffffffffff", r.MaxAddress.Hex())
+		assert.Equal(t, "0x100000000000000000000000000000000000000", hex(r.MinAddress))
+		assert.Equal(t, "0x1ffffffffffffffffffffffffffffffffffffff", hex(r.MaxAddress))
 
 		r.Advance()
-		assert.Equal(t, "0x200000000000000000000000000000000000000", r.MinAddress.Hex())
-		assert.Equal(t, "0x2ffffffffffffffffffffffffffffffffffffff", r.MaxAddress.Hex())
+		assert.Equal(t, "0x200000000000000000000000000000000000000", hex(r.MinAddress))
+		assert.Equal(t, "0x2ffffffffffffffffffffffffffffffffffffff", hex(r.MaxAddress))
 
 		for range 253 {
 			r.Advance()
 		}
-		assert.Equal(t, "0xff00000000000000000000000000000000000000", r.MinAddress.Hex())
-		assert.Equal(t, "0xffffffffffffffffffffffffffffffffffffffff", r.MaxAddress.Hex())
+		assert.Equal(t, "0xff00000000000000000000000000000000000000", hex(r.MinAddress))
+		assert.Equal(t, "0xffffffffffffffffffffffffffffffffffffffff", hex(r.MaxAddress))
 
 		// initial
 		r.Advance()
 		assert.Equal(t, s4.MinAddress, r.MinAddress)
-		assert.Equal(t, "0xffffffffffffffffffffffffffffffffffffff", r.MaxAddress.Hex())
+		assert.Equal(t, "0xffffffffffffffffffffffffffffffffffffff", hex(r.MaxAddress))
 	})
 }
 
@@ -103,4 +104,8 @@ func TestAddressRange_Contains(t *testing.T) {
 	assert.True(t, r.Contains(r.MinAddress))
 	assert.True(t, r.Contains(r.MaxAddress))
 	assert.False(t, r.Contains(sqlutil.New(bigmath.Sub(r.MinAddress.ToInt(), big.NewInt(1)))))
+}
+
+func hex(b *sqlutil.Big) string {
+	return hexutil.EncodeBig(b.ToInt())
 }

--- a/core/services/s4/address_range_test.go
+++ b/core/services/s4/address_range_test.go
@@ -4,11 +4,12 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/big_math"
-	"github.com/smartcontractkit/chainlink/v2/core/services/s4"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/smartcontractkit/chainlink/v2/core/services/s4"
 )
 
 func TestAddressRange_NewFullAddressRange(t *testing.T) {

--- a/core/services/s4/address_range_test.go
+++ b/core/services/s4/address_range_test.go
@@ -4,11 +4,12 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/big_math"
+	bigmath "github.com/smartcontractkit/chainlink-common/pkg/utils/big_math"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/s4"
 )

--- a/core/services/s4/address_range_test.go
+++ b/core/services/s4/address_range_test.go
@@ -1,9 +1,11 @@
 package s4_test
 
 import (
+	"math/big"
 	"testing"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/big_math"
 	"github.com/smartcontractkit/chainlink/v2/core/services/s4"
 
 	"github.com/stretchr/testify/assert"
@@ -26,13 +28,13 @@ func TestAddressRange_NewFullAddressRange(t *testing.T) {
 func TestAddressRange_NewSingleAddressRange(t *testing.T) {
 	t.Parallel()
 
-	addr := big.NewI(0x123)
+	addr := sqlutil.NewI(0x123)
 	sar, err := s4.NewSingleAddressRange(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, addr, sar.MinAddress)
 	assert.Equal(t, addr, sar.MaxAddress)
 	assert.True(t, sar.Contains(addr))
-	assert.Equal(t, int64(1), sar.Interval().Int64())
+	assert.Equal(t, int64(1), sar.Interval().ToInt().Int64())
 
 	sar.Advance()
 	assert.False(t, sar.Contains(addr))
@@ -94,10 +96,10 @@ func TestAddressRange_Contains(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, r.Contains(r.MinAddress))
 	assert.True(t, r.Contains(r.MaxAddress))
-	assert.False(t, r.Contains(r.MaxAddress.Add(big.NewI(1))))
+	assert.False(t, r.Contains(sqlutil.New(bigmath.Add(r.MaxAddress.ToInt(), big.NewInt(1)))))
 
 	r.Advance()
 	assert.True(t, r.Contains(r.MinAddress))
 	assert.True(t, r.Contains(r.MaxAddress))
-	assert.False(t, r.Contains(r.MinAddress.Sub(big.NewI(1))))
+	assert.False(t, r.Contains(sqlutil.New(bigmath.Sub(r.MinAddress.ToInt(), big.NewInt(1)))))
 }

--- a/core/services/s4/cached_orm_wrapper.go
+++ b/core/services/s4/cached_orm_wrapper.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/patrickmn/go-cache"
 
-	ubig "github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
@@ -40,7 +40,7 @@ func NewCachedORMWrapper(orm ORM, lggr logger.Logger) *CachedORM {
 	}
 }
 
-func (c CachedORM) Get(ctx context.Context, address *ubig.Big, slotId uint) (*Row, error) {
+func (c CachedORM) Get(ctx context.Context, address *sqlutil.Big, slotId uint) (*Row, error) {
 	return c.underlayingORM.Get(ctx, address, slotId)
 }
 

--- a/core/services/s4/cached_orm_wrapper.go
+++ b/core/services/s4/cached_orm_wrapper.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/patrickmn/go-cache"
 
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	ubig "github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 

--- a/core/services/s4/cached_orm_wrapper_test.go
+++ b/core/services/s4/cached_orm_wrapper_test.go
@@ -11,8 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -101,7 +100,7 @@ func TestUpdateInvalidatesSnapshotCache(t *testing.T) {
 
 		// this update call will invalidate the cache
 		row := &s4.Row{
-			Address:    big.New(common.HexToAddress("0x0000000000000000000000000000000000000000000000000000000000000005").Big()),
+			Address:    sqlutil.New(common.HexToAddress("0x0000000000000000000000000000000000000000000000000000000000000005").Big()),
 			SlotId:     1,
 			Payload:    cltest.MustRandomBytes(t, 32),
 			Version:    1,
@@ -125,8 +124,8 @@ func TestUpdateInvalidatesSnapshotCache(t *testing.T) {
 		rows := generateTestSnapshotRows(t, 5)
 
 		addressRange := &s4.AddressRange{
-			MinAddress: ubig.New(common.BytesToAddress(bytes.Repeat([]byte{0x00}, common.AddressLength)).Big()),
-			MaxAddress: ubig.New(common.BytesToAddress(append(bytes.Repeat([]byte{0x00}, common.AddressLength-1), 3)).Big()),
+			MinAddress: sqlutil.New(common.BytesToAddress(bytes.Repeat([]byte{0x00}, common.AddressLength)).Big()),
+			MaxAddress: sqlutil.New(common.BytesToAddress(append(bytes.Repeat([]byte{0x00}, common.AddressLength-1), 3)).Big()),
 		}
 
 		lggr := logger.TestLogger(t)
@@ -146,7 +145,7 @@ func TestUpdateInvalidatesSnapshotCache(t *testing.T) {
 		assert.Len(t, cache_snapshot, len(rows))
 
 		// this update call wont invalidate the cache because the address is out of the cache address range
-		outOfCachedRangeAddress := ubig.New(common.BytesToAddress(append(bytes.Repeat([]byte{0x00}, common.AddressLength-1), 5)).Big())
+		outOfCachedRangeAddress := sqlutil.New(common.BytesToAddress(append(bytes.Repeat([]byte{0x00}, common.AddressLength-1), 5)).Big())
 		row := &s4.Row{
 			Address:    outOfCachedRangeAddress,
 			SlotId:     1,
@@ -168,7 +167,7 @@ func TestUpdateInvalidatesSnapshotCache(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	address := big.New(testutils.NewAddress().Big())
+	address := sqlutil.New(testutils.NewAddress().Big())
 	var slotID uint = 1
 
 	lggr := logger.TestLogger(t)
@@ -236,7 +235,7 @@ func TestGetUnconfirmedRows(t *testing.T) {
 
 	t.Run("OK-GetUnconfirmedRows_underlaying_ORM_returns_a_row", func(t *testing.T) {
 		ctx := testutils.Context(t)
-		address := big.New(testutils.NewAddress().Big())
+		address := sqlutil.New(testutils.NewAddress().Big())
 		var slotID uint = 1
 
 		expectedRow := []*s4.Row{{
@@ -269,7 +268,7 @@ func generateTestSnapshotRows(t *testing.T, n int) []*s4.SnapshotRow {
 	rows := make([]*s4.SnapshotRow, n)
 	for i := range n {
 		row := &s4.SnapshotRow{
-			Address:     big.New(testutils.NewAddress().Big()),
+			Address:     sqlutil.New(testutils.NewAddress().Big()),
 			SlotId:      1,
 			PayloadSize: 32,
 			Version:     1 + uint64(i),

--- a/core/services/s4/in_memory_orm.go
+++ b/core/services/s4/in_memory_orm.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 )
 
 type key struct {
@@ -32,7 +32,7 @@ func NewInMemoryORM() ORM {
 	}
 }
 
-func (o *inMemoryOrm) Get(ctx context.Context, address *big.Big, slotId uint) (*Row, error) {
+func (o *inMemoryOrm) Get(ctx context.Context, address *sqlutil.Big, slotId uint) (*Row, error) {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
 
@@ -103,7 +103,7 @@ func (o *inMemoryOrm) GetSnapshot(ctx context.Context, _ *AddressRange) ([]*Snap
 	for _, mrow := range o.rows {
 		if mrow.Row.Expiration > now {
 			rows = append(rows, &SnapshotRow{
-				Address:    big.New(mrow.Row.Address.ToInt()),
+				Address:    sqlutil.New(mrow.Row.Address.ToInt()),
 				SlotId:     mrow.Row.SlotId,
 				Version:    mrow.Row.Version,
 				Expiration: mrow.Row.Expiration,

--- a/core/services/s4/in_memory_orm.go
+++ b/core/services/s4/in_memory_orm.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 )
 
@@ -37,7 +39,7 @@ func (o *inMemoryOrm) Get(ctx context.Context, address *sqlutil.Big, slotId uint
 	defer o.mu.RUnlock()
 
 	mkey := key{
-		address: address.Hex(),
+		address: hexutil.EncodeBig(address.ToInt()),
 		slot:    slotId,
 	}
 	mrow, ok := o.rows[mkey]
@@ -52,7 +54,7 @@ func (o *inMemoryOrm) Update(ctx context.Context, row *Row) error {
 	defer o.mu.Unlock()
 
 	mkey := key{
-		address: row.Address.Hex(),
+		address: hexutil.EncodeBig(row.Address.ToInt()),
 		slot:    row.SlotId,
 	}
 	existing, ok := o.rows[mkey]

--- a/core/services/s4/in_memory_orm_test.go
+++ b/core/services/s4/in_memory_orm_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/s4"
 
@@ -21,7 +21,7 @@ func TestInMemoryORM(t *testing.T) {
 	signature := testutils.Random32Byte()
 	expiration := time.Now().Add(time.Minute).UnixMilli()
 	row := &s4.Row{
-		Address:    big.New(address.Big()),
+		Address:    sqlutil.New(address.Big()),
 		SlotId:     slotId,
 		Payload:    payload[:],
 		Version:    3,
@@ -34,7 +34,7 @@ func TestInMemoryORM(t *testing.T) {
 
 	t.Run("row not found", func(t *testing.T) {
 		ctx := testutils.Context(t)
-		_, err := orm.Get(ctx, big.New(address.Big()), slotId)
+		_, err := orm.Get(ctx, sqlutil.New(address.Big()), slotId)
 		assert.ErrorIs(t, err, s4.ErrNotFound)
 	})
 
@@ -43,7 +43,7 @@ func TestInMemoryORM(t *testing.T) {
 		err := orm.Update(ctx, row)
 		assert.NoError(t, err)
 
-		e, err := orm.Get(ctx, big.New(address.Big()), slotId)
+		e, err := orm.Get(ctx, sqlutil.New(address.Big()), slotId)
 		assert.NoError(t, err)
 		assert.Equal(t, row, e)
 	})
@@ -62,7 +62,7 @@ func TestInMemoryORM(t *testing.T) {
 		err = orm.Update(ctx, row)
 		assert.NoError(t, err)
 
-		e, err := orm.Get(ctx, big.New(address.Big()), slotId)
+		e, err := orm.Get(ctx, sqlutil.New(address.Big()), slotId)
 		assert.NoError(t, err)
 		assert.Equal(t, row, e)
 	})
@@ -80,7 +80,7 @@ func TestInMemoryORM_DeleteExpired(t *testing.T) {
 		thisAddress[0] = byte(i)
 
 		row := &s4.Row{
-			Address:    big.New(thisAddress.Big()),
+			Address:    sqlutil.New(thisAddress.Big()),
 			SlotId:     1,
 			Payload:    []byte{},
 			Version:    1,
@@ -114,7 +114,7 @@ func TestInMemoryORM_GetUnconfirmedRows(t *testing.T) {
 		thisAddress[0] = byte(i)
 
 		row := &s4.Row{
-			Address:    big.New(thisAddress.Big()),
+			Address:    sqlutil.New(thisAddress.Big()),
 			SlotId:     1,
 			Payload:    []byte{},
 			Version:    1,
@@ -145,7 +145,7 @@ func TestInMemoryORM_GetSnapshot(t *testing.T) {
 		thisAddress[0] = byte(i)
 
 		row := &s4.Row{
-			Address:    big.New(thisAddress.Big()),
+			Address:    sqlutil.New(thisAddress.Big()),
 			SlotId:     1,
 			Payload:    []byte{},
 			Version:    uint64(i),

--- a/core/services/s4/mocks/orm.go
+++ b/core/services/s4/mocks/orm.go
@@ -5,7 +5,7 @@ package mocks
 import (
 	context "context"
 
-	big "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	sqlutil "github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
 	mock "github.com/stretchr/testify/mock"
 
@@ -86,7 +86,7 @@ func (_c *ORM_DeleteExpired_Call) RunAndReturn(run func(context.Context, uint, t
 }
 
 // Get provides a mock function with given fields: ctx, address, slotId
-func (_m *ORM) Get(ctx context.Context, address *big.Big, slotId uint) (*s4.Row, error) {
+func (_m *ORM) Get(ctx context.Context, address *sqlutil.Big, slotId uint) (*s4.Row, error) {
 	ret := _m.Called(ctx, address, slotId)
 
 	if len(ret) == 0 {
@@ -95,10 +95,10 @@ func (_m *ORM) Get(ctx context.Context, address *big.Big, slotId uint) (*s4.Row,
 
 	var r0 *s4.Row
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *big.Big, uint) (*s4.Row, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *sqlutil.Big, uint) (*s4.Row, error)); ok {
 		return rf(ctx, address, slotId)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *big.Big, uint) *s4.Row); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *sqlutil.Big, uint) *s4.Row); ok {
 		r0 = rf(ctx, address, slotId)
 	} else {
 		if ret.Get(0) != nil {
@@ -106,7 +106,7 @@ func (_m *ORM) Get(ctx context.Context, address *big.Big, slotId uint) (*s4.Row,
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *big.Big, uint) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *sqlutil.Big, uint) error); ok {
 		r1 = rf(ctx, address, slotId)
 	} else {
 		r1 = ret.Error(1)
@@ -122,15 +122,15 @@ type ORM_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - ctx context.Context
-//   - address *big.Big
+//   - address *sqlutil.Big
 //   - slotId uint
 func (_e *ORM_Expecter) Get(ctx interface{}, address interface{}, slotId interface{}) *ORM_Get_Call {
 	return &ORM_Get_Call{Call: _e.mock.On("Get", ctx, address, slotId)}
 }
 
-func (_c *ORM_Get_Call) Run(run func(ctx context.Context, address *big.Big, slotId uint)) *ORM_Get_Call {
+func (_c *ORM_Get_Call) Run(run func(ctx context.Context, address *sqlutil.Big, slotId uint)) *ORM_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*big.Big), args[2].(uint))
+		run(args[0].(context.Context), args[1].(*sqlutil.Big), args[2].(uint))
 	})
 	return _c
 }
@@ -140,7 +140,7 @@ func (_c *ORM_Get_Call) Return(_a0 *s4.Row, _a1 error) *ORM_Get_Call {
 	return _c
 }
 
-func (_c *ORM_Get_Call) RunAndReturn(run func(context.Context, *big.Big, uint) (*s4.Row, error)) *ORM_Get_Call {
+func (_c *ORM_Get_Call) RunAndReturn(run func(context.Context, *sqlutil.Big, uint) (*s4.Row, error)) *ORM_Get_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/services/s4/mocks/orm.go
+++ b/core/services/s4/mocks/orm.go
@@ -5,11 +5,10 @@ package mocks
 import (
 	context "context"
 
-	sqlutil "github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-
+	s4 "github.com/smartcontractkit/chainlink/v2/core/services/s4"
 	mock "github.com/stretchr/testify/mock"
 
-	s4 "github.com/smartcontractkit/chainlink/v2/core/services/s4"
+	sqlutil "github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
 	time "time"
 )

--- a/core/services/s4/orm.go
+++ b/core/services/s4/orm.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 )
 
 // Row represents a data row persisted by ORM.
 type Row struct {
-	Address    *big.Big
+	Address    *sqlutil.Big
 	SlotId     uint
 	Payload    []byte
 	Version    uint64
@@ -20,7 +20,7 @@ type Row struct {
 
 // SnapshotRow(s) are returned by GetSnapshot function.
 type SnapshotRow struct {
-	Address     *big.Big
+	Address     *sqlutil.Big
 	SlotId      uint
 	Version     uint64
 	Expiration  int64
@@ -34,7 +34,7 @@ type ORM interface {
 	// Get reads a row for the given address and slotId combination.
 	// If such row does not exist, ErrNotFound is returned.
 	// There is no filter on Expiration.
-	Get(ctx context.Context, address *big.Big, slotId uint) (*Row, error)
+	Get(ctx context.Context, address *sqlutil.Big, slotId uint) (*Row, error)
 
 	// Update inserts or updates the row identified by (Address, SlotId) pair.
 	// When updating, the new row must have greater or equal version,
@@ -58,7 +58,7 @@ type ORM interface {
 
 func (r Row) Clone() *Row {
 	clone := Row{
-		Address:    big.New(r.Address.ToInt()),
+		Address:    sqlutil.New(r.Address.ToInt()),
 		SlotId:     r.SlotId,
 		Payload:    make([]byte, len(r.Payload)),
 		Version:    r.Version,

--- a/core/services/s4/postgres_orm.go
+++ b/core/services/s4/postgres_orm.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 )
 
 const (
@@ -33,7 +32,7 @@ func NewPostgresORM(ds sqlutil.DataSource, tableName, namespace string) ORM {
 	}
 }
 
-func (o *orm) Get(ctx context.Context, address *big.Big, slotId uint) (*Row, error) {
+func (o *orm) Get(ctx context.Context, address *sqlutil.Big, slotId uint) (*Row, error) {
 	row := &Row{}
 
 	stmt := fmt.Sprintf(`SELECT address, slot_id, version, expiration, confirmed, payload, signature FROM %s 

--- a/core/services/s4/postgres_orm_test.go
+++ b/core/services/s4/postgres_orm_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
@@ -34,7 +34,7 @@ func generateTestRows(t *testing.T, n int) []*s4.Row {
 	rows := make([]*s4.Row, n)
 	for i := range n {
 		row := &s4.Row{
-			Address:    big.New(testutils.NewAddress().Big()),
+			Address:    sqlutil.New(testutils.NewAddress().Big()),
 			SlotId:     1,
 			Payload:    cltest.MustRandomBytes(t, 32),
 			Version:    1 + uint64(i),

--- a/core/services/s4/storage.go
+++ b/core/services/s4/storage.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
@@ -91,7 +91,7 @@ func (s *storage) Get(ctx context.Context, key *Key) (*Record, *Metadata, error)
 		return nil, nil, ErrSlotIdTooBig
 	}
 
-	bigAddress := big.New(key.Address.Big())
+	bigAddress := sqlutil.New(key.Address.Big())
 	row, err := s.orm.Get(ctx, bigAddress, key.SlotId)
 	if err != nil {
 		return nil, nil, err
@@ -117,7 +117,7 @@ func (s *storage) Get(ctx context.Context, key *Key) (*Record, *Metadata, error)
 }
 
 func (s *storage) List(ctx context.Context, address common.Address) ([]*SnapshotRow, error) {
-	bigAddress := big.New(address.Big())
+	bigAddress := sqlutil.New(address.Big())
 	sar, err := NewSingleAddressRange(bigAddress)
 	if err != nil {
 		return nil, err
@@ -147,7 +147,7 @@ func (s *storage) Put(ctx context.Context, key *Key, record *Record, signature [
 	}
 
 	row := &Row{
-		Address:    big.New(key.Address.Big()),
+		Address:    sqlutil.New(key.Address.Big()),
 		SlotId:     key.SlotId,
 		Payload:    make([]byte, len(record.Payload)),
 		Version:    key.Version,

--- a/core/services/s4/storage_test.go
+++ b/core/services/s4/storage_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/jonboulle/clockwork"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/s4"
@@ -53,7 +53,7 @@ func TestStorage_Errors(t *testing.T) {
 			SlotId:  1,
 			Version: 0,
 		}
-		ormMock.On("Get", mock.Anything, big.New(key.Address.Big()), key.SlotId).Return(nil, s4.ErrNotFound)
+		ormMock.On("Get", mock.Anything, sqlutil.New(key.Address.Big()), key.SlotId).Return(nil, s4.ErrNotFound)
 		_, _, err := storage.Get(testutils.Context(t), key)
 		assert.ErrorIs(t, err, s4.ErrNotFound)
 	})
@@ -181,8 +181,8 @@ func TestStorage_PutAndGet(t *testing.T) {
 	assert.NoError(t, err)
 
 	ormMock.On("Update", mock.Anything, mock.Anything).Return(nil)
-	ormMock.On("Get", mock.Anything, big.New(key.Address.Big()), uint(2)).Return(&s4.Row{
-		Address:    big.New(key.Address.Big()),
+	ormMock.On("Get", mock.Anything, sqlutil.New(key.Address.Big()), uint(2)).Return(&s4.Row{
+		Address:    sqlutil.New(key.Address.Big()),
 		SlotId:     key.SlotId,
 		Version:    key.Version,
 		Payload:    record.Payload,
@@ -219,7 +219,7 @@ func TestStorage_List(t *testing.T) {
 		},
 	}
 
-	addressRange, err := s4.NewSingleAddressRange(big.New(address.Big()))
+	addressRange, err := s4.NewSingleAddressRange(sqlutil.New(address.Big()))
 	assert.NoError(t, err)
 	ormMock.On("GetSnapshot", mock.Anything, addressRange).Return(ormRows, nil)
 

--- a/core/services/vrf/v1/integration_test.go
+++ b/core/services/vrf/v1/integration_test.go
@@ -16,10 +16,10 @@ import (
 	"gopkg.in/guregu/null.v4"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/solidity_vrf_coordinator_interface"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
@@ -52,7 +52,7 @@ func TestIntegration_VRF_JPV2(t *testing.T) {
 			ctx := testutils.Context(t)
 			config, _ := heavyweight.FullTestDBV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 				c.EVM[0].GasEstimator.EIP1559DynamicFees = &test.eip1559
-				c.EVM[0].ChainID = (*ubig.Big)(testutils.SimulatedChainID)
+				c.EVM[0].ChainID = (*sqlutil.Big)(testutils.SimulatedChainID)
 			})
 			key1 := cltest.MustGenerateRandomKey(t)
 			key2 := cltest.MustGenerateRandomKey(t)
@@ -140,7 +140,7 @@ func TestIntegration_VRF_WithBHS(t *testing.T) {
 		c.Feature.LogPoller = ptr(true)
 		c.EVM[0].FinalityDepth = ptr[uint32](2)
 		c.EVM[0].LogPollInterval = commonconfig.MustNewDuration(time.Second)
-		c.EVM[0].ChainID = (*ubig.Big)(testutils.SimulatedChainID)
+		c.EVM[0].ChainID = (*sqlutil.Big)(testutils.SimulatedChainID)
 	})
 	key := cltest.MustGenerateRandomKey(t)
 	cu := vrftesthelpers.NewVRFCoordinatorUniverse(t, key)

--- a/core/services/vrf/v2/integration_helpers_test.go
+++ b/core/services/vrf/v2/integration_helpers_test.go
@@ -16,17 +16,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
-	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/vrf_consumer_v2_upgradeable_example"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/vrf_external_sub_owner_example"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/vrfv2_transparent_upgradeable_proxy"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
+	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	v2 "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -558,7 +558,7 @@ func testSingleConsumerHappyPathBatchFulfillment(
 		})(c, s)
 		c.EVM[0].GasEstimator.LimitDefault = ptr[uint64](5_000_000)
 		c.EVM[0].MinIncomingConfirmations = ptr[uint32](2)
-		c.EVM[0].ChainID = (*ubig.Big)(testutils.SimulatedChainID)
+		c.EVM[0].ChainID = (*sqlutil.Big)(testutils.SimulatedChainID)
 		c.Feature.LogPoller = ptr(true)
 		c.EVM[0].LogPollInterval = commonconfig.MustNewDuration(1 * time.Second)
 	})
@@ -1674,7 +1674,7 @@ func testMaliciousConsumer(
 		c.EVM[0].GasEstimator.PriceMax = assets.GWei(1)
 		c.EVM[0].GasEstimator.PriceDefault = assets.GWei(1)
 		c.EVM[0].GasEstimator.FeeCapDefault = assets.GWei(1)
-		c.EVM[0].ChainID = (*ubig.Big)(testutils.SimulatedChainID)
+		c.EVM[0].ChainID = (*sqlutil.Big)(testutils.SimulatedChainID)
 		c.Feature.LogPoller = ptr(true)
 		c.EVM[0].LogPollInterval = commonconfig.MustNewDuration(1 * time.Second)
 	})

--- a/core/services/vrf/v2/integration_v2_test.go
+++ b/core/services/vrf/v2/integration_v2_test.go
@@ -44,7 +44,6 @@ import (
 	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
 
@@ -2158,7 +2157,7 @@ func TestStartingCountsV1(t *testing.T) {
 	md2, err := json.Marshal(&m2)
 	md2SQL := sqlutil.JSON(md2)
 	require.NoError(t, err)
-	chainID := ubig.New(testutils.SimulatedChainID)
+	chainID := sqlutil.New(testutils.SimulatedChainID)
 	confirmedTxes := []txmgr.Tx{
 		{
 			Sequence:           &n1,

--- a/core/services/vrf/v2/listener_v2_log_listener_test.go
+++ b/core/services/vrf/v2/listener_v2_log_listener_test.go
@@ -22,6 +22,7 @@ import (
 	commonkeystore "github.com/smartcontractkit/chainlink-common/keystore"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/vrf_coordinator_v2"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/log_emitter"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/vrf_log_emitter"
@@ -30,7 +31,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	evmmocks "github.com/smartcontractkit/chainlink/v2/common/chains/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -793,8 +793,8 @@ func TestUpdateLastProcessedBlock_UnfulfilledNFulfilledVRFReqs(t *testing.T) {
  * TestGetUnfulfilled_UnfulfilledNFulfilledVRFReqs
  */
 
-func SetupGetUnfulfilledTH(t *testing.T) (*listenerV2, *ubig.Big) {
-	chainID := ubig.New(big.NewInt(12345))
+func SetupGetUnfulfilledTH(t *testing.T) (*listenerV2, *sqlutil.Big) {
+	chainID := sqlutil.New(big.NewInt(12345))
 	lggr := logger.Test(t)
 	j, err := vrfcommon.ValidatedVRFSpec(testspecs.GenerateVRFSpec(testspecs.VRFSpecParams{
 		RequestedConfsDelay: 10,

--- a/core/store/migrate/migrate_test.go
+++ b/core/store/migrate/migrate_test.go
@@ -18,7 +18,6 @@ import (
 
 	evmcfg "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/config/env"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
@@ -423,7 +422,7 @@ func TestMigrate(t *testing.T) {
 
 func TestSetMigrationENVVars(t *testing.T) {
 	t.Run("ValidEVMConfig", func(t *testing.T) {
-		chainID := ubig.New(big.NewInt(1337))
+		chainID := sqlutil.New(big.NewInt(1337))
 		testConfig := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 			evmEnabled := true
 			c.EVM = evmcfg.EVMConfigs{&evmcfg.EVMConfig{
@@ -439,7 +438,7 @@ func TestSetMigrationENVVars(t *testing.T) {
 	})
 
 	t.Run("EVMConfigMissing", func(t *testing.T) {
-		chainID := ubig.New(big.NewInt(1337))
+		chainID := sqlutil.New(big.NewInt(1337))
 		testConfig := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) { c.EVM = nil })
 
 		require.NoError(t, migrate.SetMigrationENVVars(testConfig.EVMConfigs()))
@@ -484,7 +483,7 @@ func BenchmarkBackfillingRecordsWithMigration202(b *testing.B) {
 		var blocks []logpoller.Block
 		for i := range maxLogsSize {
 			blocks = append(blocks, logpoller.Block{
-				EVMChainID:           ubig.NewI(int64(j + 1)),
+				EVMChainID:           sqlutil.NewI(int64(j + 1)),
 				BlockHash:            testutils.Random32Byte(),
 				BlockNumber:          int64(i + 1000),
 				FinalizedBlockNumber: 0,

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -17,8 +17,8 @@ import (
 	"github.com/robfig/cron/v3"
 	"github.com/tidwall/gjson"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 )
 
 // CronParser is the global parser for crontabs.
@@ -202,7 +202,7 @@ type SendEtherRequest struct {
 	DestinationAddress common.Address `json:"address"`
 	FromAddress        common.Address `json:"from"`
 	Amount             assets.Eth     `json:"amount"`
-	EVMChainID         *big.Big       `json:"evmChainID"`
+	EVMChainID         *sqlutil.Big   `json:"evmChainID"`
 	AllowHigherAmounts bool           `json:"allowHigherAmounts"`
 	SkipWaitTxAttempt  bool           `json:"skipWaitTxAttempt"`
 	WaitAttemptTimeout *time.Duration `json:"waitAttemptTimeout"`

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -23,9 +23,9 @@ import (
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	pgcommon "github.com/smartcontractkit/chainlink-common/pkg/sqlutil/pg"
 	cutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	"github.com/smartcontractkit/chainlink/v2/core/store/migrate"
 	"github.com/smartcontractkit/chainlink/v2/internal/testdb"
@@ -311,7 +311,7 @@ func randomizeTestDBSequences(db *sqlx.DB) error {
 		}
 
 		var randNum *big.Int
-		randNum, err = crand.Int(crand.Reader, ubig.NewI(10000).ToInt())
+		randNum, err = crand.Int(crand.Reader, sqlutil.NewI(10000).ToInt())
 		if err != nil {
 			return fmt.Errorf("%s: failed to generate random number", failedToRandomizeTestDBSequencesError{})
 		}

--- a/core/web/chains_controller_test.go
+++ b/core/web/chains_controller_test.go
@@ -16,12 +16,12 @@ import (
 	"github.com/smartcontractkit/quarantine"
 
 	commoncfg "github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	commonTypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -34,7 +34,7 @@ import (
 func Test_EVMChainsController_Show(t *testing.T) {
 	t.Parallel()
 
-	validID := ubig.New(testutils.NewRandomEVMChainID())
+	validID := sqlutil.New(testutils.NewRandomEVMChainID())
 
 	testCases := []struct {
 		name           string
@@ -120,9 +120,9 @@ func Test_EVMChainsController_Index(t *testing.T) {
 	})
 
 	configuredChains := toml.EVMConfigs{
-		{ChainID: ubig.New(chainIDs[0]), Chain: toml.Defaults(nil)},
+		{ChainID: sqlutil.New(chainIDs[0]), Chain: toml.Defaults(nil)},
 		{
-			ChainID: ubig.New(chainIDs[1]),
+			ChainID: sqlutil.New(chainIDs[1]),
 			Chain: toml.Defaults(nil, &toml.Chain{
 				RPCBlockQueryDelay: ptr[uint16](13),
 				GasEstimator: toml.GasEstimator{
@@ -135,7 +135,7 @@ func Test_EVMChainsController_Index(t *testing.T) {
 			}),
 		},
 		{
-			ChainID: ubig.New(chainIDs[2]),
+			ChainID: sqlutil.New(chainIDs[2]),
 			Chain: toml.Defaults(nil, &toml.Chain{
 				RPCBlockQueryDelay: ptr[uint16](5),
 				GasEstimator: toml.GasEstimator{

--- a/core/web/eth_keys_controller.go
+++ b/core/web/eth_keys_controller.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 
 	commonassets "github.com/smartcontractkit/chainlink-common/pkg/assets"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/config/toml"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/logger/audit"
@@ -401,7 +401,7 @@ func (ekc *ETHKeysController) getLinkBalance(ctx context.Context, state ethkey.S
 // gets the key specific max gas price from the chain config and sets it on the
 // resource.
 func (ekc *ETHKeysController) setKeyMaxGasPriceWei(price *assets.Wei) presenters.NewETHKeyOption {
-	return presenters.SetETHKeyMaxGasPriceWei(ubig.New(price.ToInt()))
+	return presenters.SetETHKeyMaxGasPriceWei(sqlutil.New(price.ToInt()))
 }
 
 func (ekc *ETHKeysController) getKeyMaxGasPriceWei(state ethkey.State, keyAddress common.Address) *assets.Wei {

--- a/core/web/evm_forwarders_controller.go
+++ b/core/web/evm_forwarders_controller.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/forwarders"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/logger/audit"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/utils/stringutils"
@@ -46,7 +45,7 @@ func (cc *EVMForwardersController) Index(c *gin.Context, size, page, offset int)
 
 // TrackEVMForwarderRequest is a JSONAPI request for creating an EVM forwarder.
 type TrackEVMForwarderRequest struct {
-	EVMChainID *ubig.Big      `json:"evmChainId"`
+	EVMChainID *sqlutil.Big   `json:"evmChainId"`
 	Address    common.Address `json:"address"`
 }
 

--- a/core/web/evm_forwarders_controller_test.go
+++ b/core/web/evm_forwarders_controller_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
@@ -45,7 +45,7 @@ func setupEVMForwardersControllerTest(t *testing.T, overrideFn func(c *chainlink
 func Test_EVMForwardersController_Track(t *testing.T) {
 	t.Parallel()
 
-	chainId := big.New(testutils.NewRandomEVMChainID())
+	chainId := sqlutil.New(testutils.NewRandomEVMChainID())
 	controller := setupEVMForwardersControllerTest(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM = toml.EVMConfigs{
 			{ChainID: chainId, Enabled: ptr(true), Chain: toml.Defaults(chainId)},
@@ -82,7 +82,7 @@ func Test_EVMForwardersController_Track(t *testing.T) {
 func Test_EVMForwardersController_Index(t *testing.T) {
 	t.Parallel()
 
-	chainId := big.New(testutils.NewRandomEVMChainID())
+	chainId := sqlutil.New(testutils.NewRandomEVMChainID())
 	controller := setupEVMForwardersControllerTest(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM = toml.EVMConfigs{
 			{ChainID: chainId, Enabled: ptr(true), Chain: toml.Defaults(chainId)},

--- a/core/web/evm_transfer_controller_test.go
+++ b/core/web/evm_transfer_controller_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
@@ -58,7 +57,7 @@ func TestTransfersController_CreateSuccess_From(t *testing.T) {
 		FromAddress:        key.Address,
 		Amount:             amount,
 		SkipWaitTxAttempt:  true,
-		EVMChainID:         ubig.New(evmtest.MustGetDefaultChainID(t, app.Config.EVMConfigs())),
+		EVMChainID:         sqlutil.New(evmtest.MustGetDefaultChainID(t, app.Config.EVMConfigs())),
 	}
 
 	body, err := json.Marshal(&request)
@@ -100,7 +99,7 @@ func TestTransfersController_CreateSuccess_From_WEI(t *testing.T) {
 		FromAddress:        key.Address,
 		Amount:             amount,
 		SkipWaitTxAttempt:  true,
-		EVMChainID:         ubig.New(evmtest.MustGetDefaultChainID(t, app.Config.EVMConfigs())),
+		EVMChainID:         sqlutil.New(evmtest.MustGetDefaultChainID(t, app.Config.EVMConfigs())),
 	}
 
 	body, err := json.Marshal(&request)
@@ -147,7 +146,7 @@ func TestTransfersController_CreateSuccess_From_BalanceMonitorDisabled(t *testin
 		FromAddress:        key.Address,
 		Amount:             amount,
 		SkipWaitTxAttempt:  true,
-		EVMChainID:         ubig.New(evmtest.MustGetDefaultChainID(t, app.Config.EVMConfigs())),
+		EVMChainID:         sqlutil.New(evmtest.MustGetDefaultChainID(t, app.Config.EVMConfigs())),
 	}
 
 	body, err := json.Marshal(&request)
@@ -177,7 +176,7 @@ func TestTransfersController_TransferZeroAddressError(t *testing.T) {
 		DestinationAddress: common.HexToAddress("0xFA01FA015C8A5332987319823728982379128371"),
 		FromAddress:        common.HexToAddress("0x0000000000000000000000000000000000000000"),
 		Amount:             amount,
-		EVMChainID:         ubig.New(evmtest.MustGetDefaultChainID(t, app.Config.EVMConfigs())),
+		EVMChainID:         sqlutil.New(evmtest.MustGetDefaultChainID(t, app.Config.EVMConfigs())),
 	}
 
 	body, err := json.Marshal(&request)
@@ -213,7 +212,7 @@ func TestTransfersController_TransferBalanceToLowError(t *testing.T) {
 		DestinationAddress: common.HexToAddress("0xFA01FA015C8A5332987319823728982379128371"),
 		Amount:             amount,
 		AllowHigherAmounts: false,
-		EVMChainID:         ubig.New(evmtest.MustGetDefaultChainID(t, app.Config.EVMConfigs())),
+		EVMChainID:         sqlutil.New(evmtest.MustGetDefaultChainID(t, app.Config.EVMConfigs())),
 	}
 
 	body, err := json.Marshal(&request)
@@ -252,7 +251,7 @@ func TestTransfersController_TransferBalanceToLowError_ZeroBalance(t *testing.T)
 		DestinationAddress: common.HexToAddress("0xFA01FA015C8A5332987319823728982379128371"),
 		Amount:             amount,
 		AllowHigherAmounts: false,
-		EVMChainID:         ubig.New(evmtest.MustGetDefaultChainID(t, app.Config.EVMConfigs())),
+		EVMChainID:         sqlutil.New(evmtest.MustGetDefaultChainID(t, app.Config.EVMConfigs())),
 	}
 
 	body, err := json.Marshal(&request)
@@ -295,7 +294,7 @@ func TestTransfersController_CreateSuccess_eip1559(t *testing.T) {
 	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].GasEstimator.EIP1559DynamicFees = ptr(true)
 		c.EVM[0].GasEstimator.Mode = ptr("FixedPrice")
-		c.EVM[0].ChainID = (*ubig.Big)(testutils.FixtureChainID)
+		c.EVM[0].ChainID = (*sqlutil.Big)(testutils.FixtureChainID)
 		// NOTE: FallbackPollInterval is used in this test to quickly create TxAttempts
 		// Testing triggers requires committing transactions and does not work with transactional tests
 		c.Database.Listener.FallbackPollInterval = commonconfig.MustNewDuration(time.Second)
@@ -315,7 +314,7 @@ func TestTransfersController_CreateSuccess_eip1559(t *testing.T) {
 		FromAddress:        key.Address,
 		Amount:             amount,
 		WaitAttemptTimeout: &timeout,
-		EVMChainID:         ubig.New(evmtest.MustGetDefaultChainID(t, config.EVMConfigs())),
+		EVMChainID:         sqlutil.New(evmtest.MustGetDefaultChainID(t, config.EVMConfigs())),
 	}
 
 	body, err := json.Marshal(&request)

--- a/core/web/jobs_controller_test.go
+++ b/core/web/jobs_controller_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
@@ -290,7 +289,7 @@ func TestJobController_Create_HappyPath(t *testing.T) {
 				require.NotNil(t, jb.CronSpec)
 
 				assert.NotNil(t, resource.PipelineSpec.DotDAGSource)
-				require.Equal(t, ubig.NewI(42), jb.CronSpec.EVMChainID)
+				require.Equal(t, sqlutil.NewI(42), jb.CronSpec.EVMChainID)
 			},
 		},
 		{

--- a/core/web/lca_controller.go
+++ b/core/web/lca_controller.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
 
@@ -44,15 +44,15 @@ func (bdc *LCAController) FindLCA(c *gin.Context) {
 	response := LCAResponse{
 		BlockNumber: lca.BlockNumber,
 		Hash:        lca.BlockHash.String(),
-		EVMChainID:  big.New(chainID),
+		EVMChainID:  sqlutil.New(chainID),
 	}
 	jsonAPIResponse(c, &response, "response")
 }
 
 type LCAResponse struct {
-	BlockNumber int64    `json:"blockNumber"`
-	Hash        string   `json:"hash"`
-	EVMChainID  *big.Big `json:"evmChainID"`
+	BlockNumber int64        `json:"blockNumber"`
+	Hash        string       `json:"hash"`
+	EVMChainID  *sqlutil.Big `json:"evmChainID"`
 }
 
 // GetID returns the jsonapi ID.

--- a/core/web/loader/loader_test.go
+++ b/core/web/loader/loader_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	evmtxmgrmocks "github.com/smartcontractkit/chainlink/v2/common/txmgr/mocks"
 	coremocks "github.com/smartcontractkit/chainlink/v2/core/internal/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -38,9 +38,9 @@ func TestLoader_ChainsRelayID_HandleDuplicateIDAcrossNetworks(t *testing.T) {
 	app := coremocks.NewApplication(t)
 	ctx := InjectDataloader(testutils.Context(t), app)
 
-	one := ubig.NewI(1)
+	one := sqlutil.NewI(1)
 	chain := toml.EVMConfig{ChainID: one, Chain: toml.Defaults(one)}
-	two := ubig.NewI(2)
+	two := sqlutil.NewI(2)
 	chain2 := toml.EVMConfig{ChainID: two, Chain: toml.Defaults(two)}
 	config1, err := chain.TOMLString()
 	require.NoError(t, err)

--- a/core/web/presenters/eth_key.go
+++ b/core/web/presenters/eth_key.go
@@ -4,8 +4,8 @@ import (
 	"time"
 
 	commonassets "github.com/smartcontractkit/chainlink-common/pkg/assets"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
 )
 
@@ -13,14 +13,14 @@ import (
 // representation of the address plus its ETH & LINK balances
 type ETHKeyResource struct {
 	JAID
-	EVMChainID     big.Big            `json:"evmChainID"`
+	EVMChainID     sqlutil.Big        `json:"evmChainID"`
 	Address        string             `json:"address"`
 	EthBalance     *assets.Eth        `json:"ethBalance"`
 	LinkBalance    *commonassets.Link `json:"linkBalance"`
 	Disabled       bool               `json:"disabled"`
 	CreatedAt      time.Time          `json:"createdAt"`
 	UpdatedAt      time.Time          `json:"updatedAt"`
-	MaxGasPriceWei *big.Big           `json:"maxGasPriceWei"`
+	MaxGasPriceWei *sqlutil.Big       `json:"maxGasPriceWei"`
 }
 
 // GetName implements the api2go EntityNamer interface
@@ -69,7 +69,7 @@ func SetETHKeyLinkBalance(linkBalance *commonassets.Link) NewETHKeyOption {
 	}
 }
 
-func SetETHKeyMaxGasPriceWei(maxGasPriceWei *big.Big) NewETHKeyOption {
+func SetETHKeyMaxGasPriceWei(maxGasPriceWei *sqlutil.Big) NewETHKeyOption {
 	return func(r *ETHKeyResource) {
 		r.MaxGasPriceWei = maxGasPriceWei
 	}

--- a/core/web/presenters/eth_key_test.go
+++ b/core/web/presenters/eth_key_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	commonassets "github.com/smartcontractkit/chainlink-common/pkg/assets"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -32,7 +32,7 @@ func TestETHKeyResource(t *testing.T) {
 
 	state := ethkey.State{
 		ID:         1,
-		EVMChainID: *big.NewI(42),
+		EVMChainID: *sqlutil.NewI(42),
 		Address:    eip55address,
 		CreatedAt:  now,
 		UpdatedAt:  now,
@@ -42,12 +42,12 @@ func TestETHKeyResource(t *testing.T) {
 	r := NewETHKeyResource(key, state,
 		SetETHKeyEthBalance(assets.NewEth(1)),
 		SetETHKeyLinkBalance(commonassets.NewLinkFromJuels(1)),
-		SetETHKeyMaxGasPriceWei(big.NewI(12345)),
+		SetETHKeyMaxGasPriceWei(sqlutil.NewI(12345)),
 	)
 
 	assert.Equal(t, assets.NewEth(1), r.EthBalance)
 	assert.Equal(t, commonassets.NewLinkFromJuels(1), r.LinkBalance)
-	assert.Equal(t, big.NewI(12345), r.MaxGasPriceWei)
+	assert.Equal(t, sqlutil.NewI(12345), r.MaxGasPriceWei)
 
 	b, err := jsonapi.Marshal(r)
 	require.NoError(t, err)

--- a/core/web/presenters/eth_tx.go
+++ b/core/web/presenters/eth_tx.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 )
 
 // EthTxResource represents a Ethereum Transaction JSONAPI resource.
@@ -25,7 +25,7 @@ type EthTxResource struct {
 	SentAt     string          `json:"sentAt"`
 	To         *common.Address `json:"to"`
 	Value      string          `json:"value"`
-	EVMChainID big.Big         `json:"evmChainID"`
+	EVMChainID sqlutil.Big     `json:"evmChainID"`
 }
 
 // GetName implements the api2go EntityNamer interface
@@ -50,7 +50,7 @@ func NewEthTxResource(tx txmgr.Tx) EthTxResource {
 	}
 
 	if tx.ChainID != nil {
-		r.EVMChainID = *big.New(tx.ChainID)
+		r.EVMChainID = *sqlutil.New(tx.ChainID)
 	}
 	return r
 }
@@ -65,7 +65,7 @@ func NewEthTxResourceFromAttempt(txa txmgr.TxAttempt) EthTxResource {
 	r.Hex = hexutil.Encode(txa.SignedRawTx)
 
 	if txa.Tx.ChainID != nil {
-		r.EVMChainID = *big.New(txa.Tx.ChainID)
+		r.EVMChainID = *sqlutil.New(txa.Tx.ChainID)
 		r.JAID = NewPrefixedJAID(r.ID, txa.Tx.ChainID.String())
 	}
 

--- a/core/web/presenters/evm_forwarder.go
+++ b/core/web/presenters/evm_forwarder.go
@@ -5,15 +5,15 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/forwarders"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 )
 
 // EVMForwarderResource is an EVM forwarder JSONAPI resource.
 type EVMForwarderResource struct {
 	JAID
 	Address    common.Address `json:"address"`
-	EVMChainID big.Big        `json:"evmChainId"`
+	EVMChainID sqlutil.Big    `json:"evmChainId"`
 	CreatedAt  time.Time      `json:"createdAt"`
 	UpdatedAt  time.Time      `json:"updatedAt"`
 }

--- a/core/web/presenters/evm_forwarder_test.go
+++ b/core/web/presenters/evm_forwarder_test.go
@@ -11,16 +11,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/forwarders"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 )
 
 func TestEVMForwarderResource(t *testing.T) {
 	var (
 		ID        = int64(1)
 		address   = utils.RandomAddress()
-		chainID   = *big.NewI(4)
+		chainID   = *sqlutil.NewI(4)
 		createdAt = time.Now()
 		updatedAt = time.Now().Add(time.Second)
 	)

--- a/core/web/presenters/job.go
+++ b/core/web/presenters/job.go
@@ -12,7 +12,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	clnull "github.com/smartcontractkit/chainlink/v2/core/null"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
@@ -57,7 +56,7 @@ type DirectRequestSpec struct {
 	Initiator                string                   `json:"initiator"`
 	CreatedAt                time.Time                `json:"createdAt"`
 	UpdatedAt                time.Time                `json:"updatedAt"`
-	EVMChainID               *big.Big                 `json:"evmChainID"`
+	EVMChainID               *sqlutil.Big             `json:"evmChainID"`
 }
 
 // NewDirectRequestSpec initializes a new DirectRequestSpec from a
@@ -92,7 +91,7 @@ type FluxMonitorSpec struct {
 	MinPayment          *commonassets.Link `json:"minPayment"`
 	CreatedAt           time.Time          `json:"createdAt"`
 	UpdatedAt           time.Time          `json:"updatedAt"`
-	EVMChainID          *big.Big           `json:"evmChainID"`
+	EVMChainID          *sqlutil.Big       `json:"evmChainID"`
 }
 
 // NewFluxMonitorSpec initializes a new DirectFluxMonitorSpec from a
@@ -139,7 +138,7 @@ type OffChainReportingSpec struct {
 	ContractConfigConfirmations            uint16              `json:"contractConfigConfirmations"`
 	CreatedAt                              time.Time           `json:"createdAt"`
 	UpdatedAt                              time.Time           `json:"updatedAt"`
-	EVMChainID                             *big.Big            `json:"evmChainID"`
+	EVMChainID                             *sqlutil.Big        `json:"evmChainID"`
 	DatabaseTimeout                        *sqlutil.Interval   `json:"databaseTimeout"`
 	ObservationGracePeriod                 *sqlutil.Interval   `json:"observationGracePeriod"`
 	ContractTransmitterTransmitTimeout     *sqlutil.Interval   `json:"contractTransmitterTransmitTimeout"`
@@ -230,7 +229,7 @@ type KeeperSpec struct {
 	FromAddress     types.EIP55Address `json:"fromAddress"`
 	CreatedAt       time.Time          `json:"createdAt"`
 	UpdatedAt       time.Time          `json:"updatedAt"`
-	EVMChainID      *big.Big           `json:"evmChainID"`
+	EVMChainID      *sqlutil.Big       `json:"evmChainID"`
 }
 
 // NewKeeperSpec generates a new KeeperSpec from a job.KeeperSpec
@@ -260,10 +259,10 @@ func NewWebhookSpec(spec *job.WebhookSpec) *WebhookSpec {
 
 // CronSpec defines the spec details of a Cron Job
 type CronSpec struct {
-	CronSchedule string    `json:"schedule"`
-	CreatedAt    time.Time `json:"createdAt"`
-	UpdatedAt    time.Time `json:"updatedAt"`
-	EVMChainID   *big.Big  `json:"evmChainID"`
+	CronSchedule string       `json:"schedule"`
+	CreatedAt    time.Time    `json:"createdAt"`
+	UpdatedAt    time.Time    `json:"updatedAt"`
+	EVMChainID   *sqlutil.Big `json:"evmChainID"`
 }
 
 // NewCronSpec generates a new CronSpec from a job.CronSpec
@@ -288,7 +287,7 @@ type VRFSpec struct {
 	MinIncomingConfirmations      uint32                `json:"confirmations"`
 	CreatedAt                     time.Time             `json:"createdAt"`
 	UpdatedAt                     time.Time             `json:"updatedAt"`
-	EVMChainID                    *big.Big              `json:"evmChainID"`
+	EVMChainID                    *sqlutil.Big          `json:"evmChainID"`
 	ChunkSize                     uint32                `json:"chunkSize"`
 	RequestTimeout                commonconfig.Duration `json:"requestTimeout"`
 	BackoffInitialDelay           commonconfig.Duration `json:"backoffInitialDelay"`
@@ -335,7 +334,7 @@ type BlockhashStoreSpec struct {
 	TrustedBlockhashStoreBatchSize int32                `json:"trustedBlockhashStoreBatchSize"`
 	PollPeriod                     time.Duration        `json:"pollPeriod"`
 	RunTimeout                     time.Duration        `json:"runTimeout"`
-	EVMChainID                     *big.Big             `json:"evmChainID"`
+	EVMChainID                     *sqlutil.Big         `json:"evmChainID"`
 	FromAddresses                  []types.EIP55Address `json:"fromAddresses"`
 	CreatedAt                      time.Time            `json:"createdAt"`
 	UpdatedAt                      time.Time            `json:"updatedAt"`
@@ -371,7 +370,7 @@ type BlockHeaderFeederSpec struct {
 	BatchBlockhashStoreAddress types.EIP55Address   `json:"batchBlockhashStoreAddress"`
 	PollPeriod                 time.Duration        `json:"pollPeriod"`
 	RunTimeout                 time.Duration        `json:"runTimeout"`
-	EVMChainID                 *big.Big             `json:"evmChainID"`
+	EVMChainID                 *sqlutil.Big         `json:"evmChainID"`
 	FromAddresses              []types.EIP55Address `json:"fromAddresses"`
 	GetBlockhashesBatchSize    uint16               `json:"getBlockhashesBatchSize"`
 	StoreBlockhashesBatchSize  uint16               `json:"storeBlockhashesBatchSize"`

--- a/core/web/presenters/job_test.go
+++ b/core/web/presenters/job_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	evmassets "github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	clnull "github.com/smartcontractkit/chainlink/v2/core/null"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
@@ -32,7 +31,7 @@ func TestJob(t *testing.T) {
 	contractAddress, err := types.NewEIP55Address("0x9E40733cC9df84636505f4e6Db28DCa0dC5D1bba")
 	require.NoError(t, err)
 	cronSchedule := "0 0 0 1 1 *"
-	evmChainID := big.NewI(42)
+	evmChainID := sqlutil.NewI(42)
 	fromAddress, err := types.NewEIP55Address("0xa8037A20989AFcBC51798de9762b351D63ff462e")
 	require.NoError(t, err)
 
@@ -617,7 +616,7 @@ func TestJob(t *testing.T) {
 					BlockhashStoreAddress:          contractAddress,
 					PollPeriod:                     25 * time.Second,
 					RunTimeout:                     10 * time.Second,
-					EVMChainID:                     big.NewI(4),
+					EVMChainID:                     sqlutil.NewI(4),
 					FromAddresses:                  []types.EIP55Address{fromAddress},
 					TrustedBlockhashStoreAddress:   &trustedBlockhashStoreAddress,
 					TrustedBlockhashStoreBatchSize: trustedBlockhashStoreBatchSize,
@@ -703,7 +702,7 @@ func TestJob(t *testing.T) {
 					BatchBlockhashStoreAddress: batchBHSAddress,
 					PollPeriod:                 25 * time.Second,
 					RunTimeout:                 10 * time.Second,
-					EVMChainID:                 big.NewI(4),
+					EVMChainID:                 sqlutil.NewI(4),
 					FromAddresses:              []types.EIP55Address{fromAddress},
 					GetBlockhashesBatchSize:    5,
 					StoreBlockhashesBatchSize:  10,

--- a/core/web/resolver/chain_test.go
+++ b/core/web/resolver/chain_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 
 	evmtoml "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	chainlinkmocks "github.com/smartcontractkit/chainlink/v2/core/services/chainlink/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 	"github.com/smartcontractkit/chainlink/v2/core/web/testutils"
@@ -21,7 +21,7 @@ import (
 
 func TestResolver_Chains(t *testing.T) {
 	var (
-		chainID = *big.NewI(1)
+		chainID = *sqlutil.NewI(1)
 		query   = `
 			query GetChains {
 				chains {
@@ -141,7 +141,7 @@ ResendAfterThreshold = '1h0m0s'
 
 func TestResolver_Chain(t *testing.T) {
 	var (
-		chainID = *big.NewI(1)
+		chainID = *sqlutil.NewI(1)
 		query   = `
 			query GetChain {
 				chain(id: "1") {

--- a/core/web/resolver/eth_key_test.go
+++ b/core/web/resolver/eth_key_test.go
@@ -12,6 +12,7 @@ import (
 
 	commonassets "github.com/smartcontractkit/chainlink-common/pkg/assets"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
@@ -20,7 +21,6 @@ import (
 	mocks2 "github.com/smartcontractkit/chainlink-evm/pkg/config/mocks"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 	evmrelay "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
@@ -85,13 +85,13 @@ func TestResolver_ETHKeys(t *testing.T) {
 				states := []ethkey.State{
 					{
 						Address:    evmtypes.MustEIP55Address(address.Hex()),
-						EVMChainID: *big.NewI(12),
+						EVMChainID: *sqlutil.NewI(12),
 						Disabled:   false,
 						CreatedAt:  f.Timestamp(),
 						UpdatedAt:  f.Timestamp(),
 					},
 				}
-				chainID := *big.NewI(12)
+				chainID := *sqlutil.NewI(12)
 				linkAddr := common.HexToAddress("0x5431F5F973781809D18643b87B44921b11355d81")
 
 				m := map[string]types.ChainService{states[0].EVMChainID.String(): f.Mocks.chain}
@@ -154,13 +154,13 @@ func TestResolver_ETHKeys(t *testing.T) {
 				states := []ethkey.State{
 					{
 						Address:    evmtypes.MustEIP55Address(address.Hex()),
-						EVMChainID: *big.NewI(12),
+						EVMChainID: *sqlutil.NewI(12),
 						Disabled:   false,
 						CreatedAt:  f.Timestamp(),
 						UpdatedAt:  f.Timestamp(),
 					},
 				}
-				chainID := *big.NewI(12)
+				chainID := *sqlutil.NewI(12)
 				f.Mocks.legacyEVMChains.On("Get", states[0].EVMChainID.String()).Return(nil, evmrelay.ErrNoChains)
 				f.Mocks.ethKs.On("GetStatesForKeys", mock.Anything, keys).Return(states, nil)
 				f.Mocks.ethKs.On("Get", mock.Anything, keys[0].Address.Hex()).Return(keys[0], nil)
@@ -251,7 +251,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 				states := []ethkey.State{
 					{
 						Address:    evmtypes.MustEIP55Address(address.Hex()),
-						EVMChainID: *big.NewI(12),
+						EVMChainID: *sqlutil.NewI(12),
 						Disabled:   false,
 						CreatedAt:  f.Timestamp(),
 						UpdatedAt:  f.Timestamp(),
@@ -283,7 +283,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 				states := []ethkey.State{
 					{
 						Address:    evmtypes.MustEIP55Address(address.Hex()),
-						EVMChainID: *big.NewI(12),
+						EVMChainID: *sqlutil.NewI(12),
 						Disabled:   false,
 						CreatedAt:  f.Timestamp(),
 						UpdatedAt:  f.Timestamp(),
@@ -314,13 +314,13 @@ func TestResolver_ETHKeys(t *testing.T) {
 				states := []ethkey.State{
 					{
 						Address:    evmtypes.MustEIP55Address(address.Hex()),
-						EVMChainID: *big.NewI(12),
+						EVMChainID: *sqlutil.NewI(12),
 						Disabled:   false,
 						CreatedAt:  f.Timestamp(),
 						UpdatedAt:  f.Timestamp(),
 					},
 				}
-				chainID := *big.NewI(12)
+				chainID := *sqlutil.NewI(12)
 				linkAddr := common.HexToAddress("0x5431F5F973781809D18643b87B44921b11355d81")
 
 				f.Mocks.ethKs.On("GetStatesForKeys", mock.Anything, keys).Return(states, nil)
@@ -379,13 +379,13 @@ func TestResolver_ETHKeys(t *testing.T) {
 				states := []ethkey.State{
 					{
 						Address:    evmtypes.EIP55AddressFromAddress(address),
-						EVMChainID: *big.NewI(12),
+						EVMChainID: *sqlutil.NewI(12),
 						Disabled:   false,
 						CreatedAt:  f.Timestamp(),
 						UpdatedAt:  f.Timestamp(),
 					},
 				}
-				chainID := *big.NewI(12)
+				chainID := *sqlutil.NewI(12)
 				linkAddr := common.HexToAddress("0x5431F5F973781809D18643b87B44921b11355d81")
 
 				f.Mocks.ethKs.On("GetStatesForKeys", mock.Anything, keys).Return(states, nil)

--- a/core/web/resolver/eth_transaction_test.go
+++ b/core/web/resolver/eth_transaction_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	chainlinkmocks "github.com/smartcontractkit/chainlink/v2/core/services/chainlink/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
@@ -62,7 +62,7 @@ func TestResolver_EthTransaction(t *testing.T) {
 		"hash": "0x5431F5F973781809D18643b87B44921b11355d81",
 	}
 	hash := common.HexToHash("0x5431F5F973781809D18643b87B44921b11355d81")
-	chainID := *ubig.NewI(22)
+	chainID := *sqlutil.NewI(22)
 	gError := errors.New("error")
 
 	testCases := []GQLTestCase{

--- a/core/web/resolver/spec_test.go
+++ b/core/web/resolver/spec_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	clnull "github.com/smartcontractkit/chainlink/v2/core/null"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
@@ -45,7 +44,7 @@ func TestResolver_CronSpec(t *testing.T) {
 					Type: job.Cron,
 					CronSpec: &job.CronSpec{
 						CronSchedule: "CRON_TZ=UTC 0 0 1 1 *",
-						EVMChainID:   ubig.NewI(42),
+						EVMChainID:   sqlutil.NewI(42),
 						CreatedAt:    f.Timestamp(),
 					},
 				}, nil)
@@ -103,7 +102,7 @@ func TestResolver_DirectRequestSpec(t *testing.T) {
 					DirectRequestSpec: &job.DirectRequestSpec{
 						ContractAddress:          contractAddress,
 						CreatedAt:                f.Timestamp(),
-						EVMChainID:               ubig.NewI(42),
+						EVMChainID:               sqlutil.NewI(42),
 						MinIncomingConfirmations: clnull.NewUint32(1, true),
 						MinContractPayment:       commonassets.NewLinkFromJuels(1000),
 						Requesters:               models.AddressCollection{requesterAddress},
@@ -168,7 +167,7 @@ func TestResolver_FluxMonitorSpec(t *testing.T) {
 					FluxMonitorSpec: &job.FluxMonitorSpec{
 						ContractAddress:   contractAddress,
 						CreatedAt:         f.Timestamp(),
-						EVMChainID:        ubig.NewI(42),
+						EVMChainID:        sqlutil.NewI(42),
 						DrumbeatEnabled:   false,
 						IdleTimerDisabled: false,
 						IdleTimerPeriod:   1 * time.Hour,
@@ -235,7 +234,7 @@ func TestResolver_FluxMonitorSpec(t *testing.T) {
 					FluxMonitorSpec: &job.FluxMonitorSpec{
 						ContractAddress:     contractAddress,
 						CreatedAt:           f.Timestamp(),
-						EVMChainID:          ubig.NewI(42),
+						EVMChainID:          sqlutil.NewI(42),
 						DrumbeatEnabled:     true,
 						DrumbeatRandomDelay: 1 * time.Second,
 						DrumbeatSchedule:    "CRON_TZ=UTC 0 0 1 1 *",
@@ -318,7 +317,7 @@ func TestResolver_KeeperSpec(t *testing.T) {
 					KeeperSpec: &job.KeeperSpec{
 						ContractAddress: contractAddress,
 						CreatedAt:       f.Timestamp(),
-						EVMChainID:      ubig.NewI(42),
+						EVMChainID:      sqlutil.NewI(42),
 						FromAddress:     evmtypes.EIP55AddressFromAddress(fromAddress),
 					},
 				}, nil)
@@ -389,7 +388,7 @@ func TestResolver_OCRSpec(t *testing.T) {
 						ObservationGracePeriod:                 sqlutil.NewInterval(4 * time.Second),
 						ContractTransmitterTransmitTimeout:     sqlutil.NewInterval(555 * time.Millisecond),
 						CreatedAt:                              f.Timestamp(),
-						EVMChainID:                             ubig.NewI(42),
+						EVMChainID:                             sqlutil.NewI(42),
 						IsBootstrapPeer:                        false,
 						EncryptedOCRKeyBundleID:                &keyBundleID,
 						ObservationTimeout:                     sqlutil.Interval(2 * time.Minute),
@@ -610,7 +609,7 @@ func TestResolver_VRFSpec(t *testing.T) {
 						MinIncomingConfirmations:      1,
 						CoordinatorAddress:            coordinatorAddress,
 						CreatedAt:                     f.Timestamp(),
-						EVMChainID:                    ubig.NewI(42),
+						EVMChainID:                    sqlutil.NewI(42),
 						FromAddresses:                 []evmtypes.EIP55Address{fromAddress1, fromAddress2},
 						PollPeriod:                    1 * time.Minute,
 						PublicKey:                     pubKey,
@@ -773,7 +772,7 @@ func TestResolver_BlockhashStoreSpec(t *testing.T) {
 						CoordinatorV2Address:           &coordinatorV2Address,
 						CoordinatorV2PlusAddress:       &coordinatorV2PlusAddress,
 						CreatedAt:                      f.Timestamp(),
-						EVMChainID:                     ubig.NewI(42),
+						EVMChainID:                     sqlutil.NewI(42),
 						FromAddresses:                  []evmtypes.EIP55Address{fromAddress1, fromAddress2},
 						PollPeriod:                     1 * time.Minute,
 						RunTimeout:                     37 * time.Second,
@@ -877,7 +876,7 @@ func TestResolver_BlockHeaderFeederSpec(t *testing.T) {
 						CoordinatorV2Address:       &coordinatorV2Address,
 						CoordinatorV2PlusAddress:   &coordinatorV2PlusAddress,
 						CreatedAt:                  f.Timestamp(),
-						EVMChainID:                 ubig.NewI(42),
+						EVMChainID:                 sqlutil.NewI(42),
 						FromAddresses:              []evmtypes.EIP55Address{fromAddress},
 						PollPeriod:                 1 * time.Minute,
 						RunTimeout:                 37 * time.Second,

--- a/deployment/environment/nodeclient/chainlink_models.go
+++ b/deployment/environment/nodeclient/chainlink_models.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pelletier/go-toml/v2"
 	"gopkg.in/guregu/null.v4"
 
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 )
 
@@ -1569,8 +1569,8 @@ type ReplayResponseData struct {
 }
 
 type ReplayResponseAttributes struct {
-	Message    string   `json:"message"`
-	EVMChainID *big.Big `json:"evmChainID"`
+	Message    string       `json:"message"`
+	EVMChainID *sqlutil.Big `json:"evmChainID"`
 }
 
 // OCR2ExportKey is the model that represents the exported VRF key

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20251021173435-e86785845942

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139
-	github.com/smartcontractkit/chainlink-common v0.10.0
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -43,10 +43,10 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139
-	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20251021173435-e86785845942

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1381,8 +1381,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.11 h1:yBzjU0Cu8AcfuM858G
 github.com/smartcontractkit/chainlink-data-streams v0.1.11/go.mod h1:8rUcGhjeXBoTFx2MynWgXiBWzVSB+LXd9JR6m8y2FfQ=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6 h1:wVGho+uL3UEqhzMtAXmtZDUQ14J1Fmm7PkqJDuJWd1c=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6/go.mod h1:0EzSyjHDLYSNqo3Bp9lSQs53CTaGbXHB5ovCa6BoOOM=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717 h1:OiR/E3lq1jMlA6B9mqhom0f2JeNJOCIxbbyktBlR+Fg=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717/go.mod h1:jBZMFIz1C3sq/YyuTgk5MCu12SdHP+PcujdojZsSk6g=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 h1:vG3FwU52KCZq74Tq7elg+Gm/Eyx3rE2P7hOnJ8NrQzc=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440/go.mod h1:Nhvp2f+FW4SCaWJtDFc59vRAFoWistXNLmxk2i879Cw=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1369,8 +1369,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856 h1:e/L0oKHTwXjqIf66vw8NWYvXecCq5tybGwHm7YK9wuo=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856/go.mod h1:wLN3X89JoiWr951CX+lALwmDirEm1KzP0n+gGFblwxw=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3 h1:kKYwuaUklodjRTIz8uyjjFg/A+QC8a4VQ7jzIs684Ok=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3/go.mod h1:Xkgene5cOdtOYKxZsJfdQbhxSyomfzMDxyuQDAi0ecQ=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6 h1:bkKoQ7jW25iHtbbriRj5YPHokalaFH2ImBtiKm3QmKU=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6/go.mod h1:13YN2kb3Vqpw2S7d4IwhX/578WPGC0JHN5JrOnAEsOc=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9 h1:dWqd2lOW3GbwtgZEeDSDI1b1X175MPOlCU6GDQQVBjk=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9/go.mod h1:SMegDBf3KDs2tuKApmTRyO2xQthMu3gV2J+IuHEs0Y0=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
@@ -1381,8 +1381,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.11 h1:yBzjU0Cu8AcfuM858G
 github.com/smartcontractkit/chainlink-data-streams v0.1.11/go.mod h1:8rUcGhjeXBoTFx2MynWgXiBWzVSB+LXd9JR6m8y2FfQ=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6 h1:wVGho+uL3UEqhzMtAXmtZDUQ14J1Fmm7PkqJDuJWd1c=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6/go.mod h1:0EzSyjHDLYSNqo3Bp9lSQs53CTaGbXHB5ovCa6BoOOM=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 h1:vG3FwU52KCZq74Tq7elg+Gm/Eyx3rE2P7hOnJ8NrQzc=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440/go.mod h1:Nhvp2f+FW4SCaWJtDFc59vRAFoWistXNLmxk2i879Cw=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848 h1:B2ns2U3nZs8Wk0coMobIzO0ZI8/BmPLJzki/DHZfPEo=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848/go.mod h1:L5v6d4KEG8+WkxBE34WhjC4AsDzSB6fqF5WpeSyGJKw=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1369,8 +1369,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856 h1:e/L0oKHTwXjqIf66vw8NWYvXecCq5tybGwHm7YK9wuo=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856/go.mod h1:wLN3X89JoiWr951CX+lALwmDirEm1KzP0n+gGFblwxw=
-github.com/smartcontractkit/chainlink-common v0.10.0 h1:d90b9UPJecrIryzhl43F1oQwkJQoug3TaANlJ1xLHyI=
-github.com/smartcontractkit/chainlink-common v0.10.0/go.mod h1:13YN2kb3Vqpw2S7d4IwhX/578WPGC0JHN5JrOnAEsOc=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3 h1:kKYwuaUklodjRTIz8uyjjFg/A+QC8a4VQ7jzIs684Ok=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3/go.mod h1:Xkgene5cOdtOYKxZsJfdQbhxSyomfzMDxyuQDAi0ecQ=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9 h1:dWqd2lOW3GbwtgZEeDSDI1b1X175MPOlCU6GDQQVBjk=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9/go.mod h1:SMegDBf3KDs2tuKApmTRyO2xQthMu3gV2J+IuHEs0Y0=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=

--- a/deployment/utils/nodetestutils/node.go
+++ b/deployment/utils/nodetestutils/node.go
@@ -25,6 +25,7 @@ import (
 	commonkeystore "github.com/smartcontractkit/chainlink-common/keystore"
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
@@ -32,7 +33,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
 	evmlptesting "github.com/smartcontractkit/chainlink-evm/pkg/logpoller/testing"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
-	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	mnCfg "github.com/smartcontractkit/chainlink-framework/multinode/config"
 	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
@@ -353,9 +353,9 @@ type ConfigOpt func(c *chainlink.Config)
 func WithFinalityDepths(finalityDepths map[uint64]uint32) ConfigOpt {
 	return func(c *chainlink.Config) {
 		for chainID, depth := range finalityDepths {
-			chainIDBig := evmutils.New(new(big.Int).SetUint64(chainID))
+			chainIDBig := sqlutil.New(new(big.Int).SetUint64(chainID))
 			for _, evmChainConfig := range c.EVM {
-				if evmChainConfig.ChainID.Cmp(chainIDBig) == 0 {
+				if evmChainConfig.ChainID.ToInt().Cmp(chainIDBig.ToInt()) == 0 {
 					evmChainConfig.FinalityDepth = pointer.To(depth)
 				}
 			}
@@ -806,7 +806,7 @@ func CreateKeys(t *testing.T,
 }
 
 func createConfigV2Chain(chainID uint64) *v2toml.EVMConfig {
-	chainIDBig := evmutils.NewI(int64(chainID))
+	chainIDBig := sqlutil.NewI(int64(chainID))
 	chain := v2toml.Defaults(chainIDBig)
 	chain.GasEstimator.LimitDefault = pointer.To(uint64(5e6))
 	chain.LogPollInterval = config.MustNewDuration(500 * time.Millisecond)

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856
-	github.com/smartcontractkit/chainlink-common v0.10.0
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10
 	github.com/smartcontractkit/chainlink-data-streams v0.1.11

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10
 	github.com/smartcontractkit/chainlink-data-streams v0.1.11
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135

--- a/go.mod
+++ b/go.mod
@@ -88,11 +88,11 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856
-	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10
 	github.com/smartcontractkit/chainlink-data-streams v0.1.11
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135

--- a/go.sum
+++ b/go.sum
@@ -1183,8 +1183,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856 h1:e/L0oKHTwXjqIf66vw8NWYvXecCq5tybGwHm7YK9wuo=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856/go.mod h1:wLN3X89JoiWr951CX+lALwmDirEm1KzP0n+gGFblwxw=
-github.com/smartcontractkit/chainlink-common v0.10.0 h1:d90b9UPJecrIryzhl43F1oQwkJQoug3TaANlJ1xLHyI=
-github.com/smartcontractkit/chainlink-common v0.10.0/go.mod h1:13YN2kb3Vqpw2S7d4IwhX/578WPGC0JHN5JrOnAEsOc=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3 h1:kKYwuaUklodjRTIz8uyjjFg/A+QC8a4VQ7jzIs684Ok=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3/go.mod h1:Xkgene5cOdtOYKxZsJfdQbhxSyomfzMDxyuQDAi0ecQ=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9 h1:dWqd2lOW3GbwtgZEeDSDI1b1X175MPOlCU6GDQQVBjk=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9/go.mod h1:SMegDBf3KDs2tuKApmTRyO2xQthMu3gV2J+IuHEs0Y0=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=

--- a/go.sum
+++ b/go.sum
@@ -1193,8 +1193,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025121515250
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20251215152504-b1e41f508340/go.mod h1:P/0OSXUlFaxxD4B/P6HWbxYtIRmmWGDJAvanq19879c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.11 h1:yBzjU0Cu8AcfuM858G4xcQIulfNQkPfpUs5FDxX9UaY=
 github.com/smartcontractkit/chainlink-data-streams v0.1.11/go.mod h1:8rUcGhjeXBoTFx2MynWgXiBWzVSB+LXd9JR6m8y2FfQ=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717 h1:OiR/E3lq1jMlA6B9mqhom0f2JeNJOCIxbbyktBlR+Fg=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717/go.mod h1:jBZMFIz1C3sq/YyuTgk5MCu12SdHP+PcujdojZsSk6g=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 h1:vG3FwU52KCZq74Tq7elg+Gm/Eyx3rE2P7hOnJ8NrQzc=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440/go.mod h1:Nhvp2f+FW4SCaWJtDFc59vRAFoWistXNLmxk2i879Cw=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=

--- a/go.sum
+++ b/go.sum
@@ -1183,8 +1183,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856 h1:e/L0oKHTwXjqIf66vw8NWYvXecCq5tybGwHm7YK9wuo=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856/go.mod h1:wLN3X89JoiWr951CX+lALwmDirEm1KzP0n+gGFblwxw=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3 h1:kKYwuaUklodjRTIz8uyjjFg/A+QC8a4VQ7jzIs684Ok=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3/go.mod h1:Xkgene5cOdtOYKxZsJfdQbhxSyomfzMDxyuQDAi0ecQ=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6 h1:bkKoQ7jW25iHtbbriRj5YPHokalaFH2ImBtiKm3QmKU=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6/go.mod h1:13YN2kb3Vqpw2S7d4IwhX/578WPGC0JHN5JrOnAEsOc=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9 h1:dWqd2lOW3GbwtgZEeDSDI1b1X175MPOlCU6GDQQVBjk=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9/go.mod h1:SMegDBf3KDs2tuKApmTRyO2xQthMu3gV2J+IuHEs0Y0=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
@@ -1193,8 +1193,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025121515250
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20251215152504-b1e41f508340/go.mod h1:P/0OSXUlFaxxD4B/P6HWbxYtIRmmWGDJAvanq19879c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.11 h1:yBzjU0Cu8AcfuM858G4xcQIulfNQkPfpUs5FDxX9UaY=
 github.com/smartcontractkit/chainlink-data-streams v0.1.11/go.mod h1:8rUcGhjeXBoTFx2MynWgXiBWzVSB+LXd9JR6m8y2FfQ=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 h1:vG3FwU52KCZq74Tq7elg+Gm/Eyx3rE2P7hOnJ8NrQzc=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440/go.mod h1:Nhvp2f+FW4SCaWJtDFc59vRAFoWistXNLmxk2i879Cw=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848 h1:B2ns2U3nZs8Wk0coMobIzO0ZI8/BmPLJzki/DHZfPEo=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848/go.mod h1:L5v6d4KEG8+WkxBE34WhjC4AsDzSB6fqF5WpeSyGJKw=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=

--- a/integration-tests/ccip-tests/types/config/node/core.go
+++ b/integration-tests/ccip-tests/types/config/node/core.go
@@ -10,9 +10,9 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/ptr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
 	evmcfg "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/integration-tests/types/config/node"
 	itutils "github.com/smartcontractkit/chainlink/integration-tests/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
@@ -42,7 +42,7 @@ func WithPrivateEVMs(networks []blockchain.EVMNetwork, commonChainConfig *evmcfg
 			})
 		}
 		evmConfig := &evmcfg.EVMConfig{
-			ChainID: ubig.New(big.NewInt(network.ChainID)),
+			ChainID: sqlutil.New(big.NewInt(network.ChainID)),
 			Nodes:   evmNodes,
 			Chain:   evmcfg.Chain{},
 		}

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -51,10 +51,10 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20260203202624-5101f4d33736
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260205175622-33e65031f9a9

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20260203202624-5101f4d33736
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.10.0
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260205175622-33e65031f9a9

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1613,8 +1613,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856 h1:e/L0oKHTwXjqIf66vw8NWYvXecCq5tybGwHm7YK9wuo=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856/go.mod h1:wLN3X89JoiWr951CX+lALwmDirEm1KzP0n+gGFblwxw=
-github.com/smartcontractkit/chainlink-common v0.10.0 h1:d90b9UPJecrIryzhl43F1oQwkJQoug3TaANlJ1xLHyI=
-github.com/smartcontractkit/chainlink-common v0.10.0/go.mod h1:13YN2kb3Vqpw2S7d4IwhX/578WPGC0JHN5JrOnAEsOc=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3 h1:kKYwuaUklodjRTIz8uyjjFg/A+QC8a4VQ7jzIs684Ok=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3/go.mod h1:Xkgene5cOdtOYKxZsJfdQbhxSyomfzMDxyuQDAi0ecQ=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9 h1:dWqd2lOW3GbwtgZEeDSDI1b1X175MPOlCU6GDQQVBjk=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9/go.mod h1:SMegDBf3KDs2tuKApmTRyO2xQthMu3gV2J+IuHEs0Y0=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1625,8 +1625,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.11 h1:yBzjU0Cu8AcfuM858G
 github.com/smartcontractkit/chainlink-data-streams v0.1.11/go.mod h1:8rUcGhjeXBoTFx2MynWgXiBWzVSB+LXd9JR6m8y2FfQ=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6 h1:wVGho+uL3UEqhzMtAXmtZDUQ14J1Fmm7PkqJDuJWd1c=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6/go.mod h1:0EzSyjHDLYSNqo3Bp9lSQs53CTaGbXHB5ovCa6BoOOM=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717 h1:OiR/E3lq1jMlA6B9mqhom0f2JeNJOCIxbbyktBlR+Fg=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717/go.mod h1:jBZMFIz1C3sq/YyuTgk5MCu12SdHP+PcujdojZsSk6g=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 h1:vG3FwU52KCZq74Tq7elg+Gm/Eyx3rE2P7hOnJ8NrQzc=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440/go.mod h1:Nhvp2f+FW4SCaWJtDFc59vRAFoWistXNLmxk2i879Cw=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1613,8 +1613,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856 h1:e/L0oKHTwXjqIf66vw8NWYvXecCq5tybGwHm7YK9wuo=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856/go.mod h1:wLN3X89JoiWr951CX+lALwmDirEm1KzP0n+gGFblwxw=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3 h1:kKYwuaUklodjRTIz8uyjjFg/A+QC8a4VQ7jzIs684Ok=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3/go.mod h1:Xkgene5cOdtOYKxZsJfdQbhxSyomfzMDxyuQDAi0ecQ=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6 h1:bkKoQ7jW25iHtbbriRj5YPHokalaFH2ImBtiKm3QmKU=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6/go.mod h1:13YN2kb3Vqpw2S7d4IwhX/578WPGC0JHN5JrOnAEsOc=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9 h1:dWqd2lOW3GbwtgZEeDSDI1b1X175MPOlCU6GDQQVBjk=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9/go.mod h1:SMegDBf3KDs2tuKApmTRyO2xQthMu3gV2J+IuHEs0Y0=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
@@ -1625,8 +1625,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.11 h1:yBzjU0Cu8AcfuM858G
 github.com/smartcontractkit/chainlink-data-streams v0.1.11/go.mod h1:8rUcGhjeXBoTFx2MynWgXiBWzVSB+LXd9JR6m8y2FfQ=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6 h1:wVGho+uL3UEqhzMtAXmtZDUQ14J1Fmm7PkqJDuJWd1c=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6/go.mod h1:0EzSyjHDLYSNqo3Bp9lSQs53CTaGbXHB5ovCa6BoOOM=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 h1:vG3FwU52KCZq74Tq7elg+Gm/Eyx3rE2P7hOnJ8NrQzc=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440/go.mod h1:Nhvp2f+FW4SCaWJtDFc59vRAFoWistXNLmxk2i879Cw=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848 h1:B2ns2U3nZs8Wk0coMobIzO0ZI8/BmPLJzki/DHZfPEo=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848/go.mod h1:L5v6d4KEG8+WkxBE34WhjC4AsDzSB6fqF5WpeSyGJKw=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -32,9 +32,9 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20260203202624-5101f4d33736
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.13.14-0.20260202230832-eb33f42188d1
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20260203202624-5101f4d33736
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
-	github.com/smartcontractkit/chainlink-common v0.10.0
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1591,8 +1591,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856 h1:e/L0oKHTwXjqIf66vw8NWYvXecCq5tybGwHm7YK9wuo=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856/go.mod h1:wLN3X89JoiWr951CX+lALwmDirEm1KzP0n+gGFblwxw=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3 h1:kKYwuaUklodjRTIz8uyjjFg/A+QC8a4VQ7jzIs684Ok=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3/go.mod h1:Xkgene5cOdtOYKxZsJfdQbhxSyomfzMDxyuQDAi0ecQ=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6 h1:bkKoQ7jW25iHtbbriRj5YPHokalaFH2ImBtiKm3QmKU=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6/go.mod h1:13YN2kb3Vqpw2S7d4IwhX/578WPGC0JHN5JrOnAEsOc=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9 h1:dWqd2lOW3GbwtgZEeDSDI1b1X175MPOlCU6GDQQVBjk=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9/go.mod h1:SMegDBf3KDs2tuKApmTRyO2xQthMu3gV2J+IuHEs0Y0=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
@@ -1603,8 +1603,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.11 h1:yBzjU0Cu8AcfuM858G
 github.com/smartcontractkit/chainlink-data-streams v0.1.11/go.mod h1:8rUcGhjeXBoTFx2MynWgXiBWzVSB+LXd9JR6m8y2FfQ=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6 h1:wVGho+uL3UEqhzMtAXmtZDUQ14J1Fmm7PkqJDuJWd1c=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6/go.mod h1:0EzSyjHDLYSNqo3Bp9lSQs53CTaGbXHB5ovCa6BoOOM=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 h1:vG3FwU52KCZq74Tq7elg+Gm/Eyx3rE2P7hOnJ8NrQzc=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440/go.mod h1:Nhvp2f+FW4SCaWJtDFc59vRAFoWistXNLmxk2i879Cw=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848 h1:B2ns2U3nZs8Wk0coMobIzO0ZI8/BmPLJzki/DHZfPEo=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848/go.mod h1:L5v6d4KEG8+WkxBE34WhjC4AsDzSB6fqF5WpeSyGJKw=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1603,8 +1603,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.11 h1:yBzjU0Cu8AcfuM858G
 github.com/smartcontractkit/chainlink-data-streams v0.1.11/go.mod h1:8rUcGhjeXBoTFx2MynWgXiBWzVSB+LXd9JR6m8y2FfQ=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6 h1:wVGho+uL3UEqhzMtAXmtZDUQ14J1Fmm7PkqJDuJWd1c=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6/go.mod h1:0EzSyjHDLYSNqo3Bp9lSQs53CTaGbXHB5ovCa6BoOOM=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717 h1:OiR/E3lq1jMlA6B9mqhom0f2JeNJOCIxbbyktBlR+Fg=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717/go.mod h1:jBZMFIz1C3sq/YyuTgk5MCu12SdHP+PcujdojZsSk6g=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 h1:vG3FwU52KCZq74Tq7elg+Gm/Eyx3rE2P7hOnJ8NrQzc=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440/go.mod h1:Nhvp2f+FW4SCaWJtDFc59vRAFoWistXNLmxk2i879Cw=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1591,8 +1591,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856 h1:e/L0oKHTwXjqIf66vw8NWYvXecCq5tybGwHm7YK9wuo=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856/go.mod h1:wLN3X89JoiWr951CX+lALwmDirEm1KzP0n+gGFblwxw=
-github.com/smartcontractkit/chainlink-common v0.10.0 h1:d90b9UPJecrIryzhl43F1oQwkJQoug3TaANlJ1xLHyI=
-github.com/smartcontractkit/chainlink-common v0.10.0/go.mod h1:13YN2kb3Vqpw2S7d4IwhX/578WPGC0JHN5JrOnAEsOc=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3 h1:kKYwuaUklodjRTIz8uyjjFg/A+QC8a4VQ7jzIs684Ok=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3/go.mod h1:Xkgene5cOdtOYKxZsJfdQbhxSyomfzMDxyuQDAi0ecQ=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9 h1:dWqd2lOW3GbwtgZEeDSDI1b1X175MPOlCU6GDQQVBjk=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9/go.mod h1:SMegDBf3KDs2tuKApmTRyO2xQthMu3gV2J+IuHEs0Y0=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=

--- a/integration-tests/smoke/ccip/ccip_reader_bench_test.go
+++ b/integration-tests/smoke/ccip/ccip_reader_bench_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmchaintypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
 	evmconfig "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/configs/evm"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -392,7 +391,7 @@ func populateDatabaseForCommitReportAccepted(
 
 		// Create log entry
 		logs = append(logs, logpoller.Log{
-			EVMChainID:     ubig.New(new(big.Int).SetUint64(uint64(destChain))),
+			EVMChainID:     sqlutil.New(new(big.Int).SetUint64(uint64(destChain))),
 			LogIndex:       logIndex,
 			BlockHash:      utils.NewHash(),
 			BlockNumber:    blockNumber,
@@ -528,7 +527,7 @@ func populateDatabaseForMessageSent(
 
 		// Create log entry
 		logs = append(logs, logpoller.Log{
-			EVMChainID:     ubig.New(big.NewInt(0).SetUint64(uint64(sourceChain))),
+			EVMChainID:     sqlutil.New(big.NewInt(0).SetUint64(uint64(sourceChain))),
 			LogIndex:       logIndex,
 			BlockHash:      utils.NewHash(),
 			BlockNumber:    blockNumber,
@@ -646,7 +645,7 @@ func populateDatabaseForExecutionStateChanged(
 
 		// Create log entry
 		logs = append(logs, logpoller.Log{
-			EVMChainID:     ubig.New(big.NewInt(0).SetUint64(uint64(destChain))),
+			EVMChainID:     sqlutil.New(big.NewInt(0).SetUint64(uint64(destChain))),
 			LogIndex:       logIndex,
 			BlockHash:      utils.NewHash(),
 			BlockNumber:    blockNumber,

--- a/integration-tests/types/config/node/core.go
+++ b/integration-tests/types/config/node/core.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/blockchain"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/ptr"
 	itutils "github.com/smartcontractkit/chainlink/integration-tests/utils"
@@ -19,7 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	evmcfg "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/config/toml"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	corechainlink "github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
@@ -111,7 +111,7 @@ func WithPrivateEVMs(networks []blockchain.EVMNetwork, commonChainConfig *evmcfg
 		}
 
 		evmConfig := &evmcfg.EVMConfig{
-			ChainID: ubig.New(big.NewInt(network.ChainID)),
+			ChainID: sqlutil.New(big.NewInt(network.ChainID)),
 			Nodes:   evmNodes,
 			Chain:   evmcfg.Chain{},
 		}

--- a/system-tests/lib/cre/don/config/config.go
+++ b/system-tests/lib/cre/don/config/config.go
@@ -19,9 +19,9 @@ import (
 	"github.com/smartcontractkit/libocr/commontypes"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/chaintype"
 	evmconfigtoml "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
-	chainlinkbig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	solcfg "github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	chipingressset "github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose/chip_ingress_set"
@@ -710,7 +710,7 @@ func findOneSolanaChain(input cre.GenerateConfigsInput) (*solanaChain, error) {
 func buildTronEVMConfig(evmChain *evmChain) evmconfigtoml.EVMConfig {
 	tronRPC := strings.Replace(evmChain.HTTPRPC, "jsonrpc", "wallet", 1)
 	return evmconfigtoml.EVMConfig{
-		ChainID: chainlinkbig.New(big.NewInt(libc.MustSafeInt64(evmChain.ChainID))),
+		ChainID: sqlutil.New(big.NewInt(libc.MustSafeInt64(evmChain.ChainID))),
 		Chain: evmconfigtoml.Chain{
 			AutoCreateKey:         ptr.Ptr(false),
 			ChainType:             chaintype.NewConfig("tron"),
@@ -731,7 +731,7 @@ func buildTronEVMConfig(evmChain *evmChain) evmconfigtoml.EVMConfig {
 
 func buildEVMConfig(evmChain *evmChain) evmconfigtoml.EVMConfig {
 	return evmconfigtoml.EVMConfig{
-		ChainID: chainlinkbig.New(big.NewInt(libc.MustSafeInt64(evmChain.ChainID))),
+		ChainID: sqlutil.New(big.NewInt(libc.MustSafeInt64(evmChain.ChainID))),
 		Chain: evmconfigtoml.Chain{
 			AutoCreateKey: ptr.Ptr(false),
 		},
@@ -755,7 +755,7 @@ func appendEVMChain(existingConfig *evmconfigtoml.EVMConfigs, evmChain *evmChain
 
 	// add only unconfigured chains, since other roles might have already added some chains
 	for _, existingEVM := range *existingConfig {
-		if existingEVM.ChainID.Cmp(chainlinkbig.New(big.NewInt(libc.MustSafeInt64(evmChain.ChainID)))) == 0 {
+		if existingEVM.ChainID.ToInt().Cmp(big.NewInt(libc.MustSafeInt64(evmChain.ChainID))) == 0 {
 			return
 		}
 	}

--- a/system-tests/lib/cre/features/evm/v1/evm.go
+++ b/system-tests/lib/cre/features/evm/v1/evm.go
@@ -19,7 +19,6 @@ import (
 	cldf_tron "github.com/smartcontractkit/chainlink-deployments-framework/chain/tron"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	evmworkflow "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
-	chainlinkbig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/ptr"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -298,7 +297,7 @@ func updateNodeConfig(workerNode *cre.NodeMetadata, currentConfig string, don *c
 	for _, w := range writeEvmConfigs {
 		chainFound := false
 		for idx, evmChain := range typedConfig.EVM {
-			chainIDIsEqual := evmChain.ChainID.Cmp(chainlinkbig.New(big.NewInt(libc.MustSafeInt64(w.ChainID)))) == 0
+			chainIDIsEqual := evmChain.ChainID.ToInt().Cmp(big.NewInt(libc.MustSafeInt64(w.ChainID))) == 0
 			if chainIDIsEqual {
 				evmWorkflow, evmErr := buildEVMWorkflowConfig(w)
 				if evmErr != nil {

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/sethvargo/go-retry v0.3.0
 	github.com/smartcontractkit/chain-selectors v1.0.91
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
-	github.com/smartcontractkit/chainlink-common v0.10.0
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260210221717-2546aed27ebe
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -32,10 +32,10 @@ require (
 	github.com/sethvargo/go-retry v0.3.0
 	github.com/smartcontractkit/chain-selectors v1.0.91
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
-	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260210221717-2546aed27ebe
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.17.0

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1568,8 +1568,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856 h1:e/L0oKHTwXjqIf66vw8NWYvXecCq5tybGwHm7YK9wuo=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856/go.mod h1:wLN3X89JoiWr951CX+lALwmDirEm1KzP0n+gGFblwxw=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3 h1:kKYwuaUklodjRTIz8uyjjFg/A+QC8a4VQ7jzIs684Ok=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3/go.mod h1:Xkgene5cOdtOYKxZsJfdQbhxSyomfzMDxyuQDAi0ecQ=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6 h1:bkKoQ7jW25iHtbbriRj5YPHokalaFH2ImBtiKm3QmKU=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6/go.mod h1:13YN2kb3Vqpw2S7d4IwhX/578WPGC0JHN5JrOnAEsOc=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9 h1:dWqd2lOW3GbwtgZEeDSDI1b1X175MPOlCU6GDQQVBjk=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9/go.mod h1:SMegDBf3KDs2tuKApmTRyO2xQthMu3gV2J+IuHEs0Y0=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
@@ -1580,8 +1580,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.11 h1:yBzjU0Cu8AcfuM858G
 github.com/smartcontractkit/chainlink-data-streams v0.1.11/go.mod h1:8rUcGhjeXBoTFx2MynWgXiBWzVSB+LXd9JR6m8y2FfQ=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6 h1:wVGho+uL3UEqhzMtAXmtZDUQ14J1Fmm7PkqJDuJWd1c=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6/go.mod h1:0EzSyjHDLYSNqo3Bp9lSQs53CTaGbXHB5ovCa6BoOOM=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 h1:vG3FwU52KCZq74Tq7elg+Gm/Eyx3rE2P7hOnJ8NrQzc=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440/go.mod h1:Nhvp2f+FW4SCaWJtDFc59vRAFoWistXNLmxk2i879Cw=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848 h1:B2ns2U3nZs8Wk0coMobIzO0ZI8/BmPLJzki/DHZfPEo=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848/go.mod h1:L5v6d4KEG8+WkxBE34WhjC4AsDzSB6fqF5WpeSyGJKw=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1568,8 +1568,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856 h1:e/L0oKHTwXjqIf66vw8NWYvXecCq5tybGwHm7YK9wuo=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856/go.mod h1:wLN3X89JoiWr951CX+lALwmDirEm1KzP0n+gGFblwxw=
-github.com/smartcontractkit/chainlink-common v0.10.0 h1:d90b9UPJecrIryzhl43F1oQwkJQoug3TaANlJ1xLHyI=
-github.com/smartcontractkit/chainlink-common v0.10.0/go.mod h1:13YN2kb3Vqpw2S7d4IwhX/578WPGC0JHN5JrOnAEsOc=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3 h1:kKYwuaUklodjRTIz8uyjjFg/A+QC8a4VQ7jzIs684Ok=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3/go.mod h1:Xkgene5cOdtOYKxZsJfdQbhxSyomfzMDxyuQDAi0ecQ=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9 h1:dWqd2lOW3GbwtgZEeDSDI1b1X175MPOlCU6GDQQVBjk=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9/go.mod h1:SMegDBf3KDs2tuKApmTRyO2xQthMu3gV2J+IuHEs0Y0=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1580,8 +1580,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.11 h1:yBzjU0Cu8AcfuM858G
 github.com/smartcontractkit/chainlink-data-streams v0.1.11/go.mod h1:8rUcGhjeXBoTFx2MynWgXiBWzVSB+LXd9JR6m8y2FfQ=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6 h1:wVGho+uL3UEqhzMtAXmtZDUQ14J1Fmm7PkqJDuJWd1c=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6/go.mod h1:0EzSyjHDLYSNqo3Bp9lSQs53CTaGbXHB5ovCa6BoOOM=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717 h1:OiR/E3lq1jMlA6B9mqhom0f2JeNJOCIxbbyktBlR+Fg=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717/go.mod h1:jBZMFIz1C3sq/YyuTgk5MCu12SdHP+PcujdojZsSk6g=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 h1:vG3FwU52KCZq74Tq7elg+Gm/Eyx3rE2P7hOnJ8NrQzc=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440/go.mod h1:Nhvp2f+FW4SCaWJtDFc59vRAFoWistXNLmxk2i879Cw=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.91
-	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-data-streams v0.1.11
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6
@@ -571,7 +571,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20260203202624-5101f4d33736 // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 // indirect
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251210101658-1c5c8e4c4f15 // indirect

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -571,7 +571,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20260203202624-5101f4d33736 // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717 // indirect
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251210101658-1c5c8e4c4f15 // indirect

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.91
-	github.com/smartcontractkit/chainlink-common v0.10.0
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9
 	github.com/smartcontractkit/chainlink-data-streams v0.1.11
 	github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1789,8 +1789,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.11 h1:yBzjU0Cu8AcfuM858G
 github.com/smartcontractkit/chainlink-data-streams v0.1.11/go.mod h1:8rUcGhjeXBoTFx2MynWgXiBWzVSB+LXd9JR6m8y2FfQ=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6 h1:wVGho+uL3UEqhzMtAXmtZDUQ14J1Fmm7PkqJDuJWd1c=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6/go.mod h1:0EzSyjHDLYSNqo3Bp9lSQs53CTaGbXHB5ovCa6BoOOM=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717 h1:OiR/E3lq1jMlA6B9mqhom0f2JeNJOCIxbbyktBlR+Fg=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260205183656-836ec9472717/go.mod h1:jBZMFIz1C3sq/YyuTgk5MCu12SdHP+PcujdojZsSk6g=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 h1:vG3FwU52KCZq74Tq7elg+Gm/Eyx3rE2P7hOnJ8NrQzc=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440/go.mod h1:Nhvp2f+FW4SCaWJtDFc59vRAFoWistXNLmxk2i879Cw=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1777,8 +1777,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856 h1:e/L0oKHTwXjqIf66vw8NWYvXecCq5tybGwHm7YK9wuo=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856/go.mod h1:wLN3X89JoiWr951CX+lALwmDirEm1KzP0n+gGFblwxw=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3 h1:kKYwuaUklodjRTIz8uyjjFg/A+QC8a4VQ7jzIs684Ok=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3/go.mod h1:Xkgene5cOdtOYKxZsJfdQbhxSyomfzMDxyuQDAi0ecQ=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6 h1:bkKoQ7jW25iHtbbriRj5YPHokalaFH2ImBtiKm3QmKU=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260217084735-307a5770c4f6/go.mod h1:13YN2kb3Vqpw2S7d4IwhX/578WPGC0JHN5JrOnAEsOc=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9 h1:dWqd2lOW3GbwtgZEeDSDI1b1X175MPOlCU6GDQQVBjk=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9/go.mod h1:SMegDBf3KDs2tuKApmTRyO2xQthMu3gV2J+IuHEs0Y0=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4 h1:NOUsjsMzNecbjiPWUQGlRSRAutEvCFrqqyETDJeh5q4=
@@ -1789,8 +1789,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.11 h1:yBzjU0Cu8AcfuM858G
 github.com/smartcontractkit/chainlink-data-streams v0.1.11/go.mod h1:8rUcGhjeXBoTFx2MynWgXiBWzVSB+LXd9JR6m8y2FfQ=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6 h1:wVGho+uL3UEqhzMtAXmtZDUQ14J1Fmm7PkqJDuJWd1c=
 github.com/smartcontractkit/chainlink-deployments-framework v0.80.1-0.20260209182815-b296b7df28a6/go.mod h1:0EzSyjHDLYSNqo3Bp9lSQs53CTaGbXHB5ovCa6BoOOM=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440 h1:vG3FwU52KCZq74Tq7elg+Gm/Eyx3rE2P7hOnJ8NrQzc=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260216165558-524139c87440/go.mod h1:Nhvp2f+FW4SCaWJtDFc59vRAFoWistXNLmxk2i879Cw=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848 h1:B2ns2U3nZs8Wk0coMobIzO0ZI8/BmPLJzki/DHZfPEo=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260217091030-daa23bfb6848/go.mod h1:L5v6d4KEG8+WkxBE34WhjC4AsDzSB6fqF5WpeSyGJKw=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1777,8 +1777,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c84
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260129103204-4c8453dd8139/go.mod h1:gUbichNQBqk+fBF2aV40ZkzFmAJ8SygH6DEPd3cJkQE=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856 h1:e/L0oKHTwXjqIf66vw8NWYvXecCq5tybGwHm7YK9wuo=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260210123725-95a6e7788856/go.mod h1:wLN3X89JoiWr951CX+lALwmDirEm1KzP0n+gGFblwxw=
-github.com/smartcontractkit/chainlink-common v0.10.0 h1:d90b9UPJecrIryzhl43F1oQwkJQoug3TaANlJ1xLHyI=
-github.com/smartcontractkit/chainlink-common v0.10.0/go.mod h1:13YN2kb3Vqpw2S7d4IwhX/578WPGC0JHN5JrOnAEsOc=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3 h1:kKYwuaUklodjRTIz8uyjjFg/A+QC8a4VQ7jzIs684Ok=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260216162501-7d7392eae0c3/go.mod h1:Xkgene5cOdtOYKxZsJfdQbhxSyomfzMDxyuQDAi0ecQ=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9 h1:dWqd2lOW3GbwtgZEeDSDI1b1X175MPOlCU6GDQQVBjk=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2-0.20260211140822-b833b412cdd9/go.mod h1:SMegDBf3KDs2tuKApmTRyO2xQthMu3gV2J+IuHEs0Y0=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4 h1:NOUsjsMzNecbjiPWUQGlRSRAutEvCFrqqyETDJeh5q4=


### PR DESCRIPTION
We use moved bigInt from sqlutil package everywhere with the following caveats:
 - Inlined `hexutil.EncodeBig(b.ToInt())` to produce hex output
 - Inlined most arithmetic operations with ToInt() conversion. (Only in `core/services/s4/address_range.go` added `sub` and `add` to simplify the transition)
 - Ignored existing lint issues related to unchecked uint64->int64 conversion and var naming (to keep this PR focused on bigInt only)


Requires
	https://github.com/smartcontractkit/chainlink-common/pull/1841
	https://github.com/smartcontractkit/chainlink-evm/pull/359