### PR TITLE
Remove unused BinaryURLResolver from ConfidentialModule

### DIFF
--- a/.changeset/remove-binary-url-resolver.md
+++ b/.changeset/remove-binary-url-resolver.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-Remove unused BinaryURLResolver from ConfidentialModule (PRIV-389 credentials sidecar) #changed
+Remove unused BinaryURLResolver from ConfidentialModule (PRIV-389 credentials sidecar)

--- a/.changeset/remove-binary-url-resolver.md
+++ b/.changeset/remove-binary-url-resolver.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Remove unused BinaryURLResolver from ConfidentialModule (PRIV-389 credentials sidecar) #changed

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -933,16 +933,12 @@ func (h *eventHandler) confidentialEngineFactory(
 	lggr := logger.Named(h.lggr, "WorkflowEngine.ConfidentialModule")
 	lggr = logger.With(lggr, "workflowID", spec.WorkflowID, "workflowName", spec.WorkflowName, "workflowOwner", spec.WorkflowOwner)
 
-	// nil resolver: raw binaryURL is passed to the enclave as-is.
-	// PR 5/5 (#21642) wires this to the storage service retriever
-	// so the enclave receives a presigned URL.
 	module := v2.NewConfidentialModule(
 		h.capRegistry,
 		spec.BinaryURL,
 		binaryHash,
 		spec.WorkflowID, spec.WorkflowOwner, workflowName.String(), spec.WorkflowTag,
 		attrs.VaultDonSecrets,
-		nil,
 		lggr,
 	)
 

--- a/core/services/workflows/v2/confidential_module.go
+++ b/core/services/workflows/v2/confidential_module.go
@@ -58,26 +58,19 @@ func IsConfidential(data []byte) (bool, error) {
 	return attrs.Confidential, nil
 }
 
-// BinaryURLResolver resolves a raw binary URL into an ephemeral/presigned
-// URL that the enclave can fetch without authentication. In production this
-// calls the CRE storage service; nil means the raw URL is used as-is.
-// PR 5/5 (#21642) wires this to the storage service retriever.
-type BinaryURLResolver func(ctx context.Context, workflowID string) (string, error)
-
 // ConfidentialModule implements host.ModuleV2 for confidential workflows.
 // Instead of running WASM locally, it delegates execution to the
 // confidential-workflows capability via the CapabilitiesRegistry.
 type ConfidentialModule struct {
-	capRegistry       core.CapabilitiesRegistry
-	binaryURL         string
-	binaryHash        []byte
-	workflowID        string
-	workflowOwner     string
-	workflowName      string
-	workflowTag       string
-	vaultDonSecrets   []SecretIdentifier
-	binaryURLResolver BinaryURLResolver
-	lggr              logger.Logger
+	capRegistry     core.CapabilitiesRegistry
+	binaryURL       string
+	binaryHash      []byte
+	workflowID      string
+	workflowOwner   string
+	workflowName    string
+	workflowTag     string
+	vaultDonSecrets []SecretIdentifier
+	lggr            logger.Logger
 }
 
 var _ host.ModuleV2 = (*ConfidentialModule)(nil)
@@ -88,20 +81,18 @@ func NewConfidentialModule(
 	binaryHash []byte,
 	workflowID, workflowOwner, workflowName, workflowTag string,
 	vaultDonSecrets []SecretIdentifier,
-	binaryURLResolver BinaryURLResolver,
 	lggr logger.Logger,
 ) *ConfidentialModule {
 	return &ConfidentialModule{
-		capRegistry:       capRegistry,
-		binaryURL:         binaryURL,
-		binaryHash:        binaryHash,
-		workflowID:        workflowID,
-		workflowOwner:     workflowOwner,
-		workflowName:      workflowName,
-		workflowTag:       workflowTag,
-		vaultDonSecrets:   vaultDonSecrets,
-		binaryURLResolver: binaryURLResolver,
-		lggr:              lggr,
+		capRegistry:     capRegistry,
+		binaryURL:       binaryURL,
+		binaryHash:      binaryHash,
+		workflowID:      workflowID,
+		workflowOwner:   workflowOwner,
+		workflowName:    workflowName,
+		workflowTag:     workflowTag,
+		vaultDonSecrets: vaultDonSecrets,
+		lggr:            lggr,
 	}
 }
 
@@ -132,20 +123,11 @@ func (m *ConfidentialModule) Execute(
 		}
 	}
 
-	binaryURL := m.binaryURL
-	if m.binaryURLResolver != nil {
-		resolved, resolveErr := m.binaryURLResolver(ctx, m.workflowID)
-		if resolveErr != nil {
-			return nil, fmt.Errorf("failed to resolve binary URL: %w", resolveErr)
-		}
-		binaryURL = resolved
-	}
-
 	capInput := &confworkflowtypes.ConfidentialWorkflowRequest{
 		VaultDonSecrets: protoSecrets,
 		Execution: &confworkflowtypes.WorkflowExecution{
 			WorkflowId:     m.workflowID,
-			BinaryUrl:      binaryURL,
+			BinaryUrl:      m.binaryURL,
 			BinaryHash:     m.binaryHash,
 			ExecuteRequest: execReqBytes,
 			Owner:          m.workflowOwner,

--- a/core/services/workflows/v2/confidential_module_test.go
+++ b/core/services/workflows/v2/confidential_module_test.go
@@ -176,7 +176,6 @@ func TestConfidentialModule_Execute(t *testing.T) {
 				{Key: "API_KEY"},
 				{Key: "SIGNING_KEY", Namespace: "custom-ns"},
 			},
-			nil,
 			lggr,
 		)
 
@@ -210,7 +209,6 @@ func TestConfidentialModule_Execute(t *testing.T) {
 			[]byte("hash"),
 			"wf-1", "owner", "name", "tag",
 			[]SecretIdentifier{{Key: "SECRET_A"}}, // no namespace
-			nil,
 			lggr,
 		)
 
@@ -231,7 +229,7 @@ func TestConfidentialModule_Execute(t *testing.T) {
 			Return(nil, errors.New("capability not found")).Once()
 
 		mod := NewConfidentialModule(
-			capReg, "", nil, "wf", "owner", "name", "tag", nil, nil, lggr,
+			capReg, "", nil, "wf", "owner", "name", "tag", nil, lggr,
 		)
 
 		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{})
@@ -249,7 +247,7 @@ func TestConfidentialModule_Execute(t *testing.T) {
 			Return(capabilities.CapabilityResponse{}, errors.New("enclave unavailable")).Once()
 
 		mod := NewConfidentialModule(
-			capReg, "", nil, "wf", "owner", "name", "tag", nil, nil, lggr,
+			capReg, "", nil, "wf", "owner", "name", "tag", nil, lggr,
 		)
 
 		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{})
@@ -267,7 +265,7 @@ func TestConfidentialModule_Execute(t *testing.T) {
 			Return(capabilities.CapabilityResponse{Payload: nil}, nil).Once()
 
 		mod := NewConfidentialModule(
-			capReg, "", nil, "wf", "owner", "name", "tag", nil, nil, lggr,
+			capReg, "", nil, "wf", "owner", "name", "tag", nil, lggr,
 		)
 
 		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{})
@@ -302,7 +300,6 @@ func TestConfidentialModule_Execute(t *testing.T) {
 				{Key: "K1", Namespace: "ns1"},
 				{Key: "K2"},
 			},
-			nil,
 			lggr,
 		)
 
@@ -337,100 +334,6 @@ func TestConfidentialModule_Execute(t *testing.T) {
 		assert.Equal(t, "ns1", confReq.VaultDonSecrets[0].GetNamespace())
 		assert.Equal(t, "K2", confReq.VaultDonSecrets[1].Key)
 		assert.Equal(t, "main", confReq.VaultDonSecrets[1].GetNamespace())
-	})
-}
-
-func TestConfidentialModule_BinaryURLResolver(t *testing.T) {
-	ctx := context.Background()
-	lggr := logger.Nop()
-
-	execReq := &sdkpb.ExecuteRequest{Config: []byte("cfg")}
-
-	expectedResult := &sdkpb.ExecutionResult{
-		Result: &sdkpb.ExecutionResult_Value{
-			Value: valuespb.NewStringValue("ok"),
-		},
-	}
-	resultBytes, err := proto.Marshal(expectedResult)
-	require.NoError(t, err)
-	confResp := &confworkflowtypes.ConfidentialWorkflowResponse{ExecutionResult: resultBytes}
-	respPayload, err := anypb.New(confResp)
-	require.NoError(t, err)
-
-	t.Run("resolver replaces binary URL", func(t *testing.T) {
-		capReg := regmocks.NewCapabilitiesRegistry(t)
-		execCap := capmocks.NewExecutableCapability(t)
-
-		capReg.EXPECT().GetExecutable(matches.AnyContext, confidentialWorkflowsCapabilityID).
-			Return(execCap, nil).Once()
-
-		var capturedReq capabilities.CapabilityRequest
-		execCap.EXPECT().Execute(matches.AnyContext, mock.Anything).
-			Run(func(_ context.Context, req capabilities.CapabilityRequest) {
-				capturedReq = req
-			}).
-			Return(capabilities.CapabilityResponse{Payload: respPayload}, nil).Once()
-
-		resolver := func(_ context.Context, wfID string) (string, error) {
-			return "https://presigned.example.com/" + wfID + "?token=abc", nil
-		}
-
-		mod := NewConfidentialModule(
-			capReg, "https://storage.example.com/raw", []byte("hash"),
-			"wf-1", "owner", "name", "tag", nil, resolver, lggr,
-		)
-
-		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{executionID: "exec-1"})
-		require.NoError(t, err)
-
-		var confReq confworkflowtypes.ConfidentialWorkflowRequest
-		require.NoError(t, capturedReq.Payload.UnmarshalTo(&confReq))
-		assert.Equal(t, "https://presigned.example.com/wf-1?token=abc", confReq.Execution.BinaryUrl)
-	})
-
-	t.Run("nil resolver uses raw URL", func(t *testing.T) {
-		capReg := regmocks.NewCapabilitiesRegistry(t)
-		execCap := capmocks.NewExecutableCapability(t)
-
-		capReg.EXPECT().GetExecutable(matches.AnyContext, confidentialWorkflowsCapabilityID).
-			Return(execCap, nil).Once()
-
-		var capturedReq capabilities.CapabilityRequest
-		execCap.EXPECT().Execute(matches.AnyContext, mock.Anything).
-			Run(func(_ context.Context, req capabilities.CapabilityRequest) {
-				capturedReq = req
-			}).
-			Return(capabilities.CapabilityResponse{Payload: respPayload}, nil).Once()
-
-		mod := NewConfidentialModule(
-			capReg, "https://storage.example.com/raw", []byte("hash"),
-			"wf-1", "owner", "name", "tag", nil, nil, lggr,
-		)
-
-		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{executionID: "exec-1"})
-		require.NoError(t, err)
-
-		var confReq confworkflowtypes.ConfidentialWorkflowRequest
-		require.NoError(t, capturedReq.Payload.UnmarshalTo(&confReq))
-		assert.Equal(t, "https://storage.example.com/raw", confReq.Execution.BinaryUrl)
-	})
-
-	t.Run("resolver error propagates", func(t *testing.T) {
-		capReg := regmocks.NewCapabilitiesRegistry(t)
-
-		resolver := func(_ context.Context, _ string) (string, error) {
-			return "", errors.New("storage service unavailable")
-		}
-
-		mod := NewConfidentialModule(
-			capReg, "https://storage.example.com/raw", []byte("hash"),
-			"wf-1", "owner", "name", "tag", nil, resolver, lggr,
-		)
-
-		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{executionID: "exec-1"})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to resolve binary URL")
-		assert.Contains(t, err.Error(), "storage service unavailable")
 	})
 }
 


### PR DESCRIPTION
## Summary
- Remove dead `BinaryURLResolver` type, field, constructor parameter, and runtime nil-check from `ConfidentialModule`.
- The resolver was always `nil`. The enclave authenticates to the storage service via a credentials sidecar (PRIV-389).