### PR TITLE
Disable trigger checks in test

### DIFF
--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -399,7 +399,8 @@ func ExecuteEVMLogTriggerTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 		t_helpers.WatchWorkflowLogs(t, lggr, userLogsCh, baseMessageCh, t_helpers.WorkflowEngineInitErrorLog, expectedUserLog, 4*time.Minute)
 		emitCancelFn()
 
-		verifyTriggerEventACKs(t, triggerDB, baselineStats)
+		// TODO: (CRE-2314) Re-enable trigger event ACKS
+		// verifyTriggerEventACKs(t, triggerDB, baselineStats)
 
 		lggr.Info().Msgf("🎉 LogTrigger Workflow %s executed successfully on chain %s", workflowName, chainID)
 		successfulLogTriggerChains = append(successfulLogTriggerChains, chainID)


### PR DESCRIPTION
We will re-enable this verification once we rollout ACK system [CRE-2314](https://smartcontract-it.atlassian.net/browse/CRE-2314)

[CRE-2314]: https://smartcontract-it.atlassian.net/browse/CRE-2314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ