### PR TITLE
Test/db fixes 10 04 26

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -33,11 +33,16 @@ func removeHidden(cmds ...cli.Command) []cli.Command {
 
 // NewApp returns the command-line parser/function-router for the given client
 func NewApp(s *Shell) *cli.App {
+	var opts chainlink.GeneralConfigOpts
+	return newAppWithOpts(s, opts)
+}
+
+// newAppWithOpts returns the command-line parser/function-router for the given client
+// with custom configuration options for testing purposes.
+func newAppWithOpts(s *Shell, opts chainlink.GeneralConfigOpts) *cli.App {
 	app := cli.NewApp()
 	app.Usage = "CLI for Chainlink"
 	app.Version = fmt.Sprintf("%v@%v", static.Version, static.Sha)
-	// TOML
-	var opts chainlink.GeneralConfigOpts
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{

--- a/core/cmd/export_test.go
+++ b/core/cmd/export_test.go
@@ -1,0 +1,11 @@
+package cmd
+
+import (
+	"github.com/urfave/cli"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
+)
+
+func NewAppWithOptsForTest(s *Shell, opts chainlink.GeneralConfigOpts) *cli.App {
+	return newAppWithOpts(s, opts)
+}

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -544,7 +544,14 @@ func TestShell_BeforeNode(t *testing.T) {
 			c := cli.NewContext(nil, set, nil)
 
 			// Create full CLI app and run the Before hook first
-			app := cmd.NewApp(&shell)
+			var opts = chainlink.GeneralConfigOpts{
+				OverrideFn: func(c *chainlink.Config, s *chainlink.Secrets) {
+					s.Password.Keystore = models.NewSecret("dummy")
+					c.Database.DriverName = pgcommon.DriverTxWrappedPostgres
+				},
+			}
+
+			app := cmd.NewAppWithOptsForTest(&shell, opts)
 			err := app.Before(c)
 			if err != nil && test.wantUnlocked {
 				t.Fatalf("CLI Before hook failed: %v", err)
@@ -641,8 +648,14 @@ func TestShell_RunNode_WithBeforeNode(t *testing.T) {
 
 			c := cli.NewContext(nil, set, nil)
 
+			var opts = chainlink.GeneralConfigOpts{
+				OverrideFn: func(c *chainlink.Config, s *chainlink.Secrets) {
+					c.Database.DriverName = pgcommon.DriverTxWrappedPostgres
+				},
+			}
+
 			// First initialize components (this includes authentication)
-			cliApp := cmd.NewApp(&shell)
+			cliApp := cmd.NewAppWithOptsForTest(&shell, opts)
 			err := cliApp.Before(c)
 			require.NoError(t, err)
 

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -200,6 +200,7 @@ func TestShell_DiskMaxSizeBeforeRotateOptionDisablesAsExpected(t *testing.T) {
 }
 
 func TestShell_RebroadcastTransactions_Txm(t *testing.T) {
+	t.Parallel()
 	// Use a non-transactional db for this test because we need to
 	// test multiple connections to the database, and changes made within
 	// the transaction cannot be seen from another connection.
@@ -269,6 +270,7 @@ func TestShell_RebroadcastTransactions_Txm(t *testing.T) {
 }
 
 func TestShell_RebroadcastTransactions_OutsideRange_Txm(t *testing.T) {
+	t.Parallel()
 	beginningNonce := uint(7)
 	endingNonce := uint(10)
 	gasPrice := big.NewInt(100000000000)
@@ -284,6 +286,7 @@ func TestShell_RebroadcastTransactions_OutsideRange_Txm(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			// Use the non-transactional db for this test because we need to
 			// test multiple connections to the database, and changes made within
 			// the transaction cannot be seen from another connection.
@@ -357,6 +360,7 @@ func TestShell_RebroadcastTransactions_OutsideRange_Txm(t *testing.T) {
 }
 
 func TestShell_RebroadcastTransactions_AddressCheck(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		enableAddress bool
@@ -369,6 +373,7 @@ func TestShell_RebroadcastTransactions_AddressCheck(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			config, sqlxDB := heavyweight.FullTestDBV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 				c.Database.DriverName = pgcommon.DriverPostgres
 

--- a/core/services/keystore/csa_test.go
+++ b/core/services/keystore/csa_test.go
@@ -32,6 +32,11 @@ func Test_CSAKeyStore_E2E(t *testing.T) {
 	t.Run("initializes with an empty state", func(t *testing.T) {
 		defer reset()
 		keys, err := ks.GetAll()
+
+		for _, key := range keys {
+			t.Log("unexpected key found in keystore", "id", key.ID())
+		}
+
 		require.NoError(t, err)
 		require.Empty(t, keys)
 	})


### PR DESCRIPTION
### Notes

* When authenticating an empty/non-existing keystore, a new one is initialized with the configured password
* A CSA key is also generated alongside the keystore in the first sub-test in `TestShell_BeforeNode` and is leaked to all subsequent tests
  * The first test actually creates the CSA key and technically sets the password/encryption key for the keyring
  * Because `incorrect_password` subtest is run after `correct_password` which generates a keyring with a different password, the tests succeed. If run in a different order, they would fail.

* Swiching `TestShell_BeforeNode` to use a custom `newAppWithOpts` method allows you to properly configuration parameters, allowing for a `txdb` connection.
  * However,  with the `txdb` connection there's no key leakage, which causes `incorrect_password` subtest to fail BECAUSE, the keytore is empty. So when trying to unlock it, it actually just creates a new one.