### PR TITLE
fix: normalize OCR3 transmitter encoding in LocalRegistry

### DIFF
--- a/core/services/registrysyncer/local_registry.go
+++ b/core/services/registrysyncer/local_registry.go
@@ -2,6 +2,7 @@ package registrysyncer
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
@@ -116,7 +117,10 @@ func (c CapabilityConfiguration) Unmarshal() (capabilities.CapabilityConfigurati
 			}
 			transmitters := make([]ocrtypes.Account, len(pbCfg.Transmitters))
 			for i, t := range pbCfg.Transmitters {
-				transmitters[i] = ocrtypes.Account(t)
+				// OCR3 transmitter accounts cross the loop boundary as hex-encoded text.
+				// Keep LocalRegistry aligned with the external OCR config service so the
+				// imported registry path and the direct registry path serialize the same way.
+				transmitters[i] = ocrtypes.Account(hex.EncodeToString(t))
 			}
 			if pbCfg.F > math.MaxUint8 {
 				return capabilities.CapabilityConfiguration{}, fmt.Errorf("OCR3Config %q: F value %d exceeds uint8 max", name, pbCfg.F)

--- a/core/services/registrysyncer/local_registry_test.go
+++ b/core/services/registrysyncer/local_registry_test.go
@@ -186,7 +186,7 @@ func TestCapabilityConfiguration_Unmarshal(t *testing.T) {
 
 	t.Run("Ocr3Configs", func(t *testing.T) {
 		signer := []byte{0x01, 0x02, 0x03}
-		transmitter := []byte("0xabc")
+		transmitter := []byte{0xde, 0xad, 0xbe, 0xef}
 
 		raw := mustMarshalProto(t, &capabilitiespb.CapabilityConfig{
 			Ocr3Configs: map[string]*capabilitiespb.OCR3Config{
@@ -209,12 +209,38 @@ func TestCapabilityConfiguration_Unmarshal(t *testing.T) {
 		require.Contains(t, got.Ocr3Configs, "__default__")
 		cfg := got.Ocr3Configs["__default__"]
 		assert.Equal(t, []ocrtypes.OnchainPublicKey{signer}, cfg.Signers)
-		assert.Equal(t, []ocrtypes.Account{ocrtypes.Account(transmitter)}, cfg.Transmitters)
+		assert.Equal(t, []ocrtypes.Account{ocrtypes.Account("deadbeef")}, cfg.Transmitters)
 		assert.Equal(t, uint8(2), cfg.F)
 		assert.Equal(t, []byte("onchain"), cfg.OnchainConfig)
 		assert.Equal(t, uint64(5), cfg.OffchainConfigVersion)
 		assert.Equal(t, []byte("offchain"), cfg.OffchainConfig)
 		assert.Equal(t, uint64(3), cfg.ConfigCount)
+	})
+
+	t.Run("Ocr3Configs normalizes transmitters to hex text", func(t *testing.T) {
+		raw := mustMarshalProto(t, &capabilitiespb.CapabilityConfig{
+			Ocr3Configs: map[string]*capabilitiespb.OCR3Config{
+				"aptos": {
+					Transmitters: [][]byte{
+						{0x00, 0xff},
+						[]byte("ascii-bytes"),
+					},
+				},
+			},
+		})
+		cc := CapabilityConfiguration{Config: raw}
+
+		got, err := cc.Unmarshal()
+		require.NoError(t, err)
+
+		cfg := got.Ocr3Configs["aptos"]
+		assert.Equal(t,
+			[]ocrtypes.Account{
+				ocrtypes.Account("00ff"),
+				ocrtypes.Account("61736369692d6279746573"),
+			},
+			cfg.Transmitters,
+		)
 	})
 
 	t.Run("OracleFactoryConfigs", func(t *testing.T) {

--- a/core/services/registrysyncer/local_registry_test.go
+++ b/core/services/registrysyncer/local_registry_test.go
@@ -233,6 +233,7 @@ func TestCapabilityConfiguration_Unmarshal(t *testing.T) {
 		got, err := cc.Unmarshal()
 		require.NoError(t, err)
 
+		require.Contains(t, got.Ocr3Configs, "aptos")
 		cfg := got.Ocr3Configs["aptos"]
 		assert.Equal(t,
 			[]ocrtypes.Account{


### PR DESCRIPTION
## Summary
- normalize OCR3 transmitter accounts to hex text when `LocalRegistry` unmarshals CapReg OCR3 configs
- add regression coverage for the LocalRegistry OCR3 config path

## Why
Aptos capability startup can fall back to `ConfigForCapability(...)` when `p2pToTransmitterMap` is not present in the worker JSON config. In staging, that call goes through the external registry syncer into `LocalRegistry`, then back across the loop bridge through `chainlink-common`.

Note: `registrysyncer.LocalRegistry` is not just a local-CRE test path; it is also the synced local copy of the external onchain Capabilities Registry used in staging and other non-local environments.

`chainlink-common` expects OCR transmitter accounts to be hex-encoded text on that loop boundary, but `LocalRegistry.Unmarshal()` was reconstructing them as raw bytes inside `ocrtypes.Account`. That leaves the producer and consumer with different expectations and causes the same decode failure we previously worked around in `chainlink-common`.

This fixes the producer-side contract instead of adding another tolerant fallback in the loop bridge.

## Testing
- `GOWORK=off go test ./core/services/registrysyncer -run 'TestCapabilityConfiguration_Unmarshal' -count=1`
- `GOWORK=off go test ./core/services/cre -run TestNonExistent -count=1`
