### PR TITLE
Add failed capability IDs to workflow execution failed metric

### DIFF
--- a/core/services/workflows/monitoring/monitoring.go
+++ b/core/services/workflows/monitoring/monitoring.go
@@ -47,9 +47,10 @@ type EngineMetrics struct {
 	workflowMissingMeteringReport      metric.Int64Counter
 	workflowMeteringMode               metric.Int64Gauge
 
-	workflowExecutionFailedCounter    metric.Int64Counter
-	workflowExecutionStartedCounter   metric.Int64Counter
-	workflowExecutionSucceededCounter metric.Int64Counter
+	workflowExecutionFailedCounter             metric.Int64Counter
+	workflowExecutionStartedCounter            metric.Int64Counter
+	workflowExecutionSucceededCounter          metric.Int64Counter
+	workflowExecutionCapabilityFailureCounter  metric.Int64Counter
 
 	getSecretsDuration metric.Int64Histogram
 
@@ -157,6 +158,11 @@ func InitMonitoringResources() (em *EngineMetrics, err error) {
 	em.workflowExecutionFailedCounter, err = beholder.GetMeter().Int64Counter("platform_engine_workflow_execution_failed_count")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register workflow execution failed counter: %w", err)
+	}
+
+	em.workflowExecutionCapabilityFailureCounter, err = beholder.GetMeter().Int64Counter("platform_engine_workflow_execution_failed_capability_error_count")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register workflow execution failed capability error counter: %w", err)
 	}
 
 	em.workflowExecutionSucceededCounter, err = beholder.GetMeter().Int64Counter("platform_engine_workflow_execution_succeeded_count")
@@ -469,6 +475,11 @@ func (c WorkflowsMetricLabeler) RecordGetSecretsDuration(ctx context.Context, du
 func (c WorkflowsMetricLabeler) IncrementWorkflowExecutionFailedCounter(ctx context.Context) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
 	c.em.workflowExecutionFailedCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
+}
+
+func (c WorkflowsMetricLabeler) IncrementWorkflowExecutionCapabilityFailureCounter(ctx context.Context) {
+	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
+	c.em.workflowExecutionCapabilityFailureCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
 }
 
 func (c WorkflowsMetricLabeler) IncrementWorkflowExecutionSucceededCounter(ctx context.Context) {

--- a/core/services/workflows/monitoring/monitoring.go
+++ b/core/services/workflows/monitoring/monitoring.go
@@ -47,10 +47,10 @@ type EngineMetrics struct {
 	workflowMissingMeteringReport      metric.Int64Counter
 	workflowMeteringMode               metric.Int64Gauge
 
-	workflowExecutionFailedCounter             metric.Int64Counter
-	workflowExecutionStartedCounter            metric.Int64Counter
-	workflowExecutionSucceededCounter          metric.Int64Counter
-	workflowExecutionCapabilityFailureCounter  metric.Int64Counter
+	workflowExecutionFailedCounter            metric.Int64Counter
+	workflowExecutionStartedCounter           metric.Int64Counter
+	workflowExecutionSucceededCounter         metric.Int64Counter
+	workflowExecutionCapabilityFailureCounter metric.Int64Counter
 
 	getSecretsDuration metric.Int64Histogram
 

--- a/core/services/workflows/v2/capability_executor.go
+++ b/core/services/workflows/v2/capability_executor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -35,10 +36,11 @@ type ExecutionHelper struct {
 	TimeProvider
 	SecretsFetcher
 
-	chainAllowed limits.GateLimiter
-	callLimiters map[capCall]limits.BoundLimiter[int]
-	mu           sync.Mutex
-	callCounts   map[limits.Limiter[int]]int
+	chainAllowed        limits.GateLimiter
+	callLimiters        map[capCall]limits.BoundLimiter[int]
+	mu                  sync.Mutex
+	callCounts          map[limits.Limiter[int]]int
+	failedCapabilityIDs sync.Map
 }
 
 func (c *ExecutionHelper) initLimiters(limiters *EngineLimiters) {
@@ -208,6 +210,7 @@ func (c *ExecutionHelper) callCapability(ctx context.Context, request *sdkpb.Cap
 	executionDuration := time.Since(executionStart)
 	c.metrics.With(platform.KeyCapabilityID, request.Id).UpdateCapabilityExecutionDurationHistogram(ctx, int64(executionDuration.Seconds()))
 	if err != nil {
+		c.failedCapabilityIDs.Store(request.Id, struct{}{})
 		var capabilityError caperrors.Error
 		if errors.As(err, &capabilityError) {
 			if capabilityError.Origin() == caperrors.OriginUser {
@@ -245,6 +248,15 @@ func (c *ExecutionHelper) callCapability(ctx context.Context, request *sdkpb.Cap
 			Payload: capResp.Payload,
 		},
 	}, nil
+}
+
+func (c *ExecutionHelper) FailedCapabilityIDs() string {
+	var ids []string
+	c.failedCapabilityIDs.Range(func(key, _ any) bool {
+		ids = append(ids, key.(string))
+		return true
+	})
+	return strings.Join(ids, ",")
 }
 
 func (c *ExecutionHelper) GetWorkflowExecutionID() string {

--- a/core/services/workflows/v2/capability_executor.go
+++ b/core/services/workflows/v2/capability_executor.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -250,13 +250,14 @@ func (c *ExecutionHelper) callCapability(ctx context.Context, request *sdkpb.Cap
 	}, nil
 }
 
-func (c *ExecutionHelper) FailedCapabilityIDs() string {
+func (c *ExecutionHelper) FailedCapabilityIDs() []string {
 	var ids []string
 	c.failedCapabilityIDs.Range(func(key, _ any) bool {
 		ids = append(ids, key.(string))
 		return true
 	})
-	return strings.Join(ids, ",")
+	sort.Strings(ids)
+	return ids
 }
 
 func (c *ExecutionHelper) GetWorkflowExecutionID() string {

--- a/core/services/workflows/v2/capability_executor_test.go
+++ b/core/services/workflows/v2/capability_executor_test.go
@@ -1,8 +1,11 @@
 package v2
 
 import (
+	"sort"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/settings"
@@ -50,4 +53,37 @@ func TestExecutionHelper_ConfidentialHTTPPerWorkflowLimit(t *testing.T) {
 	// Call and expect an error from the bound limiter (limit exceeded)
 	_, err = exec.CallCapability(t.Context(), req)
 	require.Error(t, err, "expected CallCapability to fail when per-workflow confidential-http call limit is exceeded")
+}
+
+func TestExecutionHelper_FailedCapabilityIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty when no failures", func(t *testing.T) {
+		exec := &ExecutionHelper{}
+		assert.Equal(t, "", exec.FailedCapabilityIDs())
+	})
+
+	t.Run("records single failed capability", func(t *testing.T) {
+		exec := &ExecutionHelper{}
+		exec.failedCapabilityIDs.Store("evm@1.0.0", struct{}{})
+		assert.Equal(t, "evm@1.0.0", exec.FailedCapabilityIDs())
+	})
+
+	t.Run("deduplicates same capability", func(t *testing.T) {
+		exec := &ExecutionHelper{}
+		exec.failedCapabilityIDs.Store("evm@1.0.0", struct{}{})
+		exec.failedCapabilityIDs.Store("evm@1.0.0", struct{}{})
+		assert.Equal(t, "evm@1.0.0", exec.FailedCapabilityIDs())
+	})
+
+	t.Run("records multiple failed capabilities", func(t *testing.T) {
+		exec := &ExecutionHelper{}
+		exec.failedCapabilityIDs.Store("evm@1.0.0", struct{}{})
+		exec.failedCapabilityIDs.Store("confidential-http@1.0.0", struct{}{})
+
+		result := exec.FailedCapabilityIDs()
+		ids := strings.Split(result, ",")
+		sort.Strings(ids)
+		assert.Equal(t, []string{"confidential-http@1.0.0", "evm@1.0.0"}, ids)
+	})
 }

--- a/core/services/workflows/v2/capability_executor_test.go
+++ b/core/services/workflows/v2/capability_executor_test.go
@@ -1,8 +1,6 @@
 package v2
 
 import (
-	"sort"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,30 +58,26 @@ func TestExecutionHelper_FailedCapabilityIDs(t *testing.T) {
 
 	t.Run("empty when no failures", func(t *testing.T) {
 		exec := &ExecutionHelper{}
-		assert.Equal(t, "", exec.FailedCapabilityIDs())
+		assert.Empty(t, exec.FailedCapabilityIDs())
 	})
 
 	t.Run("records single failed capability", func(t *testing.T) {
 		exec := &ExecutionHelper{}
 		exec.failedCapabilityIDs.Store("evm@1.0.0", struct{}{})
-		assert.Equal(t, "evm@1.0.0", exec.FailedCapabilityIDs())
+		assert.Equal(t, []string{"evm@1.0.0"}, exec.FailedCapabilityIDs())
 	})
 
 	t.Run("deduplicates same capability", func(t *testing.T) {
 		exec := &ExecutionHelper{}
 		exec.failedCapabilityIDs.Store("evm@1.0.0", struct{}{})
 		exec.failedCapabilityIDs.Store("evm@1.0.0", struct{}{})
-		assert.Equal(t, "evm@1.0.0", exec.FailedCapabilityIDs())
+		assert.Equal(t, []string{"evm@1.0.0"}, exec.FailedCapabilityIDs())
 	})
 
-	t.Run("records multiple failed capabilities", func(t *testing.T) {
+	t.Run("records multiple failed capabilities sorted", func(t *testing.T) {
 		exec := &ExecutionHelper{}
 		exec.failedCapabilityIDs.Store("evm@1.0.0", struct{}{})
 		exec.failedCapabilityIDs.Store("confidential-http@1.0.0", struct{}{})
-
-		result := exec.FailedCapabilityIDs()
-		ids := strings.Split(result, ",")
-		sort.Strings(ids)
-		assert.Equal(t, []string{"confidential-http@1.0.0", "evm@1.0.0"}, ids)
+		assert.Equal(t, []string{"confidential-http@1.0.0", "evm@1.0.0"}, exec.FailedCapabilityIDs())
 	})
 }

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -837,9 +837,10 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	if len(result.GetError()) > 0 {
 		executionStatus = store.StatusErrored
 		execErr = errors.New(result.GetError())
+		failedCapIDs := execHelper.FailedCapabilityIDs()
 		e.metrics.UpdateWorkflowErrorDurationHistogram(ctx, int64(executionDuration.Seconds()))
-		e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String()).IncrementWorkflowExecutionFailedCounter(ctx)
-		executionLogger.Errorw("Workflow execution failed", "status", executionStatus, "durationMs", executionDuration.Milliseconds(), "error", result.GetError())
+		e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String(), platform.KeyCapabilityID, failedCapIDs).IncrementWorkflowExecutionFailedCounter(ctx)
+		executionLogger.Errorw("Workflow execution failed", "status", executionStatus, "durationMs", executionDuration.Milliseconds(), platform.KeyCapabilityID, failedCapIDs, "error", result.GetError())
 		return
 	}
 

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -839,8 +840,11 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		execErr = errors.New(result.GetError())
 		failedCapIDs := execHelper.FailedCapabilityIDs()
 		e.metrics.UpdateWorkflowErrorDurationHistogram(ctx, int64(executionDuration.Seconds()))
-		e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String(), platform.KeyCapabilityID, failedCapIDs).IncrementWorkflowExecutionFailedCounter(ctx)
-		executionLogger.Errorw("Workflow execution failed", "status", executionStatus, "durationMs", executionDuration.Milliseconds(), platform.KeyCapabilityID, failedCapIDs, "error", result.GetError())
+		e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String()).IncrementWorkflowExecutionFailedCounter(ctx)
+		for _, capID := range failedCapIDs {
+			e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String(), platform.KeyCapabilityID, capID).IncrementWorkflowExecutionCapabilityFailureCounter(ctx)
+		}
+		executionLogger.Errorw("Workflow execution failed", "status", executionStatus, "durationMs", executionDuration.Milliseconds(), platform.KeyCapabilityID, strings.Join(failedCapIDs, ","), "error", result.GetError())
 		return
 	}
 


### PR DESCRIPTION
Track which capabilities failed during a workflow execution and include them as a comma-joined capabilityID label on the platform_engine_workflow_execution_failed_count metric and in the "Workflow execution failed" log line.

## Changes

- **capability_executor.go**: Add failedCapabilityIDs sync.Map to ExecutionHelper, store capability ID on each callCapability error, expose via FailedCapabilityIDs() getter
- **engine.go**: Add capabilityID label to IncrementWorkflowExecutionFailedCounter and to the error log line in the result.GetError() path
- **capability_executor_test.go**: Unit tests for empty, single, dedup, and multiple capability ID tracking