### PR TITLE
chore(ci): remove metrics gathering

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -129,8 +129,6 @@ jobs:
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners
         uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0 # v2.1.0
-        with:
-          metrics: cpu,network,memory,disk
 
       - name: Checkout
         uses: actions/checkout@v6
@@ -249,8 +247,6 @@ jobs:
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners
         uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0 # v2.1.0
-        with:
-          metrics: cpu,network,memory,disk
 
       - name: Checkout the repo
         if: ${{ matrix.type.should-run == 'true' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,8 +44,6 @@ jobs:
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners
         uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0 # v2.1.0
-        with:
-          metrics: cpu,network,memory,disk
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -78,8 +78,6 @@ jobs:
 
       - name: Enable S3 Cache for Self-Hosted Runners
         uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0 # v2.1.0
-        with:
-          metrics: cpu,network,memory,disk
 
       - name: Set up Go
         id: setup-go

--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -50,8 +50,6 @@ jobs:
 
       - name: Enable S3 Cache for Self-Hosted Runners
         uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0 # v2.1.0
-        with:
-          metrics: cpu,network,memory,disk
 
       - name: Set up Go
         id: setup-go
@@ -111,8 +109,6 @@ jobs:
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners
         uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0 # v2.1.0
-        with:
-          metrics: cpu,network,memory,disk
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/cre-soak-memory-leak.yml
+++ b/.github/workflows/cre-soak-memory-leak.yml
@@ -45,8 +45,6 @@ jobs:
       - name: Enable S3 Cache for Self-Hosted Runners
         if: ${{ env.RUNS_ON_INSTANCE_ID != '' && env.ACTIONS_CACHE_URL != '' }}
         uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0 # v2.1.0
-        with:
-          metrics: cpu,network,memory,disk
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -50,8 +50,6 @@ jobs:
 
       - name: Enable S3 Cache for Self-Hosted Runners
         uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0 # v2.1.0
-        with:
-          metrics: cpu,network,memory,disk
 
       - name: Set up Go
         id: setup-go
@@ -158,8 +156,7 @@ jobs:
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners
         uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0 # v2.1.0
-        with:
-          metrics: cpu,network,memory,disk
+
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -54,8 +54,6 @@ jobs:
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners
         uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0 # v2.1.0
-        with:
-          metrics: cpu,network,memory,disk
 
       - name: Checkout the repo
         uses: actions/checkout@v6

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -246,8 +246,6 @@ jobs:
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners
         uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0 # v2.1.0
-        with:
-          metrics: cpu,network,memory,disk
 
       - name: Check if image exists in ECR
         id: check-image-exists


### PR DESCRIPTION
Removes the explicit metrics gathering as added in #21655. 

### Notes

* I believe this is causing metrics pressure on our instance.
* These metrics should still be available in the post-step (will post link from this PR run) even if not included here.

---

DX-3415