### PR TITLE
[CRE] [3/5] Allow capability DONs to discover remote capabilities

### DIFF
--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -410,6 +410,13 @@ func (w *launcher) OnNewRegistry(ctx context.Context, localRegistry *registrysyn
 	if belongsToACapabilityDON {
 		for _, myDON := range myCapabilityDONs {
 			w.serveCapabilities(ctx, w.myPeerID, myDON, localRegistry, remoteWorkflowDONs)
+
+			// Capability DONs may need to call capabilities on other DONs
+			// (e.g. relay DON calling vault DON for secret fetching).
+			// Without this, only workflow DONs discover cross-DON capabilities.
+			for _, rcd := range remoteCapabilityDONs {
+				w.addRemoteCapabilities(ctx, myDON, rcd, localRegistry)
+			}
 		}
 	}
 

--- a/core/capabilities/launcher_test.go
+++ b/core/capabilities/launcher_test.go
@@ -2,6 +2,8 @@ package capabilities
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -232,6 +234,79 @@ func TestLauncher(t *testing.T) {
 
 		require.NoError(t, launcher.OnNewRegistry(t.Context(), localRegistry))
 		assert.Equal(t, 1, observedLogs.FilterMessage("failed to serve capability").Len())
+	})
+
+	t.Run("OK-capability_DON_discovers_remote_capabilities", func(t *testing.T) {
+		// Regression test: a capability DON (e.g. relay DON) that needs to call
+		// another capability DON (e.g. vault DON) must discover it via
+		// addRemoteCapabilities. Previously, only workflow DONs discovered
+		// remote capabilities, so the relay DON couldn't find vault.
+		lggr, observedLogs := logger.TestObserved(t, zapcore.DebugLevel)
+		registry := NewRegistry(lggr)
+		dispatcher := remoteMocks.NewDispatcher(t)
+
+		nodes := newNodes(4)
+		remoteNodes := newNodes(4)
+		peer := mocks.NewPeer(t)
+		peer.On("UpdateConnections", mock.Anything).Return(nil)
+		peer.On("ID").Return(nodes[0])
+		peer.On("IsBootstrap").Return(false)
+		wrapper := mocks.NewPeerWrapper(t)
+		wrapper.On("GetPeer").Return(peer)
+
+		// Local DON: capability DON (relay) with a trigger capability
+		fullTriggerCapID := "streams-trigger@1.0.0"
+		mt := newMockTrigger(capabilities.MustNewCapabilityInfo(
+			fullTriggerCapID,
+			capabilities.CapabilityTypeTrigger,
+			"streams trigger",
+		))
+		require.NoError(t, registry.Add(t.Context(), mt))
+
+		triggerCapID := RandomUTF8BytesWord()
+
+		localDONID := uint32(1)
+		remoteDONID := uint32(2)
+		localRegistry := buildLocalRegistry()
+
+		// Local DON: capability DON (isPublic=true, acceptsWorkflows=false)
+		addDON(localRegistry, localDONID, uint32(0), uint8(1), true, false, nodes, []string{"zone-a"}, 1, [][32]byte{triggerCapID})
+		addCapabilityToDON(localRegistry, localDONID, fullTriggerCapID, capabilities.CapabilityTypeTrigger, nil)
+
+		// Remote DON: another capability DON (vault) that the local DON needs to call
+		remoteTargetCapID := RandomUTF8BytesWord()
+		fullRemoteTargetID := "vault@1.0.0"
+		addDON(localRegistry, remoteDONID, uint32(0), uint8(1), true, false, remoteNodes, []string{"zone-a"}, 1, [][32]byte{remoteTargetCapID})
+		addCapabilityToDON(localRegistry, remoteDONID, fullRemoteTargetID, capabilities.CapabilityTypeTarget, nil)
+
+		launcher, err := NewLauncher(
+			lggr,
+			wrapper,
+			nil,
+			nil,
+			dispatcher,
+			registry,
+			&mockDonNotifier{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, launcher.Start(t.Context()))
+		defer launcher.Close()
+
+		dispatcher.On("SetReceiver", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(nil)
+
+		require.NoError(t, launcher.OnNewRegistry(t.Context(), localRegistry))
+		// Without the fix, addRemoteCapabilities is never called for capability DONs.
+		// With the fix, the launcher attempts to add vault@1.0.0 as a remote capability.
+		// It may fail downstream (signer setup) but the attempt proves discovery works.
+		allLogs := observedLogs.All()
+		found := false
+		for _, entry := range allLogs {
+			if strings.Contains(entry.Message, "remote capability") && strings.Contains(fmt.Sprintf("%v", entry.ContextMap()), fullRemoteTargetID) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected capability DON to attempt remote capability discovery for %s", fullRemoteTargetID)
 	})
 
 	t.Run("start and close with nil peer wrapper", func(t *testing.T) {


### PR DESCRIPTION
## Context

Part of #21635 (confidential workflow execution). [3/5] in the series.
Can be reviewed and merged independently.

## What this does

Adds `addRemoteCapabilities` inside the `belongsToACapabilityDON` block
so capability DONs can discover capabilities on other DONs.

Previously, only workflow DONs called `addRemoteCapabilities`. A
capability DON (e.g. relay DON) that needs to call another capability
DON (e.g. vault DON for secret fetching) could not discover it.

## Dependencies

None.