### PR TITLE
[CLD] Don't require force flag to update DON config version

### DIFF
--- a/deployment/cre/capabilities_registry/v2/changeset/operations/contracts/update_don.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/operations/contracts/update_don.go
@@ -103,14 +103,6 @@ var UpdateDON = operations.NewOperation[UpdateDONInput, UpdateDONOutput, UpdateD
 			return UpdateDONOutput{}, fmt.Errorf("failed to call GetDONByName: %w", err)
 		}
 
-		if don.AcceptsWorkflows && !input.Force {
-			// TODO: CRE-277 ensure forwarders are support the next DON version
-			// https://github.com/smartcontractkit/chainlink/blob/4fc61bb156fe57bfd939b836c02c413ad1209ebb/contracts/src/v0.8/keystone/CapabilitiesRegistry.sol#L812
-			// and
-			// https://github.com/smartcontractkit/chainlink/blob/4fc61bb156fe57bfd939b836c02c413ad1209ebb/contracts/src/v0.8/keystone/KeystoneForwarder.sol#L274
-			return UpdateDONOutput{}, fmt.Errorf("refusing to update workflow don %d at config version %d because we cannot validate that all forwarder contracts are ready to accept the new configure version", don.Id, don.ConfigCount)
-		}
-
 		cfgs, err := computeConfigs(input.CapabilityConfigs, don.CapabilityConfigurations, input.MergeCapabilityConfigsWithOnChain)
 		if err != nil {
 			return UpdateDONOutput{}, fmt.Errorf("failed to compute configs: %w", err)

--- a/deployment/cre/capabilities_registry/v2/changeset/update_don_test.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/update_don_test.go
@@ -294,24 +294,6 @@ func TestUpdateDONChangeset_ByName_Direct_Succeeds_MCMS(t *testing.T) {
 	assert.NotEmpty(t, out.MCMSTimelockProposals, "MCMS → proposals must not be empty")
 }
 
-// Safety gate: workflow DON should refuse without Force=true (changeset passes Force through to operation).
-func TestUpdateDONChangeset_ByName_Workflow_RefusesWithoutForce(t *testing.T) {
-	t.Parallel()
-	fx := setupRegistryForUpdateDON(t /*isWorkflow=*/, true, false)
-
-	_, err := changeset.UpdateDON{}.Apply(fx.env, changeset.UpdateDONInput{
-		RegistryQualifier: fx.qualifier,
-		RegistryChainSel:  fx.selector,
-		DONName:           fx.donName, // required
-		CapabilityConfigs: []contracts.CapabilityConfig{
-			{Capability: contracts.Capability{CapabilityID: fx.capIDs[0]}, Config: map[string]any{"defaultConfig": map[string]any{}}},
-		},
-		Force: false,
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "refusing to update workflow don")
-}
-
 // Force override: workflow DON update succeeds when Force=true.
 func TestUpdateDONChangeset_ByName_Workflow_Force_Succeeds(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Version is now pinned to 1 on the Workflow DON: https://github.com/smartcontractkit/chainlink/pull/20730
No safety checks on version are needed when deploying.