### PR TITLE
[chore] bump confidential http gitref

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -52,5 +52,5 @@ plugins:
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "6e03ab2b759f6a6983673e4071b712438b1c923c"
+      gitRef: "187018af88ce265ca70b86222f8587e3fcb7ff32"
       installPath: "./cmd/confidential-http"


### PR DESCRIPTION
Bumps our gitref for confidential HTTP to our patched v0.0.6 release. This patch has been tested in staging.
