### PR TITLE
fix: release 2.36.1 changeset

### DIFF
--- a/.changeset/late-wolves-feel.md
+++ b/.changeset/late-wolves-feel.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#updated Bump libocr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Minor Changes
 
 - [#21208](https://github.com/smartcontractkit/chainlink/pull/21208) [`140625e`](https://github.com/smartcontractkit/chainlink/commit/140625edee02df6a608178b166e72cf2bd8a14a1) - Minor bump to start next version
+- [#21420](https://github.com/smartcontractkit/chainlink/pull/21420) [`fd6e29e`](https://github.com/smartcontractkit/chainlink/commit/fd6e29e2ba22fa8f3c15203372d4a7854b1d67ae) - #updated Bump libocr
 
 ### Patch Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@
 
 - Hotfix release from v2.36.0
 
+- [#21420](https://github.com/smartcontractkit/chainlink/pull/21420) [`fd6e29e`](https://github.com/smartcontractkit/chainlink/commit/fd6e29e2ba22fa8f3c15203372d4a7854b1d67ae) - #updated Bump libocr
+
 ## 2.36.0
 
 ### Minor Changes
 
 - [#21208](https://github.com/smartcontractkit/chainlink/pull/21208) [`140625e`](https://github.com/smartcontractkit/chainlink/commit/140625edee02df6a608178b166e72cf2bd8a14a1) - Minor bump to start next version
-- [#21420](https://github.com/smartcontractkit/chainlink/pull/21420) [`fd6e29e`](https://github.com/smartcontractkit/chainlink/commit/fd6e29e2ba22fa8f3c15203372d4a7854b1d67ae) - #updated Bump libocr
 
 ### Patch Changes
 


### PR DESCRIPTION
### Changes

* Runs `pnpm changeset version`
* Undoes version bump in `package.json` from minor changeset
* Moves changelog entry to under 2.36.1
