### PR TITLE
fix(test): prevent Mercury v02 goroutine leak in timeout test

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v02/request.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v02/request.go
@@ -56,6 +56,10 @@ func NewClient(mercuryConfig mercury.MercuryConfigProvider, httpClient mercury.H
 	}
 }
 
+func (c *client) Start() error {
+	return c.StartOnce("v02_request", func() error { return nil })
+}
+
 func (c *client) DoRequest(ctx context.Context, streamsLookup *mercury.StreamsLookup, upkeepType automationTypes.UpkeepType, pluginRetryKey string) (encoding.PipelineExecutionState, [][]byte, encoding.ErrCode, bool, time.Duration, error) {
 	if len(streamsLookup.Feeds) == 0 {
 		return encoding.NoPipelineError, nil, encoding.ErrCodeStreamsBadRequest, false, 0 * time.Second, nil

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v02/v02_request_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v02/v02_request_test.go
@@ -2,6 +2,7 @@ package v02
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -26,6 +27,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -91,13 +93,14 @@ func setupClient(t *testing.T) *client {
 	mercuryConfig := NewMockMercuryConfigProvider()
 	threadCtl := utils.NewThreadControl()
 
-	client := NewClient(
+	c := NewClient(
 		mercuryConfig,
 		mockHttpClient,
 		threadCtl,
 		lggr,
 	)
-	return client
+	require.NoError(t, c.StartOnce("v02_request", func() error { return nil }))
+	return c
 }
 
 func TestV02_SingleFeedRequest(t *testing.T) {
@@ -690,15 +693,17 @@ func TestV02_DoMercuryRequestV02_Timeout(t *testing.T) {
 	}
 	hc.On("Do", mock.Anything).Return(resp, nil).Once() // First request sends result normally
 
-	resp2 := &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(bytes.NewReader([]byte{})),
-	}
-	// Second request has timeout
-	serverTimeout := 15 * time.Second // Server has delay of 15s, higher than mercury.RequestTimeout = 10s
+	// Second request simulates a server that takes longer than mercury.RequestTimeout.
+	// Block until the request context is cancelled rather than using time.Sleep,
+	// so the goroutine exits promptly during cleanup.
+	serverTimeout := 15 * time.Second
 	hc.On("Do", mock.Anything).Run(func(args mock.Arguments) {
-		time.Sleep(serverTimeout)
-	}).Return(resp2, nil).Once()
+		req := args.Get(0).(*http.Request)
+		select {
+		case <-req.Context().Done():
+		case <-time.After(serverTimeout):
+		}
+	}).Return((*http.Response)(nil), context.DeadlineExceeded).Once()
 
 	c.httpClient = hc
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v02/v02_request_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v02/v02_request_test.go
@@ -99,7 +99,7 @@ func setupClient(t *testing.T) *client {
 		threadCtl,
 		lggr,
 	)
-	require.NoError(t, c.StartOnce("v02_request", func() error { return nil }))
+	require.NoError(t, c.Start())
 	return c
 }
 


### PR DESCRIPTION
## Summary
- `TestV02_DoMercuryRequestV02_Timeout` panicked with "Log in goroutine after Test has completed"
- **Root cause 1**: `setupClient` never called `StartOnce`, so `c.Close()` (via `StopOnce`) was a no-op — goroutines were never cleaned up
- **Root cause 2**: Mock used `time.Sleep(15s)` which ignored context cancellation
- **Fix**: Call `StartOnce` in `setupClient` so `Close()` properly waits for goroutines. Replace `time.Sleep` with context-aware `select` and return typed nil response with error

## Test plan
- [x] Passes with `-count=20 -race` locally (202s, no panics)
- [ ] CI passes

Fixes: CORE-2372