### PR TITLE
chore(cre): bumps http-action capability

### DIFF
--- a/.changeset/eighty-deer-glow.md
+++ b/.changeset/eighty-deer-glow.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix bumps http-action capability version to classify timeouts as UserError

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -27,7 +27,7 @@ plugins:
       installPath: "."
   httpaction:
     - moduleURI: "github.com/smartcontractkit/capabilities/http_action"
-      gitRef: "dbb47b09ac25eb30262fc649149fd36f979851af"
+      gitRef: "564be39f22e416ed75a78fcd96b7f980122c1a63"
       installPath: "."
   httptrigger:
     - moduleURI: "github.com/smartcontractkit/capabilities/http_trigger"


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

make gateway proxied requests return `UserError` on timeouts when waiting for a gateway response

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
