### PR TITLE
CCIP-9952: Adding AllowAdditiveRemotePools variable to add additional…

### DIFF
--- a/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools.go
@@ -499,7 +499,7 @@ func configureTokenPool(
 				// Remote pool is not supported - behavior depends on AllowAdditiveRemotePools flag
 				if poolUpdate.AllowAdditiveRemotePools {
 					// Add the new remote pool without removing the chain
-					remotePoolAddressAdditions[remoteChainSelector] = remotePoolAddress.Bytes()
+					remotePoolAddressAdditions[remoteChainSelector] = common.LeftPadBytes(remotePoolAddress.Bytes(), 32)
 					// Also update rate limits
 					remoteChainSelectorsToUpdate = append(remoteChainSelectorsToUpdate, remoteChainSelector)
 					updatedOutboundConfigs = append(updatedOutboundConfigs, chainUpdate.RateLimiterConfig.Outbound)
@@ -522,8 +522,8 @@ func configureTokenPool(
 				RemoteChainSelector:       remoteChainSelector,
 				InboundRateLimiterConfig:  chainUpdate.RateLimiterConfig.Inbound,
 				OutboundRateLimiterConfig: chainUpdate.RateLimiterConfig.Outbound,
-				RemoteTokenAddress:        remoteTokenAddress.Bytes(),
-				RemotePoolAddresses:       [][]byte{remotePoolAddress.Bytes()},
+				RemoteTokenAddress:        common.LeftPadBytes(remoteTokenAddress.Bytes(), 32),
+				RemotePoolAddresses:       [][]byte{common.LeftPadBytes(remotePoolAddress.Bytes(), 32)},
 			})
 		}
 	}

--- a/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools.go
@@ -489,11 +489,13 @@ func configureTokenPool(
 				}
 			}
 
-			// Check if the remote token has changed - this always requires chain removal/re-addition
-			if !bytes.Equal(remoteTokenAddress.Bytes(), remoteToken) {
+			// Determine the action based on token and pool status
+			switch {
+			case !bytes.Equal(remoteTokenAddress.Bytes(), remoteToken):
+				// Remote token has changed - this always requires chain removal/re-addition
 				chainRemovals = append(chainRemovals, remoteChainSelector)
 				addChain = true
-			} else if !isRemotePoolSupported {
+			case !isRemotePoolSupported:
 				// Remote pool is not supported - behavior depends on AllowAdditiveRemotePools flag
 				if poolUpdate.AllowAdditiveRemotePools {
 					// Add the new remote pool without removing the chain
@@ -507,7 +509,7 @@ func configureTokenPool(
 					chainRemovals = append(chainRemovals, remoteChainSelector)
 					addChain = true
 				}
-			} else {
+			default:
 				// Remote pool is already supported, just update the rate limits
 				remoteChainSelectorsToUpdate = append(remoteChainSelectorsToUpdate, remoteChainSelector)
 				updatedOutboundConfigs = append(updatedOutboundConfigs, chainUpdate.RateLimiterConfig.Outbound)

--- a/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools.go
@@ -262,6 +262,12 @@ type TokenPoolConfig struct {
 
 	// SkipOwnershipValidation, if true, skips validation of ownership on the token pool. Optional, defaults to false.
 	SkipOwnershipValidation bool `json:"skipOwnershipValidation,omitempty"`
+
+	// AllowAdditiveRemotePools, if true, allows adding additional remote pools to existing chain configurations
+	// without removing and re-adding the chain selector. When false (default), the behavior is to remove
+	// the chain selector and re-add it with the new pool configuration (spot replacement).
+	// This is particularly useful for Solana and other chains where multiple pools may need to coexist.
+	AllowAdditiveRemotePools bool `json:"allowAdditiveRemotePools,omitempty"`
 }
 
 func (c TokenPoolConfig) Validate(ctx context.Context, chain cldf_evm.Chain, ccipState stateview.CCIPOnChainState, useMcms bool, tokenSymbol shared.TokenSymbol) error {
@@ -482,13 +488,27 @@ func configureTokenPool(
 					break
 				}
 			}
-			if !bytes.Equal(remoteTokenAddress.Bytes(), remoteToken) || !isRemotePoolSupported {
-				// Remove & later re-add the chain if the remote token has changed OR the remote pool address is not supported
+
+			// Check if the remote token has changed - this always requires chain removal/re-addition
+			if !bytes.Equal(remoteTokenAddress.Bytes(), remoteToken) {
 				chainRemovals = append(chainRemovals, remoteChainSelector)
 				addChain = true
+			} else if !isRemotePoolSupported {
+				// Remote pool is not supported - behavior depends on AllowAdditiveRemotePools flag
+				if poolUpdate.AllowAdditiveRemotePools {
+					// Add the new remote pool without removing the chain
+					remotePoolAddressAdditions[remoteChainSelector] = remotePoolAddress.Bytes()
+					// Also update rate limits
+					remoteChainSelectorsToUpdate = append(remoteChainSelectorsToUpdate, remoteChainSelector)
+					updatedOutboundConfigs = append(updatedOutboundConfigs, chainUpdate.RateLimiterConfig.Outbound)
+					updatedInboundConfigs = append(updatedInboundConfigs, chainUpdate.RateLimiterConfig.Inbound)
+				} else {
+					// Default behavior: Remove & later re-add the chain (spot replacement)
+					chainRemovals = append(chainRemovals, remoteChainSelector)
+					addChain = true
+				}
 			} else {
-				// Update the rate limits if the chain is already supported
-				// We dont need to add a new remote pool because solana only supports one remote pool per token
+				// Remote pool is already supported, just update the rate limits
 				remoteChainSelectorsToUpdate = append(remoteChainSelectorsToUpdate, remoteChainSelector)
 				updatedOutboundConfigs = append(updatedOutboundConfigs, chainUpdate.RateLimiterConfig.Outbound)
 				updatedInboundConfigs = append(updatedInboundConfigs, chainUpdate.RateLimiterConfig.Inbound)
@@ -587,7 +607,9 @@ func configureTokenPool(
 				}
 			}
 			// Check if the remote pool to-be-set is non-empty and not already configured on the token pool
-			if len(remotePoolAddress) == 0 && !isRemotePoolSupported {
+			// For Sui, the default behavior has always been additive, so we maintain backward compatibility
+			// The AllowAdditiveRemotePools flag doesn't change Sui's existing behavior
+			if len(remotePoolAddress) > 0 && !isRemotePoolSupported {
 				remotePoolAddressAdditions[remoteChainSelector] = common.LeftPadBytes(remotePoolAddress, 32)
 			}
 		} else {


### PR DESCRIPTION
… remote pools for solana

This pull request introduces a new configuration option to the token pool management logic, allowing for more flexible handling of remote pools—especially beneficial for chains like Solana that may require multiple pools to coexist. The changes revolve around how remote pools are added or updated, with a new flag to control whether pools are added additively or via the previous "spot replacement" behavior.

Key changes:

**New configuration option:**

* Added `AllowAdditiveRemotePools` to the `TokenPoolConfig` struct, enabling the option to add new remote pools to existing chain configurations without removing and re-adding the chain selector. This is particularly useful for chains that need to support multiple pools simultaneously.

**Token pool update logic:**

* Updated the logic in `configureTokenPool` to respect the `AllowAdditiveRemotePools` flag:  
  - If the flag is set and a remote pool is not yet supported, the new pool is added without removing the chain.  
  - If the flag is not set (default), the previous behavior of removing and re-adding the chain selector is retained.
* Clarified that for Sui, the default behavior remains additive for backward compatibility, and the new flag does not alter Sui's handling of remote pools.
