### PR TITLE
bump aptos capabilities plugin for pre-submission gas gating

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -48,7 +48,7 @@ plugins:
       installPath: "."
   aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "ebca0cad82543712816668e5c418e1df49ec0c88"
+      gitRef: "232da22eecffc8c826b72819df37b0efc82dc472"
       installPath: "."
   mock:
     - moduleURI: "github.com/smartcontractkit/capabilities/mock"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -48,7 +48,7 @@ plugins:
       installPath: "."
   aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "232da22eecffc8c826b72819df37b0efc82dc472"
+      gitRef: "cb250a07e73a839972eded3b15d3d846f8be9db5"
       installPath: "."
   mock:
     - moduleURI: "github.com/smartcontractkit/capabilities/mock"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -48,7 +48,7 @@ plugins:
       installPath: "."
   aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "cb250a07e73a839972eded3b15d3d846f8be9db5"
+      gitRef: "4608f9170a0fff492e65c69f2bf63803388d8d32"
       installPath: "."
   mock:
     - moduleURI: "github.com/smartcontractkit/capabilities/mock"


### PR DESCRIPTION
## Summary
- Bumps the aptos capabilities plugin `gitRef` in `plugins/plugins.private.yaml` to `232da22eecffc8c826b72819df37b0efc82dc472`
- Picks up changes from smartcontractkit/capabilities#522 which adds pre-submission gas gating to avoid wasting gas on known-fatal write report submissions on Aptos

## Test plan
- [x] CI `Test_CRE_V2_Aptos_Suite` passes with the new plugin version
- [x] `Aptos_Write_Expected_Failure` and `Aptos_Write_Read_Roundtrip` tests pass