### PR TITLE
feat(ci): advanced triggers rollout for unit and integration tests

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -96,6 +96,68 @@ jobs:
             all:
               - '**'
 
+      - name: Decide which tests to run (rollout-only)
+        # To validate that this properly tests, we will run this beside the dorny/paths-filter actions
+        # before using it's output to actually gate any jobs.
+        id: triggers
+        uses: smartcontractkit/.github/actions/advanced-triggers@advanced-triggers/v1
+        continue-on-error: true
+        with:
+          file-sets: |
+            go-files:
+              - "**/*.go"
+              - "**/go.mod"
+              - "**/go.sum"
+            core-files:
+              - "core/**"
+            all-test-files:
+              - "**/testdata/**"
+              - "**/*_test.go"
+            core-test-files:
+              - "testdata/**"
+              - "core/**/testdata/**"
+              - "core/**/*_test.go"
+            e2e-tests-files:
+              - "system-tests/**"
+              - "integration-tests/**"
+            workflow-files:
+              - ".github/workflows/ci-core.yml"
+              - ".github/actions/**/*.y*ml"
+            deployment-files:
+              - "deployment/**"
+          # Note:
+          # - for pull_request, merge_group, and push events, a trigger will resolve to true if any changed files match the path/glob patterns
+          #     - exclusion-sets/negations are applied first, and therefore filter all changed files before inclusion sets are applied
+          # - by default these will resolve to true for schedule, and workflow_dispatch events
+          triggers: |
+            core-tests:
+              exclusion-sets: [ e2e-tests-files, deployment-files ]
+              inclusion-sets: [ go-files, core-files, all-test-files, workflow-files ]
+              paths:
+                - "tools/bin/go_core_tests"
+            core-fuzz-tests:
+              exclusion-sets: [ e2e-tests-files, deployment-files ]
+              inclusion-sets: [ go-files, core-files, all-test-files, workflow-files ]
+              paths:
+                - "!**/testdata/**"
+                - "**/fuzz/**"
+                - "tools/bin/go_core_fuzz"
+            core-race-tests:
+              exclusion-sets: [ e2e-tests-files, deployment-files ]
+              inclusion-sets: [ go-files, core-files, all-test-files, workflow-files ]
+              paths:
+                - "tools/bin/go_core_race_tests"
+            core-integration-tests:
+              exclusion-sets: [ e2e-tests-files, deployment-files ]
+              inclusion-sets: [ go-files, core-files, all-test-files, workflow-files ]
+              paths:
+                - "tools/bin/go_core_tests_integration"
+            deployment-tests:
+              exclusion-sets: [ e2e-tests-files, core-test-files ]
+              inclusion-sets: [ go-files, core-files, deployment-files, workflow-files ]
+              paths:
+                - "tools/bin/go_core_ccip_deployment_tests"
+
       - name: Changed modules
         id: changed-modules
         uses: smartcontractkit/.github/actions/changed-modules-go@changed-modules-go/v1

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Decide which tests to run (rollout-only)
         # To validate that this properly tests, we will run this beside the dorny/paths-filter actions
-        # before using it's output to actually gate any jobs.
+        # before using its output to actually gate any jobs.
         id: triggers
         uses: smartcontractkit/.github/actions/advanced-triggers@advanced-triggers/v1
         continue-on-error: true
@@ -122,38 +122,40 @@ jobs:
               - "integration-tests/**"
             workflow-files:
               - ".github/workflows/ci-core.yml"
-              - ".github/actions/**/*.y*ml"
+              - ".github/actions/**"
             deployment-files:
               - "deployment/**"
+            ignored-files:
+              - "core/scripts/cre/environment/examples/workflows/**"
           # Note:
           # - for pull_request, merge_group, and push events, a trigger will resolve to true if any changed files match the path/glob patterns
           #     - exclusion-sets/negations are applied first, and therefore filter all changed files before inclusion sets are applied
           # - by default these will resolve to true for schedule, and workflow_dispatch events
           triggers: |
             core-tests:
-              exclusion-sets: [ e2e-tests-files, deployment-files ]
+              exclusion-sets: [ e2e-tests-files, deployment-files, ignored-files ]
               inclusion-sets: [ go-files, core-files, all-test-files, workflow-files ]
               paths:
                 - "tools/bin/go_core_tests"
             core-fuzz-tests:
-              exclusion-sets: [ e2e-tests-files, deployment-files ]
+              exclusion-sets: [ e2e-tests-files, deployment-files, ignored-files ]
               inclusion-sets: [ go-files, core-files, all-test-files, workflow-files ]
               paths:
                 - "!**/testdata/**"
                 - "**/fuzz/**"
                 - "tools/bin/go_core_fuzz"
             core-race-tests:
-              exclusion-sets: [ e2e-tests-files, deployment-files ]
+              exclusion-sets: [ e2e-tests-files, deployment-files, ignored-files ]
               inclusion-sets: [ go-files, core-files, all-test-files, workflow-files ]
               paths:
                 - "tools/bin/go_core_race_tests"
             core-integration-tests:
-              exclusion-sets: [ e2e-tests-files, deployment-files ]
+              exclusion-sets: [ e2e-tests-files, deployment-files, ignored-files ]
               inclusion-sets: [ go-files, core-files, all-test-files, workflow-files ]
               paths:
                 - "tools/bin/go_core_tests_integration"
             deployment-tests:
-              exclusion-sets: [ e2e-tests-files, core-test-files ]
+              exclusion-sets: [ e2e-tests-files, core-test-files, ignored-files ]
               inclusion-sets: [ go-files, core-files, deployment-files, workflow-files ]
               paths:
                 - "tools/bin/go_core_ccip_deployment_tests"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Decide which tests to run (rollout-only)
         # To validate that this properly tests, we will run this beside the dorny/paths-filter actions
-        # before using it's output to actually gate any jobs.
+        # before using its output to actually gate any jobs.
         id: triggers
         uses: smartcontractkit/.github/actions/advanced-triggers@advanced-triggers/v1
         continue-on-error: true
@@ -178,6 +178,10 @@ jobs:
             deployment-test-files:
               - "deployment/**/*_test.go"
               - "deployment/**/testdata/**"
+          # Note:
+          # - for pull_request, merge_group, and push events, a trigger will resolve to true if any changed files match the path/glob patterns
+          #     - exclusion-sets/negations are applied first, and therefore filter all changed files before inclusion sets are applied
+          # - by default these will resolve to true for schedule, and workflow_dispatch events
           triggers: |
               cre-e2e:
                 exclusion-sets: [ core-test-files, deployment-test-files, legacy-integ-test-files ]

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -138,6 +138,65 @@ jobs:
               - '**/*ccip*'
               - '**/*ccip*/**'
 
+
+      - name: Decide which tests to run (rollout-only)
+        # To validate that this properly tests, we will run this beside the dorny/paths-filter actions
+        # before using it's output to actually gate any jobs.
+        id: triggers
+        uses: smartcontractkit/.github/actions/advanced-triggers@advanced-triggers/v1
+        continue-on-error: true
+        with:
+          file-sets: |
+            go-files:
+              - "**/*.go"
+              - "**/go.mod"
+              - "**/go.sum"
+            core-files:
+              - "GNUmakefile"
+              - "core/**/*.go"
+              - "core/**/migrations/*.sql"
+              - "core/**/config/**/*.toml"
+            workflow-files:
+              - ".github/workflows/integration-tests.yml"
+              - ".github/actions/**/*.y*ml"
+            docker-files:
+              - "**/*Dockerfile"
+              - "plugins/plugins.public.yaml"
+              - "plugins/plugins.private.yaml"
+            legacy-integ-test-files:
+              - "integration-tests/**"
+              - ".github/e2e-tests.yml"
+            system-test-files:
+              - "system-tests/**"
+              - "core/scripts/cre/**"
+              - ".github/workflows/cre-system-tests.yaml"
+              - ".github/workflows/cre-regression-system-tests.yaml"
+            core-test-files:
+              - "testdata/**"
+              - "core/**/testdata/**"
+              - "core/**/*_test.go"
+            deployment-test-files:
+              - "deployment/**/*_test.go"
+              - "deployment/**/testdata/**"
+          triggers: |
+              cre-e2e:
+                exclusion-sets: [ core-test-files, deployment-test-files, legacy-integ-test-files ]
+                inclusion-sets: [ go-files, core-files, workflow-files, docker-files, system-test-files ]
+                paths:
+                  - "!deployment/**"
+              core-e2e: # also triggers solana tests
+                exclusion-sets: [ core-test-files, deployment-test-files, system-test-files ]
+                inclusion-sets: [ go-files, core-files, workflow-files, docker-files, legacy-integ-test-files ]
+                paths:
+                  - "!deployment/**"
+              ccip-e2e:
+                exclusion-sets: [ core-test-files, deployment-test-files, system-test-files ]
+                inclusion-sets: [ go-files, core-files, workflow-files, docker-files, legacy-integ-test-files ]
+                paths:
+                  - "!deployment/**"
+                  - "**/*ccip*"
+                  - "**/*ccip*/**"
+
   labels:
     name: Get PR labels and set runner labels
     if: github.actor != 'dependabot[bot]'


### PR DESCRIPTION
This adds an `advanced-triggers` step which in the future will be used to gate jobs more effectively. The outputs of this are currently unused so we can validate the behaviour while still relying on the known-working existing conditional logic.

Utilizes [`advanced-triggers`](https://github.com/smartcontractkit/.github/tree/main/actions/advanced-triggers).


### Changes

* Adds `advanced-triggers` step to both `ci-core` and `integration-tests` 

### Motivation

This provides more granular control for job-level run conditions based on file changes.
* Allows for more intuitive reusable glob groupings, and proper negations

### Notes

This replaces #21686, #21685. 

---

DX-3534
