### PR TITLE
vault: batch smoke coverage and retry stale allowlists

### DIFF
--- a/core/capabilities/vault/request_authorizer.go
+++ b/core/capabilities/vault/request_authorizer.go
@@ -21,7 +21,13 @@ type requestAuthorizer struct {
 	workflowRegistrySyncer workflowsyncerv2.WorkflowRegistrySyncer
 	replayGuard            *DigestReplayGuard
 	lggr                   logger.Logger
+	sleep                  func(time.Duration)
 }
+
+const (
+	allowlistReadRetryCount    = 3
+	allowlistReadRetryInterval = 3 * time.Second
+)
 
 // AuthorizeRequest authorizes a request based on the request digest and the allowlisted requests.
 // It does NOT check if the request method is allowed.
@@ -43,20 +49,8 @@ func (r *requestAuthorizer) AuthorizeRequest(ctx context.Context, req jsonrpc.Re
 		r.lggr.Errorw("AuthorizeRequest workflowRegistrySyncer is nil", "method", req.Method, "requestID", req.ID)
 		return false, "", errors.New("internal error: workflowRegistrySyncer is nil")
 	}
-	allowedRequests := r.workflowRegistrySyncer.GetAllowlistedRequests(ctx)
-	allowedRequestsStrs := make([]string, 0, len(allowedRequests))
-	for _, rr := range allowedRequests {
-		allowedReqStr := fmt.Sprintf("Owner: %s, RequestDigest: %s, ExpiryTimestamp: %d", rr.Owner.Hex(), hex.EncodeToString(rr.RequestDigest[:]), rr.ExpiryTimestamp)
-		allowedRequestsStrs = append(allowedRequestsStrs, allowedReqStr)
-	}
-	r.lggr.Infow("AuthorizeRequest GetAllowlistedRequests", "method", req.Method, "requestID", req.ID, "allowedRequests", allowedRequestsStrs)
-	allowlistedRequest := r.fetchAllowlistedItem(allowedRequests, requestDigestBytes32)
+	allowlistedRequest, _ := r.fetchAllowlistedItemWithRetry(ctx, req.Method, req.ID, requestDigest, requestDigestBytes32)
 	if allowlistedRequest == nil {
-		r.lggr.Infow("AuthorizeRequest fetchAllowlistedItem request not allowlisted",
-			"method", req.Method,
-			"requestID", req.ID,
-			"digestHexStr", requestDigest,
-			"allowedRequestsStrs", allowedRequestsStrs)
 		return false, "", errors.New("request not allowlisted")
 	}
 
@@ -76,6 +70,56 @@ func (r *requestAuthorizer) AuthorizeRequest(ctx context.Context, req jsonrpc.Re
 	return true, allowlistedRequest.Owner.Hex(), nil
 }
 
+func (r *requestAuthorizer) fetchAllowlistedItemWithRetry(ctx context.Context, method string, requestID interface{}, requestDigest string, digest [32]byte) (*workflow_registry_wrapper_v2.WorkflowRegistryOwnerAllowlistedRequest, []string) {
+	var allowedRequestsStrs []string
+	for attempt := 0; attempt <= allowlistReadRetryCount; attempt++ {
+		allowedRequests := r.workflowRegistrySyncer.GetAllowlistedRequests(ctx)
+		allowedRequestsStrs = make([]string, 0, len(allowedRequests))
+		for _, rr := range allowedRequests {
+			allowedReqStr := fmt.Sprintf("Owner: %s, RequestDigest: %s, ExpiryTimestamp: %d", rr.Owner.Hex(), hex.EncodeToString(rr.RequestDigest[:]), rr.ExpiryTimestamp)
+			allowedRequestsStrs = append(allowedRequestsStrs, allowedReqStr)
+		}
+		r.lggr.Infow("AuthorizeRequest GetAllowlistedRequests", "method", method, "requestID", requestID, "attempt", attempt+1, "allowedRequests", allowedRequestsStrs)
+
+		allowlistedRequest := r.fetchAllowlistedItem(allowedRequests, digest)
+		if allowlistedRequest != nil {
+			return allowlistedRequest, allowedRequestsStrs
+		}
+
+		if attempt == allowlistReadRetryCount {
+			break
+		}
+
+		r.lggr.Warnw("AuthorizeRequest request not found in allowlist, retrying",
+			"method", method,
+			"requestID", requestID,
+			"digestHexStr", requestDigest,
+			"attempt", attempt+1,
+			"retryInterval", allowlistReadRetryInterval,
+			"allowedRequestsStrs", allowedRequestsStrs)
+
+		select {
+		case <-ctx.Done():
+			r.lggr.Warnw("AuthorizeRequest allowlist retry canceled",
+				"method", method,
+				"requestID", requestID,
+				"digestHexStr", requestDigest,
+				"attempt", attempt+1)
+			return nil, allowedRequestsStrs
+		default:
+		}
+
+		r.sleep(allowlistReadRetryInterval)
+	}
+
+	r.lggr.Infow("AuthorizeRequest fetchAllowlistedItem request not allowlisted",
+		"method", method,
+		"requestID", requestID,
+		"digestHexStr", requestDigest,
+		"allowedRequestsStrs", allowedRequestsStrs)
+	return nil, allowedRequestsStrs
+}
+
 func (r *requestAuthorizer) fetchAllowlistedItem(allowListedRequests []workflow_registry_wrapper_v2.WorkflowRegistryOwnerAllowlistedRequest, digest [32]byte) *workflow_registry_wrapper_v2.WorkflowRegistryOwnerAllowlistedRequest {
 	for _, item := range allowListedRequests {
 		if item.RequestDigest == digest {
@@ -90,5 +134,6 @@ func NewRequestAuthorizer(lggr logger.Logger, workflowRegistrySyncer workflowsyn
 		workflowRegistrySyncer: workflowRegistrySyncer,
 		lggr:                   logger.Named(lggr, "VaultRequestAuthorizer"),
 		replayGuard:            NewDigestReplayGuard(),
+		sleep:                  time.Sleep,
 	}
 }

--- a/core/capabilities/vault/request_authorizer_test.go
+++ b/core/capabilities/vault/request_authorizer_test.go
@@ -218,7 +218,7 @@ func TestRequestAuthorizer_RetriesAllowlistReadsUntilDigestAppears(t *testing.T)
 		{
 			RequestDigest:   [32]byte(digestBytes),
 			Owner:           owner,
-			ExpiryTimestamp: uint32(time.Now().UTC().Unix() + 100), //nolint:gosec
+			ExpiryTimestamp: uint32(time.Now().UTC().Unix() + 100), //nolint:gosec // test fixture expiry is bounded and safe here
 		},
 	}
 

--- a/core/capabilities/vault/request_authorizer_test.go
+++ b/core/capabilities/vault/request_authorizer_test.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"testing"
@@ -201,4 +202,98 @@ func testAuthForRequests(t *testing.T, allowlistedRequest, notAllowlistedRequest
 	isAuthorized, _, err = auth.AuthorizeRequest(t.Context(), notAllowlistedRequest)
 	require.False(t, isAuthorized)
 	require.ErrorContains(t, err, "not allowlisted")
+}
+
+func TestRequestAuthorizer_RetriesAllowlistReadsUntilDigestAppears(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	owner := common.Address{1, 2, 3}
+	req := makeListSecretsRequest(t, "123", "b")
+
+	digest, err := req.Digest()
+	require.NoError(t, err)
+	digestBytes, err := hex.DecodeString(digest)
+	require.NoError(t, err)
+
+	allowlisted := []workflow_registry_wrapper_v2.WorkflowRegistryOwnerAllowlistedRequest{
+		{
+			RequestDigest:   [32]byte(digestBytes),
+			Owner:           owner,
+			ExpiryTimestamp: uint32(time.Now().UTC().Unix() + 100), //nolint:gosec
+		},
+	}
+
+	mockSyncer := syncerv2mocks.NewWorkflowRegistrySyncer(t)
+	mockSyncer.On("GetAllowlistedRequests", mock.Anything).Return([]workflow_registry_wrapper_v2.WorkflowRegistryOwnerAllowlistedRequest{}).Once()
+	mockSyncer.On("GetAllowlistedRequests", mock.Anything).Return([]workflow_registry_wrapper_v2.WorkflowRegistryOwnerAllowlistedRequest{}).Once()
+	mockSyncer.On("GetAllowlistedRequests", mock.Anything).Return(allowlisted).Once()
+
+	auth := NewRequestAuthorizer(lggr, mockSyncer)
+	sleepCalls := 0
+	auth.sleep = func(d time.Duration) {
+		require.Equal(t, allowlistReadRetryInterval, d)
+		sleepCalls++
+	}
+
+	isAuthorized, gotOwner, err := auth.AuthorizeRequest(t.Context(), req)
+	require.True(t, isAuthorized, err)
+	require.NoError(t, err)
+	require.Equal(t, owner.Hex(), gotOwner)
+	require.Equal(t, 2, sleepCalls)
+}
+
+func TestRequestAuthorizer_FailsAfterAllowlistReadRetries(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	req := makeListSecretsRequest(t, "123", "b")
+
+	mockSyncer := syncerv2mocks.NewWorkflowRegistrySyncer(t)
+	mockSyncer.On("GetAllowlistedRequests", mock.Anything).Return([]workflow_registry_wrapper_v2.WorkflowRegistryOwnerAllowlistedRequest{}).Times(allowlistReadRetryCount + 1)
+
+	auth := NewRequestAuthorizer(lggr, mockSyncer)
+	sleepCalls := 0
+	auth.sleep = func(d time.Duration) {
+		require.Equal(t, allowlistReadRetryInterval, d)
+		sleepCalls++
+	}
+
+	isAuthorized, _, err := auth.AuthorizeRequest(t.Context(), req)
+	require.False(t, isAuthorized)
+	require.ErrorContains(t, err, "not allowlisted")
+	require.Equal(t, allowlistReadRetryCount, sleepCalls)
+}
+
+func TestRequestAuthorizer_StopsRetriesWhenContextCanceled(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	req := makeListSecretsRequest(t, "123", "b")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	mockSyncer := syncerv2mocks.NewWorkflowRegistrySyncer(t)
+	mockSyncer.On("GetAllowlistedRequests", mock.Anything).Return([]workflow_registry_wrapper_v2.WorkflowRegistryOwnerAllowlistedRequest{}).Once()
+
+	auth := NewRequestAuthorizer(lggr, mockSyncer)
+	sleepCalls := 0
+	auth.sleep = func(time.Duration) {
+		sleepCalls++
+	}
+
+	isAuthorized, _, err := auth.AuthorizeRequest(ctx, req)
+	require.False(t, isAuthorized)
+	require.ErrorContains(t, err, "not allowlisted")
+	require.Zero(t, sleepCalls)
+}
+
+func makeListSecretsRequest(t *testing.T, id, namespace string) jsonrpc.Request[json.RawMessage] {
+	t.Helper()
+
+	params, err := json.Marshal(vaultcommon.ListSecretIdentifiersRequest{
+		Namespace: namespace,
+	})
+	require.NoError(t, err)
+
+	return jsonrpc.Request[json.RawMessage]{
+		ID:     id,
+		Method: vaulttypes.MethodSecretsList,
+		Params: (*json.RawMessage)(&params),
+	}
 }

--- a/system-tests/tests/smoke/cre/v2_vault_don_test.go
+++ b/system-tests/tests/smoke/cre/v2_vault_don_test.go
@@ -96,76 +96,44 @@ func ExecuteVaultTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 		bmCh := make(chan *commonevents.BaseMessage, 1000)
 		sink := t_helpers.StartChipTestSink(t, t_helpers.GetPublishFn(testLogger, ulCh, bmCh))
 		t.Cleanup(func() { sink.Shutdown(t.Context()); close(ulCh); close(bmCh) })
+		namespaces := []string{"main", "alt"}
 
-		executeVaultSecretsCreateTest(t, enc, secretID, owner, gwURL, "main", sc, wfReg)
+		executeVaultSecretsCreateTest(t, enc, secretID, owner, gwURL, namespaces, sc, wfReg)
 		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "bget1", secretID, "main", ulCh, bmCh)
-		executeVaultSecretsUpdateTest(t, enc, secretID, owner, gwURL, "main", sc, wfReg)
+		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "bgeta1", secretID, "alt", ulCh, bmCh)
+		executeVaultSecretsUpdateTest(t, enc, secretID, owner, gwURL, namespaces, sc, wfReg)
 		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "bget2", secretID, "main", ulCh, bmCh)
+		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "bgeta2", secretID, "alt", ulCh, bmCh)
 		executeVaultSecretsListTest(t, secretID, owner, gwURL, "main", sc, wfReg)
-		executeVaultSecretsDeleteTest(t, secretID, owner, gwURL, "main", sc, wfReg)
+		executeVaultSecretsListTest(t, secretID, owner, gwURL, "alt", sc, wfReg)
+		executeVaultSecretsDeleteTest(t, secretID, owner, gwURL, []string{"main"}, sc, wfReg)
 		executeVaultSecretsGetNotFoundViaWorkflowTest(t, subEnv, "bdel1", secretID, "main", ulCh, bmCh)
-	})
-
-	t.Run("cross_namespace", func(t *testing.T) {
-		if parallelEnabled && fanoutEnabled {
-			t.Parallel()
-		}
-		subEnv := t_helpers.SetupTestEnvironmentWithPerTestKeys(t, testEnv.TestConfig)
-		sc := subEnv.CreEnvironment.Blockchains[0].(*evm.Blockchain).SethClient
-		owner := sc.MustGetRootKeyAddress().Hex()
-		wfRegAddr := crecontracts.MustGetAddressFromDataStore(subEnv.CreEnvironment.CldfEnvironment.DataStore, subEnv.CreEnvironment.Blockchains[0].ChainSelector(), keystone_changeset.WorkflowRegistry.String(), subEnv.CreEnvironment.ContractVersions[keystone_changeset.WorkflowRegistry.String()], "")
-		wfReg, err := workflow_registry_v2_wrapper.NewWorkflowRegistry(common.HexToAddress(wfRegAddr), sc.Client)
-		require.NoError(t, err)
-		require.NoError(t, creworkflow.LinkOwner(sc, common.HexToAddress(wfRegAddr), subEnv.CreEnvironment.ContractVersions[keystone_changeset.WorkflowRegistry.String()]))
-		secretID := strconv.Itoa(rand.Intn(10000))
-		enc, err := crevault.EncryptSecret("secret-xns", vaultPublicKey, sc.MustGetRootKeyAddress())
-		require.NoError(t, err)
-		ulCh := make(chan *workflowevents.UserLogs, 1000)
-		bmCh := make(chan *commonevents.BaseMessage, 1000)
-		sink := t_helpers.StartChipTestSink(t, t_helpers.GetPublishFn(testLogger, ulCh, bmCh))
-		t.Cleanup(func() { sink.Shutdown(t.Context()); close(ulCh); close(bmCh) })
-
-		altNS := "alt"
-
-		executeVaultSecretsCreateTest(t, enc, secretID, owner, gwURL, "main", sc, wfReg)
-		executeVaultSecretsCreateTest(t, enc, secretID, owner, gwURL, altNS, sc, wfReg)
-
-		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "xget1", secretID, "main", ulCh, bmCh)
-		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "xgeta1", secretID, altNS, ulCh, bmCh)
-
-		executeVaultSecretsUpdateTest(t, enc, secretID, owner, gwURL, "main", sc, wfReg)
-		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "xget2", secretID, "main", ulCh, bmCh)
-		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "xgeta2", secretID, altNS, ulCh, bmCh)
-
-		executeVaultSecretsListTest(t, secretID, owner, gwURL, "main", sc, wfReg)
-		executeVaultSecretsListTest(t, secretID, owner, gwURL, altNS, sc, wfReg)
-
-		executeVaultSecretsDeleteTest(t, secretID, owner, gwURL, "main", sc, wfReg)
-		executeVaultSecretsGetNotFoundViaWorkflowTest(t, subEnv, "xdel1", secretID, "main", ulCh, bmCh)
-		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "xgeta3", secretID, altNS, ulCh, bmCh)
-
-		executeVaultSecretsDeleteTest(t, secretID, owner, gwURL, altNS, sc, wfReg)
-		executeVaultSecretsGetNotFoundViaWorkflowTest(t, subEnv, "xdela1", secretID, altNS, ulCh, bmCh)
+		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "bgeta3", secretID, "alt", ulCh, bmCh)
+		executeVaultSecretsDeleteTest(t, secretID, owner, gwURL, []string{"alt"}, sc, wfReg)
+		executeVaultSecretsGetNotFoundViaWorkflowTest(t, subEnv, "bdela1", secretID, "alt", ulCh, bmCh)
 	})
 }
 
-func executeVaultSecretsCreateTest(t *testing.T, encryptedSecret, secretID, owner, gatewayURL, namespace string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
-	framework.L.Info().Msgf("Creating secret (namespace=%s)...", namespace)
+func executeVaultSecretsCreateTest(t *testing.T, encryptedSecret, secretID, owner, gatewayURL string, namespaces []string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
+	framework.L.Info().Msgf("Creating secrets (namespaces=%v)...", namespaces)
 
 	uniqueRequestID := uuid.New().String()
 
-	secretsCreateRequest := vault_helpers.CreateSecretsRequest{
-		RequestId: uniqueRequestID,
-		EncryptedSecrets: []*vault_helpers.EncryptedSecret{
-			{
-				Id: &vault_helpers.SecretIdentifier{
-					Key:       secretID,
-					Owner:     owner,
-					Namespace: namespace,
-				},
-				EncryptedValue: encryptedSecret,
+	encryptedSecrets := make([]*vault_helpers.EncryptedSecret, 0, len(namespaces))
+	for _, namespace := range namespaces {
+		encryptedSecrets = append(encryptedSecrets, &vault_helpers.EncryptedSecret{
+			Id: &vault_helpers.SecretIdentifier{
+				Key:       secretID,
+				Owner:     owner,
+				Namespace: namespace,
 			},
-		},
+			EncryptedValue: encryptedSecret,
+		})
+	}
+
+	secretsCreateRequest := vault_helpers.CreateSecretsRequest{
+		RequestId:        uniqueRequestID,
+		EncryptedSecrets: encryptedSecrets,
 	}
 	secretsCreateRequestBody, err := json.Marshal(secretsCreateRequest) //nolint:govet // The lock field is not set on this proto
 	require.NoError(t, err, "failed to marshal secrets request")
@@ -205,14 +173,16 @@ func executeVaultSecretsCreateTest(t *testing.T, encryptedSecret, secretID, owne
 	require.NoError(t, err, "failed to decode payload into CreateSecretsResponse proto")
 	framework.L.Info().Msgf("CreateSecretsResponse decoded as: %s", createSecretsResponse.String())
 
-	require.Len(t, createSecretsResponse.Responses, 1, "Expected one item in the response")
-	result0 := createSecretsResponse.GetResponses()[0]
-	require.Empty(t, result0.GetError())
-	require.Equal(t, secretID, result0.GetId().Key)
-	require.Equal(t, owner, result0.GetId().Owner)
-	require.Equal(t, namespace, result0.GetId().Namespace)
+	require.Len(t, createSecretsResponse.Responses, len(namespaces), "Expected one item in the response per namespace")
+	for i, namespace := range namespaces {
+		result := createSecretsResponse.GetResponses()[i]
+		require.Empty(t, result.GetError())
+		require.Equal(t, secretID, result.GetId().Key)
+		require.Equal(t, owner, result.GetId().Owner)
+		require.Equal(t, namespace, result.GetId().Namespace)
+	}
 
-	framework.L.Info().Msgf("Secret created successfully (namespace=%s)", namespace)
+	framework.L.Info().Msgf("Secrets created successfully (namespaces=%v)", namespaces)
 }
 
 func executeVaultSecretsGetViaWorkflowTest(
@@ -258,30 +228,33 @@ func executeVaultSecretsGetNotFoundViaWorkflowTest(
 	testLogger.Info().Msg("Vault secret not-found via workflow test completed")
 }
 
-func executeVaultSecretsUpdateTest(t *testing.T, encryptedSecret, secretID, owner, gatewayURL, namespace string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
-	framework.L.Info().Msgf("Updating secret (namespace=%s)...", namespace)
+func executeVaultSecretsUpdateTest(t *testing.T, encryptedSecret, secretID, owner, gatewayURL string, namespaces []string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
+	framework.L.Info().Msgf("Updating secrets (namespaces=%v)...", namespaces)
 	uniqueRequestID := uuid.New().String()
 
-	secretsUpdateRequest := vault_helpers.UpdateSecretsRequest{
-		RequestId: uniqueRequestID,
-		EncryptedSecrets: []*vault_helpers.EncryptedSecret{
-			{
-				Id: &vault_helpers.SecretIdentifier{
-					Key:       secretID,
-					Owner:     owner,
-					Namespace: namespace,
-				},
-				EncryptedValue: encryptedSecret,
+	encryptedSecrets := make([]*vault_helpers.EncryptedSecret, 0, len(namespaces)+1)
+	for _, namespace := range namespaces {
+		encryptedSecrets = append(encryptedSecrets, &vault_helpers.EncryptedSecret{
+			Id: &vault_helpers.SecretIdentifier{
+				Key:       secretID,
+				Owner:     owner,
+				Namespace: namespace,
 			},
-			{
-				Id: &vault_helpers.SecretIdentifier{
-					Key:       "invalid",
-					Owner:     owner,
-					Namespace: namespace,
-				},
-				EncryptedValue: encryptedSecret,
-			},
+			EncryptedValue: encryptedSecret,
+		})
+	}
+	encryptedSecrets = append(encryptedSecrets, &vault_helpers.EncryptedSecret{
+		Id: &vault_helpers.SecretIdentifier{
+			Key:       "invalid",
+			Owner:     owner,
+			Namespace: namespaces[0],
 		},
+		EncryptedValue: encryptedSecret,
+	})
+
+	secretsUpdateRequest := vault_helpers.UpdateSecretsRequest{
+		RequestId:        uniqueRequestID,
+		EncryptedSecrets: encryptedSecrets,
 	}
 	secretsUpdateRequestBody, err := json.Marshal(secretsUpdateRequest) //nolint:govet // The lock field is not set on this proto
 	require.NoError(t, err, "failed to marshal secrets request")
@@ -323,17 +296,19 @@ func executeVaultSecretsUpdateTest(t *testing.T, encryptedSecret, secretID, owne
 	require.NoError(t, err, "failed to decode payload into UpdateSecretsResponse proto")
 	framework.L.Info().Msgf("UpdateSecretsResponse decoded as: %s", updateSecretsResponse.String())
 
-	require.Len(t, updateSecretsResponse.Responses, 2, "Expected 2 items in the response")
-	result0 := updateSecretsResponse.GetResponses()[0]
-	require.Empty(t, result0.GetError())
-	require.Equal(t, secretID, result0.GetId().Key)
-	require.Equal(t, owner, result0.GetId().Owner)
-	require.Equal(t, namespace, result0.GetId().Namespace)
+	require.Len(t, updateSecretsResponse.Responses, len(namespaces)+1, "Expected one updated item per namespace plus one invalid item")
+	for i, namespace := range namespaces {
+		result := updateSecretsResponse.GetResponses()[i]
+		require.Empty(t, result.GetError())
+		require.Equal(t, secretID, result.GetId().Key)
+		require.Equal(t, owner, result.GetId().Owner)
+		require.Equal(t, namespace, result.GetId().Namespace)
+	}
 
-	result1 := updateSecretsResponse.GetResponses()[1]
-	require.Contains(t, result1.Error, "key does not exist")
+	resultInvalid := updateSecretsResponse.GetResponses()[len(namespaces)]
+	require.Contains(t, resultInvalid.Error, "key does not exist")
 
-	framework.L.Info().Msgf("Secret updated successfully (namespace=%s)", namespace)
+	framework.L.Info().Msgf("Secrets updated successfully (namespaces=%v)", namespaces)
 }
 
 func executeVaultSecretsListTest(t *testing.T, secretID, owner, gatewayURL, namespace string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
@@ -431,24 +406,27 @@ func executeVaultSecretsListTest(t *testing.T, secretID, owner, gatewayURL, name
 	framework.L.Info().Msgf("Secrets listed successfully (namespace=%s)", namespace)
 }
 
-func executeVaultSecretsDeleteTest(t *testing.T, secretID, owner, gatewayURL, namespace string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
-	framework.L.Info().Msgf("Deleting secret (namespace=%s)...", namespace)
+func executeVaultSecretsDeleteTest(t *testing.T, secretID, owner, gatewayURL string, namespaces []string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
+	framework.L.Info().Msgf("Deleting secrets (namespaces=%v)...", namespaces)
 	uniqueRequestID := uuid.New().String()
+
+	deleteIDs := make([]*vault_helpers.SecretIdentifier, 0, len(namespaces)+1)
+	for _, namespace := range namespaces {
+		deleteIDs = append(deleteIDs, &vault_helpers.SecretIdentifier{
+			Key:       secretID,
+			Owner:     owner,
+			Namespace: namespace,
+		})
+	}
+	deleteIDs = append(deleteIDs, &vault_helpers.SecretIdentifier{
+		Key:       "invalid",
+		Owner:     owner,
+		Namespace: namespaces[0],
+	})
 
 	secretsDeleteRequest := vault_helpers.DeleteSecretsRequest{
 		RequestId: uniqueRequestID,
-		Ids: []*vault_helpers.SecretIdentifier{
-			{
-				Key:       secretID,
-				Owner:     owner,
-				Namespace: namespace,
-			},
-			{
-				Key:       "invalid",
-				Owner:     owner,
-				Namespace: namespace,
-			},
-		},
+		Ids:       deleteIDs,
 	}
 	secretsDeleteRequestBody, err := json.Marshal(secretsDeleteRequest) //nolint:govet // The lock field is not set on this proto
 	require.NoError(t, err, "failed to marshal secrets request")
@@ -489,16 +467,19 @@ func executeVaultSecretsDeleteTest(t *testing.T, secretID, owner, gatewayURL, na
 	require.NoError(t, err, "failed to decode payload into DeleteSecretResponse proto")
 	framework.L.Info().Msgf("DeleteSecretResponse decoded as: %s", deleteSecretsResponse.String())
 
-	require.Len(t, deleteSecretsResponse.Responses, 2, "Expected 2 items in the response")
-	result0 := deleteSecretsResponse.GetResponses()[0]
-	require.True(t, result0.Success, result0.Error)
-	require.Equal(t, result0.Id.Owner, owner)
-	require.Equal(t, result0.Id.Key, secretID)
+	require.Len(t, deleteSecretsResponse.Responses, len(namespaces)+1, "Expected one deleted item per namespace plus one invalid item")
+	for i, namespace := range namespaces {
+		result := deleteSecretsResponse.GetResponses()[i]
+		require.True(t, result.Success, result.Error)
+		require.Equal(t, result.Id.Owner, owner)
+		require.Equal(t, result.Id.Key, secretID)
+		require.Equal(t, result.Id.Namespace, namespace)
+	}
 
-	result1 := deleteSecretsResponse.GetResponses()[1]
-	require.Contains(t, result1.Error, "key does not exist")
+	resultInvalid := deleteSecretsResponse.GetResponses()[len(namespaces)]
+	require.Contains(t, resultInvalid.Error, "key does not exist")
 
-	framework.L.Info().Msgf("Secrets deleted successfully (namespace=%s)", namespace)
+	framework.L.Info().Msgf("Secrets deleted successfully (namespaces=%v)", namespaces)
 }
 
 // updateVaultCapabilityConfigInRegistry updates the on-chain capabilities registry


### PR DESCRIPTION
## Summary
Speed up vault coverage by folding cross-namespace smoke assertions into the existing CRUD flow, and harden vault request authorization against stale allowlist reads.

## What changed
- fold the separate `cross_namespace` vault smoke test into `basic_crud`
- batch `main` and `alt` namespace create/update requests in the vault smoke flow
- keep `List` namespace-scoped and assert each namespace returns only its own secret
- verify `Get` succeeds for both namespaces and still behaves correctly after partial deletion
- remove the duplicate parallel cross-namespace CRUD smoke test
- retry workflow-registry allowlist reads up to 3 times with 3-second intervals before rejecting a vault request
- add request-authorizer tests covering retry success, retry exhaustion, and canceled contexts
