### PR TITLE
do not run broken CCIP tests that always timeout on push trigger

### DIFF
--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -157,7 +157,6 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -207,7 +206,6 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -257,7 +255,6 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -282,7 +279,6 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -358,7 +354,6 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -383,7 +378,6 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -408,7 +402,6 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
       - Workflow Dispatch E2E CCIP Tests
     test_cmd: |
       cd smoke/ccip && \


### PR DESCRIPTION
This PR disables CCIP tests that [fail on each single run](https://github.com/smartcontractkit/chainlink/actions/workflows/integration-tests.yml?query=branch%3Adevelop):
<img width="304" height="783" alt="image" src="https://github.com/user-attachments/assets/49849dd6-7241-4c42-b5fb-7036d79fe892" />