### PR TITLE
Pass qualifier to deployment/cre/contracts GetOwnableContractV2

### DIFF
--- a/deployment/cre/contracts/contracts.go
+++ b/deployment/cre/contracts/contracts.go
@@ -180,7 +180,7 @@ func getOwnerReference[T Ownable](contract T, store datastore.AddressRefStore, c
 // GetOwnableContractV2 retrieves a contract instance of type T from the datastore.
 // If `targetAddr` is provided, it will look for that specific address.
 // If not, it will default to looking one contract of type T, and if it doesn't find exactly one, it will error.
-func GetOwnableContractV2[T Ownable](addrs datastore.AddressRefStore, chain cldf_evm.Chain, targetAddr string) (*T, error) {
+func GetOwnableContractV2[T Ownable](addrs datastore.AddressRefStore, chain cldf_evm.Chain, targetAddr string, qualifier string) (*T, error) {
 	// Determine contract type based on T
 	switch any(*new(T)).(type) {
 	case *forwarder.KeystoneForwarder:
@@ -194,7 +194,14 @@ func GetOwnableContractV2[T Ownable](addrs datastore.AddressRefStore, chain cldf
 		return nil, fmt.Errorf("unsupported contract type %T", *new(T))
 	}
 
-	addresses := addrs.Filter(datastore.AddressRefByChainSelector(chain.Selector), datastore.AddressRefByAddress(targetAddr))
+	filters := []datastore.FilterFunc[datastore.AddressRefKey, datastore.AddressRef]{
+		datastore.AddressRefByChainSelector(chain.Selector),
+		datastore.AddressRefByAddress(targetAddr),
+	}
+	if qualifier != "" {
+		filters = append(filters, datastore.AddressRefByQualifier(qualifier))
+	}
+	addresses := addrs.Filter(filters...)
 	if len(addresses) != 1 {
 		return nil, fmt.Errorf("expected exactly one address for contract at %s on chain %d, found %d", targetAddr, chain.Selector, len(addresses))
 	}
@@ -241,17 +248,24 @@ func createContractInstance[T Ownable](addr string, chain cldf_evm.Chain) (*T, e
 }
 
 // GetOwnedContractV2 retrieves an OwnedContract instance of type T from the datastore for a specific address.
-func GetOwnedContractV2[T Ownable](store datastore.AddressRefStore, chain cldf_evm.Chain, addr string) (*OwnedContract[T], error) {
-	addresses := store.Filter(datastore.AddressRefByChainSelector(chain.Selector), datastore.AddressRefByAddress(addr))
+func GetOwnedContractV2[T Ownable](store datastore.AddressRefStore, chain cldf_evm.Chain, addr string, qualifier string) (*OwnedContract[T], error) {
+	filters := []datastore.FilterFunc[datastore.AddressRefKey, datastore.AddressRef]{
+		datastore.AddressRefByChainSelector(chain.Selector),
+		datastore.AddressRefByAddress(addr),
+	}
+	if qualifier != "" {
+		filters = append(filters, datastore.AddressRefByQualifier(qualifier))
+	}
+	addresses := store.Filter(filters...)
 
 	if len(addresses) == 0 {
 		return nil, fmt.Errorf("address %s not found in address ref store for chain %d", addr, chain.Selector)
 	}
-	// should not happen since address is unique
+	// should not happen since address+qualifier is unique
 	if len(addresses) > 1 {
 		return nil, fmt.Errorf("multiple addresses found for %s in address ref store for chain %d", addr, chain.Selector)
 	}
-	contract, err := GetOwnableContractV2[T](store, chain, addr)
+	contract, err := GetOwnableContractV2[T](store, chain, addr, qualifier)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get contract at %s: %w", addr, err)
 	}

--- a/deployment/cre/contracts/contracts.go
+++ b/deployment/cre/contracts/contracts.go
@@ -178,8 +178,9 @@ func getOwnerReference[T Ownable](contract T, store datastore.AddressRefStore, c
 }
 
 // GetOwnableContractV2 retrieves a contract instance of type T from the datastore.
-// If `targetAddr` is provided, it will look for that specific address.
-// If not, it will default to looking one contract of type T, and if it doesn't find exactly one, it will error.
+// It looks up the contract by the provided `targetAddr` on the specified chain.
+// If `qualifier` is non-empty, it is applied as an additional filter.
+// The lookup must resolve to exactly one datastore entry or an error is returned.
 func GetOwnableContractV2[T Ownable](addrs datastore.AddressRefStore, chain cldf_evm.Chain, targetAddr string, qualifier string) (*T, error) {
 	// Determine contract type based on T
 	switch any(*new(T)).(type) {
@@ -203,7 +204,10 @@ func GetOwnableContractV2[T Ownable](addrs datastore.AddressRefStore, chain cldf
 	}
 	addresses := addrs.Filter(filters...)
 	if len(addresses) != 1 {
-		return nil, fmt.Errorf("expected exactly one address for contract at %s on chain %d, found %d", targetAddr, chain.Selector, len(addresses))
+		return nil, fmt.Errorf(
+			"expected exactly one address for contract at %s on chain %d, found %d (qualifier filter applied: %t, qualifier: %q)",
+			targetAddr, chain.Selector, len(addresses), qualifier != "", qualifier,
+		)
 	}
 
 	return createContractInstance[T](targetAddr, chain)
@@ -259,11 +263,18 @@ func GetOwnedContractV2[T Ownable](store datastore.AddressRefStore, chain cldf_e
 	addresses := store.Filter(filters...)
 
 	if len(addresses) == 0 {
+		if qualifier != "" {
+			return nil, fmt.Errorf("address %s with qualifier %q not found in address ref store for chain %d", addr, qualifier, chain.Selector)
+		}
 		return nil, fmt.Errorf("address %s not found in address ref store for chain %d", addr, chain.Selector)
 	}
-	// should not happen since address+qualifier is unique
+	// When qualifier is non-empty, address+qualifier should be unique.
+	// When qualifier is empty, duplicates are possible if the same address is stored under multiple qualifiers.
 	if len(addresses) > 1 {
-		return nil, fmt.Errorf("multiple addresses found for %s in address ref store for chain %d", addr, chain.Selector)
+		if qualifier != "" {
+			return nil, fmt.Errorf("multiple addresses found for %s in address ref store for chain %d with qualifier %q", addr, chain.Selector, qualifier)
+		}
+		return nil, fmt.Errorf("multiple addresses found for %s in address ref store for chain %d (no qualifier filter applied)", addr, chain.Selector)
 	}
 	contract, err := GetOwnableContractV2[T](store, chain, addr, qualifier)
 	if err != nil {

--- a/deployment/cre/contracts/contracts_test.go
+++ b/deployment/cre/contracts/contracts_test.go
@@ -95,6 +95,44 @@ func TestGetOwnableContractV2(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "found 0")
 	})
+
+	t.Run("succeeds with correct qualifier when duplicates exist", func(t *testing.T) {
+		t.Parallel()
+
+		ds := datastore.NewMemoryDataStore()
+		targetAddr := testutils.NewAddress()
+		targetAddrStr := targetAddr.String()
+
+		addrRefA := datastore.AddressRef{
+			ChainSelector: selector,
+			Address:       targetAddrStr,
+			Type:          datastore.ContractType(contracts.CapabilitiesRegistry),
+			Version:       v1,
+			Qualifier:     "zone-a",
+		}
+		addrRefB := addrRefA
+		addrRefB.Qualifier = "zone-b"
+
+		err := ds.AddressRefStore.Add(addrRefA)
+		require.NoError(t, err)
+		err = ds.AddressRefStore.Add(addrRefB)
+		require.NoError(t, err)
+
+		// Correct qualifier succeeds
+		c, err := contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](ds.Addresses(), chain, targetAddrStr, "zone-a")
+		require.NoError(t, err)
+		assert.NotNil(t, c)
+
+		// Non-matching qualifier errors
+		_, err = contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](ds.Addresses(), chain, targetAddrStr, "zone-c")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "found 0")
+
+		// No qualifier errors with duplicates
+		_, err = contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](ds.Addresses(), chain, targetAddrStr, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "found 2")
+	})
 }
 
 func TestGetOwnerTypeAndVersionV2(t *testing.T) {

--- a/deployment/cre/contracts/contracts_test.go
+++ b/deployment/cre/contracts/contracts_test.go
@@ -61,7 +61,7 @@ func TestGetOwnableContractV2(t *testing.T) {
 		err := ds.AddressRefStore.Add(addrRef)
 		require.NoError(t, err)
 
-		c, err := contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](ds.Addresses(), chain, targetAddrStr)
+		c, err := contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](ds.Addresses(), chain, targetAddrStr, "")
 		require.NoError(t, err)
 		assert.NotNil(t, c)
 		contract := *c
@@ -90,7 +90,7 @@ func TestGetOwnableContractV2(t *testing.T) {
 		err := ds.AddressRefStore.Add(addrRef)
 		require.NoError(t, err)
 
-		_, err = contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](ds.Addresses(), chain, nonExistentAddrStr)
+		_, err = contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](ds.Addresses(), chain, nonExistentAddrStr, "")
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "found 0")
@@ -137,7 +137,7 @@ func TestGetOwnerTypeAndVersionV2(t *testing.T) {
 		err = ds.AddressRefStore.Add(registryAddrRef)
 		require.NoError(t, err)
 
-		contract, err := contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](ds.Addresses(), chain, targetAddrStr)
+		contract, err := contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](ds.Addresses(), chain, targetAddrStr, "")
 		require.NoError(t, err)
 
 		owner, err := (*contract).Owner(nil)
@@ -176,7 +176,7 @@ func TestGetOwnerTypeAndVersionV2(t *testing.T) {
 		err = ds.AddressRefStore.Add(registryAddrRef)
 		require.NoError(t, err)
 
-		contract, err := contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](ds.Addresses(), chain, targetAddrStr)
+		contract, err := contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](ds.Addresses(), chain, targetAddrStr, "")
 		require.NoError(t, err)
 
 		ownerTV, err := contracts.GetOwnerTypeAndVersionV2(*contract, ds.Addresses(), chain)
@@ -231,7 +231,7 @@ func TestNewOwnableV2(t *testing.T) {
 		err = ds.AddressRefStore.Add(registryAddrRef)
 		require.NoError(t, err)
 
-		contract, err := contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](ds.Addresses(), chain, targetAddrStr)
+		contract, err := contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](ds.Addresses(), chain, targetAddrStr, "")
 		require.NoError(t, err)
 
 		owner, err := (*contract).Owner(nil)
@@ -257,7 +257,7 @@ func TestNewOwnableV2(t *testing.T) {
 	})
 
 	t.Run("no error when owner type lookup fails due to missing address in datastore (it is non-MCMS owned)", func(t *testing.T) {
-		contract, err := contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](rt.Environment().DataStore.Addresses(), chain, targetAddrStr)
+		contract, err := contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](rt.Environment().DataStore.Addresses(), chain, targetAddrStr, "")
 		require.NoError(t, err)
 
 		// Don't add owner to datastore, so lookup will return nil TV and no error
@@ -283,7 +283,7 @@ func TestNewOwnableV2(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		contract, err := contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](rt.State().DataStore.Addresses(), chain, targetAddrStr)
+		contract, err := contracts.GetOwnableContractV2[*capabilities_registry.CapabilitiesRegistry](rt.State().DataStore.Addresses(), chain, targetAddrStr, "")
 		require.NoError(t, err)
 
 		ownedContract, err := contracts.NewOwnableV2(*contract, rt.State().DataStore.Addresses(), chain)
@@ -323,7 +323,7 @@ func TestGetOwnedContractV2(t *testing.T) {
 	t.Run("successfully creates owned contract", func(t *testing.T) {
 		t.Parallel()
 
-		ownedContract, err := contracts.GetOwnedContractV2[*capabilities_registry.CapabilitiesRegistry](addrStore, chain, targetAddrStr)
+		ownedContract, err := contracts.GetOwnedContractV2[*capabilities_registry.CapabilitiesRegistry](addrStore, chain, targetAddrStr, "")
 		require.NoError(t, err)
 		assert.NotNil(t, ownedContract)
 		assert.NotNil(t, ownedContract.Contract)
@@ -335,8 +335,86 @@ func TestGetOwnedContractV2(t *testing.T) {
 		t.Parallel()
 
 		nonExistentAddr := testutils.NewAddress().String()
-		_, err := contracts.GetOwnedContractV2[*capabilities_registry.CapabilitiesRegistry](addrStore, chain, nonExistentAddr)
+		_, err := contracts.GetOwnedContractV2[*capabilities_registry.CapabilitiesRegistry](addrStore, chain, nonExistentAddr, "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found in address ref store")
+	})
+
+	t.Run("errors when multiple entries for same address without qualifier", func(t *testing.T) {
+		t.Parallel()
+
+		rt2, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+			environment.WithEVMSimulated(t, []uint64{selector}),
+			environment.WithLogger(logger.Test(t)),
+		))
+		require.NoError(t, err)
+
+		err = rt2.Exec(
+			runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployCapabilityRegistryV2), &changeset.DeployRequestV2{
+				ChainSel: selector,
+			}),
+		)
+		require.NoError(t, err)
+
+		chain2 := rt2.Environment().BlockChains.EVMChains()[selector]
+		addrStore2 := rt2.State().DataStore.Addresses()
+		addrs2, err := addrStore2.Fetch()
+		require.NoError(t, err)
+		require.Len(t, addrs2, 1)
+		addr := addrs2[0].Address
+
+		// Build a new MemoryDataStore with duplicate entries (different qualifiers)
+		ds2 := datastore.NewMemoryDataStore()
+		err = ds2.AddressRefStore.Add(addrs2[0])
+		require.NoError(t, err)
+		duplicate := addrs2[0]
+		duplicate.Qualifier = "zone-b"
+		err = ds2.AddressRefStore.Add(duplicate)
+		require.NoError(t, err)
+
+		// Without qualifier: should fail with multiple addresses
+		_, err = contracts.GetOwnedContractV2[*capabilities_registry.CapabilitiesRegistry](ds2.Addresses(), chain2, addr, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple addresses found")
+	})
+
+	t.Run("succeeds with qualifier when multiple entries exist for same address", func(t *testing.T) {
+		t.Parallel()
+
+		rt2, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+			environment.WithEVMSimulated(t, []uint64{selector}),
+			environment.WithLogger(logger.Test(t)),
+		))
+		require.NoError(t, err)
+
+		err = rt2.Exec(
+			runtime.ChangesetTask(cldf.CreateLegacyChangeSet(changeset.DeployCapabilityRegistryV2), &changeset.DeployRequestV2{
+				ChainSel:  selector,
+				Qualifier: "zone-a",
+			}),
+		)
+		require.NoError(t, err)
+
+		chain2 := rt2.Environment().BlockChains.EVMChains()[selector]
+		addrStore2 := rt2.State().DataStore.Addresses()
+		addrs2, err := addrStore2.Fetch()
+		require.NoError(t, err)
+		require.Len(t, addrs2, 1)
+		addr := addrs2[0].Address
+
+		// Build a new MemoryDataStore with duplicate entries (different qualifiers)
+		ds2 := datastore.NewMemoryDataStore()
+		err = ds2.AddressRefStore.Add(addrs2[0])
+		require.NoError(t, err)
+		duplicate := addrs2[0]
+		duplicate.Qualifier = "zone-b"
+		err = ds2.AddressRefStore.Add(duplicate)
+		require.NoError(t, err)
+
+		// With qualifier: should succeed
+		ownedContract, err := contracts.GetOwnedContractV2[*capabilities_registry.CapabilitiesRegistry](ds2.Addresses(), chain2, addr, "zone-a")
+		require.NoError(t, err)
+		assert.NotNil(t, ownedContract)
+		assert.NotNil(t, ownedContract.Contract)
 	})
 }

--- a/deployment/cre/forwarder/configure.go
+++ b/deployment/cre/forwarder/configure.go
@@ -137,7 +137,7 @@ var ConfigureSeq = operations.NewSequence[ConfigureSeqInput, ConfigureSeqOutput,
 					return ConfigureSeqOutput{}, fmt.Errorf("failed to create strategy: %w", err)
 				}
 
-				contract, err := contracts.GetOwnedContractV2[*forwarder.KeystoneForwarder](deps.Env.DataStore.Addresses(), chain, addrRef.Address)
+				contract, err := contracts.GetOwnedContractV2[*forwarder.KeystoneForwarder](deps.Env.DataStore.Addresses(), chain, addrRef.Address, addrRef.Qualifier)
 				if err != nil {
 					return ConfigureSeqOutput{}, fmt.Errorf("configure-forwarders-seq failed: failed to get KeystoneForwarder contract for chain selector %d: %w", chain.Selector, err)
 				}

--- a/deployment/cre/ocr3/ocr3_1/changeset/operations/contracts/configure_dkg.go
+++ b/deployment/cre/ocr3/ocr3_1/changeset/operations/contracts/configure_dkg.go
@@ -65,7 +65,7 @@ var ConfigureDKG = operations.NewOperation(
 			return ConfigureDKGOpOutput{}, fmt.Errorf("chain %d not found in environment", input.ChainSelector)
 		}
 
-		contract, err := contracts.GetOwnedContractV2[*ocr3_capability.OCR3Capability](deps.Env.DataStore.Addresses(), chain, input.ContractAddress.Hex())
+		contract, err := contracts.GetOwnedContractV2[*ocr3_capability.OCR3Capability](deps.Env.DataStore.Addresses(), chain, input.ContractAddress.Hex(), "")
 		if err != nil {
 			return ConfigureDKGOpOutput{}, fmt.Errorf("failed to get DKG contract: %w", err)
 		}

--- a/deployment/cre/ocr3/ocr3_1/changeset/operations/contracts/configure_ocr3_1.go
+++ b/deployment/cre/ocr3/ocr3_1/changeset/operations/contracts/configure_ocr3_1.go
@@ -65,7 +65,7 @@ var ConfigureOCR3_1 = operations.NewOperation[ConfigureOCR3_1Input, ConfigureOCR
 			return ConfigureOCR3_1OpOutput{}, fmt.Errorf("chain %d not found in environment", input.ChainSelector)
 		}
 
-		contract, err := contracts.GetOwnedContractV2[*ocr3_capability.OCR3Capability](deps.Env.DataStore.Addresses(), chain, input.ContractAddress.Hex())
+		contract, err := contracts.GetOwnedContractV2[*ocr3_capability.OCR3Capability](deps.Env.DataStore.Addresses(), chain, input.ContractAddress.Hex(), "")
 		if err != nil {
 			return ConfigureOCR3_1OpOutput{}, fmt.Errorf("failed to get OCR3 contract: %w", err)
 		}

--- a/deployment/cre/ocr3/v2/changeset/operations/contracts/configure_ocr3.go
+++ b/deployment/cre/ocr3/v2/changeset/operations/contracts/configure_ocr3.go
@@ -61,7 +61,7 @@ var ConfigureOCR3 = operations.NewOperation[ConfigureOCR3Input, ConfigureOCR3OpO
 			return ConfigureOCR3OpOutput{}, fmt.Errorf("chain %d not found in environment", input.ChainSelector)
 		}
 
-		contract, err := contracts.GetOwnedContractV2[*ocr3_capability.OCR3Capability](deps.Env.DataStore.Addresses(), chain, input.ContractAddress.Hex())
+		contract, err := contracts.GetOwnedContractV2[*ocr3_capability.OCR3Capability](deps.Env.DataStore.Addresses(), chain, input.ContractAddress.Hex(), "")
 		if err != nil {
 			return ConfigureOCR3OpOutput{}, fmt.Errorf("failed to get OCR3 contract: %w", err)
 		}

--- a/deployment/cre/state/contracts.go
+++ b/deployment/cre/state/contracts.go
@@ -75,7 +75,7 @@ func getContractsPerChain(e deployment.Environment) (contractsPerChain, error) {
 		switch contractAddress.Type {
 		case datastore.ContractType(crecontracts.CapabilitiesRegistry):
 			ownedContract, err := crecontracts.GetOwnedContractV2[*capabilities_registry_v2.CapabilitiesRegistry](
-				e.DataStore.Addresses(), chain, contractAddress.Address,
+				e.DataStore.Addresses(), chain, contractAddress.Address, contractAddress.Qualifier,
 			)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("failed to retrieve capabilities registry contract at %s: %w",
@@ -86,7 +86,7 @@ func getContractsPerChain(e deployment.Environment) (contractsPerChain, error) {
 
 		case datastore.ContractType(crecontracts.OCR3Capability):
 			ownedContract, err := crecontracts.GetOwnedContractV2[*ocr3_capability.OCR3Capability](
-				e.DataStore.Addresses(), chain, contractAddress.Address,
+				e.DataStore.Addresses(), chain, contractAddress.Address, contractAddress.Qualifier,
 			)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("failed to retrieve OCR3 capability contract at %s: %w",
@@ -97,7 +97,7 @@ func getContractsPerChain(e deployment.Environment) (contractsPerChain, error) {
 
 		case datastore.ContractType(crecontracts.KeystoneForwarder):
 			ownedContract, err := crecontracts.GetOwnedContractV2[*forwarder.KeystoneForwarder](
-				e.DataStore.Addresses(), chain, contractAddress.Address,
+				e.DataStore.Addresses(), chain, contractAddress.Address, contractAddress.Qualifier,
 			)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("failed to retrieve forwarder contract at %s: %w",
@@ -108,7 +108,7 @@ func getContractsPerChain(e deployment.Environment) (contractsPerChain, error) {
 
 		case datastore.ContractType(crecontracts.WorkflowRegistry):
 			ownedContract, err := crecontracts.GetOwnedContractV2[*workflow_registry_v2.WorkflowRegistry](
-				e.DataStore.Addresses(), chain, contractAddress.Address,
+				e.DataStore.Addresses(), chain, contractAddress.Address, contractAddress.Qualifier,
 			)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("failed to retrieve workflow registry contract at %s: %w",

--- a/deployment/keystone/changeset/deploy_ocr3.go
+++ b/deployment/keystone/changeset/deploy_ocr3.go
@@ -63,7 +63,7 @@ func ConfigureOCR3Contract(env cldf.Environment, cfg ConfigureOCR3Config) (cldf.
 		return cldf.ChangesetOutput{}, errors.New("address of OCR3 contract to configure is required")
 	}
 
-	contract, err := contracts.GetOwnedContractV2[*ocr3_capability.OCR3Capability](env.DataStore.Addresses(), chain, cfg.Address.Hex())
+	contract, err := contracts.GetOwnedContractV2[*ocr3_capability.OCR3Capability](env.DataStore.Addresses(), chain, cfg.Address.Hex(), "")
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get OCR3 contract: %w", err)
 	}

--- a/deployment/keystone/changeset/deploy_registry.go
+++ b/deployment/keystone/changeset/deploy_registry.go
@@ -89,7 +89,7 @@ func loadCapabilityRegistry(registryChain cldf_evm.Chain, env cldf.Environment, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get address: %w", err)
 	}
-	cr, err = contracts.GetOwnedContractV2[*capabilities_registry.CapabilitiesRegistry](env.DataStore.Addresses(), registryChain, a.Address)
+	cr, err = contracts.GetOwnedContractV2[*capabilities_registry.CapabilitiesRegistry](env.DataStore.Addresses(), registryChain, a.Address, a.Qualifier)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get owned contract: %w", err)
 	}

--- a/deployment/keystone/changeset/operations/contracts/configure_capabilities_registry_seq.go
+++ b/deployment/keystone/changeset/operations/contracts/configure_capabilities_registry_seq.go
@@ -62,7 +62,7 @@ var ConfigureCapabilitiesRegistrySeq = operations.NewSequence[ConfigureCapabilit
 			return ConfigureCapabilitiesRegistrySeqOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", input.RegistryChainSel)
 		}
 
-		capabilitiesRegistry, err := contracts.GetOwnedContractV2[*capabilities_registry.CapabilitiesRegistry](deps.Env.DataStore.Addresses(), chain, input.ContractAddress.Hex())
+		capabilitiesRegistry, err := contracts.GetOwnedContractV2[*capabilities_registry.CapabilitiesRegistry](deps.Env.DataStore.Addresses(), chain, input.ContractAddress.Hex(), "")
 		if err != nil {
 			return ConfigureCapabilitiesRegistrySeqOutput{}, fmt.Errorf("failed to get capabilities registry contract: %w", err)
 		}

--- a/deployment/keystone/changeset/operations/contracts/deploy_configure_forwarders_seq.go
+++ b/deployment/keystone/changeset/operations/contracts/deploy_configure_forwarders_seq.go
@@ -260,7 +260,7 @@ func configureForwarderOp(
 	if err != nil {
 		return fmt.Errorf("configure-forwarders-seq failed: failed to resolve DONs for chain %d: %w", target, err)
 	}
-	forwarderContract, err := crecontracts.GetOwnedContractV2[*forwarder.KeystoneForwarder](as.Addresses(), chain, forwarderAddress.String())
+	forwarderContract, err := crecontracts.GetOwnedContractV2[*forwarder.KeystoneForwarder](as.Addresses(), chain, forwarderAddress.String(), "")
 	if err != nil {
 		return fmt.Errorf("configure-forwarders-seq failed: failed to get KeystoneForwarder contract for chain selector %d: %w", target, err)
 	}

--- a/deployment/keystone/changeset/operations/contracts/update_allowed_dons_op.go
+++ b/deployment/keystone/changeset/operations/contracts/update_allowed_dons_op.go
@@ -50,7 +50,7 @@ var UpdateAllowedDonsOp = operations.NewOperation[UpdateAllowedDonsOpInput, Upda
 			return UpdateAllowedDonsOpOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", input.RegistryChainSel)
 		}
 
-		registry, err := contracts.GetOwnedContractV2[*workflow_registry.WorkflowRegistry](deps.Env.DataStore.Addresses(), chain, input.ContractAddress)
+		registry, err := contracts.GetOwnedContractV2[*workflow_registry.WorkflowRegistry](deps.Env.DataStore.Addresses(), chain, input.ContractAddress, "")
 		if err != nil {
 			return UpdateAllowedDonsOpOutput{}, fmt.Errorf("failed to get workflow registry contract: %w", err)
 		}

--- a/deployment/keystone/changeset/operations/contracts/update_authorized_addresses_op.go
+++ b/deployment/keystone/changeset/operations/contracts/update_authorized_addresses_op.go
@@ -51,7 +51,7 @@ var UpdateAuthorizedAddressesOp = operations.NewOperation[UpdateAuthorizedAddres
 			return UpdateAuthorizedAddressesOpOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", input.RegistryChainSel)
 		}
 
-		registry, err := contracts.GetOwnedContractV2[*workflow_registry.WorkflowRegistry](deps.Env.DataStore.Addresses(), chain, input.ContractAddress)
+		registry, err := contracts.GetOwnedContractV2[*workflow_registry.WorkflowRegistry](deps.Env.DataStore.Addresses(), chain, input.ContractAddress, "")
 		if err != nil {
 			return UpdateAuthorizedAddressesOpOutput{}, fmt.Errorf("failed to get workflow registry contract: %w", err)
 		}

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -142,7 +142,7 @@ func loadOneContract[T contracts.Ownable](t *testing.T, env cldf.Environment, ch
 	t.Helper()
 	addrs := env.DataStore.Addresses().Filter(datastore.AddressRefByQualifier(qualifier))
 	require.Len(t, addrs, 1)
-	c, err := contracts.GetOwnedContractV2[T](env.DataStore.Addresses(), chain, addrs[0].Address)
+	c, err := contracts.GetOwnedContractV2[T](env.DataStore.Addresses(), chain, addrs[0].Address, addrs[0].Qualifier)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 	return c
@@ -169,7 +169,7 @@ func (te EnvWrapper) OwnedForwarders() map[uint64][]*contracts.OwnedContract[*fo
 	require.NotEmpty(te.t, addrs)
 	out := make(map[uint64][]*contracts.OwnedContract[*forwarder.KeystoneForwarder])
 	for _, addr := range addrs {
-		c, err := contracts.GetOwnedContractV2[*forwarder.KeystoneForwarder](te.Env.DataStore.Addresses(), te.Env.BlockChains.EVMChains()[addr.ChainSelector], addr.Address)
+		c, err := contracts.GetOwnedContractV2[*forwarder.KeystoneForwarder](te.Env.DataStore.Addresses(), te.Env.BlockChains.EVMChains()[addr.ChainSelector], addr.Address, addr.Qualifier)
 		require.NoError(te.t, err)
 		require.NotNil(te.t, c)
 		out[addr.ChainSelector] = append(out[addr.ChainSelector], c)

--- a/deployment/keystone/changeset/view.go
+++ b/deployment/keystone/changeset/view.go
@@ -227,7 +227,7 @@ func getContractsPerChain(e deployment.Environment) (contractsPerChain, error) {
 		switch contractAddress.Type {
 		case datastore.ContractType(internal.CapabilitiesRegistry):
 			ownedContract, err := crecontracts.GetOwnedContractV2[*capabilities_registry.CapabilitiesRegistry](
-				e.DataStore.Addresses(), chain, contractAddress.Address,
+				e.DataStore.Addresses(), chain, contractAddress.Address, contractAddress.Qualifier,
 			)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("failed to retrieve capabilities registry contract at %s: %w",
@@ -238,7 +238,7 @@ func getContractsPerChain(e deployment.Environment) (contractsPerChain, error) {
 
 		case datastore.ContractType(internal.OCR3Capability):
 			ownedContract, err := crecontracts.GetOwnedContractV2[*ocr3_capability.OCR3Capability](
-				e.DataStore.Addresses(), chain, contractAddress.Address,
+				e.DataStore.Addresses(), chain, contractAddress.Address, contractAddress.Qualifier,
 			)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("failed to retrieve OCR3 capability contract at %s: %w",
@@ -249,7 +249,7 @@ func getContractsPerChain(e deployment.Environment) (contractsPerChain, error) {
 
 		case datastore.ContractType(internal.KeystoneForwarder):
 			ownedContract, err := crecontracts.GetOwnedContractV2[*forwarder.KeystoneForwarder](
-				e.DataStore.Addresses(), chain, contractAddress.Address,
+				e.DataStore.Addresses(), chain, contractAddress.Address, contractAddress.Qualifier,
 			)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("failed to retrieve forwarder contract at %s: %w",
@@ -260,7 +260,7 @@ func getContractsPerChain(e deployment.Environment) (contractsPerChain, error) {
 
 		case datastore.ContractType(internal.WorkflowRegistry):
 			ownedContract, err := crecontracts.GetOwnedContractV2[*workflow_registry.WorkflowRegistry](
-				e.DataStore.Addresses(), chain, contractAddress.Address,
+				e.DataStore.Addresses(), chain, contractAddress.Address, contractAddress.Qualifier,
 			)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("failed to retrieve workflow registry contract at %s: %w",

--- a/deployment/keystone/changeset/view_test.go
+++ b/deployment/keystone/changeset/view_test.go
@@ -245,7 +245,7 @@ func TestKeystoneView(t *testing.T) {
 			}
 			var allDons = []internal.DonCapabilities{wfDonCapabilities}
 			cr, err := contracts.GetOwnedContractV2[*capabilities_registry.CapabilitiesRegistry](
-				env.Env.DataStore.Addresses(), env.Env.BlockChains.EVMChains()[env.RegistrySelector], capabilityRegistryAddr,
+				env.Env.DataStore.Addresses(), env.Env.BlockChains.EVMChains()[env.RegistrySelector], capabilityRegistryAddr, "",
 			)
 			require.NoError(t, err)
 

--- a/system-tests/lib/cre/contracts/keystone.go
+++ b/system-tests/lib/cre/contracts/keystone.go
@@ -492,6 +492,7 @@ func ConfigureCapabilityRegistry(ctx context.Context, input cre.ConfigureCapabil
 			input.CldEnv.DataStore.Addresses(),
 			input.CldEnv.BlockChains.EVMChains()[input.ChainSelector],
 			input.CapabilitiesRegistryAddress.Hex(),
+			"",
 		)
 		if cErr != nil {
 			return nil, errors.Wrap(cErr, "failed to get capabilities registry contract")
@@ -516,6 +517,7 @@ func ConfigureCapabilityRegistry(ctx context.Context, input cre.ConfigureCapabil
 			input.CldEnv.DataStore.Addresses(),
 			input.CldEnv.BlockChains.EVMChains()[input.ChainSelector],
 			input.CapabilitiesRegistryAddress.Hex(),
+			"",
 		)
 		if cErr != nil {
 			return nil, errors.Wrap(cErr, "failed to get capabilities registry contract")


### PR DESCRIPTION
## Description
Pass qualifier to `deployment/cre/contracts`'s `GetOwnableContractV2` to allow the data store to have the same address exists with different qualifiers. (e.g. "global" qualifier and also per zone qualifiers)

NOTE: This change has a large blast radius, for a small change because of all the call points.

### What it covers:

Same behavior:
- 8 callers pass "". This is identical to old behavior (no qualifier filter applied)
   - Core function logic: `if qualifier != ""` guard means empty string = no filter

Improved behavior:
- 8 callers pass from the same datastore entry being looked up.
   - The filter will always match the entry itself. This prevents the "multiple addresses found" error, when the same address exists with different qualifiers 