### PR TITLE
chore: update confidential-http to v0.0.7

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -53,5 +53,5 @@ plugins:
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "6e03ab2b759f6a6983673e4071b712438b1c923c"
+      gitRef: "854d537b54e50906801d53b0c3c92777dde1d1fb"
       installPath: "./cmd/confidential-http"


### PR DESCRIPTION
Updates the confidential-http capability plugin gitRef to confidential-compute release/v0.0.7 (854d537b54e50906801d53b0c3c92777dde1d1fb).