### PR TITLE
Fix vault gateway auth propagation

### DIFF
--- a/core/capabilities/vault/allow_list_based_auth.go
+++ b/core/capabilities/vault/allow_list_based_auth.go
@@ -15,7 +15,10 @@ import (
 )
 
 const (
-	allowListBasedAuthRetryCount    = 3
+	// The workflow registry syncer polls every 12s by default. Keep the
+	// retry window comfortably above that so newly allowlisted requests
+	// can propagate to every node before auth gives up.
+	allowListBasedAuthRetryCount    = 10
 	allowListBasedAuthRetryInterval = 3 * time.Second
 )
 

--- a/core/capabilities/vault/allow_list_based_auth_test.go
+++ b/core/capabilities/vault/allow_list_based_auth_test.go
@@ -180,8 +180,8 @@ func testAuthForRequests(t *testing.T, allowlistedRequest, notAllowlistedRequest
 	authResult, err := auth.AuthorizeRequest(t.Context(), allowlistedRequest)
 	require.NoError(t, err)
 	require.Equal(t, owner.Hex(), authResult.AuthorizedOwner())
-	require.Equal(t, expiry, authResult.GetExpiresAt())
-	require.NotEmpty(t, authResult.GetDigest())
+	require.Equal(t, expiry, authResult.ExpiresAt())
+	require.NotEmpty(t, authResult.Digest())
 
 	// Same request is still authorized here; replay protection lives in the generic Authorizer.
 	authResult, err = auth.AuthorizeRequest(t.Context(), allowlistedRequest)
@@ -237,7 +237,7 @@ func TestAllowListBasedAuth_RetriesUntilRequestIsAllowlisted(t *testing.T) {
 	authResult, err := auth.AuthorizeRequest(t.Context(), req)
 	require.NoError(t, err)
 	require.Equal(t, owner.Hex(), authResult.AuthorizedOwner())
-	require.Equal(t, expiry, authResult.GetExpiresAt())
+	require.Equal(t, expiry, authResult.ExpiresAt())
 }
 
 func TestAllowListBasedAuth_FailsAfterAllowlistReadRetries(t *testing.T) {

--- a/core/capabilities/vault/authorizer.go
+++ b/core/capabilities/vault/authorizer.go
@@ -29,6 +29,22 @@ func NewAuthResult(orgID, workflowOwner, digest string, expiresAt int64) *AuthRe
 	}
 }
 
+// OrgID returns the authorized org ID, if present.
+func (a *AuthResult) OrgID() string {
+	if a == nil {
+		return ""
+	}
+	return a.orgID
+}
+
+// WorkflowOwner returns the authorized workflow owner, if present.
+func (a *AuthResult) WorkflowOwner() string {
+	if a == nil {
+		return ""
+	}
+	return a.workflowOwner
+}
+
 // AuthorizedOwner returns the canonical owner to use for request scoping.
 func (a *AuthResult) AuthorizedOwner() string {
 	if a == nil {
@@ -40,32 +56,21 @@ func (a *AuthResult) AuthorizedOwner() string {
 	return a.workflowOwner
 }
 
-// GetDigest returns the request digest used for replay protection.
-func (a *AuthResult) GetDigest() string {
+// Digest returns the request digest used for replay protection.
+func (a *AuthResult) Digest() string {
 	if a == nil {
 		return ""
 	}
 	return a.digest
 }
 
-// GetExpiresAt returns the unix timestamp (UTC) after which this
+// ExpiresAt returns the unix timestamp (UTC) after which this
 // authorization is no longer valid.
-func (a *AuthResult) GetExpiresAt() int64 {
+func (a *AuthResult) ExpiresAt() int64 {
 	if a == nil {
 		return 0
 	}
 	return a.expiresAt
-}
-
-// GetUntrustedWorkflowOwner returns the workflow owner only for JWTBasedAuth results.
-func (a *AuthResult) GetUntrustedWorkflowOwner() (string, error) {
-	if a == nil {
-		return "", errors.New("auth result is nil")
-	}
-	if a.orgID == "" {
-		return "", errors.New("untrusted workflow owner only applies to JWTBasedAuth results")
-	}
-	return a.workflowOwner, nil
 }
 
 // Authorizer selects the applicable auth mechanism for a Vault request.
@@ -99,11 +104,11 @@ func (a *authorizer) AuthorizeRequest(ctx context.Context, req jsonrpc.Request[j
 		a.lggr.Errorw("auth mechanism returned nil auth result", "method", req.Method, "requestID", req.ID, "hasAuth", req.Auth != "")
 		return nil, err
 	}
-	if err := a.replayGuard.CheckAndRecord(authResult.GetDigest(), authResult.GetExpiresAt()); err != nil {
-		a.lggr.Debugw("replay guard rejected request", "method", req.Method, "requestID", req.ID, "owner", authResult.AuthorizedOwner(), "digest", authResult.GetDigest(), "expiresAt", authResult.GetExpiresAt(), "hasAuth", req.Auth != "", "error", err)
+	if err := a.replayGuard.CheckAndRecord(authResult.Digest(), authResult.ExpiresAt()); err != nil {
+		a.lggr.Debugw("replay guard rejected request", "method", req.Method, "requestID", req.ID, "owner", authResult.AuthorizedOwner(), "digest", authResult.Digest(), "expiresAt", authResult.ExpiresAt(), "hasAuth", req.Auth != "", "error", err)
 		return nil, err
 	}
-	a.lggr.Debugw("request authorized", "method", req.Method, "requestID", req.ID, "owner", authResult.AuthorizedOwner(), "digest", authResult.GetDigest(), "expiresAt", authResult.GetExpiresAt(), "hasAuth", req.Auth != "")
+	a.lggr.Debugw("request authorized", "method", req.Method, "requestID", req.ID, "owner", authResult.AuthorizedOwner(), "digest", authResult.Digest(), "expiresAt", authResult.ExpiresAt(), "hasAuth", req.Auth != "")
 	return authResult, nil
 }
 

--- a/core/capabilities/vault/authorizer_test.go
+++ b/core/capabilities/vault/authorizer_test.go
@@ -66,11 +66,9 @@ func TestAuthorizer_UsesJWTWhenGateEnabled(t *testing.T) {
 
 	authResult, err := a.AuthorizeRequest(t.Context(), req)
 	require.NoError(t, err)
+	require.Equal(t, "org-1", authResult.OrgID())
+	require.Equal(t, "0xworkflow", authResult.WorkflowOwner())
 	require.Equal(t, "org-1", authResult.AuthorizedOwner())
-
-	untrustedWorkflowOwner, err := authResult.GetUntrustedWorkflowOwner()
-	require.NoError(t, err)
-	require.Equal(t, "0xworkflow", untrustedWorkflowOwner)
 }
 
 func TestAuthorizer_DelegatesDigestVerificationToJWTAuth(t *testing.T) {
@@ -91,6 +89,8 @@ func TestAuthorizer_DelegatesDigestVerificationToJWTAuth(t *testing.T) {
 
 	authResult, err := a.AuthorizeRequest(t.Context(), req)
 	require.NoError(t, err)
+	require.Equal(t, "org-1", authResult.OrgID())
+	require.Empty(t, authResult.WorkflowOwner())
 	require.Equal(t, "org-1", authResult.AuthorizedOwner())
 }
 
@@ -133,6 +133,8 @@ func TestAuthorizer_RejectsAllowListBasedAuthReplay(t *testing.T) {
 
 	authResult, err := a.AuthorizeRequest(t.Context(), req)
 	require.NoError(t, err)
+	require.Empty(t, authResult.OrgID())
+	require.Equal(t, "0xabc", authResult.WorkflowOwner())
 	require.Equal(t, "0xabc", authResult.AuthorizedOwner())
 
 	authResult, err = a.AuthorizeRequest(t.Context(), req)

--- a/core/capabilities/vault/gw_handler.go
+++ b/core/capabilities/vault/gw_handler.go
@@ -162,33 +162,33 @@ func (h *GatewayHandler) HandleGatewayMessage(ctx context.Context, gatewayID str
 	var response *jsonrpc.Response[json.RawMessage]
 	switch req.Method {
 	case vaulttypes.MethodSecretsCreate:
-		owner, authErr := h.authorizeAndPrefixRequest(ctx, req)
+		authResult, authErr := h.authorizeAndPrefixRequest(ctx, req)
 		if authErr != nil {
 			response = h.errorResponse(ctx, gatewayID, req, api.HandlerError, authErr)
 			break
 		}
-		response = h.handleSecretsCreate(ctx, gatewayID, req, owner)
+		response = h.handleSecretsCreate(ctx, gatewayID, req, authResult)
 	case vaulttypes.MethodSecretsUpdate:
-		owner, authErr := h.authorizeAndPrefixRequest(ctx, req)
+		authResult, authErr := h.authorizeAndPrefixRequest(ctx, req)
 		if authErr != nil {
 			response = h.errorResponse(ctx, gatewayID, req, api.HandlerError, authErr)
 			break
 		}
-		response = h.handleSecretsUpdate(ctx, gatewayID, req, owner)
+		response = h.handleSecretsUpdate(ctx, gatewayID, req, authResult)
 	case vaulttypes.MethodSecretsDelete:
-		owner, authErr := h.authorizeAndPrefixRequest(ctx, req)
+		authResult, authErr := h.authorizeAndPrefixRequest(ctx, req)
 		if authErr != nil {
 			response = h.errorResponse(ctx, gatewayID, req, api.HandlerError, authErr)
 			break
 		}
-		response = h.handleSecretsDelete(ctx, gatewayID, req, owner)
+		response = h.handleSecretsDelete(ctx, gatewayID, req, authResult)
 	case vaulttypes.MethodSecretsList:
-		owner, authErr := h.authorizeAndPrefixRequest(ctx, req)
+		authResult, authErr := h.authorizeAndPrefixRequest(ctx, req)
 		if authErr != nil {
 			response = h.errorResponse(ctx, gatewayID, req, api.HandlerError, authErr)
 			break
 		}
-		response = h.handleSecretsList(ctx, gatewayID, req, owner)
+		response = h.handleSecretsList(ctx, gatewayID, req, authResult)
 	case vaulttypes.MethodPublicKeyGet:
 		response = h.handlePublicKeyGet(ctx, gatewayID, req)
 	default:
@@ -207,11 +207,11 @@ func (h *GatewayHandler) HandleGatewayMessage(ctx context.Context, gatewayID str
 	return nil
 }
 
-func (h *GatewayHandler) authorizeAndPrefixRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage]) (string, error) {
+func (h *GatewayHandler) authorizeAndPrefixRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage]) (*AuthResult, error) {
 	if h.authorizer == nil {
 		err := errors.New("authorizer is nil")
 		h.lggr.Errorw("failed to authorize gateway request", "method", req.Method, "requestID", req.ID, "error", err)
-		return "", err
+		return nil, err
 	}
 
 	originalRequestID := req.ID
@@ -225,7 +225,7 @@ func (h *GatewayHandler) authorizeAndPrefixRequest(ctx context.Context, req *jso
 	authReq.ID = originalRequestID
 	if err := stripPrefixedRequestIDFromParams(&authReq, originalRequestID); err != nil {
 		h.lggr.Errorw("failed to normalize gateway request for authorization", "method", req.Method, "requestID", originalRequestID, "error", err)
-		return "", err
+		return nil, err
 	}
 
 	h.lggr.Debugw("authorizing gateway request", "method", req.Method, "requestID", originalRequestID)
@@ -233,18 +233,18 @@ func (h *GatewayHandler) authorizeAndPrefixRequest(ctx context.Context, req *jso
 	if err != nil {
 		authErr := fmt.Errorf("request not authorized: %w", err)
 		h.lggr.Errorw("gateway request authorization failed", "method", req.Method, "requestID", originalRequestID, "hasAuth", req.Auth != "", "incomingOwner", incomingOwner, "error", authErr)
-		return "", authErr
+		return nil, authErr
 	}
 	authorizedOwner := authResult.AuthorizedOwner()
 	if incomingOwner != "" && normalizeOwner(incomingOwner) != normalizeOwner(authorizedOwner) {
 		prefixErr := fmt.Errorf("request owner prefix %q does not match authorized owner %q", incomingOwner, authorizedOwner)
 		h.lggr.Errorw("gateway request owner prefix mismatch", "method", req.Method, "requestID", originalRequestID, "incomingOwner", incomingOwner, "authorizedOwner", authorizedOwner, "error", prefixErr)
-		return "", prefixErr
+		return nil, prefixErr
 	}
 
 	req.ID = authorizedOwner + vaulttypes.RequestIDSeparator + originalRequestID
-	h.lggr.Debugw("authorized gateway request", "method", req.Method, "requestID", req.ID, "owner", authorizedOwner)
-	return authorizedOwner, nil
+	h.lggr.Debugw("authorized gateway request", "method", req.Method, "requestID", req.ID, "owner", authorizedOwner, "orgID", authResult.OrgID(), "workflowOwner", authResult.WorkflowOwner())
+	return authResult, nil
 }
 
 func stripPrefixedRequestIDFromParams(req *jsonrpc.Request[json.RawMessage], originalRequestID string) error {
@@ -296,18 +296,50 @@ func rewriteRequestParams(req *jsonrpc.Request[json.RawMessage], payload any) er
 	return nil
 }
 
-func (h *GatewayHandler) handleSecretsCreate(ctx context.Context, gatewayID string, req *jsonrpc.Request[json.RawMessage], owner string) *jsonrpc.Response[json.RawMessage] {
+func setAuthorizedIdentityFields(req any, authResult *AuthResult) error {
+	if authResult == nil {
+		return errors.New("auth result is nil")
+	}
+
+	// Critical: the Vault capability trusts OrgId and WorkflowOwner to be set by
+	// the Vault node only after authorization and request validation succeed. We
+	// must overwrite any JSON-provided values here; otherwise a malicious request
+	// could smuggle mismatched identity fields into the capability call.
+	switch r := req.(type) {
+	case *vaultcommon.CreateSecretsRequest:
+		r.OrgId = authResult.OrgID()
+		r.WorkflowOwner = authResult.WorkflowOwner()
+	case *vaultcommon.UpdateSecretsRequest:
+		r.OrgId = authResult.OrgID()
+		r.WorkflowOwner = authResult.WorkflowOwner()
+	case *vaultcommon.DeleteSecretsRequest:
+		r.OrgId = authResult.OrgID()
+		r.WorkflowOwner = authResult.WorkflowOwner()
+	case *vaultcommon.ListSecretIdentifiersRequest:
+		r.OrgId = authResult.OrgID()
+		r.WorkflowOwner = authResult.WorkflowOwner()
+	default:
+		return fmt.Errorf("unsupported vault request type %T", req)
+	}
+
+	return nil
+}
+
+func (h *GatewayHandler) handleSecretsCreate(ctx context.Context, gatewayID string, req *jsonrpc.Request[json.RawMessage], authResult *AuthResult) *jsonrpc.Response[json.RawMessage] {
 	vaultCapRequest := vaultcommon.CreateSecretsRequest{}
 	if err := json.Unmarshal(*req.Params, &vaultCapRequest); err != nil {
 		return h.errorResponse(ctx, gatewayID, req, api.UserMessageParseError, err)
 	}
 
+	authorizedOwner := authResult.AuthorizedOwner()
 	vaultCapRequest.RequestId = req.ID
-	vaultCapRequest.WorkflowOwner = owner
+	if err := setAuthorizedIdentityFields(&vaultCapRequest, authResult); err != nil {
+		return h.errorResponse(ctx, gatewayID, req, api.FatalError, err)
+	}
 	for idx, encryptedSecret := range vaultCapRequest.EncryptedSecrets {
-		if encryptedSecret != nil && encryptedSecret.Id != nil && normalizeOwner(encryptedSecret.Id.Owner) != normalizeOwner(owner) {
-			h.lggr.Debugw("create secrets request owner mismatch", "requestID", req.ID, "secretOwner", encryptedSecret.Id.Owner, "authorizedOwner", owner, "index", idx)
-			return h.errorResponse(ctx, gatewayID, req, api.FatalError, fmt.Errorf("secret ID owner %q does not match authorized owner %q at index %d", encryptedSecret.Id.Owner, owner, idx))
+		if encryptedSecret != nil && encryptedSecret.Id != nil && normalizeOwner(encryptedSecret.Id.Owner) != normalizeOwner(authorizedOwner) {
+			h.lggr.Debugw("create secrets request owner mismatch", "requestID", req.ID, "secretOwner", encryptedSecret.Id.Owner, "authorizedOwner", authorizedOwner, "index", idx)
+			return h.errorResponse(ctx, gatewayID, req, api.FatalError, fmt.Errorf("secret ID owner %q does not match authorized owner %q at index %d", encryptedSecret.Id.Owner, authorizedOwner, idx))
 		}
 	}
 
@@ -324,17 +356,20 @@ func (h *GatewayHandler) handleSecretsCreate(ctx context.Context, gatewayID stri
 	return jsonResponse
 }
 
-func (h *GatewayHandler) handleSecretsUpdate(ctx context.Context, gatewayID string, req *jsonrpc.Request[json.RawMessage], owner string) *jsonrpc.Response[json.RawMessage] {
+func (h *GatewayHandler) handleSecretsUpdate(ctx context.Context, gatewayID string, req *jsonrpc.Request[json.RawMessage], authResult *AuthResult) *jsonrpc.Response[json.RawMessage] {
 	vaultCapRequest := vaultcommon.UpdateSecretsRequest{}
 	if err := json.Unmarshal(*req.Params, &vaultCapRequest); err != nil {
 		return h.errorResponse(ctx, gatewayID, req, api.UserMessageParseError, err)
 	}
+	authorizedOwner := authResult.AuthorizedOwner()
 	vaultCapRequest.RequestId = req.ID
-	vaultCapRequest.WorkflowOwner = owner
+	if err := setAuthorizedIdentityFields(&vaultCapRequest, authResult); err != nil {
+		return h.errorResponse(ctx, gatewayID, req, api.FatalError, err)
+	}
 	for idx, encryptedSecret := range vaultCapRequest.EncryptedSecrets {
-		if encryptedSecret != nil && encryptedSecret.Id != nil && normalizeOwner(encryptedSecret.Id.Owner) != normalizeOwner(owner) {
-			h.lggr.Debugw("update secrets request owner mismatch", "requestID", req.ID, "secretOwner", encryptedSecret.Id.Owner, "authorizedOwner", owner, "index", idx)
-			return h.errorResponse(ctx, gatewayID, req, api.FatalError, fmt.Errorf("secret ID owner %q does not match authorized owner %q at index %d", encryptedSecret.Id.Owner, owner, idx))
+		if encryptedSecret != nil && encryptedSecret.Id != nil && normalizeOwner(encryptedSecret.Id.Owner) != normalizeOwner(authorizedOwner) {
+			h.lggr.Debugw("update secrets request owner mismatch", "requestID", req.ID, "secretOwner", encryptedSecret.Id.Owner, "authorizedOwner", authorizedOwner, "index", idx)
+			return h.errorResponse(ctx, gatewayID, req, api.FatalError, fmt.Errorf("secret ID owner %q does not match authorized owner %q at index %d", encryptedSecret.Id.Owner, authorizedOwner, idx))
 		}
 	}
 
@@ -351,17 +386,20 @@ func (h *GatewayHandler) handleSecretsUpdate(ctx context.Context, gatewayID stri
 	return jsonResponse
 }
 
-func (h *GatewayHandler) handleSecretsDelete(ctx context.Context, gatewayID string, req *jsonrpc.Request[json.RawMessage], owner string) *jsonrpc.Response[json.RawMessage] {
+func (h *GatewayHandler) handleSecretsDelete(ctx context.Context, gatewayID string, req *jsonrpc.Request[json.RawMessage], authResult *AuthResult) *jsonrpc.Response[json.RawMessage] {
 	r := &vaultcommon.DeleteSecretsRequest{}
 	if err := json.Unmarshal(*req.Params, r); err != nil {
 		return h.errorResponse(ctx, gatewayID, req, api.UserMessageParseError, err)
 	}
+	authorizedOwner := authResult.AuthorizedOwner()
 	r.RequestId = req.ID
-	r.WorkflowOwner = owner
+	if err := setAuthorizedIdentityFields(r, authResult); err != nil {
+		return h.errorResponse(ctx, gatewayID, req, api.FatalError, err)
+	}
 	for idx, secretID := range r.Ids {
-		if secretID != nil && normalizeOwner(secretID.Owner) != normalizeOwner(owner) {
-			h.lggr.Debugw("delete secrets request owner mismatch", "requestID", req.ID, "secretOwner", secretID.Owner, "authorizedOwner", owner, "index", idx)
-			return h.errorResponse(ctx, gatewayID, req, api.FatalError, fmt.Errorf("secret ID owner %q does not match authorized owner %q at index %d", secretID.Owner, owner, idx))
+		if secretID != nil && normalizeOwner(secretID.Owner) != normalizeOwner(authorizedOwner) {
+			h.lggr.Debugw("delete secrets request owner mismatch", "requestID", req.ID, "secretOwner", secretID.Owner, "authorizedOwner", authorizedOwner, "index", idx)
+			return h.errorResponse(ctx, gatewayID, req, api.FatalError, fmt.Errorf("secret ID owner %q does not match authorized owner %q at index %d", secretID.Owner, authorizedOwner, idx))
 		}
 	}
 
@@ -384,13 +422,16 @@ func (h *GatewayHandler) handleSecretsDelete(ctx context.Context, gatewayID stri
 	}
 }
 
-func (h *GatewayHandler) handleSecretsList(ctx context.Context, gatewayID string, req *jsonrpc.Request[json.RawMessage], owner string) *jsonrpc.Response[json.RawMessage] {
+func (h *GatewayHandler) handleSecretsList(ctx context.Context, gatewayID string, req *jsonrpc.Request[json.RawMessage], authResult *AuthResult) *jsonrpc.Response[json.RawMessage] {
 	r := &vaultcommon.ListSecretIdentifiersRequest{}
 	if err := json.Unmarshal(*req.Params, r); err != nil {
 		return h.errorResponse(ctx, gatewayID, req, api.UserMessageParseError, err)
 	}
 	r.RequestId = req.ID
-	r.Owner = owner
+	r.Owner = authResult.AuthorizedOwner()
+	if err := setAuthorizedIdentityFields(r, authResult); err != nil {
+		return h.errorResponse(ctx, gatewayID, req, api.FatalError, err)
+	}
 
 	h.lggr.Debugf("Processing authorized and normalized list secrets request [%s]", r.String())
 	resp, err := h.secretsService.ListSecretIdentifiers(ctx, r)

--- a/core/capabilities/vault/gw_handler_test.go
+++ b/core/capabilities/vault/gw_handler_test.go
@@ -26,8 +26,12 @@ import (
 func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	ctx := t.Context()
-	authResult := func(owner string) *vaultcap.AuthResult {
-		return vaultcap.NewAuthResult("", owner, "digest-"+owner, time.Now().Add(time.Minute).Unix())
+	authResult := func(orgID, workflowOwner string) *vaultcap.AuthResult {
+		digestOwner := workflowOwner
+		if orgID != "" {
+			digestOwner = orgID
+		}
+		return vaultcap.NewAuthResult(orgID, workflowOwner, "digest-"+digestOwner, time.Now().Add(time.Minute).Unix())
 	}
 
 	tests := []struct {
@@ -41,12 +45,14 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
 				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.MatchedBy(func(req jsonrpc.Request[json.RawMessage]) bool {
 					return req.Method == vaulttypes.MethodSecretsCreate && req.ID == "1"
-				})).Return(authResult("0xabc"), nil)
+				})).Return(authResult("", "0xabc"), nil)
 				ss.EXPECT().CreateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.CreateSecretsRequest) bool {
 					return len(req.EncryptedSecrets) == 1 &&
 						req.EncryptedSecrets[0].Id.Key == "test-secret" &&
 						req.EncryptedSecrets[0].Id.Owner == "0xAbC" &&
-						req.RequestId == "0xabc"+vaulttypes.RequestIDSeparator+"1"
+						req.RequestId == "0xabc"+vaulttypes.RequestIDSeparator+"1" &&
+						req.OrgId == "" &&
+						req.WorkflowOwner == "0xabc"
 				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
 
 				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
@@ -76,9 +82,49 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name: "success - create secrets propagates jwt auth identity",
+			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
+				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.MatchedBy(func(req jsonrpc.Request[json.RawMessage]) bool {
+					return req.Method == vaulttypes.MethodSecretsCreate && req.ID == "1"
+				})).Return(authResult("org-1", "0xworkflow"), nil)
+				ss.EXPECT().CreateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.CreateSecretsRequest) bool {
+					return len(req.EncryptedSecrets) == 1 &&
+						req.EncryptedSecrets[0].Id.Key == "test-secret" &&
+						req.EncryptedSecrets[0].Id.Owner == "org-1" &&
+						req.RequestId == "org-1"+vaulttypes.RequestIDSeparator+"1" &&
+						req.OrgId == "org-1" &&
+						req.WorkflowOwner == "0xworkflow"
+				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
+
+				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
+					return resp.Error == nil
+				})).Return(nil)
+			},
+			request: &jsonrpc.Request[json.RawMessage]{
+				Method: vaulttypes.MethodSecretsCreate,
+				ID:     "1",
+				Params: func() *json.RawMessage {
+					params, _ := json.Marshal(vaultcommon.CreateSecretsRequest{
+						EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+							{
+								Id: &vaultcommon.SecretIdentifier{
+									Key:   "test-secret",
+									Owner: "org-1",
+								},
+								EncryptedValue: "encrypted-value",
+							},
+						},
+					})
+					raw := json.RawMessage(params)
+					return &raw
+				}(),
+			},
+			expectedError: false,
+		},
+		{
 			name: "failure - service error",
 			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
-				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Return(authResult("0xabc"), nil)
+				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Return(authResult("", "0xabc"), nil)
 				ss.EXPECT().CreateSecrets(mock.Anything, mock.Anything).Return(nil, errors.New("service error"))
 
 				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
@@ -145,13 +191,15 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
 				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.MatchedBy(func(req jsonrpc.Request[json.RawMessage]) bool {
 					return req.Method == vaulttypes.MethodSecretsDelete && req.ID == "1"
-				})).Return(authResult("0xabc"), nil)
+				})).Return(authResult("", "0xabc"), nil)
 				ss.EXPECT().DeleteSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.DeleteSecretsRequest) bool {
 					return len(req.Ids) == 1 &&
 						req.Ids[0].Key == "Foo" &&
 						req.Ids[0].Namespace == "Bar" &&
 						req.Ids[0].Owner == "0xAbC" &&
-						req.RequestId == "0xabc"+vaulttypes.RequestIDSeparator+"1"
+						req.RequestId == "0xabc"+vaulttypes.RequestIDSeparator+"1" &&
+						req.OrgId == "" &&
+						req.WorkflowOwner == "0xabc"
 				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
 
 				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
@@ -171,6 +219,117 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 								Owner:     "0xAbC",
 							},
 						},
+					})
+					raw := json.RawMessage(params)
+					return &raw
+				}(),
+			},
+			expectedError: false,
+		},
+		{
+			name: "success - update secrets propagates jwt auth identity",
+			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
+				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.MatchedBy(func(req jsonrpc.Request[json.RawMessage]) bool {
+					return req.Method == vaulttypes.MethodSecretsUpdate && req.ID == "1"
+				})).Return(authResult("org-1", "0xworkflow"), nil)
+				ss.EXPECT().UpdateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.UpdateSecretsRequest) bool {
+					return len(req.EncryptedSecrets) == 1 &&
+						req.EncryptedSecrets[0].Id.Key == "updated-secret" &&
+						req.EncryptedSecrets[0].Id.Owner == "org-1" &&
+						req.RequestId == "org-1"+vaulttypes.RequestIDSeparator+"1" &&
+						req.OrgId == "org-1" &&
+						req.WorkflowOwner == "0xworkflow"
+				})).Return(&vaulttypes.Response{ID: "updated-secret"}, nil)
+
+				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
+					return resp.Error == nil
+				})).Return(nil)
+			},
+			request: &jsonrpc.Request[json.RawMessage]{
+				Method: vaulttypes.MethodSecretsUpdate,
+				ID:     "1",
+				Params: func() *json.RawMessage {
+					params, _ := json.Marshal(vaultcommon.UpdateSecretsRequest{
+						EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+							{
+								Id: &vaultcommon.SecretIdentifier{
+									Key:   "updated-secret",
+									Owner: "org-1",
+								},
+								EncryptedValue: "encrypted-value",
+							},
+						},
+					})
+					raw := json.RawMessage(params)
+					return &raw
+				}(),
+			},
+			expectedError: false,
+		},
+		{
+			name: "success - delete secrets propagates jwt auth identity",
+			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
+				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.MatchedBy(func(req jsonrpc.Request[json.RawMessage]) bool {
+					return req.Method == vaulttypes.MethodSecretsDelete && req.ID == "1"
+				})).Return(authResult("org-1", "0xworkflow"), nil)
+				ss.EXPECT().DeleteSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.DeleteSecretsRequest) bool {
+					return len(req.Ids) == 1 &&
+						req.Ids[0].Key == "Foo" &&
+						req.Ids[0].Namespace == "Bar" &&
+						req.Ids[0].Owner == "org-1" &&
+						req.RequestId == "org-1"+vaulttypes.RequestIDSeparator+"1" &&
+						req.OrgId == "org-1" &&
+						req.WorkflowOwner == "0xworkflow"
+				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
+
+				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
+					return resp.Error == nil
+				})).Return(nil)
+			},
+			request: &jsonrpc.Request[json.RawMessage]{
+				Method: vaulttypes.MethodSecretsDelete,
+				ID:     "1",
+				Params: func() *json.RawMessage {
+					params, _ := json.Marshal(vaultcommon.DeleteSecretsRequest{
+						Ids: []*vaultcommon.SecretIdentifier{
+							{
+								Key:       "Foo",
+								Namespace: "Bar",
+								Owner:     "org-1",
+							},
+						},
+					})
+					raw := json.RawMessage(params)
+					return &raw
+				}(),
+			},
+			expectedError: false,
+		},
+		{
+			name: "success - list secrets propagates jwt auth identity",
+			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
+				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.MatchedBy(func(req jsonrpc.Request[json.RawMessage]) bool {
+					return req.Method == vaulttypes.MethodSecretsList && req.ID == "1"
+				})).Return(authResult("org-1", "0xworkflow"), nil)
+				ss.EXPECT().ListSecretIdentifiers(mock.Anything, mock.MatchedBy(func(req *vaultcommon.ListSecretIdentifiersRequest) bool {
+					return req.RequestId == "org-1"+vaulttypes.RequestIDSeparator+"1" &&
+						req.Owner == "org-1" &&
+						req.Namespace == "ns" &&
+						req.OrgId == "org-1" &&
+						req.WorkflowOwner == "0xworkflow"
+				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
+
+				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
+					return resp.Error == nil
+				})).Return(nil)
+			},
+			request: &jsonrpc.Request[json.RawMessage]{
+				Method: vaulttypes.MethodSecretsList,
+				ID:     "1",
+				Params: func() *json.RawMessage {
+					params, _ := json.Marshal(vaultcommon.ListSecretIdentifiersRequest{
+						Owner:     "user-supplied-owner",
+						Namespace: "ns",
 					})
 					raw := json.RawMessage(params)
 					return &raw
@@ -226,9 +385,11 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 						len(parsed.EncryptedSecrets) == 1 &&
 						parsed.EncryptedSecrets[0].Id != nil &&
 						parsed.EncryptedSecrets[0].Id.Owner == "0xAbC"
-				})).Return(authResult("0xabc"), nil)
+				})).Return(authResult("", "0xabc"), nil)
 				ss.EXPECT().CreateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.CreateSecretsRequest) bool {
-					return req.RequestId == "0xabc"+vaulttypes.RequestIDSeparator+"1"
+					return req.RequestId == "0xabc"+vaulttypes.RequestIDSeparator+"1" &&
+						req.OrgId == "" &&
+						req.WorkflowOwner == "0xabc"
 				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
 
 				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
@@ -260,7 +421,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 		{
 			name: "failure - owner mismatch against authorized owner",
 			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
-				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Return(authResult("0xdef"), nil)
+				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Return(authResult("", "0xdef"), nil)
 				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
 					return resp.Error != nil &&
 						resp.Error.Code == api.ToJSONRPCErrorCode(api.FatalError) &&

--- a/core/capabilities/vault/validator.go
+++ b/core/capabilities/vault/validator.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/smartcontractkit/tdh2/go/tdh2/tdh2easy"
 
@@ -179,9 +180,11 @@ func EnsureRightLabelOnSecret(publicKey *tdh2easy.PublicKey, secret string, work
 		return errors.New("failed to verify encrypted value:" + err.Error())
 	}
 	secretLabel := cipherText.Label()
+	expectedLabels := make([]string, 0, 2)
 
 	if workflowOwner != "" {
 		expected := vaultutils.WorkflowOwnerToLabel(workflowOwner)
+		expectedLabels = append(expectedLabels, hex.EncodeToString(expected[:]))
 		if secretLabel == expected {
 			return nil
 		}
@@ -189,10 +192,11 @@ func EnsureRightLabelOnSecret(publicKey *tdh2easy.PublicKey, secret string, work
 
 	if orgID != "" {
 		expected := vaultutils.OrgIDToLabel(orgID)
+		expectedLabels = append(expectedLabels, hex.EncodeToString(expected[:]))
 		if secretLabel == expected {
 			return nil
 		}
 	}
 
-	return errors.New("secret label [" + hex.EncodeToString(secretLabel[:]) + "] does not match any of the provided owner labels")
+	return errors.New("secret label [" + hex.EncodeToString(secretLabel[:]) + "] does not match any of the provided owner labels; expectedLabels=[" + strings.Join(expectedLabels, ", ") + "]")
 }

--- a/core/capabilities/vault/validator_test.go
+++ b/core/capabilities/vault/validator_test.go
@@ -128,10 +128,15 @@ func TestEnsureRightLabelOnSecret_NeitherMatches(t *testing.T) {
 	wrongAddr := "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 	wrongOrgID := "org_wrong"
 	secret := encryptWithEthAddressLabel(t, pk, ethAddr)
+	expectedWorkflowOwnerLabelBytes := vaultutils.WorkflowOwnerToLabel(wrongAddr)
+	expectedOrgIDLabelBytes := vaultutils.OrgIDToLabel(wrongOrgID)
+	expectedWorkflowOwnerLabel := hex.EncodeToString(expectedWorkflowOwnerLabelBytes[:])
+	expectedOrgIDLabel := hex.EncodeToString(expectedOrgIDLabelBytes[:])
 
 	err := EnsureRightLabelOnSecret(pk, secret, wrongAddr, wrongOrgID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not match any of the provided owner labels")
+	assert.Contains(t, err.Error(), "expectedLabels=["+expectedWorkflowOwnerLabel+", "+expectedOrgIDLabel+"]")
 }
 
 func TestEnsureRightLabelOnSecret_BothEmpty(t *testing.T) {
@@ -142,6 +147,7 @@ func TestEnsureRightLabelOnSecret_BothEmpty(t *testing.T) {
 	err := EnsureRightLabelOnSecret(pk, secret, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not match any of the provided owner labels")
+	assert.Contains(t, err.Error(), "expectedLabels=[]")
 }
 
 func TestEnsureRightLabelOnSecret_NilPublicKey(t *testing.T) {


### PR DESCRIPTION
## Summary
- propagate the authorizer's `orgID` and `workflowOwner` onto all authenticated gateway vault requests
- extend allowlist auth retries to tolerate longer propagation lag
- include the checked `expectedLabels` in vault label-validation errors

## Root Cause
The vault capability's gateway handler was forwarding capability requests without overwriting identity fields from the trusted auth result, so the vault capability was seeing empty fields. Separately, allowlist propagation could lag long enough for gateway and node authorization to disagree, and validator errors did not show which labels were compared.
