### PR TITLE
[DX-3584] Run smoke tests after releasing an image

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -208,18 +208,16 @@ jobs:
             ccip-prereleases-prod-testnet
 
   post-build:
-    needs: [docker-core, docker-ccip]
-    name: Post-Build Actions
-    uses: ./.github/workflows/post-build.yml
+    needs: [docker-core]
+    name: Post Build Checks
+    uses: ./.github/workflows/post-build-publish.yml
     secrets: inherit
     permissions:
       actions: read
-      checks: write
       id-token: write
       contents: read
     with:
-      chainlink_core_full_image: ${{ needs.docker-core.result == 'success' && format('public.ecr.aws/chainlink/chainlink:{0}|{1}', needs.docker-core.outputs.docker-manifest-tag, needs.docker-core.outputs.docker-manifest-digest) || '' }}
-      chainlink_ccip_full_image: ${{ needs.docker-ccip.result == 'success' && format('public.ecr.aws/chainlink/ccip:{0}|{1}', needs.docker-ccip.outputs.docker-manifest-tag, needs.docker-ccip.outputs.docker-manifest-digest) || '' }}
+      chainlink_core_image_tag: ${{ format('{0}|{1}', needs.docker-core.outputs.docker-manifest-tag, needs.docker-core.outputs.docker-manifest-digest) }}
       chainlink_version: ${{ github.ref_name }}
 
   # Notify Slack channel for new git tags associated with pre-releases.

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -217,7 +217,7 @@ jobs:
       id-token: write
       contents: read
     with:
-      chainlink_core_image_tag: ${{ format('{0}|{1}', needs.docker-core.outputs.docker-manifest-tag, needs.docker-core.outputs.docker-manifest-digest) }}
+      chainlink_core_image_tag: ${{ needs.docker-core.outputs.docker-manifest-tag }}
       chainlink_version: ${{ github.ref_name }}
 
   # Notify Slack channel for new git tags associated with pre-releases.

--- a/.github/workflows/devenv-compat.yml
+++ b/.github/workflows/devenv-compat.yml
@@ -73,6 +73,7 @@ on:
 
 jobs:
   compatibility:
+    name: Upgrade Compatibility Test for ${{ inputs.product }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/devenv-compat.yml
+++ b/.github/workflows/devenv-compat.yml
@@ -73,7 +73,7 @@ on:
 
 jobs:
   compatibility:
-    name: Upgrade Compatibility Test for ${{ inputs.product }}
+    name: Upgrade Compatibility Test
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/post-build-publish.yml
+++ b/.github/workflows/post-build-publish.yml
@@ -24,7 +24,6 @@ jobs:
         uses: ./.github/workflows/devenv-compat.yml
         name: Data Feeds v1 Upgrade Test
         with:
-            product: "Data Feeds v1"
             buildcmd: "just cli"
             envcmd: "cl u env.toml,products/ocr2/basic.toml"
             testcmd: "cl test ocr2 TestSmoke/rounds"
@@ -45,7 +44,6 @@ jobs:
         uses: ./.github/workflows/devenv-compat.yml
         name: CRE Upgrade Test
         with:
-            product: "CRE"
             buildcmd: "echo nothing-to-build" # added to prevent `just cli` from being used (default buildcmd if not provided)
             envcmd: "go run -C ../../core/scripts/cre/environment . env start"
             testcmd: "go test -v -run Test_Upgrade_Suite ./smoke/cre"

--- a/.github/workflows/post-build-publish.yml
+++ b/.github/workflows/post-build-publish.yml
@@ -1,17 +1,13 @@
-name: "Post-Build Chainlink"
+name: "Post Build, Sign and Publish Chainlink"
 
 on:
     # to be used with post-release tests
     workflow_call:
         inputs:
-            chainlink_core_full_image:
+            chainlink_core_image_tag:
                 required: false
                 type: string
-                description: "The Chainlink (core) image to use for the tests."
-            chainlink_ccip_full_image:
-                required: false
-                type: string
-                description: "The Chainlink (CCIP) image to use for the tests."
+                description: "The Chainlink (core) image tagto use for the tests."
             chainlink_version:
                 required: false
                 type: string
@@ -19,7 +15,6 @@ on:
 
 permissions:
     actions: read
-    checks: write
     id-token: write
     contents: read
 
@@ -29,6 +24,7 @@ jobs:
         uses: ./.github/workflows/devenv-compat.yml
         name: Data Feeds v1 Upgrade Test
         with:
+            product: "Data Feeds v1"
             buildcmd: "just cli"
             envcmd: "cl u env.toml,products/ocr2/basic.toml"
             testcmd: "cl test ocr2 TestSmoke/rounds"
@@ -49,6 +45,7 @@ jobs:
         uses: ./.github/workflows/devenv-compat.yml
         name: CRE Upgrade Test
         with:
+            product: "CRE"
             buildcmd: "echo nothing-to-build" # added to prevent `just cli` from being used (default buildcmd if not provided)
             envcmd: "go run -C ../../core/scripts/cre/environment . env start"
             testcmd: "go test -v -run Test_Upgrade_Suite ./smoke/cre"
@@ -63,4 +60,45 @@ jobs:
             logs-directory: "./system-tests/tests/smoke/cre/logs"
             ctf-log-level: "debug"
             strip-image-suffix: "v"
+        secrets: inherit
+
+    legacy-system-tests:
+        name: Legacy Smoke Tests
+        permissions:
+            contents: read
+            id-token: write
+        uses: ./.github/workflows/legacy-system-tests.yml
+        with:
+            ecr: "public"
+            chainlink_version: ${{ inputs.chainlink_version }}
+            chainlink_image_repository_path: "chainlink/chainlink"
+            chainlink_image_tag: ${{ inputs.chainlink_core_image_tag }}
+        secrets: inherit
+
+    cre-smoke-tests:
+        name: CRE Smoke Tests
+        permissions:
+            actions: read
+            contents: read
+            id-token: write
+        uses: ./.github/workflows/cre-system-tests.yaml
+        with:
+            ecr: "public"
+            chainlink_image_repository_path: "chainlink/chainlink"
+            chainlink_version: ${{ inputs.chainlink_version }}
+            chainlink_image_tag: ${{ inputs.chainlink_core_image_tag }}
+        secrets: inherit
+
+    cre-regression-tests:
+        name: CRE Regression Tests
+        permissions:
+            actions: read
+            contents: read
+            id-token: write
+        uses: ./.github/workflows/cre-regression-system-tests.yaml
+        with:
+            ecr: "public"
+            chainlink_image_repository_path: "chainlink/chainlink"
+            chainlink_version: ${{ inputs.chainlink_version }}
+            chainlink_image_tag: ${{ inputs.chainlink_core_image_tag }}
         secrets: inherit


### PR DESCRIPTION
When a new image has been published we will now run:
- CRE smoke tests
- CRE regression tests
- legacy smoke tests

Example run via "hacked" [Docker Build](https://github.com/smartcontractkit/chainlink/actions/runs/24500925868) ✅ :
- no problems with permissions
- correct image was resolved and used in tests

<img width="297" height="806" alt="image" src="https://github.com/user-attachments/assets/34a7a2c5-eb04-424a-b573-b8dfa06e22b1" />
