### PR TITLE
Prevent response cache mutex from serializing concurrent HTTP action requests

### DIFF
--- a/core/services/gateway/handlers/capabilities/v2/http_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_handler.go
@@ -59,12 +59,12 @@ type gatewayHandler struct {
 
 type ResponseCache interface {
 	// Set caches a response if it is cacheable (2xx or 4xx status codes) and the cache is empty or expired for the given request.
-	Set(workflowID string, req gateway_common.OutboundHTTPRequest, response gateway_common.OutboundHTTPResponse)
+	Set(req gateway_common.OutboundHTTPRequest, response gateway_common.OutboundHTTPResponse)
 
 	// Fetch retrieves a response from the cache if it exists and the age of cached response is less than the max age of the request.
 	// If the cached response is expired or not cached, it fetches a new response from the fetchFn.
 	// The response is cached if it is cacheable and storeOnFetch is true.
-	Fetch(ctx context.Context, workflowID string, req gateway_common.OutboundHTTPRequest, fetchFn func() gateway_common.OutboundHTTPResponse, storeOnFetch bool) gateway_common.OutboundHTTPResponse
+	Fetch(ctx context.Context, req gateway_common.OutboundHTTPRequest, fetchFn func() gateway_common.OutboundHTTPResponse, storeOnFetch bool) gateway_common.OutboundHTTPResponse
 
 	// DeleteExpired removes all cached responses that have exceeded their TTL (Time To Live).
 	DeleteExpired(ctx context.Context) int
@@ -306,16 +306,6 @@ func (h *gatewayHandler) createHTTPRequestCallback(ctx context.Context, requestI
 	}
 }
 
-// extractWorkflowIDFromRequestPath extracts the workflowID from an outgoing request path string.
-// The workflowID is expected to be the first element after splitting the string by "/".
-func extractWorkflowIDFromRequestPath(path string) string {
-	parts := strings.Split(path, "/")
-	if len(parts) > 1 {
-		return parts[1]
-	}
-	return ""
-}
-
 func (h *gatewayHandler) HandleLegacyUserMessage(context.Context, *api.Message, handlers.Callback) error {
 	return errors.New("HTTP capability gateway handler does not support legacy messages")
 }
@@ -340,7 +330,6 @@ func (h *gatewayHandler) makeOutgoingRequest(ctx context.Context, resp *jsonrpc.
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal HTTP request from node %s: %w", nodeAddr, err)
 	}
-	workflowID := extractWorkflowIDFromRequestPath(requestID)
 	timeout := time.Duration(req.TimeoutMs) * time.Millisecond
 	httpReq := network.HTTPRequest{
 		Method:           req.Method,
@@ -367,11 +356,11 @@ func (h *gatewayHandler) makeOutgoingRequest(ctx context.Context, resp *jsonrpc.
 		callback := h.createHTTPRequestCallback(httpCtx, requestID, httpReq, req)
 		if req.CacheSettings.MaxAgeMs > 0 {
 			h.metrics.IncrementCacheReadCount(ctx, h.lggr)
-			outboundResp = h.responseCache.Fetch(httpCtx, workflowID, req, callback, req.CacheSettings.Store)
+			outboundResp = h.responseCache.Fetch(httpCtx, req, callback, req.CacheSettings.Store)
 		} else {
 			outboundResp = callback()
 			if req.CacheSettings.Store {
-				h.responseCache.Set(workflowID, req, outboundResp)
+				h.responseCache.Set(req, outboundResp)
 			}
 		}
 		h.metrics.IncrementActionCapabilityRequestCount(ctx, nodeAddr, h.lggr)

--- a/core/services/gateway/handlers/capabilities/v2/http_handler_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_handler_test.go
@@ -402,11 +402,11 @@ func newMockResponseCache() *mockResponseCache {
 	}
 }
 
-func (m *mockResponseCache) Set(workflowID string, req gateway_common.OutboundHTTPRequest, response gateway_common.OutboundHTTPResponse) {
+func (m *mockResponseCache) Set(req gateway_common.OutboundHTTPRequest, response gateway_common.OutboundHTTPResponse) {
 	m.setCallCount++
 }
 
-func (m *mockResponseCache) Fetch(ctx context.Context, workflowID string, req gateway_common.OutboundHTTPRequest, fetchFn func() gateway_common.OutboundHTTPResponse, storeOnFetch bool) gateway_common.OutboundHTTPResponse {
+func (m *mockResponseCache) Fetch(ctx context.Context, req gateway_common.OutboundHTTPRequest, fetchFn func() gateway_common.OutboundHTTPResponse, storeOnFetch bool) gateway_common.OutboundHTTPResponse {
 	m.fetchCallCount++
 	return fetchFn()
 }

--- a/core/services/gateway/handlers/capabilities/v2/response_cache.go
+++ b/core/services/gateway/handlers/capabilities/v2/response_cache.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/gateway"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities/v2/metrics"
@@ -16,6 +18,7 @@ import (
 type responseCache struct {
 	cacheMu sync.Mutex
 	cache   map[string]*cachedResponse
+	flight  singleflight.Group
 	lggr    logger.Logger
 	ttl     time.Duration
 	metrics *metrics.Metrics
@@ -55,22 +58,44 @@ func (rc *responseCache) isExpiredOrNotCached(_ string, req gateway.OutboundHTTP
 // the age of cached response is less than the max age of the request.
 // If the cached response is expired or not cached, it fetches a new response from the fetchFn.
 // and caches the response if it is cacheable and storeOnFetch is true.
+//
+// The mutex is only held during cache map access (microseconds), not during fetchFn execution.
+// Singleflight deduplicates concurrent requests to the same cache key so only one fetchFn
+// runs per key, while requests to different keys execute in parallel.
 func (rc *responseCache) Fetch(ctx context.Context, workflowID string, req gateway.OutboundHTTPRequest, fetchFn func() gateway.OutboundHTTPResponse, storeOnFetch bool) gateway.OutboundHTTPResponse {
-	rc.cacheMu.Lock()
-	defer rc.cacheMu.Unlock()
+	cacheKey := req.Hash()
 	cacheMaxAge := time.Duration(req.CacheSettings.MaxAgeMs) * time.Millisecond
-	cachedResp, exists := rc.cache[req.Hash()]
+
+	// Short lock: check cache
+	rc.cacheMu.Lock()
+	cachedResp, exists := rc.cache[cacheKey]
 	if exists && cachedResp.storedAt.Add(cacheMaxAge).After(time.Now()) {
+		rc.cacheMu.Unlock()
 		rc.metrics.IncrementCacheHitCount(ctx, rc.lggr)
 		return cachedResp.response
 	}
-	response := fetchFn()
-	if storeOnFetch && isCacheableStatusCode(response.StatusCode) && rc.isExpiredOrNotCached(workflowID, req) {
-		rc.cache[req.Hash()] = &cachedResponse{
-			response: response,
-			storedAt: time.Now(),
+	rc.cacheMu.Unlock()
+
+	// Fetch without holding mutex. Singleflight deduplicates concurrent
+	// requests to the same cache key — only one fetchFn runs, others
+	// wait for its result. Requests to different keys run in parallel.
+	result, _, _ := rc.flight.Do(cacheKey, func() (interface{}, error) {
+		return fetchFn(), nil
+	})
+	response := result.(gateway.OutboundHTTPResponse)
+
+	// Short lock: store result
+	if storeOnFetch && isCacheableStatusCode(response.StatusCode) {
+		rc.cacheMu.Lock()
+		if rc.isExpiredOrNotCached(workflowID, req) {
+			rc.cache[cacheKey] = &cachedResponse{
+				response: response,
+				storedAt: time.Now(),
+			}
 		}
+		rc.cacheMu.Unlock()
 	}
+
 	return response
 }
 

--- a/core/services/gateway/handlers/capabilities/v2/response_cache.go
+++ b/core/services/gateway/handlers/capabilities/v2/response_cache.go
@@ -55,17 +55,19 @@ func (rc *responseCache) isExpiredOrNotCached(req gateway.OutboundHTTPRequest) b
 
 // Fetch fetches a response from the cache if it exists and
 // the age of cached response is less than the max age of the request.
-// If the cached response is expired or not cached, it fetches a new response from the fetchFn.
+// If the cached response is expired or not cached, it fetches a new response from the fetchFn
 // and caches the response if it is cacheable and storeOnFetch is true.
 //
 // The mutex is only held during cache map access (microseconds), not during fetchFn execution.
 // Singleflight deduplicates concurrent requests to the same cache key so only one fetchFn
 // runs per key, while requests to different keys execute in parallel.
+// Cache read and write happen inside the singleflight callback to ensure the key remains
+// in-flight until the result is stored, preventing duplicate fetches.
 func (rc *responseCache) Fetch(ctx context.Context, req gateway.OutboundHTTPRequest, fetchFn func() gateway.OutboundHTTPResponse, storeOnFetch bool) gateway.OutboundHTTPResponse {
 	cacheKey := req.Hash()
 	cacheMaxAge := time.Duration(req.CacheSettings.MaxAgeMs) * time.Millisecond
 
-	// Short read lock: check cache
+	// Fast path: check cache without singleflight overhead.
 	rc.cacheMu.RLock()
 	cachedResp, exists := rc.cache[cacheKey]
 	rc.cacheMu.RUnlock()
@@ -74,27 +76,35 @@ func (rc *responseCache) Fetch(ctx context.Context, req gateway.OutboundHTTPRequ
 		return cachedResp.response
 	}
 
-	// Fetch without holding mutex. Singleflight deduplicates concurrent
-	// requests to the same cache key — only one fetchFn runs, others
-	// wait for its result. Requests to different keys run in parallel.
+	// Slow path: singleflight deduplicates concurrent fetches per key.
+	// Cache check + store happen inside the flight so the key isn't released
+	// until the result is cached, closing the race window between singleflight
+	// completion and cache write.
 	result, _, _ := rc.flight.Do(cacheKey, func() (interface{}, error) {
-		return fetchFn(), nil
-	})
-	response := result.(gateway.OutboundHTTPResponse)
+		// Re-check cache: a previous flight may have just stored the result.
+		rc.cacheMu.RLock()
+		cachedResp, exists := rc.cache[cacheKey]
+		rc.cacheMu.RUnlock()
+		if exists && cachedResp.storedAt.Add(cacheMaxAge).After(time.Now()) {
+			rc.metrics.IncrementCacheHitCount(ctx, rc.lggr)
+			return cachedResp.response, nil
+		}
 
-	// Short lock: store result
-	if storeOnFetch && isCacheableStatusCode(response.StatusCode) {
-		rc.cacheMu.Lock()
-		if rc.isExpiredOrNotCached(req) {
+		response := fetchFn()
+
+		if storeOnFetch && isCacheableStatusCode(response.StatusCode) {
+			rc.cacheMu.Lock()
 			rc.cache[cacheKey] = &cachedResponse{
 				response: response,
 				storedAt: time.Now(),
 			}
+			rc.cacheMu.Unlock()
 		}
-		rc.cacheMu.Unlock()
-	}
 
-	return response
+		return response, nil
+	})
+
+	return result.(gateway.OutboundHTTPResponse)
 }
 
 // Set caches a response if it is cacheable (2xx or 4xx and cache is empty or expired for the given request)

--- a/core/services/gateway/handlers/capabilities/v2/response_cache.go
+++ b/core/services/gateway/handlers/capabilities/v2/response_cache.go
@@ -16,7 +16,7 @@ import (
 // It uses a map to store responses keyed by a unique identifier generated from the request
 // cache key is prefixed by workflowID to avoid collisions between different workflows.
 type responseCache struct {
-	cacheMu sync.Mutex
+	cacheMu sync.RWMutex
 	cache   map[string]*cachedResponse
 	flight  singleflight.Group
 	lggr    logger.Logger
@@ -45,7 +45,7 @@ func isCacheableStatusCode(statusCode int) bool {
 }
 
 // isExpiredOrNotCached returns true if the cached response is expired or not cached.
-// IMPORTANT: this method does not lock the cache map. MUST be called with the cacheMu locked.
+// IMPORTANT: this method does not lock the cache map. MUST be called with cacheMu write-locked.
 func (rc *responseCache) isExpiredOrNotCached(_ string, req gateway.OutboundHTTPRequest) bool {
 	cachedResp, exists := rc.cache[req.Hash()]
 	if !exists || time.Now().After(cachedResp.storedAt.Add(rc.ttl)) {
@@ -66,15 +66,14 @@ func (rc *responseCache) Fetch(ctx context.Context, workflowID string, req gatew
 	cacheKey := req.Hash()
 	cacheMaxAge := time.Duration(req.CacheSettings.MaxAgeMs) * time.Millisecond
 
-	// Short lock: check cache
-	rc.cacheMu.Lock()
+	// Short read lock: check cache
+	rc.cacheMu.RLock()
 	cachedResp, exists := rc.cache[cacheKey]
+	rc.cacheMu.RUnlock()
 	if exists && cachedResp.storedAt.Add(cacheMaxAge).After(time.Now()) {
-		rc.cacheMu.Unlock()
 		rc.metrics.IncrementCacheHitCount(ctx, rc.lggr)
 		return cachedResp.response
 	}
-	rc.cacheMu.Unlock()
 
 	// Fetch without holding mutex. Singleflight deduplicates concurrent
 	// requests to the same cache key — only one fetchFn runs, others

--- a/core/services/gateway/handlers/capabilities/v2/response_cache.go
+++ b/core/services/gateway/handlers/capabilities/v2/response_cache.go
@@ -13,8 +13,7 @@ import (
 )
 
 // responseCache is a thread-safe cache for storing HTTP responses.
-// It uses a map to store responses keyed by a unique identifier generated from the request
-// cache key is prefixed by workflowID to avoid collisions between different workflows.
+// It uses a map to store responses keyed by a hash of the request (method, URL, headers, body, workflowOwner).
 type responseCache struct {
 	cacheMu sync.RWMutex
 	cache   map[string]*cachedResponse
@@ -46,7 +45,7 @@ func isCacheableStatusCode(statusCode int) bool {
 
 // isExpiredOrNotCached returns true if the cached response is expired or not cached.
 // IMPORTANT: this method does not lock the cache map. MUST be called with cacheMu write-locked.
-func (rc *responseCache) isExpiredOrNotCached(_ string, req gateway.OutboundHTTPRequest) bool {
+func (rc *responseCache) isExpiredOrNotCached(req gateway.OutboundHTTPRequest) bool {
 	cachedResp, exists := rc.cache[req.Hash()]
 	if !exists || time.Now().After(cachedResp.storedAt.Add(rc.ttl)) {
 		return true
@@ -62,7 +61,7 @@ func (rc *responseCache) isExpiredOrNotCached(_ string, req gateway.OutboundHTTP
 // The mutex is only held during cache map access (microseconds), not during fetchFn execution.
 // Singleflight deduplicates concurrent requests to the same cache key so only one fetchFn
 // runs per key, while requests to different keys execute in parallel.
-func (rc *responseCache) Fetch(ctx context.Context, workflowID string, req gateway.OutboundHTTPRequest, fetchFn func() gateway.OutboundHTTPResponse, storeOnFetch bool) gateway.OutboundHTTPResponse {
+func (rc *responseCache) Fetch(ctx context.Context, req gateway.OutboundHTTPRequest, fetchFn func() gateway.OutboundHTTPResponse, storeOnFetch bool) gateway.OutboundHTTPResponse {
 	cacheKey := req.Hash()
 	cacheMaxAge := time.Duration(req.CacheSettings.MaxAgeMs) * time.Millisecond
 
@@ -86,7 +85,7 @@ func (rc *responseCache) Fetch(ctx context.Context, workflowID string, req gatew
 	// Short lock: store result
 	if storeOnFetch && isCacheableStatusCode(response.StatusCode) {
 		rc.cacheMu.Lock()
-		if rc.isExpiredOrNotCached(workflowID, req) {
+		if rc.isExpiredOrNotCached(req) {
 			rc.cache[cacheKey] = &cachedResponse{
 				response: response,
 				storedAt: time.Now(),
@@ -99,10 +98,10 @@ func (rc *responseCache) Fetch(ctx context.Context, workflowID string, req gatew
 }
 
 // Set caches a response if it is cacheable (2xx or 4xx and cache is empty or expired for the given request)
-func (rc *responseCache) Set(workflowID string, req gateway.OutboundHTTPRequest, response gateway.OutboundHTTPResponse) {
+func (rc *responseCache) Set(req gateway.OutboundHTTPRequest, response gateway.OutboundHTTPResponse) {
 	rc.cacheMu.Lock()
 	defer rc.cacheMu.Unlock()
-	if isCacheableStatusCode(response.StatusCode) && rc.isExpiredOrNotCached(workflowID, req) {
+	if isCacheableStatusCode(response.StatusCode) && rc.isExpiredOrNotCached(req) {
 		rc.cache[req.Hash()] = &cachedResponse{
 			response: response,
 			storedAt: time.Now(),

--- a/core/services/gateway/handlers/capabilities/v2/response_cache_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/response_cache_test.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -177,11 +178,11 @@ func TestRequestHash(t *testing.T) {
 func TestIsExpiredOrNotCached(t *testing.T) {
 	testMetrics := createCacheTestMetrics(t)
 	cache := newResponseCache(logger.Test(t), 1000, testMetrics) // 1 second TTL
-	workflowID := "workflow-123"
+
 	req := createTestRequest("GET", "https://example.com")
 
 	t.Run("returns true for non-existent entry", func(t *testing.T) {
-		result := cache.isExpiredOrNotCached(workflowID, req)
+		result := cache.isExpiredOrNotCached(req)
 		require.True(t, result)
 	})
 
@@ -191,7 +192,7 @@ func TestIsExpiredOrNotCached(t *testing.T) {
 			storedAt: time.Now(),
 		}
 
-		result := cache.isExpiredOrNotCached(workflowID, req)
+		result := cache.isExpiredOrNotCached(req)
 		require.False(t, result)
 	})
 
@@ -201,7 +202,7 @@ func TestIsExpiredOrNotCached(t *testing.T) {
 			storedAt: time.Now().Add(-2 * time.Second),
 		}
 
-		result := cache.isExpiredOrNotCached(workflowID, req)
+		result := cache.isExpiredOrNotCached(req)
 		require.True(t, result)
 	})
 }
@@ -209,7 +210,6 @@ func TestIsExpiredOrNotCached(t *testing.T) {
 func TestFetch(t *testing.T) {
 	testMetrics := createCacheTestMetrics(t)
 	cache := newResponseCache(logger.Test(t), 10000, testMetrics) // 10 seconds TTL
-	workflowID := "workflow-123"
 
 	t.Run("calls fetchFn when cache miss", func(t *testing.T) {
 		req := createTestRequest("GET", "https://example.com/miss")
@@ -221,7 +221,7 @@ func TestFetch(t *testing.T) {
 			return expectedResp
 		}
 
-		result := cache.Fetch(t.Context(), workflowID, req, fetchFn, true)
+		result := cache.Fetch(t.Context(), req, fetchFn, true)
 
 		require.True(t, fetchCalled)
 		require.Equal(t, expectedResp, result)
@@ -243,7 +243,7 @@ func TestFetch(t *testing.T) {
 			return createTestResponse(200, "should not be called")
 		}
 
-		result := cache.Fetch(t.Context(), workflowID, req, fetchFn, true)
+		result := cache.Fetch(t.Context(), req, fetchFn, true)
 
 		require.False(t, fetchCalled, "fetchFn should not be called on cache hit")
 		require.Equal(t, cachedResp, result)
@@ -265,7 +265,7 @@ func TestFetch(t *testing.T) {
 			return expectedResp
 		}
 
-		result := cache.Fetch(t.Context(), workflowID, req, fetchFn, true)
+		result := cache.Fetch(t.Context(), req, fetchFn, true)
 
 		require.True(t, fetchCalled)
 		require.Equal(t, expectedResp, result)
@@ -279,7 +279,7 @@ func TestFetch(t *testing.T) {
 			return response
 		}
 
-		cache.Fetch(t.Context(), workflowID, req, fetchFn, true)
+		cache.Fetch(t.Context(), req, fetchFn, true)
 
 		cachedEntry, exists := cache.cache[req.Hash()]
 		require.True(t, exists)
@@ -294,7 +294,7 @@ func TestFetch(t *testing.T) {
 			return response
 		}
 
-		result := cache.Fetch(t.Context(), workflowID, req, fetchFn, false)
+		result := cache.Fetch(t.Context(), req, fetchFn, false)
 
 		// Should return the response but not cache it
 		require.Equal(t, response, result)
@@ -311,7 +311,7 @@ func TestFetch(t *testing.T) {
 			return response
 		}
 
-		result := cache.Fetch(t.Context(), workflowID, req, fetchFn, true)
+		result := cache.Fetch(t.Context(), req, fetchFn, true)
 
 		// Should return the response but not cache it
 		require.Equal(t, response, result)
@@ -324,7 +324,6 @@ func TestFetch(t *testing.T) {
 func TestFetch_ConcurrentDifferentKeys_RunInParallel(t *testing.T) {
 	testMetrics := createCacheTestMetrics(t)
 	cache := newResponseCache(logger.Test(t), 10000, testMetrics)
-	workflowID := "workflow-123"
 
 	const n = 10
 	const fetchDelay = 100 * time.Millisecond
@@ -342,7 +341,7 @@ func TestFetch_ConcurrentDifferentKeys_RunInParallel(t *testing.T) {
 					time.Sleep(fetchDelay)
 					return createTestResponse(200, fmt.Sprintf("response-%d", idx))
 				}
-				resp := cache.Fetch(t.Context(), workflowID, req, fetchFn, true)
+				resp := cache.Fetch(t.Context(), req, fetchFn, true)
 				assert.Equal(t, 200, resp.StatusCode)
 			}(i)
 		}
@@ -358,11 +357,9 @@ func TestFetch_ConcurrentDifferentKeys_RunInParallel(t *testing.T) {
 func TestFetch_ConcurrentSameKey_Deduplicated(t *testing.T) {
 	testMetrics := createCacheTestMetrics(t)
 	cache := newResponseCache(logger.Test(t), 10000, testMetrics)
-	workflowID := "workflow-123"
 
 	const n = 5
-	var fetchCount int32
-	var mu sync.Mutex
+	var fetchCount atomic.Int32
 
 	req := createTestRequest("GET", "https://example.com/dedup")
 	expectedResp := createTestResponse(200, "deduplicated")
@@ -375,37 +372,73 @@ func TestFetch_ConcurrentSameKey_Deduplicated(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				fetchFn := func() gateway_common.OutboundHTTPResponse {
-					mu.Lock()
-					fetchCount++
-					mu.Unlock()
+					fetchCount.Add(1)
 					time.Sleep(100 * time.Millisecond)
 					return expectedResp
 				}
-				resp := cache.Fetch(t.Context(), workflowID, req, fetchFn, true)
+				resp := cache.Fetch(t.Context(), req, fetchFn, true)
 				assert.Equal(t, expectedResp, resp)
 			}()
 		}
 		wg.Wait()
 
-		mu.Lock()
-		count := fetchCount
-		mu.Unlock()
-
 		// Singleflight should deduplicate: only 1 fetchFn call for the same key
-		assert.Equal(t, int32(1), count, "singleflight should deduplicate concurrent requests to the same key")
+		assert.Equal(t, int32(1), fetchCount.Load(), "singleflight should deduplicate concurrent requests to the same key")
+	})
+}
+
+func TestFetch_PanicInFetchFn_PropagatedToCaller(t *testing.T) {
+	testMetrics := createCacheTestMetrics(t)
+	cache := newResponseCache(logger.Test(t), 10000, testMetrics)
+
+	req := createTestRequest("GET", "https://example.com/panic")
+	fetchFn := func() gateway_common.OutboundHTTPResponse {
+		panic("unexpected error in HTTP callback")
+	}
+
+	require.Panics(t, func() {
+		cache.Fetch(t.Context(), req, fetchFn, true)
+	})
+}
+
+func TestFetch_PanicInFetchFn_PropagatedToAllWaiters(t *testing.T) {
+	testMetrics := createCacheTestMetrics(t)
+	cache := newResponseCache(logger.Test(t), 10000, testMetrics)
+
+	const n = 5
+	req := createTestRequest("GET", "https://example.com/panic-shared")
+
+	synctest.Test(t, func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(n)
+
+		for i := 0; i < n; i++ {
+			go func() {
+				defer wg.Done()
+				defer func() {
+					r := recover()
+					assert.NotNil(t, r, "panic from fetchFn should propagate to all waiters")
+				}()
+				fetchFn := func() gateway_common.OutboundHTTPResponse {
+					time.Sleep(50 * time.Millisecond)
+					panic("shared panic")
+				}
+				cache.Fetch(t.Context(), req, fetchFn, true)
+			}()
+		}
+		wg.Wait()
 	})
 }
 
 func TestSet(t *testing.T) {
 	testMetrics := createCacheTestMetrics(t)
 	cache := newResponseCache(logger.Test(t), 10000, testMetrics)
-	workflowID := "workflow-123"
 
 	t.Run("sets cacheable response", func(t *testing.T) {
 		req := createTestRequest("GET", "https://example.com/set")
 		response := createTestResponse(200, "response to cache")
 
-		cache.Set(workflowID, req, response)
+		cache.Set(req, response)
 
 		cachedEntry, exists := cache.cache[req.Hash()]
 		require.True(t, exists)
@@ -416,7 +449,7 @@ func TestSet(t *testing.T) {
 		req := createTestRequest("GET", "https://example.com/nonset")
 		response := createTestResponse(500, "server error")
 
-		cache.Set(workflowID, req, response)
+		cache.Set(req, response)
 
 		_, exists := cache.cache[req.Hash()]
 		require.False(t, exists, "5xx response should not be cached")
@@ -427,10 +460,10 @@ func TestSet(t *testing.T) {
 		originalResponse := createTestResponse(200, "original")
 		newResponse := createTestResponse(200, "new")
 
-		cache.Set(workflowID, req, originalResponse)
+		cache.Set(req, originalResponse)
 
 		// Immediately try to set again
-		cache.Set(workflowID, req, newResponse)
+		cache.Set(req, newResponse)
 
 		cachedEntry, exists := cache.cache[req.Hash()]
 		require.True(t, exists)
@@ -446,7 +479,7 @@ func TestSet(t *testing.T) {
 		}
 
 		newResponse := createTestResponse(200, "fresh")
-		cache.Set(workflowID, req, newResponse)
+		cache.Set(req, newResponse)
 
 		cachedEntry, exists := cache.cache[req.Hash()]
 		require.True(t, exists)
@@ -501,12 +534,12 @@ func TestEdgeCases(t *testing.T) {
 	t.Run("zero TTL cache", func(t *testing.T) {
 		testMetrics := createCacheTestMetrics(t)
 		cache := newResponseCache(logger.Test(t), 0, testMetrics)
-		workflowID := "workflow-123"
+
 		req := createTestRequest("GET", "https://example.com/zero-ttl")
 
-		require.True(t, cache.isExpiredOrNotCached(workflowID, req))
+		require.True(t, cache.isExpiredOrNotCached(req))
 
-		cache.Set(workflowID, req, createTestResponse(200, "test"))
+		cache.Set(req, createTestResponse(200, "test"))
 		count := cache.DeleteExpired(t.Context())
 		require.Equal(t, 1, count, "entry should be immediately expired")
 	})
@@ -514,7 +547,7 @@ func TestEdgeCases(t *testing.T) {
 	t.Run("handles nil response headers", func(t *testing.T) {
 		testMetrics := createCacheTestMetrics(t)
 		cache := newResponseCache(logger.Test(t), 5000, testMetrics)
-		workflowID := "workflow-123"
+
 		req := createTestRequest("GET", "https://example.com/nil-headers")
 
 		resp := gateway_common.OutboundHTTPResponse{
@@ -523,9 +556,9 @@ func TestEdgeCases(t *testing.T) {
 			Headers:    nil,
 		}
 
-		cache.Set(workflowID, req, resp)
+		cache.Set(req, resp)
 
-		result := cache.Fetch(t.Context(), workflowID, req, func() gateway_common.OutboundHTTPResponse {
+		result := cache.Fetch(t.Context(), req, func() gateway_common.OutboundHTTPResponse {
 			return resp
 		}, true)
 		require.Equal(t, resp, result)
@@ -534,7 +567,6 @@ func TestEdgeCases(t *testing.T) {
 	t.Run("handles empty request", func(t *testing.T) {
 		testMetrics := createCacheTestMetrics(t)
 		cache := newResponseCache(logger.Test(t), 5000, testMetrics)
-		workflowID := "workflow-123"
 
 		emptyReq := gateway_common.OutboundHTTPRequest{
 			CacheSettings: gateway_common.CacheSettings{MaxAgeMs: 1000},
@@ -543,6 +575,6 @@ func TestEdgeCases(t *testing.T) {
 		hash := emptyReq.Hash()
 		require.NotEmpty(t, hash)
 
-		cache.Set(workflowID, emptyReq, createTestResponse(200, "test"))
+		cache.Set(emptyReq, createTestResponse(200, "test"))
 	})
 }

--- a/core/services/gateway/handlers/capabilities/v2/response_cache_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/response_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -328,31 +329,30 @@ func TestFetch_ConcurrentDifferentKeys_RunInParallel(t *testing.T) {
 	const n = 10
 	const fetchDelay = 100 * time.Millisecond
 
-	var wg sync.WaitGroup
-	wg.Add(n)
+	synctest.Test(t, func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(n)
 
-	start := time.Now()
-	for i := 0; i < n; i++ {
-		go func(idx int) {
-			defer wg.Done()
-			req := createTestRequest("GET", fmt.Sprintf("https://example.com/parallel/%d", idx))
-			fetchFn := func() gateway_common.OutboundHTTPResponse {
-				time.Sleep(fetchDelay)
-				return createTestResponse(200, fmt.Sprintf("response-%d", idx))
-			}
-			resp := cache.Fetch(t.Context(), workflowID, req, fetchFn, true)
-			assert.Equal(t, 200, resp.StatusCode)
-		}(i)
-	}
-	wg.Wait()
-	elapsed := time.Since(start)
+		start := time.Now()
+		for i := 0; i < n; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				req := createTestRequest("GET", fmt.Sprintf("https://example.com/parallel/%d", idx))
+				fetchFn := func() gateway_common.OutboundHTTPResponse {
+					time.Sleep(fetchDelay)
+					return createTestResponse(200, fmt.Sprintf("response-%d", idx))
+				}
+				resp := cache.Fetch(t.Context(), workflowID, req, fetchFn, true)
+				assert.Equal(t, 200, resp.StatusCode)
+			}(i)
+		}
+		wg.Wait()
+		elapsed := time.Since(start)
 
-	// If requests run in parallel, total time should be ~fetchDelay (100ms).
-	// If serialized, it would be ~n*fetchDelay (1000ms).
-	// Use 3x fetchDelay as a generous upper bound to avoid flakiness.
-	maxExpected := 3 * fetchDelay
-	assert.Less(t, elapsed, maxExpected,
-		"concurrent fetches to different keys should run in parallel, took %v (max expected %v)", elapsed, maxExpected)
+		// If requests run in parallel, total time should be exactly fetchDelay.
+		assert.Equal(t, fetchDelay, elapsed,
+			"concurrent fetches to different keys should run in parallel, took %v (expected %v)", elapsed, fetchDelay)
+	})
 }
 
 func TestFetch_ConcurrentSameKey_Deduplicated(t *testing.T) {
@@ -364,34 +364,36 @@ func TestFetch_ConcurrentSameKey_Deduplicated(t *testing.T) {
 	var fetchCount int32
 	var mu sync.Mutex
 
-	var wg sync.WaitGroup
-	wg.Add(n)
-
 	req := createTestRequest("GET", "https://example.com/dedup")
 	expectedResp := createTestResponse(200, "deduplicated")
 
-	for i := 0; i < n; i++ {
-		go func() {
-			defer wg.Done()
-			fetchFn := func() gateway_common.OutboundHTTPResponse {
-				mu.Lock()
-				fetchCount++
-				mu.Unlock()
-				time.Sleep(100 * time.Millisecond)
-				return expectedResp
-			}
-			resp := cache.Fetch(t.Context(), workflowID, req, fetchFn, true)
-			assert.Equal(t, expectedResp, resp)
-		}()
-	}
-	wg.Wait()
+	synctest.Test(t, func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(n)
 
-	mu.Lock()
-	count := fetchCount
-	mu.Unlock()
+		for i := 0; i < n; i++ {
+			go func() {
+				defer wg.Done()
+				fetchFn := func() gateway_common.OutboundHTTPResponse {
+					mu.Lock()
+					fetchCount++
+					mu.Unlock()
+					time.Sleep(100 * time.Millisecond)
+					return expectedResp
+				}
+				resp := cache.Fetch(t.Context(), workflowID, req, fetchFn, true)
+				assert.Equal(t, expectedResp, resp)
+			}()
+		}
+		wg.Wait()
 
-	// Singleflight should deduplicate: only 1 fetchFn call for the same key
-	assert.Equal(t, int32(1), count, "singleflight should deduplicate concurrent requests to the same key")
+		mu.Lock()
+		count := fetchCount
+		mu.Unlock()
+
+		// Singleflight should deduplicate: only 1 fetchFn call for the same key
+		assert.Equal(t, int32(1), count, "singleflight should deduplicate concurrent requests to the same key")
+	})
 }
 
 func TestSet(t *testing.T) {

--- a/core/services/gateway/handlers/capabilities/v2/response_cache_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/response_cache_test.go
@@ -326,7 +326,6 @@ func TestFetch_ConcurrentDifferentKeys_RunInParallel(t *testing.T) {
 	cache := newResponseCache(logger.Test(t), 10000, testMetrics)
 
 	const n = 10
-	const maxFetchDelay = 100 * time.Millisecond
 
 	synctest.Test(t, func(t *testing.T) {
 		var wg sync.WaitGroup
@@ -337,8 +336,8 @@ func TestFetch_ConcurrentDifferentKeys_RunInParallel(t *testing.T) {
 			go func(idx int) {
 				defer wg.Done()
 				req := createTestRequest("GET", fmt.Sprintf("https://example.com/parallel/%d", idx))
-				// Non-uniform delays to simulate realistic conditions.
-				delay := time.Duration(idx+1) * 10 * time.Millisecond
+				// Non-uniform delays — synctest only cares about relative order.
+				delay := time.Duration(idx+1) * time.Second
 				fetchFn := func() gateway_common.OutboundHTTPResponse {
 					time.Sleep(delay)
 					return createTestResponse(200, fmt.Sprintf("response-%d", idx))
@@ -351,8 +350,8 @@ func TestFetch_ConcurrentDifferentKeys_RunInParallel(t *testing.T) {
 		elapsed := time.Since(start)
 
 		// If requests run in parallel, total time should be the longest delay.
-		assert.Equal(t, maxFetchDelay, elapsed,
-			"concurrent fetches to different keys should run in parallel, took %v (expected %v)", elapsed, maxFetchDelay)
+		assert.Equal(t, time.Duration(n)*time.Second, elapsed,
+			"concurrent fetches to different keys should run in parallel, took %v (expected %v)", elapsed, time.Duration(n)*time.Second)
 	})
 }
 

--- a/core/services/gateway/handlers/capabilities/v2/response_cache_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/response_cache_test.go
@@ -1,9 +1,12 @@
 package v2
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -315,6 +318,80 @@ func TestFetch(t *testing.T) {
 		_, exists := cache.cache[req.Hash()]
 		require.False(t, exists, "5xx response should not be cached")
 	})
+}
+
+func TestFetch_ConcurrentDifferentKeys_RunInParallel(t *testing.T) {
+	testMetrics := createCacheTestMetrics(t)
+	cache := newResponseCache(logger.Test(t), 10000, testMetrics)
+	workflowID := "workflow-123"
+
+	const n = 10
+	const fetchDelay = 100 * time.Millisecond
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	start := time.Now()
+	for i := 0; i < n; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			req := createTestRequest("GET", fmt.Sprintf("https://example.com/parallel/%d", idx))
+			fetchFn := func() gateway_common.OutboundHTTPResponse {
+				time.Sleep(fetchDelay)
+				return createTestResponse(200, fmt.Sprintf("response-%d", idx))
+			}
+			resp := cache.Fetch(t.Context(), workflowID, req, fetchFn, true)
+			assert.Equal(t, 200, resp.StatusCode)
+		}(i)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	// If requests run in parallel, total time should be ~fetchDelay (100ms).
+	// If serialized, it would be ~n*fetchDelay (1000ms).
+	// Use 3x fetchDelay as a generous upper bound to avoid flakiness.
+	maxExpected := 3 * fetchDelay
+	assert.Less(t, elapsed, maxExpected,
+		"concurrent fetches to different keys should run in parallel, took %v (max expected %v)", elapsed, maxExpected)
+}
+
+func TestFetch_ConcurrentSameKey_Deduplicated(t *testing.T) {
+	testMetrics := createCacheTestMetrics(t)
+	cache := newResponseCache(logger.Test(t), 10000, testMetrics)
+	workflowID := "workflow-123"
+
+	const n = 5
+	var fetchCount int32
+	var mu sync.Mutex
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	req := createTestRequest("GET", "https://example.com/dedup")
+	expectedResp := createTestResponse(200, "deduplicated")
+
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			fetchFn := func() gateway_common.OutboundHTTPResponse {
+				mu.Lock()
+				fetchCount++
+				mu.Unlock()
+				time.Sleep(100 * time.Millisecond)
+				return expectedResp
+			}
+			resp := cache.Fetch(t.Context(), workflowID, req, fetchFn, true)
+			assert.Equal(t, expectedResp, resp)
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	count := fetchCount
+	mu.Unlock()
+
+	// Singleflight should deduplicate: only 1 fetchFn call for the same key
+	assert.Equal(t, int32(1), count, "singleflight should deduplicate concurrent requests to the same key")
 }
 
 func TestSet(t *testing.T) {

--- a/core/services/gateway/handlers/capabilities/v2/response_cache_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/response_cache_test.go
@@ -326,7 +326,7 @@ func TestFetch_ConcurrentDifferentKeys_RunInParallel(t *testing.T) {
 	cache := newResponseCache(logger.Test(t), 10000, testMetrics)
 
 	const n = 10
-	const fetchDelay = 100 * time.Millisecond
+	const maxFetchDelay = 100 * time.Millisecond
 
 	synctest.Test(t, func(t *testing.T) {
 		var wg sync.WaitGroup
@@ -337,8 +337,10 @@ func TestFetch_ConcurrentDifferentKeys_RunInParallel(t *testing.T) {
 			go func(idx int) {
 				defer wg.Done()
 				req := createTestRequest("GET", fmt.Sprintf("https://example.com/parallel/%d", idx))
+				// Non-uniform delays to simulate realistic conditions.
+				delay := time.Duration(idx+1) * 10 * time.Millisecond
 				fetchFn := func() gateway_common.OutboundHTTPResponse {
-					time.Sleep(fetchDelay)
+					time.Sleep(delay)
 					return createTestResponse(200, fmt.Sprintf("response-%d", idx))
 				}
 				resp := cache.Fetch(t.Context(), req, fetchFn, true)
@@ -348,9 +350,9 @@ func TestFetch_ConcurrentDifferentKeys_RunInParallel(t *testing.T) {
 		wg.Wait()
 		elapsed := time.Since(start)
 
-		// If requests run in parallel, total time should be exactly fetchDelay.
-		assert.Equal(t, fetchDelay, elapsed,
-			"concurrent fetches to different keys should run in parallel, took %v (expected %v)", elapsed, fetchDelay)
+		// If requests run in parallel, total time should be the longest delay.
+		assert.Equal(t, maxFetchDelay, elapsed,
+			"concurrent fetches to different keys should run in parallel, took %v (expected %v)", elapsed, maxFetchDelay)
 	})
 }
 
@@ -385,6 +387,60 @@ func TestFetch_ConcurrentSameKey_Deduplicated(t *testing.T) {
 		// Singleflight should deduplicate: only 1 fetchFn call for the same key
 		assert.Equal(t, int32(1), fetchCount.Load(), "singleflight should deduplicate concurrent requests to the same key")
 	})
+}
+
+// TestFetch_StoreOnFetch_FlightLeaderDecides documents that only the singleflight
+// leader's storeOnFetch value is used. Waiters' storeOnFetch is silently ignored
+// because only the leader's closure executes inside flight.Do.
+// This is not a production bug (callers with storeOnFetch=false bypass Fetch entirely),
+// but it makes the contract explicit.
+func TestFetch_StoreOnFetch_FlightLeaderDecides(t *testing.T) {
+	testMetrics := createCacheTestMetrics(t)
+	cache := newResponseCache(logger.Test(t), 10000, testMetrics)
+
+	req := createTestRequest("GET", "https://example.com/leader-store")
+	expectedResp := createTestResponse(200, "response")
+	var fetchCount atomic.Int32
+	leaderRunning := make(chan struct{})
+
+	synctest.Test(t, func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// Goroutine A: flight leader with storeOnFetch=false.
+		go func() {
+			defer wg.Done()
+			fetchFn := func() gateway_common.OutboundHTTPResponse {
+				fetchCount.Add(1)
+				close(leaderRunning)
+				time.Sleep(100 * time.Millisecond)
+				return expectedResp
+			}
+			resp := cache.Fetch(t.Context(), req, fetchFn, false)
+			assert.Equal(t, expectedResp, resp)
+		}()
+
+		// Goroutine B: waiter with storeOnFetch=true.
+		go func() {
+			defer wg.Done()
+			<-leaderRunning // ensure A is the flight leader
+			fetchFn := func() gateway_common.OutboundHTTPResponse {
+				fetchCount.Add(1)
+				return expectedResp
+			}
+			resp := cache.Fetch(t.Context(), req, fetchFn, true)
+			assert.Equal(t, expectedResp, resp)
+		}()
+
+		wg.Wait()
+	})
+
+	assert.Equal(t, int32(1), fetchCount.Load(),
+		"singleflight should deduplicate: only leader's fetchFn runs")
+
+	_, exists := cache.cache[req.Hash()]
+	assert.False(t, exists,
+		"result should NOT be cached: leader had storeOnFetch=false, waiter's storeOnFetch=true was ignored")
 }
 
 func TestFetch_PanicInFetchFn_PropagatedToCaller(t *testing.T) {


### PR DESCRIPTION
 - Fix `responseCache.Fetch()` holding a global mutex during the entire HTTP round-trip, which serialized all concurrent HTTP action requests
    - Split the mutex into short-lived locks around cache map access only
    - Add `singleflight` to deduplicate concurrent requests to the same cache key without blocking unrelated requests
  - Change `cacheMu` from `sync.Mutex` to `sync.RWMutex` — cache lookups use `RLock`, only writes take the exclusive lock
  - Simplify unlock pattern: unlock immediately after map access instead of branching across code paths
  - Remove unused `workflowID` parameter from `isExpiredOrNotCached`, `Fetch`, `Set`, and the `ResponseCache` interface — it was never used in cache key generation despite the comment claiming
  otherwise
  - Remove dead `extractWorkflowIDFromRequestPath` function (only caller was removed)
  - Fix misleading struct comment that claimed cache keys were prefixed by workflowID
  - Add tests verifying panic propagation through singleflight to all concurrent waiters
  - Use `synctest` for deterministic, non-flaky concurrency tests
 
Problem: `responseCache.Fetch()` acquires `cacheMu.Lock()` and holds it until the HTTP request completes. Every concurrent goroutine blocks on the mutex, causing sequential execution even when `Store: false` (caching disabled), as long as `MaxAgeMs > 0`

Fix: The mutex now only protects cache map reads and writes (microseconds). The HTTP request runs outside the lock. `singleflight.Group` ensures concurrent requests to the same cache key are deduplicated (one fetch, shared result), preserving the original cache semantics.