### PR TITLE
Consume richer Aptos write reply semantics

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -48,7 +48,7 @@ plugins:
       installPath: "."
   aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "ebca0cad82543712816668e5c418e1df49ec0c88"
+      gitRef: "17f0b0e00d3bc32de8f5d32f5df524b9c2dd4f8c"
       installPath: "."
   mock:
     - moduleURI: "github.com/smartcontractkit/capabilities/mock"

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -10,7 +10,7 @@ defaults:
 plugins:
   aptos:
     - moduleURI: "github.com/smartcontractkit/chainlink-aptos"
-      gitRef: "v0.0.0-20260324144720-484863604698"
+      gitRef: "v0.0.0-20260330141118-49ad2c07d895"
       installPath: "./cmd/chainlink-aptos"
 
   sui:

--- a/system-tests/tests/smoke/cre/aptos/aptosread/go.mod
+++ b/system-tests/tests/smoke/cre/aptos/aptosread/go.mod
@@ -3,8 +3,8 @@ module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/aptos/
 go 1.25.5
 
 require (
-	github.com/smartcontractkit/cre-sdk-go v1.4.1-0.20260312154349-ecb4cb615f37
-	github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260312154349-ecb4cb615f37
+	github.com/smartcontractkit/cre-sdk-go v1.5.0
+	github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260401193157-417adf0c4123
 	github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron v0.10.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/system-tests/tests/smoke/cre/aptos/aptosread/go.sum
+++ b/system-tests/tests/smoke/cre/aptos/aptosread/go.sum
@@ -10,10 +10,10 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260325181729-0cac87f98cd4 h1:kqdSsgt2OzJnAk0io8GsA2lJE5hKlLM2EY4uy+R6H9Y=
 github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260325181729-0cac87f98cd4/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
-github.com/smartcontractkit/cre-sdk-go v1.4.1-0.20260312154349-ecb4cb615f37 h1:+awsWWPj1CWtvcDwU8QAkUvljo/YYpnKGDrZc2afYls=
-github.com/smartcontractkit/cre-sdk-go v1.4.1-0.20260312154349-ecb4cb615f37/go.mod h1:yYrQFz1UH7hhRbPO0q4fgo1tfsJNd4yXnI3oCZE0RzM=
-github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260312154349-ecb4cb615f37 h1:UNem52lhklNEp4VdPBYHN+p1wgG0vDYEKSvonQgV+3o=
-github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260312154349-ecb4cb615f37/go.mod h1:Ht8wSAAJRJgaZig5kwE5ogRJFngEmfQqBO0e+0y0Zng=
+github.com/smartcontractkit/cre-sdk-go v1.5.0 h1:kepW3QDKARrOOHjXwWAZ9j5KLk6bxLzvi6OMrLsFwVo=
+github.com/smartcontractkit/cre-sdk-go v1.5.0/go.mod h1:yYrQFz1UH7hhRbPO0q4fgo1tfsJNd4yXnI3oCZE0RzM=
+github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260401193157-417adf0c4123 h1:dpp9ewx9Cn8WRNviBSrVGlOesyZVDUKxfm8dZGiz76M=
+github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260401193157-417adf0c4123/go.mod h1:2YPeHbHbDCjO6i1kobLzjl1M/mBfbN5B3BFDEZpoXc0=
 github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron v0.10.0 h1:g7UrVaNKVEmIhVkJTk4f8raCM8Kp/RTFnAT64wqNmTY=
 github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron v0.10.0/go.mod h1:PWyrIw16It4TSyq6mDXqmSR0jF2evZRKuBxu7pK1yDw=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/system-tests/tests/smoke/cre/aptos/aptoswrite/go.mod
+++ b/system-tests/tests/smoke/cre/aptos/aptoswrite/go.mod
@@ -4,8 +4,8 @@ go 1.25.5
 
 require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260325181729-0cac87f98cd4
-	github.com/smartcontractkit/cre-sdk-go v1.4.1-0.20260312154349-ecb4cb615f37
-	github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260312154349-ecb4cb615f37
+	github.com/smartcontractkit/cre-sdk-go v1.5.0
+	github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260401193157-417adf0c4123
 	github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron v0.10.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/system-tests/tests/smoke/cre/aptos/aptoswrite/go.sum
+++ b/system-tests/tests/smoke/cre/aptos/aptoswrite/go.sum
@@ -10,10 +10,10 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260325181729-0cac87f98cd4 h1:kqdSsgt2OzJnAk0io8GsA2lJE5hKlLM2EY4uy+R6H9Y=
 github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260325181729-0cac87f98cd4/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
-github.com/smartcontractkit/cre-sdk-go v1.4.1-0.20260312154349-ecb4cb615f37 h1:+awsWWPj1CWtvcDwU8QAkUvljo/YYpnKGDrZc2afYls=
-github.com/smartcontractkit/cre-sdk-go v1.4.1-0.20260312154349-ecb4cb615f37/go.mod h1:yYrQFz1UH7hhRbPO0q4fgo1tfsJNd4yXnI3oCZE0RzM=
-github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260312154349-ecb4cb615f37 h1:UNem52lhklNEp4VdPBYHN+p1wgG0vDYEKSvonQgV+3o=
-github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260312154349-ecb4cb615f37/go.mod h1:Ht8wSAAJRJgaZig5kwE5ogRJFngEmfQqBO0e+0y0Zng=
+github.com/smartcontractkit/cre-sdk-go v1.5.0 h1:kepW3QDKARrOOHjXwWAZ9j5KLk6bxLzvi6OMrLsFwVo=
+github.com/smartcontractkit/cre-sdk-go v1.5.0/go.mod h1:yYrQFz1UH7hhRbPO0q4fgo1tfsJNd4yXnI3oCZE0RzM=
+github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260401193157-417adf0c4123 h1:dpp9ewx9Cn8WRNviBSrVGlOesyZVDUKxfm8dZGiz76M=
+github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260401193157-417adf0c4123/go.mod h1:2YPeHbHbDCjO6i1kobLzjl1M/mBfbN5B3BFDEZpoXc0=
 github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron v0.10.0 h1:g7UrVaNKVEmIhVkJTk4f8raCM8Kp/RTFnAT64wqNmTY=
 github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron v0.10.0/go.mod h1:PWyrIw16It4TSyq6mDXqmSR0jF2evZRKuBxu7pK1yDw=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/system-tests/tests/smoke/cre/aptos/aptoswrite/main.go
+++ b/system-tests/tests/smoke/cre/aptos/aptoswrite/main.go
@@ -135,9 +135,9 @@ func onAptosWriteTrigger(cfg config.Config, runtime sdk.Runtime, payload *cron.P
 		"maxGasAmount", cfg.MaxGasAmount,
 		"gasUnitPrice", cfg.GasUnitPrice,
 	)
-	reply, err := client.WriteReport(runtime, &aptos.WriteCreReportRequest{
+	reply, err := client.WriteReport(runtime, &aptos.WriteReportRequest{
 		Receiver: receiver,
-		Report:   report,
+		Report:   reportResp,
 		GasConfig: &aptos.GasConfig{
 			MaxGasAmount: cfg.MaxGasAmount,
 			GasUnitPrice: cfg.GasUnitPrice,
@@ -191,16 +191,34 @@ func onAptosWriteTrigger(cfg config.Config, runtime sdk.Runtime, payload *cron.P
 			return nil, fmt.Errorf("invalid failed tx hash format: %w", err)
 		}
 
-		errorMsg := ""
-		if reply.ErrorMessage != nil {
-			errorMsg = *reply.ErrorMessage
+		if reply.ReceiverContractExecutionStatus == nil {
+			runtime.Logger().Info("Aptos write failed: expected receiver execution status on failed write", "workflow", cfg.WorkflowName)
+			return nil, fmt.Errorf("expected receiver execution status in failed WriteReport reply")
+		}
+		if *reply.ReceiverContractExecutionStatus != aptos.ReceiverContractExecutionStatus_RECEIVER_CONTRACT_EXECUTION_STATUS_REVERTED {
+			runtime.Logger().Info(
+				"Aptos write failed: expected receiver execution revert status",
+				"workflow", cfg.WorkflowName,
+				"receiverExecutionStatus", reply.ReceiverContractExecutionStatus.String(),
+			)
+			return nil, fmt.Errorf("expected receiver execution status REVERTED, got %s", reply.ReceiverContractExecutionStatus.String())
+		}
+		if reply.TransactionFee == nil || *reply.TransactionFee == 0 {
+			runtime.Logger().Info("Aptos write failed: expected failed write transaction fee", "workflow", cfg.WorkflowName)
+			return nil, fmt.Errorf("expected non-zero transaction fee in failed WriteReport reply")
+		}
+		if reply.ErrorMessage == nil || strings.TrimSpace(*reply.ErrorMessage) == "" {
+			runtime.Logger().Info("Aptos write failed: expected failed write error message", "workflow", cfg.WorkflowName)
+			return nil, fmt.Errorf("expected non-empty error message in failed WriteReport reply")
 		}
 		runtime.Logger().Info(
 			fmt.Sprintf("Aptos write failure observed as expected txHash=%s", txHash),
 			"workflow", cfg.WorkflowName,
 			"txStatus", reply.TxStatus.String(),
 			"txHash", txHash,
-			"error", errorMsg,
+			"receiverExecutionStatus", reply.ReceiverContractExecutionStatus.String(),
+			"transactionFee", *reply.TransactionFee,
+			"error", *reply.ErrorMessage,
 		)
 		return nil, nil
 	}
@@ -223,13 +241,36 @@ func onAptosWriteTrigger(cfg config.Config, runtime sdk.Runtime, payload *cron.P
 		return nil, fmt.Errorf("expected non-empty tx hash in successful WriteReport reply")
 	}
 
+	if reply.ReceiverContractExecutionStatus == nil {
+		runtime.Logger().Info("Aptos write failed: expected receiver execution status on successful write", "workflow", cfg.WorkflowName)
+		return nil, fmt.Errorf("expected receiver execution status in successful WriteReport reply")
+	}
+	if *reply.ReceiverContractExecutionStatus != aptos.ReceiverContractExecutionStatus_RECEIVER_CONTRACT_EXECUTION_STATUS_SUCCESS {
+		runtime.Logger().Info(
+			"Aptos write failed: expected successful receiver execution status",
+			"workflow", cfg.WorkflowName,
+			"receiverExecutionStatus", reply.ReceiverContractExecutionStatus.String(),
+		)
+		return nil, fmt.Errorf("expected receiver execution status SUCCESS, got %s", reply.ReceiverContractExecutionStatus.String())
+	}
+	if reply.TransactionFee == nil || *reply.TransactionFee == 0 {
+		runtime.Logger().Info("Aptos write failed: expected transaction fee on successful write", "workflow", cfg.WorkflowName)
+		return nil, fmt.Errorf("expected non-zero transaction fee in successful WriteReport reply")
+	}
+
 	txHash, err := normalizeTxHash(txHashRaw)
 	if err != nil {
 		runtime.Logger().Info("Aptos write failed: invalid tx hash format", "workflow", cfg.WorkflowName, "error", err.Error())
 		return nil, fmt.Errorf("invalid tx hash format: %w", err)
 	}
 
-	runtime.Logger().Info("Aptos write capability succeeded", "workflow", cfg.WorkflowName, "txHash", txHash)
+	runtime.Logger().Info(
+		"Aptos write capability succeeded",
+		"workflow", cfg.WorkflowName,
+		"txHash", txHash,
+		"receiverExecutionStatus", reply.ReceiverContractExecutionStatus.String(),
+		"transactionFee", *reply.TransactionFee,
+	)
 	return nil, nil
 }
 

--- a/system-tests/tests/smoke/cre/aptos/aptoswriteroundtrip/go.mod
+++ b/system-tests/tests/smoke/cre/aptos/aptoswriteroundtrip/go.mod
@@ -4,8 +4,8 @@ go 1.25.5
 
 require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260325181729-0cac87f98cd4
-	github.com/smartcontractkit/cre-sdk-go v1.4.1-0.20260312154349-ecb4cb615f37
-	github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260312154349-ecb4cb615f37
+	github.com/smartcontractkit/cre-sdk-go v1.5.0
+	github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260401193157-417adf0c4123
 	github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron v0.10.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/system-tests/tests/smoke/cre/aptos/aptoswriteroundtrip/go.sum
+++ b/system-tests/tests/smoke/cre/aptos/aptoswriteroundtrip/go.sum
@@ -10,10 +10,10 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260325181729-0cac87f98cd4 h1:kqdSsgt2OzJnAk0io8GsA2lJE5hKlLM2EY4uy+R6H9Y=
 github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260325181729-0cac87f98cd4/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
-github.com/smartcontractkit/cre-sdk-go v1.4.1-0.20260312154349-ecb4cb615f37 h1:+awsWWPj1CWtvcDwU8QAkUvljo/YYpnKGDrZc2afYls=
-github.com/smartcontractkit/cre-sdk-go v1.4.1-0.20260312154349-ecb4cb615f37/go.mod h1:yYrQFz1UH7hhRbPO0q4fgo1tfsJNd4yXnI3oCZE0RzM=
-github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260312154349-ecb4cb615f37 h1:UNem52lhklNEp4VdPBYHN+p1wgG0vDYEKSvonQgV+3o=
-github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260312154349-ecb4cb615f37/go.mod h1:Ht8wSAAJRJgaZig5kwE5ogRJFngEmfQqBO0e+0y0Zng=
+github.com/smartcontractkit/cre-sdk-go v1.5.0 h1:kepW3QDKARrOOHjXwWAZ9j5KLk6bxLzvi6OMrLsFwVo=
+github.com/smartcontractkit/cre-sdk-go v1.5.0/go.mod h1:yYrQFz1UH7hhRbPO0q4fgo1tfsJNd4yXnI3oCZE0RzM=
+github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260401193157-417adf0c4123 h1:dpp9ewx9Cn8WRNviBSrVGlOesyZVDUKxfm8dZGiz76M=
+github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/aptos v0.0.0-20260401193157-417adf0c4123/go.mod h1:2YPeHbHbDCjO6i1kobLzjl1M/mBfbN5B3BFDEZpoXc0=
 github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron v0.10.0 h1:g7UrVaNKVEmIhVkJTk4f8raCM8Kp/RTFnAT64wqNmTY=
 github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron v0.10.0/go.mod h1:PWyrIw16It4TSyq6mDXqmSR0jF2evZRKuBxu7pK1yDw=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/system-tests/tests/smoke/cre/aptos/aptoswriteroundtrip/main.go
+++ b/system-tests/tests/smoke/cre/aptos/aptoswriteroundtrip/main.go
@@ -89,9 +89,9 @@ func onAptosWriteReadRoundtripTrigger(cfg config.Config, runtime sdk.Runtime, pa
 	}
 
 	client := aptos.Client{ChainSelector: cfg.ChainSelector}
-	reply, err := client.WriteReport(runtime, &aptos.WriteCreReportRequest{
+	reply, err := client.WriteReport(runtime, &aptos.WriteReportRequest{
 		Receiver: receiverBytes,
-		Report:   report,
+		Report:   reportResp,
 		GasConfig: &aptos.GasConfig{
 			MaxGasAmount: cfg.MaxGasAmount,
 			GasUnitPrice: cfg.GasUnitPrice,
@@ -105,6 +105,18 @@ func onAptosWriteReadRoundtripTrigger(cfg config.Config, runtime sdk.Runtime, pa
 	}
 	if reply.TxStatus != aptos.TxStatus_TX_STATUS_SUCCESS {
 		return nil, fmt.Errorf("unexpected tx status: %s", reply.TxStatus.String())
+	}
+	if strings.TrimSpace(reply.GetTxHash()) == "" {
+		return nil, fmt.Errorf("empty tx hash in successful WriteReport reply")
+	}
+	if reply.ReceiverContractExecutionStatus == nil {
+		return nil, fmt.Errorf("missing receiver execution status in successful WriteReport reply")
+	}
+	if *reply.ReceiverContractExecutionStatus != aptos.ReceiverContractExecutionStatus_RECEIVER_CONTRACT_EXECUTION_STATUS_SUCCESS {
+		return nil, fmt.Errorf("unexpected receiver execution status: %s", reply.ReceiverContractExecutionStatus.String())
+	}
+	if reply.TransactionFee == nil || *reply.TransactionFee == 0 {
+		return nil, fmt.Errorf("missing transaction fee in successful WriteReport reply")
 	}
 
 	viewReply, err := client.View(runtime, &aptos.ViewRequest{
@@ -137,6 +149,8 @@ func onAptosWriteReadRoundtripTrigger(cfg config.Config, runtime sdk.Runtime, pa
 	runtime.Logger().Info(
 		"Aptos write/read consensus succeeded",
 		"workflow", cfg.WorkflowName,
+		"txHash", reply.GetTxHash(),
+		"transactionFee", *reply.TransactionFee,
 		"benchmark", benchmark,
 		"feedID", normalizeHex(cfg.FeedIDHex),
 	)


### PR DESCRIPTION
## Summary
Consumes the richer Aptos write reply contract downstream and tightens the Aptos smoke assertions around it.

## Depends On
- smartcontractkit/capabilities#519
- smartcontractkit/cre-sdk-go#126

## What Changed
- bump the Aptos capability pin in `plugins.private.yaml` to the upstream write-reply-semantics commit
- keep the newer `chainlink-aptos` relayer/TXM pin in `plugins.public.yaml`
- bump the Aptos workflow modules to the compatible `cre-sdk-go` Aptos SDK commit
- strengthen Aptos smoke assertions so write success and expected failure validate:
  - `receiver_contract_execution_status`
  - `transaction_fee`
  - `error_message` where the capability now guarantees it

## Validation
- `cd system-tests/tests/smoke/cre/aptos/aptoswrite && GOOS=wasip1 GOARCH=wasm GOWORK=off go build .`
- `cd system-tests/tests/smoke/cre/aptos/aptoswriteroundtrip && GOOS=wasip1 GOARCH=wasm GOWORK=off go build .`
- fresh local Aptos CRE env start on the bumped plugin stack
- `cd system-tests/tests && CRE_TEST_PARALLEL_ENABLED=false CRE_TEST_CHIP_SINK_FANOUT_ENABLED=false GOWORK=off go test -mod=mod ./smoke/cre -run '^Test_CRE_V2_Aptos_Suite$' -count=1 -v`

## Result
Validated locally:
- `Aptos_Write_Read_Roundtrip`
- `Aptos_Write_Expected_Failure`
