### PR TITLE
revert confidential http binary to v0.0.6 (#21576)

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -52,5 +52,5 @@ plugins:
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "c35ae2937dcb63196d87c3dea27ebd0ef5701c29"
+      gitRef: "6e03ab2b759f6a6983673e4071b712438b1c923c"
       installPath: "./cmd/confidential-http"


### PR DESCRIPTION
## Summary

Cherry-pick of #21576: reverts the confidential http binary to v0.0.6. (Closed — superseded by #21580.)
