### PR TITLE
fix(test): replace spin-wait with Eventually for service startup race

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/transmit/event_provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/transmit/event_provider_test.go
@@ -2,8 +2,8 @@ package transmit
 
 import (
 	"math/big"
-	"runtime"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -45,12 +45,9 @@ func TestTransmitEventProvider_Sanity(t *testing.T) {
 		}
 	}()
 
-	for provider.Ready() != nil {
-		runtime.Gosched()
-	}
-	errs := provider.HealthReport()
-	require.Len(t, errs, 1)
-	require.NoError(t, errs[provider.Name()])
+	require.Eventually(t, func() bool {
+		return provider.Ready() == nil && provider.HealthReport()[provider.Name()] == nil
+	}, time.Second, 10*time.Millisecond)
 
 	tests := []struct {
 		name        string

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/transmit/event_provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/transmit/event_provider_test.go
@@ -2,8 +2,8 @@ package transmit
 
 import (
 	"math/big"
+	"runtime"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -45,9 +45,9 @@ func TestTransmitEventProvider_Sanity(t *testing.T) {
 		}
 	}()
 
-	require.Eventually(t, func() bool {
-		return provider.Ready() == nil && provider.HealthReport()[provider.Name()] == nil
-	}, time.Second, 10*time.Millisecond)
+	for provider.Ready() != nil || provider.HealthReport()[provider.Name()] != nil {
+		runtime.Gosched()
+	}
 
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary
- `TestTransmitEventProvider_Sanity` used `runtime.Gosched()` spin-wait until `Ready()` returned nil, then immediately asserted `HealthReport()` had no errors
- Brief window where `Ready()` returns nil but `HealthReport()` still shows "Starting"
- Replace with `require.Eventually` that polls both `Ready()` and `HealthReport()` together

## Test plan
- [x] Passes with `-count=100 -race` locally
- [ ] CI passes

Fixes: CORE-2386