### PR TITLE
[LocalCRE] Migrate Aptos write to CapRegistry OCR config

### DIFF
--- a/.changeset/aptos-capreg-write.md
+++ b/.changeset/aptos-capreg-write.md
@@ -1,0 +1,7 @@
+---
+"chainlink": patch
+---
+
+#internal
+
+Migrate Aptos local CRE write setup to use Capabilities Registry OCR config.

--- a/deployment/cre/ocr3/v2/changeset/configure_ocr3.go
+++ b/deployment/cre/ocr3/v2/changeset/configure_ocr3.go
@@ -25,10 +25,9 @@ type ConfigureOCR3Input struct {
 	ContractChainSelector uint64 `json:"contractChainSelector" yaml:"contractChainSelector"`
 	ContractQualifier     string `json:"contractQualifier" yaml:"contractQualifier"`
 
-	DON                 contracts.DonNodeSet `json:"don" yaml:"don"`
-	OracleConfig        *ocr3.OracleConfig   `json:"oracleConfig" yaml:"oracleConfig"`
-	DryRun              bool                 `json:"dryRun" yaml:"dryRun"`
-	ExtraSignerFamilies []string             `json:"extraSignerFamilies,omitempty" yaml:"extraSignerFamilies,omitempty"`
+	DON          contracts.DonNodeSet `json:"don" yaml:"don"`
+	OracleConfig *ocr3.OracleConfig   `json:"oracleConfig" yaml:"oracleConfig"`
+	DryRun       bool                 `json:"dryRun" yaml:"dryRun"`
 
 	MCMSConfig *crecontracts.MCMSConfig `json:"mcmsConfig" yaml:"mcmsConfig"`
 }
@@ -50,9 +49,6 @@ func (l ConfigureOCR3) VerifyPreconditions(_ cldf.Environment, input ConfigureOC
 	}
 	if input.OracleConfig == nil {
 		return errors.New("oracle config is required")
-	}
-	if err := ocr3.ValidateExtraSignerFamilies(input.ExtraSignerFamilies); err != nil {
-		return fmt.Errorf("invalid extra signer families: %w", err)
 	}
 	return nil
 }
@@ -97,13 +93,12 @@ func (l ConfigureOCR3) Apply(e cldf.Environment, input ConfigureOCR3Input) (cldf
 		Env:      &e,
 		Strategy: strategy,
 	}, contracts.ConfigureOCR3Input{
-		ContractAddress:     &contractAddr,
-		ChainSelector:       input.ContractChainSelector,
-		DON:                 input.DON,
-		Config:              input.OracleConfig,
-		DryRun:              input.DryRun,
-		ExtraSignerFamilies: input.ExtraSignerFamilies,
-		MCMSConfig:          input.MCMSConfig,
+		ContractAddress: &contractAddr,
+		ChainSelector:   input.ContractChainSelector,
+		DON:             input.DON,
+		Config:          input.OracleConfig,
+		DryRun:          input.DryRun,
+		MCMSConfig:      input.MCMSConfig,
 	})
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to configure OCR3 contract: %w", err)

--- a/deployment/cre/ocr3/v2/changeset/operations/contracts/configure_ocr3.go
+++ b/deployment/cre/ocr3/v2/changeset/operations/contracts/configure_ocr3.go
@@ -35,7 +35,6 @@ type ConfigureOCR3Input struct {
 	DryRun          bool
 
 	ReportingPluginConfigOverride []byte
-	ExtraSignerFamilies           []string
 
 	MCMSConfig *contracts.MCMSConfig
 }
@@ -73,7 +72,6 @@ var ConfigureOCR3 = operations.NewOperation[ConfigureOCR3Input, ConfigureOCR3OpO
 			OCR3Config:                    input.Config,
 			Contract:                      contract.Contract,
 			DryRun:                        input.DryRun,
-			ExtraSignerFamilies:           input.ExtraSignerFamilies,
 			UseMCMS:                       input.UseMCMS(),
 			Strategy:                      deps.Strategy,
 			ReportingPluginConfigOverride: input.ReportingPluginConfigOverride,

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -23,7 +23,7 @@ plugins:
       installPath: "."
   consensus:
     - moduleURI: "github.com/smartcontractkit/capabilities/consensus"
-      gitRef: "edadc5b6025c4927e79d8fa98093c230bf5aaba6"
+      gitRef: "06c5ed299fe6a58ec53923f9b0fe9f696c386d4b"
       installPath: "."
   workflowevent:
     - enabled: false

--- a/system-tests/lib/cre/features/aptos/aptos.go
+++ b/system-tests/lib/cre/features/aptos/aptos.go
@@ -36,7 +36,6 @@ const (
 	deltaStageKey           = "DeltaStage"
 	transmissionScheduleKey = "TransmissionSchedule"
 	forwarderQualifier      = ""
-	zeroForwarderHex        = "0x0000000000000000000000000000000000000000000000000000000000000000"
 	defaultWriteDeltaStage  = 500*time.Millisecond + 1*time.Second
 	defaultRequestTimeout   = 30 * time.Second
 )

--- a/system-tests/lib/cre/features/aptos/aptos.go
+++ b/system-tests/lib/cre/features/aptos/aptos.go
@@ -10,15 +10,11 @@ import (
 	"github.com/Masterminds/semver/v3"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/rs/zerolog"
-
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
-
 	"github.com/smartcontractkit/chainlink/deployment/cre/ocr3"
-	creocr3changeset "github.com/smartcontractkit/chainlink/deployment/cre/ocr3/v2/changeset"
-	creocr3contracts "github.com/smartcontractkit/chainlink/deployment/cre/ocr3/v2/changeset/operations/contracts"
 	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 	crecontracts "github.com/smartcontractkit/chainlink/system-tests/lib/cre/contracts"
@@ -40,7 +36,6 @@ const (
 	deltaStageKey           = "DeltaStage"
 	transmissionScheduleKey = "TransmissionSchedule"
 	forwarderQualifier      = ""
-	ocr3ContractQualifier   = "aptos_capability_ocr3"
 	zeroForwarderHex        = "0x0000000000000000000000000000000000000000000000000000000000000000"
 	defaultWriteDeltaStage  = 500*time.Millisecond + 1*time.Second
 	defaultRequestTimeout   = 30 * time.Second
@@ -136,10 +131,6 @@ func (a *Aptos) PostEnvStartup(
 	if err != nil {
 		return err
 	}
-	_, _, err = crecontracts.DeployOCR3Contract(testLogger, ocr3ContractQualifier, creEnv.RegistryChainSelector, creEnv.CldfEnvironment, creEnv.ContractVersions)
-	if err != nil {
-		return fmt.Errorf("failed to deploy Aptos OCR3 contract: %w", err)
-	}
 
 	specs, err := proposeAptosWorkerSpecs(ctx, don, dons, creEnv, nodeSet, enabledChainIDs)
 	if err != nil {
@@ -151,33 +142,6 @@ func (a *Aptos) PostEnvStartup(
 	err = crejobs.Approve(ctx, creEnv.CldfEnvironment.Offchain, dons, specs)
 	if err != nil {
 		return fmt.Errorf("failed to approve Aptos jobs: %w", err)
-	}
-
-	workers, err := don.Workers()
-	if err != nil {
-		return fmt.Errorf("failed to collect Aptos worker nodes for OCR3 config: %w", err)
-	}
-	workerNodeIDs := make([]string, 0, len(workers))
-	for _, worker := range workers {
-		if worker.JobDistributorDetails == nil {
-			return fmt.Errorf("worker %q is missing job distributor details", worker.Name)
-		}
-		workerNodeIDs = append(workerNodeIDs, worker.JobDistributorDetails.NodeID)
-	}
-
-	_, err = creocr3changeset.ConfigureOCR3{}.Apply(*creEnv.CldfEnvironment, creocr3changeset.ConfigureOCR3Input{
-		ContractChainSelector: creEnv.RegistryChainSelector,
-		ContractQualifier:     ocr3ContractQualifier,
-		DON: creocr3contracts.DonNodeSet{
-			Name:    don.Name,
-			NodeIDs: workerNodeIDs,
-		},
-		OracleConfig:        don.ResolveORC3Config(crecontracts.DefaultChainCapabilityOCR3Config()),
-		DryRun:              false,
-		ExtraSignerFamilies: cre.OCRExtraSignerFamiliesForFamily(chainselectors.FamilyAptos),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to configure Aptos OCR3 contract: %w", err)
 	}
 	return nil
 }
@@ -215,7 +179,7 @@ func buildCapabilityRegistrations(
 				CapabilityType: 1,
 			},
 			Config:             capConfig,
-			UseCapRegOCRConfig: false,
+			UseCapRegOCRConfig: true,
 		})
 		capabilityLabels = append(capabilityLabels, labelledName)
 		capabilityToOCR3Config[labelledName] = crecontracts.DefaultChainCapabilityOCR3Config()

--- a/system-tests/lib/cre/features/aptos/aptos_test.go
+++ b/system-tests/lib/cre/features/aptos/aptos_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/p2pkey"
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	cldfchain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
@@ -19,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/clnode"
 	ns "github.com/smartcontractkit/chainlink-testing-framework/framework/components/simple_node_set"
+	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/don/secrets"
 	creblockchains "github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/blockchains"
@@ -328,7 +330,79 @@ func TestFindAptosChainByChainID_ErrorsOnTypeMismatch(t *testing.T) {
 	require.ErrorContains(t, err, "unexpected type")
 }
 
+func TestBuildCapabilityRegistrations_UsesCapRegOCRConfig(t *testing.T) {
+	don := testDonMetadataWithCapabilities(t, []string{"[Aptos]\n"}, []string{cre.WriteAptosCapability + "-4"}, cre.CapabilityConfigs{
+		cre.WriteAptosCapability: {
+			BinaryName: "write-aptos",
+			Values: map[string]any{
+				requestTimeoutKey:       "45s",
+				deltaStageKey:           "2500ms",
+				transmissionScheduleKey: "allAtOnce",
+			},
+		},
+	})
+
+	caps, capabilityToOCR3Config, capabilityLabels, err := buildCapabilityRegistrations(
+		don,
+		[]creblockchains.Blockchain{testAptosBlockchain(4, 4457093679053095497)},
+		[]uint64{4},
+		map[string]string{"peer-a": "0x1"},
+	)
+	require.NoError(t, err)
+	require.Len(t, caps, 1)
+	require.Len(t, capabilityLabels, 1)
+	require.True(t, caps[0].UseCapRegOCRConfig)
+	require.Equal(t, CapabilityLabel(4457093679053095497), caps[0].Capability.LabelledName)
+	require.Contains(t, capabilityToOCR3Config, capabilityLabels[0])
+	require.NotNil(t, capabilityToOCR3Config[capabilityLabels[0]])
+}
+
+func TestNewAptosWorkerJobInput_UsesCapRegVersion(t *testing.T) {
+	creEnv := &cre.Environment{
+		RegistryChainSelector: 111,
+		ContractVersions: map[cre.ContractType]*semver.Version{
+			keystone_changeset.CapabilitiesRegistry.String(): semver.MustParse("2.0.0"),
+		},
+	}
+
+	input, err := newAptosWorkerJobInput(
+		creEnv,
+		"workflow-don",
+		"/usr/local/bin/aptos",
+		`{"chainId":"4"}`,
+		[]string{"peer@127.0.0.1:6690"},
+		222,
+		4,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "write-aptos-worker-4", input.JobName)
+	require.Equal(t, true, input.Inputs["useCapRegOCRConfig"])
+	require.Equal(t, "2.0.0", input.Inputs["capRegVersion"])
+	require.Equal(t, uint64(111), input.Inputs["chainSelectorEVM"])
+	require.Equal(t, uint64(222), input.Inputs["chainSelectorAptos"])
+	_, hasQualifier := input.Inputs["contractQualifier"]
+	require.False(t, hasQualifier)
+}
+
+func TestNewAptosWorkerJobInput_ErrorsWithoutCapRegVersion(t *testing.T) {
+	_, err := newAptosWorkerJobInput(
+		&cre.Environment{},
+		"workflow-don",
+		"/usr/local/bin/aptos",
+		`{"chainId":"4"}`,
+		nil,
+		222,
+		4,
+	)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "CapabilitiesRegistry version not found")
+}
+
 func testDonMetadata(t *testing.T, nodeConfigs ...string) *cre.DonMetadata {
+	return testDonMetadataWithCapabilities(t, nodeConfigs, nil, nil)
+}
+
+func testDonMetadataWithCapabilities(t *testing.T, nodeConfigs []string, capabilities []string, capabilityConfigs cre.CapabilityConfigs) *cre.DonMetadata {
 	t.Helper()
 
 	nodeSpecs := make([]*cre.NodeSpecWithRole, len(nodeConfigs))
@@ -342,11 +416,12 @@ func testDonMetadata(t *testing.T, nodeConfigs ...string) *cre.DonMetadata {
 	}
 
 	nodeSet := &cre.NodeSet{
-		Input:     &ns.Input{Name: "aptos-don"},
-		NodeSpecs: nodeSpecs,
+		Input:        &ns.Input{Name: "aptos-don"},
+		NodeSpecs:    nodeSpecs,
+		Capabilities: capabilities,
 	}
 
-	don, err := cre.NewDonMetadata(nodeSet, 1, infra.Provider{Type: infra.Docker}, nil)
+	don, err := cre.NewDonMetadata(nodeSet, 1, infra.Provider{Type: infra.Docker}, capabilityConfigs)
 	require.NoError(t, err)
 	return don
 }

--- a/system-tests/lib/cre/features/aptos/aptos_test.go
+++ b/system-tests/lib/cre/features/aptos/aptos_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/pelletier/go-toml/v2"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/p2pkey"
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	cldfchain "github.com/smartcontractkit/chainlink-deployments-framework/chain"

--- a/system-tests/lib/cre/features/aptos/aptos_workers.go
+++ b/system-tests/lib/cre/features/aptos/aptos_workers.go
@@ -3,6 +3,7 @@ package aptos
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -107,7 +108,7 @@ func newAptosWorkerJobInput(
 ) (jobs.ProposeJobSpecInput, error) {
 	capRegVersion, ok := creEnv.ContractVersions[keystone_changeset.CapabilitiesRegistry.String()]
 	if !ok {
-		return jobs.ProposeJobSpecInput{}, fmt.Errorf("CapabilitiesRegistry version not found in contract versions")
+		return jobs.ProposeJobSpecInput{}, errors.New("CapabilitiesRegistry version not found in contract versions")
 	}
 
 	return jobs.ProposeJobSpecInput{

--- a/system-tests/lib/cre/features/aptos/aptos_workers.go
+++ b/system-tests/lib/cre/features/aptos/aptos_workers.go
@@ -15,6 +15,7 @@ import (
 	crejobops "github.com/smartcontractkit/chainlink/deployment/cre/jobs/operations"
 	jobtypes "github.com/smartcontractkit/chainlink/deployment/cre/jobs/types"
 	"github.com/smartcontractkit/chainlink/deployment/cre/pkg/offchain"
+	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/don/jobs/standardcapability"
 )
@@ -66,25 +67,9 @@ func proposeAptosWorkerSpecs(
 			return nil, fmt.Errorf("failed to build Aptos worker config: %w", err)
 		}
 
-		workerInput := jobs.ProposeJobSpecInput{
-			Domain:      offchain.ProductLabel,
-			Environment: cre.EnvironmentName,
-			DONName:     don.Name,
-			JobName:     "write-aptos-worker-" + strconv.FormatUint(chainID, 10),
-			ExtraLabels: map[string]string{cre.CapabilityLabelKey: flag},
-			DONFilters: []offchain.TargetDONFilter{
-				{Key: offchain.FilterKeyDONName, Value: don.Name},
-			},
-			Template: jobtypes.Aptos,
-			Inputs: jobtypes.JobSpecInput{
-				"command":            command,
-				"config":             configStr,
-				"chainSelectorEVM":   creEnv.RegistryChainSelector,
-				"chainSelectorAptos": aptosChain.ChainSelector(),
-				"bootstrapPeers":     bootstrapPeers,
-				"useCapRegOCRConfig": false,
-				"contractQualifier":  ocr3ContractQualifier,
-			},
+		workerInput, err := newAptosWorkerJobInput(creEnv, don.Name, command, configStr, bootstrapPeers, aptosChain.ChainSelector(), chainID)
+		if err != nil {
+			return nil, err
 		}
 
 		proposer := jobs.ProposeJobSpec{}
@@ -109,6 +94,42 @@ func proposeAptosWorkerSpecs(
 	}
 
 	return specs, nil
+}
+
+func newAptosWorkerJobInput(
+	creEnv *cre.Environment,
+	donName string,
+	command string,
+	configStr string,
+	bootstrapPeers []string,
+	aptosChainSelector uint64,
+	chainID uint64,
+) (jobs.ProposeJobSpecInput, error) {
+	capRegVersion, ok := creEnv.ContractVersions[keystone_changeset.CapabilitiesRegistry.String()]
+	if !ok {
+		return jobs.ProposeJobSpecInput{}, fmt.Errorf("CapabilitiesRegistry version not found in contract versions")
+	}
+
+	return jobs.ProposeJobSpecInput{
+		Domain:      offchain.ProductLabel,
+		Environment: cre.EnvironmentName,
+		DONName:     donName,
+		JobName:     "write-aptos-worker-" + strconv.FormatUint(chainID, 10),
+		ExtraLabels: map[string]string{cre.CapabilityLabelKey: flag},
+		DONFilters: []offchain.TargetDONFilter{
+			{Key: offchain.FilterKeyDONName, Value: donName},
+		},
+		Template: jobtypes.Aptos,
+		Inputs: jobtypes.JobSpecInput{
+			"command":            command,
+			"config":             configStr,
+			"chainSelectorEVM":   creEnv.RegistryChainSelector,
+			"chainSelectorAptos": aptosChainSelector,
+			"bootstrapPeers":     bootstrapPeers,
+			"useCapRegOCRConfig": true,
+			"capRegVersion":      capRegVersion.String(),
+		},
+	}, nil
 }
 
 func donOraclePublicKeys(ctx context.Context, don *cre.Don) ([][]byte, error) {


### PR DESCRIPTION
## Summary
- migrate Aptos local CRE write setup to use Capabilities Registry OCR config
- repin `capabilities/consensus` to a `main` commit that includes Aptos signing support (`#510`)
- remove Aptos-only dependency on the legacy direct `ConfigureOCR3` path
- add focused Aptos tests for CapReg OCR config registration and worker job input

## What Changed
- set Aptos capability registration to `UseCapRegOCRConfig: true`
- switch Aptos worker jobs to `useCapRegOCRConfig: true` plus `capRegVersion`
- remove the Aptos-specific direct OCR3 contract/configure detour
- drop Aptos-only extra signer family plumbing from the legacy direct OCR3 changeset path
- bump the `consensus` private plugin pin from `edadc5b...` to `06c5ed299fe6a58ec53923f9b0fe9f696c386d4b`

## Local Validation
- `cd system-tests/lib && GOWORK=off go test -vet=off ./cre/features/aptos -count=1`
- `cd deployment && GOWORK=off go test ./cre/jobs/... ./cre/ocr3/... -count=1`
- `cd . && GOWORK=off go test ./core/services/ocr/capregconfig -count=1`
- `cd system-tests/tests && GOWORK=off go test -run '^$' ./smoke/cre`
- `cd system-tests/tests && PATH=/opt/homebrew/bin:$PATH CRE_APTOS_SCENARIOS='write' GOWORK=off go test -mod=mod ./smoke/cre -run '^Test_CRE_V2_Aptos_Suite$' -count=1 -v`
- `cd system-tests/tests && PATH=/opt/homebrew/bin:$PATH CRE_APTOS_SCENARIOS='write-expected-failure' GOWORK=off go test -mod=mod ./smoke/cre -run '^Test_CRE_V2_Aptos_Suite$' -count=1 -v`

## Notes
- This PR is intentionally based on `feature/aptos-local-cre-minimal-write-refresh-rerun` to keep [#21766](https://github.com/smartcontractkit/chainlink/pull/21766) as the checkpoint PR.