### PR TITLE
Use user provided forwarder address for aptos job spec

### DIFF
--- a/deployment/cre/jobs/propose_aptos_cap.go
+++ b/deployment/cre/jobs/propose_aptos_cap.go
@@ -90,10 +90,10 @@ func (u ProposeAptosCapJobSpec) VerifyPreconditions(e cldf.Environment, input Pr
 		return fmt.Errorf("failed to get chainID from selector: %w", err)
 	}
 
-	resolved, err := resolveContractAddresses(e, input.OCRChainSelector, input.OCRContractQualifier, input.ChainSelector, input.ForwardersQualifier)
-	if err != nil {
-		return err
-	}
+	// resolved, err := resolveContractAddresses(e, input.OCRChainSelector, input.OCRContractQualifier, input.ChainSelector, input.ForwardersQualifier)
+	// if err != nil {
+	// 	return err
+	// }
 
 	for _, aptosCapInput := range input.AptosCapabilityInputs {
 		ov := aptosCapInput.OverrideDefaultCfg
@@ -109,9 +109,9 @@ func (u ProposeAptosCapJobSpec) VerifyPreconditions(e cldf.Environment, input Pr
 		if err := validateOverrideNetwork(ov.Network, aptosNetwork, aptosCapInput.NodeID); err != nil {
 			return err
 		}
-		if err := validateOverrideForwarder(ov.CREForwarderAddress, resolved.ForwarderAddress, aptosCapInput.NodeID); err != nil {
-			return err
-		}
+		// if err := validateOverrideForwarder(ov.CREForwarderAddress, resolved.ForwarderAddress, aptosCapInput.NodeID); err != nil {
+		// 	return err
+		// }
 	}
 
 	return nil
@@ -141,10 +141,10 @@ func (u ProposeAptosCapJobSpec) Apply(e cldf.Environment, input ProposeAptosCapJ
 		BootstrapPeers:        input.BootstrapperOCR3Urls,
 	}
 
-	resolved, err := resolveContractAddresses(e, input.OCRChainSelector, input.OCRContractQualifier, input.ChainSelector, input.ForwardersQualifier)
-	if err != nil {
-		return cldf.ChangesetOutput{}, err
-	}
+	// resolved, err := resolveContractAddresses(e, input.OCRChainSelector, input.OCRContractQualifier, input.ChainSelector, input.ForwardersQualifier)
+	// if err != nil {
+	// 	return cldf.ChangesetOutput{}, err
+	// }
 
 	nodeIDToConfig := make(map[string]string, len(input.AptosCapabilityInputs))
 	for _, aptosCapInput := range input.AptosCapabilityInputs {
@@ -155,7 +155,7 @@ func (u ProposeAptosCapJobSpec) Apply(e cldf.Environment, input ProposeAptosCapJ
 		cfg := aptosCapInput.OverrideDefaultCfg
 		cfg.ChainID = chainIDStr
 		cfg.Network = aptosNetwork
-		cfg.CREForwarderAddress = resolved.ForwarderAddress
+		// cfg.CREForwarderAddress = resolved.ForwarderAddress
 		cfg.DeltaStage = input.DeltaStage
 		cfg.TxSearchStartingBuffer = input.TxSearchStartingBuffer
 		enc, err := json.Marshal(cfg)

--- a/deployment/cre/jobs/propose_aptos_cap.go
+++ b/deployment/cre/jobs/propose_aptos_cap.go
@@ -43,7 +43,6 @@ type ProposeAptosCapJobSpecInput struct {
 	BootstrapperOCR3Urls []string `json:"bootstrapperOCR3Urls" yaml:"bootstrapperOCR3Urls"`
 	OCRContractQualifier string   `json:"ocrContractQualifier" yaml:"ocrContractQualifier"`
 	OCRChainSelector     uint64   `json:"ocrChainSelector" yaml:"ocrChainSelector"`
-	ForwardersQualifier  string   `json:"forwardersContractQualifier" yaml:"forwardersContractQualifier"`
 
 	DeltaStage             time.Duration          `json:"deltaStage" yaml:"deltaStage,omitempty"`
 	TxSearchStartingBuffer time.Duration          `json:"txSearchStartingBuffer" yaml:"txSearchStartingBuffer,omitempty"`
@@ -72,7 +71,6 @@ func (u ProposeAptosCapJobSpec) VerifyPreconditions(e cldf.Environment, input Pr
 		OCRChainSelector:     input.OCRChainSelector,
 		BootstrapperOCR3Urls: input.BootstrapperOCR3Urls,
 		OCRContractQualifier: input.OCRContractQualifier,
-		ForwardersQualifier:  input.ForwardersQualifier,
 		DeltaStage:           input.DeltaStage,
 	}); err != nil {
 		return err

--- a/deployment/cre/jobs/propose_aptos_cap.go
+++ b/deployment/cre/jobs/propose_aptos_cap.go
@@ -47,6 +47,7 @@ type ProposeAptosCapJobSpecInput struct {
 
 	DeltaStage             time.Duration          `json:"deltaStage" yaml:"deltaStage,omitempty"`
 	TxSearchStartingBuffer time.Duration          `json:"txSearchStartingBuffer" yaml:"txSearchStartingBuffer,omitempty"`
+	CREForwarderAddress    string                 `json:"creForwarderAddress" yaml:"creForwarderAddress,omitempty"`
 	AptosCapabilityInputs  []AptosCapabilityInput `json:"aptosCapabilityInputs" yaml:"aptosCapabilityInputs"`
 }
 
@@ -77,6 +78,12 @@ func (u ProposeAptosCapJobSpec) VerifyPreconditions(e cldf.Environment, input Pr
 		return err
 	}
 
+	// PLEX-2797: accept forwarder address directly instead of deriving from datastore,
+	// since Aptos forwarder addresses are not yet managed in the catalog.
+	if input.CREForwarderAddress == "" {
+		return errors.New("cre forwarder address is required")
+	}
+
 	family, err := chainselectors.GetSelectorFamily(input.ChainSelector)
 	if err != nil {
 		return fmt.Errorf("failed to get family for chain selector %d: %w", input.ChainSelector, err)
@@ -90,10 +97,10 @@ func (u ProposeAptosCapJobSpec) VerifyPreconditions(e cldf.Environment, input Pr
 		return fmt.Errorf("failed to get chainID from selector: %w", err)
 	}
 
-	// resolved, err := resolveContractAddresses(e, input.OCRChainSelector, input.OCRContractQualifier, input.ChainSelector, input.ForwardersQualifier)
-	// if err != nil {
-	// 	return err
-	// }
+	ocrAddrRefKey := pkg.GetOCR3CapabilityAddressRefKey(input.OCRChainSelector, input.OCRContractQualifier)
+	if _, err := e.DataStore.Addresses().Get(ocrAddrRefKey); err != nil {
+		return fmt.Errorf("failed to get OCR contract address for ref key %s: %w", ocrAddrRefKey, err)
+	}
 
 	for _, aptosCapInput := range input.AptosCapabilityInputs {
 		ov := aptosCapInput.OverrideDefaultCfg
@@ -109,9 +116,6 @@ func (u ProposeAptosCapJobSpec) VerifyPreconditions(e cldf.Environment, input Pr
 		if err := validateOverrideNetwork(ov.Network, aptosNetwork, aptosCapInput.NodeID); err != nil {
 			return err
 		}
-		// if err := validateOverrideForwarder(ov.CREForwarderAddress, resolved.ForwarderAddress, aptosCapInput.NodeID); err != nil {
-		// 	return err
-		// }
 	}
 
 	return nil
@@ -141,11 +145,6 @@ func (u ProposeAptosCapJobSpec) Apply(e cldf.Environment, input ProposeAptosCapJ
 		BootstrapPeers:        input.BootstrapperOCR3Urls,
 	}
 
-	// resolved, err := resolveContractAddresses(e, input.OCRChainSelector, input.OCRContractQualifier, input.ChainSelector, input.ForwardersQualifier)
-	// if err != nil {
-	// 	return cldf.ChangesetOutput{}, err
-	// }
-
 	nodeIDToConfig := make(map[string]string, len(input.AptosCapabilityInputs))
 	for _, aptosCapInput := range input.AptosCapabilityInputs {
 		if _, exists := nodeIDToConfig[aptosCapInput.NodeID]; exists {
@@ -155,7 +154,7 @@ func (u ProposeAptosCapJobSpec) Apply(e cldf.Environment, input ProposeAptosCapJ
 		cfg := aptosCapInput.OverrideDefaultCfg
 		cfg.ChainID = chainIDStr
 		cfg.Network = aptosNetwork
-		// cfg.CREForwarderAddress = resolved.ForwarderAddress
+		cfg.CREForwarderAddress = input.CREForwarderAddress // PLEX-2797
 		cfg.DeltaStage = input.DeltaStage
 		cfg.TxSearchStartingBuffer = input.TxSearchStartingBuffer
 		enc, err := json.Marshal(cfg)

--- a/deployment/cre/jobs/propose_aptos_cap_test.go
+++ b/deployment/cre/jobs/propose_aptos_cap_test.go
@@ -64,6 +64,7 @@ func freshAptosBase(ocrSel, aptosSel uint64) jobs.ProposeAptosCapJobSpecInput {
 		BootstrapperOCR3Urls: []string{"12D3KooWxyz@127.0.0.1:5001"},
 		OCRContractQualifier: testAptosOCRQualifier,
 		ForwardersQualifier:  testAptosForwarderQualifier,
+		CREForwarderAddress:  "0x2222222222222222222222222222222222222222222222222222222222222222",
 		DeltaStage:           10 * time.Second,
 		AptosCapabilityInputs: []jobs.AptosCapabilityInput{
 			minimalAptosCapInput("peer-1"),
@@ -132,9 +133,9 @@ func TestProposeAptosCapJobSpec_VerifyPreconditions_requiredFields(t *testing.T)
 		{"missing bootstrapper urls", func(in *jobs.ProposeAptosCapJobSpecInput) { in.BootstrapperOCR3Urls = nil }, "at least one bootstrapper OCR3 URL is required"},
 		{"empty bootstrapper url element", func(in *jobs.ProposeAptosCapJobSpecInput) { in.BootstrapperOCR3Urls = []string{""} }, "bootstrapper OCR3 URL at index 0 is empty"},
 		{"missing OCR qualifier", func(in *jobs.ProposeAptosCapJobSpecInput) { in.OCRContractQualifier = "" }, "ocr contract qualifier is required"},
-		{"missing forwarder qualifier", func(in *jobs.ProposeAptosCapJobSpecInput) { in.ForwardersQualifier = "" }, "cre forwarder qualifier is required"},
 		{"missing node id", func(in *jobs.ProposeAptosCapJobSpecInput) { in.AptosCapabilityInputs[0].NodeID = "" }, "nodeID is required for aptos capability input"},
 		{"missing delta stage", func(in *jobs.ProposeAptosCapJobSpecInput) { in.DeltaStage = 0 }, "deltaStage"},
+		{"missing cre forwarder address", func(in *jobs.ProposeAptosCapJobSpecInput) { in.CREForwarderAddress = "" }, "cre forwarder address is required"},
 	}
 
 	for _, tc := range cases {
@@ -171,22 +172,8 @@ func TestProposeAptosCapJobSpec_VerifyPreconditions_missingAddresses(t *testing.
 		assert.Contains(t, err.Error(), "failed to get OCR contract address")
 	})
 
-	t.Run("missing forwarder address", func(t *testing.T) {
-		ds := datastore.NewMemoryDataStore()
-		require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
-			ChainSelector: ocrSel,
-			Type:          datastore.ContractType(ocr3.OCR3Capability),
-			Version:       semver.MustParse("1.0.0"),
-			Address:       "0x1111111111111111111111111111111111111111",
-			Qualifier:     testAptosOCRQualifier,
-		}))
-		env.DataStore = ds.Seal()
-
-		in := freshAptosBase(ocrSel, aptosSel)
-		err := jobs.ProposeAptosCapJobSpec{}.VerifyPreconditions(env, in)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to get CRE forwarder address")
-	})
+	// PLEX-2797: forwarder address is now provided directly via CREForwarderAddress,
+	// so there is no datastore lookup for it.
 }
 
 func TestProposeAptosCapJobSpec_VerifyPreconditions_overrideMismatches(t *testing.T) {
@@ -194,12 +181,11 @@ func TestProposeAptosCapJobSpec_VerifyPreconditions_overrideMismatches(t *testin
 
 	ocrSel := chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector
 	aptosSel := chainsel.APTOS_TESTNET.Selector
-	fwdAddr := "0x2222222222222222222222222222222222222222222222222222222222222222"
 
 	ds := datastore.NewMemoryDataStore()
 	seedAptosAddresses(t, ds, ocrSel, aptosSel,
 		"0x1111111111111111111111111111111111111111",
-		fwdAddr,
+		"0x2222222222222222222222222222222222222222222222222222222222222222",
 	)
 	env.DataStore = ds.Seal()
 
@@ -235,19 +221,8 @@ func TestProposeAptosCapJobSpec_VerifyPreconditions_overrideMismatches(t *testin
 		require.NoError(t, jobs.ProposeAptosCapJobSpec{}.VerifyPreconditions(env, in))
 	})
 
-	t.Run("forwarder address mismatch when provided", func(t *testing.T) {
-		in := deepCloneAptosInput(base)
-		in.AptosCapabilityInputs[0].OverrideDefaultCfg.CREForwarderAddress = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-		err := jobs.ProposeAptosCapJobSpec{}.VerifyPreconditions(env, in)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "CRE forwarder address in override config")
-	})
-
-	t.Run("matching forwarder address is accepted", func(t *testing.T) {
-		in := deepCloneAptosInput(base)
-		in.AptosCapabilityInputs[0].OverrideDefaultCfg.CREForwarderAddress = fwdAddr
-		require.NoError(t, jobs.ProposeAptosCapJobSpec{}.VerifyPreconditions(env, in))
-	})
+	// PLEX-2797: forwarder override validation removed — address is now set directly
+	// via input.CREForwarderAddress and not derived from the datastore.
 }
 
 type aptosCapTestSetup struct {
@@ -310,6 +285,7 @@ func setupAptosCapTest(t *testing.T) aptosCapTestSetup {
 		BootstrapperOCR3Urls:   []string{"12D3KooWabc@127.0.0.1:5001"},
 		OCRContractQualifier:   testAptosOCRQualifier,
 		ForwardersQualifier:    testAptosForwarderQualifier,
+		CREForwarderAddress:    "0x2222222222222222222222222222222222222222222222222222222222222222",
 		DeltaStage:             time.Second,
 		TxSearchStartingBuffer: 30 * time.Second,
 		AptosCapabilityInputs:  aptosCapInputs,

--- a/deployment/cre/jobs/propose_aptos_cap_test.go
+++ b/deployment/cre/jobs/propose_aptos_cap_test.go
@@ -23,10 +23,7 @@ import (
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 )
 
-const (
-	testAptosForwarderQualifier = "aptos-forwarder-qualifier"
-	testAptosOCRQualifier       = "aptos-ocr-qualifier"
-)
+const testAptosOCRQualifier = "aptos-ocr-qualifier"
 
 func minimalAptosCapInput(nodeID string) jobs.AptosCapabilityInput {
 	return jobs.AptosCapabilityInput{
@@ -35,7 +32,7 @@ func minimalAptosCapInput(nodeID string) jobs.AptosCapabilityInput {
 	}
 }
 
-func seedAptosAddresses(t *testing.T, ds *datastore.MemoryDataStore, ocrSel, aptosSel uint64, ocrAddr, fwdAddr string) {
+func seedAptosAddresses(t *testing.T, ds *datastore.MemoryDataStore, ocrSel uint64, ocrAddr string) {
 	t.Helper()
 	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
 		ChainSelector: ocrSel,
@@ -43,13 +40,6 @@ func seedAptosAddresses(t *testing.T, ds *datastore.MemoryDataStore, ocrSel, apt
 		Version:       semver.MustParse("1.0.0"),
 		Address:       ocrAddr,
 		Qualifier:     testAptosOCRQualifier,
-	}))
-	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
-		ChainSelector: aptosSel,
-		Type:          testForwarderContractType,
-		Version:       semver.MustParse("1.0.0"),
-		Address:       fwdAddr,
-		Qualifier:     testAptosForwarderQualifier,
 	}))
 }
 
@@ -63,7 +53,6 @@ func freshAptosBase(ocrSel, aptosSel uint64) jobs.ProposeAptosCapJobSpecInput {
 		OCRChainSelector:     ocrSel,
 		BootstrapperOCR3Urls: []string{"12D3KooWxyz@127.0.0.1:5001"},
 		OCRContractQualifier: testAptosOCRQualifier,
-		ForwardersQualifier:  testAptosForwarderQualifier,
 		CREForwarderAddress:  "0x2222222222222222222222222222222222222222222222222222222222222222",
 		DeltaStage:           10 * time.Second,
 		AptosCapabilityInputs: []jobs.AptosCapabilityInput{
@@ -87,10 +76,7 @@ func TestProposeAptosCapJobSpec_VerifyPreconditions_success(t *testing.T) {
 	aptosSel := chainsel.APTOS_TESTNET.Selector
 
 	ds := datastore.NewMemoryDataStore()
-	seedAptosAddresses(t, ds, ocrSel, aptosSel,
-		"0x1111111111111111111111111111111111111111",
-		"0x2222222222222222222222222222222222222222222222222222222222222222",
-	)
+	seedAptosAddresses(t, ds, ocrSel, "0x1111111111111111111111111111111111111111")
 	env.DataStore = ds.Seal()
 
 	in := freshAptosBase(ocrSel, aptosSel)
@@ -110,10 +96,7 @@ func TestProposeAptosCapJobSpec_VerifyPreconditions_requiredFields(t *testing.T)
 	aptosSel := chainsel.APTOS_TESTNET.Selector
 
 	ds := datastore.NewMemoryDataStore()
-	seedAptosAddresses(t, ds, ocrSel, aptosSel,
-		"0x1111111111111111111111111111111111111111",
-		"0x2222222222222222222222222222222222222222222222222222222222222222",
-	)
+	seedAptosAddresses(t, ds, ocrSel, "0x1111111111111111111111111111111111111111")
 	env.DataStore = ds.Seal()
 
 	base := freshAptosBase(ocrSel, aptosSel)
@@ -157,13 +140,6 @@ func TestProposeAptosCapJobSpec_VerifyPreconditions_missingAddresses(t *testing.
 
 	t.Run("missing OCR address", func(t *testing.T) {
 		ds := datastore.NewMemoryDataStore()
-		require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
-			ChainSelector: aptosSel,
-			Type:          testForwarderContractType,
-			Version:       semver.MustParse("1.0.0"),
-			Address:       "0x2222222222222222222222222222222222222222222222222222222222222222",
-			Qualifier:     testAptosForwarderQualifier,
-		}))
 		env.DataStore = ds.Seal()
 
 		in := freshAptosBase(ocrSel, aptosSel)
@@ -183,10 +159,7 @@ func TestProposeAptosCapJobSpec_VerifyPreconditions_overrideMismatches(t *testin
 	aptosSel := chainsel.APTOS_TESTNET.Selector
 
 	ds := datastore.NewMemoryDataStore()
-	seedAptosAddresses(t, ds, ocrSel, aptosSel,
-		"0x1111111111111111111111111111111111111111",
-		"0x2222222222222222222222222222222222222222222222222222222222222222",
-	)
+	seedAptosAddresses(t, ds, ocrSel, "0x1111111111111111111111111111111111111111")
 	env.DataStore = ds.Seal()
 
 	base := freshAptosBase(ocrSel, aptosSel)
@@ -240,10 +213,7 @@ func setupAptosCapTest(t *testing.T) aptosCapTestSetup {
 	aptosSel := testEnv.AptosSelector
 
 	ds := datastore.NewMemoryDataStore()
-	seedAptosAddresses(t, ds, ocrSel, aptosSel,
-		"0x1111111111111111111111111111111111111111",
-		"0x2222222222222222222222222222222222222222222222222222222222222222",
-	)
+	seedAptosAddresses(t, ds, ocrSel, "0x1111111111111111111111111111111111111111")
 	env := testEnv.Env
 	env.DataStore = ds.Seal()
 
@@ -284,7 +254,6 @@ func setupAptosCapTest(t *testing.T) aptosCapTestSetup {
 		OCRChainSelector:       ocrSel,
 		BootstrapperOCR3Urls:   []string{"12D3KooWabc@127.0.0.1:5001"},
 		OCRContractQualifier:   testAptosOCRQualifier,
-		ForwardersQualifier:    testAptosForwarderQualifier,
 		CREForwarderAddress:    "0x2222222222222222222222222222222222222222222222222222222222222222",
 		DeltaStage:             time.Second,
 		TxSearchStartingBuffer: 30 * time.Second,

--- a/deployment/cre/jobs/propose_chain_cap_helpers.go
+++ b/deployment/cre/jobs/propose_chain_cap_helpers.go
@@ -55,9 +55,6 @@ func validateCommonFields(f commonCapFields) error {
 	if f.OCRContractQualifier == "" {
 		return errors.New("ocr contract qualifier is required")
 	}
-	// if f.ForwardersQualifier == "" {
-	// 	return errors.New("cre forwarder qualifier is required")
-	// }
 	if f.DeltaStage <= 0 {
 		return fmt.Errorf("deltaStage (%s) must be greater than 0", f.DeltaStage)
 	}

--- a/deployment/cre/jobs/propose_chain_cap_helpers.go
+++ b/deployment/cre/jobs/propose_chain_cap_helpers.go
@@ -21,7 +21,6 @@ type commonCapFields struct {
 	OCRChainSelector     uint64
 	BootstrapperOCR3Urls []string
 	OCRContractQualifier string
-	ForwardersQualifier  string
 	DeltaStage           time.Duration
 }
 

--- a/deployment/cre/jobs/propose_chain_cap_helpers.go
+++ b/deployment/cre/jobs/propose_chain_cap_helpers.go
@@ -55,9 +55,9 @@ func validateCommonFields(f commonCapFields) error {
 	if f.OCRContractQualifier == "" {
 		return errors.New("ocr contract qualifier is required")
 	}
-	if f.ForwardersQualifier == "" {
-		return errors.New("cre forwarder qualifier is required")
-	}
+	// if f.ForwardersQualifier == "" {
+	// 	return errors.New("cre forwarder qualifier is required")
+	// }
 	if f.DeltaStage <= 0 {
 		return fmt.Errorf("deltaStage (%s) must be greater than 0", f.DeltaStage)
 	}

--- a/deployment/cre/jobs/propose_evm_cap.go
+++ b/deployment/cre/jobs/propose_evm_cap.go
@@ -90,7 +90,6 @@ func (u ProposeEVMCapJobSpec) VerifyPreconditions(e cldf.Environment, input Prop
 		OCRChainSelector:     input.OCRChainSelector,
 		BootstrapperOCR3Urls: input.BootstrapperOCR3Urls,
 		OCRContractQualifier: input.OCRContractQualifier,
-		ForwardersQualifier:  input.ForwardersQualifier,
 		DeltaStage:           input.DeltaStage,
 	}); err != nil {
 		return err

--- a/deployment/cre/jobs/propose_evm_cap.go
+++ b/deployment/cre/jobs/propose_evm_cap.go
@@ -96,6 +96,10 @@ func (u ProposeEVMCapJobSpec) VerifyPreconditions(e cldf.Environment, input Prop
 		return err
 	}
 
+	if input.ForwardersQualifier == "" {
+		return errors.New("cre forwarder qualifier is required")
+	}
+
 	chainIDStr, err := chainselectors.GetChainIDFromSelector(input.ChainSelector)
 	if err != nil {
 		return fmt.Errorf("failed to get chainID from selector: %w", err)


### PR DESCRIPTION
- We are using existing keystone forwarders for aptos
- These do not exist in CLD catalog
- We can feed those forwarders into the catalog but that might create confusion later because the forwarders are not owned by the KMS. They are owned by wallets / aptos native msig.
- For now, we are just going to accept it as user input.
- Once, we migrate forwarders to MCMs, we should be able to move the forwarder into catalog and as a result use the ForwarderQualifier.
- Alternatively, we can feed it into catalog by creating a changeset which accepts inputs, skips deployment, and just outputs that, so that the contract gets registered into catalog.
- https://smartcontract-it.atlassian.net/browse/PLEX-2797 Created the ticket to derive from qualifier if we feed into catalog as is