### PR TITLE
fix: prevent test DB leakage from TestShell_BeforeNode

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -80,15 +80,20 @@ func NewApp(s *Shell) *cli.App {
 		// logger instead.
 		lggr, closeFn := logger.NewLogger()
 
-		cfg, err := opts.New()
-		if err != nil {
-			return err
-		}
-
 		s.Logger = lggr
 		s.Registerer = prometheus.DefaultRegisterer // use the global DefaultRegisterer, should be safe since we only ever run one instance of the app per shell
 		s.CloseLogger = closeFn
-		s.Config = cfg
+
+		// Only create a new config from opts if one hasn't been pre-set.
+		// Tests pre-set s.Config with a txdb-wrapped driver for DB isolation;
+		// unconditionally overwriting it here causes DB writes to leak between tests.
+		if s.Config == nil {
+			cfg, err := opts.New()
+			if err != nil {
+				return err
+			}
+			s.Config = cfg
+		}
 
 		if c.Bool("json") {
 			s.Renderer = RendererJSON{Writer: os.Stdout}
@@ -122,11 +127,11 @@ func NewApp(s *Shell) *cli.App {
 
 		// Allow for initServerConfig to be called if the flag is provided.
 		if c.Bool("applyInitServerConfig") {
-			cfg, err = initServerConfig(&opts, s.configFiles, s.secretsFiles)
+			serverCfg, err := initServerConfig(&opts, s.configFiles, s.secretsFiles)
 			if err != nil {
 				return err
 			}
-			s.Config = cfg
+			s.Config = serverCfg
 		}
 
 		return nil

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -507,6 +507,15 @@ func TestShell_RemoveBlocks(t *testing.T) {
 
 func TestShell_BeforeNode(t *testing.T) {
 	testutils.SkipShortDB(t)
+
+	// Use a dedicated test database so subtests share state without leaking
+	// data to the shared test database. The "incorrect password" subtest relies
+	// on a key ring created by the "correct password" subtest to verify that
+	// decryption fails with the wrong password.
+	cfg, _ := heavyweight.FullTestDBV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.Insecure.OCRDevelopmentMode = nil
+	})
+
 	tests := []struct {
 		name         string
 		pwdfile      string
@@ -519,14 +528,6 @@ func TestShell_BeforeNode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-				s.Password.Keystore = models.NewSecret("dummy")
-				c.EVM[0].Nodes[0].Name = ptr("fake")
-				c.EVM[0].Nodes[0].HTTPURL = commonconfig.MustParseURL("http://fake.com")
-				c.EVM[0].Nodes[0].WSURL = commonconfig.MustParseURL("WSS://fake.com/ws")
-				c.Insecure.OCRDevelopmentMode = nil
-			})
-
 			shell := cmd.Shell{
 				Config: cfg,
 				KeyStoreAuthenticator: cmd.TerminalKeyStoreAuthenticator{
@@ -577,6 +578,13 @@ func TestShell_BeforeNode(t *testing.T) {
 }
 
 func TestShell_RunNode_WithBeforeNode(t *testing.T) {
+	// Use a dedicated test database so subtests share state without leaking
+	// data to the shared test database. The "incorrect password" subtest relies
+	// on keystore entries from prior setup to verify decryption failure.
+	cfg, db := heavyweight.FullTestDBV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.Insecure.OCRDevelopmentMode = nil
+	})
+
 	tests := []struct {
 		name        string
 		pwdfile     string
@@ -588,16 +596,6 @@ func TestShell_RunNode_WithBeforeNode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-				s.Password.Keystore = models.NewSecret("dummy")
-				c.EVM[0].Nodes[0].Name = ptr("fake")
-				c.EVM[0].Nodes[0].HTTPURL = commonconfig.MustParseURL("http://fake.com")
-				c.EVM[0].Nodes[0].WSURL = commonconfig.MustParseURL("WSS://fake.com/ws")
-				// seems to be needed for config validate
-				c.Insecure.OCRDevelopmentMode = nil
-			})
-
-			db := pgtest.NewSqlxDB(t)
 			keyStore := cltest.NewKeyStore(t, db)
 			authProviderORM := localauth.NewORM(db, time.Minute, logger.TestLogger(t), audit.NoopLogger)
 


### PR DESCRIPTION
## Summary

- **Root cause**: `NewApp().Before()` unconditionally overwrites `shell.Config` with a fresh config using the default `pgx` driver, even when tests pre-set a config with the `txdb` driver for DB isolation. This causes `BeforeNode()` to open real database connections, leaking keystore entries (`encrypted_key_rings`) to the shared test database.
- **Symptom**: `Test_CSAKeyStore_E2E` fails intermittently because it finds unexpected CSA keys leaked by `TestShell_BeforeNode` — causing PRs to be ejected from the merge queue.
- **Fix**: Guard config creation in `app.Before()` with a nil check so pre-set test configs are preserved. Migrate `TestShell_BeforeNode` and `TestShell_RunNode_WithBeforeNode` to `heavyweight.FullTestDBV2` for proper DB isolation.

### Root Cause Trace

```
TestShell_BeforeNode
  → configtest.NewGeneralConfig() → DriverTxWrappedPostgres ✓
  → cmd.NewApp(&shell) → app.Before(c)
    → var opts GeneralConfigOpts{}   // fresh, empty
    → opts.New()                     // defaults → DriverPostgres (pgx)
    → s.Config = cfg                 // OVERWRITES test config ✗
  → shell.BeforeNode(c)
    → pg.NewLockedDB(cfg.Database()) // uses pgx, not txdb
    → BuildBeholderAuth() → EnsureKey() → safeAddKey()
    → CSA key written to encrypted_key_rings with pgx (LEAKS)
```

### Changes

| File | Change |
|------|--------|
| `core/cmd/app.go` | Guard `opts.New()` + `s.Config = cfg` with `if s.Config == nil` — preserves pre-set test configs |
| `core/cmd/shell_local_test.go` | Migrate `TestShell_BeforeNode` and `TestShell_RunNode_WithBeforeNode` to `heavyweight.FullTestDBV2` for dedicated test databases |

### Why heavyweight?

The subtests are ordered: "correct password" creates a key ring, "incorrect password" verifies decryption fails with the wrong password. With `txdb`, each subtest gets an isolated transaction and can't see the other's data. `heavyweight.FullTestDBV2` gives a dedicated database with `pgx` where subtests naturally share state, while the dedicated DB is dropped after the test — no leakage.

## Test plan

- [x] `TestShell_BeforeNode` — all 3 subtests pass
- [x] `TestShell_RunNode_WithBeforeNode` — all 2 subtests pass
- [x] `Test_CSAKeyStore_E2E` — "initializes with an empty state" passes (the flaking test)
- [x] `encrypted_key_rings` count = 0 after test run (no leakage)
- [x] `go vet ./core/cmd/...` — no issues
- [ ] CI `go_core_tests` passes

Related: #21504 (Erik's WIP fix for the same issue)