### PR TITLE
Fake EVM - check if log filters match

### DIFF
--- a/.changeset/fast-clocks-act.md
+++ b/.changeset/fast-clocks-act.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#changed add support for log filters in fake EVM capability

--- a/core/capabilities/fakes/evm_chain.go
+++ b/core/capabilities/fakes/evm_chain.go
@@ -1,6 +1,7 @@
 package fakes
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"errors"
@@ -42,8 +43,9 @@ type FakeEVMChain struct {
 
 	lggr logger.Logger
 
-	// log trigger callback channel
-	callbackCh map[string]chan commonCap.TriggerAndId[*evmcappb.Log]
+	// log trigger callback channels and their registered filters
+	callbackCh        map[string]chan commonCap.TriggerAndId[*evmcappb.Log]
+	logTriggerFilters map[string]*evmcappb.FilterLogTriggerRequest
 }
 
 var evmExecInfo = commonCap.MustNewCapabilityInfo(
@@ -79,6 +81,7 @@ func NewFakeEvmChain(
 		mockKeystoneForwarderAddress: mockKeystoneForwarderAddress,
 		chainSelector:                chainSelector,
 		callbackCh:                   make(map[string]chan commonCap.TriggerAndId[*evmcappb.Log]),
+		logTriggerFilters:            make(map[string]*evmcappb.FilterLogTriggerRequest),
 		dryRunWrites:                 dryRunWrites,
 	}
 	fc.Service, fc.eng = services.Config{
@@ -232,10 +235,13 @@ func (fc *FakeEVMChain) WriteReport(
 
 func (fc *FakeEVMChain) RegisterLogTrigger(ctx context.Context, triggerID string, metadata commonCap.RequestMetadata, input *evmcappb.FilterLogTriggerRequest) (<-chan commonCap.TriggerAndId[*evmcappb.Log], caperrors.Error) {
 	fc.callbackCh[triggerID] = make(chan commonCap.TriggerAndId[*evmcappb.Log])
+	fc.logTriggerFilters[triggerID] = input
 	return fc.callbackCh[triggerID], nil
 }
 
 func (fc *FakeEVMChain) UnregisterLogTrigger(ctx context.Context, triggerID string, metadata commonCap.RequestMetadata, input *evmcappb.FilterLogTriggerRequest) caperrors.Error {
+	delete(fc.logTriggerFilters, triggerID)
+	delete(fc.callbackCh, triggerID)
 	return nil
 }
 
@@ -245,6 +251,12 @@ func (fc *FakeEVMChain) AckEvent(ctx context.Context, triggerID string, eventID 
 
 func (fc *FakeEVMChain) ManualTrigger(ctx context.Context, triggerID string, log *evmcappb.Log) error {
 	fc.eng.Debugf("ManualTrigger: %s", log.String())
+
+	if filter, ok := fc.logTriggerFilters[triggerID]; ok && filter != nil {
+		if !fakeEVMLogMatchesFilter(log, filter) {
+			return fmt.Errorf("log does not match registered filter for trigger %s: address or topic mismatch", triggerID)
+		}
+	}
 
 	go func() {
 		select {
@@ -257,6 +269,49 @@ func (fc *FakeEVMChain) ManualTrigger(ctx context.Context, triggerID string, log
 	}()
 
 	return nil
+}
+
+// fakeEVMLogMatchesFilter checks whether log satisfies the FilterLogTriggerRequest
+// registered for a trigger. It mirrors production EVM log filter semantics:
+//   - Address: if Addresses is non-empty, log.Address must equal one of them (OR).
+//   - Topics: fixed 4-slot array; slot 0 = event signature, slots 1-3 = indexed args.
+//     Within each slot the match is OR (any value matches); across slots it is AND
+//     (all non-empty slots must match). An empty Values slice in a slot is a wildcard.
+func fakeEVMLogMatchesFilter(log *evmcappb.Log, filter *evmcappb.FilterLogTriggerRequest) bool {
+	if len(filter.GetAddresses()) > 0 {
+		addrMatched := false
+		for _, addr := range filter.GetAddresses() {
+			if bytes.Equal(log.GetAddress(), addr) {
+				addrMatched = true
+				break
+			}
+		}
+		if !addrMatched {
+			return false
+		}
+	}
+
+	logTopics := log.GetTopics()
+	for i, topicValues := range filter.GetTopics() {
+		if len(topicValues.GetValues()) == 0 {
+			continue // wildcard slot
+		}
+		if i >= len(logTopics) {
+			return false
+		}
+		slotMatched := false
+		for _, v := range topicValues.GetValues() {
+			if bytes.Equal(logTopics[i], v) {
+				slotMatched = true
+				break
+			}
+		}
+		if !slotMatched {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (fc *FakeEVMChain) createManualTriggerEvent(log *evmcappb.Log) commonCap.TriggerAndId[*evmcappb.Log] {

--- a/core/capabilities/fakes/evm_chain.go
+++ b/core/capabilities/fakes/evm_chain.go
@@ -253,8 +253,8 @@ func (fc *FakeEVMChain) ManualTrigger(ctx context.Context, triggerID string, log
 	fc.eng.Debugf("ManualTrigger: %s", log.String())
 
 	if filter, ok := fc.logTriggerFilters[triggerID]; ok && filter != nil {
-		if !fakeEVMLogMatchesFilter(log, filter) {
-			return fmt.Errorf("log does not match registered filter for trigger %s: address or topic mismatch", triggerID)
+		if err := fakeEVMLogMatchesFilter(log, filter); err != nil {
+			return fmt.Errorf("log does not match registered filter for trigger %s: %w", triggerID, err)
 		}
 	}
 
@@ -277,7 +277,7 @@ func (fc *FakeEVMChain) ManualTrigger(ctx context.Context, triggerID string, log
 //   - Topics: fixed 4-slot array; slot 0 = event signature, slots 1-3 = indexed args.
 //     Within each slot the match is OR (any value matches); across slots it is AND
 //     (all non-empty slots must match). An empty Values slice in a slot is a wildcard.
-func fakeEVMLogMatchesFilter(log *evmcappb.Log, filter *evmcappb.FilterLogTriggerRequest) bool {
+func fakeEVMLogMatchesFilter(log *evmcappb.Log, filter *evmcappb.FilterLogTriggerRequest) error {
 	if len(filter.GetAddresses()) > 0 {
 		addrMatched := false
 		for _, addr := range filter.GetAddresses() {
@@ -287,7 +287,7 @@ func fakeEVMLogMatchesFilter(log *evmcappb.Log, filter *evmcappb.FilterLogTrigge
 			}
 		}
 		if !addrMatched {
-			return false
+			return fmt.Errorf("log address %s does not match any of the addresses in the filter", log.GetAddress())
 		}
 	}
 
@@ -297,7 +297,7 @@ func fakeEVMLogMatchesFilter(log *evmcappb.Log, filter *evmcappb.FilterLogTrigge
 			continue // wildcard slot
 		}
 		if i >= len(logTopics) {
-			return false
+			return fmt.Errorf("log topics length %d does not match the filter topics length %d", len(logTopics), len(filter.GetTopics()))
 		}
 		slotMatched := false
 		for _, v := range topicValues.GetValues() {
@@ -307,11 +307,11 @@ func fakeEVMLogMatchesFilter(log *evmcappb.Log, filter *evmcappb.FilterLogTrigge
 			}
 		}
 		if !slotMatched {
-			return false
+			return fmt.Errorf("log topic %d does not match any of the values in the filter", i)
 		}
 	}
 
-	return true
+	return nil
 }
 
 func (fc *FakeEVMChain) createManualTriggerEvent(log *evmcappb.Log) commonCap.TriggerAndId[*evmcappb.Log] {

--- a/core/capabilities/fakes/evm_chain.go
+++ b/core/capabilities/fakes/evm_chain.go
@@ -285,7 +285,7 @@ func (fc *FakeEVMChain) ManualTrigger(ctx context.Context, triggerID string, log
 func fakeEVMLogMatchesFilter(log *evmcappb.Log, filter *evmcappb.FilterLogTriggerRequest) error {
 	topics := filter.GetTopics()
 	if len(topics) == 0 || len(topics[0].GetValues()) == 0 {
-		return fmt.Errorf("filter is missing topic0 (event signature hash): " +
+		return errors.New("filter is missing topic0 (event signature hash): " +
 			"omitting topic0 would match every event emitted by the contract; " +
 			"set Topics[0] to the keccak256 hash of the event signature")
 	}

--- a/core/capabilities/fakes/evm_chain.go
+++ b/core/capabilities/fakes/evm_chain.go
@@ -277,7 +277,19 @@ func (fc *FakeEVMChain) ManualTrigger(ctx context.Context, triggerID string, log
 //   - Topics: fixed 4-slot array; slot 0 = event signature, slots 1-3 = indexed args.
 //     Within each slot the match is OR (any value matches); across slots it is AND
 //     (all non-empty slots must match). An empty Values slice in a slot is a wildcard.
+//
+// As a developer aid, this fake rejects filters that omit topic0 (the event
+// signature hash). Leaving topic0 empty is a common mistake — especially when
+// using the raw API or TypeScript bindings — and silently causes the trigger to
+// fire for every event emitted by the contract, not just the intended one.
 func fakeEVMLogMatchesFilter(log *evmcappb.Log, filter *evmcappb.FilterLogTriggerRequest) error {
+	topics := filter.GetTopics()
+	if len(topics) == 0 || len(topics[0].GetValues()) == 0 {
+		return fmt.Errorf("filter is missing topic0 (event signature hash): " +
+			"omitting topic0 would match every event emitted by the contract; " +
+			"set Topics[0] to the keccak256 hash of the event signature")
+	}
+
 	if len(filter.GetAddresses()) > 0 {
 		addrMatched := false
 		for _, addr := range filter.GetAddresses() {
@@ -294,7 +306,7 @@ func fakeEVMLogMatchesFilter(log *evmcappb.Log, filter *evmcappb.FilterLogTrigge
 	logTopics := log.GetTopics()
 	for i, topicValues := range filter.GetTopics() {
 		if len(topicValues.GetValues()) == 0 {
-			continue // wildcard slot
+			continue // wildcard slot (only valid for slots 1-3, slot 0 is checked above)
 		}
 		if i >= len(logTopics) {
 			return fmt.Errorf("log topics length %d does not match the filter topics length %d", len(logTopics), len(filter.GetTopics()))

--- a/core/capabilities/fakes/evm_chain_test.go
+++ b/core/capabilities/fakes/evm_chain_test.go
@@ -1,0 +1,156 @@
+package fakes
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	evmcappb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/chain-capabilities/evm"
+)
+
+// transferEventSig is keccak256("Transfer(address,address,uint256)"), used as a
+// stand-in event signature (topic0) throughout the filter tests.
+var transferEventSig = mustDecodeHex("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")
+
+func mustDecodeHex(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+var (
+	testAddr  = []byte{0x11, 0x22, 0x33}
+	otherAddr = []byte{0xAA, 0xBB, 0xCC}
+	topic1    = []byte{0x01, 0x02, 0x03}
+	topic2    = []byte{0x04, 0x05, 0x06}
+)
+
+func makeLog(addr []byte, topics ...[]byte) *evmcappb.Log {
+	return &evmcappb.Log{
+		Address: addr,
+		Topics:  topics,
+	}
+}
+
+func makeFilter(addr []byte, topics ...*evmcappb.TopicValues) *evmcappb.FilterLogTriggerRequest {
+	return &evmcappb.FilterLogTriggerRequest{
+		Addresses: func() [][]byte {
+			if addr == nil {
+				return nil
+			}
+			return [][]byte{addr}
+		}(),
+		Topics: topics,
+	}
+}
+
+func tv(values ...[]byte) *evmcappb.TopicValues {
+	return &evmcappb.TopicValues{Values: values}
+}
+
+func wildcardTV() *evmcappb.TopicValues {
+	return &evmcappb.TopicValues{} // empty Values = wildcard
+}
+
+func TestFakeEVMLogMatchesFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		log         *evmcappb.Log
+		filter      *evmcappb.FilterLogTriggerRequest
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:   "exact match on address and topic0",
+			log:    makeLog(testAddr, transferEventSig),
+			filter: makeFilter(testAddr, tv(transferEventSig)),
+		},
+		{
+			// This is the most common real-world user error: a developer (especially
+			// using the TypeScript SDK or a raw call) registers a log trigger without
+			// specifying topic0.  Without topic0 the trigger fires for every event
+			// emitted by the contract, not just the intended one.  The fake surfaces
+			// this mistake immediately instead of letting it slip through to staging.
+			name:        "missing topic0 — empty Topics slice",
+			log:         makeLog(testAddr, transferEventSig),
+			filter:      makeFilter(testAddr /* no Topics */),
+			wantErr:     true,
+			errContains: "missing topic0",
+		},
+		{
+			// Same mistake, slightly different form: Topics slice present but slot 0
+			// has no Values, i.e. it was left as a wildcard.
+			name:        "missing topic0 — slot 0 has empty Values",
+			log:         makeLog(testAddr, transferEventSig),
+			filter:      makeFilter(testAddr, wildcardTV()),
+			wantErr:     true,
+			errContains: "missing topic0",
+		},
+		{
+			name:        "address mismatch",
+			log:         makeLog(otherAddr, transferEventSig),
+			filter:      makeFilter(testAddr, tv(transferEventSig)),
+			wantErr:     true,
+			errContains: "does not match any of the addresses",
+		},
+		{
+			name:        "topic0 mismatch",
+			log:         makeLog(testAddr, topic1),
+			filter:      makeFilter(testAddr, tv(transferEventSig)),
+			wantErr:     true,
+			errContains: "log topic 0 does not match",
+		},
+		{
+			// No address constraint in the filter — any address should match.
+			name:   "wildcard address (no Addresses in filter)",
+			log:    makeLog(otherAddr, transferEventSig),
+			filter: makeFilter(nil, tv(transferEventSig)),
+		},
+		{
+			// Slots 1-3 are allowed to be wildcards even when topic0 is set.
+			name:   "wildcard slot 1 matches any indexed arg",
+			log:    makeLog(testAddr, transferEventSig, topic1),
+			filter: makeFilter(testAddr, tv(transferEventSig), wildcardTV()),
+		},
+		{
+			name:   "OR semantics within a topic slot",
+			log:    makeLog(testAddr, transferEventSig, topic2),
+			filter: makeFilter(testAddr, tv(transferEventSig), tv(topic1, topic2)),
+		},
+		{
+			name:        "AND semantics across topic slots — second slot mismatch",
+			log:         makeLog(testAddr, transferEventSig, topic1),
+			filter:      makeFilter(testAddr, tv(transferEventSig), tv(topic2)),
+			wantErr:     true,
+			errContains: "log topic 1 does not match",
+		},
+		{
+			name:        "log has fewer topics than filter requires",
+			log:         makeLog(testAddr, transferEventSig), // no topic1
+			filter:      makeFilter(testAddr, tv(transferEventSig), tv(topic1)),
+			wantErr:     true,
+			errContains: "log topics length",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := fakeEVMLogMatchesFilter(tc.log, tc.filter)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.errContains != "" {
+					assert.Contains(t, err.Error(), tc.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/core/capabilities/fakes/evm_chain_test.go
+++ b/core/capabilities/fakes/evm_chain_test.go
@@ -27,6 +27,7 @@ var (
 	otherAddr = []byte{0xAA, 0xBB, 0xCC}
 	topic1    = []byte{0x01, 0x02, 0x03}
 	topic2    = []byte{0x04, 0x05, 0x06}
+	topic3    = []byte{0x07, 0x08, 0x09}
 )
 
 func makeLog(addr []byte, topics ...[]byte) *evmcappb.Log {
@@ -137,11 +138,39 @@ func TestFakeEVMLogMatchesFilter(t *testing.T) {
 			wantErr:     true,
 			errContains: "log topics length",
 		},
+		{
+			// A real customer scenario: the filter constrains topic0, topic1, and
+			// topic3, but intentionally leaves topic2 as a wildcard (null) so that
+			// any value in that indexed arg position is accepted.  The filter still
+			// must match a log that carries all four topics.
+			name: "wildcard topic2 with constrained topic0, topic1, and topic3",
+			log:  makeLog(testAddr, transferEventSig, topic1, topic2, topic3),
+			filter: makeFilter(testAddr,
+				tv(transferEventSig), // slot 0: event signature
+				tv(topic1),           // slot 1: constrained
+				wildcardTV(),         // slot 2: wildcard — any value accepted
+				tv(topic3),           // slot 3: constrained
+			),
+		},
+		{
+			// Same layout but topic3 on the log does not match the filter value.
+			name: "wildcard topic2 — topic3 mismatch",
+			log:  makeLog(testAddr, transferEventSig, topic1, topic2, topic2 /* wrong topic3 */),
+			filter: makeFilter(testAddr,
+				tv(transferEventSig),
+				tv(topic1),
+				wildcardTV(),
+				tv(topic3),
+			),
+			wantErr:     true,
+			errContains: "log topic 3 does not match",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			
 			err := fakeEVMLogMatchesFilter(tc.log, tc.filter)
 			if tc.wantErr {
 				require.Error(t, err)

--- a/core/capabilities/fakes/evm_chain_test.go
+++ b/core/capabilities/fakes/evm_chain_test.go
@@ -170,7 +170,7 @@ func TestFakeEVMLogMatchesFilter(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			
+
 			err := fakeEVMLogMatchesFilter(tc.log, tc.filter)
 			if tc.wantErr {
 				require.Error(t, err)


### PR DESCRIPTION
[DEVSVCS-2932](https://smartcontract-it.atlassian.net/browse/DEVSVCS-2932)

This pull request enhances the `FakeEVMChain` in the testing fakes for EVM capabilities by adding support for log trigger filters that closely mirror production log filtering semantics. The main improvements ensure that manual log triggers are only processed if they match the registered filter, providing more realistic and robust test behavior.


[DEVSVCS-2932]: https://smartcontract-it.atlassian.net/browse/DEVSVCS-2932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ