### PR TITLE
Fix translate Feetoken config to pick only the enabled tokens

### DIFF
--- a/deployment/ccip/sequence/evm/migration/seq_translate_onramp_fq.go
+++ b/deployment/ccip/sequence/evm/migration/seq_translate_onramp_fq.go
@@ -87,9 +87,10 @@ var (
 
 					// This is per token in 1.5.0 onRamp, but in FeeQuoter its per destination chain,
 					// But RDD values are just redundant & can be adjusted by the premium multiplier, so simplified in 1.6 FQ
-					// So we can just use the any token's config (the last one in the loop here)
+					// So we can just use the first enabled token's config in the loop here
 					onRampFeeTokenCfgReport := evm_2_evm_onramp.EVM2EVMOnRampFeeTokenConfig{}
 
+					enabledFeeTokens := make([]common.Address, 0, len(allFeeTokensOp.Output))
 					feeTokenPremiumMultipliers := make([]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs, 0, len(allFeeTokensOp.Output))
 					for _, ft := range allFeeTokensOp.Output {
 						feetokenCfgReport, err := operations.ExecuteOperation(
@@ -111,6 +112,7 @@ var (
 							continue // skip disabled fee tokens, same as TTFC loop below
 						}
 
+						enabledFeeTokens = append(enabledFeeTokens, ft)
 						// Translate the feeToken PremiumMultiplierCfg to 1.6 FeeQuoter config
 						premiumMultiplierCfg := EVM2EVMOnRampMigratePremiumMultiplierCfg{}
 						premiumMultiplierCfg.TranslateOnrampToFeeQFeePremiumCfg(ft, feetokenCfgReport.Output)
@@ -124,7 +126,7 @@ var (
 						feeQuoterUpdates[chainSel] = make(map[uint64]fee_quoter.FeeQuoterDestChainConfig)
 					}
 					feeQuoterUpdates[chainSel][destChainSel] = feeQuoterTranslatedDestCfg.FeeQuoterDestChainConfig
-					allFeeTokens[chainSel] = append(allFeeTokens[chainSel], allFeeTokensOp.Output...)
+					allFeeTokens[chainSel] = append(allFeeTokens[chainSel], enabledFeeTokens...)
 					allFeetokenPremiumMultipliers[chainSel] = append(allFeetokenPremiumMultipliers[chainSel], feeTokenPremiumMultipliers...)
 				}
 			}

--- a/deployment/ccip/sequence/evm/migration/seq_translate_onramp_fq.go
+++ b/deployment/ccip/sequence/evm/migration/seq_translate_onramp_fq.go
@@ -90,8 +90,8 @@ var (
 					// So we can just use the any token's config (the last one in the loop here)
 					onRampFeeTokenCfgReport := evm_2_evm_onramp.EVM2EVMOnRampFeeTokenConfig{}
 
-					feeTokenPremiumMultipliers := make([]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs, len(allFeeTokensOp.Output))
-					for idx, ft := range allFeeTokensOp.Output {
+					feeTokenPremiumMultipliers := make([]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs, 0, len(allFeeTokensOp.Output))
+					for _, ft := range allFeeTokensOp.Output {
 						feetokenCfgReport, err := operations.ExecuteOperation(
 							b, migration_ops.EVM2EVMOnrampGetFeeTokenConfigOp,
 							migration_ops.MigrateOnRampToFQDeps{
@@ -107,10 +107,14 @@ var (
 							return OnRampToFeeQuoterDestChainConfigOutput{}, fmt.Errorf("failed to Execute GetOnRampGetFeeTokenConfigOps: %w", err)
 						}
 
+						if !feetokenCfgReport.Output.Enabled {
+							continue // skip disabled fee tokens, same as TTFC loop below
+						}
+
 						// Translate the feeToken PremiumMultiplierCfg to 1.6 FeeQuoter config
 						premiumMultiplierCfg := EVM2EVMOnRampMigratePremiumMultiplierCfg{}
 						premiumMultiplierCfg.TranslateOnrampToFeeQFeePremiumCfg(ft, feetokenCfgReport.Output)
-						feeTokenPremiumMultipliers[idx] = premiumMultiplierCfg.FeeQuoterPremiumMultiplierWeiPerEthArgs
+						feeTokenPremiumMultipliers = append(feeTokenPremiumMultipliers, premiumMultiplierCfg.FeeQuoterPremiumMultiplierWeiPerEthArgs)
 						if onRampFeeTokenCfgReport == (evm_2_evm_onramp.EVM2EVMOnRampFeeTokenConfig{}) {
 							onRampFeeTokenCfgReport = feetokenCfgReport.Output
 						}

--- a/deployment/ccip/sequence/evm/migration/seq_translate_onramp_fq.go
+++ b/deployment/ccip/sequence/evm/migration/seq_translate_onramp_fq.go
@@ -90,7 +90,6 @@ var (
 					// So we can just use the first enabled token's config in the loop here
 					onRampFeeTokenCfgReport := evm_2_evm_onramp.EVM2EVMOnRampFeeTokenConfig{}
 
-					enabledFeeTokens := make([]common.Address, 0, len(allFeeTokensOp.Output))
 					feeTokenPremiumMultipliers := make([]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs, 0, len(allFeeTokensOp.Output))
 					for _, ft := range allFeeTokensOp.Output {
 						feetokenCfgReport, err := operations.ExecuteOperation(
@@ -112,7 +111,6 @@ var (
 							continue // skip disabled fee tokens, same as TTFC loop below
 						}
 
-						enabledFeeTokens = append(enabledFeeTokens, ft)
 						// Translate the feeToken PremiumMultiplierCfg to 1.6 FeeQuoter config
 						premiumMultiplierCfg := EVM2EVMOnRampMigratePremiumMultiplierCfg{}
 						premiumMultiplierCfg.TranslateOnrampToFeeQFeePremiumCfg(ft, feetokenCfgReport.Output)
@@ -126,7 +124,7 @@ var (
 						feeQuoterUpdates[chainSel] = make(map[uint64]fee_quoter.FeeQuoterDestChainConfig)
 					}
 					feeQuoterUpdates[chainSel][destChainSel] = feeQuoterTranslatedDestCfg.FeeQuoterDestChainConfig
-					allFeeTokens[chainSel] = append(allFeeTokens[chainSel], enabledFeeTokens...)
+					allFeeTokens[chainSel] = append(allFeeTokens[chainSel], allFeeTokensOp.Output...)
 					allFeetokenPremiumMultipliers[chainSel] = append(allFeetokenPremiumMultipliers[chainSel], feeTokenPremiumMultipliers...)
 				}
 			}


### PR DESCRIPTION
Fixt he Feetokens that are not enabled on an 1.5 onramp currently setting the Premium Multiplier to zero