### PR TITLE
fix(test): quarantine flaky CCIP Sui upgrade integration tests

### DIFF
--- a/integration-tests/smoke/ccip/ccip_sui_upgrade_test.go
+++ b/integration-tests/smoke/ccip/ccip_sui_upgrade_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/block-vision/sui-go-sdk/models"
+	"github.com/smartcontractkit/quarantine"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -129,6 +130,7 @@ func Test_CCIP_Upgrade_Sui2EVM(t *testing.T) {
 }
 
 func Test_CCIP_Upgrade_EVM2Sui(t *testing.T) {
+	quarantine.Flaky(t, "CORE-2414")
 	ctx := testcontext.Get(t)
 	e, _, _ := testsetups.NewIntegrationEnvironment(
 		t,
@@ -359,6 +361,7 @@ func Test_CCIP_Upgrade_NoBlock_EVM2Sui(t *testing.T) {
 }
 
 func Test_CCIP_Upgrade_CommonPkg_EVM2Sui(t *testing.T) {
+	quarantine.Flaky(t, "CORE-2414")
 	ctx := testcontext.Get(t)
 	e, _, _ := testsetups.NewIntegrationEnvironment(
 		t,


### PR DESCRIPTION
## Summary
- `Test_CCIP_Upgrade_EVM2Sui` and `Test_CCIP_Upgrade_CommonPkg_EVM2Sui` fail intermittently in CI
- Root cause: state synchronization gaps between contract upgrades and test setup initialization on Sui chain
- Add `quarantine.Flaky(t, "CORE-2414")` to both tests

Fixes: CORE-2414