### PR TITLE
security: default to non-privileged chainlink user in Dockerfile

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -68,7 +68,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 ##
 FROM ubuntu:24.04
 
-ARG CHAINLINK_USER=root
+ARG CHAINLINK_USER=chainlink
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y ca-certificates gnupg lsb-release curl && rm -rf /var/lib/apt/lists/*
 

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -72,7 +72,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 ##
 FROM ubuntu:24.04
 
-ARG CHAINLINK_USER=root
+ARG CHAINLINK_USER=chainlink
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y ca-certificates gnupg lsb-release curl && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes #21005

## Summary

Improved Docker security by defaulting to a non-privileged `chainlink` user instead of `root`. This follows the principle of least privilege and represents secure-by-default configuration for container deployments.

## Changes

Updated both official Chainlink Dockerfiles:
1. `core/chainlink.Dockerfile` - main production Dockerfile
2. `plugins/chainlink.Dockerfile` - experimental/testing Dockerfile

Changed default `CHAINLINK_USER` argument from:
```
ARG CHAINLINK_USER=root
```
To:
```
ARG CHAINLINK_USER=chainlink
```

## Impact

- **Security:** Containers now run as non-root by default
- **Compatibility:** Users who need root can still override with `--build-arg CHAINLINK_USER=root`
- **Minimal:** No other changes needed - existing logic already handles user creation when `CHAINLINK_USER != root`

## Testing

The existing Dockerfile logic handles this change correctly:
```dockerfile
RUN if [ ${CHAINLINK_USER} != root ]; then useradd --uid 14933 --create-home ${CHAINLINK_USER}; fi
```

When `CHAINLINK_USER=chainlink`, the container will:
1. Create a new `chainlink` user with UID 14933
2. Switch to that user via `USER ${CHAINLINK_USER}`
3. Set appropriate working directory and environment variables

## Security Rationale

Running containers as root by default violates security best practices:
- **Privilege escalation:** Root processes can exploit container escape vulnerabilities
- **Host filesystem access:** Root can potentially access host resources
- **Kernel vulnerabilities:** Root can exploit kernel bugs more easily
- **Industry standard:** Most production containers run as non-root users