### PR TITLE
Remove -p=4 limit on concurrent packages in go_core_tests

### DIFF
--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -14,8 +14,6 @@ export PATH
 
 echo "Running go_core_tests for event: $GITHUB_EVENT_NAME"
 GO_TEST_FLAGS="-timeout=${GO_TEST_TIMEOUT}"
-# Temporary reduction in concurrent packages to reduce RAM usage
-GO_TEST_FLAGS="$GO_TEST_FLAGS -p=4"
 if [[ "$GITHUB_EVENT_NAME" == 'push' ]]; then
   GO_TEST_FLAGS="$GO_TEST_FLAGS -count=1"
 elif [[ "$GITHUB_EVENT_NAME" == 'schedule' ]]; then


### PR DESCRIPTION
This reduces runtime by more than 50%, but let's see if there is still a memory issue...