### PR TITLE
[CRE] Add test framework support for confidential relay DON

### DIFF
--- a/deployment/cre/jobs/pkg/gateway_job.go
+++ b/deployment/cre/jobs/pkg/gateway_job.go
@@ -14,6 +14,7 @@ const (
 	GatewayHandlerTypeWebAPICapabilities = "web-api-capabilities"
 	GatewayHandlerTypeHTTPCapabilities   = "http-capabilities"
 	GatewayHandlerTypeVault              = "vault"
+	GatewayHandlerTypeConfidentialRelay  = "confidential-compute-relay"
 
 	minimumRequestTimeoutSec = 5
 )
@@ -101,6 +102,8 @@ func (g GatewayJob) Resolve(gatewayNodeIdx int) (string, error) {
 				hs = append(hs, newDefaultVaultHandler(g.RequestTimeoutSec))
 			case GatewayHandlerTypeHTTPCapabilities:
 				hs = append(hs, newDefaultHTTPCapabilitiesHandler())
+			case GatewayHandlerTypeConfidentialRelay:
+				hs = append(hs, newDefaultConfidentialRelayHandler())
 			default:
 				return "", errors.New("unknown handler type: " + ht)
 			}
@@ -317,6 +320,24 @@ func newDefaultHTTPCapabilitiesHandler() handler {
 				PerSenderRPS:   100,
 			},
 			CleanUpPeriodMs: 10 * 60 * 1000, // 10 minutes
+		},
+	}
+}
+
+type confidentialRelayHandlerConfig struct {
+	NodeRateLimiter nodeRateLimiterConfig `toml:"NodeRateLimiter"`
+}
+
+func newDefaultConfidentialRelayHandler() handler {
+	return handler{
+		Name: GatewayHandlerTypeConfidentialRelay,
+		Config: confidentialRelayHandlerConfig{
+			NodeRateLimiter: nodeRateLimiterConfig{
+				GlobalBurst:    10,
+				GlobalRPS:      50,
+				PerSenderBurst: 10,
+				PerSenderRPS:   10,
+			},
 		},
 	}
 }

--- a/system-tests/lib/cre/features/confidential_relay/confidential_relay.go
+++ b/system-tests/lib/cre/features/confidential_relay/confidential_relay.go
@@ -1,0 +1,77 @@
+package confidentialrelay
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink/deployment/cre/jobs/pkg"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
+)
+
+const flag = cre.ConfidentialRelayCapability
+
+type ConfidentialRelay struct{}
+
+func (o *ConfidentialRelay) Flag() cre.CapabilityFlag {
+	return flag
+}
+
+func (o *ConfidentialRelay) PreEnvStartup(
+	ctx context.Context,
+	testLogger zerolog.Logger,
+	don *cre.DonMetadata,
+	topology *cre.Topology,
+	creEnv *cre.Environment,
+) (*cre.PreEnvStartupOutput, error) {
+	registryChainID, chErr := chainselectors.ChainIdFromSelector(creEnv.RegistryChainSelector)
+	if chErr != nil {
+		return nil, errors.Wrapf(chErr, "failed to get chain ID from selector %d", creEnv.RegistryChainSelector)
+	}
+
+	hErr := topology.AddGatewayHandlers(*don, []string{pkg.GatewayHandlerTypeConfidentialRelay})
+	if hErr != nil {
+		return nil, errors.Wrapf(hErr, "failed to add gateway handlers to gateway config for don %s", don.Name)
+	}
+
+	cErr := don.ConfigureForGatewayAccess(registryChainID, *topology.GatewayConnectors)
+	if cErr != nil {
+		return nil, errors.Wrapf(cErr, "failed to add gateway connectors to node's TOML config for don %s", don.Name)
+	}
+
+	// Set env vars from capability config to activate the confidential relay handler on DON nodes.
+	// The handler is gated by CL_CONFIDENTIAL_RELAY_TRUSTED_PCRS; without it, the subservice won't start.
+	capConfig, ok := don.CapabilityConfigs[flag]
+	if ok && capConfig.Values != nil {
+		ns := don.MustNodeSet()
+		if ns.EnvVars == nil {
+			ns.EnvVars = make(map[string]string)
+		}
+
+		if v, exists := capConfig.Values["trustedPCRs"]; exists {
+			ns.EnvVars["CL_CONFIDENTIAL_RELAY_TRUSTED_PCRS"] = fmt.Sprintf("%v", v)
+		}
+		if v, exists := capConfig.Values["caRootsPEM"]; exists {
+			ns.EnvVars["CL_CONFIDENTIAL_RELAY_CA_ROOTS_PEM"] = fmt.Sprintf("%v", v)
+		}
+	}
+
+	// No on-chain capability registration needed. The relay handler is a CRE subservice,
+	// not a registered capability. The mock capability that runs on the relay DON is
+	// registered separately via the mock flag.
+	return &cre.PreEnvStartupOutput{}, nil
+}
+
+func (o *ConfidentialRelay) PostEnvStartup(
+	ctx context.Context,
+	testLogger zerolog.Logger,
+	don *cre.Don,
+	dons *cre.Dons,
+	creEnv *cre.Environment,
+) error {
+	return nil
+}

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -54,22 +54,23 @@ const (
 
 // Capabilities
 const (
-	ConsensusCapability       CapabilityFlag = "ocr3"
-	DONTimeCapability         CapabilityFlag = "don-time"
-	ConsensusCapabilityV2     CapabilityFlag = "consensus" // v2
-	CronCapability            CapabilityFlag = "cron"
-	EVMCapability             CapabilityFlag = "evm"
-	CustomComputeCapability   CapabilityFlag = "custom-compute"
-	WriteEVMCapability        CapabilityFlag = "write-evm"
-	ReadContractCapability    CapabilityFlag = "read-contract"
-	LogEventTriggerCapability CapabilityFlag = "log-event-trigger"
-	WebAPITargetCapability    CapabilityFlag = "web-api-target"
-	WebAPITriggerCapability   CapabilityFlag = "web-api-trigger"
-	MockCapability            CapabilityFlag = "mock"
-	VaultCapability           CapabilityFlag = "vault"
-	HTTPTriggerCapability     CapabilityFlag = "http-trigger"
-	HTTPActionCapability      CapabilityFlag = "http-action"
-	SolanaCapability          CapabilityFlag = "solana"
+	ConsensusCapability         CapabilityFlag = "ocr3"
+	DONTimeCapability           CapabilityFlag = "don-time"
+	ConsensusCapabilityV2       CapabilityFlag = "consensus" // v2
+	CronCapability              CapabilityFlag = "cron"
+	EVMCapability               CapabilityFlag = "evm"
+	CustomComputeCapability     CapabilityFlag = "custom-compute"
+	WriteEVMCapability          CapabilityFlag = "write-evm"
+	ReadContractCapability      CapabilityFlag = "read-contract"
+	LogEventTriggerCapability   CapabilityFlag = "log-event-trigger"
+	WebAPITargetCapability      CapabilityFlag = "web-api-target"
+	WebAPITriggerCapability     CapabilityFlag = "web-api-trigger"
+	MockCapability              CapabilityFlag = "mock"
+	VaultCapability             CapabilityFlag = "vault"
+	HTTPTriggerCapability       CapabilityFlag = "http-trigger"
+	HTTPActionCapability        CapabilityFlag = "http-action"
+	SolanaCapability            CapabilityFlag = "solana"
+	ConfidentialRelayCapability CapabilityFlag = "confidential-relay"
 	// Add more capabilities as needed
 )
 


### PR DESCRIPTION
> **Confidential CRE Workflows** ([implementation plan](https://github.com/smartcontractkit/confidential-compute/blob/cw-implementation-plan/docs/confidential-cre-workflows/README.md) | [relay DON design](https://github.com/smartcontractkit/confidential-compute/blob/cw-implementation-plan/docs/confidential-cre-workflows/06-relayer-don.md))

## Summary

The CRE test framework can't spin up a relay DON because the gateway job spec generator doesn't know about the `confidential-compute-relay` handler type, and there's no Feature to wire it. This adds both, unblocking remote-mode E2E tests in `confidential-compute`.

## Changes

- **`deployment/cre/jobs/pkg/gateway_job.go`**: Add `GatewayHandlerTypeConfidentialRelay` constant, `confidentialRelayHandlerConfig` struct, `newDefaultConfidentialRelayHandler()` factory, and switch case in `Resolve()`. Config is NodeRateLimiter-only; `RequestTimeoutSec` defaults to 30 in the handler constructor.
- **`system-tests/lib/cre/types.go`**: Add `ConfidentialRelayCapability` flag.
- **`system-tests/lib/cre/features/confidential_relay/confidential_relay.go`** (new): Feature implementation. `PreEnvStartup` adds the gateway handler, configures gateway access, and propagates `CL_CONFIDENTIAL_RELAY_TRUSTED_PCRS` / `CL_CONFIDENTIAL_RELAY_CA_ROOTS_PEM` from `CapabilityConfig.Values` to `NodeSet.EnvVars`. `PostEnvStartup` is a no-op; the relay handler auto-starts via env var gate. No on-chain capability registration (the relay handler is a CRE subservice, not a registered capability).

## Related PRs

- Gateway-side handler: [#21356](https://github.com/smartcontractkit/chainlink/pull/21356)
- Node-side wiring: [#21375](https://github.com/smartcontractkit/chainlink/pull/21375)