### PR TITLE
Add failed capability IDs to workflow execution failed metric

### DIFF
--- a/.changeset/grumpy-hawks-gain.md
+++ b/.changeset/grumpy-hawks-gain.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix llo outcome telemetry is only output for epochs where enough quourom is reached

--- a/.changeset/minor-bump-1773165956.md
+++ b/.changeset/minor-bump-1773165956.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-Minor bump to start next version

--- a/.changeset/wet-cups-curl.md
+++ b/.changeset/wet-cups-curl.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-Add supportsDualBroadcast to txm/txmv2 to indicate if it can run SVR feeds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog Chainlink Core
 
+## 2.39.0
+
+### Minor Changes
+
+- [#21480](https://github.com/smartcontractkit/chainlink/pull/21480) [`a58e1d7`](https://github.com/smartcontractkit/chainlink/commit/a58e1d764d12d6af08161723c5676c32670db62f) - Minor bump to start next version
+
+- [#21548](https://github.com/smartcontractkit/chainlink/pull/21548) [`a893225`](https://github.com/smartcontractkit/chainlink/commit/a893225701cb64f6c34c6df9fb18acc0d7b6a7c1) - Add supportsDualBroadcast to txm/txmv2 to indicate if it can run SVR feeds
+
+### Patch Changes
+
+- [#21349](https://github.com/smartcontractkit/chainlink/pull/21349) [`2f048a6`](https://github.com/smartcontractkit/chainlink/commit/2f048a6cd4d5b2b28241512889c790d62f198906) - #bugfix llo outcome telemetry is only output for epochs where enough quourom is reached
+
 ## 2.38.0
 
 ### Minor Changes

--- a/core/services/workflows/v2/capability_executor.go
+++ b/core/services/workflows/v2/capability_executor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -35,10 +36,11 @@ type ExecutionHelper struct {
 	TimeProvider
 	SecretsFetcher
 
-	chainAllowed limits.GateLimiter
-	callLimiters map[capCall]limits.BoundLimiter[int]
-	mu           sync.Mutex
-	callCounts   map[limits.Limiter[int]]int
+	chainAllowed        limits.GateLimiter
+	callLimiters        map[capCall]limits.BoundLimiter[int]
+	mu                  sync.Mutex
+	callCounts          map[limits.Limiter[int]]int
+	failedCapabilityIDs sync.Map
 }
 
 func (c *ExecutionHelper) initLimiters(limiters *EngineLimiters) {
@@ -208,6 +210,7 @@ func (c *ExecutionHelper) callCapability(ctx context.Context, request *sdkpb.Cap
 	executionDuration := time.Since(executionStart)
 	c.metrics.With(platform.KeyCapabilityID, request.Id).UpdateCapabilityExecutionDurationHistogram(ctx, int64(executionDuration.Seconds()))
 	if err != nil {
+		c.failedCapabilityIDs.Store(request.Id, struct{}{})
 		var capabilityError caperrors.Error
 		if errors.As(err, &capabilityError) {
 			if capabilityError.Origin() == caperrors.OriginUser {
@@ -245,6 +248,15 @@ func (c *ExecutionHelper) callCapability(ctx context.Context, request *sdkpb.Cap
 			Payload: capResp.Payload,
 		},
 	}, nil
+}
+
+func (c *ExecutionHelper) FailedCapabilityIDs() string {
+	var ids []string
+	c.failedCapabilityIDs.Range(func(key, _ any) bool {
+		ids = append(ids, key.(string))
+		return true
+	})
+	return strings.Join(ids, ",")
 }
 
 func (c *ExecutionHelper) GetWorkflowExecutionID() string {

--- a/core/services/workflows/v2/capability_executor_test.go
+++ b/core/services/workflows/v2/capability_executor_test.go
@@ -1,8 +1,11 @@
 package v2
 
 import (
+	"sort"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/settings"
@@ -50,4 +53,37 @@ func TestExecutionHelper_ConfidentialHTTPPerWorkflowLimit(t *testing.T) {
 	// Call and expect an error from the bound limiter (limit exceeded)
 	_, err = exec.CallCapability(t.Context(), req)
 	require.Error(t, err, "expected CallCapability to fail when per-workflow confidential-http call limit is exceeded")
+}
+
+func TestExecutionHelper_FailedCapabilityIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty when no failures", func(t *testing.T) {
+		exec := &ExecutionHelper{}
+		assert.Equal(t, "", exec.FailedCapabilityIDs())
+	})
+
+	t.Run("records single failed capability", func(t *testing.T) {
+		exec := &ExecutionHelper{}
+		exec.failedCapabilityIDs.Store("evm@1.0.0", struct{}{})
+		assert.Equal(t, "evm@1.0.0", exec.FailedCapabilityIDs())
+	})
+
+	t.Run("deduplicates same capability", func(t *testing.T) {
+		exec := &ExecutionHelper{}
+		exec.failedCapabilityIDs.Store("evm@1.0.0", struct{}{})
+		exec.failedCapabilityIDs.Store("evm@1.0.0", struct{}{})
+		assert.Equal(t, "evm@1.0.0", exec.FailedCapabilityIDs())
+	})
+
+	t.Run("records multiple failed capabilities", func(t *testing.T) {
+		exec := &ExecutionHelper{}
+		exec.failedCapabilityIDs.Store("evm@1.0.0", struct{}{})
+		exec.failedCapabilityIDs.Store("confidential-http@1.0.0", struct{}{})
+
+		result := exec.FailedCapabilityIDs()
+		ids := strings.Split(result, ",")
+		sort.Strings(ids)
+		assert.Equal(t, []string{"confidential-http@1.0.0", "evm@1.0.0"}, ids)
+	})
 }

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -832,9 +832,10 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	if len(result.GetError()) > 0 {
 		executionStatus = store.StatusErrored
 		execErr = errors.New(result.GetError())
+		failedCapIDs := execHelper.FailedCapabilityIDs()
 		e.metrics.UpdateWorkflowErrorDurationHistogram(ctx, int64(executionDuration.Seconds()))
-		e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String()).IncrementWorkflowExecutionFailedCounter(ctx)
-		executionLogger.Errorw("Workflow execution failed", "status", executionStatus, "durationMs", executionDuration.Milliseconds(), "error", result.GetError())
+		e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String(), platform.KeyCapabilityID, failedCapIDs).IncrementWorkflowExecutionFailedCounter(ctx)
+		executionLogger.Errorw("Workflow execution failed", "status", executionStatus, "durationMs", executionDuration.Milliseconds(), platform.KeyCapabilityID, failedCapIDs, "error", result.GetError())
 		return
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.38.0",
+  "version": "2.39.0",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.39.0",
+  "version": "2.39.2",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -52,5 +52,5 @@ plugins:
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "c35ae2937dcb63196d87c3dea27ebd0ef5701c29"
+      gitRef: "187018af88ce265ca70b86222f8587e3fcb7ff32"
       installPath: "./cmd/confidential-http"

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -357,11 +357,12 @@ func ExecuteEVMLogTriggerTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 
 	successfulLogTriggerChains := make([]string, 0, len(chainsToTest))
 	for chainID, bcOutput := range chainsToTest {
-		triggerDB := connectTriggerDB(t, testEnv.Config.NodeSets, chainID)
+		// TODO: (CRE-2314) Re-enable trigger event ACKS
+		// triggerDB := connectTriggerDB(t, testEnv.Config.NodeSets, chainID)
 
-		baselineStats, err := snapshotTriggerStats(t.Context(), triggerDB)
-		require.NoError(t, err, "failed to snapshot trigger_pending_events stats for chain %s", chainID)
-		t.Logf("baseline trigger_pending_events stats for chain %s: inserts=%d deletes=%d", chainID, baselineStats.inserts, baselineStats.deletes)
+		// baselineStats, err := snapshotTriggerStats(t.Context(), triggerDB)
+		// require.NoError(t, err, "failed to snapshot trigger_pending_events stats for chain %s", chainID)
+		// lggr.Info().Msgf("baseline trigger_pending_events stats for chain %s: inserts=%d deletes=%d", chainID, baselineStats.inserts, baselineStats.deletes)
 
 		lggr.Info().Msgf("Creating EVM LogTrigger workflow configuration for chain %s", chainID)
 		workflowConfig, msgEmitter := configureEVMLogTriggerWorkflow(t, lggr, bcOutput)
@@ -399,7 +400,8 @@ func ExecuteEVMLogTriggerTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 		t_helpers.WatchWorkflowLogs(t, lggr, userLogsCh, baseMessageCh, t_helpers.WorkflowEngineInitErrorLog, expectedUserLog, 4*time.Minute)
 		emitCancelFn()
 
-		verifyTriggerEventACKs(t, triggerDB, baselineStats)
+		// TODO: (CRE-2314) Re-enable trigger event ACKS
+        // verifyTriggerEventACKs(t, triggerDB, baselineStats)
 
 		lggr.Info().Msgf("🎉 LogTrigger Workflow %s executed successfully on chain %s", workflowName, chainID)
 		successfulLogTriggerChains = append(successfulLogTriggerChains, chainID)


### PR DESCRIPTION
Track which capabilities failed during a workflow execution and include them as a comma-joined capabilityID label on the platform_engine_workflow_execution_failed_count metric and in the "Workflow execution failed" log line.

## Changes

- **capability_executor.go**: Add `failedCapabilityIDs sync.Map` to `ExecutionHelper`, store capability ID on each `callCapability` error, expose via `FailedCapabilityIDs()` getter
- **engine.go**: Add `capabilityID` label to `IncrementWorkflowExecutionFailedCounter` and to the error log line in the `result.GetError()` path
- **capability_executor_test.go**: Unit tests for empty, single, dedup, and multiple capability ID tracking