### PR TITLE
chore: update confidential http gitref

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -56,5 +56,5 @@ plugins:
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "187018af88ce265ca70b86222f8587e3fcb7ff32"
+      gitRef: "bdd7aefb1805a00f4d5258eefe87c268d1f60db4"
       installPath: "./cmd/confidential-http"


### PR DESCRIPTION
## Summary

Bumps the confidential HTTP gitref in `plugins/plugins.private.yaml`.
