### PR TITLE
[Dx-3233] disable old v1 example PoR test in the CI

### DIFF
--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -238,6 +238,7 @@ jobs:
           go run . env swap nodes
 
       - name: Execute example PoR workflow
+        if: false # TODO: Migrate example test to V2 and run here (DX-3233)
         shell: bash
         working-directory: core/scripts/cre/environment
         run: |


### PR DESCRIPTION
Why? With new gateway config there's no way this test can work. Plus it's a V1 workflow and V1 is practically deprecated.