### PR TITLE
Populate WorkflowOwner field in gateway handler requests

### DIFF
--- a/core/capabilities/vault/gw_handler.go
+++ b/core/capabilities/vault/gw_handler.go
@@ -303,6 +303,7 @@ func (h *GatewayHandler) handleSecretsCreate(ctx context.Context, gatewayID stri
 	}
 
 	vaultCapRequest.RequestId = req.ID
+	vaultCapRequest.WorkflowOwner = owner
 	for idx, encryptedSecret := range vaultCapRequest.EncryptedSecrets {
 		if encryptedSecret != nil && encryptedSecret.Id != nil && normalizeOwner(encryptedSecret.Id.Owner) != normalizeOwner(owner) {
 			h.lggr.Debugw("create secrets request owner mismatch", "requestID", req.ID, "secretOwner", encryptedSecret.Id.Owner, "authorizedOwner", owner, "index", idx)
@@ -329,6 +330,7 @@ func (h *GatewayHandler) handleSecretsUpdate(ctx context.Context, gatewayID stri
 		return h.errorResponse(ctx, gatewayID, req, api.UserMessageParseError, err)
 	}
 	vaultCapRequest.RequestId = req.ID
+	vaultCapRequest.WorkflowOwner = owner
 	for idx, encryptedSecret := range vaultCapRequest.EncryptedSecrets {
 		if encryptedSecret != nil && encryptedSecret.Id != nil && normalizeOwner(encryptedSecret.Id.Owner) != normalizeOwner(owner) {
 			h.lggr.Debugw("update secrets request owner mismatch", "requestID", req.ID, "secretOwner", encryptedSecret.Id.Owner, "authorizedOwner", owner, "index", idx)
@@ -355,6 +357,7 @@ func (h *GatewayHandler) handleSecretsDelete(ctx context.Context, gatewayID stri
 		return h.errorResponse(ctx, gatewayID, req, api.UserMessageParseError, err)
 	}
 	r.RequestId = req.ID
+	r.WorkflowOwner = owner
 	for idx, secretID := range r.Ids {
 		if secretID != nil && normalizeOwner(secretID.Owner) != normalizeOwner(owner) {
 			h.lggr.Debugw("delete secrets request owner mismatch", "requestID", req.ID, "secretOwner", secretID.Owner, "authorizedOwner", owner, "index", idx)

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -1625,7 +1625,7 @@ func TestSecretsFetcher_Integration(t *testing.T) {
 	// received.
 	res := <-resultReceivedCh
 	require.NotNil(t, capturedVaultReq)
-	require.Empty(t, capturedVaultReq.WorkflowOwner)
+	require.Equal(t, cfg.WorkflowOwner, capturedVaultReq.WorkflowOwner) // WorkflowOwner is always set for label validation
 	require.Empty(t, capturedVaultReq.OrgId)
 	switch output := res.Result.(type) {
 	case *sdkpb.ExecutionResult_Value:

--- a/core/services/workflows/v2/secrets.go
+++ b/core/services/workflows/v2/secrets.go
@@ -204,11 +204,11 @@ func (s *secretsFetcher) getSecretsForBatch(ctx context.Context, request *sdkpb.
 	}
 
 	vp := &vault.GetSecretsRequest{
-		Requests: make([]*vault.SecretRequest, 0),
+		Requests:      make([]*vault.SecretRequest, 0),
+		WorkflowOwner: s.workflowOwner, // Always set for label validation
 	}
 	if orgIDGateEnabled {
 		vp.OrgId = s.orgID
-		vp.WorkflowOwner = s.workflowOwner
 	}
 
 	owner, err := normalizeOwner(s.workflowOwner)

--- a/core/services/workflows/v2/secrets_test.go
+++ b/core/services/workflows/v2/secrets_test.go
@@ -378,7 +378,7 @@ func TestSecretsFetcher_ForwardsOrgIDAndWorkflowOwner(t *testing.T) {
 	assert.Equal(t, owner, capturedReq.WorkflowOwner)
 }
 
-func TestSecretsFetcher_OmitsOrgIDAndWorkflowOwnerWhenGateDisabled(t *testing.T) {
+func TestSecretsFetcher_OmitsOrgIDWhenGateDisabled(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	reg := coreCap.NewRegistry(lggr)
 	peer := coreCap.RandomUTF8BytesWord()
@@ -441,7 +441,7 @@ func TestSecretsFetcher_OmitsOrgIDAndWorkflowOwnerWhenGateDisabled(t *testing.T)
 	require.NoError(t, err)
 	require.NotNil(t, capturedReq)
 	assert.Empty(t, capturedReq.OrgId)
-	assert.Empty(t, capturedReq.WorkflowOwner)
+	assert.Equal(t, owner, capturedReq.WorkflowOwner) // WorkflowOwner is always set for label validation
 }
 
 func TestSecretsFetcher_ReturnsErrorIfNoResponseForRequest(t *testing.T) {


### PR DESCRIPTION
 - Set `WorkflowOwner` field on vault requests
 - Always set `WorkflowOwner` on `GetSecretsRequest` for label validation
 - Update tests to reflect the new behavior