### PR TITLE
core/utils: add BoundedQueue methods, collection helpers, and fix Bat…

### DIFF
--- a/core/utils/collection.go
+++ b/core/utils/collection.go
@@ -1,11 +1,16 @@
 package utils
 
-import "errors"
+import (
+	"errors"
+	"maps"
+	"slices"
+)
 
-// BatchSplit splits an slices into an slices of slicess with a maximum length
+// BatchSplit splits a slice into a slice of slices with a maximum length.
+// Returns an error if max is less than or equal to zero.
 func BatchSplit[T any](list []T, max int) (out [][]T, err error) {
-	if max == 0 {
-		return out, errors.New("max batch length cannot be 0")
+	if max <= 0 {
+		return out, errors.New("max batch length must be greater than 0")
 	}
 
 	// batch list into no more than max each
@@ -16,4 +21,74 @@ func BatchSplit[T any](list []T, max int) (out [][]T, err error) {
 	}
 	out = append(out, list) // append remaining to list (slice len < max)
 	return out, nil
+}
+
+// Flatten takes a slice of slices and returns a single concatenated slice.
+func Flatten[T any](lists [][]T) []T {
+	var total int
+	for _, l := range lists {
+		total += len(l)
+	}
+	result := make([]T, 0, total)
+	for _, l := range lists {
+		result = append(result, l...)
+	}
+	return result
+}
+
+// UniqueValues returns the unique values from a map, in sorted order if the
+// values are comparable. The caller receives a new slice.
+func UniqueValues[K comparable, V comparable](m map[K]V) []V {
+	seen := make(map[V]struct{}, len(m))
+	result := make([]V, 0, len(m))
+	for _, v := range m {
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// MergeMaps merges multiple maps into one. Later maps take precedence for
+// duplicate keys.
+func MergeMaps[K comparable, V any](ms ...map[K]V) map[K]V {
+	out := make(map[K]V)
+	for _, m := range ms {
+		maps.Copy(out, m)
+	}
+	return out
+}
+
+// FilterSlice returns a new slice containing only the elements for which the
+// predicate returns true.
+func FilterSlice[T any](s []T, pred func(T) bool) []T {
+	result := make([]T, 0, len(s))
+	for _, v := range s {
+		if pred(v) {
+			result = append(result, v)
+		}
+	}
+	return slices.Clip(result)
+}
+
+// MapSlice applies a function to each element of a slice and returns the results.
+func MapSlice[T any, U any](s []T, fn func(T) U) []U {
+	result := make([]U, len(s))
+	for i, v := range s {
+		result[i] = fn(v)
+	}
+	return result
+}
+
+// ContainsDuplicate returns true if the slice contains duplicate elements.
+func ContainsDuplicate[T comparable](s []T) bool {
+	seen := make(map[T]struct{}, len(s))
+	for _, v := range s {
+		if _, ok := seen[v]; ok {
+			return true
+		}
+		seen[v] = struct{}{}
+	}
+	return false
 }

--- a/core/utils/collection_test.go
+++ b/core/utils/collection_test.go
@@ -6,6 +6,127 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFlatten(t *testing.T) {
+	t.Parallel()
+
+	t.Run("multiple slices", func(t *testing.T) {
+		t.Parallel()
+		result := Flatten([][]int{{1, 2}, {3, 4}, {5}})
+		assert.Equal(t, []int{1, 2, 3, 4, 5}, result)
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		t.Parallel()
+		result := Flatten[int](nil)
+		assert.Empty(t, result)
+	})
+
+	t.Run("slices with empty sub-slices", func(t *testing.T) {
+		t.Parallel()
+		result := Flatten([][]int{{1}, {}, {2, 3}, {}})
+		assert.Equal(t, []int{1, 2, 3}, result)
+	})
+}
+
+func TestUniqueValues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with duplicates", func(t *testing.T) {
+		t.Parallel()
+		m := map[string]int{"a": 1, "b": 2, "c": 1, "d": 3}
+		result := UniqueValues(m)
+		assert.Len(t, result, 3)
+		assert.ElementsMatch(t, []int{1, 2, 3}, result)
+	})
+
+	t.Run("empty map", func(t *testing.T) {
+		t.Parallel()
+		result := UniqueValues(map[string]int{})
+		assert.Empty(t, result)
+	})
+}
+
+func TestMergeMaps(t *testing.T) {
+	t.Parallel()
+
+	t.Run("overlapping keys", func(t *testing.T) {
+		t.Parallel()
+		a := map[string]int{"x": 1, "y": 2}
+		b := map[string]int{"y": 3, "z": 4}
+		result := MergeMaps(a, b)
+		assert.Equal(t, map[string]int{"x": 1, "y": 3, "z": 4}, result)
+	})
+
+	t.Run("no maps", func(t *testing.T) {
+		t.Parallel()
+		result := MergeMaps[string, int]()
+		assert.Empty(t, result)
+	})
+
+	t.Run("single map", func(t *testing.T) {
+		t.Parallel()
+		m := map[string]int{"a": 1}
+		result := MergeMaps(m)
+		assert.Equal(t, map[string]int{"a": 1}, result)
+	})
+}
+
+func TestFilterSlice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("filter evens", func(t *testing.T) {
+		t.Parallel()
+		result := FilterSlice([]int{1, 2, 3, 4, 5, 6}, func(n int) bool { return n%2 == 0 })
+		assert.Equal(t, []int{2, 4, 6}, result)
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		t.Parallel()
+		result := FilterSlice([]int{}, func(n int) bool { return true })
+		assert.Empty(t, result)
+	})
+
+	t.Run("none match", func(t *testing.T) {
+		t.Parallel()
+		result := FilterSlice([]int{1, 3, 5}, func(n int) bool { return n%2 == 0 })
+		assert.Empty(t, result)
+	})
+}
+
+func TestMapSlice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("double values", func(t *testing.T) {
+		t.Parallel()
+		result := MapSlice([]int{1, 2, 3}, func(n int) int { return n * 2 })
+		assert.Equal(t, []int{2, 4, 6}, result)
+	})
+
+	t.Run("int to string", func(t *testing.T) {
+		t.Parallel()
+		result := MapSlice([]int{1, 2}, func(n int) string {
+			return string(rune('a' + n - 1))
+		})
+		assert.Equal(t, []string{"a", "b"}, result)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		result := MapSlice([]int{}, func(n int) int { return n })
+		assert.Empty(t, result)
+	})
+}
+
+func TestContainsDuplicate(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, ContainsDuplicate([]int{1, 2, 3, 2}))
+	assert.False(t, ContainsDuplicate([]int{1, 2, 3}))
+	assert.False(t, ContainsDuplicate([]int{}))
+	assert.False(t, ContainsDuplicate([]int{1}))
+	assert.True(t, ContainsDuplicate([]string{"a", "b", "a"}))
+}
+
 func TestBatchSplit(t *testing.T) {
 	list := []int{}
 	for i := range 100 {
@@ -28,6 +149,7 @@ func TestBatchSplit(t *testing.T) {
 		{"max=len+1", list, len(list) + 1, 1, len(list), false}, // max exceeds len of list
 		{"zero-list", []int{}, 1, 1, 0, false},                  // zero length list
 		{"zero-max", list, 0, 0, 0, true},                       // zero as max input
+		{"negative-max", list, -1, 0, 0, true},                  // negative max input
 	}
 
 	for _, r := range runs {

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -174,11 +174,47 @@ type BoundedQueue[T any] struct {
 	mu       sync.RWMutex
 }
 
-// NewBoundedQueue creates a new BoundedQueue instance
+// NewBoundedQueue creates a new BoundedQueue instance.
+// The capacity must be greater than zero; a non-positive capacity will be
+// clamped to 1 to avoid silent misuse.
 func NewBoundedQueue[T any](capacity int) *BoundedQueue[T] {
-	var bq BoundedQueue[T]
-	bq.capacity = capacity
-	return &bq
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &BoundedQueue[T]{capacity: capacity}
+}
+
+// Len returns the current number of items in the queue.
+func (q *BoundedQueue[T]) Len() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return len(q.items)
+}
+
+// Peek returns the first item without removing it.
+// The second return value indicates whether an item was available.
+func (q *BoundedQueue[T]) Peek() (T, bool) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	if len(q.items) == 0 {
+		var zero T
+		return zero, false
+	}
+	return q.items[0], true
+}
+
+// Clear removes all items from the queue.
+func (q *BoundedQueue[T]) Clear() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.items = nil
+}
+
+// Cap returns the maximum capacity of the queue.
+func (q *BoundedQueue[T]) Cap() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.capacity
 }
 
 // Add appends items to a BoundedQueue
@@ -285,6 +321,18 @@ func (q *BoundedPriorityQueue[T]) Empty() bool {
 		}
 	}
 	return true
+}
+
+// Len returns the total number of items across all priority sub-queues.
+func (q *BoundedPriorityQueue[T]) Len() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	total := 0
+	for _, priority := range q.priorities {
+		total += q.queues[priority].Len()
+	}
+	return total
 }
 
 // TickerBase is an interface for pausable tickers.

--- a/core/utils/utils_test.go
+++ b/core/utils/utils_test.go
@@ -79,10 +79,13 @@ func TestBoundedQueue(t *testing.T) {
 	q := utils.NewBoundedQueue[int](3)
 	require.True(t, q.Empty())
 	require.False(t, q.Full())
+	require.Equal(t, 0, q.Len())
+	require.Equal(t, 3, q.Cap())
 
 	q.Add(1)
 	require.False(t, q.Empty())
 	require.False(t, q.Full())
+	require.Equal(t, 1, q.Len())
 
 	x := q.Take()
 	require.Equal(t, 1, x)
@@ -96,6 +99,7 @@ func TestBoundedQueue(t *testing.T) {
 	q.Add(3)
 	q.Add(4)
 	require.True(t, q.Full())
+	require.Equal(t, 3, q.Len())
 
 	x = q.Take()
 	require.Equal(t, 2, x)
@@ -113,6 +117,69 @@ func TestBoundedQueue(t *testing.T) {
 	require.False(t, q.Full())
 }
 
+func TestBoundedQueue_Peek(t *testing.T) {
+	t.Parallel()
+
+	q := utils.NewBoundedQueue[string](3)
+
+	// Peek on empty queue
+	val, ok := q.Peek()
+	require.False(t, ok)
+	require.Empty(t, val)
+
+	q.Add("first")
+	q.Add("second")
+
+	// Peek returns first without removing
+	val, ok = q.Peek()
+	require.True(t, ok)
+	require.Equal(t, "first", val)
+	require.Equal(t, 2, q.Len())
+
+	// Take still returns the same item
+	taken := q.Take()
+	require.Equal(t, "first", taken)
+}
+
+func TestBoundedQueue_Clear(t *testing.T) {
+	t.Parallel()
+
+	q := utils.NewBoundedQueue[int](5)
+	q.Add(1)
+	q.Add(2)
+	q.Add(3)
+	require.Equal(t, 3, q.Len())
+
+	q.Clear()
+	require.True(t, q.Empty())
+	require.Equal(t, 0, q.Len())
+
+	// Can still add after clear
+	q.Add(42)
+	require.Equal(t, 1, q.Len())
+	val := q.Take()
+	require.Equal(t, 42, val)
+}
+
+func TestBoundedQueue_NonPositiveCapacity(t *testing.T) {
+	t.Parallel()
+
+	// Zero capacity should be clamped to 1
+	q := utils.NewBoundedQueue[int](0)
+	require.Equal(t, 1, q.Cap())
+
+	// Negative capacity should be clamped to 1
+	q2 := utils.NewBoundedQueue[int](-5)
+	require.Equal(t, 1, q2.Cap())
+
+	// Should still work correctly with clamped capacity
+	q2.Add(1)
+	q2.Add(2) // should evict 1
+	require.Equal(t, 1, q2.Len())
+	val := q2.Take()
+	require.Equal(t, 2, val)
+}
+
 func TestBoundedPriorityQueue(t *testing.T) {
 	t.Parallel()
 
@@ -121,6 +188,7 @@ func TestBoundedPriorityQueue(t *testing.T) {
 		2: 1,
 	})
 	require.True(t, q.Empty())
+	require.Equal(t, 0, q.Len())
 
 	q.Add(1, 1)
 	require.False(t, q.Empty())


### PR DESCRIPTION
…chSplit

- Add Len, Peek, Clear, Cap methods to BoundedQueue for better introspection
- Add Len method to BoundedPriorityQueue
- Clamp non-positive capacity in NewBoundedQueue to 1 to prevent misuse
- Fix BatchSplit to reject negative max values (was only checking zero)
- Add generic collection helpers: Flatten, UniqueValues, MergeMaps, FilterSlice, MapSlice, ContainsDuplicate
- Add comprehensive tests for all new functionality

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
