### PR TITLE
core/internal/cltest: fix mock server race

### DIFF
--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -168,7 +169,7 @@ func NewHTTPMockServer(
 	response string,
 	callback ...func(http.Header, string),
 ) *httptest.Server {
-	called := false
+	var called atomic.Bool
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
@@ -176,7 +177,7 @@ func NewHTTPMockServer(
 		if len(callback) > 0 {
 			callback[0](r.Header, string(b))
 		}
-		called = true
+		called.Store(true)
 
 		w.WriteHeader(status)
 		_, _ = io.WriteString(w, response) // Assignment for errcheck. Only used in tests so we can ignore.
@@ -185,7 +186,7 @@ func NewHTTPMockServer(
 	server := httptest.NewServer(handler)
 	t.Cleanup(func() {
 		server.Close()
-		assert.True(t, called, "expected call Mock HTTP endpoint '%s'", server.URL)
+		assert.True(t, called.Load(), "expected call Mock HTTP endpoint '%s'", server.URL)
 	})
 	return server
 }


### PR DESCRIPTION
```
WARNING: DATA RACE
Write at 0x00c001a9e0ef by goroutine 890:
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewHTTPMockServer.func1()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/mocks.go:179 +0x21b
  net/http.HandlerFunc.ServeHTTP()
      /opt/hostedtoolcache/go/1.25.7/x64/src/net/http/server.go:2322 +0x47
  net/http.serverHandler.ServeHTTP()
      /opt/hostedtoolcache/go/1.25.7/x64/src/net/http/server.go:3340 +0x2a1
  net/http.(*conn).serve()
      /opt/hostedtoolcache/go/1.25.7/x64/src/net/http/server.go:2109 +0xda4
  net/http.(*Server).Serve.gowrap3()
      /opt/hostedtoolcache/go/1.25.7/x64/src/net/http/server.go:3493 +0x4f

Previous write at 0x00c001a9e0ef by goroutine 891:
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewHTTPMockServer.func1()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/mocks.go:179 +0x21b
  net/http.HandlerFunc.ServeHTTP()
      /opt/hostedtoolcache/go/1.25.7/x64/src/net/http/server.go:2322 +0x47
  net/http.serverHandler.ServeHTTP()
      /opt/hostedtoolcache/go/1.25.7/x64/src/net/http/server.go:3340 +0x2a1
  net/http.(*conn).serve()
      /opt/hostedtoolcache/go/1.25.7/x64/src/net/http/server.go:2109 +0xda4
  net/http.(*Server).Serve.gowrap3()
      /opt/hostedtoolcache/go/1.25.7/x64/src/net/http/server.go:3493 +0x4f

Goroutine 890 (running) created at:
  net/http.(*Server).Serve()
      /opt/hostedtoolcache/go/1.25.7/x64/src/net/http/server.go:3493 +0x889
  net/http/httptest.(*Server).goServe.func1()
      /opt/hostedtoolcache/go/1.25.7/x64/src/net/http/httptest/server.go:311 +0xb2

Goroutine 891 (running) created at:
  net/http.(*Server).Serve()
      /opt/hostedtoolcache/go/1.25.7/x64/src/net/http/server.go:3493 +0x889
  net/http/httptest.(*Server).goServe.func1()
      /opt/hostedtoolcache/go/1.25.7/x64/src/net/http/httptest/server.go:311 +0xb2
```
https://github.com/smartcontractkit/chainlink/actions/runs/24134916661/job/70420468221