### PR TITLE
fix(web/loader): use job not found for missing external job ID batch slots

### DIFF
--- a/core/web/loader/job.go
+++ b/core/web/loader/job.go
@@ -55,9 +55,9 @@ func (b *jobBatcher) loadByExternalJobIDs(ctx context.Context, keys dataloader.K
 		}
 	}
 
-	// fill array positions without any feeds managers
+	// fill array positions without any jobs
 	for _, ix := range keyOrder {
-		results[ix] = &dataloader.Result{Data: nil, Error: errors.New("feeds manager not found")}
+		results[ix] = &dataloader.Result{Data: nil, Error: errors.New("job not found")}
 	}
 
 	return results


### PR DESCRIPTION
## Summary
When batch-loading jobs by external job ID, unfilled slots now return the same `"job not found"` error as the pipeline-spec ID path, instead of the incorrect `"feeds manager not found"`. Updated the stale comment to match.

## Testing
- [ ] `go test ./core/web/loader/...` (local env had toolchain/GOSUMDB issue)