### PR TITLE
chore(ci): bump actionlint to v1.72.0

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,10 @@
+# See https://github.com/rhysd/actionlint/blob/main/docs/config.md
+
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      # ignore unknown runner labels, as we have fully custom runners
+      - 'label ".*" is unknown. available labels are .*'
+      # https://www.shellcheck.net/wiki/SC2129
+      - '.*SC2129:style:1:1:.*'
+

--- a/.github/workflows/lint-gh-workflows.yml
+++ b/.github/workflows/lint-gh-workflows.yml
@@ -1,14 +1,26 @@
 name: Lint GH Workflows
+
 on:
-  push:
+  pull_request:
+    paths:
+      - '.github/workflows/*.y*ml'
+      - '.github/actions/**/action.y*ml'
+
+permissions: {}
+
 jobs:
   lint_workflows:
     name: Validate Github Action Workflows
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
     steps:
       - name: Check out Code
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@c6ee1eb0a5d47b2af53a203652b5dac0b6c4016e # v1.43.0
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d #v v1.72.0

--- a/.github/workflows/lint-gh-workflows.yml
+++ b/.github/workflows/lint-gh-workflows.yml
@@ -23,4 +23,4 @@ jobs:
           persist-credentials: false
 
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d #v v1.72.0
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0


### PR DESCRIPTION
### Changes

Bumps `reviewdog/action-actionlint` to `v1.72.0` (https://github.com/reviewdog/action-actionlint/commit/6fb7acc99f4a1008869fa8a0f09cfca740837d9d)


### Notes

Follow-up PR incoming to fix a bunch of errors.