### PR TITLE
fix(keeper): thread context into GetUpkeep and GetConfig RPC calls

### DIFF
--- a/core/services/keeper/registry_synchronizer_sync.go
+++ b/core/services/keeper/registry_synchronizer_sync.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"sync"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
@@ -108,7 +109,7 @@ func (rs *RegistrySynchronizer) syncUpkeepWithCallback(ctx context.Context, gett
 }
 
 func (rs *RegistrySynchronizer) syncUpkeep(ctx context.Context, getter upkeepGetter, registry Registry, upkeepID *sqlutil.Big) error {
-	upkeep, err := getter.GetUpkeep(nil, upkeepID.ToInt())
+	upkeep, err := getter.GetUpkeep(&bind.CallOpts{Context: ctx}, upkeepID.ToInt())
 	if err != nil {
 		return errors.Wrap(err, "failed to get upkeep config")
 	}
@@ -144,7 +145,7 @@ func (rs *RegistrySynchronizer) newRegistryFromChain(ctx context.Context) (Regis
 	fromAddress := rs.effectiveKeeperAddress
 	contractAddress := rs.job.KeeperSpec.ContractAddress
 
-	registryConfig, err := rs.registryWrapper.GetConfig(nil)
+	registryConfig, err := rs.registryWrapper.GetConfig(&bind.CallOpts{Context: ctx})
 	if err != nil {
 		rs.jrm.TryRecordError(ctx, rs.job.ID, err.Error())
 		return Registry{}, errors.Wrap(err, "failed to get contract config")


### PR DESCRIPTION
Fixes #21489.

Noticed during a slow shutdown investigation that syncUpkeep and newRegistryFromChain both pass nil CallOpts to their on-chain calls even though they receive a context from the caller. The GetUpkeep and GetConfig RPCs end up ignoring cancellation, so they block until RPC timeout during shutdown instead of stopping when the context is done.

The fix just wires the existing ctx through bind.CallOpts on both call sites. No behavior change under normal operation - the context only matters on cancellation paths.