### PR TITLE
CRE-1843: execution store clean-up on wf delete

### DIFF
--- a/core/services/workflows/store/store.go
+++ b/core/services/workflows/store/store.go
@@ -14,6 +14,7 @@ type Store interface {
 	UpsertStep(ctx context.Context, step *WorkflowExecutionStep) (WorkflowExecution, error)
 	FinishExecution(ctx context.Context, executionID string, status string) (WorkflowExecution, error)
 	Get(ctx context.Context, executionID string) (WorkflowExecution, error)
+	DeleteByWorkflowID(ctx context.Context, workflowID string) error
 }
 
 var _ Store = (*InMemoryStore)(nil)

--- a/core/services/workflows/store/store_memory.go
+++ b/core/services/workflows/store/store_memory.go
@@ -164,6 +164,17 @@ func (s *InMemoryStore) Name() string {
 	return "WorkflowStore"
 }
 
+func (s *InMemoryStore) DeleteByWorkflowID(_ context.Context, workflowID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, state := range s.idToExecution {
+		if state.WorkflowID == workflowID {
+			delete(s.idToExecution, id)
+		}
+	}
+	return nil
+}
+
 func (s *InMemoryStore) pruneExpiredExecutionEntries() {
 	defer s.shutdownWaitGroup.Done()
 	ticker := s.clock.NewTicker(s.pruneInterval)

--- a/core/services/workflows/store/store_memory_test.go
+++ b/core/services/workflows/store/store_memory_test.go
@@ -85,6 +85,28 @@ func TestInMemoryStore_FinishedExecution(t *testing.T) {
 	}, 10*time.Second, 10*time.Millisecond)
 }
 
+func TestInMemoryStore_DeleteByWorkflowID(t *testing.T) {
+	s := NewInMemoryStore(logger.TestLogger(t), clockwork.NewFakeClock())
+
+	_, err := s.Add(t.Context(), nil, "exec-1", "wf-A", StatusStarted)
+	require.NoError(t, err)
+	_, err = s.Add(t.Context(), nil, "exec-2", "wf-A", StatusStarted)
+	require.NoError(t, err)
+	_, err = s.Add(t.Context(), nil, "exec-3", "wf-B", StatusStarted)
+	require.NoError(t, err)
+
+	require.NoError(t, s.DeleteByWorkflowID(t.Context(), "wf-A"))
+
+	_, err = s.Get(t.Context(), "exec-1")
+	assert.Error(t, err)
+	_, err = s.Get(t.Context(), "exec-2")
+	assert.Error(t, err)
+
+	got, err := s.Get(t.Context(), "exec-3")
+	require.NoError(t, err)
+	assert.Equal(t, "wf-B", got.WorkflowID)
+}
+
 func TestInMemoryStore_ExpiresNonCompletedExecutions(t *testing.T) {
 	expirationDuration := 50 * time.Millisecond
 

--- a/core/services/workflows/store/store_memory_test.go
+++ b/core/services/workflows/store/store_memory_test.go
@@ -98,9 +98,9 @@ func TestInMemoryStore_DeleteByWorkflowID(t *testing.T) {
 	require.NoError(t, s.DeleteByWorkflowID(t.Context(), "wf-A"))
 
 	_, err = s.Get(t.Context(), "exec-1")
-	assert.Error(t, err)
+	require.Error(t, err)
 	_, err = s.Get(t.Context(), "exec-2")
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	got, err := s.Get(t.Context(), "exec-3")
 	require.NoError(t, err)

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -799,6 +799,10 @@ func (e *Engine) close() error {
 	e.triggersRegMu.Unlock()
 	e.metrics.IncrementWorkflowUnregisteredCounter(ctx)
 
+	if err := e.cfg.ExecutionsStore.DeleteByWorkflowID(ctx, e.cfg.WorkflowID); err != nil {
+		e.logger().Errorw("Failed to purge executions on close", "err", err)
+	}
+
 	e.cfg.Module.Close()
 
 	// reset metering mode metric so that a positive value does not persist


### PR DESCRIPTION
Self-contained change with no dependencies on other scopes. Addresses the memory retention of execution data for deleted workflows.

[CRE-1843](https://smartcontract-it.atlassian.net/browse/CRE-1843)

[CRE-1843]: https://smartcontract-it.atlassian.net/browse/CRE-1843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ