### PR TITLE
Comment doesn't apply. This is the cleanest way

### DIFF
--- a/core/services/gateway/network/httpserver.go
+++ b/core/services/gateway/network/httpserver.go
@@ -146,9 +146,6 @@ func (s *httpServer) isAllowedOrigin(origin string) bool {
 		return false
 	}
 	for _, allowed := range s.config.CORSAllowedOrigins {
-		// probably better to do this once when server starts and store it in a map
-		// this is an easier solution so we don't have to apply more changes to the code
-		// just need to be careful when specifying allowed origins in the config file
 		allowedScheme, allowedHost, allowedPort, err := s.splitURL(allowed)
 		if err != nil {
 			s.lggr.Debug("error parsing allowed origin URL", err)


### PR DESCRIPTION
I got sucked down a rabbit hole here, but after trying a few different ways of doing this, the current code is the most readable. You can write an `allowedOrigins` struct, then use `path.Match` to match the host and `ParseRequestURI` to validate the CORs domains at deploy time but that requires the readers to know the details of those APIs. 

```
		// check for wildcard host match (e.g., *.remix.com)
		if strings.HasPrefix(allowedHost, "*.") {
			allowedHost = allowedHost[2:]
```

is a lot more readable than the permutations I tried. 