### PR TITLE
fix(proposalutils): remove duplicate Timelock nil check in TimelockConfig.Validate

### DIFF
--- a/deployment/common/proposalutils/propose.go
+++ b/deployment/common/proposalutils/propose.go
@@ -116,9 +116,6 @@ func (tc *TimelockConfig) Validate(chain cldf_evm.Chain, s state.MCMSWithTimeloc
 	if tc.MCMSAction == types.TimelockActionBypass && s.BypasserMcm == nil {
 		return fmt.Errorf("missing bypasserMcm on %s", chain)
 	}
-	if s.Timelock == nil {
-		return fmt.Errorf("missing timelock on %s", chain)
-	}
 	if s.CallProxy == nil {
 		return fmt.Errorf("missing callProxy on %s", chain)
 	}


### PR DESCRIPTION
## Summary
Removes a redundant `s.Timelock == nil` check in `TimelockConfig.Validate`. Timelock is already validated at the beginning of the function.

## Testing
- [ ] Not run (small validation cleanup; existing callers unchanged)