### PR TITLE
core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider: fix concurrent map accesses

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -185,7 +185,7 @@ func (b *logBuffer) dequeue(start int64, capacity int, minimumDequeue bool) ([]B
 	for _, qid := range b.queueIDs {
 		q := b.queues[qid]
 
-		if minimumDequeue && q.dequeued[start] >= logLimit {
+		if minimumDequeue && q.getDequeued(start) >= logLimit {
 			// if we have already dequeued the minimum commitment for this window, skip it
 			minimumDequeueMet++
 			continue
@@ -206,7 +206,7 @@ func (b *logBuffer) dequeue(start int64, capacity int, minimumDequeue bool) ([]B
 		remaining := 0
 
 		if minimumDequeue {
-			logs, remaining = q.dequeue(start, end, min(capacity, logLimit-q.dequeued[start]))
+			logs, remaining = q.dequeue(start, end, min(capacity, logLimit-q.getDequeued(start)))
 		} else {
 			logs, remaining = q.dequeue(start, end, capacity)
 		}
@@ -218,7 +218,7 @@ func (b *logBuffer) dequeue(start int64, capacity int, minimumDequeue bool) ([]B
 		remainingLogs += remaining
 
 		// update the buffer with how many logs we have dequeued for this window
-		q.dequeued[start] += len(logs)
+		q.addDequeued(start, len(logs))
 	}
 	b.lggr.Debugw("minimum commitment logs dequeued", "start", start, "end", end, "numUpkeeps", len(b.queues), "minimumDequeueMet", minimumDequeueMet)
 	return result, remainingLogs
@@ -337,6 +337,18 @@ func (q *upkeepLogQueue) sizeOfRange(start, end int64) int {
 		}
 	}
 	return size
+}
+
+func (q *upkeepLogQueue) getDequeued(k int64) int {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+	return q.dequeued[k]
+}
+
+func (q *upkeepLogQueue) addDequeued(k int64, add int) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	q.dequeued[k] += add
 }
 
 // dequeue pulls logs from the buffer that are within the given block range,

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -401,13 +401,13 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 			buffer.Enqueue(big.NewInt(1), logpoller.Log{BlockNumber: int64(i + 1), TxHash: common.HexToHash(fmt.Sprintf("0x%d", i+1)), LogIndex: 0})
 		}
 
-		assert.Equal(t, 100, countRemainingLogs(buffer.queues["1"].logs))
+		assert.Equal(t, 100, countRemainingLogs(buffer.getQueue("1").logs))
 
 		payloads, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
 		assert.Len(t, payloads, 100)
 
-		assert.Equal(t, 0, countRemainingLogs(buffer.queues["1"].logs))
+		assert.Equal(t, 0, countRemainingLogs(buffer.getQueue("1").logs))
 	})
 
 	t.Run("100 logs are dequeued for two upkeeps, 25 logs each as min commitment (50 logs total best effort), followed by best effort", func(t *testing.T) {
@@ -430,15 +430,15 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 			buffer.Enqueue(big.NewInt(2), logpoller.Log{BlockNumber: int64(i + 1), TxHash: common.HexToHash(fmt.Sprintf("0x2%d", i+1)), LogIndex: 0})
 		}
 
-		assert.Equal(t, 100, countRemainingLogs(buffer.queues["1"].logs))
-		assert.Equal(t, 100, countRemainingLogs(buffer.queues["2"].logs))
+		assert.Equal(t, 100, countRemainingLogs(buffer.getQueue("1").logs))
+		assert.Equal(t, 100, countRemainingLogs(buffer.getQueue("2").logs))
 
 		payloads, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
 		assert.Len(t, payloads, 100)
 
-		assert.Equal(t, 50, countRemainingLogs(buffer.queues["1"].logs))
-		assert.Equal(t, 50, countRemainingLogs(buffer.queues["2"].logs))
+		assert.Equal(t, 50, countRemainingLogs(buffer.getQueue("1").logs))
+		assert.Equal(t, 50, countRemainingLogs(buffer.getQueue("2").logs))
 
 		windowCount := remainingBlockWindowCounts(buffer.queues, 4)
 
@@ -451,8 +451,8 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, payloads, 100)
 
-		assert.Equal(t, 0, countRemainingLogs(buffer.queues["1"].logs))
-		assert.Equal(t, 0, countRemainingLogs(buffer.queues["2"].logs))
+		assert.Equal(t, 0, countRemainingLogs(buffer.getQueue("1").logs))
+		assert.Equal(t, 0, countRemainingLogs(buffer.getQueue("2").logs))
 
 		windowCount = remainingBlockWindowCounts(buffer.queues, 4)
 
@@ -481,8 +481,8 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 			buffer.Enqueue(big.NewInt(2), logpoller.Log{BlockNumber: int64(i + 1), TxHash: common.HexToHash(fmt.Sprintf("0x2%d", i+1)), LogIndex: 0})
 		}
 
-		assert.Equal(t, 102, countRemainingLogs(buffer.queues["1"].logs))
-		assert.Equal(t, 102, countRemainingLogs(buffer.queues["2"].logs))
+		assert.Equal(t, 102, countRemainingLogs(buffer.getQueue("1").logs))
+		assert.Equal(t, 102, countRemainingLogs(buffer.getQueue("2").logs))
 
 		payloads, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -497,17 +497,17 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Len(t, payloads, 100)
 
 		// upkeep 1 has had the minimum number of logs dequeued on the latest (incomplete) window
-		assert.Equal(t, 1, buffer.queues["1"].dequeued[100])
+		assert.Equal(t, 1, buffer.getQueue("1").getDequeued(100))
 		// upkeep 2 has had the minimum number of logs dequeued on the latest (incomplete) window
-		assert.Equal(t, 1, buffer.queues["2"].dequeued[100])
+		assert.Equal(t, 1, buffer.getQueue("2").getDequeued(100))
 
 		// the third dequeue call will retrieve the remaining 100 logs and exhaust the queues
 		payloads, err = provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
 		assert.Len(t, payloads, 4)
 
-		assert.Equal(t, 0, countRemainingLogs(buffer.queues["1"].logs))
-		assert.Equal(t, 0, countRemainingLogs(buffer.queues["2"].logs))
+		assert.Equal(t, 0, countRemainingLogs(buffer.getQueue("1").logs))
+		assert.Equal(t, 0, countRemainingLogs(buffer.getQueue("2").logs))
 
 		windowCount = remainingBlockWindowCounts(buffer.queues, 4)
 
@@ -540,8 +540,8 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 			buffer.Enqueue(big.NewInt(2), logpoller.Log{BlockNumber: int64(i + 1), TxHash: common.HexToHash(fmt.Sprintf("0x2%d", i+1)), LogIndex: 0})
 		}
 
-		assert.Equal(t, 100, countRemainingLogs(buffer.queues["1"].logs))
-		assert.Equal(t, 100, countRemainingLogs(buffer.queues["2"].logs))
+		assert.Equal(t, 100, countRemainingLogs(buffer.getQueue("1").logs))
+		assert.Equal(t, 100, countRemainingLogs(buffer.getQueue("2").logs))
 
 		payloads, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -609,11 +609,11 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 			}
 		}
 
-		assert.Equal(t, 80, countRemainingLogs(buffer.queues["1"].logs))
-		assert.Equal(t, 50, countRemainingLogs(buffer.queues["2"].logs))
-		assert.Equal(t, 90, countRemainingLogs(buffer.queues["3"].logs))
-		assert.Equal(t, 95, countRemainingLogs(buffer.queues["4"].logs))
-		assert.Equal(t, 100, countRemainingLogs(buffer.queues["5"].logs))
+		assert.Equal(t, 80, countRemainingLogs(buffer.getQueue("1").logs))
+		assert.Equal(t, 50, countRemainingLogs(buffer.getQueue("2").logs))
+		assert.Equal(t, 90, countRemainingLogs(buffer.getQueue("3").logs))
+		assert.Equal(t, 95, countRemainingLogs(buffer.getQueue("4").logs))
+		assert.Equal(t, 100, countRemainingLogs(buffer.getQueue("5").logs))
 
 		// perform two dequeues
 		payloads, err := provider.GetLatestPayloads(ctx)
@@ -624,11 +624,11 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, payloads, 100)
 
-		assert.Equal(t, 40, countRemainingLogs(buffer.queues["1"].logs))
-		assert.Equal(t, 10, countRemainingLogs(buffer.queues["2"].logs))
-		assert.Equal(t, 50, countRemainingLogs(buffer.queues["3"].logs))
-		assert.Equal(t, 55, countRemainingLogs(buffer.queues["4"].logs))
-		assert.Equal(t, 60, countRemainingLogs(buffer.queues["5"].logs))
+		assert.Equal(t, 40, countRemainingLogs(buffer.getQueue("1").logs))
+		assert.Equal(t, 10, countRemainingLogs(buffer.getQueue("2").logs))
+		assert.Equal(t, 50, countRemainingLogs(buffer.getQueue("3").logs))
+		assert.Equal(t, 55, countRemainingLogs(buffer.getQueue("4").logs))
+		assert.Equal(t, 60, countRemainingLogs(buffer.getQueue("5").logs))
 	})
 }
 
@@ -637,4 +637,10 @@ type mockedPacker struct {
 
 func (p *mockedPacker) PackLogData(log logpoller.Log) ([]byte, error) {
 	return log.Data, nil
+}
+
+func (l *logBuffer) getQueue(k string) *upkeepLogQueue {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+	return l.queues[k]
 }


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/CRE-3479
```
goroutine 221080 [running]:
internal/runtime/maps.fatal({0x73d622d?, 0x4d?})
    /usr/local/go/src/runtime/panic.go:1046 +0x18
<http://github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider.(*logBuffer).dequeue(0xc00109a600|github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider.(*logBuffer).dequeue(0xc00109a600>, 0x858, 0xc0010712c0?, 0x1)
    /chainlink/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go:188 +0x145
<http://github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider.(*logBuffer).Dequeue(0xc002eede40|github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider.(*logBuffer).Dequeue(0xc002eede40>?, 0x2?, 0xdbca77522ecfffe1?, 0xdc?)
    /chainlink/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go:168 +0xb1
<http://github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider.(*logEventProvider).minimumCommitmentDequeue(0xc000fe8900|github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider.(*logEventProvider).minimumCommitmentDequeue(0xc000fe8900>, 0x868, 0xc004a65ad8?)
    /chainlink/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go:261 +0xf3
<http://github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider.(*logEventProvider).getLogsFromBuffer(0xc000fe8900|github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider.(*logEventProvider).getLogsFromBuffer(0xc000fe8900>, 0x868)
    /chainlink/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go:241 +0x3b
<http://github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider.(*logEventProvider).GetLatestPayloads(0xc000fe8900|github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider.(*logEventProvider).GetLatestPayloads(0xc000fe8900>, {0x86b7a40?, 0xc002142a10?})
    /chainlink/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go:209 +0x186
<http://github.com/smartcontractkit/chainlink-automation/pkg/v3/flows.logTick.Value({{0x7fd090c3f0d0|github.com/smartcontractkit/chainlink-automation/pkg/v3/flows.logTick.Value({{0x7fd090c3f0d0>?, 0xc000fe8900?}, 0xc00195ce70?}, {0x86b7a40?, 0xc002142a10?})
    /go/pkg/mod/github.com/smartcontractkit/chainlink-automation@v0.8.1/pkg/v3/flows/logtrigger.go:73 +0x5f
<http://github.com/smartcontractkit/chainlink-automation/pkg/v3.(*Observer[...]).Process(0x1|github.com/smartcontractkit/chainlink-automation/pkg/v3.(*Observer[...]).Process(0x1>, {0x86b79d0?, 0xc00156cd70?}, {0x8689d80?, 0xc004781e00})
    /go/pkg/mod/github.com/smartcontractkit/chainlink-automation@v0.8.1/pkg/v3/observer.go:84 +0xa5
<http://github.com/smartcontractkit/chainlink-automation/pkg/v3/tickers.(*timeTicker[...]).Start.func2({0x8689d80|github.com/smartcontractkit/chainlink-automation/pkg/v3/tickers.(*timeTicker[...]).Start.func2({0x8689d80>?, 0xc004781e00?}, {0x8689ce0?, 0xc000978ac0?}, 0xc0009b3cb0?)
    /go/pkg/mod/github.com/smartcontractkit/chainlink-automation@v0.8.1/pkg/v3/tickers/time.go:74 +0x5c
created by <http://github.com/smartcontractkit/chainlink-automation/pkg/v3/tickers.(*timeTicker[...]).Start|github.com/smartcontractkit/chainlink-automation/pkg/v3/tickers.(*timeTicker[...]).Start> in goroutine 7928
    /go/pkg/mod/github.com/smartcontractkit/chainlink-automation@v0.8.1/pkg/v3/tickers/time.go:73 +0x4ca

goroutine 1 [sync.WaitGroup.Wait, 7 minutes]:
sync.runtime_SemacquireWaitGroup(0xc00097def0?, 0x80?)
    /usr/local/go/src/runtime/sema.go:114 +0x2e
sync.(*WaitGroup).Wait(0xc0010a0a48)
    /usr/local/go/src/sync/waitgroup.go:206 +0x85
<http://golang.org/x/sync/errgroup.(*Group).Wait(0xc0010a0a40)|golang.org/x/sync/errgroup.(*Group).Wait(0xc0010a0a40)>
    /go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:56 +0x1e
<http://github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).runNode|github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).runNode>(0xc000f5c600, 0xc00068ab00)
    /chainlink/core/cmd/shell_local.go:664 +0x29c5
<http://github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).RunNode|github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).RunNode>(0xc00126ec68?, 0xc00126ec68?)
    /chainlink/core/cmd/shell_local.go:359 +0x17
<http://github.com/urfave/cli.HandleAction({0x67c0fa0|github.com/urfave/cli.HandleAction({0x67c0fa0>?, 0xc001d98a60?}, 0x5?)
    /go/pkg/mod/github.com/urfave/cli@v1.22.14/app.go:524 +0x9f
<http://github.com/urfave/cli.Command.Run(|github.com/urfave/cli.Command.Run(>{{0x7337ae0, 0x5}, {0x0, 0x0}, {0xc00158eca0, 0x2, 0x2}, {0x73867ac, 0x16}, {0x0, ...}, ...}, ...)
    /go/pkg/mod/github.com/urfave/cli@v1.22.14/command.go:175 +0x656
<http://github.com/urfave/cli.(*App).RunAsSubcommand(0xc00058b180|github.com/urfave/cli.(*App).RunAsSubcommand(0xc00058b180>, 0xc00068a000)
    /go/pkg/mod/github.com/urfave/cli@v1.22.14/app.go:405 +0xddb
<http://github.com/urfave/cli.Command.startApp({{0x7335b44|github.com/urfave/cli.Command.startApp({{0x7335b44>, 0x4}, {0x0, 0x0}, {0xc001d98fc0, 0x1, 0x1}, {0x745a87f, 0x33}, {0x0, ...}, ...}, ...)
    /go/pkg/mod/github.com/urfave/cli@v1.22.14/command.go:380 +0xb38
<http://github.com/urfave/cli.Command.Run(|github.com/urfave/cli.Command.Run(>{{0x7335b44, 0x4}, {0x0, 0x0}, {0xc001d98fc0, 0x1, 0x1}, {0x745a87f, 0x33}, {0x0, ...}, ...}, ...)
    /go/pkg/mod/github.com/urfave/cli@v1.22.14/command.go:103 +0x785
<http://github.com/urfave/cli.(*App).Run(0xc00058afc0|github.com/urfave/cli.(*App).Run(0xc00058afc0>, {0xc000074140, 0x14, 0x14})
    /go/pkg/mod/github.com/urfave/cli@v1.22.14/app.go:277 +0xb1b
<http://github.com/smartcontractkit/chainlink/v2/core.Main.func1()|github.com/smartcontractkit/chainlink/v2/core.Main.func1()>
    /chainlink/core/main.go:31 +0x45
<http://github.com/smartcontractkit/chainlink/v2/core/recovery.HandleFn|github.com/smartcontractkit/chainlink/v2/core/recovery.HandleFn>(0x0?, 0xc000000000?)
    /chainlink/core/recovery/recover.go:40 +0x42
<http://github.com/smartcontractkit/chainlink/v2/core/recovery.ReportPanics(...)|github.com/smartcontractkit/chainlink/v2/core/recovery.ReportPanics(...)>
    /chainlink/core/recovery/recover.go:12
<http://github.com/smartcontractkit/chainlink/v2/core.Main()|github.com/smartcontractkit/chainlink/v2/core.Main()>
    /chainlink/core/main.go:29 +0x3e
main.main()
    /chainlink/main.go:11 +0x13
```