### PR TITLE
[DX-3042] Parallelize Docker artifact copying in CRE system tests

### DIFF
--- a/system-tests/lib/cre/workflow/docker.go
+++ b/system-tests/lib/cre/workflow/docker.go
@@ -11,6 +11,7 @@ import (
 	ctypes "github.com/docker/docker/api/types/container"
 	dc "github.com/docker/docker/client"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 )
@@ -46,80 +47,91 @@ func findAllDockerContainerNames(pattern string) ([]string, error) {
 }
 
 func CopyArtifactsToDockerContainers(containerTargetDir string, containerNamePattern string, filesToCopy ...string) error {
+	start := time.Now()
+	framework.L.Info().
+		Int("file_count", len(filesToCopy)).
+		Str("container_pattern", containerNamePattern).
+		Msg("Copying workflow artifacts to Docker containers (parallel)")
+
+	eg := errgroup.Group{}
 	for _, file := range filesToCopy {
 		if _, err := os.Stat(file); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: File '%s' does not exist. Skipping file copying to docker containers\n", file)
 			continue
 		}
-
-		workflowCopyErr := copyArtifactToDockerContainers(file, containerNamePattern, containerTargetDir)
-		if workflowCopyErr != nil {
-			return errors.Wrapf(workflowCopyErr, "failed to copy a file (%s) to docker containers", file)
-		}
+		eg.Go(func() error {
+			return errors.Wrapf(
+				copyArtifactToDockerContainers(file, containerNamePattern, containerTargetDir),
+				"failed to copy a file (%s) to docker containers", file,
+			)
+		})
 	}
+
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	framework.L.Info().
+		Dur("duration", time.Since(start)).
+		Msg("Workflow artifacts copied to Docker containers")
 	return nil
 }
 
 func copyArtifactToDockerContainers(filePath string, containerNamePattern string, targetDir string) error {
 	framework.L.Info().Msgf("Copying file '%s' to Docker containers", filePath)
-	containerNames, containerNamesErr := findAllDockerContainerNames(containerNamePattern)
-	if containerNamesErr != nil {
-		return errors.Wrap(containerNamesErr, "failed to find Docker containers")
+	containerNames, err := findAllDockerContainerNames(containerNamePattern)
+	if err != nil {
+		return errors.Wrap(err, "failed to find Docker containers")
 	}
-
 	if len(containerNames) == 0 {
 		return fmt.Errorf("no Docker containers found with name pattern %s", containerNamePattern)
 	}
 
-	frameworkDockerClient, frameworkDockerClientErr := framework.NewDockerClient()
-	if frameworkDockerClientErr != nil {
-		return errors.Wrap(frameworkDockerClientErr, "failed to create framework Docker client")
+	frameworkDockerClient, err := framework.NewDockerClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to create framework Docker client")
+	}
+	dockerClient, err := dc.NewClientWithOpts(dc.FromEnv, dc.WithAPIVersionNegotiation())
+	if err != nil {
+		return errors.Wrap(err, "failed to create Docker client")
 	}
 
+	eg := errgroup.Group{}
 	for _, containerName := range containerNames {
-		execOutput, execOutputErr := frameworkDockerClient.ExecContainer(containerName, []string{"mkdir", "-p", targetDir})
-		if execOutputErr != nil {
-			fmt.Fprint(os.Stderr, execOutput)
-			return errors.Wrap(execOutputErr, "failed to execute mkdir command in Docker container")
-		}
-
-		copyErr := frameworkDockerClient.CopyFile(containerName, filePath, targetDir)
-		if copyErr != nil {
-			fmt.Fprint(os.Stderr, execOutput)
-			return errors.Wrap(copyErr, "failed to copy artifact to Docker container")
-		}
-
-		dockerClient, dockerClientErr := dc.NewClientWithOpts(dc.FromEnv, dc.WithAPIVersionNegotiation())
-		if dockerClientErr != nil {
-			return errors.Wrap(dockerClientErr, "failed to create Docker client")
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-
-		containerJSON, ispectErr := dockerClient.ContainerInspect(ctx, containerName)
-		if ispectErr != nil {
-			cancel()
-			return errors.Wrap(ispectErr, "failed to inspect Docker container")
-		}
-		cancel()
-		user := containerJSON.Config.User
-		// if not running as root, change ownership to user that is running the container to avoid permission issues
-		if user != "" {
-			targetFilePath := filepath.Join(targetDir, filepath.Base(filePath))
-			execConfig := ctypes.ExecOptions{
-				Cmd:          []string{"chown", user, targetFilePath},
-				AttachStdout: true,
-				AttachStderr: true,
-				User:         "root",
-			}
-			execOutput, execOutputErr := frameworkDockerClient.ExecContainerOptions(containerName, execConfig)
-			if execOutputErr != nil {
+		eg.Go(func() error {
+			execOutput, execErr := frameworkDockerClient.ExecContainer(containerName, []string{"mkdir", "-p", targetDir})
+			if execErr != nil {
 				fmt.Fprint(os.Stderr, execOutput)
-				return errors.Wrap(execOutputErr, "failed to execute mkdir command in Docker container")
+				return errors.Wrap(execErr, "failed to execute mkdir command in Docker container")
 			}
-			fmt.Println("output " + execOutput)
-		}
+			if copyErr := frameworkDockerClient.CopyFile(containerName, filePath, targetDir); copyErr != nil {
+				return errors.Wrap(copyErr, "failed to copy artifact to Docker container")
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			containerJSON, inspectErr := dockerClient.ContainerInspect(ctx, containerName)
+			if inspectErr != nil {
+				return errors.Wrap(inspectErr, "failed to inspect Docker container")
+			}
+			user := containerJSON.Config.User
+			// if not running as root, change ownership to user that is running the container to avoid permission issues
+			if user != "" {
+				targetFilePath := filepath.Join(targetDir, filepath.Base(filePath))
+				execConfig := ctypes.ExecOptions{
+					Cmd:          []string{"chown", user, targetFilePath},
+					AttachStdout: true,
+					AttachStderr: true,
+					User:         "root",
+				}
+				execOutput, execErr = frameworkDockerClient.ExecContainerOptions(containerName, execConfig)
+				if execErr != nil {
+					fmt.Fprint(os.Stderr, execOutput)
+					return errors.Wrap(execErr, "failed to execute chown command in Docker container")
+				}
+				fmt.Println("output " + execOutput)
+			}
+			return nil
+		})
 	}
-
-	return nil
+	return eg.Wait()
 }

--- a/system-tests/lib/cre/workflow/docker.go
+++ b/system-tests/lib/cre/workflow/docker.go
@@ -26,6 +26,7 @@ func findAllDockerContainerNames(pattern string) ([]string, error) {
 	if dockerClientErr != nil {
 		return nil, errors.Wrap(dockerClientErr, "failed to create Docker client")
 	}
+	defer dockerClient.Close()
 
 	containers, containersErr := dockerClient.ContainerList(context.Background(), ctypes.ListOptions{})
 	if containersErr != nil {
@@ -54,6 +55,7 @@ func CopyArtifactsToDockerContainers(containerTargetDir string, containerNamePat
 		Msg("Copying workflow artifacts to Docker containers (parallel)")
 
 	eg := errgroup.Group{}
+	eg.SetLimit(4)
 	for _, file := range filesToCopy {
 		if _, err := os.Stat(file); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: File '%s' does not exist. Skipping file copying to docker containers\n", file)
@@ -95,8 +97,10 @@ func copyArtifactToDockerContainers(filePath string, containerNamePattern string
 	if err != nil {
 		return errors.Wrap(err, "failed to create Docker client")
 	}
+	defer dockerClient.Close()
 
 	eg := errgroup.Group{}
+	eg.SetLimit(4)
 	for _, containerName := range containerNames {
 		eg.Go(func() error {
 			execOutput, execErr := frameworkDockerClient.ExecContainer(containerName, []string{"mkdir", "-p", targetDir})
@@ -128,7 +132,7 @@ func copyArtifactToDockerContainers(filePath string, containerNamePattern string
 					fmt.Fprint(os.Stderr, execOutput)
 					return errors.Wrap(execErr, "failed to execute chown command in Docker container")
 				}
-				fmt.Println("output " + execOutput)
+				framework.L.Debug().Str("container", containerName).Msgf("chown output: %s", execOutput)
 			}
 			return nil
 		})


### PR DESCRIPTION
Copy workflow artifacts to Docker containers concurrently at both the file level and the container level using errgroup, reducing the copy phase duration proportionally to the number of files × containers.
