### PR TITLE
fix(test): add minimal retry delay in ccipexec/ccipcommit plugin tests

### DIFF
--- a/core/services/ocr2/plugins/ccip/ccipcommit/factory_test.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/factory_test.go
@@ -31,10 +31,9 @@ func TestNewReportingPluginRetriesUntilSuccess(t *testing.T) {
 	commitConfig.lggr = logger.TestLogger(t)
 	commitConfig.metricsCollector = ccip2.NoopMetricsCollector
 
-	// For this unit test, ensure that there is no delay between retries
 	commitConfig.newReportingPluginRetryConfig = ccipdata.RetryConfig{
-		InitialDelay: 0 * time.Nanosecond,
-		MaxDelay:     0 * time.Nanosecond,
+		InitialDelay: 1 * time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
 	}
 
 	// Set up the OffRampReader mock

--- a/core/services/ocr2/plugins/ccip/ccipexec/factory_test.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/factory_test.go
@@ -29,10 +29,9 @@ func TestNewReportingPluginRetriesUntilSuccess(t *testing.T) {
 	execConfig.lggr = logger.TestLogger(t)
 	execConfig.metricsCollector = ccip2.NoopMetricsCollector
 
-	// For this unit test, ensure that there is no delay between retries
 	execConfig.newReportingPluginRetryConfig = ccipdata.RetryConfig{
-		InitialDelay: 0 * time.Nanosecond,
-		MaxDelay:     0 * time.Nanosecond,
+		InitialDelay: 1 * time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
 	}
 
 	// Set up the OffRampReader mock


### PR DESCRIPTION
## Summary
- `TestNewReportingPluginRetriesUntilSuccess` (both ccipexec and ccipcommit) used 0ns retry delays
- Zero-delay retry loops race with testify mock `.Once()` → `.Times(N)` state transitions under `-race`
- Add 1ms initial / 10ms max delay — still fast but gives mocks time to transition

## Test plan
- [x] Both tests pass with `-count=100 -race` locally
- [ ] CI passes

Fixes: CORE-2398