### PR TITLE
Bump confidential-compute ref

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -56,5 +56,5 @@ plugins:
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "187018af88ce265ca70b86222f8587e3fcb7ff32"
+      gitRef: "73a860c9a949ab26f9fd03e487a06998fbb6430a"
       installPath: "./cmd/confidential-http"


### PR DESCRIPTION
## Summary
- bump `plugins.private.yaml` to `github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability@73a860c9a949ab26f9fd03e487a06998fbb6430a`
- pull in the confidential-compute change from smartcontractkit/confidential-compute#287

