### PR TITLE
Set node platform build info beat to 3 minutes

### DIFF
--- a/core/services/chainlink/node_platform.go
+++ b/core/services/chainlink/node_platform.go
@@ -19,6 +19,7 @@ const (
 	nodePlatformDomain     = "node-platform"
 	nodePlatformEntity     = "common.v1.NodeBuildInfo"
 	nodePlatformDataSchema = "/node-platform/common/v1"
+	nodePlatformBeat       = 3 * time.Minute
 )
 
 type NodePlatformBuildInfoService struct {
@@ -58,7 +59,7 @@ func NewNodePlatformBuildInfoConfig(opts ApplicationOpts) NodePlatformBuildInfoC
 	}
 
 	return NodePlatformBuildInfoConfig{
-		Beat:        opts.Config.Telemetry().HeartbeatInterval(),
+		Beat:        nodePlatformBeat,
 		Lggr:        opts.Logger,
 		CSAKeyStore: opts.KeyStore.CSA(),
 		CommitSHA:   static.Sha,

--- a/core/services/chainlink/node_platform_test.go
+++ b/core/services/chainlink/node_platform_test.go
@@ -11,13 +11,34 @@ import (
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/csakey"
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder/beholdertest"
+	commoncfg "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	commonv1 "github.com/smartcontractkit/chainlink-protos/node-platform/common/v1"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	keystoremocks "github.com/smartcontractkit/chainlink/v2/core/services/keystore/mocks"
 )
+
+func TestNewNodePlatformBuildInfoConfig_UsesThreeMinuteBeat(t *testing.T) {
+	csaStore := &keystoremocks.CSA{}
+	keyStore := &keystoremocks.Master{}
+	keyStore.EXPECT().CSA().Return(csaStore).Once()
+
+	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, _ *chainlink.Secrets) {
+		c.Telemetry.HeartbeatInterval = commoncfg.MustNewDuration(5 * time.Second)
+	})
+
+	buildInfoCfg := chainlink.NewNodePlatformBuildInfoConfig(chainlink.ApplicationOpts{
+		Config:   cfg,
+		Logger:   logger.TestLogger(t),
+		KeyStore: keyStore,
+	})
+
+	require.Equal(t, 3*time.Minute, buildInfoCfg.Beat)
+	require.Same(t, csaStore, buildInfoCfg.CSAKeyStore)
+}
 
 func TestNodePlatformBuildInfo_EmitsNodeBuildInfo(t *testing.T) {
 	obs := beholdertest.NewObserver(t)


### PR DESCRIPTION
This PR reduces the node platform build info emission cadence from the global telemetry heartbeat to a fixed `3m` interval.

Previously, `NodePlatformBuildInfoService` used `Telemetry().HeartbeatInterval()`, which defaults to `1s`, so build info could be emitted once per second. That is more frequent than needed for static build metadata. This change makes the service use its own explicit `3 * time.Minute` beat instead.

It also adds a test to verify the node platform build info config stays at `3m` even when the global telemetry heartbeat is set to a different value.