### PR TITLE
 Fix Solana msghasher to handle LOOP gRPC type conversions for SVMExtraArgsV1   

### DIFF
--- a/core/capabilities/ccip/ccipsolana/msghasher.go
+++ b/core/capabilities/ccip/ccipsolana/msghasher.go
@@ -2,8 +2,8 @@ package ccipsolana
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -108,44 +108,83 @@ func parseExtraDataMap(input map[string]any) (extraData, error) {
 	var accounts []solana.PublicKey
 	var tokenReceiver solana.PublicKey
 
-	// Iterate through the expected fields in the struct
-	// the field name should match with the one in SVMExtraArgsV1
+	// Iterate through the expected fields in the struct.
+	// The field names should match SVMExtraArgsV1 from the EVM Client library:
 	// https://github.com/smartcontractkit/chainlink/blob/33c0bda696b0ed97f587a46eacd5c65bed9fb2c1/contracts/src/v0.8/ccip/libraries/Client.sol#L57
+	//
+	// Note: when the source chain ExtraDataCodec runs in a LOOP plugin (e.g. TON relay),
+	// the map[string]any values go through gRPC protobuf serialization which changes types:
+	//   uint32 -> int64, [32]byte -> []byte, [][32]byte -> []interface{}
+	// Each case below handles both the native type and the LOOP-converted type.
 	for fieldName, fieldValue := range input {
 		lowercase := strings.ToLower(fieldName)
 		switch lowercase {
 		case "computeunits":
-			// Expect uint32
-			if v, ok := fieldValue.(uint32); ok {
+			switch v := fieldValue.(type) {
+			case uint32:
 				extraArgs.ComputeUnits = v
-			} else {
-				return out, errors.New("invalid type for ComputeUnits, expected uint32")
+			case int64: // LOOP gRPC converts uint32 -> int64
+				if v < 0 || v > math.MaxUint32 {
+					return out, fmt.Errorf("ComputeUnits out of uint32 range: %d", v)
+				}
+				extraArgs.ComputeUnits = uint32(v) //nolint:gosec // validated above
+			default:
+				return out, fmt.Errorf("invalid type for ComputeUnits, expected uint32, got %T", fieldValue)
 			}
 		case "accountiswritablebitmap":
-			// Expect uint64
-			if v, ok := fieldValue.(uint64); ok {
+			switch v := fieldValue.(type) {
+			case uint64:
 				extraArgs.IsWritableBitmap = v
-			} else {
-				return out, errors.New("invalid type for IsWritableBitmap, expected uint64")
+			case int64: // LOOP gRPC may convert uint64 -> int64
+				extraArgs.IsWritableBitmap = uint64(v) //nolint:gosec // bitmap, interpret bits as-is
+			default:
+				return out, fmt.Errorf("invalid type for IsWritableBitmap, expected uint64, got %T", fieldValue)
 			}
 		case "accounts":
-			// Expect [][32]byte
-			if v, ok := fieldValue.([][32]byte); ok {
+			switch v := fieldValue.(type) {
+			case [][32]byte:
 				a := make([]solana.PublicKey, len(v))
 				for i, val := range v {
 					a[i] = solana.PublicKeyFromBytes(val[:])
 				}
 				accounts = a
-			} else {
-				return out, errors.New("invalid type for Accounts, expected [][32]byte")
+			case []interface{}: // LOOP gRPC converts [][32]byte -> []interface{}
+				a := make([]solana.PublicKey, len(v))
+				for i, elem := range v {
+					bs, ok := elem.([]byte)
+					if !ok {
+						return out, fmt.Errorf("invalid type for Accounts[%d], expected []byte, got %T", i, elem)
+					}
+					if len(bs) != 32 {
+						return out, fmt.Errorf("invalid length for Accounts[%d]: expected 32, got %d", i, len(bs))
+					}
+					a[i] = solana.PublicKeyFromBytes(bs)
+				}
+				accounts = a
+			case [][]byte: // alternative LOOP representation
+				a := make([]solana.PublicKey, len(v))
+				for i, bs := range v {
+					if len(bs) != 32 {
+						return out, fmt.Errorf("invalid length for Accounts[%d]: expected 32, got %d", i, len(bs))
+					}
+					a[i] = solana.PublicKeyFromBytes(bs)
+				}
+				accounts = a
+			default:
+				return out, fmt.Errorf("invalid type for Accounts, expected [][32]byte, got %T", fieldValue)
 			}
 		case "tokenreceiver":
-			// Expect [32]byte
-			v, ok := fieldValue.([32]byte)
-			if !ok {
-				return out, errors.New("invalid type for TokenReceiver, expected [32]byte")
+			switch v := fieldValue.(type) {
+			case [32]byte:
+				tokenReceiver = solana.PublicKeyFromBytes(v[:])
+			case []byte: // LOOP gRPC converts [32]byte -> []byte
+				if len(v) != 32 {
+					return out, fmt.Errorf("invalid length for TokenReceiver: expected 32, got %d", len(v))
+				}
+				tokenReceiver = solana.PublicKeyFromBytes(v)
+			default:
+				return out, fmt.Errorf("invalid type for TokenReceiver, expected [32]byte, got %T", fieldValue)
 			}
-			tokenReceiver = solana.PublicKeyFromBytes(v[:])
 		default:
 			// no error here, unneeded keys can be skipped without return errors
 		}

--- a/core/capabilities/ccip/ccipsolana/msghasher.go
+++ b/core/capabilities/ccip/ccipsolana/msghasher.go
@@ -127,7 +127,7 @@ func parseExtraDataMap(input map[string]any) (extraData, error) {
 				if v < 0 || v > math.MaxUint32 {
 					return out, fmt.Errorf("ComputeUnits out of uint32 range: %d", v)
 				}
-				extraArgs.ComputeUnits = uint32(v) //nolint:gosec // validated above
+				extraArgs.ComputeUnits = uint32(v)
 			default:
 				return out, fmt.Errorf("invalid type for ComputeUnits, expected uint32, got %T", fieldValue)
 			}

--- a/core/capabilities/ccip/ccipsolana/msghasher_test.go
+++ b/core/capabilities/ccip/ccipsolana/msghasher_test.go
@@ -109,11 +109,11 @@ func TestParseExtraDataMap_NativeTypes(t *testing.T) {
 	receiver := [32]byte{0x03}
 
 	input := map[string]any{
-		"ComputeUnits":            uint32(2000000),
-		"AccountIsWritableBitmap": uint64(6),
+		"ComputeUnits":             uint32(2000000),
+		"AccountIsWritableBitmap":  uint64(6),
 		"AllowOutOfOrderExecution": true,
-		"TokenReceiver":           receiver,
-		"Accounts":                [][32]byte{account1, account2},
+		"TokenReceiver":            receiver,
+		"Accounts":                 [][32]byte{account1, account2},
 	}
 
 	ed, err := parseExtraDataMap(input)
@@ -137,11 +137,11 @@ func TestParseExtraDataMap_LOOPConvertedTypes(t *testing.T) {
 	receiver[0] = 0x03
 
 	input := map[string]any{
-		"ComputeUnits":            int64(2000000),   // LOOP: uint32 -> int64
-		"AccountIsWritableBitmap": int64(6),         // LOOP: uint64 -> int64
+		"ComputeUnits":             int64(2000000), // LOOP: uint32 -> int64
+		"AccountIsWritableBitmap":  int64(6),       // LOOP: uint64 -> int64
 		"AllowOutOfOrderExecution": true,
-		"TokenReceiver":           receiver,          // LOOP: [32]byte -> []byte
-		"Accounts":                []interface{}{     // LOOP: [][32]byte -> []interface{}
+		"TokenReceiver":            receiver, // LOOP: [32]byte -> []byte
+		"Accounts": []interface{}{ // LOOP: [][32]byte -> []interface{}
 			account1,
 			account2,
 		},

--- a/core/capabilities/ccip/ccipsolana/msghasher_test.go
+++ b/core/capabilities/ccip/ccipsolana/msghasher_test.go
@@ -102,6 +102,117 @@ func TestMessageHasher_InvalidDestinationTokenAddress(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestParseExtraDataMap_NativeTypes(t *testing.T) {
+	// Test with native Go types (in-process codec, no LOOP)
+	account1 := [32]byte{0x01}
+	account2 := [32]byte{0x02}
+	receiver := [32]byte{0x03}
+
+	input := map[string]any{
+		"ComputeUnits":            uint32(2000000),
+		"AccountIsWritableBitmap": uint64(6),
+		"AllowOutOfOrderExecution": true,
+		"TokenReceiver":           receiver,
+		"Accounts":                [][32]byte{account1, account2},
+	}
+
+	ed, err := parseExtraDataMap(input)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2000000), ed.extraArgs.ComputeUnits)
+	assert.Equal(t, uint64(6), ed.extraArgs.IsWritableBitmap)
+	assert.Equal(t, solana.PublicKeyFromBytes(receiver[:]), ed.tokenReceiver)
+	require.Len(t, ed.accounts, 2)
+	assert.Equal(t, solana.PublicKeyFromBytes(account1[:]), ed.accounts[0])
+	assert.Equal(t, solana.PublicKeyFromBytes(account2[:]), ed.accounts[1])
+}
+
+func TestParseExtraDataMap_LOOPConvertedTypes(t *testing.T) {
+	// Test with types as they arrive after LOOP gRPC roundtrip:
+	// uint32 -> int64, [32]byte -> []byte, [][32]byte -> []interface{}
+	account1 := make([]byte, 32)
+	account1[0] = 0x01
+	account2 := make([]byte, 32)
+	account2[0] = 0x02
+	receiver := make([]byte, 32)
+	receiver[0] = 0x03
+
+	input := map[string]any{
+		"ComputeUnits":            int64(2000000),   // LOOP: uint32 -> int64
+		"AccountIsWritableBitmap": int64(6),         // LOOP: uint64 -> int64
+		"AllowOutOfOrderExecution": true,
+		"TokenReceiver":           receiver,          // LOOP: [32]byte -> []byte
+		"Accounts":                []interface{}{     // LOOP: [][32]byte -> []interface{}
+			account1,
+			account2,
+		},
+	}
+
+	ed, err := parseExtraDataMap(input)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2000000), ed.extraArgs.ComputeUnits)
+	assert.Equal(t, uint64(6), ed.extraArgs.IsWritableBitmap)
+	assert.Equal(t, solana.PublicKeyFromBytes(receiver), ed.tokenReceiver)
+	require.Len(t, ed.accounts, 2)
+	assert.Equal(t, solana.PublicKeyFromBytes(account1), ed.accounts[0])
+	assert.Equal(t, solana.PublicKeyFromBytes(account2), ed.accounts[1])
+}
+
+func TestParseExtraDataMap_LOOPAccountsAsByteSlice(t *testing.T) {
+	// Test [][]byte variant (alternative LOOP representation)
+	account1 := make([]byte, 32)
+	account1[0] = 0x01
+
+	input := map[string]any{
+		"ComputeUnits":            uint32(1000),
+		"AccountIsWritableBitmap": uint64(0),
+		"TokenReceiver":           [32]byte{},
+		"Accounts":                [][]byte{account1},
+	}
+
+	ed, err := parseExtraDataMap(input)
+	require.NoError(t, err)
+	require.Len(t, ed.accounts, 1)
+	assert.Equal(t, solana.PublicKeyFromBytes(account1), ed.accounts[0])
+}
+
+func TestParseExtraDataMap_InvalidTypes(t *testing.T) {
+	t.Run("ComputeUnits out of range", func(t *testing.T) {
+		input := map[string]any{
+			"ComputeUnits": int64(5000000000), // exceeds uint32 max
+		}
+		_, err := parseExtraDataMap(input)
+		require.ErrorContains(t, err, "ComputeUnits out of uint32 range")
+	})
+
+	t.Run("TokenReceiver wrong length", func(t *testing.T) {
+		input := map[string]any{
+			"TokenReceiver": []byte{0x01, 0x02}, // not 32 bytes
+		}
+		_, err := parseExtraDataMap(input)
+		require.ErrorContains(t, err, "invalid length for TokenReceiver")
+	})
+
+	t.Run("Accounts element wrong length", func(t *testing.T) {
+		input := map[string]any{
+			"Accounts": []interface{}{
+				[]byte{0x01, 0x02}, // not 32 bytes
+			},
+		}
+		_, err := parseExtraDataMap(input)
+		require.ErrorContains(t, err, "invalid length for Accounts[0]")
+	})
+
+	t.Run("Accounts element wrong type", func(t *testing.T) {
+		input := map[string]any{
+			"Accounts": []interface{}{
+				"not bytes",
+			},
+		}
+		_, err := parseExtraDataMap(input)
+		require.ErrorContains(t, err, "invalid type for Accounts[0]")
+	})
+}
+
 func createEVM2SolanaMessages(t *testing.T) (cciptypes.Message, ccip_offramp.Any2SVMRampMessage, []solana.PublicKey) {
 	messageID := utils.RandomBytes32()
 	sourceChain := uint64(5009297550715157269) // evm mainnet

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -516,7 +516,7 @@ require (
 	github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260304150206-c64e48eb0cb0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221 // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8 // indirect
 	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b // indirect
 	github.com/smartcontractkit/cre-sdk-go v1.5.0 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1714,8 +1714,8 @@ github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 h1:cWUHB6Q
 github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2/go.mod h1:Z4K5VJLjsfqIIaBcZ1Sfccxu0xsCxBjPa6zF+5gtQaM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5 h1:RwZXxdIAOyjp6cwc9Quxgr38k8r7ACz+Lxh9o/A6oH0=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221 h1:m2ZikJ4OS5EkH+d55mNnw8DEstnhM49ohfp3TMxHDkc=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221/go.mod h1:xvvqQRZ0jlM++hn7DWs4eGH5F5hpjj3UQva5nfCoj94=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8 h1:ZwvCZtqeIwXC1wAvI27ykpgM8/3WhaRb3D/6ia7XkLA=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8/go.mod h1:xvvqQRZ0jlM++hn7DWs4eGH5F5hpjj3UQva5nfCoj94=
 github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221 h1:V3dzVscW43oFKApX6W4ajJjoA3oBH8D117RrjL4vPZM=
 github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221/go.mod h1:+s3oNftU548Gp+Q017oGUQJQzce9WKXcPE91r3Me3g4=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b h1:0XLtETkgkzwnEgUIIgyO/oydkUpzDVVuuFLf6aBeNPg=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260304150206-c64e48eb0cb0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.3
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8
 	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221
 	github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad
 	github.com/smartcontractkit/libocr v0.0.0-20260304194147-a03701e2c02e

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1463,8 +1463,8 @@ github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 h1:cWUHB6Q
 github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2/go.mod h1:Z4K5VJLjsfqIIaBcZ1Sfccxu0xsCxBjPa6zF+5gtQaM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5 h1:RwZXxdIAOyjp6cwc9Quxgr38k8r7ACz+Lxh9o/A6oH0=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221 h1:m2ZikJ4OS5EkH+d55mNnw8DEstnhM49ohfp3TMxHDkc=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221/go.mod h1:xvvqQRZ0jlM++hn7DWs4eGH5F5hpjj3UQva5nfCoj94=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8 h1:ZwvCZtqeIwXC1wAvI27ykpgM8/3WhaRb3D/6ia7XkLA=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8/go.mod h1:xvvqQRZ0jlM++hn7DWs4eGH5F5hpjj3UQva5nfCoj94=
 github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221 h1:V3dzVscW43oFKApX6W4ajJjoA3oBH8D117RrjL4vPZM=
 github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221/go.mod h1:+s3oNftU548Gp+Q017oGUQJQzce9WKXcPE91r3Me3g4=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b h1:0XLtETkgkzwnEgUIIgyO/oydkUpzDVVuuFLf6aBeNPg=

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260217043601-5cc966896c4f
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260325152920-167c7a34804c
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8
 	github.com/smartcontractkit/cre-sdk-go v1.5.0
 	github.com/smartcontractkit/cre-sdk-go/capabilities/networking/http v1.3.0
 	github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1293,8 +1293,8 @@ github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260325152920-167c7a34804
 github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260325152920-167c7a34804c/go.mod h1:tHAxfvRGFtttKFw4YnMwRLgawWLNWVfPbL0Wl07wuP8=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0 h1:4mGJySR1GAJAAFRwEo6YiSKM2zSHzYT5b/FSmrpNUGI=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0/go.mod h1:U3XStbEnbx/+L22n1/8aOIdgcGVxtsZB7p59xJGngAs=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221 h1:m2ZikJ4OS5EkH+d55mNnw8DEstnhM49ohfp3TMxHDkc=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221/go.mod h1:xvvqQRZ0jlM++hn7DWs4eGH5F5hpjj3UQva5nfCoj94=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8 h1:ZwvCZtqeIwXC1wAvI27ykpgM8/3WhaRb3D/6ia7XkLA=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8/go.mod h1:xvvqQRZ0jlM++hn7DWs4eGH5F5hpjj3UQva5nfCoj94=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b h1:0XLtETkgkzwnEgUIIgyO/oydkUpzDVVuuFLf6aBeNPg=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b/go.mod h1:XMp5GoxJzF/L5xoA2Og5uAMIUK0WDnZIHzhIilCV8zM=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b h1:RarA5fTnBzQY9wHhl6g7Ac7Nv0d/izr2/zuSWhveB4c=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2
 	github.com/smartcontractkit/chainlink-testing-framework/sentinel v0.1.2
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8
 	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221
 	github.com/smartcontractkit/libocr v0.0.0-20260304194147-a03701e2c02e
 	github.com/smartcontractkit/mcms v0.38.2

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1450,8 +1450,8 @@ github.com/smartcontractkit/chainlink-testing-framework/sentinel v0.1.2 h1:ihRlW
 github.com/smartcontractkit/chainlink-testing-framework/sentinel v0.1.2/go.mod h1:J1Za5EuI/vWDsQSIh6qbPXlVvuEhmHmnvLQBN0XVxqA=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5 h1:RwZXxdIAOyjp6cwc9Quxgr38k8r7ACz+Lxh9o/A6oH0=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221 h1:m2ZikJ4OS5EkH+d55mNnw8DEstnhM49ohfp3TMxHDkc=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221/go.mod h1:xvvqQRZ0jlM++hn7DWs4eGH5F5hpjj3UQva5nfCoj94=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8 h1:ZwvCZtqeIwXC1wAvI27ykpgM8/3WhaRb3D/6ia7XkLA=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8/go.mod h1:xvvqQRZ0jlM++hn7DWs4eGH5F5hpjj3UQva5nfCoj94=
 github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221 h1:V3dzVscW43oFKApX6W4ajJjoA3oBH8D117RrjL4vPZM=
 github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221/go.mod h1:+s3oNftU548Gp+Q017oGUQJQzce9WKXcPE91r3Me3g4=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b h1:0XLtETkgkzwnEgUIIgyO/oydkUpzDVVuuFLf6aBeNPg=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -505,7 +505,7 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.51.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/sentinel v0.1.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221 // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8 // indirect
 	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1670,8 +1670,8 @@ github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5 h1:RwZXxdIA
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.2 h1:QFO9Ar1zY9SHj//7LXWq5caVrfyTFrkRcfkMQeSOAaQ=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.2/go.mod h1:OLczwaAvyObFG+eq4tQHkWqkbPBB0cHkZj0JzY3inik=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221 h1:m2ZikJ4OS5EkH+d55mNnw8DEstnhM49ohfp3TMxHDkc=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221/go.mod h1:xvvqQRZ0jlM++hn7DWs4eGH5F5hpjj3UQva5nfCoj94=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8 h1:ZwvCZtqeIwXC1wAvI27ykpgM8/3WhaRb3D/6ia7XkLA=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8/go.mod h1:xvvqQRZ0jlM++hn7DWs4eGH5F5hpjj3UQva5nfCoj94=
 github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221 h1:V3dzVscW43oFKApX6W4ajJjoA3oBH8D117RrjL4vPZM=
 github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221/go.mod h1:+s3oNftU548Gp+Q017oGUQJQzce9WKXcPE91r3Me3g4=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b h1:0XLtETkgkzwnEgUIIgyO/oydkUpzDVVuuFLf6aBeNPg=

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -50,7 +50,7 @@ plugins:
 
   ton:
     - moduleURI: "github.com/smartcontractkit/chainlink-ton"
-      gitRef: "v0.0.0-20260326230916-bcfdbe85f221"
+      gitRef: "v0.0.0-20260331005855-7b5a4b3384f8
       installPath: "./cmd/chainlink-ton"
 
   tron:

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -50,7 +50,7 @@ plugins:
 
   ton:
     - moduleURI: "github.com/smartcontractkit/chainlink-ton"
-      gitRef: "v0.0.0-20260331005855-7b5a4b3384f8
+      gitRef: "v0.0.0-20260331005855-7b5a4b3384f8"
       installPath: "./cmd/chainlink-ton"
 
   tron:

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -481,7 +481,7 @@ require (
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260304150206-c64e48eb0cb0 // indirect
 	github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260304150206-c64e48eb0cb0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221 // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8 // indirect
 	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1681,8 +1681,8 @@ github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 h1:cWUHB6Q
 github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2/go.mod h1:Z4K5VJLjsfqIIaBcZ1Sfccxu0xsCxBjPa6zF+5gtQaM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5 h1:RwZXxdIAOyjp6cwc9Quxgr38k8r7ACz+Lxh9o/A6oH0=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221 h1:m2ZikJ4OS5EkH+d55mNnw8DEstnhM49ohfp3TMxHDkc=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221/go.mod h1:xvvqQRZ0jlM++hn7DWs4eGH5F5hpjj3UQva5nfCoj94=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8 h1:ZwvCZtqeIwXC1wAvI27ykpgM8/3WhaRb3D/6ia7XkLA=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8/go.mod h1:xvvqQRZ0jlM++hn7DWs4eGH5F5hpjj3UQva5nfCoj94=
 github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221 h1:V3dzVscW43oFKApX6W4ajJjoA3oBH8D117RrjL4vPZM=
 github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221/go.mod h1:+s3oNftU548Gp+Q017oGUQJQzce9WKXcPE91r3Me3g4=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b h1:0XLtETkgkzwnEgUIIgyO/oydkUpzDVVuuFLf6aBeNPg=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -606,7 +606,7 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.18
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
-	github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221 // indirect
+	github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8 // indirect
 	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b // indirect
 	github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/httpaction-negative v0.0.0-20251015074515-1acc1d3fb4c0

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1871,8 +1871,8 @@ github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5 h1:RwZXxdIA
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.3 h1:cjkfMmIpzpl9wJyTbuUVlymwTFPdzp+KBlEGifkAhUc=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.3/go.mod h1:OLczwaAvyObFG+eq4tQHkWqkbPBB0cHkZj0JzY3inik=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221 h1:m2ZikJ4OS5EkH+d55mNnw8DEstnhM49ohfp3TMxHDkc=
-github.com/smartcontractkit/chainlink-ton v0.0.0-20260326230916-bcfdbe85f221/go.mod h1:xvvqQRZ0jlM++hn7DWs4eGH5F5hpjj3UQva5nfCoj94=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8 h1:ZwvCZtqeIwXC1wAvI27ykpgM8/3WhaRb3D/6ia7XkLA=
+github.com/smartcontractkit/chainlink-ton v0.0.0-20260331005855-7b5a4b3384f8/go.mod h1:xvvqQRZ0jlM++hn7DWs4eGH5F5hpjj3UQva5nfCoj94=
 github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221 h1:V3dzVscW43oFKApX6W4ajJjoA3oBH8D117RrjL4vPZM=
 github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260326230916-bcfdbe85f221/go.mod h1:+s3oNftU548Gp+Q017oGUQJQzce9WKXcPE91r3Me3g4=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260218133534-cbd44da2856b h1:0XLtETkgkzwnEgUIIgyO/oydkUpzDVVuuFLf6aBeNPg=


### PR DESCRIPTION
When a non-EVM source chain (e.g. TON) sends a message to Solana, the source chain's ExtraDataCodec runs in a LOOP plugin. The decoded map[string]any goes through gRPC protobuf serialization which       
  changes Go types:                                                                                                                                                                                          
   - uint32 → int64                                                                                                                                                                                           
   - [32]byte → []byte                                                                                                                                                                                        
   - [][32]byte → []interface{}                                                                                                                                                                               
                                                                                                                                                                                                               
   The Solana parseExtraDataMap only accepted the native types, causing "invalid type for ComputeUnits/TokenReceiver/Accounts" errors on TON→Solana lanes.                                                    
                                                                                                                                                                                                               
   This follows the same pattern as the EVM msghasher which already handles int64 for destGasAmount (see comment on line 303 of deployment/common/msghasher.go).                                              
                                                                                                                                                                                                             
   Adds test coverage for both native and LOOP-converted type paths.