### PR TITLE
disable bhs full tests for vrfv2/plus

### DIFF
--- a/devenv/tests/vrfv2/bhs_test.go
+++ b/devenv/tests/vrfv2/bhs_test.go
@@ -58,6 +58,8 @@ func TestVRFV2WithBHS(t *testing.T) {
 	require.NoError(t, err, "failed to connect to Chainlink nodes")
 
 	t.Run("BHS Job with complete E2E - wait 256 blocks to see if Rand Request is fulfilled", func(t *testing.T) {
+		t.Skip("This test is flaky on CI. Originally it only run on live testnets. Owners should work on fixing it.")
+		// Failure reason: blockhash not found in the store.
 		consumers, subIDs, err := deployConsumersAndFundSubs(ctx, chainClient, coord, linkToken, 0, 1, 1)
 		require.NoError(t, err, "error setting up new consumers and subs")
 		subID := subIDs[0]

--- a/devenv/tests/vrfv2plus/bhs_test.go
+++ b/devenv/tests/vrfv2plus/bhs_test.go
@@ -113,6 +113,8 @@ func TestVRFV2PlusWithBHS(t *testing.T) {
 	})
 
 	t.Run("BHS complete E2E fund later and fulfill", func(t *testing.T) {
+		t.Skip("This test is flaky on CI. Originally it only run on live testnets. Owners should work on fixing it.")
+		// Failure reason: blockhash not found in the store.
 		consumer, dErr := contracts.DeployVRFv2PlusLoadTestConsumer(chainClient, coord.Address())
 		require.NoError(t, dErr, "failed to deploy load test consumer")
 


### PR DESCRIPTION
Why? These tests were flaky and originals weren't running in CI anyway.
Plus use a stronger runner for LogPoller tests to make sure CL node doesn't crash at the end.