### PR TITLE
chore(ci): small simplifications to ci-core

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -121,7 +121,7 @@ jobs:
       contents: read
       # For golangci-lint-action's `only-new-issues` option.
       pull-requests: read
-    runs-on: runs-on=${{ github.run_id }}-${{ strategy.job-index }}/cpu=8/ram=16/family=c6gd/spot=false/image=ubuntu24-full-arm64/extras=s3-cache
+    runs-on: runs-on=${{ github.run_id }}-${{ strategy.job-index }}/cpu=16/ram=32/family=c6gd/spot=false/image=ubuntu24-full-arm64/extras=s3-cache
     strategy:
       fail-fast: false
       matrix:
@@ -218,7 +218,7 @@ jobs:
             install-loopps: "true"
 
           - cmd: go_core_fuzz
-            os: runs-on=${{ github.run_id}}-fuzz/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+            os: runs-on=${{ github.run_id}}-fuzz/cpu=8/ram=32/family=m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
 
           - cmd: go_core_race_tests
@@ -226,7 +226,7 @@ jobs:
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
 
           - cmd: go_core_ccip_deployment_tests
-            os: runs-on=${{ github.run_id }}-deployment/cpu=48/ram=96/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+            os: runs-on=${{ github.run_id }}-deployment/cpu=64/ram=128/family=c6i+c7i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
             should-run: ${{ needs.filter.outputs.should-run-deployment-tests }}
             trunk-auto-quarantine: "true"
             go-mod-directory: "deployment/"
@@ -241,12 +241,7 @@ jobs:
     needs: [filter, run-frequency ]
     timeout-minutes: 60
     # Use ubuntu-latest for jobs that will be skipped
-    runs-on: >-
-      ${{
-        matrix.type.should-run == 'true' &&
-        matrix.type.os ||
-        'ubuntu-latest'
-      }}
+    runs-on: ${{ matrix.type.should-run == 'true' && matrix.type.os || 'ubuntu-latest' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -112,16 +112,16 @@ jobs:
 
   golangci:
     name: GolangCI Lint
-    needs: [filter, run-frequency, runner-config]
+    needs: [filter, run-frequency ]
     # We don't directly merge dependabot PRs to not waste the resources.
-    if: ${{ (github.event_name == 'pull_request' ||  github.event_name == 'schedule') && github.actor != 'dependabot[bot]' }}
+    if: ${{ needs.filter.outputs.affected-modules != '[]' && github.actor != 'dependabot[bot]' }}
     permissions:
       # To annotate code in the PR.
       checks: write
       contents: read
       # For golangci-lint-action's `only-new-issues` option.
       pull-requests: read
-    runs-on: ${{ needs.runner-config.outputs.lint-runner }}
+    runs-on: runs-on=${{ github.run_id }}-${{ strategy.job-index }}/cpu=8/ram=16/family=c6gd/spot=false/image=ubuntu24-full-arm64/extras=s3-cache
     strategy:
       fail-fast: false
       matrix:
@@ -206,27 +206,27 @@ jobs:
       matrix:
         type:
           - cmd: go_core_tests
-            os: ${{ needs.runner-config.outputs.core-tests-runner }}
+            os: runs-on=${{ github.run_id }}-unit/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
             trunk-auto-quarantine: "true"
 
           - cmd: go_core_tests_integration
-            os: ${{ needs.runner-config.outputs.core-tests-integration-runner }}
+            os: runs-on=${{ github.run_id }}-integ/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
             trunk-auto-quarantine: "true"
             setup-solana: "true"
             install-loopps: "true"
 
           - cmd: go_core_fuzz
-            os: ${{ needs.runner-config.outputs.core-fuzz-tests-runner }}
+            os: runs-on=${{ github.run_id}}-fuzz/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
 
           - cmd: go_core_race_tests
-            os: ${{ needs.runner-config.outputs.core-race-tests-runner }}
+            os: runs-on=${{ github.run_id}}-race/cpu=64/ram=128/family=c7i/volume=80gb/spot=false/image=ubuntu24-full-x64/extras=s3-cache
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
 
           - cmd: go_core_ccip_deployment_tests
-            os: ${{ needs.runner-config.outputs.deployment-tests-runner }}
+            os: runs-on=${{ github.run_id }}-deployment/cpu=48/ram=96/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
             should-run: ${{ needs.filter.outputs.should-run-deployment-tests }}
             trunk-auto-quarantine: "true"
             go-mod-directory: "deployment/"
@@ -238,7 +238,7 @@ jobs:
     name: Core Tests (${{ matrix.type.cmd }}) # Be careful modifying the job name, as it is used to fetch the job URL
     # We don't directly merge dependabot PRs, so let's not waste the resources
     if: ${{ github.actor != 'dependabot[bot]' }}
-    needs: [filter, run-frequency, runner-config]
+    needs: [filter, run-frequency ]
     timeout-minutes: 60
     runs-on: ${{ matrix.type.os }}
     permissions:
@@ -597,116 +597,6 @@ jobs:
           if [ "$current_hour" -eq "00" ]; then
             echo "one-per-day-frequency=true" | tee -a $GITHUB_OUTPUT
           fi
-
-  # This chooses which runner labels we pass for the matrix jobs above.
-  # General Criteria:
-  # 1. If we are going to 'skip' a test suite, we use the base Github-hosted runner.
-  #   - This is based off `should-run-core-tests`, and `should-run-deployment-tests`
-  # 2. If we are not skipping, we check if the PR has the "runs-on-opt-out" label.
-  #   - If the PR has the label, we use the larger Github-hosted runners.
-  #   - If the PR does not have the label, we use the self-hosted runners.
-  runner-config:
-    name: Runner Config
-    needs: [filter]
-    runs-on: ubuntu-latest
-    env:
-      # include unique label (core/deployment/etc...) to ensure jobs are not competing for the same runner
-      SH_TEST_RUNNER: runs-on=${{ github.run_id }}-core/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
-      SH_DEPLOYMENT_TEST_RUNNER: runs-on=${{ github.run_id }}-deployment/cpu=48/ram=96/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
-      SH_FUZZ_RUNNER: runs-on=${{ github.run_id}}-fuzz/cpu=8+16/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
-      SH_RACE_TEST_RUNNER: runs-on=${{ github.run_id}}-race/cpu=64+128/ram=128+128/family=c7+m7/volume=80gb/spot=false/image=ubuntu24-full-x64/extras=s3-cache
-      SH_LINT_RUNNER: runs-on=${{ github.run_id }}-lint/cpu=16/ram=32/family=c6gd/spot=false/image=ubuntu24-full-arm64/extras=s3-cache
-      GH_TEST_RUNNER: ubuntu22.04-32cores-128GB
-      GH_FUZZ_RUNNER: ubuntu22.04-8cores-32GB
-      GH_BASE_RUNNER: ubuntu-latest
-      GH_LINT_RUNNER: ubuntu-24.04-8cores-32GB-ARM
-    outputs:
-      # go_core_tests / go_core_race_tests / go_core_tests_integration
-      core-tests-runner: ${{ steps.core-tests.outputs.core-tests-runner }}
-      core-tests-integration-runner: ${{ steps.core-tests.outputs.core-tests-integration-runner }}
-      core-fuzz-tests-runner: ${{ steps.core-tests.outputs.core-fuzz-tests-runner }}
-      core-race-tests-runner: ${{ steps.core-tests.outputs.core-race-tests-runner }}
-      # go_core_ccip_deployment_tests
-      deployment-tests-runner: ${{ steps.deployment-tests.outputs.deployment-tests-runner }}
-      # linting
-      lint-runner: ${{ steps.linting.outputs.lint-runner }}
-    steps:
-      - name: Get PR Labels
-        id: pr-labels
-        uses: smartcontractkit/.github/actions/get-pr-labels@get-pr-labels/v1
-        with:
-          check-label: "runs-on-opt-out"
-
-      - name: Select runners for deployment tests
-        id: deployment-tests
-        shell: bash
-        env:
-          OPT_OUT: ${{ steps.pr-labels.outputs.check-label-found || 'false' }}
-          SHOULD_RUN_DEPLOYMENT_TESTS: ${{ needs.filter.outputs.should-run-deployment-tests }}
-        run: |
-          if [[ "${SHOULD_RUN_DEPLOYMENT_TESTS}" == "false" ]]; then
-            echo "Deployment tests will be skipped, using base Github-hosted runner."
-            echo "deployment-tests-runner=${GH_BASE_RUNNER}" | tee -a $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          if [[ "$OPT_OUT" == "true" ]]; then
-            echo "Opt-out is true for current run. Using gh-hosted runner for deployment tests."
-            echo "deployment-tests-runner=${GH_TEST_RUNNER}" | tee -a $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "Opt-out is false for current run. Using self-hosted runner for deployment tests."
-          echo "deployment-tests-runner=${SH_DEPLOYMENT_TEST_RUNNER}" | tee -a $GITHUB_OUTPUT
-
-      - name: Select runners for core tests
-        id: core-tests
-        shell: bash
-        env:
-          OPT_OUT: ${{ steps.pr-labels.outputs.check-label-found || 'false' }}
-          SHOULD_RUN_CORE_TESTS: ${{ needs.filter.outputs.should-run-core-tests }}
-        run: |
-          if [[ "${SHOULD_RUN_CORE_TESTS}" == "false" ]]; then
-            echo "Core tests will be skipped, using base Github-hosted runner."
-
-            echo "core-tests-runner=${GH_BASE_RUNNER}" | tee -a $GITHUB_OUTPUT
-            echo "core-tests-integration-runner=${GH_BASE_RUNNER}" | tee -a $GITHUB_OUTPUT
-            echo "core-fuzz-tests-runner=${GH_BASE_RUNNER}" | tee -a $GITHUB_OUTPUT
-            echo "core-race-tests-runner=${GH_BASE_RUNNER}" | tee -a $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          if [[ "$OPT_OUT" == "true" ]]; then
-            echo "Opt-out is true for current run. Using gh-hosted runner for core tests."
-
-            echo "core-tests-runner=${GH_TEST_RUNNER}" | tee -a $GITHUB_OUTPUT
-            echo "core-tests-integration-runner=${GH_TEST_RUNNER}" | tee -a $GITHUB_OUTPUT
-            echo "core-fuzz-tests-runner=${GH_FUZZ_RUNNER}" | tee -a $GITHUB_OUTPUT
-            echo "core-race-tests-runner=${GH_TEST_RUNNER}" | tee -a $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "Opt-out is false for current run. Using self-hosted runner for core tests."
-
-          echo "core-tests-runner=${SH_TEST_RUNNER}" | tee -a $GITHUB_OUTPUT
-          echo "core-tests-integration-runner=${SH_TEST_RUNNER}" | tee -a $GITHUB_OUTPUT
-          echo "core-fuzz-tests-runner=${SH_FUZZ_RUNNER}" | tee -a $GITHUB_OUTPUT
-          echo "core-race-tests-runner=${SH_RACE_TEST_RUNNER}" | tee -a $GITHUB_OUTPUT
-
-      - name: Select runners for linting
-        id: linting
-        shell: bash
-        env:
-          OPT_OUT: ${{ steps.pr-labels.outputs.check-label-found || 'false' }}
-        run: |
-          if [[ "$OPT_OUT" == "true" ]]; then
-            echo "Opt-out is true for current run. Using gh-hosted runner for linting."
-            echo "lint-runner=${GH_LINT_RUNNER}" | tee -a $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "Opt-out is false for current run. Using self-hosted runner for linting."
-          echo "lint-runner=${SH_LINT_RUNNER}" | tee -a $GITHUB_OUTPUT
 
   misc:
     # Catchall job for miscellaneous steps.

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -114,7 +114,7 @@ jobs:
     name: GolangCI Lint
     needs: [filter, run-frequency ]
     # We don't directly merge dependabot PRs to not waste the resources.
-    if: ${{ needs.filter.outputs.affected-modules != '[]' && github.actor != 'dependabot[bot]' }}
+    if: ${{ needs.filter.outputs.affected-modules != '[]' && github.event_name != 'merge_group' && github.actor != 'dependabot[bot]' }}
     permissions:
       # To annotate code in the PR.
       checks: write
@@ -240,7 +240,13 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     needs: [filter, run-frequency ]
     timeout-minutes: 60
-    runs-on: ${{ matrix.type.os }}
+    # Use ubuntu-latest for jobs that will be skipped
+    runs-on: >-
+      ${{
+        matrix.type.should-run == 'true' &&
+        matrix.type.os ||
+        'ubuntu-latest'
+      }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
### Changes

* Inline all self-hosted runners directly to their job
* Removes `runner-config` job that dynamically chose a self-hosted or github-hosted runners
    * This was there for 2 reasons:
        * in case there were reliability issues with our self-hosted runners, we could easily opt-out through the label but we haven't seen that enough to actually justify this job and increased complexity of the pipeline
        * to use `ubuntu-latest` runners if we were going to skip the job anyways
    * If we ever need to switch off, we will need a PR to change the string of the runner back to GH, which isn't too bad
* Properly skip linting when there's no modified modules

### Testing

* Workflow dispatch: https://github.com/smartcontractkit/chainlink/actions/runs/23465687811
* This PR: https://github.com/smartcontractkit/chainlink/actions/runs/23466131921?pr=21657
* Test when jobs would skip (uses gh-hosted): https://github.com/smartcontractkit/chainlink/actions/runs/23466234045/job/68278850496
* Test when skipping only 1 job, rest use SHR: https://github.com/smartcontractkit/chainlink/actions/runs/23466278044/job/68279009811
