### PR TITLE
fix: guard config initialization to prevent txdb config overwrite [CORE-2388]

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -80,15 +80,20 @@ func NewApp(s *Shell) *cli.App {
 		// logger instead.
 		lggr, closeFn := logger.NewLogger()
 
-		cfg, err := opts.New()
-		if err != nil {
-			return err
-		}
-
 		s.Logger = lggr
 		s.Registerer = prometheus.DefaultRegisterer // use the global DefaultRegisterer, should be safe since we only ever run one instance of the app per shell
 		s.CloseLogger = closeFn
-		s.Config = cfg
+
+		// Preserve a pre-set s.Config. Overwriting it here would clobber
+		// test configs that use a txdb-wrapped driver and cause real pgx
+		// connections to leak into the shared test database.
+		if s.Config == nil {
+			cfg, err := opts.New()
+			if err != nil {
+				return err
+			}
+			s.Config = cfg
+		}
 
 		if c.Bool("json") {
 			s.Renderer = RendererJSON{Writer: os.Stdout}
@@ -122,11 +127,11 @@ func NewApp(s *Shell) *cli.App {
 
 		// Allow for initServerConfig to be called if the flag is provided.
 		if c.Bool("applyInitServerConfig") {
-			cfg, err = initServerConfig(&opts, s.configFiles, s.secretsFiles)
+			serverCfg, err := initServerConfig(&opts, s.configFiles, s.secretsFiles)
 			if err != nil {
 				return err
 			}
-			s.Config = cfg
+			s.Config = serverCfg
 		}
 
 		return nil

--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -1241,8 +1241,10 @@ func (s *Shell) afterNode(lggr logger.SugaredLogger) {
 		}
 		lggr.Debug("Closed DB")
 
-		if err := s.CloseLogger(); err != nil {
-			log.Printf("Failed to close Logger: %v", err)
+		if s.CloseLogger != nil {
+			if err := s.CloseLogger(); err != nil {
+				log.Printf("Failed to close Logger: %v", err)
+			}
 		}
 	})
 }

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -513,7 +513,6 @@ func TestShell_BeforeNode(t *testing.T) {
 		wantUnlocked bool
 	}{
 		{"correct password", "../internal/fixtures/correct_password.txt", true},
-		{"incorrect password", "../internal/fixtures/incorrect_password.txt", false},
 		{"wrong file", "doesntexist.txt", false},
 	}
 
@@ -543,15 +542,7 @@ func TestShell_BeforeNode(t *testing.T) {
 
 			c := cli.NewContext(nil, set, nil)
 
-			// Create full CLI app and run the Before hook first
-			app := cmd.NewApp(&shell)
-			err := app.Before(c)
-			if err != nil && test.wantUnlocked {
-				t.Fatalf("CLI Before hook failed: %v", err)
-			}
-
-			// Run before hook to initialize components with authentication
-			err = shell.BeforeNode(c)
+			err := shell.BeforeNode(c)
 
 			if test.wantUnlocked {
 				require.NoError(t, err)
@@ -583,7 +574,6 @@ func TestShell_RunNode_WithBeforeNode(t *testing.T) {
 		expectStart bool
 	}{
 		{"correct password", "../internal/fixtures/correct_password.txt", true},
-		{"incorrect password", "../internal/fixtures/incorrect_password.txt", false},
 	}
 
 	for _, test := range tests {
@@ -641,29 +631,18 @@ func TestShell_RunNode_WithBeforeNode(t *testing.T) {
 
 			c := cli.NewContext(nil, set, nil)
 
-			// First initialize components (this includes authentication)
-			cliApp := cmd.NewApp(&shell)
-			err := cliApp.Before(c)
-			require.NoError(t, err)
+			err := shell.BeforeNode(c)
+			require.NoError(t, err, "BeforeNode should succeed")
+			assert.NotNil(t, shell.KeyStore)
+			assert.NotNil(t, shell.DS)
+			assert.NotNil(t, shell.LDB)
 
-			err = shell.BeforeNode(c)
+			// Now test RunNode with pre-authenticated keystore
+			// Note: RunNode will start the app but we expect it to work since keystore is authenticated
+			err = shell.RunNode(c)
+			require.NoError(t, err, "RunNode should succeed with authenticated keystore")
+			assert.Equal(t, 1, apiPrompt.Count, "API should be initialized")
 
-			if test.expectStart {
-				require.NoError(t, err, "BeforeNode should succeed")
-				// Verify components are initialized
-				assert.NotNil(t, shell.KeyStore)
-				assert.NotNil(t, shell.DS)
-				assert.NotNil(t, shell.LDB)
-
-				// Now test RunNode with pre-authenticated keystore
-				// Note: RunNode will start the app but we expect it to work since keystore is authenticated
-				err = shell.RunNode(c)
-				require.NoError(t, err, "RunNode should succeed with authenticated keystore")
-				assert.Equal(t, 1, apiPrompt.Count, "API should be initialized")
-			} else {
-				require.Error(t, err, "BeforeNode should fail with incorrect password")
-				// Don't test RunNode if BeforeNode failed
-			}
 			// Clean up database if it was opened
 			if shell.LDB != nil {
 				cleanupErr := shell.AfterNode(c)

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -508,23 +508,34 @@ func TestShell_RemoveBlocks(t *testing.T) {
 func TestShell_BeforeNode(t *testing.T) {
 	testutils.SkipShortDB(t)
 	tests := []struct {
-		name         string
-		pwdfile      string
-		wantUnlocked bool
+		name            string
+		pwdfile         string
+		wantUnlocked    bool
+		prePopulateKeys bool
 	}{
-		{"correct password", "../internal/fixtures/correct_password.txt", true},
-		{"wrong file", "doesntexist.txt", false},
+		{"correct password", "../internal/fixtures/correct_password.txt", true, false},
+		{"incorrect password", "../internal/fixtures/incorrect_password.txt", false, true},
+		{"wrong file", "doesntexist.txt", false, false},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-				s.Password.Keystore = models.NewSecret("dummy")
-				c.EVM[0].Nodes[0].Name = ptr("fake")
-				c.EVM[0].Nodes[0].HTTPURL = commonconfig.MustParseURL("http://fake.com")
-				c.EVM[0].Nodes[0].WSURL = commonconfig.MustParseURL("WSS://fake.com/ws")
+			cfg, db := heavyweight.FullTestDBV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				c.Database.DriverName = pgcommon.DriverPostgres
+				c.EVM = nil
 				c.Insecure.OCRDevelopmentMode = nil
 			})
+
+			// Seed key material so the wrong password actually fails decryption.
+			// An empty keystore accepts any password.
+			if test.prePopulateKeys {
+				correctPwd, err := utils.PasswordFromFile("../internal/fixtures/correct_password.txt")
+				require.NoError(t, err)
+				ks := cltest.NewKeyStore(t, db)
+				require.NoError(t, ks.Unlock(testutils.Context(t), correctPwd))
+				_, err = ks.CSA().Create(testutils.Context(t))
+				require.NoError(t, err)
+			}
 
 			shell := cmd.Shell{
 				Config: cfg,
@@ -543,8 +554,8 @@ func TestShell_BeforeNode(t *testing.T) {
 			c := cli.NewContext(nil, set, nil)
 
 			// Create full CLI app and run the Before hook first
-			cliApp := cmd.NewApp(&shell)
-			err := cliApp.Before(c)
+			app := cmd.NewApp(&shell)
+			err := app.Before(c)
 			if err != nil && test.wantUnlocked {
 				t.Fatalf("CLI Before hook failed: %v", err)
 			}
@@ -645,17 +656,23 @@ func TestShell_RunNode_WithBeforeNode(t *testing.T) {
 			require.NoError(t, err)
 
 			err = shell.BeforeNode(c)
-			require.NoError(t, err, "BeforeNode should succeed")
-			assert.NotNil(t, shell.KeyStore)
-			assert.NotNil(t, shell.DS)
-			assert.NotNil(t, shell.LDB)
 
-			// Now test RunNode with pre-authenticated keystore
-			// Note: RunNode will start the app but we expect it to work since keystore is authenticated
-			err = shell.RunNode(c)
-			require.NoError(t, err, "RunNode should succeed with authenticated keystore")
-			assert.Equal(t, 1, apiPrompt.Count, "API should be initialized")
+			if test.expectStart {
+				require.NoError(t, err, "BeforeNode should succeed")
+				// Verify components are initialized
+				assert.NotNil(t, shell.KeyStore)
+				assert.NotNil(t, shell.DS)
+				assert.NotNil(t, shell.LDB)
 
+				// Now test RunNode with pre-authenticated keystore
+				// Note: RunNode will start the app but we expect it to work since keystore is authenticated
+				err = shell.RunNode(c)
+				require.NoError(t, err, "RunNode should succeed with authenticated keystore")
+				assert.Equal(t, 1, apiPrompt.Count, "API should be initialized")
+			} else {
+				require.Error(t, err, "BeforeNode should fail with incorrect password")
+				// Don't test RunNode if BeforeNode failed
+			}
 			// Clean up database if it was opened
 			if shell.LDB != nil {
 				cleanupErr := shell.AfterNode(c)

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
 
+	commonkeystore "github.com/smartcontractkit/chainlink-common/keystore"
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	pgcommon "github.com/smartcontractkit/chainlink-common/pkg/sqlutil/pg"
@@ -531,7 +532,7 @@ func TestShell_BeforeNode(t *testing.T) {
 			if test.prePopulateKeys {
 				correctPwd, err := utils.PasswordFromFile("../internal/fixtures/correct_password.txt")
 				require.NoError(t, err)
-				ks := cltest.NewKeyStore(t, db)
+				ks := keystore.New(db, commonkeystore.FastScryptParams, logger.TestLogger(t).Infof)
 				require.NoError(t, ks.Unlock(testutils.Context(t), correctPwd))
 				_, err = ks.CSA().Create(testutils.Context(t))
 				require.NoError(t, err)

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -542,7 +542,15 @@ func TestShell_BeforeNode(t *testing.T) {
 
 			c := cli.NewContext(nil, set, nil)
 
-			err := shell.BeforeNode(c)
+			// Create full CLI app and run the Before hook first
+			cliApp := cmd.NewApp(&shell)
+			err := cliApp.Before(c)
+			if err != nil && test.wantUnlocked {
+				t.Fatalf("CLI Before hook failed: %v", err)
+			}
+
+			// Run before hook to initialize components with authentication
+			err = shell.BeforeNode(c)
 
 			if test.wantUnlocked {
 				require.NoError(t, err)
@@ -631,7 +639,12 @@ func TestShell_RunNode_WithBeforeNode(t *testing.T) {
 
 			c := cli.NewContext(nil, set, nil)
 
-			err := shell.BeforeNode(c)
+			// First initialize components (this includes authentication)
+			cliApp := cmd.NewApp(&shell)
+			err := cliApp.Before(c)
+			require.NoError(t, err)
+
+			err = shell.BeforeNode(c)
 			require.NoError(t, err, "BeforeNode should succeed")
 			assert.NotNil(t, shell.KeyStore)
 			assert.NotNil(t, shell.DS)


### PR DESCRIPTION
## Summary

Fixes DB connection leakage in tests caused by `app.Before()` unconditionally overwriting `s.Config` with a fresh config using the default `pgx` driver, clobbering test configs that use a `txdb`-wrapped driver.

## Root Cause

1. Test creates config: `configtest.NewGeneralConfig` → `Database.DriverName = DriverTxWrappedPostgres`
2. Test sets `shell.Config = cfg`
3. Test calls `app.Before(c)` → `opts.New()` → `Database.DriverName = DriverPostgres`
4. `Before` sets `s.Config = cfg` → **overwrites txdb config with real pgx config**
5. `BeforeNode` → `pg.NewLockedDB(cfg.Database())` → opens a real pgx connection instead of txdb
6. Real DB connections leak into the shared test database → pool exhaustion

## Production Changes

### `core/cmd/app.go`
- **Conditional config initialization:** Wraps `opts.New()` in `if s.Config == nil`, so a pre-set config (e.g. from tests using txdb) is preserved rather than overwritten.
- **Variable scoping fix:** `cfg` is now declared inside the `if` block, so the `applyInitServerConfig` branch uses `serverCfg` — a mechanical consequence of the guard, not a behavioral change.

### `core/cmd/shell_local.go`
- **Nil-safe logger cleanup:** Added `if s.CloseLogger != nil` guard in `afterNode`. When tests call `BeforeNode` without `app.Before`, `CloseLogger` is never assigned. This matches the existing pattern in `app.After`.

## Test Changes

### `core/cmd/shell_local_test.go`

**`TestShell_BeforeNode`:** Switched from `configtest.NewGeneralConfig` (txdb) to `heavyweight.FullTestDBV2` (real Postgres) and restored the "incorrect password" test case.

The original "incorrect password" test only worked by accident — it relied on the config overwrite bug causing all subtests to share a single leaked pgx connection. The "correct password" subtest ran first, creating key material that the "incorrect password" subtest could then fail to decrypt. With the config fix, txdb isolation means each subtest gets an empty keystore, and an empty keystore accepts any password (`Decrypt` short-circuits when `EncryptedKeys` is nil).

The heavyweight DB solves this because it uses real Postgres connections (not transactions), so:
- We pre-populate the DB with key material encrypted under the correct password
- `beforeNode` opens its own connection to the same DB and sees the seeded keys
- Attempting to decrypt with the wrong password correctly fails

This is the same pattern used by `TestShell_RebroadcastTransactions_Txm` and other tests in the same file.

**`TestShell_RunNode_WithBeforeNode`:** Removed the "incorrect password" test case. This test uses txdb, so the same empty-keystore problem applies. The incorrect password path is now covered by `TestShell_BeforeNode` above.

## Related

- Fixes CORE-2388
- Fixes 8 Trunk-tracked flaky tests (CRE-2672, CRE-2675, CRE-2676, CRE-2677, CRE-2678, CRE-2680, CRE-2681, CRE-2213)