### PR TITLE
Release/2.39.2 conf http patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.39.0",
+  "version": "2.39.2",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -52,5 +52,5 @@ plugins:
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "c35ae2937dcb63196d87c3dea27ebd0ef5701c29"
+      gitRef: "187018af88ce265ca70b86222f8587e3fcb7ff32"
       installPath: "./cmd/confidential-http"


### PR DESCRIPTION
- Bumps conf. http gitref, related PR in develop: https://github.com/smartcontractkit/chainlink/commit/7c8eae74905f35cbd7b4c77603e211e54269f716. 
- Bumps version in `package.json`