### PR TITLE
Disable Vault.secrets.get method from gateway

### DIFF
--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -357,15 +357,6 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 		}
 		h.lggr.Debugw("returning cached public key response")
 		return h.handlePublicKeyGetSynchronously(ctx, req, publicKeyResponseBytes, callback)
-
-	case vaulttypes.MethodSecretsGet:
-		// Secrets get is only allowed in non-production builds for testing purposes
-		// So no authorization is required
-		ar, err := h.newActiveRequest(req, callback)
-		if err != nil {
-			return err
-		}
-		return h.handleSecretsGet(ctx, ar)
 	}
 
 	isAuthorized, owner, err := h.requestAuthorizer.AuthorizeRequest(ctx, req)

--- a/system-tests/tests/smoke/cre/v2_vault_don_test.go
+++ b/system-tests/tests/smoke/cre/v2_vault_don_test.go
@@ -89,7 +89,8 @@ func ExecuteVaultTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 	framework.L.Info().Msg("Waiting 30 seconds for the Vault DON to be ready...")
 	time.Sleep(30 * time.Second)
 	executeVaultSecretsCreateTest(t, encryptedSecret, secretID, ownerAddr, gatewayURL.String(), sethClient, wfRegistryContract)
-	executeVaultSecretsGetTest(t, secretID, ownerAddr, gatewayURL.String(), sethClient, wfRegistryContract)
+	// Disable Vault Get tests
+	// executeVaultSecretsGetTest(t, secretID, ownerAddr, gatewayURL.String(), sethClient, wfRegistryContract)
 	executeVaultSecretsUpdateTest(t, encryptedSecret, secretID, ownerAddr, gatewayURL.String(), sethClient, wfRegistryContract)
 	executeVaultSecretsListTest(t, secretID, ownerAddr, gatewayURL.String(), sethClient, wfRegistryContract)
 	executeVaultSecretsDeleteTest(t, secretID, ownerAddr, gatewayURL.String(), sethClient, wfRegistryContract)


### PR DESCRIPTION
Same PR was added to previous release too: https://github.com/smartcontractkit/chainlink/pull/21323
