### PR TITLE
fix(pgtest): use t.Fatalf instead of t.Errorf for missing CL_DATABASE_URL

### DIFF
--- a/core/internal/testutils/pgtest/pgtest.go
+++ b/core/internal/testutils/pgtest/pgtest.go
@@ -18,8 +18,7 @@ func NewSqlxDB(t testing.TB) *sqlx.DB {
 	testutils.SkipShortDB(t)
 	dbURL := string(env.DatabaseURL.Get())
 	if dbURL == "" {
-		t.Errorf("you must provide a CL_DATABASE_URL environment variable")
-		return nil
+		t.Fatalf("you must provide a CL_DATABASE_URL environment variable")
 	}
 	return sqltest.NewDB(t, dbURL)
 }


### PR DESCRIPTION
## Summary
- Changes `t.Errorf` → `t.Fatalf` in `pgtest.NewSqlxDB` when `CL_DATABASE_URL` is missing
- Prevents SIGSEGV panics from nil `*sqlx.DB` propagating to downstream tests

## Root Cause
`t.Errorf` is non-fatal, so the function returned `nil`. Any test calling `pgtest.NewSqlxDB` without a database URL would get a nil DB and panic on the first query.

## Test plan
- [ ] CI passes
- [ ] Tests that call `pgtest.NewSqlxDB` without DB fail cleanly instead of panicking

Fixes: CORE-2371