### PR TITLE
fix(ccip): remove unused Solana env from empty-config flaky test [CCIP-10960]

### DIFF
--- a/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config_test.go
+++ b/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config_test.go
@@ -282,10 +282,11 @@ func TestSetTokenTransferFeeConfig_Validations(t *testing.T) {
 }
 
 func TestSetTokenTransferFeeConfig_EmptyConfigIsGracefullyHandled(t *testing.T) {
+	// No Solana chains needed: empty InputsByChain early-exits before any chain interaction.
+	// Including WithSolChains would spin up a Docker container + download .so artifacts,
+	// introducing network and Docker flakiness for a path that never touches those chains.
 	env, _ := testhelpers.NewMemoryEnvironment(t,
-		testhelpers.WithCCIPSolanaContractVersion(ccip_cs_sol_v0_1_1.SolanaContractV0_1_1),
 		testhelpers.WithNumOfChains(2),
-		testhelpers.WithSolChains(1),
 	)
 
 	_, err := commonchangeset.Apply(t, env.Env,


### PR DESCRIPTION
## Summary

- Fixes flaky test `TestSetTokenTransferFeeConfig_EmptyConfigIsGracefullyHandled` in `deployment/ccip/changeset/crossfamily`
- Jira: [CCIP-10960](https://smartcontract-it.atlassian.net/browse/CCIP-10960)
- Trunk flaky test: https://app.trunk.io/chainlink/flaky-tests/test/0d675f65-acb7-53e2-b83b-7d3b4c5a8558/?repo=smartcontractkit%2Fchainlink

## Root Cause

The test called `testhelpers.NewMemoryEnvironment` with `WithSolChains(1)` and `WithCCIPSolanaContractVersion(SolanaContractV0_1_1)`, which triggers two expensive, non-deterministic operations:

1. **Network download** — `soltestutils.LoadCCIPPrograms` downloads Solana `.so` program artifacts from the internet via `downloadChainlinkCCIPProgramArtifacts` (guarded by a `sync.Once`)
2. **Docker container startup** — `environment.WithSolanaContainerN` starts a Solana test-validator Docker container

Neither operation is ever used. Both `setTokenTransferFeePrecondition` and `setTokenTransferFeeLogic` guard with an early-exit:

```go
if len(cfg.InputsByChain) == 0 {
    env.Logger.Info("no inputs were provided - exiting gracefully")
    return nil
}
```

With an empty `SetTokenTransferFeeConfigInput{}`, execution returns before touching any chain.

**Failure modes observed in CI:**
- `require.NoError` on Docker container startup (port conflict / slow startup)
- Network timeout downloading `.so` artifacts
- Cascading `file not found` errors: `sync.Once` in `downloadChainlinkCCIPProgramArtifacts` marks the download as done even when it fails via `t.FailNow()`, leaving subsequent parallel tests with an empty cache

## Fix

Removed `WithCCIPSolanaContractVersion` and `WithSolChains(1)` from `TestSetTokenTransferFeeConfig_EmptyConfigIsGracefullyHandled`. The test now uses a pure in-memory EVM environment (2 simulated chains) — fully deterministic, no Docker, no network.

The test intent is unchanged: it still verifies that an empty `SetTokenTransferFeeConfigInput{}` is handled gracefully.

## Steps to Reproduce (before fix)

```sh
cd deployment

# Stress-run to surface the flake
go test ./ccip/changeset/crossfamily/... \
  -run '^TestSetTokenTransferFeeConfig_EmptyConfigIsGracefullyHandled$' \
  -count 100 -failfast -v

# With race detector
GORACE="log_path=$PWD/race" go test -race -shuffle on -timeout 60s -count 50 \
  ./ccip/changeset/crossfamily/... \
  -run '^TestSetTokenTransferFeeConfig_EmptyConfigIsGracefullyHandled$' -failfast
```

## Test Plan

- [ ] `go test ./deployment/ccip/changeset/crossfamily/... -run '^TestSetTokenTransferFeeConfig_EmptyConfigIsGracefullyHandled$' -count 100 -failfast` passes reliably
- [ ] All other tests in the `crossfamily` package pass (they keep their Solana environments where needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCIP-10960]: https://smartcontract-it.atlassian.net/browse/CCIP-10960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ