### PR TITLE
Restore post-build workflow + fix permissions

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -205,48 +205,14 @@ jobs:
           products: |
             ccip-prereleases-prod-testnet
 
-  # Upgrade compatibility tests
-  df1-compat:
-    uses: ./.github/workflows/devenv-compat.yml
-    name: Data Feeds v1 Upgrade Test
-    needs: [docker-core]
+  post-build:
+    needs: [docker-core, docker-ccip]
+    name: Post-Build Actions
+    uses: ./.github/workflows/post-build.yml
     with:
-      buildcmd: "just cli"
-      envcmd: "cl u env.toml,products/ocr2/basic.toml"
-      testcmd: "cl test ocr2 TestSmoke/rounds"
-      upgrade-nodes: "3"
-      node-name-template: "don-node%d"
-      versions-back: "3"
-      # uncomment once we have tested this pipeline with beta/rc releases
-      # exclude-refs: "beta,rc,ccip"
-      # remove when ^^ is uncommented
-      exclude-refs: "ccip"
-      working-directory: "devenv"
-      logs-directory: "./devenv/tests/ocr2/logs"
-      ctf-log-level: "info"
-      strip-image-suffix: "v"
-    secrets: inherit
-
-  cre-compat:
-    uses: ./.github/workflows/devenv-compat.yml
-    name: CRE Upgrade Test
-    needs: [docker-core]
-    with:
-      buildcmd: "echo nothing-to-build" # added to prevent `just cli` from being used (default buildcmd if not provided)
-      envcmd: "go run -C ../../core/scripts/cre/environment . env start"
-      testcmd: "go test -v -run Test_Upgrade_Suite ./smoke/cre"
-      upgrade-nodes: "3"
-      node-name-template: "workflow-node%d"
-      versions-back: "3"
-      # uncomment once we have tested this pipeline with beta/rc releases
-      # exclude-refs: "beta,rc,ccip"
-      # remove when ^^ is uncommented
-      exclude-refs: "ccip"
-      working-directory: "./system-tests/tests"
-      logs-directory: "./system-tests/tests/smoke/cre/logs"
-      ctf-log-level: "info"
-      strip-image-suffix: "v"
-    secrets: inherit
+      chainlink_core_full_image: ${{ needs.docker-core.result == 'success' && format('public.ecr.aws/chainlink/chainlink:{0}|{1}', needs.docker-core.outputs.docker-manifest-tag, needs.docker-core.outputs.docker-manifest-digest) || '' }}
+      chainlink_ccip_full_image: ${{ needs.docker-ccip.result == 'success' && format('public.ecr.aws/chainlink/ccip:{0}|{1}', needs.docker-ccip.outputs.docker-manifest-tag, needs.docker-ccip.outputs.docker-manifest-digest) || '' }}
+      chainlink_version: ${{ github.ref_name }}
 
   # Notify Slack channel for new git tags associated with pre-releases.
   # Final release notifications originate from the release coordinator repo.

--- a/.github/workflows/devenv-core-compat.yml
+++ b/.github/workflows/devenv-core-compat.yml
@@ -1,12 +1,10 @@
-name: (Nightly) CL Cluster Node Version Compatibility
+name: CL Cluster Node Version Compatibility
 
 on:
-  schedule:
-    - cron: "0 6 * * *" # Run daily at 6 AM
   workflow_dispatch:
     inputs:
       refs:
-        description: "Git refs to test, should be used only if automatically detected refs are not enough"
+        description: "Git refs to test, should be used only if automatically detected refs are not enough. Enter multiple refs separated by commas, from oldest to newest."
         required: false
         type: string
 
@@ -62,7 +60,7 @@ jobs:
       # patterns to exclude specific refs
       exclude-refs: "beta,rc,ccip"
       # Git refs to test, should be used only for tool testing purposes.
-      refs: ${{ github.event_name == 'workflow_dispatch' && inputs.refs || '' }}
+      refs: ${{ inputs.refs }}
       # directory with your developer environment to run buildcmd and envcmd
       working-directory: "devenv"
       # directory for executing your tests, to run testcmd
@@ -92,7 +90,7 @@ jobs:
       # patterns to exclude specific refs
       exclude-refs: "beta,rc,ccip"
       # Git refs to test, should be used only for tool testing purposes.
-      refs: ${{ github.event_name == 'workflow_dispatch' && inputs.refs || '' }}
+      refs: ${{ inputs.refs }}
       # directory with your developer environment to run buildcmd and envcmd
       working-directory: "./system-tests/tests"
       # directory for executing your tests, to run testcmd

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -1,0 +1,67 @@
+name: "Post-Build Chainlink"
+
+on:
+    # to be used with post-release tests
+    workflow_call:
+        inputs:
+            chainlink_core_full_image:
+                required: false
+                type: string
+                description: "The Chainlink (core) image to use for the tests."
+            chainlink_ccip_full_image:
+                required: false
+                type: string
+                description: "The Chainlink (CCIP) image to use for the tests."
+            chainlink_version:
+                required: false
+                type: string
+                description: "The version of Chainlink repository to use for the tests. If empty github.sha will be used."
+
+permissions:
+    actions: read
+    checks: write
+    pull-requests: write
+    id-token: write
+    contents: read
+
+jobs:
+    # Upgrade compatibility tests
+    df1-compat:
+        uses: ./.github/workflows/devenv-compat.yml
+        name: Data Feeds v1 Upgrade Test
+        with:
+            buildcmd: "just cli"
+            envcmd: "cl u env.toml,products/ocr2/basic.toml"
+            testcmd: "cl test ocr2 TestSmoke/rounds"
+            upgrade-nodes: "3"
+            node-name-template: "don-node%d"
+            versions-back: "3"
+            # uncomment once we have tested this pipeline with beta/rc releases
+            # exclude-refs: "beta,rc,ccip"
+            # remove when ^^ is uncommented
+            exclude-refs: "ccip"
+            working-directory: "devenv"
+            logs-directory: "./devenv/tests/ocr2/logs"
+            ctf-log-level: "info"
+            strip-image-suffix: "v"
+        secrets: inherit
+
+    cre-compat:
+        uses: ./.github/workflows/devenv-compat.yml
+        name: CRE Upgrade Test
+        with:
+            buildcmd: "echo nothing-to-build" # added to prevent `just cli` from being used (default buildcmd if not provided)
+            envcmd: "go run -C ../../core/scripts/cre/environment . env start"
+            testcmd: "go test -v -run Test_Upgrade_Suite ./smoke/cre"
+            upgrade-nodes: "3"
+            node-name-template: "workflow-node%d"
+            versions-back: "3"
+            # uncomment once we have tested this pipeline with beta/rc releases
+            # exclude-refs: "beta,rc,ccip"
+            # remove when ^^ is uncommented
+            exclude-refs: "ccip"
+            working-directory: "./system-tests/tests"
+            logs-directory: "./system-tests/tests/smoke/cre/logs"
+            ctf-log-level: "info"
+            strip-image-suffix: "v"
+        secrets: inherit


### PR DESCRIPTION
Reverts the earlier revert of the post-build workflow refactor. Follow-up will grant required permissions to reusable workflow callers to fix the validation failures.