### PR TITLE
fix(ci): pass unique artifact-name per matrix job to prevent 409 collision

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -349,6 +349,8 @@ jobs:
           trunk-previous-step-outcome: ${{ steps.run-tests.outcome }}
           # when auto-quarantine is enabled, allow this to determine test failures
           trunk-upload-only: ${{ matrix.type.trunk-auto-quarantine != 'true' }}
+          # unique name per matrix job to avoid 409 conflict when multiple jobs upload in the same workflow run
+          artifact-name: ${{ matrix.type.cmd }}_test_logs
 
       - name: Print Races
         id: print-races

--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -256,6 +256,8 @@ jobs:
           trunk-previous-step-outcome: ${{ steps.run-regression-tests.outcome }}
           # when auto-quarantine is enabled, allow this to determine test failures
           trunk-upload-only: ${{ env.ENABLE_AUTO_QUARANTINE != 'true' }}
+          # unique name per matrix job to avoid 409 conflict when multiple jobs upload in the same workflow run
+          artifact-name: ${{ matrix.tests.test_id }}_test_logs
 
       - name: Show Docker containers status
         if: failure()

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -361,6 +361,8 @@ jobs:
           trunk-previous-step-outcome: ${{ steps.run-tests.outcome }}
           # when auto-quarantine is enabled, allow this to determine test failures
           trunk-upload-only: ${{ env.ENABLE_AUTO_QUARANTINE != 'true' }}
+          # unique name per matrix job to avoid 409 conflict when multiple jobs upload in the same workflow run
+          artifact-name: ${{ matrix.tests.test_id }}_test_logs
 
       - name: Show Docker containers status
         if: failure()


### PR DESCRIPTION
## Summary

- Passes `artifact-name: ${{ matrix.type.cmd }}_test_logs` to `branch-out-upload` so each matrix job uploads a uniquely named artifact

## Problem

`go_core_tests`, `go_core_tests_integration`, and `go_core_ccip_deployment_tests` all have `trunk-auto-quarantine: true` and call `branch-out-upload` in the same workflow run. The action hardcodes the artifact name `individual_test_logs`, causing a deterministic 409 conflict — the second job to upload always fails, even when tests pass. This affects every PR touching core Go code.

## Dependency

Requires smartcontractkit/.github#1512 to be merged and the `branch-out-upload/v1` tag updated first. Until then, the `artifact-name` input is silently ignored (composite actions don't fail on unknown inputs), so this PR is safe to merge in any order.

## Test plan

- [ ] After smartcontractkit/.github#1512 merges and `v1` tag is updated, both `go_core_tests` and `go_core_tests_integration` should upload separate artifacts (`go_core_tests_test_logs` and `go_core_tests_integration_test_logs`) with no 409 conflict

Fixes: CORE-2418