### PR TITLE
Wire confidential relay service into CRE startup

### DIFF
--- a/.changeset/confidential-workflow-execution.md
+++ b/.changeset/confidential-workflow-execution.md
@@ -2,4 +2,4 @@
 "chainlink": minor
 ---
 
-Wire confidential relay service into CRE startup and support HTTP URLs in file fetcher for local confidential workflow testing #added
+Wire confidential relay service into CRE startup #added

--- a/.changeset/confidential-workflow-execution.md
+++ b/.changeset/confidential-workflow-execution.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Wire confidential relay service into CRE startup and support HTTP URLs in file fetcher for local confidential workflow testing #added

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -173,13 +173,15 @@ func (s *Services) newSubservices(
 		s.GatewayConnectorWrapper = gatewayConnectorWrapper
 		srvs = append(srvs, gatewayConnectorWrapper)
 
-		relayService := confidentialrelay.NewService(
-			gatewayConnectorWrapper,
-			opts.CapabilitiesRegistry,
-			lggr,
-			opts.LimitsFactory,
-		)
-		srvs = append(srvs, relayService)
+		if cfg.CRE().ConfidentialRelay().Enabled() {
+			relayService := confidentialrelay.NewService(
+				gatewayConnectorWrapper,
+				opts.CapabilitiesRegistry,
+				lggr,
+				opts.LimitsFactory,
+			)
+			srvs = append(srvs, relayService)
+		}
 	}
 
 	if cfg.CRE().Linking().URL() != "" {

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/compute"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/confidentialrelay"
 	gatewayconnector "github.com/smartcontractkit/chainlink/v2/core/capabilities/gateway_connector"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/localcapmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
@@ -171,6 +172,14 @@ func (s *Services) newSubservices(
 		}
 		s.GatewayConnectorWrapper = gatewayConnectorWrapper
 		srvs = append(srvs, gatewayConnectorWrapper)
+
+		relayService := confidentialrelay.NewService(
+			gatewayConnectorWrapper,
+			opts.CapabilitiesRegistry,
+			lggr,
+			opts.LimitsFactory,
+		)
+		srvs = append(srvs, relayService)
 	}
 
 	if cfg.CRE().Linking().URL() != "" {


### PR DESCRIPTION
## Summary
- Register `confidentialrelay.NewService` as a CRE subservice so the relay DON handler starts alongside the gateway connector.