### PR TITLE
Fix domain filtering so it is not tied to `cre`

### DIFF
--- a/deployment/cre/jobs/operations/propose_job_spec.go
+++ b/deployment/cre/jobs/operations/propose_job_spec.go
@@ -45,6 +45,7 @@ var ProposeJobSpec = operations.NewOperation[ProposeJobSpecInput, ProposeJobSpec
 		b.Logger.Debugw("Proposing job", "DON", input.DONName, "domain", input.Domain, "environment", deps.Env.Name)
 		req := pkg.ProposeJobRequest{
 			Spec:      input.Spec,
+			Domain:    input.Domain,
 			DONName:   input.DONName,
 			Env:       deps.Env.Name,
 			JobLabels: input.JobLabels,

--- a/deployment/cre/jobs/pkg/jobs.go
+++ b/deployment/cre/jobs/pkg/jobs.go
@@ -13,6 +13,7 @@ import (
 
 type ProposeJobRequest struct {
 	DONName   string
+	Domain    string
 	Spec      string // toml
 	Env       string // staging, testnet, mainnet, etc...
 	JobLabels map[string]string
@@ -30,11 +31,15 @@ func ProposeJob(ctx context.Context, e cldf.Environment, req ProposeJobRequest) 
 	}
 
 	jobSpecs := map[string][]string{}
+	domain := offchain.ProductLabel
+	if req.Domain != "" {
+		domain = req.Domain
+	}
 	for _, node := range nodes {
 		e.Logger.Debugw("Proposing job", logLabels(req, node)...)
 		offchainReq := offchain.ProposeJobRequest{
 			Job:            req.Spec,
-			Domain:         offchain.ProductLabel,
+			Domain:         domain,
 			Environment:    req.Env,
 			PublicKeys:     []string{node.GetPublicKey()},
 			JobLabels:      req.JobLabels,

--- a/deployment/cre/pkg/offchain/propose_job.go
+++ b/deployment/cre/pkg/offchain/propose_job.go
@@ -95,7 +95,7 @@ func ProposeJob(ctx context.Context, req ProposeJobRequest) error {
 		return fmt.Errorf("no nodes found for domain %s environment %s with labels %v and public keys %v", req.Domain, req.Environment, req.NodeLabels, req.PublicKeys)
 	}
 
-	for _, node := range nodes.GetNodes() {
+	for _, node := range jdNodes {
 		_, err1 := req.OffchainClient.ProposeJob(ctx,
 			&jobv1.ProposeJobRequest{
 				NodeId: node.Id,

--- a/deployment/cre/pkg/offchain/propose_job.go
+++ b/deployment/cre/pkg/offchain/propose_job.go
@@ -90,6 +90,11 @@ func ProposeJob(ctx context.Context, req ProposeJobRequest) error {
 		return err
 	}
 
+	jdNodes := nodes.GetNodes()
+	if len(jdNodes) == 0 {
+		return fmt.Errorf("no nodes found for domain %s environment %s with labels %v and public keys %v", req.Domain, req.Environment, req.NodeLabels, req.PublicKeys)
+	}
+
 	for _, node := range nodes.GetNodes() {
 		_, err1 := req.OffchainClient.ProposeJob(ctx,
 			&jobv1.ProposeJobRequest{


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
This PR helps addressing [CRE-1780](https://smartcontract-it.atlassian.net/browse/CRE-1780) by fixing an issue that always propose jobs to the `cre` product only, but that doesn't work for other domains that we can register nodes to JD under other domain name.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
- <https://github.com/smartcontractkit/chainlink-deployments/pull/10911>

[CRE-1780]: https://smartcontract-it.atlassian.net/browse/CRE-1780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ