### PR TITLE
Fix Solana DestExecData length validation

### DIFF
--- a/core/capabilities/ccip/ccipsolana/extradatacodec.go
+++ b/core/capabilities/ccip/ccipsolana/extradatacodec.go
@@ -86,6 +86,10 @@ func (d ExtraDataDecoder) DecodeExtraArgsToMap(extraArgs cciptypes.Bytes) (map[s
 
 // DecodeDestExecDataToMap is a helper function for converting dest exec data bytes into map[string]any
 func (d ExtraDataDecoder) DecodeDestExecDataToMap(destExecData cciptypes.Bytes) (map[string]any, error) {
+	if len(destExecData) != 4 {
+		return nil, fmt.Errorf("dest exec data invalid length: %d, should be 4 bytes", len(destExecData))
+	}
+
 	return map[string]any{
 		svmDestExecDataKey: binary.BigEndian.Uint32(destExecData),
 	}, nil

--- a/core/capabilities/ccip/ccipsolana/extradatacodec_test.go
+++ b/core/capabilities/ccip/ccipsolana/extradatacodec_test.go
@@ -28,6 +28,11 @@ func Test_decodeExtraArgs(t *testing.T) {
 		require.Equal(t, destGasAmount, decoded)
 	})
 
+	t.Run("rejects dest exec data with invalid length", func(t *testing.T) {
+		_, err := extraDataDecoder.DecodeDestExecDataToMap([]byte{1, 2, 3})
+		require.EqualError(t, err, "dest exec data invalid length: 3, should be 4 bytes")
+	})
+
 	t.Run("decode extra args into map svm", func(t *testing.T) {
 		destGasAmount := uint32(10000)
 		bitmap := uint64(0)


### PR DESCRIPTION
Fix Solana DestExecData decoding to validate the encoded length before reading
the gas amount. This prevents malformed inputs from panicking the process and
returns a regular decoding error instead.

### Requires

N/A

### Supports

N/A