### PR TITLE
vault: default qualifier, shared MCMS per chain, migration changeset

### DIFF
--- a/deployment/common/changeset/deploy_mcms_with_timelock.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock.go
@@ -28,8 +28,21 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 )
 
+// DefaultTimelockQualifier is the qualifier used for the first (default) timelock on a chain when the user omits qualifier.
+// Existing prod_mainnet refs should be migrated to this qualifier so FindQualifierWithFullMCMSSet and lookups work.
+const DefaultTimelockQualifier = "default"
+
+// timelockQualifierFromConfig returns the qualifier to use for deploy/storage. Empty or nil from config becomes DefaultTimelockQualifier.
+func timelockQualifierFromConfig(q *string) string {
+	if q != nil && *q != "" {
+		return *q
+	}
+	return DefaultTimelockQualifier
+}
+
 // migrateAddressBookWithQualifiers migrates an address book to a data store,
-// applying custom qualifiers from MCMS configs when available
+// applying custom qualifiers from MCMS configs when available.
+// First deploy on a chain uses DefaultTimelockQualifier ("default") when qualifier is omitted.
 func migrateAddressBookWithQualifiers(ab cldf.AddressBook, cfgByChain map[uint64]types.MCMSWithTimelockConfigV2) (datastore.MutableDataStore, error) {
 	addrs, err := ab.Addresses()
 	if err != nil {
@@ -39,10 +52,9 @@ func migrateAddressBookWithQualifiers(ab cldf.AddressBook, cfgByChain map[uint64
 	ds := datastore.NewMemoryDataStore()
 
 	for chainSelector, chainAddresses := range addrs {
-		// Get the qualifier for this chain from the config
-		qualifier := ""
-		if cfg, exists := cfgByChain[chainSelector]; exists && cfg.Qualifier != nil && *cfg.Qualifier != "" {
-			qualifier = *cfg.Qualifier
+		qualifier := DefaultTimelockQualifier
+		if cfg, exists := cfgByChain[chainSelector]; exists {
+			qualifier = timelockQualifierFromConfig(cfg.Qualifier)
 		}
 
 		for addr, typever := range chainAddresses {
@@ -53,8 +65,7 @@ func migrateAddressBookWithQualifiers(ab cldf.AddressBook, cfgByChain map[uint64
 				Version:       &typever.Version,
 			}
 
-			// If we have a custom qualifier for this chain, use it for MCMS contracts
-			if qualifier != "" && isMCMSContract(string(typever.Type)) {
+			if isMCMSContract(string(typever.Type)) {
 				ref.Qualifier = qualifier
 			}
 
@@ -85,8 +96,17 @@ func isMCMSContract(contractType string) bool {
 	return slices.Contains(mcmsTypes, contractType)
 }
 
+// DeployTimelockInput is the input for deploy_timelock when using SharedMCMSPerChain (e.g. prod_mainnet, staging_testnet).
+// When SharedMCMSPerChain is true, for any chain that already has a full MCMS set in the datastore (Bypasser, Canceller, Proposer, CallProxy, RBACTimelock),
+// only a new RBACTimelock (and its CallProxy) is deployed with the new qualifier; the existing MCMS contracts are reused.
+type DeployTimelockInput struct {
+	Chains            map[uint64]types.MCMSWithTimelockConfigV2 `json:"chains"`
+	SharedMCMSPerChain bool                                     `json:"sharedMCMSPerChain"`
+}
+
 var (
 	_ cldf.ChangeSet[map[uint64]types.MCMSWithTimelockConfigV2] = DeployMCMSWithTimelockV2
+	_ cldf.ChangeSet[DeployTimelockInput]                        = DeployMCMSWithTimelockV2FromInput
 
 	// GrantRoleInTimeLock grants proposer, canceller, bypasser, executor, admin roles to the timelock contract with corresponding addresses if the
 	// roles are not already set with the same addresses.
@@ -96,16 +116,63 @@ var (
 	GrantRoleInTimeLock = cldf.CreateChangeSet(grantRoleLogic, grantRolePreconditions)
 )
 
+// DeployMCMSWithTimelockV2FromInput runs deploy_timelock with optional SharedMCMSPerChain behavior.
+// When SharedMCMSPerChain is true and a chain already has a full MCMS set in the datastore, only a new RBACTimelock (and CallProxy) is deployed for the new qualifier.
+func DeployMCMSWithTimelockV2FromInput(env cldf.Environment, input DeployTimelockInput) (cldf.ChangesetOutput, error) {
+	return deployMCMSWithTimelockV2Core(env, input.Chains, input.SharedMCMSPerChain)
+}
+
 // DeployMCMSWithTimelockV2 deploys and initializes the MCM and Timelock contracts
 func DeployMCMSWithTimelockV2(
 	env cldf.Environment, cfgByChain map[uint64]types.MCMSWithTimelockConfigV2,
 ) (cldf.ChangesetOutput, error) {
+	return deployMCMSWithTimelockV2Core(env, cfgByChain, false)
+}
+
+func deployMCMSWithTimelockV2Core(
+	env cldf.Environment, cfgByChain map[uint64]types.MCMSWithTimelockConfigV2, sharedMCMSPerChain bool,
+) (cldf.ChangesetOutput, error) {
+	// Fail if any (chain, qualifier) already has addresses in the datastore so we never overwrite or duplicate.
+	if env.DataStore != nil {
+		for chainSel, cfg := range cfgByChain {
+			qualifier := timelockQualifierFromConfig(cfg.Qualifier)
+			existing := env.DataStore.Addresses().Filter(
+				datastore.AddressRefByChainSelector(chainSel),
+				datastore.AddressRefByQualifier(qualifier),
+			)
+			if len(existing) > 0 {
+				return cldf.ChangesetOutput{}, fmt.Errorf(
+					"chain %d qualifier %q already has %d address ref(s) in the datastore; cannot deploy again with the same qualifier on this chain",
+					chainSel, qualifier, len(existing),
+				)
+			}
+		}
+	}
+
+	// Require proposer, bypasser, and canceller for chains that will do a full deploy.
+	// When SharedMCMSPerChain is true and the chain already has a full set, we only deploy timelock+callProxy and skip MCMS validation.
+	for chainSel, cfg := range cfgByChain {
+		skipValidation := false
+		if sharedMCMSPerChain && env.DataStore != nil {
+			if _, found := state.FindQualifierWithFullMCMSSet(env.DataStore.Addresses(), chainSel); found {
+				skipValidation = true
+			}
+		}
+		if !skipValidation {
+			if err := evminternal.ValidateMCMSWithTimelockConfigV2(cfg); err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("chain %d: %w", chainSel, err)
+			}
+		}
+	}
+
 	newAddresses := cldf.NewMemoryAddressBook()
 
 	eg := xerrgroup.Group{}
 	mu := sync.Mutex{}
 	allReports := make([]operations.Report[any, any], 0)
 	for chainSel, cfg := range cfgByChain {
+		chainSel := chainSel
+		cfg := cfg
 		eg.Go(func() error {
 			family, err := chain_selectors.GetSelectorFamily(chainSel)
 			if err != nil {
@@ -114,28 +181,38 @@ func DeployMCMSWithTimelockV2(
 
 			switch family {
 			case chain_selectors.FamilyEVM:
-				// Extract qualifier from config for this chain
-				qualifier := ""
-				if cfg.Qualifier != nil {
-					qualifier = *cfg.Qualifier
-				}
+				qualifier := timelockQualifierFromConfig(cfg.Qualifier)
 
-				// load mcms state with qualifier awareness
-				// we load the state one by one to avoid early return from MaybeLoadMCMSWithTimelockStateWithQualifier
-				// due to one of the chain not found
 				var chainstate *state.MCMSWithTimelockState
-				s, err := state.MaybeLoadMCMSWithTimelockStateWithQualifier(env, []uint64{chainSel}, qualifier)
-				if err != nil {
-					// if the state is not found for chain, we assume it's a fresh deployment
-					// this includes "no addresses found" which is expected for new qualifiers
-					if !strings.Contains(err.Error(), cldf.ErrChainNotFound.Error()) &&
-						!strings.Contains(err.Error(), "no addresses found") {
-						return err
+				if sharedMCMSPerChain && env.DataStore != nil {
+					if sharedQ, found := state.FindQualifierWithFullMCMSSet(env.DataStore.Addresses(), chainSel); found {
+						// Reuse existing MCMS + CallProxy; only deploy new Timelock + CallProxy for this qualifier.
+						fullState, err := state.GetMCMSWithTimelockState(env.DataStore.Addresses(), env.BlockChains.EVMChains()[chainSel], sharedQ)
+						if err != nil {
+							return fmt.Errorf("chain %d: load shared MCMS state: %w", chainSel, err)
+						}
+						chainstate = &state.MCMSWithTimelockState{
+							BypasserMcm:  fullState.BypasserMcm,
+							ProposerMcm:  fullState.ProposerMcm,
+							CancellerMcm: fullState.CancellerMcm,
+							Timelock:     nil,
+							CallProxy:    nil,
+						}
 					}
 				}
-				if s != nil {
-					chainstate = s[chainSel]
+				if chainstate == nil {
+					s, err := state.MaybeLoadMCMSWithTimelockStateWithQualifier(env, []uint64{chainSel}, qualifier)
+					if err != nil {
+						if !strings.Contains(err.Error(), cldf.ErrChainNotFound.Error()) &&
+							!strings.Contains(err.Error(), "no addresses found") {
+							return err
+						}
+					}
+					if s != nil {
+						chainstate = s[chainSel]
+					}
 				}
+
 				reports, err := evminternal.DeployMCMSWithTimelockContractsEVM(env, env.BlockChains.EVMChains()[chainSel], newAddresses, cfg, chainstate)
 				mu.Lock()
 				allReports = append(allReports, reports...)

--- a/deployment/common/changeset/deploy_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock_test.go
@@ -36,6 +36,85 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/internal/soltestutils"
 )
 
+func TestDeployMCMSWithTimelockV2FailsWhenQualifierAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	selector := chain_selectors.TEST_90000001.Selector
+	ds := datastore.NewMemoryDataStore()
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: selector,
+		Address:       "0x1234567890123456789012345678901234567890",
+		Type:          datastore.ContractType(commontypes.RBACTimelock),
+		Version:       &deployment.Version1_0_0,
+		Qualifier:     "",
+	}))
+
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
+		environment.WithDatastore(ds.Seal()),
+	)
+	require.NoError(t, err)
+
+	_, err = commonchangeset.DeployMCMSWithTimelockV2(*env, map[uint64]commontypes.MCMSWithTimelockConfigV2{
+		selector: proposalutils.SingleGroupTimelockConfigV2(t),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already has")
+	require.Contains(t, err.Error(), "address ref")
+	require.Contains(t, err.Error(), "cannot deploy again with the same qualifier")
+
+	// Same chain with non-empty qualifier that already exists should also fail
+	ds2 := datastore.NewMemoryDataStore()
+	require.NoError(t, ds2.Addresses().Add(datastore.AddressRef{
+		ChainSelector: selector,
+		Address:       "0xabcdef0000000000000000000000000000000000",
+		Type:          datastore.ContractType(commontypes.RBACTimelock),
+		Version:       &deployment.Version1_0_0,
+		Qualifier:     "vault_2",
+	}))
+	env2, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
+		environment.WithDatastore(ds2.Seal()),
+	)
+	require.NoError(t, err)
+	qualifierV2 := "vault_2"
+	_, err = commonchangeset.DeployMCMSWithTimelockV2(*env2, map[uint64]commontypes.MCMSWithTimelockConfigV2{
+		selector: {
+			Proposer:        proposalutils.SingleGroupTimelockConfigV2(t).Proposer,
+			Canceller:       proposalutils.SingleGroupTimelockConfigV2(t).Canceller,
+			Bypasser:        proposalutils.SingleGroupTimelockConfigV2(t).Bypasser,
+			TimelockMinDelay: big.NewInt(0),
+			Qualifier:        &qualifierV2,
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "vault_2")
+	require.Contains(t, err.Error(), "already has")
+}
+
+func TestDeployMCMSWithTimelockV2FailsWhenProposerBypasserCancellerMissing(t *testing.T) {
+	t.Parallel()
+
+	selector := chain_selectors.TEST_90000001.Selector
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
+	)
+	require.NoError(t, err)
+
+	// Omit proposer, bypasser, canceller in YAML → unmarshalled as zero value; deploy must fail fast.
+	_, err = commonchangeset.DeployMCMSWithTimelockV2(*env, map[uint64]commontypes.MCMSWithTimelockConfigV2{
+		selector: {
+			TimelockMinDelay: big.NewInt(0),
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "chain ")
+	require.Regexp(t, `(proposer|bypasser|canceller).*required|required.*(proposer|bypasser|canceller)`, err.Error())
+}
+
 func TestGrantRoleInTimeLock(t *testing.T) {
 	selector := chain_selectors.TEST_90000001.Selector
 	env, err := environment.New(t.Context(),
@@ -93,6 +172,11 @@ func TestGrantRoleInTimeLock(t *testing.T) {
 	chain := evmChains[selector]
 	chain.DeployerKey = evmChains[selector].Users[0]
 
+	// Clear DataStore so the duplicate-(chain,qualifier) check does not run; this test is
+	// re-deploying only the proposer (state is loaded from AddressBook). In production,
+	// deploy with the same (chain, qualifier) would fail if refs already exist.
+	updatedEnv.DataStore = nil
+
 	// now deploy MCMS again so that only the proposer is new
 	updatedEnv, err = commonchangeset.Apply(t, updatedEnv, configuredChangeset)
 	require.NoError(t, err)
@@ -128,39 +212,22 @@ func TestDeployMCMSWithTimelockV2WithFewExistingContracts(t *testing.T) {
 	selector2 := chain_selectors.TEST_90000002.Selector
 	selectors := []uint64{selector1, selector2}
 
-	// Build a datastore with some dummy address for callproxy, canceller and bypasser
-	// to simulate the case where they already exist and so the changeset will not try to deploy
-	// them again
-	ds := datastore.NewMemoryDataStore()
-
 	callProxyAddress := utils.RandomAddress()
 	mcmsAddress := utils.RandomAddress()
 	mcmsType := cldf.NewTypeAndVersion(commontypes.ManyChainMultisig, deployment.Version1_0_0)
-	// we use same address for bypasser and canceller
 	mcmsType.AddLabel(commontypes.BypasserRole.String())
 	mcmsType.AddLabel(commontypes.CancellerRole.String())
 
-	// Add CallProxy for first chain only
-	require.NoError(t, ds.AddressRefStore.Add(datastore.AddressRef{
-		ChainSelector: selector1,
-		Address:       callProxyAddress.String(),
-		Type:          datastore.ContractType(commontypes.CallProxy),
-		Version:       &deployment.Version1_0_0,
-	}))
-
-	// Add MCMS contract with both bypasser and canceller labels for first chain only
-	require.NoError(t, ds.AddressRefStore.Add(datastore.AddressRef{
-		ChainSelector: selector1,
-		Address:       mcmsAddress.String(),
-		Type:          datastore.ContractType(mcmsType.Type),
-		Version:       &mcmsType.Version,
-		Labels:        datastore.NewLabelSet(mcmsType.Labels.List()...),
-	}))
+	// Use empty datastore so the duplicate-(chain,qualifier) check passes. Put "few existing"
+	// refs in the address book so the deploy sees them and does not redeploy CallProxy/MCMS for chain1.
+	ab := cldf.NewMemoryAddressBook()
+	require.NoError(t, ab.Save(selector1, callProxyAddress.String(), cldf.NewTypeAndVersion(commontypes.CallProxy, deployment.Version1_0_0)))
+	require.NoError(t, ab.Save(selector1, mcmsAddress.String(), mcmsType))
 
 	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithEVMSimulated(t, selectors),
 		environment.WithLogger(logger.Test(t)),
-		environment.WithDatastore(ds.Seal()),
+		environment.WithAddressBook(ab),
 	))
 	require.NoError(t, err)
 

--- a/deployment/common/changeset/evm/mcms/mcms.go
+++ b/deployment/common/changeset/evm/mcms/mcms.go
@@ -55,6 +55,22 @@ type MCMSWithTimelockEVMDeploy struct {
 	CallProxy *cldf.ContractDeploy[*bindings.CallProxy]
 }
 
+// ValidateMCMSWithTimelockConfigV2 checks that proposer, bypasser, and canceller
+// configs are valid (can be used by ExtractSetConfigInputs). Returns an error
+// describing which role is missing or invalid so deploy fails fast with a clear message.
+func ValidateMCMSWithTimelockConfigV2(config commontypes.MCMSWithTimelockConfigV2) error {
+	for role, cfg := range map[string]mcmsTypes.Config{
+		"proposer": config.Proposer,
+		"bypasser": config.Bypasser,
+		"canceller": config.Canceller,
+	} {
+		if _, _, _, _, err := sdk.ExtractSetConfigInputs(&cfg); err != nil {
+			return fmt.Errorf("%s config is required and must be valid (quorum and at least one signer): %w", role, err)
+		}
+	}
+	return nil
+}
+
 // TODO: Remove this function once the tests are implemented for the new sequence.
 func DeployMCMSWithConfigEVM(
 	contractType cldf.ContractType,
@@ -184,6 +200,15 @@ func DeployMCMSWithTimelockContractsEVM(
 		lggr.Infow("Bypasser MCMS deployed", "chain", chain.String(), "address", bypasser.Address().String())
 	} else {
 		lggr.Infow("Bypasser MCMS already deployed", "chain", chain.String(), "address", bypasser.Address().String())
+		// Persist existing MCMS to address book so migration writes it under this run's qualifier (shared-MCMS / timelock-only path).
+		typeAndVersion := cldf.NewTypeAndVersion(commontypes.BypasserManyChainMultisig, deployment.Version1_0_0)
+		for _, option := range opts {
+			option(&typeAndVersion)
+		}
+		if err := ab.Save(chain.Selector, bypasser.Address().Hex(), typeAndVersion); err != nil {
+			lggr.Errorw("Failed to save existing bypasser MCMS to address book", "chain", chain.String(), "err", err)
+			return execReports, err
+		}
 	}
 
 	if canceller == nil {
@@ -223,6 +248,14 @@ func DeployMCMSWithTimelockContractsEVM(
 		lggr.Infow("Canceller MCMS deployed", "chain", chain.String(), "address", canceller.Address().String())
 	} else {
 		lggr.Infow("Canceller MCMS already deployed", "chain", chain.String(), "address", canceller.Address().String())
+		typeAndVersion := cldf.NewTypeAndVersion(commontypes.CancellerManyChainMultisig, deployment.Version1_0_0)
+		for _, option := range opts {
+			option(&typeAndVersion)
+		}
+		if err := ab.Save(chain.Selector, canceller.Address().Hex(), typeAndVersion); err != nil {
+			lggr.Errorw("Failed to save existing canceller MCMS to address book", "chain", chain.String(), "err", err)
+			return execReports, err
+		}
 	}
 
 	if proposer == nil {
@@ -262,6 +295,14 @@ func DeployMCMSWithTimelockContractsEVM(
 		lggr.Infow("Proposer MCMS deployed", "chain", chain.String(), "address", proposer.Address().String())
 	} else {
 		lggr.Infow("Proposer MCMS already deployed", "chain", chain.String(), "address", proposer.Address().String())
+		typeAndVersion := cldf.NewTypeAndVersion(commontypes.ProposerManyChainMultisig, deployment.Version1_0_0)
+		for _, option := range opts {
+			option(&typeAndVersion)
+		}
+		if err := ab.Save(chain.Selector, proposer.Address().Hex(), typeAndVersion); err != nil {
+			lggr.Errorw("Failed to save existing proposer MCMS to address book", "chain", chain.String(), "err", err)
+			return execReports, err
+		}
 	}
 
 	if timelock == nil {

--- a/deployment/common/changeset/migrate_address_refs_to_default_qualifier.go
+++ b/deployment/common/changeset/migrate_address_refs_to_default_qualifier.go
@@ -1,0 +1,66 @@
+package changeset
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/types"
+)
+
+// MigrateAddressRefsToDefaultQualifierInput is the input for the migration pipeline.
+// ChainSelectors lists the chain selectors whose MCMS address refs should get qualifier "default".
+// Run this once per environment (e.g. prod_mainnet) to add refs with qualifier "default" so
+// FindQualifierWithFullMCMSSet and batch_native/set_whitelist/transfer_erc20 lookups work.
+type MigrateAddressRefsToDefaultQualifierInput struct {
+	ChainSelectors []uint64 `json:"chain_selectors"`
+}
+
+// MigrateAddressRefsToDefaultQualifier reads the current datastore and outputs a new DataStore
+// containing one ref per MCMS contract (Bypasser, Canceller, Proposer, CallProxy, RBACTimelock)
+// on the given chains with qualifier DefaultTimelockQualifier ("default"). When the framework
+// merges this into the environment, lookups by qualifier "default" will find these refs.
+// Run once per environment; safe to run multiple times (adds refs, may duplicate if already migrated).
+func MigrateAddressRefsToDefaultQualifier(env cldf.Environment, input MigrateAddressRefsToDefaultQualifierInput) (cldf.ChangesetOutput, error) {
+	if env.DataStore == nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("datastore is required for migration")
+	}
+	if len(input.ChainSelectors) == 0 {
+		return cldf.ChangesetOutput{}, fmt.Errorf("chain_selectors must be non-empty")
+	}
+
+	store := env.DataStore.Addresses()
+	ds := datastore.NewMemoryDataStore()
+	mcmsTypes := map[datastore.ContractType]bool{
+		datastore.ContractType(types.BypasserManyChainMultisig):  true,
+		datastore.ContractType(types.CancellerManyChainMultisig): true,
+		datastore.ContractType(types.ProposerManyChainMultisig):  true,
+		datastore.ContractType(types.CallProxy):                  true,
+		datastore.ContractType(types.RBACTimelock):               true,
+	}
+
+	var added int
+	for _, chainSelector := range input.ChainSelectors {
+		refs := store.Filter(datastore.AddressRefByChainSelector(chainSelector))
+		for _, ref := range refs {
+			if !mcmsTypes[datastore.ContractType(ref.Type)] {
+				continue
+			}
+			migrated := ref
+			migrated.Qualifier = DefaultTimelockQualifier
+			if err := ds.Addresses().Add(migrated); err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("chain %d: add migrated ref: %w", chainSelector, err)
+			}
+			added++
+		}
+	}
+
+	if added == 0 {
+		return cldf.ChangesetOutput{}, fmt.Errorf("no MCMS address refs found for the given chain_selectors; nothing to migrate")
+	}
+
+	_ = state.RequiredMCMSContractTypes // keep state package in use so FindQualifierWithFullMCMSSet stays consistent
+	return cldf.ChangesetOutput{DataStore: ds}, nil
+}

--- a/deployment/common/changeset/state/evm.go
+++ b/deployment/common/changeset/state/evm.go
@@ -20,6 +20,47 @@ import (
 	view "github.com/smartcontractkit/chainlink/deployment/common/view/v1_0"
 )
 
+// RequiredMCMSContractTypes is the set of contract types that must exist for a "full" MCMS+timelock set per qualifier.
+var RequiredMCMSContractTypes = []datastore.ContractType{
+	datastore.ContractType(types.BypasserManyChainMultisig),
+	datastore.ContractType(types.CancellerManyChainMultisig),
+	datastore.ContractType(types.ProposerManyChainMultisig),
+	datastore.ContractType(types.CallProxy),
+	datastore.ContractType(types.RBACTimelock),
+}
+
+// FindQualifierWithFullMCMSSet returns a qualifier for the given chain that has at least one address ref
+// for each of BypasserManyChainMultiSig, CancellerManyChainMultiSig, ProposerManyChainMultisig, CallProxy, RBACTimelock.
+// If none exists, returns ("", false).
+func FindQualifierWithFullMCMSSet(store datastore.AddressRefStore, chainSelector uint64) (qualifier string, found bool) {
+	refs := store.Filter(datastore.AddressRefByChainSelector(chainSelector))
+	if len(refs) == 0 {
+		return "", false
+	}
+	// Group by qualifier (use string for map key; empty string for nil/empty qualifier)
+	byQualifier := make(map[string]map[datastore.ContractType]bool)
+	for _, ref := range refs {
+		q := ref.Qualifier
+		if byQualifier[q] == nil {
+			byQualifier[q] = make(map[datastore.ContractType]bool)
+		}
+		byQualifier[q][datastore.ContractType(ref.Type)] = true
+	}
+	for q, typesSet := range byQualifier {
+		hasAll := true
+		for _, t := range RequiredMCMSContractTypes {
+			if !typesSet[t] {
+				hasAll = false
+				break
+			}
+		}
+		if hasAll {
+			return q, true
+		}
+	}
+	return "", false
+}
+
 // MCMSWithTimelockState holds the Go bindings
 // for a MCMSWithTimelock contract deployment.
 // It is public for use in product specific packages.

--- a/deployment/vault/changeset/batch_native_transfer.go
+++ b/deployment/vault/changeset/batch_native_transfer.go
@@ -49,9 +49,10 @@ func (b batchNativeTransferChangeset) Apply(e cldf.Environment, cfg types.BatchN
 	}
 
 	seqInput := BatchNativeTransferSequenceInput{
-		TransfersByChain: cfg.TransfersByChain,
-		MCMSConfig:       cfg.MCMSConfig,
-		Description:      cfg.Description,
+		TransfersByChain:  cfg.TransfersByChain,
+		MCMSConfig:        cfg.MCMSConfig,
+		Description:       cfg.Description,
+		TimelockIDByChain: cfg.TimelockIDByChain,
 	}
 
 	seqReport, err := operations.ExecuteSequence(e.OperationsBundle, BatchNativeTransferSequence, deps, seqInput)

--- a/deployment/vault/changeset/batch_native_transfer_test.go
+++ b/deployment/vault/changeset/batch_native_transfer_test.go
@@ -101,6 +101,21 @@ func TestBatchNativeTransferValidation(t *testing.T) {
 			wantError: true,
 			errorMsg:  "'to' address cannot be zero address",
 		},
+		{
+			name: "TimelockIDByChain but timelock not found for qualifier",
+			config: types.BatchNativeTransferConfig{
+				TransfersByChain: map[uint64][]types.NativeTransfer{
+					testChainID: {
+						{To: testAddr1, Amount: OneETH},
+					},
+				},
+				TimelockIDByChain: map[uint64]string{testChainID: "nonexistent_timelock"},
+				MCMSConfig:        &proposalutils.TimelockConfig{MinDelay: 0},
+				Description:       "Multi-timelock test",
+			},
+			wantError: true,
+			errorMsg:  "timelock not found",
+		},
 	}
 
 	for _, tt := range tests {

--- a/deployment/vault/changeset/manage_whitelist.go
+++ b/deployment/vault/changeset/manage_whitelist.go
@@ -36,39 +36,88 @@ func (s whitelistChangeset) Apply(e cldf.Environment, cfg types.SetWhitelistConf
 		}
 	}
 
-	totalAddresses := 0
-	for _, addresses := range cfg.WhitelistByChain {
-		totalAddresses += len(addresses)
-	}
+	useMulti := len(cfg.WhitelistByChainAndTimelock) > 0
 
-	lggr.Infow("Setting whitelist state",
-		"chains", len(cfg.WhitelistByChain),
-		"total_addresses", totalAddresses,
-		"mode", s.mode)
-
-	for chainSelector, addresses := range cfg.WhitelistByChain {
-		lggr.Infow("Setting whitelist for chain",
-			"chain", chainSelector,
-			"address_count", len(addresses),
+	if useMulti {
+		totalAddresses := 0
+		for _, byTimelock := range cfg.WhitelistByChainAndTimelock {
+			for _, addrs := range byTimelock {
+				totalAddresses += len(addrs)
+			}
+		}
+		lggr.Infow("Setting whitelist state (multi-timelock)",
+			"chains", len(cfg.WhitelistByChainAndTimelock),
+			"total_addresses", totalAddresses,
 			"mode", s.mode)
 
-		existingMetadata, err := getChainWhitelist(ds.Seal(), chainSelector)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to load existing whitelist for chain %d: %w", chainSelector, err)
+		for chainSelector, byTimelock := range cfg.WhitelistByChainAndTimelock {
+			vaultMeta, err := getVaultChainMetadata(ds.Seal(), chainSelector)
+			if err != nil {
+				return cldf.ChangesetOutput{}, err
+			}
+			if vaultMeta.ByTimelock == nil {
+				vaultMeta.ByTimelock = make(map[string][]types.WhitelistAddress)
+			}
+
+			for timelockID, addresses := range byTimelock {
+				lggr.Infow("Setting whitelist for chain and timelock",
+					"chain", chainSelector,
+					"timelock_id", timelockID,
+					"address_count", len(addresses),
+					"mode", s.mode)
+
+				existingAddrs, err := getChainWhitelistForTimelock(ds.Seal(), chainSelector, timelockID)
+				if err != nil {
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to load existing whitelist for chain %d timelock %q: %w", chainSelector, timelockID, err)
+				}
+
+				combined := s.reducer(existingAddrs, addresses)
+				vaultMeta.ByTimelock[timelockID] = combined
+			}
+
+			err = ds.ChainMetadata().Upsert(datastore.ChainMetadata{
+				ChainSelector: chainSelector,
+				Metadata:      *vaultMeta,
+			})
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to set whitelist chain metadata for chain %d: %w", chainSelector, err)
+			}
+		}
+	} else {
+		totalAddresses := 0
+		for _, addresses := range cfg.WhitelistByChain {
+			totalAddresses += len(addresses)
 		}
 
-		combined := s.reducer(existingMetadata.Addresses, addresses)
+		lggr.Infow("Setting whitelist state",
+			"chains", len(cfg.WhitelistByChain),
+			"total_addresses", totalAddresses,
+			"mode", s.mode)
 
-		whitelistMetadata := types.WhitelistMetadata{
-			Addresses: combined,
-		}
+		for chainSelector, addresses := range cfg.WhitelistByChain {
+			lggr.Infow("Setting whitelist for chain",
+				"chain", chainSelector,
+				"address_count", len(addresses),
+				"mode", s.mode)
 
-		err = ds.ChainMetadata().Upsert(datastore.ChainMetadata{
-			ChainSelector: chainSelector,
-			Metadata:      whitelistMetadata,
-		})
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to set whitelist chain metadata for chain %d: %w", chainSelector, err)
+			existingMetadata, err := getChainWhitelist(ds.Seal(), chainSelector)
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to load existing whitelist for chain %d: %w", chainSelector, err)
+			}
+
+			combined := s.reducer(existingMetadata.Addresses, addresses)
+
+			whitelistMetadata := types.VaultChainMetadata{
+				Addresses: combined,
+			}
+
+			err = ds.ChainMetadata().Upsert(datastore.ChainMetadata{
+				ChainSelector: chainSelector,
+				Metadata:      whitelistMetadata,
+			})
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to set whitelist chain metadata for chain %d: %w", chainSelector, err)
+			}
 		}
 	}
 
@@ -183,39 +232,53 @@ func validateWhitelist(e cldf.Environment, cfg types.BatchNativeTransferConfig) 
 }
 
 func getChainWhitelist(dataStore datastore.DataStore, chainSelector uint64) (*types.WhitelistMetadata, error) {
-	chainMetadataKey := datastore.NewChainMetadataKey(chainSelector)
-	chainMetadata, err := dataStore.ChainMetadata().Get(chainMetadataKey)
+	addrs, err := getChainWhitelistForTimelock(dataStore, chainSelector, "")
 	if err != nil {
-		if errors.Is(err, datastore.ErrChainMetadataNotFound) {
-			return &types.WhitelistMetadata{Addresses: []types.WhitelistAddress{}}, nil
-		}
-		return nil, fmt.Errorf("failed to get chain metadata for chain %d: %w", chainSelector, err)
+		return nil, err
 	}
-
-	whitelistMetadata, err := datastore.As[types.WhitelistMetadata](chainMetadata.Metadata)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert chain metadata to whitelist metadata for chain %d: %w", chainSelector, err)
-	}
-
-	return &whitelistMetadata, nil
+	return &types.WhitelistMetadata{Addresses: addrs}, nil
 }
 
 func getChainWhitelistMutable(dataStore datastore.DataStore, chainSelector uint64) (*types.WhitelistMetadata, error) {
+	return getChainWhitelist(dataStore, chainSelector)
+}
+
+// getChainWhitelistForTimelock returns whitelist addresses for (chain, timelockID). Use "" for default/legacy timelock.
+func getChainWhitelistForTimelock(dataStore datastore.DataStore, chainSelector uint64, timelockID string) ([]types.WhitelistAddress, error) {
+	vaultMeta, err := getVaultChainMetadata(dataStore, chainSelector)
+	if err != nil {
+		return nil, err
+	}
+	if vaultMeta.ByTimelock != nil {
+		if addrs, ok := vaultMeta.ByTimelock[timelockID]; ok && len(addrs) > 0 {
+			return addrs, nil
+		}
+	}
+	return vaultMeta.Addresses, nil
+}
+
+// getVaultChainMetadata loads chain metadata as VaultChainMetadata (supports legacy WhitelistMetadata shape).
+func getVaultChainMetadata(dataStore datastore.DataStore, chainSelector uint64) (*types.VaultChainMetadata, error) {
 	chainMetadataKey := datastore.NewChainMetadataKey(chainSelector)
 	chainMetadata, err := dataStore.ChainMetadata().Get(chainMetadataKey)
 	if err != nil {
 		if errors.Is(err, datastore.ErrChainMetadataNotFound) {
-			return &types.WhitelistMetadata{Addresses: []types.WhitelistAddress{}}, nil
+			return &types.VaultChainMetadata{}, nil
 		}
 		return nil, fmt.Errorf("failed to get chain metadata for chain %d: %w", chainSelector, err)
 	}
 
-	whitelistMetadata, err := datastore.As[types.WhitelistMetadata](chainMetadata.Metadata)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert chain metadata to whitelist metadata for chain %d: %w", chainSelector, err)
+	// Try VaultChainMetadata first (handles both legacy "addresses" and "by_timelock")
+	if vaultMeta, err := datastore.As[types.VaultChainMetadata](chainMetadata.Metadata); err == nil {
+		return &vaultMeta, nil
 	}
 
-	return &whitelistMetadata, nil
+	// Fallback: legacy WhitelistMetadata
+	legacy, err := datastore.As[types.WhitelistMetadata](chainMetadata.Metadata)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert chain metadata for chain %d: %w", chainSelector, err)
+	}
+	return &types.VaultChainMetadata{Addresses: legacy.Addresses}, nil
 }
 
 type WhitelistEntry struct {

--- a/deployment/vault/changeset/manage_whitelist_test.go
+++ b/deployment/vault/changeset/manage_whitelist_test.go
@@ -45,7 +45,47 @@ func TestSetWhitelistValidation(t *testing.T) {
 				WhitelistByChain: map[uint64][]types.WhitelistAddress{},
 			},
 			wantError: true,
-			errorMsg:  "whitelist_by_chain must not be empty",
+			errorMsg:  "either whitelist_by_chain or whitelist_by_chain_and_timelock must be non-empty",
+		},
+		{
+			name: "neither whitelist_by_chain nor whitelist_by_chain_and_timelock",
+			config: types.SetWhitelistConfig{
+				WhitelistByChain:           map[uint64][]types.WhitelistAddress{},
+				WhitelistByChainAndTimelock: map[uint64]map[string][]types.WhitelistAddress{},
+			},
+			wantError: true,
+			errorMsg:  "either whitelist_by_chain or whitelist_by_chain_and_timelock must be non-empty",
+		},
+		{
+			name: "both whitelist_by_chain and whitelist_by_chain_and_timelock set",
+			config: types.SetWhitelistConfig{
+				WhitelistByChain: map[uint64][]types.WhitelistAddress{
+					selector1: {
+						{Address: common.HexToAddress(whitelistTestAddr1).Hex(), Description: "A", Labels: []string{"test"}},
+					},
+				},
+				WhitelistByChainAndTimelock: map[uint64]map[string][]types.WhitelistAddress{
+					selector1: {"": {{Address: common.HexToAddress(whitelistTestAddr2).Hex(), Description: "B", Labels: []string{"test"}}}},
+				},
+			},
+			wantError: true,
+			errorMsg:  "cannot set both whitelist_by_chain and whitelist_by_chain_and_timelock",
+		},
+		{
+			name: "valid whitelist_by_chain_and_timelock",
+			config: types.SetWhitelistConfig{
+				WhitelistByChainAndTimelock: map[uint64]map[string][]types.WhitelistAddress{
+					selector1: {
+						"": {
+							{Address: common.HexToAddress(whitelistTestAddr1).Hex(), Description: "Default timelock", Labels: []string{"team"}},
+						},
+						"vault_1": {
+							{Address: common.HexToAddress(whitelistTestAddr2).Hex(), Description: "Vault 1", Labels: []string{"partner"}},
+						},
+					},
+				},
+			},
+			wantError: false,
 		},
 		{
 			name: "zero address in whitelist",

--- a/deployment/vault/changeset/operations.go
+++ b/deployment/vault/changeset/operations.go
@@ -34,6 +34,7 @@ type VaultDeps struct {
 type ValidateTransferInput struct {
 	ChainSelector uint64                 `json:"chain_selector"`
 	Transfers     []types.NativeTransfer `json:"transfers"`
+	TimelockID    string                 `json:"timelock_id,omitempty"` // optional; for multi-timelock whitelist lookup
 }
 
 // ValidateTransferOutput contains validation results
@@ -77,18 +78,19 @@ var ValidateTransferOp = operations.NewOperation(
 	func(b operations.Bundle, deps VaultDeps, input ValidateTransferInput) (ValidateTransferOutput, error) {
 		b.Logger.Infow("Validating transfers against whitelist",
 			"chain", input.ChainSelector,
+			"timelock_id", input.TimelockID,
 			"transfers", len(input.Transfers))
 
 		output := ValidateTransferOutput{Valid: true, Errors: []string{}}
 
-		whitelistMetadata, err := getChainWhitelistMutable(deps.DataStore, input.ChainSelector)
+		whitelistAddrs, err := getChainWhitelistForTimelock(deps.DataStore, input.ChainSelector, input.TimelockID)
 		if err != nil {
 			return output, fmt.Errorf("failed to get whitelist for chain %d: %w", input.ChainSelector, err)
 		}
 
 		for _, transfer := range input.Transfers {
 			found := false
-			for _, whitelistedAddr := range whitelistMetadata.Addresses {
+			for _, whitelistedAddr := range whitelistAddrs {
 				if whitelistedAddr.Address == common.HexToAddress(transfer.To).Hex() {
 					found = true
 					break
@@ -240,9 +242,10 @@ var ExecuteNativeTransferOp = operations.NewOperation(
 
 // BatchNativeTransferSequenceInput is the input for the batch transfer sequence
 type BatchNativeTransferSequenceInput struct {
-	TransfersByChain map[uint64][]types.NativeTransfer `json:"transfers_by_chain"`
-	MCMSConfig       *proposalutils.TimelockConfig     `json:"mcms_config,omitempty"`
-	Description      string                            `json:"description"`
+	TransfersByChain   map[uint64][]types.NativeTransfer `json:"transfers_by_chain"`
+	MCMSConfig         *proposalutils.TimelockConfig     `json:"mcms_config,omitempty"`
+	Description        string                            `json:"description"`
+	TimelockIDByChain  map[uint64]string                 `json:"timelock_id_by_chain,omitempty"` // optional; for multi-timelock
 }
 
 type BatchNativeTransferSequenceOutput struct {
@@ -275,9 +278,14 @@ var BatchNativeTransferSequence = operations.NewSequence(
 
 		b.Logger.Infow("Validating transfers against whitelist")
 		for chainSelector, transfers := range input.TransfersByChain {
+			timelockID := ""
+			if input.TimelockIDByChain != nil {
+				timelockID = input.TimelockIDByChain[chainSelector]
+			}
 			validateInput := ValidateTransferInput{
 				ChainSelector: chainSelector,
 				Transfers:     transfers,
+				TimelockID:    timelockID,
 			}
 
 			validateReport, err := operations.ExecuteOperation(
@@ -358,7 +366,12 @@ func generateMCMSProposals(b operations.Bundle, deps VaultDeps, input BatchNativ
 			return BatchNativeTransferSequenceOutput{}, fmt.Errorf("chain %d not found in environment", chainSelector)
 		}
 
-		timelockAddr, err := GetContractAddress(deps.DataStore, chainSelector, commontypes.RBACTimelock)
+		qualifier := ""
+		if input.TimelockIDByChain != nil {
+			qualifier = input.TimelockIDByChain[chainSelector]
+		}
+
+		timelockAddr, err := GetContractAddressWithQualifier(deps.DataStore, chainSelector, commontypes.RBACTimelock, qualifier)
 		if err != nil {
 			return BatchNativeTransferSequenceOutput{}, fmt.Errorf("timelock not found for chain %d: %w", chainSelector, err)
 		}
@@ -366,10 +379,10 @@ func generateMCMSProposals(b operations.Bundle, deps VaultDeps, input BatchNativ
 		var mcmAddr string
 		var contractName string
 		if input.MCMSConfig.MCMSAction == mcmstypes.TimelockActionBypass {
-			mcmAddr, err = GetContractAddress(deps.DataStore, chainSelector, commontypes.BypasserManyChainMultisig)
+			mcmAddr, err = GetContractAddressWithQualifier(deps.DataStore, chainSelector, commontypes.BypasserManyChainMultisig, qualifier)
 			contractName = "bypasser"
 		} else {
-			mcmAddr, err = GetContractAddress(deps.DataStore, chainSelector, commontypes.ProposerManyChainMultisig)
+			mcmAddr, err = GetContractAddressWithQualifier(deps.DataStore, chainSelector, commontypes.ProposerManyChainMultisig, qualifier)
 			contractName = "proposer"
 		}
 		if err != nil {

--- a/deployment/vault/changeset/transfer_erc20.go
+++ b/deployment/vault/changeset/transfer_erc20.go
@@ -1,0 +1,135 @@
+package changeset
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/mcms"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+	mcmsevmsdk "github.com/smartcontractkit/mcms/sdk/evm"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/vault/changeset/types"
+)
+
+// ERC20 transfer method selector (transfer(address,uint256))
+var erc20TransferSelector = []byte{0xa9, 0x05, 0x9c, 0xbb}
+
+// encodeERC20TransferCalldata returns ABI-encoded transfer(to, amount) for standard ERC20
+func encodeERC20TransferCalldata(tr types.ERC20Transfer) ([]byte, error) {
+	uint256Ty, err := abi.NewType("uint256", "", nil)
+	if err != nil {
+		return nil, err
+	}
+	addressTy, err := abi.NewType("address", "", nil)
+	if err != nil {
+		return nil, err
+	}
+	args := abi.Arguments{
+		{Type: addressTy},
+		{Type: uint256Ty},
+	}
+	packed, err := args.Pack(
+		common.HexToAddress(tr.Payee),
+		tr.Amount,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return append(erc20TransferSelector, packed...), nil
+}
+
+var TransferERC20Changeset cldf.ChangeSetV2[types.TransferERC20Config] = transferERC20Changeset{}
+
+type transferERC20Changeset struct{}
+
+func (t transferERC20Changeset) VerifyPreconditions(e cldf.Environment, cfg types.TransferERC20Config) error {
+	return ValidateTransferERC20Config(e, cfg)
+}
+
+func (t transferERC20Changeset) Apply(e cldf.Environment, cfg types.TransferERC20Config) (cldf.ChangesetOutput, error) {
+	lggr := e.Logger
+
+	lggr.Infow("Starting ERC20 transfer from timelock",
+		"chain", cfg.ChainSelector,
+		"timelock_id", cfg.TimelockIdentifier,
+		"transfers", len(cfg.Transfers),
+		"description", cfg.Description)
+
+	evmChains := e.BlockChains.EVMChains()
+	chain, exists := evmChains[cfg.ChainSelector]
+	if !exists {
+		return cldf.ChangesetOutput{}, fmt.Errorf("chain %d not found in environment", cfg.ChainSelector)
+	}
+
+	timelockAddr, err := GetContractAddressWithQualifier(e.DataStore, cfg.ChainSelector, commontypes.RBACTimelock, cfg.TimelockIdentifier)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("timelock not found for chain %d: %w", cfg.ChainSelector, err)
+	}
+
+	proposerAddr, err := GetContractAddressWithQualifier(e.DataStore, cfg.ChainSelector, commontypes.ProposerManyChainMultisig, cfg.TimelockIdentifier)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("proposer not found for chain %d: %w", cfg.ChainSelector, err)
+	}
+
+	var transactions []mcmstypes.Transaction
+	for i, tr := range cfg.Transfers {
+		data, err := encodeERC20TransferCalldata(tr)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("transfer %d: failed to encode calldata: %w", i, err)
+		}
+
+		tx, err := proposalutils.TransactionForChain(
+			cfg.ChainSelector,
+			tr.Token,
+			data,
+			nil,
+			"ERC20Transfer",
+			[]string{"vault", "erc20-transfer"},
+		)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("transfer %d: %w", i, err)
+		}
+		transactions = append(transactions, tx)
+	}
+
+	batches := []mcmstypes.BatchOperation{{
+		ChainSelector: mcmstypes.ChainSelector(cfg.ChainSelector),
+		Transactions:  transactions,
+	}}
+
+	description := cfg.Description
+	if description == "" {
+		description = "Vault ERC20 Transfer"
+	}
+
+	mcmsConfig := proposalutils.TimelockConfig{MinDelay: 0}
+	if cfg.MCMSConfig != nil {
+		mcmsConfig = *cfg.MCMSConfig
+	}
+
+	proposal, err := proposalutils.BuildProposalFromBatchesV2(
+		e,
+		map[uint64]string{cfg.ChainSelector: timelockAddr},
+		map[uint64]string{cfg.ChainSelector: proposerAddr},
+		map[uint64]mcmsevmsdk.Inspector{cfg.ChainSelector: mcmsevmsdk.NewInspector(chain.Client)},
+		batches,
+		description,
+		mcmsConfig,
+	)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to build MCMS proposal: %w", err)
+	}
+
+	lggr.Infow("ERC20 transfer proposal built",
+		"chain", cfg.ChainSelector,
+		"transfers", len(cfg.Transfers))
+
+	return cldf.ChangesetOutput{
+		MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
+	}, nil
+}

--- a/deployment/vault/changeset/transfer_erc20_test.go
+++ b/deployment/vault/changeset/transfer_erc20_test.go
@@ -1,0 +1,185 @@
+package changeset
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	"github.com/smartcontractkit/chainlink/deployment/vault/changeset/types"
+)
+
+const (
+	transferERC20Payee    = "0x742d35cc64ca395db82e2e3e8fa8bc6d1b7c0832"
+	transferERC20Token    = "0x1234567890123456789012345678901234567890"
+	transferERC20ZeroAddr = "0x0000000000000000000000000000000000000000"
+)
+
+func TestValidateTransferERC20Config(t *testing.T) {
+	t.Parallel()
+
+	selector := chainselectors.TEST_90000001.Selector
+	env, err := environment.New(t.Context(), environment.WithEVMSimulated(t, []uint64{selector}))
+	require.NoError(t, err)
+
+	validMCMSConfig := &proposalutils.TimelockConfig{MinDelay: 0}
+
+	tests := []struct {
+		name      string
+		config    types.TransferERC20Config
+		wantError bool
+		errorMsg  string
+	}{
+		{
+			name: "empty transfers",
+			config: types.TransferERC20Config{
+				ChainSelector:      selector,
+				TimelockIdentifier: "",
+				Transfers:          []types.ERC20Transfer{},
+				MCMSConfig:         validMCMSConfig,
+			},
+			wantError: true,
+			errorMsg:  "transfers must not be empty",
+		},
+		{
+			name: "zero payee",
+			config: types.TransferERC20Config{
+				ChainSelector:      selector,
+				TimelockIdentifier: "",
+				Transfers: []types.ERC20Transfer{
+					{Payee: transferERC20ZeroAddr, Token: transferERC20Token, Amount: big.NewInt(100)},
+				},
+				MCMSConfig: validMCMSConfig,
+			},
+			wantError: true,
+			errorMsg:  "payee cannot be zero address",
+		},
+		{
+			name: "zero token",
+			config: types.TransferERC20Config{
+				ChainSelector:      selector,
+				TimelockIdentifier: "",
+				Transfers: []types.ERC20Transfer{
+					{Payee: transferERC20Payee, Token: transferERC20ZeroAddr, Amount: big.NewInt(100)},
+				},
+				MCMSConfig: validMCMSConfig,
+			},
+			wantError: true,
+			errorMsg:  "token address cannot be zero",
+		},
+		{
+			name: "zero amount",
+			config: types.TransferERC20Config{
+				ChainSelector:      selector,
+				TimelockIdentifier: "",
+				Transfers: []types.ERC20Transfer{
+					{Payee: transferERC20Payee, Token: transferERC20Token, Amount: big.NewInt(0)},
+				},
+				MCMSConfig: validMCMSConfig,
+			},
+			wantError: true,
+			errorMsg:  "amount must be positive",
+		},
+		{
+			name: "nil amount",
+			config: types.TransferERC20Config{
+				ChainSelector:      selector,
+				TimelockIdentifier: "",
+				Transfers: []types.ERC20Transfer{
+					{Payee: transferERC20Payee, Token: transferERC20Token, Amount: nil},
+				},
+				MCMSConfig: validMCMSConfig,
+			},
+			wantError: true,
+			errorMsg:  "amount must be positive",
+		},
+		{
+			name: "missing MCMSConfig",
+			config: types.TransferERC20Config{
+				ChainSelector:      selector,
+				TimelockIdentifier: "",
+				Transfers: []types.ERC20Transfer{
+					{Payee: transferERC20Payee, Token: transferERC20Token, Amount: big.NewInt(100)},
+				},
+				MCMSConfig: nil,
+			},
+			wantError: true,
+			errorMsg:  "MCMSConfig is required",
+		},
+		{
+			name: "invalid chain selector",
+			config: types.TransferERC20Config{
+				ChainSelector:      999999,
+				TimelockIdentifier: "",
+				Transfers: []types.ERC20Transfer{
+					{Payee: transferERC20Payee, Token: transferERC20Token, Amount: big.NewInt(100)},
+				},
+				MCMSConfig: validMCMSConfig,
+			},
+			wantError: true,
+			errorMsg:  "invalid chain selector",
+		},
+		{
+			name: "chain not in environment",
+			config: types.TransferERC20Config{
+				ChainSelector:      chainselectors.TEST_90000002.Selector,
+				TimelockIdentifier: "",
+				Transfers: []types.ERC20Transfer{
+					{Payee: transferERC20Payee, Token: transferERC20Token, Amount: big.NewInt(100)},
+				},
+				MCMSConfig: validMCMSConfig,
+			},
+			wantError: true,
+			errorMsg:  "not found in environment",
+		},
+		{
+			name: "timelock not found for qualifier",
+			config: types.TransferERC20Config{
+				ChainSelector:      selector,
+				TimelockIdentifier: "nonexistent_timelock",
+				Transfers: []types.ERC20Transfer{
+					{Payee: transferERC20Payee, Token: transferERC20Token, Amount: big.NewInt(100)},
+				},
+				MCMSConfig: validMCMSConfig,
+			},
+			wantError: true,
+			errorMsg:  "timelock not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateTransferERC20Config(*env, tt.config)
+			if tt.wantError {
+				require.Error(t, err)
+				if tt.errorMsg != "" {
+					require.Contains(t, err.Error(), tt.errorMsg)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestEncodeERC20TransferCalldata(t *testing.T) {
+	t.Parallel()
+
+	payee := common.HexToAddress(transferERC20Payee)
+	amount := big.NewInt(1000)
+
+	calldata, err := encodeERC20TransferCalldata(types.ERC20Transfer{
+		Payee:  payee.Hex(),
+		Token:  transferERC20Token,
+		Amount: amount,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, calldata, 4+32+32) // selector + address + uint256
+	require.Equal(t, erc20TransferSelector, calldata[:4])
+}

--- a/deployment/vault/changeset/types/types.go
+++ b/deployment/vault/changeset/types/types.go
@@ -22,6 +22,11 @@ type BatchNativeTransferConfig struct {
 
 	// Description for the MCMS proposal
 	Description string `json:"description"`
+
+	// TimelockIDByChain optionally maps chain selector to timelock qualifier for multi-timelock.
+	// When set, the timelock and proposer for each chain are resolved by this qualifier from the datastore.
+	// Omit or use empty string for legacy single-timelock-per-chain behavior.
+	TimelockIDByChain map[uint64]string `json:"timelock_id_by_chain,omitempty"`
 }
 
 // FundTimelockConfig configures funding timelock contracts with native tokens
@@ -39,13 +44,25 @@ type WhitelistAddress struct {
 
 // SetWhitelistConfig configures address whitelist state
 type SetWhitelistConfig struct {
-	// WhitelistByChain maps chain selector to the list of whitelisted addresses for that chain
-	WhitelistByChain map[uint64][]WhitelistAddress `json:"whitelist_by_chain"`
+	// WhitelistByChain maps chain selector to the list of whitelisted addresses for that chain (legacy, default timelock).
+	// Use when only one timelock per chain or for the default/empty qualifier.
+	WhitelistByChain map[uint64][]WhitelistAddress `json:"whitelist_by_chain,omitempty"`
+
+	// WhitelistByChainAndTimelock maps chain -> timelock_id -> list of addresses for multi-timelock.
+	// Use "" as timelock_id for the default/legacy timelock. When set, takes precedence over WhitelistByChain for that (chain, timelock).
+	WhitelistByChainAndTimelock map[uint64]map[string][]WhitelistAddress `json:"whitelist_by_chain_and_timelock,omitempty"`
 }
 
 // WhitelistMetadata represents the whitelist state for a single chain stored in chain metadata
 type WhitelistMetadata struct {
 	Addresses []WhitelistAddress `json:"addresses"`
+}
+
+// VaultChainMetadata is the value stored in chain metadata for vault. It supports both legacy (Addresses only)
+// and multi-timelock (ByTimelock keyed by timelock qualifier). Use "" for default/legacy timelock.
+type VaultChainMetadata struct {
+	Addresses   []WhitelistAddress            `json:"addresses,omitempty"`
+	ByTimelock  map[string][]WhitelistAddress `json:"by_timelock,omitempty"`
 }
 
 // TimelockNativeBalanceInfo represents native token balance information for Timelock
@@ -71,4 +88,29 @@ type BatchNativeTransferState struct {
 
 	// ValidationErrors contains any validation errors found
 	ValidationErrors []TransferValidationError `json:"validation_errors"`
+}
+
+// ERC20Transfer is a single ERC20 transfer (payee, token, amount in token units)
+type ERC20Transfer struct {
+	Payee  string   `json:"payee"`  // Destination address
+	Token  string   `json:"token"`  // ERC20 token contract address
+	Amount *big.Int `json:"amount"` // Amount in token units (not wei)
+}
+
+// TransferERC20Config configures an ERC20 transfer from a timelock on a single chain
+type TransferERC20Config struct {
+	// ChainSelector is the chain where the timelock and token live
+	ChainSelector uint64 `json:"chain_selector"`
+
+	// TimelockIdentifier is the qualifier for the timelock (e.g. "vault_1"). Use "" for default/legacy.
+	TimelockIdentifier string `json:"timelock_identifier"`
+
+	// Transfers is the list of ERC20 transfers to execute from the timelock
+	Transfers []ERC20Transfer `json:"transfers"`
+
+	// MCMSConfig contains timelock and MCMS configuration for building the proposal
+	MCMSConfig *proposalutils.TimelockConfig `json:"mcms_config"`
+
+	// Description for the MCMS proposal
+	Description string `json:"description"`
 }

--- a/deployment/vault/changeset/utils.go
+++ b/deployment/vault/changeset/utils.go
@@ -6,34 +6,47 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
+	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 )
 
 func GetContractAddress(ds any, chainSelector uint64, contractType cldf.ContractType) (string, error) {
+	return GetContractAddressWithQualifier(ds, chainSelector, contractType, "")
+}
+
+// GetContractAddressWithQualifier returns the contract address for the given chain and type, optionally filtered by qualifier.
+// When qualifier is empty, it is treated as commonchangeset.DefaultTimelockQualifier ("default") so the first timelock per chain is used (matches deploy_timelock and migrated refs).
+func GetContractAddressWithQualifier(ds any, chainSelector uint64, contractType cldf.ContractType, qualifier string) (string, error) {
 	if ds == nil {
 		return "", errors.New("datastore is nil")
+	}
+	if qualifier == "" {
+		qualifier = commonchangeset.DefaultTimelockQualifier
 	}
 
 	var addresses []datastore.AddressRef
 
 	switch v := ds.(type) {
 	case datastore.DataStore:
-		addresses = v.Addresses().Filter(
+		filters := []datastore.FilterFunc[datastore.AddressRefKey, datastore.AddressRef]{
 			datastore.AddressRefByChainSelector(chainSelector),
 			datastore.AddressRefByType(datastore.ContractType(contractType)),
-		)
+			datastore.AddressRefByQualifier(qualifier),
+		}
+		addresses = v.Addresses().Filter(filters...)
 	case datastore.MutableDataStore:
-		addresses = v.Addresses().Filter(
+		filters := []datastore.FilterFunc[datastore.AddressRefKey, datastore.AddressRef]{
 			datastore.AddressRefByChainSelector(chainSelector),
 			datastore.AddressRefByType(datastore.ContractType(contractType)),
-		)
+			datastore.AddressRefByQualifier(qualifier),
+		}
+		addresses = v.Addresses().Filter(filters...)
 	default:
 		return "", fmt.Errorf("unsupported datastore type: %T", ds)
 	}
 
-	// Return the first match since we expect only one contract of each type per chain (for now)
 	if len(addresses) > 0 {
 		return addresses[0].Address, nil
 	}
-
-	return "", fmt.Errorf("contract of type %s not found for chain %d", contractType, chainSelector)
+	return "", fmt.Errorf("contract of type %s not found for chain %d with qualifier %q", contractType, chainSelector, qualifier)
 }

--- a/deployment/vault/changeset/validation.go
+++ b/deployment/vault/changeset/validation.go
@@ -38,8 +38,23 @@ func ValidateBatchNativeTransferConfig(ctx context.Context, e cldf.Environment, 
 	}
 
 	if cfg.MCMSConfig != nil {
-		if err := validateMCMSConfig(e, cfg.MCMSConfig, cfg.TransfersByChain); err != nil {
+		if err := validateMCMSConfig(e, cfg.MCMSConfig, cfg.TransfersByChain, cfg.TimelockIDByChain); err != nil {
 			return fmt.Errorf("MCMS configuration validation failed: %w", err)
+		}
+	}
+
+	// When TimelockIDByChain is set, ensure each (chain, qualifier) has timelock and proposer
+	if len(cfg.TimelockIDByChain) > 0 {
+		for chainSelector, qualifier := range cfg.TimelockIDByChain {
+			if _, hasChain := cfg.TransfersByChain[chainSelector]; !hasChain {
+				continue
+			}
+			if _, err := GetContractAddressWithQualifier(e.DataStore, chainSelector, commontypes.RBACTimelock, qualifier); err != nil {
+				return fmt.Errorf("timelock not found for chain %d qualifier %q: %w", chainSelector, qualifier, err)
+			}
+			if _, err := GetContractAddressWithQualifier(e.DataStore, chainSelector, commontypes.ProposerManyChainMultisig, qualifier); err != nil {
+				return fmt.Errorf("proposer not found for chain %d qualifier %q: %w", chainSelector, qualifier, err)
+			}
 		}
 	}
 
@@ -130,25 +145,28 @@ func validateTimelockBalance(e cldf.Environment, chainSelector uint64, requiredA
 	return nil
 }
 
-func validateMCMSConfig(e cldf.Environment, mcmsConfig *proposalutils.TimelockConfig, transfersByChain map[uint64][]types.NativeTransfer) error {
+func validateMCMSConfig(e cldf.Environment, mcmsConfig *proposalutils.TimelockConfig, transfersByChain map[uint64][]types.NativeTransfer, timelockIDByChain map[uint64]string) error {
 	if mcmsConfig != nil {
 		if mcmsConfig.MinDelay < 0 {
 			return fmt.Errorf("MCMS minimum delay cannot be negative: %d", mcmsConfig.MinDelay)
 		}
 	}
-	const emptyQualifier = ""
 	for chainSelector := range transfersByChain {
-		addresses, err := evmstate.LoadAddressesFromDataStore(e.DataStore, chainSelector, emptyQualifier)
+		qualifier := ""
+		if timelockIDByChain != nil {
+			qualifier = timelockIDByChain[chainSelector]
+		}
+		addresses, err := evmstate.LoadAddressesFromDataStore(e.DataStore, chainSelector, qualifier)
 		if err != nil {
 			return fmt.Errorf("failed to get addresses from datastore for chain %d: %w", chainSelector, err)
 		}
 
-		_, err = GetContractAddress(e.DataStore, chainSelector, commontypes.RBACTimelock)
+		_, err = GetContractAddressWithQualifier(e.DataStore, chainSelector, commontypes.RBACTimelock, qualifier)
 		if err != nil {
 			return fmt.Errorf("timelock not found for chain %d: %w", chainSelector, err)
 		}
 
-		_, err = GetContractAddress(e.DataStore, chainSelector, commontypes.ProposerManyChainMultisig)
+		_, err = GetContractAddressWithQualifier(e.DataStore, chainSelector, commontypes.ProposerManyChainMultisig, qualifier)
 		if err != nil {
 			return fmt.Errorf("proposer not found for chain %d: %w", chainSelector, err)
 		}
@@ -196,28 +214,88 @@ func ValidateFundTimelockConfig(ctx context.Context, e cldf.Environment, cfg typ
 }
 
 func ValidateSetWhitelistConfig(e cldf.Environment, cfg types.SetWhitelistConfig) error {
-	if len(cfg.WhitelistByChain) == 0 {
-		return errors.New("whitelist_by_chain must not be empty")
+	useLegacy := len(cfg.WhitelistByChain) > 0
+	useMulti := len(cfg.WhitelistByChainAndTimelock) > 0
+	if !useLegacy && !useMulti {
+		return errors.New("either whitelist_by_chain or whitelist_by_chain_and_timelock must be non-empty")
+	}
+	if useLegacy && useMulti {
+		return errors.New("cannot set both whitelist_by_chain and whitelist_by_chain_and_timelock in the same config")
 	}
 
-	for chainSelector, addresses := range cfg.WhitelistByChain {
-		if err := validateChainSelector(chainSelector, e); err != nil {
-			return fmt.Errorf("invalid chain selector %d: %w", chainSelector, err)
-		}
-
-		addressSet := make(map[string]bool)
-		for i, addr := range addresses {
-			if addr.Address == "" || addr.Address == "0x0000000000000000000000000000000000000000" {
-				return fmt.Errorf("chain %d, address %d: address cannot be zero address", chainSelector, i)
+	if useLegacy {
+		for chainSelector, addresses := range cfg.WhitelistByChain {
+			if err := validateChainSelector(chainSelector, e); err != nil {
+				return fmt.Errorf("invalid chain selector %d: %w", chainSelector, err)
 			}
-
-			// Check for duplicate addresses within the same chain
-			if addressSet[addr.Address] {
-				return fmt.Errorf("chain %d: duplicate address %s", chainSelector, addr.Address)
+			if err := validateWhitelistAddresses(chainSelector, addresses); err != nil {
+				return err
 			}
-			addressSet[addr.Address] = true
 		}
 	}
 
+	if useMulti {
+		for chainSelector, byTimelock := range cfg.WhitelistByChainAndTimelock {
+			if err := validateChainSelector(chainSelector, e); err != nil {
+				return fmt.Errorf("invalid chain selector %d: %w", chainSelector, err)
+			}
+			for timelockID, addresses := range byTimelock {
+				if err := validateWhitelistAddresses(chainSelector, addresses); err != nil {
+					return fmt.Errorf("chain %d timelock %q: %w", chainSelector, timelockID, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func ValidateTransferERC20Config(e cldf.Environment, cfg types.TransferERC20Config) error {
+	if len(cfg.Transfers) == 0 {
+		return errors.New("transfers must not be empty")
+	}
+	if err := validateChainSelector(cfg.ChainSelector, e); err != nil {
+		return fmt.Errorf("invalid chain selector: %w", err)
+	}
+	_, exists := e.BlockChains.EVMChains()[cfg.ChainSelector]
+	if !exists {
+		return fmt.Errorf("chain %d not found in environment", cfg.ChainSelector)
+	}
+	if cfg.MCMSConfig == nil {
+		return errors.New("MCMSConfig is required for transfer_erc20")
+	}
+	for i, tr := range cfg.Transfers {
+		if tr.Payee == "" || tr.Payee == "0x0000000000000000000000000000000000000000" {
+			return fmt.Errorf("transfer %d: payee cannot be zero address", i)
+		}
+		if tr.Token == "" || tr.Token == "0x0000000000000000000000000000000000000000" {
+			return fmt.Errorf("transfer %d: token address cannot be zero", i)
+		}
+		if tr.Amount == nil || tr.Amount.Cmp(big.NewInt(0)) <= 0 {
+			return fmt.Errorf("transfer %d: amount must be positive", i)
+		}
+	}
+	// Validate timelock and proposer exist for this chain and qualifier
+	qualifier := cfg.TimelockIdentifier
+	if _, err := GetContractAddressWithQualifier(e.DataStore, cfg.ChainSelector, commontypes.RBACTimelock, qualifier); err != nil {
+		return fmt.Errorf("timelock not found for chain %d: %w", cfg.ChainSelector, err)
+	}
+	if _, err := GetContractAddressWithQualifier(e.DataStore, cfg.ChainSelector, commontypes.ProposerManyChainMultisig, qualifier); err != nil {
+		return fmt.Errorf("proposer not found for chain %d: %w", cfg.ChainSelector, err)
+	}
+	return nil
+}
+
+func validateWhitelistAddresses(chainSelector uint64, addresses []types.WhitelistAddress) error {
+	addressSet := make(map[string]bool)
+	for i, addr := range addresses {
+		if addr.Address == "" || addr.Address == "0x0000000000000000000000000000000000000000" {
+			return fmt.Errorf("address %d: address cannot be zero address", i)
+		}
+		if addressSet[addr.Address] {
+			return fmt.Errorf("duplicate address %s", addr.Address)
+		}
+		addressSet[addr.Address] = true
+	}
 	return nil
 }


### PR DESCRIPTION
- Add DefaultTimelockQualifier ("default") and timelockQualifierFromConfig for first timelock when qualifier omitted; duplicate (chain,qualifier) check.
- DeployTimelockInput + DeployMCMSWithTimelockV2FromInput with SharedMCMSPerChain: reuse existing MCMS, deploy only RBACTimelock+CallProxy for new qualifier when full set exists in datastore.
- FindQualifierWithFullMCMSSet + RequiredMCMSContractTypes in state/evm; persist existing Bypasser/Canceller/Proposer to address book in timelock-only path.
- MigrateAddressRefsToDefaultQualifier changeset for one-off migration of address refs to qualifier "default".
- Vault: GetContractAddressWithQualifier treats empty qualifier as "default"; batch_native, set_whitelist, transfer_erc20 support timelock_id/qualifier.
- prod_oev_mainnet unchanged (uses DeployMCMSWithTimelockV2, no qualifier).

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
