### PR TITLE
[DX-2917] add a memory leak CRE soak test

### DIFF
--- a/.github/workflows/cre-soak-memory-leak.yml
+++ b/.github/workflows/cre-soak-memory-leak.yml
@@ -141,16 +141,6 @@ jobs:
           path: alloc.pprof
           retention-days: 7
 
-      - name: Save Docker logs on failure
-        if: failure()
-        shell: bash
-        working-directory: system-tests/tests/soak/cre
-        run: |
-          mkdir -p logs
-          for c in $(docker ps -a --format '{{.Names}}'); do
-            docker logs "$c" > "logs/${c}.log" 2>&1
-          done
-
       - name: Upload Docker logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cre-soak-memory-leak.yml
+++ b/.github/workflows/cre-soak-memory-leak.yml
@@ -1,0 +1,160 @@
+name: CRE PoR Memory Leak Soak Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      ecr_name:
+        description: "ECR repository name (default: chainlink)"
+        required: false
+        type: string
+        default: "chainlink"
+      chainlink_image_tag:
+        description: "Chainlink image tag to use"
+        required: true
+        type: string
+      chainlink_version:
+        description: "Git ref / branch to check out"
+        required: false
+        type: string
+        default: "develop"
+  workflow_call:
+    inputs:
+      ecr_name:
+        required: false
+        type: string
+        default: "chainlink"
+      chainlink_image_tag:
+        required: true
+        type: string
+      chainlink_version:
+        required: true
+        type: string
+        default: "develop"
+
+jobs:
+  soak:
+    name: CRE PoR Memory Leak Soak
+    runs-on: runs-on=${{ github.run_id }}/cpu=16/ram=64/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    environment: "integration"
+    timeout-minutes: 270 # 4h30m — test timeout is 4h20m
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CTF_CONFIGS: configs/workflow-gateway-capabilities-don.toml
+      CRE_SOAK_DURATION: "2h"
+      CTF_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name || 'chainlink' }}:${{ inputs.chainlink_image_tag }}"
+      CHIP_INGRESS_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/atlas-chip-ingress:da84cb72d3a160e02896247d46ab4b9806ebee2f"
+      CHIP_CONFIG_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/atlas-chip-config:7b4e9ee68fd1c737dd3480b5a3ced0188f29b969"
+
+    steps:
+      - name: Enable S3 Cache for Self-Hosted Runners
+        if: ${{ env.RUNS_ON_INSTANCE_ID != '' && env.ACTIONS_CACHE_URL != '' }}
+        uses: runs-on/action@66d4449b717b5462159659523d1241051ff470b9 # v1
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.chainlink_version || github.sha }}
+          persist-credentials: false
+
+      - name: Set up Go
+        id: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: system-tests/tests/go.mod
+          cache: true
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        with:
+          aws-region: ${{ secrets.QA_AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_CTF_READ_ACCESS_ROLE_ARN }}
+          role-duration-seconds: 3600
+          mask-aws-account-id: true
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        with:
+          registries: ${{ format('{0},{1}', secrets.QA_AWS_ACCOUNT_NUMBER, secrets.AWS_ACCOUNT_ID_PROD) }}
+        env:
+          AWS_REGION: ${{ secrets.QA_AWS_REGION }}
+
+      - name: Install CTF binary
+        shell: bash
+        working-directory: core/scripts/cre/environment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CTF_TAG: "framework/v0.15.2"
+        run: |
+          echo "::startgroup::Install CTF binary"
+          mkdir -p bin
+          gh release download "${CTF_TAG}" --pattern "framework-v*-linux-amd64.tar.gz" --clobber --repo smartcontractkit/chainlink-testing-framework -O ctf.tar.gz
+          tar -xzf ctf.tar.gz
+          mv ctf bin/ctf
+          chmod +x bin/ctf
+          echo "::endgroup::"
+
+      - name: Start observability stack
+        shell: bash
+        working-directory: core/scripts/cre/environment
+        run: |
+          echo "::startgroup::Starting observability stack (required by leak package)"
+          ./bin/ctf obs up -f
+          echo "::endgroup::"
+
+      - name: Start local CRE
+        shell: bash
+        working-directory: core/scripts/cre/environment
+        run: |
+          echo "::startgroup::Starting local CRE"
+          go run . env start --cleanup-on-error=false
+          echo "::endgroup::"
+
+      - name: Install gotestsum
+        shell: bash
+        run: go install gotest.tools/gotestsum@v1.12.3
+
+      - name: Run CRE PoR Memory Leak Soak test
+        id: run-soak
+        shell: bash
+        working-directory: system-tests/tests
+        env:
+          GITHUB_TOKEN: ${{ steps.github-token.outputs.access-token || '' }}
+        run: |
+          gotestsum \
+            --jsonfile=/tmp/gotest.log \
+            --junitfile=/tmp/junit-report.xml \
+            --format=github-actions \
+            -- \
+            -v -run "^Test_CRE_PoR_MemoryLeakSoak$" \
+            -timeout 4h20m \
+            -count=1 \
+            github.com/smartcontractkit/chainlink/system-tests/tests/soak/cre
+
+      - name: Upload alloc.pprof
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: alloc.pprof
+          path: alloc.pprof
+          retention-days: 7
+
+      - name: Save Docker logs on failure
+        if: failure()
+        shell: bash
+        working-directory: system-tests/tests/soak/cre
+        run: |
+          mkdir -p logs
+          for c in $(docker ps -a --format '{{.Names}}'); do
+            docker logs "$c" > "logs/${c}.log" 2>&1
+          done
+
+      - name: Upload Docker logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: soak-docker-logs
+          path: system-tests/tests/soak/cre/logs
+          retention-days: 7

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -267,6 +267,18 @@ jobs:
       chainlink_version: ${{ github.ref_name != '' && github.ref_name || 'develop' }}
     secrets: inherit
 
+  soak-cre-memory-leak:
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    needs: [docker-core-plugins]
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/cre-soak-memory-leak.yml
+    with:
+      chainlink_image_tag: ${{ needs.docker-core-plugins.outputs.docker-manifest-tag }}
+      chainlink_version: ${{ github.ref_name != '' && github.ref_name || 'develop' }}
+    secrets: inherit
+
   deploy-nightly-core:
     if: false
     # temporarily disabled

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ debug.env
 operator_ui/install
 .devenv
 event_dump.ndjson
+.cursor/
+.claude/
 
 # neovim
 .nvim.lua

--- a/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/main.go
+++ b/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/main.go
@@ -29,9 +29,13 @@ import (
 )
 
 func RunProofOfReservesWorkflow(config types.WorkflowConfig, logger *slog.Logger, secretsProvider cre.SecretsProvider) (cre.Workflow[types.WorkflowConfig], error) {
+	schedule := "*/30 * * * * *" // every 30 seconds by default
+	if config.CronSchedule != "" {
+		schedule = config.CronSchedule
+	}
 	return cre.Workflow[types.WorkflowConfig]{
 		cre.Handler(
-			cron.Trigger(&cron.Config{Schedule: "*/30 * * * * *"}), // every 30 seconds
+			cron.Trigger(&cron.Config{Schedule: schedule}),
 			onTrigger,
 		),
 	}, nil

--- a/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/types/types.go
+++ b/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/types/types.go
@@ -10,6 +10,9 @@ type WorkflowConfig struct {
 	// name of the secret that stores authentication key
 	AuthKeySecretName string `yaml:"auth_key_secret_name"`
 	ChainSelector     uint64 `yaml:"chain_selector,omitempty"`
+	// CronSchedule overrides the default cron trigger schedule (*/30 * * * * *).
+	// Leave empty to use the default. Example: "15/30 * * * * *"
+	CronSchedule string `yaml:"cron_schedule,omitempty"`
 	BalanceReaderConfig
 	ComputeConfig
 }

--- a/go.md
+++ b/go.md
@@ -469,6 +469,7 @@ flowchart LR
 	chainlink/system-tests/tests --> chainlink-testing-framework/havoc
 	chainlink/system-tests/tests --> chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based
 	chainlink/system-tests/tests --> chainlink/core/scripts/cre/environment/examples/workflows/v2/cron
+	chainlink/system-tests/tests --> chainlink/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based
 	chainlink/system-tests/tests --> chainlink/system-tests/lib
 	chainlink/system-tests/tests --> chainlink/system-tests/tests/regression/cre/consensus
 	chainlink/system-tests/tests --> chainlink/system-tests/tests/regression/cre/evm/evmread-negative

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.2
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based v0.0.0-20251008094352-f74459c46e8c
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/cron v0.0.0-20251008094352-f74459c46e8c
+	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink/deployment v0.0.0-20251021194914-c0e3fec1a97c
 	github.com/smartcontractkit/chainlink/system-tests/lib v0.0.0-20251008094352-f74459c46e8c
 	github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/consensus v0.0.0-20251008094352-f74459c46e8c

--- a/system-tests/tests/smoke/cre/cre_suite_test.go
+++ b/system-tests/tests/smoke/cre/cre_suite_test.go
@@ -36,14 +36,14 @@ func Test_CRE_V1_Proof_Of_Reserve(t *testing.T) {
 	// logging into CL node with GraphQL API, which allows only 1 session per user at a time.
 
 	// requires `readcontract`, `cron`
-	priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV1", PoRWFV1Location)
+	priceProvider, porWfCfg := BeforePoRTest(t, testEnv, "por-workflowV1", PoRWFV1Location)
 	ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, false)
 }
 
 func Test_CRE_V1_Tron(t *testing.T) {
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetTestConfig(t, "/configs/workflow-don-tron.toml"), v1RegistriesFlags...)
 
-	priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV1", PoRWFV1Location)
+	priceProvider, porWfCfg := BeforePoRTest(t, testEnv, "por-workflowV1", PoRWFV1Location)
 	ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, false)
 }
 
@@ -59,7 +59,7 @@ func Test_CRE_V1_Billing_EVM_Write(t *testing.T) {
 		"failed to start Billing stack",
 	)
 
-	priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV2-billing", PoRWFV2Location)
+	priceProvider, porWfCfg := BeforePoRTest(t, testEnv, "por-workflowV2-billing", PoRWFV2Location)
 	porWfCfg.FeedIDs = []string{porWfCfg.FeedIDs[0]}
 	ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, true)
 }
@@ -128,7 +128,7 @@ func runV2SuiteScenario(t *testing.T, topology string, scenario v2suite_config.S
 	case v2suite_config.SuiteScenarioProofOfReserve:
 		t.Run("[v2] Proof Of Reserve - "+topology, func(t *testing.T) {
 			testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t))
-			priceProvider, wfConfig := beforePoRTest(t, testEnv, "por-workflow-v2", PoRWFV2Location)
+			priceProvider, wfConfig := BeforePoRTest(t, testEnv, "por-workflow-v2", PoRWFV2Location)
 			ExecutePoRTest(t, testEnv, priceProvider, wfConfig, false)
 		})
 	case v2suite_config.SuiteScenarioVaultDON:
@@ -171,7 +171,7 @@ func Test_CRE_V2_EVM_Write_LogTrigger(t *testing.T) {
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetDefaultTestConfig(t))
 
 	t.Run("[v2] EVM Write - "+topology, func(t *testing.T) {
-		priceProvider, porWfCfg := beforePoRTest(t, testEnv, "por-workflowV2", PoRWFV2Location)
+		priceProvider, porWfCfg := BeforePoRTest(t, testEnv, "por-workflowV2", PoRWFV2Location)
 		ExecutePoRTest(t, testEnv, priceProvider, porWfCfg, false)
 	})
 

--- a/system-tests/tests/smoke/cre/por_helpers.go
+++ b/system-tests/tests/smoke/cre/por_helpers.go
@@ -33,6 +33,7 @@ import (
 	corevm "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 
 	portypes "github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/types"
+	porV2types "github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/types"
 
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 	crecontracts "github.com/smartcontractkit/chainlink/system-tests/lib/cre/contracts"
@@ -45,13 +46,20 @@ import (
 const PoRWFV1Location = "../../../../core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/main.go"
 const PoRWFV2Location = "../../../../core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/main.go"
 
+// WorkflowTestConfig holds per-test workflow configuration for PoR tests.
+// CronSchedule is optional; when non-empty it overrides the default "*/30 * * * * *"
+// schedule embedded in the V2 workflow binary. Leave empty for smoke tests so the
+// existing behaviour is unchanged.
 type WorkflowTestConfig struct {
 	WorkflowName         string
 	WorkflowFileLocation string
 	FeedIDs              []string
+	CronSchedule         string // optional; V2 only
 }
 
-func beforePoRTest(t *testing.T, testEnv *ttypes.TestEnvironment, workflowName, workflowLocation string) (PriceProvider, WorkflowTestConfig) {
+// BeforePoRTest creates a FakePriceProvider and a WorkflowTestConfig pre-populated with
+// two hardcoded feed IDs. It is the entry-point used by all PoR smoke tests.
+func BeforePoRTest(t *testing.T, testEnv *ttypes.TestEnvironment, workflowName, workflowLocation string) (PriceProvider, WorkflowTestConfig) {
 	porWfCfg := WorkflowTestConfig{
 		FeedIDs:              []string{"018e16c38e000320000000000000000000000000000000000000000000000000", "018e16c39e000320000000000000000000000000000000000000000000000000"},
 		WorkflowName:         workflowName,
@@ -70,6 +78,9 @@ func beforePoRTest(t *testing.T, testEnv *ttypes.TestEnvironment, workflowName, 
 	return priceProvider, porWfCfg
 }
 
+// ExecutePoRTest deploys DataFeedsCache + ReadBalances contracts on all writable chains,
+// registers a workflow per chain, and validates that each feed is updated with the
+// expected prices from priceProvider.
 func ExecutePoRTest(t *testing.T, testEnv *ttypes.TestEnvironment, priceProvider PriceProvider, cfg WorkflowTestConfig, withBilling bool) {
 	testLogger := framework.L
 	blockchainOutputs := testEnv.CreEnvironment.Blockchains
@@ -169,6 +180,100 @@ func ExecutePoRTest(t *testing.T, testEnv *ttypes.TestEnvironment, priceProvider
 		expectedMinChange := float64(49)
 		assertBillingStateChanged(t, billingState, 2*time.Minute, expectedMinChange)
 	}
+}
+
+// SetupPoRWorkflowForSoak deploys DataFeedsCache + ReadBalances on the first writable EVM
+// chain, compiles and registers the V2 PoR workflow using the supplied WorkflowTestConfig,
+// and returns the DataFeedsCache contract address so the soak loop can poll it directly.
+//
+// Workflow cleanup (unregistration) is registered automatically via t.Cleanup inside
+// CompileAndDeployWorkflow.
+func SetupPoRWorkflowForSoak(t *testing.T, testEnv *ttypes.TestEnvironment, priceProvider PriceProvider, wfConfig WorkflowTestConfig) (common.Address, error) {
+	t.Helper()
+
+	testLogger := framework.L
+	writeableChains := t_helpers.GetWritableChainsFromSavedEnvironmentState(t, testEnv)
+	require.NotEmpty(t, writeableChains, "no writable chains found in saved environment state")
+
+	// Find the first writable EVM blockchain
+	var bcOutput blockchains.Blockchain
+	for _, bc := range testEnv.CreEnvironment.Blockchains {
+		if bc.IsFamily(blockchain.FamilySolana) || bc.IsFamily(blockchain.FamilyTron) {
+			continue
+		}
+		if slices.Contains(writeableChains, bc.ChainID()) {
+			bcOutput = bc
+			break
+		}
+	}
+	require.NotNil(t, bcOutput, "no writable EVM blockchain found")
+	require.IsType(t, &evm.Blockchain{}, bcOutput, "expected EVM blockchain type")
+
+	evmBC := bcOutput.(*evm.Blockchain)
+	chainSelector := bcOutput.ChainSelector()
+	chainID := bcOutput.ChainID()
+	creEnvironment := testEnv.CreEnvironment
+	workflowOwner := evmBC.SethClient.MustGetRootKeyAddress()
+
+	require.Len(t, wfConfig.FeedIDs, 1, "SetupPoRWorkflowForSoak expects exactly one feed ID per workflow")
+	feedID := wfConfig.FeedIDs[0]
+
+	forwarderAddress := crecontracts.MustGetAddressFromDataStore(
+		creEnvironment.CldfEnvironment.DataStore, chainSelector,
+		keystone_changeset.KeystoneForwarder.String(),
+		creEnvironment.ContractVersions[keystone_changeset.KeystoneForwarder.String()], "",
+	)
+
+	dataFeedsCacheAddress, readBalancesAddress := deployAndConfigureEVMContracts(
+		t, testLogger, chainSelector, chainID, creEnvironment, workflowOwner,
+		wfConfig.WorkflowName, feedID, common.HexToAddress(forwarderAddress),
+	)
+
+	numberOfAddressesToCreate := 2
+	amountToFund := big.NewInt(10) // 10 wei
+	addressesToRead, addrErr := t_helpers.CreateAndFundAddresses(t, testLogger, numberOfAddressesToCreate, amountToFund, bcOutput, creEnvironment)
+	require.NoError(t, addrErr, "failed to create and fund addresses for soak workflow %s", wfConfig.WorkflowName)
+
+	writeTargetName := corevm.GenerateWriteTargetName(chainID)
+	testLogger.Info().Msgf("SetupPoRWorkflowForSoak: chain=%d writeTarget=%s cache=%s feedID=%s cron=%q",
+		chainID, writeTargetName, dataFeedsCacheAddress.Hex(), feedID, wfConfig.CronSchedule)
+
+	workflowConfig := porV2types.WorkflowConfig{
+		ChainSelector: chainSelector,
+		CronSchedule:  wfConfig.CronSchedule,
+		BalanceReaderConfig: porV2types.BalanceReaderConfig{
+			BalanceReaderAddress: readBalancesAddress.Hex(),
+			AddressesToRead:      addressesToRead,
+		},
+		ComputeConfig: porV2types.ComputeConfig{
+			FeedID:                feedID,
+			URL:                   priceProvider.URL(),
+			DataFeedsCacheAddress: dataFeedsCacheAddress.Hex(),
+			WriteTargetName:       writeTargetName,
+		},
+	}
+
+	_ = t_helpers.CompileAndDeployWorkflow(t, testEnv, testLogger, wfConfig.WorkflowName, &workflowConfig, wfConfig.WorkflowFileLocation)
+
+	return dataFeedsCacheAddress, nil
+}
+
+// GenerateSoakFeedIDs generates n unique 32-hex-char (16-byte) feed IDs for the soak test.
+// Each ID differs only in byte 4 (last byte of the data family), keeping all other fields fixed.
+// Layout per DF2.0 spec:
+//
+//	byte  0:    0x01   – format byte
+//	bytes 1-3:  8e16c3 – data family prefix (fixed)
+//	byte  4:    <i>    – data family suffix (varies per feed, supports up to 256 unique IDs)
+//	bytes 5-6:  0003   – attribute bucket 3
+//	byte  7:    20     – data type: Decimal0 (integer)
+//	bytes 8-15: 00…    – reserved (must be zero)
+func GenerateSoakFeedIDs(n int) []string {
+	ids := make([]string, n)
+	for i := range n {
+		ids[i] = fmt.Sprintf("018e16c3%02x0003200000000000000000", i)
+	}
+	return ids
 }
 
 func deployAndConfigureEVMContracts(t *testing.T, testLogger zerolog.Logger, chainSelector uint64, chainID uint64, creEnvironment *cre.Environment, workflowOwner common.Address, uniqueWorkflowName string, feedID string, forwarderAddress common.Address) (common.Address, common.Address) {
@@ -302,7 +407,7 @@ func validateTronPrices(t *testing.T, testEnv *ttypes.TestEnvironment, blockchai
 	tronChains := testEnv.CreEnvironment.CldfEnvironment.BlockChains.TronChains()
 	tronChain, exists := tronChains[blockchain.ChainSelector()]
 	if !exists {
-		return fmt.Errorf("Tron chain %d not found in environment", blockchain.ChainSelector())
+		return fmt.Errorf("tron chain %d not found in environment", blockchain.ChainSelector())
 	}
 
 	cacheAddr := address.EVMAddressToAddress(dataFeedsCacheAddresses)

--- a/system-tests/tests/smoke/cre/por_price_provider.go
+++ b/system-tests/tests/smoke/cre/por_price_provider.go
@@ -333,3 +333,59 @@ func (f *FakePriceProvider) URL() string {
 func (f *FakePriceProvider) AuthKey() string {
 	return f.authKey
 }
+
+// NewFakePriceProviderForSoak creates a single FakePriceProvider covering all allFeedIDs at once.
+// It must be called BEFORE any workflow is registered to ensure the HTTP handler is registered
+// for all feed IDs in a single call (subsequent calls would overwrite the handler).
+// soakPriceCount prices per feed are pre-generated so the provider can serve price updates
+// for many hours without exhausting the sequence.
+func NewFakePriceProviderForSoak(testLogger zerolog.Logger, input *fake.Input, authKey string, allFeedIDs []string) (PriceProvider, error) {
+	const soakPriceCount = 300
+
+	testLogger.Info().Msgf("Creating soak fake price provider for %d feed IDs...", len(allFeedIDs))
+	cleanFeedIDs := make([]string, 0, len(allFeedIDs))
+	for _, feedID := range allFeedIDs {
+		cleanFeedIDs = append(cleanFeedIDs, cleanFeedID(feedID))
+	}
+
+	priceIndexes := make(map[string]*int)
+	for _, feedID := range cleanFeedIDs {
+		priceIndexes[feedID] = ptr.Ptr(0)
+	}
+
+	expectedPrices := make(map[string][]*big.Int)
+	pricesToServe := make(map[string][]float64)
+	for _, feedID := range cleanFeedIDs {
+		pricesFloat64 := make([]float64, soakPriceCount)
+		for i := range soakPriceCount {
+			pricesFloat64[i] = math.Round((rand.Float64()*199+1)*100) / 100
+		}
+		pricesToServe[feedID] = pricesFloat64
+
+		expectedPrices[feedID] = make([]*big.Int, soakPriceCount)
+		for i, p := range pricesFloat64 {
+			expectedPrices[feedID][i] = big.NewInt(int64(p * 100.0))
+		}
+	}
+
+	actualPrices := make(map[string][]*big.Int)
+	for _, feedID := range cleanFeedIDs {
+		actualPrices[feedID] = make([]*big.Int, 0)
+	}
+
+	url, err := setupFakeDataProvider(testLogger, input, authKey, pricesToServe, priceIndexes)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to set up soak fake data provider")
+	}
+
+	testLogger.Info().Msgf("Soak fake price provider set up with %d prices per feed.", soakPriceCount)
+	return &FakePriceProvider{
+		testLogger:     testLogger,
+		expectedPrices: expectedPrices,
+		actualPrices:   actualPrices,
+		priceIndex:     priceIndexes,
+		url:            url,
+		authKey:        authKey,
+		mu:             sync.RWMutex{},
+	}, nil
+}

--- a/system-tests/tests/soak/cre/soak_test.go
+++ b/system-tests/tests/soak/cre/soak_test.go
@@ -44,6 +44,13 @@ func Test_CRE_PoR_MemoryLeakSoak(t *testing.T) {
 		t_helpers.GetDefaultTestConfig(t),
 	)
 
+	t.Cleanup(func() {
+		if t.Failed() {
+			_, cErr := framework.SaveContainerLogs(fmt.Sprintf("%s-%s", framework.DefaultCTFLogsDir, t.Name()))
+			require.NoError(t, cErr)
+		}
+	})
+
 	// ── Phase 1: Single shared price provider ──────────────────────────────────
 	// IMPORTANT: must be called once for ALL feed IDs before any workflow is
 	// registered.  Subsequent calls to setupFakeDataProvider would overwrite the

--- a/system-tests/tests/soak/cre/soak_test.go
+++ b/system-tests/tests/soak/cre/soak_test.go
@@ -129,6 +129,7 @@ loop:
 	for i, wf := range soakWorkflows {
 		if wf.updateCount == 0 {
 			framework.L.Error().Msgf("workflow[%02d] (feedID=%s) had zero confirmed on-chain updates — never ran", i, wf.feedID)
+			t.FailNow()
 		} else {
 			framework.L.Info().Msgf("workflow[%02d]: %d confirmed on-chain updates", i, wf.updateCount)
 		}

--- a/system-tests/tests/soak/cre/soak_test.go
+++ b/system-tests/tests/soak/cre/soak_test.go
@@ -1,0 +1,179 @@
+package cre
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/leak"
+
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/blockchains/evm"
+	smokecre "github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre"
+	t_helpers "github.com/smartcontractkit/chainlink/system-tests/tests/test-helpers"
+)
+
+/*
+Test_CRE_PoR_MemoryLeakSoak is a long-running soak test that:
+ 1. Registers 20 V2 PoR workflows, each with a unique feed ID and staggered cron schedule.
+ 2. Runs a time-bounded loop that detects on-chain price updates for every workflow.
+ 3. After the soak, asserts Prometheus CPU / memory metrics haven't exceeded configured thresholds.
+
+Prerequisites (handled by the CI workflow):
+  - Local CRE environment is running (go run . env start).
+  - Observability stack is running (./bin/ctf obs up -f) — required by the leak package.
+
+Environment variables:
+  - CRE_SOAK_DURATION: duration string (e.g. "2h"). Defaults to 2h.
+  - CTF_CONFIGS: path to the environment config TOML file.
+*/
+func Test_CRE_PoR_MemoryLeakSoak(t *testing.T) {
+	const numWorkflows = 20
+
+	start := time.Now()
+
+	testEnv := t_helpers.SetupTestEnvironmentWithConfig(
+		t,
+		t_helpers.GetDefaultTestConfig(t),
+	)
+
+	// ── Phase 1: Single shared price provider ──────────────────────────────────
+	// IMPORTANT: must be called once for ALL feed IDs before any workflow is
+	// registered.  Subsequent calls to setupFakeDataProvider would overwrite the
+	// HTTP handler and make previously-registered feeds return 400.
+	allFeedIDs := smokecre.GenerateSoakFeedIDs(numWorkflows)
+	priceProvider, err := smokecre.NewFakePriceProviderForSoak(
+		framework.L, testEnv.Config.Fake, "", allFeedIDs,
+	)
+	require.NoError(t, err, "failed to create soak price provider")
+
+	// ── Phase 2: Sequential workflow registration ──────────────────────────────
+	type soakWorkflow struct {
+		feedID       string
+		cacheAddress common.Address
+		lastPrice    *big.Int
+		updateCount  int
+	}
+
+	soakWorkflows := make([]soakWorkflow, numWorkflows)
+	for i := range numWorkflows {
+		// Stagger: first 10 use the default offset, second 10 are shifted by 15s
+		// so that not all workflows fire at the same instant.
+		cronSchedule := "*/30 * * * * *"
+		if i >= 10 {
+			cronSchedule = "15/30 * * * * *"
+		}
+
+		wfConfig := smokecre.WorkflowTestConfig{
+			WorkflowName:         fmt.Sprintf("por-soak-%02d", i),
+			WorkflowFileLocation: smokecre.PoRWFV2Location,
+			FeedIDs:              []string{allFeedIDs[i]},
+			CronSchedule:         cronSchedule,
+		}
+
+		cacheAddr, setupErr := smokecre.SetupPoRWorkflowForSoak(t, testEnv, priceProvider, wfConfig)
+		require.NoError(t, setupErr, "failed to set up soak workflow %d", i)
+
+		soakWorkflows[i] = soakWorkflow{feedID: allFeedIDs[i], cacheAddress: cacheAddr}
+		framework.L.Info().Msgf("Workflow %d/%d registered (%s)", i+1, numWorkflows, wfConfig.WorkflowName)
+	}
+
+	// ── Phase 3: Time-bounded verification + soak loop ─────────────────────────
+	soakDuration := parseDuration(os.Getenv("CRE_SOAK_DURATION"), 2*time.Hour)
+	framework.L.Info().Msgf("Soak duration: %s", soakDuration)
+
+	ctx, cancel := context.WithTimeout(t.Context(), soakDuration)
+	defer cancel()
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	// Obtain the EVM client from the first blockchain in the environment
+	require.NotEmpty(t, testEnv.CreEnvironment.Blockchains, "no blockchains in environment")
+	evmBC, ok := testEnv.CreEnvironment.Blockchains[0].(*evm.Blockchain)
+	require.True(t, ok, "first blockchain is not an EVM blockchain")
+
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			break loop
+		case <-ticker.C:
+			framework.L.Info().Msgf("Soak progress: elapsed=%s / %s", time.Since(start).Round(time.Second), soakDuration)
+			for i := range soakWorkflows {
+				wf := &soakWorkflows[i]
+				latest := pollOnChainPrice(evmBC, wf.cacheAddress, wf.feedID)
+				if latest == nil || latest.Sign() == 0 {
+					continue
+				}
+				if wf.lastPrice != nil && latest.Cmp(wf.lastPrice) == 0 {
+					continue
+				}
+				// New price landed on-chain — advance the provider to serve the next one
+				priceProvider.NextPrice(wf.feedID, latest, time.Since(start))
+				wf.updateCount++
+				wf.lastPrice = new(big.Int).Set(latest)
+				framework.L.Info().Msgf("  wf[%02d] confirmed update #%d, price=%s", i, wf.updateCount, latest)
+			}
+		}
+	}
+
+	// ── Phase 4: Verify each workflow ran ──────────────────────────────────────
+	for i, wf := range soakWorkflows {
+		if wf.updateCount == 0 {
+			framework.L.Error().Msgf("workflow[%02d] (feedID=%s) had zero confirmed on-chain updates — never ran", i, wf.feedID)
+		} else {
+			framework.L.Info().Msgf("workflow[%02d]: %d confirmed on-chain updates", i, wf.updateCount)
+		}
+	}
+
+	// ── Phase 5: Memory / CPU leak check ──────────────────────────────────────
+	leakDetector, ldErr := leak.NewCLNodesLeakDetector(leak.NewResourceLeakChecker())
+	require.NoError(t, ldErr, "failed to create CL nodes leak detector")
+
+	checkErr := leakDetector.Check(&leak.CLNodesCheck{
+		ComparisonMode:  leak.ComparisonModeAbsolute,
+		NumNodes:        len(testEnv.Dons.MustWorkflowDON().Nodes),
+		Start:           start,
+		End:             time.Now(),
+		WarmUpDuration:  30 * time.Minute,
+		CPUThreshold:    25.0,  // same as devenv OCR2 soak; calibrate after first run
+		MemoryThreshold: 350.0, // same as devenv OCR2 soak; calibrate after first run
+	})
+	require.NoError(t, checkErr, "resource leak check failed")
+}
+
+// pollOnChainPrice reads the latest answer from a DataFeedsCache contract for the given
+// feed ID. Returns nil on any error or when no price is set yet.
+func pollOnChainPrice(bc *evm.Blockchain, cacheAddress common.Address, feedID string) *big.Int {
+	instance, err := data_feeds_cache.NewDataFeedsCache(cacheAddress, bc.SethClient.Client)
+	if err != nil {
+		return nil
+	}
+	// feed ID strings are 32 hex chars (16 bytes); use first 16 bytes via slice conversion
+	feedIDBytes := [16]byte(common.Hex2Bytes(feedID))
+	price, err := instance.GetLatestAnswer(bc.SethClient.NewCallOpts(), feedIDBytes)
+	if err != nil {
+		return nil
+	}
+	return price
+}
+
+// parseDuration parses s as a time.Duration. Returns defaultVal when s is empty or invalid.
+func parseDuration(s string, defaultVal time.Duration) time.Duration {
+	if s == "" {
+		return defaultVal
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return defaultVal
+	}
+	return d
+}

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -56,6 +56,7 @@ import (
 
 	portypes "github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/types"
 	crontypes "github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/cron/types"
+	porV2types "github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based/types"
 	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 	crecontracts "github.com/smartcontractkit/chainlink/system-tests/lib/cre/contracts"
@@ -279,6 +280,7 @@ func CreateAndFundAddresses(t *testing.T, testLogger zerolog.Logger, numberOfAdd
 type WorkflowConfig interface {
 	None |
 		portypes.WorkflowConfig |
+		porV2types.WorkflowConfig |
 		crontypes.WorkflowConfig |
 		HTTPWorkflowConfig |
 		consensus_negative_config.Config |
@@ -369,6 +371,21 @@ func workflowConfigFactory[T WorkflowConfig](t *testing.T, testLogger zerolog.Lo
 			workflowConfigFilePath = workflowCfgFilePath
 			require.NoError(t, configErr, "failed to create PoR workflow config file")
 			testLogger.Info().Msg("PoR workflow config file created.")
+
+		case *porV2types.WorkflowConfig:
+			// Validate and format the feed ID (truncate to 16 bytes / 32 hex chars)
+			cleanID := strings.TrimPrefix(cfg.FeedID, "0x")
+			if len(cleanID) < 32 {
+				require.NoError(t, fmt.Errorf("v2 PoR feed ID must be at least 32 hex characters, got %d", len(cleanID)))
+			}
+			if len(cleanID) > 32 {
+				cleanID = cleanID[:32]
+			}
+			cfg.FeedID = "0x" + cleanID
+			workflowCfgFilePath, configErr := CreateWorkflowYamlConfigFile(workflowName, cfg)
+			workflowConfigFilePath = workflowCfgFilePath
+			require.NoError(t, configErr, "failed to create PoR v2 workflow config file")
+			testLogger.Info().Msg("PoR v2 workflow config file created.")
 
 		case *HTTPWorkflowConfig:
 			workflowCfgFilePath, configErr := createHTTPWorkflowConfigFile(workflowName, cfg)


### PR DESCRIPTION
##  Summary

  - Adds a scheduled memory-leak / soak test for CRE (Test_CRE_PoR_MemoryLeakSoak) that runs 20 V2 PoR workflows concurrently and asserts Prometheus CPU/memory metrics stay within thresholds after a configurable soak window (default 2 h).
  - Refactors por_test.go helpers into por_helpers.go (non-test file) so the new soak/cre package can import them.
  - Adds CronSchedule field to the V2 PoR WorkflowConfig to allow staggering 20 workflows across two 15 s-offset groups without rebuilding the binary.

  ## Changes

  - **`soak/cre/soak_test.go`** — New 5-phase soak test: shared price provider → 20 workflow registrations → timed poll loop → per-workflow update assertions → `leak.CLNodesLeakDetector` CPU/memory check
  - **`smoke/cre/por_helpers.go`** — Extracted shared helpers from `por_test.go` (now exported). Adds `SetupPoRWorkflowForSoak` and `GenerateSoakFeedIDs`
  - **`smoke/cre/por_price_provider.go`** — Adds `NewFakePriceProviderForSoak` — single provider call for all 20 feed IDs, 300 prices per feed
  - **`smoke/cre/cre_suite_test.go`** — `beforePoRTest` → `BeforePoRTest` (exported)
  - **`v2/.../types/types.go`** — Adds `CronSchedule string` field (`omitempty`, smoke tests unaffected)
  - **`v2/.../main.go`** — Uses `config.CronSchedule` when non-empty, defaults to `*/30 * * * * *`
  - **`test-helpers/t_helpers.go`** — Adds `porV2types.WorkflowConfig` to the `WorkflowConfig` union + factory case
  - **`cre-soak-memory-leak.yml`** — New reusable CI workflow: ECR login → `ctf obs up -f` → start CRE → run test (4h20m timeout) → upload pprof
  - **`docker-build.yml`** — Adds `soak-cre-memory-leak` job triggered on `schedule` and `push` to `develop`
  - **`go.mod`** — Adds missing `require` entry for the v2 PoR module