### PR TITLE
Revert "remove changeset" 

### DIFF
--- a/.changeset/sour-paths-speak.md
+++ b/.changeset/sour-paths-speak.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Bump dependency of chainlink-evm #internal


### PR DESCRIPTION
Reverts smartcontractkit/chainlink#21279

Restores changeset to release branch for proper tracking.  This was removed to sidestep bug in release workflow.