### PR TITLE
preserve tx ID after transaction status polling

### DIFF
--- a/core/services/relay/evm/evm_service.go
+++ b/core/services/relay/evm/evm_service.go
@@ -261,7 +261,7 @@ func (e *evmService) SubmitTransaction(ctx context.Context, txRequest evm.Submit
 	txStatus, err := retry.Do(retryContext, e.logger, func(ctx context.Context) (evm.TransactionStatus, error) {
 		txStatus, txStatusErr := e.chain.TxManager().GetTransactionStatus(ctx, txID)
 		if txStatusErr != nil && !errors.Is(txStatusErr, context.DeadlineExceeded) {
-			lastStatusErr = fmt.Errorf("failed get transaction status for txID: %s err: %w", txID, txStatusErr)
+			lastStatusErr = fmt.Errorf("failed to get transaction status for txID: %s err: %w", txID, txStatusErr)
 			return evm.TxFatal, lastStatusErr
 		}
 
@@ -281,7 +281,7 @@ func (e *evmService) SubmitTransaction(ctx context.Context, txRequest evm.Submit
 
 	if err != nil {
 		e.logger.Warnw("Failed getting transaction status", "txID", txID, "lastErr", lastStatusErr, "retryErr", err)
-		return &evm.TransactionResult{TxStatus: evm.TxFatal, TxIdempotencyKey: txID}, lastStatusErr
+		return &evm.TransactionResult{TxStatus: evm.TxFatal, TxIdempotencyKey: txID}, fmt.Errorf("last err: %w retry err: %w", lastStatusErr, err)
 	}
 
 	if txStatus == evm.TxFatal {

--- a/core/services/relay/evm/evm_service.go
+++ b/core/services/relay/evm/evm_service.go
@@ -257,25 +257,31 @@ func (e *evmService) SubmitTransaction(ctx context.Context, txRequest evm.Submit
 
 	retryContext, cancel := context.WithTimeout(ctx, maximumWaitTimeForConfirmation)
 	defer cancel()
+	var lastStatusErr error
 	txStatus, err := retry.Do(retryContext, e.logger, func(ctx context.Context) (evm.TransactionStatus, error) {
 		txStatus, txStatusErr := e.chain.TxManager().GetTransactionStatus(ctx, txID)
-		if txStatusErr != nil {
-			return evm.TxFatal, txStatusErr
+		if txStatusErr != nil && !errors.Is(txStatusErr, context.DeadlineExceeded) {
+			lastStatusErr = fmt.Errorf("failed get transaction status for txID: %s err: %w", txID, txStatusErr)
+			return evm.TxFatal, lastStatusErr
 		}
+
 		switch txStatus {
 		case commontypes.Fatal, commontypes.Failed:
 			return evm.TxFatal, nil
 		case commontypes.Unconfirmed, commontypes.Finalized:
 			return evm.TxSuccess, nil
 		case commontypes.Pending, commontypes.Unknown:
-			return evm.TxFatal, fmt.Errorf("tx still in state pending or unknown, tx status is %d for tx with ID %s", txStatus, txID)
+			lastStatusErr = fmt.Errorf("tx still in state pending or unknown, tx status is %d for tx with ID %s", txStatus, txID)
+			return evm.TxFatal, lastStatusErr
 		default:
-			return evm.TxFatal, fmt.Errorf("unexpected transaction status %d for tx with ID %s", txStatus, txID)
+			lastStatusErr = fmt.Errorf("unexpected transaction status %d for tx with ID %s", txStatus, txID)
+			return evm.TxFatal, lastStatusErr
 		}
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("failed getting transaction status. %w", err)
+		e.logger.Warnw("Failed getting transaction status", "txID", txID, "lastErr", lastStatusErr, "retryErr", err)
+		return &evm.TransactionResult{TxStatus: evm.TxFatal, TxIdempotencyKey: txID}, lastStatusErr
 	}
 
 	if txStatus == evm.TxFatal {

--- a/core/services/relay/evm/evm_service_test.go
+++ b/core/services/relay/evm/evm_service_test.go
@@ -141,6 +141,10 @@ func runSubmitTransactionTest(t *testing.T, tc SubmitTransactionTestCase) {
 		require.Contains(t, err.Error(), tc.ExpectedError)
 	} else {
 		require.NoError(t, err)
+	}
+
+	if tc.ExpectedResult != nil {
+		require.NotNil(t, result)
 		require.NotEmpty(t, result.TxIdempotencyKey)
 		result.TxIdempotencyKey = ""
 		require.Equal(t, tc.ExpectedResult, result)
@@ -269,14 +273,17 @@ func TestEVMService(t *testing.T) {
 			ExpectedError: "getting transaction receipt",
 		},
 		{
-			Name: "Fails getting transaction status",
+			Name: "Returns TxFatal with txID when GetTransactionStatus returns non-deadline error",
 			SetupMocks: func(m *Mocks, ctx any) {
 				expectedTx := txmgr.Tx{}
 				m.TxManager.EXPECT().CreateTransaction(ctx, mock.Anything).Return(expectedTx, nil)
-				expectedMessage := "fail getting transaction status"
-				m.TxManager.EXPECT().GetTransactionStatus(mock.Anything, mock.Anything).Return(commontypes.Fatal, errors.New(expectedMessage))
+				m.TxManager.EXPECT().GetTransactionStatus(mock.Anything, mock.Anything).Return(commontypes.Fatal, errors.New("fail getting transaction status"))
 			},
-			ExpectedError: "failed getting transaction status",
+			ExpectedResult: &evm.TransactionResult{
+				TxHash:   common.Hash{},
+				TxStatus: evm.TxFatal,
+			},
+			ExpectedError: "failed get transaction status for txID",
 		},
 		{
 			Name: "Success with pending status and then finalized status",
@@ -350,6 +357,33 @@ func TestEVMService(t *testing.T) {
 				TxHash:   common.Hash{},
 				TxStatus: evm.TxFatal,
 			},
+		},
+		{
+			Name: "Returns TxFatal with txID when GetTransactionStatus returns context deadline exceeded",
+			SetupMocks: func(m *Mocks, ctx any) {
+				expectedTx := txmgr.Tx{}
+				m.TxManager.EXPECT().CreateTransaction(ctx, mock.Anything).Return(expectedTx, nil)
+				m.TxManager.EXPECT().GetTransactionStatus(mock.Anything, mock.Anything).Return(commontypes.Pending, nil).Once()
+				m.TxManager.EXPECT().GetTransactionStatus(mock.Anything, mock.Anything).Return(commontypes.Unknown, context.DeadlineExceeded)
+			},
+			ExpectedResult: &evm.TransactionResult{
+				TxHash:   common.Hash{},
+				TxStatus: evm.TxFatal,
+			},
+			ExpectedError: "tx still in state pending or unknown",
+		},
+		{
+			Name: "Returns TxFatal with txID when retry times out waiting for pending tx",
+			SetupMocks: func(m *Mocks, ctx any) {
+				expectedTx := txmgr.Tx{}
+				m.TxManager.EXPECT().CreateTransaction(ctx, mock.Anything).Return(expectedTx, nil)
+				m.TxManager.EXPECT().GetTransactionStatus(mock.Anything, mock.Anything).Return(commontypes.Pending, nil)
+			},
+			ExpectedResult: &evm.TransactionResult{
+				TxHash:   common.Hash{},
+				TxStatus: evm.TxFatal,
+			},
+			ExpectedError: "tx still in state pending or unknown",
 		},
 		{
 			Name: "Fails with failed to get enabled addresses",

--- a/core/services/relay/evm/evm_service_test.go
+++ b/core/services/relay/evm/evm_service_test.go
@@ -283,7 +283,7 @@ func TestEVMService(t *testing.T) {
 				TxHash:   common.Hash{},
 				TxStatus: evm.TxFatal,
 			},
-			ExpectedError: "failed get transaction status for txID",
+			ExpectedError: "failed to get transaction status for txID",
 		},
 		{
 			Name: "Success with pending status and then finalized status",


### PR DESCRIPTION
Retry do overrides returned error with context.DeadlineExceeded, as the result txID gets ommited, which makes  deterministic mapping from WriteReport -> txm error impossible