### PR TITLE
core/services/workflows/syncer: more parallel tests

### DIFF
--- a/core/services/workflows/syncer/fetcher_test.go
+++ b/core/services/workflows/syncer/fetcher_test.go
@@ -48,6 +48,7 @@ func (w *wrapper) GetGatewayConnector() connector.GatewayConnector {
 }
 
 func TestNewFetcherService(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	lggr := logger.TestLogger(t)
 	connector := gcmocks.NewGatewayConnector(t)

--- a/core/services/workflows/syncer/handler_test.go
+++ b/core/services/workflows/syncer/handler_test.go
@@ -326,6 +326,7 @@ const (
 )
 
 func Test_workflowRegisteredHandler(t *testing.T) {
+	t.Parallel()
 	binaryURL := "http://example.com/binary"
 	secretsURL := "http://example.com/secrets"
 	configURL := "http://example.com/config"
@@ -880,6 +881,7 @@ func newMockArtifactStore(as *artifacts.Store, deleteWorkflowArtifactsErr error)
 }
 
 func Test_workflowDeletedHandler(t *testing.T) {
+	t.Parallel()
 	workflowEncryptionKey := workflowkey.MustNewXXXTestingOnly(big.NewInt(1))
 	t.Run("success deleting existing engine and spec", func(t *testing.T) {
 		var (
@@ -1123,6 +1125,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 }
 
 func Test_workflowPausedActivatedUpdatedHandler(t *testing.T) {
+	t.Parallel()
 	t.Run("success pausing activating and updating existing engine and spec", func(t *testing.T) {
 		var (
 			ctx     = testutils.Context(t)

--- a/core/services/workflows/syncer/v2/fetcher_test.go
+++ b/core/services/workflows/syncer/v2/fetcher_test.go
@@ -50,6 +50,7 @@ func (w *wrapper) GetGatewayConnector() connector.GatewayConnector {
 }
 
 func TestNewFetcherService(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	lggr := logger.TestLogger(t)
 	storageService := mocks.NewWorkflowClient(t)

--- a/core/services/workflows/syncer/v2/handler_test.go
+++ b/core/services/workflows/syncer/v2/handler_test.go
@@ -171,6 +171,7 @@ const (
 )
 
 func Test_workflowRegisteredHandler(t *testing.T) {
+	t.Parallel()
 	binaryURLFactory := func(wfID string) string {
 		return "http://example.com/" + wfID + "/binary"
 	}
@@ -723,6 +724,7 @@ func newMockArtifactStore(as *artifacts.Store, deleteWorkflowArtifactsErr error)
 }
 
 func Test_workflowDeletedHandler(t *testing.T) {
+	t.Parallel()
 	t.Run("success deleting existing engine and spec", func(t *testing.T) {
 		var (
 			ctx     = testutils.Context(t)

--- a/core/services/workflows/syncer/v2/workflow_syncer_v2_test.go
+++ b/core/services/workflows/syncer/v2/workflow_syncer_v2_test.go
@@ -50,6 +50,7 @@ import (
 )
 
 func Test_InitialStateSyncV2(t *testing.T) {
+	t.Parallel()
 	lggr := logger.TestLogger(t)
 	backendTH := testutils.NewEVMBackendTH(t)
 	donID := uint32(1)
@@ -153,6 +154,7 @@ func Test_InitialStateSyncV2(t *testing.T) {
 }
 
 func Test_RegistrySyncer_SkipsEventsNotBelongingToDONV2(t *testing.T) {
+	t.Parallel()
 	var (
 		lggr      = logger.TestLogger(t)
 		backendTH = testutils.NewEVMBackendTH(t)
@@ -238,6 +240,7 @@ func Test_RegistrySyncer_SkipsEventsNotBelongingToDONV2(t *testing.T) {
 }
 
 func Test_RegistrySyncer_WorkflowRegistered_InitiallyPausedV2(t *testing.T) {
+	t.Parallel()
 	var (
 		ctx       = coretestutils.Context(t)
 		lggr      = logger.TestLogger(t)
@@ -341,6 +344,7 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyPausedV2(t *testing.T) {
 }
 
 func Test_RegistrySyncer_WorkflowRegistered_InitiallyActivatedV2(t *testing.T) {
+	t.Parallel()
 	var (
 		ctx       = coretestutils.Context(t)
 		lggr      = logger.TestLogger(t)
@@ -448,6 +452,7 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyActivatedV2(t *testing.T) {
 }
 
 func Test_StratReconciliation_InitialStateSyncV2(t *testing.T) {
+	t.Parallel()
 	t.Run("with heavy load", func(t *testing.T) {
 		lggr := logger.TestLogger(t)
 		backendTH := testutils.NewEVMBackendTH(t)
@@ -522,6 +527,7 @@ func Test_StratReconciliation_InitialStateSyncV2(t *testing.T) {
 }
 
 func Test_RegistrySyncer_DONUpdate(t *testing.T) {
+	t.Parallel()
 	lggr := logger.TestLogger(t)
 	backendTH := testutils.NewEVMBackendTH(t)
 	donID := uint32(1)
@@ -617,6 +623,7 @@ func Test_RegistrySyncer_DONUpdate(t *testing.T) {
 }
 
 func Test_StratReconciliation_RetriesWithBackoffV2(t *testing.T) {
+	t.Parallel()
 	lggr := logger.TestLogger(t)
 	backendTH := testutils.NewEVMBackendTH(t)
 	donID := uint32(1)

--- a/core/services/workflows/syncer/workflow_syncer_test.go
+++ b/core/services/workflows/syncer/workflow_syncer_test.go
@@ -113,6 +113,7 @@ func (t *testDonNotifier) Subscribe(ctx context.Context) (<-chan capabilities.DO
 }
 
 func Test_EventHandlerStateSync(t *testing.T) {
+	t.Parallel()
 	lggr := logger.TestLogger(t)
 	backendTH := testutils.NewEVMBackendTH(t)
 	donID := uint32(1)
@@ -810,6 +811,7 @@ func Test_StratReconciliation_InitialStateSync(t *testing.T) {
 }
 
 func Test_StratReconciliation_RetriesWithBackoff(t *testing.T) {
+	t.Parallel()
 	lggr := logger.TestLogger(t)
 	backendTH := testutils.NewEVMBackendTH(t)
 	donID := uint32(1)


### PR DESCRIPTION
`package syncer` and `/v2` take around ~6 minutes to run in CI. This PR makes many of the slowest tests parallel. At least one could not be parallel due to using `Setenv`.