### PR TITLE
fix(test): increase simulated backend EVM timeout and use require for safe failure

### DIFF
--- a/core/capabilities/ccip/ccipevm/executecodec_test.go
+++ b/core/capabilities/ccip/ccipevm/executecodec_test.go
@@ -5,13 +5,16 @@ import (
 	"math/big"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/ethclient/simulated"
+	"github.com/ethereum/go-ethereum/node"
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -176,7 +179,9 @@ func TestExecutePluginCodecV1(t *testing.T) {
 	transactor := evmtestutils.MustNewSimTransactor(t)
 	b := simulated.NewBackend(types.GenesisAlloc{
 		transactor.From: {Balance: assets.Ether(1000).ToInt()},
-	}, simulated.WithBlockGasLimit(30e6))
+	}, simulated.WithBlockGasLimit(30e6), func(_ *node.Config, ethCfg *ethconfig.Config) {
+		ethCfg.RPCEVMTimeout = 60 * time.Second
+	})
 	simulatedBackend := &backends.SimulatedBackend{Backend: b, Client: b.Client()}
 	address, _, _, err := report_codec.DeployReportCodec(transactor, simulatedBackend)
 	require.NoError(t, err)

--- a/core/capabilities/ccip/ccipevm/executecodec_test.go
+++ b/core/capabilities/ccip/ccipevm/executecodec_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient/simulated"
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -173,9 +174,10 @@ func TestExecutePluginCodecV1(t *testing.T) {
 
 	// Deploy the contract
 	transactor := evmtestutils.MustNewSimTransactor(t)
-	simulatedBackend := backends.NewSimulatedBackend(core.GenesisAlloc{
+	b := simulated.NewBackend(types.GenesisAlloc{
 		transactor.From: {Balance: assets.Ether(1000).ToInt()},
-	}, 30e6)
+	}, simulated.WithBlockGasLimit(30e6))
+	simulatedBackend := &backends.SimulatedBackend{Backend: b, Client: b.Client()}
 	address, _, _, err := report_codec.DeployReportCodec(transactor, simulatedBackend)
 	require.NoError(t, err)
 	simulatedBackend.Commit()
@@ -213,8 +215,8 @@ func TestExecutePluginCodecV1(t *testing.T) {
 
 			// decode using the contract
 			contractDecodedReport, err := contract.DecodeExecuteReport(&bind.CallOpts{Context: ctx}, bytes)
-			assert.NoError(t, err)
-			assert.Len(t, contractDecodedReport, len(report.ChainReports))
+			require.NoError(t, err)
+			require.Len(t, contractDecodedReport, len(report.ChainReports))
 			for i, expReport := range report.ChainReports {
 				actReport := contractDecodedReport[i]
 				assert.Equal(t, expReport.OffchainTokenData, actReport.OffchainTokenData)

--- a/core/capabilities/ccip/ccipevm/msghasher_test.go
+++ b/core/capabilities/ccip/ccipevm/msghasher_test.go
@@ -14,12 +14,16 @@ import (
 	"strings"
 	"testing"
 
+	"time"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/ethclient/simulated"
+	"github.com/ethereum/go-ethereum/node"
 	agbinary "github.com/gagliardetto/binary"
 	solanago "github.com/gagliardetto/solana-go"
 	chainsel "github.com/smartcontractkit/chain-selectors"
@@ -199,9 +203,12 @@ type testSetupData struct {
 
 func testSetup(t *testing.T) *testSetupData {
 	transactor := evmtestutils.MustNewSimTransactor(t)
-	simulatedBackend := backends.NewSimulatedBackend(core.GenesisAlloc{
+	b := simulated.NewBackend(types.GenesisAlloc{
 		transactor.From: {Balance: assets.Ether(1000).ToInt()},
-	}, 30e6)
+	}, simulated.WithBlockGasLimit(30e6), func(_ *node.Config, ethCfg *ethconfig.Config) {
+		ethCfg.RPCEVMTimeout = 60 * time.Second
+	})
+	simulatedBackend := &backends.SimulatedBackend{Backend: b, Client: b.Client()}
 
 	// Deploy the contract
 	address, _, _, err := message_hasher.DeployMessageHasher(transactor, simulatedBackend)

--- a/core/capabilities/ccip/ccipevm/msghasher_test.go
+++ b/core/capabilities/ccip/ccipevm/msghasher_test.go
@@ -13,7 +13,6 @@ import (
 	"math/rand"
 	"strings"
 	"testing"
-
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"


### PR DESCRIPTION
## Summary
- The go-ethereum simulated backend defaults to a 5-second `RPCEVMTimeout` for `eth_call`
- Under `-count=100 -race`, race detector overhead (5-10x) causes EVM execution to exceed this timeout
- **Root cause fix**: Create the simulated backend with `RPCEVMTimeout: 60s` so EVM calls complete reliably under load
- **Defensive fix**: Change `assert.NoError` → `require.NoError` before slice iteration so the test stops cleanly on any failure instead of panicking on an empty slice

## Root Cause
`testSetup()` used `backends.NewSimulatedBackend()` which inherits go-ethereum's default 5s `RPCEVMTimeout`. The test calls `contract.DecodeExecuteReport()` which goes through `eth_call` → `doCall()` → `applyMessageWithEVM()` — all subject to this timeout. Under race detector overhead, the 5s limit is exceeded intermittently.

## Test plan
- [ ] CI passes
- [ ] No more `execution aborted (timeout = 5s)` panics under `-count=100 -race`

Fixes: CORE-2383