### PR TITLE
fix(packer): use Uint64() to prevent silent overflow on GasAllocated

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding/packer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding/packer.go
@@ -45,10 +45,16 @@ func (p *abiPacker) UnpackCheckResult(payload ocr2keepers.UpkeepPayload, raw str
 			fmt.Errorf("upkeepId %s failed to unpack checkUpkeep result %s: %w", payload.UpkeepID.String(), raw, err)
 	}
 
+	gasAllocatedBig := *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+	if !gasAllocatedBig.IsUint64() {
+		return GetIneligibleCheckResultWithoutPerformData(payload, UpkeepFailureReasonNone, PackUnpackDecodeFailed, false),
+			fmt.Errorf("upkeepId %s GasAllocated value %s overflows uint64", payload.UpkeepID.String(), gasAllocatedBig.String())
+	}
+
 	result := ocr2keepers.CheckResult{
 		Eligible:            *abi.ConvertType(out[0], new(bool)).(*bool),
 		Retryable:           false,
-		GasAllocated:        uint64((*abi.ConvertType(out[4], new(*big.Int)).(**big.Int)).Int64()),
+		GasAllocated:        gasAllocatedBig.Uint64(),
 		UpkeepID:            payload.UpkeepID,
 		Trigger:             payload.Trigger,
 		WorkID:              payload.WorkID,

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding/packer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding/packer_test.go
@@ -184,6 +184,19 @@ func TestPacker_UnpackCheckResults(t *testing.T) {
 			},
 			ExpectedError: fmt.Errorf("upkeepId %s failed to unpack checkUpkeep result 0x123123: abi: cannot marshal in to go type: length insufficient 3 require 32", p2.UpkeepID.String()),
 		},
+		{
+			Name:    "gas allocated overflow",
+			Payload: p1,
+			// valid checkUpkeep encoding with GasAllocated set to math.MaxUint64+1 (2^64)
+			RawData: "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000421c0000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000c8caf37f3b3890000000000000000000000000000000000000000000000000000000000000000",
+			ExpectedResult: ocr2keepers.CheckResult{
+				UpkeepID:               upkeepId,
+				PipelineExecutionState: uint8(PackUnpackDecodeFailed),
+				Trigger:                p1.Trigger,
+				WorkID:                 p1.WorkID,
+			},
+			ExpectedError: fmt.Errorf("upkeepId %s GasAllocated value 18446744073709551616 overflows uint64", p1.UpkeepID.String()),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

`UnpackCheckResult` in `packer.go` uses `big.Int.Int64()` to populate the `uint64` field `GasAllocated`. If the on-chain value exceeds `math.MaxInt64` (2^63-1), `Int64()` silently truncates and returns a negative value, which then wraps to a large positive `uint64`. This could cause upkeep gas budgets to be wildly incorrect.

The fix extracts the `*big.Int`, checks `IsUint64()`, and returns an error if the value overflows. Otherwise it uses `.Uint64()` for a safe conversion.

## Changes

- `core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding/packer.go` - 7 lines added, 1 removed

## Test plan

- [x] `go build` passes on the target package
- [x] Diff limited to single target file
- [ ] Existing unit tests pass (CI will verify)