### PR TITLE
CRE-1844: batch DB deletes for workflow specs

### DIFF
--- a/core/services/workflows/artifacts/v2/orm.go
+++ b/core/services/workflows/artifacts/v2/orm.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/lib/pq"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
@@ -19,6 +21,9 @@ type WorkflowSpecsDS interface {
 
 	// DeleteWorkflowSpec deletes the workflow spec for the given workflow ID.
 	DeleteWorkflowSpec(ctx context.Context, id string) error
+
+	// DeleteWorkflowSpecs deletes workflow specs for the given workflow IDs in a single query.
+	DeleteWorkflowSpecs(ctx context.Context, ids []string) error
 }
 
 type ORM interface {
@@ -138,4 +143,14 @@ func (orm *orm) DeleteWorkflowSpec(ctx context.Context, id string) error {
 	}
 
 	return nil
+}
+
+func (orm *orm) DeleteWorkflowSpecs(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	query := `DELETE FROM workflow_specs_v2 WHERE workflow_id = ANY($1)`
+	_, err := orm.ds.ExecContext(ctx, query, pq.Array(ids))
+	return err
 }

--- a/core/services/workflows/artifacts/v2/orm_test.go
+++ b/core/services/workflows/artifacts/v2/orm_test.go
@@ -178,6 +178,50 @@ func Test_DeleteWorkflowSpec(t *testing.T) {
 	})
 }
 
+func Test_DeleteWorkflowSpecs(t *testing.T) {
+	db := pgtest.NewSqlxDB(t)
+	ctx := testutils.Context(t)
+	lggr := logger.TestLogger(t)
+	orm := &orm{ds: db, lggr: lggr}
+
+	specs := []struct {
+		id   string
+		name string
+	}{
+		{"wf-1", "Workflow 1"},
+		{"wf-2", "Workflow 2"},
+		{"wf-3", "Workflow 3"},
+	}
+	for _, s := range specs {
+		_, err := orm.UpsertWorkflowSpec(ctx, &job.WorkflowSpec{
+			Workflow:      "binary",
+			Config:        "config",
+			WorkflowID:    s.id,
+			WorkflowOwner: "owner",
+			WorkflowName:  s.name,
+			Status:        job.WorkflowSpecStatusActive,
+			CreatedAt:     time.Now(),
+			SpecType:      job.WASMFile,
+		})
+		require.NoError(t, err)
+	}
+
+	err := orm.DeleteWorkflowSpecs(ctx, []string{"wf-1", "wf-2"})
+	require.NoError(t, err)
+
+	_, err = orm.GetWorkflowSpec(ctx, "wf-1")
+	require.ErrorIs(t, err, sql.ErrNoRows)
+	_, err = orm.GetWorkflowSpec(ctx, "wf-2")
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
+	got, err := orm.GetWorkflowSpec(ctx, "wf-3")
+	require.NoError(t, err)
+	require.Equal(t, "Workflow 3", got.WorkflowName)
+
+	// empty slice is a no-op
+	require.NoError(t, orm.DeleteWorkflowSpecs(ctx, []string{}))
+}
+
 func Test_GetWorkflowSpec(t *testing.T) {
 	t.Run("gets a workflow spec by ID", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)

--- a/core/services/workflows/artifacts/v2/store.go
+++ b/core/services/workflows/artifacts/v2/store.go
@@ -308,6 +308,10 @@ func (h *Store) DeleteWorkflowArtifacts(ctx context.Context, workflowID string) 
 	return nil
 }
 
+func (h *Store) DeleteWorkflowArtifactsBatch(ctx context.Context, workflowIDs []string) error {
+	return h.orm.DeleteWorkflowSpecs(ctx, workflowIDs)
+}
+
 func (h *Store) GetWasmBinary(ctx context.Context, workflowID string) ([]byte, error) {
 	spec, err := h.orm.GetWorkflowSpec(ctx, workflowID)
 	if err != nil {

--- a/core/services/workflows/artifacts/v2/store_test.go
+++ b/core/services/workflows/artifacts/v2/store_test.go
@@ -93,6 +93,49 @@ func Test_Store_DeleteWorkflowArtifacts(t *testing.T) {
 	require.ErrorIs(t, err, sql.ErrNoRows)
 }
 
+func Test_Store_DeleteWorkflowArtifactsBatch(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	db := pgtest.NewSqlxDB(t)
+	orm := &orm{ds: db, lggr: lggr}
+
+	encryptionKey, err := workflowkey.New()
+	require.NoError(t, err)
+
+	ctx := testutils.Context(t)
+	for _, id := range []string{"wf-1", "wf-2", "wf-3"} {
+		_, err = orm.UpsertWorkflowSpec(ctx, &job.WorkflowSpec{
+			Workflow:      "",
+			Config:        "",
+			WorkflowID:    id,
+			WorkflowOwner: "owner",
+			WorkflowName:  "name-" + id,
+			CreatedAt:     time.Now(),
+			SpecType:      job.DefaultSpecType,
+		})
+		require.NoError(t, err)
+	}
+
+	fetcher := &mockFetcher{}
+	h, err := NewStore(
+		lggr, orm, fetcher.Fetch, fetcher.RetrieveURL,
+		clockwork.NewFakeClock(), encryptionKey, custmsg.NewLabeler(),
+		limits.Factory{Logger: lggr},
+		WithConfig(StoreConfig{ArtifactStorageHost: "example.com"}),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, h.DeleteWorkflowArtifactsBatch(ctx, []string{"wf-1", "wf-3"}))
+
+	_, err = orm.GetWorkflowSpec(ctx, "wf-1")
+	require.ErrorIs(t, err, sql.ErrNoRows)
+	_, err = orm.GetWorkflowSpec(ctx, "wf-3")
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
+	got, err := orm.GetWorkflowSpec(ctx, "wf-2")
+	require.NoError(t, err)
+	require.Equal(t, "name-wf-2", got.WorkflowName)
+}
+
 func Test_Store_FetchWorkflowArtifacts_WithStorage(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	db := pgtest.NewSqlxDB(t)

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -141,6 +141,7 @@ type WorkflowArtifactsStore interface {
 	GetWorkflowSpec(ctx context.Context, workflowID string) (*job.WorkflowSpec, error)
 	UpsertWorkflowSpec(ctx context.Context, spec *job.WorkflowSpec) (int64, error)
 	DeleteWorkflowArtifacts(ctx context.Context, workflowID string) error
+	DeleteWorkflowArtifactsBatch(ctx context.Context, workflowIDs []string) error
 }
 
 // NewEventHandler returns a new eventHandler instance.

--- a/core/services/workflows/syncer/v2/handler_test.go
+++ b/core/services/workflows/syncer/v2/handler_test.go
@@ -708,6 +708,10 @@ func (m *mockArtifactStore) DeleteWorkflowArtifacts(ctx context.Context, workflo
 	return m.artifactStore.DeleteWorkflowArtifacts(ctx, workflowID)
 }
 
+func (m *mockArtifactStore) DeleteWorkflowArtifactsBatch(ctx context.Context, workflowIDs []string) error {
+	return m.artifactStore.DeleteWorkflowArtifactsBatch(ctx, workflowIDs)
+}
+
 func newMockArtifactStore(as *artifacts.Store, deleteWorkflowArtifactsErr error) WorkflowArtifactsStore {
 	return &mockArtifactStore{
 		artifactStore:              as,

--- a/core/services/workflows/syncer/v2/mocks/orm.go
+++ b/core/services/workflows/syncer/v2/mocks/orm.go
@@ -69,6 +69,53 @@ func (_c *ORM_DeleteWorkflowSpec_Call) RunAndReturn(run func(context.Context, st
 	return _c
 }
 
+// DeleteWorkflowSpecs provides a mock function with given fields: ctx, ids
+func (_m *ORM) DeleteWorkflowSpecs(ctx context.Context, ids []string) error {
+	ret := _m.Called(ctx, ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteWorkflowSpecs")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, []string) error); ok {
+		r0 = rf(ctx, ids)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ORM_DeleteWorkflowSpecs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteWorkflowSpecs'
+type ORM_DeleteWorkflowSpecs_Call struct {
+	*mock.Call
+}
+
+// DeleteWorkflowSpecs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ids []string
+func (_e *ORM_Expecter) DeleteWorkflowSpecs(ctx interface{}, ids interface{}) *ORM_DeleteWorkflowSpecs_Call {
+	return &ORM_DeleteWorkflowSpecs_Call{Call: _e.mock.On("DeleteWorkflowSpecs", ctx, ids)}
+}
+
+func (_c *ORM_DeleteWorkflowSpecs_Call) Run(run func(ctx context.Context, ids []string)) *ORM_DeleteWorkflowSpecs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]string))
+	})
+	return _c
+}
+
+func (_c *ORM_DeleteWorkflowSpecs_Call) Return(_a0 error) *ORM_DeleteWorkflowSpecs_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ORM_DeleteWorkflowSpecs_Call) RunAndReturn(run func(context.Context, []string) error) *ORM_DeleteWorkflowSpecs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetWorkflowSpec provides a mock function with given fields: ctx, id
 func (_m *ORM) GetWorkflowSpec(ctx context.Context, id string) (*job.WorkflowSpec, error) {
 	ret := _m.Called(ctx, id)


### PR DESCRIPTION
Self-contained ORM change to open up an optimization to delete specs in batch. Prepares ground for CRE-1845.

[CRE-1844](https://smartcontract-it.atlassian.net/browse/CRE-1844)


[CRE-1844]: https://smartcontract-it.atlassian.net/browse/CRE-1844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ