### PR TITLE
fix: add BalanceAt mock to prevent balance monitor race

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -631,6 +631,7 @@ func NewEthMocksWithStartupAssertions(t testing.TB) *clienttest.Client {
 	c.On("CodeAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return([]byte{}, nil)
 	c.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(uint64(0), nil)
 	c.On("PendingNonceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(uint64(0), nil)
+	c.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(big.NewInt(0), nil)
 	c.On("Close").Maybe().Return()
 	c.On("BatchCallContext", mock.Anything, mock.Anything).Maybe().Return(nil)
 


### PR DESCRIPTION
## Summary

Adds a default `BalanceAt` mock expectation to `NewEthMocksWithStartupAssertions`, preventing a data race when the EVM balance monitor is enabled.

## Root Cause

`NewEthMocksWithStartupAssertions` sets up common mock expectations but **omits `BalanceAt`**. When a test enables the balance monitor (default behavior), its background `SleeperTask` worker calls `BalanceAt` on the mock client. With no matching expectation, testify hits its "unexpected method call" error path, which calls `callString()` → `fmt.Sprintf("%#v", ctx)` → reflect-reads the context. This races with concurrent context cancellation during test teardown.

### Race stack trace (from CI)

```
Read by goroutine 3144:        // BalanceAt → mock.callString → fmt.Sprintf → reflect
  github.com/stretchr/testify/mock.callString()        mock.go:463
  github.com/stretchr/testify/mock.(*Mock).MethodCalled()  mock.go:507  ← ERROR PATH
  github.com/smartcontractkit/chainlink-evm/pkg/monitor.(*worker).checkAccountBalance()

Previous write by goroutine 2837:   // context cancel() during teardown
  sync/atomic.AddInt32()
  github.com/smartcontractkit/chainlink-common/pkg/services.StopRChan.CtxCancel.func1()
```

Note: `mock.go:507` is the "method called over N times" / unexpected call error path — this only fires because there's no `BalanceAt` expectation at all.

## Fix

One line: add `BalanceAt` with `.Maybe()` to the mock helper. This gives the balance monitor a matching expectation with unlimited repeatability, so `callString()` is never invoked.

## Related

- Root cause fix (upstream): https://github.com/smartcontractkit/chainlink-common/pull/1984
- Previous fix attempt: https://github.com/smartcontractkit/chainlink/pull/21397
- Failing CI run: https://github.com/smartcontractkit/chainlink/actions/runs/24509952973/job/71638172320
