### PR TITLE
core/services/vrf/v2: mock SubscribeToHeads to avoid test race

### DIFF
--- a/core/services/vrf/v2/integration_v2_test.go
+++ b/core/services/vrf/v2/integration_v2_test.go
@@ -3,6 +3,7 @@ package v2_test
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -2131,6 +2132,7 @@ func TestStartingCountsV1(t *testing.T) {
 	ec.On("ConfiguredChainID").Return(testutils.SimulatedChainID)
 	ec.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(big.NewInt(0), nil)
 	ec.On("LatestBlockHeight", mock.Anything).Return(big.NewInt(2), nil).Maybe()
+	ec.On("SubscribeToHeads", mock.Anything).Maybe().Return(nil, nil, errors.ErrUnsupported)
 	txm := makeTestTxm(t, txStore, ks.Eth(), ec)
 	legacyChains := evmtest.NewLegacyChains(t, evmtest.TestChainOpts{
 		KeyStore:       ks.Eth(),


### PR DESCRIPTION
~Bumping evm and~ adding a mock call to relieve some test races.

```
==================
WARNING: DATA RACE
Read at 0x00c0017f8510 by goroutine 389985:
  reflect.typedmemmove()
      /usr/local/go/src/runtime/mbarrier.go:213 +0x0
  reflect.packEfaceData()
      /usr/local/go/src/reflect/value.go:143 +0xe8
  reflect.packEface()
      /usr/local/go/src/reflect/value.go:126 +0x15c
  reflect.valueInterface()
      /usr/local/go/src/reflect/value.go:1512 +0x1b0
  reflect.Value.Interface()
      /usr/local/go/src/reflect/value.go:1490 +0x74
  fmt.(*pp).printValue()
      /usr/local/go/src/fmt/print.go:770 +0x80
  fmt.(*pp).printValue()
      /usr/local/go/src/fmt/print.go:922 +0xe38
  fmt.(*pp).printArg()
      /usr/local/go/src/fmt/print.go:760 +0x86c
  fmt.(*pp).doPrintf()
      /usr/local/go/src/fmt/print.go:1075 +0x4d8
  fmt.Sprintf()
      /usr/local/go/src/fmt/print.go:239 +0x50
  github.com/stretchr/testify/mock.callString()
      /Users/jordan/go/pkg/mod/github.com/stretchr/testify@v1.11.1/mock/mock.go:463 +0x350
  github.com/stretchr/testify/mock.(*Mock).MethodCalled()
      /Users/jordan/go/pkg/mod/github.com/stretchr/testify@v1.11.1/mock/mock.go:527 +0x514
  github.com/stretchr/testify/mock.(*Mock).Called()
      /Users/jordan/go/pkg/mod/github.com/stretchr/testify@v1.11.1/mock/mock.go:491 +0x12c
  github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest.(*Client).SubscribeToHeads()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/client/clienttest/client.go:2165 +0xb0
  github.com/smartcontractkit/chainlink-framework/chains/heads.(*listener[go.shape.*uint8,go.shape.interface { Err() <-chan error; Unsubscribe() },go.shape.*uint8,go.shape.[32]uint8]).subscribeToHead()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-framework/chains@v0.0.0-20260326122810-b657beadfb57/heads/listener.go:239 +0x60
  github.com/smartcontractkit/chainlink-framework/chains/heads.(*listener[go.shape.*uint8,go.shape.interface { Err() <-chan error; Unsubscribe() },go.shape.*uint8,go.shape.[32]uint8]).subscribe()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-framework/chains@v0.0.0-20260326122810-b657beadfb57/heads/listener.go:225 +0x260
  github.com/smartcontractkit/chainlink-framework/chains/heads.(*listener[go.shape.*uint8,go.shape.interface { Err() <-chan error; Unsubscribe() },go.shape.*uint8,go.shape.[32]uint8]).ListenForNewHeads()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-framework/chains@v0.0.0-20260326122810-b657beadfb57/heads/listener.go:109 +0x124
  github.com/smartcontractkit/chainlink-framework/chains/heads.(*listener[go.shape.*uint8,go.shape.interface { Err() <-chan error; Unsubscribe() },go.shape.*uint8,go.shape.[32]uint8]).start.func1()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-framework/chains@v0.0.0-20260326122810-b657beadfb57/heads/listener.go:101 +0x44
  github.com/smartcontractkit/chainlink-common/pkg/services.(*Engine).Go.func1()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/service.go:72 +0x68
  sync.(*WaitGroup).Go.func1()
      /usr/local/go/src/sync/waitgroup.go:258 +0x54

Previous write at 0x00c0017f8510 by goroutine 389986:
  ??()
      -:0 +0x109ae33b8
  sync/atomic.AddInt32()
      <autogenerated>:1 +0x14
  sync.(*Mutex).Unlock()
      /usr/local/go/src/sync/mutex.go:65 +0x2c
  context.(*cancelCtx).Done.deferwrap1()
      /usr/local/go/src/context/context.go:454 +0x2c
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:668 +0x5c
  github.com/smartcontractkit/chainlink-common/pkg/services.StopRChan.CtxCancel.func1()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/stop.go:59 +0x48

Goroutine 389985 (running) created at:
  sync.(*WaitGroup).Go()
      /usr/local/go/src/sync/waitgroup.go:238 +0x78
  github.com/smartcontractkit/chainlink-common/pkg/services.(*Engine).Go()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/service.go:69 +0xc8
  github.com/smartcontractkit/chainlink-framework/chains/heads.(*listener[go.shape.*uint8,go.shape.interface { Err() <-chan error; Unsubscribe() },go.shape.*uint8,go.shape.[32]uint8]).start()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-framework/chains@v0.0.0-20260326122810-b657beadfb57/heads/listener.go:101 +0xf0
  github.com/smartcontractkit/chainlink-framework/chains/heads.NewListener[go.shape.*uint8,go.shape.interface { Err() <-chan error; Unsubscribe() },go.shape.*uint8,go.shape.[32]uint8,github.com/smartcontractkit/chainlink-framework/chains/heads.Client[go.shape.*uint8,go.shape.interface { Err() <-chan error; Unsubscribe() },go.shape.*uint8,go.shape.[32]uint8]].func1()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-framework/chains@v0.0.0-20260326122810-b657beadfb57/heads/listener.go:95 +0x44
  github.com/smartcontractkit/chainlink-common/pkg/services.(*service).Start.func1()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/service.go:272 +0x2f4
  github.com/smartcontractkit/chainlink-common/pkg/services.(*StateMachine).StartOnce()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/state.go:93 +0xb4
  github.com/smartcontractkit/chainlink-common/pkg/services.(*service).Start()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/service.go:255 +0x7c
  github.com/smartcontractkit/chainlink-framework/chains/heads.(*listener[*github.com/smartcontractkit/chainlink-evm/pkg/types.Head,github.com/ethereum/go-ethereum.Subscription,*math/big.Int,github.com/ethereum/go-ethereum/common.Hash]).Start()
      <autogenerated>:1 +0x50
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).start()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/multi.go:35 +0x50
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).Start()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/multi.go:26 +0x5cc
  github.com/smartcontractkit/chainlink-common/pkg/services.(*service).Start.func1()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/service.go:265 +0x500
  github.com/smartcontractkit/chainlink-common/pkg/services.(*StateMachine).StartOnce()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/state.go:93 +0xb4
  github.com/smartcontractkit/chainlink-common/pkg/services.(*service).Start()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/service.go:255 +0x7c
  github.com/smartcontractkit/chainlink-framework/chains/heads.(*tracker[*github.com/smartcontractkit/chainlink-evm/pkg/types.Head,github.com/ethereum/go-ethereum.Subscription,*math/big.Int,github.com/ethereum/go-ethereum/common.Hash]).Start()
      <autogenerated>:1 +0x50
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).start()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/multi.go:35 +0x50
  github.com/smartcontractkit/chainlink-common/pkg/services.(*MultiStart).Start()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/multi.go:26 +0x42c
  github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm.(*chain).Start.func1()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/chains/legacyevm/chain.go:351 +0x198
  github.com/smartcontractkit/chainlink-common/pkg/services.(*StateMachine).StartOnce()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/state.go:93 +0xb4
  github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm.(*chain).Start()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/chains/legacyevm/chain.go:340 +0x84
  github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm.Chain.Start()
      <autogenerated>:1 +0x48
  github.com/smartcontractkit/chainlink-common/pkg/services/servicetest.Run[go.shape.758b40ad9be582d16ec4e4778e4db760dc29eec3de6c911b4511f2843b66d1c7]()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/servicetest/run.go:30 +0x94
  github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest.NewLegacyChains()
      /Users/jordan/git/chainlink/core/internal/testutils/evmtest/evmtest.go:76 +0x1fc
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm.NewLegacyChainsAndConfig()
      /Users/jordan/git/chainlink/core/services/relay/evm/relayer_extender.go:91 +0x14c
  github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest.NewLegacyChains()
      /Users/jordan/git/chainlink/core/internal/testutils/evmtest/evmtest.go:73 +0x20
  github.com/smartcontractkit/chainlink/v2/core/services/vrf/v2_test.TestStartingCountsV1()
      /Users/jordan/git/chainlink/core/services/vrf/v2/integration_v2_test.go:2134 +0x6e8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:2101 +0x34

Goroutine 389986 (running) created at:
  github.com/smartcontractkit/chainlink-common/pkg/services.StopRChan.CtxCancel()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/stop.go:55 +0x100
  github.com/smartcontractkit/chainlink-common/pkg/services.StopRChan.Ctx()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/stop.go:44 +0x48
  github.com/smartcontractkit/chainlink-common/pkg/services.StopRChan.NewCtx()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/stop.go:39 +0x38
  github.com/smartcontractkit/chainlink-common/pkg/services.StopChan.NewCtx()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/stop.go:14 +0x18
  github.com/smartcontractkit/chainlink-common/pkg/services.(*Engine).Go.func1()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/service.go:70 +0x40
  sync.(*WaitGroup).Go.func1()
      /usr/local/go/src/sync/waitgroup.go:258 +0x54
==================
```