### PR TITLE
fix(ccip/sui): resolve RMNProxy.GetARM and seed fee_quoter prices after upgrade

### DIFF
--- a/core/capabilities/ccip/configs/sui/contract_reader.go
+++ b/core/capabilities/ccip/configs/sui/contract_reader.go
@@ -96,8 +96,9 @@ func GetChainReaderConfig(pubKeyStr string) (map[string]any, error) {
 				"Name": "rmn_remote",
 				"Functions": map[string]*chainreaderConfig.ChainReaderFunction{
 					consts.MethodNameGetARM: {
-						Name:          "get_arm",
-						SignerAddress: fromAddress,
+						Name:               "get_arm",
+						SignerAddress:      fromAddress,
+						ResponseFromInputs: []string{"package_id"},
 					},
 				},
 			},

--- a/integration-tests/smoke/ccip/ccip_sui_upgrade_test.go
+++ b/integration-tests/smoke/ccip/ccip_sui_upgrade_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"math/big"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	operations "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	suiBind "github.com/smartcontractkit/chainlink-sui/bindings/bind"
 	suiutil "github.com/smartcontractkit/chainlink-sui/bindings/utils"
@@ -196,6 +198,8 @@ func Test_CCIP_Upgrade_EVM2Sui(t *testing.T) {
 	t.Log("Upgrading SUI contracts")
 	ccipPkgID := upgradeCCIP(ctx, t, e, destChain, contracts.CCIP)
 	upgradeSuiOffRamp(ctx, t, e, destChain, contracts.CCIPOfframp)
+
+	seedSuiFeeQuoterForRemote(ctx, t, e, destChain, sourceChain)
 
 	// Block offramp v1
 	_, _, err = commoncs.ApplyChangesets(t, e.Env, []commoncs.ConfiguredChangeSet{
@@ -439,6 +443,8 @@ func Test_CCIP_Upgrade_CommonPkg_EVM2Sui(t *testing.T) {
 
 	t.Log("Upgrading SUI contracts")
 	ccipPkgID := upgradeCCIP(ctx, t, e, destChain, contracts.CCIP)
+
+	seedSuiFeeQuoterForRemote(ctx, t, e, destChain, sourceChain)
 
 	// Block ccip v2 FQ (the pre-upgrade version)
 	_, _, err = commoncs.ApplyChangesets(t, e.Env, []commoncs.ConfiguredChangeSet{
@@ -798,4 +804,58 @@ func upgradeCCIP(ctx context.Context, t *testing.T, e testhelpers.DeployedEnv, s
 	t.Log("Upgraded SUI CCIP")
 
 	return newCCIPPkgID
+}
+
+// seedSuiFeeQuoterForRemote writes the remote dest-chain gas price and Sui-side
+// LINK token price into the Sui fee_quoter state. The CCIP commit plugin on Sui
+// polls these values every observation round; without them reads abort with
+// EUnknownDestChainSelector / EUnknownToken and the plugin's dest-config batch
+// fail-fast cache zeroes the offramp config digest, causing the plugin to
+// self-reject its own reports.
+//
+// Called after upgradeCCIP so the write targets the latest (unblocked) fee_quoter.
+func seedSuiFeeQuoterForRemote(ctx context.Context, t *testing.T, e testhelpers.DeployedEnv, suiChainSel, remoteChainSel uint64) {
+	t.Helper()
+	state, err := stateview.LoadOnchainState(e.Env)
+	require.NoError(t, err)
+
+	ccipPkg := state.SuiChains[suiChainSel].CCIPMockV2PackageId
+	if ccipPkg == "" {
+		ccipPkg = state.SuiChains[suiChainSel].CCIPAddress
+	}
+
+	// Values mirror SendSuiCCIPRequest (test_sui_helpers.go): 1e27-scale token price
+	// and optimism-sepolia-like gas price. Only magnitudes matter for the plugin's
+	// presence-check; staleness threshold defaults to generous test bounds.
+	tokenPrice, ok := new(big.Int).SetString("15377040000000000000000000000", 10)
+	require.True(t, ok)
+	gasPrice, ok := new(big.Int).SetString("41946474500", 10)
+	require.True(t, ok)
+
+	suiChain := e.Env.BlockChains.SuiChains()[suiChainSel]
+	deps := sui_ops.OpTxDeps{
+		Client: suiChain.Client,
+		Signer: suiChain.Signer,
+		GetCallOpts: func() *suiBind.CallOpts {
+			b := uint64(400_000_000)
+			return &suiBind.CallOpts{
+				Signer:           suiChain.Signer,
+				WaitForExecution: true,
+				GasBudget:        &b,
+			}
+		},
+	}
+
+	_, err = operations.ExecuteOperation(e.Env.OperationsBundle, ccipops.FeeQuoterUpdatePricesWithOwnerCapOp, deps,
+		ccipops.FeeQuoterUpdatePricesWithOwnerCapInput{
+			CCIPPackageId:         ccipPkg,
+			CCIPObjectRef:         state.SuiChains[suiChainSel].CCIPObjectRef,
+			OwnerCapObjectId:      state.SuiChains[suiChainSel].CCIPOwnerCapObjectId,
+			SourceTokens:          []string{state.SuiChains[suiChainSel].LinkTokenCoinMetadataId},
+			SourceUsdPerToken:     []*big.Int{tokenPrice},
+			GasDestChainSelectors: []uint64{remoteChainSel},
+			GasUsdPerUnitGas:      []*big.Int{gasPrice},
+		})
+	require.NoError(t, err, "seed Sui fee_quoter prices for remote chain %d", remoteChainSel)
+	_ = ctx
 }


### PR DESCRIPTION
## Summary

Fixes two independent failures in `Test_CCIP_Upgrade_EVM2Sui` and `Test_CCIP_Upgrade_CommonPkg_EVM2Sui` that cascade through the same chainaccessor batch-refresh path and zero out the offramp OCR3 config digest, causing the CCIP commit plugin to self-reject its own reports (`commit/report.go:222` — "my config digest doesn't match offramp's").

## Root causes

### X — `RMNProxy.GetARM` → `FunctionNotFound`

Sui chainreader config (`core/capabilities/ccip/configs/sui/contract_reader.go:98-101`) maps `MethodNameGetARM` to Move function `rmn_remote::get_arm`, which **does not exist** in `chainlink-sui/contracts/ccip/ccip/sources/rmn_remote.move` (grep confirms zero definitions). Every refresh cycle fails on the RMN leg of the dest-chain batch in `chainlink-ccip/pkg/chainaccessor/default_accessor.go:150-214`, fail-fast processed at `config_processors.go:107-168`, returning zero-valued `OfframpConfig{}` — `ConfigDigest = [32]byte{}`.

On Sui the `rmn_remote` module lives inside the CCIP package; the correct "ARM address" is the latest CCIP package id. Fix: `ResponseFromInputs: []string{"package_id"}` synthesizes that value via `chainlink-sui` chainreader's existing `executeFunction` plumbing (`relayer/chainreader/reader/chainreader.go:927-942`), no Move source change, no dep bump.

### Y — Sui fee_quoter price tables empty for EVM dest

`AddLane(from=EVM, to=Sui)` populates EVM-side fee_quoter only (`deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go:943-1012` — no `case chainsel.FamilySui:` on the `toFamily` switch). Sui-side `usd_per_unit_gas_by_dest_chain[EVM selector]` and `usd_per_token[LINK]` stay empty. Commit plugin observation aborts every cycle with `EUnknownDestChainSelector(3)` (`fee_quoter.move:1578-1581`) and `EUnknownToken(4)` (`fee_quoter.move:1569-1571`). In isolation these are tolerated warnings, but in the same batch as X they compound into the same zero-digest cascade.

Fix: seed via `FeeQuoterUpdatePricesWithOwnerCapOp` immediately after `upgradeCCIP` (so the write targets the post-upgrade, unblocked package). Values mirror `SendSuiCCIPRequest` in `test_sui_helpers.go:145-168`.

## Why both need to land together

Both reads live in the same batch in `chainaccessor.prepareDestChainRequest`. `processOfframpResults` / `processStandardChainConfigResults` are fail-fast: one bad sibling zeros the whole `OfframpConfig` → cached zero digest → plugin self-rejects → no commit txs → 22-min timeout. Fixing X alone leaves Y to trigger the same cascade (and vice versa).

## Evidence

Failing job 71358465085 (PR #22016 latest), log at `integration-tests/smoke/ccip/logs/2026-04-14T22-18-10_Test_CCIP_Upgrade_EVM2Sui.log`:

- L72091: **correct** on-chain OCR3 digest returned (`000acd0c35…`) — proves read path isn't broken at the contract level.
- L72678+: plugin compares against `offRampConfigDigest: 0x0000…0000` from poller cache → rejects own report.
- `default_accessor.go:115` errors repeat for full 22 min: `get_arm: FunctionNotFound` and `get_dest_chain_gas_price: EUnknownDestChainSelector`.
- Zero `SubmitTransaction`/`signAndExecute` on Sui chain writer through test lifetime.

## Scope

- `core/capabilities/ccip/configs/sui/contract_reader.go` — 3 lines
- `integration-tests/smoke/ccip/ccip_sui_upgrade_test.go` — new helper `seedSuiFeeQuoterForRemote`, called after `upgradeCCIP` in the two failing tests

`go vet ./...` and `go test -run=XXX -count=1 ./smoke/ccip/...` clean.

## Relationship to #22016

Independent fix. #22016 addresses offramp→fee_quoter linkage on the commit-tx submission path (necessary to unblock transmission once reports start being produced). This PR unblocks **report production** in the first place. Land order doesn't matter; both are needed for the tests to go green.

## Test plan

- [ ] `Test_CCIP_Upgrade_EVM2Sui` passes
- [ ] `Test_CCIP_Upgrade_CommonPkg_EVM2Sui` passes
- [ ] No regression on `Test_CCIP_Messaging_EVM2Sui`, `Test_CCIP_Upgrade_Sui2EVM`, `Test_CCIP_Upgrade_NoBlock_EVM2Sui`
- [ ] Review with CCIP team: does `ResponseFromInputs:["package_id"]` return the correct address for downstream RMNRemote binding (expected: yes — RMNRemote reads bind to the same CCIP package)