### PR TITLE
core/services/relay/evm: Relayer.Close continue after error

### DIFF
--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -289,9 +289,7 @@ func (r *Relayer) Close() error {
 		defer cancel()
 
 		err := r.capabilitiesRegistry.Remove(ctx, r.triggerCapability.ID)
-		if err != nil {
-			return err
-		}
+		r.lggr.Errorw("Failed to remove trigger capability", "err", err)
 	}
 	if r.pluginConfigEmitter != nil {
 		cs = append(cs, r.pluginConfigEmitter)


### PR DESCRIPTION
Close must make a best effort to Close everything. 