### PR TITLE
Expand ocr3 config in add_capabilities changeset

### DIFF
--- a/deployment/cre/capabilities_registry/v2/changeset/add_capabilities.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/add_capabilities.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/cre/capabilities_registry/v2/changeset/sequences"
 	"github.com/smartcontractkit/chainlink/deployment/cre/common/strategies"
 	crecontracts "github.com/smartcontractkit/chainlink/deployment/cre/contracts"
+	"github.com/smartcontractkit/chainlink/deployment/cre/ocr3"
 )
 
 var _ cldf.ChangeSetV2[AddCapabilitiesInput] = AddCapabilities{}
@@ -79,9 +80,6 @@ func (u AddCapabilities) Apply(e cldf.Environment, config AddCapabilitiesInput) 
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to create CapabilitiesRegistry: %w", err)
 	}
 
-	// returning 1 as adding new capabaility
-	firstConfigCount := func(_, _ string) (uint64, error) { return 1, nil }
-
 	for donName, donCapConfigs := range config.DonCapabilityConfigs {
 		_, nodes, donErr := sequences.GetDonNodes(donName, capReg)
 		if donErr != nil {
@@ -93,7 +91,15 @@ func (u AddCapabilities) Apply(e cldf.Environment, config AddCapabilitiesInput) 
 			ocr3CapConfigs[i] = ocr3CapConfig{CapabilityID: cc.Capability.CapabilityID, Config: cc.Config}
 		}
 
-		if expandErr := expandOCR3Configs(e, config.RegistryChainSel, nodes, ocr3CapConfigs, firstConfigCount); expandErr != nil {
+		configCountFn := func(capID, ocrConfigKey string) (uint64, error) {
+			currentCount, err := ocr3.GetCurrentOCR3ConfigCount(capReg, donName, capID, ocrConfigKey)
+			if err != nil {
+				currentCount = 0
+			}
+			return currentCount + 1, nil
+		}
+
+		if expandErr := expandOCR3Configs(e, config.RegistryChainSel, nodes, ocr3CapConfigs, configCountFn); expandErr != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("DON %q: failed to expand OCR3 configs: %w", donName, expandErr)
 		}
 	}

--- a/deployment/cre/capabilities_registry/v2/changeset/add_capabilities.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/add_capabilities.go
@@ -33,6 +33,12 @@ type AddCapabilitiesInput struct {
 	// Force indicates whether to force the update even if we cannot validate that all forwarder contracts are ready to accept the new configure version.
 	// This is very dangerous, and could break the whole platform if the forwarders are not ready. Be very careful with this option.
 	Force bool `json:"force" yaml:"force"`
+
+	// FirstOCR3ConfigCapabilities maps DON name to capability IDs for which this
+	// is the first OCR3 config (no existing config on-chain). Without listing a
+	// capability here, the changeset will fail if it cannot read the current config
+	// count from the registry, preventing accidental config count collisions.
+	FirstOCR3ConfigCapabilities map[string][]string `json:"firstOCR3ConfigCapabilities" yaml:"firstOCR3ConfigCapabilities"`
 }
 
 type AddCapabilities struct{}
@@ -92,10 +98,26 @@ func (u AddCapabilities) Apply(e cldf.Environment, config AddCapabilitiesInput) 
 			ocr3CapConfigs[i] = ocr3CapConfig{CapabilityID: cc.Capability.CapabilityID, Config: cc.Config}
 		}
 
+		firstCaps := config.FirstOCR3ConfigCapabilities[donName]
+
 		configCountFn := func(capID, ocrConfigKey string) (uint64, error) {
-			currentCount, err := ocr3.GetCurrentOCR3ConfigCount(capReg, donName, capID, ocrConfigKey)
-			if err != nil {
+			isFirst := isFirstOCR3Config(firstCaps, capID)
+
+			currentCount, countErr := ocr3.GetCurrentOCR3ConfigCount(capReg, donName, capID, ocrConfigKey)
+			if countErr != nil {
+				if !isFirst {
+					return 0, fmt.Errorf(
+						"failed to read current OCR3 config count for capability %q[%q] in DON %q: %w. "+
+							"Add %q to firstOCR3ConfigCapabilities[%q] if this is the initial OCR3 config",
+						capID, ocrConfigKey, donName, countErr, capID, donName)
+				}
 				currentCount = 0
+			}
+			if currentCount == 0 && !isFirst {
+				return 0, fmt.Errorf(
+					"OCR3 config count is 0 for capability %q[%q] in DON %q, which suggests no prior config exists. "+
+						"Add %q to firstOCR3ConfigCapabilities[%q] to confirm this is the initial OCR3 config",
+					capID, ocrConfigKey, donName, capID, donName)
 			}
 			return currentCount + 1, nil
 		}

--- a/deployment/cre/capabilities_registry/v2/changeset/add_capabilities.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/add_capabilities.go
@@ -79,6 +79,7 @@ func (u AddCapabilities) Apply(e cldf.Environment, config AddCapabilitiesInput) 
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to create CapabilitiesRegistry: %w", err)
 	}
 
+	// returning 1 as adding new capabaility
 	firstConfigCount := func(_, _ string) (uint64, error) { return 1, nil }
 
 	for donName, donCapConfigs := range config.DonCapabilityConfigs {

--- a/deployment/cre/capabilities_registry/v2/changeset/add_capabilities.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/add_capabilities.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	capabilities_registry_v2 "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/capabilities_registry_wrapper_v2"

--- a/deployment/cre/capabilities_registry/v2/changeset/add_capabilities.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/add_capabilities.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	capabilities_registry_v2 "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/capabilities_registry_wrapper_v2"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/cre/capabilities_registry/v2/changeset/operations/contracts"
@@ -59,6 +61,41 @@ func (u AddCapabilities) Apply(e cldf.Environment, config AddCapabilitiesInput) 
 	}
 
 	registryRef := pkg.GetCapRegV2AddressRefKey(config.RegistryChainSel, config.RegistryQualifier)
+
+	chain, ok := e.BlockChains.EVMChains()[config.RegistryChainSel]
+	if !ok {
+		return cldf.ChangesetOutput{}, fmt.Errorf("chain not found for selector %d", config.RegistryChainSel)
+	}
+
+	registryAddressRef, err := e.DataStore.Addresses().Get(registryRef)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get registry address: %w", err)
+	}
+
+	capReg, err := capabilities_registry_v2.NewCapabilitiesRegistry(
+		common.HexToAddress(registryAddressRef.Address), chain.Client,
+	)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to create CapabilitiesRegistry: %w", err)
+	}
+
+	firstConfigCount := func(_, _ string) (uint64, error) { return 1, nil }
+
+	for donName, donCapConfigs := range config.DonCapabilityConfigs {
+		_, nodes, donErr := sequences.GetDonNodes(donName, capReg)
+		if donErr != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("DON %q: failed to get nodes: %w", donName, donErr)
+		}
+
+		ocr3CapConfigs := make([]ocr3CapConfig, len(donCapConfigs))
+		for i, cc := range donCapConfigs {
+			ocr3CapConfigs[i] = ocr3CapConfig{CapabilityID: cc.Capability.CapabilityID, Config: cc.Config}
+		}
+
+		if expandErr := expandOCR3Configs(e, config.RegistryChainSel, nodes, ocr3CapConfigs, firstConfigCount); expandErr != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("DON %q: failed to expand OCR3 configs: %w", donName, expandErr)
+		}
+	}
 
 	seqReport, err := operations.ExecuteSequence(
 		e.OperationsBundle,

--- a/deployment/cre/capabilities_registry/v2/changeset/add_capabilities_test.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/add_capabilities_test.go
@@ -359,3 +359,88 @@ func TestAddCapabilities_Apply_Modifier(t *testing.T) {
 	addCapabilityWithModifier(t, fixture)
 	requireCapabilityWithModifier(t, fixture)
 }
+
+func TestAddCapabilities_Apply_WithOCR3Config(t *testing.T) {
+	fixture := test.SetupEnvV2(t, false)
+	require.NotNil(t, fixture.Env.Offchain)
+
+	capID := "ocr3-test-cap@1.0.0"
+	ocr3Config := map[string]any{
+		"ocr3Configs": map[string]any{
+			"__default__": map[string]any{
+				"offchainConfig": map[string]any{
+					"uniqueReports":                     true,
+					"deltaProgressMillis":               5000,
+					"deltaResendMillis":                 5000,
+					"deltaInitialMillis":                5000,
+					"deltaRoundMillis":                  2000,
+					"deltaGraceMillis":                  500,
+					"deltaCertifiedCommitRequestMillis": 1000,
+					"deltaStageMillis":                  30000,
+					"maxRoundsPerEpoch":                 10,
+					"transmissionSchedule":              []any{test.TotalNodes + 1}, // +1 for bootstrap
+					"maxDurationQueryMillis":            1000,
+					"maxDurationObservationMillis":      1000,
+					"maxDurationShouldAcceptMillis":     1000,
+					"maxDurationShouldTransmitMillis":   1000,
+					"maxFaultyOracles":                  1,
+				},
+			},
+		},
+	}
+
+	input := changeset.AddCapabilitiesInput{
+		RegistryChainSel:  fixture.RegistrySelector,
+		RegistryQualifier: test.RegistryQualifier,
+		DonCapabilityConfigs: map[string][]contracts.CapabilityConfig{
+			test.DONName: {{
+				Capability: contracts.Capability{
+					CapabilityID:          capID,
+					ConfigurationContract: common.Address{},
+					Metadata:              newCapMetadata,
+				},
+				Config: ocr3Config,
+			}},
+		},
+		Force: true,
+	}
+
+	require.NoError(t, changeset.AddCapabilities{}.VerifyPreconditions(*fixture.Env, input))
+	_, err := changeset.AddCapabilities{}.Apply(*fixture.Env, input)
+	require.NoError(t, err)
+
+	capReg, err := capabilities_registry_v2.NewCapabilitiesRegistry(
+		fixture.RegistryAddress,
+		fixture.Env.BlockChains.EVMChains()[fixture.RegistrySelector].Client,
+	)
+	require.NoError(t, err)
+
+	don, err := capReg.GetDONByName(nil, test.DONName)
+	require.NoError(t, err)
+
+	var cfgFound bool
+	for _, cfg := range don.CapabilityConfigurations {
+		if cfg.CapabilityId == capID {
+			got := new(pkg.CapabilityConfig)
+			require.NoError(t, got.UnmarshalProto(cfg.Config))
+
+			ocr3Cfgs, ok := (*got)["ocr3Configs"].(map[string]any)
+			require.True(t, ok, "ocr3Configs should be present")
+			defaultCfg, ok := ocr3Cfgs["__default__"].(map[string]any)
+			require.True(t, ok, "__default__ should be present")
+
+			_, hasSigners := defaultCfg["signers"]
+			assert.True(t, hasSigners, "expanded config should have signers")
+			_, hasTransmitters := defaultCfg["transmitters"]
+			assert.True(t, hasTransmitters, "expanded config should have transmitters")
+
+			offchainCfg, ok := defaultCfg["offchainConfig"].(string)
+			require.True(t, ok, "offchainConfig should be a base64 string after expansion")
+			assert.NotEmpty(t, offchainCfg)
+
+			cfgFound = true
+			break
+		}
+	}
+	require.True(t, cfgFound, "expected don to have %s capability configuration with expanded OCR3 config", capID)
+}

--- a/deployment/cre/capabilities_registry/v2/changeset/add_capabilities_test.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/add_capabilities_test.go
@@ -403,6 +403,9 @@ func TestAddCapabilities_Apply_WithOCR3Config(t *testing.T) {
 			}},
 		},
 		Force: true,
+		FirstOCR3ConfigCapabilities: map[string][]string{
+			test.DONName: {capID},
+		},
 	}
 
 	require.NoError(t, changeset.AddCapabilities{}.VerifyPreconditions(*fixture.Env, input))

--- a/deployment/cre/capabilities_registry/v2/changeset/modifier/modifier.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/modifier/modifier.go
@@ -132,7 +132,6 @@ func buildP2PToTransmitterMap(
 			return nil, fmt.Errorf("node %s (%s) has no OCR2 config for chain selector %d",
 				node.Name, node.PeerID.String(), chainSelector)
 		}
-		fmt.Println("ocrCfg", ocrCfg)
 		transmitter := strings.TrimSpace(string(ocrCfg.TransmitAccount))
 		if transmitter == "" {
 			return nil, fmt.Errorf("empty transmit account for node %s (%s)", node.Name, node.PeerID.String())

--- a/deployment/cre/capabilities_registry/v2/changeset/modifier/modifier.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/modifier/modifier.go
@@ -132,6 +132,7 @@ func buildP2PToTransmitterMap(
 			return nil, fmt.Errorf("node %s (%s) has no OCR2 config for chain selector %d",
 				node.Name, node.PeerID.String(), chainSelector)
 		}
+		fmt.Println("ocrCfg", ocrCfg)
 		transmitter := strings.TrimSpace(string(ocrCfg.TransmitAccount))
 		if transmitter == "" {
 			return nil, fmt.Errorf("empty transmit account for node %s (%s)", node.Name, node.PeerID.String())


### PR DESCRIPTION
This pull request enhances the `AddCapabilities` changeset logic for the Capabilities Registry v2 by integrating OCR3 configuration expansion.

**OCR3 Configuration Support and Expansion:**

* The `Apply` method in `AddCapabilities` now retrieves the registry contract, fetches DON nodes, and expands OCR3 capability configurations using the new `expandOCR3Configs` logic, which incorporates the current OCR3 config count and ensures proper config structure for each DON.
* Its done the same way in the `UpdateDon` and `ConfigureCapabilityRegistry` changesets
