### PR TITLE
fix(test): use context-aware sleeps in httptest handlers to prevent Close() hang

### DIFF
--- a/core/services/gateway/network/httpclient_test.go
+++ b/core/services/gateway/network/httpclient_test.go
@@ -86,7 +86,11 @@ func TestHTTPClient_Send(t *testing.T) {
 			name: "context canceled due to timeout passed in request",
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					time.Sleep(10 * time.Second)
+					select {
+					case <-r.Context().Done():
+						return
+					case <-time.After(10 * time.Second):
+					}
 					w.WriteHeader(http.StatusOK)
 					_, err2 := w.Write([]byte("success"))
 					assert.NoError(t, err2)
@@ -106,7 +110,11 @@ func TestHTTPClient_Send(t *testing.T) {
 			name: "context canceled due to default timeout",
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					time.Sleep(10 * time.Second)
+					select {
+					case <-r.Context().Done():
+						return
+					case <-time.After(10 * time.Second):
+					}
 					w.WriteHeader(http.StatusOK)
 					_, err2 := w.Write([]byte("success"))
 					assert.NoError(t, err2)
@@ -124,7 +132,11 @@ func TestHTTPClient_Send(t *testing.T) {
 			name: "success with long timeout passed in request",
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					time.Sleep(1 * time.Second)
+					select {
+					case <-r.Context().Done():
+						return
+					case <-time.After(1 * time.Second):
+					}
 					w.WriteHeader(http.StatusOK)
 					_, err2 := w.Write([]byte("success"))
 					assert.NoError(t, err2)
@@ -147,7 +159,11 @@ func TestHTTPClient_Send(t *testing.T) {
 			name: "fails with long timeout capped by default",
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					time.Sleep(1 * time.Second)
+					select {
+					case <-r.Context().Done():
+						return
+					case <-time.After(1 * time.Second):
+					}
 					w.WriteHeader(http.StatusOK)
 					_, err2 := w.Write([]byte("success"))
 					assert.NoError(t, err2)

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_test.go
@@ -105,7 +105,11 @@ func TestUSDCReader_callAttestationApiMockError(t *testing.T) {
 				responseBytes, _ := json.Marshal(response)
 
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					time.Sleep(defaultAttestationTimeout + time.Second)
+					select {
+					case <-r.Context().Done():
+						return
+					case <-time.After(defaultAttestationTimeout + time.Second):
+					}
 					_, err := w.Write(responseBytes)
 					require.NoError(t, err)
 				}))
@@ -123,7 +127,11 @@ func TestUSDCReader_callAttestationApiMockError(t *testing.T) {
 				responseBytes, _ := json.Marshal(response)
 
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					time.Sleep(2*time.Second + time.Second)
+					select {
+					case <-r.Context().Done():
+						return
+					case <-time.After(2*time.Second + time.Second):
+					}
 					_, err := w.Write(responseBytes)
 					require.NoError(t, err)
 				}))
@@ -179,7 +187,10 @@ func TestUSDCReader_callAttestationApiMockError(t *testing.T) {
 			name: "parent context timeout",
 			getTs: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					time.Sleep(defaultAttestationTimeout + time.Second)
+					select {
+					case <-r.Context().Done():
+					case <-time.After(defaultAttestationTimeout + time.Second):
+					}
 				}))
 			},
 			parentTimeoutSeconds: 1,


### PR DESCRIPTION
## Summary
- `TestHTTPClient_Send` and `TestUSDCReader_callAttestationApiMockError` hang on `httptest.Server.Close()` 
- Handlers use unconditional `time.Sleep` that ignores client cancellation
- Replace with `select { case <-r.Context().Done(): return; case <-time.After(d): }` so handlers exit when client cancels

Fixes: CORE-2385