### PR TITLE
capabilities: retain don2don request IDs longer

### DIFF
--- a/core/capabilities/remote/executable/request/server_request.go
+++ b/core/capabilities/remote/executable/request/server_request.go
@@ -208,6 +208,11 @@ func (e *ServerRequest) Expired() bool {
 	return time.Since(e.createdTime) > e.requestTimeout
 }
 
+func (e *ServerRequest) Evictable(minRetention time.Duration) bool {
+	age := time.Since(e.createdTime)
+	return age > e.requestTimeout && age > minRetention
+}
+
 func (e *ServerRequest) Cancel(ctx context.Context, err types.Error, msg string) error {
 	e.mux.Lock()
 	defer e.mux.Unlock()

--- a/core/capabilities/remote/executable/request/server_request_test.go
+++ b/core/capabilities/remote/executable/request/server_request_test.go
@@ -338,6 +338,44 @@ func Test_ServerRequest_MessageValidation(t *testing.T) {
 	})
 }
 
+func Test_ServerRequest_Evictable(t *testing.T) {
+	lggr := logger.Test(t)
+	capability := TestCapability{}
+	capabilityPeerID := NewP2PPeerID(t)
+	workflowPeer := NewP2PPeerID(t)
+
+	callingDon := commoncap.DON{
+		Members: []p2ptypes.PeerID{workflowPeer},
+		ID:      1,
+		F:       0,
+	}
+
+	newRequest := func(requestTimeout time.Duration) *request.ServerRequest {
+		req, err := request.NewServerRequest(capability, types.MethodExecute, "capabilityID", 2,
+			capabilityPeerID, callingDon, "requestMessageID", &testDispatcher{}, requestTimeout, "", lggr)
+		require.NoError(t, err)
+		return req
+	}
+
+	t.Run("expired but below minimum retention", func(t *testing.T) {
+		req := newRequest(20 * time.Millisecond)
+		time.Sleep(60 * time.Millisecond)
+		assert.False(t, req.Evictable(200*time.Millisecond))
+	})
+
+	t.Run("expired and retained past minimum retention", func(t *testing.T) {
+		req := newRequest(20 * time.Millisecond)
+		time.Sleep(60 * time.Millisecond)
+		assert.True(t, req.Evictable(10*time.Millisecond))
+	})
+
+	t.Run("minimum retention elapsed but request timeout still active", func(t *testing.T) {
+		req := newRequest(200 * time.Millisecond)
+		time.Sleep(60 * time.Millisecond)
+		assert.False(t, req.Evictable(10*time.Millisecond))
+	})
+}
+
 type serverRequest interface {
 	OnMessage(ctx context.Context, msg *types.MessageBody) error
 }

--- a/core/capabilities/remote/executable/server.go
+++ b/core/capabilities/remote/executable/server.go
@@ -222,7 +222,7 @@ func (r *server) expireRequests() {
 	defer r.receiveLock.Unlock()
 
 	for requestID, executeReq := range r.requestIDToRequest {
-		if executeReq.request.Expired() {
+		if executeReq.request.Evictable(commoncap.DefaultExecutableRequestTimeout) {
 			ctx, cancelFn := r.stopCh.NewCtx()
 			err := executeReq.request.Cancel(ctx, types.Error_TIMEOUT, "request expired by executable server")
 			cancelFn()

--- a/core/capabilities/remote/executable/server_test.go
+++ b/core/capabilities/remote/executable/server_test.go
@@ -1000,3 +1000,101 @@ func Test_Server_Execute_WithConcurrentSetConfig(t *testing.T) {
 	expectedResponses := numWorkflowPeers * numExecuteCalls
 	require.Equal(t, expectedResponses, successCount)
 }
+
+func Test_Server_DuplicateRequestRemainsDedupedPastRequestTimeout(t *testing.T) {
+	ctx := testutils.Context(t)
+	lggr := logger.Test(t)
+
+	serverPeerID := NewP2PPeerID(t)
+	senderPeerID := NewP2PPeerID(t)
+
+	dispatcher := &noopDispatcher{}
+	server := executable.NewServer("cap_id@1.0.0", "", serverPeerID, dispatcher, lggr)
+
+	cfg := &commoncap.RemoteExecutableConfig{
+		RequestTimeout:            20 * time.Millisecond,
+		ServerMaxParallelRequests: 1,
+	}
+	capInfo := commoncap.CapabilityInfo{
+		ID:             "cap_id@1.0.0",
+		CapabilityType: commoncap.CapabilityTypeTarget,
+	}
+	localDON := commoncap.DON{
+		ID:      1,
+		Members: []p2ptypes.PeerID{serverPeerID},
+		F:       0,
+	}
+	workflowDONs := map[uint32]commoncap.DON{
+		2: {
+			ID:      2,
+			Members: []p2ptypes.PeerID{senderPeerID},
+			F:       0,
+		},
+	}
+
+	require.NoError(t, server.SetConfig(cfg, TestCapability{}, capInfo, localDON, workflowDONs, nil))
+	require.NoError(t, server.Start(ctx))
+	defer func() {
+		require.NoError(t, server.Close())
+	}()
+
+	inputs, err := values.NewMap(map[string]any{"executeValue1": "aValue1"})
+	require.NoError(t, err)
+	rawRequest, err := pb.MarshalCapabilityRequest(commoncap.CapabilityRequest{
+		Metadata: commoncap.RequestMetadata{
+			WorkflowExecutionID: "exec-1",
+		},
+		Inputs: inputs,
+	})
+	require.NoError(t, err)
+
+	msg := &remotetypes.MessageBody{
+		CapabilityId:    capInfo.ID,
+		CapabilityDonId: localDON.ID,
+		CallerDonId:     2,
+		Method:          remotetypes.MethodExecute,
+		Payload:         rawRequest,
+		MessageId:       []byte(remotetypes.MethodExecute + ":exec-1"),
+		Sender:          senderPeerID[:],
+		Receiver:        serverPeerID[:],
+	}
+
+	server.Receive(ctx, msg)
+	require.Eventually(t, func() bool { return len(dispatcher.sent) == 1 }, time.Second, 10*time.Millisecond)
+
+	time.Sleep(2 * cfg.RequestTimeout)
+	server.Receive(ctx, msg)
+
+	time.Sleep(100 * time.Millisecond)
+	require.Len(t, dispatcher.sent, 1)
+}
+
+type noopDispatcher struct {
+	services.StateMachine
+	sent []*remotetypes.MessageBody
+}
+
+func (n *noopDispatcher) Name() string { return "noopDispatcher" }
+
+func (n *noopDispatcher) Start(context.Context) error { return nil }
+
+func (n *noopDispatcher) Close() error { return nil }
+
+func (n *noopDispatcher) Ready() error { return nil }
+
+func (n *noopDispatcher) HealthReport() map[string]error { return nil }
+
+func (n *noopDispatcher) SetReceiver(string, uint32, remotetypes.Receiver) error { return nil }
+
+func (n *noopDispatcher) RemoveReceiver(string, uint32) {}
+
+func (n *noopDispatcher) SetReceiverForMethod(string, uint32, string, remotetypes.Receiver) error {
+	return nil
+}
+
+func (n *noopDispatcher) RemoveReceiverForMethod(string, uint32, string) {}
+
+func (n *noopDispatcher) Send(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) error {
+	n.sent = append(n.sent, msgBody)
+	return nil
+}


### PR DESCRIPTION
## Summary
We've seen in production that some lagging nodes can send the same Don2Don request ID well after the earlier copies of that request have already been cleaned up on the capability DON.

When that happens, the later message is treated like a fresh request instead of being recognized as a duplicate of an old one. That creates confusing follow-on errors in the stack because we lose the original dedup context too early.

This change increases the eviction window for executable Don2Don request IDs so we retain old request state for longer and get a better error surface when delayed duplicates arrive.

## What this change does
- keeps executable server request entries until they are both expired and have been retained for at least `DefaultExecutableRequestTimeout`
- effectively changes the retention window to `max(requestTimeout, DefaultExecutableRequestTimeout)` instead of only `requestTimeout`
- preserves the current request-timeout behavior for execution and cancellation while delaying eviction of dedup state
- adds tests in the existing executable server and server-request test files for the new retention behavior

