### PR TITLE
cre-3270: flaky test fix for remote capability

### DIFF
--- a/core/capabilities/remote/executable/request/client_request_test.go
+++ b/core/capabilities/remote/executable/request/client_request_test.go
@@ -32,6 +32,8 @@ const (
 	workflowID1          = "15c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0"
 	workflowExecutionID1 = "95ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0abbadeed"
 	stepRef1             = "stepRef1"
+
+	testDispatcherChanCap = 100
 )
 
 func Test_ClientRequest_MessageValidation(t *testing.T) {
@@ -82,7 +84,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		ctx := t.Context()
 		capabilityPeers, capDonInfo, capInfo := capabilityDon(t, 2, 1)
 
-		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
+		dispatcher := newClientRequestTestDispatcher()
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
 			workflowDonInfo, dispatcher, 10*time.Minute, nil, "")
 		defer req.Cancel(errors.New("test end"))
@@ -133,7 +135,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		ctx := t.Context()
 		capabilityPeers, capDonInfo, capInfo := capabilityDon(t, 2, 1)
 
-		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
+		dispatcher := newClientRequestTestDispatcher()
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
 			workflowDonInfo, dispatcher, 10*time.Minute, nil, "")
 		require.NoError(t, err)
@@ -167,7 +169,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		ctx := t.Context()
 		capabilityPeers, capDonInfo, capInfo := capabilityDon(t, 2, 1)
 
-		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
+		dispatcher := newClientRequestTestDispatcher()
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
 			workflowDonInfo, dispatcher, 10*time.Minute, nil, "")
 		require.NoError(t, err)
@@ -198,7 +200,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		ctx := t.Context()
 		capabilityPeers, capDonInfo, capInfo := capabilityDon(t, 4, 1)
 
-		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
+		dispatcher := newClientRequestTestDispatcher()
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
 			workflowDonInfo, dispatcher, 10*time.Minute, nil, "")
 		require.NoError(t, err)
@@ -240,7 +242,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		ctx := t.Context()
 		capabilityPeers, capDonInfo, capInfo := capabilityDon(t, 4, 1)
 
-		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
+		dispatcher := newClientRequestTestDispatcher()
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
 			workflowDonInfo, dispatcher, 10*time.Minute, nil, "")
 		require.NoError(t, err)
@@ -284,7 +286,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		ctx := t.Context()
 		capabilityPeers, capDonInfo, capInfo := capabilityDon(t, 4, 1)
 
-		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
+		dispatcher := newClientRequestTestDispatcher()
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
 			workflowDonInfo, dispatcher, 10*time.Minute, nil, "")
 		require.NoError(t, err)
@@ -343,7 +345,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		ctx := t.Context()
 		capabilityPeers, capDonInfo, capInfo := capabilityDon(t, 4, 1)
 
-		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
+		dispatcher := newClientRequestTestDispatcher()
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
 			workflowDonInfo, dispatcher, 10*time.Minute, nil, "")
 		require.NoError(t, err)
@@ -389,9 +391,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		// that the schedule is still executed entirely.
 		cancelFn()
 
-		// Buffered channel so the goroutines block
-		// when executing the schedule
-		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody)}
+		dispatcher := newClientRequestTestDispatcher()
 		req, err := request.NewClientExecuteRequest(
 			ctxWithCancel,
 			lggr,
@@ -408,10 +408,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 
 		// Despite the context being cancelled,
 		// we still send the full schedule.
-		<-dispatcher.msgs
-		<-dispatcher.msgs
-		<-dispatcher.msgs
-		assert.Empty(t, dispatcher.msgs)
+		drainInitialPeerSends(t, dispatcher, len(capPeers))
 
 		msg := &types.MessageBody{
 			CapabilityId:    capInfo.ID,
@@ -508,9 +505,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		ctx, cancelFn := context.WithTimeout(ctx, 15*time.Second)
 		defer cancelFn()
 
-		// Buffered channel so the goroutines block
-		// when executing the schedule
-		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody)}
+		dispatcher := newClientRequestTestDispatcher()
 		req, err := request.NewClientExecuteRequest(
 			ctx,
 			lggr,
@@ -527,10 +522,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 
 		// Despite the context being cancelled,
 		// we still send the full schedule.
-		<-dispatcher.msgs
-		<-dispatcher.msgs
-		<-dispatcher.msgs
-		assert.Empty(t, dispatcher.msgs)
+		drainInitialPeerSends(t, dispatcher, len(capPeers))
 
 		msg := &types.MessageBody{
 			CapabilityId:    capInfo.ID,
@@ -611,7 +603,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 
 		ctx := t.Context()
 
-		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
+		dispatcher := newClientRequestTestDispatcher()
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
 			workflowDonInfo, dispatcher, 10*time.Minute, nil, "")
 		require.NoError(t, err)
@@ -664,7 +656,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		beholderTester := beholdertest.NewObserver(t)
 		lggr, obs := logger.TestObserved(t, zapcore.DebugLevel)
 		capPeers, capDonInfo, capInfo := capabilityDon(t, 3, 1)
-		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody)}
+		dispatcher := newClientRequestTestDispatcher()
 		req, err := request.NewClientExecuteRequest(
 			t.Context(),
 			lggr,
@@ -682,11 +674,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		require.NoError(t, err)
 		defer req.Cancel(errors.New("test end"))
 
-		// Expect all 3 capability nodes to receive the request.
-		<-dispatcher.msgs
-		<-dispatcher.msgs
-		<-dispatcher.msgs
-		assert.Empty(t, dispatcher.msgs)
+		drainInitialPeerSends(t, dispatcher, len(capPeers))
 
 		msg := &types.MessageBody{
 			CapabilityId:    capInfo.ID,
@@ -746,12 +734,20 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 	})
 }
 
+func newClientRequestTestDispatcher() *clientRequestTestDispatcher {
+	return &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, testDispatcherChanCap)}
+}
+
 func drainInitialPeerSends(t *testing.T, d *clientRequestTestDispatcher, numCapabilityPeers int) {
 	t.Helper()
+	require.Eventually(t, func() bool {
+		return len(d.msgs) == numCapabilityPeers
+	}, 2*time.Second, time.Millisecond, "timed out waiting for %d buffered outbound messages", numCapabilityPeers)
+	require.Len(t, d.msgs, numCapabilityPeers, "dispatcher outbound buffer before draining initial peer sends")
 	for range numCapabilityPeers {
 		<-d.msgs
 	}
-	assert.Empty(t, d.msgs)
+	require.Empty(t, d.msgs)
 }
 
 func capabilityDon(t *testing.T, numCapabilityPeers int, f uint8) ([]p2ptypes.PeerID, commoncap.DON, commoncap.CapabilityInfo) {

--- a/core/capabilities/remote/executable/request/client_request_test.go
+++ b/core/capabilities/remote/executable/request/client_request_test.go
@@ -204,9 +204,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		require.NoError(t, err)
 		defer req.Cancel(errors.New("test end"))
 
-		<-dispatcher.msgs
-		<-dispatcher.msgs
-		assert.Empty(t, dispatcher.msgs)
+		drainInitialPeerSends(t, dispatcher, len(capabilityPeers))
 
 		msgWithError := &types.MessageBody{
 			CapabilityId:    capInfo.ID,
@@ -248,9 +246,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		require.NoError(t, err)
 		defer req.Cancel(errors.New("test end"))
 
-		<-dispatcher.msgs
-		<-dispatcher.msgs
-		assert.Empty(t, dispatcher.msgs)
+		drainInitialPeerSends(t, dispatcher, len(capabilityPeers))
 
 		serialized := caperrors.NewPublicUserError(errors.New("rpc error: EVM error invalid argument"), caperrors.FailedPrecondition).SerializeToRemoteString()
 		msgWithError := &types.MessageBody{
@@ -294,9 +290,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		require.NoError(t, err)
 		defer req.Cancel(errors.New("test end"))
 
-		<-dispatcher.msgs
-		<-dispatcher.msgs
-		assert.Empty(t, dispatcher.msgs)
+		drainInitialPeerSends(t, dispatcher, len(capabilityPeers))
 
 		msgWithError := &types.MessageBody{
 			CapabilityId:    capInfo.ID,
@@ -355,9 +349,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		require.NoError(t, err)
 		defer req.Cancel(errors.New("test end"))
 
-		<-dispatcher.msgs
-		<-dispatcher.msgs
-		assert.Empty(t, dispatcher.msgs)
+		drainInitialPeerSends(t, dispatcher, len(capabilityPeers))
 
 		msg := &types.MessageBody{
 			CapabilityId:    capInfo.ID,
@@ -752,6 +744,14 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 			assert.Equal(t, delays[i-1], delays[i], "v2 capabilities should be all at once")
 		}
 	})
+}
+
+func drainInitialPeerSends(t *testing.T, d *clientRequestTestDispatcher, numCapabilityPeers int) {
+	t.Helper()
+	for range numCapabilityPeers {
+		<-d.msgs
+	}
+	assert.Empty(t, d.msgs)
 }
 
 func capabilityDon(t *testing.T, numCapabilityPeers int, f uint8) ([]p2ptypes.PeerID, commoncap.DON, commoncap.CapabilityInfo) {


### PR DESCRIPTION
cause: `newClientRequest` sends one outbound message per capability DON peer. Tests used a 4-node DON but only read two messages, then `assert.Empty` on the buffered channel. That passed only if the other two sends hadn’t landed yet.

fix: introduced `drainInitialPeerSends(t, dispatcher, len(capabilityPeers))`, which receives exactly `numCapabilityPeers` messages (matching the schedule) and then checks the channel is empty. wired it into the four subtests that use 4 peers and the old two-receive pattern.

[cre-3270](https://smartcontract-it.atlassian.net/browse/cre-3270)