### PR TITLE
[DX-3522] do not run ccip tags in upgrade tests for df1/cre + test 3 versions back

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -216,9 +216,11 @@ jobs:
       testcmd: "cl test ocr2 TestSmoke/rounds"
       upgrade-nodes: "3"
       node-name-template: "don-node%d"
-      versions-back: "2"
+      versions-back: "3"
       # uncomment once we have tested this pipeline with beta/rc releases
-      # exclude-refs: "beta,rc"
+      # exclude-refs: "beta,rc,ccip"
+      # remove when ^^ is uncommented
+      exclude-refs: "ccip"
       working-directory: "devenv"
       logs-directory: "./devenv/tests/ocr2/logs"
       ctf-log-level: "info"
@@ -235,9 +237,11 @@ jobs:
       testcmd: "go test -v -run Test_Upgrade_Suite ./smoke/cre"
       upgrade-nodes: "3"
       node-name-template: "workflow-node%d"
-      versions-back: "2"
+      versions-back: "3"
       # uncomment once we have tested this pipeline with beta/rc releases
-      # exclude-refs: "beta,rc"
+      # exclude-refs: "beta,rc,ccip"
+      # remove when ^^ is uncommented
+      exclude-refs: "ccip"
       working-directory: "./system-tests/tests"
       logs-directory: "./system-tests/tests/smoke/cre/logs"
       ctf-log-level: "info"

--- a/.github/workflows/devenv-nightly-compat.yml
+++ b/.github/workflows/devenv-nightly-compat.yml
@@ -58,9 +58,9 @@ jobs:
       # cl node Docker container name template, omit if you are using 'devenv'
       node-name-template: "don-node%d"
       # previous versions to test (sorted by tags, SemVer)
-      versions-back: "2"
+      versions-back: "3"
       # patterns to exclude specific refs
-      exclude-refs: "beta,rc"
+      exclude-refs: "beta,rc,ccip"
       # Git refs to test, should be used only for tool testing purposes.
       refs: ${{ github.event_name == 'workflow_dispatch' && inputs.refs || '' }}
       # directory with your developer environment to run buildcmd and envcmd
@@ -88,9 +88,9 @@ jobs:
       # cl node Docker container name template, omit if you are using 'devenv'
       node-name-template: "workflow-node%d"
       # previous versions to test (sorted by tags, SemVer)
-      versions-back: "2"
+      versions-back: "3"
       # patterns to exclude specific refs
-      exclude-refs: "beta,rc"
+      exclude-refs: "beta,rc,ccip"
       # Git refs to test, should be used only for tool testing purposes.
       refs: ${{ github.event_name == 'workflow_dispatch' && inputs.refs || '' }}
       # directory with your developer environment to run buildcmd and envcmd


### PR DESCRIPTION
exclude ccip-related tags from core-specific jobs triggered in build publish workflow.