### PR TITLE
CRE-1845: parallel engine close in the handler

### DIFF
--- a/core/services/workflows/syncer/v2/engine_registry.go
+++ b/core/services/workflows/syncer/v2/engine_registry.go
@@ -120,6 +120,25 @@ func (r *EngineRegistry) Pop(workflowID types.WorkflowID) (ServiceWithMetadata, 
 	}, nil
 }
 
+// PopMany removes the specified engines from the registry in a single lock acquisition.
+func (r *EngineRegistry) PopMany(workflowIDs []types.WorkflowID) []ServiceWithMetadata {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var result []ServiceWithMetadata
+	for _, id := range workflowIDs {
+		entry, ok := r.engines[id]
+		if ok {
+			result = append(result, ServiceWithMetadata{
+				WorkflowID: id,
+				Source:     entry.source,
+				Service:    entry.engine,
+			})
+			delete(r.engines, id)
+		}
+	}
+	return result
+}
+
 // PopAll removes and returns all engines.
 func (r *EngineRegistry) PopAll() []ServiceWithMetadata {
 	r.mu.Lock()

--- a/core/services/workflows/syncer/v2/engine_registry_test.go
+++ b/core/services/workflows/syncer/v2/engine_registry_test.go
@@ -130,6 +130,28 @@ func TestEngineRegistry_PopReturnsSource(t *testing.T) {
 	require.Equal(t, ContractWorkflowSourceName, engine.Source)
 }
 
+func TestEngineRegistry_PopMany(t *testing.T) {
+	er := NewEngineRegistry()
+
+	wfID1 := types.WorkflowID([32]byte{1})
+	wfID2 := types.WorkflowID([32]byte{2})
+	wfID3 := types.WorkflowID([32]byte{3})
+	wfID4 := types.WorkflowID([32]byte{4})
+
+	require.NoError(t, er.Add(wfID1, "S1", &fakeService{}))
+	require.NoError(t, er.Add(wfID2, "S1", &fakeService{}))
+	require.NoError(t, er.Add(wfID3, "S2", &fakeService{}))
+
+	popped := er.PopMany([]types.WorkflowID{wfID1, wfID3, wfID4})
+	require.Len(t, popped, 2)
+
+	require.False(t, er.Contains(wfID1))
+	require.True(t, er.Contains(wfID2))
+	require.False(t, er.Contains(wfID3))
+
+	require.Len(t, er.GetAll(), 1)
+}
+
 func TestEngineRegistry_PopAllReturnsSource(t *testing.T) {
 	er := NewEngineRegistry()
 

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -637,6 +637,38 @@ func (h *eventHandler) workflowDeletedEvent(
 	return err
 }
 
+// HandleDeleteBatch closes engines concurrently and batch-deletes artifacts.
+// Engine close errors are logged but do not prevent cleanup — matching the
+// handler.close() shutdown pattern that uses services.CloseAll.
+func (h *eventHandler) HandleDeleteBatch(ctx context.Context, payloads []WorkflowDeletedEvent) error {
+	if len(payloads) == 0 {
+		return nil
+	}
+
+	var closers []io.Closer
+	ids := make([]string, 0, len(payloads))
+	wfIDs := make([]types.WorkflowID, 0, len(payloads))
+
+	for _, p := range payloads {
+		if e, ok := h.engineRegistry.Get(p.WorkflowID); ok {
+			closers = append(closers, e)
+		}
+		ids = append(ids, p.WorkflowID.Hex())
+		wfIDs = append(wfIDs, p.WorkflowID)
+	}
+
+	if err := services.CloseAll(closers...); err != nil {
+		h.lggr.Errorw("errors closing engines in batch delete", "err", err, "count", len(closers))
+	}
+
+	if err := h.workflowArtifactsStore.DeleteWorkflowArtifactsBatch(ctx, ids); err != nil {
+		return fmt.Errorf("failed to batch delete workflow artifacts: %w", err)
+	}
+
+	h.engineRegistry.PopMany(wfIDs)
+	return nil
+}
+
 // tryEngineCleanup attempts to stop the workflow engine for the given workflow ID.  Does nothing if the
 // workflow engine is not running.
 func (h *eventHandler) tryEngineCleanup(workflowID types.WorkflowID) error {

--- a/core/services/workflows/syncer/v2/handler_test.go
+++ b/core/services/workflows/syncer/v2/handler_test.go
@@ -971,6 +971,130 @@ func Test_workflowDeletedHandler(t *testing.T) {
 	})
 }
 
+type stubArtifactStore struct {
+	deleteBatchErr error
+}
+
+func (s *stubArtifactStore) FetchWorkflowArtifacts(context.Context, string, string, string) ([]byte, []byte, error) {
+	return nil, nil, nil
+}
+func (s *stubArtifactStore) GetWorkflowSpec(context.Context, string) (*job.WorkflowSpec, error) {
+	return nil, nil
+}
+func (s *stubArtifactStore) UpsertWorkflowSpec(context.Context, *job.WorkflowSpec) (int64, error) {
+	return 0, nil
+}
+func (s *stubArtifactStore) DeleteWorkflowArtifacts(context.Context, string) error { return nil }
+func (s *stubArtifactStore) DeleteWorkflowArtifactsBatch(_ context.Context, _ []string) error {
+	return s.deleteBatchErr
+}
+
+func Test_HandleDeleteBatch(t *testing.T) {
+	t.Run("closes engines concurrently and cleans up", func(t *testing.T) {
+		lggr := logger.TestLogger(t)
+		lf := limits.Factory{Logger: lggr}
+		er := NewEngineRegistry()
+		wfStore := store.NewInMemoryStore(lggr, clockwork.NewFakeClock())
+		registry := capabilities.NewRegistry(lggr)
+		registry.SetLocalRegistry(&capabilities.TestMetadataRegistry{})
+		workflowEncryptionKey := workflowkey.MustNewXXXTestingOnly(big.NewInt(1))
+
+		limiters, err := v2.NewLimiters(lf, nil)
+		require.NoError(t, err)
+		rl, err := ratelimiter.NewRateLimiter(rlConfig)
+		require.NoError(t, err)
+		workflowLimits, err := syncerlimiter.NewWorkflowLimits(lggr, syncerlimiter.Config{Global: 200, PerOwner: 200}, lf)
+		require.NoError(t, err)
+
+		h, err := NewEventHandler(lggr, wfStore, nil, true, registry, er, custmsg.NewLabeler(), limiters, rl, workflowLimits, &stubArtifactStore{}, workflowEncryptionKey, &testDonNotifier{},
+			WithEngineRegistry(er),
+		)
+		require.NoError(t, err)
+
+		wfID1 := types.WorkflowID([32]byte{1})
+		wfID2 := types.WorkflowID([32]byte{2})
+		wfID3 := types.WorkflowID([32]byte{3})
+
+		e1 := &mockEngine{}
+		e2 := &mockEngine{}
+		e3 := &mockEngine{}
+		require.NoError(t, er.Add(wfID1, "src", e1))
+		require.NoError(t, er.Add(wfID2, "src", e2))
+		require.NoError(t, er.Add(wfID3, "src", e3))
+
+		ctx := testutils.Context(t)
+		err = h.HandleDeleteBatch(ctx, []WorkflowDeletedEvent{
+			{WorkflowID: wfID1},
+			{WorkflowID: wfID3},
+		})
+		require.NoError(t, err)
+
+		require.False(t, er.Contains(wfID1))
+		require.True(t, er.Contains(wfID2))
+		require.False(t, er.Contains(wfID3))
+	})
+
+	t.Run("returns error when batch DB delete fails", func(t *testing.T) {
+		lggr := logger.TestLogger(t)
+		lf := limits.Factory{Logger: lggr}
+		er := NewEngineRegistry()
+		wfStore := store.NewInMemoryStore(lggr, clockwork.NewFakeClock())
+		registry := capabilities.NewRegistry(lggr)
+		registry.SetLocalRegistry(&capabilities.TestMetadataRegistry{})
+		workflowEncryptionKey := workflowkey.MustNewXXXTestingOnly(big.NewInt(1))
+
+		limiters, err := v2.NewLimiters(lf, nil)
+		require.NoError(t, err)
+		rl, err := ratelimiter.NewRateLimiter(rlConfig)
+		require.NoError(t, err)
+		workflowLimits, err := syncerlimiter.NewWorkflowLimits(lggr, syncerlimiter.Config{Global: 200, PerOwner: 200}, lf)
+		require.NoError(t, err)
+
+		h, err := NewEventHandler(lggr, wfStore, nil, true, registry, er, custmsg.NewLabeler(), limiters, rl, workflowLimits,
+			&stubArtifactStore{deleteBatchErr: errors.New("db failure")},
+			workflowEncryptionKey, &testDonNotifier{},
+			WithEngineRegistry(er),
+		)
+		require.NoError(t, err)
+
+		wfID1 := types.WorkflowID([32]byte{1})
+		require.NoError(t, er.Add(wfID1, "src", &mockEngine{}))
+
+		ctx := testutils.Context(t)
+		err = h.HandleDeleteBatch(ctx, []WorkflowDeletedEvent{{WorkflowID: wfID1}})
+		require.ErrorContains(t, err, "db failure")
+
+		// Engine stays in registry since DB delete failed
+		require.True(t, er.Contains(wfID1))
+	})
+
+	t.Run("handles empty batch", func(t *testing.T) {
+		lggr := logger.TestLogger(t)
+		lf := limits.Factory{Logger: lggr}
+		er := NewEngineRegistry()
+		wfStore := store.NewInMemoryStore(lggr, clockwork.NewFakeClock())
+		registry := capabilities.NewRegistry(lggr)
+		registry.SetLocalRegistry(&capabilities.TestMetadataRegistry{})
+		workflowEncryptionKey := workflowkey.MustNewXXXTestingOnly(big.NewInt(1))
+
+		limiters, err := v2.NewLimiters(lf, nil)
+		require.NoError(t, err)
+		rl, err := ratelimiter.NewRateLimiter(rlConfig)
+		require.NoError(t, err)
+		workflowLimits, err := syncerlimiter.NewWorkflowLimits(lggr, syncerlimiter.Config{Global: 200, PerOwner: 200}, lf)
+		require.NoError(t, err)
+
+		h, err := NewEventHandler(lggr, wfStore, nil, true, registry, er, custmsg.NewLabeler(), limiters, rl, workflowLimits, &stubArtifactStore{}, workflowEncryptionKey, &testDonNotifier{},
+			WithEngineRegistry(er),
+		)
+		require.NoError(t, err)
+
+		ctx := testutils.Context(t)
+		err = h.HandleDeleteBatch(ctx, nil)
+		require.NoError(t, err)
+	})
+}
+
 // mockLinkingService implements the LinkingServiceServer interface for testing
 type mockLinkingService struct {
 	linkingclient.UnimplementedLinkingServiceServer

--- a/core/services/workflows/syncer/v2/helpers.go
+++ b/core/services/workflows/syncer/v2/helpers.go
@@ -48,6 +48,21 @@ func (m *testEvtHandler) Handle(ctx context.Context, event Event) error {
 	return nil
 }
 
+func (m *testEvtHandler) HandleDeleteBatch(_ context.Context, payloads []WorkflowDeletedEvent) error {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	for _, p := range payloads {
+		m.events = append(m.events, Event{
+			Name: WorkflowDeleted,
+			Data: p,
+		})
+	}
+	if m.errFn != nil {
+		return m.errFn()
+	}
+	return nil
+}
+
 func (m *testEvtHandler) ClearEvents() {
 	m.mux.Lock()
 	defer m.mux.Unlock()

--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -751,74 +751,74 @@ func (w *workflowRegistry) syncUsingReconciliationStrategy(ctx context.Context) 
 				// Clear pending events after successful reconciliation
 				pendingEventsBySource[sourceIdentifier] = make(map[string]*reconciliationEvent)
 
-			// Partition events: ready deletes go to batch, everything else is sequential
-			var batchDeletePayloads []WorkflowDeletedEvent
-			var batchDeleteEvents []*reconciliationEvent
-			var sequentialEvents []*reconciliationEvent
+				// Partition events: ready deletes go to batch, everything else is sequential
+				var batchDeletePayloads []WorkflowDeletedEvent
+				var batchDeleteEvents []*reconciliationEvent
+				var sequentialEvents []*reconciliationEvent
 
-			for _, event := range events {
-				isDelete := event.Name == WorkflowDeleted || event.Name == WorkflowPaused
-				isReady := event.retryCount == 0 || w.clock.Now().After(event.nextRetryAt)
+				for _, event := range events {
+					isDelete := event.Name == WorkflowDeleted || event.Name == WorkflowPaused
+					isReady := event.retryCount == 0 || w.clock.Now().After(event.nextRetryAt)
 
-				if isDelete && isReady {
-					var payload WorkflowDeletedEvent
-					switch d := event.Data.(type) {
-					case WorkflowDeletedEvent:
-						payload = d
-					case WorkflowPausedEvent:
-						payload = WorkflowDeletedEvent{WorkflowID: d.WorkflowID, Source: d.Source}
+					if isDelete && isReady {
+						var payload WorkflowDeletedEvent
+						switch d := event.Data.(type) {
+						case WorkflowDeletedEvent:
+							payload = d
+						case WorkflowPausedEvent:
+							payload = WorkflowDeletedEvent{WorkflowID: d.WorkflowID, Source: d.Source}
+						}
+						batchDeletePayloads = append(batchDeletePayloads, payload)
+						batchDeleteEvents = append(batchDeleteEvents, event)
+						reconcileReport.NumEventsByType[string(event.Name)]++
+					} else {
+						sequentialEvents = append(sequentialEvents, event)
 					}
-					batchDeletePayloads = append(batchDeletePayloads, payload)
-					batchDeleteEvents = append(batchDeleteEvents, event)
-					reconcileReport.NumEventsByType[string(event.Name)]++
-				} else {
-					sequentialEvents = append(sequentialEvents, event)
 				}
-			}
 
-			// Batch delete
-			if len(batchDeletePayloads) > 0 {
-				batchStart := time.Now()
-				if batchErr := w.handler.HandleDeleteBatch(ctx, batchDeletePayloads); batchErr != nil {
-					for _, event := range batchDeleteEvents {
-						event.updateNextRetryFor(w.clock, w.retryInterval, w.maxRetryInterval)
-						pendingEventsBySource[sourceIdentifier][event.id] = event
-						reconcileReport.Backoffs[event.id] = event.nextRetryAt
-					}
-					w.lggr.Errorw("batch delete failed", "err", batchErr, "count", len(batchDeleteEvents), "durationMs", time.Since(batchStart).Milliseconds())
-				} else {
-					w.lggr.Debugw("batch delete succeeded", "source", sourceName, "count", len(batchDeletePayloads), "durationMs", time.Since(batchStart).Milliseconds())
-				}
-			}
-
-			// Handle remaining events sequentially
-			for _, event := range sequentialEvents {
-				select {
-				case <-ctx.Done():
-					w.lggr.Debug("readRegistryStateLoop stopped during processing")
-					return
-				default:
-					w.lggr.Debugw("processing event", "source", sourceName, "event", event.Name, "id", event.id, "signature", event.signature, "workflowInfo", event.Info)
-					reconcileReport.NumEventsByType[string(event.Name)]++
-
-					if event.retryCount == 0 || w.clock.Now().After(event.nextRetryAt) {
-						handleErr := w.handleWithMetrics(ctx, event.Event)
-						if handleErr != nil {
+				// Batch delete
+				if len(batchDeletePayloads) > 0 {
+					batchStart := time.Now()
+					if batchErr := w.handler.HandleDeleteBatch(ctx, batchDeletePayloads); batchErr != nil {
+						for _, event := range batchDeleteEvents {
 							event.updateNextRetryFor(w.clock, w.retryInterval, w.maxRetryInterval)
+							pendingEventsBySource[sourceIdentifier][event.id] = event
+							reconcileReport.Backoffs[event.id] = event.nextRetryAt
+						}
+						w.lggr.Errorw("batch delete failed", "err", batchErr, "count", len(batchDeleteEvents), "durationMs", time.Since(batchStart).Milliseconds())
+					} else {
+						w.lggr.Debugw("batch delete succeeded", "source", sourceName, "count", len(batchDeletePayloads), "durationMs", time.Since(batchStart).Milliseconds())
+					}
+				}
 
+				// Handle remaining events sequentially
+				for _, event := range sequentialEvents {
+					select {
+					case <-ctx.Done():
+						w.lggr.Debug("readRegistryStateLoop stopped during processing")
+						return
+					default:
+						w.lggr.Debugw("processing event", "source", sourceName, "event", event.Name, "id", event.id, "signature", event.signature, "workflowInfo", event.Info)
+						reconcileReport.NumEventsByType[string(event.Name)]++
+
+						if event.retryCount == 0 || w.clock.Now().After(event.nextRetryAt) {
+							handleErr := w.handleWithMetrics(ctx, event.Event)
+							if handleErr != nil {
+								event.updateNextRetryFor(w.clock, w.retryInterval, w.maxRetryInterval)
+
+								pendingEventsBySource[sourceIdentifier][event.id] = event
+
+								reconcileReport.Backoffs[event.id] = event.nextRetryAt
+								w.lggr.Errorw("failed to handle event, backing off...", "err", handleErr, "type", event.Name, "nextRetryAt", event.nextRetryAt, "retryCount", event.retryCount, "workflowInfo", event.Info)
+							}
+						} else {
 							pendingEventsBySource[sourceIdentifier][event.id] = event
 
 							reconcileReport.Backoffs[event.id] = event.nextRetryAt
-							w.lggr.Errorw("failed to handle event, backing off...", "err", handleErr, "type", event.Name, "nextRetryAt", event.nextRetryAt, "retryCount", event.retryCount, "workflowInfo", event.Info)
+							w.lggr.Debugw("skipping event, still in backoff", "nextRetryAt", event.nextRetryAt, "event", event.Name, "id", event.id, "signature", event.signature, "workflowInfo", event.Info)
 						}
-					} else {
-						pendingEventsBySource[sourceIdentifier][event.id] = event
-
-						reconcileReport.Backoffs[event.id] = event.nextRetryAt
-						w.lggr.Debugw("skipping event, still in backoff", "nextRetryAt", event.nextRetryAt, "event", event.Name, "id", event.id, "signature", event.signature, "workflowInfo", event.Info)
 					}
 				}
-			}
 			}
 
 			w.metrics.recordFetchedWorkflows(ctx, totalWorkflowsFetched)

--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -122,6 +122,7 @@ type evtHandler interface {
 	Start(context.Context) error
 
 	Handle(ctx context.Context, event Event) error
+	HandleDeleteBatch(ctx context.Context, payloads []WorkflowDeletedEvent) error
 }
 
 type donNotifier interface {
@@ -750,35 +751,74 @@ func (w *workflowRegistry) syncUsingReconciliationStrategy(ctx context.Context) 
 				// Clear pending events after successful reconciliation
 				pendingEventsBySource[sourceIdentifier] = make(map[string]*reconciliationEvent)
 
-				// Handle events (shared handler)
-				for _, event := range events {
-					select {
-					case <-ctx.Done():
-						w.lggr.Debug("readRegistryStateLoop stopped during processing")
-						return
-					default:
-						w.lggr.Debugw("processing event", "source", sourceName, "event", event.Name, "id", event.id, "signature", event.signature, "workflowInfo", event.Info)
-						reconcileReport.NumEventsByType[string(event.Name)]++
+			// Partition events: ready deletes go to batch, everything else is sequential
+			var batchDeletePayloads []WorkflowDeletedEvent
+			var batchDeleteEvents []*reconciliationEvent
+			var sequentialEvents []*reconciliationEvent
 
-						if event.retryCount == 0 || w.clock.Now().After(event.nextRetryAt) {
-							handleErr := w.handleWithMetrics(ctx, event.Event)
-							if handleErr != nil {
-								event.updateNextRetryFor(w.clock, w.retryInterval, w.maxRetryInterval)
+			for _, event := range events {
+				isDelete := event.Name == WorkflowDeleted || event.Name == WorkflowPaused
+				isReady := event.retryCount == 0 || w.clock.Now().After(event.nextRetryAt)
 
-								pendingEventsBySource[sourceIdentifier][event.id] = event
+				if isDelete && isReady {
+					var payload WorkflowDeletedEvent
+					switch d := event.Data.(type) {
+					case WorkflowDeletedEvent:
+						payload = d
+					case WorkflowPausedEvent:
+						payload = WorkflowDeletedEvent{WorkflowID: d.WorkflowID, Source: d.Source}
+					}
+					batchDeletePayloads = append(batchDeletePayloads, payload)
+					batchDeleteEvents = append(batchDeleteEvents, event)
+					reconcileReport.NumEventsByType[string(event.Name)]++
+				} else {
+					sequentialEvents = append(sequentialEvents, event)
+				}
+			}
 
-								reconcileReport.Backoffs[event.id] = event.nextRetryAt
-								w.lggr.Errorw("failed to handle event, backing off...", "err", handleErr, "type", event.Name, "nextRetryAt", event.nextRetryAt, "retryCount", event.retryCount, "workflowInfo", event.Info)
-							}
-						} else {
-							// It's not ready to execute yet, let's put it back on the pending queue.
+			// Batch delete
+			if len(batchDeletePayloads) > 0 {
+				batchStart := time.Now()
+				if batchErr := w.handler.HandleDeleteBatch(ctx, batchDeletePayloads); batchErr != nil {
+					for _, event := range batchDeleteEvents {
+						event.updateNextRetryFor(w.clock, w.retryInterval, w.maxRetryInterval)
+						pendingEventsBySource[sourceIdentifier][event.id] = event
+						reconcileReport.Backoffs[event.id] = event.nextRetryAt
+					}
+					w.lggr.Errorw("batch delete failed", "err", batchErr, "count", len(batchDeleteEvents), "durationMs", time.Since(batchStart).Milliseconds())
+				} else {
+					w.lggr.Debugw("batch delete succeeded", "source", sourceName, "count", len(batchDeletePayloads), "durationMs", time.Since(batchStart).Milliseconds())
+				}
+			}
+
+			// Handle remaining events sequentially
+			for _, event := range sequentialEvents {
+				select {
+				case <-ctx.Done():
+					w.lggr.Debug("readRegistryStateLoop stopped during processing")
+					return
+				default:
+					w.lggr.Debugw("processing event", "source", sourceName, "event", event.Name, "id", event.id, "signature", event.signature, "workflowInfo", event.Info)
+					reconcileReport.NumEventsByType[string(event.Name)]++
+
+					if event.retryCount == 0 || w.clock.Now().After(event.nextRetryAt) {
+						handleErr := w.handleWithMetrics(ctx, event.Event)
+						if handleErr != nil {
+							event.updateNextRetryFor(w.clock, w.retryInterval, w.maxRetryInterval)
+
 							pendingEventsBySource[sourceIdentifier][event.id] = event
 
 							reconcileReport.Backoffs[event.id] = event.nextRetryAt
-							w.lggr.Debugw("skipping event, still in backoff", "nextRetryAt", event.nextRetryAt, "event", event.Name, "id", event.id, "signature", event.signature, "workflowInfo", event.Info)
+							w.lggr.Errorw("failed to handle event, backing off...", "err", handleErr, "type", event.Name, "nextRetryAt", event.nextRetryAt, "retryCount", event.retryCount, "workflowInfo", event.Info)
 						}
+					} else {
+						pendingEventsBySource[sourceIdentifier][event.id] = event
+
+						reconcileReport.Backoffs[event.id] = event.nextRetryAt
+						w.lggr.Debugw("skipping event, still in backoff", "nextRetryAt", event.nextRetryAt, "event", event.Name, "id", event.id, "signature", event.signature, "workflowInfo", event.Info)
 					}
 				}
+			}
 			}
 
 			w.metrics.recordFetchedWorkflows(ctx, totalWorkflowsFetched)

--- a/core/services/workflows/syncer/v2/workflow_registry_test.go
+++ b/core/services/workflows/syncer/v2/workflow_registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -1393,6 +1394,94 @@ func Test_isZeroOwner(t *testing.T) {
 		almostZero[0] = 1 // first byte is 1
 		require.False(t, isZeroOwner(almostZero))
 	})
+}
+
+type batchTrackingHandler struct {
+	testEvtHandler
+	batchPayloads []WorkflowDeletedEvent
+	mux           sync.Mutex
+}
+
+func (h *batchTrackingHandler) HandleDeleteBatch(_ context.Context, payloads []WorkflowDeletedEvent) error {
+	h.mux.Lock()
+	defer h.mux.Unlock()
+	h.batchPayloads = append(h.batchPayloads, payloads...)
+	return nil
+}
+
+func (h *batchTrackingHandler) GetBatchPayloads() []WorkflowDeletedEvent {
+	h.mux.Lock()
+	defer h.mux.Unlock()
+	out := make([]WorkflowDeletedEvent, len(h.batchPayloads))
+	copy(out, h.batchPayloads)
+	return out
+}
+
+func Test_ReconciliationBatchDeletes(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := testutils.Context(t)
+	workflowDonNotifier := capabilities.NewDonNotifier()
+	er := NewEngineRegistry()
+
+	n := 5
+	wfIDs := make([]wfTypes.WorkflowID, n)
+	for i := range wfIDs {
+		wfIDs[i] = wfTypes.WorkflowID([32]byte{byte(i + 1)})
+		require.NoError(t, er.Add(wfIDs[i], "TestSource", &mockService{}))
+	}
+
+	handler := &batchTrackingHandler{
+		testEvtHandler: testEvtHandler{events: make([]Event, 0)},
+	}
+
+	wr, err := NewWorkflowRegistry(
+		lggr,
+		func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
+			return nil, nil
+		},
+		"",
+		"test-chain-selector",
+		Config{
+			QueryCount:   20,
+			SyncStrategy: SyncStrategyReconciliation,
+		},
+		handler,
+		workflowDonNotifier,
+		er,
+	)
+	require.NoError(t, err)
+
+	pendingEvents := map[string]*reconciliationEvent{}
+	events, err := wr.generateReconciliationEvents(ctx, pendingEvents, []WorkflowMetadataView{}, &types.Head{Height: "123"}, "TestSource")
+	require.NoError(t, err)
+	require.Len(t, events, n)
+
+	for _, event := range events {
+		require.Equal(t, WorkflowDeleted, event.Name)
+	}
+
+	// Simulate the reconciliation loop's partitioning and batch dispatch
+	var batchDeletePayloads []WorkflowDeletedEvent
+	for _, event := range events {
+		if d, ok := event.Data.(WorkflowDeletedEvent); ok {
+			batchDeletePayloads = append(batchDeletePayloads, d)
+		}
+	}
+	require.Len(t, batchDeletePayloads, n)
+
+	err = handler.HandleDeleteBatch(ctx, batchDeletePayloads)
+	require.NoError(t, err)
+
+	got := handler.GetBatchPayloads()
+	require.Len(t, got, n)
+
+	gotIDs := make(map[wfTypes.WorkflowID]bool)
+	for _, p := range got {
+		gotIDs[p.WorkflowID] = true
+	}
+	for _, id := range wfIDs {
+		require.True(t, gotIDs[id], "expected workflow %x in batch delete payloads", id)
+	}
 }
 
 type mockShardMappingClient struct {


### PR DESCRIPTION
Performance fix using #21283 . Transforms the sequential workflowDeletedEvent flow into a parallel one.

[CRE-1845](https://smartcontract-it.atlassian.net/browse/CRE-1845)


[CRE-1845]: https://smartcontract-it.atlassian.net/browse/CRE-1845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ