### PR TITLE
chore: bump confidential-http gitref (#21536)

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -52,5 +52,5 @@ plugins:
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "5fdcd59a92b7137982f9f3c51d868ce01a158340"
+      gitRef: "c35ae2937dcb63196d87c3dea27ebd0ef5701c29"
       installPath: "./cmd/confidential-http"


### PR DESCRIPTION
## Summary

Cherry-pick of #21536 to `release/2.38.1-beta-for-cre`: bumps the confidential-http gitref in `plugins/plugins.private.yaml`.
