### PR TITLE
fix(test): reduce StreamsConsensusAggregator test load to prevent timeout

### DIFF
--- a/core/capabilities/streams/consensus_agg_test.go
+++ b/core/capabilities/streams/consensus_agg_test.go
@@ -23,8 +23,8 @@ func TestStreamsConsensusAggregator(t *testing.T) {
 	Ft := 3  // trigger DON faulty nodes
 	Nw := 10 // workflow DON nodes
 	Fw := 3  // workflow DON faulty nodes
-	P := 40  // feeds
-	T := 2   // test iterations
+	P := 15  // feeds (reduced from 40 to prevent timeout under -count=100 -race)
+	T := 1   // test iterations
 
 	triggerNodes := newNodes(t, Nt)
 	feeds := newFeedsWithSignedReports(t, triggerNodes, Nt, P, 1)


### PR DESCRIPTION
## Summary
- `TestStreamsConsensusAggregator` timed out under `-count=100 -race` due to heavy protobuf allocation (10 nodes × 40 feeds)
- Reduce feeds from 40 to 15 and iterations from 2 to 1 — still validates aggregation correctness

Fixes: CORE-2395