### PR TITLE
chore(plugins): bump chainlink-cosmos to v0.5.2-0.20260219133256-b46d473fd6f5

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -1,7 +1,7 @@
 ##
 # Build image: Chainlink binary with plugins.
 ##
-FROM golang:1.25.5-bookworm AS buildgo
+FROM golang:1.25.7-bookworm AS buildgo
 RUN go version
 RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
 

--- a/core/scripts/ccip/manual-execution/go.mod
+++ b/core/scripts/ccip/manual-execution/go.mod
@@ -1,6 +1,6 @@
 module manual-execution
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260202175443-ee6c9d2f8935

--- a/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/chainlink-common v0.9.6-0.20260202175443-ee6c9d2f8935

--- a/core/scripts/cre/environment/examples/workflows/v2/cron/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/cron/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/cron
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18

--- a/core/scripts/cre/environment/examples/workflows/v2/http/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/http/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18

--- a/core/scripts/cre/environment/examples/workflows/v2/http_simple/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/http_simple/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18

--- a/core/scripts/cre/environment/examples/workflows/v2/node-mode/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/node-mode/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/google/uuid v1.6.0

--- a/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/core/scripts/cre/environment/examples/workflows/v2/time/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/time/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18

--- a/core/scripts/cre/environment/examples/workflows/v2/time_consensus/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/time_consensus/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts
 
-go 1.25.5
+go 1.25.7
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../../

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/deployment
 
-go 1.25.5
+go 1.25.7
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../

--- a/devenv/fakes/go.mod
+++ b/devenv/fakes/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/devenv/fakes
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/gin-gonic/gin v1.10.1

--- a/devenv/go.mod
+++ b/devenv/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/devenv
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/v2
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/BurntSushi/toml v1.5.0

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/integration-tests
 
-go 1.25.5
+go 1.25.7
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/load-tests
 
-go 1.25.5
+go 1.25.7
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../../

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -3,7 +3,7 @@
 # XXX: Experimental -- not to be used to build images for production use.
 # See: ../core/chainlink.Dockerfile for the production Dockerfile.
 ##
-FROM golang:1.25.5-bookworm AS buildgo
+FROM golang:1.25.7-bookworm AS buildgo
 RUN go version
 RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
 

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -22,8 +22,7 @@ plugins:
     - moduleURI: "github.com/smartcontractkit/chainlink-cosmos"
       # Git reference - can be a tag, branch, or commit hash
       # If not specified, uses the latest version.
-      # fb7ced... currently panics on startup with "codec sealed"; keep last known good until upstream fix lands.
-      gitRef: "f740e9ae54e79762991bdaf8ad6b50363261c056" # 2025-02-07
+      gitRef: "v0.5.2-0.20260219133256-b46d473fd6f5"
       installPath: "./pkg/cosmos/cmd/chainlink-cosmos"
       # These will be copied into /usr/lib in the container.
       libs:

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/lib
 
-go 1.25.5
+go 1.25.7
 
 // Using a separate `require` here to avoid surrounding line changes
 // creating potential merge conflicts.

--- a/system-tests/tests/canaries_sentinels/proof-of-reserve/cron-based/go.mod
+++ b/system-tests/tests/canaries_sentinels/proof-of-reserve/cron-based/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests
 
-go 1.25.5
+go 1.25.7
 
 // Using a separate `require` here to avoid surrounding line changes
 // creating potential merge conflicts.

--- a/system-tests/tests/regression/cre/consensus/go.mod
+++ b/system-tests/tests/regression/cre/consensus/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/consensus
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/system-tests/tests/regression/cre/evm/evmread-negative/go.mod
+++ b/system-tests/tests/regression/cre/evm/evmread-negative/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/evm/evmread-negative
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/system-tests/tests/regression/cre/evm/evmwrite-negative/go.mod
+++ b/system-tests/tests/regression/cre/evm/evmwrite-negative/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/evm/evmwrite-negative
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/system-tests/tests/regression/cre/evm/logtrigger-negative/go.mod
+++ b/system-tests/tests/regression/cre/evm/logtrigger-negative/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/evm/logtrigger-negative
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v0.10.0

--- a/system-tests/tests/regression/cre/http/go.mod
+++ b/system-tests/tests/regression/cre/http/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/http
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18

--- a/system-tests/tests/regression/cre/httpaction-negative/go.mod
+++ b/system-tests/tests/regression/cre/httpaction-negative/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/httpaction-negative
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.0.1-0.20251111122439-00032d582c18

--- a/system-tests/tests/smoke/cre/evm/evmread/go.mod
+++ b/system-tests/tests/smoke/cre/evm/evmread/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evm/evmread
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/system-tests/tests/smoke/cre/evm/logtrigger/go.mod
+++ b/system-tests/tests/smoke/cre/evm/logtrigger/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evm/logtrigger
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/system-tests/tests/smoke/cre/httpaction/go.mod
+++ b/system-tests/tests/smoke/cre/httpaction/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/httpaction
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.3.0

--- a/system-tests/tests/smoke/cre/solana/solwrite/go.mod
+++ b/system-tests/tests/smoke/cre/solana/solwrite/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/solana/solwrite
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/gagliardetto/binary v0.8.0

--- a/testdata/scripts/health/multi-chain-loopp.txtar
+++ b/testdata/scripts/health/multi-chain-loopp.txtar
@@ -112,6 +112,7 @@ ok Cosmos.Foo.RelayerService
 ok Cosmos.Foo.RelayerService.PluginRelayerClient
 ok Cosmos.Foo.RelayerService.PluginRelayerClient.PluginCosmos
 ok Cosmos.Foo.RelayerService.PluginRelayerClient.PluginCosmos.Chain
+ok Cosmos.Foo.RelayerService.PluginRelayerClient.PluginCosmos.PluginRelayerConfigEmitter
 ok Cosmos.Foo.RelayerService.PluginRelayerClient.PluginCosmos.Relayer
 ok Cosmos.Foo.RelayerService.PluginRelayerClient.PluginCosmos.Txm
 ok EVM.1.RelayerService
@@ -271,6 +272,15 @@ ok WorkflowStore
       "id": "Cosmos.Foo.RelayerService.PluginRelayerClient.PluginCosmos.Chain",
       "attributes": {
         "name": "Cosmos.Foo.RelayerService.PluginRelayerClient.PluginCosmos.Chain",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "Cosmos.Foo.RelayerService.PluginRelayerClient.PluginCosmos.PluginRelayerConfigEmitter",
+      "attributes": {
+        "name": "Cosmos.Foo.RelayerService.PluginRelayerClient.PluginCosmos.PluginRelayerConfigEmitter",
         "status": "passing",
         "output": ""
       }


### PR DESCRIPTION
- update `plugins/plugins.public.yaml` cosmos `gitRef` from pinned commit hash to pseudo-version
- verify plugin install with `GOTOOLCHAIN=go1.25.7 make install-plugins-public`


[RANE-4333](https://smartcontract-it.atlassian.net/browse/RANE-4333)


[RANE-4333]: https://smartcontract-it.atlassian.net/browse/RANE-4333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ