### PR TITLE
[Aptos] MigrateOnRampDestChainConfigsToV2 changeset

### DIFF
--- a/deployment/ccip/changeset/aptos/config/migrate_onramp.go
+++ b/deployment/ccip/changeset/aptos/config/migrate_onramp.go
@@ -1,0 +1,14 @@
+package config
+
+import (
+	"github.com/aptos-labs/aptos-go-sdk"
+
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+)
+
+type MigrateOnRampDestChainConfigsToV2Config struct {
+	ChainSelector         uint64
+	DestChainSelectors    []uint64
+	RouterModuleAddresses []aptos.AccountAddress
+	MCMS                  *proposalutils.TimelockConfig
+}

--- a/deployment/ccip/changeset/aptos/cs_migrate_onramp_dest_chain_configs.go
+++ b/deployment/ccip/changeset/aptos/cs_migrate_onramp_dest_chain_configs.go
@@ -1,0 +1,101 @@
+package aptos
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/smartcontractkit/mcms"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/dependency"
+	operation "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/operation"
+	seq "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/sequence"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/utils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+)
+
+var _ cldf.ChangeSetV2[config.MigrateOnRampDestChainConfigsToV2Config] = MigrateOnRampDestChainConfigsToV2{}
+
+type MigrateOnRampDestChainConfigsToV2 struct{}
+
+func (cs MigrateOnRampDestChainConfigsToV2) VerifyPreconditions(env cldf.Environment, cfg config.MigrateOnRampDestChainConfigsToV2Config) error {
+	var errs []error
+
+	if cfg.MCMS == nil {
+		errs = append(errs, errors.New("MCMS config is required"))
+	}
+	if len(cfg.DestChainSelectors) == 0 {
+		errs = append(errs, errors.New("DestChainSelectors must not be empty"))
+	}
+	if len(cfg.DestChainSelectors) != len(cfg.RouterModuleAddresses) {
+		errs = append(errs, fmt.Errorf("DestChainSelectors length (%d) must match RouterModuleAddresses length (%d)",
+			len(cfg.DestChainSelectors), len(cfg.RouterModuleAddresses)))
+	}
+
+	state, err := stateview.LoadOnchainState(env)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to load onchain state: %w", err))
+		return errors.Join(errs...)
+	}
+
+	supportedChains := state.SupportedChains()
+	if _, ok := supportedChains[cfg.ChainSelector]; !ok {
+		errs = append(errs, fmt.Errorf("unsupported chain: %d", cfg.ChainSelector))
+	}
+
+	ccipAddress := state.AptosChains[cfg.ChainSelector].CCIPAddress
+	if ccipAddress == (aptos.AccountAddress{}) {
+		errs = append(errs, fmt.Errorf("CCIP package is not deployed on Aptos chain %d", cfg.ChainSelector))
+	}
+
+	client := env.BlockChains.AptosChains()[cfg.ChainSelector].Client
+	hasOnramp, err := utils.IsModuleDeployed(client, ccipAddress, "onramp")
+	if err != nil || !hasOnramp {
+		errs = append(errs, fmt.Errorf("onRamp module is not deployed on Aptos chain %d: %w", cfg.ChainSelector, err))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (cs MigrateOnRampDestChainConfigsToV2) Apply(env cldf.Environment, cfg config.MigrateOnRampDestChainConfigsToV2Config) (cldf.ChangesetOutput, error) {
+	state, err := stateview.LoadOnchainState(env)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
+	}
+
+	deps := dependency.AptosDeps{
+		AptosChain:       env.BlockChains.AptosChains()[cfg.ChainSelector],
+		CCIPOnChainState: state,
+	}
+
+	seqInput := operation.MigrateOnRampDestChainConfigsToV2Input{
+		DestChainSelectors:    cfg.DestChainSelectors,
+		RouterModuleAddresses: cfg.RouterModuleAddresses,
+	}
+
+	seqReport, err := operations.ExecuteSequence(env.OperationsBundle, seq.MigrateOnRampDestChainConfigsToV2Sequence, deps, seqInput)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute migrate sequence: %w", err)
+	}
+
+	proposal, err := utils.GenerateProposal(
+		env,
+		state.AptosChains[cfg.ChainSelector].MCMSAddress,
+		cfg.ChainSelector,
+		[]mcmstypes.BatchOperation{seqReport.Output},
+		"Migrate OnRamp destination chain configs to V2",
+		*cfg.MCMS,
+	)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate MCMS proposal for Aptos chain %d: %w", cfg.ChainSelector, err)
+	}
+
+	return cldf.ChangesetOutput{
+		MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
+		Reports:               seqReport.ExecutionReports,
+	}, nil
+}

--- a/deployment/ccip/changeset/aptos/cs_migrate_onramp_dest_chain_configs_test.go
+++ b/deployment/ccip/changeset/aptos/cs_migrate_onramp_dest_chain_configs_test.go
@@ -1,0 +1,51 @@
+package aptos_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/require"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	aptoscs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
+	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+)
+
+func TestMigrateOnRampDestChainConfigsToV2_Apply(t *testing.T) {
+	t.Skip("skipping - no need to run these tests in CI")
+	t.Parallel()
+
+	deployedEnvironment, _ := testhelpers.NewMemoryEnvironment(
+		t,
+		testhelpers.WithAptosChains(1),
+	)
+	env := deployedEnvironment.Env
+
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyAptos))[0]
+
+	cfg := config.MigrateOnRampDestChainConfigsToV2Config{
+		ChainSelector:         chainSelector,
+		DestChainSelectors:    []uint64{chain_selectors.ETHEREUM_MAINNET.Selector},
+		RouterModuleAddresses: []aptos.AccountAddress{{}},
+		MCMS: &proposalutils.TimelockConfig{
+			MinDelay:     time.Second,
+			MCMSAction:   mcmstypes.TimelockActionSchedule,
+			OverrideRoot: false,
+		},
+	}
+
+	_, out, err := commonchangeset.ApplyChangesets(t, env, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(aptoscs.MigrateOnRampDestChainConfigsToV2{}, cfg),
+	})
+
+	require.NoError(t, err)
+	proposals := out[0].MCMSTimelockProposals
+	require.Len(t, proposals, 1)
+	require.Len(t, proposals[0].Operations, 1)
+}

--- a/deployment/ccip/changeset/aptos/operation/on_ramp.go
+++ b/deployment/ccip/changeset/aptos/operation/on_ramp.go
@@ -16,6 +16,7 @@ import (
 
 var OnRampOperations = []*operations.Operation[any, any, any]{
 	UpdateOnRampDestsOp.AsUntypedRelaxed(),
+	MigrateOnRampDestChainConfigsToV2Op.AsUntypedRelaxed(),
 }
 
 // UpdateOnRampDestsInput contains configuration for updating OnRamp destinations
@@ -103,4 +104,40 @@ func updateOnRampDests(b operations.Bundle, deps dependency.AptosDeps, in Update
 		"chainCount", len(destChainSelectors))
 
 	return txs, nil
+}
+
+type MigrateOnRampDestChainConfigsToV2Input struct {
+	DestChainSelectors    []uint64
+	RouterModuleAddresses []aptos.AccountAddress
+}
+
+var MigrateOnRampDestChainConfigsToV2Op = operations.NewOperation(
+	"migrate-onramp-dest-chain-configs-to-v2-op",
+	Version1_0_0,
+	"Migrates OnRamp destination chain configs from V1 to V2",
+	migrateOnRampDestChainConfigsToV2,
+)
+
+func migrateOnRampDestChainConfigsToV2(b operations.Bundle, deps dependency.AptosDeps, in MigrateOnRampDestChainConfigsToV2Input) ([]mcmstypes.Transaction, error) {
+	aptosState := deps.CCIPOnChainState.AptosChains[deps.AptosChain.Selector]
+	ccipAddress := aptosState.CCIPAddress
+	onrampBind := ccip_onramp.Bind(ccipAddress, deps.AptosChain.Client)
+
+	moduleInfo, function, _, args, err := onrampBind.Onramp().Encoder().MigrateDestChainConfigsToV2(
+		in.DestChainSelectors,
+		in.RouterModuleAddresses,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode MigrateDestChainConfigsToV2 for OnRamp: %w", err)
+	}
+
+	tx, err := utils.GenerateMCMSTx(ccipAddress, moduleInfo, function, args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transaction: %w", err)
+	}
+
+	b.Logger.Infow("Adding OnRamp migrate dest chain configs to V2 operation",
+		"chainCount", len(in.DestChainSelectors))
+
+	return []mcmstypes.Transaction{tx}, nil
 }

--- a/deployment/ccip/changeset/aptos/sequence/migrate_onramp.go
+++ b/deployment/ccip/changeset/aptos/sequence/migrate_onramp.go
@@ -1,0 +1,30 @@
+package sequence
+
+import (
+	"fmt"
+
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/dependency"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/operation"
+)
+
+var MigrateOnRampDestChainConfigsToV2Sequence = operations.NewSequence(
+	"migrate-onramp-dest-chain-configs-to-v2-sequence",
+	operation.Version1_0_0,
+	"Migrates OnRamp destination chain configs from V1 to V2",
+	migrateOnRampDestChainConfigsToV2Sequence,
+)
+
+func migrateOnRampDestChainConfigsToV2Sequence(b operations.Bundle, deps dependency.AptosDeps, in operation.MigrateOnRampDestChainConfigsToV2Input) (mcmstypes.BatchOperation, error) {
+	report, err := operations.ExecuteOperation(b, operation.MigrateOnRampDestChainConfigsToV2Op, deps, in)
+	if err != nil {
+		return mcmstypes.BatchOperation{}, fmt.Errorf("failed to migrate OnRamp dest chain configs to V2: %w", err)
+	}
+
+	return mcmstypes.BatchOperation{
+		ChainSelector: mcmstypes.ChainSelector(deps.AptosChain.Selector),
+		Transactions:  report.Output,
+	}, nil
+}


### PR DESCRIPTION
## Description
Adding Aptos MigrateOnRampDestChainConfigsToV2 changeset

## Tests
Aptos test are failing due to resource account not being published. The changes are here: https://github.com/smartcontractkit/chainlink/pull/18882/changes#diff-85404bc196b62462ec8e90397d487e0a427366dfc91326534a184959a902f79a

This will be merged in a following PR.