### PR TITLE
vault: Wire vault plugin through KVStoreWrapper

### DIFF
--- a/core/services/ocr2/plugins/vault/kvstore_wrapper.go
+++ b/core/services/ocr2/plugins/vault/kvstore_wrapper.go
@@ -23,6 +23,15 @@ type KVStoreWrapper struct {
 	migrationEnabled bool
 }
 
+// requestScopedKVStore binds a wrapper to the orgID/workflowOwner for a single
+// top-level plugin request while preserving the existing ReadKVStore /
+// WriteKVStore interfaces used throughout plugin.go.
+type requestScopedKVStore struct {
+	wrapper       *KVStoreWrapper
+	orgID         string
+	workflowOwner string
+}
+
 // NewKVStoreWrapper creates a wrapper around the given store.
 // When migrationEnabled is true, an internal ownerMigrationAdapter handles
 // the transition from workflow_owner-keyed entries to org_id-keyed entries.
@@ -36,6 +45,18 @@ func NewKVStoreWrapper(store WriteKVStore, migrationEnabled bool, lggr logger.Lo
 		w.adapter = newOwnerMigrationAdapter(store, lggr)
 	}
 	return w
+}
+
+// WithRequest returns a store view bound to the top-level request's orgID and
+// workflowOwner. When migration is enabled, owner-scoped operations are routed
+// through the migration adapter using the bound orgID/workflowOwner while
+// preserving the plugin's existing store interface usage.
+func (w *KVStoreWrapper) WithRequest(orgID, workflowOwner string) WriteKVStore {
+	return &requestScopedKVStore{
+		wrapper:       w,
+		orgID:         orgID,
+		workflowOwner: workflowOwner,
+	}
 }
 
 // GetSecret tries orgID first, falling back to workflowOwner for legacy entries.
@@ -110,6 +131,57 @@ func (w *KVStoreWrapper) GetPendingQueue(ctx context.Context) ([]*vault.StoredPe
 // WritePendingQueue is always a pass-through (pending queue is not owner-scoped).
 func (w *KVStoreWrapper) WritePendingQueue(ctx context.Context, pending []*vault.StoredPendingQueueItem) error {
 	return w.store.WritePendingQueue(ctx, pending)
+}
+
+func (s *requestScopedKVStore) effectiveOwner(owner string) string {
+	if s.wrapper.migrationEnabled && s.orgID != "" {
+		return s.orgID
+	}
+	return owner
+}
+
+func (s *requestScopedKVStore) GetSecret(ctx context.Context, id *vault.SecretIdentifier) (*vault.StoredSecret, error) {
+	orgID := ""
+	if id != nil {
+		orgID = s.effectiveOwner(id.Owner)
+	}
+	return s.wrapper.GetSecret(ctx, id, orgID, s.workflowOwner)
+}
+
+func (s *requestScopedKVStore) GetMetadata(ctx context.Context, owner string) (*vault.StoredMetadata, error) {
+	return s.wrapper.GetMetadata(ctx, s.effectiveOwner(owner), s.workflowOwner)
+}
+
+func (s *requestScopedKVStore) GetSecretIdentifiersCountForOwner(ctx context.Context, owner string) (int, error) {
+	return s.wrapper.GetSecretIdentifiersCountForOwner(ctx, s.effectiveOwner(owner), s.workflowOwner)
+}
+
+func (s *requestScopedKVStore) WriteSecret(ctx context.Context, id *vault.SecretIdentifier, secret *vault.StoredSecret) error {
+	orgID := ""
+	if id != nil {
+		orgID = s.effectiveOwner(id.Owner)
+	}
+	return s.wrapper.WriteSecret(ctx, id, secret, orgID, s.workflowOwner)
+}
+
+func (s *requestScopedKVStore) WriteMetadata(ctx context.Context, owner string, metadata *vault.StoredMetadata) error {
+	return s.wrapper.WriteMetadata(ctx, s.effectiveOwner(owner), metadata)
+}
+
+func (s *requestScopedKVStore) DeleteSecret(ctx context.Context, id *vault.SecretIdentifier) error {
+	orgID := ""
+	if id != nil {
+		orgID = s.effectiveOwner(id.Owner)
+	}
+	return s.wrapper.DeleteSecret(ctx, id, orgID, s.workflowOwner)
+}
+
+func (s *requestScopedKVStore) GetPendingQueue(ctx context.Context) ([]*vault.StoredPendingQueueItem, error) {
+	return s.wrapper.GetPendingQueue(ctx)
+}
+
+func (s *requestScopedKVStore) WritePendingQueue(ctx context.Context, pending []*vault.StoredPendingQueueItem) error {
+	return s.wrapper.WritePendingQueue(ctx, pending)
 }
 
 // ownerMigrationAdapter handles the migration of secrets from workflow_owner-keyed

--- a/core/services/ocr2/plugins/vault/kvstore_wrapper_test.go
+++ b/core/services/ocr2/plugins/vault/kvstore_wrapper_test.go
@@ -34,7 +34,7 @@ func writeTestSecret(ctx context.Context, t *testing.T, store WriteKVStore, owne
 // --- GetSecret tests ---
 
 func TestKVStoreWrapper_GetSecret_FoundUnderOrgID(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "secret1", []byte("org-data"))
 
@@ -48,7 +48,7 @@ func TestKVStoreWrapper_GetSecret_FoundUnderOrgID(t *testing.T) {
 }
 
 func TestKVStoreWrapper_GetSecret_FallbackToWorkflowOwner(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "secret1", []byte("legacy-data"))
 
@@ -62,7 +62,7 @@ func TestKVStoreWrapper_GetSecret_FallbackToWorkflowOwner(t *testing.T) {
 }
 
 func TestKVStoreWrapper_GetSecret_NotFoundUnderEither(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 
 	store := NewKVStoreWrapper(inner, true, logger.TestLogger(t))
@@ -74,7 +74,7 @@ func TestKVStoreWrapper_GetSecret_NotFoundUnderEither(t *testing.T) {
 }
 
 func TestKVStoreWrapper_GetSecret_PrefersOrgIDOverWorkflowOwner(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "secret1", []byte("org-data"))
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "secret1", []byte("legacy-data"))
@@ -89,7 +89,7 @@ func TestKVStoreWrapper_GetSecret_PrefersOrgIDOverWorkflowOwner(t *testing.T) {
 }
 
 func TestKVStoreWrapper_GetSecret_NoFallbackWhenWorkflowOwnerEmpty(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "secret1", []byte("legacy-data"))
 
@@ -102,7 +102,7 @@ func TestKVStoreWrapper_GetSecret_NoFallbackWhenWorkflowOwnerEmpty(t *testing.T)
 }
 
 func TestKVStoreWrapper_GetSecret_NoFallbackWhenSameOwner(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 
 	store := NewKVStoreWrapper(inner, true, logger.TestLogger(t))
@@ -114,7 +114,7 @@ func TestKVStoreWrapper_GetSecret_NoFallbackWhenSameOwner(t *testing.T) {
 }
 
 func TestKVStoreWrapper_GetSecret_NilID(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	store := NewKVStoreWrapper(inner, true, logger.TestLogger(t))
 
@@ -123,7 +123,7 @@ func TestKVStoreWrapper_GetSecret_NilID(t *testing.T) {
 }
 
 func TestKVStoreWrapper_GetSecret_DifferentOwnersPerCall(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, "org_A", "main", "s1", []byte("data-A"))
 	writeTestSecret(ctx, t, inner, "wo_B", "main", "s2", []byte("data-B"))
@@ -146,7 +146,7 @@ func TestKVStoreWrapper_GetSecret_DifferentOwnersPerCall(t *testing.T) {
 // --- GetMetadata tests ---
 
 func TestKVStoreWrapper_GetMetadata_OnlyOrgID(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "secret1", []byte("data"))
 
@@ -160,7 +160,7 @@ func TestKVStoreWrapper_GetMetadata_OnlyOrgID(t *testing.T) {
 }
 
 func TestKVStoreWrapper_GetMetadata_OnlyWorkflowOwner(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "legacy1", []byte("data"))
 
@@ -174,7 +174,7 @@ func TestKVStoreWrapper_GetMetadata_OnlyWorkflowOwner(t *testing.T) {
 }
 
 func TestKVStoreWrapper_GetMetadata_MergeAndDedup(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "shared_key", []byte("org-data"))
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "org_only", []byte("data1"))
@@ -201,7 +201,7 @@ func TestKVStoreWrapper_GetMetadata_MergeAndDedup(t *testing.T) {
 }
 
 func TestKVStoreWrapper_GetMetadata_BothEmpty(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	store := NewKVStoreWrapper(inner, true, logger.TestLogger(t))
 
@@ -211,7 +211,7 @@ func TestKVStoreWrapper_GetMetadata_BothEmpty(t *testing.T) {
 }
 
 func TestKVStoreWrapper_GetMetadata_NoMergeWhenSameOwner(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "secret1", []byte("data"))
 
@@ -223,7 +223,7 @@ func TestKVStoreWrapper_GetMetadata_NoMergeWhenSameOwner(t *testing.T) {
 }
 
 func TestKVStoreWrapper_GetMetadata_CrossNamespaceDedup(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "ns1", "secret1", []byte("data-ns1"))
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "ns2", "secret1", []byte("data-ns2"))
@@ -238,7 +238,7 @@ func TestKVStoreWrapper_GetMetadata_CrossNamespaceDedup(t *testing.T) {
 // --- GetSecretIdentifiersCountForOwner tests ---
 
 func TestKVStoreWrapper_GetSecretIdentifiersCountForOwner_Merged(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "s1", []byte("data"))
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "s2", []byte("data"))
@@ -250,7 +250,7 @@ func TestKVStoreWrapper_GetSecretIdentifiersCountForOwner_Merged(t *testing.T) {
 }
 
 func TestKVStoreWrapper_GetSecretIdentifiersCountForOwner_Deduped(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "shared", []byte("data"))
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "shared", []byte("data"))
@@ -262,7 +262,7 @@ func TestKVStoreWrapper_GetSecretIdentifiersCountForOwner_Deduped(t *testing.T) 
 }
 
 func TestKVStoreWrapper_GetSecretIdentifiersCountForOwner_Empty(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	store := NewKVStoreWrapper(inner, true, logger.TestLogger(t))
 
@@ -274,7 +274,7 @@ func TestKVStoreWrapper_GetSecretIdentifiersCountForOwner_Empty(t *testing.T) {
 // --- GetPendingQueue / WritePendingQueue pass-through tests ---
 
 func TestKVStoreWrapper_GetPendingQueue_Passthrough(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 
 	empty, err := anypb.New(&emptypb.Empty{})
@@ -294,7 +294,7 @@ func TestKVStoreWrapper_GetPendingQueue_Passthrough(t *testing.T) {
 }
 
 func TestKVStoreWrapper_WritePendingQueue_Passthrough(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	store := NewKVStoreWrapper(inner, true, logger.TestLogger(t))
 
@@ -314,7 +314,7 @@ func TestKVStoreWrapper_WritePendingQueue_Passthrough(t *testing.T) {
 // --- WriteSecret tests ---
 
 func TestKVStoreWrapper_WriteSecret_WritesUnderOrgID(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	store := NewKVStoreWrapper(inner, true, logger.TestLogger(t))
 
@@ -334,7 +334,7 @@ func TestKVStoreWrapper_WriteSecret_WritesUnderOrgID(t *testing.T) {
 }
 
 func TestKVStoreWrapper_WriteSecret_LazyMigration(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "legacy_secret", []byte("old-data"))
 
@@ -361,7 +361,7 @@ func TestKVStoreWrapper_WriteSecret_LazyMigration(t *testing.T) {
 }
 
 func TestKVStoreWrapper_WriteSecret_NoMigrationWhenNoLegacy(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	store := NewKVStoreWrapper(inner, true, logger.TestLogger(t))
 
@@ -374,7 +374,7 @@ func TestKVStoreWrapper_WriteSecret_NoMigrationWhenNoLegacy(t *testing.T) {
 }
 
 func TestKVStoreWrapper_WriteSecret_NoMigrationWhenSameOwner(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	store := NewKVStoreWrapper(inner, true, logger.TestLogger(t))
 
@@ -385,7 +385,7 @@ func TestKVStoreWrapper_WriteSecret_NoMigrationWhenSameOwner(t *testing.T) {
 // --- WriteMetadata test ---
 
 func TestKVStoreWrapper_WriteMetadata_WritesUnderOrgID(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	store := NewKVStoreWrapper(inner, true, logger.TestLogger(t))
 
@@ -405,7 +405,7 @@ func TestKVStoreWrapper_WriteMetadata_WritesUnderOrgID(t *testing.T) {
 // --- DeleteSecret tests ---
 
 func TestKVStoreWrapper_DeleteSecret_DeletesFromOrgID(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "to_delete", []byte("data"))
 
@@ -419,7 +419,7 @@ func TestKVStoreWrapper_DeleteSecret_DeletesFromOrgID(t *testing.T) {
 }
 
 func TestKVStoreWrapper_DeleteSecret_FallsBackToWorkflowOwner(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "legacy_del", []byte("data"))
 
@@ -433,7 +433,7 @@ func TestKVStoreWrapper_DeleteSecret_FallsBackToWorkflowOwner(t *testing.T) {
 }
 
 func TestKVStoreWrapper_DeleteSecret_CleansBothOwners(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "both_owners", []byte("org-data"))
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "both_owners", []byte("legacy-data"))
@@ -452,7 +452,7 @@ func TestKVStoreWrapper_DeleteSecret_CleansBothOwners(t *testing.T) {
 }
 
 func TestKVStoreWrapper_DeleteSecret_NotFoundAnywhere(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	store := NewKVStoreWrapper(inner, true, logger.TestLogger(t))
 
@@ -464,7 +464,7 @@ func TestKVStoreWrapper_DeleteSecret_NotFoundAnywhere(t *testing.T) {
 // --- End-to-end migration scenarios ---
 
 func TestKVStoreWrapper_CreateOldFlow_ReadNewFlow(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "migrating_secret", []byte("old-data"))
 
@@ -477,7 +477,7 @@ func TestKVStoreWrapper_CreateOldFlow_ReadNewFlow(t *testing.T) {
 }
 
 func TestKVStoreWrapper_CreateOldFlow_UpdateNewFlow_LazyMigration(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "migrating", []byte("old"))
 
@@ -496,7 +496,7 @@ func TestKVStoreWrapper_CreateOldFlow_UpdateNewFlow_LazyMigration(t *testing.T) 
 }
 
 func TestKVStoreWrapper_CreateOldFlow_ListNewFlow(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "legacy1", []byte("d1"))
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "alt", "legacy2", []byte("d2"))
@@ -512,7 +512,7 @@ func TestKVStoreWrapper_CreateOldFlow_ListNewFlow(t *testing.T) {
 }
 
 func TestKVStoreWrapper_CreateOldFlow_DeleteNewFlow(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "to_delete", []byte("data"))
 
@@ -526,7 +526,7 @@ func TestKVStoreWrapper_CreateOldFlow_DeleteNewFlow(t *testing.T) {
 }
 
 func TestKVStoreWrapper_UpdateMigration_ThenListShowsNoDuplicates(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "s1", []byte("old1"))
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "s2", []byte("old2"))
@@ -662,7 +662,7 @@ func TestNeedsMigration(t *testing.T) {
 // --- Error propagation tests ---
 
 func TestKVStoreWrapper_GetSecret_PropagatesInnerError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	inner := &kv{m: map[string]response{}}
 	inner.m["Metadata::"+testOrgID] = response{err: assert.AnError}
 	store := NewKVStoreWrapper(NewWriteStore(inner, newTestMetrics(t)), true, logger.TestLogger(t))
@@ -672,7 +672,7 @@ func TestKVStoreWrapper_GetSecret_PropagatesInnerError(t *testing.T) {
 }
 
 func TestKVStoreWrapper_GetMetadata_PropagatesOrgIDError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	inner := &kv{m: map[string]response{}}
 	inner.m["Metadata::"+testOrgID] = response{err: assert.AnError}
 	store := NewKVStoreWrapper(NewWriteStore(inner, newTestMetrics(t)), true, logger.TestLogger(t))
@@ -682,7 +682,7 @@ func TestKVStoreWrapper_GetMetadata_PropagatesOrgIDError(t *testing.T) {
 }
 
 func TestKVStoreWrapper_GetMetadata_PropagatesWorkflowOwnerError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	inner := &kv{m: map[string]response{}}
 	orgMdBytes, _ := proto.Marshal(&vault.StoredMetadata{SecretIdentifiers: []*vault.SecretIdentifier{}})
 	inner.m["Metadata::"+testOrgID] = response{data: orgMdBytes}
@@ -696,7 +696,7 @@ func TestKVStoreWrapper_GetMetadata_PropagatesWorkflowOwnerError(t *testing.T) {
 // --- Migration disabled (passthrough) tests ---
 
 func TestKVStoreWrapper_Disabled_GetSecret_Passthrough(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "s1", []byte("data"))
 
@@ -710,7 +710,7 @@ func TestKVStoreWrapper_Disabled_GetSecret_Passthrough(t *testing.T) {
 }
 
 func TestKVStoreWrapper_Disabled_GetSecret_NoFallback(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "s1", []byte("legacy"))
 
@@ -723,7 +723,7 @@ func TestKVStoreWrapper_Disabled_GetSecret_NoFallback(t *testing.T) {
 }
 
 func TestKVStoreWrapper_Disabled_GetMetadata_Passthrough(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "s1", []byte("data"))
 
@@ -736,7 +736,7 @@ func TestKVStoreWrapper_Disabled_GetMetadata_Passthrough(t *testing.T) {
 }
 
 func TestKVStoreWrapper_Disabled_GetMetadata_NoMerge(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "org_secret", []byte("data"))
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "legacy_secret", []byte("data"))
@@ -750,7 +750,7 @@ func TestKVStoreWrapper_Disabled_GetMetadata_NoMerge(t *testing.T) {
 }
 
 func TestKVStoreWrapper_Disabled_GetSecretIdentifiersCountForOwner_Passthrough(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "s1", []byte("data"))
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "s2", []byte("data"))
@@ -762,7 +762,7 @@ func TestKVStoreWrapper_Disabled_GetSecretIdentifiersCountForOwner_Passthrough(t
 }
 
 func TestKVStoreWrapper_Disabled_WriteSecret_Passthrough(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	store := NewKVStoreWrapper(inner, false, logger.TestLogger(t))
 
@@ -776,7 +776,7 @@ func TestKVStoreWrapper_Disabled_WriteSecret_Passthrough(t *testing.T) {
 }
 
 func TestKVStoreWrapper_Disabled_WriteSecret_NoLazyMigration(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "s1", []byte("legacy"))
 
@@ -790,7 +790,7 @@ func TestKVStoreWrapper_Disabled_WriteSecret_NoLazyMigration(t *testing.T) {
 }
 
 func TestKVStoreWrapper_Disabled_WriteMetadata_Passthrough(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	store := NewKVStoreWrapper(inner, false, logger.TestLogger(t))
 
@@ -808,7 +808,7 @@ func TestKVStoreWrapper_Disabled_WriteMetadata_Passthrough(t *testing.T) {
 }
 
 func TestKVStoreWrapper_Disabled_DeleteSecret_Passthrough(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "s1", []byte("data"))
 
@@ -822,7 +822,7 @@ func TestKVStoreWrapper_Disabled_DeleteSecret_Passthrough(t *testing.T) {
 }
 
 func TestKVStoreWrapper_Disabled_DeleteSecret_NoDualOwnerCleanup(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	writeTestSecret(ctx, t, inner, testOrgID, "main", "s1", []byte("org-data"))
 	writeTestSecret(ctx, t, inner, testWorkflowOwner, "main", "s1", []byte("legacy-data"))
@@ -837,7 +837,7 @@ func TestKVStoreWrapper_Disabled_DeleteSecret_NoDualOwnerCleanup(t *testing.T) {
 }
 
 func TestKVStoreWrapper_Disabled_GetPendingQueue_Passthrough(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 
 	empty, err := anypb.New(&emptypb.Empty{})
@@ -853,7 +853,7 @@ func TestKVStoreWrapper_Disabled_GetPendingQueue_Passthrough(t *testing.T) {
 }
 
 func TestKVStoreWrapper_Disabled_WritePendingQueue_Passthrough(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, inner := newMigrationTestStore(t)
 	store := NewKVStoreWrapper(inner, false, logger.TestLogger(t))
 

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -386,15 +386,23 @@ func generateRandomNonce() ([]byte, error) {
 	return nonceBytes, nil
 }
 
+func (r *ReportingPlugin) orgIDAsSecretOwnerEnabled(ctx context.Context) bool {
+	return r.cfg.OrgIDAsSecretOwnerEnabled.AllowErr(ctx) == nil
+}
+
+type pendingQueueStore interface {
+	WritePendingQueue(ctx context.Context, pending []*vaultcommon.StoredPendingQueueItem) error
+}
+
 func (r *ReportingPlugin) Observation(ctx context.Context, seqNr uint64, aq types.AttributedQuery, keyValueReader ocr3_1types.KeyValueStateReader, blobBroadcastFetcher ocr3_1types.BlobBroadcastFetcher) (types.Observation, error) {
 	start := time.Now()
 	defer func() {
 		r.lggr.Debugw("observation finished", "seqNr", seqNr, "elapsed", time.Since(start))
 	}()
 
-	readStore := NewReadStore(keyValueReader, r.metrics)
+	wrappedReadStore := NewKVStoreWrapper(NewReadStore(keyValueReader, r.metrics), r.orgIDAsSecretOwnerEnabled(ctx), r.lggr)
 
-	batch, err := readStore.GetPendingQueue(ctx)
+	batch, err := wrappedReadStore.GetPendingQueue(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch batch of requests: %w", err)
 	}
@@ -418,17 +426,17 @@ func (r *ReportingPlugin) Observation(ctx context.Context, seqNr uint64, aq type
 			continue
 		}
 
-		switch payload.(type) {
+		switch tp := payload.(type) {
 		case *vaultcommon.GetSecretsRequest:
-			r.observeGetSecrets(ctx, readStore, payload, o)
+			r.observeGetSecrets(ctx, wrappedReadStore.WithRequest(tp.OrgId, tp.WorkflowOwner), tp, o)
 		case *vaultcommon.CreateSecretsRequest:
-			r.observeCreateSecrets(ctx, readStore, payload, o)
+			r.observeCreateSecrets(ctx, wrappedReadStore.WithRequest(tp.OrgId, tp.WorkflowOwner), tp, o)
 		case *vaultcommon.UpdateSecretsRequest:
-			r.observeUpdateSecrets(ctx, readStore, payload, o)
+			r.observeUpdateSecrets(ctx, wrappedReadStore.WithRequest(tp.OrgId, tp.WorkflowOwner), tp, o)
 		case *vaultcommon.DeleteSecretsRequest:
-			r.observeDeleteSecrets(ctx, readStore, payload, o)
+			r.observeDeleteSecrets(ctx, wrappedReadStore.WithRequest(tp.OrgId, tp.WorkflowOwner), tp, o)
 		case *vaultcommon.ListSecretIdentifiersRequest:
-			r.observeListSecretIdentifiers(ctx, readStore, payload, o)
+			r.observeListSecretIdentifiers(ctx, wrappedReadStore.WithRequest(tp.OrgId, tp.WorkflowOwner), tp, o)
 		default:
 			r.lggr.Errorw("unknown request type, skipping...", "requestType", fmt.Sprintf("%T", payload), "id", req.Id)
 			continue
@@ -466,7 +474,7 @@ func (r *ReportingPlugin) Observation(ctx context.Context, seqNr uint64, aq type
 	// Next, get the current pending queue. We'll use this to dedupe
 	// requests when generating an observation for the next state of the
 	// pending queue.
-	pendingQueue, ierr := readStore.GetPendingQueue(ctx)
+	pendingQueue, ierr := wrappedReadStore.GetPendingQueue(ctx)
 	if ierr != nil {
 		return nil, ierr
 	}
@@ -709,7 +717,7 @@ func (r *ReportingPlugin) observeGetSecretsRequest(ctx context.Context, reader R
 		return nil, newUserError("key does not exist")
 	}
 
-	if r.cfg.OrgIDAsSecretOwnerEnabled.AllowErr(ctx) != nil {
+	if !r.orgIDAsSecretOwnerEnabled(ctx) {
 		orgID = ""
 	}
 	sh, err := generatePlaintextShare(r.cfg.PublicKey, r.cfg.PrivateKeyShare, secret.EncryptedSecret, workflowOwner, orgID)
@@ -809,7 +817,7 @@ func (r *ReportingPlugin) observeCreateSecretRequest(ctx context.Context, reader
 		return id, newUserError(ierr.Error())
 	}
 
-	if r.cfg.OrgIDAsSecretOwnerEnabled.AllowErr(ctx) != nil {
+	if !r.orgIDAsSecretOwnerEnabled(ctx) {
 		orgID = ""
 	}
 	err = vaultcap.EnsureRightLabelOnSecret(r.cfg.PublicKey, secretRequest.EncryptedValue, workflowOwner, orgID)
@@ -1142,8 +1150,8 @@ func (r *ReportingPlugin) ValidateObservation(ctx context.Context, seqNr uint64,
 	//   This is because honest nodes will all be reading from
 	//   the same deterministic key-value store-based queue.
 	// - that all pending queue items can be fetched as blobs.
-	store := NewReadStore(keyValueReader, r.metrics)
-	pendingQueueItems, err := store.GetPendingQueue(ctx)
+	wrappedStore := NewKVStoreWrapper(NewReadStore(keyValueReader, r.metrics), r.orgIDAsSecretOwnerEnabled(ctx), r.lggr)
+	pendingQueueItems, err := wrappedStore.GetPendingQueue(ctx)
 	if err != nil {
 		return fmt.Errorf("could not fetch pending queue from store: %w", err)
 	}
@@ -1494,7 +1502,7 @@ func (r *ReportingPlugin) validateListSecretIdentifiersObservation(ctx context.C
 }
 
 func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq types.AttributedQuery, aos []types.AttributedObservation, keyValueReadWriter ocr3_1types.KeyValueStateReadWriter, blobFetcher ocr3_1types.BlobFetcher) (ocr3_1types.ReportsPlusPrecursor, error) {
-	store := NewWriteStore(keyValueReadWriter, r.metrics)
+	wrappedStore := NewKVStoreWrapper(NewWriteStore(keyValueReadWriter, r.metrics), r.orgIDAsSecretOwnerEnabled(ctx), r.lggr)
 
 	marshalledObs := map[uint8]*vaultcommon.Observations{}
 	for _, ao := range aos {
@@ -1599,16 +1607,20 @@ func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq 
 			r.stateTransitionGetSecrets(ctx, chosen, o)
 			os.Outcomes = append(os.Outcomes, o)
 		case vaultcommon.RequestType_CREATE_SECRETS:
-			r.stateTransitionCreateSecrets(ctx, store, chosen, o)
+			req := first.GetCreateSecretsRequest()
+			r.stateTransitionCreateSecrets(ctx, wrappedStore.WithRequest(req.OrgId, req.WorkflowOwner), chosen, o)
 			os.Outcomes = append(os.Outcomes, o)
 		case vaultcommon.RequestType_UPDATE_SECRETS:
-			r.stateTransitionUpdateSecrets(ctx, store, chosen, o)
+			req := first.GetUpdateSecretsRequest()
+			r.stateTransitionUpdateSecrets(ctx, wrappedStore.WithRequest(req.OrgId, req.WorkflowOwner), chosen, o)
 			os.Outcomes = append(os.Outcomes, o)
 		case vaultcommon.RequestType_DELETE_SECRETS:
-			r.stateTransitionDeleteSecrets(ctx, store, chosen, o)
+			req := first.GetDeleteSecretsRequest()
+			r.stateTransitionDeleteSecrets(ctx, wrappedStore.WithRequest(req.OrgId, req.WorkflowOwner), chosen, o)
 			os.Outcomes = append(os.Outcomes, o)
 		case vaultcommon.RequestType_LIST_SECRET_IDENTIFIERS:
-			r.stateTransitionListSecretIdentifiers(ctx, store, chosen, o)
+			req := first.GetListSecretIdentifiersRequest()
+			r.stateTransitionListSecretIdentifiers(ctx, wrappedStore.WithRequest(req.OrgId, req.WorkflowOwner), chosen, o)
 			os.Outcomes = append(os.Outcomes, o)
 		default:
 			r.lggr.Debugw("unknown request type, skipping...", "requestType", first.RequestType, "id", id)
@@ -1619,7 +1631,7 @@ func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq 
 	// ---
 	// Phase 2: Process the pending queue.
 	// ---
-	err := r.stateTransitionPendingQueue(ctx, store, marshalledObs, blobFetcher)
+	err := r.stateTransitionPendingQueue(ctx, wrappedStore, marshalledObs, blobFetcher)
 	if err != nil {
 		return ocr3_1types.ReportsPlusPrecursor{}, fmt.Errorf("could not process pending queue during state transition: %w", err)
 	}
@@ -1635,7 +1647,7 @@ func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq 
 	return ocr3_1types.ReportsPlusPrecursor(ospb), nil
 }
 
-func (r *ReportingPlugin) stateTransitionPendingQueue(ctx context.Context, store WriteKVStore, obs map[uint8]*vaultcommon.Observations, blobFetcher ocr3_1types.BlobFetcher) error {
+func (r *ReportingPlugin) stateTransitionPendingQueue(ctx context.Context, store pendingQueueStore, obs map[uint8]*vaultcommon.Observations, blobFetcher ocr3_1types.BlobFetcher) error {
 	// Step 1: Create a map of id -> sha -> count.
 	idToShaToCount := map[string]map[string]int{}
 	oidsToIDs := map[uint8][]string{} // for debugging only
@@ -1767,7 +1779,9 @@ func (r *ReportingPlugin) stateTransitionGetSecrets(ctx context.Context, chosen 
 
 	o.Request = &vaultcommon.Outcome_GetSecretsRequest{
 		GetSecretsRequest: &vaultcommon.GetSecretsRequest{
-			Requests: newReqs,
+			Requests:      newReqs,
+			OrgId:         first.GetGetSecretsRequest().OrgId,
+			WorkflowOwner: first.GetGetSecretsRequest().WorkflowOwner,
 		},
 	}
 
@@ -1867,6 +1881,8 @@ func (r *ReportingPlugin) stateTransitionCreateSecrets(ctx context.Context, stor
 		CreateSecretsRequest: &vaultcommon.CreateSecretsRequest{
 			RequestId:        reqID,
 			EncryptedSecrets: newReqs,
+			OrgId:            first.GetCreateSecretsRequest().OrgId,
+			WorkflowOwner:    first.GetCreateSecretsRequest().WorkflowOwner,
 		},
 	}
 
@@ -1985,6 +2001,8 @@ func (r *ReportingPlugin) stateTransitionUpdateSecrets(ctx context.Context, stor
 		UpdateSecretsRequest: &vaultcommon.UpdateSecretsRequest{
 			RequestId:        reqID,
 			EncryptedSecrets: newReqs,
+			OrgId:            first.GetUpdateSecretsRequest().OrgId,
+			WorkflowOwner:    first.GetUpdateSecretsRequest().WorkflowOwner,
 		},
 	}
 
@@ -2085,8 +2103,10 @@ func (r *ReportingPlugin) stateTransitionDeleteSecrets(ctx context.Context, stor
 
 	o.Request = &vaultcommon.Outcome_DeleteSecretsRequest{
 		DeleteSecretsRequest: &vaultcommon.DeleteSecretsRequest{
-			RequestId: reqID,
-			Ids:       newReqs,
+			RequestId:     reqID,
+			Ids:           newReqs,
+			OrgId:         first.GetDeleteSecretsRequest().OrgId,
+			WorkflowOwner: first.GetDeleteSecretsRequest().WorkflowOwner,
 		},
 	}
 

--- a/core/services/ocr2/plugins/vault/plugin_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_test.go
@@ -3627,6 +3627,102 @@ func TestPlugin_StateTransition_CreateSecretsRequest_WritesSecrets(t *testing.T)
 	assert.Equal(t, 1, observed.FilterMessage("sufficient observations for sha").Len())
 }
 
+func TestPlugin_StateTransition_CreateSecretsRequest_UsesWorkflowOwnerMetadataWhenGateEnabled(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	store := requests.NewStore[*vaulttypes.Request]()
+	cfg := makeReportingPluginConfig(
+		t,
+		10,
+		nil,
+		nil,
+		1,
+		1024,
+		100,
+		100,
+		100,
+		10,
+	)
+	cfg.OrgIDAsSecretOwnerEnabled = limits.NewGateLimiter(true)
+	r := &ReportingPlugin{
+		lggr: lggr,
+		onchainCfg: ocr3types.ReportingPluginConfig{
+			N: 4,
+			F: 1,
+		},
+		store:   store,
+		metrics: newTestMetrics(t),
+		cfg:     cfg,
+	}
+
+	const (
+		orgID         = "org-create"
+		workflowOwner = "0x2222222222222222222222222222222222222222"
+	)
+
+	kv := &kv{m: make(map[string]response)}
+	require.NoError(t, newTestWriteStore(t, kv).WriteSecret(t.Context(), &vaultcommon.SecretIdentifier{
+		Owner:     workflowOwner,
+		Namespace: "main",
+		Key:       "legacy",
+	}, &vaultcommon.StoredSecret{EncryptedSecret: []byte("legacy-value")}))
+	rs := newTestReadStore(t, kv)
+
+	id := &vaultcommon.SecretIdentifier{
+		Owner:     orgID,
+		Namespace: "main",
+		Key:       "new-secret",
+	}
+	req := &vaultcommon.CreateSecretsRequest{
+		RequestId: "request-id",
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{
+				Id:             id,
+				EncryptedValue: hex.EncodeToString([]byte("encrypted-value")),
+			},
+		},
+		OrgId:         orgID,
+		WorkflowOwner: workflowOwner,
+	}
+	resp := &vaultcommon.CreateSecretsResponse{
+		Responses: []*vaultcommon.CreateSecretResponse{
+			{
+				Id:      id,
+				Success: false,
+				Error:   "",
+			},
+		},
+	}
+
+	obsb := marshalObservations(t, observation{id, req, resp})
+	reportPrecursor, err := r.StateTransition(
+		t.Context(),
+		1,
+		types.AttributedQuery{},
+		[]types.AttributedObservation{
+			{Observer: 0, Observation: types.Observation(obsb)},
+			{Observer: 1, Observation: types.Observation(obsb)},
+			{Observer: 2, Observation: types.Observation(obsb)},
+		},
+		kv,
+		nil,
+	)
+	require.NoError(t, err)
+
+	os := &vaultcommon.Outcomes{}
+	require.NoError(t, proto.Unmarshal(reportPrecursor, os))
+	require.Len(t, os.Outcomes, 1)
+
+	o := os.Outcomes[0]
+	assert.True(t, proto.Equal(req, o.GetCreateSecretsRequest()), o.GetCreateSecretsRequest())
+	require.Len(t, o.GetCreateSecretsResponse().Responses, 1)
+	assert.False(t, o.GetCreateSecretsResponse().Responses[0].Success)
+	assert.Contains(t, o.GetCreateSecretsResponse().Responses[0].Error, "has reached maximum number of secrets")
+
+	ss, err := rs.GetSecret(t.Context(), id)
+	require.NoError(t, err)
+	assert.Nil(t, ss)
+}
+
 func TestPlugin_Reports(t *testing.T) {
 	value := "encrypted-value"
 	id := &vaultcommon.SecretIdentifier{
@@ -4385,6 +4481,109 @@ func TestPlugin_StateTransition_UpdateSecretsRequest_WritesSecrets(t *testing.T)
 	assert.Equal(t, 1, observed.FilterMessage("sufficient observations for sha").Len())
 }
 
+func TestPlugin_StateTransition_UpdateSecretsRequest_MigratesWorkflowOwnerSecretWhenGateEnabled(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	store := requests.NewStore[*vaulttypes.Request]()
+	cfg := makeReportingPluginConfig(
+		t,
+		10,
+		nil,
+		nil,
+		5,
+		1024,
+		100,
+		100,
+		100,
+		10,
+	)
+	cfg.OrgIDAsSecretOwnerEnabled = limits.NewGateLimiter(true)
+	r := &ReportingPlugin{
+		lggr: lggr,
+		onchainCfg: ocr3types.ReportingPluginConfig{
+			N: 4,
+			F: 1,
+		},
+		store:   store,
+		metrics: newTestMetrics(t),
+		cfg:     cfg,
+	}
+
+	const (
+		orgID         = "org-update"
+		workflowOwner = "0x3333333333333333333333333333333333333333"
+	)
+
+	kv := &kv{m: make(map[string]response)}
+	legacyID := &vaultcommon.SecretIdentifier{
+		Owner:     workflowOwner,
+		Namespace: "main",
+		Key:       "secret",
+	}
+	require.NoError(t, newTestWriteStore(t, kv).WriteSecret(t.Context(), legacyID, &vaultcommon.StoredSecret{
+		EncryptedSecret: []byte("old-encrypted-value"),
+	}))
+	rs := newTestReadStore(t, kv)
+
+	id := &vaultcommon.SecretIdentifier{
+		Owner:     orgID,
+		Namespace: "main",
+		Key:       "secret",
+	}
+	req := &vaultcommon.UpdateSecretsRequest{
+		RequestId: "request-id",
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{
+				Id:             id,
+				EncryptedValue: hex.EncodeToString([]byte("encrypted-value")),
+			},
+		},
+		OrgId:         orgID,
+		WorkflowOwner: workflowOwner,
+	}
+	resp := &vaultcommon.UpdateSecretsResponse{
+		Responses: []*vaultcommon.UpdateSecretResponse{
+			{
+				Id:      id,
+				Success: false,
+				Error:   "",
+			},
+		},
+	}
+
+	obsb := marshalObservations(t, observation{id, req, resp})
+	reportPrecursor, err := r.StateTransition(
+		t.Context(),
+		1,
+		types.AttributedQuery{},
+		[]types.AttributedObservation{
+			{Observer: 0, Observation: types.Observation(obsb)},
+			{Observer: 1, Observation: types.Observation(obsb)},
+			{Observer: 2, Observation: types.Observation(obsb)},
+		},
+		kv,
+		nil,
+	)
+	require.NoError(t, err)
+
+	os := &vaultcommon.Outcomes{}
+	require.NoError(t, proto.Unmarshal(reportPrecursor, os))
+	require.Len(t, os.Outcomes, 1)
+
+	o := os.Outcomes[0]
+	assert.True(t, proto.Equal(req, o.GetUpdateSecretsRequest()), o.GetUpdateSecretsRequest())
+	require.Len(t, o.GetUpdateSecretsResponse().Responses, 1)
+	assert.True(t, o.GetUpdateSecretsResponse().Responses[0].Success)
+
+	ss, err := rs.GetSecret(t.Context(), id)
+	require.NoError(t, err)
+	require.NotNil(t, ss)
+	assert.Equal(t, []byte("encrypted-value"), ss.EncryptedSecret)
+
+	legacySecret, err := rs.GetSecret(t.Context(), legacyID)
+	require.NoError(t, err)
+	assert.Nil(t, legacySecret)
+}
+
 func TestPlugin_Reports_UpdateSecretsRequest(t *testing.T) {
 	value := "encrypted-value"
 	id := &vaultcommon.SecretIdentifier{
@@ -4808,6 +5007,99 @@ func TestPlugin_StateTransition_DeleteSecretsRequest(t *testing.T) {
 	require.Nil(t, ss)
 
 	assert.Equal(t, 1, observed.FilterMessage("sufficient observations for sha").Len())
+}
+
+func TestPlugin_StateTransition_DeleteSecretsRequest_DeletesWorkflowOwnerSecretWhenGateEnabled(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	store := requests.NewStore[*vaulttypes.Request]()
+	cfg := makeReportingPluginConfig(
+		t,
+		10,
+		nil,
+		nil,
+		5,
+		1024,
+		100,
+		100,
+		100,
+		10,
+	)
+	cfg.OrgIDAsSecretOwnerEnabled = limits.NewGateLimiter(true)
+	r := &ReportingPlugin{
+		lggr: lggr,
+		onchainCfg: ocr3types.ReportingPluginConfig{
+			N: 4,
+			F: 1,
+		},
+		store:   store,
+		metrics: newTestMetrics(t),
+		cfg:     cfg,
+	}
+
+	const (
+		orgID         = "org-delete"
+		workflowOwner = "0x4444444444444444444444444444444444444444"
+	)
+
+	kv := &kv{m: make(map[string]response)}
+	legacyID := &vaultcommon.SecretIdentifier{
+		Owner:     workflowOwner,
+		Namespace: "main",
+		Key:       "item4",
+	}
+	require.NoError(t, newTestWriteStore(t, kv).WriteSecret(t.Context(), legacyID, &vaultcommon.StoredSecret{
+		EncryptedSecret: []byte("encrypted-value"),
+	}))
+	rs := newTestReadStore(t, kv)
+
+	id := &vaultcommon.SecretIdentifier{
+		Owner:     orgID,
+		Namespace: "main",
+		Key:       "item4",
+	}
+	req := &vaultcommon.DeleteSecretsRequest{
+		RequestId:     "request-id",
+		Ids:           []*vaultcommon.SecretIdentifier{id},
+		OrgId:         orgID,
+		WorkflowOwner: workflowOwner,
+	}
+	resp := &vaultcommon.DeleteSecretsResponse{
+		Responses: []*vaultcommon.DeleteSecretResponse{
+			{
+				Id:      id,
+				Success: false,
+				Error:   "",
+			},
+		},
+	}
+
+	obsb := marshalObservations(t, observation{id, req, resp})
+	reportPrecursor, err := r.StateTransition(
+		t.Context(),
+		1,
+		types.AttributedQuery{},
+		[]types.AttributedObservation{
+			{Observer: 0, Observation: types.Observation(obsb)},
+			{Observer: 1, Observation: types.Observation(obsb)},
+			{Observer: 2, Observation: types.Observation(obsb)},
+		},
+		kv,
+		nil,
+	)
+	require.NoError(t, err)
+
+	os := &vaultcommon.Outcomes{}
+	require.NoError(t, proto.Unmarshal(reportPrecursor, os))
+	require.Len(t, os.Outcomes, 1)
+
+	o := os.Outcomes[0]
+	assert.True(t, proto.Equal(req, o.GetDeleteSecretsRequest()), o.GetDeleteSecretsRequest())
+	require.Len(t, o.GetDeleteSecretsResponse().Responses, 1)
+	assert.True(t, o.GetDeleteSecretsResponse().Responses[0].Success)
+
+	ss, err := rs.GetSecret(t.Context(), legacyID)
+	require.NoError(t, err)
+	assert.Nil(t, ss)
 }
 
 func TestPlugin_StateTransition_DeleteSecretsRequest_SecretDoesNotExist(t *testing.T) {
@@ -5255,6 +5547,132 @@ func TestPlugin_Observation_ListSecretIdentifiers_FilterByNamespace(t *testing.T
 	assert.Len(t, resp.Identifiers, 2)
 	assert.True(t, resp.Success)
 	assert.Empty(t, resp.GetError())
+}
+
+func TestPlugin_Observation_ListSecretIdentifiers_FallsBackToWorkflowOwnerWhenGateEnabled(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	store := requests.NewStore[*vaulttypes.Request]()
+	cfg := makeReportingPluginConfig(
+		t,
+		10,
+		nil,
+		nil,
+		5,
+		1024,
+		30,
+		30,
+		30,
+		10,
+	)
+	cfg.OrgIDAsSecretOwnerEnabled = limits.NewGateLimiter(true)
+	r := &ReportingPlugin{
+		lggr:          lggr,
+		store:         store,
+		metrics:       newTestMetrics(t),
+		marshalBlob:   mockMarshalBlob,
+		unmarshalBlob: mockUnmarshalBlob,
+		cfg:           cfg,
+	}
+
+	const (
+		orgID         = "org-list"
+		workflowOwner = "0x1111111111111111111111111111111111111111"
+	)
+
+	rdr := &kv{m: make(map[string]response)}
+	require.NoError(t, newTestWriteStore(t, rdr).WriteSecret(t.Context(), &vaultcommon.SecretIdentifier{
+		Owner:     workflowOwner,
+		Namespace: "main",
+		Key:       "legacy-item",
+	}, &vaultcommon.StoredSecret{EncryptedSecret: []byte("legacy-data")}))
+
+	p := &vaultcommon.ListSecretIdentifiersRequest{
+		RequestId:     "request-id",
+		Owner:         orgID,
+		OrgId:         orgID,
+		WorkflowOwner: workflowOwner,
+	}
+	anyp, err := anypb.New(p)
+	require.NoError(t, err)
+	require.NoError(t, newTestWriteStore(t, rdr).WritePendingQueue(t.Context(),
+		[]*vaultcommon.StoredPendingQueueItem{
+			{Id: "request-1", Item: anyp},
+		},
+	))
+
+	data, err := r.Observation(t.Context(), 1, types.AttributedQuery{}, rdr, &blobber{})
+	require.NoError(t, err)
+
+	obs := &vaultcommon.Observations{}
+	require.NoError(t, proto.Unmarshal(data, obs))
+	require.Len(t, obs.Observations, 1)
+
+	resp := obs.Observations[0].GetListSecretIdentifiersResponse()
+	require.True(t, resp.Success, resp.GetError())
+	require.Len(t, resp.Identifiers, 1)
+	assert.Equal(t, orgID, resp.Identifiers[0].Owner)
+	assert.Equal(t, "legacy-item", resp.Identifiers[0].Key)
+}
+
+func TestPlugin_Observation_ListSecretIdentifiers_DoesNotFallbackWhenGateDisabled(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	store := requests.NewStore[*vaulttypes.Request]()
+	r := &ReportingPlugin{
+		lggr:          lggr,
+		store:         store,
+		metrics:       newTestMetrics(t),
+		marshalBlob:   mockMarshalBlob,
+		unmarshalBlob: mockUnmarshalBlob,
+		cfg: makeReportingPluginConfig(
+			t,
+			10,
+			nil,
+			nil,
+			5,
+			1024,
+			30,
+			30,
+			30,
+			10,
+		),
+	}
+
+	const (
+		orgID         = "org-list"
+		workflowOwner = "0x1111111111111111111111111111111111111111"
+	)
+
+	rdr := &kv{m: make(map[string]response)}
+	require.NoError(t, newTestWriteStore(t, rdr).WriteSecret(t.Context(), &vaultcommon.SecretIdentifier{
+		Owner:     workflowOwner,
+		Namespace: "main",
+		Key:       "legacy-item",
+	}, &vaultcommon.StoredSecret{EncryptedSecret: []byte("legacy-data")}))
+
+	p := &vaultcommon.ListSecretIdentifiersRequest{
+		RequestId:     "request-id",
+		Owner:         orgID,
+		OrgId:         orgID,
+		WorkflowOwner: workflowOwner,
+	}
+	anyp, err := anypb.New(p)
+	require.NoError(t, err)
+	require.NoError(t, newTestWriteStore(t, rdr).WritePendingQueue(t.Context(),
+		[]*vaultcommon.StoredPendingQueueItem{
+			{Id: "request-1", Item: anyp},
+		},
+	))
+
+	data, err := r.Observation(t.Context(), 1, types.AttributedQuery{}, rdr, &blobber{})
+	require.NoError(t, err)
+
+	obs := &vaultcommon.Observations{}
+	require.NoError(t, proto.Unmarshal(data, obs))
+	require.Len(t, obs.Observations, 1)
+
+	resp := obs.Observations[0].GetListSecretIdentifiersResponse()
+	require.True(t, resp.Success, resp.GetError())
+	assert.Empty(t, resp.Identifiers)
 }
 
 func TestPlugin_Reports_ListSecretIdentifiersRequest(t *testing.T) {


### PR DESCRIPTION
## Summary
- wire vault plugin request handling through `KVStoreWrapper` via a request-scoped store so secret operations use `org_id`/`workflowOwner` migration behavior with minimal plugin churn
- keep pending-queue-only paths on the wrapper directly and preserve `org_id` / `workflow_owner` on aggregated outcomes
- add plugin tests covering gated workflow-owner fallback, migration on update/delete, and per-owner limit accounting during create

