### PR TITLE
Update CRE AddCapabilities changeset to support multiple don updates

### DIFF
--- a/deployment/cre/capabilities_registry/v2/changeset/add_capabilities.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/add_capabilities.go
@@ -3,6 +3,7 @@ package changeset
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
@@ -22,7 +23,8 @@ type AddCapabilitiesInput struct {
 	RegistryQualifier string `json:"registryQualifier" yaml:"registryQualifier"`
 
 	MCMSConfig        *crecontracts.MCMSConfig     `json:"mcmsConfig" yaml:"mcmsConfig"`
-	DonName           string                       `json:"donName" yaml:"donName"`
+	DonName           string                       `json:"donName" yaml:"donName"`   // optional if DonNames is set; for backward compatibility
+	DonNames          []string                     `json:"donNames" yaml:"donNames"` // multiple DONs to update
 	CapabilityConfigs []contracts.CapabilityConfig `json:"capabilityConfigs" yaml:"capabilityConfigs"`
 
 	// Force indicates whether to force the update even if we cannot validate that all forwarder contracts are ready to accept the new configure version.
@@ -33,11 +35,29 @@ type AddCapabilitiesInput struct {
 type AddCapabilities struct{}
 
 func (u AddCapabilities) VerifyPreconditions(_ cldf.Environment, config AddCapabilitiesInput) error {
-	if config.DonName == "" {
-		return errors.New("must specify DONName")
+	if config.DonName != "" && len(config.DonNames) > 0 {
+		return errors.New("cannot specify both donName and donNames")
+	}
+	donNames := u.donNames(config)
+	if len(donNames) == 0 {
+		return errors.New("must specify donName or donNames")
+	}
+	if slices.Contains(donNames, "") {
+		return errors.New("donName or donNames cannot contain an empty string")
 	}
 	if len(config.CapabilityConfigs) == 0 {
 		return errors.New("capabilityConfigs is required")
+	}
+	return nil
+}
+
+// donNames returns the list of DON names to update (from DonNames or single DonName for backward compatibility).
+func (u AddCapabilities) donNames(config AddCapabilitiesInput) []string {
+	if len(config.DonNames) > 0 {
+		return config.DonNames
+	}
+	if config.DonName != "" {
+		return []string{config.DonName}
 	}
 	return nil
 }
@@ -60,7 +80,7 @@ func (u AddCapabilities) Apply(e cldf.Environment, config AddCapabilitiesInput) 
 		sequences.AddCapabilitiesDeps{Env: &e, MCMSContracts: mcmsContracts},
 		sequences.AddCapabilitiesInput{
 			RegistryRef:       registryRef,
-			DonName:           config.DonName,
+			DonNames:          u.donNames(config),
 			CapabilityConfigs: config.CapabilityConfigs,
 			Force:             config.Force,
 			MCMSConfig:        config.MCMSConfig,

--- a/deployment/cre/capabilities_registry/v2/changeset/add_capabilities_test.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/add_capabilities_test.go
@@ -74,31 +74,70 @@ func TestAddCapabilities_VerifyPreconditions(t *testing.T) {
 	env := test.SetupEnvV2(t, false)
 	chainSelector := env.RegistrySelector
 
-	// Missing DON name
+	// Missing donName and donNames
 	err := cs.VerifyPreconditions(*env.Env, changeset.AddCapabilitiesInput{
 		RegistryChainSel:  chainSelector,
 		RegistryQualifier: "qual",
-		DonName:           "", // invalid
+		DonNames:          nil,
 		CapabilityConfigs: []contracts.CapabilityConfig{{Capability: contracts.Capability{CapabilityID: "cap@1.0.0"}}},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "DONName")
+	assert.Contains(t, err.Error(), "must specify donName or donNames")
+
+	// Both donName and donNames set
+	err = cs.VerifyPreconditions(*env.Env, changeset.AddCapabilitiesInput{
+		RegistryChainSel:  chainSelector,
+		RegistryQualifier: "qual",
+		DonName:           "don-1",
+		DonNames:          []string{"don-2"},
+		CapabilityConfigs: []contracts.CapabilityConfig{{Capability: contracts.Capability{CapabilityID: "cap@1.0.0"}}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot specify both donName and donNames")
+
+	// donNames with empty string
+	err = cs.VerifyPreconditions(*env.Env, changeset.AddCapabilitiesInput{
+		RegistryChainSel:  chainSelector,
+		RegistryQualifier: "qual",
+		DonNames:          []string{"don-1", ""},
+		CapabilityConfigs: []contracts.CapabilityConfig{{Capability: contracts.Capability{CapabilityID: "cap@1.0.0"}}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot contain an empty string")
 
 	// Missing capability configs
 	err = cs.VerifyPreconditions(*env.Env, changeset.AddCapabilitiesInput{
 		RegistryChainSel:  chainSelector,
 		RegistryQualifier: "qual",
-		DonName:           "don-1",
+		DonNames:          []string{"don-1"},
 		CapabilityConfigs: nil,
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "capabilityConfigs")
 
-	// Valid
+	// Valid (single DON via donNames)
+	err = cs.VerifyPreconditions(*env.Env, changeset.AddCapabilitiesInput{
+		RegistryChainSel:  chainSelector,
+		RegistryQualifier: "qual",
+		DonNames:          []string{"don-1"},
+		CapabilityConfigs: []contracts.CapabilityConfig{{Capability: contracts.Capability{CapabilityID: "cap@1.0.0"}, Config: map[string]any{"k": "v"}}},
+	})
+	require.NoError(t, err)
+
+	// Valid (single DON via donName - backward compatibility)
 	err = cs.VerifyPreconditions(*env.Env, changeset.AddCapabilitiesInput{
 		RegistryChainSel:  chainSelector,
 		RegistryQualifier: "qual",
 		DonName:           "don-1",
+		CapabilityConfigs: []contracts.CapabilityConfig{{Capability: contracts.Capability{CapabilityID: "cap@1.0.0"}, Config: map[string]any{"k": "v"}}},
+	})
+	require.NoError(t, err)
+
+	// Valid (multiple DONs)
+	err = cs.VerifyPreconditions(*env.Env, changeset.AddCapabilitiesInput{
+		RegistryChainSel:  chainSelector,
+		RegistryQualifier: "qual",
+		DonNames:          []string{"don-1", "don-2"},
 		CapabilityConfigs: []contracts.CapabilityConfig{{Capability: contracts.Capability{CapabilityID: "cap@1.0.0"}, Config: map[string]any{"k": "v"}}},
 	})
 	require.NoError(t, err)
@@ -108,7 +147,7 @@ func addNewCapability(t *testing.T, fixture *test.EnvWrapperV2, capID string) {
 	input := changeset.AddCapabilitiesInput{
 		RegistryChainSel:  fixture.RegistrySelector,
 		RegistryQualifier: test.RegistryQualifier,
-		DonName:           test.DONName,
+		DonNames:          []string{test.DONName},
 		CapabilityConfigs: []contracts.CapabilityConfig{{
 			Capability: contracts.Capability{
 				CapabilityID:          capID,
@@ -207,7 +246,7 @@ func TestAddCapabilities_Apply_MCMS(t *testing.T) {
 	input := changeset.AddCapabilitiesInput{
 		RegistryChainSel:  fixture.RegistrySelector,
 		RegistryQualifier: test.RegistryQualifier,
-		DonName:           test.DONName,
+		DonNames:          []string{test.DONName},
 		CapabilityConfigs: []contracts.CapabilityConfig{{
 			Capability: contracts.Capability{
 				CapabilityID:          newCapID,

--- a/deployment/cre/capabilities_registry/v2/changeset/sequences/add_capabilities.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/sequences/add_capabilities.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
@@ -31,8 +32,8 @@ type AddCapabilitiesDeps struct {
 type AddCapabilitiesInput struct {
 	CapabilityConfigs []contracts.CapabilityConfig // if Config subfield is nil, a default config is used
 
-	// DonName to update, this is required
-	DonName string
+	// DonNames are the DONs to update. At least one is required.
+	DonNames []string
 
 	// Force indicates whether to force the update even if we cannot validate that all forwarder contracts are ready to accept the new configure version.
 	// This is very dangerous, and could break the whole platform if the forwarders are not ready. Be very careful with this option.
@@ -43,8 +44,11 @@ type AddCapabilitiesInput struct {
 }
 
 func (i *AddCapabilitiesInput) Validate() error {
-	if i.DonName == "" {
-		return errors.New("must specify DONName")
+	if len(i.DonNames) == 0 {
+		return errors.New("must specify at least one DON name")
+	}
+	if slices.Contains(i.DonNames, "") {
+		return errors.New("donNames cannot contain an empty string")
 	}
 	if len(i.CapabilityConfigs) == 0 {
 		return errors.New("capabilityConfigs is required")
@@ -54,7 +58,7 @@ func (i *AddCapabilitiesInput) Validate() error {
 
 type AddCapabilitiesOutput struct {
 	AddedCapabilities []contracts.RegisterableCapability
-	DonInfo           capabilities_registry_v2.CapabilitiesRegistryUpdateDONParams
+	DonInfos          []capabilities_registry_v2.CapabilitiesRegistryUpdateDONParams
 	UpdatedNodes      []capabilities_registry_v2.CapabilitiesRegistryNodeParams
 	Proposals         []mcmslib.TimelockProposal
 }
@@ -86,44 +90,10 @@ var AddCapabilities = operations.NewSequence[AddCapabilitiesInput, AddCapabiliti
 			return AddCapabilitiesOutput{}, fmt.Errorf("failed to create CapabilitiesRegistry: %w", err)
 		}
 
-		don, nodes, err := GetDonNodes(input.DonName, capReg)
+		// Build capabilities list once (registry-level; same for all DONs).
+		capabilities, err := buildCapabilitiesFromConfigs(input.CapabilityConfigs)
 		if err != nil {
-			return AddCapabilitiesOutput{}, fmt.Errorf("failed to get DON %s nodes: %w", input.DonName, err)
-		}
-
-		p2pIDs := make([]p2pkey.PeerID, 0)
-		for _, node := range nodes {
-			p2pIDs = append(p2pIDs, node.P2pId)
-		}
-
-		nodeUpdates := make(map[string]contracts.NodeConfig, len(p2pIDs))
-		capabilities := make([]contracts.RegisterableCapability, len(input.CapabilityConfigs))
-		for i, cfg := range input.CapabilityConfigs {
-			metadataBytes, err := json.Marshal(cfg.Capability.Metadata)
-			if err != nil {
-				return AddCapabilitiesOutput{}, fmt.Errorf("failed to marshal capability metadata for capability %s: %w", cfg.Capability.CapabilityID, err)
-			}
-			capability := capabilities_registry_v2.CapabilitiesRegistryCapability{
-				CapabilityId:          cfg.Capability.CapabilityID,
-				ConfigurationContract: cfg.Capability.ConfigurationContract,
-				Metadata:              metadataBytes,
-			}
-			capabilities[i] = contracts.RegisterableCapability{
-				Metadata:              cfg.Capability.Metadata,
-				CapabilityID:          cfg.Capability.CapabilityID,
-				ConfigurationContract: cfg.Capability.ConfigurationContract,
-			}
-			for _, p2pID := range p2pIDs {
-				p2pIDStr := p2pID.String()
-				nodeUpdate, exists := nodeUpdates[p2pIDStr]
-				if !exists {
-					nodeUpdate = contracts.NodeConfig{
-						Capabilities: make([]capabilities_registry_v2.CapabilitiesRegistryCapability, 0, len(input.CapabilityConfigs)),
-					}
-				}
-				nodeUpdate.Capabilities = append(nodeUpdates[p2pIDStr].Capabilities, capability)
-				nodeUpdates[p2pIDStr] = nodeUpdate
-			}
+			return AddCapabilitiesOutput{}, err
 		}
 
 		// Create the appropriate strategy
@@ -139,6 +109,7 @@ var AddCapabilities = operations.NewSequence[AddCapabilitiesInput, AddCapabiliti
 			return AddCapabilitiesOutput{}, fmt.Errorf("failed to create strategy: %w", err)
 		}
 
+		// Register capabilities once for the registry.
 		regCapsReport, err := operations.ExecuteOperation(
 			b,
 			contracts.RegisterCapabilities,
@@ -157,58 +128,85 @@ var AddCapabilities = operations.NewSequence[AddCapabilitiesInput, AddCapabiliti
 			return AddCapabilitiesOutput{}, fmt.Errorf("failed to register capabilities: %w", err)
 		}
 
-		updateNodesReport, err := operations.ExecuteOperation(
-			b,
-			contracts.UpdateNodes,
-			contracts.UpdateNodesDeps{
-				Env:                  deps.Env,
-				CapabilitiesRegistry: capReg,
-				Strategy:             strategy,
-			},
-			contracts.UpdateNodesInput{
-				ChainSelector: chainSel,
-				NodesUpdates:  nodeUpdates,
-				MCMSConfig:    input.MCMSConfig,
-			},
-		)
-		if err != nil {
-			return AddCapabilitiesOutput{}, fmt.Errorf("failed to update nodes: %w", err)
+		var allOps []types.BatchOperation
+		if regCapsReport.Output.Operation != nil {
+			allOps = append(allOps, *regCapsReport.Output.Operation)
 		}
 
-		updateDonReport, err := operations.ExecuteOperation(
-			b,
-			contracts.UpdateDON,
-			contracts.UpdateDONDeps{
-				Env:                  deps.Env,
-				CapabilitiesRegistry: capReg,
-				Strategy:             strategy,
-			},
-			contracts.UpdateDONInput{
-				ChainSelector:                     chainSel,
-				P2PIDs:                            p2pIDs,
-				CapabilityConfigs:                 input.CapabilityConfigs,
-				MergeCapabilityConfigsWithOnChain: true,
-				DonName:                           input.DonName,
-				F:                                 don.F,
-				IsPrivate:                         !don.IsPublic,
-				Force:                             input.Force,
-				MCMSConfig:                        input.MCMSConfig,
-			},
-		)
-		if err != nil {
-			return AddCapabilitiesOutput{}, fmt.Errorf("failed to update don: %w", err)
+		var donInfos []capabilities_registry_v2.CapabilitiesRegistryUpdateDONParams
+		var allUpdatedNodes []capabilities_registry_v2.CapabilitiesRegistryNodeParams
+
+		// Update each DON: get nodes, update node configs, update DON.
+		for _, donName := range input.DonNames {
+			don, nodes, err := GetDonNodes(donName, capReg)
+			if err != nil {
+				return AddCapabilitiesOutput{}, fmt.Errorf("failed to get DON %s nodes: %w", donName, err)
+			}
+
+			p2pIDs := make([]p2pkey.PeerID, 0, len(nodes))
+			for _, node := range nodes {
+				p2pIDs = append(p2pIDs, node.P2pId)
+			}
+
+			nodeUpdates, err := buildNodeUpdatesForDON(p2pIDs, input.CapabilityConfigs)
+			if err != nil {
+				return AddCapabilitiesOutput{}, fmt.Errorf("failed to build node updates for DON %s: %w", donName, err)
+			}
+
+			updateNodesReport, err := operations.ExecuteOperation(
+				b,
+				contracts.UpdateNodes,
+				contracts.UpdateNodesDeps{
+					Env:                  deps.Env,
+					CapabilitiesRegistry: capReg,
+					Strategy:             strategy,
+				},
+				contracts.UpdateNodesInput{
+					ChainSelector: chainSel,
+					NodesUpdates:  nodeUpdates,
+					MCMSConfig:    input.MCMSConfig,
+				},
+			)
+			if err != nil {
+				return AddCapabilitiesOutput{}, fmt.Errorf("failed to update nodes for DON %s: %w", donName, err)
+			}
+
+			updateDonReport, err := operations.ExecuteOperation(
+				b,
+				contracts.UpdateDON,
+				contracts.UpdateDONDeps{
+					Env:                  deps.Env,
+					CapabilitiesRegistry: capReg,
+					Strategy:             strategy,
+				},
+				contracts.UpdateDONInput{
+					ChainSelector:                     chainSel,
+					P2PIDs:                            p2pIDs,
+					CapabilityConfigs:                 input.CapabilityConfigs,
+					MergeCapabilityConfigsWithOnChain: true,
+					DonName:                           donName,
+					F:                                 don.F,
+					IsPrivate:                         !don.IsPublic,
+					Force:                             input.Force,
+					MCMSConfig:                        input.MCMSConfig,
+				},
+			)
+			if err != nil {
+				return AddCapabilitiesOutput{}, fmt.Errorf("failed to update DON %s: %w", donName, err)
+			}
+
+			allOps = append(allOps, toOpsSlice(updateNodesReport.Output.Operation, updateDonReport.Output.Operation)...)
+			donInfos = append(donInfos, updateDonReport.Output.DonInfo)
+			allUpdatedNodes = append(allUpdatedNodes, updateNodesReport.Output.UpdatedNodes...)
 		}
 
 		var proposals []mcmslib.TimelockProposal
-
 		if input.MCMSConfig != nil {
-			ops := toOpsSlice(regCapsReport.Output.Operation, updateNodesReport.Output.Operation, updateDonReport.Output.Operation)
-			if len(ops) > 0 {
-				proposal, mcmsErr := strategy.BuildProposal(ops)
+			if len(allOps) > 0 {
+				proposal, mcmsErr := strategy.BuildProposal(allOps)
 				if mcmsErr != nil {
 					return AddCapabilitiesOutput{}, fmt.Errorf("failed to build MCMS proposal: %w", mcmsErr)
 				}
-
 				proposals = append(proposals, *proposal)
 			} else {
 				deps.Env.Logger.Warnw("Add capability sequence has not produced any operations to execute")
@@ -216,8 +214,8 @@ var AddCapabilities = operations.NewSequence[AddCapabilitiesInput, AddCapabiliti
 		}
 
 		return AddCapabilitiesOutput{
-			DonInfo:           updateDonReport.Output.DonInfo,
-			UpdatedNodes:      updateNodesReport.Output.UpdatedNodes,
+			DonInfos:          donInfos,
+			UpdatedNodes:      allUpdatedNodes,
 			AddedCapabilities: regCapsReport.Output.Capabilities,
 			Proposals:         proposals,
 		}, nil
@@ -233,6 +231,45 @@ func toOpsSlice(opPtrs ...*types.BatchOperation) []types.BatchOperation {
 	}
 
 	return result
+}
+
+// buildCapabilitiesFromConfigs builds the capability list for RegisterCapabilities (registry-level, no DON).
+func buildCapabilitiesFromConfigs(configs []contracts.CapabilityConfig) ([]contracts.RegisterableCapability, error) {
+	out := make([]contracts.RegisterableCapability, len(configs))
+	for i, cfg := range configs {
+		out[i] = contracts.RegisterableCapability{
+			Metadata:              cfg.Capability.Metadata,
+			CapabilityID:          cfg.Capability.CapabilityID,
+			ConfigurationContract: cfg.Capability.ConfigurationContract,
+		}
+	}
+	return out, nil
+}
+
+// buildNodeUpdatesForDON builds node config updates for a DON's nodes (adds the new capabilities to each node).
+func buildNodeUpdatesForDON(p2pIDs []p2pkey.PeerID, configs []contracts.CapabilityConfig) (map[string]contracts.NodeConfig, error) {
+	nodeUpdates := make(map[string]contracts.NodeConfig, len(p2pIDs))
+	for _, cfg := range configs {
+		metadataBytes, err := json.Marshal(cfg.Capability.Metadata)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal capability metadata for capability %s: %w", cfg.Capability.CapabilityID, err)
+		}
+		capability := capabilities_registry_v2.CapabilitiesRegistryCapability{
+			CapabilityId:          cfg.Capability.CapabilityID,
+			ConfigurationContract: cfg.Capability.ConfigurationContract,
+			Metadata:              metadataBytes,
+		}
+		for _, p2pID := range p2pIDs {
+			p2pIDStr := p2pID.String()
+			nodeUpdate := nodeUpdates[p2pIDStr]
+			if nodeUpdate.Capabilities == nil {
+				nodeUpdate.Capabilities = make([]capabilities_registry_v2.CapabilitiesRegistryCapability, 0, len(configs))
+			}
+			nodeUpdate.Capabilities = append(nodeUpdate.Capabilities, capability)
+			nodeUpdates[p2pIDStr] = nodeUpdate
+		}
+	}
+	return nodeUpdates, nil
 }
 
 func GetDonNodes(donName string, capReg *capabilities_registry_v2.CapabilitiesRegistry) (


### PR DESCRIPTION
- AddCapabilities changeset and sequence now support updating multiple DONs in one run.
- RegisterCapabilities is executed once per run; UpdateNodes and UpdateDON run once per DON.
- Backward compatibility: config can use either donName (single) or donNames (multiple); specifying both is invalid.