### PR TITLE
Bump cl-ton hotfix2 and package.json

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -513,8 +513,8 @@ require (
 	github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260304150206-c64e48eb0cb0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598 // indirect
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697 // indirect
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b // indirect
 	github.com/smartcontractkit/cre-sdk-go v1.5.0 // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1700,10 +1700,10 @@ github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 h1:cWUHB6Q
 github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2/go.mod h1:Z4K5VJLjsfqIIaBcZ1Sfccxu0xsCxBjPa6zF+5gtQaM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5 h1:RwZXxdIAOyjp6cwc9Quxgr38k8r7ACz+Lxh9o/A6oH0=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598 h1:wapNckQf2shX1Qjk3mj95f0FFc7/CapEk3PE6ll9iik=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598/go.mod h1:FDDjLuc4vrfclu3JHkMaREg0XZz7Lw1MK47Z4jJ4U5Q=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a h1:Dfq094ki0dBTFLhurm9AHNtIdi0gNwhyWojSh9wQi7s=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a/go.mod h1:w83O9EU6BEtAJ1FifeVAqp1mQNISnH3BY+MLbYX5PBg=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697 h1:Rx2oAgERkBKv7RsqaFjXQ5w+t2ZmJBjwgijQN0i+ywI=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697/go.mod h1:FDDjLuc4vrfclu3JHkMaREg0XZz7Lw1MK47Z4jJ4U5Q=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697 h1:/U9roqU6BdP3G/o9sYO6U9F9HM428LLtQNfZdnAQemw=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697/go.mod h1:w83O9EU6BEtAJ1FifeVAqp1mQNISnH3BY+MLbYX5PBg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b h1:0XLtETkgkzwnEgUIIgyO/oydkUpzDVVuuFLf6aBeNPg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b/go.mod h1:XMp5GoxJzF/L5xoA2Og5uAMIUK0WDnZIHzhIilCV8zM=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b h1:RarA5fTnBzQY9wHhl6g7Ac7Nv0d/izr2/zuSWhveB4c=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -59,8 +59,8 @@ require (
 	github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260304150206-c64e48eb0cb0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.0
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697
 	github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad
 	github.com/smartcontractkit/libocr v0.0.0-20260304194147-a03701e2c02e
 	github.com/smartcontractkit/mcms v0.36.4

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1459,10 +1459,10 @@ github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 h1:cWUHB6Q
 github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2/go.mod h1:Z4K5VJLjsfqIIaBcZ1Sfccxu0xsCxBjPa6zF+5gtQaM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5 h1:RwZXxdIAOyjp6cwc9Quxgr38k8r7ACz+Lxh9o/A6oH0=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598 h1:wapNckQf2shX1Qjk3mj95f0FFc7/CapEk3PE6ll9iik=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598/go.mod h1:FDDjLuc4vrfclu3JHkMaREg0XZz7Lw1MK47Z4jJ4U5Q=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a h1:Dfq094ki0dBTFLhurm9AHNtIdi0gNwhyWojSh9wQi7s=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a/go.mod h1:w83O9EU6BEtAJ1FifeVAqp1mQNISnH3BY+MLbYX5PBg=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697 h1:Rx2oAgERkBKv7RsqaFjXQ5w+t2ZmJBjwgijQN0i+ywI=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697/go.mod h1:FDDjLuc4vrfclu3JHkMaREg0XZz7Lw1MK47Z4jJ4U5Q=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697 h1:/U9roqU6BdP3G/o9sYO6U9F9HM428LLtQNfZdnAQemw=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697/go.mod h1:w83O9EU6BEtAJ1FifeVAqp1mQNISnH3BY+MLbYX5PBg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b h1:0XLtETkgkzwnEgUIIgyO/oydkUpzDVVuuFLf6aBeNPg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b/go.mod h1:XMp5GoxJzF/L5xoA2Og5uAMIUK0WDnZIHzhIilCV8zM=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b h1:RarA5fTnBzQY9wHhl6g7Ac7Nv0d/izr2/zuSWhveB4c=

--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260223222711-2fa6b0e07db0
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697
 	github.com/smartcontractkit/cre-sdk-go v1.5.0
 	github.com/smartcontractkit/cre-sdk-go/capabilities/networking/http v1.3.0
 	github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1241,8 +1241,8 @@ github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260223222711-2fa6b0e07db
 github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260223222711-2fa6b0e07db0/go.mod h1:UsRdX5DVRd2HTkx6amXG1RYJSsL+1/SDB/iPRQjfD+Q=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0 h1:4mGJySR1GAJAAFRwEo6YiSKM2zSHzYT5b/FSmrpNUGI=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0/go.mod h1:U3XStbEnbx/+L22n1/8aOIdgcGVxtsZB7p59xJGngAs=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598 h1:wapNckQf2shX1Qjk3mj95f0FFc7/CapEk3PE6ll9iik=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598/go.mod h1:FDDjLuc4vrfclu3JHkMaREg0XZz7Lw1MK47Z4jJ4U5Q=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697 h1:Rx2oAgERkBKv7RsqaFjXQ5w+t2ZmJBjwgijQN0i+ywI=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697/go.mod h1:FDDjLuc4vrfclu3JHkMaREg0XZz7Lw1MK47Z4jJ4U5Q=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b h1:0XLtETkgkzwnEgUIIgyO/oydkUpzDVVuuFLf6aBeNPg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b/go.mod h1:XMp5GoxJzF/L5xoA2Og5uAMIUK0WDnZIHzhIilCV8zM=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b h1:RarA5fTnBzQY9wHhl6g7Ac7Nv0d/izr2/zuSWhveB4c=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -65,8 +65,8 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/sentinel v0.1.2
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.2
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697
 	github.com/smartcontractkit/libocr v0.0.0-20260304194147-a03701e2c02e
 	github.com/smartcontractkit/mcms v0.36.4
 	github.com/smartcontractkit/quarantine v0.0.0-20250909213106-ece491bef618

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1706,10 +1706,10 @@ github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5 h1:RwZXxdIA
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.2 h1:QFO9Ar1zY9SHj//7LXWq5caVrfyTFrkRcfkMQeSOAaQ=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.2/go.mod h1:OLczwaAvyObFG+eq4tQHkWqkbPBB0cHkZj0JzY3inik=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598 h1:wapNckQf2shX1Qjk3mj95f0FFc7/CapEk3PE6ll9iik=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598/go.mod h1:FDDjLuc4vrfclu3JHkMaREg0XZz7Lw1MK47Z4jJ4U5Q=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a h1:Dfq094ki0dBTFLhurm9AHNtIdi0gNwhyWojSh9wQi7s=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a/go.mod h1:w83O9EU6BEtAJ1FifeVAqp1mQNISnH3BY+MLbYX5PBg=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697 h1:Rx2oAgERkBKv7RsqaFjXQ5w+t2ZmJBjwgijQN0i+ywI=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697/go.mod h1:FDDjLuc4vrfclu3JHkMaREg0XZz7Lw1MK47Z4jJ4U5Q=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697 h1:/U9roqU6BdP3G/o9sYO6U9F9HM428LLtQNfZdnAQemw=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697/go.mod h1:w83O9EU6BEtAJ1FifeVAqp1mQNISnH3BY+MLbYX5PBg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b h1:0XLtETkgkzwnEgUIIgyO/oydkUpzDVVuuFLf6aBeNPg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b/go.mod h1:XMp5GoxJzF/L5xoA2Og5uAMIUK0WDnZIHzhIilCV8zM=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b h1:RarA5fTnBzQY9wHhl6g7Ac7Nv0d/izr2/zuSWhveB4c=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -513,8 +513,8 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.51.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/sentinel v0.1.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598 // indirect
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697 // indirect
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1684,10 +1684,10 @@ github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5 h1:RwZXxdIA
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.2 h1:QFO9Ar1zY9SHj//7LXWq5caVrfyTFrkRcfkMQeSOAaQ=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.2/go.mod h1:OLczwaAvyObFG+eq4tQHkWqkbPBB0cHkZj0JzY3inik=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598 h1:wapNckQf2shX1Qjk3mj95f0FFc7/CapEk3PE6ll9iik=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598/go.mod h1:FDDjLuc4vrfclu3JHkMaREg0XZz7Lw1MK47Z4jJ4U5Q=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a h1:Dfq094ki0dBTFLhurm9AHNtIdi0gNwhyWojSh9wQi7s=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a/go.mod h1:w83O9EU6BEtAJ1FifeVAqp1mQNISnH3BY+MLbYX5PBg=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697 h1:Rx2oAgERkBKv7RsqaFjXQ5w+t2ZmJBjwgijQN0i+ywI=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697/go.mod h1:FDDjLuc4vrfclu3JHkMaREg0XZz7Lw1MK47Z4jJ4U5Q=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697 h1:/U9roqU6BdP3G/o9sYO6U9F9HM428LLtQNfZdnAQemw=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697/go.mod h1:w83O9EU6BEtAJ1FifeVAqp1mQNISnH3BY+MLbYX5PBg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b h1:0XLtETkgkzwnEgUIIgyO/oydkUpzDVVuuFLf6aBeNPg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b/go.mod h1:XMp5GoxJzF/L5xoA2Og5uAMIUK0WDnZIHzhIilCV8zM=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b h1:RarA5fTnBzQY9wHhl6g7Ac7Nv0d/izr2/zuSWhveB4c=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.38.2",
+  "version": "2.38.3",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -50,7 +50,7 @@ plugins:
 
   ton:
     - moduleURI: "github.com/smartcontractkit/chainlink-ton"
-      gitRef: "v0.0.0-20260318231213-ffe3b9cca598"
+      gitRef: "v0.0.0-20260326234217-437b71ad5697"
       installPath: "./cmd/chainlink-ton"
 
   tron:

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -473,8 +473,8 @@ require (
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0 // indirect
 	github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260304150206-c64e48eb0cb0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598 // indirect
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697 // indirect
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1663,10 +1663,10 @@ github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 h1:cWUHB6Q
 github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2/go.mod h1:Z4K5VJLjsfqIIaBcZ1Sfccxu0xsCxBjPa6zF+5gtQaM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5 h1:RwZXxdIAOyjp6cwc9Quxgr38k8r7ACz+Lxh9o/A6oH0=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598 h1:wapNckQf2shX1Qjk3mj95f0FFc7/CapEk3PE6ll9iik=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598/go.mod h1:FDDjLuc4vrfclu3JHkMaREg0XZz7Lw1MK47Z4jJ4U5Q=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a h1:Dfq094ki0dBTFLhurm9AHNtIdi0gNwhyWojSh9wQi7s=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a/go.mod h1:w83O9EU6BEtAJ1FifeVAqp1mQNISnH3BY+MLbYX5PBg=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697 h1:Rx2oAgERkBKv7RsqaFjXQ5w+t2ZmJBjwgijQN0i+ywI=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697/go.mod h1:FDDjLuc4vrfclu3JHkMaREg0XZz7Lw1MK47Z4jJ4U5Q=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697 h1:/U9roqU6BdP3G/o9sYO6U9F9HM428LLtQNfZdnAQemw=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697/go.mod h1:w83O9EU6BEtAJ1FifeVAqp1mQNISnH3BY+MLbYX5PBg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b h1:0XLtETkgkzwnEgUIIgyO/oydkUpzDVVuuFLf6aBeNPg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b/go.mod h1:XMp5GoxJzF/L5xoA2Og5uAMIUK0WDnZIHzhIilCV8zM=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b h1:RarA5fTnBzQY9wHhl6g7Ac7Nv0d/izr2/zuSWhveB4c=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -592,8 +592,8 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.18
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598 // indirect
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697 // indirect
+	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b // indirect
 	github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/httpaction-negative v0.0.0-20251015074515-1acc1d3fb4c0
 	github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/httpaction v0.0.0-20251015074515-1acc1d3fb4c0

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1876,10 +1876,10 @@ github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5 h1:RwZXxdIA
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.2 h1:QFO9Ar1zY9SHj//7LXWq5caVrfyTFrkRcfkMQeSOAaQ=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.2/go.mod h1:OLczwaAvyObFG+eq4tQHkWqkbPBB0cHkZj0JzY3inik=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598 h1:wapNckQf2shX1Qjk3mj95f0FFc7/CapEk3PE6ll9iik=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260318231213-ffe3b9cca598/go.mod h1:FDDjLuc4vrfclu3JHkMaREg0XZz7Lw1MK47Z4jJ4U5Q=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a h1:Dfq094ki0dBTFLhurm9AHNtIdi0gNwhyWojSh9wQi7s=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260309192839-c93b1af6a35a/go.mod h1:w83O9EU6BEtAJ1FifeVAqp1mQNISnH3BY+MLbYX5PBg=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697 h1:Rx2oAgERkBKv7RsqaFjXQ5w+t2ZmJBjwgijQN0i+ywI=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260326234217-437b71ad5697/go.mod h1:FDDjLuc4vrfclu3JHkMaREg0XZz7Lw1MK47Z4jJ4U5Q=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697 h1:/U9roqU6BdP3G/o9sYO6U9F9HM428LLtQNfZdnAQemw=
+github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326234217-437b71ad5697/go.mod h1:w83O9EU6BEtAJ1FifeVAqp1mQNISnH3BY+MLbYX5PBg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b h1:0XLtETkgkzwnEgUIIgyO/oydkUpzDVVuuFLf6aBeNPg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b/go.mod h1:XMp5GoxJzF/L5xoA2Og5uAMIUK0WDnZIHzhIilCV8zM=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b h1:RarA5fTnBzQY9wHhl6g7Ac7Nv0d/izr2/zuSWhveB4c=


### PR DESCRIPTION
- Bumps cl-ton import and plugin version to bring in hotfix version: https://github.com/smartcontractkit/chainlink-ton/pull/674/commits
- Bumps package.json to `2.38.3`