### PR TITLE
feat: Add CL_GOPRIVATE support for private Go module dependencies

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -107,6 +107,7 @@ jobs:
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
         VERSION_TAG=${{ github.ref_name }}
+        CL_GOPRIVATE=${{ github.repository != 'smartcontractkit/chainlink' && 'github.com/smartcontractkit/*' || '' }}
       docker-cache-behaviour: "disable"
       docker-manifest-sign: true
       docker-registry-url-override: public.ecr.aws/chainlink
@@ -145,6 +146,7 @@ jobs:
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_CHAIN_DEFAULTS=/ccip-config
         CL_SOLANA_CMD=
+        CL_GOPRIVATE=${{ github.repository != 'smartcontractkit/chainlink' && 'github.com/smartcontractkit/*' || '' }}
       docker-cache-behaviour: "disable"
       docker-manifest-sign: true
       docker-registry-url-override: public.ecr.aws/chainlink

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -12,7 +12,19 @@ RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
 WORKDIR /chainlink
 
 ADD go.mod go.sum ./
-RUN go mod download
+COPY plugins/scripts/setup_git_auth.sh ./plugins/scripts/
+
+# CL_GOPRIVATE: set to "github.com/smartcontractkit/*" when building images
+# that depend on private Go modules (e.g. chainlink-internal-solana). When
+# empty (the default), go mod download uses the public module proxy as usual.
+ARG CL_GOPRIVATE=""
+RUN --mount=type=secret,id=GIT_AUTH_TOKEN \
+    set -e && \
+    export GIT_CONFIG_GLOBAL=/tmp/gitconfig-go-mod-download && \
+    export GOPRIVATE="${CL_GOPRIVATE}" && \
+    trap 'rm -f "$GIT_CONFIG_GLOBAL"' EXIT && \
+    ./plugins/scripts/setup_git_auth.sh && \
+    go mod download
 
 COPY GNUmakefile package.json ./
 COPY tools/bin/ldflags ./tools/bin/

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -18,10 +18,10 @@ COPY plugins/scripts/setup_git_auth.sh ./plugins/scripts/
 # that depend on private Go modules (e.g. chainlink-internal-solana). When
 # empty (the default), go mod download uses the public module proxy as usual.
 ARG CL_GOPRIVATE=""
+ENV GOPRIVATE="${CL_GOPRIVATE}"
 RUN --mount=type=secret,id=GIT_AUTH_TOKEN \
     set -e && \
     export GIT_CONFIG_GLOBAL=/tmp/gitconfig-go-mod-download && \
-    export GOPRIVATE="${CL_GOPRIVATE}" && \
     trap 'rm -f "$GIT_CONFIG_GLOBAL"' EXIT && \
     ./plugins/scripts/setup_git_auth.sh && \
     go mod download

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -14,7 +14,16 @@ RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
 WORKDIR /chainlink
 
 ADD go.mod go.sum ./
-RUN go mod download
+COPY plugins/scripts/setup_git_auth.sh ./plugins/scripts/
+
+ARG CL_GOPRIVATE=""
+RUN --mount=type=secret,id=GIT_AUTH_TOKEN \
+    set -e && \
+    export GIT_CONFIG_GLOBAL=/tmp/gitconfig-go-mod-download && \
+    export GOPRIVATE="${CL_GOPRIVATE}" && \
+    trap 'rm -f "$GIT_CONFIG_GLOBAL"' EXIT && \
+    ./plugins/scripts/setup_git_auth.sh && \
+    go mod download
 
 COPY GNUmakefile package.json ./
 COPY tools/bin/ldflags ./tools/bin/

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -17,10 +17,10 @@ ADD go.mod go.sum ./
 COPY plugins/scripts/setup_git_auth.sh ./plugins/scripts/
 
 ARG CL_GOPRIVATE=""
+ENV GOPRIVATE="${CL_GOPRIVATE}"
 RUN --mount=type=secret,id=GIT_AUTH_TOKEN \
     set -e && \
     export GIT_CONFIG_GLOBAL=/tmp/gitconfig-go-mod-download && \
-    export GOPRIVATE="${CL_GOPRIVATE}" && \
     trap 'rm -f "$GIT_CONFIG_GLOBAL"' EXIT && \
     ./plugins/scripts/setup_git_auth.sh && \
     go mod download


### PR DESCRIPTION
## Summary

- Adds a `CL_GOPRIVATE` build arg to the `deps-base` stage of `core/chainlink.Dockerfile` that, when set, configures git authentication before `go mod download` so private Go modules can be fetched
- Adds a conditional `CL_GOPRIVATE` build arg to both Docker build jobs in `build-publish.yml` that activates only when the workflow runs on a repository other than `smartcontractkit/chainlink`

**No-op on public `smartcontractkit/chainlink` builds.** The `CL_GOPRIVATE` arg defaults to empty, and the workflow expression evaluates to empty on this repo. This only activates on forks like `chainlink-canary` where `go.mod` may reference private modules (e.g. `chainlink-internal-solana`).

## Context

Part of [RANE-4462](https://smartcontract-it.atlassian.net/browse/RANE-4462) — operationalizing private dependency releases. See the [private release runbook](https://github.com/smartcontractkit/chainlink-releases/pull/27) for full documentation.

`chainlink-canary` will inherit these changes via an automated develop sync ([chainlink-canary#9](https://github.com/smartcontractkit/chainlink-canary/pull/9)).

## Test plan

- [ ] Verify CI passes on this PR (no behavioral change on `smartcontractkit/chainlink`)
- [ ] Once synced to `chainlink-canary`, verify a canary build with a private `go.mod` dep succeeds

Made with [Cursor](https://cursor.com)

[RANE-4462]: https://smartcontract-it.atlassian.net/browse/RANE-4462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ