### PR TITLE
cre-3245: prevent panic on empty observation while tearing down

### DIFF
--- a/core/services/ring/plugin.go
+++ b/core/services/ring/plugin.go
@@ -172,6 +172,9 @@ func (p *Plugin) getHealthyShards(shardHealth map[uint32]int) []uint32 {
 }
 
 func (p *Plugin) Outcome(_ context.Context, outctx ocr3types.OutcomeContext, _ types.Query, aos []types.AttributedObservation) (ocr3types.Outcome, error) {
+	if len(aos) == 0 {
+		return nil, errors.New("RingOCR Outcome: no attributed observations")
+	}
 	currentShardHealth, allWorkflows, nows, wantShardVotes := p.collectShardInfo(aos)
 	p.lggr.Infow("RingOCR Outcome collect shard info", "currentShardHealth", currentShardHealth, "wantShardVotes", wantShardVotes)
 


### PR DESCRIPTION
prevent panic on empty observation while tearing down

[cre-3245](https://smartcontract-it.atlassian.net/browse/cre-3245)