### PR TITLE
cre-3262: non-determinism fix in confidential relay aggregator

### DIFF
--- a/core/services/gateway/handlers/confidentialrelay/aggregator.go
+++ b/core/services/gateway/handlers/confidentialrelay/aggregator.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -41,8 +43,27 @@ func (a *aggregator) Aggregate(resps map[string]jsonrpc.Response[json.RawMessage
 		if shaToCount[sha] > maxShaToCount {
 			maxShaToCount = shaToCount[sha]
 		}
-		if shaToCount[sha] >= requiredQuorum {
-			return &r, nil
+	}
+
+	var qualifiedDigests []string
+	for sha, n := range shaToCount {
+		if n >= requiredQuorum {
+			qualifiedDigests = append(qualifiedDigests, sha)
+		}
+	}
+	if len(qualifiedDigests) > 0 {
+		slices.Sort(qualifiedDigests)
+		want := qualifiedDigests[0]
+		for _, k := range slices.Sorted(maps.Keys(resps)) {
+			r := resps[k]
+			sha, err := r.Digest()
+			if err != nil {
+				continue
+			}
+			if sha == want {
+				out := r
+				return &out, nil
+			}
 		}
 	}
 

--- a/core/services/gateway/handlers/confidentialrelay/aggregator_test.go
+++ b/core/services/gateway/handlers/confidentialrelay/aggregator_test.go
@@ -1,0 +1,63 @@
+package confidentialrelay
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+func TestAggregator_tiedMajoritiesPickDigestDeterministically(t *testing.T) {
+	t.Parallel()
+
+	lggr := logger.Test(t)
+	agg := &aggregator{}
+
+	const id = "req-tie"
+	makeResp := func(payload string) jsonrpc.Response[json.RawMessage] {
+		buf, err := json.Marshal(map[string]string{"payload": payload})
+		require.NoError(t, err)
+		rd := make(json.RawMessage, len(buf))
+		copy(rd, buf)
+		return jsonrpc.Response[json.RawMessage]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      id,
+			Method:  MethodCapabilityExec,
+			Result:  &rd,
+		}
+	}
+
+	a := makeResp("aaa")
+	b := makeResp("zzz")
+	digestA, err := a.Digest()
+	require.NoError(t, err)
+	digestB, err := b.Digest()
+	require.NoError(t, err)
+	require.NotEqual(t, digestA, digestB, "fixtures must produce distinct digests")
+
+	wantWinnerDigest := digestA
+	if digestB < digestA {
+		wantWinnerDigest = digestB
+	}
+
+	// Two nodes report A, two report B: each side has F+1 when F=1. Map iteration order
+	// must not change which digest wins.
+	for range 300 {
+		m := map[string]jsonrpc.Response[json.RawMessage]{
+			"n0": a,
+			"n1": a,
+			"n2": b,
+			"n3": b,
+		}
+		got, err := agg.Aggregate(m, 1, 4, lggr)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		gotDigest, derr := got.Digest()
+		require.NoError(t, derr)
+		require.Equal(t, wantWinnerDigest, gotDigest,
+			"with tied majorities the chosen digest must be order-independent (lexicographically smallest qualifying digest)")
+	}
+}


### PR DESCRIPTION
in `chainlink/core/services/gateway/handlers/confidentialrelay/aggregator.go`, `Aggregate` walks resps with `for _, r := range resps`. `resps` is a `map[string]jsonrpc.Response[...]`, so iteration order is undefined and can differ across runs and processes

because map range order is random, in a true two-way tie (e.g. two distinct digests each with exactly `F+1` supporters among `donMembersCount` relay nodes), which aggregated response is returned is whichever group’s count crosses the threshold first in that iteration - so different nodes or different executions can pick different “winning” bodies even when the multiset of digests is the same

test:
test added to prove the phenomenon - pinpoints the bug - it loops 300 times with a new map each time and requires the returned digest to always equal `min(digestA, digestB)` (lexicographic order on the hex digests). on the old implementation (return as soon as `shaToCount[sha] >= requiredQuorum` while ranging `resps`), that assertion fails quickly: whichever digest reaches quorum first depends on map iteration order, so you sometimes get `digestA`, sometimes `digestB`

fix:
- first pass: count digests
- collect digests with `count >= requiredQuorum`, `slices.Sort`, pick the smallest string.
- return the first response with that digest when iterating `slices.Sorted(maps.Keys(resps))` so the chosen instance is stable too.

[cre-3262](https://smartcontract-it.atlassian.net/browse/cre-3262)