### PR TITLE
fix/inefficient-counter

### DIFF
--- a/deployment/ccip/shared/deployergroup/deployer_group.go
+++ b/deployment/ccip/shared/deployergroup/deployer_group.go
@@ -450,14 +450,13 @@ func (d *DeployerGroup) enactMcms() (cldf.ChangesetOutput, error) {
 }
 
 func getBatchCountForChain(chain mcmstypes.ChainSelector, timelockProposal *mcmslib.TimelockProposal) uint64 {
-	batches := make([]mcmstypes.BatchOperation, 0)
+	var count uint64
 	for _, batchOperation := range timelockProposal.Operations {
 		if batchOperation.ChainSelector == chain {
-			batches = append(batches, batchOperation)
+			count++
 		}
 	}
-
-	return uint64(len(batches))
+	return count
 }
 
 func (d *DeployerGroup) enactDeployer() (cldf.ChangesetOutput, error) {


### PR DESCRIPTION
An obvious inefficiency: getBatchCountForChain builds a slice only to take its length — wasteful allocations. Replacing it with a counter.