### PR TITLE
fix(ci): unique integration test image tags

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -213,12 +213,16 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    outputs:
+      core-tag: ${{ steps.image-tag.outputs.core-tag }}
+      plugins-tag: ${{ steps.image-tag.outputs.plugins-tag }}
     strategy:
       matrix:
         image:
           - name: ""
             runner: ${{ needs.labels.outputs.builder-runner-label-core || 'ubuntu22.04-8cores-32GB' }}
             dockerfile: core/chainlink.Dockerfile
+            output-key: core-tag
             tag-suffix: ""
             # todo: optimize this conditional
             should-build: >-
@@ -232,6 +236,7 @@ jobs:
           - name: (plugins)
             runner: ${{ needs.labels.outputs.builder-runner-label-plugins || 'ubuntu22.04-8cores-32GB' }}
             dockerfile: plugins/chainlink.Dockerfile
+            output-key: plugins-tag
             tag-suffix: -plugins
             # todo: optimize this conditional
             should-build: >-
@@ -271,6 +276,30 @@ jobs:
             echo "image-exists: ${IMAGE_EXISTS}"
           fi
 
+      - name: Build image tag
+        if: matrix.image.should-build && steps.check-image-exists.outputs.exists != 'true'
+        id: image-tag
+        env:
+          OUTPUT_KEY: ${{ matrix.image.output-key }}
+          REF: ${{ inputs.evm-ref || env.CHAINLINK_REF }}
+          TAG_SUFFIX: ${{ matrix.image.tag-suffix }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          event="event"
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            event="push"
+          elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+            event="pr"
+          elif [[ "$EVENT_NAME" == "merge_group" ]]; then
+            event="mg"
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            event="wd"
+          fi
+
+          IMAGE_TAG="${event}-${REF}${TAG_SUFFIX}"
+          echo "image-tag=${IMAGE_TAG}" | tee -a "${GITHUB_OUTPUT}"
+          echo "${OUTPUT_KEY}=${IMAGE_TAG}" | tee -a "${GITHUB_OUTPUT}"
+
       - name: Checkout the repo
         if: matrix.image.should-build && steps.check-image-exists.outputs.exists != 'true'
         uses: actions/checkout@v4
@@ -283,7 +312,7 @@ jobs:
         if: matrix.image.should-build && steps.check-image-exists.outputs.exists != 'true'
         uses: smartcontractkit/.github/actions/ctf-build-image@ctf-build-image/v1
         with:
-          image-tag: ${{ inputs.evm-ref || env.CHAINLINK_REF }}${{ matrix.image.tag-suffix }}
+          image-tag: ${{ steps.image-tag.outputs.image-tag }}
           dockerfile: ${{ matrix.image.dockerfile }}
           docker-registry-url: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com
           docker-repository-name: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
@@ -384,7 +413,7 @@ jobs:
     with:
       ecr_name: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
-      chainlink_image_tag: ${{ inputs.evm-ref && format('{0}', inputs.evm-ref) || inputs.cl_ref && format('{0}', inputs.cl_ref) || format('{0}', github.sha) }}
+      chainlink_image_tag: ${{ needs.build-chainlink.outputs.core-tag }}
     secrets: inherit
 
   run-core-cre-e2e-regression-tests:
@@ -401,7 +430,7 @@ jobs:
     with:
       ecr_name: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
-      chainlink_image_tag: ${{ inputs.evm-ref && format('{0}', inputs.evm-ref) || inputs.cl_ref && format('{0}', inputs.cl_ref) || format('{0}', github.sha) }}
+      chainlink_image_tag: ${{ needs.build-chainlink.outputs.core-tag }}
     secrets: inherit
 
   run-core-e2e-tests-setup:
@@ -472,7 +501,7 @@ jobs:
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@fed09778ce127da5d37f902d8bee01387856550a # 2026-03-12
     with:
       workflow_name: ${{ needs.run-core-e2e-tests-setup.outputs.workflow-name }}
-      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+      chainlink_version: ${{ needs.build-chainlink.outputs.core-tag }}
       test_path: .github/e2e-tests.yml
       test_trigger: ${{ needs.run-core-e2e-tests-setup.outputs.test-trigger }}
       upload_cl_node_coverage_artifact: true
@@ -571,7 +600,7 @@ jobs:
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@fed09778ce127da5d37f902d8bee01387856550a # 2026-03-12
     with:
       workflow_name: ${{ needs.run-ccip-e2e-tests-setup.outputs.workflow-name }}
-      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+      chainlink_version: ${{ needs.build-chainlink.outputs.core-tag }}
       test_path: .github/e2e-tests.yml
       test_trigger: ${{ needs.run-ccip-e2e-tests-setup.outputs.test-trigger }}
       upload_cl_node_coverage_artifact: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -876,7 +876,7 @@ jobs:
     with:
       solana_ref: ${{ needs.get-solana-sha.outputs.sha }}
       ecr_repository: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
-      image_tag: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+      image_tag: ${{ needs.build-chainlink.outputs.core-tag }}
     secrets:
       aws_account_id: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
       aws_region: ${{ secrets.QA_AWS_REGION }}


### PR DESCRIPTION
I noticed that pushes to develop were using the image made during the `merge_group` as the sha refs were the same, and we dedupe image builds based on existing refs.

* merge group: https://github.com/smartcontractkit/chainlink/actions/runs/23571346889/job/68634435331#step:5:52
* push to develop:https://github.com/smartcontractkit/chainlink/actions/runs/23571948356/job/68636276533#step:5:54

This is bad because we want pushes to develop to build an image, so they can populate the docker layer cache.
* Merge groups don't populate the docker layer cache because basically nothing would ever actually use them. This is because only caches from the default branch, or the current branch can be restored from
    * ie. no cross feature branch cache sharing for security reasons


### Changes

* Adds a shortform event name to the image name
* Outputs the image tags from the job instead of inferring the expected tag


