### PR TITLE
fix: TestShell_BeforeNode db leakage

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -31,9 +31,9 @@ func removeHidden(cmds ...cli.Command) []cli.Command {
 	return ret
 }
 
-// NewAppWithOpts returns the command-line parser/function-router for the given client
+// newAppWithOpts returns the command-line parser/function-router for the given client
 // with custom configuration options for testing purposes.
-func NewAppWithOpts(s *Shell, opts chainlink.GeneralConfigOpts) *cli.App {
+func newAppWithOpts(s *Shell, opts chainlink.GeneralConfigOpts) *cli.App {
 	app := cli.NewApp()
 	app.Usage = "CLI for Chainlink"
 	app.Version = fmt.Sprintf("%v@%v", static.Version, static.Sha)
@@ -333,7 +333,7 @@ func NewAppWithOpts(s *Shell, opts chainlink.GeneralConfigOpts) *cli.App {
 // NewApp returns the command-line parser/function-router for the given client
 func NewApp(s *Shell) *cli.App {
 	var opts chainlink.GeneralConfigOpts
-	return NewAppWithOpts(s, opts)
+	return newAppWithOpts(s, opts)
 }
 
 var whitespace = regexp.MustCompile(`\s+`)

--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -31,13 +31,12 @@ func removeHidden(cmds ...cli.Command) []cli.Command {
 	return ret
 }
 
-// NewApp returns the command-line parser/function-router for the given client
-func NewApp(s *Shell) *cli.App {
+// NewAppWithOpts returns the command-line parser/function-router for the given client
+// with custom configuration options for testing purposes.
+func NewAppWithOpts(s *Shell, opts chainlink.GeneralConfigOpts) *cli.App {
 	app := cli.NewApp()
 	app.Usage = "CLI for Chainlink"
 	app.Version = fmt.Sprintf("%v@%v", static.Version, static.Sha)
-	// TOML
-	var opts chainlink.GeneralConfigOpts
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
@@ -329,6 +328,12 @@ func NewApp(s *Shell) *cli.App {
 		},
 	}...)
 	return app
+}
+
+// NewApp returns the command-line parser/function-router for the given client
+func NewApp(s *Shell) *cli.App {
+	var opts chainlink.GeneralConfigOpts
+	return NewAppWithOpts(s, opts)
 }
 
 var whitespace = regexp.MustCompile(`\s+`)

--- a/core/cmd/export_test.go
+++ b/core/cmd/export_test.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/urfave/cli"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
 
 func NewAppWithOptsForTest(s *Shell, opts chainlink.GeneralConfigOpts) *cli.App {

--- a/core/cmd/export_test.go
+++ b/core/cmd/export_test.go
@@ -1,0 +1,10 @@
+package cmd
+
+import (
+	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
+	"github.com/urfave/cli"
+)
+
+func NewAppWithOptsForTest(s *Shell, opts chainlink.GeneralConfigOpts) *cli.App {
+	return newAppWithOpts(s, opts)
+}

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -525,7 +525,6 @@ func TestShell_BeforeNode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			shell := cmd.Shell{
 				KeyStoreAuthenticator: cmd.TerminalKeyStoreAuthenticator{
 					Prompter: &cltest.MockCountingPrompter{T: t, NotTerminal: true},

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -372,7 +372,6 @@ func TestShell_RebroadcastTransactions_AddressCheck(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			config, sqlxDB := heavyweight.FullTestDBV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 				c.Database.DriverName = pgcommon.DriverPostgres
 

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -200,6 +200,7 @@ func TestShell_DiskMaxSizeBeforeRotateOptionDisablesAsExpected(t *testing.T) {
 }
 
 func TestShell_RebroadcastTransactions_Txm(t *testing.T) {
+	t.Parallel()
 	// Use a non-transactional db for this test because we need to
 	// test multiple connections to the database, and changes made within
 	// the transaction cannot be seen from another connection.
@@ -269,6 +270,7 @@ func TestShell_RebroadcastTransactions_Txm(t *testing.T) {
 }
 
 func TestShell_RebroadcastTransactions_OutsideRange_Txm(t *testing.T) {
+	t.Parallel()
 	beginningNonce := uint(7)
 	endingNonce := uint(10)
 	gasPrice := big.NewInt(100000000000)
@@ -357,6 +359,7 @@ func TestShell_RebroadcastTransactions_OutsideRange_Txm(t *testing.T) {
 }
 
 func TestShell_RebroadcastTransactions_AddressCheck(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		enableAddress bool
@@ -369,6 +372,7 @@ func TestShell_RebroadcastTransactions_AddressCheck(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			config, sqlxDB := heavyweight.FullTestDBV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 				c.Database.DriverName = pgcommon.DriverPostgres
 

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -521,6 +521,11 @@ func TestShell_BeforeNode(t *testing.T) {
 		{"wrong file", "doesntexist.txt", false},
 	}
 
+	// forces txdb to be used.
+	// app.Before(c), loads a default config and ignores the config we create
+	// This sets the driver to pgx, instead of txdb, which causes db leakage across tests.
+	t.Setenv("CL_FORCE_TXDB", "true")
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -521,23 +521,9 @@ func TestShell_BeforeNode(t *testing.T) {
 		{"wrong file", "doesntexist.txt", false},
 	}
 
-	// forces txdb to be used.
-	// app.Before(c), loads a default config and ignores the config we create
-	// This sets the driver to pgx, instead of txdb, which causes db leakage across tests.
-	t.Setenv("CL_FORCE_TXDB", "true")
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-				s.Password.Keystore = models.NewSecret("dummy")
-				c.EVM[0].Nodes[0].Name = ptr("fake")
-				c.EVM[0].Nodes[0].HTTPURL = commonconfig.MustParseURL("http://fake.com")
-				c.EVM[0].Nodes[0].WSURL = commonconfig.MustParseURL("WSS://fake.com/ws")
-				c.Insecure.OCRDevelopmentMode = nil
-			})
-
 			shell := cmd.Shell{
-				Config: cfg,
 				KeyStoreAuthenticator: cmd.TerminalKeyStoreAuthenticator{
 					Prompter: &cltest.MockCountingPrompter{T: t, NotTerminal: true},
 				},
@@ -553,7 +539,14 @@ func TestShell_BeforeNode(t *testing.T) {
 			c := cli.NewContext(nil, set, nil)
 
 			// Create full CLI app and run the Before hook first
-			app := cmd.NewApp(&shell)
+			var opts = chainlink.GeneralConfigOpts{
+				OverrideFn: func(c *chainlink.Config, s *chainlink.Secrets) {
+					s.Password.Keystore = models.NewSecret("dummy")
+					c.Database.DriverName = pgcommon.DriverTxWrappedPostgres
+				},
+			}
+
+			app := cmd.NewAppWithOpts(&shell, opts)
 			err := app.Before(c)
 			if err != nil && test.wantUnlocked {
 				t.Fatalf("CLI Before hook failed: %v", err)

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -646,8 +646,14 @@ func TestShell_RunNode_WithBeforeNode(t *testing.T) {
 
 			c := cli.NewContext(nil, set, nil)
 
+			var opts = chainlink.GeneralConfigOpts{
+				OverrideFn: func(c *chainlink.Config, s *chainlink.Secrets) {
+					c.Database.DriverName = pgcommon.DriverTxWrappedPostgres
+				},
+			}
+
 			// First initialize components (this includes authentication)
-			cliApp := cmd.NewApp(&shell)
+			cliApp := cmd.NewAppWithOptsForTest(&shell, opts)
 			err := cliApp.Before(c)
 			require.NoError(t, err)
 

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -511,6 +511,8 @@ func TestShell_RemoveBlocks(t *testing.T) {
 
 func TestShell_BeforeNode(t *testing.T) {
 	testutils.SkipShortDB(t)
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		pwdfile      string
@@ -523,6 +525,7 @@ func TestShell_BeforeNode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			shell := cmd.Shell{
 				KeyStoreAuthenticator: cmd.TerminalKeyStoreAuthenticator{
 					Prompter: &cltest.MockCountingPrompter{T: t, NotTerminal: true},
@@ -546,7 +549,7 @@ func TestShell_BeforeNode(t *testing.T) {
 				},
 			}
 
-			app := cmd.NewAppWithOpts(&shell, opts)
+			app := cmd.NewAppWithOptsForTest(&shell, opts)
 			err := app.Before(c)
 			if err != nil && test.wantUnlocked {
 				t.Fatalf("CLI Before hook failed: %v", err)

--- a/core/services/keystore/csa_test.go
+++ b/core/services/keystore/csa_test.go
@@ -32,6 +32,11 @@ func Test_CSAKeyStore_E2E(t *testing.T) {
 	t.Run("initializes with an empty state", func(t *testing.T) {
 		defer reset()
 		keys, err := ks.GetAll()
+
+		for _, key := range keys {
+			t.Log("unexpected key found in keystore", "id", key.ID())
+		}
+
 		require.NoError(t, err)
 		require.Empty(t, keys)
 	})

--- a/core/services/pg/connection.go
+++ b/core/services/pg/connection.go
@@ -42,10 +42,6 @@ type ConnectionConfig interface {
 }
 
 func NewConnection(ctx context.Context, uri string, driverName string, config ConnectionConfig) (db *sqlx.DB, err error) {
-	if os.Getenv("CL_FORCE_TXDB") == "true" {
-		driverName = commonpg.DriverTxWrappedPostgres
-	}
-
 	if driverName == commonpg.DriverTxWrappedPostgres {
 		if err = sqltest.RegisterTxDB(uri); err != nil {
 			return nil, fmt.Errorf("failed to register %s: %w", commonpg.DriverTxWrappedPostgres, err)

--- a/core/services/pg/connection.go
+++ b/core/services/pg/connection.go
@@ -42,6 +42,10 @@ type ConnectionConfig interface {
 }
 
 func NewConnection(ctx context.Context, uri string, driverName string, config ConnectionConfig) (db *sqlx.DB, err error) {
+	if os.Getenv("CL_FORCE_TXDB") == "true" {
+		driverName = commonpg.DriverTxWrappedPostgres
+	}
+
 	if driverName == commonpg.DriverTxWrappedPostgres {
 		if err = sqltest.RegisterTxDB(uri); err != nil {
 			return nil, fmt.Errorf("failed to register %s: %w", commonpg.DriverTxWrappedPostgres, err)


### PR DESCRIPTION
### Changes

* Parallelize more tests (#21466)
* Fix issue with csa_test.go as seen in that PR^

### Notes

* In `TestShell_BeforeNode` we are trying to use `txdb` driver so the changes are not actually persisted/leaked to other tests
    * However, when calling `app.Before(c)` it ignores any preexisting config set on the Shell object. Defaulting the driver to `pgx` which causes db leakage, which resulted in `csa_test.go` failling as it was expecting a clean keystore
    * Adding `newAppWithOpts` and allow the opts object to actually set the driver, does allow for txdb driver, but that comes with other issues.
* The current solution in this PR (newAppWithOpts) does work locally when running only the core/cmd package.
    * There's something else at play when we run the full suite in CI which causes these tests to timeout.
    * Although, it's also failing for the "go core integration tests` pipeline
* Running with locally `-race` also breaks some more tests in the same package

### Testing

https://github.com/smartcontractkit/chainlink/actions/runs/22979409950/job/66715662324?pr=21504