### PR TITLE
fix/logevents-store-allocation-improvement

### DIFF
--- a/core/capabilities/triggers/logevent/store.go
+++ b/core/capabilities/triggers/logevent/store.go
@@ -41,7 +41,7 @@ func (cs *capabilitiesStore[T, Resp]) Read(capabilityID string) (value *T, ok bo
 func (cs *capabilitiesStore[T, Resp]) ReadAll() (values []*T) {
 	cs.mu.RLock()
 	defer cs.mu.RUnlock()
-	vals := make([]*T, 0)
+	vals := make([]*T, 0, len(cs.capabilities))
 	for _, v := range cs.capabilities {
 		vals = append(vals, v)
 	}


### PR DESCRIPTION
appending every value from cs.capabilities, so the slice could reallocate as it grew even though len(cs.capabilities) was already known. fix: backing array sized once and appends stay on that buffer.