### PR TITLE
Remove unnecessary ldflags when installing local plugins

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -105,11 +105,11 @@ install-plugins-testing: ## Build & install testing only LOOPP binaries (plugins
 
 .PHONY: install-plugins-local
 install-plugins-local: ## Build & install local plugins
-	go install -ldflags="-s" ./plugins/cmd/chainlink-evm & \
-	go install -ldflags="-s" ./plugins/cmd/chainlink-medianpoc & \
-	go install -ldflags="-s" ./plugins/cmd/chainlink-ocr3-capability & \
-	go install -ldflags="-s" ./plugins/cmd/capabilities/log-event-trigger & \
-	wait
+	go install -ldflags="-s" \
+		./plugins/cmd/chainlink-evm \
+		./plugins/cmd/chainlink-medianpoc \
+		./plugins/cmd/chainlink-ocr3-capability \
+		./plugins/cmd/capabilities/log-event-trigger
 
 .PHONY: make install-plugins
 install-plugins: install-plugins-local install-plugins-public ## Build and install local and public plugins via loopinstall

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -105,10 +105,10 @@ install-plugins-testing: ## Build & install testing only LOOPP binaries (plugins
 
 .PHONY: install-plugins-local
 install-plugins-local: ## Build & install local plugins
-	go install $(GOFLAGS) ./plugins/cmd/chainlink-evm
-	go install $(GOFLAGS) ./plugins/cmd/chainlink-medianpoc
-	go install $(GOFLAGS) ./plugins/cmd/chainlink-ocr3-capability
-	go install $(GOFLAGS) ./plugins/cmd/capabilities/log-event-trigger
+	go install -ldflags="-s" ./plugins/cmd/chainlink-evm
+	go install -ldflags="-s" ./plugins/cmd/chainlink-medianpoc
+	go install -ldflags="-s" ./plugins/cmd/chainlink-ocr3-capability
+	go install -ldflags="-s" ./plugins/cmd/capabilities/log-event-trigger
 
 .PHONY: make install-plugins
 install-plugins: install-plugins-local install-plugins-public ## Build and install local and public plugins via loopinstall

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -105,10 +105,11 @@ install-plugins-testing: ## Build & install testing only LOOPP binaries (plugins
 
 .PHONY: install-plugins-local
 install-plugins-local: ## Build & install local plugins
-	go install -ldflags="-s" ./plugins/cmd/chainlink-evm
-	go install -ldflags="-s" ./plugins/cmd/chainlink-medianpoc
-	go install -ldflags="-s" ./plugins/cmd/chainlink-ocr3-capability
-	go install -ldflags="-s" ./plugins/cmd/capabilities/log-event-trigger
+	go install -ldflags="-s" ./plugins/cmd/chainlink-evm & \
+	go install -ldflags="-s" ./plugins/cmd/chainlink-medianpoc & \
+	go install -ldflags="-s" ./plugins/cmd/chainlink-ocr3-capability & \
+	go install -ldflags="-s" ./plugins/cmd/capabilities/log-event-trigger & \
+	wait
 
 .PHONY: make install-plugins
 install-plugins: install-plugins-local install-plugins-public ## Build and install local and public plugins via loopinstall


### PR DESCRIPTION
We were passing in unnecessary flags that weren't actually being used before.

Before:
```
❯ time make install-plugins-local
go install -ldflags "-X github.com/smartcontractkit/chainlink/v2/core/static.Version=2.35.0 -X github.com/smartcontractkit/chainlink/v2/core/static.VersionTag=v2.29.1-cre-beta.0-582-g140625edee -X github.com/smartcontractkit/chainlink/v2/core/static.Sha=140625edee02df6a608178b166e72cf2bd8a14a1" ./plugins/cmd/chainlink-evm
go install -ldflags "-X github.com/smartcontractkit/chainlink/v2/core/static.Version=2.35.0 -X github.com/smartcontractkit/chainlink/v2/core/static.VersionTag=v2.29.1-cre-beta.0-582-g140625edee -X github.com/smartcontractkit/chainlink/v2/core/static.Sha=140625edee02df6a608178b166e72cf2bd8a14a1" ./plugins/cmd/chainlink-medianpoc
go install -ldflags "-X github.com/smartcontractkit/chainlink/v2/core/static.Version=2.35.0 -X github.com/smartcontractkit/chainlink/v2/core/static.VersionTag=v2.29.1-cre-beta.0-582-g140625edee -X github.com/smartcontractkit/chainlink/v2/core/static.Sha=140625edee02df6a608178b166e72cf2bd8a14a1" ./plugins/cmd/chainlink-ocr3-capability
go install -ldflags "-X github.com/smartcontractkit/chainlink/v2/core/static.Version=2.35.0 -X github.com/smartcontractkit/chainlink/v2/core/static.VersionTag=v2.29.1-cre-beta.0-582-g140625edee -X github.com/smartcontractkit/chainlink/v2/core/static.Sha=140625edee02df6a608178b166e72cf2bd8a14a1" ./plugins/cmd/capabilities/log-event-trigger

________________________________________________________
Executed in   20.53 secs    fish           external
   usr time   21.88 secs    0.25 millis   21.88 secs
   sys time   24.19 secs    1.78 millis   24.19 secs
```

After:
```
❯ time make install-plugins-local
go install -ldflags="-s" \
                ./plugins/cmd/chainlink-evm \
                ./plugins/cmd/chainlink-medianpoc \
                ./plugins/cmd/chainlink-ocr3-capability \
                ./plugins/cmd/capabilities/log-event-trigger

________________________________________________________
Executed in    1.03 secs    fish           external
   usr time    0.91 secs   23.31 millis    0.88 secs
   sys time    8.59 secs    1.37 millis    8.59 secs
```

Installs all local plugins concurrently for a slight speedup (20s (old) vs 1s (new)) and adding the `-ldflags="-s"` makes the binaries smaller (168 MB (old) for chainlink-evm vs 120 MB (new)).