### PR TITLE
fix: add Maybe BalanceAt expectations to tests missing them

### DIFF
--- a/core/internal/features/features_test.go
+++ b/core/internal/features/features_test.go
@@ -86,6 +86,7 @@ func TestIntegration_ExternalInitiatorV2(t *testing.T) {
 
 	ctx := testutils.Context(t)
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
+	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(big.NewInt(0), nil)
 
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.JobPipeline.ExternalInitiatorsEnabled = ptr(true)

--- a/core/services/job/runner_integration_test.go
+++ b/core/services/job/runner_integration_test.go
@@ -784,6 +784,7 @@ func TestRunner_Success_Callback_AsyncJob(t *testing.T) {
 	t.Parallel()
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
+	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(big.NewInt(0), nil)
 
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		t := true
@@ -963,6 +964,7 @@ func TestRunner_Error_Callback_AsyncJob(t *testing.T) {
 	t.Parallel()
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
+	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(big.NewInt(0), nil)
 
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		t := true

--- a/core/services/pipeline/task.eth_call_test.go
+++ b/core/services/pipeline/task.eth_call_test.go
@@ -297,6 +297,7 @@ func TestETHCallTask(t *testing.T) {
 			}
 
 			ethClient := clienttest.NewClient(t)
+			ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(big.NewInt(0), nil)
 			config := pipelinemocks.NewConfig(t)
 			test.setupClientMocks(ethClient, config)
 

--- a/core/services/relay/evm/write_target_test.go
+++ b/core/services/relay/evm/write_target_test.go
@@ -125,6 +125,7 @@ func TestEvmWrite(t *testing.T) {
 	ht.On("LatestAndFinalizedBlock", mock.Anything).Return(&evmtypes.Head{Number: 99}, &evmtypes.Head{}, nil)
 	chain.On("HeadTracker").Return(ht)
 
+	evmClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(big.NewInt(0), nil)
 	chain.On("Client").Return(evmClient)
 
 	evmCfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {

--- a/core/services/vrf/v2/integration_v2_test.go
+++ b/core/services/vrf/v2/integration_v2_test.go
@@ -2129,6 +2129,7 @@ func TestStartingCountsV1(t *testing.T) {
 	ec.On("Dial", mock.Anything).Maybe().Return(nil)
 	ec.On("Close").Maybe().Return(nil)
 	ec.On("ConfiguredChainID").Return(testutils.SimulatedChainID)
+	ec.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(big.NewInt(0), nil)
 	ec.On("LatestBlockHeight", mock.Anything).Return(big.NewInt(2), nil).Maybe()
 	txm := makeTestTxm(t, txStore, ks.Eth(), ec)
 	legacyChains := evmtest.NewLegacyChains(t, evmtest.TestChainOpts{

--- a/core/web/pipeline_runs_controller_test.go
+++ b/core/web/pipeline_runs_controller_test.go
@@ -3,8 +3,8 @@ package web_test
 import (
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"io"
+	"math/big"
 	"net/http"
 	"net/url"
 	"strconv"

--- a/core/web/pipeline_runs_controller_test.go
+++ b/core/web/pipeline_runs_controller_test.go
@@ -3,6 +3,7 @@ package web_test
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"io"
 	"net/http"
 	"net/url"
@@ -36,6 +37,7 @@ func TestPipelineRunsController_CreateWithBody_HappyPath(t *testing.T) {
 
 	ctx := testutils.Context(t)
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
+	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(big.NewInt(0), nil)
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.JobPipeline.HTTPRequest.DefaultTimeout = commonconfig.MustNewDuration(2 * time.Second)
 		c.Database.Listener.FallbackPollInterval = commonconfig.MustNewDuration(10 * time.Millisecond)
@@ -92,6 +94,7 @@ func TestPipelineRunsController_CreateNoBody_HappyPath(t *testing.T) {
 
 	ctx := testutils.Context(t)
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
+	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(big.NewInt(0), nil)
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.JobPipeline.HTTPRequest.DefaultTimeout = commonconfig.MustNewDuration(2 * time.Second)
 		c.Database.Listener.FallbackPollInterval = commonconfig.MustNewDuration(10 * time.Millisecond)


### PR DESCRIPTION
## Summary

Adds `.Maybe()` BalanceAt mock expectations to 8 tests that use mock eth clients without their own BalanceAt expectation. This prevents a data race in `go_core_race_tests`.

## Problem

Tests that create chains with mock clients but complete quickly may never need a `BalanceAt` expectation. However, the balance monitor's background worker can fire during shutdown, calling `BalanceAt` on the mock. With no matching expectation, testify hits its "unexpected method call" error path, which calls `callString()` → `fmt.Sprintf("%#v", ctx)` — an unsynchronized reflect read that races with concurrent context cancellation.

testify's `callString()` reflecting into arguments is fundamentally broken (unsynchronized), but an upstream fix was rejected. The workaround: make the call expected so testify takes the happy path (match → return, no reflect).

## Fix

Added to each vulnerable test:
```go
ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(big.NewInt(0), nil)
```

`.Maybe()` means "this call might happen, I don't care either way." If the balance monitor calls `BalanceAt`, testify matches it and returns — no reflect, no race. If it doesn't call it, `AssertExpectations` doesn't complain.

## Tests Modified

| File | Test |
|------|------|
| `core/internal/features/features_test.go` | `TestIntegration_ExternalInitiatorV2` |
| `core/services/job/runner_integration_test.go` | `TestRunner_Success_Callback_AsyncJob` |
| `core/services/job/runner_integration_test.go` | `TestRunner_Error_Callback_AsyncJob` |
| `core/services/pipeline/task.eth_call_test.go` | `TestETHCallTask` |
| `core/services/relay/evm/write_target_test.go` | `TestEvmWrite` |
| `core/services/vrf/v2/integration_v2_test.go` | `TestStartingCountsV1` |
| `core/web/pipeline_runs_controller_test.go` | `TestPipelineRunsController_CreateWithBody_HappyPath` |
| `core/web/pipeline_runs_controller_test.go` | `TestPipelineRunsController_CreateNoBody_HappyPath` |

## Related

- Root cause fix (shutdown ordering): https://github.com/smartcontractkit/chainlink-evm/pull/425
- Defense-in-depth (context impl): https://github.com/smartcontractkit/chainlink-common/pull/1984
- Failing CI: https://github.com/smartcontractkit/chainlink/actions/runs/24509952973/job/71638172320
