### PR TITLE
fix(ccip/integration-tests): mine each tx in commitSqNrs to avoid nonce race

### DIFF
--- a/integration-tests/smoke/ccip/ccip_reader_test.go
+++ b/integration-tests/smoke/ccip/ccip_reader_test.go
@@ -1221,6 +1221,7 @@ func commitSqNrs(
 		if err != nil {
 			return err
 		}
+		s.sb.Commit()
 	}
 	return nil
 }


### PR DESCRIPTION
## Smoking gun

```
ccip_reader_test.go:515:
    Error Trace: .../integration-tests/smoke/ccip/ccip_reader_test.go:515
    Error:       Received unexpected error:
                 replacement transaction underpriced
    Test:        TestCCIPReader_ExecutedMessages_MultiChainDisjoint
```

CI: smartcontractkit/chainlink#22016 run [24424913522](https://github.com/smartcontractkit/chainlink/actions/runs/24424913522) job 71356857697. Reproduces on base branch (not introduced by #22016).

## Root cause

`commitSqNrs` (ccip_reader_test.go:1204) loops `EmitExecutionStateChanged` with no `Commit()` between iterations:

```go
for _, sqnr := range seqNums {
    _, err := s.contract.EmitExecutionStateChanged(s.auth, ...)
    ...
}
```

Generated binding in `chainlink-ccip/.../ccip_reader_tester/ccip_reader_tester.go:357` is a straight-through `contract.Transact(opts, "emitExecutionStateChanged", ...)` — it sends a tx to the simulated mempool and does **not** mine. Only `s.sb.Commit()` mines.

`s.auth` is constructed by `setupSimulatedBackendAndAuth` with `Nonce==nil`, so `BoundContract.transact` calls `PendingNonceAt(opts.From)` for each tx. On `ethclient/simulated` the pending-pool nonce update is asynchronous with `SendTransaction` returning, so two back-to-back sends can read the same pending nonce. The second tx then lands at an already-occupied mempool nonce with the same suggested gas price → go-ethereum returns `ErrReplaceUnderpriced` ("replacement transaction underpriced").

## Why only `_MultiChainDisjoint`

Only that test passes multi-element `seqNums`:

| Caller (line) | `seqNums` | Loops? |
|---|---|---|
| 429, 433, 437, 441, 471, 475 | 1 element | no |
| **514** | `[15, 17, 70]` | **yes** |
| **518** | `[15, 16]` | **yes** |

Single-element callers never hit the race.

## Fix

Mirror `emitCommitReports` (line 1635), which already commits inside its loop. Add `s.sb.Commit()` at the end of each iteration of `commitSqNrs` so the next iteration's `PendingNonceAt` sees the bumped state nonce. Single-element callers are unaffected — the extra commit is an empty block after the existing outer `Commit()`; `lp.Replay(ctx, 1)` reads from block 1 regardless.

## Verification

`go test -count=10 -run TestCCIPReader_ExecutedMessages_MultiChainDisjoint ./integration-tests/smoke/ccip/` — 10/10 green.
Full `TestCCIPReader_ExecutedMessages*` — green.

## Scope

Single file, +1 line. No production code touched.

