### PR TITLE
use testing.T.Context()

### DIFF
--- a/core/bridges/cache_test.go
+++ b/core/bridges/cache_test.go
@@ -1,7 +1,6 @@
 package bridges_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -32,13 +31,13 @@ func TestBridgeCache_Type(t *testing.T) {
 
 		// first call to find should fallthrough to data source
 		mORM.On("FindBridge", mock.Anything, bridge).Return(expected, nil)
-		result, err := cache.FindBridge(context.Background(), bridge)
+		result, err := cache.FindBridge(t.Context(), bridge)
 
 		require.NoError(t, err)
 		assert.Equal(t, expected, result)
 
 		// calling find again should return from cache
-		result, err = cache.FindBridge(context.Background(), bridge)
+		result, err = cache.FindBridge(t.Context(), bridge)
 
 		require.NoError(t, err)
 		assert.Equal(t, expected, result)
@@ -51,7 +50,7 @@ func TestBridgeCache_Type(t *testing.T) {
 		lggr, _ := logger.NewLogger()
 		cache := bridges.NewCache(mORM, lggr, bridges.DefaultUpsertInterval)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		nameA := bridges.BridgeName("A")
 		nameB := bridges.BridgeName("B")
 		nameC := bridges.BridgeName("C")
@@ -85,7 +84,7 @@ func TestBridgeCache_Type(t *testing.T) {
 		lggr, _ := logger.NewLogger()
 		cache := bridges.NewCache(mORM, lggr, bridges.DefaultUpsertInterval)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		bridge := bridges.BridgeName("test")
 		expected := &bridges.BridgeType{
 			Name:          bridge,
@@ -138,7 +137,7 @@ func TestBridgeCache_Response(t *testing.T) {
 		lggr, _ := logger.NewLogger()
 		cache := bridges.NewCache(mORM, lggr, bridges.DefaultUpsertInterval)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		dotId := "test"
 		specId := int32(42)
 		responseData := []byte("test")
@@ -168,9 +167,9 @@ func TestBridgeCache_Response(t *testing.T) {
 			require.NoError(t, cache.Close())
 		})
 
-		require.NoError(t, cache.Start(context.Background()))
+		require.NoError(t, cache.Start(t.Context()))
 
-		ctx := context.Background()
+		ctx := t.Context()
 		dotId := "test"
 		specId := int32(42)
 		expected := []byte("test")

--- a/core/capabilities/ccip/ccipaptos/executecodec_test.go
+++ b/core/capabilities/ccip/ccipaptos/executecodec_test.go
@@ -1,7 +1,6 @@
 package ccipaptos
 
 import (
-	"context"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -225,7 +224,7 @@ func TestExecutePluginCodecV1_Decode(t *testing.T) {
 	codec := NewExecutePluginCodecV1(nil)
 
 	// Decode the report
-	decodedReport, err := codec.Decode(context.Background(), reportBytes)
+	decodedReport, err := codec.Decode(t.Context(), reportBytes)
 	require.NoError(t, err)
 
 	require.Len(t, decodedReport.ChainReports, 1, "Expected exactly one chain report")

--- a/core/capabilities/ccip/oraclecreator/observation_metrics_collector.go
+++ b/core/capabilities/ccip/oraclecreator/observation_metrics_collector.go
@@ -38,12 +38,10 @@ func NewObservationMetricsCollector(
 	constantLabels map[string]string,
 	beholderLabels map[string]string,
 ) *ObservationMetricsCollector {
-	_, cancel := context.WithCancel(context.Background())
-
 	collector := &ObservationMetricsCollector{
 		logger:         logger,
 		publisher:      publisher,
-		cancel:         cancel,
+		cancel:         func() {},
 		constantLabels: constantLabels,
 		beholderLabels: beholderLabels,
 	}

--- a/core/capabilities/ccip/oraclecreator/observation_metrics_publisher_test.go
+++ b/core/capabilities/ccip/oraclecreator/observation_metrics_publisher_test.go
@@ -11,7 +11,7 @@ import (
 func TestBeholderMetricsPublisher_PublishMetric(t *testing.T) {
 	t.Run("publishes with correct context", func(t *testing.T) {
 		// Create a context with cancellation
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		// Create mock publisher
@@ -40,7 +40,7 @@ func TestBeholderMetricsPublisher_PublishMetric(t *testing.T) {
 			"plugin_type": "commit",
 		}
 
-		mockPub.PublishMetric(context.Background(), "ocr3_sent_observations_total", 5.0, labels)
+		mockPub.PublishMetric(t.Context(), "ocr3_sent_observations_total", 5.0, labels)
 
 		metrics := mockPub.getMetrics()
 		require.Len(t, metrics, 1)
@@ -56,7 +56,7 @@ func TestBeholderMetricsPublisher_PublishMetric(t *testing.T) {
 	t.Run("handles empty labels", func(t *testing.T) {
 		mockPub := &mockPublisher{}
 
-		mockPub.PublishMetric(context.Background(), "test_metric", 1.0, map[string]string{})
+		mockPub.PublishMetric(t.Context(), "test_metric", 1.0, map[string]string{})
 
 		metrics := mockPub.getMetrics()
 		require.Len(t, metrics, 1)
@@ -66,7 +66,7 @@ func TestBeholderMetricsPublisher_PublishMetric(t *testing.T) {
 	t.Run("handles nil labels map", func(t *testing.T) {
 		mockPub := &mockPublisher{}
 
-		mockPub.PublishMetric(context.Background(), "test_metric", 1.0, nil)
+		mockPub.PublishMetric(t.Context(), "test_metric", 1.0, nil)
 
 		assert.NotPanics(t, func() {
 			metrics := mockPub.getMetrics()

--- a/core/capabilities/don_notifier_test.go
+++ b/core/capabilities/don_notifier_test.go
@@ -28,7 +28,7 @@ func TestDonNotifier_WaitForDon(t *testing.T) {
 		close(setCh)
 	}()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	close(notifyCh)
@@ -47,7 +47,7 @@ func TestDonNotifier_WaitForDon(t *testing.T) {
 func TestDonNotifier_WaitForDon_ContextTimeout(t *testing.T) {
 	notifier := capabilities.NewDonNotifier()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	_, err := notifier.WaitForDon(ctx)
@@ -80,7 +80,7 @@ func TestDonNotifier_DonUpdate(t *testing.T) {
 		notifier.NotifyDonSet(don2)
 	}()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	// Call notify with don 1 and wait for don 1

--- a/core/capabilities/integration_tests/framework/fake_trigger.go
+++ b/core/capabilities/integration_tests/framework/fake_trigger.go
@@ -123,15 +123,13 @@ func (s *fakeTrigger) RegisterTrigger(ctx context.Context, request capabilities.
 
 	responseCh := make(chan capabilities.TriggerResponse)
 
-	ctxWithCancel, cancel := context.WithCancel(context.Background())
+	ctxWithCancel, cancel := s.stopCh.NewCtx()
 	s.cancel = cancel
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
 		for {
 			select {
-			case <-s.stopCh:
-				return
 			case <-ctxWithCancel.Done():
 				return
 			case resp := <-s.toSend:

--- a/core/capabilities/remote/executable/client_test.go
+++ b/core/capabilities/remote/executable/client_test.go
@@ -305,7 +305,7 @@ func newTestServer(peerID p2ptypes.PeerID, dispatcher remotetypes.Dispatcher, wo
 	}
 }
 
-func (t *clientTestServer) Receive(_ context.Context, msg *remotetypes.MessageBody) {
+func (t *clientTestServer) Receive(ctx context.Context, msg *remotetypes.MessageBody) {
 	t.mux.Lock()
 	defer t.mux.Unlock()
 
@@ -333,7 +333,7 @@ func (t *clientTestServer) Receive(_ context.Context, msg *remotetypes.MessageBo
 			if err != nil {
 				panic(err)
 			}
-			resp, responseErr := t.executableCapability.Execute(context.Background(), capabilityRequest)
+			resp, responseErr := t.executableCapability.Execute(ctx, capabilityRequest)
 			payload, marshalErr := pb.MarshalCapabilityResponse(resp)
 			t.sendResponse(messageID, responseErr, payload, marshalErr)
 		default:
@@ -407,7 +407,7 @@ func TestClient_SetConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify config was set
-		info, err := client.Info(context.Background())
+		info, err := client.Info(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, validCapInfo.ID, info.ID)
 	})
@@ -454,7 +454,7 @@ func TestClient_SetConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify the config was completely replaced
-		info, err := client.Info(context.Background())
+		info, err := client.Info(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, validCapInfo.ID, info.ID)
 	})

--- a/core/capabilities/remote/executable/parallel_executor_test.go
+++ b/core/capabilities/remote/executable/parallel_executor_test.go
@@ -20,7 +20,7 @@ func Test_CancellingContext_StopsTask(t *testing.T) {
 
 	var counter int32
 	for range 10 {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancelFns = append(cancelFns, cancel)
 		err := tp.ExecuteTask(ctx, func(ctx context.Context) {
 			atomic.AddInt32(&counter, 1)
@@ -49,13 +49,13 @@ func Test_ExecuteRequestTimesOutWhenParallelExecutionLimitReached(t *testing.T) 
 	servicetest.Run(t, tp)
 
 	for range 3 {
-		err := tp.ExecuteTask(context.Background(), func(ctx context.Context) {
+		err := tp.ExecuteTask(t.Context(), func(ctx context.Context) {
 			<-ctx.Done()
 		})
 		require.NoError(t, err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 	err := tp.ExecuteTask(ctx, func(ctx context.Context) {
 	})
 	cancel()
@@ -69,7 +69,7 @@ func Test_ExecutingMultipleTasksInParallel(t *testing.T) {
 
 	var counter int32
 	for range 10 {
-		err := tp.ExecuteTask(context.Background(), func(ctx context.Context) {
+		err := tp.ExecuteTask(t.Context(), func(ctx context.Context) {
 			atomic.AddInt32(&counter, 1)
 			<-ctx.Done()
 			atomic.AddInt32(&counter, -1)
@@ -92,7 +92,7 @@ func Test_StopsExecutingMultipleParallelTasksWhenClosed(t *testing.T) {
 	servicetest.Run(t, tp)
 
 	for range 10 {
-		err := tp.ExecuteTask(context.Background(), func(ctx context.Context) {
+		err := tp.ExecuteTask(t.Context(), func(ctx context.Context) {
 			atomic.AddInt32(&counter, 1)
 			<-ctx.Done()
 			atomic.AddInt32(&counter, -1)

--- a/core/capabilities/remote/executable/server_test.go
+++ b/core/capabilities/remote/executable/server_test.go
@@ -39,7 +39,7 @@ func Test_Server_Execute_SlowCapabilityExecutionDoesNotImpactSubsequentCall(t *t
 	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{}, &TestSlowExecutionCapability{workflowIDToPause: workflowIDToPause}, 10, 9, numCapabilityPeers, 3, 10*time.Minute, nil)
 
 	for _, caller := range callers {
-		_, err := caller.Execute(context.Background(),
+		_, err := caller.Execute(t.Context(),
 			commoncap.CapabilityRequest{
 				Metadata: commoncap.RequestMetadata{
 					WorkflowID:          workflowID1,
@@ -50,7 +50,7 @@ func Test_Server_Execute_SlowCapabilityExecutionDoesNotImpactSubsequentCall(t *t
 	}
 
 	for _, caller := range callers {
-		_, err := caller.Execute(context.Background(),
+		_, err := caller.Execute(t.Context(),
 			commoncap.CapabilityRequest{
 				Metadata: commoncap.RequestMetadata{
 					WorkflowID:          workflowID2,
@@ -96,7 +96,7 @@ func Test_Server_DefaultExcludedAttributes(t *testing.T) {
 		inputs, err := values.NewMap(rawInputs)
 		require.NoError(t, err)
 
-		_, err = caller.Execute(context.Background(),
+		_, err = caller.Execute(t.Context(),
 			commoncap.CapabilityRequest{
 				Metadata: commoncap.RequestMetadata{
 					WorkflowID:          workflowID1,
@@ -132,7 +132,7 @@ func Test_Server_ExcludesNonDeterministicInputAttributes(t *testing.T) {
 		inputs, err := values.NewMap(rawInputs)
 		require.NoError(t, err)
 
-		_, err = caller.Execute(context.Background(),
+		_, err = caller.Execute(t.Context(),
 			commoncap.CapabilityRequest{
 				Metadata: commoncap.RequestMetadata{
 					WorkflowID:          workflowID1,
@@ -160,7 +160,7 @@ func Test_Server_Execute_RespondsAfterSufficientRequests(t *testing.T) {
 	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{}, &TestCapability{}, 10, 9, numCapabilityPeers, 3, 10*time.Minute, nil)
 
 	for _, caller := range callers {
-		_, err := caller.Execute(context.Background(),
+		_, err := caller.Execute(t.Context(),
 			commoncap.CapabilityRequest{
 				Metadata: commoncap.RequestMetadata{
 					WorkflowID:          workflowID1,
@@ -187,7 +187,7 @@ func Test_Server_InsufficientCallers(t *testing.T) {
 	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{}, &TestCapability{}, 10, 10, numCapabilityPeers, 3, 100*time.Millisecond, nil)
 
 	for _, caller := range callers {
-		_, err := caller.Execute(context.Background(),
+		_, err := caller.Execute(t.Context(),
 			commoncap.CapabilityRequest{
 				Metadata: commoncap.RequestMetadata{
 					WorkflowID:          workflowID1,
@@ -214,7 +214,7 @@ func Test_Server_CapabilityError(t *testing.T) {
 	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{}, &TestErrorCapability{}, 10, 9, numCapabilityPeers, 3, 100*time.Millisecond, nil)
 
 	for _, caller := range callers {
-		_, err := caller.Execute(context.Background(),
+		_, err := caller.Execute(t.Context(),
 			commoncap.CapabilityRequest{
 				Metadata: commoncap.RequestMetadata{
 					WorkflowID:          workflowID1,
@@ -261,7 +261,7 @@ func Test_Server_V2Request_ExcludesNonDeterministicInputAttributes(t *testing.T)
 		anyPayload, err := anypb.New(payload)
 		require.NoError(t, err)
 
-		_, err = caller.Execute(context.Background(),
+		_, err = caller.Execute(t.Context(),
 			commoncap.CapabilityRequest{
 				Metadata: commoncap.RequestMetadata{
 					WorkflowID:          workflowID1,
@@ -355,7 +355,7 @@ func testRemoteExecutableCapabilityServer(ctx context.Context, t *testing.T,
 
 	var srvcs []services.Service
 	broker := newTestAsyncMessageBroker(t, 1000)
-	err := broker.Start(context.Background())
+	err := broker.Start(t.Context())
 	require.NoError(t, err)
 	srvcs = append(srvcs, broker)
 
@@ -743,7 +743,7 @@ func Test_Server_SetConfig_DONMembershipChange(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a request
-	_, err = workflowNode.Execute(context.Background(), commoncap.CapabilityRequest{
+	_, err = workflowNode.Execute(t.Context(), commoncap.CapabilityRequest{
 		Metadata: commoncap.RequestMetadata{
 			WorkflowID:          workflowID1,
 			WorkflowExecutionID: workflowExecutionID1,
@@ -874,7 +874,7 @@ func Test_Server_Execute_WithConcurrentSetConfig(t *testing.T) {
 	}
 
 	broker := newTestAsyncMessageBroker(t, 1000)
-	err := broker.Start(context.Background())
+	err := broker.Start(t.Context())
 	require.NoError(t, err)
 	defer broker.Close()
 
@@ -950,7 +950,7 @@ func Test_Server_Execute_WithConcurrentSetConfig(t *testing.T) {
 				time.Sleep(delay)
 
 				workflowExecutionID := fmt.Sprintf("exec-%d", execID)
-				_, err := node.Execute(context.Background(),
+				_, err := node.Execute(t.Context(),
 					commoncap.CapabilityRequest{
 						Metadata: commoncap.RequestMetadata{
 							WorkflowID:          workflowID1,

--- a/core/capabilities/vault/gw_handler_test.go
+++ b/core/capabilities/vault/gw_handler_test.go
@@ -1,7 +1,6 @@
 package vault_test
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -23,7 +22,7 @@ import (
 
 func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name          string
@@ -188,7 +187,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 
 func TestGatewayHandler_Lifecycle(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	secretsService := vaulttypesmocks.NewSecretsService(t)
 	gwConnector := connector_mocks.NewGatewayConnector(t)

--- a/core/capabilities/vault/request_authorizer_test.go
+++ b/core/capabilities/vault/request_authorizer_test.go
@@ -1,7 +1,6 @@
 package vault
 
 import (
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"testing"
@@ -175,13 +174,13 @@ func testAuthForRequests(t *testing.T, allowlistedRequest, notAllowlistedRequest
 		},
 	}
 	mockSyncer.On("GetAllowlistedRequests", mock.Anything).Return(allowlisted)
-	isAuthorized, gotOwner, err := auth.AuthorizeRequest(context.Background(), allowlistedRequest)
+	isAuthorized, gotOwner, err := auth.AuthorizeRequest(t.Context(), allowlistedRequest)
 	require.True(t, isAuthorized, err)
 	require.Equal(t, owner.Hex(), gotOwner)
 	require.NoError(t, err)
 
 	// Already authorized
-	isAuthorized, _, err = auth.AuthorizeRequest(context.Background(), allowlistedRequest)
+	isAuthorized, _, err = auth.AuthorizeRequest(t.Context(), allowlistedRequest)
 	require.False(t, isAuthorized)
 	require.ErrorContains(t, err, "already authorized previously")
 
@@ -195,11 +194,11 @@ func testAuthForRequests(t *testing.T, allowlistedRequest, notAllowlistedRequest
 	allowlisted[0].RequestDigest = [32]byte(allowlistedReqCopyDigestBytes)
 	allowlisted[0].ExpiryTimestamp = uint32(time.Now().UTC().Unix() - 1) //nolint:gosec // it is a safe conversion
 	mockSyncer.On("GetAllowlistedRequests", mock.Anything).Return(allowlisted)
-	isAuthorized, _, err = auth.AuthorizeRequest(context.Background(), allowlistedReqCopy)
+	isAuthorized, _, err = auth.AuthorizeRequest(t.Context(), allowlistedReqCopy)
 	require.False(t, isAuthorized)
 	require.ErrorContains(t, err, "authorization expired")
 
-	isAuthorized, _, err = auth.AuthorizeRequest(context.Background(), notAllowlistedRequest)
+	isAuthorized, _, err = auth.AuthorizeRequest(t.Context(), notAllowlistedRequest)
 	require.False(t, isAuthorized)
 	require.ErrorContains(t, err, "not allowlisted")
 }

--- a/core/capabilities/webapi/outgoing_connector_handler_test.go
+++ b/core/capabilities/webapi/outgoing_connector_handler_test.go
@@ -447,6 +447,6 @@ func TestOutgoingConnectorHandler_HandleGatewayMessage_InvalidMessage(t *testing
 		Method:  invalidMsg.Body.Method,
 		Params:  &rawParams,
 	}
-	err = handler.HandleGatewayMessage(context.Background(), "gateway1", req)
+	err = handler.HandleGatewayMessage(t.Context(), "gateway1", req)
 	require.NoError(t, err)
 }

--- a/core/services/gateway/handlers/functions/allowlist/allowlist_internal_test.go
+++ b/core/services/gateway/handlers/functions/allowlist/allowlist_internal_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestUpdateAllowedSendersInBatches(t *testing.T) {
 	t.Run("OK-simple_update_in_batches", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		config := OnchainAllowlistConfig{
 			ContractAddress:           testutils.NewAddress(),
 			ContractVersion:           1,
@@ -49,12 +49,12 @@ func TestUpdateAllowedSendersInBatches(t *testing.T) {
 
 		// with the orm mock we can validate the actual order in which the allowlist is fetched giving priority to newest addresses
 		orm := amocks.NewORM(t)
-		firstCall := orm.On("CreateAllowedSenders", context.Background(), allowlist[43:53]).Times(1).Return(nil)
-		secondCall := orm.On("CreateAllowedSenders", context.Background(), allowlist[33:43]).Times(1).Return(nil).NotBefore(firstCall)
-		thirdCall := orm.On("CreateAllowedSenders", context.Background(), allowlist[23:33]).Times(1).Return(nil).NotBefore(secondCall)
-		forthCall := orm.On("CreateAllowedSenders", context.Background(), allowlist[13:23]).Times(1).Return(nil).NotBefore(thirdCall)
-		fifthCall := orm.On("CreateAllowedSenders", context.Background(), allowlist[3:13]).Times(1).Return(nil).NotBefore(forthCall)
-		orm.On("CreateAllowedSenders", context.Background(), allowlist[0:3]).Times(1).Return(nil).NotBefore(fifthCall)
+		firstCall := orm.On("CreateAllowedSenders", t.Context(), allowlist[43:53]).Times(1).Return(nil)
+		secondCall := orm.On("CreateAllowedSenders", t.Context(), allowlist[33:43]).Times(1).Return(nil).NotBefore(firstCall)
+		thirdCall := orm.On("CreateAllowedSenders", t.Context(), allowlist[23:33]).Times(1).Return(nil).NotBefore(secondCall)
+		forthCall := orm.On("CreateAllowedSenders", t.Context(), allowlist[13:23]).Times(1).Return(nil).NotBefore(thirdCall)
+		fifthCall := orm.On("CreateAllowedSenders", t.Context(), allowlist[3:13]).Times(1).Return(nil).NotBefore(forthCall)
+		orm.On("CreateAllowedSenders", t.Context(), allowlist[0:3]).Times(1).Return(nil).NotBefore(fifthCall)
 
 		onchainAllowlist := &onchainAllowlist{
 			config:             config,
@@ -76,7 +76,7 @@ func TestUpdateAllowedSendersInBatches(t *testing.T) {
 	})
 
 	t.Run("OK-new_address_added_while_updating_in_batches", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		config := OnchainAllowlistConfig{
 			ContractAddress:           testutils.NewAddress(),
 			ContractVersion:           1,
@@ -106,7 +106,7 @@ func TestUpdateAllowedSendersInBatches(t *testing.T) {
 
 		// with the orm mock we can validate the actual order in which the allowlist is fetched giving priority to newest addresses
 		orm := amocks.NewORM(t)
-		firstCall := orm.On("CreateAllowedSenders", context.Background(), allowlist[40:50]).Times(1).Run(func(args mock.Arguments) {
+		firstCall := orm.On("CreateAllowedSenders", t.Context(), allowlist[40:50]).Times(1).Run(func(args mock.Arguments) {
 			// after the first call we update the tosContract by adding a new address
 			addr := testutils.NewAddress()
 			allowlist = append(allowlist, addr)
@@ -115,12 +115,12 @@ func TestUpdateAllowedSendersInBatches(t *testing.T) {
 		}).Return(nil)
 
 		// this is the extra step that will fetch the new address we want to validate
-		extraStepCall := orm.On("CreateAllowedSenders", context.Background(), allowlist[50:51]).Times(1).Return(nil).NotBefore(firstCall)
+		extraStepCall := orm.On("CreateAllowedSenders", t.Context(), allowlist[50:51]).Times(1).Return(nil).NotBefore(firstCall)
 
-		secondCall := orm.On("CreateAllowedSenders", context.Background(), allowlist[30:40]).Times(1).Return(nil).NotBefore(extraStepCall)
-		thirdCall := orm.On("CreateAllowedSenders", context.Background(), allowlist[20:30]).Times(1).Return(nil).NotBefore(secondCall)
-		forthCall := orm.On("CreateAllowedSenders", context.Background(), allowlist[10:20]).Times(1).Return(nil).NotBefore(thirdCall)
-		orm.On("CreateAllowedSenders", context.Background(), allowlist[0:10]).Times(1).Return(nil).NotBefore(forthCall)
+		secondCall := orm.On("CreateAllowedSenders", t.Context(), allowlist[30:40]).Times(1).Return(nil).NotBefore(extraStepCall)
+		thirdCall := orm.On("CreateAllowedSenders", t.Context(), allowlist[20:30]).Times(1).Return(nil).NotBefore(secondCall)
+		forthCall := orm.On("CreateAllowedSenders", t.Context(), allowlist[10:20]).Times(1).Return(nil).NotBefore(thirdCall)
+		orm.On("CreateAllowedSenders", t.Context(), allowlist[0:10]).Times(1).Return(nil).NotBefore(forthCall)
 
 		onchainAllowlist := &onchainAllowlist{
 			config:             config,

--- a/core/services/gateway/handlers/functions/allowlist/allowlist_test.go
+++ b/core/services/gateway/handlers/functions/allowlist/allowlist_test.go
@@ -40,7 +40,7 @@ func TestUpdateAndCheck(t *testing.T) {
 		client.On("LatestBlockHeight", mock.Anything).Return(big.NewInt(42), nil)
 
 		addr := common.HexToAddress("0x0000000000000000000000000000000000000020")
-		typeAndVersionResponse, err := encodeTypeAndVersionResponse(ToSContractV100)
+		typeAndVersionResponse, err := encodeTypeAndVersionResponse(t, ToSContractV100)
 		require.NoError(t, err)
 
 		client.On("CallContract", mock.Anything, ethereum.CallMsg{ // typeAndVersion
@@ -80,7 +80,7 @@ func TestUpdateAndCheck(t *testing.T) {
 		client := clienttest.NewClient(t)
 		client.On("LatestBlockHeight", mock.Anything).Return(big.NewInt(42), nil)
 
-		typeAndVersionResponse, err := encodeTypeAndVersionResponse(ToSContractV110)
+		typeAndVersionResponse, err := encodeTypeAndVersionResponse(t, ToSContractV110)
 		require.NoError(t, err)
 
 		addr := common.HexToAddress("0x0000000000000000000000000000000000000020")
@@ -142,7 +142,7 @@ func TestUpdatePeriodically(t *testing.T) {
 		client.On("LatestBlockHeight", mock.Anything).Return(big.NewInt(42), nil)
 
 		addr := common.HexToAddress("0x0000000000000000000000000000000000000020")
-		typeAndVersionResponse, err := encodeTypeAndVersionResponse(ToSContractV100)
+		typeAndVersionResponse, err := encodeTypeAndVersionResponse(t, ToSContractV100)
 		require.NoError(t, err)
 
 		client.On("CallContract", mock.Anything, ethereum.CallMsg{ // typeAndVersion
@@ -186,7 +186,7 @@ func TestUpdatePeriodically(t *testing.T) {
 		client.On("LatestBlockHeight", mock.Anything).Return(big.NewInt(42), nil)
 
 		addr := common.HexToAddress("0x0000000000000000000000000000000000000020")
-		typeAndVersionResponse, err := encodeTypeAndVersionResponse(ToSContractV110)
+		typeAndVersionResponse, err := encodeTypeAndVersionResponse(t, ToSContractV110)
 		require.NoError(t, err)
 
 		client.On("CallContract", mock.Anything, ethereum.CallMsg{ // typeAndVersion
@@ -234,7 +234,7 @@ func TestUpdateFromContract(t *testing.T) {
 		client.On("LatestBlockHeight", mock.Anything).Return(big.NewInt(42), nil)
 
 		addr := common.HexToAddress("0x0000000000000000000000000000000000000020")
-		typeAndVersionResponse, err := encodeTypeAndVersionResponse(ToSContractV100)
+		typeAndVersionResponse, err := encodeTypeAndVersionResponse(t, ToSContractV100)
 		require.NoError(t, err)
 
 		client.On("CallContract", mock.Anything, ethereum.CallMsg{ // typeAndVersion
@@ -277,7 +277,7 @@ func TestUpdateFromContract(t *testing.T) {
 		client.On("LatestBlockHeight", mock.Anything).Return(big.NewInt(42), nil)
 
 		addr := common.HexToAddress("0x0000000000000000000000000000000000000020")
-		typeAndVersionResponse, err := encodeTypeAndVersionResponse(ToSContractV110)
+		typeAndVersionResponse, err := encodeTypeAndVersionResponse(t, ToSContractV110)
 		require.NoError(t, err)
 
 		client.On("CallContract", mock.Anything, ethereum.CallMsg{ // typeAndVersion
@@ -369,7 +369,7 @@ func TestExtractContractVersion(t *testing.T) {
 	}
 }
 
-func encodeTypeAndVersionResponse(typeAndVersion string) ([]byte, error) {
+func encodeTypeAndVersionResponse(t *testing.T, typeAndVersion string) ([]byte, error) {
 	codecName := "my_codec"
 	evmEncoderConfig := `[{"Name":"typeAndVersion","Type":"string"}]`
 	codecConfig := config.CodecConfig{Configs: map[string]config.ChainCodecConfig{
@@ -383,7 +383,7 @@ func encodeTypeAndVersionResponse(typeAndVersion string) ([]byte, error) {
 	input := map[string]any{
 		"typeAndVersion": typeAndVersion,
 	}
-	typeAndVersionResponse, err := encoder.Encode(context.Background(), input, codecName)
+	typeAndVersionResponse, err := encoder.Encode(t.Context(), input, codecName)
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/gateway/network/httpclient_test.go
+++ b/core/services/gateway/network/httpclient_test.go
@@ -285,7 +285,7 @@ func TestHTTPClient_Send(t *testing.T) {
 
 			tt.request.URL = server.URL + tt.request.URL
 
-			resp, err := client.Send(context.Background(), tt.request)
+			resp, err := client.Send(t.Context(), tt.request)
 			if tt.expectedError != nil {
 				require.Error(t, err)
 				require.ErrorContains(t, err, tt.expectedError.Error())
@@ -498,7 +498,7 @@ func TestHTTPClient_BlocksUnallowed(t *testing.T) {
 			client, err := NewHTTPClient(config, lggr)
 			require.NoError(t, err)
 
-			_, err = client.Send(context.Background(), HTTPRequest{
+			_, err = client.Send(t.Context(), HTTPRequest{
 				Method:  "GET",
 				URL:     testURL.String(),
 				Headers: map[string]string{},
@@ -562,7 +562,7 @@ func TestHTTPClient_AllowedIPsCIDR(t *testing.T) {
 			client, err := NewHTTPClient(config, lggr)
 			require.NoError(t, err)
 
-			_, err = client.Send(context.Background(), HTTPRequest{
+			_, err = client.Send(t.Context(), HTTPRequest{
 				Method:  "GET",
 				URL:     server.URL,
 				Headers: map[string]string{},
@@ -888,7 +888,7 @@ func TestHTTPClient_BlockedRequests_ReturnErrBlockedRequest(t *testing.T) {
 				headers = map[string]string{}
 			}
 
-			_, err = client.Send(context.Background(), HTTPRequest{
+			_, err = client.Send(t.Context(), HTTPRequest{
 				Method:  method,
 				URL:     tt.url,
 				Headers: headers,
@@ -942,7 +942,7 @@ func TestHTTPClient_MultiHeaders(t *testing.T) {
 		client, err := NewHTTPClient(*config, lggr)
 		require.NoError(t, err)
 
-		resp, err := client.Send(context.Background(), HTTPRequest{
+		resp, err := client.Send(t.Context(), HTTPRequest{
 			Method:  "GET",
 			URL:     server.URL,
 			Headers: map[string]string{},
@@ -998,7 +998,7 @@ func TestHTTPClient_MultiHeaders(t *testing.T) {
 		client, err := NewHTTPClient(*config, lggr)
 		require.NoError(t, err)
 
-		resp, err := client.Send(context.Background(), HTTPRequest{
+		resp, err := client.Send(t.Context(), HTTPRequest{
 			Method:  "GET",
 			URL:     server.URL,
 			Headers: map[string]string{},
@@ -1048,7 +1048,7 @@ func TestHTTPClient_MultiHeaders(t *testing.T) {
 		client, err := NewHTTPClient(*config, lggr)
 		require.NoError(t, err)
 
-		resp, err := client.Send(context.Background(), HTTPRequest{
+		resp, err := client.Send(t.Context(), HTTPRequest{
 			Method:  "GET",
 			URL:     server.URL,
 			Headers: map[string]string{},
@@ -1094,7 +1094,7 @@ func TestHTTPClient_MultiHeaders(t *testing.T) {
 		client, err := NewHTTPClient(*config, lggr)
 		require.NoError(t, err)
 
-		resp, err := client.Send(context.Background(), HTTPRequest{
+		resp, err := client.Send(t.Context(), HTTPRequest{
 			Method:  "GET",
 			URL:     server.URL,
 			Headers: map[string]string{},

--- a/core/services/nodestatusreporter/bridgestatus/bridge_status_reporter_test.go
+++ b/core/services/nodestatusreporter/bridgestatus/bridge_status_reporter_test.go
@@ -135,7 +135,7 @@ func TestService_Start_Disabled(t *testing.T) {
 	httpClient := &http.Client{}
 	service, _, _, _ := setupTestService(t, false, testPollingInterval, httpClient)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := service.Start(ctx)
 	require.NoError(t, err)
 
@@ -152,7 +152,7 @@ func TestService_Start_Enabled(t *testing.T) {
 	jobORM.On("FindJobIDsWithBridge", mock.Anything, mock.AnythingOfType("string")).Return([]int32{}, nil).Maybe()
 	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := service.Start(ctx)
 	require.NoError(t, err)
 
@@ -174,7 +174,7 @@ func TestService_pollAllBridges_NoBridges(t *testing.T) {
 
 	bridgeORM.On("BridgeTypes", mock.Anything, 0, 1000).Return([]bridges.BridgeType{}, 0, nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Should handle no bridges gracefully
 	assert.NotPanics(t, func() {
@@ -195,7 +195,7 @@ func TestService_pollAllBridges_WithBridges(t *testing.T) {
 
 	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollAllBridges(ctx)
 
 	bridgeORM.AssertExpectations(t)
@@ -209,7 +209,7 @@ func TestService_pollAllBridges_FetchError(t *testing.T) {
 
 	bridgeORM.On("BridgeTypes", mock.Anything, 0, 1000).Return([]bridges.BridgeType{}, 0, assert.AnError)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Should handle bridge ORM error gracefully
 	assert.NotPanics(t, func() {
@@ -228,7 +228,7 @@ func TestService_pollBridge_Success(t *testing.T) {
 
 	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollBridge(ctx, "test-bridge", "http://example.com")
 
 	jobORM.AssertExpectations(t)
@@ -242,7 +242,7 @@ func TestService_pollBridge_HTTPError(t *testing.T) {
 	// Mock job ORM call that now happens at the start of pollBridge
 	jobORM.On("FindJobIDsWithBridge", mock.Anything, "test-bridge").Return([]int32{}, nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Should handle HTTP error gracefully
 	assert.NotPanics(t, func() {
@@ -261,7 +261,7 @@ func TestService_pollBridge_InvalidJSON(t *testing.T) {
 	// Mock job ORM call that now happens at the start of pollBridge
 	jobORM.On("FindJobIDsWithBridge", mock.Anything, "test-bridge").Return([]int32{}, nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	assert.NotPanics(t, func() {
 		service.pollBridge(ctx, "test-bridge", "http://invalid.invalid:8080")
@@ -279,7 +279,7 @@ func TestService_pollBridge_InvalidURL(t *testing.T) {
 	// Mock job ORM call that now happens at the start of pollBridge
 	jobORM.On("FindJobIDsWithBridge", mock.Anything, "test-bridge").Return([]int32{}, nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	assert.NotPanics(t, func() {
 		service.pollBridge(ctx, "test-bridge", "://invalid-url")
@@ -298,7 +298,7 @@ func TestService_pollBridge_EmptyURL(t *testing.T) {
 	// Mock job ORM call that now happens at the start of pollBridge
 	jobORM.On("FindJobIDsWithBridge", mock.Anything, "test-bridge").Return([]int32{}, nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	assert.NotPanics(t, func() {
 		service.pollBridge(ctx, "test-bridge", "")
@@ -323,7 +323,7 @@ func TestService_pollBridge_URLPathPreservation(t *testing.T) {
 	jobORM.On("FindJobIDsWithBridge", mock.Anything, "test-bridge").Return([]int32{}, nil)
 	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// If URL path joining is broken, this will fail with "unexpected URL" error
 	service.pollBridge(ctx, "test-bridge", "http://localhost:8080/bridge/v1")
@@ -339,7 +339,7 @@ func TestService_pollBridge_Non200Status(t *testing.T) {
 	// Mock job ORM call that now happens at the start of pollBridge
 	jobORM.On("FindJobIDsWithBridge", mock.Anything, "test-bridge").Return([]int32{}, nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	assert.NotPanics(t, func() {
 		service.pollBridge(ctx, "test-bridge", "http://example.com")
@@ -356,7 +356,7 @@ func TestService_emitBridgeStatus_Success(t *testing.T) {
 
 	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.emitBridgeStatus(ctx, "test-bridge", loadFixtureAsEAResponse(t, "bridge_status_response.json"), []JobInfo{})
 
 	emitter.AssertExpectations(t)
@@ -369,7 +369,7 @@ func TestService_pollAllBridges_RefreshError(t *testing.T) {
 	// Setup bridge ORM mock to return error
 	bridgeORM.On("BridgeTypes", mock.Anything, 0, 1000).Return([]bridges.BridgeType{}, 0, assert.AnError)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Should handle bridge refresh error gracefully (no panic)
 	assert.NotPanics(t, func() {
@@ -405,7 +405,7 @@ func TestService_pollAllBridges_MultipleBridges(t *testing.T) {
 		}
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollAllBridges(ctx)
 
 	bridgeORM.AssertExpectations(t)
@@ -438,7 +438,7 @@ func TestService_emitBridgeStatus_CaptureOutput(t *testing.T) {
 	)
 
 	// Load fixture and emit
-	ctx := context.Background()
+	ctx := t.Context()
 	status := loadFixtureAsEAResponse(t, "bridge_status_response.json")
 	service.emitBridgeStatus(ctx, "test-bridge", status, []JobInfo{})
 
@@ -505,7 +505,7 @@ func TestService_Start_AlreadyStarted(t *testing.T) {
 	jobORM.On("FindJobIDsWithBridge", mock.Anything, mock.AnythingOfType("string")).Return([]int32{}, nil).Maybe()
 	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err := service.Start(ctx)
 	require.NoError(t, err)
@@ -527,7 +527,7 @@ func TestService_Close_AlreadyClosed(t *testing.T) {
 	jobORM.On("FindJobIDsWithBridge", mock.Anything, mock.AnythingOfType("string")).Return([]int32{}, nil).Maybe()
 	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err := service.Start(ctx)
 	require.NoError(t, err)
@@ -576,7 +576,7 @@ func TestService_PollAllBridges_3000Bridges(t *testing.T) {
 	// Expect 3000 telemetry emissions
 	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(numBridges)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	service.pollAllBridges(ctx)
 	mockORM.AssertExpectations(t)
@@ -617,7 +617,7 @@ func TestService_PollAllBridges_ContextTimeout(t *testing.T) {
 		allBridges[i].URL = models.WebURL(*serverURL)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	service.pollAllBridges(ctx)
@@ -644,7 +644,7 @@ func TestService_emitBridgeStatus_EmptyFields(t *testing.T) {
 	)
 
 	// Load empty fixture and emit
-	ctx := context.Background()
+	ctx := t.Context()
 	status := loadFixtureAsEAResponse(t, "bridge_status_empty.json")
 	service.emitBridgeStatus(ctx, "empty-bridge", status, []JobInfo{})
 
@@ -709,7 +709,7 @@ func TestService_pollBridge_WithJobInfo(t *testing.T) {
 		capturedProtobufBytes = args.Get(1).([]byte)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollBridge(ctx, "test-bridge", "http://example.com")
 
 	// Verify the job information (IDs and names) were included in the protobuf
@@ -739,7 +739,7 @@ func TestService_pollBridge_JobORMError(t *testing.T) {
 	// Should still emit telemetry with empty external job IDs
 	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollBridge(ctx, "test-bridge", "http://example.com")
 
 	jobORM.AssertExpectations(t)
@@ -758,7 +758,7 @@ func TestService_pollBridge_IgnoreJoblessBridges_Enabled(t *testing.T) {
 	// Should NOT emit telemetry for jobless bridge when ignoreJoblessBridges is true
 	emitter.AssertNotCalled(t, "Emit", mock.Anything, mock.Anything, mock.Anything)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollBridge(ctx, "jobless-bridge", "http://example.com")
 
 	jobORM.AssertExpectations(t)
@@ -776,7 +776,7 @@ func TestService_pollBridge_IgnoreJoblessBridges_Disabled(t *testing.T) {
 	// Should emit telemetry for jobless bridge when ignoreJoblessBridges is false
 	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollBridge(ctx, "jobless-bridge", "http://example.com")
 
 	jobORM.AssertExpectations(t)
@@ -795,7 +795,7 @@ func TestService_pollBridge_IgnoreInvalidBridges_HTTPError_Enabled(t *testing.T)
 	jobORM.On("FindJobIDsWithBridge", mock.Anything, "invalid-bridge").Return([]int32{1}, nil)
 	jobORM.On("FindJob", mock.Anything, int32(1)).Return(testJob, nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollBridge(ctx, "invalid-bridge", "http://invalid.invalid:8080")
 
 	// Should NOT emit telemetry for invalid bridge when ignoreInvalidBridges is true
@@ -820,7 +820,7 @@ func TestService_pollBridge_IgnoreInvalidBridges_HTTPError_Disabled(t *testing.T
 	// Should emit empty telemetry for invalid bridge when ignoreInvalidBridges is false
 	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollBridge(ctx, "invalid-bridge", "http://invalid.invalid:8080") // This will fail with HTTP error
 
 	jobORM.AssertExpectations(t)
@@ -839,7 +839,7 @@ func TestService_pollBridge_IgnoreInvalidBridges_Non200Status_Enabled(t *testing
 	jobORM.On("FindJobIDsWithBridge", mock.Anything, "invalid-bridge").Return([]int32{1}, nil)
 	jobORM.On("FindJob", mock.Anything, int32(1)).Return(testJob, nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollBridge(ctx, "invalid-bridge", "http://example.com")
 
 	// Should NOT emit telemetry for invalid bridge when ignoreInvalidBridges is true
@@ -864,7 +864,7 @@ func TestService_pollBridge_IgnoreInvalidBridges_Non200Status_Disabled(t *testin
 	// Should emit empty telemetry for invalid bridge when ignoreInvalidBridges is false
 	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollBridge(ctx, "invalid-bridge", "http://example.com")
 
 	jobORM.AssertExpectations(t)
@@ -883,7 +883,7 @@ func TestService_pollBridge_IgnoreInvalidBridges_InvalidJSON_Enabled(t *testing.
 	jobORM.On("FindJobIDsWithBridge", mock.Anything, "invalid-bridge").Return([]int32{1}, nil)
 	jobORM.On("FindJob", mock.Anything, int32(1)).Return(testJob, nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollBridge(ctx, "invalid-bridge", "http://example.com")
 
 	// Should NOT emit telemetry for invalid bridge when ignoreInvalidBridges is true
@@ -908,7 +908,7 @@ func TestService_pollBridge_IgnoreInvalidBridges_InvalidJSON_Disabled(t *testing
 	// Should emit empty telemetry for invalid bridge when ignoreInvalidBridges is false
 	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollBridge(ctx, "invalid-bridge", "http://example.com")
 
 	jobORM.AssertExpectations(t)
@@ -923,7 +923,7 @@ func TestService_pollBridge_BothIgnoreFlags_Enabled(t *testing.T) {
 	// Mock job ORM to return no job IDs (jobless bridge)
 	jobORM.On("FindJobIDsWithBridge", mock.Anything, "jobless-invalid-bridge").Return([]int32{}, nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollBridge(ctx, "jobless-invalid-bridge", "http://invalid.invalid:8080") // This would fail with HTTP error too
 
 	// Should NOT emit telemetry - skipped because of no jobs (ignoreJoblessBridges)
@@ -944,7 +944,7 @@ func TestService_pollBridge_BothIgnoreFlags_Disabled(t *testing.T) {
 	// Should emit empty telemetry even for jobless invalid bridge when both flags are false
 	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollBridge(ctx, "jobless-invalid-bridge", "http://invalid.invalid:8080") // This will fail with HTTP error
 
 	jobORM.AssertExpectations(t)
@@ -979,7 +979,7 @@ func TestService_pollBridge_EndToEnd_RealWebServer(t *testing.T) {
 		capturedProtobufBytes = args.Get(1).([]byte)
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	service.pollBridge(ctx, "test-bridge", server.URL)
 
 	// Verify the complete end-to-end flow worked

--- a/core/services/ocr/capregconfig/ocrconfigservice_test.go
+++ b/core/services/ocr/capregconfig/ocrconfigservice_test.go
@@ -35,7 +35,7 @@ func TestOCRConfigService_StartClose(t *testing.T) {
 	lggr := logger.Test(t)
 	svc := NewOCRConfigService(lggr, testPeerIDProvider(), 1, "0x1234567890abcdef")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	require.NoError(t, svc.Start(ctx))
 	require.NoError(t, svc.Close())
 }
@@ -44,7 +44,7 @@ func TestOCRConfigService_Start_NilPeerIDProvider(t *testing.T) {
 	lggr := logger.Test(t)
 	svc := NewOCRConfigService(lggr, nil, 1, "0x1234567890abcdef")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := svc.Start(ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "peerIDProvider function is required")
@@ -54,7 +54,7 @@ func TestOCRConfigService_OnNewRegistry(t *testing.T) {
 	lggr := logger.Test(t)
 	svc := NewOCRConfigService(lggr, testPeerIDProvider(), 1, "0x1234567890abcdef")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	require.NoError(t, svc.Start(ctx))
 	defer svc.Close()
 
@@ -106,7 +106,7 @@ func TestOCRConfigService_GetConfigTracker(t *testing.T) {
 	lggr := logger.Test(t)
 	svc := NewOCRConfigService(lggr, testPeerIDProvider(), 1, "0x1234567890abcdef")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	require.NoError(t, svc.Start(ctx))
 	defer svc.Close()
 
@@ -124,7 +124,7 @@ func TestOCRConfigService_GetConfigTracker_WithConfig(t *testing.T) {
 	lggr := logger.Test(t)
 	svc := NewOCRConfigService(lggr, testPeerIDProvider(), 1, "0x1234567890abcdef")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	require.NoError(t, svc.Start(ctx))
 	defer svc.Close()
 
@@ -188,7 +188,7 @@ func TestOCRConfigService_GetConfigDigester(t *testing.T) {
 	lggr := logger.Test(t)
 	svc := NewOCRConfigService(lggr, testPeerIDProvider(), 1, "0x1234567890abcdef")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	require.NoError(t, svc.Start(ctx))
 	defer svc.Close()
 
@@ -206,7 +206,7 @@ func TestOCRConfigService_GetConfigDigester_WithConfig(t *testing.T) {
 	lggr := logger.Test(t)
 	svc := NewOCRConfigService(lggr, testPeerIDProvider(), 1, "0x1234567890abcdef")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	require.NoError(t, svc.Start(ctx))
 	defer svc.Close()
 
@@ -262,7 +262,7 @@ func TestOCRConfigService_ConfigChangeDetection(t *testing.T) {
 	lggr := logger.Test(t)
 	svc := NewOCRConfigService(lggr, testPeerIDProvider(), 1, "0x1234567890abcdef")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	require.NoError(t, svc.Start(ctx))
 	defer svc.Close()
 
@@ -357,7 +357,7 @@ func TestOCRConfigService_TransmitterHexEncoding(t *testing.T) {
 	lggr := logger.Test(t)
 	svc := NewOCRConfigService(lggr, testPeerIDProvider(), 1, "0x1234567890abcdef")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	require.NoError(t, svc.Start(ctx))
 	defer svc.Close()
 
@@ -415,7 +415,7 @@ func TestOCRConfigService_ConfigDigestComputation(t *testing.T) {
 	lggr := logger.Test(t)
 	svc := NewOCRConfigService(lggr, testPeerIDProvider(), 1, "0x1234567890abcdef")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	require.NoError(t, svc.Start(ctx))
 	defer svc.Close()
 
@@ -476,7 +476,7 @@ func TestOCRConfigService_ConfigDigestUniqueness(t *testing.T) {
 	lggr := logger.Test(t)
 	svc := NewOCRConfigService(lggr, testPeerIDProvider(), 1, "0x1234567890abcdef")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	require.NoError(t, svc.Start(ctx))
 	defer svc.Close()
 
@@ -533,7 +533,7 @@ func TestOCRConfigService_LegacyFallbackAfterRegistryReceived(t *testing.T) {
 	lggr := logger.Test(t)
 	svc := NewOCRConfigService(lggr, testPeerIDProvider(), 1, "0x1234567890abcdef")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	require.NoError(t, svc.Start(ctx))
 	defer svc.Close()
 
@@ -588,7 +588,7 @@ func TestOCRConfigService_MultipleOCRKeys(t *testing.T) {
 	lggr := logger.Test(t)
 	svc := NewOCRConfigService(lggr, testPeerIDProvider(), 1, "0x1234567890abcdef")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	require.NoError(t, svc.Start(ctx))
 	defer svc.Close()
 
@@ -665,7 +665,7 @@ func TestOCRConfigService_DONMembershipFiltering(t *testing.T) {
 	peerIDProvider := func() (ragetypes.PeerID, error) { return myPeerID, nil }
 	svc := NewOCRConfigService(lggr, peerIDProvider, 1, "0x1234567890abcdef")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	require.NoError(t, svc.Start(ctx))
 	defer svc.Close()
 

--- a/core/services/ocr2/plugins/ccip/clo_ccip_integration_test.go
+++ b/core/services/ocr2/plugins/ccip/clo_ccip_integration_test.go
@@ -1,7 +1,6 @@
 package ccip_test
 
 import (
-	"context"
 	"encoding/json"
 	"math/big"
 	"testing"
@@ -169,7 +168,7 @@ func test_CLOSpecApprovalFlow(t *testing.T, ccipTH integrationtesthelpers.CCIPIn
 	ccipTH.Source.Chain.Commit()
 	blockHash := ccipTH.Dest.Chain.Commit()
 	// get the block number
-	block, err := ccipTH.Dest.Chain.Client().BlockByHash(context.Background(), blockHash)
+	block, err := ccipTH.Dest.Chain.Client().BlockByHash(t.Context(), blockHash)
 	require.NoError(t, err)
 	blockNumber := block.Number().Uint64() + 1 // +1 as a block will be mined for the request from EventuallyReportCommitted
 

--- a/core/services/ocr2/plugins/ccip/integration_test.go
+++ b/core/services/ocr2/plugins/ccip/integration_test.go
@@ -1,7 +1,6 @@
 package ccip_test
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -385,12 +384,12 @@ func TestIntegration_CCIP(t *testing.T) {
 					id := node.FindJobIDForContract(t, commitStoreV1.Address())
 					require.Positive(t, id)
 					t.Logf("deleting job %d", id)
-					err = node.App.DeleteJob(context.Background(), id)
+					err = node.App.DeleteJob(t.Context(), id)
 					require.NoError(t, err)
 					id = node.FindJobIDForContract(t, offRampV1.Address())
 					require.Positive(t, id)
 					t.Logf("deleting job %d", id)
-					err = node.App.DeleteJob(context.Background(), id)
+					err = node.App.DeleteJob(t.Context(), id)
 					require.NoError(t, err)
 				}
 
@@ -709,7 +708,7 @@ func TestReorg(t *testing.T) {
 	gasLimit := big.NewInt(200_00)
 	tokenAmount := big.NewInt(1)
 
-	forkBlock, err := ccipTH.Dest.Chain.Client().BlockByNumber(context.Background(), nil)
+	forkBlock, err := ccipTH.Dest.Chain.Client().BlockByNumber(t.Context(), nil)
 	require.NoError(t, err, "Error while fetching the destination chain current block number")
 
 	// Adjust time to start next blocks with timestamps two hours after the fork block.
@@ -726,7 +725,7 @@ func TestReorg(t *testing.T) {
 	executionLog := ccipTH.AllNodesHaveExecutedSeqNums(t, 1, 1)
 	ccipTH.AssertExecState(t, executionLog[0], testhelpers.ExecutionStateSuccess)
 
-	currentBlock, err := ccipTH.Dest.Chain.Client().BlockByNumber(context.Background(), nil)
+	currentBlock, err := ccipTH.Dest.Chain.Client().BlockByNumber(t.Context(), nil)
 	require.NoError(t, err, "Error while fetching the current block number of destination chain")
 
 	// Reorg back to the `forkBlock`. Next blocks in the fork will have block_timestamps right after the fork,

--- a/core/services/ocr2/plugins/ccip/internal/ccipdb/price_service_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdb/price_service_test.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"math/big"
@@ -270,7 +269,7 @@ func TestPriceService_observeGasPriceUpdates(t *testing.T) {
 			).(*priceService)
 			priceService.gasPriceEstimator = gasPriceEstimator
 
-			sourceGasPriceUSD, err := priceService.observeGasPriceUpdates(context.Background(), lggr)
+			sourceGasPriceUSD, err := priceService.observeGasPriceUpdates(t.Context(), lggr)
 			if tc.expErr {
 				assert.Error(t, err)
 				return
@@ -491,7 +490,7 @@ func TestPriceService_observeTokenPriceUpdates(t *testing.T) {
 			).(*priceService)
 			priceService.destPriceRegistryReader = destPriceReg
 
-			tokenPricesUSD, err := priceService.observeTokenPriceUpdates(context.Background(), lggr)
+			tokenPricesUSD, err := priceService.observeTokenPriceUpdates(t.Context(), lggr)
 			if tc.expErr {
 				assert.Error(t, err)
 				return

--- a/core/services/ocr2/plugins/ccip/prices/da_price_estimator_test.go
+++ b/core/services/ocr2/plugins/ccip/prices/da_price_estimator_test.go
@@ -1,7 +1,6 @@
 package prices
 
 import (
-	"context"
 	"errors"
 	"math/big"
 	"testing"
@@ -21,8 +20,6 @@ func encodeGasPrice(daPrice, execPrice *big.Int) *big.Int {
 }
 
 func TestDAPriceEstimator_GetGasPrice(t *testing.T) {
-	ctx := context.Background()
-
 	testCases := []struct {
 		name            string
 		daGasPrice      *big.Int
@@ -96,6 +93,7 @@ func TestDAPriceEstimator_GetGasPrice(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
 			execEstimator := NewMockGasPriceEstimator(t)
 			execEstimator.On("GetGasPrice", ctx).Return(tc.execGasPrice, nil)
 
@@ -134,6 +132,7 @@ func TestDAPriceEstimator_GetGasPrice(t *testing.T) {
 	}
 
 	t.Run("nil L1 oracle", func(t *testing.T) {
+		ctx := t.Context()
 		expPrice := big.NewInt(1)
 
 		execEstimator := NewMockGasPriceEstimator(t)

--- a/core/services/ocr2/plugins/ccip/prices/exec_price_estimator_test.go
+++ b/core/services/ocr2/plugins/ccip/prices/exec_price_estimator_test.go
@@ -1,7 +1,6 @@
 package prices
 
 import (
-	"context"
 	"math/big"
 	"testing"
 
@@ -16,8 +15,6 @@ import (
 )
 
 func TestExecPriceEstimator_GetGasPrice(t *testing.T) {
-	ctx := context.Background()
-
 	testCases := []struct {
 		name                      string
 		sourceFeeEstimatorRespFee gas.EvmFee
@@ -85,6 +82,7 @@ func TestExecPriceEstimator_GetGasPrice(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
 			sourceFeeEstimator := mocks.NewEvmFeeEstimator(t)
 			sourceFeeEstimator.On("GetFee", ctx, []byte(nil), uint64(0), assets.NewWei(tc.maxGasPrice), (*common.Address)(nil), (*common.Address)(nil)).Return(
 				tc.sourceFeeEstimatorRespFee, uint64(0), tc.sourceFeeEstimatorRespErr)

--- a/core/services/ocr2/plugins/ccip/tokendata/lbtc/lbtc_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/lbtc/lbtc_test.go
@@ -50,7 +50,7 @@ func TestLBTCReader_callAttestationApi(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	lbtcService := NewLBTCTokenDataReader(lggr, attestationURI, 0, common.Address{}, APIIntervalRateLimitDisabled)
 
-	attestation, err := lbtcService.callAttestationAPI(context.Background(), [32]byte(common.FromHex(lbtcMessageHash)))
+	attestation, err := lbtcService.callAttestationAPI(t.Context(), [32]byte(common.FromHex(lbtcMessageHash)))
 	require.NoError(t, err)
 
 	require.Equal(t, lbtcMessageHash, attestation.Attestations[0].MessageHash)
@@ -76,7 +76,7 @@ func TestLBTCReader_callAttestationApiMock(t *testing.T) {
 
 	lggr := logger.TestLogger(t)
 	lbtcService := NewLBTCTokenDataReader(lggr, attestationURI, 0, common.Address{}, APIIntervalRateLimitDisabled)
-	attestation, err := lbtcService.callAttestationAPI(context.Background(), [32]byte(common.FromHex(lbtcMessageHash)))
+	attestation, err := lbtcService.callAttestationAPI(t.Context(), [32]byte(common.FromHex(lbtcMessageHash)))
 	require.NoError(t, err)
 
 	require.Equal(t, response.Attestations[0].Status, attestation.Attestations[0].Status)
@@ -177,7 +177,7 @@ func TestLBTCReader_callAttestationApiMockError(t *testing.T) {
 			lggr := logger.TestLogger(t)
 			lbtcService := NewLBTCTokenDataReader(lggr, attestationURI, test.customTimeoutSeconds, common.Address{}, APIIntervalRateLimitDisabled)
 
-			parentCtx, cancel := context.WithTimeout(context.Background(), time.Duration(test.parentTimeoutSeconds)*time.Second)
+			parentCtx, cancel := context.WithTimeout(t.Context(), time.Duration(test.parentTimeoutSeconds)*time.Second)
 			defer cancel()
 
 			_, err = lbtcService.callAttestationAPI(parentCtx, [32]byte(common.FromHex(lbtcMessageHash)))
@@ -261,7 +261,7 @@ func TestLBTCReader_rateLimiting(t *testing.T) {
 			lggr := logger.TestLogger(t)
 			lbtcService := NewLBTCTokenDataReader(lggr, attestationURI, 0, utils.RandomAddress(), tc.rateConfig)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.timeout > 0 {
 				var cf context.CancelFunc
 				ctx, cf = context.WithTimeout(ctx, tc.timeout)
@@ -346,7 +346,7 @@ func TestLBTCReader_skipApiOnFullPayload(t *testing.T) {
 	lggr, logs := logger.TestLoggerObserved(t, zapcore.InfoLevel)
 	lbtcService := NewLBTCTokenDataReader(lggr, attestationURI, 0, utils.RandomAddress(), APIIntervalRateLimitDefault)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	destTokenData, err := lbtcService.ReadTokenData(ctx, cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
 		EVM2EVMMessage: cciptypes.EVM2EVMMessage{
@@ -462,7 +462,7 @@ func TestLBTCReader_expectedOutput(t *testing.T) {
 			lggr := logger.TestLogger(t)
 			lbtcService := NewLBTCTokenDataReader(lggr, attestationURI, 0, utils.RandomAddress(), APIIntervalRateLimitDefault)
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			payloadAndProof, err := lbtcService.ReadTokenData(ctx, cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
 				EVM2EVMMessage: cciptypes.EVM2EVMMessage{

--- a/core/services/ocr2/plugins/ccip/tokendata/observability/usdc_client_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/observability/usdc_client_test.go
@@ -1,7 +1,6 @@
 package observability
 
 import (
-	"context"
 	"encoding/json"
 	"math/big"
 	"math/rand"
@@ -93,7 +92,7 @@ func testMonitoring(t *testing.T, name string, server *httptest.Server, requests
 	require.NotNil(t, tokenDataReader)
 
 	for range requests {
-		_, _ = tokenDataReader.ReadTokenData(context.Background(), cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
+		_, _ = tokenDataReader.ReadTokenData(t.Context(), cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
 			EVM2EVMMessage: cciptypes.EVM2EVMMessage{
 				TokenAmounts: []cciptypes.TokenAmount{
 					{

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_blackbox_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_blackbox_test.go
@@ -1,7 +1,6 @@
 package usdc_test
 
 import (
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
@@ -98,7 +97,7 @@ func TestUSDCReader_ReadTokenData(t *testing.T) {
 
 			addr := utils.RandomAddress()
 			usdcService := usdc.NewUSDCTokenDataReader(lggr, &usdcReader, attestationURI, 0, addr, usdc.APIIntervalRateLimitDisabled)
-			msgAndAttestation, err := usdcService.ReadTokenData(context.Background(), cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
+			msgAndAttestation, err := usdcService.ReadTokenData(t.Context(), cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
 				EVM2EVMMessage: cciptypes.EVM2EVMMessage{
 					SequenceNumber: seqNum,
 					TokenAmounts:   []cciptypes.TokenAmount{{Token: ccipcalc.EvmAddrToGeneric(addr), Amount: nil}},

--- a/core/services/ocr2/plugins/generic/relayerset_test.go
+++ b/core/services/ocr2/plugins/generic/relayerset_test.go
@@ -24,12 +24,12 @@ func TestRelayerSet_List(t *testing.T) {
 
 	relayerSet, err := NewRelayerSet(testGetter, uuid.New(), 1, true)
 	assert.NoError(t, err)
-	relayers, err := relayerSet.List(context.Background())
+	relayers, err := relayerSet.List(t.Context())
 	assert.NoError(t, err)
 
 	assert.Len(t, relayers, 3)
 
-	relayers, err = relayerSet.List(context.Background(), types.RelayID{Network: "N1", ChainID: "C1"}, types.RelayID{Network: "N3", ChainID: "C3"})
+	relayers, err = relayerSet.List(t.Context(), types.RelayID{Network: "N1", ChainID: "C1"}, types.RelayID{Network: "N3", ChainID: "C3"})
 	assert.NoError(t, err)
 
 	assert.Len(t, relayers, 2)
@@ -52,10 +52,10 @@ func TestRelayerSet_Get(t *testing.T) {
 	relayerSet, err := NewRelayerSet(testGetter, uuid.New(), 1, true)
 	assert.NoError(t, err)
 
-	_, err = relayerSet.Get(context.Background(), types.RelayID{Network: "N1", ChainID: "C1"})
+	_, err = relayerSet.Get(t.Context(), types.RelayID{Network: "N1", ChainID: "C1"})
 	assert.NoError(t, err)
 
-	_, err = relayerSet.Get(context.Background(), types.RelayID{Network: "N4", ChainID: "C4"})
+	_, err = relayerSet.Get(t.Context(), types.RelayID{Network: "N4", ChainID: "C4"})
 	assert.Error(t, err)
 }
 
@@ -72,10 +72,10 @@ func TestRelayerSet_NewPluginProvider(t *testing.T) {
 	relayerSet, err := NewRelayerSet(testGetter, externalJobID, 1, true)
 	assert.NoError(t, err)
 
-	relayer, err := relayerSet.Get(context.Background(), types.RelayID{Network: "N1", ChainID: "C1"})
+	relayer, err := relayerSet.Get(t.Context(), types.RelayID{Network: "N1", ChainID: "C1"})
 	assert.NoError(t, err)
 
-	_, err = relayer.NewPluginProvider(context.Background(), core.RelayArgs{
+	_, err = relayer.NewPluginProvider(t.Context(), core.RelayArgs{
 		ContractID:   "c1",
 		RelayConfig:  []byte("relayconfig"),
 		ProviderType: "p1",

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -328,7 +328,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		payloads, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -346,7 +346,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		buffer := provider.buffer
 
@@ -368,7 +368,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		buffer := provider.buffer
 
@@ -393,7 +393,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		buffer := provider.buffer.(*logBuffer)
 
@@ -421,7 +421,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		buffer := provider.buffer.(*logBuffer)
 
@@ -472,7 +472,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		buffer := provider.buffer.(*logBuffer)
 
@@ -531,7 +531,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		buffer := provider.buffer.(*logBuffer)
 
@@ -585,7 +585,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		buffer := provider.buffer.(*logBuffer)
 

--- a/core/services/ocr2/plugins/ring/ring_integration_test.go
+++ b/core/services/ocr2/plugins/ring/ring_integration_test.go
@@ -65,7 +65,7 @@ func TestRingStoreIntegration(t *testing.T) {
 		})
 
 		// Test workflow routing via consistent hashing
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 		shardID, err := store.GetShardForWorkflow(ctx, "workflow1")
 		require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestRingStoreIntegration(t *testing.T) {
 			State: &ringpb.RoutingState_RoutableShards{RoutableShards: 3},
 		})
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		// Test that different workflows can route to different shards
@@ -114,7 +114,7 @@ func TestRingStoreIntegration(t *testing.T) {
 		// Manually set a workflow allocation
 		store.SetShardForWorkflow("cached-workflow", 0)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		// Should return the cached value

--- a/core/services/ocr2/plugins/vault/disk_monitor_test.go
+++ b/core/services/ocr2/plugins/vault/disk_monitor_test.go
@@ -31,7 +31,7 @@ func TestDiskMonitor_emitDirSizeMetric(t *testing.T) {
 		lggr:  lggr,
 	}
 
-	dm.emitDirSizeMetric(context.Background())
+	dm.emitDirSizeMetric(t.Context())
 	assert.Equal(t, int64(42), dm.gauge.(*mockGauge).gotValue)
 
 	assert.Len(t, observed.FilterMessage("Emitting vault directory size metric").All(), 1)
@@ -48,7 +48,7 @@ func TestDiskMonitor_emitDirSizeMetric_error(t *testing.T) {
 		lggr:  lggr,
 	}
 
-	dm.emitDirSizeMetric(context.Background())
+	dm.emitDirSizeMetric(t.Context())
 	assert.Equal(t, int64(0), dm.gauge.(*mockGauge).gotValue)
 
 	assert.Len(t, observed.FilterMessage("Failed to measure vault directory size").All(), 1)

--- a/core/services/ring/factory_test.go
+++ b/core/services/ring/factory_test.go
@@ -1,7 +1,6 @@
 package ring
 
 import (
-	"context"
 	"testing"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
@@ -67,7 +66,7 @@ func TestFactory_NewReportingPlugin(t *testing.T) {
 	require.NoError(t, err)
 
 	config := ocr3types.ReportingPluginConfig{N: 4, F: 1}
-	plugin, info, err := f.NewReportingPlugin(context.Background(), config)
+	plugin, info, err := f.NewReportingPlugin(t.Context(), config)
 	require.NoError(t, err)
 	require.NotNil(t, plugin)
 	require.NotEmpty(t, info.Name)
@@ -81,7 +80,7 @@ func TestFactory_Lifecycle(t *testing.T) {
 	f, err := NewFactory(store, nil, &mockArbiter{}, lggr, nil)
 	require.NoError(t, err)
 
-	err = f.Start(context.Background())
+	err = f.Start(t.Context())
 	require.NoError(t, err)
 
 	name := f.Name()

--- a/core/services/ring/plugin_test.go
+++ b/core/services/ring/plugin_test.go
@@ -443,7 +443,7 @@ func TestPlugin_NoHealthyShardsFallbackToShardZero(t *testing.T) {
 
 	transmitter := NewTransmitter(lggr, store, nil, arbiter, "test-account")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
 	defer cancel()
 
 	// Start a goroutine that requests allocation (will block waiting for OCR)
@@ -538,7 +538,7 @@ func TestPlugin_ObservationQuorum(t *testing.T) {
 	plugin, err := NewPlugin(store, &mockArbiter{}, config, lggr, nil)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	outctx := ocr3types.OutcomeContext{}
 
 	t.Run("quorum_reached", func(t *testing.T) {
@@ -614,7 +614,7 @@ func TestPlugin_ShardOrchestratorIntegration(t *testing.T) {
 	// Create transmitter with both stores
 	transmitter := NewTransmitter(lggr, ringStore, orchestratorStore, arbiter, "test-account")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	now := time.Now()
 
 	t.Run("initial_workflow_assignments", func(t *testing.T) {

--- a/core/services/ring/store_test.go
+++ b/core/services/ring/store_test.go
@@ -24,7 +24,7 @@ func TestStore_DeterministicHashing(t *testing.T) {
 		State: &ringpb.RoutingState_RoutableShards{RoutableShards: 3},
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Test determinism: same workflow always gets same shard
 	shard1, err := store.GetShardForWorkflow(ctx, "workflow-123")
@@ -56,7 +56,7 @@ func TestStore_ConsistentRingConsistency(t *testing.T) {
 	store3.SetAllShardHealth(healthyShards)
 	store3.SetRoutingState(steadyState)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// All compute same assignments
 	workflows := []string{"workflow-A", "workflow-B", "workflow-C", "workflow-D"}
@@ -75,7 +75,7 @@ func TestStore_ConsistentRingConsistency(t *testing.T) {
 
 func TestStore_Rebalancing(t *testing.T) {
 	store := NewStore()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Start with 3 healthy shards
 	store.SetAllShardHealth(map[uint32]bool{0: true, 1: true, 2: true})
@@ -131,7 +131,7 @@ func TestStore_GetHealthyShards(t *testing.T) {
 
 func TestStore_DistributionAcrossShards(t *testing.T) {
 	store := NewStore()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	store.SetAllShardHealth(map[uint32]bool{
 		0: true,
@@ -172,7 +172,7 @@ func sum(distribution map[uint32]int) int {
 
 func TestStore_GetShardForWorkflow_CacheHit(t *testing.T) {
 	store := NewStore()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Set up steady state
 	store.SetAllShardHealth(map[uint32]bool{0: true, 1: true, 2: true})
@@ -206,7 +206,7 @@ func TestStore_GetShardForWorkflow_ContextCancelledDuringSend(t *testing.T) {
 	}
 
 	// Context that's already cancelled
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	// Should fail: channel is full and context is cancelled
@@ -225,7 +225,7 @@ func TestStore_PendingAllocsDuringTransition(t *testing.T) {
 		},
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 
 	// Start a goroutine that requests allocation (will block)

--- a/core/services/ring/transmitter_test.go
+++ b/core/services/ring/transmitter_test.go
@@ -47,7 +47,7 @@ func TestTransmitter_FromAccount(t *testing.T) {
 	store := NewStore()
 	tx := NewTransmitter(lggr, store, nil, nil, "my-account")
 
-	account, err := tx.FromAccount(context.Background())
+	account, err := tx.FromAccount(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, types.Account("my-account"), account)
 }
@@ -72,7 +72,7 @@ func TestTransmitter_Transmit(t *testing.T) {
 	require.NoError(t, err)
 
 	report := ocr3types.ReportWithInfo[[]byte]{Report: outcomeBytes}
-	err = tx.Transmit(context.Background(), types.ConfigDigest{}, 0, report, nil)
+	err = tx.Transmit(t.Context(), types.ConfigDigest{}, 0, report, nil)
 	require.NoError(t, err)
 
 	// Verify arbiter was notified
@@ -100,7 +100,7 @@ func TestTransmitter_Transmit_NilArbiter(t *testing.T) {
 	}
 	outcomeBytes, _ := proto.Marshal(outcome)
 
-	err := tx.Transmit(context.Background(), types.ConfigDigest{}, 0, ocr3types.ReportWithInfo[[]byte]{Report: outcomeBytes}, nil)
+	err := tx.Transmit(t.Context(), types.ConfigDigest{}, 0, ocr3types.ReportWithInfo[[]byte]{Report: outcomeBytes}, nil)
 	require.NoError(t, err)
 }
 
@@ -120,7 +120,7 @@ func TestTransmitter_Transmit_TransitionState(t *testing.T) {
 	}
 	outcomeBytes, _ := proto.Marshal(outcome)
 
-	err := tx.Transmit(context.Background(), types.ConfigDigest{}, 0, ocr3types.ReportWithInfo[[]byte]{Report: outcomeBytes}, nil)
+	err := tx.Transmit(t.Context(), types.ConfigDigest{}, 0, ocr3types.ReportWithInfo[[]byte]{Report: outcomeBytes}, nil)
 	require.NoError(t, err)
 	require.Equal(t, uint32(5), mock.nShards)
 }
@@ -132,7 +132,7 @@ func TestTransmitter_Transmit_InvalidReport(t *testing.T) {
 
 	// Send invalid protobuf data
 	report := ocr3types.ReportWithInfo[[]byte]{Report: []byte("invalid protobuf")}
-	err := tx.Transmit(context.Background(), types.ConfigDigest{}, 0, report, nil)
+	err := tx.Transmit(t.Context(), types.ConfigDigest{}, 0, report, nil)
 	require.Error(t, err)
 }
 
@@ -150,7 +150,7 @@ func TestTransmitter_Transmit_ArbiterError(t *testing.T) {
 	}
 	outcomeBytes, _ := proto.Marshal(outcome)
 
-	err := tx.Transmit(context.Background(), types.ConfigDigest{}, 0, ocr3types.ReportWithInfo[[]byte]{Report: outcomeBytes}, nil)
+	err := tx.Transmit(t.Context(), types.ConfigDigest{}, 0, ocr3types.ReportWithInfo[[]byte]{Report: outcomeBytes}, nil)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
@@ -165,7 +165,7 @@ func TestTransmitter_Transmit_NilState(t *testing.T) {
 	}
 	outcomeBytes, _ := proto.Marshal(outcome)
 
-	err := tx.Transmit(context.Background(), types.ConfigDigest{}, 0, ocr3types.ReportWithInfo[[]byte]{Report: outcomeBytes}, nil)
+	err := tx.Transmit(t.Context(), types.ConfigDigest{}, 0, ocr3types.ReportWithInfo[[]byte]{Report: outcomeBytes}, nil)
 	require.NoError(t, err)
 
 	// Routes should still be applied

--- a/core/services/shardorchestrator/client_test.go
+++ b/core/services/shardorchestrator/client_test.go
@@ -88,7 +88,7 @@ func createTestClient(t *testing.T, lis *bufconn.Listener) *Client {
 }
 
 func TestClient_GetWorkflowShardMapping(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mock := &mockShardOrchestratorServer{
 		mappings: map[string]uint32{
@@ -142,7 +142,7 @@ func TestClient_GetWorkflowShardMapping(t *testing.T) {
 }
 
 func TestClient_ReportWorkflowTriggerRegistration(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mock := &mockShardOrchestratorServer{
 		mappings: map[string]uint32{},
@@ -187,7 +187,7 @@ func TestClient_Close(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify connection is closed by attempting to use it
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 
 	_, err = client.GetWorkflowShardMapping(ctx, []string{"test"})

--- a/core/services/shardorchestrator/service_test.go
+++ b/core/services/shardorchestrator/service_test.go
@@ -1,7 +1,6 @@
 package shardorchestrator_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,10 +11,9 @@ import (
 )
 
 func TestServer_GetWorkflowShardMapping(t *testing.T) {
-	ctx := context.Background()
-	lggr := logger.Test(t)
-
 	t.Run("returns_mappings_for_multiple_workflows", func(t *testing.T) {
+		ctx := t.Context()
+		lggr := logger.Test(t)
 		store := shardorchestrator.NewStore(lggr)
 		server := shardorchestrator.NewServer(store, lggr)
 
@@ -78,6 +76,8 @@ func TestServer_GetWorkflowShardMapping(t *testing.T) {
 	})
 
 	t.Run("rejects_empty_workflow_ids", func(t *testing.T) {
+		ctx := t.Context()
+		lggr := logger.Test(t)
 		store := shardorchestrator.NewStore(lggr)
 		server := shardorchestrator.NewServer(store, lggr)
 
@@ -92,6 +92,8 @@ func TestServer_GetWorkflowShardMapping(t *testing.T) {
 	})
 
 	t.Run("handles_partial_results_for_nonexistent_workflows", func(t *testing.T) {
+		ctx := t.Context()
+		lggr := logger.Test(t)
 		store := shardorchestrator.NewStore(lggr)
 		server := shardorchestrator.NewServer(store, lggr)
 

--- a/core/services/shardorchestrator/shard_orchestrator_test.go
+++ b/core/services/shardorchestrator/shard_orchestrator_test.go
@@ -1,7 +1,6 @@
 package shardorchestrator_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -20,7 +19,7 @@ func setupShardOrchestrator(t *testing.T) (*shardorchestrator.Store, ringpb.Shar
 	lggr := logger.Test(t)
 	store := shardorchestrator.NewStore(lggr)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	orchestrator := shardorchestrator.New(0, store, lggr)
 
 	err := orchestrator.Start(ctx)
@@ -52,7 +51,7 @@ func TestShardOrchestrator_GetWorkflowShardMapping(t *testing.T) {
 		store, client, cleanup := setupShardOrchestrator(t)
 		defer cleanup()
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Add some test mappings to the store
 		err := store.UpdateWorkflowMapping(ctx, "workflow1", 0, 1, shardorchestrator.StateSteady)
@@ -77,7 +76,7 @@ func TestShardOrchestrator_GetWorkflowShardMapping(t *testing.T) {
 		_, client, cleanup := setupShardOrchestrator(t)
 		defer cleanup()
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Call with empty workflow IDs
 		resp, err := client.GetWorkflowShardMapping(ctx, &ringpb.GetWorkflowShardMappingRequest{
@@ -95,7 +94,7 @@ func TestShardOrchestrator_ReportWorkflowTriggerRegistration(t *testing.T) {
 		_, client, cleanup := setupShardOrchestrator(t)
 		defer cleanup()
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Report workflows registered on a shard
 		resp, err := client.ReportWorkflowTriggerRegistration(ctx, &ringpb.ReportWorkflowTriggerRegistrationRequest{
@@ -116,7 +115,7 @@ func TestShardOrchestrator_ReportWorkflowTriggerRegistration(t *testing.T) {
 		_, client, cleanup := setupShardOrchestrator(t)
 		defer cleanup()
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Report with no workflows
 		resp, err := client.ReportWorkflowTriggerRegistration(ctx, &ringpb.ReportWorkflowTriggerRegistrationRequest{
@@ -134,7 +133,7 @@ func TestShardOrchestrator_ReportWorkflowTriggerRegistration(t *testing.T) {
 		_, client, cleanup := setupShardOrchestrator(t)
 		defer cleanup()
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Multiple shards reporting different workflows
 		resp1, err := client.ReportWorkflowTriggerRegistration(ctx, &ringpb.ReportWorkflowTriggerRegistrationRequest{
@@ -164,7 +163,7 @@ func TestShardOrchestrator_Integration(t *testing.T) {
 		store, client, cleanup := setupShardOrchestrator(t)
 		defer cleanup()
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Step 1: Add workflows to the store
 		err := store.UpdateWorkflowMapping(ctx, "workflow-a", 0, 1, shardorchestrator.StateSteady)

--- a/core/services/shardorchestrator/store_test.go
+++ b/core/services/shardorchestrator/store_test.go
@@ -1,7 +1,6 @@
 package shardorchestrator_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestStore_BatchUpdateAndQuery(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	lggr := logger.Test(t)
 	store := shardorchestrator.NewStore(lggr)
 
@@ -60,7 +59,7 @@ func TestStore_BatchUpdateAndQuery(t *testing.T) {
 }
 
 func TestStore_WorkflowTransition(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	lggr := logger.Test(t)
 	store := shardorchestrator.NewStore(lggr)
 
@@ -94,7 +93,7 @@ func TestStore_WorkflowTransition(t *testing.T) {
 }
 
 func TestStore_VersionTracking(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	lggr := logger.Test(t)
 	store := shardorchestrator.NewStore(lggr)
 
@@ -120,7 +119,7 @@ func TestStore_VersionTracking(t *testing.T) {
 }
 
 func TestStore_ShardRegistrations(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	lggr := logger.Test(t)
 	store := shardorchestrator.NewStore(lggr)
 
@@ -161,7 +160,7 @@ func TestStore_ShardRegistrations(t *testing.T) {
 }
 
 func TestStore_NotFoundError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	lggr := logger.Test(t)
 	store := shardorchestrator.NewStore(lggr)
 
@@ -172,7 +171,7 @@ func TestStore_NotFoundError(t *testing.T) {
 }
 
 func TestStore_BatchQueryPartialResults(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	lggr := logger.Test(t)
 	store := shardorchestrator.NewStore(lggr)
 

--- a/core/services/workflows/internal/retry_test.go
+++ b/core/services/workflows/internal/retry_test.go
@@ -15,7 +15,7 @@ import (
 func TestRetryableZeroMaxRetries(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 	defer cancel()
 
 	fn := func() error {
@@ -93,7 +93,7 @@ func TestRetryableErrorAfterMultipleRetries(t *testing.T) {
 func TestRetryableCancellationHandling(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	fn := func() error {
 		return errors.New("test error")

--- a/core/services/workflows/store/store_memory_test.go
+++ b/core/services/workflows/store/store_memory_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -16,7 +15,7 @@ import (
 func TestInMemoryStore_Add(t *testing.T) {
 	store := NewInMemoryStore(logger.TestLogger(t), clockwork.NewFakeClock())
 
-	execution, err := store.Add(context.Background(), map[string]*WorkflowExecutionStep{
+	execution, err := store.Add(t.Context(), map[string]*WorkflowExecutionStep{
 		"step-1": {Ref: "step-1"},
 	}, "test-id", "w1", StatusStarted)
 	require.NoError(t, err)
@@ -29,7 +28,7 @@ func TestInMemoryStore_Add(t *testing.T) {
 	assert.Equal(t, "step-1", execution.Steps["step-1"].Ref)
 
 	// Try adding the same execution ID again
-	_, err = store.Add(context.Background(), map[string]*WorkflowExecutionStep{}, "test-id", "", "")
+	_, err = store.Add(t.Context(), map[string]*WorkflowExecutionStep{}, "test-id", "", "")
 	assert.Error(t, err)
 }
 
@@ -37,14 +36,14 @@ func TestInMemoryStore_UpsertStep(t *testing.T) {
 	fakeClock := clockwork.NewFakeClock()
 	store := NewInMemoryStore(logger.TestLogger(t), fakeClock)
 
-	initialState, err := store.Add(context.Background(), map[string]*WorkflowExecutionStep{}, "test-id", "w1", StatusStarted)
+	initialState, err := store.Add(t.Context(), map[string]*WorkflowExecutionStep{}, "test-id", "w1", StatusStarted)
 	require.NoError(t, err)
 
 	previousUpdatedAt := initialState.UpdatedAt
 	fakeClock.Advance(1 * time.Hour)
 
 	step := &WorkflowExecutionStep{ExecutionID: "test-id", Ref: "step-1"}
-	updatedState, err := store.UpsertStep(context.Background(), step)
+	updatedState, err := store.UpsertStep(t.Context(), step)
 	require.NoError(t, err)
 	assert.Equal(t, step, updatedState.Steps["step-1"])
 
@@ -54,10 +53,10 @@ func TestInMemoryStore_UpsertStep(t *testing.T) {
 
 func TestInMemoryStore_Get(t *testing.T) {
 	store := NewInMemoryStore(logger.TestLogger(t), clockwork.NewFakeClock())
-	_, err := store.Add(context.Background(), map[string]*WorkflowExecutionStep{}, "test-id", "w1", StatusStarted)
+	_, err := store.Add(t.Context(), map[string]*WorkflowExecutionStep{}, "test-id", "w1", StatusStarted)
 	require.NoError(t, err)
 
-	retrievedState, err := store.Get(context.Background(), "test-id")
+	retrievedState, err := store.Get(t.Context(), "test-id")
 	require.NoError(t, err)
 	assert.Equal(t, "test-id", retrievedState.ExecutionID)
 	assert.Equal(t, "w1", retrievedState.WorkflowID)
@@ -69,19 +68,19 @@ func TestInMemoryStore_FinishedExecution(t *testing.T) {
 		10*time.Millisecond, 1*time.Hour)
 	servicetest.Run(t, store)
 
-	_, err := store.Add(context.Background(), map[string]*WorkflowExecutionStep{
+	_, err := store.Add(t.Context(), map[string]*WorkflowExecutionStep{
 		"step-1": {Ref: "step-1"},
 	}, "test-id", "w1", StatusStarted)
 	require.NoError(t, err)
 
-	updatedState, err := store.FinishExecution(context.Background(), "test-id", "completed")
+	updatedState, err := store.FinishExecution(t.Context(), "test-id", "completed")
 	require.NoError(t, err)
 
 	assert.Equal(t, "completed", updatedState.Status)
 
 	// Assert eventually that the execution is no longer in the store
 	require.Eventually(t, func() bool {
-		_, err := store.Get(context.Background(), "test-id")
+		_, err := store.Get(t.Context(), "test-id")
 		return err != nil
 	}, 10*time.Second, 10*time.Millisecond)
 }
@@ -94,14 +93,14 @@ func TestInMemoryStore_ExpiresNonCompletedExecutions(t *testing.T) {
 
 	servicetest.Run(t, store)
 
-	_, err := store.Add(context.Background(), map[string]*WorkflowExecutionStep{
+	_, err := store.Add(t.Context(), map[string]*WorkflowExecutionStep{
 		"step-1": {Ref: "step-1"},
 	}, "test-id", "w1", StatusStarted)
 	require.NoError(t, err)
 
 	// Expect the state to be removed from the store after the expiration duration
 	require.Eventually(t, func() bool {
-		_, err2 := store.Get(context.Background(), "test-id")
+		_, err2 := store.Get(t.Context(), "test-id")
 		return err2 != nil
 	}, 10*time.Second, 50*time.Millisecond)
 
@@ -109,13 +108,13 @@ func TestInMemoryStore_ExpiresNonCompletedExecutions(t *testing.T) {
 	store = NewInMemoryStoreWithPruneConfiguration(logger.TestLogger(t), clockwork.NewRealClock(),
 		10*time.Millisecond, 30*time.Second)
 
-	_, err = store.Add(context.Background(), map[string]*WorkflowExecutionStep{
+	_, err = store.Add(t.Context(), map[string]*WorkflowExecutionStep{
 		"step-1": {Ref: "step-1"},
 	}, "test-id", "w1", StatusStarted)
 	require.NoError(t, err)
 
 	require.Never(t, func() bool {
-		_, err2 := store.Get(context.Background(), "test-id")
+		_, err2 := store.Get(t.Context(), "test-id")
 		return err2 != nil
 	}, 300*time.Millisecond, 50*time.Millisecond)
 }

--- a/core/services/workflows/syncer/fetcher_test.go
+++ b/core/services/workflows/syncer/fetcher_test.go
@@ -48,7 +48,7 @@ func (w *wrapper) GetGatewayConnector() connector.GatewayConnector {
 }
 
 func TestNewFetcherService(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	lggr := logger.TestLogger(t)
 	connector := gcmocks.NewGatewayConnector(t)
 	wrapper := &wrapper{c: connector}
@@ -299,7 +299,7 @@ func TestNewFetcherService(t *testing.T) {
 
 func TestNewFetcherFunc(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	testContent := []byte("test content")
 
 	t.Run("error cases", func(t *testing.T) {
@@ -430,7 +430,7 @@ func TestNewFetcherFunc(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a canceled context
-		canceledCtx, cancel := context.WithCancel(context.Background())
+		canceledCtx, cancel := context.WithCancel(t.Context())
 		cancel()
 
 		// Try to fetch with canceled context
@@ -456,7 +456,7 @@ func TestNewFetcherFunc(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a context with short timeout
-		timeoutCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		timeoutCtx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 		defer cancel()
 
 		// Try to fetch with timeout context - should fail with deadline exceeded

--- a/core/services/workflows/syncer/v2/contract_workflow_source_test.go
+++ b/core/services/workflows/syncer/v2/contract_workflow_source_test.go
@@ -98,7 +98,7 @@ func createTestWorkflowMetadata(name string, family string) workflow_registry_wr
 
 func TestContractWorkflowSource_ListWorkflowMetadata_Success(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mockReader := &mockWorkflowContractReader{
 		workflowList: []workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{
@@ -135,7 +135,7 @@ func TestContractWorkflowSource_ListWorkflowMetadata_Success(t *testing.T) {
 
 func TestContractWorkflowSource_ListWorkflowMetadata_MultipleDONFamilies(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// This mock will be called twice (once for each DON family)
 	mockReader := &mockWorkflowContractReader{
@@ -170,7 +170,7 @@ func TestContractWorkflowSource_ListWorkflowMetadata_MultipleDONFamilies(t *test
 
 func TestContractWorkflowSource_ListWorkflowMetadata_NotInitialized(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Factory that always fails
 	source := NewContractWorkflowSource(
@@ -197,7 +197,7 @@ func TestContractWorkflowSource_ListWorkflowMetadata_NotInitialized(t *testing.T
 
 func TestContractWorkflowSource_ListWorkflowMetadata_ContractReaderError(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mockReader := &mockWorkflowContractReader{
 		getLatestErr: errors.New("contract read failed"),
@@ -227,7 +227,7 @@ func TestContractWorkflowSource_ListWorkflowMetadata_ContractReaderError(t *test
 
 func TestContractWorkflowSource_ListWorkflowMetadata_EmptyResult(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mockReader := &mockWorkflowContractReader{
 		workflowList: []workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{},
@@ -293,7 +293,7 @@ func TestContractWorkflowSource_Ready_Initialized(t *testing.T) {
 
 func TestContractWorkflowSource_tryInitialize_Success(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mockReader := &mockWorkflowContractReader{}
 
@@ -319,7 +319,7 @@ func TestContractWorkflowSource_tryInitialize_Success(t *testing.T) {
 
 func TestContractWorkflowSource_tryInitialize_AlreadyInitialized(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	callCount := 0
 	mockReader := &mockWorkflowContractReader{}
@@ -347,7 +347,7 @@ func TestContractWorkflowSource_tryInitialize_AlreadyInitialized(t *testing.T) {
 
 func TestContractWorkflowSource_tryInitialize_FactoryError(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	source := NewContractWorkflowSource(
 		lggr,

--- a/core/services/workflows/syncer/v2/fetcher_test.go
+++ b/core/services/workflows/syncer/v2/fetcher_test.go
@@ -50,7 +50,7 @@ func (w *wrapper) GetGatewayConnector() connector.GatewayConnector {
 }
 
 func TestNewFetcherService(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	lggr := logger.TestLogger(t)
 	storageService := mocks.NewWorkflowClient(t)
 	connector := gcmocks.NewGatewayConnector(t)
@@ -348,7 +348,7 @@ func TestNewFetcherService(t *testing.T) {
 
 func TestNewFetcherFunc(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	testContent := []byte("test content")
 
 	t.Run("error cases", func(t *testing.T) {
@@ -479,7 +479,7 @@ func TestNewFetcherFunc(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a canceled context
-		canceledCtx, cancel := context.WithCancel(context.Background())
+		canceledCtx, cancel := context.WithCancel(t.Context())
 		cancel()
 
 		// Try to fetch with canceled context
@@ -505,7 +505,7 @@ func TestNewFetcherFunc(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a context with short timeout
-		timeoutCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		timeoutCtx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 		defer cancel()
 
 		// Try to fetch with timeout context - should fail with deadline exceeded

--- a/core/services/workflows/syncer/v2/file_workflow_source_test.go
+++ b/core/services/workflows/syncer/v2/file_workflow_source_test.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"os"
@@ -47,7 +46,7 @@ func TestFileWorkflowSource_ListWorkflowMetadata_EmptyFile(t *testing.T) {
 	source, err := NewFileWorkflowSourceWithPath(lggr, "test-file-source", tmpFile)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	don := capabilities.DON{
 		ID:       1,
 		Families: []string{"workflow"},
@@ -113,7 +112,7 @@ func TestFileWorkflowSource_ListWorkflowMetadata_ValidFile(t *testing.T) {
 	source, err := NewFileWorkflowSourceWithPath(lggr, "test-file-source", tmpFile)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	don := capabilities.DON{
 		ID:       1,
 		Families: []string{"workflow"},
@@ -185,7 +184,7 @@ func TestFileWorkflowSource_ListWorkflowMetadata_MultipleDONFamilies(t *testing.
 	source, err := NewFileWorkflowSourceWithPath(lggr, "test-file-source", tmpFile)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	don := capabilities.DON{
 		ID:       1,
 		Families: []string{"family-a", "family-b"},
@@ -230,7 +229,7 @@ func TestFileWorkflowSource_ListWorkflowMetadata_PausedWorkflow(t *testing.T) {
 	source, err := NewFileWorkflowSourceWithPath(lggr, "test-file-source", tmpFile)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	don := capabilities.DON{
 		ID:       1,
 		Families: []string{"workflow"},
@@ -284,7 +283,7 @@ func TestFileWorkflowSource_InvalidJSON(t *testing.T) {
 	source, err := NewFileWorkflowSourceWithPath(lggr, "test-file-source", tmpFile)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	don := capabilities.DON{
 		ID:       1,
 		Families: []string{"workflow"},
@@ -324,7 +323,7 @@ func TestFileWorkflowSource_InvalidWorkflowID(t *testing.T) {
 	source, err := NewFileWorkflowSourceWithPath(lggr, "test-file-source", tmpFile)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	don := capabilities.DON{
 		ID:       1,
 		Families: []string{"workflow"},

--- a/core/services/workflows/syncer/v2/grpc_workflow_source_test.go
+++ b/core/services/workflows/syncer/v2/grpc_workflow_source_test.go
@@ -150,7 +150,7 @@ func TestGRPCWorkflowSourceWithClient_EmptyName(t *testing.T) {
 
 func TestGRPCWorkflowSource_ListWorkflowMetadata_Success(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mockClient := &mockGRPCClient{
 		allWorkflows: []*pb.WorkflowMetadata{
@@ -182,7 +182,7 @@ func TestGRPCWorkflowSource_ListWorkflowMetadata_Success(t *testing.T) {
 
 func TestGRPCWorkflowSource_ListWorkflowMetadata_Pagination(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Configure mock with all workflows - pagination is handled stateless via offset/limit
 	mockClient := &mockGRPCClient{
@@ -214,7 +214,7 @@ func TestGRPCWorkflowSource_ListWorkflowMetadata_Pagination(t *testing.T) {
 
 func TestGRPCWorkflowSource_ListWorkflowMetadata_InvalidWorkflow(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a workflow with invalid ID (not 32 bytes)
 	invalidWorkflow := &pb.WorkflowMetadata{
@@ -249,7 +249,7 @@ func TestGRPCWorkflowSource_ListWorkflowMetadata_InvalidWorkflow(t *testing.T) {
 
 func TestGRPCWorkflowSource_Retry_Unavailable(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Use errSequence to return errors on first two calls, then succeed
 	mockClient := &mockGRPCClient{
@@ -286,7 +286,7 @@ func TestGRPCWorkflowSource_Retry_Unavailable(t *testing.T) {
 
 func TestGRPCWorkflowSource_Retry_ResourceExhausted(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mockClient := &mockGRPCClient{
 		allWorkflows: []*pb.WorkflowMetadata{
@@ -318,7 +318,7 @@ func TestGRPCWorkflowSource_Retry_ResourceExhausted(t *testing.T) {
 
 func TestGRPCWorkflowSource_Retry_MaxExceeded(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Always return unavailable error
 	mockClient := &mockGRPCClient{
@@ -345,7 +345,7 @@ func TestGRPCWorkflowSource_Retry_MaxExceeded(t *testing.T) {
 
 func TestGRPCWorkflowSource_Retry_NonRetryable(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mockClient := &mockGRPCClient{
 		err: status.Error(codes.InvalidArgument, "bad request"),
@@ -399,7 +399,7 @@ func TestGRPCWorkflowSource_Backoff_Jitter(t *testing.T) {
 
 func TestGRPCWorkflowSource_ContextCancellation(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	// Always return unavailable to trigger retries
 	mockClient := &mockGRPCClient{
@@ -465,7 +465,7 @@ func TestGRPCWorkflowSource_Ready(t *testing.T) {
 
 func TestGRPCWorkflowSource_ListWorkflowMetadata_NotReady(t *testing.T) {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	source, err := NewGRPCWorkflowSourceWithClient(lggr, &mockGRPCClient{}, GRPCWorkflowSourceConfig{
 		Name: "test-source",

--- a/core/services/workflows/syncer/v2/workflow_syncer_v2_test.go
+++ b/core/services/workflows/syncer/v2/workflow_syncer_v2_test.go
@@ -146,7 +146,7 @@ func Test_InitialStateSyncV2(t *testing.T) {
 	}
 
 	assert.Len(t,
-		worker.GetAllowlistedRequests(context.Background()),
+		worker.GetAllowlistedRequests(t.Context()),
 		activeAllowlistedRequestsCount,
 		"synced allowlisted requests do not match expectations",
 	)

--- a/core/services/workflows/v2/capability_executor_test.go
+++ b/core/services/workflows/v2/capability_executor_test.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -49,6 +48,6 @@ func TestExecutionHelper_ConfidentialHTTPPerWorkflowLimit(t *testing.T) {
 	}
 
 	// Call and expect an error from the bound limiter (limit exceeded)
-	_, err = exec.CallCapability(context.Background(), req)
+	_, err = exec.CallCapability(t.Context(), req)
 	require.Error(t, err, "expected CallCapability to fail when per-workflow confidential-http call limit is exceeded")
 }

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -1968,7 +1968,7 @@ func TestEngine_HandleNewDON(t *testing.T) {
 func TestEngine_DonVersionLabelUpdatePinned(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	lggr := logger.Test(t)

--- a/core/services/workflows/v2/local_secrets_fetcher_test.go
+++ b/core/services/workflows/v2/local_secrets_fetcher_test.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +17,7 @@ func TestLocalSecretsFetcher_GetSecrets(t *testing.T) {
 	fetcher := NewLocalSecretsFetcher(secrets)
 
 	t.Run("returns known secrets", func(t *testing.T) {
-		resp, err := fetcher.GetSecrets(context.Background(), &sdkpb.GetSecretsRequest{
+		resp, err := fetcher.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
 			Requests: []*sdkpb.SecretRequest{
 				{Id: "api-key", Namespace: "default"},
 				{Id: "db-password"},
@@ -40,7 +39,7 @@ func TestLocalSecretsFetcher_GetSecrets(t *testing.T) {
 	})
 
 	t.Run("returns error for unknown secret", func(t *testing.T) {
-		resp, err := fetcher.GetSecrets(context.Background(), &sdkpb.GetSecretsRequest{
+		resp, err := fetcher.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
 			Requests: []*sdkpb.SecretRequest{
 				{Id: "nonexistent"},
 			},
@@ -55,7 +54,7 @@ func TestLocalSecretsFetcher_GetSecrets(t *testing.T) {
 	})
 
 	t.Run("handles mixed known and unknown", func(t *testing.T) {
-		resp, err := fetcher.GetSecrets(context.Background(), &sdkpb.GetSecretsRequest{
+		resp, err := fetcher.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
 			Requests: []*sdkpb.SecretRequest{
 				{Id: "api-key"},
 				{Id: "missing"},
@@ -70,7 +69,7 @@ func TestLocalSecretsFetcher_GetSecrets(t *testing.T) {
 
 	t.Run("empty map returns errors for all", func(t *testing.T) {
 		emptyFetcher := NewLocalSecretsFetcher(map[string]string{})
-		resp, err := emptyFetcher.GetSecrets(context.Background(), &sdkpb.GetSecretsRequest{
+		resp, err := emptyFetcher.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
 			Requests: []*sdkpb.SecretRequest{
 				{Id: "anything"},
 			},

--- a/core/utils/thread_control_test.go
+++ b/core/utils/thread_control_test.go
@@ -39,7 +39,7 @@ func TestThreadControl_GoCtx(t *testing.T) {
 	timeout := 100 * time.Millisecond
 
 	start := time.Now()
-	ctx, cancel := context.WithDeadline(context.Background(), start.Add(timeout))
+	ctx, cancel := context.WithDeadline(t.Context(), start.Add(timeout))
 	defer cancel()
 
 	wg.Add(1)

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pools_test.go
@@ -1,7 +1,6 @@
 package v1_5_1_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -223,7 +222,7 @@ func TestValidateDeployTokenPoolInput(t *testing.T) {
 			state, err := stateview.LoadOnchainState(e)
 			require.NoError(t, err)
 
-			err = test.Input.Validate(context.Background(), e.BlockChains.EVMChains()[selectorA], state.Chains[selectorA], test.Symbol)
+			err = test.Input.Validate(t.Context(), e.BlockChains.EVMChains()[selectorA], state.Chains[selectorA], test.Symbol)
 			require.Contains(t, err.Error(), test.ErrStr)
 		})
 	}

--- a/deployment/ccip/shared/stateview/state_test.go
+++ b/deployment/ccip/shared/stateview/state_test.go
@@ -1,7 +1,6 @@
 package stateview_test
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"testing"
 	"time"
@@ -34,7 +33,7 @@ func TestLoadChainState_MultipleFeeQuoters(t *testing.T) {
 	tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithNumOfChains(3))
 	fq1 := utils.RandomAddress().Hex()
 	fq2 := utils.RandomAddress().Hex()
-	state, err := stateview.LoadChainState(context.Background(), tenv.Env.BlockChains.EVMChains()[tenv.HomeChainSel], map[string]cldf.TypeAndVersion{
+	state, err := stateview.LoadChainState(t.Context(), tenv.Env.BlockChains.EVMChains()[tenv.HomeChainSel], map[string]cldf.TypeAndVersion{
 		fq1: cldf.NewTypeAndVersion(shared.FeeQuoter, deployment.Version1_0_0),
 		fq2: cldf.NewTypeAndVersion(shared.FeeQuoter, deployment.Version1_2_0),
 	})

--- a/deployment/environment/test/jd_test.go
+++ b/deployment/environment/test/jd_test.go
@@ -1,7 +1,6 @@
 package test_test
 
 import (
-	"context"
 	"encoding/hex"
 	"strconv"
 	"testing"
@@ -58,7 +57,7 @@ func TestJDNodeService_GetNode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := &nodev1.GetNodeRequest{Id: tt.nodeID}
-			resp, err := service.GetNode(context.Background(), req)
+			resp, err := service.GetNode(t.Context(), req)
 			if tt.expectErr {
 				require.Error(t, err)
 			} else {
@@ -149,7 +148,7 @@ func TestJDNodeService_ListNodes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := &nodev1.ListNodesRequest{Filter: tt.filter}
-			resp, err := service.ListNodes(context.Background(), req)
+			resp, err := service.ListNodes(t.Context(), req)
 			require.NoError(t, err)
 			require.NotNil(t, resp)
 			require.ElementsMatch(t, tt.want, resp.Nodes)
@@ -319,7 +318,7 @@ func TestJDNodeService_ListNodeChainConfigs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp, err := service.ListNodeChainConfigs(context.Background(), tt.req)
+			resp, err := service.ListNodeChainConfigs(t.Context(), tt.req)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -365,7 +364,7 @@ func TestNewJDServiceFromListNodes(t *testing.T) {
 	require.NoError(t, err)
 
 	req := &nodev1.ListNodesRequest{}
-	got, err := service.ListNodes(context.Background(), req)
+	got, err := service.ListNodes(t.Context(), req)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.ElementsMatch(t, testData.Nodes, got.Nodes)

--- a/deployment/environment/test/job_service_client_test.go
+++ b/deployment/environment/test/job_service_client_test.go
@@ -119,7 +119,6 @@ func TestBatchProposeJob(t *testing.T) {
 
 func TestProposeJob(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	// Create mock job approvers
 	mockGetter := &MockJobApproverGetter{
@@ -138,7 +137,7 @@ func TestProposeJob(t *testing.T) {
 			Spec:   jobSpec,
 		}
 
-		resp, err := client.ProposeJob(ctx, req)
+		resp, err := client.ProposeJob(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.NotNil(t, resp.Proposal)
@@ -162,7 +161,7 @@ func TestProposeJob(t *testing.T) {
 			},
 		}
 
-		resp, err := client.ProposeJob(ctx, req)
+		resp, err := client.ProposeJob(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.NotNil(t, resp.Proposal)
@@ -181,7 +180,7 @@ func TestProposeJob(t *testing.T) {
 			Spec:   jobSpec,
 		}
 
-		resp, err := client.ProposeJob(ctx, req)
+		resp, err := client.ProposeJob(t.Context(), req)
 		require.Error(t, err)
 		require.Nil(t, resp)
 		require.Contains(t, err.Error(), "node not found")
@@ -193,7 +192,7 @@ func TestProposeJob(t *testing.T) {
 			Spec:   "invalid job spec",
 		}
 
-		resp, err := client.ProposeJob(ctx, req)
+		resp, err := client.ProposeJob(t.Context(), req)
 		require.Error(t, err)
 		require.Nil(t, resp)
 	})
@@ -209,7 +208,7 @@ name = "Test Job"
 			Spec:   jobSpec,
 		}
 
-		resp, err := client.ProposeJob(ctx, req)
+		resp, err := client.ProposeJob(t.Context(), req)
 		require.Error(t, err)
 		require.Nil(t, resp)
 	})
@@ -225,7 +224,7 @@ name = "Test Job"
 			Spec:   jobSpec,
 		}
 
-		resp, err := client.ProposeJob(ctx, req)
+		resp, err := client.ProposeJob(t.Context(), req)
 		require.Error(t, err)
 		require.Nil(t, resp)
 		require.Contains(t, err.Error(), "failed to auto approve job")
@@ -314,7 +313,6 @@ func TestRevokeJob(t *testing.T) {
 
 func TestGetJob(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	// Create mock job approvers
 	mockGetter := &MockJobApproverGetter{
@@ -333,7 +331,7 @@ func TestGetJob(t *testing.T) {
 		Spec:   jobSpec,
 	}
 
-	_, err := client.ProposeJob(ctx, proposeReq)
+	_, err := client.ProposeJob(t.Context(), proposeReq)
 	require.NoError(t, err)
 
 	t.Run("get existing job", func(t *testing.T) {
@@ -343,7 +341,7 @@ func TestGetJob(t *testing.T) {
 			},
 		}
 
-		resp, err := client.GetJob(ctx, req)
+		resp, err := client.GetJob(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.NotNil(t, resp.Job)
@@ -358,7 +356,7 @@ func TestGetJob(t *testing.T) {
 			},
 		}
 
-		resp, err := client.GetJob(ctx, req)
+		resp, err := client.GetJob(t.Context(), req)
 		require.Error(t, err)
 		require.Nil(t, resp)
 		require.Contains(t, err.Error(), "failed to get job")
@@ -367,7 +365,6 @@ func TestGetJob(t *testing.T) {
 
 func TestGetProposal(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	// Create mock job approvers
 	mockGetter := &MockJobApproverGetter{
@@ -386,7 +383,7 @@ func TestGetProposal(t *testing.T) {
 		Spec:   jobSpec,
 	}
 
-	proposeResp, err := client.ProposeJob(ctx, proposeReq)
+	proposeResp, err := client.ProposeJob(t.Context(), proposeReq)
 	require.NoError(t, err)
 	require.NotNil(t, proposeResp)
 
@@ -397,7 +394,7 @@ func TestGetProposal(t *testing.T) {
 			Id: proposalID,
 		}
 
-		resp, err := client.GetProposal(ctx, req)
+		resp, err := client.GetProposal(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.NotNil(t, resp.Proposal)
@@ -410,7 +407,7 @@ func TestGetProposal(t *testing.T) {
 			Id: "non-existent-proposal",
 		}
 
-		resp, err := client.GetProposal(ctx, req)
+		resp, err := client.GetProposal(t.Context(), req)
 		require.Error(t, err)
 		require.Nil(t, resp)
 		require.Contains(t, err.Error(), "failed to get proposal")
@@ -452,7 +449,7 @@ func TestListJobs(t *testing.T) {
 	t.Run("list all jobs", func(t *testing.T) {
 		req := &jobv1.ListJobsRequest{}
 
-		resp, err := client.ListJobs(ctx, req)
+		resp, err := client.ListJobs(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Len(t, resp.Jobs, 2)
@@ -465,7 +462,7 @@ func TestListJobs(t *testing.T) {
 			},
 		}
 
-		resp, err := client.ListJobs(ctx, req)
+		resp, err := client.ListJobs(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Len(t, resp.Jobs, 1)
@@ -479,7 +476,7 @@ func TestListJobs(t *testing.T) {
 			},
 		}
 
-		resp, err := client.ListJobs(ctx, req)
+		resp, err := client.ListJobs(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Len(t, resp.Jobs, 1)
@@ -493,7 +490,7 @@ func TestListJobs(t *testing.T) {
 			},
 		}
 
-		resp, err := client.ListJobs(ctx, req)
+		resp, err := client.ListJobs(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Len(t, resp.Jobs, 1)
@@ -507,7 +504,7 @@ func TestListJobs(t *testing.T) {
 			},
 		}
 
-		resp, err := client.ListJobs(ctx, req)
+		resp, err := client.ListJobs(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Empty(t, resp.Jobs)
@@ -522,7 +519,7 @@ func TestListJobs(t *testing.T) {
 			},
 		}
 
-		resp, err := client.ListJobs(ctx, req)
+		resp, err := client.ListJobs(t.Context(), req)
 		require.Error(t, err)
 		require.Nil(t, resp)
 		require.Contains(t, err.Error(), "only one of NodeIds, Uuids or Ids can be set")
@@ -565,7 +562,7 @@ func TestListProposals(t *testing.T) {
 	t.Run("list all proposals", func(t *testing.T) {
 		req := &jobv1.ListProposalsRequest{}
 
-		resp, err := client.ListProposals(ctx, req)
+		resp, err := client.ListProposals(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Len(t, resp.Proposals, 2)
@@ -578,7 +575,7 @@ func TestListProposals(t *testing.T) {
 			},
 		}
 
-		resp, err := client.ListProposals(ctx, req)
+		resp, err := client.ListProposals(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Len(t, resp.Proposals, 1)
@@ -592,7 +589,7 @@ func TestListProposals(t *testing.T) {
 			},
 		}
 
-		resp, err := client.ListProposals(ctx, req)
+		resp, err := client.ListProposals(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Len(t, resp.Proposals, 1)
@@ -606,7 +603,7 @@ func TestListProposals(t *testing.T) {
 			},
 		}
 
-		resp, err := client.ListProposals(ctx, req)
+		resp, err := client.ListProposals(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Empty(t, resp.Proposals)
@@ -620,7 +617,7 @@ func TestListProposals(t *testing.T) {
 			},
 		}
 
-		resp, err := client.ListProposals(ctx, req)
+		resp, err := client.ListProposals(t.Context(), req)
 		require.Error(t, err)
 		require.Nil(t, resp)
 		require.Contains(t, err.Error(), "only one of Ids or JobIds can be set")

--- a/devenv/products/automation/concurrency/executor_test.go
+++ b/devenv/products/automation/concurrency/executor_test.go
@@ -261,7 +261,7 @@ func TestExecuteSimple(t *testing.T) {
 }
 
 func TestParentContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	executor := concurrency.NewConcurrentExecutor(framework.L, concurrency.WithContext[int, result, config](ctx))
 
 	processorFn := func(resultCh chan result, errCh chan error, keyNum int, _ config) {

--- a/devenv/tests/directrequest/smoke_test.go
+++ b/devenv/tests/directrequest/smoke_test.go
@@ -1,7 +1,6 @@
 package directrequest
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"testing"
@@ -21,7 +20,7 @@ import (
 )
 
 func TestSmoke(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	outputFile := "../../env-out.toml"
 	in, err := de.LoadOutput[de.Cfg](outputFile)
 	require.NoError(t, err)

--- a/devenv/tests/flux/smoke_test.go
+++ b/devenv/tests/flux/smoke_test.go
@@ -1,7 +1,6 @@
 package flux
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -20,7 +19,6 @@ import (
 )
 
 func TestSmoke(t *testing.T) {
-	ctx := context.Background()
 	outputFile := "../../env-out.toml"
 	in, err := de.LoadOutput[de.Cfg](outputFile)
 	require.NoError(t, err)
@@ -32,7 +30,7 @@ func TestSmoke(t *testing.T) {
 	})
 
 	c, _, _, err := products.ETHClient(
-		ctx,
+		t.Context(),
 		in.Blockchains[0].Out.Nodes[0].ExternalWSUrl,
 		productCfg.Config[0].GasSettings.FeeCapMultiplier,
 		productCfg.Config[0].GasSettings.TipCapMultiplier,

--- a/devenv/tests/keepers/smoke_test.go
+++ b/devenv/tests/keepers/smoke_test.go
@@ -1,7 +1,6 @@
 package keepers
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"math/big"
@@ -170,7 +169,7 @@ func TestKeeperBasic(t *testing.T) {
 			err = test.LinkToken.Transfer(test.Registry.Address(), big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(int64(testcase.UpkeepCount))))
 			require.NoError(t, err, "Funding keeper registry contract shouldn't fail")
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			upkeeps, upkeepIDs := automation.DeployLegacyConsumers(t, chainClient, test.Registry, test.Registrar, test.LinkToken, testcase.UpkeepCount, big.NewInt(0).Mul(big.NewInt(testcase.UpkeepFundingLink), big.NewInt(1e18)), defaultUpkeepGasLimit, false, false, false, nil)
@@ -313,7 +312,7 @@ func TestKeeperBlockCountPerTurn(t *testing.T) {
 			err = test.LinkToken.Transfer(test.Registry.Address(), big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(int64(testcase.UpkeepCount))))
 			require.NoError(t, err, "Funding keeper registry contract shouldn't fail")
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			upkeeps, upkeepIDs := automation.DeployLegacyConsumers(t, chainClient, test.Registry, test.Registrar, test.LinkToken, testcase.UpkeepCount, big.NewInt(0).Mul(big.NewInt(testcase.UpkeepFundingLink), big.NewInt(1e18)), defaultUpkeepGasLimit, false, false, false, nil)
@@ -516,7 +515,7 @@ func TestKeeperSimulation(t *testing.T) {
 			err = test.LinkToken.Transfer(test.Registry.Address(), big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(int64(testcase.UpkeepCount))))
 			require.NoError(t, err, "Funding keeper registry contract shouldn't fail")
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			t.Cleanup(func() {
@@ -663,7 +662,7 @@ func TestKeeperCheckPerformGasLimit(t *testing.T) {
 			err = test.LinkToken.Transfer(test.Registry.Address(), big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(int64(testcase.UpkeepCount))))
 			require.NoError(t, err, "Funding keeper registry contract shouldn't fail")
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			t.Cleanup(func() {
@@ -878,7 +877,7 @@ func TestKeeperRegisterUpkeep(t *testing.T) {
 			err = test.LinkToken.Transfer(test.Registry.Address(), big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(int64(testcase.UpkeepCount))))
 			require.NoError(t, err, "Funding keeper registry contract shouldn't fail")
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := automation.DeployLegacyConsumers(t, chainClient, test.Registry, test.Registrar, test.LinkToken, testcase.UpkeepCount, big.NewInt(0).Mul(big.NewInt(testcase.UpkeepFundingLink), big.NewInt(1e18)), defaultUpkeepGasLimit, false, false, false, nil)
@@ -1033,7 +1032,7 @@ func TestKeeperAddFunds(t *testing.T) {
 			err = test.LinkToken.Transfer(test.Registry.Address(), big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(int64(testcase.UpkeepCount))))
 			require.NoError(t, err, "Funding keeper registry contract shouldn't fail")
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			// don't fund the upkeeps with LINK, we will add funds later
@@ -1167,7 +1166,7 @@ func TestKeeperRemove(t *testing.T) {
 			err = test.LinkToken.Transfer(test.Registry.Address(), big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(int64(testcase.UpkeepCount))))
 			require.NoError(t, err, "Funding keeper registry contract shouldn't fail")
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := automation.DeployLegacyConsumers(t, chainClient, test.Registry, test.Registrar, test.LinkToken, testcase.UpkeepCount, big.NewInt(0).Mul(big.NewInt(testcase.UpkeepFundingLink), big.NewInt(1e18)), defaultUpkeepGasLimit, false, false, false, nil)
@@ -1314,7 +1313,7 @@ func TestKeeperPauseRegistry(t *testing.T) {
 			err = test.LinkToken.Transfer(test.Registry.Address(), big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(int64(testcase.UpkeepCount))))
 			require.NoError(t, err, "Funding keeper registry contract shouldn't fail")
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := automation.DeployLegacyConsumers(t, chainClient, test.Registry, test.Registrar, test.LinkToken, testcase.UpkeepCount, big.NewInt(0).Mul(big.NewInt(testcase.UpkeepFundingLink), big.NewInt(1e18)), defaultUpkeepGasLimit, false, false, false, nil)
@@ -1439,7 +1438,7 @@ func TestKeeperMigrateRegistry(t *testing.T) {
 			err = test.LinkToken.Transfer(test.Registry.Address(), big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(int64(testcase.UpkeepCount))))
 			require.NoError(t, err, "Funding keeper registry contract shouldn't fail")
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := automation.DeployLegacyConsumers(t, chainClient, test.Registry, test.Registrar, test.LinkToken, testcase.UpkeepCount, big.NewInt(0).Mul(big.NewInt(testcase.UpkeepFundingLink), big.NewInt(1e18)), defaultUpkeepGasLimit, false, false, false, nil)
@@ -1655,7 +1654,7 @@ func TestKeeperJobReplacement(t *testing.T) {
 			err = test.LinkToken.Transfer(test.Registry.Address(), big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(int64(testcase.UpkeepCount))))
 			require.NoError(t, err, "Funding keeper registry contract shouldn't fail")
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := automation.DeployLegacyConsumers(t, chainClient, test.Registry, test.Registrar, test.LinkToken, testcase.UpkeepCount, big.NewInt(0).Mul(big.NewInt(testcase.UpkeepFundingLink), big.NewInt(1e18)), defaultUpkeepGasLimit, false, false, false, nil)
@@ -1816,7 +1815,7 @@ func TestKeeperNodeDown(t *testing.T) {
 			err = test.LinkToken.Transfer(test.Registry.Address(), big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(int64(testcase.UpkeepCount))))
 			require.NoError(t, err, "Funding keeper registry contract shouldn't fail")
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := automation.DeployLegacyConsumers(t, chainClient, test.Registry, test.Registrar, test.LinkToken, testcase.UpkeepCount, big.NewInt(0).Mul(big.NewInt(testcase.UpkeepFundingLink), big.NewInt(1e18)), defaultUpkeepGasLimit, false, false, false, nil)
@@ -2001,7 +2000,7 @@ func TestKeeperPauseUnPauseUpkeep(t *testing.T) {
 			err = test.LinkToken.Transfer(test.Registry.Address(), big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(int64(testcase.UpkeepCount))))
 			require.NoError(t, err, "Funding keeper registry contract shouldn't fail")
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := automation.DeployLegacyConsumers(t, chainClient, test.Registry, test.Registrar, test.LinkToken, testcase.UpkeepCount, big.NewInt(0).Mul(big.NewInt(testcase.UpkeepFundingLink), big.NewInt(1e18)), defaultUpkeepGasLimit, false, false, false, nil)
@@ -2150,7 +2149,7 @@ func TestKeeperUpdateCheckData(t *testing.T) {
 			err = test.LinkToken.Transfer(test.Registry.Address(), big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(int64(testcase.UpkeepCount))))
 			require.NoError(t, err, "Funding keeper registry contract shouldn't fail")
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			performDataChecker := keepers.DeployPerformDataChecker(t, chainClient, testcase.UpkeepCount, []byte(expectedData))

--- a/devenv/tests/ocr2/load_test.go
+++ b/devenv/tests/ocr2/load_test.go
@@ -1,7 +1,6 @@
 package ocr2
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"testing"
@@ -22,7 +21,7 @@ import (
 )
 
 func TestOCR2Load(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	outputFile := "../../env-out.toml"
 	in, err := de.LoadOutput[de.Cfg](outputFile)
 	require.NoError(t, err)
@@ -131,7 +130,7 @@ func TestOCR2Load(t *testing.T) {
 			o2, err := ocr2aggregator.NewOCR2Aggregator(common.HexToAddress(pdConfig.Config[0].DeployedContracts.OCRv2AggregatorAddr), c)
 			require.NoError(t, err)
 			L.Info().Any("Config", tc.cfg).Msg("Applying new OCR2 configuration")
-			err = ocr2.UpdateOCR2ConfigOffChainValues(context.Background(), in.Blockchains[0], pdConfig.Config[0], o2, clNodes, tc.cfg)
+			err = ocr2.UpdateOCR2ConfigOffChainValues(t.Context(), in.Blockchains[0], pdConfig.Config[0], o2, clNodes, tc.cfg)
 			require.NoError(t, err)
 			for range tc.repeat {
 				verifyRounds(t, in, o2, tc, anvilClient)

--- a/integration-tests/crib/ocr_test.go
+++ b/integration-tests/crib/ocr_test.go
@@ -1,7 +1,6 @@
 package crib
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
@@ -47,10 +46,10 @@ func TestCRIBChaos(t *testing.T) {
 			os.Getenv("CRIB_NAMESPACE"),
 		)
 		require.NoError(t, err, "Error rebooting CL namespace")
-		ch.Create(context.Background())
+		ch.Create(t.Context())
 		ch.AddListener(havoc.NewChaosLogger(l))
 		t.Cleanup(func() {
-			err := ch.Delete(context.Background())
+			err := ch.Delete(t.Context())
 			require.NoError(t, err, "Error deleting chaos")
 		})
 		require.Eventually(t, func() bool {

--- a/integration-tests/load/ccip/ccip_chaos_test.go
+++ b/integration-tests/load/ccip/ccip_chaos_test.go
@@ -1,7 +1,6 @@
 package ccip
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -68,7 +67,7 @@ func runRealisticRPCLatencySuite(t *testing.T, testDuration, latency, jitter tim
 		{
 			name: "Realistic RPC Latency",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodDelay(context.Background(),
+				_, err := cr.RunPodDelay(t.Context(),
 					havoc.PodDelayCfg{
 						Namespace:         cfg.Namespace,
 						LabelKey:          "app.kubernetes.io/instance",
@@ -157,7 +156,7 @@ func runFullChaosSuite(t *testing.T) {
 		{
 			name: "Fail 3 chains",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodFail(context.Background(),
+				_, err := cr.RunPodFail(t.Context(),
 					havoc.PodFailCfg{
 						Namespace:         chaosCfg.Namespace,
 						LabelKey:          "app.kubernetes.io/instance",
@@ -171,7 +170,7 @@ func runFullChaosSuite(t *testing.T) {
 		{
 			name: "Fail 3 CL nodes",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodFail(context.Background(),
+				_, err := cr.RunPodFail(t.Context(),
 					havoc.PodFailCfg{
 						Namespace:         chaosCfg.Namespace,
 						LabelKey:          "app.kubernetes.io/instance",
@@ -185,7 +184,7 @@ func runFullChaosSuite(t *testing.T) {
 		{
 			name: "Fail 3 CL node DB",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodFail(context.Background(),
+				_, err := cr.RunPodFail(t.Context(),
 					havoc.PodFailCfg{
 						Namespace:         chaosCfg.Namespace,
 						LabelKey:          "app.kubernetes.io/instance",
@@ -201,7 +200,7 @@ func runFullChaosSuite(t *testing.T) {
 		{
 			name: "Fail two RMN nodes",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodFail(context.Background(),
+				_, err := cr.RunPodFail(t.Context(),
 					havoc.PodFailCfg{
 						Namespace:         chaosCfg.Namespace,
 						LabelKey:          "app.kubernetes.io/instance",
@@ -217,7 +216,7 @@ func runFullChaosSuite(t *testing.T) {
 		{
 			name: "Three slow chains",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodDelay(context.Background(),
+				_, err := cr.RunPodDelay(t.Context(),
 					havoc.PodDelayCfg{
 						Namespace:         chaosCfg.Namespace,
 						LabelKey:          "app.kubernetes.io/instance",
@@ -234,7 +233,7 @@ func runFullChaosSuite(t *testing.T) {
 		{
 			name: "Three slow CL nodes",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodDelay(context.Background(),
+				_, err := cr.RunPodDelay(t.Context(),
 					havoc.PodDelayCfg{
 						Namespace:         chaosCfg.Namespace,
 						LabelKey:          "app.kubernetes.io/instance",
@@ -251,7 +250,7 @@ func runFullChaosSuite(t *testing.T) {
 		{
 			name: "Three slow CL node DBs",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodDelay(context.Background(),
+				_, err := cr.RunPodDelay(t.Context(),
 					havoc.PodDelayCfg{
 						Namespace:         chaosCfg.Namespace,
 						LabelKey:          "app.kubernetes.io/instance",
@@ -270,7 +269,7 @@ func runFullChaosSuite(t *testing.T) {
 		{
 			name: "Two slow RMN nodes",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodDelay(context.Background(),
+				_, err := cr.RunPodDelay(t.Context(),
 					havoc.PodDelayCfg{
 						Namespace:         chaosCfg.Namespace,
 						LabelKey:          "app.kubernetes.io/instance",
@@ -289,7 +288,7 @@ func runFullChaosSuite(t *testing.T) {
 		{
 			name: "2 CL nodes <> 2 CL nodes partition",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodPartition(context.Background(),
+				_, err := cr.RunPodPartition(t.Context(),
 					havoc.PodPartitionCfg{
 						Namespace:         chaosCfg.Namespace,
 						LabelFromKey:      "app.kubernetes.io/instance",
@@ -305,7 +304,7 @@ func runFullChaosSuite(t *testing.T) {
 		{
 			name: "4 nodes partition",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodPartition(context.Background(),
+				_, err := cr.RunPodPartition(t.Context(),
 					havoc.PodPartitionCfg{
 						Namespace:         chaosCfg.Namespace,
 						LabelFromKey:      "app.kubernetes.io/instance",
@@ -321,7 +320,7 @@ func runFullChaosSuite(t *testing.T) {
 		{
 			name: "CL node <> DB partition",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodPartition(context.Background(),
+				_, err := cr.RunPodPartition(t.Context(),
 					havoc.PodPartitionCfg{
 						Namespace:         chaosCfg.Namespace,
 						LabelFromKey:      "app.kubernetes.io/instance",
@@ -339,7 +338,7 @@ func runFullChaosSuite(t *testing.T) {
 		{
 			name: "2 RMN nodes <> 2 RMN nodes partition",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodPartition(context.Background(),
+				_, err := cr.RunPodPartition(t.Context(),
 					havoc.PodPartitionCfg{
 						Namespace:         chaosCfg.Namespace,
 						LabelFromKey:      "app.kubernetes.io/instance",
@@ -356,7 +355,7 @@ func runFullChaosSuite(t *testing.T) {
 		{
 			name: "2 CL nodes <> 2 RMN nodes partition",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodPartition(context.Background(),
+				_, err := cr.RunPodPartition(t.Context(),
 					havoc.PodPartitionCfg{
 						Namespace:         chaosCfg.Namespace,
 						LabelFromKey:      "app.kubernetes.io/instance",
@@ -382,7 +381,7 @@ func runFullChaosSuite(t *testing.T) {
 		{
 			name: "8-8 CL nodes split brain",
 			run: func(t *testing.T) {
-				_, err := cr.RunPodPartition(context.Background(),
+				_, err := cr.RunPodPartition(t.Context(),
 					havoc.PodPartitionCfg{
 						Namespace:         chaosCfg.Namespace,
 						LabelFromKey:      "app.kubernetes.io/instance",

--- a/integration-tests/load/ccip/ccip_test.go
+++ b/integration-tests/load/ccip/ccip_test.go
@@ -127,12 +127,12 @@ func TestCCIPLoad_RPS(t *testing.T) {
 	blockTimes := make(map[uint64]uint64)
 	for _, cs := range evmChains {
 		// Get the first block
-		block1, err := env.BlockChains.EVMChains()[cs].Client.HeaderByNumber(context.Background(), big.NewInt(1))
+		block1, err := env.BlockChains.EVMChains()[cs].Client.HeaderByNumber(t.Context(), big.NewInt(1))
 		require.NoError(t, err)
 		time1 := time.Unix(int64(block1.Time), 0) //nolint:gosec // G115
 
 		// Get the second block
-		block2, err := env.BlockChains.EVMChains()[cs].Client.HeaderByNumber(context.Background(), big.NewInt(2))
+		block2, err := env.BlockChains.EVMChains()[cs].Client.HeaderByNumber(t.Context(), big.NewInt(2))
 		require.NoError(t, err)
 		time2 := time.Unix(int64(block2.Time), 0) //nolint:gosec // G115
 

--- a/integration-tests/reorg/automation_reorg_test.go
+++ b/integration-tests/reorg/automation_reorg_test.go
@@ -2,7 +2,6 @@ package reorg
 
 //revive:disable:dot-imports
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"regexp"
@@ -147,7 +146,7 @@ func TestAutomationReorg(t *testing.T) {
 			a.SetupAutomationDeployment(t)
 			a.SetDockerEnv(env)
 
-			sb, err := a.ChainClient.Client.BlockNumber(context.Background())
+			sb, err := a.ChainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			t.Cleanup(func() {

--- a/integration-tests/smoke/automation_test.go
+++ b/integration-tests/smoke/automation_test.go
@@ -1,7 +1,6 @@
 package smoke
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -131,7 +130,7 @@ func SetupAutomationBasic(t *testing.T, nodeUpgrade bool) {
 				t, registryVersion, actions.ReadRegistryConfig(cfg), isMercuryV02, isMercuryV03, &cfg,
 			)
 
-			sb, err := a.ChainClient.Client.BlockNumber(context.Background())
+			sb, err := a.ChainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := actions.DeployConsumers(
@@ -271,7 +270,7 @@ func TestSetUpkeepTriggerConfig(t *testing.T) {
 				t, registryVersion, actions.ReadRegistryConfig(config), false, false, &config,
 			)
 
-			sb, err := a.ChainClient.Client.BlockNumber(context.Background())
+			sb, err := a.ChainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := actions.DeployConsumers(t, a.ChainClient, a.Registry, a.Registrar, a.LinkToken, defaultAmountOfUpkeeps, big.NewInt(automationDefaultLinkFunds), automationDefaultUpkeepGasLimit, true, false, false, nil, &config)
@@ -441,7 +440,7 @@ func TestAutomationAddFunds(t *testing.T) {
 				t, registryVersion, actions.ReadRegistryConfig(config), false, false, &config,
 			)
 
-			sb, err := a.ChainClient.Client.BlockNumber(context.Background())
+			sb, err := a.ChainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := actions.DeployConsumers(t, a.ChainClient, a.Registry, a.Registrar, a.LinkToken, defaultAmountOfUpkeeps, big.NewInt(1), automationDefaultUpkeepGasLimit, false, false, false, nil, &config)
@@ -508,7 +507,7 @@ func TestAutomationPauseUnPause(t *testing.T) {
 				t, registryVersion, actions.ReadRegistryConfig(config), false, false, &config,
 			)
 
-			sb, err := a.ChainClient.Client.BlockNumber(context.Background())
+			sb, err := a.ChainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := actions.DeployConsumers(t, a.ChainClient, a.Registry, a.Registrar, a.LinkToken, defaultAmountOfUpkeeps, big.NewInt(automationDefaultLinkFunds), automationDefaultUpkeepGasLimit, false, false, false, nil, &config)
@@ -596,7 +595,7 @@ func TestAutomationRegisterUpkeep(t *testing.T) {
 				t, registryVersion, actions.ReadRegistryConfig(config), false, false, &config,
 			)
 
-			sb, err := a.ChainClient.Client.BlockNumber(context.Background())
+			sb, err := a.ChainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := actions.DeployConsumers(t, a.ChainClient, a.Registry, a.Registrar, a.LinkToken, defaultAmountOfUpkeeps, big.NewInt(automationDefaultLinkFunds), automationDefaultUpkeepGasLimit, false, false, false, nil, &config)
@@ -679,7 +678,7 @@ func TestAutomationPauseRegistry(t *testing.T) {
 				t, registryVersion, actions.ReadRegistryConfig(config), false, false, &config,
 			)
 
-			sb, err := a.ChainClient.Client.BlockNumber(context.Background())
+			sb, err := a.ChainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := actions.DeployConsumers(t, a.ChainClient, a.Registry, a.Registrar, a.LinkToken, defaultAmountOfUpkeeps, big.NewInt(automationDefaultLinkFunds), automationDefaultUpkeepGasLimit, false, false, false, nil, &config)
@@ -746,7 +745,7 @@ func TestAutomationKeeperNodesDown(t *testing.T) {
 				t, registryVersion, actions.ReadRegistryConfig(config), false, false, &config,
 			)
 
-			sb, err := a.ChainClient.Client.BlockNumber(context.Background())
+			sb, err := a.ChainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := actions.DeployConsumers(t, a.ChainClient, a.Registry, a.Registrar, a.LinkToken, defaultAmountOfUpkeeps, big.NewInt(automationDefaultLinkFunds), automationDefaultUpkeepGasLimit, false, false, false, nil, &config)
@@ -841,7 +840,7 @@ func TestAutomationPerformSimulation(t *testing.T) {
 				t, registryVersion, actions.ReadRegistryConfig(config), false, false, &config,
 			)
 
-			sb, err := a.ChainClient.Client.BlockNumber(context.Background())
+			sb, err := a.ChainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumersPerformance, _ := actions.DeployPerformanceConsumers(
@@ -913,7 +912,7 @@ func TestAutomationCheckPerformGasLimit(t *testing.T) {
 				t, registryVersion, actions.ReadRegistryConfig(config), false, false, &config,
 			)
 
-			sb, err := a.ChainClient.Client.BlockNumber(context.Background())
+			sb, err := a.ChainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumersPerformance, upkeepIDs := actions.DeployPerformanceConsumers(
@@ -1069,7 +1068,7 @@ func TestUpdateCheckData(t *testing.T) {
 				t, registryVersion, actions.ReadRegistryConfig(config), false, false, &config,
 			)
 
-			sb, err := a.ChainClient.Client.BlockNumber(context.Background())
+			sb, err := a.ChainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			performDataChecker, upkeepIDs := actions.DeployPerformDataCheckerConsumers(
@@ -1152,7 +1151,7 @@ func TestSetOffchainConfigWithMaxGasPrice(t *testing.T) {
 				t, registryVersion, actions.ReadRegistryConfig(config), false, false, &config,
 			)
 
-			sb, err := a.ChainClient.Client.BlockNumber(context.Background())
+			sb, err := a.ChainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			consumers, upkeepIDs := actions.DeployConsumers(t, a.ChainClient, a.Registry, a.Registrar, a.LinkToken, defaultAmountOfUpkeeps, big.NewInt(automationDefaultLinkFunds), automationDefaultUpkeepGasLimit, false, false, false, nil, &config)

--- a/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
+++ b/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
@@ -1,7 +1,6 @@
 package ccip
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
@@ -588,7 +587,7 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	require.NotNil(t, sentEvent)
 	evmChains := e.Env.BlockChains.EVMChains()
 	destChain := evmChains[dest]
-	destStartBlock, err := destChain.Client.HeaderByNumber(context.Background(), nil)
+	destStartBlock, err := destChain.Client.HeaderByNumber(t.Context(), nil)
 	require.NoError(t, err)
 	v1_5testhelpers.WaitForCommit(t, evmChains[src2], destChain, state.MustGetEVMChainState(dest).CommitStore[src2],
 		sentEvent.Message.SequenceNumber)
@@ -865,7 +864,7 @@ func sendContinuousMessages(
 				v1_5Msgs = append(v1_5Msgs, msg)
 				if initialDestBlock == 0 {
 					destChain := e.Env.BlockChains.EVMChains()[dest]
-					destStartBlock, err := destChain.Client.HeaderByNumber(context.Background(), nil)
+					destStartBlock, err := destChain.Client.HeaderByNumber(t.Context(), nil)
 					if err != nil {
 						t.Errorf("failed to get block header")
 					}
@@ -907,7 +906,7 @@ func sendMessageInRealRouter(
 	if err != nil {
 		t.Errorf("failed to send message: %v", err)
 	}
-	receipt, err := e.Env.BlockChains.EVMChains()[src].Client.TransactionReceipt(context.Background(), tx.Hash())
+	receipt, err := e.Env.BlockChains.EVMChains()[src].Client.TransactionReceipt(t.Context(), tx.Hash())
 	if err != nil {
 		t.Errorf("failed to get transaction receipt: %v", err)
 	}

--- a/integration-tests/smoke/job_distributor_test.go
+++ b/integration-tests/smoke/job_distributor_test.go
@@ -1,7 +1,6 @@
 package smoke
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,7 +35,7 @@ func TestRegisteringMultipleJobDistributor(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err = env.ClCluster.Nodes[0].GraphqlAPI.CreateJobDistributor(ctx, graphqlClient.JobDistributorInput{
 		Name:      "job-distributor-1",
 		Uri:       "http://job-distributor-1:8080",

--- a/integration-tests/smoke/keeper_test.go
+++ b/integration-tests/smoke/keeper_test.go
@@ -1,7 +1,6 @@
 package smoke
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -96,7 +95,7 @@ func TestKeeperBasicSmoke(t *testing.T) {
 
 			chainClient, chainlinkNodes, linkToken, _ := setupKeeperTest(l, t, &config)
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
@@ -182,7 +181,7 @@ func TestKeeperBlockCountPerTurn(t *testing.T) {
 
 			chainClient, chainlinkNodes, linkToken, _ := setupKeeperTest(l, t, &config)
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
@@ -327,7 +326,7 @@ func TestKeeperSimulation(t *testing.T) {
 
 			chainClient, chainlinkNodes, linkToken, _ := setupKeeperTest(l, t, &config)
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			registry, _, consumersPerformance, upkeepIDs := actions.DeployPerformanceKeeperContracts(
@@ -407,7 +406,7 @@ func TestKeeperCheckPerformGasLimit(t *testing.T) {
 
 			chainClient, chainlinkNodes, linkToken, _ := setupKeeperTest(l, t, &config)
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			registry, _, consumersPerformance, upkeepIDs := actions.DeployPerformanceKeeperContracts(
@@ -545,7 +544,7 @@ func TestKeeperRegisterUpkeep(t *testing.T) {
 
 			chainClient, chainlinkNodes, linkToken, _ := setupKeeperTest(l, t, &config)
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			registry, registrar, consumers, upkeepIDs := actions.DeployKeeperContracts(
@@ -642,7 +641,7 @@ func TestKeeperAddFunds(t *testing.T) {
 
 			chainClient, chainlinkNodes, linkToken, _ := setupKeeperTest(l, t, &config)
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
@@ -724,7 +723,7 @@ func TestKeeperRemove(t *testing.T) {
 
 			chainClient, chainlinkNodes, linkToken, _ := setupKeeperTest(l, t, &config)
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
@@ -810,7 +809,7 @@ func TestKeeperPauseRegistry(t *testing.T) {
 
 			chainClient, chainlinkNodes, linkToken, _ := setupKeeperTest(l, t, &config)
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
@@ -877,7 +876,7 @@ func TestKeeperMigrateRegistry(t *testing.T) {
 	require.NoError(t, err, "Error getting config")
 	chainClient, chainlinkNodes, linkToken, _ := setupKeeperTest(l, t, &config)
 
-	sb, err := chainClient.Client.BlockNumber(context.Background())
+	sb, err := chainClient.Client.BlockNumber(t.Context())
 	require.NoError(t, err, "Failed to get start block")
 
 	registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
@@ -986,7 +985,7 @@ func TestKeeperNodeDown(t *testing.T) {
 
 			chainClient, chainlinkNodes, linkToken, _ := setupKeeperTest(l, t, &config)
 
-			sb, err := chainClient.Client.BlockNumber(context.Background())
+			sb, err := chainClient.Client.BlockNumber(t.Context())
 			require.NoError(t, err, "Failed to get start block")
 
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
@@ -1097,7 +1096,7 @@ func TestKeeperPauseUnPauseUpkeep(t *testing.T) {
 
 	chainClient, chainlinkNodes, linkToken, _ := setupKeeperTest(l, t, &config)
 
-	sb, err := chainClient.Client.BlockNumber(context.Background())
+	sb, err := chainClient.Client.BlockNumber(t.Context())
 	require.NoError(t, err, "Failed to get start block")
 
 	registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
@@ -1190,7 +1189,7 @@ func TestKeeperUpdateCheckData(t *testing.T) {
 
 	chainClient, chainlinkNodes, linkToken, _ := setupKeeperTest(l, t, &config)
 
-	sb, err := chainClient.Client.BlockNumber(context.Background())
+	sb, err := chainClient.Client.BlockNumber(t.Context())
 	require.NoError(t, err, "Failed to get start block")
 
 	registry, _, performDataChecker, upkeepIDs := actions.DeployPerformDataCheckerContracts(

--- a/system-tests/tests/load/cre/workflow_don_chaos_test.go
+++ b/system-tests/tests/load/cre/workflow_don_chaos_test.go
@@ -1,7 +1,6 @@
 package cre
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -124,7 +123,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Realistic RPC Latency",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodDelay(context.Background(),
+					_, err := cr.RunPodDelay(t.Context(),
 						havoc.PodDelayCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/name",
@@ -144,7 +143,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Fail EVM Chain",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodFail(context.Background(),
+					_, err := cr.RunPodFail(t.Context(),
 						havoc.PodFailCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -158,7 +157,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "400ms+200ms jitter for EVM Chain",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodDelay(context.Background(),
+					_, err := cr.RunPodDelay(t.Context(),
 						havoc.PodDelayCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -175,7 +174,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "30% corrupt for EVM Chain",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodCorrupt(context.Background(),
+					_, err := cr.RunPodCorrupt(t.Context(),
 						havoc.PodCorruptCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -191,7 +190,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "30% loss for EVM Chain",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodLoss(context.Background(),
+					_, err := cr.RunPodLoss(t.Context(),
 						havoc.PodLossCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -207,7 +206,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Partition EVM Chain from 2 Assets nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodPartition(context.Background(),
+					_, err := cr.RunPodPartition(t.Context(),
 						havoc.PodPartitionCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelFromKey:      "app.kubernetes.io/instance",
@@ -223,7 +222,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Partition EVM Chain from 2 Workflow nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodPartition(context.Background(),
+					_, err := cr.RunPodPartition(t.Context(),
 						havoc.PodPartitionCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelFromKey:      "app.kubernetes.io/instance",
@@ -239,7 +238,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Partition EVM Chain from 2 Writer nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodPartition(context.Background(),
+					_, err := cr.RunPodPartition(t.Context(),
 						havoc.PodPartitionCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelFromKey:      "app.kubernetes.io/instance",
@@ -259,7 +258,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Fail Assets Node",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodFail(context.Background(),
+					_, err := cr.RunPodFail(t.Context(),
 						havoc.PodFailCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -273,7 +272,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "400ms+200ms jitter for 2 DBs of Assets Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodDelay(context.Background(),
+					_, err := cr.RunPodDelay(t.Context(),
 						havoc.PodDelayCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -290,7 +289,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "400ms+200ms jitter for 2 Assets Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodDelay(context.Background(),
+					_, err := cr.RunPodDelay(t.Context(),
 						havoc.PodDelayCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -307,7 +306,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "30% corrupt for 2 Assets Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodCorrupt(context.Background(),
+					_, err := cr.RunPodCorrupt(t.Context(),
 						havoc.PodCorruptCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -323,7 +322,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "30% loss for 2 Assets Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodLoss(context.Background(),
+					_, err := cr.RunPodLoss(t.Context(),
 						havoc.PodLossCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -339,7 +338,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Partition 2 Assets nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodPartition(context.Background(),
+					_, err := cr.RunPodPartition(t.Context(),
 						havoc.PodPartitionCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelFromKey:      "app.kubernetes.io/instance",
@@ -355,7 +354,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Fail 2 Assets Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodFail(context.Background(),
+					_, err := cr.RunPodFail(t.Context(),
 						havoc.PodFailCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -369,7 +368,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Partition 2 Assets Nodes <> 2 Assets Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodPartition(context.Background(),
+					_, err := cr.RunPodPartition(t.Context(),
 						havoc.PodPartitionCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelFromKey:      "app.kubernetes.io/instance",
@@ -387,7 +386,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Fail Workflow Node",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodFail(context.Background(),
+					_, err := cr.RunPodFail(t.Context(),
 						havoc.PodFailCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -401,7 +400,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "400ms+200ms jitter for 2 DBs of Workflow Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodDelay(context.Background(),
+					_, err := cr.RunPodDelay(t.Context(),
 						havoc.PodDelayCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -418,7 +417,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "400ms+200ms jitter for 2 Workflow Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodDelay(context.Background(),
+					_, err := cr.RunPodDelay(t.Context(),
 						havoc.PodDelayCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -435,7 +434,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "30% corrupt for 2 Workflow Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodCorrupt(context.Background(),
+					_, err := cr.RunPodCorrupt(t.Context(),
 						havoc.PodCorruptCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -451,7 +450,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "30% loss for 2 Workflow Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodLoss(context.Background(),
+					_, err := cr.RunPodLoss(t.Context(),
 						havoc.PodLossCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -467,7 +466,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Partition 2 Workflow nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodPartition(context.Background(),
+					_, err := cr.RunPodPartition(t.Context(),
 						havoc.PodPartitionCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelFromKey:      "app.kubernetes.io/instance",
@@ -483,7 +482,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Fail 2 Workflow Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodFail(context.Background(),
+					_, err := cr.RunPodFail(t.Context(),
 						havoc.PodFailCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -497,7 +496,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Partition 2 Workflow Nodes <> 2 Workflow Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodPartition(context.Background(),
+					_, err := cr.RunPodPartition(t.Context(),
 						havoc.PodPartitionCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelFromKey:      "app.kubernetes.io/instance",
@@ -515,7 +514,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Fail Writer Node",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodFail(context.Background(),
+					_, err := cr.RunPodFail(t.Context(),
 						havoc.PodFailCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -529,7 +528,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "400ms+200ms jitter for 2 DBs of Writer Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodDelay(context.Background(),
+					_, err := cr.RunPodDelay(t.Context(),
 						havoc.PodDelayCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -546,7 +545,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "400ms+200ms jitter for 2 Writer Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodDelay(context.Background(),
+					_, err := cr.RunPodDelay(t.Context(),
 						havoc.PodDelayCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -563,7 +562,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "30% corrupt for 2 Writer Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodCorrupt(context.Background(),
+					_, err := cr.RunPodCorrupt(t.Context(),
 						havoc.PodCorruptCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -579,7 +578,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "30% loss for 2 Writer Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodLoss(context.Background(),
+					_, err := cr.RunPodLoss(t.Context(),
 						havoc.PodLossCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -595,7 +594,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Partition 2 Writer nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodPartition(context.Background(),
+					_, err := cr.RunPodPartition(t.Context(),
 						havoc.PodPartitionCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelFromKey:      "app.kubernetes.io/instance",
@@ -611,7 +610,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Fail 2 Writer Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodFail(context.Background(),
+					_, err := cr.RunPodFail(t.Context(),
 						havoc.PodFailCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -625,7 +624,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Partition 2 Writer Nodes <> 2 Writer Nodes",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodPartition(context.Background(),
+					_, err := cr.RunPodPartition(t.Context(),
 						havoc.PodPartitionCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelFromKey:      "app.kubernetes.io/instance",
@@ -643,7 +642,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "2 Assets Nodes <> 2 Workflow Nodes partition",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodPartition(context.Background(),
+					_, err := cr.RunPodPartition(t.Context(),
 						havoc.PodPartitionCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelFromKey:      "app.kubernetes.io/instance",
@@ -659,7 +658,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "2 Workflow Nodes <> 2 Writer Nodes partition",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodPartition(context.Background(),
+					_, err := cr.RunPodPartition(t.Context(),
 						havoc.PodPartitionCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelFromKey:      "app.kubernetes.io/instance",
@@ -677,7 +676,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Fail Job Distributor",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodFail(context.Background(),
+					_, err := cr.RunPodFail(t.Context(),
 						havoc.PodFailCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",
@@ -691,7 +690,7 @@ func runChaosSuite(t *testing.T, testConfig *TestConfigLoadTest) {
 			{
 				name: "Fail Job Distributor DB",
 				run: func(t *testing.T, r []*blockchain.Node) {
-					_, err := cr.RunPodFail(context.Background(),
+					_, err := cr.RunPodFail(t.Context(),
 						havoc.PodFailCfg{
 							Namespace:         kubernetesCfg.Namespace,
 							LabelKey:          "app.kubernetes.io/instance",

--- a/system-tests/tests/smoke/cre/v2_sharding_test.go
+++ b/system-tests/tests/smoke/cre/v2_sharding_test.go
@@ -138,7 +138,7 @@ func validateShardOrchestratorRPC(t *testing.T, logger zerolog.Logger, addr stri
 
 	client := ringpb.NewShardOrchestratorServiceClient(conn)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 	resp, err := client.GetWorkflowShardMapping(ctx, &ringpb.GetWorkflowShardMappingRequest{
 		WorkflowIds: []string{"test-workflow-id"},
@@ -160,7 +160,7 @@ func validateArbiterRPC(t *testing.T, logger zerolog.Logger, addr string) {
 
 	client := ringpb.NewArbiterClient(conn)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 	resp, err := client.GetDesiredReplicas(ctx, &ringpb.ShardStatusRequest{})
 
@@ -182,7 +182,7 @@ func validateArbiterRPC(t *testing.T, logger zerolog.Logger, addr string) {
 func validateShardingScaleScenario(t *testing.T, testEnv *ttypes.TestEnvironment, rpcHost string) {
 	t.Helper()
 	logger := framework.L
-	ctx := context.Background()
+	ctx := t.Context()
 
 	shardConfigRef := getShardConfigRef(t, testEnv)
 	chainSelector := testEnv.CreEnvironment.RegistryChainSelector
@@ -278,7 +278,7 @@ func updateShardCount(t *testing.T, testEnv *ttypes.TestEnvironment, chainSelect
 func waitForArbiterShardCount(t *testing.T, client ringpb.ArbiterClient, expected uint32) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 		resp, err := client.GetDesiredReplicas(ctx, &ringpb.ShardStatusRequest{})
 		if err != nil {

--- a/system-tests/tests/smoke/cre/v2_vault_don_test_helpers.go
+++ b/system-tests/tests/smoke/cre/v2_vault_don_test_helpers.go
@@ -2,7 +2,6 @@ package cre
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -53,7 +52,7 @@ func FetchVaultPublicKey(t *testing.T, gatewayURL string) (publicKey string) {
 
 func sendVaultRequestToGateway(t *testing.T, gatewayURL string, requestBody []byte) (statusCode int, body []byte) {
 	framework.L.Info().Msgf("Request Body: %s", string(requestBody))
-	req, err := http.NewRequestWithContext(context.Background(), "POST", gatewayURL, bytes.NewBuffer(requestBody))
+	req, err := http.NewRequestWithContext(t.Context(), "POST", gatewayURL, bytes.NewBuffer(requestBody))
 	require.NoError(t, err, "failed to create request")
 
 	req.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
There were 1071 uses of `background.Context()`. This PR replaces 357 of them with `t.Context()`, bringing it down to 714.