### PR TITLE
CCIP - disable broken changeset tests

### DIFF
--- a/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config_test.go
+++ b/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config_test.go
@@ -90,6 +90,8 @@ func getSolanaTokenTransferFeeConfig(t *testing.T, tEnv cldf.Environment, srcSel
 }
 
 func TestSetTokenTransferFeeConfig_Validations(t *testing.T) {
+	t.Skip("broken")
+
 	// Build a mixed env with EVM + non-EVM so we can validate both families in one table-driven test
 	env, _ := testhelpers.NewMemoryEnvironment(t,
 		testhelpers.WithCCIPSolanaContractVersion(ccip_cs_sol_v0_1_1.SolanaContractV0_1_1),

--- a/deployment/ccip/changeset/v1_6_2/cs_configure_cctp_message_transmitter_proxy_test.go
+++ b/deployment/ccip/changeset/v1_6_2/cs_configure_cctp_message_transmitter_proxy_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
-	"github.com/smartcontractkit/quarantine"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6_2"
 
@@ -187,8 +186,6 @@ func TestValidateConfigureCCTPMessageTransmitterProxyInput(t *testing.T) {
 
 func TestConfigureCCTPMessageTransmitterProxy(t *testing.T) {
 	t.Skip("broken")
-	
-	quarantine.Flaky(t, "DX-2064")
 
 	rt := setupCCTPMsgTransmitterProxyEnvironmentForConfigure(t, true)
 	evmChainsBySel := rt.Environment().BlockChains.EVMChains()

--- a/deployment/ccip/changeset/v1_6_2/cs_configure_cctp_message_transmitter_proxy_test.go
+++ b/deployment/ccip/changeset/v1_6_2/cs_configure_cctp_message_transmitter_proxy_test.go
@@ -186,6 +186,8 @@ func TestValidateConfigureCCTPMessageTransmitterProxyInput(t *testing.T) {
 }
 
 func TestConfigureCCTPMessageTransmitterProxy(t *testing.T) {
+	t.Skip("broken")
+	
 	quarantine.Flaky(t, "DX-2064")
 
 	rt := setupCCTPMsgTransmitterProxyEnvironmentForConfigure(t, true)

--- a/deployment/common/changeset/example/solana_transfer_mcm_test.go
+++ b/deployment/common/changeset/example/solana_transfer_mcm_test.go
@@ -188,6 +188,8 @@ func TestTransferFromTimelockConfig_VerifyPreconditions(t *testing.T) {
 }
 
 func TestTransferFromTimelockConfig_Apply(t *testing.T) {
+	t.Skip("broken")
+	
 	quarantine.Flaky(t, "DX-1754")
 	t.Parallel()
 

--- a/deployment/common/changeset/example/solana_transfer_mcm_test.go
+++ b/deployment/common/changeset/example/solana_transfer_mcm_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gagliardetto/solana-go/rpc"
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
-	"github.com/smartcontractkit/quarantine"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -189,8 +188,6 @@ func TestTransferFromTimelockConfig_VerifyPreconditions(t *testing.T) {
 
 func TestTransferFromTimelockConfig_Apply(t *testing.T) {
 	t.Skip("broken")
-	
-	quarantine.Flaky(t, "DX-1754")
 	t.Parallel()
 
 	selector := chainselectors.TEST_22222222222222222222222222222222222222222222.Selector


### PR DESCRIPTION
Disables:
1. `TestSetTokenTransferFeeConfig_Validations`
2. `TestConfigureCCTPMessageTransmitterProxy`
3. `TestTransferFromTimelockConfig_Apply`