### PR TITLE
Change output file from race.txt to races.txt

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -360,9 +360,9 @@ jobs:
           GH_RUN_ID: ${{ github.run_id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          find race.* | xargs cat > race.txt
-          if [[ -s race.txt ]]; then
-            cat race.txt
+          find race.* | xargs cat >> races.txt
+          if [[ -s races.txt ]]; then
+            cat races.txt
             echo "post_to_slack=true" | tee -a "$GITHUB_OUTPUT"
           else
             echo "post_to_slack=false" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fix support for multiple `race.*` files by appending results and using a filename which does not match the filter.

Failed here: https://github.com/smartcontractkit/chainlink/actions/runs/24432225624/job/71380659852?pr=22009
> input file is output file