### PR TITLE
[CRE] Short-circuit past failed trigger registrations

### DIFF
--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -5,11 +5,18 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
+	"fmt"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -43,6 +50,13 @@ type triggerPublisher struct {
 	stopCh        services.StopChan
 	wg            sync.WaitGroup
 	lggr          logger.Logger
+	metrics       triggerPublisherMetrics
+}
+
+type triggerPublisherMetrics struct {
+	registerTriggerCounter   metric.Int64Counter
+	unregisterTriggerCounter metric.Int64Counter
+	ackEventCounter          metric.Int64Counter
 }
 
 type dynamicPublisherConfig struct {
@@ -67,9 +81,10 @@ type ackKey struct {
 }
 
 type pubRegState struct {
-	callback <-chan commoncap.TriggerResponse
-	request  commoncap.TriggerRegistrationRequest
-	cancel   context.CancelFunc
+	callback        <-chan commoncap.TriggerResponse
+	request         commoncap.TriggerRegistrationRequest
+	cancel          context.CancelFunc
+	registrationErr error // non-nil if RegisterTrigger returned an error; used to suppress retries
 }
 
 type batchedResponse struct {
@@ -144,6 +159,23 @@ func (p *triggerPublisher) SetConfig(config *commoncap.RemoteTriggerConfig, unde
 	return nil
 }
 
+func (p *triggerPublisher) initMetrics() error {
+	var err error
+	p.metrics.registerTriggerCounter, err = beholder.GetMeter().Int64Counter("platform_trigger_publisher_register_trigger_total")
+	if err != nil {
+		return fmt.Errorf("failed to register platform_trigger_publisher_register_trigger_total: %w", err)
+	}
+	p.metrics.unregisterTriggerCounter, err = beholder.GetMeter().Int64Counter("platform_trigger_publisher_unregister_trigger_total")
+	if err != nil {
+		return fmt.Errorf("failed to register platform_trigger_publisher_unregister_trigger_total: %w", err)
+	}
+	p.metrics.ackEventCounter, err = beholder.GetMeter().Int64Counter("platform_trigger_publisher_ack_event_total")
+	if err != nil {
+		return fmt.Errorf("failed to register platform_trigger_publisher_ack_event_total: %w", err)
+	}
+	return nil
+}
+
 func (p *triggerPublisher) Start(ctx context.Context) error {
 	cfg := p.cfg.Load()
 
@@ -162,6 +194,9 @@ func (p *triggerPublisher) Start(ctx context.Context) error {
 	}
 	if p.dispatcher == nil {
 		return errors.New("dispatcher set to nil, cannot start triggerPublisher")
+	}
+	if err := p.initMetrics(); err != nil {
+		return fmt.Errorf("failed to initialize metrics: %w", err)
 	}
 
 	p.wg.Add(1)
@@ -216,9 +251,13 @@ func (p *triggerPublisher) Receive(_ context.Context, msg *types.MessageBody) {
 		p.mu.Lock()
 		defer p.mu.Unlock()
 		p.messageCache.Insert(key, sender, nowMs, msg.Payload)
-		_, exists := p.registrations[key]
-		if exists {
-			p.lggr.Debugw("trigger registration already exists", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
+		if existing, exists := p.registrations[key]; exists {
+			if existing.registrationErr != nil {
+				p.lggr.Debugw("skipping trigger registration; previous attempt failed with user error",
+					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", existing.registrationErr)
+			} else {
+				p.lggr.Debugw("trigger registration already exists", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
+			}
 			return
 		}
 		// NOTE: require 2F+1 by default, introduce different strategies later (KS-76)
@@ -240,7 +279,12 @@ func (p *triggerPublisher) Receive(_ context.Context, msg *types.MessageBody) {
 		}
 		ctx, cancel := p.stopCh.NewCtx()
 		callbackCh, err := cfg.underlying.RegisterTrigger(ctx, unmarshaled)
+		capAttrs := metric.WithAttributes(
+			attribute.String("capabilityID", p.capabilityID),
+			attribute.String("callerDonID", strconv.FormatUint(uint64(key.callerDonID), 10)),
+		)
 		if err == nil {
+			p.metrics.registerTriggerCounter.Add(ctx, 1, capAttrs, metric.WithAttributes(attribute.String("outcome", "success")))
 			p.registrations[key] = &pubRegState{
 				callback: callbackCh,
 				request:  unmarshaled,
@@ -250,8 +294,17 @@ func (p *triggerPublisher) Receive(_ context.Context, msg *types.MessageBody) {
 			go p.triggerEventLoop(callbackCh, key)
 			p.lggr.Debugw("updated trigger registration", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
 		} else {
+			p.metrics.registerTriggerCounter.Add(ctx, 1, capAttrs, metric.WithAttributes(attribute.String("outcome", "error")))
 			cancel()
-			p.lggr.Errorw("failed to register trigger", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", err)
+			var capErr caperrors.Error
+			if errors.As(err, &capErr) && capErr.Origin() == caperrors.OriginUser {
+				p.registrations[key] = &pubRegState{registrationErr: err}
+				p.lggr.Errorw("trigger registration failed with user error; will not retry",
+					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", err)
+			} else {
+				p.lggr.Errorw("trigger registration failed with system error; will retry",
+					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", err)
+			}
 		}
 	case types.MethodTriggerEvent:
 		p.lggr.Errorw("trigger request failed with error",
@@ -297,9 +350,16 @@ func (p *triggerPublisher) Receive(_ context.Context, msg *types.MessageBody) {
 		defer cancel()
 		p.lggr.Debugw("ACKing trigger event", "triggerEventId", triggerEventID)
 		err = cfg.underlying.AckEvent(ctx, triggerID, triggerEventID, p.capMethodName)
+		ackAttrs := metric.WithAttributes(
+			attribute.String("capabilityID", p.capabilityID),
+			attribute.String("callerDonID", strconv.FormatUint(uint64(msg.CallerDonId), 10)),
+		)
 		if err != nil {
+			p.metrics.ackEventCounter.Add(ctx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "error")))
 			p.lggr.Errorw("failed to AckEvent on underlying trigger capability",
 				"eventID", triggerEventID, "capabilityID", p.capabilityID, "err", err)
+		} else {
+			p.metrics.ackEventCounter.Add(ctx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "success")))
 		}
 	default:
 		p.lggr.Errorw("received message with unknown method",
@@ -333,16 +393,29 @@ func (p *triggerPublisher) cacheCleanupLoop() {
 			now := time.Now().UnixMilli()
 
 			p.mu.Lock()
-			for key, req := range p.registrations {
+			for key, reg := range p.registrations {
 				callerDon := cfg.workflowDONs[key.callerDonID]
 				ready, _ := p.messageCache.Ready(key, uint32(2*callerDon.F+1), now-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), false)
 				if !ready {
 					p.lggr.Infow("trigger registration expired", "callerDonID", key.callerDonID, "workflowId", key.workflowID, "triggerID", key.triggerID)
-					ctx, cancel := p.stopCh.NewCtx()
-					err := cfg.underlying.UnregisterTrigger(ctx, req.request)
-					cancel()
-					p.registrations[key].cancel() // Cancel context on register trigger
-					p.lggr.Infow("unregistered trigger", "callerDonID", key.callerDonID, "workflowId", key.workflowID, "triggerID", key.triggerID, "err", err)
+					if reg.registrationErr == nil {
+						ctx, cancel := p.stopCh.NewCtx()
+						err := cfg.underlying.UnregisterTrigger(ctx, reg.request)
+						cancel()
+						reg.cancel()
+						unregAttrs := metric.WithAttributes(
+							attribute.String("capabilityID", p.capabilityID),
+							attribute.String("callerDonID", strconv.FormatUint(uint64(key.callerDonID), 10)),
+						)
+						if err != nil {
+							p.metrics.unregisterTriggerCounter.Add(ctx, 1, unregAttrs, metric.WithAttributes(attribute.String("outcome", "error")))
+						} else {
+							p.metrics.unregisterTriggerCounter.Add(ctx, 1, unregAttrs, metric.WithAttributes(attribute.String("outcome", "success")))
+						}
+						p.lggr.Infow("unregistered trigger", "callerDonID", key.callerDonID, "workflowId", key.workflowID, "triggerID", key.triggerID, "err", err)
+					} else {
+						p.lggr.Debugw("removing failed user-error registration from local state", "callerDonID", key.callerDonID, "workflowId", key.workflowID, "triggerID", key.triggerID, "err", reg.registrationErr)
+					}
 					// after calling UnregisterTrigger, the underlying trigger will not send any more events to the channel
 					delete(p.registrations, key)
 					p.messageCache.Delete(key)

--- a/core/capabilities/remote/trigger_publisher_test.go
+++ b/core/capabilities/remote/trigger_publisher_test.go
@@ -2,6 +2,7 @@ package remote_test
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
@@ -574,6 +576,141 @@ func TestTriggerPublisher_ResendBehavior_MultiTriggerBatch(t *testing.T) {
 		defer mu.Unlock()
 		require.Empty(t, sendRecords)
 	})
+}
+
+func TestTriggerPublisher_RegisterTrigger_FailureShortCircuit(t *testing.T) {
+	t.Run("user error suppresses retries", func(t *testing.T) {
+		ctx := testutils.Context(t)
+		lggr := logger.Test(t)
+		capabilityDONID, workflowDONID := uint32(1), uint32(2)
+
+		peers := make([]p2ptypes.PeerID, 2)
+		require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+		require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+
+		capDonInfo := commoncap.DON{
+			ID:      capabilityDONID,
+			Members: []p2ptypes.PeerID{peers[0]},
+			F:       0,
+		}
+		workflowDonInfo := commoncap.DON{
+			ID:      workflowDONID,
+			Members: []p2ptypes.PeerID{peers[1]},
+			F:       0,
+		}
+		workflowDONs := map[uint32]commoncap.DON{
+			workflowDonInfo.ID: workflowDonInfo,
+		}
+
+		capInfo := commoncap.CapabilityInfo{
+			ID:             capID,
+			CapabilityType: commoncap.CapabilityTypeTrigger,
+		}
+		userErr := caperrors.NewPublicUserError(errors.New("bad workflow config"), caperrors.InvalidArgument)
+		underlying := &errTrigger{info: capInfo, err: userErr}
+
+		dispatcher := mocks.NewDispatcher(t)
+		config := &commoncap.RemoteTriggerConfig{
+			RegistrationRefresh:     100 * time.Millisecond,
+			RegistrationExpiry:      100 * time.Second,
+			MinResponsesToAggregate: 1,
+			MessageExpiry:           100 * time.Second,
+			MaxBatchSize:            1,
+			BatchCollectionPeriod:   time.Second,
+		}
+		publisher := remote.NewTriggerPublisher(capInfo.ID, "", dispatcher, lggr)
+		require.NoError(t, publisher.SetConfig(config, underlying, capDonInfo, workflowDONs))
+		require.NoError(t, publisher.Start(ctx))
+
+		regMsg := newRegisterTriggerMessage(t, workflowDONID, peers[1])
+		publisher.Receive(ctx, regMsg)
+		require.Equal(t, 1, underlying.callCount, "RegisterTrigger should be called once on first quorum")
+
+		publisher.Receive(ctx, regMsg)
+		publisher.Receive(ctx, regMsg)
+		require.Equal(t, 1, underlying.callCount, "RegisterTrigger must not be retried after a user error")
+
+		require.NoError(t, publisher.Close())
+	})
+
+	t.Run("system error allows retries", func(t *testing.T) {
+		ctx := testutils.Context(t)
+		lggr := logger.Test(t)
+		capabilityDONID, workflowDONID := uint32(1), uint32(2)
+
+		peers := make([]p2ptypes.PeerID, 2)
+		require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+		require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+
+		capDonInfo := commoncap.DON{
+			ID:      capabilityDONID,
+			Members: []p2ptypes.PeerID{peers[0]},
+			F:       0,
+		}
+		workflowDonInfo := commoncap.DON{
+			ID:      workflowDONID,
+			Members: []p2ptypes.PeerID{peers[1]},
+			F:       0,
+		}
+		workflowDONs := map[uint32]commoncap.DON{
+			workflowDonInfo.ID: workflowDonInfo,
+		}
+
+		capInfo := commoncap.CapabilityInfo{
+			ID:             capID,
+			CapabilityType: commoncap.CapabilityTypeTrigger,
+		}
+		underlying := &errTrigger{info: capInfo, err: errors.New("transient system failure")}
+
+		dispatcher := mocks.NewDispatcher(t)
+		config := &commoncap.RemoteTriggerConfig{
+			RegistrationRefresh:     100 * time.Millisecond,
+			RegistrationExpiry:      100 * time.Second,
+			MinResponsesToAggregate: 1,
+			MessageExpiry:           100 * time.Second,
+			MaxBatchSize:            1,
+			BatchCollectionPeriod:   time.Second,
+		}
+		publisher := remote.NewTriggerPublisher(capInfo.ID, "", dispatcher, lggr)
+		require.NoError(t, publisher.SetConfig(config, underlying, capDonInfo, workflowDONs))
+		require.NoError(t, publisher.Start(ctx))
+
+		regMsg := newRegisterTriggerMessage(t, workflowDONID, peers[1])
+		publisher.Receive(ctx, regMsg)
+		require.Equal(t, 1, underlying.callCount, "RegisterTrigger should be called once on first quorum")
+
+		publisher.Receive(ctx, regMsg)
+		require.Equal(t, 2, underlying.callCount, "RegisterTrigger should be retried after a system error")
+
+		publisher.Receive(ctx, regMsg)
+		require.Equal(t, 3, underlying.callCount, "RegisterTrigger should keep retrying on system errors")
+
+		require.NoError(t, publisher.Close())
+	})
+}
+
+// errTrigger is a TriggerCapability that always returns an error from RegisterTrigger.
+type errTrigger struct {
+	info      commoncap.CapabilityInfo
+	err       error
+	callCount int
+}
+
+func (tr *errTrigger) Info(_ context.Context) (commoncap.CapabilityInfo, error) {
+	return tr.info, nil
+}
+
+func (tr *errTrigger) RegisterTrigger(_ context.Context, _ commoncap.TriggerRegistrationRequest) (<-chan commoncap.TriggerResponse, error) {
+	tr.callCount++
+	return nil, tr.err
+}
+
+func (tr *errTrigger) UnregisterTrigger(_ context.Context, _ commoncap.TriggerRegistrationRequest) error {
+	return nil
+}
+
+func (tr *errTrigger) AckEvent(_ context.Context, _ string, _ string, _ string) error {
+	return nil
 }
 
 func newRegisterTriggerMessageWithTriggerID(t *testing.T, callerDonID uint32, sender p2ptypes.PeerID, triggerID string) *remotetypes.MessageBody {


### PR DESCRIPTION
1. Do not retry registrations on user errors.
2. Add metrics to track underlying calls.