### PR TITLE
use unique nightly artifact name

### DIFF
--- a/.github/workflows/devenv-compat.yml
+++ b/.github/workflows/devenv-compat.yml
@@ -216,6 +216,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: container-logs-smoke
+          name: container-logs-smoke-${{ job.check_run_id }}
           path: ${{ env.LOGS_DIR }}
           retention-days: 3


### PR DESCRIPTION
So that we can avoid this:
<img width="1210" height="155" alt="image" src="https://github.com/user-attachments/assets/c3bcd49e-aa3a-4556-a823-e1c452d27f92" />

Source: https://github.com/smartcontractkit/chainlink/actions/runs/23634251893/job/68840031250