### PR TITLE
chore: remove unused timelock converter helper  [CLD-1910]

### DIFF
--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -60,6 +60,12 @@ type mcmsInspectorOptions struct {
 
 type MCMSInspectorOption func(*mcmsInspectorOptions)
 
+func WithAptosRole(role mcmsaptossdk.TimelockRole) MCMSInspectorOption {
+	return func(opts *mcmsInspectorOptions) {
+		opts.AptosRole = role
+	}
+}
+
 func McmsInspectorForChain(env cldf.Environment, chain uint64, opts ...MCMSInspectorOption) (mcmssdk.Inspector, error) {
 	var options mcmsInspectorOptions
 	for _, opt := range opts {

--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -1,16 +1,18 @@
 package proposalutils
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
 	owner_helpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
-	cldfmcmsadapters "github.com/smartcontractkit/chainlink-deployments-framework/chain/mcms/adapters"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	mcmschainwrappers "github.com/smartcontractkit/mcms/chainwrappers"
 	mcmssdk "github.com/smartcontractkit/mcms/sdk"
+
+	cldfmcmsadapters "github.com/smartcontractkit/chainlink-deployments-framework/chain/mcms/adapters"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	mcmsaptossdk "github.com/smartcontractkit/mcms/sdk/aptos"

--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -1,14 +1,12 @@
 package proposalutils
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
 
-	owner_helpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	mcmschainwrappers "github.com/smartcontractkit/mcms/chainwrappers"
 	mcmssdk "github.com/smartcontractkit/mcms/sdk"
@@ -21,50 +19,44 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
-// MCMSWithTimelockContracts holds the Go bindings
-// for a MCMSWithTimelock contract deployment.
-// It is public for use in product specific packages.
-// Either all fields are nil or all fields are non-nil.
-type MCMSWithTimelockContracts struct {
-	CancellerMcm *owner_helpers.ManyChainMultiSig
-	BypasserMcm  *owner_helpers.ManyChainMultiSig
-	ProposerMcm  *owner_helpers.ManyChainMultiSig
-	Timelock     *owner_helpers.RBACTimelock
-	CallProxy    *owner_helpers.CallProxy
-}
-
-// Validate checks that all fields are non-nil, ensuring it's ready
-// for use generating views or interactions.
-func (state MCMSWithTimelockContracts) Validate() error {
-	if state.Timelock == nil {
-		return errors.New("timelock not found")
-	}
-	if state.CancellerMcm == nil {
-		return errors.New("canceller not found")
-	}
-	if state.ProposerMcm == nil {
-		return errors.New("proposer not found")
-	}
-	if state.BypasserMcm == nil {
-		return errors.New("bypasser not found")
-	}
-	if state.CallProxy == nil {
-		return errors.New("call proxy not found")
-	}
-	return nil
-}
+//// MCMSWithTimelockContracts holds the Go bindings
+//// for a MCMSWithTimelock contract deployment.
+//// It is public for use in product specific packages.
+//// Either all fields are nil or all fields are non-nil.
+//type MCMSWithTimelockContracts struct {
+//	CancellerMcm *owner_helpers.ManyChainMultiSig
+//	BypasserMcm  *owner_helpers.ManyChainMultiSig
+//	ProposerMcm  *owner_helpers.ManyChainMultiSig
+//	Timelock     *owner_helpers.RBACTimelock
+//	CallProxy    *owner_helpers.CallProxy
+//}
+//
+//// Validate checks that all fields are non-nil, ensuring it's ready
+//// for use generating views or interactions.
+//func (state MCMSWithTimelockContracts) Validate() error {
+//	if state.Timelock == nil {
+//		return errors.New("timelock not found")
+//	}
+//	if state.CancellerMcm == nil {
+//		return errors.New("canceller not found")
+//	}
+//	if state.ProposerMcm == nil {
+//		return errors.New("proposer not found")
+//	}
+//	if state.BypasserMcm == nil {
+//		return errors.New("bypasser not found")
+//	}
+//	if state.CallProxy == nil {
+//		return errors.New("call proxy not found")
+//	}
+//	return nil
+//}
 
 type mcmsInspectorOptions struct {
 	AptosRole mcmsaptossdk.TimelockRole
 }
 
 type MCMSInspectorOption func(*mcmsInspectorOptions)
-
-func WithAptosRole(role mcmsaptossdk.TimelockRole) MCMSInspectorOption {
-	return func(opts *mcmsInspectorOptions) {
-		opts.AptosRole = role
-	}
-}
 
 func McmsInspectorForChain(env cldf.Environment, chain uint64, opts ...MCMSInspectorOption) (mcmssdk.Inspector, error) {
 	var options mcmsInspectorOptions

--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -6,51 +6,51 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
-
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	owner_helpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
+	cldfmcmsadapters "github.com/smartcontractkit/chainlink-deployments-framework/chain/mcms/adapters"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	mcmschainwrappers "github.com/smartcontractkit/mcms/chainwrappers"
 	mcmssdk "github.com/smartcontractkit/mcms/sdk"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	mcmsaptossdk "github.com/smartcontractkit/mcms/sdk/aptos"
 	mcmsevmsdk "github.com/smartcontractkit/mcms/sdk/evm"
 	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
-
-	cldfmcmsadapters "github.com/smartcontractkit/chainlink-deployments-framework/chain/mcms/adapters"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
-//// MCMSWithTimelockContracts holds the Go bindings
-//// for a MCMSWithTimelock contract deployment.
-//// It is public for use in product specific packages.
-//// Either all fields are nil or all fields are non-nil.
-//type MCMSWithTimelockContracts struct {
-//	CancellerMcm *owner_helpers.ManyChainMultiSig
-//	BypasserMcm  *owner_helpers.ManyChainMultiSig
-//	ProposerMcm  *owner_helpers.ManyChainMultiSig
-//	Timelock     *owner_helpers.RBACTimelock
-//	CallProxy    *owner_helpers.CallProxy
-//}
-//
-//// Validate checks that all fields are non-nil, ensuring it's ready
-//// for use generating views or interactions.
-//func (state MCMSWithTimelockContracts) Validate() error {
-//	if state.Timelock == nil {
-//		return errors.New("timelock not found")
-//	}
-//	if state.CancellerMcm == nil {
-//		return errors.New("canceller not found")
-//	}
-//	if state.ProposerMcm == nil {
-//		return errors.New("proposer not found")
-//	}
-//	if state.BypasserMcm == nil {
-//		return errors.New("bypasser not found")
-//	}
-//	if state.CallProxy == nil {
-//		return errors.New("call proxy not found")
-//	}
-//	return nil
-//}
+// MCMSWithTimelockContracts holds the Go bindings
+// for a MCMSWithTimelock contract deployment.
+// It is public for use in product specific packages.
+// Either all fields are nil or all fields are non-nil.
+type MCMSWithTimelockContracts struct {
+	CancellerMcm *owner_helpers.ManyChainMultiSig
+	BypasserMcm  *owner_helpers.ManyChainMultiSig
+	ProposerMcm  *owner_helpers.ManyChainMultiSig
+	Timelock     *owner_helpers.RBACTimelock
+	CallProxy    *owner_helpers.CallProxy
+}
+
+// Validate checks that all fields are non-nil, ensuring it's ready
+// for use generating views or interactions.
+func (state MCMSWithTimelockContracts) Validate() error {
+	if state.Timelock == nil {
+		return errors.New("timelock not found")
+	}
+	if state.CancellerMcm == nil {
+		return errors.New("canceller not found")
+	}
+	if state.ProposerMcm == nil {
+		return errors.New("proposer not found")
+	}
+	if state.BypasserMcm == nil {
+		return errors.New("bypasser not found")
+	}
+	if state.CallProxy == nil {
+		return errors.New("call proxy not found")
+	}
+	return nil
+}
 
 type mcmsInspectorOptions struct {
 	AptosRole mcmsaptossdk.TimelockRole

--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -54,22 +54,6 @@ func (state MCMSWithTimelockContracts) Validate() error {
 	return nil
 }
 
-func McmsTimelockConverterForChain(chain uint64) (mcmssdk.TimelockConverter, error) {
-	chainFamily, err := mcmstypes.GetChainSelectorFamily(mcmstypes.ChainSelector(chain))
-	if err != nil {
-		return nil, fmt.Errorf("failed to get chain family for chain %d: %w", chain, err)
-	}
-
-	switch chainFamily {
-	case chain_selectors.FamilyEVM:
-		return &mcmsevmsdk.TimelockConverter{}, nil
-	case chain_selectors.FamilySolana:
-		return mcmssolanasdk.TimelockConverter{}, nil
-	default:
-		return nil, fmt.Errorf("unsupported chain family %s", chainFamily)
-	}
-}
-
 type mcmsInspectorOptions struct {
 	AptosRole mcmsaptossdk.TimelockRole
 }


### PR DESCRIPTION
The `McmsTimelockConverterForChain` was unused in the repo and on our other usages.

## AI Summary
This pull request removes the `McmsTimelockConverterForChain` function from `mcms_helpers.go`. This function was responsible for returning the appropriate `TimelockConverter` implementation based on the chain family. No other significant changes are included.

* Removed the `McmsTimelockConverterForChain` function, which selected and returned a `TimelockConverter` implementation depending on the chain family (EVM, Solana, etc.), from `mcms_helpers.go`.