### PR TITLE
Add gocs make target

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -107,7 +107,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           message: |
-            I see you updated files related to `core`. Please run `pnpm changeset` in the root directory to add a changeset as well as in the text include at least one of the following tags:
+            I see you updated files related to `core`. Please run `make gocs` in the root directory to add a changeset as well as in the text include at least one of the following tags:
             ${{ env.TAGS }}
           reactions: eyes
           comment_tag: changeset-core

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -264,6 +264,10 @@ modgraph:
 test-short: ## Run 'go test -short' and suppress uninteresting output
 	go test -short ./... | grep -v "\[no test files\]" | grep -v "\(cached\)"
 
+.PHONY: gocs
+gocs: ## Run gocs to generate changeset markdown files.
+	go run github.com/smartcontractkit/gocs/cmd/gocs@v0.2.0
+
 help:
 	@echo ""
 	@echo "         .__           .__       .__  .__        __"

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ To install `changesets`:
 1. Install `pnpm` if it is not already installed - [docs](https://pnpm.io/installation).
 2. Run `pnpm install`.
 
-Either after or before you create a commit, run the `pnpm changeset` command to create an accompanying changeset entry which will reflect on the CHANGELOG for the next release.
+Either after or before you create a commit, run the `make gocs` command to create an accompanying changeset entry which will reflect on the CHANGELOG for the next release.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 


### PR DESCRIPTION
Run `make gocs` to create `.changeset/*.md` files as an alternative to `pnpm changeset`. See https://github.com/smartcontractkit/gocs for more.