### PR TITLE
DS-2516 - llo telemetry: llo outcome telemetry is output only for successful rounds

### DIFF
--- a/.changeset/grumpy-hawks-gain.md
+++ b/.changeset/grumpy-hawks-gain.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix llo outcome telemetry is only output for epochs where enough quourom is reached

--- a/core/services/llo/telem/telemetry.go
+++ b/core/services/llo/telem/telemetry.go
@@ -325,7 +325,27 @@ func (t *telemeter) enqueueTelemetry(digest string, seqNr uint64, typ synchroniz
 		if t.sampler.Sample(typ, msg) {
 			t.monitoringEndpoint.SendTypedLog(typ, bytes)
 		}
-	default: // synchronization.LLOOutcome, synchronization.LLOReport
+	case synchronization.LLOOutcome:
+		// Outcome telemetry: overwrite rather than append. Outcome() can be
+		// called multiple times for the same seqNr across epoch transitions
+		// (when the first epoch fails prepare-quorum). The buffer is only
+		// flushed on Transmit(), which happens after commit-quorum, so the
+		// last Outcome() call is always from the committed epoch.
+		t.telemetryBufferMu.Lock()
+		defer t.telemetryBufferMu.Unlock()
+
+		if _, ok := t.telemetryBuffer[digest]; !ok {
+			t.telemetryBuffer[digest] = make(map[uint64][]telemetryEntry)
+		}
+		if t.sampler.Sample(typ, msg) {
+			t.telemetryBuffer[digest][seqNr] = []telemetryEntry{{
+				telemType: typ,
+				msg:       msg,
+			}}
+		}
+	default: // synchronization.LLOReport and other buffered types
+		// Report telemetry: append, since multiple reports per seqNr is
+		// expected (one per reportable channel).
 		t.telemetryBufferMu.Lock()
 		defer t.telemetryBufferMu.Unlock()
 

--- a/core/services/llo/telem/telemetry_test.go
+++ b/core/services/llo/telem/telemetry_test.go
@@ -528,6 +528,92 @@ func Test_Telemeter_outcomeTelemetry(t *testing.T) {
 			assert.Equal(t, cd[:], decoded.ConfigDigest)
 			assert.Equal(t, uint32(10), decoded.DonId)
 		})
+
+	})
+
+	t.Run("overwrites previous outcome for same seqNr (epoch transition)", func(t *testing.T) {
+		// Simulates the bug scenario: Outcome() is called twice for the
+		// same seqNr across two epochs (first epoch fails prepare-quorum,
+		// second commits). Only the last outcome should survive in the
+		// buffer and be flushed.
+		m := &mockMonitoringEndpoint{chTypedLogs: make(chan typedLog, 100)}
+		tm := newTelemeter(TelemeterParams{
+			Logger:                  lggr,
+			MonitoringEndpoint:      m,
+			DonID:                   donID,
+			CaptureOutcomeTelemetry: true,
+		})
+		servicetest.Run(t, tm)
+		ch := tm.GetOutcomeTelemetryCh()
+		require.NotNil(t, ch)
+
+		opts := &mockOpts{}
+		cd := opts.ConfigDigest()
+
+		// First outcome (from failed epoch)
+		epoch1Outcome := &datastreamsllo.LLOOutcomeTelemetry{
+			LifeCycleStage:                  "production",
+			ObservationTimestampNanoseconds: 1000000001,
+			SeqNr:                           opts.SeqNr(),
+			ConfigDigest:                    cd[:],
+			DonId:                           10,
+		}
+		ch <- epoch1Outcome
+
+		testutils.RequireEventually(t, func() bool {
+			tm.telemetryBufferMu.Lock()
+			defer tm.telemetryBufferMu.Unlock()
+			return len(tm.telemetryBuffer[cd.Hex()][opts.SeqNr()]) > 0
+		})
+
+		// Second outcome (from committed epoch) — different observation timestamp
+		epoch2Outcome := &datastreamsllo.LLOOutcomeTelemetry{
+			LifeCycleStage:                  "production",
+			ObservationTimestampNanoseconds: 2000000002,
+			SeqNr:                           opts.SeqNr(),
+			ConfigDigest:                    cd[:],
+			DonId:                           10,
+		}
+		ch <- epoch2Outcome
+
+		testutils.RequireEventually(t, func() bool {
+			tm.telemetryBufferMu.Lock()
+			defer tm.telemetryBufferMu.Unlock()
+			buf := tm.telemetryBuffer[cd.Hex()][opts.SeqNr()]
+			if len(buf) == 0 {
+				return false
+			}
+			// Wait until the buffer contains the second outcome
+			msg := buf[0].msg.(*datastreamsllo.LLOOutcomeTelemetry)
+			return msg.ObservationTimestampNanoseconds == 2000000002
+		})
+
+		// Verify buffer has exactly 1 entry (overwritten, not appended)
+		tm.telemetryBufferMu.Lock()
+		bufLen := len(tm.telemetryBuffer[cd.Hex()][opts.SeqNr()])
+		tm.telemetryBufferMu.Unlock()
+		assert.Equal(t, 1, bufLen, "expected exactly 1 outcome in buffer (overwrite), got %d", bufLen)
+
+		// Flush and verify only one message is sent
+		tm.TrackSeqNr(opts.ConfigDigest(), opts.SeqNr())
+
+		tLog := <-m.chTypedLogs
+		assert.Equal(t, synchronization.LLOOutcome, tLog.telemType)
+		decoded := &datastreamsllo.LLOOutcomeTelemetry{}
+		require.NoError(t, proto.Unmarshal(tLog.log, decoded))
+
+		// The flushed outcome should be from the second (committed) epoch
+		assert.Equal(t, uint64(2000000002), decoded.ObservationTimestampNanoseconds,
+			"expected observation timestamp from committed epoch")
+		assert.Equal(t, opts.SeqNr(), decoded.SeqNr)
+
+		// Verify no additional messages were sent
+		select {
+		case extra := <-m.chTypedLogs:
+			t.Fatalf("expected no more outcome messages, but got one with type %v", extra.telemType)
+		default:
+			// good — no extra messages
+		}
 	})
 }
 
@@ -644,6 +730,69 @@ func Test_Telemeter_reportTelemetry(t *testing.T) {
 			assert.Equal(t, opts.SeqNr(), decoded.SeqNr)
 			assert.Equal(t, cd[:], decoded.ConfigDigest)
 		})
+	})
+
+	t.Run("appends multiple reports for same seqNr (one per channel)", func(t *testing.T) {
+		// Report telemetry must append, not overwrite. Reports() generates
+		// one report per reportable channel (up to ~1000+), all sharing
+		// the same seqNr. Overwriting would lose all but the last channel.
+		m := &mockMonitoringEndpoint{chTypedLogs: make(chan typedLog, 100)}
+		tm := newTelemeter(TelemeterParams{
+			Logger:                 lggr,
+			MonitoringEndpoint:     m,
+			DonID:                  donID,
+			CaptureReportTelemetry: true,
+		})
+		servicetest.Run(t, tm)
+		ch := tm.GetReportTelemetryCh()
+		require.NotNil(t, ch)
+
+		opts := &mockOpts{}
+		cd := opts.ConfigDigest()
+
+		// Send 3 reports for different channels, all with the same seqNr
+		for i := uint32(1); i <= 3; i++ {
+			ch <- &datastreamsllo.LLOReportTelemetry{
+				ChannelId:    i,
+				SeqNr:        opts.SeqNr(),
+				ConfigDigest: cd[:],
+			}
+		}
+
+		// Wait until all 3 are buffered
+		testutils.RequireEventually(t, func() bool {
+			tm.telemetryBufferMu.Lock()
+			defer tm.telemetryBufferMu.Unlock()
+			return len(tm.telemetryBuffer[cd.Hex()][opts.SeqNr()]) == 3
+		})
+
+		// Verify buffer has all 3 entries (appended, not overwritten)
+		tm.telemetryBufferMu.Lock()
+		bufLen := len(tm.telemetryBuffer[cd.Hex()][opts.SeqNr()])
+		tm.telemetryBufferMu.Unlock()
+		assert.Equal(t, 3, bufLen, "expected 3 reports in buffer (append), got %d", bufLen)
+
+		// Flush and verify all 3 messages are sent
+		tm.TrackSeqNr(opts.ConfigDigest(), opts.SeqNr())
+
+		receivedChannels := make([]uint32, 0, 3)
+		for i := 0; i < 3; i++ {
+			tLog := <-m.chTypedLogs
+			assert.Equal(t, synchronization.LLOReport, tLog.telemType)
+			decoded := &datastreamsllo.LLOReportTelemetry{}
+			require.NoError(t, proto.Unmarshal(tLog.log, decoded))
+			receivedChannels = append(receivedChannels, decoded.ChannelId)
+		}
+		assert.ElementsMatch(t, []uint32{1, 2, 3}, receivedChannels,
+			"all 3 channel reports should be flushed")
+
+		// Verify no additional messages were sent
+		select {
+		case extra := <-m.chTypedLogs:
+			t.Fatalf("expected no more report messages, but got one with type %v", extra.telemType)
+		default:
+			// good — no extra messages
+		}
 	})
 }
 

--- a/core/services/llo/telem/telemetry_test.go
+++ b/core/services/llo/telem/telemetry_test.go
@@ -528,7 +528,6 @@ func Test_Telemeter_outcomeTelemetry(t *testing.T) {
 			assert.Equal(t, cd[:], decoded.ConfigDigest)
 			assert.Equal(t, uint32(10), decoded.DonId)
 		})
-
 	})
 
 	t.Run("overwrites previous outcome for same seqNr (epoch transition)", func(t *testing.T) {


### PR DESCRIPTION
Relates to:
https://smartcontract-it.atlassian.net/browse/DS-2516

Related investigation:
https://smartcontract-it.atlassian.net/wiki/spaces/DAST/pages/2447802370/DS-2459+-+Investigate+duplicate+seq_nrs+in+llo+outcome+telemetry

## Summary

  - Outcome telemetry buffer now overwrites instead of appending for LLOOutcome entries, ensuring only one outcome per seq_nr is flushed
  - This ensures that the produced outcome telemetry is for epochs in which enough quorum is reached, instead of producing messages with conflicting seq_nrs but different stream values whenever there are multiple epochs due to not enough quorum
  - LLOReport entries are unaffected and continue to append (multiple reports per seq_nr is expected: one per channel)

## Why

When a `seq_nr` spans two OCR3 epochs (first epoch fails prepare-quorum, second commits), `Outcome()` is called twice for the same `seq_nr`. The telemetry buffer was appending both, causing downstream consumers to see `llo_outcome` messages with different observation timestamps and different stream values (prices) for the same `seq_nr`. The same NOP could emit two contradictory messages.

The committed consensus outcome is identical across all NOPs, this was strictly a telemetry emission issue, not a protocol problem.

This change ensures that the produced outcome telemetry reflects the epoch that actually reached quorum, instead of emitting conflicting messages from failed epochs that never committed

## Details

In `enqueueTelemetry()`, split the default buffer case into:
  - `LLOOutcome`: overwrite  only the latest outcome per `seq_nr` survives. last epoch = committed epoch, since the buffer is flushed onc Transmit() which fires after commit-quorum.
  - `default (LLOReport + future types)`: append. unchanged, since `Reports()` emits one entry per reportable channel (~1000+ per seq_nr)


# Tests

  - New test: outcome telemetry overwrites on same seq_nr (epoch transition simulation)
  - New test: report telemetry appends multiple entries for same seq_nr (regression guard)
  - Existing tests pass