### PR TITLE
fix: use transaction context in OIDC/LDAP SetAuthToken

### DIFF
--- a/core/sessions/ldapauth/ldap.go
+++ b/core/sessions/ldapauth/ldap.go
@@ -554,17 +554,17 @@ func (l *ldapAuthenticator) SetAuthToken(ctx context.Context, user *sessions.Use
 		// Check presence in local users table. Set localauth_user column true if present.
 		// This flag omits the session/token from being purged by the sync daemon/reaper.go
 		isLocalCLIAdmin := false
-		err = l.ds.QueryRowxContext(ctx, "SELECT EXISTS (SELECT 1 FROM users WHERE email = $1)", user.Email).Scan(&isLocalCLIAdmin)
+		err = tx.QueryRowxContext(ctx, "SELECT EXISTS (SELECT 1 FROM users WHERE email = $1)", user.Email).Scan(&isLocalCLIAdmin)
 		if err != nil {
 			return fmt.Errorf("error checking user presence in users table: %w", err)
 		}
 
 		// Remove any existing API tokens
-		if _, err = l.ds.ExecContext(ctx, "DELETE FROM ldap_user_api_tokens WHERE user_email = $1", user.Email); err != nil {
+		if _, err = tx.ExecContext(ctx, "DELETE FROM ldap_user_api_tokens WHERE user_email = $1", user.Email); err != nil {
 			return fmt.Errorf("error executing DELETE FROM ldap_user_api_tokens: %w", err)
 		}
 		// Create new API token for user
-		_, err = l.ds.ExecContext(
+		_, err = tx.ExecContext(
 			ctx,
 			"INSERT INTO ldap_user_api_tokens (user_email, user_role, localauth_user, token_key, token_salt, token_hashed_secret, created_at) VALUES ($1, $2, $3, $4, $5, $6, now())",
 			user.Email,

--- a/core/sessions/oidcauth/oidc.go
+++ b/core/sessions/oidcauth/oidc.go
@@ -517,12 +517,12 @@ func (oi *oidcAuthenticator) SetAuthToken(ctx context.Context, user *clsessions.
 
 	err = sqlutil.TransactDataSource(ctx, oi.ds, nil, func(tx sqlutil.DataSource) error {
 		// Remove any existing API tokens
-		if _, err = oi.ds.ExecContext(ctx, "DELETE FROM oidc_user_api_tokens WHERE user_email = $1", user.Email); err != nil {
+		if _, err = tx.ExecContext(ctx, "DELETE FROM oidc_user_api_tokens WHERE user_email = $1", user.Email); err != nil {
 			return fmt.Errorf("error executing DELETE FROM oidc_user_api_tokens: %w", err)
 		}
 		// Create new API token for user
-		_, err = oi.ds.ExecContext(ctx,
-			"INSERT INTO oidc_user_api_tokens (user_email, user_role, token_key, token_salt, token_hashed_secret, created_at) VALUES ($1, $2, $3, $4, $5, $6, now())",
+		_, err = tx.ExecContext(ctx,
+			"INSERT INTO oidc_user_api_tokens (user_email, user_role, token_key, token_salt, token_hashed_secret, created_at) VALUES ($1, $2, $3, $4, $5, now())",
 			user.Email,
 			user.Role,
 			token.AccessKey,


### PR DESCRIPTION
## Summary

Fixes two bugs in `SetAuthToken` for both OIDC and LDAP authentication:

1. **Transaction bypass**: SQL operations inside `sqlutil.TransactDataSource` were using the outer `oi.ds`/`l.ds` datasource instead of the `tx` transaction parameter. This means DELETE and INSERT run outside the transaction, so a failed INSERT leaves the old token deleted with no replacement.

2. **OIDC SQL column mismatch**: The INSERT statement specified 6 columns but the VALUES clause had 7 entries (`$1` through `$6` plus `now()`). With only 5 Go arguments provided, `$5` receives `hashedSecret` and `$6` is unbound. PostgreSQL rejects this with a parameter count error.

## Changes

**core/sessions/oidcauth/oidc.go**
- `oi.ds.ExecContext` -> `tx.ExecContext` for DELETE and INSERT in `SetAuthToken`
- Fix VALUES clause: `$1, $2, $3, $4, $5, $6, now()` -> `$1, $2, $3, $4, $5, now()` (5 placeholders for 5 args + now() for 6 columns)

**core/sessions/ldapauth/ldap.go**
- `l.ds.QueryRowxContext` -> `tx.QueryRowxContext` for SELECT in `SetAuthToken`
- `l.ds.ExecContext` -> `tx.ExecContext` for DELETE and INSERT in `SetAuthToken`

## Test plan

- [ ] Existing OIDC/LDAP auth tests pass
- [ ] `SetAuthToken` succeeds for OIDC users (was always failing due to SQL error)
- [ ] `SetAuthToken` rolls back cleanly on INSERT failure (transaction integrity)