### PR TITLE
[CRE] Add confidential relay gateway handler

### DIFF
--- a/core/services/gateway/handler_factory.go
+++ b/core/services/gateway/handler_factory.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/confidentialrelay"
 	v2 "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities/v2"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/functions"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/vault"
@@ -29,7 +30,8 @@ const (
 	DummyHandlerType       HandlerType = "dummy"
 	WebAPICapabilitiesType HandlerType = "web-api-capabilities" //  Handler for v0.1 HTTP capabilities for DAG workflows
 	HTTPCapabilityType     HandlerType = "http-capabilities"    // Handler for v1.0 HTTP capabilities for NoDAG workflows
-	VaultHandlerType       HandlerType = "vault"
+	VaultHandlerType                HandlerType = "vault"
+	ConfidentialRelayHandlerType    HandlerType = "confidential-compute-relay"
 )
 
 type handlerFactory struct {
@@ -87,6 +89,8 @@ func (hf *handlerFactory) NewHandler(
 	case VaultHandlerType:
 		requestAuthorizer := vaultcap.NewRequestAuthorizer(hf.lggr, hf.workflowRegistrySyncer)
 		return vault.NewHandler(handlerConfig, donConfig, don, hf.capabilitiesRegistry, requestAuthorizer, hf.lggr, clockwork.NewRealClock(), hf.lf)
+	case ConfidentialRelayHandlerType:
+		return confidentialrelay.NewHandler(handlerConfig, donConfig, don, hf.lggr, clockwork.NewRealClock())
 	default:
 		return nil, fmt.Errorf("unsupported handler type %s", handlerType)
 	}

--- a/core/services/gateway/handler_factory.go
+++ b/core/services/gateway/handler_factory.go
@@ -17,8 +17,8 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities"
-	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/confidentialrelay"
 	v2 "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities/v2"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/confidentialrelay"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/functions"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/vault"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/network"
@@ -30,8 +30,8 @@ const (
 	DummyHandlerType       HandlerType = "dummy"
 	WebAPICapabilitiesType HandlerType = "web-api-capabilities" //  Handler for v0.1 HTTP capabilities for DAG workflows
 	HTTPCapabilityType     HandlerType = "http-capabilities"    // Handler for v1.0 HTTP capabilities for NoDAG workflows
-	VaultHandlerType                HandlerType = "vault"
-	ConfidentialRelayHandlerType    HandlerType = "confidential-compute-relay"
+	VaultHandlerType             HandlerType = "vault"
+	ConfidentialRelayHandlerType HandlerType = "confidential-compute-relay"
 )
 
 type handlerFactory struct {

--- a/core/services/gateway/handlers/confidentialrelay/aggregator.go
+++ b/core/services/gateway/handlers/confidentialrelay/aggregator.go
@@ -1,0 +1,50 @@
+package confidentialrelay
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+
+	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+var (
+	errInsufficientResponsesForQuorum = errors.New("insufficient valid responses to reach quorum")
+	errQuorumUnobtainable             = errors.New("quorum unobtainable")
+)
+
+type aggregator struct{}
+
+func (a *aggregator) Aggregate(resps map[string]jsonrpc.Response[json.RawMessage], donF int, donMembersCount int, l logger.Logger) (*jsonrpc.Response[json.RawMessage], error) {
+	requiredQuorum := 2*donF + 1
+
+	if len(resps) < requiredQuorum {
+		return nil, errInsufficientResponsesForQuorum
+	}
+
+	shaToCount := map[string]int{}
+	maxShaToCount := 0
+	for _, r := range resps {
+		sha, err := r.Digest()
+		if err != nil {
+			l.Errorw("failed to compute digest of response during quorum validation, skipping...", "error", err)
+			continue
+		}
+		shaToCount[sha]++
+		if shaToCount[sha] > maxShaToCount {
+			maxShaToCount = shaToCount[sha]
+		}
+		if shaToCount[sha] >= requiredQuorum {
+			return &r, nil
+		}
+	}
+
+	remainingResponses := donMembersCount - len(resps)
+	if maxShaToCount+remainingResponses < requiredQuorum {
+		l.Warnw("quorum unattainable for request", "requiredQuorum", requiredQuorum, "remainingResponses", remainingResponses, "maxShaToCount", maxShaToCount)
+		return nil, errors.New(errQuorumUnobtainable.Error() + ". RequiredQuorum=" + strconv.Itoa(requiredQuorum) + ". maxShaToCount=" + strconv.Itoa(maxShaToCount) + " remainingResponses=" + strconv.Itoa(remainingResponses))
+	}
+
+	return nil, errInsufficientResponsesForQuorum
+}

--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -1,0 +1,433 @@
+package confidentialrelay
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/ratelimit"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/api"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
+	gwhandlers "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
+)
+
+const (
+	defaultCleanUpPeriod = 5 * time.Second
+
+	// Method names for confidential relay JSON-RPC requests.
+	// Duplicated from chainlink-common/pkg/capabilities/actions/confidentialrelay
+	// to avoid a dependency bump until the next chainlink-common version is pinned.
+	MethodSecretsGet     = "confidential.secrets.get"
+	MethodCapabilityExec = "confidential.capability.execute"
+)
+
+var _ gwhandlers.Handler = (*handler)(nil)
+
+type metrics struct {
+	requestInternalError metric.Int64Counter
+	requestUserError     metric.Int64Counter
+	requestSuccess       metric.Int64Counter
+}
+
+func newMetrics() (*metrics, error) {
+	requestInternalError, err := beholder.GetMeter().Int64Counter("confidential_relay_gateway_request_internal_error")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register internal error counter: %w", err)
+	}
+
+	requestUserError, err := beholder.GetMeter().Int64Counter("confidential_relay_gateway_request_user_error")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register user error counter: %w", err)
+	}
+
+	requestSuccess, err := beholder.GetMeter().Int64Counter("confidential_relay_gateway_request_success")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register success counter: %w", err)
+	}
+
+	return &metrics{
+		requestInternalError: requestInternalError,
+		requestUserError:     requestUserError,
+		requestSuccess:       requestSuccess,
+	}, nil
+}
+
+type activeRequest struct {
+	req       jsonrpc.Request[json.RawMessage]
+	responses map[string]*jsonrpc.Response[json.RawMessage]
+	mu        sync.Mutex
+
+	createdAt time.Time
+	gwhandlers.Callback
+}
+
+func (ar *activeRequest) addResponseForNode(nodeAddr string, resp *jsonrpc.Response[json.RawMessage]) bool {
+	ar.mu.Lock()
+	defer ar.mu.Unlock()
+	_, exists := ar.responses[nodeAddr]
+	if exists {
+		return false
+	}
+
+	ar.responses[nodeAddr] = resp
+	return true
+}
+
+func (ar *activeRequest) copiedResponses() map[string]jsonrpc.Response[json.RawMessage] {
+	ar.mu.Lock()
+	defer ar.mu.Unlock()
+	copied := make(map[string]jsonrpc.Response[json.RawMessage], len(ar.responses))
+	for k, response := range ar.responses {
+		var copiedResponse jsonrpc.Response[json.RawMessage]
+		if response != nil {
+			copiedResponse = *response
+			if response.Result != nil {
+				copiedResult := *response.Result
+				copiedResponse.Result = &copiedResult
+			}
+			if response.Error != nil {
+				copiedError := *response.Error
+				copiedResponse.Error = &copiedError
+			}
+		}
+		copied[k] = copiedResponse
+	}
+	return copied
+}
+
+type relayAggregator interface {
+	Aggregate(resps map[string]jsonrpc.Response[json.RawMessage], donF int, donMembersCount int, l logger.Logger) (*jsonrpc.Response[json.RawMessage], error)
+}
+
+type Config struct {
+	NodeRateLimiter   ratelimit.RateLimiterConfig `json:"nodeRateLimiter"`
+	RequestTimeoutSec int                         `json:"requestTimeoutSec"`
+}
+
+type handler struct {
+	services.StateMachine
+	donConfig *config.DONConfig
+	don       gwhandlers.DON
+	codec     api.JsonRPCCodec
+	lggr      logger.Logger
+	mu        sync.RWMutex
+	stopCh    services.StopChan
+
+	nodeRateLimiter *ratelimit.RateLimiter
+	requestTimeout  time.Duration
+
+	activeRequests map[string]*activeRequest
+	metrics        *metrics
+
+	aggregator relayAggregator
+
+	clock clockwork.Clock
+}
+
+func (h *handler) HealthReport() map[string]error {
+	return map[string]error{h.Name(): h.Healthy()}
+}
+
+func (h *handler) Name() string {
+	return h.lggr.Name()
+}
+
+func NewHandler(methodConfig json.RawMessage, donConfig *config.DONConfig, don gwhandlers.DON, lggr logger.Logger, clock clockwork.Clock) (*handler, error) {
+	var cfg Config
+	if err := json.Unmarshal(methodConfig, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal method config: %w", err)
+	}
+
+	if cfg.RequestTimeoutSec == 0 {
+		cfg.RequestTimeoutSec = 30
+	}
+
+	nodeRateLimiter, err := ratelimit.NewRateLimiter(cfg.NodeRateLimiter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create node rate limiter: %w", err)
+	}
+
+	metrics, err := newMetrics()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metrics: %w", err)
+	}
+
+	return &handler{
+		donConfig:       donConfig,
+		don:             don,
+		lggr:            logger.Named(lggr, "ConfidentialRelayHandler:"+donConfig.DonId),
+		requestTimeout:  time.Duration(cfg.RequestTimeoutSec) * time.Second,
+		nodeRateLimiter: nodeRateLimiter,
+		activeRequests:  make(map[string]*activeRequest),
+		mu:              sync.RWMutex{},
+		stopCh:          make(services.StopChan),
+		metrics:         metrics,
+		aggregator:      &aggregator{},
+		clock:           clock,
+	}, nil
+}
+
+func (h *handler) Start(_ context.Context) error {
+	return h.StartOnce("ConfidentialRelayHandler", func() error {
+		h.lggr.Info("starting confidential relay handler")
+		go func() {
+			ctx, cancel := h.stopCh.NewCtx()
+			defer cancel()
+			ticker := h.clock.NewTicker(defaultCleanUpPeriod)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.Chan():
+					h.removeExpiredRequests(ctx)
+				case <-h.stopCh:
+					return
+				}
+			}
+		}()
+		return nil
+	})
+}
+
+func (h *handler) Close() error {
+	return h.StopOnce("ConfidentialRelayHandler", func() error {
+		h.lggr.Info("closing confidential relay handler")
+		close(h.stopCh)
+		return nil
+	})
+}
+
+func (h *handler) removeExpiredRequests(ctx context.Context) {
+	h.mu.RLock()
+	var expiredRequests []*activeRequest
+	now := h.clock.Now()
+	for _, userRequest := range h.activeRequests {
+		if now.Sub(userRequest.createdAt) > h.requestTimeout {
+			expiredRequests = append(expiredRequests, userRequest)
+		}
+	}
+	h.mu.RUnlock()
+
+	for _, er := range expiredRequests {
+		var nodeResponses string
+		for nodeKey, nodeResponse := range er.responses {
+			nodeResponses += fmt.Sprintf("%s ---::: %v               ", nodeKey, nodeResponse)
+		}
+		err := h.sendResponse(ctx, er, h.errorResponse(er.req, api.RequestTimeoutError, errors.New("request expired without getting quorum of responses from nodes. Available responses: "+nodeResponses), []byte(nodeResponses)))
+		if err != nil {
+			h.lggr.Errorw("error sending response to user", "requestID", er.req.ID, "error", err)
+		}
+	}
+}
+
+func (h *handler) Methods() []string {
+	return []string{MethodSecretsGet, MethodCapabilityExec}
+}
+
+func (h *handler) HandleLegacyUserMessage(_ context.Context, _ *api.Message, _ gwhandlers.Callback) error {
+	return errors.New("confidential relay handler does not support legacy messages")
+}
+
+func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Request[json.RawMessage], callback gwhandlers.Callback) error {
+	if req.ID == "" {
+		return errors.New("request ID cannot be empty")
+	}
+	if len(req.ID) > 200 {
+		return errors.New("request ID is too long: " + strconv.Itoa(len(req.ID)) + ". max is 200 characters")
+	}
+
+	l := logger.With(h.lggr, "method", req.Method, "requestID", req.ID)
+	l.Debugw("handling confidential relay request")
+
+	ar, err := h.newActiveRequest(req, callback)
+	if err != nil {
+		return err
+	}
+
+	return h.fanOutToNodes(ctx, l, ar)
+}
+
+func (h *handler) newActiveRequest(req jsonrpc.Request[json.RawMessage], callback gwhandlers.Callback) (*activeRequest, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.activeRequests[req.ID] != nil {
+		h.lggr.Errorw("request id already exists", "requestID", req.ID)
+		return nil, errors.New("request ID already exists: " + req.ID)
+	}
+	ar := &activeRequest{
+		Callback:  callback,
+		req:       req,
+		createdAt: h.clock.Now(),
+		responses: map[string]*jsonrpc.Response[json.RawMessage]{},
+	}
+	h.activeRequests[req.ID] = ar
+	return ar, nil
+}
+
+func (h *handler) getActiveRequest(requestID string) *activeRequest {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.activeRequests[requestID]
+}
+
+func (h *handler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Response[json.RawMessage], nodeAddr string) error {
+	l := logger.With(h.lggr, "method", resp.Method, "requestID", resp.ID, "nodeAddr", nodeAddr)
+	l.Debugw("handling node response")
+
+	if !h.nodeRateLimiter.Allow(nodeAddr) {
+		l.Debugw("node is rate limited", "nodeAddr", nodeAddr)
+		return nil
+	}
+
+	ar := h.getActiveRequest(resp.ID)
+	if ar == nil {
+		l.Debugw("no pending request found for ID")
+		return nil
+	}
+
+	ok := ar.addResponseForNode(nodeAddr, resp)
+	if !ok {
+		l.Errorw("duplicate response from node, ignoring", "nodeAddr", nodeAddr)
+		return nil
+	}
+
+	copiedResponses := ar.copiedResponses()
+	aggregatedResp, err := h.aggregator.Aggregate(copiedResponses, h.donConfig.F, len(h.donConfig.Members), l)
+	switch {
+	case errors.Is(err, errInsufficientResponsesForQuorum):
+		l.Debugw("aggregating responses, waiting for other nodes...", "error", err)
+		return nil
+	case err != nil:
+		l.Error("quorum unobtainable, returning response to user...", "error", err, "responses", maps.Values(ar.responses))
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.FatalError, err, nil))
+	}
+
+	return h.sendSuccessResponse(ctx, l, ar, aggregatedResp)
+}
+
+func (h *handler) fanOutToNodes(ctx context.Context, l logger.Logger, ar *activeRequest) error {
+	var nodeErrors []error
+	for _, node := range h.donConfig.Members {
+		err := h.don.SendToNode(ctx, node.Address, &ar.req)
+		if err != nil {
+			nodeErrors = append(nodeErrors, err)
+			l.Errorw("error sending request to node", "node", node.Address, "error", err)
+		}
+	}
+
+	if len(nodeErrors) == len(h.donConfig.Members) && len(nodeErrors) > 0 {
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.FatalError, errors.New("failed to forward user request to nodes"), nil))
+	}
+
+	l.Debugw("successfully forwarded request to relay nodes")
+	return nil
+}
+
+func (h *handler) sendSuccessResponse(ctx context.Context, l logger.Logger, ar *activeRequest, resp *jsonrpc.Response[json.RawMessage]) error {
+	rawResponse, err := jsonrpc.EncodeResponse(resp)
+	if err != nil {
+		l.Errorw("failed to encode response", "error", err)
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.NodeReponseEncodingError, fmt.Errorf("failed to marshal response: %w", err), nil))
+	}
+
+	var errorCode api.ErrorCode
+	if resp.Error != nil {
+		errorCode = api.FromJSONRPCErrorCode(resp.Error.Code)
+	} else {
+		errorCode = api.NoError
+	}
+
+	l.Debugw("issued user callback", "errorCode", errorCode)
+	successResp := gwhandlers.UserCallbackPayload{
+		RawResponse: rawResponse,
+		ErrorCode:   errorCode,
+	}
+	return h.sendResponse(ctx, ar, successResp)
+}
+
+func (h *handler) errorResponse(
+	req jsonrpc.Request[json.RawMessage],
+	errorCode api.ErrorCode,
+	err error,
+	data []byte,
+) gwhandlers.UserCallbackPayload {
+	switch errorCode {
+	case api.FatalError:
+	case api.NodeReponseEncodingError:
+		h.lggr.Errorw(err.Error(), "requestID", req.ID)
+		err = errors.New(errorCode.String())
+	case api.InvalidParamsError:
+		h.lggr.Errorw("invalid params", "requestID", req.ID, "params", string(*req.Params))
+		err = errors.New("invalid params error: " + err.Error())
+	case api.UnsupportedMethodError:
+		h.lggr.Errorw("unsupported method", "requestID", req.ID, "method", req.Method, "error", err.Error())
+		err = errors.New("unsupported method(" + req.Method + "): " + err.Error())
+	case api.UserMessageParseError:
+		h.lggr.Errorw("user message parse error", "requestID", req.ID, "error", err.Error())
+		err = errors.New("user message parse error: " + err.Error())
+	case api.NoError:
+	case api.UnsupportedDONIdError:
+	case api.HandlerError:
+	case api.RequestTimeoutError:
+	case api.StaleNodeResponseError:
+	}
+
+	return gwhandlers.UserCallbackPayload{
+		RawResponse: h.codec.EncodeNewErrorResponse(
+			req.ID,
+			api.ToJSONRPCErrorCode(errorCode),
+			err.Error(),
+			data,
+		),
+		ErrorCode: errorCode,
+	}
+}
+
+func (h *handler) sendResponse(ctx context.Context, userRequest *activeRequest, resp gwhandlers.UserCallbackPayload) error {
+	switch resp.ErrorCode {
+	case api.StaleNodeResponseError:
+	case api.FatalError:
+	case api.NodeReponseEncodingError:
+	case api.RequestTimeoutError:
+	case api.HandlerError:
+		h.metrics.requestInternalError.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("don_id", h.donConfig.DonId),
+			attribute.String("error", resp.ErrorCode.String()),
+		))
+	case api.InvalidParamsError:
+	case api.UnsupportedMethodError:
+	case api.UserMessageParseError:
+	case api.UnsupportedDONIdError:
+		h.metrics.requestUserError.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("don_id", h.donConfig.DonId),
+		))
+	case api.NoError:
+		h.metrics.requestSuccess.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("don_id", h.donConfig.DonId),
+		))
+	}
+
+	err := userRequest.SendResponse(resp)
+	if err != nil {
+		h.lggr.Errorw("error sending response to user", "requestID", userRequest.req.ID, "error", err)
+		return err
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.activeRequests, userRequest.req.ID)
+	h.lggr.Debugw("response sent to user", "requestID", userRequest.req.ID, "errorCode", resp.ErrorCode)
+	return nil
+}

--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+	relaytypes "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/confidentialrelay"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/ratelimit"
@@ -27,11 +28,9 @@ import (
 const (
 	defaultCleanUpPeriod = 5 * time.Second
 
-	// Method names for confidential relay JSON-RPC requests.
-	// Duplicated from chainlink-common/pkg/capabilities/actions/confidentialrelay
-	// to avoid a dependency bump until the next chainlink-common version is pinned.
-	MethodSecretsGet     = "confidential.secrets.get"
-	MethodCapabilityExec = "confidential.capability.execute"
+	// Re-exported from chainlink-common for local use and test convenience.
+	MethodSecretsGet     = relaytypes.MethodSecretsGet
+	MethodCapabilityExec = relaytypes.MethodCapabilityExec
 )
 
 var _ gwhandlers.Handler = (*handler)(nil)

--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -377,6 +377,12 @@ func (h *handler) errorResponse(
 	case api.UserMessageParseError:
 		h.lggr.Errorw("user message parse error", "requestID", req.ID, "error", err.Error())
 		err = errors.New("user message parse error: " + err.Error())
+	case api.ConflictError:
+		h.lggr.Errorw("conflict error", "requestID", req.ID, "error", err.Error())
+		err = errors.New("conflict error: " + err.Error())
+	case api.LimitExceededError:
+		h.lggr.Errorw("limit exceeded error", "requestID", req.ID, "error", err.Error())
+		err = errors.New("limit exceeded error: " + err.Error())
 	case api.NoError:
 	case api.UnsupportedDONIdError:
 	case api.HandlerError:
@@ -410,6 +416,8 @@ func (h *handler) sendResponse(ctx context.Context, userRequest *activeRequest, 
 	case api.UnsupportedMethodError:
 	case api.UserMessageParseError:
 	case api.UnsupportedDONIdError:
+	case api.ConflictError:
+	case api.LimitExceededError:
 		h.metrics.requestUserError.Add(ctx, 1, metric.WithAttributes(
 			attribute.String("don_id", h.donConfig.DonId),
 		))

--- a/core/services/gateway/handlers/confidentialrelay/handler_test.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler_test.go
@@ -1,0 +1,572 @@
+package confidentialrelay
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/ratelimit"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/api"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/common"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/mocks"
+)
+
+var nodeOne = config.NodeConfig{
+	Name:    "node1",
+	Address: "0x1234",
+}
+
+func setupHandler(t *testing.T, numNodes int) (*handler, *common.Callback, *mocks.DON, *clockwork.FakeClock) {
+	t.Helper()
+	lggr := logger.Test(t)
+	don := mocks.NewDON(t)
+
+	members := make([]config.NodeConfig, numNodes)
+	for i := range numNodes {
+		members[i] = config.NodeConfig{
+			Name:    fmt.Sprintf("node%d", i),
+			Address: fmt.Sprintf("0x%04d", i),
+		}
+	}
+
+	donConfig := &config.DONConfig{
+		DonId:   "test_relay_don",
+		F:       1,
+		Members: members,
+	}
+	handlerConfig := Config{
+		RequestTimeoutSec: 30,
+		NodeRateLimiter: ratelimit.RateLimiterConfig{
+			GlobalRPS:      100,
+			GlobalBurst:    100,
+			PerSenderRPS:   10,
+			PerSenderBurst: 10,
+		},
+	}
+	methodConfig, err := json.Marshal(handlerConfig)
+	require.NoError(t, err)
+
+	clock := clockwork.NewFakeClock()
+	h, err := NewHandler(methodConfig, donConfig, don, lggr, clock)
+	require.NoError(t, err)
+	h.aggregator = &mockAggregator{}
+	cb := common.NewCallback()
+	return h, cb, don, clock
+}
+
+type mockAggregator struct {
+	err error
+}
+
+func (m *mockAggregator) Aggregate(_ map[string]jsonrpc.Response[json.RawMessage], _ int, _ int, _ logger.Logger) (*jsonrpc.Response[json.RawMessage], error) {
+	return nil, m.err
+}
+
+type respondingMockAggregator struct{}
+
+func (m *respondingMockAggregator) Aggregate(resps map[string]jsonrpc.Response[json.RawMessage], _ int, _ int, _ logger.Logger) (*jsonrpc.Response[json.RawMessage], error) {
+	if len(resps) == 0 {
+		return nil, errInsufficientResponsesForQuorum
+	}
+	// Return the first response we find.
+	for _, r := range resps {
+		return &r, nil
+	}
+	return nil, errInsufficientResponsesForQuorum
+}
+
+func TestConfidentialRelayHandler_Methods(t *testing.T) {
+	h, _, _, _ := setupHandler(t, 4)
+	methods := h.Methods()
+	assert.Contains(t, methods, MethodSecretsGet)
+	assert.Contains(t, methods, MethodCapabilityExec)
+	assert.Len(t, methods, 2)
+}
+
+func TestConfidentialRelayHandler_HandleLegacyUserMessage(t *testing.T) {
+	h, cb, _, _ := setupHandler(t, 4)
+	err := h.HandleLegacyUserMessage(t.Context(), nil, cb)
+	require.ErrorContains(t, err, "confidential relay handler does not support legacy messages")
+}
+
+func TestConfidentialRelayHandler_RequestIDTooLong(t *testing.T) {
+	h, cb, _, _ := setupHandler(t, 4)
+
+	longID := strings.Repeat("x", 201)
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     longID,
+		Method: MethodSecretsGet,
+	}
+
+	err := h.HandleJSONRPCUserMessage(t.Context(), req, cb)
+	expected := fmt.Sprintf("request ID is too long: %d. max is 200 characters", len(longID))
+	require.EqualError(t, err, expected)
+}
+
+func TestConfidentialRelayHandler_EmptyRequestID(t *testing.T) {
+	h, cb, _, _ := setupHandler(t, 4)
+
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "",
+		Method: MethodSecretsGet,
+	}
+
+	err := h.HandleJSONRPCUserMessage(t.Context(), req, cb)
+	require.EqualError(t, err, "request ID cannot be empty")
+}
+
+func TestConfidentialRelayHandler_FanOutAndQuorumSuccess(t *testing.T) {
+	h, cb, don, _ := setupHandler(t, 4)
+	h.aggregator = &respondingMockAggregator{}
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	params := json.RawMessage(`{"workflow_id":"wf1","secrets":[{"key":"k","namespace":"ns"}],"enclave_public_key":"pk"}`)
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-1",
+		Method: MethodSecretsGet,
+		Params: &params,
+	}
+
+	resultData := json.RawMessage(`{"secrets":[],"master_public_key":"mpk","threshold":1}`)
+	response := jsonrpc.Response[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "req-1",
+		Method:  MethodSecretsGet,
+		Result:  &resultData,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := cb.Wait(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, api.NoError, resp.ErrorCode)
+		var jsonResp jsonrpc.Response[json.RawMessage]
+		err = json.Unmarshal(resp.RawResponse, &jsonResp)
+		assert.NoError(t, err)
+		assert.Equal(t, "req-1", jsonResp.ID)
+	}()
+
+	err := h.HandleJSONRPCUserMessage(t.Context(), req, cb)
+	require.NoError(t, err)
+
+	err = h.HandleNodeMessage(t.Context(), &response, "0x0000")
+	require.NoError(t, err)
+	wg.Wait()
+}
+
+func TestConfidentialRelayHandler_QuorumWithRealAggregator(t *testing.T) {
+	h, cb, don, _ := setupHandler(t, 4)
+	// Use the real aggregator; DON F=1 so quorum = 2*1+1 = 3
+	h.aggregator = &aggregator{}
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	params := json.RawMessage(`{"workflow_id":"wf1"}`)
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-quorum",
+		Method: MethodCapabilityExec,
+		Params: &params,
+	}
+
+	resultData := json.RawMessage(`{"payload":"result"}`)
+	makeResp := func() *jsonrpc.Response[json.RawMessage] {
+		rd := make(json.RawMessage, len(resultData))
+		copy(rd, resultData)
+		return &jsonrpc.Response[json.RawMessage]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      "req-quorum",
+			Method:  MethodCapabilityExec,
+			Result:  &rd,
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := cb.Wait(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, api.NoError, resp.ErrorCode)
+	}()
+
+	err := h.HandleJSONRPCUserMessage(t.Context(), req, cb)
+	require.NoError(t, err)
+
+	// Send 3 matching responses (2F+1 = 3)
+	for i := range 3 {
+		err = h.HandleNodeMessage(t.Context(), makeResp(), fmt.Sprintf("0x%04d", i))
+		require.NoError(t, err)
+	}
+	wg.Wait()
+}
+
+func TestConfidentialRelayHandler_QuorumWithDivergentResponses(t *testing.T) {
+	h, cb, don, _ := setupHandler(t, 4)
+	h.aggregator = &aggregator{}
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	params := json.RawMessage(`{"workflow_id":"wf1"}`)
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-diverge",
+		Method: MethodSecretsGet,
+		Params: &params,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := cb.Wait(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, api.NoError, resp.ErrorCode)
+	}()
+
+	err := h.HandleJSONRPCUserMessage(t.Context(), req, cb)
+	require.NoError(t, err)
+
+	// One divergent response
+	divergentResult := json.RawMessage(`{"secrets":[],"master_public_key":"DIFFERENT","threshold":1}`)
+	divergentResp := &jsonrpc.Response[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "req-diverge",
+		Method:  MethodSecretsGet,
+		Result:  &divergentResult,
+	}
+	err = h.HandleNodeMessage(t.Context(), divergentResp, "0x0000")
+	require.NoError(t, err)
+
+	// Three matching responses (quorum = 3)
+	matchingResult := json.RawMessage(`{"secrets":[],"master_public_key":"mpk","threshold":1}`)
+	for i := 1; i <= 3; i++ {
+		rd := make(json.RawMessage, len(matchingResult))
+		copy(rd, matchingResult)
+		resp := &jsonrpc.Response[json.RawMessage]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      "req-diverge",
+			Method:  MethodSecretsGet,
+			Result:  &rd,
+		}
+		err = h.HandleNodeMessage(t.Context(), resp, fmt.Sprintf("0x%04d", i))
+		require.NoError(t, err)
+	}
+	wg.Wait()
+}
+
+func TestConfidentialRelayHandler_QuorumUnobtainable(t *testing.T) {
+	h, cb, don, _ := setupHandler(t, 4)
+	h.aggregator = &mockAggregator{err: errQuorumUnobtainable}
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	params := json.RawMessage(`{"workflow_id":"wf1"}`)
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-unobtainable",
+		Method: MethodSecretsGet,
+		Params: &params,
+	}
+
+	response := jsonrpc.Response[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "req-unobtainable",
+		Method:  MethodSecretsGet,
+		Error: &jsonrpc.WireError{
+			Code:    -32603,
+			Message: errQuorumUnobtainable.Error(),
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := cb.Wait(t.Context())
+		assert.NoError(t, err)
+		var jsonResp jsonrpc.Response[json.RawMessage]
+		err = json.Unmarshal(resp.RawResponse, &jsonResp)
+		assert.NoError(t, err)
+		assert.Equal(t, "req-unobtainable", jsonResp.ID)
+		assert.NotNil(t, jsonResp.Error)
+		assert.Contains(t, jsonResp.Error.Message, "quorum unobtainable")
+	}()
+
+	err := h.HandleJSONRPCUserMessage(t.Context(), req, cb)
+	require.NoError(t, err)
+
+	err = h.HandleNodeMessage(t.Context(), &response, "0x0000")
+	require.NoError(t, err)
+	wg.Wait()
+}
+
+func TestConfidentialRelayHandler_RequestTimeout(t *testing.T) {
+	h, cb, don, clock := setupHandler(t, 4)
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	// Use the real aggregator so responses are not immediately satisfied
+	h.aggregator = &aggregator{}
+
+	params := json.RawMessage(`{"workflow_id":"wf1"}`)
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-timeout",
+		Method: MethodSecretsGet,
+		Params: &params,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := cb.Wait(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, api.RequestTimeoutError, resp.ErrorCode)
+	}()
+
+	err := h.HandleJSONRPCUserMessage(t.Context(), req, cb)
+	require.NoError(t, err)
+
+	// Advance clock past the request timeout and trigger cleanup
+	clock.Advance(31 * time.Second)
+	h.removeExpiredRequests(t.Context())
+	wg.Wait()
+}
+
+func TestConfidentialRelayHandler_DuplicateRequestID(t *testing.T) {
+	h, cb, don, _ := setupHandler(t, 4)
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	params := json.RawMessage(`{"workflow_id":"wf1"}`)
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-dup",
+		Method: MethodSecretsGet,
+		Params: &params,
+	}
+
+	err := h.HandleJSONRPCUserMessage(t.Context(), req, cb)
+	require.NoError(t, err)
+
+	cb2 := common.NewCallback()
+	err = h.HandleJSONRPCUserMessage(t.Context(), req, cb2)
+	require.ErrorContains(t, err, "request ID already exists")
+}
+
+func TestConfidentialRelayHandler_RateLimitedNode(t *testing.T) {
+	handlerConfig := Config{
+		RequestTimeoutSec: 30,
+		NodeRateLimiter: ratelimit.RateLimiterConfig{
+			GlobalRPS:      100,
+			GlobalBurst:    100,
+			PerSenderRPS:   0.001, // Effectively zero
+			PerSenderBurst: 1,
+		},
+	}
+	methodConfig, err := json.Marshal(handlerConfig)
+	require.NoError(t, err)
+
+	lggr := logger.Test(t)
+	don := mocks.NewDON(t)
+	donConfig := &config.DONConfig{
+		DonId:   "test_relay_don",
+		F:       1,
+		Members: []config.NodeConfig{nodeOne},
+	}
+	clock := clockwork.NewFakeClock()
+	h, err := NewHandler(methodConfig, donConfig, don, lggr, clock)
+	require.NoError(t, err)
+	h.aggregator = &respondingMockAggregator{}
+
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	cb := common.NewCallback()
+	params := json.RawMessage(`{"workflow_id":"wf1"}`)
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-ratelimit",
+		Method: MethodSecretsGet,
+		Params: &params,
+	}
+
+	err = h.HandleJSONRPCUserMessage(t.Context(), req, cb)
+	require.NoError(t, err)
+
+	resultData := json.RawMessage(`{"secrets":[]}`)
+	response := jsonrpc.Response[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "req-ratelimit",
+		Method:  MethodSecretsGet,
+		Result:  &resultData,
+	}
+
+	// First response from node uses the burst allowance
+	err = h.HandleNodeMessage(t.Context(), &response, nodeOne.Address)
+	require.NoError(t, err)
+
+	// Verify callback was called
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	resp, err := cb.Wait(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, api.NoError, resp.ErrorCode)
+
+	// Start a new request
+	cb2 := common.NewCallback()
+	req2 := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-ratelimit-2",
+		Method: MethodSecretsGet,
+		Params: &params,
+	}
+	err = h.HandleJSONRPCUserMessage(t.Context(), req2, cb2)
+	require.NoError(t, err)
+
+	response2 := jsonrpc.Response[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "req-ratelimit-2",
+		Method:  MethodSecretsGet,
+		Result:  &resultData,
+	}
+
+	// Second response should be rate limited (silently dropped)
+	err = h.HandleNodeMessage(t.Context(), &response2, nodeOne.Address)
+	require.NoError(t, err)
+
+	// Callback should NOT be called - verify with timeout
+	ctx2, cancel2 := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel2()
+	_, err = cb2.Wait(ctx2)
+	require.Error(t, err) // Should timeout
+}
+
+func TestConfidentialRelayHandler_LateNodeResponse(t *testing.T) {
+	h, cb, _, _ := setupHandler(t, 4)
+
+	resultData := json.RawMessage(`{"secrets":[]}`)
+	staleResponse := jsonrpc.Response[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "nonexistent-request",
+		Method:  MethodSecretsGet,
+		Result:  &resultData,
+	}
+
+	// This should not error, just silently ignore
+	err := h.HandleNodeMessage(t.Context(), &staleResponse, "0x0000")
+	require.NoError(t, err)
+
+	// Verify callback was not triggered
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+	_, err = cb.Wait(ctx)
+	require.Error(t, err)
+}
+
+func TestConfidentialRelayHandler_AllNodesFanOutFail(t *testing.T) {
+	h, cb, don, _ := setupHandler(t, 4)
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("connection refused"))
+
+	params := json.RawMessage(`{"workflow_id":"wf1"}`)
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-allfail",
+		Method: MethodSecretsGet,
+		Params: &params,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := cb.Wait(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, api.FatalError, resp.ErrorCode)
+		var jsonResp jsonrpc.Response[json.RawMessage]
+		err = json.Unmarshal(resp.RawResponse, &jsonResp)
+		assert.NoError(t, err)
+		assert.Contains(t, jsonResp.Error.Message, "failed to forward user request to nodes")
+	}()
+
+	err := h.HandleJSONRPCUserMessage(t.Context(), req, cb)
+	require.NoError(t, err)
+	wg.Wait()
+}
+
+func TestConfidentialRelayHandler_SecretsGetMethod(t *testing.T) {
+	h, cb, don, _ := setupHandler(t, 4)
+	h.aggregator = &respondingMockAggregator{}
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	params := json.RawMessage(`{"workflow_id":"wf1","secrets":[{"key":"k","namespace":"ns"}],"enclave_public_key":"pk"}`)
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-secrets",
+		Method: MethodSecretsGet,
+		Params: &params,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := cb.Wait(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, api.NoError, resp.ErrorCode)
+	}()
+
+	err := h.HandleJSONRPCUserMessage(t.Context(), req, cb)
+	require.NoError(t, err)
+
+	resultData := json.RawMessage(`{"secrets":[],"master_public_key":"mpk","threshold":1}`)
+	response := jsonrpc.Response[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "req-secrets",
+		Method:  MethodSecretsGet,
+		Result:  &resultData,
+	}
+	err = h.HandleNodeMessage(t.Context(), &response, "0x0000")
+	require.NoError(t, err)
+	wg.Wait()
+	don.AssertCalled(t, "SendToNode", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestConfidentialRelayHandler_CapabilityExecMethod(t *testing.T) {
+	h, cb, don, _ := setupHandler(t, 4)
+	h.aggregator = &respondingMockAggregator{}
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	params := json.RawMessage(`{"workflow_id":"wf1","capability_id":"cap1","payload":"data"}`)
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-cap",
+		Method: MethodCapabilityExec,
+		Params: &params,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := cb.Wait(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, api.NoError, resp.ErrorCode)
+	}()
+
+	err := h.HandleJSONRPCUserMessage(t.Context(), req, cb)
+	require.NoError(t, err)
+
+	resultData := json.RawMessage(`{"payload":"result"}`)
+	response := jsonrpc.Response[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "req-cap",
+		Method:  MethodCapabilityExec,
+		Result:  &resultData,
+	}
+	err = h.HandleNodeMessage(t.Context(), &response, "0x0000")
+	require.NoError(t, err)
+	wg.Wait()
+	don.AssertCalled(t, "SendToNode", mock.Anything, mock.Anything, mock.Anything)
+}

--- a/go.mod
+++ b/go.mod
@@ -84,11 +84,11 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-ccv v0.0.0-20260225114453-965dabf4bcb0
-	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260302172713-40eba758f144
+	github.com/smartcontractkit/chainlink-common v0.10.1-0.20260303010151-2879e49d71bd
 	github.com/smartcontractkit/chainlink-common/keystore v1.0.2
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10
 	github.com/smartcontractkit/chainlink-data-streams v0.1.12-0.20260227110503-42b236799872
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260302180243-1e75633e454e
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260227175232-0de99d1959de
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135

--- a/go.sum
+++ b/go.sum
@@ -1180,8 +1180,10 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260225114453-965dabf4bcb0 h1:kaIN9AjmCEZAEmIMhIqmKddKFqGBVsKToNABk+TWsRY=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260225114453-965dabf4bcb0/go.mod h1:RnuNcn7DZmjmzEkeEWX0uL5y1oslB3c9URPLOjFU+jE=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260302172713-40eba758f144 h1:XKvx3xnke2K7/5z6rM/r5k8kE1hWriDm8V/f2TKC/b4=
-github.com/smartcontractkit/chainlink-common v0.10.1-0.20260302172713-40eba758f144/go.mod h1:0ghbAr7tRO0tT5ZqBXhOyzgUO37tNNe33Yn0hskauVM=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260227202051-0f1cea05d443 h1:13rc5e14/qLMzj6ib0FZkbggXUCL4fgAZ0f/RZAkzvg=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260227202051-0f1cea05d443/go.mod h1:0ghbAr7tRO0tT5ZqBXhOyzgUO37tNNe33Yn0hskauVM=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260303010151-2879e49d71bd h1:UOvUWF2yXt+KOaD460/nwdicKa+3oipa4pgVhzCJYiI=
+github.com/smartcontractkit/chainlink-common v0.10.1-0.20260303010151-2879e49d71bd/go.mod h1:0ghbAr7tRO0tT5ZqBXhOyzgUO37tNNe33Yn0hskauVM=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2 h1:AWisx4JT3QV8tcgh6J5NCrex+wAgTYpWyHsyNPSXzsQ=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2/go.mod h1:rSkIHdomyak3YnUtXLenl6poIq8q0V3UZPiiyYqPdGA=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
@@ -1190,8 +1192,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025121515250
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20251215152504-b1e41f508340/go.mod h1:P/0OSXUlFaxxD4B/P6HWbxYtIRmmWGDJAvanq19879c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.12-0.20260227110503-42b236799872 h1:/nhvP6cBqGLrf4JwA/1FHLxnJjFhKRP6xtXAPcpE8g0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.12-0.20260227110503-42b236799872/go.mod h1:5jROIH/4cgHBQn875A+E2DCqvkBtrkHs+ciedcGTjNI=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260302180243-1e75633e454e h1:PuaXre4zVd9xH3uZAVCW3cGIPyQDdYwUZOy1nGZoIjY=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260302180243-1e75633e454e/go.mod h1:RbSY8We8s4ac7uO7Q3cJ7f1IqnCzTD/TErVoLmXH8N8=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260227175232-0de99d1959de h1:T9LNES9gAKP3GH8YK48hTHb+iN2lpWQuEGTEXGMCryE=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260227175232-0de99d1959de/go.mod h1:RbSY8We8s4ac7uO7Q3cJ7f1IqnCzTD/TErVoLmXH8N8=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3 h1:V22ITnWmgBAyxH+VVVo1jxm/LeJ3jcVMCVYB+zLN5mU=
 github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260107191744-4b93f62cffe3/go.mod h1:u5vhpPHVUdGUni9o00MBu2aKPE0Q2DRoipAGPYD01e0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251222115927-36a18321243c h1:eX7SCn5AGUGduv5OrjbVJkUSOnyeal0BtVem6zBSB2Y=


### PR DESCRIPTION
> **Confidential CRE Workflows** ([implementation plan](https://github.com/smartcontractkit/confidential-compute/blob/cw-implementation-plan/docs/confidential-cre-workflows/README.md) | [reviewer's guide](https://github.com/smartcontractkit/confidential-compute/blob/cw-implementation-plan/docs/confidential-cre-workflows/reviewers-guide.md) | [relay DON design](https://github.com/smartcontractkit/confidential-compute/blob/cw-implementation-plan/docs/confidential-cre-workflows/06-relayer-don.md))

## Summary

- Gateway-side handler for confidential compute relay, implementing `handlers.Handler`
- Receives JSON-RPC requests from the enclave, fans out to relay DON nodes, aggregates 2F+1 quorum responses
- Registered as `confidential-compute-relay` handler type in `handler_factory.go`
- Simplified vs vault handler: no authorization, no caching, no OCR3 signatures, no owner-prefixed request IDs

Pairs with [#265](https://github.com/smartcontractkit/confidential-compute/pull/265) (node-side relay handler in confidential-compute).

## Changes

- **`core/services/gateway/handlers/confidentialrelay/handler.go`**: `Handler` interface implementation. Fan-out to relay DON nodes, response aggregation, timeout cleanup. Single code path for all methods.
- **`core/services/gateway/handlers/confidentialrelay/aggregator.go`**: 2F+1 quorum by response digest. No signature validation tier (relay responses have no OCR3 signatures).
- **`core/services/gateway/handlers/confidentialrelay/handler_test.go`**: 13 tests covering quorum success (mock + real aggregator), divergent responses, quorum unobtainable, timeout, duplicate request IDs, rate limiting, late responses, fan-out failure, legacy message rejection, and both JSON-RPC methods.
- **`core/services/gateway/handler_factory.go`**: New `ConfidentialRelayHandlerType` constant and switch case.

## Key simplifications vs vault handler

| Vault | Relay |
|-------|-------|
| Owner-prefixed request IDs | Plain request IDs |
| Request authorization | No authorization (attestation validated by relay DON nodes) |
| Public key caching + refresh ticker | No caching |
| OCR3 signature validation (F+1) then quorum fallback | Quorum only (2F+1 matching digests) |
| `capabilitiesRegistry` dependency | No registry dependency |
| `writeMethodsEnabled` gate limiter | No write method gating |
| Method-specific handle* functions | Single fan-out path for all methods |

## Note: shared handler infrastructure

~400 of the ~430 lines here are generic fan-out/aggregate boilerplate copied from the vault handler (`activeRequest` lifecycle, `HandleNodeMessage`, `fanOutToNodes`, `removeExpiredRequests`, `sendResponse`, `errorResponse`, metrics). The actual method-specific logic is ~5 lines in `HandleJSONRPCUserMessage`.

The same pattern is independently re-implemented in at least three handlers:

| Handler | Fan-out | Aggregation | Extras |
|---|---|---|---|
| Vault | activeRequest + fanOutToVaultNodes | Signature validation, quorum fallback | Auth, caching, owner-prefix, method routing |
| Confidential relay (this PR) | Copy-paste from vault | 2F+1 digest only | Nothing |
| v2 HTTP trigger | Own httpTriggerHandler | IdenticalNodeResponseAggregator (same 2F+1 idea) | Response cache, sub-handler routing |

A generic base handler in `handlers/common/` could extract the shared ~400 lines. Relay would shrink to ~50 lines. Vault would wrap the base with its auth/caching/routing layer. Didn't do this here because it's a refactor of existing gateway handler internals that should be its own PR.