### PR TITLE
fix(ccip/sui): link upgraded offramp against upgraded ccip pkg

### DIFF
--- a/core/capabilities/ccip/configs/sui/contract_reader.go
+++ b/core/capabilities/ccip/configs/sui/contract_reader.go
@@ -96,8 +96,9 @@ func GetChainReaderConfig(pubKeyStr string) (map[string]any, error) {
 				"Name": "rmn_remote",
 				"Functions": map[string]*chainreaderConfig.ChainReaderFunction{
 					consts.MethodNameGetARM: {
-						Name:          "get_arm",
-						SignerAddress: fromAddress,
+						Name:               "get_arm",
+						SignerAddress:      fromAddress,
+						ResponseFromInputs: []string{"package_id"},
 					},
 				},
 			},

--- a/integration-tests/smoke/ccip/ccip_sui_upgrade_test.go
+++ b/integration-tests/smoke/ccip/ccip_sui_upgrade_test.go
@@ -610,14 +610,16 @@ func upgradeSuiOffRamp(ctx context.Context, t *testing.T, e testhelpers.Deployed
 	signerAddr, err := suiChain.Signer.GetAddress()
 	require.NoError(t, err)
 
-	// compile packages
+	// ccip published-at points at the upgraded pkg so offramp v2 dispatches
+	// fee_quoter::update_prices into v3. original_ccip_pkg preserves the
+	// original-id for Sui's upgrade validator.
 	compiledPackage, err := suiBind.CompilePackage(version, map[string]string{
-		"ccip":         state.SuiChains[sourceChain].CCIPAddress,
-		"ccip_offramp": "0x0",
-		"mcms":         state.SuiChains[sourceChain].MCMSPackageID,
-		"mcms_owner":   "0x1",
+		"ccip":              state.SuiChains[sourceChain].CCIPMockV2PackageId,
+		"original_ccip_pkg": state.SuiChains[sourceChain].CCIPAddress,
+		"ccip_offramp":      "0x0",
+		"mcms":              state.SuiChains[sourceChain].MCMSPackageID,
+		"mcms_owner":        "0x1",
 
-		"latest_ccip_pkg":      state.SuiChains[sourceChain].CCIPMockV2PackageId,
 		"original_offramp_pkg": state.SuiChains[sourceChain].OffRampAddress,
 		"upgrade_cap":          state.SuiChains[sourceChain].OffRampUpgradeCapId,
 		"signer":               signerAddr,


### PR DESCRIPTION
## Summary

Resolves intermittent 20-min timeouts in `Test_CCIP_Upgrade_EVM2Sui` and `Test_CCIP_Upgrade_CommonPkg_EVM2Sui` (`(sui) timed out after waiting for commit report`). Two Sui-specific bugs independently gate commit-report delivery; both must be fixed together.

## Issue 1 — offramp v2 linked against v1 ccip pkg

`upgradeSuiOffRamp` compiled offramp v2 with `"ccip": state.CCIPAddress` (v1 pkg) in the named-address map. Sui Move captures linkage at compile time, so offramp v2 dispatched `fee_quoter::update_prices` into the v1 fee_quoter (`VERSION=2`). After `BlockVersion(fee_quoter, v=2)`, commit reports carrying price updates aborted on `verify_function_allowed` and the whole tx reverted. The flake surfaces because OCR decides per-round whether to include price updates — empty-price rounds committed cleanly, price-carrying rounds reverted.

**Fix:** point `ccip` at `CCIPMockV2PackageId`. Supply `original_ccip_pkg: CCIPAddress` so Sui's upgrade validator accepts the dep swap (`Published.toml` original-id must match on-chain).

## Issue 2 — `RMNProxy.GetARM` references a Move function that doesn't exist

The Sui chain-reader config mapped `MethodNameGetARM` to Move function `rmn_remote::get_arm`, which is not defined in `chainlink-sui/contracts/ccip/ccip/sources/rmn_remote.move`. On Sui `rmn_remote` lives inside the CCIP package — there is no proxy indirection, so there's no `get_arm` to call.

Every config-refresh batch failed on the RMN leg. `chainlink-ccip`'s `DefaultAccessor.GetAllConfigsLegacy` catches that error, replaces the entire `ChainConfigSnapshot` with a zero-valued struct, and returns nil; `configPollerV2` caches it as if successful. `GetOffRampConfigDigest` then returns `0x0`, the commit plugin self-rejects every report at `commit/report.go:221`, and nothing transmits.

**Fix:** `ResponseFromInputs: []string{"package_id"}` on the `GetARM` binding synthesizes the response via chainlink-sui's existing `executeFunction` short-circuit — the correct "ARM address" on Sui is the latest CCIP package id since `rmn_remote` lives there.

## Evidence (pre-fix failing log)

`integration-tests/smoke/ccip/logs/2026-04-14T22-18-10_Test_CCIP_Upgrade_EVM2Sui.log`:
- 349 × `default_accessor.go:115 "failed to process standard chain config results" err="... get_arm: FunctionNotFound in command 0"`
- `config_poller_v2.go:464` caching snapshot with `ConfigDigest=0x000…0`
- First `"my config digest doesn't match offramp's config digest"` warning immediately follows
- On-chain `offramp::latest_config_details` returned the correct digest `0x000acd0c35…` — confirming the `0x0` is cache-poisoning, not a contract issue
- Zero `SubmitTransaction` calls on the Sui chain writer across the 22-min run

## CI

Previously red with the digest-zero signature. Post-fix: 6 consecutive CI runs of both tests green. `P(6 passes | 50% flake rate) = 1.6%` — empirical null rejected.

## Follow-up (out of scope)

`chainlink-ccip/pkg/chainaccessor/config_processors.go` is fail-fast across all reads in the dest-chain batch — one broken view zeros the whole `ChainConfigSnapshot`, exposing every non-EVM family to the same fragility. Worth a separate PR to isolate per-contract failures.

Closes CORE-2414.
