### PR TITLE
fix: correct shebang and POSIX syntax in setup_testdb.sh (#16179)

### DIFF
--- a/core/scripts/setup_testdb.sh
+++ b/core/scripts/setup_testdb.sh
@@ -1,12 +1,12 @@
-#/bin/sh
+#!/bin/bash
 
-function exit_error {
+exit_error() {
     echo "Error: $1"
     exit 1
 }
 # Create a new user and database for development
 # This script is intended to be run on a local development machine
-tdir=$(mktemp -d -t db-dev-user)
+tdir=$(mktemp -d)
 
 username="chainlink_dev"
 password="insecurepassword"


### PR DESCRIPTION
## Summary

Fixes #16179.

**Root cause:** `core/scripts/setup_testdb.sh` had three issues: (1) shebang `#/bin/sh` was missing `!`, so the script was not executed by any interpreter correctly, (2) `function exit_error {` is bash-only syntax invalid in POSIX sh, (3) `mktemp -d -t db-dev-user` requires a template with 6+ X's on GNU mktemp, causing `mktemp: too few X's in template` on Linux.

**Fix:** Use `#!/bin/bash` shebang (needed for `pushd`/`popd`), POSIX-compliant `exit_error() {` function syntax, and portable `mktemp -d` without template argument.

## Changes

- `core/scripts/setup_testdb.sh`: Fix shebang, function syntax, mktemp call

## Testing

- Verified script parses without syntax errors on bash
- Minimal change, no behavior modification beyond portability
- No unrelated changes included

Made with [Cursor](https://cursor.com)