### PR TITLE
[DX-3681] Increase core test timeout to `25m`

### DIFF
--- a/tools/bin/go_core_ccip_deployment_tests
+++ b/tools/bin/go_core_ccip_deployment_tests
@@ -5,7 +5,7 @@ set +e
 SCRIPT_PATH=`dirname "$0"`; SCRIPT_PATH=`eval "cd \"$SCRIPT_PATH\" && pwd"`
 OUTPUT_FILE=${OUTPUT_FILE:-"./output.txt"}
 JUNIT_FILE=${JUNIT_FILE:-"./junit.xml"}
-GO_TEST_TIMEOUT=${GO_TEST_TIMEOUT:-"15m"}
+GO_TEST_TIMEOUT=${GO_TEST_TIMEOUT:-"25m"}
 # Adjusting freeport port block size for tests.
 export CL_RESERVE_PORTS=128
 

--- a/tools/bin/go_core_ccip_deployment_tests
+++ b/tools/bin/go_core_ccip_deployment_tests
@@ -12,7 +12,7 @@ export CL_RESERVE_PORTS=128
 cd deployment || exit 1
 
 echo "Installing gotestsum..."
-go install gotest.tools/gotestsum@v1.12.3
+go install gotest.tools/gotestsum@v1.13.0
 PATH=$PATH:$(go env GOPATH)/bin
 export PATH
 

--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -5,10 +5,10 @@ set +e
 SCRIPT_PATH=`dirname "$0"`; SCRIPT_PATH=`eval "cd \"$SCRIPT_PATH\" && pwd"`
 OUTPUT_FILE=${OUTPUT_FILE:-"./output.txt"}
 JUNIT_FILE=${JUNIT_FILE:-"./junit.xml"}
-GO_TEST_TIMEOUT=${GO_TEST_TIMEOUT:-"15m"}
+GO_TEST_TIMEOUT=${GO_TEST_TIMEOUT:-"25m"}
 
 echo "Installing gotestsum..."
-go install gotest.tools/gotestsum@v1.12.3
+go install gotest.tools/gotestsum@v1.13.0
 PATH=$PATH:$(go env GOPATH)/bin
 export PATH
 

--- a/tools/bin/go_core_tests_integration
+++ b/tools/bin/go_core_tests_integration
@@ -10,7 +10,7 @@ EXTRA_FLAGS=""
 
 # Install gotestsum as test runner
 echo "Installing gotestsum..."
-go install gotest.tools/gotestsum@v1.12.3
+go install gotest.tools/gotestsum@v1.13.0
 PATH=$PATH:$(go env GOPATH)/bin
 export PATH
 

--- a/tools/bin/go_core_tests_integration
+++ b/tools/bin/go_core_tests_integration
@@ -5,7 +5,7 @@ set +e
 SCRIPT_PATH=$(dirname "$0"); SCRIPT_PATH=$(eval "cd \"$SCRIPT_PATH\" && pwd")
 OUTPUT_FILE=${OUTPUT_FILE:-"./output.txt"}
 JUNIT_FILE=${JUNIT_FILE:-"./junit.xml"}
-GO_TEST_TIMEOUT=${GO_TEST_TIMEOUT:-"10m"}
+GO_TEST_TIMEOUT=${GO_TEST_TIMEOUT:-"25m"}
 EXTRA_FLAGS=""
 
 # Install gotestsum as test runner


### PR DESCRIPTION
The old timeout of `15m` was giving us panics. Bumping timeout to make it stop runs from crossing the `p(95)` threshold. Also updated gotestsum version.