### PR TITLE
Remove RMNRemote transfer ownership for new chains

### DIFF
--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
@@ -803,7 +803,6 @@ func connectNewChainLogic(env cldf.Environment, c ConnectNewChainConfig) (cldf.C
 			state.Chains[c.NewChainSelector].NonceManager,
 			state.Chains[c.NewChainSelector].TokenAdminRegistry,
 			state.Chains[c.NewChainSelector].Router,
-			state.Chains[c.NewChainSelector].RMNRemote,
 		}
 		addressesToTransfer := make([]common.Address, 0, len(allContracts))
 		for _, contract := range allContracts {

--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e_test.go
@@ -206,7 +206,6 @@ func TestConnectNewChain(t *testing.T) {
 						mustHaveOwner(t, state.Chains[selector].NonceManager, state.Chains[selector].Timelock.Address().Hex())
 						mustHaveOwner(t, state.Chains[selector].TokenAdminRegistry, state.Chains[selector].Timelock.Address().Hex())
 						mustHaveOwner(t, state.Chains[selector].Router, state.Chains[selector].Timelock.Address().Hex())
-						mustHaveOwner(t, state.Chains[selector].RMNRemote, state.Chains[selector].Timelock.Address().Hex())
 
 						// Admin role for deployer key should be revoked
 						adminRole, err := state.Chains[selector].Timelock.ADMINROLE(nil)


### PR DESCRIPTION
Remove RMNRemote transfer ownership from the ChainConfigure changeset. 
As RMNRemote will be transferred through different changeset