### PR TITLE
chore: update confidential-compute gitref to v0.0.8

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -52,5 +52,5 @@ plugins:
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "854d537b54e50906801d53b0c3c92777dde1d1fb"
+      gitRef: "5fdcd59a92b7137982f9f3c51d868ce01a158340"
       installPath: "./cmd/confidential-http"


### PR DESCRIPTION
Updates the confidential-compute capability gitref in `plugins/plugins.private.yaml` to the tip of `release/v0.0.8` (`5fdcd59a92b7137982f9f3c51d868ce01a158340`).