### PR TITLE
(fix): prevent duplicate wfIDs in syncer

### DIFF
--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -106,17 +106,11 @@ type workflowRegistry struct {
 	maxConcurrency   int
 	clock            clockwork.Clock
 
-	hooks Hooks
-
 	shardOrchestratorClient shardorchestrator.ClientInterface
 
 	// myShardID is the shard index this syncer belongs to. Used to filter workflows.
 	myShardID       uint32
 	shardingEnabled bool
-}
-
-type Hooks struct {
-	OnStartFailure func(error)
 }
 
 type evtHandler interface {
@@ -300,10 +294,7 @@ func NewWorkflowRegistry(
 		maxRetryInterval:                 defaultMaxRetryInterval,
 		maxConcurrency:                   defaultMaxConcurrency,
 		clock:                            clockwork.NewRealClock(),
-		hooks: Hooks{
-			OnStartFailure: func(_ error) {},
-		},
-		workflowSources: workflowSources,
+		workflowSources:                  workflowSources,
 	}
 
 	for _, opt := range opts {
@@ -364,12 +355,6 @@ func (w *workflowRegistry) Start(_ context.Context) error {
 			select {
 			case <-initDoneCh:
 			case <-ctx.Done():
-				return
-			}
-			w.lggr.Debugw("read from don received channel while waiting to start reconciliation sync")
-			_, err := w.workflowDonNotifier.WaitForDon(ctx)
-			if err != nil {
-				w.hooks.OnStartFailure(fmt.Errorf("failed to start workflow sync strategy: %w", err))
 				return
 			}
 			w.syncUsingReconciliationStrategy(ctx)
@@ -463,11 +448,18 @@ func (w *workflowRegistry) generateReconciliationEvents(
 			// we can't tell the difference between an activation and registration without holding
 			// state in the db; so we handle as an activation event.
 			case false:
+				// Skip if we already generated an event for this workflow ID in this pass.
+				// Duplicate IDs can occur when the same workflow is associated with multiple DON
+				// families queried in ListWorkflowMetadata.
+				if workflowsSeen[id] {
+					continue
+				}
 				signature := fmt.Sprintf("%s-%s-%s", WorkflowActivated, id, toSpecStatus(wfMeta.Status))
 
 				if _, ok := pendingEvents[id]; ok && pendingEvents[id].signature == signature {
 					events = append(events, pendingEvents[id])
 					delete(pendingEvents, id)
+					workflowsSeen[id] = true
 					continue
 				}
 
@@ -499,9 +491,20 @@ func (w *workflowRegistry) generateReconciliationEvents(
 			// if the workflow is active, the workflow engine is in the engine registry, and the metadata has not changed
 			// then we don't need to action the event further. Mark as seen and continue.
 			case true:
+				// Clear any stale pending activation event for this workflow. This can accumulate
+				// when a different source registered the engine between ticks — source B's pending
+				// event would otherwise never be cleared, causing a permanent invariant violation
+				// that blocks all further reconciliation for source B.
+				delete(pendingEvents, id)
 				workflowsSeen[id] = true
 			}
 		case WorkflowStatusPaused:
+			// Skip if we already generated an event for this workflow ID in this pass.
+			// Duplicate IDs can occur when the same workflow is associated with multiple DON
+			// families queried in ListWorkflowMetadata.
+			if workflowsSeen[id] {
+				continue
+			}
 			signature := fmt.Sprintf("%s-%s-%s", WorkflowPaused, id, toSpecStatus(wfMeta.Status))
 			switch engineFound {
 			case false:

--- a/core/services/workflows/syncer/v2/workflow_registry_test.go
+++ b/core/services/workflows/syncer/v2/workflow_registry_test.go
@@ -776,6 +776,139 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 		require.Empty(t, events)
 		require.Empty(t, pendingEvents)
 	})
+
+	t.Run("duplicate workflow ID in metadata with pending event produces only one activation", func(t *testing.T) {
+		lggr := logger.TestLogger(t)
+		ctx := testutils.Context(t)
+		workflowDonNotifier := capabilities.NewDonNotifier()
+		er := NewEngineRegistry()
+		wr, err := NewWorkflowRegistry(
+			lggr,
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) { return nil, nil },
+			"",
+			"test-chain-selector",
+			Config{QueryCount: 20, SyncStrategy: SyncStrategyReconciliation},
+			&eventHandler{},
+			workflowDonNotifier,
+			er,
+		)
+		require.NoError(t, err)
+
+		wfID := [32]byte{42}
+		owner := []byte{1}
+		wfView := WorkflowMetadataView{
+			WorkflowID:   wfID,
+			Owner:        owner,
+			Status:       WorkflowStatusActive,
+			WorkflowName: "dup-wf",
+			BinaryURL:    "b1",
+			ConfigURL:    "c1",
+		}
+		// Simulate the same workflow appearing twice (e.g. registered under two DON families).
+		metadata := []WorkflowMetadataView{wfView, wfView}
+
+		// Simulate a previously-failed activation event sitting in the pending queue.
+		sig := fmt.Sprintf("%s-%s-%s", WorkflowActivated, wfTypes.WorkflowID(wfID).Hex(), toSpecStatus(WorkflowStatusActive))
+		pendingEvents := map[string]*reconciliationEvent{
+			wfTypes.WorkflowID(wfID).Hex(): {
+				Event:     Event{Data: WorkflowActivatedEvent{WorkflowID: wfID}, Name: WorkflowActivated},
+				signature: sig,
+				id:        wfTypes.WorkflowID(wfID).Hex(),
+			},
+		}
+
+		events, err := wr.generateReconciliationEvents(ctx, pendingEvents, metadata, &types.Head{Height: "1"}, "TestSource")
+		require.NoError(t, err)
+		// Must be exactly one event — the recycled pending event — not two.
+		require.Len(t, events, 1)
+		require.Equal(t, WorkflowActivated, events[0].Name)
+	})
+
+	t.Run("active engine with stale pending event clears the stale event without error", func(t *testing.T) {
+		lggr := logger.TestLogger(t)
+		ctx := testutils.Context(t)
+		workflowDonNotifier := capabilities.NewDonNotifier()
+		er := NewEngineRegistry()
+
+		wfID := [32]byte{7}
+		// The engine was already registered (e.g. by another source earlier in the same tick).
+		require.NoError(t, er.Add(wfID, "SourceA", &mockService{}))
+
+		wr, err := NewWorkflowRegistry(
+			lggr,
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) { return nil, nil },
+			"",
+			"test-chain-selector",
+			Config{QueryCount: 20, SyncStrategy: SyncStrategyReconciliation},
+			&eventHandler{},
+			workflowDonNotifier,
+			er,
+		)
+		require.NoError(t, err)
+
+		metadata := []WorkflowMetadataView{{
+			WorkflowID:   wfID,
+			Owner:        []byte{1},
+			Status:       WorkflowStatusActive,
+			WorkflowName: "wf",
+		}}
+
+		// Source B has a stale pending activation event from a previous tick where
+		// the handler failed before another source managed to register the engine.
+		sig := fmt.Sprintf("%s-%s-%s", WorkflowActivated, wfTypes.WorkflowID(wfID).Hex(), toSpecStatus(WorkflowStatusActive))
+		pendingEvents := map[string]*reconciliationEvent{
+			wfTypes.WorkflowID(wfID).Hex(): {
+				Event:      Event{Data: WorkflowActivatedEvent{WorkflowID: wfID}, Name: WorkflowActivated},
+				signature:  sig,
+				id:         wfTypes.WorkflowID(wfID).Hex(),
+				retryCount: 3,
+			},
+		}
+
+		events, err := wr.generateReconciliationEvents(ctx, pendingEvents, metadata, &types.Head{Height: "1"}, "SourceB")
+		// Before the fix this returned an invariant violation error.
+		require.NoError(t, err)
+		require.Empty(t, events)
+		require.Empty(t, pendingEvents, "stale pending event must be cleared")
+	})
+
+	t.Run("duplicate workflow ID in metadata with paused status produces only one pause event", func(t *testing.T) {
+		lggr := logger.TestLogger(t)
+		ctx := testutils.Context(t)
+		workflowDonNotifier := capabilities.NewDonNotifier()
+		er := NewEngineRegistry()
+
+		wfID := [32]byte{99}
+		require.NoError(t, er.Add(wfID, "TestSource", &mockService{}))
+
+		wr, err := NewWorkflowRegistry(
+			lggr,
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) { return nil, nil },
+			"",
+			"test-chain-selector",
+			Config{QueryCount: 20, SyncStrategy: SyncStrategyReconciliation},
+			&eventHandler{},
+			workflowDonNotifier,
+			er,
+		)
+		require.NoError(t, err)
+
+		wfView := WorkflowMetadataView{
+			WorkflowID:   wfID,
+			Owner:        []byte{1},
+			Status:       WorkflowStatusPaused,
+			WorkflowName: "paused-wf",
+		}
+		// Same workflow ID appears twice, simulating a multi-DON-family query result.
+		metadata := []WorkflowMetadataView{wfView, wfView}
+
+		pendingEvents := map[string]*reconciliationEvent{}
+		events, err := wr.generateReconciliationEvents(ctx, pendingEvents, metadata, &types.Head{Height: "1"}, "TestSource")
+		require.NoError(t, err)
+		// Must be exactly one pause event — not two.
+		require.Len(t, events, 1)
+		require.Equal(t, WorkflowPaused, events[0].Name)
+	})
 }
 
 func Test_Start(t *testing.T) {


### PR DESCRIPTION
### Changes
Since the Workflow Syncer invokes the event handler via goroutines, duplicate events can cause races.

Three scenarios can lead to unintended workflow loading behavior:
- When there is a contract source that has multiple families with the same workflow on them, this can lead to duplicate workflows being loaded.
- When there is both a contract source and an extra source there could be duplicates across them.
- If one of the sources contains duplicates of a workflow.

These happen because of a lack of checks for `workflowsSeen[id]`. Adds guards for these cases.

Additionally this PR:
- Cleans up "hooks". There is only one left `OnStartFailure`, and it is not used. The place where it is invoked is in an initial `w.workflowDonNotifier.WaitForDon(ctx)` call. This is redundant, because `syncUsingReconciliationStrategy` calls this on every tick.