### PR TITLE
[DX-3581] revamp private/public images handling in cre system tests pipeline

### DIFF
--- a/.github/scripts/resolve-chainlink-image.sh
+++ b/.github/scripts/resolve-chainlink-image.sh
@@ -2,7 +2,7 @@
 # Resolves the Chainlink Docker image based on ECR type and environment variables.
 # Required:
 #   - ECR_TYPE: one of "sdlc" or "public" (case-insensitive)
-#   - CHAINLINK_IMAGE_REPO
+#   - CHAINLINK_IMAGE_REPO_PATH
 #   - CHAINLINK_IMAGE_TAG
 # For ECR_TYPE=sdlc, also required:
 #   - AWS_ACCOUNT_NUMBER
@@ -23,21 +23,21 @@ trim() {
   printf '%s' "${s}"
 }
 
-repository="${CHAINLINK_IMAGE_REPO:-}"
+repository_path="${CHAINLINK_IMAGE_REPO_PATH:-}"
 image_tag="${CHAINLINK_IMAGE_TAG:-}"
 ecr_type="${ECR_TYPE:-}"
 aws_account="${AWS_ACCOUNT_NUMBER:-}"
 aws_region="${AWS_REGION:-}"
 
 # Trim whitespace before normalization/validation.
-repository="$(trim "${repository}")"
+repository_path="$(trim "${repository_path}")"
 image_tag="$(trim "${image_tag}")"
 ecr_type="$(trim "${ecr_type}")"
 aws_account="$(trim "${aws_account}")"
 aws_region="$(trim "${aws_region}")"
 
 # Normalize all input fields to lowercase for case-insensitive handling.
-repository="$(printf '%s' "${repository}" | tr '[:upper:]' '[:lower:]')"
+repository_path="$(printf '%s' "${repository_path}" | tr '[:upper:]' '[:lower:]')"
 image_tag="$(printf '%s' "${image_tag}" | tr '[:upper:]' '[:lower:]')"
 ecr_type="$(printf '%s' "${ecr_type}" | tr '[:upper:]' '[:lower:]')"
 aws_account="$(printf '%s' "${aws_account}" | tr '[:upper:]' '[:lower:]')"
@@ -51,8 +51,8 @@ if [[ "${ecr_type}" != "sdlc" && "${ecr_type}" != "public" ]]; then
   error "Invalid 'ECR_TYPE': '${ecr_type}'. Allowed values: 'sdlc' or 'public'."
 fi
 
-if [[ -z "${repository}" ]]; then
-  error "'CHAINLINK_IMAGE_REPO' must be set and non-empty."
+if [[ -z "${repository_path}" ]]; then
+  error "'CHAINLINK_IMAGE_REPO_PATH' must be set and non-empty."
 fi
 
 if [[ -z "${image_tag}" ]]; then
@@ -60,7 +60,7 @@ if [[ -z "${image_tag}" ]]; then
 fi
 
 if [[ "${ecr_type}" == "public" ]]; then
-  printf '%s\n' "gallery.ecr.aws/${repository}:${image_tag}"
+  printf '%s\n' "public.ecr.aws/${repository_path}:${image_tag}"
   exit 0
 fi
 
@@ -69,4 +69,4 @@ if [[ -z "${aws_account}" || -z "${aws_region}" ]]; then
   error "For 'ECR_TYPE=sdlc', both 'AWS_ACCOUNT_NUMBER' and 'AWS_REGION' must be set and non-empty."
 fi
 
-printf '%s\n' "${aws_account}.dkr.ecr.${aws_region}.amazonaws.com/${repository}:${image_tag}"
+printf '%s\n' "${aws_account}.dkr.ecr.${aws_region}.amazonaws.com/${repository_path}:${image_tag}"

--- a/.github/scripts/resolve-chainlink-image.sh
+++ b/.github/scripts/resolve-chainlink-image.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# Resolves the Chainlink Docker image to use based on environment variables.
-# Priority:
-#   1. If CHAINLINK_FULL_IMAGE is set, use it directly (must include registry and tag/digest).
-#   2. Otherwise, construct the image from:
-#        - Repository: CHAINLINK_IMAGE_REPO (default: "chainlink")
-#        - Tag: CHAINLINK_IMAGE_TAG or fallback to CHAINLINK_VERSION
-#        - Registry: AWS ECR using AWS_ACCOUNT_NUMBER and AWS_REGION
-# Enforces mutual exclusivity between FULL_IMAGE and repo/tag inputs, and validates required fields.
+# Resolves the Chainlink Docker image based on ECR type and environment variables.
+# Required:
+#   - ECR_TYPE: one of "sdlc" or "public" (case-insensitive)
+#   - CHAINLINK_IMAGE_REPO
+#   - CHAINLINK_IMAGE_TAG
+# For ECR_TYPE=sdlc, also required:
+#   - AWS_ACCOUNT_NUMBER
+#   - AWS_REGION
+# Inputs are normalized to lowercase before validation and output.
 set -euo pipefail
 
 error() {
@@ -14,35 +15,58 @@ error() {
   exit 1
 }
 
-full_image="${CHAINLINK_FULL_IMAGE:-}"
-explicit_repo="${CHAINLINK_IMAGE_REPO:-}"
-tag="${CHAINLINK_IMAGE_TAG:-}"
-version="${CHAINLINK_VERSION:-}"
+# Trim leading/trailing whitespace.
+trim() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "${s}"
+}
+
+repository="${CHAINLINK_IMAGE_REPO:-}"
+image_tag="${CHAINLINK_IMAGE_TAG:-}"
+ecr_type="${ECR_TYPE:-}"
 aws_account="${AWS_ACCOUNT_NUMBER:-}"
 aws_region="${AWS_REGION:-}"
 
-resolved_repo="${explicit_repo:-chainlink}"
+# Trim whitespace before normalization/validation.
+repository="$(trim "${repository}")"
+image_tag="$(trim "${image_tag}")"
+ecr_type="$(trim "${ecr_type}")"
+aws_account="$(trim "${aws_account}")"
+aws_region="$(trim "${aws_region}")"
 
-if [[ -n "${full_image}" ]]; then
-  if [[ -n "${tag}" || -n "${explicit_repo}" ]]; then
-    error "'CHAINLINK_FULL_IMAGE' is mutually exclusive with 'CHAINLINK_IMAGE_TAG' and 'CHAINLINK_IMAGE_REPO'."
-  fi
+# Normalize all input fields to lowercase for case-insensitive handling.
+repository="$(printf '%s' "${repository}" | tr '[:upper:]' '[:lower:]')"
+image_tag="$(printf '%s' "${image_tag}" | tr '[:upper:]' '[:lower:]')"
+ecr_type="$(printf '%s' "${ecr_type}" | tr '[:upper:]' '[:lower:]')"
+aws_account="$(printf '%s' "${aws_account}" | tr '[:upper:]' '[:lower:]')"
+aws_region="$(printf '%s' "${aws_region}" | tr '[:upper:]' '[:lower:]')"
 
-  if [[ ! "${full_image}" =~ .+/.+(:[^@]+|@sha256:[a-f0-9]{64})$ ]]; then
-    error "Invalid 'CHAINLINK_FULL_IMAGE' format: '${full_image}'. Expected '<registry>/<repo>:<tag>' or '<registry>/<repo>@sha256:<digest>'."
-  fi
+if [[ -z "${ecr_type}" ]]; then
+  error "'ECR_TYPE' must be set and non-empty. Allowed values: 'sdlc' or 'public'."
+fi
 
-  printf '%s\n' "${full_image}"
+if [[ "${ecr_type}" != "sdlc" && "${ecr_type}" != "public" ]]; then
+  error "Invalid 'ECR_TYPE': '${ecr_type}'. Allowed values: 'sdlc' or 'public'."
+fi
+
+if [[ -z "${repository}" ]]; then
+  error "'CHAINLINK_IMAGE_REPO' must be set and non-empty."
+fi
+
+if [[ -z "${image_tag}" ]]; then
+  error "'CHAINLINK_IMAGE_TAG' must be set and non-empty."
+fi
+
+if [[ "${ecr_type}" == "public" ]]; then
+  printf '%s\n' "gallery.ecr.aws/${repository}:${image_tag}"
   exit 0
 fi
 
-resolved_tag="${tag:-$version}"
-if [[ -z "${resolved_tag}" ]]; then
-  error "Either provide 'CHAINLINK_FULL_IMAGE' or provide a tag via 'CHAINLINK_IMAGE_TAG' (or 'CHAINLINK_VERSION')."
-fi
-
+# ECR_TYPE=sdlc
 if [[ -z "${aws_account}" || -z "${aws_region}" ]]; then
-  error "When 'CHAINLINK_FULL_IMAGE' is not provided, both 'AWS_ACCOUNT_NUMBER' and 'AWS_REGION' environment variables must be set and non-empty."
+  error "For 'ECR_TYPE=sdlc', both 'AWS_ACCOUNT_NUMBER' and 'AWS_REGION' must be set and non-empty."
 fi
 
-printf '%s\n' "${aws_account}.dkr.ecr.${aws_region}.amazonaws.com/${resolved_repo}:${resolved_tag}"
+printf '%s\n' "${aws_account}.dkr.ecr.${aws_region}.amazonaws.com/${repository}:${image_tag}"

--- a/.github/scripts/resolve-chainlink-image_test.sh
+++ b/.github/scripts/resolve-chainlink-image_test.sh
@@ -55,23 +55,18 @@ assert_contains() {
 test_full_image_tag() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
-    "CHAINLINK_FULL_IMAGE=public.ecr.aws/chainlink/chainlink:2.0.0"
-  assert_eq "${RUN_STATUS}" "0" "full image with tag exits 0"
-  assert_eq "${RUN_STDOUT}" "public.ecr.aws/chainlink/chainlink:2.0.0" "full image is returned to stdout"
-  assert_eq "${RUN_STDERR}" "" "full image success does not write stderr"
-}
-
-test_full_image_digest() {
-  TESTS_RUN=$((TESTS_RUN + 1))
-  run_script \
-    "CHAINLINK_FULL_IMAGE=public.ecr.aws/chainlink/chainlink@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-  assert_eq "${RUN_STATUS}" "0" "full image with digest exits 0"
-  assert_eq "${RUN_STDOUT}" "public.ecr.aws/chainlink/chainlink@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "digest image is returned to stdout"
+    "ECR_TYPE=public" \
+    "CHAINLINK_IMAGE_REPO=chainlink" \
+    "CHAINLINK_IMAGE_TAG=v2.1.0"
+  assert_eq "${RUN_STATUS}" "0" "public ecr exits 0"
+  assert_eq "${RUN_STDOUT}" "gallery.ecr.aws/chainlink:v2.1.0" "public image is returned to stdout"
+  assert_eq "${RUN_STDERR}" "" "public ecr success does not write stderr"
 }
 
 test_repo_and_tag() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
+    "ECR_TYPE=sdlc" \
     "CHAINLINK_IMAGE_REPO=chainlink-integration-tests" \
     "CHAINLINK_IMAGE_TAG=v2.1.0" \
     "AWS_ACCOUNT_NUMBER=123456789012" \
@@ -84,67 +79,94 @@ test_repo_and_tag() {
 test_default_repo_and_version() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
-    "CHAINLINK_VERSION=abc123" \
+    "ECR_TYPE=sdlc" \
+    "CHAINLINK_IMAGE_REPO=chainlink" \
+    "CHAINLINK_IMAGE_TAG=abc123" \
     "AWS_ACCOUNT_NUMBER=123456789012" \
     "AWS_REGION=us-west-2"
-  assert_eq "${RUN_STATUS}" "0" "version fallback exits 0"
-  assert_eq "${RUN_STDOUT}" "123456789012.dkr.ecr.us-west-2.amazonaws.com/chainlink:abc123" "default repo is chainlink"
+  assert_eq "${RUN_STATUS}" "0" "explicit repo and tag exit 0"
+  assert_eq "${RUN_STDOUT}" "123456789012.dkr.ecr.us-west-2.amazonaws.com/chainlink:abc123" "sdlc image resolves correctly"
 }
 
 test_tag_wins_over_version() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
-    "CHAINLINK_IMAGE_TAG=explicit-tag" \
-    "CHAINLINK_VERSION=abc123" \
-    "AWS_ACCOUNT_NUMBER=123456789012" \
-    "AWS_REGION=us-west-2"
-  assert_eq "${RUN_STATUS}" "0" "tag override exits 0"
-  assert_eq "${RUN_STDOUT}" "123456789012.dkr.ecr.us-west-2.amazonaws.com/chainlink:explicit-tag" "tag wins over version"
+    "ECR_TYPE=PuBLic" \
+    "CHAINLINK_IMAGE_REPO=ChAinLink" \
+    "CHAINLINK_IMAGE_TAG=V2.1.0"
+  assert_eq "${RUN_STATUS}" "0" "case-insensitive inputs exit 0"
+  assert_eq "${RUN_STDOUT}" "gallery.ecr.aws/chainlink:v2.1.0" "inputs are lowercased"
 }
 
-test_mutual_exclusion_full_and_tag() {
+test_whitespace_trimming() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
-    "CHAINLINK_FULL_IMAGE=public.ecr.aws/chainlink/chainlink:2.0.0" \
+    "ECR_TYPE=  SDLC  " \
+    "CHAINLINK_IMAGE_REPO=  chainlink-integration-tests  " \
+    "CHAINLINK_IMAGE_TAG=  V2.1.0  " \
+    "AWS_ACCOUNT_NUMBER=  123456789012  " \
+    "AWS_REGION=  US-WEST-2  "
+  assert_eq "${RUN_STATUS}" "0" "whitespace-padded inputs exit 0"
+  assert_eq "${RUN_STDOUT}" "123456789012.dkr.ecr.us-west-2.amazonaws.com/chainlink-integration-tests:v2.1.0" "inputs are trimmed and lowercased"
+}
+
+test_missing_ecr_type() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  run_script \
+    "CHAINLINK_IMAGE_REPO=chainlink" \
     "CHAINLINK_IMAGE_TAG=v2.1.0"
-  assert_eq "${RUN_STATUS}" "1" "full image and tag exits 1"
-  assert_contains "${RUN_STDERR}" "mutually exclusive" "mutual exclusion error is reported"
+  assert_eq "${RUN_STATUS}" "1" "missing ecr type exits 1"
+  assert_contains "${RUN_STDERR}" "'ECR_TYPE' must be set" "missing ecr type error is reported"
 }
 
-test_invalid_full_image() {
+test_invalid_ecr_type() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
-    "CHAINLINK_FULL_IMAGE=chainlink:2.0.0"
-  assert_eq "${RUN_STATUS}" "1" "invalid full image exits 1"
-  assert_contains "${RUN_STDERR}" "Invalid 'CHAINLINK_FULL_IMAGE' format" "invalid full image format is reported"
+    "ECR_TYPE=other" \
+    "CHAINLINK_IMAGE_REPO=chainlink" \
+    "CHAINLINK_IMAGE_TAG=v2.1.0"
+  assert_eq "${RUN_STATUS}" "1" "invalid ecr type exits 1"
+  assert_contains "${RUN_STDERR}" "Invalid 'ECR_TYPE'" "invalid ecr type error is reported"
 }
 
-test_missing_tag_and_version() {
+test_missing_repo() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
-    "AWS_ACCOUNT_NUMBER=123456789012" \
-    "AWS_REGION=us-west-2"
-  assert_eq "${RUN_STATUS}" "1" "missing tag and version exits 1"
-  assert_contains "${RUN_STDERR}" "Either provide 'CHAINLINK_FULL_IMAGE'" "missing tag/version error is reported"
+    "ECR_TYPE=public" \
+    "CHAINLINK_IMAGE_TAG=v2.1.0"
+  assert_eq "${RUN_STATUS}" "1" "missing repo exits 1"
+  assert_contains "${RUN_STDERR}" "'CHAINLINK_IMAGE_REPO' must be set" "missing repo error is reported"
+}
+
+test_missing_tag() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  run_script \
+    "ECR_TYPE=public" \
+    "CHAINLINK_IMAGE_REPO=chainlink"
+  assert_eq "${RUN_STATUS}" "1" "missing tag exits 1"
+  assert_contains "${RUN_STDERR}" "'CHAINLINK_IMAGE_TAG' must be set" "missing tag error is reported"
 }
 
 test_missing_aws_envs() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
+    "ECR_TYPE=sdlc" \
+    "CHAINLINK_IMAGE_REPO=chainlink" \
     "CHAINLINK_IMAGE_TAG=v2.1.0"
   assert_eq "${RUN_STATUS}" "1" "missing AWS env vars exits 1"
-  assert_contains "${RUN_STDERR}" "'AWS_ACCOUNT_NUMBER' and 'AWS_REGION'" "missing AWS env vars error is reported"
+  assert_contains "${RUN_STDERR}" "For 'ECR_TYPE=sdlc'" "missing AWS env vars error is reported"
 }
 
 main() {
   test_full_image_tag
-  test_full_image_digest
   test_repo_and_tag
   test_default_repo_and_version
   test_tag_wins_over_version
-  test_mutual_exclusion_full_and_tag
-  test_invalid_full_image
-  test_missing_tag_and_version
+  test_whitespace_trimming
+  test_missing_ecr_type
+  test_invalid_ecr_type
+  test_missing_repo
+  test_missing_tag
   test_missing_aws_envs
 
   if [[ "${TESTS_FAILED}" -ne 0 ]]; then

--- a/.github/scripts/resolve-chainlink-image_test.sh
+++ b/.github/scripts/resolve-chainlink-image_test.sh
@@ -56,10 +56,10 @@ test_full_image_tag() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
     "ECR_TYPE=public" \
-    "CHAINLINK_IMAGE_REPO=chainlink" \
+    "CHAINLINK_IMAGE_REPO_PATH=chainlink" \
     "CHAINLINK_IMAGE_TAG=v2.1.0"
   assert_eq "${RUN_STATUS}" "0" "public ecr exits 0"
-  assert_eq "${RUN_STDOUT}" "gallery.ecr.aws/chainlink:v2.1.0" "public image is returned to stdout"
+  assert_eq "${RUN_STDOUT}" "public.ecr.aws/chainlink:v2.1.0" "public image is returned to stdout"
   assert_eq "${RUN_STDERR}" "" "public ecr success does not write stderr"
 }
 
@@ -67,7 +67,7 @@ test_repo_and_tag() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
     "ECR_TYPE=sdlc" \
-    "CHAINLINK_IMAGE_REPO=chainlink-integration-tests" \
+    "CHAINLINK_IMAGE_REPO_PATH=chainlink-integration-tests" \
     "CHAINLINK_IMAGE_TAG=v2.1.0" \
     "AWS_ACCOUNT_NUMBER=123456789012" \
     "AWS_REGION=us-west-2"
@@ -80,7 +80,7 @@ test_default_repo_and_version() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
     "ECR_TYPE=sdlc" \
-    "CHAINLINK_IMAGE_REPO=chainlink" \
+    "CHAINLINK_IMAGE_REPO_PATH=chainlink" \
     "CHAINLINK_IMAGE_TAG=abc123" \
     "AWS_ACCOUNT_NUMBER=123456789012" \
     "AWS_REGION=us-west-2"
@@ -92,17 +92,17 @@ test_tag_wins_over_version() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
     "ECR_TYPE=PuBLic" \
-    "CHAINLINK_IMAGE_REPO=ChAinLink" \
+    "CHAINLINK_IMAGE_REPO_PATH=ChAinLink" \
     "CHAINLINK_IMAGE_TAG=V2.1.0"
   assert_eq "${RUN_STATUS}" "0" "case-insensitive inputs exit 0"
-  assert_eq "${RUN_STDOUT}" "gallery.ecr.aws/chainlink:v2.1.0" "inputs are lowercased"
+  assert_eq "${RUN_STDOUT}" "public.ecr.aws/chainlink:v2.1.0" "inputs are lowercased"
 }
 
 test_whitespace_trimming() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
     "ECR_TYPE=  SDLC  " \
-    "CHAINLINK_IMAGE_REPO=  chainlink-integration-tests  " \
+    "CHAINLINK_IMAGE_REPO_PATH=  chainlink-integration-tests  " \
     "CHAINLINK_IMAGE_TAG=  V2.1.0  " \
     "AWS_ACCOUNT_NUMBER=  123456789012  " \
     "AWS_REGION=  US-WEST-2  "
@@ -113,7 +113,7 @@ test_whitespace_trimming() {
 test_missing_ecr_type() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
-    "CHAINLINK_IMAGE_REPO=chainlink" \
+    "CHAINLINK_IMAGE_REPO_PATH=chainlink" \
     "CHAINLINK_IMAGE_TAG=v2.1.0"
   assert_eq "${RUN_STATUS}" "1" "missing ecr type exits 1"
   assert_contains "${RUN_STDERR}" "'ECR_TYPE' must be set" "missing ecr type error is reported"
@@ -123,7 +123,7 @@ test_invalid_ecr_type() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
     "ECR_TYPE=other" \
-    "CHAINLINK_IMAGE_REPO=chainlink" \
+    "CHAINLINK_IMAGE_REPO_PATH=chainlink" \
     "CHAINLINK_IMAGE_TAG=v2.1.0"
   assert_eq "${RUN_STATUS}" "1" "invalid ecr type exits 1"
   assert_contains "${RUN_STDERR}" "Invalid 'ECR_TYPE'" "invalid ecr type error is reported"
@@ -135,14 +135,14 @@ test_missing_repo() {
     "ECR_TYPE=public" \
     "CHAINLINK_IMAGE_TAG=v2.1.0"
   assert_eq "${RUN_STATUS}" "1" "missing repo exits 1"
-  assert_contains "${RUN_STDERR}" "'CHAINLINK_IMAGE_REPO' must be set" "missing repo error is reported"
+  assert_contains "${RUN_STDERR}" "'CHAINLINK_IMAGE_REPO_PATH' must be set" "missing repo error is reported"
 }
 
 test_missing_tag() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
     "ECR_TYPE=public" \
-    "CHAINLINK_IMAGE_REPO=chainlink"
+    "CHAINLINK_IMAGE_REPO_PATH=chainlink"
   assert_eq "${RUN_STATUS}" "1" "missing tag exits 1"
   assert_contains "${RUN_STDERR}" "'CHAINLINK_IMAGE_TAG' must be set" "missing tag error is reported"
 }
@@ -151,7 +151,7 @@ test_missing_aws_envs() {
   TESTS_RUN=$((TESTS_RUN + 1))
   run_script \
     "ECR_TYPE=sdlc" \
-    "CHAINLINK_IMAGE_REPO=chainlink" \
+    "CHAINLINK_IMAGE_REPO_PATH=chainlink" \
     "CHAINLINK_IMAGE_TAG=v2.1.0"
   assert_eq "${RUN_STATUS}" "1" "missing AWS env vars exits 1"
   assert_contains "${RUN_STDERR}" "For 'ECR_TYPE=sdlc'" "missing AWS env vars error is reported"

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -3,14 +3,14 @@ name: CRE System Tests
 on:
   workflow_dispatch:
     inputs:
-      chainlink_image_repo:
-        description: "ECR repository name used to compose image with chainlink_image_tag (for example: chainlink-integration-tests or chainlink)."
+      chainlink_image_repository_path:
+        description: "ECR repository name used to compose image with chainlink_image_tag (for example: chainlink-integration-tests or chainlink or chainlink/chainlink)."
         required: true
         type: string
       chainlink_image_tag:
         required: true
         type: string
-        description: "Tag used with chainlink_image_repo. If empty, chainlink_version is used."
+        description: "Chainlink image tag to use."
       ecr:
         required: true
         type: choice
@@ -26,14 +26,14 @@ on:
         default: ""
   workflow_call:
     inputs:
-      chainlink_image_repo:
-        description: "ECR repository name used to compose image with chainlink_image_tag (for example: chainlink-integration-tests or chainlink)."
+      chainlink_image_repository_path:
+        description: "ECR repository name used to compose image with chainlink_image_tag (for example: chainlink-integration-tests or chainlink or chainlink/chainlink)."
         required: true
         type: string
       chainlink_image_tag:
         required: true
         type: string
-        description: "Tag used with chainlink_image_repo."
+        description: "Chainlink image tag to use."
       ecr:
         type: string
         required: true
@@ -232,7 +232,7 @@ jobs:
         working-directory: .github/scripts
         shell: bash
         env:
-          CHAINLINK_IMAGE_REPO: ${{ inputs.chainlink_image_repo }}
+          CHAINLINK_IMAGE_REPO_PATH: ${{ inputs.chainlink_image_repository_path }}
           CHAINLINK_IMAGE_TAG: ${{ inputs.chainlink_image_tag }}
           ECR_TYPE: ${{ inputs.ecr }}
           AWS_ACCOUNT_NUMBER: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -5,19 +5,20 @@ on:
     inputs:
       chainlink_image_repo:
         description: "ECR repository name used to compose image with chainlink_image_tag (for example: chainlink-integration-tests or chainlink)."
-        required: false
+        required: true
         type: string
-        default: ""
       chainlink_image_tag:
-        required: false
+        required: true
         type: string
-        default: ""
         description: "Tag used with chainlink_image_repo. If empty, chainlink_version is used."
-      chainlink_full_image:
-        required: false
-        type: string
-        default: ""
-        description: "Full Chainlink image reference including tag or digest (for example: public.ecr.aws/chainlink/chainlink:2.0.0 or ...@sha256:<digest>). Mutually exclusive with chainlink_image_repo/chainlink_image_tag."
+      ecr:
+        required: true
+        type: choice
+        options:
+          - "sdlc"
+          - "public"
+        default: "sdlc"
+        description: "Whether to use the SDLC or public ECR registry for the Chainlink image."
       chainlink_version:
         required: false
         type: string
@@ -27,19 +28,17 @@ on:
     inputs:
       chainlink_image_repo:
         description: "ECR repository name used to compose image with chainlink_image_tag (for example: chainlink-integration-tests or chainlink)."
-        required: false
+        required: true
         type: string
-        default: ""
       chainlink_image_tag:
-        required: false
+        required: true
         type: string
-        default: ""
-        description: "Tag used with chainlink_image_repo. If empty, chainlink_version is used."
-      chainlink_full_image:
-        required: false
+        description: "Tag used with chainlink_image_repo."
+      ecr:
         type: string
-        default: ""
-        description: "Full Chainlink image reference including tag or digest (for example: public.ecr.aws/chainlink/chainlink:2.0.0 or ...@sha256:<digest>). Mutually exclusive with chainlink_image_repo/chainlink_image_tag."
+        required: true
+        default: "sdlc"
+        description: "Whether to use the SDLC (sdlc) or public ECR registry (public) for the Chainlink image."
       chainlink_version:
         required: false
         type: string
@@ -57,7 +56,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.chainlink_version && inputs.chainlink_version || github.sha }}
+          ref: ${{ inputs.chainlink_version || github.sha }}
           persist-credentials: false
 
       - name: Enable S3 Cache for Self-Hosted Runners
@@ -235,8 +234,7 @@ jobs:
         env:
           CHAINLINK_IMAGE_REPO: ${{ inputs.chainlink_image_repo }}
           CHAINLINK_IMAGE_TAG: ${{ inputs.chainlink_image_tag }}
-          CHAINLINK_FULL_IMAGE: ${{ inputs.chainlink_full_image }}
-          CHAINLINK_VERSION: ${{ inputs.chainlink_version || github.sha }}
+          ECR_TYPE: ${{ inputs.ecr }}
           AWS_ACCOUNT_NUMBER: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
           AWS_REGION: ${{ secrets.QA_AWS_REGION }}
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -394,7 +394,7 @@ jobs:
     uses: ./.github/workflows/cre-system-tests.yaml
     with:
       ecr: "sdlc"
-      chainlink_image_repo: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
+      chainlink_image_repository_path: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       chainlink_image_tag: ${{ inputs.evm-ref && format('{0}', inputs.evm-ref) || inputs.cl_ref && format('{0}', inputs.cl_ref) || format('{0}', github.sha) }}
     secrets: inherit

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -393,6 +393,7 @@ jobs:
     if: needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'
     uses: ./.github/workflows/cre-system-tests.yaml
     with:
+      ecr: "sdlc"
       chainlink_image_repo: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       chainlink_image_tag: ${{ inputs.evm-ref && format('{0}', inputs.evm-ref) || inputs.cl_ref && format('{0}', inputs.cl_ref) || format('{0}', github.sha) }}


### PR DESCRIPTION
This change simplifies Chainlink image resolution to always compose the final image from explicit inputs and ECR_TYPE:

- Required inputs: `ECR_TYPE`, `CHAINLINK_IMAGE_REPO`, `CHAINLINK_IMAGE_TAG` 
- `ECR_TYPE`  must be one of:
  - `public` → `public.ecr.aws/<repository>:<image_tag>`
  - `sdlc` → `<aws_account>.dkr.ecr.<aws_region>.amazonaws.com/<repository>:<image_tag>`
- For `sdlc`, both `AWS_ACCOUNT_NUMBER` and `AWS_REGION` evn vars are required

Inputs are trimmed and lowercased before validation/resolution.

Tests:
- [public ecr](https://github.com/smartcontractkit/chainlink/actions/runs/24145193704) ✅ 
- [private ecr](https://github.com/smartcontractkit/chainlink/actions/runs/24147308060) ✅ 