### PR TITLE
[DX-2591] migrate solana tests to devenv

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -848,237 +848,29 @@ jobs:
           echo "sha is: ${full_sha}"
           echo "sha=${full_sha}" | tee -a "$GITHUB_OUTPUT"
 
-  solana-test-image-exists:
-    environment: integration
+  run-solana-smoke-tests:
+    name: Run Solana Smoke Tests
+    needs: [build-chainlink, get-solana-sha, solana-smoke-tests-setup]
     permissions:
-      checks: write
-      pull-requests: write
       id-token: write
       contents: read
-    name: Check If Solana Test Image Exists
-    runs-on: ubuntu-latest
-    needs: [get-solana-sha]
-    outputs:
-      exists: ${{ steps.check-image.outputs.exists }}
-    steps:
-      - name: Check if image exists
-        id: check-image
-        uses: smartcontractkit/chainlink-github-actions/docker/image-exists@0ce1e67b254a4f041e03cc6f0e3afc987b47c7bd # v2.3.30
-        with:
-          repository: chainlink-solana-tests
-          tag: ${{ needs.get-solana-sha.outputs.sha }}
-          AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-          AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-
-  solana-build-contracts:
-    name: Solana Build Artifacts
     if: needs.solana-smoke-tests-setup.outputs.should-run-solana-tests == 'true'
-    environment: integration
-    permissions:
-      checks: write
-      pull-requests: write
-      id-token: write
-      contents: read
-    runs-on: ubuntu22.04-8cores-32GB
-    needs:
-      [
-        changes,
-        solana-test-image-exists,
-        get-solana-sha,
-        solana-smoke-tests-setup,
-      ]
-    steps:
-      - name: Checkout the solana repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          repository: smartcontractkit/chainlink-solana
-          ref: ${{ needs.get-solana-sha.outputs.sha }}
-      - name: Build contracts
-        if: needs.solana-test-image-exists.outputs.exists == 'false'
-        uses: smartcontractkit/chainlink-solana/.github/actions/build_contract_artifacts@841f6229b6a0be0114c47cb676b1136d92f935c9 # node20 update on may 10, 2024
-        with:
-          ref: ${{ needs.get-solana-sha.outputs.sha }}
-          runner-os: ${{ runner.os }}
-
-  solana-build-test-image:
-    name: Solana Build Test Image
-    if: needs.solana-smoke-tests-setup.outputs.should-run-solana-tests == 'true'
-    environment: integration
-    permissions:
-      checks: write
-      pull-requests: write
-      id-token: write
-      contents: read
-    runs-on: ubuntu22.04-8cores-32GB
-    needs:
-      [
-        solana-build-contracts,
-        solana-test-image-exists,
-        changes,
-        get-solana-sha,
-        solana-smoke-tests-setup,
-      ]
-    env:
-      CONTRACT_ARTIFACTS_PATH: contracts/target/deploy
-      GOTOOLCHAIN: auto
-    steps:
-      - name: Checkout the repo
-        if: needs.solana-test-image-exists.outputs.exists == 'false'
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          repository: smartcontractkit/chainlink-solana
-          ref: ${{ needs.get-solana-sha.outputs.sha }}
-      - name: Download Artifacts
-        if: needs.solana-test-image-exists.outputs.exists == 'false'
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts
-          path: ${{ env.CONTRACT_ARTIFACTS_PATH }}
-      - name: Build Test Image
-        if: needs.solana-test-image-exists.outputs.exists == 'false'
-        uses: smartcontractkit/.github/actions/ctf-build-test-image@ctf-build-test-image/0.3.0
-        with:
-          repository: chainlink-solana-tests
-          tag: ${{ needs.get-solana-sha.outputs.sha }}
-          suites: smoke
-          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-          QA_AWS_ACCOUNT_NUMBER: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
-
-  solana-smoke-tests:
-    environment: integration
-    permissions:
-      checks: write
-      pull-requests: write
-      id-token: write
-      contents: read
-    name: Solana Smoke Tests
-    if: needs.solana-smoke-tests-setup.outputs.should-run-solana-tests == 'true'
-    runs-on: ${{ needs.labels.outputs.builder-runner-label || 'ubuntu22.04-8cores-32GB' }}
-    needs:
-      [
-        build-chainlink,
-        solana-build-contracts,
-        solana-build-test-image,
-        labels,
-        changes,
-        get-solana-sha,
-        solana-smoke-tests-setup,
-      ]
-    env:
-      CHAINLINK_COMMIT_SHA: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
-      CHAINLINK_ENV_USER: ${{ github.actor }}
-      TEST_LOG_LEVEL: debug
-      CONTRACT_ARTIFACTS_PATH: contracts/target/deploy
-    steps:
-      - name: Enable S3 Cache for Self-Hosted Runners
-        # these env vars are set (and exposed) when it is a self-hosted runner with extras=s3-cache
-        if: ${{ env.RUNS_ON_INSTANCE_ID != '' && env.ACTIONS_CACHE_URL != '' }}
-        uses: runs-on/action@66d4449b717b5462159659523d1241051ff470b9 # v1
-      - name: Checkout the repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          repository: smartcontractkit/chainlink-solana
-          ref: ${{ needs.get-solana-sha.outputs.sha }}
-      - name: Run Setup
-        uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@ctf-setup-run-tests-environment/0.8.0
-        with:
-          go_mod_path: ./integration-tests/go.mod
-          cache_restore_only: true
-          cache_key_id: core-solana-e2e-${{ env.MOD_CACHE_VERSION }}
-          aws_registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
-          dockerhub_username: ${{ secrets.DOCKERHUB_READONLY_USERNAME }}
-          dockerhub_password: ${{ secrets.DOCKERHUB_READONLY_PASSWORD }}
-          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-          enable-gap: "false"
-      - name: Pull Artifacts
-        run: |
-          IMAGE_NAME=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-solana-tests:${{ needs.get-solana-sha.outputs.sha }}
-          # Pull the Docker image
-          docker pull "$IMAGE_NAME"
-
-          # Create a container without starting it
-          CONTAINER_ID=$(docker create "$IMAGE_NAME")
-
-          # Copy the artifacts from the container
-          mkdir -p ./${{env.CONTRACT_ARTIFACTS_PATH}}/
-          docker cp "$CONTAINER_ID:/go/testdir/${{env.CONTRACT_ARTIFACTS_PATH}}/" "./${{env.CONTRACT_ARTIFACTS_PATH}}/../"
-
-          # Remove the created container
-          docker rm "$CONTAINER_ID"
-      - name: Install Solana CLI # required for ensuring the local test validator is configured correctly
-        run: ./scripts/install-solana-ci.sh
-
-      - name: Install gauntlet
-        run: |
-          yarn --cwd ./gauntlet install --frozen-lockfile
-          yarn --cwd ./gauntlet build
-          yarn --cwd ./gauntlet gauntlet
-      - name: Generate config overrides
-        env:
-          VERSION: ${{ inputs.evm-ref || env.CHAINLINK_REF }}
-        run:
-          | # https://github.com/smartcontractkit/chainlink-testing-framework/lib/blob/main/config/README.md
-          cat << EOF > config.toml
-          [ChainlinkImage]
-          version="${{ env.VERSION }}"
-          [Common]
-          user="${{ github.actor }}"
-          internal_docker_repo = "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com"
-          EOF
-          # shellcheck disable=SC2002
-          BASE64_CONFIG_OVERRIDE=$(cat config.toml | base64 -w 0)
-          # shellcheck disable=SC2086
-          echo ::add-mask::$BASE64_CONFIG_OVERRIDE
-          # shellcheck disable=SC2086
-          echo "BASE64_CONFIG_OVERRIDE=$BASE64_CONFIG_OVERRIDE" >> $GITHUB_ENV
-      - name: Run Tests
-        uses: smartcontractkit/.github/actions/ctf-run-tests@ctf-run-tests/0.11.0
-        env:
-          E2E_TEST_CHAINLINK_IMAGE: ${{ env.CHAINLINK_IMAGE }}
-          E2E_TEST_SOLANA_SECRET: thisisatestingonlysecret
-          CHAINLINK_USER_TEAM: "BIX"
-        with:
-          test_command_to_run: export ENV_JOB_IMAGE=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-solana-tests:${{ needs.get-solana-sha.outputs.sha }} && make test_smoke
-          test_config_override_base64: ${{ env.BASE64_CONFIG_OVERRIDE }}
-          cl_repo: ${{ env.CHAINLINK_IMAGE }}
-          cl_image_tag: test-${{ inputs.evm-ref || env.CHAINLINK_REF }}
-          publish_check_name: Solana Smoke Test Results
-          go_mod_path: ./integration-tests/go.mod
-          cache_key_id: core-solana-e2e-${{ env.MOD_CACHE_VERSION }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          aws_registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
-          artifacts_name: solana-test-artifacts
-          artifacts_location: |
-            ./integration-tests/smoke/logs
-            ./integration-tests/smoke/db_dumps
-            ./integration-tests/smoke/seth_artifacts
-            /tmp/gotest.log
-          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-          run_setup: false
-          go_coverage_src_dir: /var/tmp/go-coverage
-          go_coverage_dest_dir: ${{ github.workspace }}/.covdata
-
-      - name: Upload Coverage Data
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 2
-        continue-on-error: true
-        with:
-          name: cl_node_coverage_data_solana_tests
-          path: .covdata
-          retention-days: 1
+    uses: smartcontractkit/chainlink-solana/.github/workflows/e2e_custom_cl_reusable.yml@f2205f8506c7441d805fa779a198b52163a05bfd
+    with:
+      solana_ref: ${{ needs.get-solana-sha.outputs.sha }}
+      ecr_repository: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
+      image_tag: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+    secrets:
+      aws_account_id: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
+      aws_region: ${{ secrets.QA_AWS_REGION }}
+      aws_role_to_assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
 
   notify-test-failure:
     name: Notify Test Failure
     # TODO: uncomment this when we want to notify on test failures post-merge, if Phase 3 is necessary
     if: false
     # if: ${{ github.ref_name == 'develop' && failure() }}
-    needs: [check-e2e-test-results, solana-smoke-tests]
+    needs: [check-e2e-test-results, run-solana-smoke-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Send slack notification for failed migration tests

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -512,7 +512,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c423b3 // indirect
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f // indirect
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a // indirect
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7 // indirect
 	github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260217175957-8f1af02c5075 // indirect
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0 // indirect
 	github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260304150206-c64e48eb0cb0 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1694,8 +1694,8 @@ github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c
 github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c423b3/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f h1:3+vQMwuWL6+OqNutFqo/+gkczJwcr+MBPqeSxcjfI1Y=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f/go.mod h1:GTpDgyK0OObf7jpch6p8N281KxN92wbB8serZhU9yRc=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a h1:WBRwhIhDHF1rFfR3tLwPxTOxLMwg2Cvbr9+VcePtA8U=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7 h1:XLMJ6FDQoEiqDNZ4B1MV9Vi1lL8vOfo9SzgqkM8IiuA=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
 github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260217175957-8f1af02c5075 h1:PcR7Zdh+Z+Dh/S4lQ1xDbnFrb6He70KW9O5+9DtgloE=
 github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260217175957-8f1af02c5075/go.mod h1:APCV5fIW/a+JGM+Cz9yb6XyGt8ht5hISEYfpG/k4Z+k=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0 h1:4mGJySR1GAJAAFRwEo6YiSKM2zSHzYT5b/FSmrpNUGI=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260226130359-963f935e0396
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.10.0
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7
 	github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260217175957-8f1af02c5075
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0
 	github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260304150206-c64e48eb0cb0

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1447,8 +1447,8 @@ github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c
 github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c423b3/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f h1:3+vQMwuWL6+OqNutFqo/+gkczJwcr+MBPqeSxcjfI1Y=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f/go.mod h1:GTpDgyK0OObf7jpch6p8N281KxN92wbB8serZhU9yRc=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a h1:WBRwhIhDHF1rFfR3tLwPxTOxLMwg2Cvbr9+VcePtA8U=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7 h1:XLMJ6FDQoEiqDNZ4B1MV9Vi1lL8vOfo9SzgqkM8IiuA=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
 github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260217175957-8f1af02c5075 h1:PcR7Zdh+Z+Dh/S4lQ1xDbnFrb6He70KW9O5+9DtgloE=
 github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260217175957-8f1af02c5075/go.mod h1:APCV5fIW/a+JGM+Cz9yb6XyGt8ht5hISEYfpG/k4Z+k=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0 h1:4mGJySR1GAJAAFRwEo6YiSKM2zSHzYT5b/FSmrpNUGI=

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260128151123-605e9540b706
 	github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0
 	github.com/smartcontractkit/chainlink-ton v0.0.0-20260318210736-c3f360fd19a8
 	github.com/smartcontractkit/cre-sdk-go v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1289,8 +1289,8 @@ github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c
 github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c423b3/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f h1:3+vQMwuWL6+OqNutFqo/+gkczJwcr+MBPqeSxcjfI1Y=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f/go.mod h1:GTpDgyK0OObf7jpch6p8N281KxN92wbB8serZhU9yRc=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a h1:WBRwhIhDHF1rFfR3tLwPxTOxLMwg2Cvbr9+VcePtA8U=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7 h1:XLMJ6FDQoEiqDNZ4B1MV9Vi1lL8vOfo9SzgqkM8IiuA=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0 h1:4mGJySR1GAJAAFRwEo6YiSKM2zSHzYT5b/FSmrpNUGI=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0/go.mod h1:U3XStbEnbx/+L22n1/8aOIdgcGVxtsZB7p59xJGngAs=
 github.com/smartcontractkit/chainlink-ton v0.0.0-20260318210736-c3f360fd19a8 h1:TAa3dDeNpkR263GdXiH1hKEBev1btXLxDPnhP6VfFDY=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -522,7 +522,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c423b3 // indirect
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f // indirect
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a // indirect
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.3 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1686,8 +1686,8 @@ github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c
 github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c423b3/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f h1:3+vQMwuWL6+OqNutFqo/+gkczJwcr+MBPqeSxcjfI1Y=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f/go.mod h1:GTpDgyK0OObf7jpch6p8N281KxN92wbB8serZhU9yRc=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a h1:WBRwhIhDHF1rFfR3tLwPxTOxLMwg2Cvbr9+VcePtA8U=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7 h1:XLMJ6FDQoEiqDNZ4B1MV9Vi1lL8vOfo9SzgqkM8IiuA=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0 h1:4mGJySR1GAJAAFRwEo6YiSKM2zSHzYT5b/FSmrpNUGI=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0/go.mod h1:U3XStbEnbx/+L22n1/8aOIdgcGVxtsZB7p59xJGngAs=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260304150206-c64e48eb0cb0 h1:5NdsaclAfx+p8lZUZ3WIqMW3M9Cze1ZVPENOQhha1pk=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -500,7 +500,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c423b3 // indirect
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f // indirect
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a // indirect
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7 // indirect
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0 // indirect
 	github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260304150206-c64e48eb0cb0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.7 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1656,8 +1656,8 @@ github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c
 github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c423b3/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f h1:3+vQMwuWL6+OqNutFqo/+gkczJwcr+MBPqeSxcjfI1Y=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f/go.mod h1:GTpDgyK0OObf7jpch6p8N281KxN92wbB8serZhU9yRc=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a h1:WBRwhIhDHF1rFfR3tLwPxTOxLMwg2Cvbr9+VcePtA8U=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7 h1:XLMJ6FDQoEiqDNZ4B1MV9Vi1lL8vOfo9SzgqkM8IiuA=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0 h1:4mGJySR1GAJAAFRwEo6YiSKM2zSHzYT5b/FSmrpNUGI=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0/go.mod h1:U3XStbEnbx/+L22n1/8aOIdgcGVxtsZB7p59xJGngAs=
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260304150206-c64e48eb0cb0 h1:5NdsaclAfx+p8lZUZ3WIqMW3M9Cze1ZVPENOQhha1pk=

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -35,7 +35,7 @@ plugins:
 
   solana:
     - moduleURI: "github.com/smartcontractkit/chainlink-solana"
-      gitRef: "v1.1.2-0.20260318003508-442c25062e9a"
+      gitRef: "v1.1.2-0.20260320011913-f2205f8506c7"
       installPath: "./pkg/solana/cmd/chainlink-solana"
 
   starknet:

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260226130359-963f935e0396
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.5
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1657,8 +1657,8 @@ github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c
 github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c423b3/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f h1:3+vQMwuWL6+OqNutFqo/+gkczJwcr+MBPqeSxcjfI1Y=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f/go.mod h1:GTpDgyK0OObf7jpch6p8N281KxN92wbB8serZhU9yRc=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a h1:WBRwhIhDHF1rFfR3tLwPxTOxLMwg2Cvbr9+VcePtA8U=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7 h1:XLMJ6FDQoEiqDNZ4B1MV9Vi1lL8vOfo9SzgqkM8IiuA=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
 github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260217175957-8f1af02c5075 h1:PcR7Zdh+Z+Dh/S4lQ1xDbnFrb6He70KW9O5+9DtgloE=
 github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260217175957-8f1af02c5075/go.mod h1:APCV5fIW/a+JGM+Cz9yb6XyGt8ht5hISEYfpG/k4Z+k=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0 h1:4mGJySR1GAJAAFRwEo6YiSKM2zSHzYT5b/FSmrpNUGI=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260211172625-dff40e83b3c9 // indirect
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a // indirect
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7 // indirect
 	github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260217175957-8f1af02c5075 // indirect
 	github.com/stellar/go-stellar-sdk v0.1.0 // indirect
 	github.com/stellar/go-xdr v0.0.0-20231122183749-b53fb00bcac2 // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1841,8 +1841,8 @@ github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c
 github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c423b3/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f h1:3+vQMwuWL6+OqNutFqo/+gkczJwcr+MBPqeSxcjfI1Y=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f/go.mod h1:GTpDgyK0OObf7jpch6p8N281KxN92wbB8serZhU9yRc=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a h1:WBRwhIhDHF1rFfR3tLwPxTOxLMwg2Cvbr9+VcePtA8U=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260318003508-442c25062e9a/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7 h1:XLMJ6FDQoEiqDNZ4B1MV9Vi1lL8vOfo9SzgqkM8IiuA=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260320011913-f2205f8506c7/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
 github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260217175957-8f1af02c5075 h1:PcR7Zdh+Z+Dh/S4lQ1xDbnFrb6He70KW9O5+9DtgloE=
 github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260217175957-8f1af02c5075/go.mod h1:APCV5fIW/a+JGM+Cz9yb6XyGt8ht5hISEYfpG/k4Z+k=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0 h1:4mGJySR1GAJAAFRwEo6YiSKM2zSHzYT5b/FSmrpNUGI=


### PR DESCRIPTION
Work was done in https://github.com/smartcontractkit/chainlink-solana/actions/runs/22773002907/job/66059931939?pr=1477, here I've only updated how we run these tests.

Successful run: https://github.com/smartcontractkit/chainlink/actions/runs/23332266185/job/67868284327?pr=21447

To do:
- [x] merge https://github.com/smartcontractkit/chainlink-solana/pull/1477 in `chainlink-solana` and update reusable workflow reference in `integration-tests.yaml`.