### PR TITLE
chore(ci): action version bumps

### DIFF
--- a/.github/actions/golangci-lint/action.yml
+++ b/.github/actions/golangci-lint/action.yml
@@ -65,7 +65,7 @@ runs:
         fi
 
     - name: Golangci-lint
-      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       env:
         # golangci-lint runs with absolute path mode: --path-mode=abs
         REPORT_PATH: ${{ github.workspace }}/${{ steps.set-working-directory.outputs.golangci-lint-working-directory }}golangci-lint-report.xml

--- a/.github/actions/setup-cre-e2e-test-dependencies/action.yml
+++ b/.github/actions/setup-cre-e2e-test-dependencies/action.yml
@@ -48,7 +48,7 @@ runs:
 
     - name: Restore Cache
       id: cache-restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         key: ${{ steps.setup-cache-dir-key.outputs.cache-key }}
         path: ${{ steps.setup-cache-dir-key.outputs.download-path }}
@@ -82,7 +82,7 @@ runs:
 
     - name: Save cache
       if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         key: ${{ steps.setup-cache-dir-key.outputs.cache-key }}
         path: ${{ steps.setup-cache-dir-key.outputs.download-path }}

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -105,7 +105,7 @@ runs:
     - name: Get branch name
       if: ${{ inputs.only-modules == 'false' }}
       id: branch-name
-      uses: smartcontractkit/.github/actions/branch-names@branch-names/1.0.0
+      uses: smartcontractkit/.github/actions/branch-names@branch-names/v1
 
     # 2. Build the cache keys
     # ---

--- a/.github/workflows/bash-scripts.yml
+++ b/.github/workflows/bash-scripts.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
       - name: Run ShellCheck
         if: needs.changes.outputs.bash-scripts-src == 'true'
-        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           scandir: "./tools/bin"
           # Consider changing this to check for warnings once all warnings are fixed.

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Check release tag
         id: release-tag-check
-        uses: smartcontractkit/.github/actions/release-tag-check@c5c4a8186da4218cff6cac8184e47dd3dec69ba3 # release-tag-check@0.1.0
+        uses: smartcontractkit/.github/actions/release-tag-check@release-tag-check/1.0.0
 
       - name: Compute CCIP image tag
         id: compute-ccip-tag

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -63,13 +63,13 @@ jobs:
         run: bash ./.github/scripts/check-changeset-tags.sh ${{ steps.files-changed.outputs.core-changeset_files }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         if: ${{ steps.files-changed.outputs.core == 'true' || steps.files-changed.outputs.shared == 'true' }}
         with:
           version: ^10.0.0
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         if: ${{ steps.files-changed.outputs.core == 'true' || steps.files-changed.outputs.shared == 'true' }}
         with:
           node-version: 20
@@ -101,7 +101,7 @@ jobs:
           path: ./dot_github
 
       - name: Make a comment
-        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         if: ${{ steps.files-changed.outputs.core == 'true' || steps.files-changed.outputs.shared == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -110,12 +110,12 @@ jobs:
             I see you updated files related to `core`. Please run `make gocs` in the root directory to add a changeset as well as in the text include at least one of the following tags:
             ${{ env.TAGS }}
           reactions: eyes
-          comment_tag: changeset-core
+          comment-tag: changeset-core
           mode: ${{ steps.files-changed.outputs.core-changeset == 'false' && 'upsert' || 'delete' }}
-          create_if_not_exists: ${{ steps.files-changed.outputs.core-changeset == 'false' && 'true' || 'false' }}
+          create-if-not-exists: ${{ steps.files-changed.outputs.core-changeset == 'false' && 'true' || 'false' }}
 
       - name: Make a comment
-        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         if: ${{ steps.files-changed.outputs.core-changeset == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -124,9 +124,9 @@ jobs:
             I see you added a changeset file but it does not contain a tag. Please edit the text include at least one of the following tags:
             ${{ env.TAGS }}
           reactions: eyes
-          comment_tag: changeset-core-tags
+          comment-tag: changeset-core-tags
           mode: ${{ steps.changeset-tags.outputs.has_tags == 'false' && 'upsert' || 'delete' }}
-          create_if_not_exists: ${{ steps.changeset-tags.outputs.has_tags == 'false' && 'true' || 'false' }}
+          create-if-not-exists: ${{ steps.changeset-tags.outputs.has_tags == 'false' && 'true' || 'false' }}
 
       - name: Check for new changeset tags for core
         if: ${{ steps.files-changed.outputs.core-changeset == 'true' && steps.changeset-tags.outputs.has_tags == 'false' }}

--- a/.github/workflows/changesets-preview-pr.yml
+++ b/.github/workflows/changesets-preview-pr.yml
@@ -30,13 +30,13 @@ jobs:
               - '.changeset/**'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         if: steps.change.outputs.core-changeset == 'true'
         with:
           version: ^10.0.0
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         if: steps.change.outputs.core-changeset == 'true'
         with:
           node-version: 20
@@ -52,9 +52,9 @@ jobs:
 
       - name: Create release preview PR
         if: steps.change.outputs.core-changeset == 'true'
-        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
-          git-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
             .changeset/**
             CHANGELOG.md

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -274,7 +274,7 @@ jobs:
 
       - name: Setup Aptos
         if: ${{ matrix.type.should-run == 'true' && matrix.type.setup-aptos == 'true' }}
-        uses: aptos-labs/actions/install-aptos-cli@63740b290d839b87ecfafbcf75ed03a36a54a29f # jan 15, 2025
+        uses: aptos-labs/actions/install-aptos-cli@528ef7ad9427a8c0720ea3eea790a9190d6e377d # 2026-04-09
         with:
           CLI_VERSION: 8.1.0
 

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -148,7 +148,7 @@ jobs:
         # Skip for now as it's always failing on scheduled runs
         if: false
         # if: ${{ failure() && needs.run-frequency.outputs.one-per-day-frequency == 'true' }}
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.QA_SLACK_API_KEY }}
@@ -396,7 +396,7 @@ jobs:
           steps.print-races.outputs.post_to_slack == 'true'  &&
           (github.event_name == 'merge_group' || github.ref == 'refs/heads/develop') &&
           matrix.type.should-run == 'true'
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.QA_SLACK_API_KEY }}
@@ -448,7 +448,7 @@ jobs:
           fetch-depth: 0 # fetches all history for all tags and branches to provide more metadata for sonar reports
 
       - name: Download all workflow artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: Check and Set SonarQube Report Paths
         shell: bash
@@ -529,7 +529,7 @@ jobs:
 
       - name: SonarQube Scan
         if: ${{ env.SONARQUBE_ARGS != '' }}
-        uses: sonarsource/sonarqube-scan-action@aecaf43ae57e412bd97d70ef9ce6076e672fe0a9 # v2.3.0
+        uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         with:
           args: ${{ env.SONARQUBE_ARGS }}
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,7 +63,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -83,7 +83,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -109,7 +109,7 @@ jobs:
 
       # We need to login to ECR to allow the test to pull the Job Distributor and Chainlink images
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -118,7 +118,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registries: ${{ format('{0},{1}', secrets.QA_AWS_ACCOUNT_NUMBER, secrets.AWS_ACCOUNT_ID_PROD) }}
         env:
@@ -131,7 +131,7 @@ jobs:
 
       - name: Setup GitHub token using GATI
         id: github-token
-        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/1.0.0
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
@@ -363,7 +363,7 @@ jobs:
 
       - name: Send slack notification
         if: steps.check-timeout.outputs.should_notify == 'true'
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           errors: "true"
           method: chat.postMessage

--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -141,7 +141,7 @@ jobs:
       # Required to pull private ECR images such as Job Distributor (main) and Chip Ingress (main),
       # and also the Chainlink image when inputs.ecr is "sdlc".
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_CTF_READ_ACCESS_ROLE_ARN }}
@@ -150,7 +150,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registries: ${{ format('{0},{1}', secrets.QA_AWS_ACCOUNT_NUMBER, secrets.AWS_ACCOUNT_ID_PROD) }}
         env:
@@ -159,7 +159,7 @@ jobs:
       # Required to allow pulling public images
       - name: Authenticate to ECR (public)
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registry-type: public
         env:

--- a/.github/workflows/cre-soak-memory-leak.yml
+++ b/.github/workflows/cre-soak-memory-leak.yml
@@ -62,7 +62,7 @@ jobs:
           cache: true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_CTF_READ_ACCESS_ROLE_ARN }}
@@ -71,7 +71,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registries: ${{ format('{0},{1}', secrets.QA_AWS_ACCOUNT_NUMBER, secrets.AWS_ACCOUNT_ID_PROD) }}
         env:
@@ -156,7 +156,7 @@ jobs:
     steps:
       - name: Send slack notification for failed resource regression tests
         id: send-slack-notification
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           errors: "true"
           method: chat.postMessage

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -223,7 +223,7 @@ jobs:
 
       - name: Install Aptos CLI
         if: ${{ matrix.tests.test_name == 'Test_CRE_V2_Aptos_Suite' }}
-        uses: aptos-labs/actions/install-aptos-cli@63740b290d839b87ecfafbcf75ed03a36a54a29f # jan 15, 2025
+        uses: aptos-labs/actions/install-aptos-cli@528ef7ad9427a8c0720ea3eea790a9190d6e377d # 2026-04-09
         with:
           CLI_VERSION: 7.8.0
 

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -190,7 +190,7 @@ jobs:
 
       # Required to pull Job Distributor (main), Chip Ingress (main) and Chainlink (sdlc) private images
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_CTF_READ_ACCESS_ROLE_ARN }}
@@ -199,7 +199,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registries: ${{ format('{0},{1}', secrets.QA_AWS_ACCOUNT_NUMBER, secrets.AWS_ACCOUNT_ID_PROD) }}
         env:
@@ -208,7 +208,7 @@ jobs:
       # Required to allow pulling public images
       - name: Authenticate to ECR (public)
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registry-type: public
         env:
@@ -312,7 +312,7 @@ jobs:
 
       - name: Setup GitHub token using GATI
         id: github-token
-        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/1.0.0
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}

--- a/.github/workflows/cre-workflow-don-benchmark.yaml
+++ b/.github/workflows/cre-workflow-don-benchmark.yaml
@@ -51,7 +51,7 @@ jobs:
 
       # We need to login to ECR to allow the test to pull the Job Distributor and Chainlink images
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -60,7 +60,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registries: ${{ format('{0},{1}', secrets.QA_AWS_ACCOUNT_NUMBER, secrets.AWS_ACCOUNT_ID_PROD) }}
         env:
@@ -234,7 +234,7 @@ jobs:
 
       - name: Send regression slack notification
         if: success() && steps.parse-regressions.outputs.regression_count > 0
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           errors: "true"
           method: chat.postMessage
@@ -243,7 +243,7 @@ jobs:
 
       - name: Send failure slack notification
         if: failure()
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           errors: "true"
           method: chat.postMessage

--- a/.github/workflows/devenv-compat.yml
+++ b/.github/workflows/devenv-compat.yml
@@ -101,21 +101,21 @@ jobs:
       CTF_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.22.1"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Install Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
         with:
           just-version: "1.40.0"
 
       # We need to login to ECR to allow the test to pull the Job Distributor (main) and Chainlink (sdlc) images
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_CTF_READ_ACCESS_ROLE_ARN }}
@@ -124,7 +124,7 @@ jobs:
 
       - name: Login to private Amazon ECRs
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registries: ${{ format('{0},{1}', secrets.QA_AWS_ACCOUNT_NUMBER, secrets.AWS_ACCOUNT_ID_PROD) }}
         env:
@@ -132,14 +132,14 @@ jobs:
 
       - name: Login to public Amazon ECR
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registry-type: public
         env:
           AWS_REGION: us-east-1
 
       - name: Set up Go
-        uses: actions/setup-go@v6 # v6
+        uses: actions/setup-go@v6
         with:
           cache: true
           go-version-file: ${{ env.WORKING_DIR }}/go.mod
@@ -250,7 +250,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container-logs-smoke-${{ job.check_run_id }}
           path: ${{ env.LOGS_DIR }}

--- a/.github/workflows/gomod-local-updater.yml
+++ b/.github/workflows/gomod-local-updater.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create PR
         id: create-pr
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           base: develop
           branch: ${{ env.BRANCH_HEAD}}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -744,7 +744,7 @@ jobs:
           repository: smartcontractkit/chainlink
           ref: ${{ env.CHAINLINK_REF }}
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: cl_node_coverage_data
           pattern: cl_node_coverage_data_*
@@ -893,7 +893,7 @@ jobs:
     steps:
       - name: Send slack notification for failed migration tests
         id: send-slack-notification
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           errors: "true"
           method: chat.postMessage

--- a/.github/workflows/legacy-system-tests-nightly.yml
+++ b/.github/workflows/legacy-system-tests-nightly.yml
@@ -290,13 +290,13 @@ jobs:
 
       - name: Install Just
         if: steps.gate.outputs.should_run == 'true'
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
         with:
           just-version: "1.40.0"
 
       - name: Configure AWS credentials using OIDC
         if: steps.gate.outputs.should_run == 'true'
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_IAM_ROLE_SDLC_ECR_READONLY_ARN }}
           aws-region: us-west-2
@@ -304,11 +304,11 @@ jobs:
       - name: Authenticate to ECR
         if: steps.gate.outputs.should_run == 'true'
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
       - name: Set up Go
         if: steps.gate.outputs.should_run == 'true'
-        uses: actions/setup-go@v6 # v6
+        uses: actions/setup-go@v6
         with:
           cache: true
           go-version-file: devenv/go.mod

--- a/.github/workflows/lint-gh-workflows.yml
+++ b/.github/workflows/lint-gh-workflows.yml
@@ -11,4 +11,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@c6ee1eb0a5d47b2af53a203652b5dac0b6c4016e # v1.43.0
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0

--- a/.github/workflows/lint-gh-workflows.yml
+++ b/.github/workflows/lint-gh-workflows.yml
@@ -11,4 +11,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
+        uses: reviewdog/action-actionlint@c6ee1eb0a5d47b2af53a203652b5dac0b6c4016e # v1.43.0

--- a/.github/workflows/operator-ui-ci.yml
+++ b/.github/workflows/operator-ui-ci.yml
@@ -16,20 +16,16 @@ jobs:
     name: Breaking Changes GQL Check
     runs-on: ubuntu-latest
     steps:
-      - name: Assume role capable of dispatching action
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        with:
-          role-to-assume: ${{ secrets.AWS_OIDC_CHAINLINK_CI_OPERATOR_UI_ACCESS_TOKEN_ISSUER_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 3600
-          role-session-name: operator-ui-ci.check-gql
-          mask-aws-account-id: true
-
-      - name: Get Github Token
+      - name: Setup github token
         id: get-gh-token
-        uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@5874ff7211cf5a5a2670bb010fbff914eaaae138 # v2.3.12
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
-          url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
+          aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_CI_OPERATOR_UI_ACCESS_TOKEN_ISSUER_ROLE_ARN }}
+          aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-duration-seconds: 3600
+          set-git-config: "true"
+
 
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -42,9 +38,9 @@ jobs:
         run: |
           if [[ $TARGET_BRANCH_NAME == release/* ]]; then
             TAG=$(cat ./operator_ui/TAG)
-            echo "TAG=$TAG" >> $GITHUB_OUTPUT
+            echo "TAG=$TAG" | tee -a "${GITHUB_OUTPUT}"
           else
-            echo "TAG=main" >> $GITHUB_OUTPUT
+            echo "TAG=main" | tee -a "${GITHUB_OUTPUT}"
           fi
 
       - uses: convictional/trigger-workflow-and-wait@f69fa9eedd3c62a599220f4d5745230e237904be #v1.6.5

--- a/.github/workflows/release-attest.yml
+++ b/.github/workflows/release-attest.yml
@@ -32,7 +32,7 @@ jobs:
       id-token: write
     steps:
       - name: Publish attestation to GitHub
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ inputs.docker-image-name }}
           subject-digest: ${{ inputs.docker-image-digest }}


### PR DESCRIPTION
This updates many reusable GHAs to their latest versions. This is in part testing out a tool I'm building to automate this process.

Other motivation is to update actions that have a node24 version available, because of the upcoming deprecation of node20 actions.

### Changes

```
Updated (27):
  actions/attest-build-provenance                         v3 → v4
  actions/cache/restore                                   v4 → v5
  actions/cache/save                                      v4 → v5
  actions/checkout                                        v5 → v6
  actions/download-artifact                               v4 → v8
  actions/setup-go                                        v6 → v6
  actions/setup-node                                      v4 → v6
  actions/upload-artifact                                 v4 → v7
  aws-actions/amazon-ecr-login                            062b18b96a7a → f2e9fc6c2b35  # v2.1.2
  aws-actions/configure-aws-credentials                   010d0da01d0b → ec61189d14ec  # v6.1.0
  bufbuild/buf-setup-action                               35c243d7f2a9 → a47c93e0b164  # v1.50.0
  docker/setup-buildx-action                              e468171a9de2 → 4d04d5d9486b  # v4.0.0
  extractions/setup-just                                  e33e0265a09d → 53165ef7e734  # v4.0.0
  github/codeql-action/analyze                            v3 → v4
  github/codeql-action/init                               v3 → v4
  golangci/golangci-lint-action                           4afd733a84b1 → 1e7e51e771db  # v9.2.0
  ludeeus/action-shellcheck                               00cae500b08a → 00cae500b08a  # 2.0.0
  peter-evans/create-pull-request                         271a8d034026 → c0f553fe5499  # v8.1.0
  pnpm/action-setup                                       a3252b78c470 → fc06bc1257f3  # v5.0.0
  reviewdog/action-actionlint                             c6ee1eb0a5d4 → 6fb7acc99f4a  # v1.72.0
  slackapi/slack-github-action                            6c661ce58804 → af78098f536e  # v3.0.1
  smartcontractkit/.github/actions/branch-names           branch-names/1.0.0 → branch-names/v1
  smartcontractkit/.github/actions/ctf-build-image        ctf-build-image/0.2.0 → ctf-build-image/v1
  smartcontractkit/.github/actions/release-tag-check      c5c4a8186da4 → release-tag-check/v1
  smartcontractkit/.github/actions/setup-github-token     setup-github-token/1.0.0 → setup-github-token/v1
  sonarsource/sonarqube-scan-action                       aecaf43ae57e → 299e4b793aaa  # v7.1.0
  thollander/actions-comment-pull-request                 fabd468d3a1a → 24bffb9b452b  # v3.0.1

Skipped - already up to date (14):
  actions/checkout
  actions/setup-go
  actions/upload-artifact
  bufbuild/buf-breaking-action
  runs-on/action
  smartcontractkit/.github/actions/advanced-triggers
  smartcontractkit/.github/actions/branch-out-upload
  smartcontractkit/.github/actions/changed-modules-go
  smartcontractkit/.github/actions/ctf-build-image
  smartcontractkit/.github/actions/get-pr-labels
  smartcontractkit/.github/actions/setup-github-token
  smartcontractkit/.github/actions/setup-postgres
  smartcontractkit/.github/actions/slack-notify-git-ref
  tailscale/github-action

Unknown - not in config (10):
  smartcontractkit/.github/.github/workflows/reusable-codeowners-review-analysis.yml
  smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml
  smartcontractkit/.github/.github/workflows/reusable-stale-prs-issues.yml
  smartcontractkit/.github/.github/workflows/run-e2e-tests.yml
  smartcontractkit/.github/actions/ctf-check-mod-version
  smartcontractkit/.github/actions/ecr-image-exists
  smartcontractkit/chainlink-github-actions/docker/image-exists
  smartcontractkit/chainlink-github-actions/github-app-token-issuer
  smartcontractkit/chainlink-github-actions/semver-compare
  smartcontractkit/chainlink-solana/.github/workflows/e2e_custom_cl_reusable.yml
```

### Testing

This PR.


### Notes

* Undid the actionlint change because it produced so many errors. Will update this in a separate PR, while fixing the errors.
