### PR TITLE
DF-21989: OCR2 on-chain view gauges (median relay)

### DIFF
--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -955,7 +955,7 @@ func (r *Relayer) NewMedianProvider(ctx context.Context, rargs commontypes.Relay
 		return nil, err
 	}
 
-	medianContract, err := newMedianContract(configWatcher.ContractConfigTracker(), configWatcher.contractAddress, configWatcher.chain, rargs.JobID, rargs.OracleSpecID, r.ds, lggr)
+	medianContract, err := newMedianContract(configWatcher.ContractConfigTracker(), configWatcher.contractAddress, configWatcher.chain, rargs.JobID, rargs.OracleSpecID, r.ds, lggr, pargs.TransmitterID)
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/relay/evm/median.go
+++ b/core/services/relay/evm/median.go
@@ -30,9 +30,10 @@ type medianContract struct {
 	configTracker       types.ContractConfigTracker
 	contractCaller      *ocr2aggregator.OCR2AggregatorCaller
 	requestRoundTracker *round.RequestRoundTracker
+	onchainViewMetrics  *medianOnchainViewMetrics
 }
 
-func newMedianContract(configTracker types.ContractConfigTracker, contractAddress common.Address, chain legacyevm.Chain, jobID int32, oracleSpecID int32, ds sqlutil.DataSource, lggr logger.Logger) (*medianContract, error) {
+func newMedianContract(configTracker types.ContractConfigTracker, contractAddress common.Address, chain legacyevm.Chain, jobID int32, oracleSpecID int32, ds sqlutil.DataSource, lggr logger.Logger, transmitterID string) (*medianContract, error) {
 	lggr = logger.Named(lggr, "MedianContract")
 	contract, err := offchain_aggregator_wrapper.NewOffchainAggregator(contractAddress, chain.Client())
 	if err != nil {
@@ -50,9 +51,10 @@ func newMedianContract(configTracker types.ContractConfigTracker, contractAddres
 	}
 
 	return &medianContract{
-		lggr:           lggr,
-		configTracker:  configTracker,
-		contractCaller: contractCaller,
+		lggr:               lggr,
+		configTracker:      configTracker,
+		contractCaller:     contractCaller,
+		onchainViewMetrics: newMedianOnchainViewMetrics(chain.ID().String(), contractAddress.Hex(), transmitterID),
 		requestRoundTracker: round.NewRequestRoundTracker(
 			contract,
 			contractFilterer,
@@ -87,7 +89,14 @@ func (oc *medianContract) HealthReport() map[string]error {
 func (oc *medianContract) LatestTransmissionDetails(ctx context.Context) (ocrtypes.ConfigDigest, uint32, uint8, *big.Int, time.Time, error) {
 	opts := bind.CallOpts{Context: ctx, Pending: false}
 	result, err := oc.contractCaller.LatestTransmissionDetails(&opts)
-	return result.ConfigDigest, result.Epoch, result.Round, result.LatestAnswer, time.Unix(int64(result.LatestTimestamp), 0), errors.Wrap(err, "error getting LatestTransmissionDetails")
+	if err != nil {
+		return ocrtypes.ConfigDigest{}, 0, 0, nil, time.Time{}, errors.Wrap(err, "error getting LatestTransmissionDetails")
+	}
+	updatedAt := time.Unix(int64(result.LatestTimestamp), 0)
+	if oc.onchainViewMetrics != nil {
+		oc.onchainViewMetrics.record(result.LatestAnswer, result.Epoch, result.Round, updatedAt)
+	}
+	return result.ConfigDigest, result.Epoch, result.Round, result.LatestAnswer, updatedAt, nil
 }
 
 // LatestRoundRequested returns the configDigest, epoch, and round from the latest

--- a/core/services/relay/evm/median.go
+++ b/core/services/relay/evm/median.go
@@ -94,7 +94,7 @@ func (oc *medianContract) LatestTransmissionDetails(ctx context.Context) (ocrtyp
 	}
 	updatedAt := time.Unix(int64(result.LatestTimestamp), 0)
 	if oc.onchainViewMetrics != nil {
-		oc.onchainViewMetrics.record(result.LatestAnswer, result.Epoch, result.Round, updatedAt)
+		oc.onchainViewMetrics.record(ctx, result.LatestAnswer, result.Epoch, result.Round, updatedAt)
 	}
 	return result.ConfigDigest, result.Epoch, result.Round, result.LatestAnswer, updatedAt, nil
 }

--- a/core/services/relay/evm/median_onchain_view_metrics.go
+++ b/core/services/relay/evm/median_onchain_view_metrics.go
@@ -1,11 +1,17 @@
 package evm
 
 import (
+	"context"
 	"math/big"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 )
 
 // Prometheus gauges for the node's view of on-chain OCR2 median aggregator state (DF-22676).
@@ -29,6 +35,47 @@ var (
 	}, []string{"chain_id", "contract_address", "transmitter_id"})
 )
 
+type medianOnchainOtelInstruments struct {
+	latestAnswer        metric.Float64Gauge
+	latestTimestampUnix metric.Float64Gauge
+	epoch               metric.Int64Gauge
+	round               metric.Int64Gauge
+}
+
+var (
+	medianOnchainOtelInst *medianOnchainOtelInstruments
+	medianOnchainOtelOnce sync.Once
+)
+
+func loadMedianOnchainOtel() *medianOnchainOtelInstruments {
+	medianOnchainOtelOnce.Do(func() {
+		m := beholder.GetMeter()
+		latestAnswer, err := m.Float64Gauge("ocr2_onchain_transmission_latest_answer")
+		if err != nil {
+			return
+		}
+		latestTimestampUnix, err := m.Float64Gauge("ocr2_onchain_transmission_latest_timestamp_unix")
+		if err != nil {
+			return
+		}
+		epoch, err := m.Int64Gauge("ocr2_onchain_transmission_epoch")
+		if err != nil {
+			return
+		}
+		round, err := m.Int64Gauge("ocr2_onchain_transmission_round")
+		if err != nil {
+			return
+		}
+		medianOnchainOtelInst = &medianOnchainOtelInstruments{
+			latestAnswer:        latestAnswer,
+			latestTimestampUnix: latestTimestampUnix,
+			epoch:               epoch,
+			round:               round,
+		}
+	})
+	return medianOnchainOtelInst
+}
+
 type medianOnchainViewMetrics struct {
 	chainID       string
 	contract      string
@@ -46,12 +93,28 @@ func newMedianOnchainViewMetrics(chainID, contractAddress, transmitterID string)
 	}
 }
 
-func (m *medianOnchainViewMetrics) record(latestAnswer *big.Int, epoch uint32, round uint8, updatedAt time.Time) {
+func (m *medianOnchainViewMetrics) onchainAttrs() metric.MeasurementOption {
+	return metric.WithAttributes(
+		attribute.String("chain_id", m.chainID),
+		attribute.String("contract_address", m.contract),
+		attribute.String("transmitter_id", m.transmitterID),
+	)
+}
+
+func (m *medianOnchainViewMetrics) record(ctx context.Context, latestAnswer *big.Int, epoch uint32, round uint8, updatedAt time.Time) {
 	lv := bigIntToPromGaugeValue(latestAnswer)
 	promOCR2OnchainLatestAnswer.WithLabelValues(m.chainID, m.contract, m.transmitterID).Set(lv)
 	promOCR2OnchainLatestTimestampUnix.WithLabelValues(m.chainID, m.contract, m.transmitterID).Set(float64(updatedAt.Unix()))
 	promOCR2OnchainEpoch.WithLabelValues(m.chainID, m.contract, m.transmitterID).Set(float64(epoch))
 	promOCR2OnchainRound.WithLabelValues(m.chainID, m.contract, m.transmitterID).Set(float64(round))
+
+	if ot := loadMedianOnchainOtel(); ot != nil {
+		opts := m.onchainAttrs()
+		ot.latestAnswer.Record(ctx, lv, opts)
+		ot.latestTimestampUnix.Record(ctx, float64(updatedAt.Unix()), opts)
+		ot.epoch.Record(ctx, int64(epoch), opts)
+		ot.round.Record(ctx, int64(round), opts)
+	}
 }
 
 func bigIntToPromGaugeValue(i *big.Int) float64 {

--- a/core/services/relay/evm/median_onchain_view_metrics.go
+++ b/core/services/relay/evm/median_onchain_view_metrics.go
@@ -1,0 +1,63 @@
+package evm
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Prometheus gauges for the node's view of on-chain OCR2 median aggregator state (DF-22676).
+// latest_answer is exported as float64; values above ~2^53 may lose integer precision (documented in HELP).
+var (
+	promOCR2OnchainLatestAnswer = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ocr2_onchain_transmission_latest_answer",
+		Help: "Latest median answer from the node's on-chain read of LatestTransmissionDetails (OCR2 aggregator). Float64 may not represent full int256 precision.",
+	}, []string{"chain_id", "contract_address", "transmitter_id"})
+	promOCR2OnchainLatestTimestampUnix = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ocr2_onchain_transmission_latest_timestamp_unix",
+		Help: "Unix seconds of latest on-chain transmission timestamp from the node's LatestTransmissionDetails read.",
+	}, []string{"chain_id", "contract_address", "transmitter_id"})
+	promOCR2OnchainEpoch = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ocr2_onchain_transmission_epoch",
+		Help: "Epoch from the node's on-chain LatestTransmissionDetails read.",
+	}, []string{"chain_id", "contract_address", "transmitter_id"})
+	promOCR2OnchainRound = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ocr2_onchain_transmission_round",
+		Help: "Round from the node's on-chain LatestTransmissionDetails read.",
+	}, []string{"chain_id", "contract_address", "transmitter_id"})
+)
+
+type medianOnchainViewMetrics struct {
+	chainID       string
+	contract      string
+	transmitterID string
+}
+
+func newMedianOnchainViewMetrics(chainID, contractAddress, transmitterID string) *medianOnchainViewMetrics {
+	if transmitterID == "" {
+		transmitterID = "unknown"
+	}
+	return &medianOnchainViewMetrics{
+		chainID:       chainID,
+		contract:      contractAddress,
+		transmitterID: transmitterID,
+	}
+}
+
+func (m *medianOnchainViewMetrics) record(latestAnswer *big.Int, epoch uint32, round uint8, updatedAt time.Time) {
+	lv := bigIntToPromGaugeValue(latestAnswer)
+	promOCR2OnchainLatestAnswer.WithLabelValues(m.chainID, m.contract, m.transmitterID).Set(lv)
+	promOCR2OnchainLatestTimestampUnix.WithLabelValues(m.chainID, m.contract, m.transmitterID).Set(float64(updatedAt.Unix()))
+	promOCR2OnchainEpoch.WithLabelValues(m.chainID, m.contract, m.transmitterID).Set(float64(epoch))
+	promOCR2OnchainRound.WithLabelValues(m.chainID, m.contract, m.transmitterID).Set(float64(round))
+}
+
+func bigIntToPromGaugeValue(i *big.Int) float64 {
+	if i == nil {
+		return 0
+	}
+	f, _ := new(big.Float).SetInt(i).Float64()
+	return f
+}

--- a/core/services/relay/evm/median_onchain_view_metrics.go
+++ b/core/services/relay/evm/median_onchain_view_metrics.go
@@ -35,61 +35,65 @@ var (
 	}, []string{"chain_id", "contract_address", "transmitter_id"})
 )
 
-type medianOnchainOtelInstruments struct {
+var (
+	medianOnchainOtelOnce sync.Once
+	medianOtelLatestAnswer        metric.Float64Gauge
+	medianOtelLatestTimestampUnix metric.Float64Gauge
+	medianOtelEpoch               metric.Int64Gauge
+	medianOtelRound               metric.Int64Gauge
+)
+
+func initMedianOnchainOtel() {
+	medianOnchainOtelOnce.Do(func() {
+		meter := beholder.GetMeter()
+		la, err := meter.Float64Gauge("ocr2_onchain_transmission_latest_answer")
+		if err != nil {
+			return
+		}
+		ltu, err := meter.Float64Gauge("ocr2_onchain_transmission_latest_timestamp_unix")
+		if err != nil {
+			return
+		}
+		e, err := meter.Int64Gauge("ocr2_onchain_transmission_epoch")
+		if err != nil {
+			return
+		}
+		r, err := meter.Int64Gauge("ocr2_onchain_transmission_round")
+		if err != nil {
+			return
+		}
+		medianOtelLatestAnswer = la
+		medianOtelLatestTimestampUnix = ltu
+		medianOtelEpoch = e
+		medianOtelRound = r
+	})
+}
+
+// medianOnchainViewMetrics records the same on-chain OCR2 view series to Prometheus and OpenTelemetry (Beholder), matching the txmMetrics pattern (package-level Prom vecs, OTel instruments on the metrics type).
+type medianOnchainViewMetrics struct {
+	chainID       string
+	contract      string
+	transmitterID string
+
 	latestAnswer        metric.Float64Gauge
 	latestTimestampUnix metric.Float64Gauge
 	epoch               metric.Int64Gauge
 	round               metric.Int64Gauge
 }
 
-var (
-	medianOnchainOtelInst *medianOnchainOtelInstruments
-	medianOnchainOtelOnce sync.Once
-)
-
-func loadMedianOnchainOtel() *medianOnchainOtelInstruments {
-	medianOnchainOtelOnce.Do(func() {
-		m := beholder.GetMeter()
-		latestAnswer, err := m.Float64Gauge("ocr2_onchain_transmission_latest_answer")
-		if err != nil {
-			return
-		}
-		latestTimestampUnix, err := m.Float64Gauge("ocr2_onchain_transmission_latest_timestamp_unix")
-		if err != nil {
-			return
-		}
-		epoch, err := m.Int64Gauge("ocr2_onchain_transmission_epoch")
-		if err != nil {
-			return
-		}
-		round, err := m.Int64Gauge("ocr2_onchain_transmission_round")
-		if err != nil {
-			return
-		}
-		medianOnchainOtelInst = &medianOnchainOtelInstruments{
-			latestAnswer:        latestAnswer,
-			latestTimestampUnix: latestTimestampUnix,
-			epoch:               epoch,
-			round:               round,
-		}
-	})
-	return medianOnchainOtelInst
-}
-
-type medianOnchainViewMetrics struct {
-	chainID       string
-	contract      string
-	transmitterID string
-}
-
 func newMedianOnchainViewMetrics(chainID, contractAddress, transmitterID string) *medianOnchainViewMetrics {
 	if transmitterID == "" {
 		transmitterID = "unknown"
 	}
+	initMedianOnchainOtel()
 	return &medianOnchainViewMetrics{
-		chainID:       chainID,
-		contract:      contractAddress,
-		transmitterID: transmitterID,
+		chainID:               chainID,
+		contract:              contractAddress,
+		transmitterID:         transmitterID,
+		latestAnswer:          medianOtelLatestAnswer,
+		latestTimestampUnix:   medianOtelLatestTimestampUnix,
+		epoch:                 medianOtelEpoch,
+		round:                 medianOtelRound,
 	}
 }
 
@@ -108,13 +112,14 @@ func (m *medianOnchainViewMetrics) record(ctx context.Context, latestAnswer *big
 	promOCR2OnchainEpoch.WithLabelValues(m.chainID, m.contract, m.transmitterID).Set(float64(epoch))
 	promOCR2OnchainRound.WithLabelValues(m.chainID, m.contract, m.transmitterID).Set(float64(round))
 
-	if ot := loadMedianOnchainOtel(); ot != nil {
-		opts := m.onchainAttrs()
-		ot.latestAnswer.Record(ctx, lv, opts)
-		ot.latestTimestampUnix.Record(ctx, float64(updatedAt.Unix()), opts)
-		ot.epoch.Record(ctx, int64(epoch), opts)
-		ot.round.Record(ctx, int64(round), opts)
+	if m.latestAnswer == nil {
+		return
 	}
+	opts := m.onchainAttrs()
+	m.latestAnswer.Record(ctx, lv, opts)
+	m.latestTimestampUnix.Record(ctx, float64(updatedAt.Unix()), opts)
+	m.epoch.Record(ctx, int64(epoch), opts)
+	m.round.Record(ctx, int64(round), opts)
 }
 
 func bigIntToPromGaugeValue(i *big.Int) float64 {


### PR DESCRIPTION
## Summary
Adds Prometheus gauges from `LatestTransmissionDetails` for EVM median OCR2 jobs ([DF-21989](https://smartcontract-it.atlassian.net/browse/DF-21989), PMAI DF-22676).

## Metrics
- `ocr2_onchain_transmission_latest_answer`
- `ocr2_onchain_transmission_latest_timestamp_unix`
- `ocr2_onchain_transmission_epoch`
- `ocr2_onchain_transmission_round`

Labels: `chain_id`, `contract_address`, `transmitter_id` (from plugin args).

## Related
Pairs with chainlink-evm PR for transmit outcome metrics.


Made with [Cursor](https://cursor.com)

[DF-21989]: https://smartcontract-it.atlassian.net/browse/DF-21989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ