### PR TITLE
vault: poll for DKG result in NewReportingPlugin (~12s startup speedup)

### DIFF
--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+	"time"
 
 	"golang.org/x/crypto/curve25519"
 	"golang.org/x/crypto/nacl/box"
@@ -134,6 +135,31 @@ func (r *ReportingPluginFactory) getKeyMaterial(ctx context.Context, instanceID 
 	}
 
 	return publicKey, privateKeyShare, nil
+}
+
+const dkgPollInterval = 2 * time.Second
+
+// pollForKeyMaterial polls the DKG result package database until the key
+// material for the given instance ID is available or the context is cancelled.
+// This avoids returning an immediate error when the DKG protocol hasn't
+// completed yet, which would trigger libocr's exponential backoff (up to 2
+// minutes between retries). By polling here within the MaxDurationInitialization
+// window, the vault oracle can start as soon as the DKG result is written.
+func (r *ReportingPluginFactory) pollForKeyMaterial(ctx context.Context, instanceID string) (publicKey *tdh2easy.PublicKey, privateKeyShare *tdh2easy.PrivateShare, err error) {
+	for {
+		publicKey, privateKeyShare, err = r.getKeyMaterial(ctx, instanceID)
+		if err == nil {
+			return publicKey, privateKeyShare, nil
+		}
+
+		r.lggr.Debugw("DKG result package not yet available, will retry", "instanceID", instanceID, "error", err)
+
+		select {
+		case <-ctx.Done():
+			return nil, nil, fmt.Errorf("context cancelled while waiting for DKG key material (instanceID=%s): %w", instanceID, err)
+		case <-time.After(dkgPollInterval):
+		}
+	}
 }
 
 func initializePluginLimits(ctx context.Context, limitsFactory limits.Factory) (ocr3_1types.ReportingPluginLimits, error) {
@@ -277,7 +303,7 @@ func (r *ReportingPluginFactory) NewReportingPlugin(ctx context.Context, config 
 	}
 
 	r.lggr.Debugw("fetching key material for instance id", "instanceID", *configProto.DKGInstanceID)
-	publicKey, privateKeyShare, err := r.getKeyMaterial(ctx, *configProto.DKGInstanceID)
+	publicKey, privateKeyShare, err := r.pollForKeyMaterial(ctx, *configProto.DKGInstanceID)
 	if err != nil {
 		return nil, ocr3_1types.ReportingPluginInfo1{}, fmt.Errorf("could not get key material from DB: %w", err)
 	}


### PR DESCRIPTION
## Summary

**Performance improvement: saves ~12 seconds** from vault oracle startup.

When the vault OCR3.1 oracle starts before DKG completes, `NewReportingPlugin` fails immediately because the DKG result isn't in the DB yet. This triggers libocr's exponential backoff (1s, 2s, 4s, 8s, 13s…), wasting ~12s even after DKG finishes.

### Change

Add `pollForKeyMaterial()` that polls the DB every 2s within libocr's `MaxDurationInitialization` window (10s), instead of failing immediately. The vault oracle now starts within ~2s of DKG completion rather than waiting for the next backoff cycle.

### Impact

From local CRE log analysis:
- **Before:** DKG result available at T+69s, vault oracle ready at T+81s (12s wasted in backoff)
- **After:** DKG result available at T+69s, vault oracle ready at ~T+71s

Eliminates the occasional first-request timeout in vault E2E tests.
