### PR TITLE
try remove docker buildx

### DIFF
--- a/.github/workflows/system-tests-nightly.yml
+++ b/.github/workflows/system-tests-nightly.yml
@@ -288,10 +288,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Docker Buildx
-        if: steps.gate.outputs.should_run == 'true'
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
       - name: Install Just
         if: steps.gate.outputs.should_run == 'true'
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3


### PR DESCRIPTION
Sometimes buildx step has issues, in reality it no longer needed
https://github.com/smartcontractkit/chainlink/actions/runs/23655430453
Fixed run: https://github.com/smartcontractkit/chainlink/actions/runs/23656288969