### PR TITLE
[CRE-2154] Migrate Local CRE gateway to new, service-centric config format

### DIFF
--- a/core/services/gateway/connectionmanager.go
+++ b/core/services/gateway/connectionmanager.go
@@ -305,6 +305,7 @@ func (m *donConnectionManager) getHandler(method string) (handlers.Handler, erro
 			return h, nil // supports legacy single-handler case
 		}
 	}
+
 	serviceName := strings.Split(method, ".")[0]
 	// Special case for legacy methods - default to "workflows" service.
 	if !strings.Contains(method, ".") {

--- a/core/services/gateway/connectionmanager.go
+++ b/core/services/gateway/connectionmanager.go
@@ -305,7 +305,6 @@ func (m *donConnectionManager) getHandler(method string) (handlers.Handler, erro
 			return h, nil // supports legacy single-handler case
 		}
 	}
-
 	serviceName := strings.Split(method, ".")[0]
 	// Special case for legacy methods - default to "workflows" service.
 	if !strings.Contains(method, ".") {

--- a/deployment/cre/jobs/operations/propose_gateway_job.go
+++ b/deployment/cre/jobs/operations/propose_gateway_job.go
@@ -21,18 +21,18 @@ import (
 const defaultGatewayRequestTimeoutSec = 12
 
 type ProposeGatewayJobInput struct {
-	Domain                   string
-	DONFilters               []offchain.TargetDONFilter
-	UseServiceCentricFormat  bool              `yaml:"useServiceCentricFormat"`
-	DONs                     []DON             `yaml:"dons"`
-	Services                 []GatewayService  `yaml:"services"`
-	GatewayRequestTimeoutSec int               `yaml:"gatewayRequestTimeoutSec"`
-	AllowedPorts             []int             `yaml:"allowedPorts"`
-	AllowedSchemes           []string          `yaml:"allowedSchemes"`
-	AllowedIPsCIDR           []string          `yaml:"allowedIPsCIDR"`
-	AuthGatewayID            string            `yaml:"authGatewayID"`
-	GatewayKeyChainSelector  pkg.ChainSelector `yaml:"gatewayKeyChainSelector"`
-	JobLabels                map[string]string
+	Domain                      string
+	DONFilters                  []offchain.TargetDONFilter
+	ServiceCentricFormatEnabled bool              `yaml:"serviceCentricFormatEnabled"`
+	DONs                        []DON             `yaml:"dons"`
+	Services                    []GatewayService  `yaml:"services"`
+	GatewayRequestTimeoutSec    int               `yaml:"gatewayRequestTimeoutSec"`
+	AllowedPorts                []int             `yaml:"allowedPorts"`
+	AllowedSchemes              []string          `yaml:"allowedSchemes"`
+	AllowedIPsCIDR              []string          `yaml:"allowedIPsCIDR"`
+	AuthGatewayID               string            `yaml:"authGatewayID"`
+	GatewayKeyChainSelector     pkg.ChainSelector `yaml:"gatewayKeyChainSelector"`
+	JobLabels                   map[string]string
 }
 
 type DON struct {
@@ -63,7 +63,7 @@ var ProposeGatewayJob = operations.NewOperation[ProposeGatewayJobInput, ProposeG
 )
 
 // proposeGatewayJob builds a gateway job spec and then proposes it to the nodes of a DON.
-// When UseServiceCentricFormat is true, it derives the set of unique DON names from
+// When ServiceCentricFormatEnabled is true, it derives the set of unique DON names from
 // input.Services; otherwise it uses the don-centric input.DONs list.
 func proposeGatewayJob(b operations.Bundle, deps ProposeGatewayJobDeps, input ProposeGatewayJobInput) (ProposeGatewayJobOutput, error) {
 	requestTimeoutSec := input.GatewayRequestTimeoutSec
@@ -72,7 +72,7 @@ func proposeGatewayJob(b operations.Bundle, deps ProposeGatewayJobDeps, input Pr
 	}
 
 	var gj pkg.GatewayJob
-	if input.UseServiceCentricFormat {
+	if input.ServiceCentricFormatEnabled {
 		built, err := buildServiceCentricJob(deps, input, requestTimeoutSec)
 		if err != nil {
 			return ProposeGatewayJobOutput{}, err
@@ -176,15 +176,15 @@ func buildServiceCentricJob(deps ProposeGatewayJobDeps, input ProposeGatewayJobI
 	}
 
 	return pkg.GatewayJob{
-		UseServiceCentricFormat: true,
-		JobName:                 "CRE Gateway",
-		DONs:                    dons,
-		Services:                services,
-		RequestTimeoutSec:       requestTimeoutSec,
-		AllowedPorts:            input.AllowedPorts,
-		AllowedSchemes:          input.AllowedSchemes,
-		AllowedIPsCIDR:          input.AllowedIPsCIDR,
-		AuthGatewayID:           input.AuthGatewayID,
+		ServiceCentricFormatEnabled: true,
+		JobName:                     "CRE Gateway",
+		DONs:                        dons,
+		Services:                    services,
+		RequestTimeoutSec:           requestTimeoutSec,
+		AllowedPorts:                input.AllowedPorts,
+		AllowedSchemes:              input.AllowedSchemes,
+		AllowedIPsCIDR:              input.AllowedIPsCIDR,
+		AuthGatewayID:               input.AuthGatewayID,
 	}, nil
 }
 

--- a/deployment/cre/jobs/operations/propose_gateway_job.go
+++ b/deployment/cre/jobs/operations/propose_gateway_job.go
@@ -23,6 +23,8 @@ const defaultGatewayRequestTimeoutSec = 12
 type ProposeGatewayJobInput struct {
 	Domain                   string
 	DONFilters               []offchain.TargetDONFilter
+	UseServiceCentricFormat  bool              `yaml:"useServiceCentricFormat"`
+	DONs                     []DON             `yaml:"dons"`
 	Services                 []GatewayService  `yaml:"services"`
 	GatewayRequestTimeoutSec int               `yaml:"gatewayRequestTimeoutSec"`
 	AllowedPorts             []int             `yaml:"allowedPorts"`
@@ -31,6 +33,12 @@ type ProposeGatewayJobInput struct {
 	AuthGatewayID            string            `yaml:"authGatewayID"`
 	GatewayKeyChainSelector  pkg.ChainSelector `yaml:"gatewayKeyChainSelector"`
 	JobLabels                map[string]string
+}
+
+type DON struct {
+	Name     string   `yaml:"name"`
+	F        int      `yaml:"f"`
+	Handlers []string `yaml:"handlers"`
 }
 
 type GatewayService struct {
@@ -55,52 +63,27 @@ var ProposeGatewayJob = operations.NewOperation[ProposeGatewayJobInput, ProposeG
 )
 
 // proposeGatewayJob builds a gateway job spec and then proposes it to the nodes of a DON.
-// It derives the set of unique DON names from input.Services, fetches node information and
-// chain configurations for each DON from JD, then builds the gateway job.
+// When UseServiceCentricFormat is true, it derives the set of unique DON names from
+// input.Services; otherwise it uses the don-centric input.DONs list.
 func proposeGatewayJob(b operations.Bundle, deps ProposeGatewayJobDeps, input ProposeGatewayJobInput) (ProposeGatewayJobOutput, error) {
-	donNameSet := make(map[string]struct{})
-	for _, svc := range input.Services {
-		for _, donName := range svc.DONs {
-			donNameSet[donName] = struct{}{}
-		}
-	}
-
-	dons := make([]pkg.TargetDON, 0, len(donNameSet))
-	for donName := range donNameSet {
-		members, f, err := resolveDONMembers(deps, input, donName)
-		if err != nil {
-			return ProposeGatewayJobOutput{}, err
-		}
-		dons = append(dons, pkg.TargetDON{
-			ID:      donName,
-			F:       f,
-			Members: members,
-		})
-	}
-
-	services := make([]pkg.GatewayServiceConfig, len(input.Services))
-	for i, svc := range input.Services {
-		services[i] = pkg.GatewayServiceConfig{
-			ServiceName: svc.ServiceName,
-			Handlers:    svc.Handlers,
-			DONs:        svc.DONs,
-		}
-	}
-
 	requestTimeoutSec := input.GatewayRequestTimeoutSec
 	if requestTimeoutSec == 0 {
 		requestTimeoutSec = defaultGatewayRequestTimeoutSec
 	}
 
-	gj := pkg.GatewayJob{
-		JobName:           "CRE Gateway",
-		DONs:              dons,
-		Services:          services,
-		RequestTimeoutSec: requestTimeoutSec,
-		AllowedPorts:      input.AllowedPorts,
-		AllowedSchemes:    input.AllowedSchemes,
-		AllowedIPsCIDR:    input.AllowedIPsCIDR,
-		AuthGatewayID:     input.AuthGatewayID,
+	var gj pkg.GatewayJob
+	if input.UseServiceCentricFormat {
+		built, err := buildServiceCentricJob(deps, input, requestTimeoutSec)
+		if err != nil {
+			return ProposeGatewayJobOutput{}, err
+		}
+		gj = built
+	} else {
+		built, err := buildLegacyFormatJob(deps, input, requestTimeoutSec)
+		if err != nil {
+			return ProposeGatewayJobOutput{}, err
+		}
+		gj = built
 	}
 
 	if err := gj.Validate(); err != nil {
@@ -160,6 +143,75 @@ func proposeGatewayJob(b operations.Bundle, deps ProposeGatewayJobDeps, input Pr
 	}
 
 	return output, nil
+}
+
+func buildServiceCentricJob(deps ProposeGatewayJobDeps, input ProposeGatewayJobInput, requestTimeoutSec int) (pkg.GatewayJob, error) {
+	donNameSet := make(map[string]struct{})
+	for _, svc := range input.Services {
+		for _, donName := range svc.DONs {
+			donNameSet[donName] = struct{}{}
+		}
+	}
+
+	dons := make([]pkg.TargetDON, 0, len(donNameSet))
+	for donName := range donNameSet {
+		members, f, err := resolveDONMembers(deps, input, donName)
+		if err != nil {
+			return pkg.GatewayJob{}, err
+		}
+		dons = append(dons, pkg.TargetDON{
+			ID:      donName,
+			F:       f,
+			Members: members,
+		})
+	}
+
+	services := make([]pkg.GatewayServiceConfig, len(input.Services))
+	for i, svc := range input.Services {
+		services[i] = pkg.GatewayServiceConfig{
+			ServiceName: svc.ServiceName,
+			Handlers:    svc.Handlers,
+			DONs:        svc.DONs,
+		}
+	}
+
+	return pkg.GatewayJob{
+		UseServiceCentricFormat: true,
+		JobName:                 "CRE Gateway",
+		DONs:                    dons,
+		Services:                services,
+		RequestTimeoutSec:       requestTimeoutSec,
+		AllowedPorts:            input.AllowedPorts,
+		AllowedSchemes:          input.AllowedSchemes,
+		AllowedIPsCIDR:          input.AllowedIPsCIDR,
+		AuthGatewayID:           input.AuthGatewayID,
+	}, nil
+}
+
+func buildLegacyFormatJob(deps ProposeGatewayJobDeps, input ProposeGatewayJobInput, requestTimeoutSec int) (pkg.GatewayJob, error) {
+	targetDONs := make([]pkg.TargetDON, 0, len(input.DONs))
+	for _, ad := range input.DONs {
+		members, _, err := resolveDONMembers(deps, input, ad.Name)
+		if err != nil {
+			return pkg.GatewayJob{}, err
+		}
+		targetDONs = append(targetDONs, pkg.TargetDON{
+			ID:       ad.Name,
+			F:        ad.F,
+			Members:  members,
+			Handlers: ad.Handlers,
+		})
+	}
+
+	return pkg.GatewayJob{
+		JobName:           "CRE Gateway",
+		TargetDONs:        targetDONs,
+		RequestTimeoutSec: requestTimeoutSec,
+		AllowedPorts:      input.AllowedPorts,
+		AllowedSchemes:    input.AllowedSchemes,
+		AllowedIPsCIDR:    input.AllowedIPsCIDR,
+		AuthGatewayID:     input.AuthGatewayID,
+	}, nil
 }
 
 func resolveDONMembers(deps ProposeGatewayJobDeps, input ProposeGatewayJobInput, donName string) ([]pkg.TargetDONMember, int, error) {

--- a/deployment/cre/jobs/operations/propose_gateway_job.go
+++ b/deployment/cre/jobs/operations/propose_gateway_job.go
@@ -23,7 +23,7 @@ const defaultGatewayRequestTimeoutSec = 12
 type ProposeGatewayJobInput struct {
 	Domain                   string
 	DONFilters               []offchain.TargetDONFilter
-	DONs                     []DON             `yaml:"dons"`
+	Services                 []GatewayService  `yaml:"services"`
 	GatewayRequestTimeoutSec int               `yaml:"gatewayRequestTimeoutSec"`
 	AllowedPorts             []int             `yaml:"allowedPorts"`
 	AllowedSchemes           []string          `yaml:"allowedSchemes"`
@@ -33,10 +33,10 @@ type ProposeGatewayJobInput struct {
 	JobLabels                map[string]string
 }
 
-type DON struct {
-	Name     string
-	F        int
-	Handlers []string
+type GatewayService struct {
+	ServiceName string   `yaml:"servicename"`
+	Handlers    []string `yaml:"handlers"`
+	DONs        []string `yaml:"dons"`
 }
 
 type ProposeGatewayJobDeps struct {
@@ -55,94 +55,36 @@ var ProposeGatewayJob = operations.NewOperation[ProposeGatewayJobInput, ProposeG
 )
 
 // proposeGatewayJob builds a gateway job spec and then proposes it to the nodes of a DON.
-// It first fetches node information and chain configurations about the target DONs given in input.DONs to build the job spec.
-// Target DONs are the DONs that the Gateway allows communication with.
-// It then proposes this job spec to each node of the specific DON based on input filters and a chain selector.
-// All nodes must be connected to job distributor and have the proper chain declared.
+// It derives the set of unique DON names from input.Services, fetches node information and
+// chain configurations for each DON from JD, then builds the gateway job.
 func proposeGatewayJob(b operations.Bundle, deps ProposeGatewayJobDeps, input ProposeGatewayJobInput) (ProposeGatewayJobOutput, error) {
-	targetDONs := make([]pkg.TargetDON, 0)
-
-	for _, ad := range input.DONs {
-		// Use filters from input, except the DON name which needs to be the target DON
-		filters := &nodev1.ListNodesRequest_Filter{}
-		for _, f := range input.DONFilters {
-			if f.Key == offchain.FilterKeyDONName {
-				continue
-			}
-			filters = offchain.TargetDONFilter{
-				Key:   f.Key,
-				Value: f.Value,
-			}.AddToFilter(filters)
+	donNameSet := make(map[string]struct{})
+	for _, svc := range input.Services {
+		for _, donName := range svc.DONs {
+			donNameSet[donName] = struct{}{}
 		}
-		filtersWithTargetDONName := offchain.TargetDONFilter{
-			Key:   offchain.FilterKeyDONName,
-			Value: ad.Name,
-		}.AddToFilter(filters)
+	}
 
-		ns, err := pkg.FetchNodesFromJD(deps.Env.GetContext(), deps.Env, pkg.FetchNodesRequest{
-			Domain:  input.Domain,
-			Filters: filtersWithTargetDONName,
+	dons := make([]pkg.TargetDON, 0, len(donNameSet))
+	for donName := range donNameSet {
+		members, f, err := resolveDONMembers(deps, input, donName)
+		if err != nil {
+			return ProposeGatewayJobOutput{}, err
+		}
+		dons = append(dons, pkg.TargetDON{
+			ID:      donName,
+			F:       f,
+			Members: members,
 		})
-		if err != nil {
-			return ProposeGatewayJobOutput{}, err
-		}
-		if len(ns) == 0 {
-			return ProposeGatewayJobOutput{}, fmt.Errorf("no nodes with filters %s", input.DONFilters)
-		}
+	}
 
-		nodes, err := pkg.FetchNodeChainConfigsFromJD(deps.Env.GetContext(), deps.Env, pkg.FetchNodesRequest{
-			Domain:  input.Domain,
-			Filters: filtersWithTargetDONName,
-		})
-		if err != nil {
-			return ProposeGatewayJobOutput{}, err
+	services := make([]pkg.GatewayServiceConfig, len(input.Services))
+	for i, svc := range input.Services {
+		services[i] = pkg.GatewayServiceConfig{
+			ServiceName: svc.ServiceName,
+			Handlers:    svc.Handlers,
+			DONs:        svc.DONs,
 		}
-		if len(nodes) == 0 {
-			return ProposeGatewayJobOutput{}, fmt.Errorf("no chain configs with filters %s", input.DONFilters)
-		}
-
-		fam, chainID, err := parseSelector(uint64(input.GatewayKeyChainSelector))
-		if err != nil {
-			return ProposeGatewayJobOutput{}, err
-		}
-
-		// make map of node id to node
-		m := make(map[string]*nodev1.Node, len(ns))
-		for _, n := range ns {
-			m[n.Id] = n
-		}
-
-		var members []pkg.TargetDONMember
-		for _, n := range nodes {
-			var found bool
-			for _, cc := range n.ChainConfigs {
-				if cc.Chain.Id == chainID && cc.Chain.Type == fam {
-					nodeName := n.NodeID
-					if matched, ok := m[n.NodeID]; ok {
-						nodeName = matched.Name
-					}
-					members = append(members, pkg.TargetDONMember{
-						Address: cc.AccountAddress,
-						Name:    fmt.Sprintf("%s (DON %s)", nodeName, ad.Name),
-					})
-					found = true
-
-					break
-				}
-			}
-
-			if !found {
-				return ProposeGatewayJobOutput{}, fmt.Errorf("could not find key belonging to chain id %s on node %s", chainID, n.NodeID)
-			}
-		}
-
-		td := pkg.TargetDON{
-			ID:       ad.Name,
-			F:        ad.F,
-			Members:  members,
-			Handlers: ad.Handlers,
-		}
-		targetDONs = append(targetDONs, td)
 	}
 
 	requestTimeoutSec := input.GatewayRequestTimeoutSec
@@ -152,7 +94,8 @@ func proposeGatewayJob(b operations.Bundle, deps ProposeGatewayJobDeps, input Pr
 
 	gj := pkg.GatewayJob{
 		JobName:           "CRE Gateway",
-		TargetDONs:        targetDONs,
+		DONs:              dons,
+		Services:          services,
 		RequestTimeoutSec: requestTimeoutSec,
 		AllowedPorts:      input.AllowedPorts,
 		AllowedSchemes:    input.AllowedSchemes,
@@ -160,8 +103,7 @@ func proposeGatewayJob(b operations.Bundle, deps ProposeGatewayJobDeps, input Pr
 		AuthGatewayID:     input.AuthGatewayID,
 	}
 
-	err := gj.Validate()
-	if err != nil {
+	if err := gj.Validate(); err != nil {
 		return ProposeGatewayJobOutput{}, err
 	}
 
@@ -197,18 +139,18 @@ func proposeGatewayJob(b operations.Bundle, deps ProposeGatewayJobDeps, input Pr
 		Specs: make(map[string][]string),
 	}
 	for nodeIdx, n := range nodes {
-		spec, err := gj.Resolve(nodeIdx)
-		if err != nil {
-			return ProposeGatewayJobOutput{}, err
+		spec, specErr := gj.Resolve(nodeIdx)
+		if specErr != nil {
+			return ProposeGatewayJobOutput{}, specErr
 		}
 
-		_, err = deps.Env.Offchain.ProposeJob(b.GetContext(), &jobv1.ProposeJobRequest{
+		_, propErr := deps.Env.Offchain.ProposeJob(b.GetContext(), &jobv1.ProposeJobRequest{
 			NodeId: n.GetId(),
 			Spec:   spec,
 			Labels: labels,
 		})
-		if err != nil {
-			return ProposeGatewayJobOutput{}, fmt.Errorf("error proposing job to node %s spec %s : %w", n.GetId(), spec, err)
+		if propErr != nil {
+			return ProposeGatewayJobOutput{}, fmt.Errorf("error proposing job to node %s spec %s : %w", n.GetId(), spec, propErr)
 		}
 
 		output.Specs[n.GetId()] = append(output.Specs[n.GetId()], spec)
@@ -218,6 +160,80 @@ func proposeGatewayJob(b operations.Bundle, deps ProposeGatewayJobDeps, input Pr
 	}
 
 	return output, nil
+}
+
+func resolveDONMembers(deps ProposeGatewayJobDeps, input ProposeGatewayJobInput, donName string) ([]pkg.TargetDONMember, int, error) {
+	filters := &nodev1.ListNodesRequest_Filter{}
+	for _, f := range input.DONFilters {
+		if f.Key == offchain.FilterKeyDONName {
+			continue
+		}
+		filters = offchain.TargetDONFilter{
+			Key:   f.Key,
+			Value: f.Value,
+		}.AddToFilter(filters)
+	}
+	filtersWithTargetDONName := offchain.TargetDONFilter{
+		Key:   offchain.FilterKeyDONName,
+		Value: donName,
+	}.AddToFilter(filters)
+
+	ns, err := pkg.FetchNodesFromJD(deps.Env.GetContext(), deps.Env, pkg.FetchNodesRequest{
+		Domain:  input.Domain,
+		Filters: filtersWithTargetDONName,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(ns) == 0 {
+		return nil, 0, fmt.Errorf("no nodes with filters %s", input.DONFilters)
+	}
+
+	nodeChainConfigs, err := pkg.FetchNodeChainConfigsFromJD(deps.Env.GetContext(), deps.Env, pkg.FetchNodesRequest{
+		Domain:  input.Domain,
+		Filters: filtersWithTargetDONName,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(nodeChainConfigs) == 0 {
+		return nil, 0, fmt.Errorf("no chain configs with filters %s", input.DONFilters)
+	}
+
+	fam, chainID, err := parseSelector(uint64(input.GatewayKeyChainSelector))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	m := make(map[string]*nodev1.Node, len(ns))
+	for _, n := range ns {
+		m[n.Id] = n
+	}
+
+	var members []pkg.TargetDONMember
+	for _, n := range nodeChainConfigs {
+		var found bool
+		for _, cc := range n.ChainConfigs {
+			if cc.Chain.Id == chainID && cc.Chain.Type == fam {
+				nodeName := n.NodeID
+				if matched, ok := m[n.NodeID]; ok {
+					nodeName = matched.Name
+				}
+				members = append(members, pkg.TargetDONMember{
+					Address: cc.AccountAddress,
+					Name:    fmt.Sprintf("%s (DON %s)", nodeName, donName),
+				})
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, 0, fmt.Errorf("could not find key belonging to chain id %s on node %s", chainID, n.NodeID)
+		}
+	}
+
+	f := (len(members) - 1) / 3
+	return members, f, nil
 }
 
 func parseSelector(sel uint64) (nodev1.ChainType, string, error) {

--- a/deployment/cre/jobs/operations/propose_gateway_job_test.go
+++ b/deployment/cre/jobs/operations/propose_gateway_job_test.go
@@ -112,14 +112,14 @@ var commonInput = ProposeGatewayJobInput{
 			Value: "zone-b",
 		},
 	},
-	DONs: []DON{
+	Services: []GatewayService{
 		{
-			Name: "workflow_1_zone-b",
+			ServiceName: "workflows",
 			Handlers: []string{
 				"http-capabilities",
 				"web-api-capabilities",
 			},
-			F: 1,
+			DONs: []string{"workflow_1_zone-b"},
 		},
 	},
 	GatewayKeyChainSelector:  10344971235874465080,
@@ -149,7 +149,8 @@ func TestProposeGatewayJob(t *testing.T) {
 			output: ProposeGatewayJobOutput{
 				Specs: map[string][]string{
 					"node_5": {
-						"type = 'gateway'\nschemaVersion = 1\nname = 'CRE Gateway'\nexternalJobID = 'cf8aa339-6349-5e5b-9289-5c2907711200'\nforwardingAllowed = false\n\n[gatewayConfig]\n[gatewayConfig.ConnectionManagerConfig]\nAuthChallengeLen = 10\nAuthGatewayId = 'gateway-node-0'\nAuthTimestampToleranceSec = 5\nHeartbeatIntervalSec = 20\n\n[[gatewayConfig.Dons]]\nDonId = 'workflow_1_zone-b'\nF = 1\n\n[[gatewayConfig.Dons.Handlers]]\nName = 'http-capabilities'\nServiceName = 'workflows'\n\n[gatewayConfig.Dons.Handlers.Config]\nCleanUpPeriodMs = 600000\n\n[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]\nglobalBurst = 100\nglobalRPS = 500\nperSenderBurst = 100\nperSenderRPS = 100\n\n[[gatewayConfig.Dons.Handlers]]\nName = 'web-api-capabilities'\n\n[gatewayConfig.Dons.Handlers.Config]\nmaxAllowedMessageAgeSec = 1000\n\n[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]\nglobalBurst = 10\nglobalRPS = 50\nperSenderBurst = 10\nperSenderRPS = 10\n\n[[gatewayConfig.Dons.Members]]\nAddress = '0x04'\nName = 'cl-cre-one-zone-b-0 (DON workflow_1_zone-b)'\n\n[gatewayConfig.HTTPClientConfig]\nMaxResponseBytes = 50000000\nAllowedPorts = [443]\nAllowedSchemes = ['https']\nAllowedIPsCIDR = []\n\n[gatewayConfig.NodeServerConfig]\nHandshakeTimeoutMillis = 1000\nMaxRequestBytes = 100000\nPath = '/'\nPort = 5003\nReadTimeoutMillis = 1000\nRequestTimeoutMillis = 5000\nWriteTimeoutMillis = 1000\n\n[gatewayConfig.UserServerConfig]\nContentTypeHeader = 'application/jsonrpc'\nMaxRequestBytes = 100000\nPath = '/'\nPort = 5002\nReadTimeoutMillis = 5000\nRequestTimeoutMillis = 5000\nWriteTimeoutMillis = 6000\n"},
+						"type = 'gateway'\nschemaVersion = 1\nname = 'CRE Gateway'\nexternalJobID = 'cf8aa339-6349-5e5b-9289-5c2907711200'\nforwardingAllowed = false\n\n[gatewayConfig]\n[gatewayConfig.ConnectionManagerConfig]\nAuthChallengeLen = 10\nAuthGatewayId = 'gateway-node-0'\nAuthTimestampToleranceSec = 5\nHeartbeatIntervalSec = 20\n\n[[gatewayConfig.ShardedDONs]]\nDonName = 'workflow_1_zone-b'\nF = 0\n\n[[gatewayConfig.ShardedDONs.Shards]]\n[[gatewayConfig.ShardedDONs.Shards.Nodes]]\nAddress = '0x04'\nName = 'cl-cre-one-zone-b-0 (DON workflow_1_zone-b)'\n\n[[gatewayConfig.Services]]\nServiceName = 'workflows'\nDONs = ['workflow_1_zone-b']\n\n[[gatewayConfig.Services.Handlers]]\nName = 'http-capabilities'\nServiceName = 'workflows'\n\n[gatewayConfig.Services.Handlers.Config]\nCleanUpPeriodMs = 600000\n\n[gatewayConfig.Services.Handlers.Config.NodeRateLimiter]\nglobalBurst = 100\nglobalRPS = 500\nperSenderBurst = 100\nperSenderRPS = 100\n\n[[gatewayConfig.Services.Handlers]]\nName = 'web-api-capabilities'\n\n[gatewayConfig.Services.Handlers.Config]\nmaxAllowedMessageAgeSec = 1000\n\n[gatewayConfig.Services.Handlers.Config.NodeRateLimiter]\nglobalBurst = 10\nglobalRPS = 50\nperSenderBurst = 10\nperSenderRPS = 10\n\n[gatewayConfig.HTTPClientConfig]\nMaxResponseBytes = 50000000\nAllowedPorts = [443]\nAllowedSchemes = ['https']\nAllowedIPsCIDR = []\n\n[gatewayConfig.NodeServerConfig]\nHandshakeTimeoutMillis = 1000\nMaxRequestBytes = 100000\nPath = '/'\nPort = 5003\nReadTimeoutMillis = 1000\nRequestTimeoutMillis = 5000\nWriteTimeoutMillis = 1000\n\n[gatewayConfig.UserServerConfig]\nContentTypeHeader = 'application/jsonrpc'\nMaxRequestBytes = 100000\nPath = '/'\nPort = 5002\nReadTimeoutMillis = 5000\nRequestTimeoutMillis = 5000\nWriteTimeoutMillis = 6000\n",
+					},
 				},
 			},
 		},
@@ -193,7 +194,6 @@ func TestProposeGatewayJob(t *testing.T) {
 				assert.Contains(t, err.Error(), tc.errorMsg)
 			} else {
 				require.NoError(t, err)
-				require.NotNil(t, output)
 			}
 
 			require.Equal(t, tc.output, output)

--- a/deployment/cre/jobs/operations/propose_gateway_job_test.go
+++ b/deployment/cre/jobs/operations/propose_gateway_job_test.go
@@ -92,7 +92,7 @@ func (oc *mockOffchainClient) ProposeJob(ctx context.Context, in *jobv1.ProposeJ
 	return &jobv1.ProposeJobResponse{}, nil
 }
 
-var commonInput = ProposeGatewayJobInput{
+var commonInputServiceCentric = ProposeGatewayJobInput{
 	Domain: "cre",
 	DONFilters: []offchain.TargetDONFilter{
 		{
@@ -112,6 +112,7 @@ var commonInput = ProposeGatewayJobInput{
 			Value: "zone-b",
 		},
 	},
+	UseServiceCentricFormat: true,
 	Services: []GatewayService{
 		{
 			ServiceName: "workflows",
@@ -120,6 +121,41 @@ var commonInput = ProposeGatewayJobInput{
 				"web-api-capabilities",
 			},
 			DONs: []string{"workflow_1_zone-b"},
+		},
+	},
+	GatewayKeyChainSelector:  10344971235874465080,
+	GatewayRequestTimeoutSec: 5,
+	JobLabels:                map[string]string{},
+}
+
+var commonInputDONCentric = ProposeGatewayJobInput{
+	Domain: "cre",
+	DONFilters: []offchain.TargetDONFilter{
+		{
+			Key:   "don_name",
+			Value: "gateway_1_zone-b",
+		},
+		{
+			Key:   "environment",
+			Value: "staging",
+		},
+		{
+			Key:   "product",
+			Value: "cre",
+		},
+		{
+			Key:   "zone",
+			Value: "zone-b",
+		},
+	},
+	DONs: []DON{
+		{
+			Name: "workflow_1_zone-b",
+			F:    1,
+			Handlers: []string{
+				"http-capabilities",
+				"web-api-capabilities",
+			},
 		},
 	},
 	GatewayKeyChainSelector:  10344971235874465080,
@@ -139,8 +175,8 @@ func TestProposeGatewayJob(t *testing.T) {
 		output                ProposeGatewayJobOutput
 	}{
 		{
-			name:  "success",
-			input: commonInput,
+			name:  "success - service-centric format",
+			input: commonInputServiceCentric,
 			offchainClientFactory: func() *mockOffchainClient {
 				return newOffchainClient(nodes, chainConfigs, nil, nil)
 			},
@@ -155,8 +191,24 @@ func TestProposeGatewayJob(t *testing.T) {
 			},
 		},
 		{
+			name:  "success - don-centric format",
+			input: commonInputDONCentric,
+			offchainClientFactory: func() *mockOffchainClient {
+				return newOffchainClient(nodes, chainConfigs, nil, nil)
+			},
+			expectError: false,
+			errorMsg:    "",
+			output: ProposeGatewayJobOutput{
+				Specs: map[string][]string{
+					"node_5": {
+						"type = 'gateway'\nschemaVersion = 1\nname = 'CRE Gateway'\nexternalJobID = 'cf8aa339-6349-5e5b-9289-5c2907711200'\nforwardingAllowed = false\n\n[gatewayConfig]\n[gatewayConfig.ConnectionManagerConfig]\nAuthChallengeLen = 10\nAuthGatewayId = 'gateway-node-0'\nAuthTimestampToleranceSec = 5\nHeartbeatIntervalSec = 20\n\n[[gatewayConfig.Dons]]\nDonId = 'workflow_1_zone-b'\nF = 1\n\n[[gatewayConfig.Dons.Handlers]]\nName = 'http-capabilities'\nServiceName = 'workflows'\n\n[gatewayConfig.Dons.Handlers.Config]\nCleanUpPeriodMs = 600000\n\n[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]\nglobalBurst = 100\nglobalRPS = 500\nperSenderBurst = 100\nperSenderRPS = 100\n\n[[gatewayConfig.Dons.Handlers]]\nName = 'web-api-capabilities'\n\n[gatewayConfig.Dons.Handlers.Config]\nmaxAllowedMessageAgeSec = 1000\n\n[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]\nglobalBurst = 10\nglobalRPS = 50\nperSenderBurst = 10\nperSenderRPS = 10\n\n[[gatewayConfig.Dons.Members]]\nAddress = '0x04'\nName = 'cl-cre-one-zone-b-0 (DON workflow_1_zone-b)'\n\n[gatewayConfig.HTTPClientConfig]\nMaxResponseBytes = 50000000\nAllowedPorts = [443]\nAllowedSchemes = ['https']\nAllowedIPsCIDR = []\n\n[gatewayConfig.NodeServerConfig]\nHandshakeTimeoutMillis = 1000\nMaxRequestBytes = 100000\nPath = '/'\nPort = 5003\nReadTimeoutMillis = 1000\nRequestTimeoutMillis = 5000\nWriteTimeoutMillis = 1000\n\n[gatewayConfig.UserServerConfig]\nContentTypeHeader = 'application/jsonrpc'\nMaxRequestBytes = 100000\nPath = '/'\nPort = 5002\nReadTimeoutMillis = 5000\nRequestTimeoutMillis = 5000\nWriteTimeoutMillis = 6000\n",
+					},
+				},
+			},
+		},
+		{
 			name:  "fail - no nodes found",
-			input: commonInput,
+			input: commonInputServiceCentric,
 			offchainClientFactory: func() *mockOffchainClient {
 				return newOffchainClient([]*nodev1.Node{}, chainConfigs, nil, nil)
 			},
@@ -166,7 +218,7 @@ func TestProposeGatewayJob(t *testing.T) {
 		},
 		{
 			name:  "fail - no chain configs found",
-			input: commonInput,
+			input: commonInputServiceCentric,
 			offchainClientFactory: func() *mockOffchainClient {
 				return newOffchainClient(nodes, []*nodev1.ChainConfig{}, nil, nil)
 			},

--- a/deployment/cre/jobs/operations/propose_gateway_job_test.go
+++ b/deployment/cre/jobs/operations/propose_gateway_job_test.go
@@ -112,7 +112,7 @@ var commonInputServiceCentric = ProposeGatewayJobInput{
 			Value: "zone-b",
 		},
 	},
-	UseServiceCentricFormat: true,
+	ServiceCentricFormatEnabled: true,
 	Services: []GatewayService{
 		{
 			ServiceName: "workflows",

--- a/deployment/cre/jobs/pkg/gateway_job.go
+++ b/deployment/cre/jobs/pkg/gateway_job.go
@@ -39,9 +39,10 @@ type TargetDONMember struct {
 }
 
 type TargetDON struct {
-	ID      string
-	F       int
-	Members []TargetDONMember
+	ID       string
+	F        int
+	Members  []TargetDONMember
+	Handlers []string // used only in legacy (don-centric) format
 }
 
 type GatewayServiceConfig struct {
@@ -51,8 +52,15 @@ type GatewayServiceConfig struct {
 }
 
 type GatewayJob struct {
-	DONs              []TargetDON
-	Services          []GatewayServiceConfig
+	UseServiceCentricFormat bool
+
+	// Don-centric format (UseServiceCentricFormat == false): handlers are per-DON.
+	TargetDONs []TargetDON
+
+	// Service-centric format (UseServiceCentricFormat == true): handlers are per-service, DONs referenced by name.
+	DONs     []TargetDON
+	Services []GatewayServiceConfig
+
 	JobName           string
 	RequestTimeoutSec int
 	AllowedPorts      []int
@@ -67,12 +75,15 @@ func (g GatewayJob) Validate() error {
 		return errors.New("must provide job name")
 	}
 
-	if len(g.DONs) == 0 {
-		return errors.New("must provide at least one DON")
-	}
-
-	if len(g.Services) == 0 {
-		return errors.New("must provide at least one service")
+	if g.UseServiceCentricFormat {
+		if len(g.DONs) == 0 {
+			return errors.New("must provide at least one DON")
+		}
+		if len(g.Services) == 0 {
+			return errors.New("must provide at least one service")
+		}
+	} else if len(g.TargetDONs) == 0 {
+		return errors.New("must provide at least one target DON")
 	}
 
 	// We impose a lower bound to account for other timeouts which are hardcoded,
@@ -110,60 +121,76 @@ func (g GatewayJob) Resolve(gatewayNodeIdx int) (string, error) {
 		externalJobID = uuid.NewSHA1(uuid.Nil, []byte(g.JobName)).String()
 	}
 
-	shardedDONs, services, err := g.buildServicesAndShardedDONs()
-	if err != nil {
-		return "", err
-	}
-
 	requestTimeout := time.Duration(g.RequestTimeoutSec) * time.Second
-	config := gatewayConfig{
-		ConnectionManagerConfig: connectionManagerConfig{
-			AuthChallengeLen:          10,
-			AuthGatewayID:             "gateway-node-" + strconv.Itoa(gatewayNodeIdx),
-			AuthTimestampToleranceSec: 5,
-			HeartbeatIntervalSec:      20,
-		},
-		NodeServerConfig: nodeServerConfig{
-			HandshakeTimeoutMillis: 1_000,
-			MaxRequestBytes:        100_000,
-			Path:                   "/",
-			Port:                   5_003,
-			ReadTimeoutMillis:      1_000,
-			RequestTimeoutMillis:   int(requestTimeout.Milliseconds()),
-			WriteTimeoutMillis:     1_000,
-		},
-		UserServerConfig: userServerConfig{
-			ContentTypeHeader:    "application/jsonrpc",
-			MaxRequestBytes:      100_000,
-			Path:                 "/",
-			Port:                 5_002,
-			ReadTimeoutMillis:    int(requestTimeout.Milliseconds()),
-			RequestTimeoutMillis: int(requestTimeout.Milliseconds()),
-			WriteTimeoutMillis:   int(requestTimeout.Milliseconds() + 1000),
-		},
-		HTTPClientConfig: httpClientConfig{
-			MaxResponseBytes: 50_000_000,
-			AllowedPorts:     []int{443},
-			AllowedSchemes:   []string{"https"},
-		},
-		ShardedDONs: shardedDONs,
-		Services:    services,
+	connCfg := connectionManagerConfig{
+		AuthChallengeLen:          10,
+		AuthGatewayID:             "gateway-node-" + strconv.Itoa(gatewayNodeIdx),
+		AuthTimestampToleranceSec: 5,
+		HeartbeatIntervalSec:      20,
+	}
+	nodeCfg := nodeServerConfig{
+		HandshakeTimeoutMillis: 1_000,
+		MaxRequestBytes:        100_000,
+		Path:                   "/",
+		Port:                   5_003,
+		ReadTimeoutMillis:      1_000,
+		RequestTimeoutMillis:   int(requestTimeout.Milliseconds()),
+		WriteTimeoutMillis:     1_000,
+	}
+	userCfg := userServerConfig{
+		ContentTypeHeader:    "application/jsonrpc",
+		MaxRequestBytes:      100_000,
+		Path:                 "/",
+		Port:                 5_002,
+		ReadTimeoutMillis:    int(requestTimeout.Milliseconds()),
+		RequestTimeoutMillis: int(requestTimeout.Milliseconds()),
+		WriteTimeoutMillis:   int(requestTimeout.Milliseconds() + 1000),
+	}
+	httpCfg := httpClientConfig{
+		MaxResponseBytes: 50_000_000,
+		AllowedPorts:     []int{443},
+		AllowedSchemes:   []string{"https"},
 	}
 
 	if len(g.AllowedPorts) > 0 {
-		config.HTTPClientConfig.AllowedPorts = g.AllowedPorts
+		httpCfg.AllowedPorts = g.AllowedPorts
 	}
-
 	if len(g.AllowedSchemes) > 0 {
-		config.HTTPClientConfig.AllowedSchemes = g.AllowedSchemes
+		httpCfg.AllowedSchemes = g.AllowedSchemes
 	}
-
 	if len(g.AllowedIPsCIDR) > 0 {
-		config.HTTPClientConfig.AllowedIPsCIDR = g.AllowedIPsCIDR
+		httpCfg.AllowedIPsCIDR = g.AllowedIPsCIDR
+	}
+	if g.AuthGatewayID != "" {
+		connCfg.AuthGatewayID = g.AuthGatewayID
 	}
 
-	if g.AuthGatewayID != "" {
-		config.ConnectionManagerConfig.AuthGatewayID = g.AuthGatewayID
+	var gwConfig any
+	if g.UseServiceCentricFormat {
+		shardedDONs, services, err := g.buildServicesAndShardedDONs()
+		if err != nil {
+			return "", err
+		}
+		gwConfig = gatewayConfigServiceCentric{
+			ConnectionManagerConfig: connCfg,
+			ShardedDONs:             shardedDONs,
+			Services:                services,
+			HTTPClientConfig:        httpCfg,
+			NodeServerConfig:        nodeCfg,
+			UserServerConfig:        userCfg,
+		}
+	} else {
+		dons, err := g.buildLegacyDons()
+		if err != nil {
+			return "", err
+		}
+		gwConfig = gatewayConfigLegacy{
+			ConnectionManagerConfig: connCfg,
+			Dons:                    dons,
+			HTTPClientConfig:        httpCfg,
+			NodeServerConfig:        nodeCfg,
+			UserServerConfig:        userCfg,
+		}
 	}
 
 	spec := &gatewaySpec{
@@ -172,7 +199,7 @@ func (g GatewayJob) Resolve(gatewayNodeIdx int) (string, error) {
 		Name:              g.JobName,
 		ExternalJobID:     externalJobID,
 		ForwardingAllowed: false,
-		GatewayConfig:     config,
+		GatewayConfig:     gwConfig,
 	}
 	b, marshalErr := toml.Marshal(spec)
 	if marshalErr != nil {
@@ -180,6 +207,38 @@ func (g GatewayJob) Resolve(gatewayNodeIdx int) (string, error) {
 	}
 
 	return string(b), nil
+}
+
+func (g GatewayJob) buildLegacyDons() ([]legacyDON, error) {
+	dons := make([]legacyDON, 0, len(g.TargetDONs))
+	for _, targetDON := range g.TargetDONs {
+		ms := make([]member, 0, len(targetDON.Members))
+		for _, mem := range targetDON.Members {
+			ms = append(ms, member(mem))
+		}
+
+		hs := make([]handler, 0, len(targetDON.Handlers))
+		for _, ht := range targetDON.Handlers {
+			switch ht {
+			case GatewayHandlerTypeWebAPICapabilities:
+				hs = append(hs, newDefaultWebAPICapabilitiesHandler())
+			case GatewayHandlerTypeVault:
+				hs = append(hs, newDefaultVaultHandler(g.RequestTimeoutSec))
+			case GatewayHandlerTypeHTTPCapabilities:
+				hs = append(hs, newDefaultHTTPCapabilitiesHandler())
+			default:
+				return nil, errors.New("unknown handler type: " + ht)
+			}
+		}
+
+		dons = append(dons, legacyDON{
+			DonID:    targetDON.ID,
+			F:        targetDON.F,
+			Handlers: hs,
+			Members:  ms,
+		})
+	}
+	return dons, nil
 }
 
 func (g GatewayJob) buildServicesAndShardedDONs() ([]shardedDON, []service, error) {
@@ -265,21 +324,36 @@ func newDefaultVaultHandler(requestTimeoutSec int) handler {
 }
 
 type gatewaySpec struct {
-	Type              string        `toml:"type"`
-	SchemaVersion     int           `toml:"schemaVersion"`
-	Name              string        `toml:"name"`
-	ExternalJobID     string        `toml:"externalJobID"`
-	ForwardingAllowed bool          `toml:"forwardingAllowed"`
-	GatewayConfig     gatewayConfig `toml:"gatewayConfig"`
+	Type              string `toml:"type"`
+	SchemaVersion     int    `toml:"schemaVersion"`
+	Name              string `toml:"name"`
+	ExternalJobID     string `toml:"externalJobID"`
+	ForwardingAllowed bool   `toml:"forwardingAllowed"`
+	GatewayConfig     any    `toml:"gatewayConfig"`
 }
 
-type gatewayConfig struct {
+type gatewayConfigLegacy struct {
+	ConnectionManagerConfig connectionManagerConfig `toml:"ConnectionManagerConfig"`
+	Dons                    []legacyDON             `toml:"Dons"`
+	HTTPClientConfig        httpClientConfig        `toml:"HTTPClientConfig"`
+	NodeServerConfig        nodeServerConfig        `toml:"NodeServerConfig"`
+	UserServerConfig        userServerConfig        `toml:"UserServerConfig"`
+}
+
+type gatewayConfigServiceCentric struct {
 	ConnectionManagerConfig connectionManagerConfig `toml:"ConnectionManagerConfig"`
 	ShardedDONs             []shardedDON            `toml:"ShardedDONs"`
 	Services                []service               `toml:"Services"`
 	HTTPClientConfig        httpClientConfig        `toml:"HTTPClientConfig"`
 	NodeServerConfig        nodeServerConfig        `toml:"NodeServerConfig"`
 	UserServerConfig        userServerConfig        `toml:"UserServerConfig"`
+}
+
+type legacyDON struct {
+	DonID    string    `toml:"DonId"`
+	F        int       `toml:"F"`
+	Handlers []handler `toml:"Handlers"`
+	Members  []member  `toml:"Members"`
 }
 
 type service struct {

--- a/deployment/cre/jobs/pkg/gateway_job.go
+++ b/deployment/cre/jobs/pkg/gateway_job.go
@@ -52,12 +52,12 @@ type GatewayServiceConfig struct {
 }
 
 type GatewayJob struct {
-	UseServiceCentricFormat bool
+	ServiceCentricFormatEnabled bool
 
-	// Don-centric format (UseServiceCentricFormat == false): handlers are per-DON.
+	// Don-centric format (ServiceCentricFormatEnabled == false): handlers are per-DON.
 	TargetDONs []TargetDON
 
-	// Service-centric format (UseServiceCentricFormat == true): handlers are per-service, DONs referenced by name.
+	// Service-centric format (ServiceCentricFormatEnabled == true): handlers are per-service, DONs referenced by name.
 	DONs     []TargetDON
 	Services []GatewayServiceConfig
 
@@ -75,7 +75,7 @@ func (g GatewayJob) Validate() error {
 		return errors.New("must provide job name")
 	}
 
-	if g.UseServiceCentricFormat {
+	if g.ServiceCentricFormatEnabled {
 		if len(g.DONs) == 0 {
 			return errors.New("must provide at least one DON")
 		}
@@ -166,7 +166,7 @@ func (g GatewayJob) Resolve(gatewayNodeIdx int) (string, error) {
 	}
 
 	var gwConfig any
-	if g.UseServiceCentricFormat {
+	if g.ServiceCentricFormatEnabled {
 		shardedDONs, services, err := g.buildServicesAndShardedDONs()
 		if err != nil {
 			return "", err

--- a/deployment/cre/jobs/pkg/gateway_job.go
+++ b/deployment/cre/jobs/pkg/gateway_job.go
@@ -15,8 +15,23 @@ const (
 	GatewayHandlerTypeHTTPCapabilities   = "http-capabilities"
 	GatewayHandlerTypeVault              = "vault"
 
+	ServiceNameWorkflows = "workflows"
+	ServiceNameVault     = "vault"
+
 	minimumRequestTimeoutSec = 5
 )
+
+// HandlerServiceName returns the service name for a given handler type.
+func HandlerServiceName(handlerType string) string {
+	switch handlerType {
+	case GatewayHandlerTypeVault:
+		return ServiceNameVault
+	case GatewayHandlerTypeHTTPCapabilities, GatewayHandlerTypeWebAPICapabilities:
+		return ServiceNameWorkflows
+	default:
+		return handlerType
+	}
+}
 
 type TargetDONMember struct {
 	Address string
@@ -24,14 +39,20 @@ type TargetDONMember struct {
 }
 
 type TargetDON struct {
-	ID       string
-	F        int
-	Members  []TargetDONMember
-	Handlers []string
+	ID      string
+	F       int
+	Members []TargetDONMember
+}
+
+type GatewayServiceConfig struct {
+	ServiceName string
+	Handlers    []string
+	DONs        []string
 }
 
 type GatewayJob struct {
-	TargetDONs        []TargetDON
+	DONs              []TargetDON
+	Services          []GatewayServiceConfig
 	JobName           string
 	RequestTimeoutSec int
 	AllowedPorts      []int
@@ -46,8 +67,12 @@ func (g GatewayJob) Validate() error {
 		return errors.New("must provide job name")
 	}
 
-	if len(g.TargetDONs) == 0 {
-		return errors.New("must provide at least one target DON")
+	if len(g.DONs) == 0 {
+		return errors.New("must provide at least one DON")
+	}
+
+	if len(g.Services) == 0 {
+		return errors.New("must provide at least one service")
 	}
 
 	// We impose a lower bound to account for other timeouts which are hardcoded,
@@ -85,34 +110,9 @@ func (g GatewayJob) Resolve(gatewayNodeIdx int) (string, error) {
 		externalJobID = uuid.NewSHA1(uuid.Nil, []byte(g.JobName)).String()
 	}
 
-	dons := []don{}
-	for _, targetDON := range g.TargetDONs {
-		ms := []member{}
-		for _, mem := range targetDON.Members {
-			ms = append(ms, member(mem))
-		}
-
-		hs := []handler{}
-		for _, ht := range targetDON.Handlers {
-			switch ht {
-			case GatewayHandlerTypeWebAPICapabilities:
-				hs = append(hs, newDefaultWebAPICapabilitiesHandler())
-			case GatewayHandlerTypeVault:
-				hs = append(hs, newDefaultVaultHandler(g.RequestTimeoutSec))
-			case GatewayHandlerTypeHTTPCapabilities:
-				hs = append(hs, newDefaultHTTPCapabilitiesHandler())
-			default:
-				return "", errors.New("unknown handler type: " + ht)
-			}
-		}
-
-		d := don{
-			DonID:    targetDON.ID,
-			F:        targetDON.F,
-			Members:  ms,
-			Handlers: hs,
-		}
-		dons = append(dons, d)
+	shardedDONs, services, err := g.buildServicesAndShardedDONs()
+	if err != nil {
+		return "", err
 	}
 
 	requestTimeout := time.Duration(g.RequestTimeoutSec) * time.Second
@@ -146,7 +146,8 @@ func (g GatewayJob) Resolve(gatewayNodeIdx int) (string, error) {
 			AllowedPorts:     []int{443},
 			AllowedSchemes:   []string{"https"},
 		},
-		Dons: dons,
+		ShardedDONs: shardedDONs,
+		Services:    services,
 	}
 
 	if len(g.AllowedPorts) > 0 {
@@ -173,12 +174,51 @@ func (g GatewayJob) Resolve(gatewayNodeIdx int) (string, error) {
 		ForwardingAllowed: false,
 		GatewayConfig:     config,
 	}
-	b, err := toml.Marshal(spec)
-	if err != nil {
-		return "", err
+	b, marshalErr := toml.Marshal(spec)
+	if marshalErr != nil {
+		return "", marshalErr
 	}
 
 	return string(b), nil
+}
+
+func (g GatewayJob) buildServicesAndShardedDONs() ([]shardedDON, []service, error) {
+	shardedDONs := make([]shardedDON, len(g.DONs))
+	for i, don := range g.DONs {
+		nodes := make([]member, len(don.Members))
+		for j, mem := range don.Members {
+			nodes[j] = member(mem)
+		}
+		shardedDONs[i] = shardedDON{
+			DonName: don.ID,
+			F:       don.F,
+			Shards:  []shard{{Nodes: nodes}},
+		}
+	}
+
+	services := make([]service, 0, len(g.Services))
+	for _, svcCfg := range g.Services {
+		var handlers []handler
+		for _, ht := range svcCfg.Handlers {
+			switch ht {
+			case GatewayHandlerTypeWebAPICapabilities:
+				handlers = append(handlers, newDefaultWebAPICapabilitiesHandler())
+			case GatewayHandlerTypeVault:
+				handlers = append(handlers, newDefaultVaultHandler(g.RequestTimeoutSec))
+			case GatewayHandlerTypeHTTPCapabilities:
+				handlers = append(handlers, newDefaultHTTPCapabilitiesHandler())
+			default:
+				return nil, nil, errors.New("unknown handler type: " + ht)
+			}
+		}
+		services = append(services, service{
+			ServiceName: svcCfg.ServiceName,
+			Handlers:    handlers,
+			DONs:        svcCfg.DONs,
+		})
+	}
+
+	return shardedDONs, services, nil
 }
 
 type webAPICapabilitiesHandlerConfig struct {
@@ -235,10 +275,27 @@ type gatewaySpec struct {
 
 type gatewayConfig struct {
 	ConnectionManagerConfig connectionManagerConfig `toml:"ConnectionManagerConfig"`
-	Dons                    []don                   `toml:"Dons"`
+	ShardedDONs             []shardedDON            `toml:"ShardedDONs"`
+	Services                []service               `toml:"Services"`
 	HTTPClientConfig        httpClientConfig        `toml:"HTTPClientConfig"`
 	NodeServerConfig        nodeServerConfig        `toml:"NodeServerConfig"`
 	UserServerConfig        userServerConfig        `toml:"UserServerConfig"`
+}
+
+type service struct {
+	ServiceName string    `toml:"ServiceName"`
+	Handlers    []handler `toml:"Handlers"`
+	DONs        []string  `toml:"DONs"`
+}
+
+type shardedDON struct {
+	DonName string  `toml:"DonName"`
+	F       int     `toml:"F"`
+	Shards  []shard `toml:"Shards"`
+}
+
+type shard struct {
+	Nodes []member `toml:"Nodes"`
 }
 
 type connectionManagerConfig struct {
@@ -246,13 +303,6 @@ type connectionManagerConfig struct {
 	AuthGatewayID             string `toml:"AuthGatewayId"`
 	AuthTimestampToleranceSec int    `toml:"AuthTimestampToleranceSec"`
 	HeartbeatIntervalSec      int    `toml:"HeartbeatIntervalSec"`
-}
-
-type don struct {
-	DonID    string    `toml:"DonId"`
-	F        int       `toml:"F"`
-	Handlers []handler `toml:"Handlers"`
-	Members  []member  `toml:"Members"`
 }
 
 type handler struct {

--- a/deployment/cre/jobs/pkg/gateway_job_test.go
+++ b/deployment/cre/jobs/pkg/gateway_job_test.go
@@ -7,14 +7,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGateway_Validate(t *testing.T) {
+func TestGateway_Validate_DONCentric(t *testing.T) {
 	t.Parallel()
 
 	g := GatewayJob{}
 	require.ErrorContains(t, g.Validate(), "must provide job name")
 
 	g.JobName = "AGatewayJob"
+	require.ErrorContains(t, g.Validate(), "must provide at least one target DON")
+}
+
+func TestGateway_Validate_ServiceCentric(t *testing.T) {
+	t.Parallel()
+
+	g := GatewayJob{UseServiceCentricFormat: true}
+	require.ErrorContains(t, g.Validate(), "must provide job name")
+
+	g.JobName = "AGatewayJob"
 	require.ErrorContains(t, g.Validate(), "must provide at least one DON")
+
+	g.DONs = []TargetDON{{ID: "don1"}}
+	require.ErrorContains(t, g.Validate(), "must provide at least one service")
 }
 
 const (
@@ -326,12 +339,13 @@ WriteTimeoutMillis = 16000
 `
 )
 
-func TestGateway_Resolve(t *testing.T) {
+func TestGateway_Resolve_ServiceCentric(t *testing.T) {
 	t.Parallel()
 
 	g := GatewayJob{
-		JobName:           "Gateway1",
-		RequestTimeoutSec: 15,
+		UseServiceCentricFormat: true,
+		JobName:                 "Gateway1",
+		RequestTimeoutSec:       15,
 		DONs: []TargetDON{
 			{
 				ID: "workflow_1",
@@ -367,12 +381,13 @@ func TestGateway_Resolve(t *testing.T) {
 	assert.Equal(t, expected, spec)
 }
 
-func TestGateway_Resolve_WithVaultHandler(t *testing.T) {
+func TestGateway_Resolve_WithVaultHandler_ServiceCentric(t *testing.T) {
 	t.Parallel()
 
 	g := GatewayJob{
-		JobName:           "Gateway1",
-		RequestTimeoutSec: 15,
+		UseServiceCentricFormat: true,
+		JobName:                 "Gateway1",
+		RequestTimeoutSec:       15,
 		DONs: []TargetDON{
 			{
 				ID: "workflow_1",
@@ -413,12 +428,13 @@ func TestGateway_Resolve_WithVaultHandler(t *testing.T) {
 	assert.Equal(t, expectedWithVault, spec)
 }
 
-func TestGateway_Resolve_WithHTTPCapabilitiesHandler(t *testing.T) {
+func TestGateway_Resolve_WithHTTPCapabilitiesHandler_ServiceCentric(t *testing.T) {
 	t.Parallel()
 
 	g := GatewayJob{
-		JobName:           "Gateway1",
-		RequestTimeoutSec: 15,
+		UseServiceCentricFormat: true,
+		JobName:                 "Gateway1",
+		RequestTimeoutSec:       15,
 		DONs: []TargetDON{
 			{
 				ID: "workflow_1",
@@ -453,4 +469,144 @@ func TestGateway_Resolve_WithHTTPCapabilitiesHandler(t *testing.T) {
 	spec, err := g.Resolve(1)
 	require.NoError(t, err)
 	assert.Equal(t, expectedWithHTTPCapabilities, spec)
+}
+
+const (
+	expectedDONCentric = `type = 'gateway'
+schemaVersion = 1
+name = 'Gateway1'
+externalJobID = '4657f08a-e8cd-526f-9c13-66bbef7e4e03'
+forwardingAllowed = false
+
+[gatewayConfig]
+[gatewayConfig.ConnectionManagerConfig]
+AuthChallengeLen = 10
+AuthGatewayId = 'gateway-node-1'
+AuthTimestampToleranceSec = 5
+HeartbeatIntervalSec = 20
+
+[[gatewayConfig.Dons]]
+DonId = 'workflow_1'
+F = 1
+
+[[gatewayConfig.Dons.Handlers]]
+Name = 'web-api-capabilities'
+
+[gatewayConfig.Dons.Handlers.Config]
+maxAllowedMessageAgeSec = 1000
+
+[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]
+globalBurst = 10
+globalRPS = 50
+perSenderBurst = 10
+perSenderRPS = 10
+
+[[gatewayConfig.Dons.Members]]
+Address = '0xabc'
+Name = 'Node 1'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0xdef'
+Name = 'Node 2'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0xghi'
+Name = 'Node 3'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0xjkl'
+Name = 'Node 4'
+
+[[gatewayConfig.Dons]]
+DonId = 'workflow_2'
+F = 0
+
+[[gatewayConfig.Dons.Handlers]]
+Name = 'web-api-capabilities'
+
+[gatewayConfig.Dons.Handlers.Config]
+maxAllowedMessageAgeSec = 1000
+
+[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]
+globalBurst = 10
+globalRPS = 50
+perSenderBurst = 10
+perSenderRPS = 10
+
+[[gatewayConfig.Dons.Members]]
+Address = '0x2abc'
+Name = 'Node 1'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0x2def'
+Name = 'Node 2'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0x2ghi'
+Name = 'Node 3'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0x2jkl'
+Name = 'Node 4'
+
+[gatewayConfig.HTTPClientConfig]
+MaxResponseBytes = 50000000
+AllowedPorts = [443]
+AllowedSchemes = ['https']
+AllowedIPsCIDR = []
+
+[gatewayConfig.NodeServerConfig]
+HandshakeTimeoutMillis = 1000
+MaxRequestBytes = 100000
+Path = '/'
+Port = 5003
+ReadTimeoutMillis = 1000
+RequestTimeoutMillis = 15000
+WriteTimeoutMillis = 1000
+
+[gatewayConfig.UserServerConfig]
+ContentTypeHeader = 'application/jsonrpc'
+MaxRequestBytes = 100000
+Path = '/'
+Port = 5002
+ReadTimeoutMillis = 15000
+RequestTimeoutMillis = 15000
+WriteTimeoutMillis = 16000
+`
+)
+
+func TestGateway_Resolve_DONCentric(t *testing.T) {
+	t.Parallel()
+
+	g := GatewayJob{
+		JobName:           "Gateway1",
+		RequestTimeoutSec: 15,
+		TargetDONs: []TargetDON{
+			{
+				ID:       "workflow_1",
+				F:        1,
+				Handlers: []string{GatewayHandlerTypeWebAPICapabilities},
+				Members: []TargetDONMember{
+					{Address: "0xabc", Name: "Node 1"},
+					{Address: "0xdef", Name: "Node 2"},
+					{Address: "0xghi", Name: "Node 3"},
+					{Address: "0xjkl", Name: "Node 4"},
+				},
+			},
+			{
+				ID:       "workflow_2",
+				Handlers: []string{GatewayHandlerTypeWebAPICapabilities},
+				Members: []TargetDONMember{
+					{Address: "0x2abc", Name: "Node 1"},
+					{Address: "0x2def", Name: "Node 2"},
+					{Address: "0x2ghi", Name: "Node 3"},
+					{Address: "0x2jkl", Name: "Node 4"},
+				},
+			},
+		},
+	}
+
+	spec, err := g.Resolve(1)
+	require.NoError(t, err)
+	assert.Equal(t, expectedDONCentric, spec)
 }

--- a/deployment/cre/jobs/pkg/gateway_job_test.go
+++ b/deployment/cre/jobs/pkg/gateway_job_test.go
@@ -20,7 +20,7 @@ func TestGateway_Validate_DONCentric(t *testing.T) {
 func TestGateway_Validate_ServiceCentric(t *testing.T) {
 	t.Parallel()
 
-	g := GatewayJob{UseServiceCentricFormat: true}
+	g := GatewayJob{ServiceCentricFormatEnabled: true}
 	require.ErrorContains(t, g.Validate(), "must provide job name")
 
 	g.JobName = "AGatewayJob"
@@ -343,9 +343,9 @@ func TestGateway_Resolve_ServiceCentric(t *testing.T) {
 	t.Parallel()
 
 	g := GatewayJob{
-		UseServiceCentricFormat: true,
-		JobName:                 "Gateway1",
-		RequestTimeoutSec:       15,
+		ServiceCentricFormatEnabled: true,
+		JobName:                     "Gateway1",
+		RequestTimeoutSec:           15,
 		DONs: []TargetDON{
 			{
 				ID: "workflow_1",
@@ -385,9 +385,9 @@ func TestGateway_Resolve_WithVaultHandler_ServiceCentric(t *testing.T) {
 	t.Parallel()
 
 	g := GatewayJob{
-		UseServiceCentricFormat: true,
-		JobName:                 "Gateway1",
-		RequestTimeoutSec:       15,
+		ServiceCentricFormatEnabled: true,
+		JobName:                     "Gateway1",
+		RequestTimeoutSec:           15,
 		DONs: []TargetDON{
 			{
 				ID: "workflow_1",
@@ -432,9 +432,9 @@ func TestGateway_Resolve_WithHTTPCapabilitiesHandler_ServiceCentric(t *testing.T
 	t.Parallel()
 
 	g := GatewayJob{
-		UseServiceCentricFormat: true,
-		JobName:                 "Gateway1",
-		RequestTimeoutSec:       15,
+		ServiceCentricFormatEnabled: true,
+		JobName:                     "Gateway1",
+		RequestTimeoutSec:           15,
 		DONs: []TargetDON{
 			{
 				ID: "workflow_1",

--- a/deployment/cre/jobs/pkg/gateway_job_test.go
+++ b/deployment/cre/jobs/pkg/gateway_job_test.go
@@ -1,7 +1,6 @@
 package pkg
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +14,7 @@ func TestGateway_Validate(t *testing.T) {
 	require.ErrorContains(t, g.Validate(), "must provide job name")
 
 	g.JobName = "AGatewayJob"
-	require.ErrorContains(t, g.Validate(), "must provide at least one target DON")
+	require.ErrorContains(t, g.Validate(), "must provide at least one DON")
 }
 
 const (
@@ -32,69 +31,63 @@ AuthGatewayId = 'gateway-node-1'
 AuthTimestampToleranceSec = 5
 HeartbeatIntervalSec = 20
 
-[[gatewayConfig.Dons]]
-DonId = 'workflow_1'
+[[gatewayConfig.ShardedDONs]]
+DonName = 'workflow_1'
 F = 1
 
-[[gatewayConfig.Dons.Handlers]]
-Name = 'web-api-capabilities'
-
-[gatewayConfig.Dons.Handlers.Config]
-maxAllowedMessageAgeSec = 1000
-
-[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]
-globalBurst = 10
-globalRPS = 50
-perSenderBurst = 10
-perSenderRPS = 10
-
-[[gatewayConfig.Dons.Members]]
+[[gatewayConfig.ShardedDONs.Shards]]
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
 Address = '0xabc'
 Name = 'Node 1'
 
-[[gatewayConfig.Dons.Members]]
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
 Address = '0xdef'
 Name = 'Node 2'
 
-[[gatewayConfig.Dons.Members]]
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
 Address = '0xghi'
 Name = 'Node 3'
 
-[[gatewayConfig.Dons.Members]]
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
 Address = '0xjkl'
 Name = 'Node 4'
 
-[[gatewayConfig.Dons]]
-DonId = 'workflow_2'
+[[gatewayConfig.ShardedDONs]]
+DonName = 'workflow_2'
 F = 0
 
-[[gatewayConfig.Dons.Handlers]]
+[[gatewayConfig.ShardedDONs.Shards]]
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
+Address = '0x2abc'
+Name = 'Node 1'
+
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
+Address = '0x2def'
+Name = 'Node 2'
+
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
+Address = '0x2ghi'
+Name = 'Node 3'
+
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
+Address = '0x2jkl'
+Name = 'Node 4'
+
+[[gatewayConfig.Services]]
+ServiceName = 'workflows'
+DONs = ['workflow_1', 'workflow_2']
+
+[[gatewayConfig.Services.Handlers]]
 Name = 'web-api-capabilities'
 
-[gatewayConfig.Dons.Handlers.Config]
+[gatewayConfig.Services.Handlers.Config]
 maxAllowedMessageAgeSec = 1000
 
-[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]
+[gatewayConfig.Services.Handlers.Config.NodeRateLimiter]
 globalBurst = 10
 globalRPS = 50
 perSenderBurst = 10
 perSenderRPS = 10
-
-[[gatewayConfig.Dons.Members]]
-Address = '0x2abc'
-Name = 'Node 1'
-
-[[gatewayConfig.Dons.Members]]
-Address = '0x2def'
-Name = 'Node 2'
-
-[[gatewayConfig.Dons.Members]]
-Address = '0x2ghi'
-Name = 'Node 3'
-
-[[gatewayConfig.Dons.Members]]
-Address = '0x2jkl'
-Name = 'Node 4'
 
 [gatewayConfig.HTTPClientConfig]
 MaxResponseBytes = 50000000
@@ -134,82 +127,80 @@ AuthGatewayId = 'gateway-node-1'
 AuthTimestampToleranceSec = 5
 HeartbeatIntervalSec = 20
 
-[[gatewayConfig.Dons]]
-DonId = 'workflow_1'
+[[gatewayConfig.ShardedDONs]]
+DonName = 'workflow_1'
 F = 1
 
-[[gatewayConfig.Dons.Handlers]]
-Name = 'web-api-capabilities'
-
-[gatewayConfig.Dons.Handlers.Config]
-maxAllowedMessageAgeSec = 1000
-
-[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]
-globalBurst = 10
-globalRPS = 50
-perSenderBurst = 10
-perSenderRPS = 10
-
-[[gatewayConfig.Dons.Handlers]]
-Name = 'vault'
-ServiceName = 'vault'
-
-[gatewayConfig.Dons.Handlers.Config]
-requestTimeoutSec = 14
-
-[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]
-globalBurst = 10
-globalRPS = 50
-perSenderBurst = 10
-perSenderRPS = 10
-
-[[gatewayConfig.Dons.Members]]
+[[gatewayConfig.ShardedDONs.Shards]]
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
 Address = '0xabc'
 Name = 'Node 1'
 
-[[gatewayConfig.Dons.Members]]
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
 Address = '0xdef'
 Name = 'Node 2'
 
-[[gatewayConfig.Dons.Members]]
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
 Address = '0xghi'
 Name = 'Node 3'
 
-[[gatewayConfig.Dons.Members]]
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
 Address = '0xjkl'
 Name = 'Node 4'
 
-[[gatewayConfig.Dons]]
-DonId = 'workflow_2'
+[[gatewayConfig.ShardedDONs]]
+DonName = 'workflow_2'
 F = 0
 
-[[gatewayConfig.Dons.Handlers]]
+[[gatewayConfig.ShardedDONs.Shards]]
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
+Address = '0x2abc'
+Name = 'Node 1'
+
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
+Address = '0x2def'
+Name = 'Node 2'
+
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
+Address = '0x2ghi'
+Name = 'Node 3'
+
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
+Address = '0x2jkl'
+Name = 'Node 4'
+
+[[gatewayConfig.Services]]
+ServiceName = 'workflows'
+DONs = ['workflow_1', 'workflow_2']
+
+[[gatewayConfig.Services.Handlers]]
 Name = 'web-api-capabilities'
 
-[gatewayConfig.Dons.Handlers.Config]
+[gatewayConfig.Services.Handlers.Config]
 maxAllowedMessageAgeSec = 1000
 
-[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]
+[gatewayConfig.Services.Handlers.Config.NodeRateLimiter]
 globalBurst = 10
 globalRPS = 50
 perSenderBurst = 10
 perSenderRPS = 10
 
-[[gatewayConfig.Dons.Members]]
-Address = '0x2abc'
-Name = 'Node 1'
+[[gatewayConfig.Services]]
+ServiceName = 'vault'
+DONs = ['workflow_1']
 
-[[gatewayConfig.Dons.Members]]
-Address = '0x2def'
-Name = 'Node 2'
+[[gatewayConfig.Services.Handlers]]
+Name = 'vault'
+ServiceName = 'vault'
 
-[[gatewayConfig.Dons.Members]]
-Address = '0x2ghi'
-Name = 'Node 3'
+[gatewayConfig.Services.Handlers.Config]
+requestTimeoutSec = 14
 
-[[gatewayConfig.Dons.Members]]
-Address = '0x2jkl'
-Name = 'Node 4'
+[gatewayConfig.Services.Handlers.Config.NodeRateLimiter]
+globalBurst = 10
+globalRPS = 50
+perSenderBurst = 10
+perSenderRPS = 10
 
 [gatewayConfig.HTTPClientConfig]
 MaxResponseBytes = 50000000
@@ -249,55 +240,65 @@ AuthGatewayId = 'gateway-node-1'
 AuthTimestampToleranceSec = 5
 HeartbeatIntervalSec = 20
 
-[[gatewayConfig.Dons]]
-DonId = 'workflow_1'
+[[gatewayConfig.ShardedDONs]]
+DonName = 'workflow_1'
 F = 3
 
-[[gatewayConfig.Dons.Handlers]]
+[[gatewayConfig.ShardedDONs.Shards]]
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
+Address = '0xabc'
+Name = 'Node 1'
+
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
+Address = '0xdef'
+Name = 'Node 2'
+
+[[gatewayConfig.ShardedDONs]]
+DonName = 'workflow_2'
+F = 0
+
+[[gatewayConfig.ShardedDONs.Shards]]
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
+Address = '0xghi'
+Name = 'Node 3'
+
+[[gatewayConfig.ShardedDONs.Shards.Nodes]]
+Address = '0xjkl'
+Name = 'Node 4'
+
+[[gatewayConfig.Services]]
+ServiceName = 'workflows'
+DONs = ['workflow_1']
+
+[[gatewayConfig.Services.Handlers]]
 Name = 'http-capabilities'
 ServiceName = 'workflows'
 
-[gatewayConfig.Dons.Handlers.Config]
+[gatewayConfig.Services.Handlers.Config]
 CleanUpPeriodMs = 600000
 
-[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]
+[gatewayConfig.Services.Handlers.Config.NodeRateLimiter]
 globalBurst = 100
 globalRPS = 500
 perSenderBurst = 100
 perSenderRPS = 100
 
-[[gatewayConfig.Dons.Members]]
-Address = '0xabc'
-Name = 'Node 1'
+[[gatewayConfig.Services]]
+ServiceName = 'vault'
+DONs = ['workflow_2']
 
-[[gatewayConfig.Dons.Members]]
-Address = '0xdef'
-Name = 'Node 2'
-
-[[gatewayConfig.Dons]]
-DonId = 'workflow_2'
-F = 0
-
-[[gatewayConfig.Dons.Handlers]]
+[[gatewayConfig.Services.Handlers]]
 Name = 'vault'
 ServiceName = 'vault'
 
-[gatewayConfig.Dons.Handlers.Config]
+[gatewayConfig.Services.Handlers.Config]
 requestTimeoutSec = 14
 
-[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]
+[gatewayConfig.Services.Handlers.Config.NodeRateLimiter]
 globalBurst = 10
 globalRPS = 50
 perSenderBurst = 10
 perSenderRPS = 10
-
-[[gatewayConfig.Dons.Members]]
-Address = '0xghi'
-Name = 'Node 3'
-
-[[gatewayConfig.Dons.Members]]
-Address = '0xjkl'
-Name = 'Node 4'
 
 [gatewayConfig.HTTPClientConfig]
 MaxResponseBytes = 50000000
@@ -331,51 +332,32 @@ func TestGateway_Resolve(t *testing.T) {
 	g := GatewayJob{
 		JobName:           "Gateway1",
 		RequestTimeoutSec: 15,
-		TargetDONs: []TargetDON{
+		DONs: []TargetDON{
 			{
-				ID:       "workflow_1",
-				F:        1,
-				Handlers: []string{GatewayHandlerTypeWebAPICapabilities},
+				ID: "workflow_1",
+				F:  1,
 				Members: []TargetDONMember{
-					{
-						Address: "0xabc",
-						Name:    "Node 1",
-					},
-					{
-						Address: "0xdef",
-						Name:    "Node 2",
-					},
-					{
-						Address: "0xghi",
-						Name:    "Node 3",
-					},
-					{
-						Address: "0xjkl",
-						Name:    "Node 4",
-					},
+					{Address: "0xabc", Name: "Node 1"},
+					{Address: "0xdef", Name: "Node 2"},
+					{Address: "0xghi", Name: "Node 3"},
+					{Address: "0xjkl", Name: "Node 4"},
 				},
 			},
 			{
-				ID:       "workflow_2",
-				Handlers: []string{GatewayHandlerTypeWebAPICapabilities},
+				ID: "workflow_2",
 				Members: []TargetDONMember{
-					{
-						Address: "0x2abc",
-						Name:    "Node 1",
-					},
-					{
-						Address: "0x2def",
-						Name:    "Node 2",
-					},
-					{
-						Address: "0x2ghi",
-						Name:    "Node 3",
-					},
-					{
-						Address: "0x2jkl",
-						Name:    "Node 4",
-					},
+					{Address: "0x2abc", Name: "Node 1"},
+					{Address: "0x2def", Name: "Node 2"},
+					{Address: "0x2ghi", Name: "Node 3"},
+					{Address: "0x2jkl", Name: "Node 4"},
 				},
+			},
+		},
+		Services: []GatewayServiceConfig{
+			{
+				ServiceName: ServiceNameWorkflows,
+				Handlers:    []string{GatewayHandlerTypeWebAPICapabilities},
+				DONs:        []string{"workflow_1", "workflow_2"},
 			},
 		},
 	}
@@ -391,58 +373,42 @@ func TestGateway_Resolve_WithVaultHandler(t *testing.T) {
 	g := GatewayJob{
 		JobName:           "Gateway1",
 		RequestTimeoutSec: 15,
-		TargetDONs: []TargetDON{
+		DONs: []TargetDON{
 			{
-				ID:       "workflow_1",
-				F:        1,
-				Handlers: []string{GatewayHandlerTypeWebAPICapabilities, GatewayHandlerTypeVault},
+				ID: "workflow_1",
+				F:  1,
 				Members: []TargetDONMember{
-					{
-						Address: "0xabc",
-						Name:    "Node 1",
-					},
-					{
-						Address: "0xdef",
-						Name:    "Node 2",
-					},
-					{
-						Address: "0xghi",
-						Name:    "Node 3",
-					},
-					{
-						Address: "0xjkl",
-						Name:    "Node 4",
-					},
+					{Address: "0xabc", Name: "Node 1"},
+					{Address: "0xdef", Name: "Node 2"},
+					{Address: "0xghi", Name: "Node 3"},
+					{Address: "0xjkl", Name: "Node 4"},
 				},
 			},
 			{
 				ID: "workflow_2",
-
-				Handlers: []string{GatewayHandlerTypeWebAPICapabilities},
 				Members: []TargetDONMember{
-					{
-						Address: "0x2abc",
-						Name:    "Node 1",
-					},
-					{
-						Address: "0x2def",
-						Name:    "Node 2",
-					},
-					{
-						Address: "0x2ghi",
-						Name:    "Node 3",
-					},
-					{
-						Address: "0x2jkl",
-						Name:    "Node 4",
-					},
+					{Address: "0x2abc", Name: "Node 1"},
+					{Address: "0x2def", Name: "Node 2"},
+					{Address: "0x2ghi", Name: "Node 3"},
+					{Address: "0x2jkl", Name: "Node 4"},
 				},
+			},
+		},
+		Services: []GatewayServiceConfig{
+			{
+				ServiceName: ServiceNameWorkflows,
+				Handlers:    []string{GatewayHandlerTypeWebAPICapabilities},
+				DONs:        []string{"workflow_1", "workflow_2"},
+			},
+			{
+				ServiceName: ServiceNameVault,
+				Handlers:    []string{GatewayHandlerTypeVault},
+				DONs:        []string{"workflow_1"},
 			},
 		},
 	}
 
 	spec, err := g.Resolve(1)
-	fmt.Println(spec)
 	require.NoError(t, err)
 	assert.Equal(t, expectedWithVault, spec)
 }
@@ -453,36 +419,33 @@ func TestGateway_Resolve_WithHTTPCapabilitiesHandler(t *testing.T) {
 	g := GatewayJob{
 		JobName:           "Gateway1",
 		RequestTimeoutSec: 15,
-		TargetDONs: []TargetDON{
+		DONs: []TargetDON{
 			{
-				ID:       "workflow_1",
-				F:        3,
-				Handlers: []string{GatewayHandlerTypeHTTPCapabilities},
+				ID: "workflow_1",
+				F:  3,
 				Members: []TargetDONMember{
-					{
-						Address: "0xabc",
-						Name:    "Node 1",
-					},
-					{
-						Address: "0xdef",
-						Name:    "Node 2",
-					},
+					{Address: "0xabc", Name: "Node 1"},
+					{Address: "0xdef", Name: "Node 2"},
 				},
 			},
 			{
-				ID:       "workflow_2",
-				F:        0,
-				Handlers: []string{GatewayHandlerTypeVault},
+				ID: "workflow_2",
 				Members: []TargetDONMember{
-					{
-						Address: "0xghi",
-						Name:    "Node 3",
-					},
-					{
-						Address: "0xjkl",
-						Name:    "Node 4",
-					},
+					{Address: "0xghi", Name: "Node 3"},
+					{Address: "0xjkl", Name: "Node 4"},
 				},
+			},
+		},
+		Services: []GatewayServiceConfig{
+			{
+				ServiceName: ServiceNameWorkflows,
+				Handlers:    []string{GatewayHandlerTypeHTTPCapabilities},
+				DONs:        []string{"workflow_1"},
+			},
+			{
+				ServiceName: ServiceNameVault,
+				Handlers:    []string{GatewayHandlerTypeVault},
+				DONs:        []string{"workflow_2"},
 			},
 		},
 	}

--- a/system-tests/lib/cre/don/gateway/gateway.go
+++ b/system-tests/lib/cre/don/gateway/gateway.go
@@ -23,13 +23,7 @@ type WhitelistConfig struct {
 	ExtraAllowedIPsCIDR []string
 }
 
-type JobConfig struct {
-	UseServiceCentricFormat bool
-	GatewayConfigs          []cre.GatewayConfig
-	GatewayServiceConfigs   []cre.GatewayServiceConfig
-}
-
-func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, gwJobConfig JobConfig, whitelistConfig WhitelistConfig) error {
+func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, gatewayServiceConfigs []cre.GatewayServiceConfig, whitelistConfig WhitelistConfig) error {
 	specs := make(map[string][]string)
 
 	if !dons.RequiresGateway() {
@@ -42,20 +36,6 @@ func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, gw
 			return fmt.Errorf("could not find gateway node with UUID %s in DON topology", config.NodeUUID)
 		}
 
-		inputs := job_types.JobSpecInput{
-			"useServiceCentricFormat": gwJobConfig.UseServiceCentricFormat,
-			"allowedPorts":            append(whitelistConfig.ExtraAllowedPorts, DefaultAllowedPorts...),
-			"allowedSchemes":          []string{"http", "https"},
-			"allowedIPsCIDR":          whitelistConfig.ExtraAllowedIPsCIDR,
-			"gatewayKeyChainSelector": creEnv.RegistryChainSelector,
-			"authGatewayID":           config.AuthGatewayID,
-		}
-		if gwJobConfig.UseServiceCentricFormat {
-			inputs["services"] = gwJobConfig.GatewayServiceConfigs
-		} else {
-			inputs["dons"] = gwJobConfig.GatewayConfigs
-		}
-
 		workerInput := cre_jobs.ProposeJobSpecInput{
 			Domain:      offchain.ProductLabel,
 			Environment: cre.EnvironmentName,
@@ -65,7 +45,15 @@ func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, gw
 				{Key: offchain.FilterKeyDONName, Value: gatewayNode.DON.Name},
 			},
 			Template: job_types.Gateway,
-			Inputs:   inputs,
+			Inputs: job_types.JobSpecInput{
+				"allowedPorts":            append(whitelistConfig.ExtraAllowedPorts, DefaultAllowedPorts...),
+				"allowedSchemes":          []string{"http", "https"},
+				"allowedIPsCIDR":          whitelistConfig.ExtraAllowedIPsCIDR,
+				"gatewayKeyChainSelector": creEnv.RegistryChainSelector,
+				"authGatewayID":           config.AuthGatewayID,
+				"useServiceCentricFormat": true,
+				"services":                gatewayServiceConfigs,
+			},
 		}
 
 		workerVerErr := cre_jobs.ProposeJobSpec{}.VerifyPreconditions(*creEnv.CldfEnvironment, workerInput)

--- a/system-tests/lib/cre/don/gateway/gateway.go
+++ b/system-tests/lib/cre/don/gateway/gateway.go
@@ -46,13 +46,13 @@ func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, ga
 			},
 			Template: job_types.Gateway,
 			Inputs: job_types.JobSpecInput{
-				"allowedPorts":            append(whitelistConfig.ExtraAllowedPorts, DefaultAllowedPorts...),
-				"allowedSchemes":          []string{"http", "https"},
-				"allowedIPsCIDR":          whitelistConfig.ExtraAllowedIPsCIDR,
-				"gatewayKeyChainSelector": creEnv.RegistryChainSelector,
-				"authGatewayID":           config.AuthGatewayID,
-				"useServiceCentricFormat": true,
-				"services":                gatewayServiceConfigs,
+				"allowedPorts":                append(whitelistConfig.ExtraAllowedPorts, DefaultAllowedPorts...),
+				"allowedSchemes":              []string{"http", "https"},
+				"allowedIPsCIDR":              whitelistConfig.ExtraAllowedIPsCIDR,
+				"gatewayKeyChainSelector":     creEnv.RegistryChainSelector,
+				"authGatewayID":               config.AuthGatewayID,
+				"serviceCentricFormatEnabled": true,
+				"services":                    gatewayServiceConfigs,
 			},
 		}
 

--- a/system-tests/lib/cre/don/gateway/gateway.go
+++ b/system-tests/lib/cre/don/gateway/gateway.go
@@ -23,7 +23,7 @@ type WhitelistConfig struct {
 	ExtraAllowedIPsCIDR []string
 }
 
-func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, gatewayConfigs []cre.GatewayConfig, whitelistConfig WhitelistConfig) error {
+func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, gatewayServiceConfigs []cre.GatewayServiceConfig, whitelistConfig WhitelistConfig) error {
 	specs := make(map[string][]string)
 
 	if !dons.RequiresGateway() {
@@ -46,7 +46,7 @@ func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, ga
 			},
 			Template: job_types.Gateway,
 			Inputs: job_types.JobSpecInput{
-				"dons":                    gatewayConfigs,
+				"services":                gatewayServiceConfigs,
 				"allowedPorts":            append(whitelistConfig.ExtraAllowedPorts, DefaultAllowedPorts...),
 				"allowedSchemes":          []string{"http", "https"},
 				"allowedIPsCIDR":          whitelistConfig.ExtraAllowedIPsCIDR,

--- a/system-tests/lib/cre/don/gateway/gateway.go
+++ b/system-tests/lib/cre/don/gateway/gateway.go
@@ -23,7 +23,13 @@ type WhitelistConfig struct {
 	ExtraAllowedIPsCIDR []string
 }
 
-func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, gatewayServiceConfigs []cre.GatewayServiceConfig, whitelistConfig WhitelistConfig) error {
+type JobConfig struct {
+	UseServiceCentricFormat bool
+	GatewayConfigs          []cre.GatewayConfig
+	GatewayServiceConfigs   []cre.GatewayServiceConfig
+}
+
+func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, gwJobConfig JobConfig, whitelistConfig WhitelistConfig) error {
 	specs := make(map[string][]string)
 
 	if !dons.RequiresGateway() {
@@ -36,6 +42,20 @@ func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, ga
 			return fmt.Errorf("could not find gateway node with UUID %s in DON topology", config.NodeUUID)
 		}
 
+		inputs := job_types.JobSpecInput{
+			"useServiceCentricFormat": gwJobConfig.UseServiceCentricFormat,
+			"allowedPorts":            append(whitelistConfig.ExtraAllowedPorts, DefaultAllowedPorts...),
+			"allowedSchemes":          []string{"http", "https"},
+			"allowedIPsCIDR":          whitelistConfig.ExtraAllowedIPsCIDR,
+			"gatewayKeyChainSelector": creEnv.RegistryChainSelector,
+			"authGatewayID":           config.AuthGatewayID,
+		}
+		if gwJobConfig.UseServiceCentricFormat {
+			inputs["services"] = gwJobConfig.GatewayServiceConfigs
+		} else {
+			inputs["dons"] = gwJobConfig.GatewayConfigs
+		}
+
 		workerInput := cre_jobs.ProposeJobSpecInput{
 			Domain:      offchain.ProductLabel,
 			Environment: cre.EnvironmentName,
@@ -45,14 +65,7 @@ func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, ga
 				{Key: offchain.FilterKeyDONName, Value: gatewayNode.DON.Name},
 			},
 			Template: job_types.Gateway,
-			Inputs: job_types.JobSpecInput{
-				"services":                gatewayServiceConfigs,
-				"allowedPorts":            append(whitelistConfig.ExtraAllowedPorts, DefaultAllowedPorts...),
-				"allowedSchemes":          []string{"http", "https"},
-				"allowedIPsCIDR":          whitelistConfig.ExtraAllowedIPsCIDR,
-				"gatewayKeyChainSelector": creEnv.RegistryChainSelector,
-				"authGatewayID":           config.AuthGatewayID,
-			},
+			Inputs:   inputs,
 		}
 
 		workerVerErr := cre_jobs.ProposeJobSpec{}.VerifyPreconditions(*creEnv.CldfEnvironment, workerInput)

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -277,7 +277,7 @@ func SetupTestEnvironment(
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.WrapAndNext("DONs and Job Distributor started and linked in %.2f seconds", input.StageGen.Elapsed().Seconds())))
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.Wrap("Creating Jobs with Job Distributor")))
 
-	gJobErr := gateway.CreateJobs(ctx, creEnvironment, dons, topology.GatewayConfigs, input.GatewayWhitelistConfig)
+	gJobErr := gateway.CreateJobs(ctx, creEnvironment, dons, topology.GatewayServiceConfigs, input.GatewayWhitelistConfig)
 	if gJobErr != nil {
 		return nil, pkgerrors.Wrap(gJobErr, "failed to create gateway jobs with Job Distributor")
 	}

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -277,11 +277,7 @@ func SetupTestEnvironment(
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.WrapAndNext("DONs and Job Distributor started and linked in %.2f seconds", input.StageGen.Elapsed().Seconds())))
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.Wrap("Creating Jobs with Job Distributor")))
 
-	gJobErr := gateway.CreateJobs(ctx, creEnvironment, dons, gateway.JobConfig{
-		UseServiceCentricFormat: topology.UseServiceCentricFormat,
-		GatewayConfigs:          topology.GatewayConfigs,
-		GatewayServiceConfigs:   topology.GatewayServiceConfigs,
-	}, input.GatewayWhitelistConfig)
+	gJobErr := gateway.CreateJobs(ctx, creEnvironment, dons, topology.GatewayServiceConfigs, input.GatewayWhitelistConfig)
 	if gJobErr != nil {
 		return nil, pkgerrors.Wrap(gJobErr, "failed to create gateway jobs with Job Distributor")
 	}

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -277,7 +277,11 @@ func SetupTestEnvironment(
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.WrapAndNext("DONs and Job Distributor started and linked in %.2f seconds", input.StageGen.Elapsed().Seconds())))
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.Wrap("Creating Jobs with Job Distributor")))
 
-	gJobErr := gateway.CreateJobs(ctx, creEnvironment, dons, topology.GatewayServiceConfigs, input.GatewayWhitelistConfig)
+	gJobErr := gateway.CreateJobs(ctx, creEnvironment, dons, gateway.JobConfig{
+		UseServiceCentricFormat: topology.UseServiceCentricFormat,
+		GatewayConfigs:          topology.GatewayConfigs,
+		GatewayServiceConfigs:   topology.GatewayServiceConfigs,
+	}, input.GatewayWhitelistConfig)
 	if gJobErr != nil {
 		return nil, pkgerrors.Wrap(gJobErr, "failed to create gateway jobs with Job Distributor")
 	}

--- a/system-tests/lib/cre/topology.go
+++ b/system-tests/lib/cre/topology.go
@@ -18,10 +18,12 @@ const (
 )
 
 type Topology struct {
-	WorkflowDONIDs        []uint64               `toml:"workflow_don_ids" json:"workflow_don_ids"`
-	DonsMetadata          *DonsMetadata          `toml:"dons_metadata" json:"dons_metadata"`
-	GatewayServiceConfigs []GatewayServiceConfig `toml:"gateway_service_configs" json:"gateway_service_configs"`
-	GatewayConnectors     *GatewayConnectors     `toml:"gateway_connectors" json:"gateway_connectors"`
+	UseServiceCentricFormat bool                   `toml:"use_service_centric_format" json:"use_service_centric_format"`
+	WorkflowDONIDs          []uint64               `toml:"workflow_don_ids" json:"workflow_don_ids"`
+	DonsMetadata            *DonsMetadata          `toml:"dons_metadata" json:"dons_metadata"`
+	GatewayConfigs          []GatewayConfig        `toml:"gateway_configs" json:"gateway_configs"`
+	GatewayServiceConfigs   []GatewayServiceConfig `toml:"gateway_service_configs" json:"gateway_service_configs"`
+	GatewayConnectors       *GatewayConnectors     `toml:"gateway_connectors" json:"gateway_connectors"`
 }
 
 func NewTopology(nodeSet []*NodeSet, provider infra.Provider, capabilityConfigs map[CapabilityFlag]CapabilityConfig) (*Topology, error) {
@@ -47,14 +49,19 @@ func NewTopology(nodeSet []*NodeSet, provider infra.Provider, capabilityConfigs 
 	}
 
 	topology := &Topology{
-		WorkflowDONIDs: []uint64{},
-		DonsMetadata:   donsMetadata,
+		UseServiceCentricFormat: true, // default to true in all tests and Local CRE
+		WorkflowDONIDs:          []uint64{},
+		DonsMetadata:            donsMetadata,
 	}
 
 	donNames := make([]string, 0, len(wfDONs))
 	for _, wfDON := range wfDONs {
 		donNames = append(donNames, wfDON.Name)
 		topology.WorkflowDONIDs = append(topology.WorkflowDONIDs, wfDON.ID)
+		topology.GatewayConfigs = append(topology.GatewayConfigs, GatewayConfig{
+			Name:     wfDON.Name,
+			Handlers: []string{pkg.GatewayHandlerTypeWebAPICapabilities},
+		})
 	}
 
 	topology.GatewayServiceConfigs = append(topology.GatewayServiceConfigs, GatewayServiceConfig{
@@ -123,10 +130,44 @@ func (t *Topology) Bootstrap() (*NodeMetadata, bool) {
 	return t.DonsMetadata.Bootstrap()
 }
 
-// AddGatewayHandlers adds the given handler names to the appropriate service configs for the given DON.
-// Handlers are grouped by service name (derived from handler type). If a service doesn't exist yet, it is created.
-// The DON is added to each service's DON list if not already present.
+// AddGatewayHandlers adds the given handler names for the given DON.
+// It updates both the legacy, don-centric GatewayConfigs and the service-centric GatewayServiceConfigs
+// so that consumers can use whichever format is active.
 func (t *Topology) AddGatewayHandlers(donMetadata DonMetadata, handlers []string) error {
+	t.addGatewayHandlersLegacy(donMetadata, handlers)
+	t.addGatewayHandlersServiceFormat(donMetadata, handlers)
+	return nil
+}
+
+func (t *Topology) addGatewayHandlersLegacy(donMetadata DonMetadata, handlers []string) {
+	donFound := false
+	for idx, gc := range t.GatewayConfigs {
+		if gc.Name == donMetadata.Name {
+			donFound = true
+			for _, handlerName := range handlers {
+				alreadyPresent := false
+				for _, existingHandler := range gc.Handlers {
+					if strings.EqualFold(existingHandler, handlerName) {
+						alreadyPresent = true
+						break
+					}
+				}
+				if !alreadyPresent {
+					t.GatewayConfigs[idx].Handlers = append(t.GatewayConfigs[idx].Handlers, handlerName)
+				}
+			}
+			break
+		}
+	}
+	if !donFound {
+		t.GatewayConfigs = append(t.GatewayConfigs, GatewayConfig{
+			Name:     donMetadata.Name,
+			Handlers: handlers,
+		})
+	}
+}
+
+func (t *Topology) addGatewayHandlersServiceFormat(donMetadata DonMetadata, handlers []string) {
 	for _, handlerName := range handlers {
 		svcName := pkg.HandlerServiceName(handlerName)
 
@@ -157,8 +198,6 @@ func (t *Topology) AddGatewayHandlers(donMetadata DonMetadata, handlers []string
 			t.GatewayServiceConfigs[svcIdx].DONs = append(t.GatewayServiceConfigs[svcIdx].DONs, donMetadata.Name)
 		}
 	}
-
-	return nil
 }
 
 type PeeringNode interface {

--- a/system-tests/lib/cre/topology.go
+++ b/system-tests/lib/cre/topology.go
@@ -18,12 +18,10 @@ const (
 )
 
 type Topology struct {
-	UseServiceCentricFormat bool                   `toml:"use_service_centric_format" json:"use_service_centric_format"`
-	WorkflowDONIDs          []uint64               `toml:"workflow_don_ids" json:"workflow_don_ids"`
-	DonsMetadata            *DonsMetadata          `toml:"dons_metadata" json:"dons_metadata"`
-	GatewayConfigs          []GatewayConfig        `toml:"gateway_configs" json:"gateway_configs"`
-	GatewayServiceConfigs   []GatewayServiceConfig `toml:"gateway_service_configs" json:"gateway_service_configs"`
-	GatewayConnectors       *GatewayConnectors     `toml:"gateway_connectors" json:"gateway_connectors"`
+	WorkflowDONIDs        []uint64               `toml:"workflow_don_ids" json:"workflow_don_ids"`
+	DonsMetadata          *DonsMetadata          `toml:"dons_metadata" json:"dons_metadata"`
+	GatewayServiceConfigs []GatewayServiceConfig `toml:"gateway_service_configs" json:"gateway_service_configs"`
+	GatewayConnectors     *GatewayConnectors     `toml:"gateway_connectors" json:"gateway_connectors"`
 }
 
 func NewTopology(nodeSet []*NodeSet, provider infra.Provider, capabilityConfigs map[CapabilityFlag]CapabilityConfig) (*Topology, error) {
@@ -49,19 +47,14 @@ func NewTopology(nodeSet []*NodeSet, provider infra.Provider, capabilityConfigs 
 	}
 
 	topology := &Topology{
-		UseServiceCentricFormat: true, // default to true in all tests and Local CRE
-		WorkflowDONIDs:          []uint64{},
-		DonsMetadata:            donsMetadata,
+		WorkflowDONIDs: []uint64{},
+		DonsMetadata:   donsMetadata,
 	}
 
 	donNames := make([]string, 0, len(wfDONs))
 	for _, wfDON := range wfDONs {
 		donNames = append(donNames, wfDON.Name)
 		topology.WorkflowDONIDs = append(topology.WorkflowDONIDs, wfDON.ID)
-		topology.GatewayConfigs = append(topology.GatewayConfigs, GatewayConfig{
-			Name:     wfDON.Name,
-			Handlers: []string{pkg.GatewayHandlerTypeWebAPICapabilities},
-		})
 	}
 
 	topology.GatewayServiceConfigs = append(topology.GatewayServiceConfigs, GatewayServiceConfig{
@@ -131,40 +124,10 @@ func (t *Topology) Bootstrap() (*NodeMetadata, bool) {
 }
 
 // AddGatewayHandlers adds the given handler names for the given DON.
-// It updates both the legacy, don-centric GatewayConfigs and the service-centric GatewayServiceConfigs
-// so that consumers can use whichever format is active.
+// It updates service-centric GatewayServiceConfigs.
 func (t *Topology) AddGatewayHandlers(donMetadata DonMetadata, handlers []string) error {
-	t.addGatewayHandlersLegacy(donMetadata, handlers)
 	t.addGatewayHandlersServiceFormat(donMetadata, handlers)
 	return nil
-}
-
-func (t *Topology) addGatewayHandlersLegacy(donMetadata DonMetadata, handlers []string) {
-	donFound := false
-	for idx, gc := range t.GatewayConfigs {
-		if gc.Name == donMetadata.Name {
-			donFound = true
-			for _, handlerName := range handlers {
-				alreadyPresent := false
-				for _, existingHandler := range gc.Handlers {
-					if strings.EqualFold(existingHandler, handlerName) {
-						alreadyPresent = true
-						break
-					}
-				}
-				if !alreadyPresent {
-					t.GatewayConfigs[idx].Handlers = append(t.GatewayConfigs[idx].Handlers, handlerName)
-				}
-			}
-			break
-		}
-	}
-	if !donFound {
-		t.GatewayConfigs = append(t.GatewayConfigs, GatewayConfig{
-			Name:     donMetadata.Name,
-			Handlers: handlers,
-		})
-	}
 }
 
 func (t *Topology) addGatewayHandlersServiceFormat(donMetadata DonMetadata, handlers []string) {

--- a/system-tests/lib/cre/topology.go
+++ b/system-tests/lib/cre/topology.go
@@ -2,13 +2,13 @@ package cre
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink/deployment/cre/jobs/pkg"
 	libc "github.com/smartcontractkit/chainlink/system-tests/lib/conversions"
-
 	"github.com/smartcontractkit/chainlink/system-tests/lib/infra"
 )
 
@@ -18,10 +18,10 @@ const (
 )
 
 type Topology struct {
-	WorkflowDONIDs    []uint64           `toml:"workflow_don_ids" json:"workflow_don_ids"`
-	DonsMetadata      *DonsMetadata      `toml:"dons_metadata" json:"dons_metadata"`
-	GatewayConfigs    []GatewayConfig    `toml:"gateway_configs" json:"gateway_configs"`
-	GatewayConnectors *GatewayConnectors `toml:"gateway_connectors" json:"gateway_connectors"`
+	WorkflowDONIDs        []uint64               `toml:"workflow_don_ids" json:"workflow_don_ids"`
+	DonsMetadata          *DonsMetadata          `toml:"dons_metadata" json:"dons_metadata"`
+	GatewayServiceConfigs []GatewayServiceConfig `toml:"gateway_service_configs" json:"gateway_service_configs"`
+	GatewayConnectors     *GatewayConnectors     `toml:"gateway_connectors" json:"gateway_connectors"`
 }
 
 func NewTopology(nodeSet []*NodeSet, provider infra.Provider, capabilityConfigs map[CapabilityFlag]CapabilityConfig) (*Topology, error) {
@@ -51,13 +51,17 @@ func NewTopology(nodeSet []*NodeSet, provider infra.Provider, capabilityConfigs 
 		DonsMetadata:   donsMetadata,
 	}
 
+	donNames := make([]string, 0, len(wfDONs))
 	for _, wfDON := range wfDONs {
-		topology.GatewayConfigs = append(topology.GatewayConfigs, GatewayConfig{
-			Name:     wfDON.Name,
-			Handlers: []string{pkg.GatewayHandlerTypeWebAPICapabilities},
-		})
+		donNames = append(donNames, wfDON.Name)
 		topology.WorkflowDONIDs = append(topology.WorkflowDONIDs, wfDON.ID)
 	}
+
+	topology.GatewayServiceConfigs = append(topology.GatewayServiceConfigs, GatewayServiceConfig{
+		ServiceName: pkg.ServiceNameWorkflows,
+		Handlers:    []string{pkg.GatewayHandlerTypeWebAPICapabilities},
+		DONs:        donNames,
+	})
 
 	if donsMetadata.RequiresGateway() {
 		topology.GatewayConnectors = NewGatewayConnectorOutput()
@@ -119,39 +123,39 @@ func (t *Topology) Bootstrap() (*NodeMetadata, bool) {
 	return t.DonsMetadata.Bootstrap()
 }
 
-// AddGatewayHandlers adds the given handler names to the gateway config of the given DON. It only adds handlers, if they are not already present.
-// Actual configuration for each handler is generated later during deployment.
+// AddGatewayHandlers adds the given handler names to the appropriate service configs for the given DON.
+// Handlers are grouped by service name (derived from handler type). If a service doesn't exist yet, it is created.
+// The DON is added to each service's DON list if not already present.
 func (t *Topology) AddGatewayHandlers(donMetadata DonMetadata, handlers []string) error {
-	donFound := false
+	for _, handlerName := range handlers {
+		svcName := pkg.HandlerServiceName(handlerName)
 
-	for idx, gc := range t.GatewayConfigs {
-		if gc.Name == donMetadata.Name {
-			donFound = true
-		}
-
-		if donFound {
-			for _, handlerName := range handlers {
-				alreadyPresent := false
-				for _, existingHandler := range gc.Handlers {
-					if strings.EqualFold(existingHandler, handlerName) {
-						alreadyPresent = true
-						break
-					}
-				}
-				if !alreadyPresent {
-					t.GatewayConfigs[idx].Handlers = append(t.GatewayConfigs[idx].Handlers, handlerName)
-				}
+		svcIdx := -1
+		for i, svc := range t.GatewayServiceConfigs {
+			if strings.EqualFold(svc.ServiceName, svcName) {
+				svcIdx = i
+				break
 			}
-			break
 		}
-	}
 
-	// if we did not find the DON in the gateway config, we need to add it
-	if !donFound {
-		t.GatewayConfigs = append(t.GatewayConfigs, GatewayConfig{
-			Name:     donMetadata.Name,
-			Handlers: handlers,
-		})
+		if svcIdx == -1 {
+			t.GatewayServiceConfigs = append(t.GatewayServiceConfigs, GatewayServiceConfig{
+				ServiceName: svcName,
+				Handlers:    []string{handlerName},
+				DONs:        []string{donMetadata.Name},
+			})
+			continue
+		}
+
+		if !slices.ContainsFunc(t.GatewayServiceConfigs[svcIdx].Handlers, func(h string) bool {
+			return strings.EqualFold(h, handlerName)
+		}) {
+			t.GatewayServiceConfigs[svcIdx].Handlers = append(t.GatewayServiceConfigs[svcIdx].Handlers, handlerName)
+		}
+
+		if !slices.Contains(t.GatewayServiceConfigs[svcIdx].DONs, donMetadata.Name) {
+			t.GatewayServiceConfigs[svcIdx].DONs = append(t.GatewayServiceConfigs[svcIdx].DONs, donMetadata.Name)
+		}
 	}
 
 	return nil

--- a/system-tests/lib/cre/topology.go
+++ b/system-tests/lib/cre/topology.go
@@ -126,11 +126,6 @@ func (t *Topology) Bootstrap() (*NodeMetadata, bool) {
 // AddGatewayHandlers adds the given handler names for the given DON.
 // It updates service-centric GatewayServiceConfigs.
 func (t *Topology) AddGatewayHandlers(donMetadata DonMetadata, handlers []string) error {
-	t.addGatewayHandlersServiceFormat(donMetadata, handlers)
-	return nil
-}
-
-func (t *Topology) addGatewayHandlersServiceFormat(donMetadata DonMetadata, handlers []string) {
 	for _, handlerName := range handlers {
 		svcName := pkg.HandlerServiceName(handlerName)
 
@@ -161,6 +156,8 @@ func (t *Topology) addGatewayHandlersServiceFormat(donMetadata DonMetadata, hand
 			t.GatewayServiceConfigs[svcIdx].DONs = append(t.GatewayServiceConfigs[svcIdx].DONs, donMetadata.Name)
 		}
 	}
+
+	return nil
 }
 
 type PeeringNode interface {

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -416,7 +416,13 @@ func (c *ConfigureCapabilityRegistryInput) Validate() error {
 	return nil
 }
 
-// GatewayServiceConfig represents a service in the new multi-DON gateway format.
+// GatewayConfig is the legacy, don-centric gateway config format.
+type GatewayConfig struct {
+	Name     string // DON name
+	Handlers []string
+}
+
+// GatewayServiceConfig represents a service in the new, service-centric gateway format.
 // Each service groups handlers and references the DON names it operates on.
 type GatewayServiceConfig struct {
 	ServiceName string   `yaml:"servicename"`

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -416,13 +416,7 @@ func (c *ConfigureCapabilityRegistryInput) Validate() error {
 	return nil
 }
 
-// GatewayConfig is the legacy, don-centric gateway config format.
-type GatewayConfig struct {
-	Name     string // DON name
-	Handlers []string
-}
-
-// GatewayServiceConfig represents a service in the new, service-centric gateway format.
+// GatewayServiceConfig represents a service in the service-centric gateway format.
 // Each service groups handlers and references the DON names it operates on.
 type GatewayServiceConfig struct {
 	ServiceName string   `yaml:"servicename"`

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -416,9 +416,12 @@ func (c *ConfigureCapabilityRegistryInput) Validate() error {
 	return nil
 }
 
-type GatewayConfig struct {
-	Name     string // DON name
-	Handlers []string
+// GatewayServiceConfig represents a service in the new multi-DON gateway format.
+// Each service groups handlers and references the DON names it operates on.
+type GatewayServiceConfig struct {
+	ServiceName string   `yaml:"servicename"`
+	Handlers    []string `yaml:"handlers"`
+	DONs        []string `yaml:"dons"`
 }
 
 type GatewayConnectors struct {


### PR DESCRIPTION
## Summary

- Replaces the DON-centric `GatewayConfig` with a service-centric `GatewayServiceConfig` type in the Local CRE topology layer, where each service groups handlers and references DON names
- Refactors `GatewayJob.Resolve()` to emit the new `[[gatewayConfig.Services]]` + `[[gatewayConfig.ShardedDONs]]` TOML structure instead of the deprecated `[[gatewayConfig.Dons]]` array
- Updates `ProposeGatewayJobInput` to accept `Services` instead of `DONs`, deriving DON membership and F value from JD at resolve time