### PR TITLE
Mark go.sum as generated in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sol linguist-language=Solidity
+**go.sum linguist-generated=true


### PR DESCRIPTION
This PR proposes marking `go.sum` files as generated so that github will collapse them in PRs.