### PR TITLE
feat: add gRPC health check and reflection support to arbiter

### DIFF
--- a/core/services/arbiter/arbiter.go
+++ b/core/services/arbiter/arbiter.go
@@ -8,6 +8,9 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	ringpb "github.com/smartcontractkit/chainlink-protos/ring/go"
@@ -27,6 +30,7 @@ type arbiter struct {
 	services.StateMachine
 
 	grpcServer         *grpc.Server
+	healthServer       *health.Server
 	grpcHandler        *GRPCServer
 	ringArbiterHandler *RingArbiterHandler
 	state              *State
@@ -70,8 +74,16 @@ func New(
 	ringpb.RegisterArbiterServer(grpcServer, grpcHandler)
 	ringpb.RegisterArbiterScalerServer(grpcServer, ringArbiterHandler)
 
+	// Register gRPC health check service
+	healthServer := health.NewServer()
+	healthgrpc.RegisterHealthServer(grpcServer, healthServer)
+
+	// Register gRPC server reflection (enables grpcurl and other tools)
+	reflection.Register(grpcServer)
+
 	return &arbiter{
 		grpcServer:         grpcServer,
+		healthServer:       healthServer,
 		grpcHandler:        grpcHandler,
 		ringArbiterHandler: ringArbiterHandler,
 		state:              state,
@@ -102,6 +114,9 @@ func (a *arbiter) Start(ctx context.Context) error {
 		a.lggr.Infow("Arbiter service started",
 			"grpcAddr", a.grpcAddr,
 		)
+
+		// Mark gRPC health as serving
+		a.healthServer.SetServingStatus("", healthgrpc.HealthCheckResponse_SERVING)
 
 		return nil
 	})
@@ -144,6 +159,9 @@ func (a *arbiter) Close() error {
 
 		// Signal stop
 		close(a.stopCh)
+
+		// Mark health as not serving before stopping
+		a.healthServer.SetServingStatus("", healthgrpc.HealthCheckResponse_NOT_SERVING)
 
 		// Graceful shutdown of gRPC server
 		a.grpcServer.GracefulStop()


### PR DESCRIPTION
## Add gRPC Health Check and Server Reflection to Arbiter Service

### Problem

The arbiter gRPC server did not support the standard `grpc.health.v1.Health` service or server reflection, causing health check probes to fail:

```
grpcurl -plaintext cre-wf-0-0.nop-b.svc.cluster.local:9876 grpc.health.v1.Health/Check
Error invoking method "grpc.health.v1.Health/Check": failed to query for service descriptor "grpc.health.v1.Health": server does not support the reflection API
```

Neither the health check service nor reflection were registered on the gRPC server — they simply weren't implemented.

### Solution

Registered the standard gRPC health check service and server reflection on the arbiter's gRPC server.

#### Changes in `core/services/arbiter/arbiter.go`:

- **Added imports** for `google.golang.org/grpc/health`, `google.golang.org/grpc/health/grpc_health_v1`, and `google.golang.org/grpc/reflection`
- **Added `healthServer *health.Server`** field to the `arbiter` struct
- **Registered `grpc.health.v1.Health` service** via `healthgrpc.RegisterHealthServer()` — enables standard gRPC health check probes (used by Kubernetes, `grpcurl`, load balancers, etc.)
- **Registered gRPC server reflection** via `reflection.Register()` — enables service discovery tools like `grpcurl` to introspect available services
- **Set serving status to `SERVING`** in `Start()` after the service is fully initialized
- **Set serving status to `NOT_SERVING`** in `Close()` before initiating graceful shutdown, ensuring in-flight health probes get an accurate response during draining

### Risk: **LOW**

Additive change — registers two well-known gRPC services on an existing server. No changes to business logic, existing RPCs, or the arbiter's core behavior. All existing tests continue to pass.
