### PR TITLE
[CRE] Fix capability serving in single-DON topologies

### DIFF
--- a/.changeset/fix-single-don-capability-serving.md
+++ b/.changeset/fix-single-don-capability-serving.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Fix capability serving in single-DON topologies where the same DON is both workflow and capability DON (e.g. local CRE). Previously capabilities failed with "empty workflowDONs provided" because only remote workflow DONs were passed to serveCapabilities. #bugfix

--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -401,8 +401,16 @@ func (w *launcher) OnNewRegistry(ctx context.Context, localRegistry *registrysyn
 
 	belongsToACapabilityDON := len(myCapabilityDONs) > 0
 	if belongsToACapabilityDON {
+		// Include both remote workflow DONs and the node's own workflow DONs.
+		// In single-DON topologies (e.g. local CRE), the same DON is both a
+		// workflow DON and a capability DON, so remoteWorkflowDONs is empty.
+		// Without including myWorkflowDONs, capabilities fail to serve with
+		// "empty workflowDONs provided".
+		allWorkflowDONs := make([]registrysyncer.DON, 0, len(remoteWorkflowDONs)+len(myWorkflowDONs))
+		allWorkflowDONs = append(allWorkflowDONs, remoteWorkflowDONs...)
+		allWorkflowDONs = append(allWorkflowDONs, myWorkflowDONs...)
 		for _, myDON := range myCapabilityDONs {
-			w.serveCapabilities(ctx, w.myPeerID, myDON, localRegistry, remoteWorkflowDONs)
+			w.serveCapabilities(ctx, w.myPeerID, myDON, localRegistry, allWorkflowDONs)
 		}
 	}
 

--- a/core/capabilities/launcher_test.go
+++ b/core/capabilities/launcher_test.go
@@ -233,6 +233,73 @@ func TestLauncher(t *testing.T) {
 		assert.Equal(t, 1, observedLogs.FilterMessage("failed to serve capability").Len())
 	})
 
+	t.Run("OK-single_DON_serves_capabilities", func(t *testing.T) {
+		// Regression test: in single-DON topologies (e.g. local CRE), the same
+		// DON is both a workflow DON and a capability DON. The DON appears in
+		// myWorkflowDONs (not remoteWorkflowDONs). Previously, serveCapabilities
+		// only received remoteWorkflowDONs, causing executable.Server.SetConfig
+		// to fail with "empty workflowDONs provided".
+		lggr, observedLogs := logger.TestObserved(t, zapcore.DebugLevel)
+		registry := NewRegistry(lggr)
+		dispatcher := remoteMocks.NewDispatcher(t)
+
+		nodes := newNodes(4)
+		peer := mocks.NewPeer(t)
+		peer.On("UpdateConnections", mock.Anything).Return(nil)
+		peer.On("ID").Return(nodes[0])
+		peer.On("IsBootstrap").Return(false)
+		wrapper := mocks.NewPeerWrapper(t)
+		wrapper.On("GetPeer").Return(peer)
+
+		fullTriggerCapID := "streams-trigger@1.0.0"
+		mt := newMockTrigger(capabilities.MustNewCapabilityInfo(
+			fullTriggerCapID,
+			capabilities.CapabilityTypeTrigger,
+			"streams trigger",
+		))
+		require.NoError(t, registry.Add(t.Context(), mt))
+
+		fullTargetID := "write-chain_evm_1@1.0.0"
+		mtarg := &mockCapability{
+			CapabilityInfo: capabilities.MustNewCapabilityInfo(
+				fullTargetID,
+				capabilities.CapabilityTypeTarget,
+				"write chain",
+			),
+		}
+		require.NoError(t, registry.Add(t.Context(), mtarg))
+
+		triggerCapID := RandomUTF8BytesWord()
+		targetCapID := RandomUTF8BytesWord()
+
+		// Single DON: acceptsWorkflows=true AND has capability configurations.
+		// This puts it in both myWorkflowDONs and myCapabilityDONs.
+		dID := uint32(1)
+		localRegistry := buildLocalRegistry()
+		addDON(localRegistry, dID, uint32(0), uint8(1), true, true, nodes, []string{"zone-a"}, 1, [][32]byte{triggerCapID, targetCapID})
+		addCapabilityToDON(localRegistry, dID, fullTriggerCapID, capabilities.CapabilityTypeTrigger, nil)
+		addCapabilityToDON(localRegistry, dID, fullTargetID, capabilities.CapabilityTypeTarget, nil)
+
+		launcher, err := NewLauncher(
+			lggr,
+			wrapper,
+			nil,
+			nil,
+			dispatcher,
+			registry,
+			&mockDonNotifier{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, launcher.Start(t.Context()))
+		defer launcher.Close()
+
+		dispatcher.On("SetReceiver", fullTriggerCapID, dID, mock.AnythingOfType("*remote.triggerPublisher")).Return(nil)
+		dispatcher.On("SetReceiver", fullTargetID, dID, mock.AnythingOfType("*executable.server")).Return(nil)
+
+		require.NoError(t, launcher.OnNewRegistry(t.Context(), localRegistry))
+		assert.Equal(t, 0, observedLogs.FilterMessage("failed to serve capability").Len())
+	})
+
 	t.Run("start and close with nil peer wrapper", func(t *testing.T) {
 		lggr := logger.Test(t)
 		registry := NewRegistry(lggr)


### PR DESCRIPTION
## Summary

In single-DON topologies (e.g. local CRE), a single DON acts as both the workflow DON and the capability DON. The launcher classifies this DON into `myWorkflowDONs` (since the node is a member), not `remoteWorkflowDONs`. When the launcher then calls `serveCapabilities`, it only passes `remoteWorkflowDONs`, which is empty. This causes `executable/server.go` to reject every capability with:

```
failed to serve capability: <capability-id>
err: empty workflowDONs provided
```

The fix combines `remoteWorkflowDONs` and `myWorkflowDONs` before passing them to `serveCapabilities`. This is safe because `serveCapabilities` builds an `idsToDONs` map from the workflow DONs and uses it to route incoming requests to the correct DON. Including the node's own workflow DON in that map is correct; the DON is a legitimate workflow DON that should be able to invoke capabilities on itself.

## How to reproduce

1. Start a local CRE environment (`go run . env setup`) with a single DON that has both workflow and capability roles
2. Register any LOOP-based capability (e.g. `confidential-http`)
3. Observe the capability fails to start with `empty workflowDONs provided` in the node logs

## Why this wasn't caught earlier

In multi-DON production deployments, workflow DONs and capability DONs are separate. The workflow DON appears in `remoteWorkflowDONs` from the capability DON's perspective, so the list is never empty. The single-DON topology only occurs in local CRE and similar dev/test environments.

The `workflowDONs` validation was added in commit `5950b6ab79` (CRE-941, dynamic config updates). Before that commit, an empty `workflowDONs` was silently accepted.

## What this changes

`core/capabilities/launcher.go`: When serving capabilities, pass all known workflow DONs (both remote and the node's own) instead of only remote ones.

### Requires

### Supports