### PR TITLE
revert confidential http binary to v0.0.6

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -52,5 +52,5 @@ plugins:
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "c35ae2937dcb63196d87c3dea27ebd0ef5701c29"
+      gitRef: "6e03ab2b759f6a6983673e4071b712438b1c923c"
       installPath: "./cmd/confidential-http"


### PR DESCRIPTION
## Summary

Reverts the confidential HTTP capability binary in `plugins/plugins.private.yaml` back to `v0.0.6`.

## Why

The newly-pushed binary was broken in the plugin environment; v0.0.6 was the last known-good release.
