### PR TITLE
[codex] Add Vault JWT local CRE and smoke coverage

### DIFF
--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -160,7 +160,9 @@ jobs:
       # http://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments
       name: integration
       deployment: false
-    timeout-minutes: 10
+    # Bucket B now runs both legacy Vault auth and JWT auth against the same topology.
+    # Give that matrix entry a larger budget without slowing the rest of the suite.
+    timeout-minutes: ${{ matrix.tests.test_name == 'Test_CRE_V2_Suite_Bucket_B' && 16 || 10 }}
     env:
       ENABLE_AUTO_QUARANTINE: "true"
       # override Chip Ingress and Chip Config images with remote images. We have added this env var here, instead of the "Start local CRE" step, because
@@ -328,9 +330,12 @@ jobs:
         continue-on-error: ${{ env.ENABLE_AUTO_QUARANTINE == 'true' }}
         env:
           TEST_NAME: ${{ matrix.tests.test_name }}
-          TEST_TIMEOUT: 7m # let's leave 3 minutes for other steps (the whole job times out after 10 minutes)
+          TEST_TIMEOUT: ${{ matrix.tests.test_name == 'Test_CRE_V2_Suite_Bucket_B' && '12m' || '7m' }}
           RUN_QUARANTINED_TESTS: "true" # always run quarantined tests in CI
           TOPOLOGY_NAME: ${{ matrix.tests.topology }}
+          CTF_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.22.1"
+          CTF_CHAINLINK_IMAGE: "${{ steps.resolve-chainlink-image.outputs.resolved_image }}"
+          CTF_CHIP_ROUTER_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/local-cre-chip-router:v1.0.1"
           GITHUB_TOKEN: ${{ steps.github-token.outputs.access-token || '' }} # to avoid rate limiting when downloading protobuf files from GitHub
           PARALLEL_COUNT: "10"
           CRE_TEST_PARALLEL_ENABLED: "true"

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -86,6 +86,9 @@ jobs:
 
           # Add list of tests with certain topologies
           PER_TEST_TOPOLOGIES_JSON=${PER_TEST_TOPOLOGIES_JSON:-'{
+            "Test_CRE_V2_Suite_Bucket_B": [
+               {"topology":"workflow-gateway-capabilities-vault-flags-enabled","configs":"configs/workflow-gateway-capabilities-don-vault-flags-enabled.toml"}
+             ],
             "Test_CRE_V2_Aptos_Suite": [
                {"topology":"workflow-gateway-aptos","configs":"configs/workflow-gateway-don-aptos.toml"}
              ],

--- a/core/capabilities/vault/authorizer_test.go
+++ b/core/capabilities/vault/authorizer_test.go
@@ -11,29 +11,20 @@ import (
 
 	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
-	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
-	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	vault "github.com/smartcontractkit/chainlink/v2/core/capabilities/vault"
 	vaultmocks "github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
-func testLimitsFactory() limits.Factory {
-	return limits.Factory{Settings: cresettings.DefaultGetter}
-}
-
-func TestAuthorizer_RejectsJWTBasedAuthWhenDisabled(t *testing.T) {
+func TestAuthorizer_RejectsJWTBasedAuthWhenUnavailable(t *testing.T) {
 	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{})
 	require.NoError(t, err)
 
 	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
 	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Maybe()
 
-	jwtBasedAuth, err := vault.NewJWTBasedAuth(vault.JWTBasedAuthConfig{}, testLimitsFactory(), logger.TestLogger(t), vault.WithDisabledJWTBasedAuth())
-	require.NoError(t, err)
-
-	a := vault.NewAuthorizer(allowListBasedAuth, jwtBasedAuth, logger.TestLogger(t))
+	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
 
 	authResult, err := a.AuthorizeRequest(t.Context(), jsonrpc.Request[json.RawMessage]{
 		ID:     "1",
@@ -42,7 +33,7 @@ func TestAuthorizer_RejectsJWTBasedAuthWhenDisabled(t *testing.T) {
 		Auth:   "jwt-token",
 	})
 	require.Nil(t, authResult)
-	require.ErrorContains(t, err, "JWTBasedAuth is disabled")
+	require.ErrorContains(t, err, "JWTBasedAuth is nil")
 	allowListBasedAuth.AssertNotCalled(t, "AuthorizeRequest", mock.Anything, mock.Anything)
 }
 
@@ -126,10 +117,7 @@ func TestAuthorizer_RejectsAllowListBasedAuthReplay(t *testing.T) {
 	req := jsonrpc.Request[json.RawMessage]{ID: "1", Method: vaulttypes.MethodSecretsCreate}
 	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, req).Return(vault.NewAuthResult("", "0xabc", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Twice()
 
-	jwtBasedAuth, err := vault.NewJWTBasedAuth(vault.JWTBasedAuthConfig{}, testLimitsFactory(), logger.TestLogger(t), vault.WithDisabledJWTBasedAuth())
-	require.NoError(t, err)
-
-	a := vault.NewAuthorizer(allowListBasedAuth, jwtBasedAuth, logger.TestLogger(t))
+	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
 
 	authResult, err := a.AuthorizeRequest(t.Context(), req)
 	require.NoError(t, err)

--- a/core/capabilities/vault/gw_handler.go
+++ b/core/capabilities/vault/gw_handler.go
@@ -60,6 +60,7 @@ type gatewayConnector interface {
 
 type gatewayHandlerConfig struct {
 	authorizer Authorizer
+	auth0      *Auth0Config
 }
 
 // GatewayHandlerOption customizes GatewayHandler construction for tests and future auth extensions.
@@ -69,6 +70,13 @@ type GatewayHandlerOption func(*gatewayHandlerConfig)
 func WithAuthorizer(authorizer Authorizer) GatewayHandlerOption {
 	return func(cfg *gatewayHandlerConfig) {
 		cfg.authorizer = authorizer
+	}
+}
+
+// WithJWTAuth0Config enables JWT-based request validation for the node-side Vault handler.
+func WithJWTAuth0Config(auth0 *Auth0Config) GatewayHandlerOption {
+	return func(cfg *gatewayHandlerConfig) {
+		cfg.auth0 = auth0
 	}
 }
 
@@ -93,12 +101,21 @@ func NewGatewayHandler(secretsService vaulttypes.SecretsService, connector gatew
 	}
 	if cfg.authorizer == nil {
 		allowListBasedAuth := NewAllowListBasedAuth(lggr, workflowRegistrySyncer)
-		jwtBasedAuth, err := NewJWTBasedAuth(JWTBasedAuthConfig{}, limitsFactory, lggr, WithDisabledJWTBasedAuth())
-		if err != nil {
-			return nil, fmt.Errorf("failed to create JWTBasedAuth: %w", err)
+		var jwtBasedAuth Authorizer
+		var jwtAuthService services.Service
+		if cfg.auth0 != nil {
+			var err error
+			jwtAuthService, err = NewJWTBasedAuth(JWTBasedAuthConfig{
+				IssuerURL: cfg.auth0.IssuerURL,
+				Audience:  cfg.auth0.Audience,
+			}, limitsFactory, lggr)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create JWTBasedAuth: %w", err)
+			}
+			jwtBasedAuth = jwtAuthService.(Authorizer)
 		}
 		cfg.authorizer = NewAuthorizer(allowListBasedAuth, jwtBasedAuth, lggr)
-		return newGatewayHandlerWithAuthorizer(secretsService, connector, cfg.authorizer, jwtBasedAuth, lggr)
+		return newGatewayHandlerWithAuthorizer(secretsService, connector, cfg.authorizer, jwtAuthService, lggr)
 	}
 	return newGatewayHandlerWithAuthorizer(secretsService, connector, cfg.authorizer, nil, lggr)
 }
@@ -225,6 +242,11 @@ func (h *GatewayHandler) authorizeAndPrefixRequest(ctx context.Context, req *jso
 	authReq.ID = originalRequestID
 	if err := stripPrefixedRequestIDFromParams(&authReq, originalRequestID); err != nil {
 		h.lggr.Errorw("failed to normalize gateway request for authorization", "method", req.Method, "requestID", originalRequestID, "error", err)
+		return nil, err
+	}
+	authReq, err := StripRequestIdentity(authReq)
+	if err != nil {
+		h.lggr.Errorw("failed to strip authorized identity fields before authorization", "method", req.Method, "requestID", originalRequestID, "error", err)
 		return nil, err
 	}
 

--- a/core/capabilities/vault/gw_handler_test.go
+++ b/core/capabilities/vault/gw_handler_test.go
@@ -122,6 +122,56 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name: "success - create secrets strips forwarded identity before reauthorization",
+			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
+				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.MatchedBy(func(req jsonrpc.Request[json.RawMessage]) bool {
+					if req.Method != vaulttypes.MethodSecretsCreate || req.ID != "1" || req.Params == nil {
+						return false
+					}
+					parsed := &vaultcommon.CreateSecretsRequest{}
+					if err := json.Unmarshal(*req.Params, parsed); err != nil {
+						return false
+					}
+					return parsed.OrgId == "" && parsed.WorkflowOwner == ""
+				})).Return(authResult("org-1", "0xworkflow"), nil)
+				ss.EXPECT().CreateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.CreateSecretsRequest) bool {
+					return len(req.EncryptedSecrets) == 1 &&
+						req.EncryptedSecrets[0].Id.Key == "test-secret" &&
+						req.EncryptedSecrets[0].Id.Owner == "org-1" &&
+						req.RequestId == "org-1"+vaulttypes.RequestIDSeparator+"1" &&
+						req.OrgId == "org-1" &&
+						req.WorkflowOwner == "0xworkflow"
+				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
+
+				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
+					return resp.Error == nil
+				})).Return(nil)
+			},
+			request: &jsonrpc.Request[json.RawMessage]{
+				Method: vaulttypes.MethodSecretsCreate,
+				ID:     "org-1" + vaulttypes.RequestIDSeparator + "1",
+				Params: func() *json.RawMessage {
+					params, _ := json.Marshal(vaultcommon.CreateSecretsRequest{
+						RequestId:     "org-1" + vaulttypes.RequestIDSeparator + "1",
+						OrgId:         "org-1",
+						WorkflowOwner: "0xworkflow",
+						EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+							{
+								Id: &vaultcommon.SecretIdentifier{
+									Key:   "test-secret",
+									Owner: "org-1",
+								},
+								EncryptedValue: "encrypted-value",
+							},
+						},
+					})
+					raw := json.RawMessage(params)
+					return &raw
+				}(),
+			},
+			expectedError: false,
+		},
+		{
 			name: "failure - service error",
 			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
 				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Return(authResult("", "0xabc"), nil)
@@ -456,9 +506,6 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 			secretsService := vaulttypesmocks.NewSecretsService(t)
 			gwConnector := connector_mocks.NewGatewayConnector(t)
 			allowListBasedAuth := vaultcapmocks.NewAuthorizer(t)
-			limitsFactory := limits.Factory{Settings: cresettings.DefaultGetter}
-			jwtBasedAuth, err := vaultcap.NewJWTBasedAuth(vaultcap.JWTBasedAuthConfig{}, limitsFactory, lggr, vaultcap.WithDisabledJWTBasedAuth())
-			require.NoError(t, err)
 
 			tt.setupMocks(secretsService, gwConnector, allowListBasedAuth)
 
@@ -467,8 +514,8 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 				gwConnector,
 				nil,
 				lggr,
-				limitsFactory,
-				vaultcap.WithAuthorizer(vaultcap.NewAuthorizer(allowListBasedAuth, jwtBasedAuth, lggr)),
+				limits.Factory{Settings: cresettings.DefaultGetter},
+				vaultcap.WithAuthorizer(vaultcap.NewAuthorizer(allowListBasedAuth, nil, lggr)),
 			)
 			require.NoError(t, err)
 
@@ -490,17 +537,14 @@ func TestGatewayHandler_Lifecycle(t *testing.T) {
 	secretsService := vaulttypesmocks.NewSecretsService(t)
 	gwConnector := connector_mocks.NewGatewayConnector(t)
 	allowListBasedAuth := vaultcapmocks.NewAuthorizer(t)
-	limitsFactory := limits.Factory{Settings: cresettings.DefaultGetter}
-	jwtBasedAuth, err := vaultcap.NewJWTBasedAuth(vaultcap.JWTBasedAuthConfig{}, limitsFactory, lggr, vaultcap.WithDisabledJWTBasedAuth())
-	require.NoError(t, err)
 
 	handler, err := vaultcap.NewGatewayHandler(
 		secretsService,
 		gwConnector,
 		nil,
 		lggr,
-		limitsFactory,
-		vaultcap.WithAuthorizer(vaultcap.NewAuthorizer(allowListBasedAuth, jwtBasedAuth, lggr)),
+		limits.Factory{Settings: cresettings.DefaultGetter},
+		vaultcap.WithAuthorizer(vaultcap.NewAuthorizer(allowListBasedAuth, nil, lggr)),
 	)
 	require.NoError(t, err)
 
@@ -521,4 +565,27 @@ func TestGatewayHandler_Lifecycle(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, vaultcap.HandlerName, id)
 	})
+}
+
+func TestGatewayHandler_Lifecycle_DefaultAuthorizer_NoJWTConfig(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+
+	secretsService := vaulttypesmocks.NewSecretsService(t)
+	gwConnector := connector_mocks.NewGatewayConnector(t)
+
+	handler, err := vaultcap.NewGatewayHandler(
+		secretsService,
+		gwConnector,
+		nil,
+		lggr,
+		limits.Factory{Settings: cresettings.DefaultGetter},
+	)
+	require.NoError(t, err)
+
+	gwConnector.On("AddHandler", mock.Anything, vaulttypes.Methods, handler).Return(nil).Once()
+	require.NoError(t, handler.Start(ctx))
+
+	gwConnector.On("RemoveHandler", mock.Anything, vaulttypes.Methods).Return(nil).Once()
+	require.NoError(t, handler.Close())
 }

--- a/core/capabilities/vault/jwt_based_auth.go
+++ b/core/capabilities/vault/jwt_based_auth.go
@@ -37,6 +37,12 @@ const (
 	defaultHTTPTimeout         = 5 * time.Second
 )
 
+// Auth0Config captures the Vault JWT issuer settings shared by gateway and node handlers.
+type Auth0Config struct {
+	IssuerURL string `json:"issuerURL" toml:"issuerURL" yaml:"issuerURL"`
+	Audience  string `json:"audience" toml:"audience" yaml:"audience"`
+}
+
 // JWTBasedAuthConfig holds the configuration for JWTBasedAuth validation.
 type JWTBasedAuthConfig struct {
 	IssuerURL           string
@@ -84,7 +90,6 @@ type jwtBasedAuth struct {
 	jwksURL         string
 	refreshInterval time.Duration
 	authEnabledGate limits.GateLimiter
-	refreshEnabled  bool
 
 	mu            sync.RWMutex
 	keySet        *jsonWebKeySet
@@ -97,8 +102,7 @@ type jwtBasedAuth struct {
 }
 
 type jwtBasedAuthOptions struct {
-	authEnabledGate  limits.GateLimiter
-	skipConfigChecks bool
+	authEnabledGate limits.GateLimiter
 }
 
 // JWTBasedAuthOption customizes JWTBasedAuth construction without multiplying constructors.
@@ -108,14 +112,6 @@ type JWTBasedAuthOption func(*jwtBasedAuthOptions)
 func WithJWTBasedAuthGateLimiter(gateLimiter limits.GateLimiter) JWTBasedAuthOption {
 	return func(opts *jwtBasedAuthOptions) {
 		opts.authEnabledGate = gateLimiter
-	}
-}
-
-// WithDisabledJWTBasedAuth makes the constructed JWTBasedAuth fail closed without requiring issuer config.
-func WithDisabledJWTBasedAuth() JWTBasedAuthOption {
-	return func(opts *jwtBasedAuthOptions) {
-		opts.authEnabledGate = limits.NewGateLimiter(false)
-		opts.skipConfigChecks = true
 	}
 }
 
@@ -130,10 +126,10 @@ func NewJWTBasedAuth(cfg JWTBasedAuthConfig, limitsFactory limits.Factory, lggr 
 	if options.authEnabledGate == nil {
 		options.authEnabledGate = newVaultJWTAuthEnabledGateLimiter(limitsFactory, lggr)
 	}
-	if !options.skipConfigChecks && cfg.IssuerURL == "" {
+	if cfg.IssuerURL == "" {
 		return nil, errors.New("issuer URL is required")
 	}
-	if !options.skipConfigChecks && cfg.Audience == "" {
+	if cfg.Audience == "" {
 		return nil, errors.New("audience is required")
 	}
 
@@ -156,7 +152,6 @@ func NewJWTBasedAuth(cfg JWTBasedAuthConfig, limitsFactory limits.Factory, lggr 
 		jwksURL:         jwksURL,
 		refreshInterval: refreshInterval,
 		authEnabledGate: options.authEnabledGate,
-		refreshEnabled:  !options.skipConfigChecks,
 		httpClient:      httpClient,
 		lggr:            logger.Named(lggr, "VaultJWTBasedAuth"),
 	}
@@ -180,11 +175,6 @@ func newVaultJWTAuthEnabledGateLimiter(limitsFactory limits.Factory, lggr logger
 }
 
 func (v *jwtBasedAuth) start(context.Context) error {
-	if !v.refreshEnabled {
-		v.lggr.Debug("JWTBasedAuth periodic JWKS refresh disabled")
-		return nil
-	}
-
 	v.eng.GoTick(services.NewTicker(v.refreshInterval), func(ctx context.Context) {
 		if err := v.refreshJWKS(ctx); err != nil {
 			v.lggr.Warnw("periodic JWKS refresh failed", "error", err)
@@ -209,21 +199,21 @@ func (v *jwtBasedAuth) AuthorizeRequest(ctx context.Context, req jsonrpc.Request
 		return nil, errors.New("JWTBasedAuth is disabled")
 	}
 
-	requestDigest, err := req.Digest()
-	if err != nil {
-		v.lggr.Debugw("JWTBasedAuth failed to compute request digest", "method", req.Method, "requestID", req.ID, "error", err)
-		return nil, fmt.Errorf("failed to compute request digest: %w", err)
-	}
-
 	claims, err := v.validateToken(ctx, req.Auth)
 	if err != nil {
 		v.lggr.Debugw("JWTBasedAuth token validation failed", "method", req.Method, "requestID", req.ID, "error", err)
 		return nil, fmt.Errorf("invalid JWT auth token: %w", err)
 	}
 
+	requestDigest, err := req.Digest()
+	if err != nil {
+		v.lggr.Debugw("JWTBasedAuth failed to compute request digest", "method", req.Method, "requestID", req.ID, "orgID", claims.OrgID, "workflowOwner", claims.WorkflowOwner, "error", err)
+		return nil, fmt.Errorf("failed to compute request digest: %w", err)
+	}
+
 	if !strings.EqualFold(requestDigest, claims.RequestDigest) {
 		v.lggr.Debugw("JWTBasedAuth request digest mismatch", "method", req.Method, "requestID", req.ID, "orgID", claims.OrgID, "workflowOwner", claims.WorkflowOwner, "computedDigest", requestDigest, "claimedDigest", claims.RequestDigest)
-		return nil, errors.New("request digest mismatch")
+		return nil, fmt.Errorf("request digest mismatch: computed=%s claimed=%s", requestDigest, claims.RequestDigest)
 	}
 
 	v.lggr.Debugw("JWTBasedAuth authorization succeeded", "method", req.Method, "requestID", req.ID, "orgID", claims.OrgID, "workflowOwner", claims.WorkflowOwner, "digest", requestDigest, "expiresAt", claims.ExpiresAt.UTC().Unix())

--- a/core/capabilities/vault/jwt_based_auth_test.go
+++ b/core/capabilities/vault/jwt_based_auth_test.go
@@ -449,18 +449,6 @@ func TestJWTBasedAuth_StartRefreshesJWKSPeriodically(t *testing.T) {
 	require.NoError(t, v.Close())
 }
 
-func TestJWTBasedAuth_DisabledStartSkipsPeriodicRefresh(t *testing.T) {
-	v, err := NewJWTBasedAuth(
-		JWTBasedAuthConfig{},
-		limits.Factory{Settings: cresettings.DefaultGetter},
-		logger.TestLogger(t),
-		WithDisabledJWTBasedAuth(),
-	)
-	require.NoError(t, err)
-	require.NoError(t, v.Start(t.Context()))
-	require.NoError(t, v.Close())
-}
-
 func TestNewJWTBasedAuth_InvalidConfig(t *testing.T) {
 	lggr := logger.TestLogger(t)
 
@@ -517,6 +505,48 @@ func TestNewJWTBasedAuth_UsesVaultJWTAuthEnabledLimiter_Enabled(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "invalid JWT auth token")
 	require.ErrorContains(t, err, ErrMissingToken.Error())
+}
+
+func TestJWTBasedAuth_AuthorizeCreateRequestFromRawJSON(t *testing.T) {
+	rsaKey := generateTestRSAKey(t, "key-1")
+	jwksServer := newTestJWKSServer(t, rsaKey)
+
+	issuer := jwksServer.URL() + "/"
+	audience := "https://vault.test.chain.link"
+	v := newTestValidator(t, issuer, audience)
+
+	rawRequest := []byte(`{"jsonrpc":"2.0","id":"req-1","method":"vault.secrets.create","params":{"request_id":"req-1","encrypted_secrets":[{"id":{"key":"7611","namespace":"main","owner":"org-123"},"encrypted_value":"cipher+/=="}]}}`)
+	req, err := jsonrpc.DecodeRequest[json.RawMessage](rawRequest, "")
+	require.NoError(t, err)
+
+	digest, err := req.Digest()
+	require.NoError(t, err)
+
+	token := createTestJWT(t, rsaKey, jwt.MapClaims{
+		"iss":    issuer,
+		"aud":    audience,
+		"exp":    jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+		"iat":    jwt.NewNumericDate(time.Now()),
+		"org_id": "org-123",
+		"authorization_details": []interface{}{
+			map[string]interface{}{
+				"type":  "request_digest",
+				"value": digest,
+			},
+			map[string]interface{}{
+				"type":  "workflow_owner",
+				"value": "0xAbCdEf0123456789AbCdEf0123456789AbCdEf01",
+			},
+		},
+	})
+
+	req, err = jsonrpc.DecodeRequest[json.RawMessage](rawRequest, token)
+	require.NoError(t, err)
+
+	authResult, err := v.AuthorizeRequest(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, "org-123", authResult.OrgID())
+	require.Equal(t, digest, authResult.Digest())
 }
 
 func setDefaultGetter(t *testing.T, payload string) {

--- a/core/capabilities/vault/request_normalization.go
+++ b/core/capabilities/vault/request_normalization.go
@@ -1,0 +1,74 @@
+package vault
+
+import (
+	"encoding/json"
+
+	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
+	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
+)
+
+// NormalizeRequestWithIdentity returns a copy of req with the supplied identity
+// fields materialized into params for Vault secret-management methods. Requests
+// with malformed params are returned unchanged so downstream parsing can surface
+// the existing method-specific error paths.
+func NormalizeRequestWithIdentity(req jsonrpc.Request[json.RawMessage], orgID, workflowOwner string) (jsonrpc.Request[json.RawMessage], error) {
+	if req.Params == nil {
+		return req, nil
+	}
+
+	rewrite := func(payload any) error {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		raw := json.RawMessage(b)
+		req.Params = &raw
+		return nil
+	}
+
+	switch req.Method {
+	case vaulttypes.MethodSecretsCreate:
+		parsed := &vaultcommon.CreateSecretsRequest{}
+		if err := json.Unmarshal(*req.Params, parsed); err != nil {
+			return req, nil
+		}
+		parsed.OrgId = orgID
+		parsed.WorkflowOwner = workflowOwner
+		return req, rewrite(parsed)
+	case vaulttypes.MethodSecretsUpdate:
+		parsed := &vaultcommon.UpdateSecretsRequest{}
+		if err := json.Unmarshal(*req.Params, parsed); err != nil {
+			return req, nil
+		}
+		parsed.OrgId = orgID
+		parsed.WorkflowOwner = workflowOwner
+		return req, rewrite(parsed)
+	case vaulttypes.MethodSecretsDelete:
+		parsed := &vaultcommon.DeleteSecretsRequest{}
+		if err := json.Unmarshal(*req.Params, parsed); err != nil {
+			return req, nil
+		}
+		parsed.OrgId = orgID
+		parsed.WorkflowOwner = workflowOwner
+		return req, rewrite(parsed)
+	case vaulttypes.MethodSecretsList:
+		parsed := &vaultcommon.ListSecretIdentifiersRequest{}
+		if err := json.Unmarshal(*req.Params, parsed); err != nil {
+			return req, nil
+		}
+		parsed.OrgId = orgID
+		parsed.WorkflowOwner = workflowOwner
+		return req, rewrite(parsed)
+	default:
+		return req, nil
+	}
+}
+
+// StripRequestIdentity removes any org/workflow identity fields from Vault
+// secret-management request params. This restores the request body shape used by
+// the original client when the gateway had previously injected trusted identity
+// fields for internal forwarding.
+func StripRequestIdentity(req jsonrpc.Request[json.RawMessage]) (jsonrpc.Request[json.RawMessage], error) {
+	return NormalizeRequestWithIdentity(req, "", "")
+}

--- a/core/capabilities/vault/request_normalization_test.go
+++ b/core/capabilities/vault/request_normalization_test.go
@@ -1,0 +1,73 @@
+package vault
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
+	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
+)
+
+func TestNormalizeRequestWithIdentity_RoundTripsCreateRequestIdentity(t *testing.T) {
+	req := mustVaultJSONRPCRequest(t, vaulttypes.MethodSecretsCreate, &vaultcommon.CreateSecretsRequest{
+		RequestId:     "req-1",
+		OrgId:         "",
+		WorkflowOwner: "",
+	})
+
+	withIdentity, err := NormalizeRequestWithIdentity(req, "org-123", "0xowner")
+	require.NoError(t, err)
+
+	parsedWithIdentity := mustParseCreateSecretsRequest(t, withIdentity)
+	require.Equal(t, "org-123", parsedWithIdentity.OrgId)
+	require.Equal(t, "0xowner", parsedWithIdentity.WorkflowOwner)
+
+	stripped, err := StripRequestIdentity(withIdentity)
+	require.NoError(t, err)
+
+	parsedStripped := mustParseCreateSecretsRequest(t, stripped)
+	require.Empty(t, parsedStripped.OrgId)
+	require.Empty(t, parsedStripped.WorkflowOwner)
+	require.Equal(t, "req-1", parsedStripped.RequestId)
+}
+
+func TestStripRequestIdentity_LeavesMalformedParamsUnchanged(t *testing.T) {
+	raw := json.RawMessage(`{"not":"valid"`)
+	req := jsonrpc.Request[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "req-1",
+		Method:  vaulttypes.MethodSecretsCreate,
+		Params:  &raw,
+	}
+
+	stripped, err := StripRequestIdentity(req)
+	require.NoError(t, err)
+	require.Equal(t, string(raw), string(*stripped.Params))
+}
+
+func mustVaultJSONRPCRequest(t *testing.T, method string, payload any) jsonrpc.Request[json.RawMessage] {
+	t.Helper()
+
+	b, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	raw := json.RawMessage(b)
+	return jsonrpc.Request[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "req-1",
+		Method:  method,
+		Params:  &raw,
+	}
+}
+
+func mustParseCreateSecretsRequest(t *testing.T, req jsonrpc.Request[json.RawMessage]) *vaultcommon.CreateSecretsRequest {
+	t.Helper()
+
+	parsed := &vaultcommon.CreateSecretsRequest{}
+	require.NotNil(t, req.Params)
+	require.NoError(t, json.Unmarshal(*req.Params, parsed))
+	return parsed
+}

--- a/core/capabilities/vault/validator.go
+++ b/core/capabilities/vault/validator.go
@@ -23,16 +23,16 @@ type RequestValidator struct {
 }
 
 func (r *RequestValidator) ValidateCreateSecretsRequest(publicKey *tdh2easy.PublicKey, request *vaultcommon.CreateSecretsRequest) error {
-	return r.validateWriteRequest(publicKey, request.RequestId, request.EncryptedSecrets)
+	return r.validateWriteRequest(publicKey, request.RequestId, request.OrgId, request.WorkflowOwner, request.EncryptedSecrets)
 }
 
 func (r *RequestValidator) ValidateUpdateSecretsRequest(publicKey *tdh2easy.PublicKey, request *vaultcommon.UpdateSecretsRequest) error {
-	return r.validateWriteRequest(publicKey, request.RequestId, request.EncryptedSecrets)
+	return r.validateWriteRequest(publicKey, request.RequestId, request.OrgId, request.WorkflowOwner, request.EncryptedSecrets)
 }
 
 // validateWriteRequest performs common validation for CreateSecrets and UpdateSecrets requests
 // It treats publicKey as optional, since it can be nil if the gateway nodes don't have the public key cached yet
-func (r *RequestValidator) validateWriteRequest(publicKey *tdh2easy.PublicKey, id string, encryptedSecrets []*vaultcommon.EncryptedSecret) error {
+func (r *RequestValidator) validateWriteRequest(publicKey *tdh2easy.PublicKey, id string, orgID string, workflowOwner string, encryptedSecrets []*vaultcommon.EncryptedSecret) error {
 	if id == "" {
 		return errors.New("request ID must not be empty")
 	}
@@ -66,7 +66,11 @@ func (r *RequestValidator) validateWriteRequest(publicKey *tdh2easy.PublicKey, i
 		if err := r.validateCiphertextSize(req.EncryptedValue); err != nil {
 			return fmt.Errorf("secret encrypted value at index %d is invalid: %w", idx, err)
 		}
-		err := EnsureRightLabelOnSecret(publicKey, req.EncryptedValue, req.Id.Owner, "")
+		expectedWorkflowOwner := workflowOwner
+		if expectedWorkflowOwner == "" && orgID == "" {
+			expectedWorkflowOwner = req.Id.Owner
+		}
+		err := EnsureRightLabelOnSecret(publicKey, req.EncryptedValue, expectedWorkflowOwner, orgID)
 		if err != nil {
 			return errors.New("Encrypted Secret at index [" + strconv.Itoa(idx) + "] doesn't have owner as the label. Error: " + err.Error())
 		}

--- a/core/capabilities/vault/validator_test.go
+++ b/core/capabilities/vault/validator_test.go
@@ -298,3 +298,60 @@ func TestRequestValidator_CiphertextSizeLimit(t *testing.T) {
 		})
 	}
 }
+
+func TestRequestValidator_ValidateCreateSecretsRequest_UsesRequestIdentityForOrgLabels(t *testing.T) {
+	pk, _ := generateTestKeys(t)
+	validator := NewRequestValidator(
+		limits.NewUpperBoundLimiter(10),
+		limits.NewUpperBoundLimiter[pkgconfig.Size](10*pkgconfig.KByte),
+	)
+
+	orgID := "org_2xAbCdEfGhIjKlMnOpQrStUvWxYz"
+	workflowOwner := "0x0001020304050607080900010203040506070809"
+	encrypted := encryptWithOrgIDLabel(t, pk, orgID)
+
+	err := validator.ValidateCreateSecretsRequest(pk, &vaultcommon.CreateSecretsRequest{
+		RequestId:     "request-id",
+		OrgId:         orgID,
+		WorkflowOwner: workflowOwner,
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{
+				Id: &vaultcommon.SecretIdentifier{
+					Key:       "key",
+					Namespace: "namespace",
+					Owner:     orgID,
+				},
+				EncryptedValue: encrypted,
+			},
+		},
+	})
+
+	require.NoError(t, err)
+}
+
+func TestRequestValidator_ValidateCreateSecretsRequest_FallsBackToSecretOwnerForLegacyRequests(t *testing.T) {
+	pk, _ := generateTestKeys(t)
+	validator := NewRequestValidator(
+		limits.NewUpperBoundLimiter(10),
+		limits.NewUpperBoundLimiter[pkgconfig.Size](10*pkgconfig.KByte),
+	)
+
+	workflowOwner := "0x0001020304050607080900010203040506070809"
+	encrypted := encryptWithEthAddressLabel(t, pk, workflowOwner)
+
+	err := validator.ValidateCreateSecretsRequest(pk, &vaultcommon.CreateSecretsRequest{
+		RequestId: "request-id",
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{
+				Id: &vaultcommon.SecretIdentifier{
+					Key:       "key",
+					Namespace: "namespace",
+					Owner:     workflowOwner,
+				},
+				EncryptedValue: encrypted,
+			},
+		},
+	})
+
+	require.NoError(t, err)
+}

--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don-vault-flags-disabled.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don-vault-flags-disabled.toml
@@ -1,0 +1,97 @@
+
+[chip_router]
+  image = "local-cre-chip-router:v1.0.1"
+
+[[blockchains]]
+  type = "anvil"
+  chain_id = "1337"
+  container_name = "anvil-1337"
+  docker_cmd_params = ["-b", "0.5", "--mixed-mining"]
+
+[[blockchains]]
+  type = "anvil"
+  chain_id = "2337"
+  container_name = "anvil-2337"
+  port = "8546"
+  docker_cmd_params = ["-b", "0.5", "--mixed-mining"]
+
+[jd]
+  csa_encryption_key = "d1093c0060d50a3c89c189b2e485da5a3ce57f3dcb38ab7e2c0d5f0bb2314a44"
+  image = "job-distributor:0.22.1"
+
+[fake]
+  port = 8171
+
+[fake_http]
+  port = 8666
+
+[infra]
+  type = "docker"
+
+[[nodesets]]
+  nodes = 4
+  name = "workflow"
+  don_types = ["workflow"]
+  override_mode = "all"
+  http_port_range_start = 10100
+  supported_evm_chains = [1337, 2337]
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS_DEFAULT = '{"VaultJWTAuthEnabled":"false","VaultOrgIdAsSecretOwnerEnabled":"false"}' }
+  capabilities = ["ocr3", "custom-compute", "web-api-trigger", "cron", "http-action", "http-trigger", "consensus", "don-time", "write-evm-1337", "read-contract-1337", "evm-1337"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+
+  [nodesets.db]
+    image = "postgres:12.0"
+    port = 13000
+
+ [[nodesets.node_specs]]
+    roles = ["plugin"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      user_config_overrides = ""
+
+[[nodesets]]
+  nodes = 4
+  name = "capabilities"
+  don_types = ["capabilities"]
+  exposes_remote_capabilities = true
+  override_mode = "all"
+  http_port_range_start = 10200
+  supported_evm_chains = [1337, 2337]
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS_DEFAULT = '{"VaultJWTAuthEnabled":"false","VaultOrgIdAsSecretOwnerEnabled":"false"}' }
+  capabilities = ["web-api-target", "vault", "write-evm-2337", "read-contract-2337", "evm-2337"]
+
+  [nodesets.db]
+    image = "postgres:12.0"
+    port = 13100
+
+  [[nodesets.node_specs]]
+    roles = ["plugin"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      user_config_overrides = ""
+
+[[nodesets]]
+  nodes = 1
+  name = "bootstrap-gateway"
+  don_types = ["bootstrap", "gateway"]
+  override_mode = "each"
+  http_port_range_start = 10300
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS_DEFAULT = '{"VaultJWTAuthEnabled":"false","VaultOrgIdAsSecretOwnerEnabled":"false"}' }
+  supported_evm_chains = [1337, 2337]
+
+  [nodesets.db]
+    image = "postgres:12.0"
+    port = 13200
+
+  [[nodesets.node_specs]]
+    roles = ["bootstrap", "gateway"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      custom_ports = ["5002:5002","15002:15002"]
+      user_config_overrides = ""

--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don-vault-flags-enabled.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don-vault-flags-enabled.toml
@@ -1,0 +1,111 @@
+
+[chip_router]
+  image = "local-cre-chip-router:v1.0.1"
+
+[[blockchains]]
+  type = "anvil"
+  chain_id = "1337"
+  container_name = "anvil-1337"
+  docker_cmd_params = ["-b", "0.5", "--mixed-mining"]
+
+[[blockchains]]
+  type = "anvil"
+  chain_id = "2337"
+  container_name = "anvil-2337"
+  port = "8546"
+  docker_cmd_params = ["-b", "0.5", "--mixed-mining"]
+
+[jd]
+  csa_encryption_key = "d1093c0060d50a3c89c189b2e485da5a3ce57f3dcb38ab7e2c0d5f0bb2314a44"
+  image = "job-distributor:0.22.1"
+
+[fake]
+  port = 8171
+
+[fake_http]
+  port = 8666
+
+[infra]
+  type = "docker"
+
+[[nodesets]]
+  nodes = 4
+  name = "workflow"
+  don_types = ["workflow"]
+  override_mode = "all"
+  http_port_range_start = 10100
+  supported_evm_chains = [1337, 2337]
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS_DEFAULT = '{"VaultJWTAuthEnabled":"true","VaultOrgIdAsSecretOwnerEnabled":"true"}' }
+  capabilities = ["ocr3", "custom-compute", "web-api-trigger", "cron", "http-action", "http-trigger", "consensus", "don-time", "write-evm-1337", "read-contract-1337", "evm-1337"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+
+  [nodesets.db]
+    image = "postgres:12.0"
+    port = 13000
+
+ [[nodesets.node_specs]]
+    roles = ["plugin"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      user_config_overrides = '''
+[CRE.Linking]
+URL = "host.docker.internal:18124"
+TLSEnabled = false
+'''
+
+[[nodesets]]
+  nodes = 4
+  name = "capabilities"
+  don_types = ["capabilities"]
+  exposes_remote_capabilities = true
+  override_mode = "all"
+  http_port_range_start = 10200
+  supported_evm_chains = [1337, 2337]
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS_DEFAULT = '{"VaultJWTAuthEnabled":"true","VaultOrgIdAsSecretOwnerEnabled":"true"}' }
+  capabilities = ["web-api-target", "vault", "write-evm-2337", "read-contract-2337", "evm-2337"]
+
+  [nodesets.capability_configs]
+    [nodesets.capability_configs.vault.values]
+      [nodesets.capability_configs.vault.values.auth0]
+        issuerURL = "http://host.docker.internal:18123/"
+        audience = "https://vault.test.chain.link"
+
+  [nodesets.db]
+    image = "postgres:12.0"
+    port = 13100
+
+  [[nodesets.node_specs]]
+    roles = ["plugin"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      user_config_overrides = '''
+[CRE.Linking]
+URL = "host.docker.internal:18124"
+TLSEnabled = false
+'''
+
+[[nodesets]]
+  nodes = 1
+  name = "bootstrap-gateway"
+  don_types = ["bootstrap", "gateway"]
+  override_mode = "each"
+  http_port_range_start = 10300
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS_DEFAULT = '{"VaultJWTAuthEnabled":"true","VaultOrgIdAsSecretOwnerEnabled":"true"}' }
+  supported_evm_chains = [1337, 2337]
+
+  [nodesets.db]
+    image = "postgres:12.0"
+    port = 13200
+
+  [[nodesets.node_specs]]
+    roles = ["bootstrap", "gateway"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      custom_ports = ["5002:5002","15002:15002"]
+      user_config_overrides = ""

--- a/core/scripts/cre/environment/environment/setup.go
+++ b/core/scripts/cre/environment/environment/setup.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/pelletier/go-toml/v2"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -289,21 +288,26 @@ func (c BuildConfig) Build(ctx context.Context) (localImage string, err error) {
 	}
 
 	// Build Docker image
-	args := []string{"build", "-t", c.LocalImage, "-f", c.Dockerfile, c.DockerCtx}
-	if c.RequireGithubToken {
-		args = append(args, "--build-arg", "GITHUB_TOKEN="+os.Getenv("GITHUB_TOKEN"))
-	}
+	args := c.dockerBuildArgs()
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	log.Info("Running command:", "cmd", cmd.String(), "dir", workingDir)
+	logger.Info().Str("cmd", cmd.String()).Str("dir", workingDir).Msg("Running docker build command")
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("failed to build Docker image: %w", err)
 	}
 
 	logger.Info().Msgf("  ✓ %s image built successfully", name)
 	return c.LocalImage, nil
+}
+
+func (c BuildConfig) dockerBuildArgs() []string {
+	args := []string{"build", "-t", c.LocalImage, "-f", c.Dockerfile}
+	if c.RequireGithubToken {
+		args = append(args, "--build-arg", "GITHUB_TOKEN="+os.Getenv("GITHUB_TOKEN"))
+	}
+	return append(args, c.DockerCtx)
 }
 
 type PullConfig struct {

--- a/core/scripts/cre/environment/environment/setup_test.go
+++ b/core/scripts/cre/environment/environment/setup_test.go
@@ -1,0 +1,44 @@
+package environment
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildConfigDockerBuildArgs(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "test-token")
+
+	cfg := BuildConfig{
+		LocalImage:         "test-image:latest",
+		Dockerfile:         "Dockerfile.test",
+		DockerCtx:          ".",
+		RequireGithubToken: true,
+	}
+
+	require.Equal(t, []string{
+		"build",
+		"-t", "test-image:latest",
+		"-f", "Dockerfile.test",
+		"--build-arg", "GITHUB_TOKEN=test-token",
+		".",
+	}, cfg.dockerBuildArgs())
+}
+
+func TestBuildConfigDockerBuildArgs_WithoutGithubToken(t *testing.T) {
+	require.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
+
+	cfg := BuildConfig{
+		LocalImage: "test-image:latest",
+		Dockerfile: "Dockerfile.test",
+		DockerCtx:  ".",
+	}
+
+	require.Equal(t, []string{
+		"build",
+		"-t", "test-image:latest",
+		"-f", "Dockerfile.test",
+		".",
+	}, cfg.dockerBuildArgs())
+}

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -1117,18 +1117,33 @@ func (s *service) ApproveSpec(ctx context.Context, id int64, force bool) error {
 			}
 		}
 
+		cleanupCreatedJob := func(cause error) error {
+			if j.ID == 0 {
+				return cause
+			}
+
+			cleanupErr := s.jobSpawner.DeleteJob(ctx, tx.ds, j.ID)
+			if cleanupErr != nil {
+				logger.Errorw("Failed to clean up job after failed approval", "jobID", j.ID, "cleanupErr", cleanupErr, "err", cause)
+				return errors.Wrapf(cause, "failed to clean up job after failed approval: %s", cleanupErr)
+			}
+
+			logger.Warnw("Cleaned up created job after failed approval", "jobID", j.ID, "err", cause)
+			return cause
+		}
+
 		// Create the job
 		if txerr = s.jobSpawner.CreateJob(ctx, tx.ds, j); txerr != nil {
 			logger.Errorw("Failed to create job", "err", txerr)
 
-			return txerr
+			return cleanupCreatedJob(txerr)
 		}
 
 		// Approve the job proposal spec
 		if txerr = tx.orm.ApproveSpec(ctx, id, j.ExternalJobID); txerr != nil {
 			logger.Errorw("Failed to approve spec", "err", txerr)
 
-			return txerr
+			return cleanupCreatedJob(txerr)
 		}
 
 		// Send to FMS Client
@@ -1138,7 +1153,7 @@ func (s *service) ApproveSpec(ctx context.Context, id int64, force bool) error {
 		}); txerr != nil {
 			logger.Errorw("Failed to approve job to FMS", "err", txerr)
 
-			return txerr
+			return cleanupCreatedJob(txerr)
 		}
 
 		return nil

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -1148,6 +1148,7 @@ func Test_Service_ProposeJob(t *testing.T) {
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
 					Return(errors.New("error creating job"))
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
 			},
 			args:    argsWF,
 			wantID:  0,
@@ -2916,6 +2917,7 @@ answer1 [type=median index=0];
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
 					Return(nil)
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
 				svc.orm.On("ApproveSpec",
 					mock.Anything,
 					spec.ID,
@@ -2959,6 +2961,7 @@ answer1 [type=median index=0];
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
 					Return(nil)
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
 				svc.orm.On("ApproveSpec",
 					mock.Anything,
 					spec.ID,
@@ -3164,6 +3167,36 @@ answer1 [type=median index=0];
 			wantErr: "could not approve job proposal: could not save",
 		},
 		{
+			name:        "create job error after partial creation cleans up job",
+			httpTimeout: commonconfig.MustNewDuration(1 * time.Minute),
+			before: func(svc *TestService) {
+				svc.orm.On("GetSpec", mock.Anything, spec.ID).Return(spec, nil)
+				svc.orm.On("GetJobProposal", mock.Anything, jp.ID).Return(jp, nil)
+				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
+				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
+
+				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
+				svc.jobORM.On("FindJobIDByAddress", mock.Anything, address, evmChainID, mock.Anything).Return(int32(0), sql.ErrNoRows)
+
+				svc.spawner.
+					On("CreateJob",
+						mock.Anything,
+						mock.Anything,
+						mock.MatchedBy(func(j *job.Job) bool {
+							return j.Name.String == "LINK / ETH | version 3 | contract 0x0000000000000000000000000000000000000000"
+						}),
+					).
+					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
+					Return(errors.New("could not save"))
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
+				svc.orm.On("WithDataSource", mock.Anything).Return(feeds.ORM(svc.orm))
+				svc.jobORM.On("WithDataSource", mock.Anything).Return(job.ORM(svc.jobORM))
+			},
+			id:      spec.ID,
+			force:   false,
+			wantErr: "could not approve job proposal: could not save",
+		},
+		{
 			name:        "approve spec orm error",
 			httpTimeout: commonconfig.MustNewDuration(1 * time.Minute),
 			before: func(svc *TestService) {
@@ -3185,6 +3218,7 @@ answer1 [type=median index=0];
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
 					Return(nil)
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
 				svc.orm.On("ApproveSpec",
 					mock.Anything,
 					spec.ID,
@@ -3219,6 +3253,7 @@ answer1 [type=median index=0];
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
 					Return(nil)
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
 				svc.orm.On("ApproveSpec",
 					mock.Anything,
 					spec.ID,
@@ -3593,6 +3628,7 @@ updateInterval = "20m"
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
 					Return(nil)
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
 				svc.orm.On("ApproveSpec",
 					mock.Anything,
 					spec.ID,
@@ -3636,6 +3672,7 @@ updateInterval = "20m"
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
 					Return(nil)
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
 				svc.orm.On("ApproveSpec",
 					mock.Anything,
 					spec.ID,
@@ -3776,6 +3813,7 @@ updateInterval = "20m"
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
 					Return(nil)
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
 				svc.orm.On("ApproveSpec",
 					mock.Anything,
 					spec.ID,
@@ -3810,6 +3848,7 @@ updateInterval = "20m"
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
 					Return(nil)
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
 				svc.orm.On("ApproveSpec",
 					mock.Anything,
 					spec.ID,
@@ -4063,6 +4102,7 @@ func Test_Service_ApproveSpec_Stream(t *testing.T) {
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
 					Return(nil)
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
 				svc.orm.On("ApproveSpec",
 					mock.Anything,
 					spec.ID,
@@ -4294,6 +4334,7 @@ func Test_Service_ApproveSpec_Stream(t *testing.T) {
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
 					Return(nil)
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
 				svc.orm.On("ApproveSpec",
 					mock.Anything,
 					spec.ID,
@@ -4328,6 +4369,7 @@ func Test_Service_ApproveSpec_Stream(t *testing.T) {
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
 					Return(nil)
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
 				svc.orm.On("ApproveSpec",
 					mock.Anything,
 					spec.ID,
@@ -4839,6 +4881,7 @@ chainID = 0
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
 					Return(nil)
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
 				svc.orm.On("ApproveSpec",
 					mock.Anything,
 					spec.ID,
@@ -4873,6 +4916,7 @@ chainID = 0
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
 					Return(nil)
+				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, int32(1)).Return(nil)
 				svc.orm.On("ApproveSpec",
 					mock.Anything,
 					spec.ID,

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -175,17 +175,32 @@ type SecretEntry struct {
 type Config struct {
 	NodeRateLimiter   ratelimit.RateLimiterConfig `json:"nodeRateLimiter"`
 	RequestTimeoutSec int                         `json:"requestTimeoutSec"`
+	Auth0             *vaultcap.Auth0Config       `json:"auth0,omitempty"`
 }
 
 // NewHandler creates the gateway-side Vault handler with internal auth wiring.
 func NewHandler(methodConfig json.RawMessage, donConfig *config.DONConfig, don gwhandlers.DON, capabilitiesRegistry capabilitiesRegistry, workflowRegistrySyncer workflowsyncerv2.WorkflowRegistrySyncer, lggr logger.Logger, clock clockwork.Clock, limitsFactory limits.Factory) (*handler, error) {
+	var cfg Config
+	if err := json.Unmarshal(methodConfig, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal method config: %w", err)
+	}
+
 	allowListBasedAuth := vaultcap.NewAllowListBasedAuth(lggr, workflowRegistrySyncer)
-	jwtBasedAuth, err := vaultcap.NewJWTBasedAuth(vaultcap.JWTBasedAuthConfig{}, limitsFactory, lggr, vaultcap.WithDisabledJWTBasedAuth())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create JWTBasedAuth: %w", err)
+	var jwtBasedAuth vaultcap.Authorizer
+	var jwtAuth services.Service
+	if cfg.Auth0 != nil {
+		validator, err := vaultcap.NewJWTBasedAuth(vaultcap.JWTBasedAuthConfig{
+			IssuerURL: cfg.Auth0.IssuerURL,
+			Audience:  cfg.Auth0.Audience,
+		}, limitsFactory, lggr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create JWTBasedAuth: %w", err)
+		}
+		jwtBasedAuth = validator
+		jwtAuth = validator
 	}
 	authorizer := vaultcap.NewAuthorizer(allowListBasedAuth, jwtBasedAuth, lggr)
-	return newHandlerWithJWTAuth(methodConfig, donConfig, don, capabilitiesRegistry, authorizer, jwtBasedAuth, lggr, clock, limitsFactory)
+	return newHandlerWithJWTAuth(methodConfig, donConfig, don, capabilitiesRegistry, authorizer, jwtAuth, lggr, clock, limitsFactory)
 }
 
 func newHandlerWithAuthorizer(methodConfig json.RawMessage, donConfig *config.DONConfig, don gwhandlers.DON, capabilitiesRegistry capabilitiesRegistry, authorizer vaultcap.Authorizer, lggr logger.Logger, clock clockwork.Clock, limitsFactory limits.Factory) (*handler, error) {
@@ -397,11 +412,17 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 		return h.handlePublicKeyGetSynchronously(ctx, req, publicKeyResponseBytes, callback)
 	}
 
-	authResult, err := h.authorizer.AuthorizeRequest(ctx, req)
-	if err != nil {
-		h.lggr.Errorw("request not authorized", "method", req.Method, "requestID", req.ID, "hasAuth", req.Auth != "", "error", err)
-		return errors.New("request not authorized: " + err.Error())
+	authResult, authErr := h.authorizer.AuthorizeRequest(ctx, req)
+	if authErr != nil {
+		h.lggr.Errorw("request not authorized", "method", req.Method, "requestID", req.ID, "hasAuth", req.Auth != "", "error", authErr)
+		return errors.New("request not authorized: " + authErr.Error())
 	}
+	normalizedReq, normalizeErr := vaultcap.NormalizeRequestWithIdentity(req, authResult.OrgID(), authResult.WorkflowOwner())
+	if normalizeErr != nil {
+		h.lggr.Errorw("failed to normalize authorized request identity", "method", req.Method, "requestID", req.ID, "orgID", authResult.OrgID(), "workflowOwner", authResult.WorkflowOwner(), "error", normalizeErr)
+		return normalizeErr
+	}
+	req = normalizedReq
 	authorizedOwner := authResult.AuthorizedOwner()
 	// Generate a unique ID for the request.
 	// Prefix request id with authorizedOwner, to ensure uniqueness across different owners
@@ -409,9 +430,9 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 	req.ID = authorizedOwner + vaulttypes.RequestIDSeparator + req.ID
 
 	h.lggr.Debugw("handling authorized vault request", "method", req.Method, "requestID", req.ID, "authorizedOwner", authorizedOwner)
-	ar, err := h.newActiveRequest(req, callback)
-	if err != nil {
-		return err
+	ar, activeRequestErr := h.newActiveRequest(req, callback)
+	if activeRequestErr != nil {
+		return activeRequestErr
 	}
 
 	switch req.Method {

--- a/core/services/gateway/handlers/vault/handler_test.go
+++ b/core/services/gateway/handlers/vault/handler_test.go
@@ -61,9 +61,7 @@ func setupHandler(t *testing.T) (handlers.Handler, *common.Callback, *mocks.DON,
 
 	clock := clockwork.NewFakeClock()
 	limitsFactory := limits.Factory{Settings: cresettings.DefaultGetter}
-	jwtBasedAuth, err := vaultcap.NewJWTBasedAuth(vaultcap.JWTBasedAuthConfig{}, limitsFactory, lggr, vaultcap.WithDisabledJWTBasedAuth())
-	require.NoError(t, err)
-	authorizer := vaultcap.NewAuthorizer(&stubAllowListBasedAuth{clock: clock}, jwtBasedAuth, lggr)
+	authorizer := vaultcap.NewAuthorizer(&stubAllowListBasedAuth{clock: clock}, nil, lggr)
 	handler, err := newHandlerWithAuthorizer(methodConfig, donConfig, don, nil, authorizer, lggr, clock, limitsFactory)
 	require.NoError(t, err)
 	handler.aggregator = &mockAggregator{}
@@ -77,6 +75,15 @@ type stubAllowListBasedAuth struct {
 
 func (s *stubAllowListBasedAuth) AuthorizeRequest(_ context.Context, req jsonrpc.Request[json.RawMessage]) (*vaultcap.AuthResult, error) {
 	return vaultcap.NewAuthResult("", owner, "digest-"+req.ID, s.clock.Now().Add(time.Minute).Unix()), nil
+}
+
+type stubAuthorizer struct {
+	result *vaultcap.AuthResult
+	err    error
+}
+
+func (s *stubAuthorizer) AuthorizeRequest(_ context.Context, _ jsonrpc.Request[json.RawMessage]) (*vaultcap.AuthResult, error) {
+	return s.result, s.err
 }
 
 type mockAggregator struct {
@@ -217,6 +224,78 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		err = h.HandleNodeMessage(t.Context(), &response, NodeOne.Address)
 		require.NoError(t, err)
 		wg.Wait()
+	})
+
+	t.Run("overwrites request identity fields after authorization", func(t *testing.T) {
+		lggr := logger.Test(t)
+		don := mocks.NewDON(t)
+		donConfig := &config.DONConfig{
+			DonId:   "test_don_id",
+			Members: []config.NodeConfig{NodeOne},
+		}
+		handlerConfig := Config{
+			RequestTimeoutSec: 30,
+			NodeRateLimiter: ratelimit.RateLimiterConfig{
+				GlobalRPS:      100,
+				GlobalBurst:    100,
+				PerSenderRPS:   10,
+				PerSenderBurst: 10,
+			},
+		}
+		methodConfig, err := json.Marshal(handlerConfig)
+		require.NoError(t, err)
+
+		clock := clockwork.NewFakeClock()
+		limitsFactory := limits.Factory{Settings: cresettings.DefaultGetter}
+		h, err := newHandlerWithAuthorizer(
+			methodConfig,
+			donConfig,
+			don,
+			nil,
+			&stubAuthorizer{result: vaultcap.NewAuthResult("org-1", "0xworkflow", "digest-1", clock.Now().Add(time.Minute).Unix())},
+			lggr,
+			clock,
+			limitsFactory,
+		)
+		require.NoError(t, err)
+
+		forgedCreateSecretsRequest := &vaultcommon.CreateSecretsRequest{
+			RequestId:     "test_request_id",
+			OrgId:         "forged-org",
+			WorkflowOwner: "0xforged",
+			EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+				{
+					Id: &vaultcommon.SecretIdentifier{
+						Key:   "test_id",
+						Owner: "org-1",
+					},
+					EncryptedValue: "abc123",
+				},
+			},
+		}
+		requestParams, err := json.Marshal(forgedCreateSecretsRequest)
+		require.NoError(t, err)
+
+		var forwarded jsonrpc.Request[json.RawMessage]
+		don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			forwarded = *args.Get(2).(*jsonrpc.Request[json.RawMessage])
+		}).Return(nil)
+
+		req := jsonrpc.Request[json.RawMessage]{
+			ID:     "1",
+			Method: vaulttypes.MethodSecretsCreate,
+			Params: (*json.RawMessage)(&requestParams),
+		}
+
+		err = h.HandleJSONRPCUserMessage(t.Context(), req, common.NewCallback())
+		require.NoError(t, err)
+
+		require.NotNil(t, forwarded.Params)
+		var forwardedCreateRequest vaultcommon.CreateSecretsRequest
+		require.NoError(t, json.Unmarshal(*forwarded.Params, &forwardedCreateRequest))
+		require.Equal(t, "org-1", forwardedCreateRequest.OrgId)
+		require.Equal(t, "0xworkflow", forwardedCreateRequest.WorkflowOwner)
+		require.Equal(t, "org-1"+vaulttypes.RequestIDSeparator+"1", forwardedCreateRequest.RequestId)
 	})
 
 	t.Run("nil EncryptedSecrets inside CreateSecrets body", func(t *testing.T) {

--- a/core/services/job/spawner.go
+++ b/core/services/job/spawner.go
@@ -146,6 +146,7 @@ func (js *spawner) startAllServices(ctx context.Context) {
 			defer wg.Done()
 			if err = js.StartService(ctx, jb); err != nil {
 				js.lggr.Errorw("Couldn't start job", "jobID", jb.ID, "jobName", jb.Name.ValueOrZero(), "err", err)
+				js.stopService(jb.ID)
 			}
 		}(jb)
 	}
@@ -211,6 +212,7 @@ func (js *spawner) StartService(ctx context.Context, jb Job) error {
 	// OnJobDeleted before deleting. However, the activeJob will only have services
 	// that it was able to start without an error.
 	aj := activeJob{delegate: delegate, spec: jb}
+	js.activeJobs[jb.ID] = aj
 
 	jb.PipelineSpec.JobName = jb.Name.ValueOrZero()
 	jb.PipelineSpec.JobID = jb.ID
@@ -225,13 +227,16 @@ func (js *spawner) StartService(ctx context.Context, jb Job) error {
 		cctx, cancel := js.chStop.NewCtx()
 		defer cancel()
 		js.orm.TryRecordError(cctx, jb.ID, err.Error())
-		js.activeJobs[jb.ID] = aj
 		return fmt.Errorf("failed to create services for job: %d: %w", jb.ID, err)
 	}
 
-	var ms services.MultiStart
 	for _, srv := range srvs {
-		err = ms.Start(ctx, srv)
+		// Track the service before Start so rollback can close it even if Start
+		// returns after partially initializing internal state.
+		aj.services = append(aj.services, srv)
+		js.activeJobs[jb.ID] = aj
+
+		err = srv.Start(ctx)
 		if err != nil {
 			lggr.Criticalw("Error starting service for job", "err", err)
 			return err
@@ -239,10 +244,10 @@ func (js *spawner) StartService(ctx context.Context, jb Job) error {
 		if c, ok := srv.(services.HealthReporter); ok {
 			err = js.checker.Register(c)
 			if err != nil {
+				js.activeJobs[jb.ID] = aj
 				return fmt.Errorf("failed to register service with health checker for job %d: %w", jb.ID, err)
 			}
 		}
-		aj.services = append(aj.services, srv)
 	}
 	js.activeJobs[jb.ID] = aj
 	return nil
@@ -272,6 +277,8 @@ func (js *spawner) CreateJob(ctx context.Context, ds sqlutil.DataSource, jb *Job
 	err = js.StartService(ctx, *jb)
 	if err != nil {
 		js.lggr.Errorw("Error starting job services", "type", jb.Type, "jobID", jb.ID, "err", err)
+		// Tear down any services that did start so retries do not inherit stale in-memory state.
+		js.stopService(jb.ID)
 	} else {
 		js.lggr.Infow("Started job services", "type", jb.Type, "jobID", jb.ID)
 	}

--- a/core/services/job/spawner_test.go
+++ b/core/services/job/spawner_test.go
@@ -2,6 +2,7 @@ package job_test
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -283,6 +284,66 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 		clearDB(t, db)
 	})
 
+	t.Run("closes partially started services after create job error", func(t *testing.T) {
+		jobA := makeOCRJobSpec(t, address, bridge.Name.String(), bridge2.Name.String())
+
+		serviceA1 := &healthService{name: "svc-a1"}
+		checker := failingChecker{err: errors.New("register boom")}
+
+		lggr := logger.TestLogger(t)
+		orm := NewTestORM(t, db, pipeline.NewORM(db, lggr, config.JobPipeline().MaxSuccessfulRuns()), bridges.NewORM(db), keyStore)
+		mailMon := servicetest.Run(t, mailboxtest.NewMonitor(t))
+		d := ocr.NewDelegate(nil, orm, nil, nil, nil, nil, monitoringEndpoint, legacyChains, logger.TestLogger(t), config, mailMon)
+		delegateA := &delegate{jobA.Type, []job.ServiceCtx{serviceA1}, 0, nil, d}
+		spawner := job.NewSpawner(orm, config.Database(), checker, map[job.Type]job.Delegate{
+			jobA.Type: delegateA,
+		}, lggr, nil)
+
+		ctx := testutils.Context(t)
+		require.NoError(t, spawner.Start(ctx))
+		defer func() { assert.NoError(t, spawner.Close()) }()
+
+		err := spawner.CreateJob(ctx, nil, jobA)
+		require.ErrorContains(t, err, "register boom")
+		assert.Empty(t, spawner.ActiveJobs())
+
+		err = spawner.DeleteJob(ctx, nil, jobA.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 1, serviceA1.closeCalls)
+
+		clearDB(t, db)
+	})
+
+	t.Run("closes failing service after partial start error", func(t *testing.T) {
+		jobA := makeOCRJobSpec(t, address, bridge.Name.String(), bridge2.Name.String())
+
+		serviceA1 := &partialStartService{startErr: errors.New("start boom")}
+
+		lggr := logger.TestLogger(t)
+		orm := NewTestORM(t, db, pipeline.NewORM(db, lggr, config.JobPipeline().MaxSuccessfulRuns()), bridges.NewORM(db), keyStore)
+		mailMon := servicetest.Run(t, mailboxtest.NewMonitor(t))
+		d := ocr.NewDelegate(nil, orm, nil, nil, nil, nil, monitoringEndpoint, legacyChains, logger.TestLogger(t), config, mailMon)
+		delegateA := &delegate{jobA.Type, []job.ServiceCtx{serviceA1}, 0, nil, d}
+		spawner := job.NewSpawner(orm, config.Database(), noopChecker{}, map[job.Type]job.Delegate{
+			jobA.Type: delegateA,
+		}, lggr, nil)
+
+		ctx := testutils.Context(t)
+		require.NoError(t, spawner.Start(ctx))
+		defer func() { assert.NoError(t, spawner.Close()) }()
+
+		err := spawner.CreateJob(ctx, nil, jobA)
+		require.ErrorContains(t, err, "start boom")
+		assert.Empty(t, spawner.ActiveJobs())
+		assert.Equal(t, 1, serviceA1.closeCalls)
+
+		err = spawner.DeleteJob(ctx, nil, jobA.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 1, serviceA1.closeCalls)
+
+		clearDB(t, db)
+	})
+
 	t.Run("Unregisters filters on 'DeleteJob()'", func(t *testing.T) {
 		config = configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 			c.Feature.LogPoller = func(b bool) *bool { return &b }(true)
@@ -365,3 +426,49 @@ func (n noopChecker) IsHealthy() (healthy bool, errors map[string]error) { retur
 func (n noopChecker) Start() error { return nil }
 
 func (n noopChecker) Close() error { return nil }
+
+type failingChecker struct {
+	err error
+}
+
+func (f failingChecker) Register(service services.HealthReporter) error { return f.err }
+
+func (f failingChecker) Unregister(name string) error { return nil }
+
+func (f failingChecker) IsReady() (ready bool, errors map[string]error) { return true, nil }
+
+func (f failingChecker) IsHealthy() (healthy bool, errors map[string]error) { return true, nil }
+
+func (f failingChecker) Start() error { return nil }
+
+func (f failingChecker) Close() error { return nil }
+
+type healthService struct {
+	name       string
+	closeCalls int
+}
+
+func (s *healthService) Start(context.Context) error { return nil }
+
+func (s *healthService) Close() error {
+	s.closeCalls++
+	return nil
+}
+
+func (s *healthService) Name() string { return s.name }
+
+func (s *healthService) Ready() error { return nil }
+
+func (s *healthService) HealthReport() map[string]error { return map[string]error{s.name: nil} }
+
+type partialStartService struct {
+	startErr   error
+	closeCalls int
+}
+
+func (s *partialStartService) Start(context.Context) error { return s.startErr }
+
+func (s *partialStartService) Close() error {
+	s.closeCalls++
+	return nil
+}

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -732,7 +732,12 @@ func (d *Delegate) newServicesVaultPlugin(
 	}
 	srvs = append(srvs, vaultCapability)
 
-	handler, err := vaultcap.NewGatewayHandler(vaultCapability, gwconnector, syncer, d.lggr, limitsFactory)
+	gatewayHandlerOpts := make([]vaultcap.GatewayHandlerOption, 0, 1)
+	if cfg.Auth0 != nil {
+		gatewayHandlerOpts = append(gatewayHandlerOpts, vaultcap.WithJWTAuth0Config(cfg.Auth0))
+	}
+
+	handler, err := vaultcap.NewGatewayHandler(vaultCapability, gwconnector, syncer, d.lggr, limitsFactory, gatewayHandlerOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate vault plugin: failed to create vault handler: %w", err)
 	}

--- a/core/services/ocr2/plugins/vault/config.go
+++ b/core/services/ocr2/plugins/vault/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+	vaultcap "github.com/smartcontractkit/chainlink/v2/core/capabilities/vault"
 )
 
 type DKGConfig struct {
@@ -13,6 +14,7 @@ type DKGConfig struct {
 type Config struct {
 	RequestExpiryDuration commonconfig.Duration `json:"requestExpiryDuration"`
 	DKG                   *DKGConfig            `json:"dkg,omitempty"`
+	Auth0                 *vaultcap.Auth0Config `json:"auth0,omitempty"`
 }
 
 func (c *Config) Validate() error {

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -390,6 +390,18 @@ func (r *ReportingPlugin) orgIDAsSecretOwnerEnabled(ctx context.Context) bool {
 	return r.cfg.OrgIDAsSecretOwnerEnabled.AllowErr(ctx) == nil
 }
 
+func (r *ReportingPlugin) canonicalResponseID(ctx context.Context, id *vaultcommon.SecretIdentifier, orgID string) *vaultcommon.SecretIdentifier {
+	if id == nil || orgID == "" || !r.orgIDAsSecretOwnerEnabled(ctx) {
+		return id
+	}
+
+	return &vaultcommon.SecretIdentifier{
+		Key:       id.Key,
+		Namespace: id.Namespace,
+		Owner:     orgID,
+	}
+}
+
 type pendingQueueStore interface {
 	WritePendingQueue(ctx context.Context, pending []*vaultcommon.StoredPendingQueueItem) error
 }
@@ -1911,7 +1923,7 @@ func (r *ReportingPlugin) stateTransitionCreateSecrets(ctx context.Context, stor
 			})
 			continue
 		}
-		resp, err := r.stateTransitionCreateSecretsRequest(ctx, store, req, resp)
+		resp, err := r.stateTransitionCreateSecretsRequest(ctx, store, req, resp, first.GetCreateSecretsRequest().OrgId)
 		if err != nil {
 			logUserErrorAware(r.lggr, "failed to handle create secret request", err, "id", req.Id, "requestID", reqID)
 			errorMsg := userFacingError(err, "failed to handle create secret request")
@@ -1933,7 +1945,7 @@ func (r *ReportingPlugin) stateTransitionCreateSecrets(ctx context.Context, stor
 	}
 }
 
-func (r *ReportingPlugin) stateTransitionCreateSecretsRequest(ctx context.Context, store WriteKVStore, req *vaultcommon.EncryptedSecret, resp *vaultcommon.CreateSecretResponse) (*vaultcommon.CreateSecretResponse, error) {
+func (r *ReportingPlugin) stateTransitionCreateSecretsRequest(ctx context.Context, store WriteKVStore, req *vaultcommon.EncryptedSecret, resp *vaultcommon.CreateSecretResponse, orgID string) (*vaultcommon.CreateSecretResponse, error) {
 	if resp.GetError() != "" {
 		return resp, newUserError(resp.GetError())
 	}
@@ -1974,7 +1986,7 @@ func (r *ReportingPlugin) stateTransitionCreateSecretsRequest(ctx context.Contex
 	}
 
 	return &vaultcommon.CreateSecretResponse{
-		Id:      req.Id,
+		Id:      r.canonicalResponseID(ctx, req.Id, orgID),
 		Success: true,
 		Error:   "",
 	}, nil
@@ -2029,7 +2041,7 @@ func (r *ReportingPlugin) stateTransitionUpdateSecrets(ctx context.Context, stor
 			})
 			continue
 		}
-		resp, err := r.stateTransitionUpdateSecretsRequest(ctx, store, req, resp)
+		resp, err := r.stateTransitionUpdateSecretsRequest(ctx, store, req, resp, first.GetUpdateSecretsRequest().OrgId)
 		if err != nil {
 			logUserErrorAware(r.lggr, "failed to handle update secret request", err, "id", req.Id, "requestID", reqID)
 			errorMsg := userFacingError(err, "failed to handle update secret request")
@@ -2051,7 +2063,7 @@ func (r *ReportingPlugin) stateTransitionUpdateSecrets(ctx context.Context, stor
 	}
 }
 
-func (r *ReportingPlugin) stateTransitionUpdateSecretsRequest(ctx context.Context, store WriteKVStore, req *vaultcommon.EncryptedSecret, resp *vaultcommon.UpdateSecretResponse) (*vaultcommon.UpdateSecretResponse, error) {
+func (r *ReportingPlugin) stateTransitionUpdateSecretsRequest(ctx context.Context, store WriteKVStore, req *vaultcommon.EncryptedSecret, resp *vaultcommon.UpdateSecretResponse, orgID string) (*vaultcommon.UpdateSecretResponse, error) {
 	if resp.GetError() != "" {
 		return resp, newUserError(resp.GetError())
 	}
@@ -2078,7 +2090,7 @@ func (r *ReportingPlugin) stateTransitionUpdateSecretsRequest(ctx context.Contex
 	}
 
 	return &vaultcommon.UpdateSecretResponse{
-		Id:      req.Id,
+		Id:      r.canonicalResponseID(ctx, req.Id, orgID),
 		Success: true,
 		Error:   "",
 	}, nil
@@ -2133,7 +2145,7 @@ func (r *ReportingPlugin) stateTransitionDeleteSecrets(ctx context.Context, stor
 			})
 			continue
 		}
-		resp, err := r.stateTransitionDeleteSecretsRequest(ctx, store, req, resp)
+		resp, err := r.stateTransitionDeleteSecretsRequest(ctx, store, req, resp, first.GetDeleteSecretsRequest().OrgId)
 		if err != nil {
 			logUserErrorAware(r.lggr, "failed to handle delete secret request", err, "id", id, "requestId", reqID)
 			errorMsg := userFacingError(err, "failed to handle delete secret request")
@@ -2155,7 +2167,7 @@ func (r *ReportingPlugin) stateTransitionDeleteSecrets(ctx context.Context, stor
 	}
 }
 
-func (r *ReportingPlugin) stateTransitionDeleteSecretsRequest(ctx context.Context, store WriteKVStore, id *vaultcommon.SecretIdentifier, resp *vaultcommon.DeleteSecretResponse) (*vaultcommon.DeleteSecretResponse, error) {
+func (r *ReportingPlugin) stateTransitionDeleteSecretsRequest(ctx context.Context, store WriteKVStore, id *vaultcommon.SecretIdentifier, resp *vaultcommon.DeleteSecretResponse, orgID string) (*vaultcommon.DeleteSecretResponse, error) {
 	if resp.GetError() != "" {
 		return resp, newUserError(resp.GetError())
 	}
@@ -2166,7 +2178,7 @@ func (r *ReportingPlugin) stateTransitionDeleteSecretsRequest(ctx context.Contex
 	}
 
 	return &vaultcommon.DeleteSecretResponse{
-		Id:      id,
+		Id:      r.canonicalResponseID(ctx, id, orgID),
 		Success: true,
 		Error:   "",
 	}, nil

--- a/core/services/ocr2/plugins/vault/plugin_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_test.go
@@ -3723,6 +3723,114 @@ func TestPlugin_StateTransition_CreateSecretsRequest_UsesWorkflowOwnerMetadataWh
 	assert.Nil(t, ss)
 }
 
+func TestPlugin_StateTransition_CreateSecretsRequest_RewritesResponseOwnerToOrgIDWhenGateEnabled(t *testing.T) {
+	lggr, observed := logger.TestLoggerObserved(t, zapcore.DebugLevel)
+	store := requests.NewStore[*vaulttypes.Request]()
+	_, pk, shares, err := tdh2easy.GenerateKeys(1, 3)
+	require.NoError(t, err)
+	cfg := makeReportingPluginConfig(
+		t,
+		10,
+		pk,
+		shares[0],
+		5,
+		1024,
+		100,
+		100,
+		100,
+		10,
+	)
+	cfg.OrgIDAsSecretOwnerEnabled = limits.NewGateLimiter(true)
+	r := &ReportingPlugin{
+		lggr: lggr,
+		onchainCfg: ocr3types.ReportingPluginConfig{
+			N: 4,
+			F: 1,
+		},
+		store:   store,
+		metrics: newTestMetrics(t),
+		cfg:     cfg,
+	}
+
+	const (
+		orgID         = "org-create-success"
+		workflowOwner = "0x5555555555555555555555555555555555555555"
+	)
+
+	requestID := &vaultcommon.SecretIdentifier{
+		Owner:     workflowOwner,
+		Namespace: "main",
+		Key:       "secret",
+	}
+	canonicalID := &vaultcommon.SecretIdentifier{
+		Owner:     orgID,
+		Namespace: "main",
+		Key:       "secret",
+	}
+
+	value := []byte("encrypted-value")
+	req := &vaultcommon.CreateSecretsRequest{
+		RequestId: "request-id",
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{
+				Id:             requestID,
+				EncryptedValue: hex.EncodeToString(value),
+			},
+		},
+		OrgId:         orgID,
+		WorkflowOwner: workflowOwner,
+	}
+	resp := &vaultcommon.CreateSecretsResponse{
+		Responses: []*vaultcommon.CreateSecretResponse{
+			{
+				Id:      requestID,
+				Success: false,
+				Error:   "",
+			},
+		},
+	}
+
+	kv := &kv{m: make(map[string]response)}
+	rs := newTestReadStore(t, kv)
+	obsb := marshalObservations(t, observation{requestID, req, resp})
+	reportPrecursor, err := r.StateTransition(
+		t.Context(),
+		1,
+		types.AttributedQuery{},
+		[]types.AttributedObservation{
+			{Observer: 0, Observation: types.Observation(obsb)},
+			{Observer: 1, Observation: types.Observation(obsb)},
+			{Observer: 2, Observation: types.Observation(obsb)},
+		},
+		kv,
+		nil,
+	)
+	require.NoError(t, err)
+
+	os := &vaultcommon.Outcomes{}
+	require.NoError(t, proto.Unmarshal(reportPrecursor, os))
+	require.Len(t, os.Outcomes, 1)
+
+	o := os.Outcomes[0]
+	assert.True(t, proto.Equal(req, o.GetCreateSecretsRequest()))
+	expectedResp := &vaultcommon.CreateSecretsResponse{
+		Responses: []*vaultcommon.CreateSecretResponse{
+			{
+				Id:      canonicalID,
+				Success: true,
+				Error:   "",
+			},
+		},
+	}
+	assert.True(t, proto.Equal(expectedResp, o.GetCreateSecretsResponse()), o.GetCreateSecretsResponse())
+
+	ss, err := rs.GetSecret(t.Context(), canonicalID)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("encrypted-value"), ss.EncryptedSecret)
+
+	assert.Equal(t, 1, observed.FilterMessage("sufficient observations for sha").Len())
+}
+
 func TestPlugin_Reports(t *testing.T) {
 	value := "encrypted-value"
 	id := &vaultcommon.SecretIdentifier{
@@ -4533,7 +4641,7 @@ func TestPlugin_StateTransition_UpdateSecretsRequest_MigratesWorkflowOwnerSecret
 		RequestId: "request-id",
 		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
 			{
-				Id:             id,
+				Id:             legacyID,
 				EncryptedValue: hex.EncodeToString([]byte("encrypted-value")),
 			},
 		},
@@ -4543,14 +4651,14 @@ func TestPlugin_StateTransition_UpdateSecretsRequest_MigratesWorkflowOwnerSecret
 	resp := &vaultcommon.UpdateSecretsResponse{
 		Responses: []*vaultcommon.UpdateSecretResponse{
 			{
-				Id:      id,
+				Id:      legacyID,
 				Success: false,
 				Error:   "",
 			},
 		},
 	}
 
-	obsb := marshalObservations(t, observation{id, req, resp})
+	obsb := marshalObservations(t, observation{legacyID, req, resp})
 	reportPrecursor, err := r.StateTransition(
 		t.Context(),
 		1,
@@ -4573,6 +4681,7 @@ func TestPlugin_StateTransition_UpdateSecretsRequest_MigratesWorkflowOwnerSecret
 	assert.True(t, proto.Equal(req, o.GetUpdateSecretsRequest()), o.GetUpdateSecretsRequest())
 	require.Len(t, o.GetUpdateSecretsResponse().Responses, 1)
 	assert.True(t, o.GetUpdateSecretsResponse().Responses[0].Success)
+	assert.Equal(t, orgID, o.GetUpdateSecretsResponse().Responses[0].Id.Owner)
 
 	ss, err := rs.GetSecret(t.Context(), id)
 	require.NoError(t, err)
@@ -5059,21 +5168,21 @@ func TestPlugin_StateTransition_DeleteSecretsRequest_DeletesWorkflowOwnerSecretW
 	}
 	req := &vaultcommon.DeleteSecretsRequest{
 		RequestId:     "request-id",
-		Ids:           []*vaultcommon.SecretIdentifier{id},
+		Ids:           []*vaultcommon.SecretIdentifier{legacyID},
 		OrgId:         orgID,
 		WorkflowOwner: workflowOwner,
 	}
 	resp := &vaultcommon.DeleteSecretsResponse{
 		Responses: []*vaultcommon.DeleteSecretResponse{
 			{
-				Id:      id,
+				Id:      legacyID,
 				Success: false,
 				Error:   "",
 			},
 		},
 	}
 
-	obsb := marshalObservations(t, observation{id, req, resp})
+	obsb := marshalObservations(t, observation{legacyID, req, resp})
 	reportPrecursor, err := r.StateTransition(
 		t.Context(),
 		1,
@@ -5096,6 +5205,7 @@ func TestPlugin_StateTransition_DeleteSecretsRequest_DeletesWorkflowOwnerSecretW
 	assert.True(t, proto.Equal(req, o.GetDeleteSecretsRequest()), o.GetDeleteSecretsRequest())
 	require.Len(t, o.GetDeleteSecretsResponse().Responses, 1)
 	assert.True(t, o.GetDeleteSecretsResponse().Responses[0].Success)
+	assert.True(t, proto.Equal(id, o.GetDeleteSecretsResponse().Responses[0].Id), o.GetDeleteSecretsResponse().Responses[0].Id)
 
 	ss, err := rs.GetSecret(t.Context(), legacyID)
 	require.NoError(t, err)

--- a/deployment/cre/jobs/operations/propose_gateway_job.go
+++ b/deployment/cre/jobs/operations/propose_gateway_job.go
@@ -42,9 +42,10 @@ type DON struct {
 }
 
 type GatewayService struct {
-	ServiceName string   `yaml:"servicename"`
-	Handlers    []string `yaml:"handlers"`
-	DONs        []string `yaml:"dons"`
+	ServiceName string           `yaml:"servicename"`
+	Handlers    []string         `yaml:"handlers"`
+	DONs        []string         `yaml:"dons"`
+	Auth0       *pkg.Auth0Config `yaml:"auth0,omitempty"`
 }
 
 type ProposeGatewayJobDeps struct {
@@ -172,6 +173,7 @@ func buildServiceCentricJob(deps ProposeGatewayJobDeps, input ProposeGatewayJobI
 			ServiceName: svc.ServiceName,
 			Handlers:    svc.Handlers,
 			DONs:        svc.DONs,
+			Auth0:       svc.Auth0,
 		}
 	}
 

--- a/deployment/cre/jobs/operations/propose_ocr3_job.go
+++ b/deployment/cre/jobs/operations/propose_ocr3_job.go
@@ -36,6 +36,7 @@ type ProposeOCR3JobInput struct {
 	// Optionals: specific to the worker vault OCR3 Job spec
 	DKGContractAddress         string
 	VaultRequestExpiryDuration string
+	Auth0                      *pkg.Auth0Config
 
 	DONFilters  []offchain.TargetDONFilter
 	ExtraLabels map[string]string
@@ -81,7 +82,7 @@ var ProposeOCR3Job = operations.NewSequence[ProposeOCR3JobInput, ProposeOCR3JobO
 
 		specs, err := pkg.BuildOCR3JobConfigSpecs(
 			deps.Env.Offchain, deps.Env.Logger, input.ContractAddress, input.ChainSelectorEVM,
-			input.ChainSelectorAptos, input.ChainSelectorSolana, nodes, input.BootstrapperOCR3Urls, input.DONName, input.JobName, input.TemplateName, input.DKGContractAddress, vaultReqExpiry,
+			input.ChainSelectorAptos, input.ChainSelectorSolana, nodes, input.BootstrapperOCR3Urls, input.DONName, input.JobName, input.TemplateName, input.DKGContractAddress, vaultReqExpiry, input.Auth0,
 		)
 		if err != nil {
 			return ProposeOCR3JobOutput{}, fmt.Errorf("failed to build OCR3 job config specs: %w", err)

--- a/deployment/cre/jobs/pkg/gateway_job.go
+++ b/deployment/cre/jobs/pkg/gateway_job.go
@@ -53,6 +53,7 @@ type GatewayServiceConfig struct {
 	ServiceName string
 	Handlers    []string
 	DONs        []string
+	Auth0       *Auth0Config
 }
 
 type GatewayJob struct {
@@ -227,7 +228,7 @@ func (g GatewayJob) buildLegacyDons() ([]legacyDON, error) {
 			case GatewayHandlerTypeWebAPICapabilities:
 				hs = append(hs, newDefaultWebAPICapabilitiesHandler())
 			case GatewayHandlerTypeVault:
-				hs = append(hs, newDefaultVaultHandler(g.RequestTimeoutSec))
+				hs = append(hs, newDefaultVaultHandler(g.RequestTimeoutSec, nil))
 			case GatewayHandlerTypeHTTPCapabilities:
 				hs = append(hs, newDefaultHTTPCapabilitiesHandler())
 			case GatewayHandlerTypeConfidentialRelay:
@@ -271,7 +272,7 @@ func (g GatewayJob) buildServicesAndShardedDONs() ([]shardedDON, []service, erro
 			case GatewayHandlerTypeWebAPICapabilities:
 				handlers = append(handlers, newDefaultWebAPICapabilitiesHandler())
 			case GatewayHandlerTypeVault:
-				handlers = append(handlers, newDefaultVaultHandler(g.RequestTimeoutSec))
+				handlers = append(handlers, newDefaultVaultHandler(g.RequestTimeoutSec, svcCfg.Auth0))
 			case GatewayHandlerTypeHTTPCapabilities:
 				handlers = append(handlers, newDefaultHTTPCapabilitiesHandler())
 			case GatewayHandlerTypeConfidentialRelay:
@@ -314,9 +315,10 @@ func newDefaultWebAPICapabilitiesHandler() handler {
 type vaultHandlerConfig struct {
 	RequestTimeoutSec int                   `toml:"requestTimeoutSec"`
 	NodeRateLimiter   nodeRateLimiterConfig `toml:"NodeRateLimiter"`
+	Auth0             *Auth0Config          `toml:"auth0,omitempty"`
 }
 
-func newDefaultVaultHandler(requestTimeoutSec int) handler {
+func newDefaultVaultHandler(requestTimeoutSec int, auth0 *Auth0Config) handler {
 	return handler{
 		Name:        GatewayHandlerTypeVault,
 		ServiceName: ServiceNameVault,
@@ -330,6 +332,7 @@ func newDefaultVaultHandler(requestTimeoutSec int) handler {
 				PerSenderBurst: 10,
 				PerSenderRPS:   10,
 			},
+			Auth0: auth0,
 		},
 	}
 }

--- a/deployment/cre/jobs/pkg/ocr3_job.go
+++ b/deployment/cre/jobs/pkg/ocr3_job.go
@@ -35,6 +35,12 @@ type OCR3JobConfigInput struct {
 	// Optionals: specific to the worker vault OCR3 Job spec
 	DKGContractQualifier       string `yaml:"dkgContractQualifier"`
 	VaultRequestExpiryDuration string `yaml:"vaultRequestExpiryDuration"`
+	Auth0                      *Auth0Config
+}
+
+type Auth0Config struct {
+	IssuerURL string `yaml:"issuerURL" toml:"issuerURL" json:"issuerURL"`
+	Audience  string `yaml:"audience" toml:"audience" json:"audience"`
 }
 
 type OCR3JobConfig struct {
@@ -52,6 +58,7 @@ type OCR3JobConfig struct {
 
 	DKGContractAddress         string
 	VaultRequestExpiryDuration string
+	Auth0                      *Auth0Config
 }
 
 func (c OCR3JobConfig) Validate() error {
@@ -92,6 +99,14 @@ func (c OCR3JobConfig) Validate() error {
 		if err != nil {
 			return fmt.Errorf("VaultRequestExpiryDuration is not a valid duration: %w", err)
 		}
+		if c.Auth0 != nil {
+			if c.Auth0.IssuerURL == "" {
+				return errors.New("Auth0.IssuerURL is required for worker-vault template when auth0 is configured")
+			}
+			if c.Auth0.Audience == "" {
+				return errors.New("Auth0.Audience is required for worker-vault template when auth0 is configured")
+			}
+		}
 	}
 
 	return nil
@@ -129,6 +144,7 @@ func BuildOCR3JobConfigSpecs(
 	donName, jobName, templateName string,
 	dkgContractAddress string,
 	vaultRequestExpiryDuration string,
+	auth0 *Auth0Config,
 ) ([]OCR3JobConfigSpec, error) {
 	nodesLen := len(nodes)
 	if nodesLen == 0 {
@@ -196,6 +212,7 @@ func BuildOCR3JobConfigSpecs(
 			TemplateName:               templateName,
 			DKGContractAddress:         dkgContractAddress,
 			VaultRequestExpiryDuration: vaultRequestExpiryDuration,
+			Auth0:                      auth0,
 		}
 
 		err1 := jobConfig.Validate()

--- a/deployment/cre/jobs/pkg/templates/worker-vault.tmpl
+++ b/deployment/cre/jobs/pkg/templates/worker-vault.tmpl
@@ -16,3 +16,8 @@ chainID = "{{ .ChainID }}"
 requestExpiryDuration = "{{ .VaultRequestExpiryDuration }}"
 [pluginConfig.dkg]
 dkgContractID = "{{ .DKGContractAddress }}"
+{{- if .Auth0 }}
+[pluginConfig.auth0]
+issuerURL = "{{ .Auth0.IssuerURL }}"
+audience = "{{ .Auth0.Audience }}"
+{{- end }}

--- a/deployment/cre/jobs/propose_job_spec.go
+++ b/deployment/cre/jobs/propose_job_spec.go
@@ -196,6 +196,7 @@ func (u ProposeJobSpec) Apply(e cldf.Environment, input ProposeJobSpecInput) (cl
 				BootstrapperOCR3Urls:       jobInput.BootstrapperOCR3Urls,
 				DKGContractAddress:         dkgContractAddr,
 				VaultRequestExpiryDuration: jobInput.VaultRequestExpiryDuration,
+				Auth0:                      jobInput.Auth0,
 				DONFilters:                 input.DONFilters,
 				ExtraLabels:                input.ExtraLabels,
 			},

--- a/system-tests/lib/cre/don/jobs/jobs.go
+++ b/system-tests/lib/cre/don/jobs/jobs.go
@@ -3,10 +3,12 @@ package jobs
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sethvargo/go-retry"
 	"go.uber.org/ratelimit"
 	"golang.org/x/sync/errgroup"
 
@@ -15,8 +17,21 @@ import (
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 )
 
+var (
+	acceptJobRetryMaxDuration = 90 * time.Second
+	acceptJobRetryBackoff     = func() retry.Backoff { return retry.NewFibonacci(1 * time.Second) }
+	acceptJobSettleDuration   = 5 * time.Second
+	acceptJobSettleInterval   = 250 * time.Millisecond
+	externalJobIDPattern      = regexp.MustCompile(`(?m)^\s*externalJobID\s*=\s*"([^"]+)"`)
+)
+
+type proposalRef struct {
+	ProposalID string
+	SpecID     string
+}
+
 // defined as variables to allow for easy testing
-var loadNodeProposalIDs = func(ctx context.Context, node *cre.Node) (map[string]string, error) {
+var loadNodeProposalRefs = func(ctx context.Context, node *cre.Node) (map[string]proposalRef, error) {
 	jd, err := node.Clients.GQLClient.GetJobDistributor(ctx, node.JobDistributorDetails.JDID)
 	if err != nil {
 		return nil, err
@@ -25,12 +40,15 @@ var loadNodeProposalIDs = func(ctx context.Context, node *cre.Node) (map[string]
 		return nil, fmt.Errorf("no job proposals found for node %s", node.Name)
 	}
 
-	proposalIDsBySpec := make(map[string]string, len(jd.JobProposals))
+	proposalRefsBySpec := make(map[string]proposalRef, len(jd.JobProposals))
 	for _, proposal := range jd.JobProposals {
-		proposalIDsBySpec[proposal.LatestSpec.Definition] = proposal.Id
+		proposalRefsBySpec[proposal.LatestSpec.Definition] = proposalRef{
+			ProposalID: proposal.Id,
+			SpecID:     proposal.LatestSpec.Id,
+		}
 	}
 
-	return proposalIDsBySpec, nil
+	return proposalRefsBySpec, nil
 }
 
 // defined as variables to allow for easy testing
@@ -44,6 +62,84 @@ var approveJobProposalSpec = func(ctx context.Context, node *cre.Node, proposalI
 	}
 
 	return nil
+}
+
+var jobProposalIsApproved = func(ctx context.Context, node *cre.Node, proposalID string) (bool, error) {
+	jd, err := node.Clients.GQLClient.GetJobDistributor(ctx, node.JobDistributorDetails.JDID)
+	if err != nil {
+		return false, err
+	}
+	if jd.GetJobProposals() == nil {
+		return false, fmt.Errorf("no job proposals found for node %s", node.Name)
+	}
+
+	for _, proposal := range jd.JobProposals {
+		if proposal.Id != proposalID {
+			continue
+		}
+
+		return string(proposal.LatestSpec.Status) == "APPROVED", nil
+	}
+
+	return false, fmt.Errorf("no job proposal found for id %s", proposalID)
+}
+
+var jobProposalHasExistingJob = func(ctx context.Context, node *cre.Node, proposalID string) (bool, error) {
+	if node == nil {
+		return false, errors.New("node is nil")
+	}
+	if node.Clients.GQLClient == nil {
+		return false, fmt.Errorf("node %s does not have a GraphQL client", node.Name)
+	}
+
+	proposal, err := node.Clients.GQLClient.GetJobProposal(ctx, proposalID)
+	if err != nil {
+		return false, err
+	}
+	if proposal == nil {
+		return false, fmt.Errorf("no job proposal found for id %s", proposalID)
+	}
+
+	externalJobID := proposal.ExternalJobID
+	if externalJobID == "" {
+		externalJobID = extractExternalJobID(proposal.LatestSpec.Definition)
+	}
+	if externalJobID == "" {
+		return false, nil
+	}
+
+	const pageSize = 1000
+	offset := 0
+	for {
+		jobs, err := node.Clients.GQLClient.ListJobs(ctx, offset, pageSize)
+		if err != nil {
+			return false, err
+		}
+		if jobs == nil {
+			return false, nil
+		}
+
+		results := jobs.Jobs.Results
+		for _, job := range results {
+			if job.ExternalJobID == externalJobID {
+				return true, nil
+			}
+		}
+
+		if len(results) < pageSize {
+			return false, nil
+		}
+		offset += len(results)
+	}
+}
+
+func extractExternalJobID(definition string) string {
+	matches := externalJobIDPattern.FindStringSubmatch(definition)
+	if len(matches) != 2 {
+		return ""
+	}
+
+	return matches[1]
 }
 
 func Approve(ctx context.Context, _ cldf_offchain.Client, dons *cre.Dons, nodeToSpecs map[string][]string) error {
@@ -64,17 +160,17 @@ func Approve(ctx context.Context, _ cldf_offchain.Client, dons *cre.Dons, nodeTo
 		}
 
 		eg.Go(func() error {
-			proposalIDsBySpec, err := loadNodeProposalIDs(egCtx, node)
+			proposalRefsBySpec, err := loadNodeProposalRefs(egCtx, node)
 			if err != nil {
 				return err
 			}
 
-			for _, jobSpec := range jobSpecs {
-				proposalID, ok := proposalIDsBySpec[jobSpec]
+			for _, jobSpec := range uniqueSpecs(jobSpecs) {
+				ref, ok := proposalRefsBySpec[jobSpec]
 				if !ok {
 					return fmt.Errorf("no job proposal found for job spec %s", jobSpec)
 				}
-				if err := accept(egCtx, node, proposalID, jobSpec); err != nil {
+				if err := accept(egCtx, node, ref, jobSpec); err != nil {
 					return err
 				}
 			}
@@ -84,6 +180,24 @@ func Approve(ctx context.Context, _ cldf_offchain.Client, dons *cre.Dons, nodeTo
 	}
 
 	return eg.Wait()
+}
+
+func uniqueSpecs(jobSpecs []string) []string {
+	if len(jobSpecs) < 2 {
+		return jobSpecs
+	}
+
+	seen := make(map[string]struct{}, len(jobSpecs))
+	deduped := make([]string, 0, len(jobSpecs))
+	for _, jobSpec := range jobSpecs {
+		if _, ok := seen[jobSpec]; ok {
+			continue
+		}
+		seen[jobSpec] = struct{}{}
+		deduped = append(deduped, jobSpec)
+	}
+
+	return deduped
 }
 
 func Create(ctx context.Context, offChainClient cldf_offchain.Client, dons *cre.Dons, jobSpecs cre.DonJobs) error {
@@ -113,7 +227,7 @@ func Create(ctx context.Context, offChainClient cldf_offchain.Client, dons *cre.
 						continue
 					}
 
-					if err := accept(ctx, node, "", jobReq.Spec); err != nil {
+					if err := accept(ctx, node, proposalRef{}, jobReq.Spec); err != nil {
 						return err
 					}
 				}
@@ -134,23 +248,75 @@ func Create(ctx context.Context, offChainClient cldf_offchain.Client, dons *cre.
 	return nil
 }
 
-func accept(ctx context.Context, node *cre.Node, proposalID, jobSpec string) error {
-	var err error
-	if proposalID == "" {
-		err = node.AcceptJob(ctx, jobSpec)
-	} else {
-		err = approveJobProposalSpec(ctx, node, proposalID)
-	}
-	if err != nil {
-		// Workflow specs get auto approved
-		if strings.Contains(err.Error(), "cannot approve an approved spec") && strings.Contains(jobSpec, `type = "workflow"`) {
+func accept(ctx context.Context, node *cre.Node, proposal proposalRef, jobSpec string) error {
+	retryErr := retry.Do(ctx, retry.WithMaxDuration(acceptJobRetryMaxDuration, acceptJobRetryBackoff()), func(ctx context.Context) error {
+		var err error
+		if proposal.SpecID == "" {
+			err = node.AcceptJob(ctx, jobSpec)
+		} else {
+			err = approveJobProposalSpec(ctx, node, proposal.SpecID)
+		}
+		if err == nil || strings.Contains(err.Error(), "cannot approve an approved spec") {
 			return nil
 		}
+		if proposal.ProposalID != "" {
+			approved, approvedErr := jobProposalIsApproved(ctx, node, proposal.ProposalID)
+			if approvedErr == nil && approved {
+				return nil
+			}
+			existingJob, existingJobErr := jobProposalHasExistingJob(ctx, node, proposal.ProposalID)
+			if existingJobErr == nil && existingJob {
+				return nil
+			}
+			settled, settleErr := waitForProposalToSettle(ctx, node, proposal.ProposalID)
+			if settleErr == nil && settled {
+				return nil
+			}
+		}
+
+		return retry.RetryableError(err)
+	})
+	if retryErr != nil {
 		fmt.Println("Failed jobspec proposal for node ", node.Name)
 		fmt.Println(jobSpec)
 
-		return fmt.Errorf("failed to accept job for node %s. err: %w", node.Name, err)
+		return fmt.Errorf("failed to accept job for node %s. err: %w", node.Name, retryErr)
 	}
 
 	return nil
+}
+
+func waitForProposalToSettle(ctx context.Context, node *cre.Node, proposalID string) (bool, error) {
+	if proposalID == "" || acceptJobSettleDuration <= 0 {
+		return false, nil
+	}
+
+	deadline := time.Now().Add(acceptJobSettleDuration)
+	for {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+
+		approved, approvedErr := jobProposalIsApproved(ctx, node, proposalID)
+		if approvedErr == nil && approved {
+			return true, nil
+		}
+
+		existingJob, existingJobErr := jobProposalHasExistingJob(ctx, node, proposalID)
+		if existingJobErr == nil && existingJob {
+			return true, nil
+		}
+
+		if time.Now().After(deadline) {
+			return false, nil
+		}
+
+		timer := time.NewTimer(acceptJobSettleInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return false, ctx.Err()
+		case <-timer.C:
+		}
+	}
 }

--- a/system-tests/lib/cre/don/jobs/jobs_test.go
+++ b/system-tests/lib/cre/don/jobs/jobs_test.go
@@ -7,16 +7,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sethvargo/go-retry"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 )
 
 func TestApproveFetchesProposalsOncePerNode(t *testing.T) {
-	restoreLoad := loadNodeProposalIDs
+	restoreLoad := loadNodeProposalRefs
 	restoreApprove := approveJobProposalSpec
 	t.Cleanup(func() {
-		loadNodeProposalIDs = restoreLoad
+		loadNodeProposalRefs = restoreLoad
 		approveJobProposalSpec = restoreApprove
 	})
 
@@ -26,18 +27,18 @@ func TestApproveFetchesProposalsOncePerNode(t *testing.T) {
 
 	var mu sync.Mutex
 	fetches := map[string]int{}
-	loadNodeProposalIDs = func(_ context.Context, node *cre.Node) (map[string]string, error) {
+	loadNodeProposalRefs = func(_ context.Context, node *cre.Node) (map[string]proposalRef, error) {
 		mu.Lock()
 		fetches[node.JobDistributorDetails.NodeID]++
 		mu.Unlock()
 		if node.JobDistributorDetails.NodeID == "node-a" {
-			return map[string]string{
-				"spec-a-1": "proposal-a-1",
-				"spec-a-2": "proposal-a-2",
+			return map[string]proposalRef{
+				"spec-a-1": {ProposalID: "proposal-a-1", SpecID: "spec-a-1-id"},
+				"spec-a-2": {ProposalID: "proposal-a-2", SpecID: "spec-a-2-id"},
 			}, nil
 		}
-		return map[string]string{
-			"spec-b-1": "proposal-b-1",
+		return map[string]proposalRef{
+			"spec-b-1": {ProposalID: "proposal-b-1", SpecID: "spec-b-1-id"},
 		}, nil
 	}
 	approveJobProposalSpec = func(_ context.Context, _ *cre.Node, _ string) error { return nil }
@@ -50,11 +51,42 @@ func TestApproveFetchesProposalsOncePerNode(t *testing.T) {
 	require.Equal(t, map[string]int{"node-a": 1, "node-b": 1}, fetches)
 }
 
-func TestApproveRunsAcrossNodesConcurrentlyAndWithinNodeSequentially(t *testing.T) {
-	restoreLoad := loadNodeProposalIDs
+func TestApproveDeduplicatesJobSpecsPerNode(t *testing.T) {
+	restoreLoad := loadNodeProposalRefs
 	restoreApprove := approveJobProposalSpec
 	t.Cleanup(func() {
-		loadNodeProposalIDs = restoreLoad
+		loadNodeProposalRefs = restoreLoad
+		approveJobProposalSpec = restoreApprove
+	})
+
+	node := &cre.Node{Name: "node-a", JobDistributorDetails: &cre.JobDistributorDetails{NodeID: "node-a"}}
+	dons := &cre.Dons{Dons: []*cre.Don{{Nodes: []*cre.Node{node}}}}
+
+	loadNodeProposalRefs = func(_ context.Context, _ *cre.Node) (map[string]proposalRef, error) {
+		return map[string]proposalRef{
+			"spec-a": {ProposalID: "proposal-a", SpecID: "spec-a-id"},
+			"spec-b": {ProposalID: "proposal-b", SpecID: "spec-b-id"},
+		}, nil
+	}
+
+	var approved []string
+	approveJobProposalSpec = func(_ context.Context, _ *cre.Node, specID string) error {
+		approved = append(approved, specID)
+		return nil
+	}
+
+	err := Approve(context.Background(), nil, dons, map[string][]string{
+		"node-a": {"spec-a", "spec-a", "spec-b", "spec-a", "spec-b"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"spec-a-id", "spec-b-id"}, approved)
+}
+
+func TestApproveRunsAcrossNodesConcurrentlyAndWithinNodeSequentially(t *testing.T) {
+	restoreLoad := loadNodeProposalRefs
+	restoreApprove := approveJobProposalSpec
+	t.Cleanup(func() {
+		loadNodeProposalRefs = restoreLoad
 		approveJobProposalSpec = restoreApprove
 	})
 
@@ -62,10 +94,10 @@ func TestApproveRunsAcrossNodesConcurrentlyAndWithinNodeSequentially(t *testing.
 	nodeB := &cre.Node{Name: "node-b", JobDistributorDetails: &cre.JobDistributorDetails{NodeID: "node-b"}}
 	dons := &cre.Dons{Dons: []*cre.Don{{Nodes: []*cre.Node{nodeA, nodeB}}}}
 
-	loadNodeProposalIDs = func(_ context.Context, node *cre.Node) (map[string]string, error) {
-		return map[string]string{
-			node.JobDistributorDetails.NodeID + "-1": node.JobDistributorDetails.NodeID + "-proposal-1",
-			node.JobDistributorDetails.NodeID + "-2": node.JobDistributorDetails.NodeID + "-proposal-2",
+	loadNodeProposalRefs = func(_ context.Context, node *cre.Node) (map[string]proposalRef, error) {
+		return map[string]proposalRef{
+			node.JobDistributorDetails.NodeID + "-1": {ProposalID: node.JobDistributorDetails.NodeID + "-proposal-1", SpecID: node.JobDistributorDetails.NodeID + "-spec-1"},
+			node.JobDistributorDetails.NodeID + "-2": {ProposalID: node.JobDistributorDetails.NodeID + "-proposal-2", SpecID: node.JobDistributorDetails.NodeID + "-spec-2"},
 		}, nil
 	}
 
@@ -115,18 +147,18 @@ func TestApproveMissingNodeID(t *testing.T) {
 }
 
 func TestApproveMissingProposalMatch(t *testing.T) {
-	restoreLoad := loadNodeProposalIDs
+	restoreLoad := loadNodeProposalRefs
 	restoreApprove := approveJobProposalSpec
 	t.Cleanup(func() {
-		loadNodeProposalIDs = restoreLoad
+		loadNodeProposalRefs = restoreLoad
 		approveJobProposalSpec = restoreApprove
 	})
 
 	node := &cre.Node{Name: "node-a", JobDistributorDetails: &cre.JobDistributorDetails{NodeID: "node-a"}}
 	dons := &cre.Dons{Dons: []*cre.Don{{Nodes: []*cre.Node{node}}}}
 
-	loadNodeProposalIDs = func(_ context.Context, _ *cre.Node) (map[string]string, error) {
-		return map[string]string{}, nil
+	loadNodeProposalRefs = func(_ context.Context, _ *cre.Node) (map[string]proposalRef, error) {
+		return map[string]proposalRef{}, nil
 	}
 	approveJobProposalSpec = func(_ context.Context, _ *cre.Node, _ string) error { return nil }
 
@@ -138,14 +170,244 @@ func TestApproveMissingProposalMatch(t *testing.T) {
 
 func TestAcceptTreatsApprovedWorkflowSpecAsSuccess(t *testing.T) {
 	restoreApprove := approveJobProposalSpec
+	restoreApprovedCheck := jobProposalIsApproved
+	restoreExistingJob := jobProposalHasExistingJob
+	restoreRetryDuration := acceptJobRetryMaxDuration
+	restoreRetryBackoff := acceptJobRetryBackoff
 	t.Cleanup(func() {
 		approveJobProposalSpec = restoreApprove
+		jobProposalIsApproved = restoreApprovedCheck
+		jobProposalHasExistingJob = restoreExistingJob
+		acceptJobRetryMaxDuration = restoreRetryDuration
+		acceptJobRetryBackoff = restoreRetryBackoff
 	})
+	acceptJobRetryMaxDuration = 10 * time.Millisecond
+	acceptJobRetryBackoff = func() retry.Backoff { return retry.NewConstant(time.Millisecond) }
 
 	approveJobProposalSpec = func(_ context.Context, _ *cre.Node, _ string) error {
 		return errors.New("cannot approve an approved spec")
 	}
+	jobProposalHasExistingJob = func(_ context.Context, _ *cre.Node, _ string) (bool, error) { return false, nil }
 
-	err := accept(context.Background(), &cre.Node{Name: "node-a"}, "proposal-id", `type = "workflow"`)
+	err := accept(context.Background(), &cre.Node{Name: "node-a"}, proposalRef{ProposalID: "proposal-id", SpecID: "spec-id"}, `type = "workflow"`)
 	require.NoError(t, err)
+}
+
+func TestAcceptTreatsApprovedSpecAfterErrorAsSuccess(t *testing.T) {
+	restoreApprove := approveJobProposalSpec
+	restoreApprovedCheck := jobProposalIsApproved
+	restoreExistingJob := jobProposalHasExistingJob
+	restoreRetryDuration := acceptJobRetryMaxDuration
+	restoreRetryBackoff := acceptJobRetryBackoff
+	restoreSettleDuration := acceptJobSettleDuration
+	restoreSettleInterval := acceptJobSettleInterval
+	t.Cleanup(func() {
+		approveJobProposalSpec = restoreApprove
+		jobProposalIsApproved = restoreApprovedCheck
+		jobProposalHasExistingJob = restoreExistingJob
+		acceptJobRetryMaxDuration = restoreRetryDuration
+		acceptJobRetryBackoff = restoreRetryBackoff
+		acceptJobSettleDuration = restoreSettleDuration
+		acceptJobSettleInterval = restoreSettleInterval
+	})
+	acceptJobRetryMaxDuration = 10 * time.Millisecond
+	acceptJobRetryBackoff = func() retry.Backoff { return retry.NewConstant(time.Millisecond) }
+	acceptJobSettleDuration = 10 * time.Millisecond
+	acceptJobSettleInterval = time.Millisecond
+
+	attempts := 0
+	approveJobProposalSpec = func(_ context.Context, _ *cre.Node, _ string) error {
+		attempts++
+		return errors.New("input: approveJobProposalSpec could not approve job proposal: error registering vault capability: capability already exists: id vault@1.0.0 found in registry: state INVALID_STATE")
+	}
+
+	statusChecks := 0
+	jobProposalIsApproved = func(_ context.Context, _ *cre.Node, _ string) (bool, error) {
+		statusChecks++
+		return true, nil
+	}
+	jobProposalHasExistingJob = func(_ context.Context, _ *cre.Node, _ string) (bool, error) {
+		return false, nil
+	}
+
+	err := accept(context.Background(), &cre.Node{Name: "node-a"}, proposalRef{ProposalID: "proposal-id", SpecID: "spec-id"}, `type = "offchainreporting2"`)
+	require.NoError(t, err)
+	require.Equal(t, 1, attempts)
+	require.Equal(t, 1, statusChecks)
+}
+
+func TestAcceptTreatsExistingJobAfterErrorAsSuccess(t *testing.T) {
+	restoreApprove := approveJobProposalSpec
+	restoreApprovedCheck := jobProposalIsApproved
+	restoreExistingJob := jobProposalHasExistingJob
+	restoreRetryDuration := acceptJobRetryMaxDuration
+	restoreRetryBackoff := acceptJobRetryBackoff
+	restoreSettleDuration := acceptJobSettleDuration
+	restoreSettleInterval := acceptJobSettleInterval
+	t.Cleanup(func() {
+		approveJobProposalSpec = restoreApprove
+		jobProposalIsApproved = restoreApprovedCheck
+		jobProposalHasExistingJob = restoreExistingJob
+		acceptJobRetryMaxDuration = restoreRetryDuration
+		acceptJobRetryBackoff = restoreRetryBackoff
+		acceptJobSettleDuration = restoreSettleDuration
+		acceptJobSettleInterval = restoreSettleInterval
+	})
+	acceptJobRetryMaxDuration = 10 * time.Millisecond
+	acceptJobRetryBackoff = func() retry.Backoff { return retry.NewConstant(time.Millisecond) }
+	acceptJobSettleDuration = 10 * time.Millisecond
+	acceptJobSettleInterval = time.Millisecond
+
+	attempts := 0
+	approveJobProposalSpec = func(_ context.Context, _ *cre.Node, _ string) error {
+		attempts++
+		return errors.New("input: approveJobProposalSpec could not approve job proposal: error registering vault capability: capability already exists: id vault@1.0.0 found in registry: state INVALID_STATE")
+	}
+
+	approvalChecks := 0
+	jobProposalIsApproved = func(_ context.Context, _ *cre.Node, _ string) (bool, error) {
+		approvalChecks++
+		return false, nil
+	}
+
+	existingJobChecks := 0
+	jobProposalHasExistingJob = func(_ context.Context, _ *cre.Node, _ string) (bool, error) {
+		existingJobChecks++
+		return true, nil
+	}
+
+	err := accept(context.Background(), &cre.Node{Name: "node-a"}, proposalRef{ProposalID: "proposal-id", SpecID: "spec-id"}, `type = "offchainreporting2"`)
+	require.NoError(t, err)
+	require.Equal(t, 1, attempts)
+	require.Equal(t, 1, approvalChecks)
+	require.Equal(t, 1, existingJobChecks)
+}
+
+func TestAcceptRetriesTransientApprovalErrors(t *testing.T) {
+	restoreApprove := approveJobProposalSpec
+	restoreApprovedCheck := jobProposalIsApproved
+	restoreExistingJob := jobProposalHasExistingJob
+	restoreRetryDuration := acceptJobRetryMaxDuration
+	restoreRetryBackoff := acceptJobRetryBackoff
+	restoreSettleDuration := acceptJobSettleDuration
+	restoreSettleInterval := acceptJobSettleInterval
+	t.Cleanup(func() {
+		approveJobProposalSpec = restoreApprove
+		jobProposalIsApproved = restoreApprovedCheck
+		jobProposalHasExistingJob = restoreExistingJob
+		acceptJobRetryMaxDuration = restoreRetryDuration
+		acceptJobRetryBackoff = restoreRetryBackoff
+		acceptJobSettleDuration = restoreSettleDuration
+		acceptJobSettleInterval = restoreSettleInterval
+	})
+	acceptJobRetryMaxDuration = 50 * time.Millisecond
+	acceptJobRetryBackoff = func() retry.Backoff { return retry.NewConstant(time.Millisecond) }
+	acceptJobSettleDuration = 5 * time.Millisecond
+	acceptJobSettleInterval = time.Millisecond
+
+	attempts := 0
+	approveJobProposalSpec = func(_ context.Context, _ *cre.Node, _ string) error {
+		attempts++
+		if attempts < 3 {
+			return errors.New("approveJobProposalSpec panic occurred: runtime error: invalid memory address or nil pointer dereference")
+		}
+		return nil
+	}
+	jobProposalIsApproved = func(_ context.Context, _ *cre.Node, _ string) (bool, error) {
+		return false, nil
+	}
+	jobProposalHasExistingJob = func(_ context.Context, _ *cre.Node, _ string) (bool, error) {
+		return false, nil
+	}
+
+	err := accept(context.Background(), &cre.Node{Name: "node-a"}, proposalRef{ProposalID: "proposal-id", SpecID: "spec-id"}, `type = "offchainreporting2"`)
+	require.NoError(t, err)
+	require.Equal(t, 3, attempts)
+}
+
+func TestAcceptWaitsForProposalToSettleAfterError(t *testing.T) {
+	restoreApprove := approveJobProposalSpec
+	restoreApprovedCheck := jobProposalIsApproved
+	restoreExistingJob := jobProposalHasExistingJob
+	restoreRetryDuration := acceptJobRetryMaxDuration
+	restoreRetryBackoff := acceptJobRetryBackoff
+	restoreSettleDuration := acceptJobSettleDuration
+	restoreSettleInterval := acceptJobSettleInterval
+	t.Cleanup(func() {
+		approveJobProposalSpec = restoreApprove
+		jobProposalIsApproved = restoreApprovedCheck
+		jobProposalHasExistingJob = restoreExistingJob
+		acceptJobRetryMaxDuration = restoreRetryDuration
+		acceptJobRetryBackoff = restoreRetryBackoff
+		acceptJobSettleDuration = restoreSettleDuration
+		acceptJobSettleInterval = restoreSettleInterval
+	})
+	acceptJobRetryMaxDuration = 20 * time.Millisecond
+	acceptJobRetryBackoff = func() retry.Backoff { return retry.NewConstant(time.Millisecond) }
+	acceptJobSettleDuration = 20 * time.Millisecond
+	acceptJobSettleInterval = time.Millisecond
+
+	attempts := 0
+	approveJobProposalSpec = func(_ context.Context, _ *cre.Node, _ string) error {
+		attempts++
+		return errors.New("input: approveJobProposalSpec could not approve job proposal: error registering vault capability: capability already exists: id vault@1.0.0 found in registry: state INVALID_STATE")
+	}
+
+	approvalChecks := 0
+	jobProposalIsApproved = func(_ context.Context, _ *cre.Node, _ string) (bool, error) {
+		approvalChecks++
+		return approvalChecks >= 3, nil
+	}
+	jobProposalHasExistingJob = func(_ context.Context, _ *cre.Node, _ string) (bool, error) {
+		return false, nil
+	}
+
+	err := accept(context.Background(), &cre.Node{Name: "node-a"}, proposalRef{ProposalID: "proposal-id", SpecID: "spec-id"}, `type = "offchainreporting2"`)
+	require.NoError(t, err)
+	require.Equal(t, 1, attempts)
+	require.GreaterOrEqual(t, approvalChecks, 3)
+}
+
+func TestApproveUsesLatestSpecIDForApproval(t *testing.T) {
+	restoreLoad := loadNodeProposalRefs
+	restoreApprove := approveJobProposalSpec
+	t.Cleanup(func() {
+		loadNodeProposalRefs = restoreLoad
+		approveJobProposalSpec = restoreApprove
+	})
+
+	node := &cre.Node{Name: "node-a", JobDistributorDetails: &cre.JobDistributorDetails{NodeID: "node-a"}}
+	dons := &cre.Dons{Dons: []*cre.Don{{Nodes: []*cre.Node{node}}}}
+
+	loadNodeProposalRefs = func(_ context.Context, _ *cre.Node) (map[string]proposalRef, error) {
+		return map[string]proposalRef{
+			"spec-a": {ProposalID: "proposal-id", SpecID: "latest-spec-id"},
+		}, nil
+	}
+
+	var approvedID string
+	approveJobProposalSpec = func(_ context.Context, _ *cre.Node, proposalID string) error {
+		approvedID = proposalID
+		return nil
+	}
+
+	err := Approve(context.Background(), nil, dons, map[string][]string{
+		"node-a": {"spec-a"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "latest-spec-id", approvedID)
+}
+
+func TestExtractExternalJobID(t *testing.T) {
+	t.Run("extracts from job spec", func(t *testing.T) {
+		definition := `type = "offchainreporting2"
+externalJobID = "123e4567-e89b-12d3-a456-426614174000"
+name = "vault-worker"`
+
+		require.Equal(t, "123e4567-e89b-12d3-a456-426614174000", extractExternalJobID(definition))
+	})
+
+	t.Run("returns empty string when missing", func(t *testing.T) {
+		require.Empty(t, extractExternalJobID(`type = "offchainreporting2"`))
+	})
 }

--- a/system-tests/lib/cre/environment/config/config.go
+++ b/system-tests/lib/cre/environment/config/config.go
@@ -174,6 +174,8 @@ func (c *Config) Load(absPath string) error {
 		return errors.Wrap(loadErr, "failed to load environment configuration")
 	}
 
+	transformHostDockerInternalReferences(in)
+
 	for _, nodeSet := range in.NodeSets {
 		if err := nodeSet.ValidateChainCapabilities(in.Blockchains); err != nil {
 			return errors.Wrap(err, "failed to validate chain capabilities")
@@ -184,6 +186,78 @@ func (c *Config) Load(absPath string) error {
 	c.loaded = true
 
 	return nil
+}
+
+func transformHostDockerInternalReferences(cfg *Config) {
+	if cfg == nil {
+		return
+	}
+
+	for _, nodeSet := range cfg.NodeSets {
+		if nodeSet == nil {
+			continue
+		}
+
+		for _, nodeSpec := range nodeSet.NodeSpecs {
+			if nodeSpec == nil || nodeSpec.Node == nil || nodeSpec.Node.UserConfigOverrides == "" {
+				continue
+			}
+			nodeSpec.Node.UserConfigOverrides = replaceHostDockerInternal(nodeSpec.Node.UserConfigOverrides)
+		}
+
+		transformCapabilityConfigs(nodeSet.CapabilityConfigs)
+	}
+
+	transformCapabilityConfigs(cfg.CapabilityConfigs)
+}
+
+func transformCapabilityConfigs(capabilityConfigs map[string]cre.CapabilityConfig) {
+	if len(capabilityConfigs) == 0 {
+		return
+	}
+
+	for key, cfg := range capabilityConfigs {
+		cfg.Values = transformCapabilityConfigValues(cfg.Values)
+		capabilityConfigs[key] = cfg
+	}
+}
+
+func transformCapabilityConfigValues(values map[string]any) map[string]any {
+	if len(values) == 0 {
+		return values
+	}
+
+	transformed := make(map[string]any, len(values))
+	for key, value := range values {
+		transformed[key] = transformCapabilityConfigValue(value)
+	}
+
+	return transformed
+}
+
+func transformCapabilityConfigValue(value any) any {
+	switch typed := value.(type) {
+	case string:
+		return replaceHostDockerInternal(typed)
+	case map[string]any:
+		return transformCapabilityConfigValues(typed)
+	case []any:
+		transformed := make([]any, len(typed))
+		for i, element := range typed {
+			transformed[i] = transformCapabilityConfigValue(element)
+		}
+		return transformed
+	default:
+		return value
+	}
+}
+
+func replaceHostDockerInternal(value string) string {
+	if value == "" {
+		return value
+	}
+
+	return strings.ReplaceAll(value, "host.docker.internal", strings.TrimPrefix(framework.HostDockerInternal(), "http://"))
 }
 
 const (

--- a/system-tests/lib/cre/environment/config/config_test.go
+++ b/system-tests/lib/cre/environment/config/config_test.go
@@ -39,7 +39,7 @@ func TestTransformHostDockerInternalReferences(t *testing.T) {
 			},
 		},
 		CapabilityConfigs: map[string]cre.CapabilityConfig{
-			string(cre.VaultCapability): {
+			cre.VaultCapability: {
 				Values: map[string]any{
 					"endpoint": "host.docker.internal:9999",
 				},
@@ -56,5 +56,5 @@ func TestTransformHostDockerInternalReferences(t *testing.T) {
 	require.Equal(t, framework.HostDockerInternal()+":18123/", auth0["issuerURL"])
 	require.Equal(t, []any{dockerHost + ":18124"}, auth0["urls"])
 
-	require.Equal(t, dockerHost+":9999", cfg.CapabilityConfigs[string(cre.VaultCapability)].Values["endpoint"])
+	require.Equal(t, dockerHost+":9999", cfg.CapabilityConfigs[cre.VaultCapability].Values["endpoint"])
 }

--- a/system-tests/lib/cre/environment/config/config_test.go
+++ b/system-tests/lib/cre/environment/config/config_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/clnode"
+
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
+)
+
+func TestTransformHostDockerInternalReferences(t *testing.T) {
+	t.Parallel()
+
+	dockerHost := strings.TrimPrefix(framework.HostDockerInternal(), "http://")
+	cfg := &Config{
+		NodeSets: []*cre.NodeSet{
+			{
+				NodeSpecs: []*cre.NodeSpecWithRole{
+					{
+						Input: &clnode.Input{
+							Node: &clnode.NodeInput{},
+						},
+					},
+				},
+				CapabilityConfigs: map[cre.CapabilityFlag]cre.CapabilityConfig{
+					cre.VaultCapability: {
+						Values: map[string]any{
+							"auth0": map[string]any{
+								"issuerURL": "http://host.docker.internal:18123/",
+								"urls":      []any{"host.docker.internal:18124"},
+							},
+						},
+					},
+				},
+			},
+		},
+		CapabilityConfigs: map[string]cre.CapabilityConfig{
+			string(cre.VaultCapability): {
+				Values: map[string]any{
+					"endpoint": "host.docker.internal:9999",
+				},
+			},
+		},
+	}
+	cfg.NodeSets[0].NodeSpecs[0].Node.UserConfigOverrides = "[CRE.Linking]\nURL = \"host.docker.internal:18124\"\n"
+
+	transformHostDockerInternalReferences(cfg)
+
+	require.Contains(t, cfg.NodeSets[0].NodeSpecs[0].Node.UserConfigOverrides, dockerHost+":18124")
+
+	auth0 := cfg.NodeSets[0].CapabilityConfigs[cre.VaultCapability].Values["auth0"].(map[string]any)
+	require.Equal(t, framework.HostDockerInternal()+":18123/", auth0["issuerURL"])
+	require.Equal(t, []any{dockerHost + ":18124"}, auth0["urls"])
+
+	require.Equal(t, dockerHost+":9999", cfg.CapabilityConfigs[string(cre.VaultCapability)].Values["endpoint"])
+}

--- a/system-tests/lib/cre/features/vault/vault.go
+++ b/system-tests/lib/cre/features/vault/vault.go
@@ -3,7 +3,9 @@ package vault
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
@@ -55,6 +57,10 @@ const (
 
 type Vault struct{}
 
+type runtimeConfig struct {
+	Auth0 *cre.GatewayServiceAuth0Config `json:"auth0"`
+}
+
 func (o *Vault) Flag() cre.CapabilityFlag {
 	return flag
 }
@@ -66,6 +72,11 @@ func (o *Vault) PreEnvStartup(
 	topology *cre.Topology,
 	creEnv *cre.Environment,
 ) (*cre.PreEnvStartupOutput, error) {
+	auth0Config, cfgErr := resolveRuntimeConfig(don.MustNodeSet())
+	if cfgErr != nil {
+		return nil, errors.Wrap(cfgErr, "failed to resolve vault runtime config")
+	}
+
 	// use registry chain, because that is the chain we used when generating gateway connector part of node config (check below)
 	registryChainID, chErr := chainselectors.ChainIdFromSelector(creEnv.RegistryChainSelector)
 	if chErr != nil {
@@ -77,6 +88,11 @@ func (o *Vault) PreEnvStartup(
 	hErr := topology.AddGatewayHandlers(*don, []string{pkg.GatewayHandlerTypeVault})
 	if hErr != nil {
 		return nil, errors.Wrapf(hErr, "failed to add gateway handlers to gateway config for don %s ", don.Name)
+	}
+	if auth0Config.Auth0 != nil {
+		if err := applyGatewayAuth0Config(topology, don.Name, auth0Config.Auth0); err != nil {
+			return nil, errors.Wrapf(err, "failed to apply auth0 gateway config for don %s", don.Name)
+		}
 	}
 
 	cErr := don.ConfigureForGatewayAccess(registryChainID, *topology.GatewayConnectors)
@@ -254,6 +270,15 @@ func createJobs(
 	don *cre.Don,
 	dons *cre.Dons,
 ) error {
+	auth0Config := &runtimeConfig{}
+	if capConfig, ok := don.GetCapabilityConfig(flag); ok {
+		var err error
+		auth0Config, err = decodeRuntimeConfig(capConfig.Values)
+		if err != nil {
+			return fmt.Errorf("failed to resolve vault runtime config: %w", err)
+		}
+	}
+
 	bootstrap, isBootstrap := dons.Bootstrap()
 	if !isBootstrap {
 		return errors.New("could not find bootstrap node in topology, exactly one bootstrap node is required")
@@ -284,6 +309,9 @@ func createJobs(
 			"bootstrapperOCR3Urls": []string{ocrPeeringCfg.OCRBootstraperPeerID + "@" + ocrPeeringCfg.OCRBootstraperHost + ":" + strconv.Itoa(ocrPeeringCfg.Port)},
 		},
 	}
+	if auth0Config.Auth0 != nil {
+		workerInput.Inputs["auth0"] = auth0Config.Auth0
+	}
 
 	workerVerErr := cre_jobs.ProposeJobSpec{}.VerifyPreconditions(*creEnv.CldfEnvironment, workerInput)
 	if workerVerErr != nil {
@@ -312,6 +340,61 @@ func createJobs(
 	}
 
 	return nil
+}
+
+func resolveRuntimeConfig(nodeSet *cre.NodeSet) (*runtimeConfig, error) {
+	if nodeSet == nil {
+		return &runtimeConfig{}, nil
+	}
+
+	capConfig, ok := nodeSet.GetCapabilityConfig(flag)
+	if !ok || len(capConfig.Values) == 0 {
+		return &runtimeConfig{}, nil
+	}
+
+	return decodeRuntimeConfig(capConfig.Values)
+}
+
+func decodeRuntimeConfig(values map[string]any) (*runtimeConfig, error) {
+	if len(values) == 0 {
+		return &runtimeConfig{}, nil
+	}
+
+	b, err := json.Marshal(values)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal vault capability values: %w", err)
+	}
+
+	cfg := &runtimeConfig{}
+	if err := json.Unmarshal(b, cfg); err != nil {
+		return nil, fmt.Errorf("failed to decode vault capability values: %w", err)
+	}
+
+	return cfg, nil
+}
+
+func applyGatewayAuth0Config(topology *cre.Topology, donName string, auth0 *cre.GatewayServiceAuth0Config) error {
+	if topology == nil || auth0 == nil {
+		return nil
+	}
+
+	for idx := range topology.GatewayServiceConfigs {
+		svc := &topology.GatewayServiceConfigs[idx]
+		if svc.ServiceName != pkg.ServiceNameVault || !slices.Contains(svc.DONs, donName) {
+			continue
+		}
+		if svc.Auth0 != nil && (svc.Auth0.IssuerURL != auth0.IssuerURL || svc.Auth0.Audience != auth0.Audience) {
+			return fmt.Errorf("vault gateway service %q already has conflicting auth0 config", svc.ServiceName)
+		}
+
+		svc.Auth0 = &cre.GatewayServiceAuth0Config{
+			IssuerURL: auth0.IssuerURL,
+			Audience:  auth0.Audience,
+		}
+		return nil
+	}
+
+	return fmt.Errorf("vault gateway service config not found for DON %s", donName)
 }
 
 func deployVaultContracts(testLogger zerolog.Logger, qualifier string, registryChainSelector uint64, env *cldf.Environment, contractVersions map[cre.ContractType]*semver.Version) (*common.Address, *common.Address, error) {

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -428,10 +428,16 @@ func (c *ConfigureCapabilityRegistryInput) Validate() error {
 
 // GatewayServiceConfig represents a service in the service-centric gateway format.
 // Each service groups handlers and references the DON names it operates on.
+type GatewayServiceAuth0Config struct {
+	IssuerURL string `yaml:"issuerURL" toml:"issuerURL" json:"issuerURL"`
+	Audience  string `yaml:"audience" toml:"audience" json:"audience"`
+}
+
 type GatewayServiceConfig struct {
-	ServiceName string   `yaml:"servicename"`
-	Handlers    []string `yaml:"handlers"`
-	DONs        []string `yaml:"dons"`
+	ServiceName string                     `yaml:"servicename"`
+	Handlers    []string                   `yaml:"handlers"`
+	DONs        []string                   `yaml:"dons"`
+	Auth0       *GatewayServiceAuth0Config `yaml:"auth0,omitempty"`
 }
 
 type GatewayConnectors struct {

--- a/system-tests/lib/cre/vault/jwt_auth.go
+++ b/system-tests/lib/cre/vault/jwt_auth.go
@@ -1,0 +1,448 @@
+package vault
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+
+	"github.com/smartcontractkit/tdh2/go/tdh2/tdh2easy"
+
+	vaultutils "github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaultutils"
+)
+
+const (
+	DefaultJWTIssuerKeyID   = "vault-jwt-test-key"
+	DefaultJWTAudience      = "https://vault.test.chain.link"
+	DefaultJWTLifetime      = 5 * time.Minute
+	defaultJWTPrivateKeyPEM = `-----BEGIN PRIVATE KEY-----
+MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDYhEVPZ8YdC3Va
+DGZ2hWPt+VYptOt0heTulBOwBW0ESavpfvokLYGFu+bLkGhIw365nCFw0eulLZYN
+tD4nzq7F5Swtb2iIaDK19PBVNcukU/CY6j44KC1eomyaOvPXKWKwcc7qxjy9bIyA
+TyOmOlxNxcNRSjL2SOApFkzb8M/RymHlMT/RY5ubytvjcbQgn2gy19U7HuNLYW1P
+gviAAMY635u0A+HAxXx83lQSz9gy08/uBarmKAd2OadCA8cNiTSYyfUS6m1pycA7
+j8ZHY75xL4hm+p2PJd9V1x3Z4S1TpZDIj+YAG/v4ZHB1vLTLoPIgwLEqwGRRWijl
+sbdUZRd9AgMBAAECggEAGCiWFTiWheof43bLvgC/OC/gedHajctc0nQKSFMqqVZR
+DMIixgOf1pyzMVaBFFFf4/T0VELQAMO34PqSDt4EaUdbaQxrxQCfW+cjI9bXTJQj
+HeTRIXH2Mf98j67xQzo2bUqdlFufLmGcwbpS13rejrz4wKq/SfSyslLvK4FQpu8x
+5J9ntn2wdgeUQCm62FyuNPxFMBldcovnwf9bbojTjMAatWfyF++W8OAcRqZCab1H
+1WNPyhBqG5vDVMtgBdTkwZHqI01B+ozMnBLuEhsLVzvQWE79ZouWtU76GIeFlr0n
+bC/3uWq9LBo1kEbLIPucxYA14ytWfpQwUvy1k11s4QKBgQD4dz2fVYSVb6hn0Pon
+EQtunruNB7F2JlobY2s3C7aBKs+l48J16whKFcqHUA6NpuSvyUhFTqIpxM0LXdar
+6nWu4Yw0kbqACJOHXuG71VhfkUgRJMOZoC/V0RKudoTwWDzFgNXvYF3bqtpmQDW7
+2dUrSJ+jMOU7eCzXOdHDTFGhbQKBgQDfFQT/NACHapIn5w6c1Dha6fy7t1Z6A2zw
+bUUzAh5C1kZ8yeDrkVfr5Ys+Y7Am/tfFteXO2XRSGH5yqq9YHVr0RihavqX72FGT
+YY2rmyht+JjnZ3y+vOG5LXePR9tilvGei3jH0lTRPdwKpa6feHKry9MBx5xmqKqQ
+xKRmyXaUUQKBgQCcOp3MqgEL1YGWhZhFKDp/+98B9mxnVgYiYojvu7Wt0jVuoZ+M
+dZRowPrvyi7ccqwou+9tZNwiV1R2aTKqNmp44+k8xMT37GyXGdnmOWev77HY1b0H
+w+lQEH4mpO9CELlllnTuZzGdBfj9gjJHQ9j9tlRqUDxTAGVxjzGOE1bgoQKBgQCu
+DxmCAlIzVqzJY5hcN53tGcrvsKJRu2CBy9CFdy6jWctPzLipNROT5Nubh27HTmqP
+QlkX50XCVIg88f60UttH44HTJBQgh+1GgIRolDycaa7sRyvnKzs4IEi8TAXaTAok
+eZB44Rz60jhhOlsg5HscnoF6TwQyeYH0SOo5pRHXsQKBgQCY/pua7PceD5ZQ4lae
+Pi5E9LzPjoeFegVgAP7bRUeC21nzLZlKYOcRCV2WkGLsz60bZm+7VEyFZmrrFoTE
+58G0eCLCUq3Dj+NPfIvXNWwSuUAdDspWOBSCyENP+y+jLzIa2OtCj+KJe6Oe28pf
+CcSeCJqr6aLeDRPcuD7yUat1OA==
+-----END PRIVATE KEY-----`
+)
+
+var (
+	ErrMissingOrgID         = errors.New("org_id is required")
+	ErrMissingRequestDigest = errors.New("request_digest is required")
+	ErrMissingIssuer        = errors.New("issuer is required")
+	ErrMissingKeyID         = errors.New("kid is required")
+	ErrMissingPrivateKey    = errors.New("private key is required")
+)
+
+type jwtWebKey struct {
+	Kid string `json:"kid"`
+	Alg string `json:"alg"`
+	Kty string `json:"kty"`
+	Use string `json:"use"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+type jwtWebKeySet struct {
+	Keys []jwtWebKey `json:"keys"`
+}
+
+// JWTTokenClaims describes the claims shape expected by Vault's JWT authorizer.
+type JWTTokenClaims struct {
+	OrgID         string
+	WorkflowOwner string
+	RequestDigest string
+	Issuer        string
+	Audience      string
+	Subject       string
+	JWTID         string
+	KeyID         string
+	IssuedAt      time.Time
+	ExpiresAt     time.Time
+	ExtraClaims   map[string]any
+}
+
+// TestJWTIssuer is a minimal fake Auth0-style issuer for local CRE and system tests.
+// It serves a JWKS endpoint and can mint RS256 JWTs matching Vault's expected claims.
+type TestJWTIssuer struct {
+	server       *http.Server
+	listener     net.Listener
+	signers      map[string]*rsa.PrivateKey
+	defaultKeyID string
+	mu           sync.RWMutex
+}
+
+// NewTestJWTIssuer creates a fake issuer with one generated RSA key and starts serving JWKS immediately.
+func NewTestJWTIssuer() (*TestJWTIssuer, error) {
+	return NewTestJWTIssuerOnAddr("0.0.0.0:0")
+}
+
+// NewTestJWTIssuerOnAddr creates a fake issuer bound to the provided TCP address.
+func NewTestJWTIssuerOnAddr(listenAddr string) (*TestJWTIssuer, error) {
+	privateKey, err := parseDefaultJWTSigningKey()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTestJWTIssuerWithKeysOnAddr(map[string]*rsa.PrivateKey{
+		DefaultJWTIssuerKeyID: privateKey,
+	}, DefaultJWTIssuerKeyID, listenAddr)
+}
+
+func parseDefaultJWTSigningKey() (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(defaultJWTPrivateKeyPEM))
+	if block == nil {
+		return nil, errors.New("failed to decode default JWT signing key PEM")
+	}
+
+	privateKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse default JWT signing key: %w", err)
+	}
+
+	rsaKey, ok := privateKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("default JWT signing key is not RSA")
+	}
+
+	return rsaKey, nil
+}
+
+// NewTestJWTIssuerWithKeys creates a fake issuer backed by the provided key set.
+func NewTestJWTIssuerWithKeys(signers map[string]*rsa.PrivateKey, defaultKeyID string) (*TestJWTIssuer, error) {
+	return NewTestJWTIssuerWithKeysOnAddr(signers, defaultKeyID, "0.0.0.0:0")
+}
+
+// NewTestJWTIssuerWithKeysOnAddr creates a fake issuer backed by the provided key set and listen address.
+func NewTestJWTIssuerWithKeysOnAddr(signers map[string]*rsa.PrivateKey, defaultKeyID, listenAddr string) (*TestJWTIssuer, error) {
+	if len(signers) == 0 {
+		return nil, errors.New("at least one signer is required")
+	}
+	if _, ok := signers[defaultKeyID]; !ok {
+		return nil, fmt.Errorf("default signer %q is not present in key set", defaultKeyID)
+	}
+	if listenAddr == "" {
+		listenAddr = "0.0.0.0:0"
+	}
+
+	// #nosec G102 -- test-only JWKS server must be reachable from Dockerized nodes during local CRE runs.
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", listenAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate JWKS listener: %w", err)
+	}
+
+	issuer := &TestJWTIssuer{
+		listener:     listener,
+		signers:      signers,
+		defaultKeyID: defaultKeyID,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/jwks.json", issuer.handleJWKS)
+	mux.HandleFunc("/.well-known/openid-configuration", issuer.handleOpenIDConfiguration)
+
+	issuer.server = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		_ = issuer.server.Serve(listener)
+	}()
+
+	return issuer, nil
+}
+
+// Close shuts down the fake issuer.
+func (i *TestJWTIssuer) Close() error {
+	if i == nil || i.server == nil {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	return i.server.Shutdown(ctx)
+}
+
+// LocalIssuerURL returns an issuer URL that the local test process can use.
+func (i *TestJWTIssuer) LocalIssuerURL() string {
+	return i.baseURL("http://127.0.0.1")
+}
+
+// DockerIssuerURL returns an issuer URL that Dockerized Chainlink nodes can use.
+func (i *TestJWTIssuer) DockerIssuerURL() string {
+	return i.baseURL(framework.HostDockerInternal())
+}
+
+// MintToken signs a Vault-compatible JWT with one of the issuer's registered keys.
+func (i *TestJWTIssuer) MintToken(claims JWTTokenClaims) (string, error) {
+	if claims.KeyID == "" {
+		claims.KeyID = i.defaultKeyID
+	}
+	if claims.Issuer == "" {
+		claims.Issuer = i.LocalIssuerURL()
+	}
+	if claims.Audience == "" {
+		claims.Audience = DefaultJWTAudience
+	}
+
+	i.mu.RLock()
+	privateKey := i.signers[claims.KeyID]
+	i.mu.RUnlock()
+	if privateKey == nil {
+		return "", fmt.Errorf("signer %q not registered in issuer", claims.KeyID)
+	}
+
+	return SignTestJWT(privateKey, claims)
+}
+
+func (i *TestJWTIssuer) handleJWKS(w http.ResponseWriter, _ *http.Request) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+
+	keySet := jwtWebKeySet{
+		Keys: make([]jwtWebKey, 0, len(i.signers)),
+	}
+	for keyID, privateKey := range i.signers {
+		keySet.Keys = append(keySet.Keys, rsaPublicKeyToJWK(keyID, &privateKey.PublicKey))
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(keySet)
+}
+
+func (i *TestJWTIssuer) handleOpenIDConfiguration(w http.ResponseWriter, r *http.Request) {
+	issuerURL := requestBaseURL(r)
+	response := map[string]string{
+		"issuer":   issuerURL,
+		"jwks_uri": strings.TrimSuffix(issuerURL, "/") + "/.well-known/jwks.json",
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func (i *TestJWTIssuer) baseURL(host string) string {
+	if i == nil || i.listener == nil {
+		return ""
+	}
+
+	tcpAddr, ok := i.listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return ""
+	}
+
+	return withPort(host, tcpAddr.Port)
+}
+
+// GenerateJWTSigningKey creates an RSA signing key suitable for RS256 JWTs.
+func GenerateJWTSigningKey() (*rsa.PrivateKey, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate RSA signing key: %w", err)
+	}
+	return privateKey, nil
+}
+
+// SignTestJWT signs a Vault-compatible RS256 JWT.
+func SignTestJWT(privateKey *rsa.PrivateKey, claims JWTTokenClaims) (string, error) {
+	if privateKey == nil {
+		return "", ErrMissingPrivateKey
+	}
+	if claims.KeyID == "" {
+		return "", ErrMissingKeyID
+	}
+	if claims.Issuer == "" {
+		return "", ErrMissingIssuer
+	}
+	if claims.OrgID == "" {
+		return "", ErrMissingOrgID
+	}
+	if claims.RequestDigest == "" {
+		return "", ErrMissingRequestDigest
+	}
+
+	now := time.Now().UTC()
+	if claims.IssuedAt.IsZero() {
+		claims.IssuedAt = now
+	}
+	if claims.ExpiresAt.IsZero() {
+		claims.ExpiresAt = claims.IssuedAt.Add(DefaultJWTLifetime)
+	}
+	if claims.Subject == "" {
+		claims.Subject = claims.OrgID
+	}
+	if claims.Audience == "" {
+		claims.Audience = DefaultJWTAudience
+	}
+
+	tokenClaims := jwt.MapClaims{
+		"iss":    claims.Issuer,
+		"aud":    claims.Audience,
+		"sub":    claims.Subject,
+		"iat":    jwt.NewNumericDate(claims.IssuedAt),
+		"exp":    jwt.NewNumericDate(claims.ExpiresAt),
+		"org_id": claims.OrgID,
+		"authorization_details": []map[string]string{
+			{
+				"type":  "request_digest",
+				"value": claims.RequestDigest,
+			},
+		},
+	}
+
+	if claims.WorkflowOwner != "" {
+		tokenClaims["authorization_details"] = []map[string]string{
+			{
+				"type":  "request_digest",
+				"value": claims.RequestDigest,
+			},
+			{
+				"type":  "workflow_owner",
+				"value": claims.WorkflowOwner,
+			},
+		}
+	}
+	if claims.JWTID != "" {
+		tokenClaims["jti"] = claims.JWTID
+	}
+	for key, value := range claims.ExtraClaims {
+		tokenClaims[key] = value
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, tokenClaims)
+	token.Header["kid"] = claims.KeyID
+
+	tokenString, err := token.SignedString(privateKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign JWT: %w", err)
+	}
+
+	return tokenString, nil
+}
+
+// ComputeRequestDigest mirrors the digest computation used by Vault's authorizer.
+func ComputeRequestDigest(req jsonrpc.Request[json.RawMessage]) (string, error) {
+	return req.Digest()
+}
+
+// ComputeRawRequestDigest computes a Vault request digest from the marshalled JSON-RPC request body.
+func ComputeRawRequestDigest(requestBody []byte) (string, error) {
+	var req jsonrpc.Request[json.RawMessage]
+	if err := json.Unmarshal(requestBody, &req); err != nil {
+		return "", fmt.Errorf("failed to decode JSON-RPC request: %w", err)
+	}
+	return ComputeRequestDigest(req)
+}
+
+// EncryptSecretWithOrgID encrypts a secret using Vault's org_id label scheme.
+func EncryptSecretWithOrgID(secret, masterPublicKeyStr, orgID string) (string, error) {
+	masterPublicKey := tdh2easy.PublicKey{}
+	masterPublicKeyBytes, err := hex.DecodeString(masterPublicKeyStr)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode master public key: %w", err)
+	}
+	if err = masterPublicKey.Unmarshal(masterPublicKeyBytes); err != nil {
+		return "", fmt.Errorf("failed to unmarshal master public key: %w", err)
+	}
+
+	return vaultutils.EncryptSecretWithOrgID(secret, &masterPublicKey, orgID)
+}
+
+func rsaPublicKeyToJWK(keyID string, publicKey *rsa.PublicKey) jwtWebKey {
+	return jwtWebKey{
+		Kid: keyID,
+		Alg: "RS256",
+		Kty: "RSA",
+		Use: "sig",
+		N:   base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes()),
+		E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(publicKey.E)).Bytes()),
+	}
+}
+
+func requestBaseURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if forwardedProto := r.Header.Get("X-Forwarded-Proto"); forwardedProto != "" {
+		scheme = forwardedProto
+	}
+
+	return withPort(scheme+"://"+r.Host, portFromRequest(r))
+}
+
+func portFromRequest(r *http.Request) int {
+	if r.URL.Port() != "" {
+		port, _ := strconv.Atoi(r.URL.Port())
+		return port
+	}
+	if _, rawPort, err := net.SplitHostPort(r.Host); err == nil {
+		port, _ := strconv.Atoi(rawPort)
+		return port
+	}
+	return 0
+}
+
+func withPort(rawBase string, port int) string {
+	base, err := url.Parse(rawBase)
+	if err != nil {
+		return rawBase
+	}
+
+	host := base.Hostname()
+	if host == "" {
+		host = strings.Trim(rawBase, "/")
+	}
+
+	if port > 0 {
+		base.Host = net.JoinHostPort(host, strconv.Itoa(port))
+	} else {
+		base.Host = host
+	}
+	base.Path = "/"
+	base.RawPath = ""
+	base.RawQuery = ""
+	base.Fragment = ""
+
+	return base.String()
+}

--- a/system-tests/lib/cre/vault/jwt_auth_test.go
+++ b/system-tests/lib/cre/vault/jwt_auth_test.go
@@ -1,0 +1,95 @@
+package vault
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
+	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
+	linkingclient "github.com/smartcontractkit/chainlink-protos/linking-service/go/v1"
+	vaultcap "github.com/smartcontractkit/chainlink/v2/core/capabilities/vault"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func TestTestJWTIssuer_WorksWithVaultJWTBasedAuth(t *testing.T) {
+	issuer, err := NewTestJWTIssuer()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, issuer.Close())
+	})
+
+	params, err := json.Marshal(vaultcommon.ListSecretIdentifiersRequest{
+		Namespace: "main",
+	})
+	require.NoError(t, err)
+
+	req := jsonrpc.Request[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "req-1",
+		Method:  vaulttypes.MethodSecretsList,
+		Params:  (*json.RawMessage)(&params),
+	}
+
+	requestDigest, err := ComputeRequestDigest(req)
+	require.NoError(t, err)
+
+	token, err := issuer.MintToken(JWTTokenClaims{
+		KeyID:         DefaultJWTIssuerKeyID,
+		Issuer:        issuer.LocalIssuerURL(),
+		Audience:      "https://api.test.chain.link",
+		OrgID:         "org-test",
+		WorkflowOwner: "0xAbCdEf0123456789AbCdEf0123456789AbCdEf01",
+		RequestDigest: requestDigest,
+	})
+	require.NoError(t, err)
+
+	req.Auth = token
+
+	auth, err := vaultcap.NewJWTBasedAuth(vaultcap.JWTBasedAuthConfig{
+		IssuerURL: issuer.LocalIssuerURL(),
+		Audience:  "https://api.test.chain.link",
+	}, limits.Factory{Settings: cresettings.DefaultGetter}, logger.TestLogger(t), vaultcap.WithJWTBasedAuthGateLimiter(limits.NewGateLimiter(true)))
+	require.NoError(t, err)
+
+	authResult, err := auth.AuthorizeRequest(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, "org-test", authResult.OrgID())
+	require.Equal(t, "0xAbCdEf0123456789AbCdEf0123456789AbCdEf01", authResult.WorkflowOwner())
+	require.Equal(t, requestDigest, authResult.Digest())
+}
+
+func TestTestLinkingService_ResolvesOwner(t *testing.T) {
+	svc, err := NewTestLinkingService(map[string]string{
+		"0xAbC": "org-123",
+		"d6d4fc38c209f53caa5a311a0cb44259daa4e9e1": "org-456",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	conn, err := grpc.NewClient(svc.LocalURL(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	resp, err := linkingclient.NewLinkingServiceClient(conn).GetOrganizationFromWorkflowOwner(t.Context(), &linkingclient.GetOrganizationFromWorkflowOwnerRequest{
+		WorkflowOwner: "0xabc",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "org-123", resp.GetOrganizationId())
+
+	resp, err = linkingclient.NewLinkingServiceClient(conn).GetOrganizationFromWorkflowOwner(t.Context(), &linkingclient.GetOrganizationFromWorkflowOwnerRequest{
+		WorkflowOwner: "0xD6d4fC38c209F53caa5a311a0cb44259dAA4E9e1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "org-456", resp.GetOrganizationId())
+}

--- a/system-tests/lib/cre/vault/linking_service.go
+++ b/system-tests/lib/cre/vault/linking_service.go
@@ -1,0 +1,132 @@
+package vault
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	linkingclient "github.com/smartcontractkit/chainlink-protos/linking-service/go/v1"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+)
+
+// TestLinkingService is a local gRPC fixture that resolves workflow owners to org IDs.
+type TestLinkingService struct {
+	linkingclient.UnimplementedLinkingServiceServer
+
+	server   *grpc.Server
+	listener net.Listener
+
+	mu         sync.RWMutex
+	ownerToOrg map[string]string
+}
+
+// NewTestLinkingService starts a mock linking service immediately.
+func NewTestLinkingService(ownerToOrg map[string]string) (*TestLinkingService, error) {
+	return NewTestLinkingServiceOnAddr(ownerToOrg, "0.0.0.0:0")
+}
+
+// NewTestLinkingServiceOnAddr starts a mock linking service on the provided TCP address.
+func NewTestLinkingServiceOnAddr(ownerToOrg map[string]string, listenAddr string) (*TestLinkingService, error) {
+	if listenAddr == "" {
+		listenAddr = "0.0.0.0:0"
+	}
+
+	// #nosec G102 -- test-only linking server must be reachable from Dockerized nodes during local CRE runs.
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", listenAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate linking service listener: %w", err)
+	}
+
+	svc := &TestLinkingService{
+		listener:   listener,
+		ownerToOrg: make(map[string]string, len(ownerToOrg)),
+	}
+	for owner, orgID := range ownerToOrg {
+		svc.ownerToOrg[normalizeWorkflowOwner(owner)] = orgID
+	}
+
+	server := grpc.NewServer()
+	linkingclient.RegisterLinkingServiceServer(server, svc)
+	svc.server = server
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	return svc, nil
+}
+
+// Close stops the mock gRPC service.
+func (s *TestLinkingService) Close() error {
+	if s == nil || s.server == nil {
+		return nil
+	}
+
+	s.server.Stop()
+	if s.listener != nil {
+		if err := s.listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// LocalURL returns the host-local gRPC address.
+func (s *TestLinkingService) LocalURL() string {
+	return s.baseURL("127.0.0.1")
+}
+
+// DockerURL returns the address Dockerized nodes can use.
+func (s *TestLinkingService) DockerURL() string {
+	return s.baseURL(strings.TrimPrefix(framework.HostDockerInternal(), "http://"))
+}
+
+// SetOwnerOrg installs or updates a workflow-owner mapping.
+func (s *TestLinkingService) SetOwnerOrg(owner, orgID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.ownerToOrg[normalizeWorkflowOwner(owner)] = orgID
+}
+
+// GetOrganizationFromWorkflowOwner implements the linking-service gRPC API.
+func (s *TestLinkingService) GetOrganizationFromWorkflowOwner(_ context.Context, req *linkingclient.GetOrganizationFromWorkflowOwnerRequest) (*linkingclient.GetOrganizationFromWorkflowOwnerResponse, error) {
+	owner := normalizeWorkflowOwner(req.GetWorkflowOwner())
+
+	s.mu.RLock()
+	orgID, ok := s.ownerToOrg[owner]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "workflow owner %q not linked", req.GetWorkflowOwner())
+	}
+
+	return &linkingclient.GetOrganizationFromWorkflowOwnerResponse{
+		OrganizationId: orgID,
+	}, nil
+}
+
+func (s *TestLinkingService) baseURL(host string) string {
+	if s == nil || s.listener == nil {
+		return ""
+	}
+
+	tcpAddr, ok := s.listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return ""
+	}
+
+	return fmt.Sprintf("%s:%d", host, tcpAddr.Port)
+}
+
+func normalizeWorkflowOwner(owner string) string {
+	owner = strings.ToLower(strings.TrimSpace(owner))
+	return strings.TrimPrefix(owner, "0x")
+}

--- a/system-tests/lib/cre/workflow/workflow.go
+++ b/system-tests/lib/cre/workflow/workflow.go
@@ -150,6 +150,9 @@ func LinkOwner(sc *seth.Client, workflowRegistryAddr common.Address, version *se
 
 		_, err = sc.Decode(registry.LinkOwner(sc.NewTXOpts(), validityTimestamp, common.HexToHash(ownershipProof), signature))
 		if err != nil {
+			if strings.Contains(err.Error(), "OwnershipLinkAlreadyExists") {
+				return nil
+			}
 			return err
 		}
 

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/gagliardetto/solana-go v1.13.0
 	github.com/go-resty/resty/v2 v2.17.2
 	github.com/goccy/go-yaml v1.19.2
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/pelletier/go-toml/v2 v2.3.0
@@ -38,6 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20260119171452-39c98c3b33cd
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260409211238-5b99921cbc7c
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0
+	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260323124644-faea187e6997
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20260415133314-f9b1fef9e55f
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.16
@@ -270,7 +272,6 @@ require (
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/btree v1.1.3 // indirect
@@ -469,7 +470,6 @@ require (
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/heartbeat v0.0.0-20260115142640-f6b99095c12e // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d // indirect
-	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b // indirect
 	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260319180422-b5808c964785 // indirect
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.10.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260331131315-f08a616d8dcd // indirect

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -382,7 +382,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gogo/status v1.1.1 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/btree v1.1.3 // indirect

--- a/system-tests/tests/regression/cre/v2_evm_regression_test.go
+++ b/system-tests/tests/regression/cre/v2_evm_regression_test.go
@@ -174,8 +174,8 @@ var evmNegativeTestsGetTransactionReceiptInvalidHash = []evmNegativeTest{
 	{"31 bytes (short) non-0x-prefixed", "12345678901234567890123456789012345678901234567890123456789012", getTransactionReceiptInvalidHash, "got 31 bytes, expected 32"},
 	{"33 bytes (long) non-0x-prefixed", "12345678901234567890123456789012345678901234567890123456789012345", getTransactionReceiptInvalidHash, "got 33 bytes, expected 32"},
 	{"malformed (non-hex) correct length", "0x123gggggggggggggggggggggggggggggggggggggggggggggggggggggggggg", getTransactionReceiptInvalidHash, "got 2 bytes, expected 32"}, // produces x01#
-	{"short hash", "0x647b7f17f9edba01d1f75ce071d0bc10173bc66b5d072f28b644275bf13bb99", getTransactionReceiptInvalidHash, "RPC call failed: not found"},
-	{"non-existent hash", "0x1234567890123456789012345678901234567890123456789012345678901234", getTransactionReceiptInvalidHash, "RPC call failed: not found"},
+	{"short hash", "0x647b7f17f9edba01d1f75ce071d0bc10173bc66b5d072f28b644275bf13bb99", getTransactionReceiptInvalidHash, "got expected error for GetTransactionReceipt with invalid hash"},
+	{"non-existent hash", "0x1234567890123456789012345678901234567890123456789012345678901234", getTransactionReceiptInvalidHash, "got expected error for GetTransactionReceipt with invalid hash"},
 }
 
 var evmNegativeTestsHeaderByNumberInvalidBlock = []evmNegativeTest{

--- a/system-tests/tests/smoke/cre/cre_suite_test.go
+++ b/system-tests/tests/smoke/cre/cre_suite_test.go
@@ -144,8 +144,13 @@ func runV2SuiteScenario(t *testing.T, topology string, scenario v2suite_config.S
 			if parallelEnabled {
 				t.Parallel()
 			}
-			testEnv := t_helpers.SetupTestEnvironmentWithPerTestKeys(t, t_helpers.GetDefaultTestConfig(t))
-			ExecuteVaultTest(t, testEnv)
+			fixture := setupVaultSharedScenarioFixture(t, getVaultFlagsEnabledTestConfig(t))
+			t.Run("allowlist_auth", func(t *testing.T) {
+				ExecuteVaultTest(t, fixture.TestEnv, fixture.LinkingService)
+			})
+			t.Run("jwt_auth", func(t *testing.T) {
+				ExecuteVaultJWTTest(t, fixture.TestEnv, fixture.Issuer, fixture.LinkingService)
+			})
 		})
 	case v2suite_config.SuiteScenarioCronBeholder:
 		// NOTE: this test is not easily parallelisable, because it uses "real" ChIP Ingress stack

--- a/system-tests/tests/smoke/cre/v2_vault_don_test.go
+++ b/system-tests/tests/smoke/cre/v2_vault_don_test.go
@@ -10,11 +10,13 @@ import (
 	"net/url"
 	"slices"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -39,6 +41,7 @@ import (
 	workflow_registry_v2_wrapper "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper_v2"
 
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
+	envconfig "github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/config"
 	crevault "github.com/smartcontractkit/chainlink/system-tests/lib/cre/features/vault"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/vault"
 	creworkflow "github.com/smartcontractkit/chainlink/system-tests/lib/cre/workflow"
@@ -47,32 +50,18 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 )
 
-func ExecuteVaultTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
+const (
+	vaultFlagsEnabledConfigPath  = "/configs/workflow-gateway-capabilities-don-vault-flags-enabled.toml"
+	vaultFlagsDisabledConfigPath = "/configs/workflow-gateway-capabilities-don-vault-flags-disabled.toml"
+	vaultJWTIssuerListenAddr     = "0.0.0.0:18123"
+	vaultLinkingServiceAddr      = "0.0.0.0:18124"
+)
+
+func ExecuteVaultTest(t *testing.T, testEnv *ttypes.TestEnvironment, linkingService *vault.TestLinkingService) {
 	var testLogger = framework.L
 
-	testLogger.Info().Msgf("Ensuring DKG result packages are present...")
-	require.Eventually(t, func() bool {
-		for _, nodeSet := range testEnv.Config.NodeSets {
-			if slices.Contains(nodeSet.Capabilities, cre.VaultCapability) {
-				for i, node := range nodeSet.NodeSpecs {
-					if !slices.Contains(node.Roles, cre.BootstrapNode) {
-						packageCount, err := vault.GetResultPackageCount(t.Context(), i, nodeSet.DbInput.Port)
-						if err != nil || packageCount != 1 {
-							return false
-						}
-					}
-				}
-				return true
-			}
-		}
-		return false
-	}, time.Second*300, time.Second*5)
-
-	testLogger.Info().Msg("Getting gateway configuration...")
-	require.NotEmpty(t, testEnv.Dons.GatewayConnectors.Configurations, "expected at least one gateway configuration")
-	gatewayURL, err := url.Parse(testEnv.Dons.GatewayConnectors.Configurations[0].Incoming.Protocol + "://" + testEnv.Dons.GatewayConnectors.Configurations[0].Incoming.Host + ":" + strconv.Itoa(testEnv.Dons.GatewayConnectors.Configurations[0].Incoming.ExternalPort) + testEnv.Dons.GatewayConnectors.Configurations[0].Incoming.Path)
-	require.NoError(t, err, "failed to parse gateway URL")
-	testLogger.Info().Msgf("Gateway URL: %s", gatewayURL.String())
+	ensureVaultDKGResultPackages(t, testEnv)
+	gatewayURL := mustVaultGatewayURL(t, testEnv)
 
 	vaultPublicKey := FetchVaultPublicKey(t, gatewayURL.String())
 	updateVaultCapabilityConfigInRegistry(t, testEnv, vaultPublicKey)
@@ -86,6 +75,12 @@ func ExecuteVaultTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 		subEnv := t_helpers.SetupTestEnvironmentWithPerTestKeys(t, testEnv.TestConfig)
 		sc := subEnv.CreEnvironment.Blockchains[0].(*evm.Blockchain).SethClient
 		owner := sc.MustGetRootKeyAddress().Hex()
+		expectedResponseOwner := owner
+		if linkingService != nil {
+			orgID := "org" + strings.ReplaceAll(uuid.NewString(), "-", "")
+			linkingService.SetOwnerOrg(owner, orgID)
+			expectedResponseOwner = orgID
+		}
 		wfRegAddr := crecontracts.MustGetAddressFromDataStore(subEnv.CreEnvironment.CldfEnvironment.DataStore, subEnv.CreEnvironment.Blockchains[0].ChainSelector(), keystone_changeset.WorkflowRegistry.String(), subEnv.CreEnvironment.ContractVersions[keystone_changeset.WorkflowRegistry.String()], "")
 		wfReg, err := workflow_registry_v2_wrapper.NewWorkflowRegistry(common.HexToAddress(wfRegAddr), sc.Client)
 		require.NoError(t, err)
@@ -104,23 +99,163 @@ func ExecuteVaultTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 		})
 		namespaces := []string{"main", "alt"}
 
-		executeVaultSecretsCreateTest(t, enc, secretID, owner, gwURL, namespaces, sc, wfReg)
+		executeVaultSecretsCreateTest(t, enc, secretID, owner, expectedResponseOwner, gwURL, namespaces, sc, wfReg)
 		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "bget1", secretID, "main", ulCh, bmCh)
 		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "bgeta1", secretID, "alt", ulCh, bmCh)
-		executeVaultSecretsUpdateTest(t, enc, secretID, owner, gwURL, namespaces, sc, wfReg)
+		executeVaultSecretsUpdateTest(t, enc, secretID, owner, expectedResponseOwner, gwURL, namespaces, sc, wfReg)
 		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "bget2", secretID, "main", ulCh, bmCh)
 		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "bgeta2", secretID, "alt", ulCh, bmCh)
-		executeVaultSecretsListTest(t, secretID, owner, gwURL, "main", sc, wfReg)
-		executeVaultSecretsListTest(t, secretID, owner, gwURL, "alt", sc, wfReg)
-		executeVaultSecretsDeleteTest(t, secretID, owner, gwURL, []string{"main"}, sc, wfReg)
+		executeVaultSecretsListTest(t, secretID, owner, expectedResponseOwner, gwURL, "main", sc, wfReg)
+		executeVaultSecretsListTest(t, secretID, owner, expectedResponseOwner, gwURL, "alt", sc, wfReg)
+		executeVaultSecretsDeleteTest(t, secretID, owner, expectedResponseOwner, gwURL, []string{"main"}, sc, wfReg)
 		executeVaultSecretsGetNotFoundViaWorkflowTest(t, subEnv, "bdel1", secretID, "main", ulCh, bmCh)
 		executeVaultSecretsGetViaWorkflowTest(t, subEnv, "bgeta3", secretID, "alt", ulCh, bmCh)
-		executeVaultSecretsDeleteTest(t, secretID, owner, gwURL, []string{"alt"}, sc, wfReg)
+		executeVaultSecretsDeleteTest(t, secretID, owner, expectedResponseOwner, gwURL, []string{"alt"}, sc, wfReg)
 		executeVaultSecretsGetNotFoundViaWorkflowTest(t, subEnv, "bdela1", secretID, "alt", ulCh, bmCh)
 	})
 }
 
-func executeVaultSecretsCreateTest(t *testing.T, encryptedSecret, secretID, owner, gatewayURL string, namespaces []string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
+type vaultScenarioFixture struct {
+	TestEnv        *ttypes.TestEnvironment
+	Issuer         *vault.TestJWTIssuer
+	LinkingService *vault.TestLinkingService
+}
+
+func getVaultFlagsEnabledTestConfig(t *testing.T) *ttypes.TestConfig {
+	t.Helper()
+
+	return t_helpers.GetTestConfig(t, vaultFlagsEnabledConfigPath)
+}
+
+func setupVaultScenarioFixture(t *testing.T, baseConfig *ttypes.TestConfig, usePerTestKeys bool) *vaultScenarioFixture {
+	t.Helper()
+
+	issuer, err := vault.NewTestJWTIssuerOnAddr(vaultJWTIssuerListenAddr)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, issuer.Close())
+	})
+
+	linkingService, err := vault.NewTestLinkingServiceOnAddr(nil, vaultLinkingServiceAddr)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, linkingService.Close())
+	})
+
+	var testEnv *ttypes.TestEnvironment
+	if usePerTestKeys {
+		testEnv = t_helpers.SetupTestEnvironmentWithPerTestKeys(t, baseConfig)
+	} else {
+		testEnv = t_helpers.SetupTestEnvironmentWithConfig(t, baseConfig)
+	}
+
+	return &vaultScenarioFixture{
+		TestEnv:        testEnv,
+		Issuer:         issuer,
+		LinkingService: linkingService,
+	}
+}
+
+func setupVaultSharedScenarioFixture(t *testing.T, baseConfig *ttypes.TestConfig) *vaultScenarioFixture {
+	t.Helper()
+
+	return setupVaultScenarioFixture(t, baseConfig, false)
+}
+
+func ExecuteVaultJWTTest(t *testing.T, testEnv *ttypes.TestEnvironment, issuer *vault.TestJWTIssuer, linkingService *vault.TestLinkingService) {
+	testLogger := framework.L
+
+	ensureVaultDKGResultPackages(t, testEnv)
+	gatewayURL := mustVaultGatewayURL(t, testEnv)
+
+	vaultPublicKey := FetchVaultPublicKey(t, gatewayURL.String())
+	updateVaultCapabilityConfigInRegistry(t, testEnv, vaultPublicKey)
+
+	sc := testEnv.CreEnvironment.Blockchains[0].(*evm.Blockchain).SethClient
+	workflowOwner := sc.MustGetRootKeyAddress().Hex()
+	orgID := "org" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	linkingService.SetOwnerOrg(workflowOwner, orgID)
+
+	wfRegAddr := crecontracts.MustGetAddressFromDataStore(
+		testEnv.CreEnvironment.CldfEnvironment.DataStore,
+		testEnv.CreEnvironment.Blockchains[0].ChainSelector(),
+		keystone_changeset.WorkflowRegistry.String(),
+		testEnv.CreEnvironment.ContractVersions[keystone_changeset.WorkflowRegistry.String()],
+		"",
+	)
+	require.NoError(t, creworkflow.LinkOwner(sc, common.HexToAddress(wfRegAddr), testEnv.CreEnvironment.ContractVersions[keystone_changeset.WorkflowRegistry.String()]))
+
+	ulCh := make(chan *workflowevents.UserLogs, 1000)
+	bmCh := make(chan *commonevents.BaseMessage, 1000)
+	sink := t_helpers.StartChipTestSink(t, t_helpers.GetPublishFn(testLogger, ulCh, bmCh))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		t_helpers.ShutdownChipSinkWithDrain(ctx, sink, ulCh, bmCh)
+	})
+
+	gwURL := gatewayURL.String()
+
+	t.Run("jwt_with_workflow_owner", func(t *testing.T) {
+		secretID := strconv.Itoa(rand.Intn(10000))
+		enc, err := vault.EncryptSecretWithOrgID("secret-jwt-workflow-owner", vaultPublicKey, orgID)
+		require.NoError(t, err)
+
+		executeVaultJWTSecretsCreateTest(t, issuer, enc, secretID, orgID, workflowOwner, gwURL, []string{"main", "alt"})
+		executeVaultSecretsGetViaWorkflowTest(t, testEnv, "jwtgetmain1", secretID, "main", ulCh, bmCh)
+		executeVaultSecretsGetViaWorkflowTest(t, testEnv, "jwtgetalt1", secretID, "alt", ulCh, bmCh)
+		executeVaultJWTSecretsListTest(t, issuer, secretID, orgID, workflowOwner, gwURL, "main")
+		executeVaultJWTSecretsListTest(t, issuer, secretID, orgID, workflowOwner, gwURL, "alt")
+		executeVaultJWTSecretsDeleteTest(t, issuer, secretID, orgID, workflowOwner, gwURL, []string{"main", "alt"})
+		executeVaultSecretsGetNotFoundViaWorkflowTest(t, testEnv, "jwtdelmain1", secretID, "main", ulCh, bmCh)
+		executeVaultSecretsGetNotFoundViaWorkflowTest(t, testEnv, "jwtdelalt1", secretID, "alt", ulCh, bmCh)
+	})
+
+	t.Run("jwt_without_workflow_owner", func(t *testing.T) {
+		secretID := strconv.Itoa(rand.Intn(10000))
+		enc, err := vault.EncryptSecretWithOrgID("secret-jwt-org-only", vaultPublicKey, orgID)
+		require.NoError(t, err)
+
+		executeVaultJWTSecretsCreateTest(t, issuer, enc, secretID, orgID, "", gwURL, []string{"main"})
+		executeVaultJWTSecretsListTest(t, issuer, secretID, orgID, "", gwURL, "main")
+		executeVaultJWTSecretsDeleteTest(t, issuer, secretID, orgID, "", gwURL, []string{"main"})
+	})
+}
+
+func ensureVaultDKGResultPackages(t *testing.T, testEnv *ttypes.TestEnvironment) {
+	t.Helper()
+
+	framework.L.Info().Msg("Ensuring DKG result packages are present...")
+	require.Eventually(t, func() bool {
+		for _, nodeSet := range testEnv.Config.NodeSets {
+			if slices.Contains(nodeSet.Capabilities, cre.VaultCapability) {
+				for i, node := range nodeSet.NodeSpecs {
+					if !slices.Contains(node.Roles, cre.BootstrapNode) {
+						packageCount, err := vault.GetResultPackageCount(t.Context(), i, nodeSet.DbInput.Port)
+						if err != nil || packageCount != 1 {
+							return false
+						}
+					}
+				}
+				return true
+			}
+		}
+		return false
+	}, time.Second*300, time.Second*5)
+}
+
+func mustVaultGatewayURL(t *testing.T, testEnv *ttypes.TestEnvironment) *url.URL {
+	t.Helper()
+
+	framework.L.Info().Msg("Getting gateway configuration...")
+	require.NotEmpty(t, testEnv.Dons.GatewayConnectors.Configurations, "expected at least one gateway configuration")
+	gatewayURL, err := url.Parse(testEnv.Dons.GatewayConnectors.Configurations[0].Incoming.Protocol + "://" + testEnv.Dons.GatewayConnectors.Configurations[0].Incoming.Host + ":" + strconv.Itoa(testEnv.Dons.GatewayConnectors.Configurations[0].Incoming.ExternalPort) + testEnv.Dons.GatewayConnectors.Configurations[0].Incoming.Path)
+	require.NoError(t, err, "failed to parse gateway URL")
+	framework.L.Info().Msgf("Gateway URL: %s", gatewayURL.String())
+	return gatewayURL
+}
+
+func executeVaultSecretsCreateTest(t *testing.T, encryptedSecret, secretID, requestOwner, expectedResponseOwner, gatewayURL string, namespaces []string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
 	framework.L.Info().Msgf("Creating secrets (namespaces=%v)...", namespaces)
 
 	uniqueRequestID := uuid.New().String()
@@ -130,7 +265,7 @@ func executeVaultSecretsCreateTest(t *testing.T, encryptedSecret, secretID, owne
 		encryptedSecrets = append(encryptedSecrets, &vault_helpers.EncryptedSecret{
 			Id: &vault_helpers.SecretIdentifier{
 				Key:       secretID,
-				Owner:     owner,
+				Owner:     requestOwner,
 				Namespace: namespace,
 			},
 			EncryptedValue: encryptedSecret,
@@ -150,7 +285,7 @@ func executeVaultSecretsCreateTest(t *testing.T, encryptedSecret, secretID, owne
 		Method:  vaulttypes.MethodSecretsCreate,
 		Params:  &secretsCreateRequestBodyJSON,
 	}
-	allowlistRequest(t, owner, jsonRequest, sethClient, wfRegistryContract)
+	allowlistRequest(t, requestOwner, jsonRequest, sethClient, wfRegistryContract)
 
 	requestBody, err := json.Marshal(jsonRequest)
 	require.NoError(t, err, "failed to marshal secrets request")
@@ -189,10 +324,358 @@ func executeVaultSecretsCreateTest(t *testing.T, encryptedSecret, secretID, owne
 		require.True(t, ok, "missing response for namespace %s", namespace)
 		require.Empty(t, result.GetError())
 		require.Equal(t, secretID, result.GetId().Key)
-		require.Equal(t, owner, result.GetId().Owner)
+		require.Equal(t, expectedResponseOwner, result.GetId().Owner)
 	}
 
 	framework.L.Info().Msgf("Secrets created successfully (namespaces=%v)", namespaces)
+}
+
+func executeVaultJWTSecretsCreateTest(t *testing.T, issuer *vault.TestJWTIssuer, encryptedSecret, secretID, orgID, workflowOwner, gatewayURL string, namespaces []string) {
+	t.Helper()
+
+	framework.L.Info().Msgf("Creating JWT-authenticated secrets (namespaces=%v)...", namespaces)
+
+	uniqueRequestID := uuid.New().String()
+	encryptedSecrets := make([]*vault_helpers.EncryptedSecret, 0, len(namespaces))
+	for _, namespace := range namespaces {
+		encryptedSecrets = append(encryptedSecrets, &vault_helpers.EncryptedSecret{
+			Id: &vault_helpers.SecretIdentifier{
+				Key:       secretID,
+				Owner:     orgID,
+				Namespace: namespace,
+			},
+			EncryptedValue: encryptedSecret,
+		})
+	}
+
+	secretsCreateRequest := vault_helpers.CreateSecretsRequest{
+		RequestId:        uniqueRequestID,
+		EncryptedSecrets: encryptedSecrets,
+	}
+	secretsCreateRequestBody, err := json.Marshal(secretsCreateRequest) //nolint:govet // The lock field is not set on this proto
+	require.NoError(t, err, "failed to marshal secrets request")
+	secretsCreateRequestBodyJSON := json.RawMessage(secretsCreateRequestBody)
+	jsonRequest := jsonrpc.Request[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      uniqueRequestID,
+		Method:  vaulttypes.MethodSecretsCreate,
+		Params:  &secretsCreateRequestBodyJSON,
+	}
+	jsonRequest.Auth = mustMintVaultJWTForRequest(t, issuer, jsonRequest, orgID, workflowOwner)
+
+	jsonResponse := sendVaultJWTRequestToGateway(t, gatewayURL, jsonRequest)
+	require.Equal(t, uniqueRequestID, jsonResponse.ID)
+	require.Equal(t, vaulttypes.MethodSecretsCreate, jsonResponse.Method)
+
+	createSecretsResponse := vault_helpers.CreateSecretsResponse{}
+	err = protojson.Unmarshal(jsonResponse.Result.Payload, &createSecretsResponse)
+	require.NoError(t, err, "failed to decode payload into CreateSecretsResponse proto")
+
+	require.Len(t, createSecretsResponse.Responses, len(namespaces), "Expected one item in the response per namespace")
+	respByNs := make(map[string]*vault_helpers.CreateSecretResponse, len(namespaces))
+	for _, r := range createSecretsResponse.GetResponses() {
+		respByNs[r.GetId().GetNamespace()] = r
+	}
+	for _, namespace := range namespaces {
+		result, ok := respByNs[namespace]
+		require.True(t, ok, "missing response for namespace %s", namespace)
+		require.Empty(t, result.GetError())
+		require.Equal(t, secretID, result.GetId().Key)
+		require.Equal(t, orgID, result.GetId().Owner)
+	}
+}
+
+func executeVaultJWTSecretsListTest(t *testing.T, issuer *vault.TestJWTIssuer, secretID, orgID, workflowOwner, gatewayURL, namespace string) {
+	t.Helper()
+
+	framework.L.Info().Msgf("Listing JWT-authenticated secrets (namespace=%s)...", namespace)
+
+	uniqueRequestID := uuid.New().String()
+	secretsListRequest := vault_helpers.ListSecretIdentifiersRequest{
+		RequestId: uniqueRequestID,
+		Owner:     orgID,
+		Namespace: namespace,
+	}
+	secretsListRequestBody, err := json.Marshal(secretsListRequest) //nolint:govet // The lock field is not set on this proto
+	require.NoError(t, err, "failed to marshal secrets request")
+	secretsListRequestBodyJSON := json.RawMessage(secretsListRequestBody)
+	jsonRequest := jsonrpc.Request[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      uniqueRequestID,
+		Method:  vaulttypes.MethodSecretsList,
+		Params:  &secretsListRequestBodyJSON,
+	}
+	jsonRequest.Auth = mustMintVaultJWTForRequest(t, issuer, jsonRequest, orgID, workflowOwner)
+
+	jsonResponse := sendVaultJWTRequestToGateway(t, gatewayURL, jsonRequest)
+	require.Equal(t, uniqueRequestID, jsonResponse.ID)
+	require.Equal(t, vaulttypes.MethodSecretsList, jsonResponse.Method)
+
+	listSecretsResponse := vault_helpers.ListSecretIdentifiersResponse{}
+	err = protojson.Unmarshal(jsonResponse.Result.Payload, &listSecretsResponse)
+	require.NoError(t, err, "failed to decode payload into ListSecretIdentifiersResponse proto")
+
+	require.True(t, listSecretsResponse.Success, "expected successful list response")
+	require.GreaterOrEqual(t, len(listSecretsResponse.Identifiers), 1, "Expected at least one item in the response")
+	var keys = make([]string, 0, len(listSecretsResponse.Identifiers))
+	for _, identifier := range listSecretsResponse.Identifiers {
+		keys = append(keys, identifier.Key)
+		require.Equal(t, orgID, identifier.Owner)
+		require.Equal(t, namespace, identifier.Namespace)
+	}
+	require.Contains(t, keys, secretID)
+}
+
+func executeVaultJWTSecretsDeleteTest(t *testing.T, issuer *vault.TestJWTIssuer, secretID, orgID, workflowOwner, gatewayURL string, namespaces []string) {
+	t.Helper()
+
+	framework.L.Info().Msgf("Deleting JWT-authenticated secrets (namespaces=%v)...", namespaces)
+
+	uniqueRequestID := uuid.New().String()
+	deleteIDs := make([]*vault_helpers.SecretIdentifier, 0, len(namespaces)+1)
+	for _, namespace := range namespaces {
+		deleteIDs = append(deleteIDs, &vault_helpers.SecretIdentifier{
+			Key:       secretID,
+			Owner:     orgID,
+			Namespace: namespace,
+		})
+	}
+	deleteIDs = append(deleteIDs, &vault_helpers.SecretIdentifier{
+		Key:       "invalid",
+		Owner:     orgID,
+		Namespace: namespaces[0],
+	})
+
+	secretsDeleteRequest := vault_helpers.DeleteSecretsRequest{
+		RequestId: uniqueRequestID,
+		Ids:       deleteIDs,
+	}
+	secretsDeleteRequestBody, err := json.Marshal(secretsDeleteRequest) //nolint:govet // The lock field is not set on this proto
+	require.NoError(t, err, "failed to marshal secrets request")
+	secretsDeleteRequestBodyJSON := json.RawMessage(secretsDeleteRequestBody)
+	jsonRequest := jsonrpc.Request[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      uniqueRequestID,
+		Method:  vaulttypes.MethodSecretsDelete,
+		Params:  &secretsDeleteRequestBodyJSON,
+	}
+	jsonRequest.Auth = mustMintVaultJWTForRequest(t, issuer, jsonRequest, orgID, workflowOwner)
+
+	jsonResponse := sendVaultJWTRequestToGateway(t, gatewayURL, jsonRequest)
+	require.Equal(t, uniqueRequestID, jsonResponse.ID)
+	require.Equal(t, vaulttypes.MethodSecretsDelete, jsonResponse.Method)
+
+	deleteSecretsResponse := vault_helpers.DeleteSecretsResponse{}
+	err = protojson.Unmarshal(jsonResponse.Result.Payload, &deleteSecretsResponse)
+	require.NoError(t, err, "failed to decode payload into DeleteSecretsResponse proto")
+
+	require.Len(t, deleteSecretsResponse.Responses, len(namespaces)+1, "Expected one deleted item per namespace plus one invalid item")
+	var foundDeleteInvalid bool
+	deleteRespByNs := make(map[string]*vault_helpers.DeleteSecretResponse, len(namespaces))
+	for _, r := range deleteSecretsResponse.GetResponses() {
+		if r.GetId().GetKey() == "invalid" {
+			require.Contains(t, r.Error, "key does not exist")
+			foundDeleteInvalid = true
+			continue
+		}
+		deleteRespByNs[r.GetId().GetNamespace()] = r
+	}
+	require.True(t, foundDeleteInvalid, "expected an error response for the 'invalid' key")
+	for _, namespace := range namespaces {
+		result, ok := deleteRespByNs[namespace]
+		require.True(t, ok, "missing delete response for namespace %s", namespace)
+		require.True(t, result.Success, result.Error)
+		require.Equal(t, orgID, result.Id.Owner)
+		require.Equal(t, secretID, result.Id.Key)
+	}
+}
+
+func TestVaultStaticTopologies_LoadExpectedConfig(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		configPath  string
+		wantJWTGate string
+		wantOrgGate string
+		wantAuth0   bool
+		wantLinking bool
+	}{
+		{
+			name:        "enabled",
+			configPath:  vaultFlagsEnabledConfigPath,
+			wantJWTGate: "true",
+			wantOrgGate: "true",
+			wantAuth0:   true,
+			wantLinking: true,
+		},
+		{
+			name:        "disabled",
+			configPath:  vaultFlagsDisabledConfigPath,
+			wantJWTGate: "false",
+			wantOrgGate: "false",
+			wantAuth0:   false,
+			wantLinking: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &envconfig.Config{}
+			require.NoError(t, cfg.Load(t_helpers.GetTestConfig(t, tc.configPath).EnvironmentConfigPath))
+
+			for _, nodeSet := range cfg.NodeSets {
+				var settings map[string]string
+				require.NoError(t, json.Unmarshal([]byte(nodeSet.EnvVars["CL_CRE_SETTINGS_DEFAULT"]), &settings))
+				require.Equal(t, tc.wantJWTGate, settings["VaultJWTAuthEnabled"])
+				require.Equal(t, tc.wantOrgGate, settings["VaultOrgIdAsSecretOwnerEnabled"])
+
+				for _, nodeSpec := range nodeSet.NodeSpecs {
+					if nodeSet.Name != "workflow" && nodeSet.Name != "capabilities" {
+						continue
+					}
+					if tc.wantLinking {
+						require.Contains(t, nodeSpec.Node.UserConfigOverrides, "[CRE.Linking]")
+						require.Contains(t, nodeSpec.Node.UserConfigOverrides, "host.docker.internal:18124")
+						continue
+					}
+					require.Empty(t, nodeSpec.Node.UserConfigOverrides)
+				}
+			}
+
+			var capabilitiesNodeSet *cre.NodeSet
+			for _, nodeSet := range cfg.NodeSets {
+				if nodeSet.Name == "capabilities" {
+					capabilitiesNodeSet = nodeSet
+					break
+				}
+			}
+			require.NotNil(t, capabilitiesNodeSet)
+
+			auth0Value, hasAuth0 := capabilitiesNodeSet.CapabilityConfigs[cre.VaultCapability].Values["auth0"]
+			if !tc.wantAuth0 {
+				require.False(t, hasAuth0)
+				return
+			}
+
+			require.True(t, hasAuth0)
+			require.Equal(t, map[string]any{
+				"issuerURL": "http://host.docker.internal:18123/",
+				"audience":  vault.DefaultJWTAudience,
+			}, auth0Value)
+		})
+	}
+}
+
+func TestMustMintVaultJWTForRequest_UsesRawRequestDigest(t *testing.T) {
+	issuer, err := vault.NewTestJWTIssuer()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, issuer.Close())
+	})
+
+	params, err := json.Marshal(vault_helpers.CreateSecretsRequest{
+		RequestId: "req-1",
+		EncryptedSecrets: []*vault_helpers.EncryptedSecret{
+			{
+				Id: &vault_helpers.SecretIdentifier{
+					Key:       "9838",
+					Namespace: "main",
+					Owner:     "org-123",
+				},
+				EncryptedValue: "cipher+/==",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	rawParams := json.RawMessage(params)
+	req := jsonrpc.Request[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "req-1",
+		Method:  vaulttypes.MethodSecretsCreate,
+		Params:  &rawParams,
+	}
+	req.Auth = mustMintVaultJWTForRequest(t, issuer, req, "org-123", "0xAbCdEf0123456789AbCdEf0123456789AbCdEf01")
+
+	outboundReq := outboundRequestWithoutAuth(req)
+	requestDigest, err := outboundReq.Digest()
+	require.NoError(t, err)
+
+	parsedToken, _, err := new(jwt.Parser).ParseUnverified(req.Auth, jwt.MapClaims{})
+	require.NoError(t, err)
+
+	claims, ok := parsedToken.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+	authorizationDetails, ok := claims["authorization_details"].([]interface{})
+	require.True(t, ok)
+
+	var claimedDigest string
+	for _, detail := range authorizationDetails {
+		entry, ok := detail.(map[string]interface{})
+		require.True(t, ok)
+		if entry["type"] == "request_digest" {
+			claimedDigest, ok = entry["value"].(string)
+			require.True(t, ok)
+			break
+		}
+	}
+
+	require.NotEmpty(t, claimedDigest)
+	require.Equal(t, requestDigest, claimedDigest)
+}
+
+func mustMintVaultJWTForRequest(t *testing.T, issuer *vault.TestJWTIssuer, req jsonrpc.Request[json.RawMessage], orgID, workflowOwner string) string {
+	t.Helper()
+
+	outboundReq := outboundRequestWithoutAuth(req)
+	requestDigest, err := outboundReq.Digest()
+	require.NoError(t, err, "failed to compute request digest")
+
+	token, err := issuer.MintToken(vault.JWTTokenClaims{
+		KeyID:         vault.DefaultJWTIssuerKeyID,
+		Issuer:        issuer.DockerIssuerURL(),
+		Audience:      vault.DefaultJWTAudience,
+		OrgID:         orgID,
+		WorkflowOwner: workflowOwner,
+		RequestDigest: requestDigest,
+	})
+	require.NoError(t, err, "failed to mint JWT")
+
+	return token
+}
+
+func sendVaultJWTRequestToGateway(t *testing.T, gatewayURL string, jsonRequest jsonrpc.Request[json.RawMessage]) jsonrpc.Response[vaulttypes.SignedOCRResponse] {
+	t.Helper()
+
+	authToken := jsonRequest.Auth
+	jsonRequest = outboundRequestWithoutAuth(jsonRequest)
+
+	requestBody, err := json.Marshal(jsonRequest)
+	require.NoError(t, err, "failed to marshal JWT-authenticated request")
+
+	headers := map[string]string{}
+	if authToken != "" {
+		headers["Authorization"] = "Bearer " + authToken
+	}
+
+	statusCode, httpResponseBody := sendVaultRequestToGatewayWithHeaders(t, gatewayURL, requestBody, headers)
+	require.Equal(t, http.StatusOK, statusCode, "Gateway endpoint should respond with 200 OK")
+
+	var jsonResponse jsonrpc.Response[vaulttypes.SignedOCRResponse]
+	err = json.Unmarshal(httpResponseBody, &jsonResponse)
+	require.NoError(t, err, "failed to unmarshal gateway response")
+	if jsonResponse.Error != nil {
+		require.Empty(t, jsonResponse.Error.Error())
+	}
+	require.Equal(t, jsonrpc.JsonRpcVersion, jsonResponse.Version)
+
+	return jsonResponse
+}
+
+func outboundRequestWithoutAuth(req jsonrpc.Request[json.RawMessage]) jsonrpc.Request[json.RawMessage] {
+	req.Auth = ""
+	return req
 }
 
 func executeVaultSecretsGetViaWorkflowTest(
@@ -238,7 +721,7 @@ func executeVaultSecretsGetNotFoundViaWorkflowTest(
 	testLogger.Info().Msg("Vault secret not-found via workflow test completed")
 }
 
-func executeVaultSecretsUpdateTest(t *testing.T, encryptedSecret, secretID, owner, gatewayURL string, namespaces []string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
+func executeVaultSecretsUpdateTest(t *testing.T, encryptedSecret, secretID, requestOwner, expectedResponseOwner, gatewayURL string, namespaces []string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
 	framework.L.Info().Msgf("Updating secrets (namespaces=%v)...", namespaces)
 	uniqueRequestID := uuid.New().String()
 
@@ -247,7 +730,7 @@ func executeVaultSecretsUpdateTest(t *testing.T, encryptedSecret, secretID, owne
 		encryptedSecrets = append(encryptedSecrets, &vault_helpers.EncryptedSecret{
 			Id: &vault_helpers.SecretIdentifier{
 				Key:       secretID,
-				Owner:     owner,
+				Owner:     requestOwner,
 				Namespace: namespace,
 			},
 			EncryptedValue: encryptedSecret,
@@ -256,7 +739,7 @@ func executeVaultSecretsUpdateTest(t *testing.T, encryptedSecret, secretID, owne
 	encryptedSecrets = append(encryptedSecrets, &vault_helpers.EncryptedSecret{
 		Id: &vault_helpers.SecretIdentifier{
 			Key:       "invalid",
-			Owner:     owner,
+			Owner:     requestOwner,
 			Namespace: namespaces[0],
 		},
 		EncryptedValue: encryptedSecret,
@@ -275,7 +758,7 @@ func executeVaultSecretsUpdateTest(t *testing.T, encryptedSecret, secretID, owne
 		Method:  vaulttypes.MethodSecretsUpdate,
 		Params:  &secretsUpdateRequestBodyJSON,
 	}
-	allowlistRequest(t, owner, jsonRequest, sethClient, wfRegistryContract)
+	allowlistRequest(t, requestOwner, jsonRequest, sethClient, wfRegistryContract)
 
 	requestBody, err := json.Marshal(jsonRequest)
 	require.NoError(t, err, "failed to marshal secrets request")
@@ -323,18 +806,18 @@ func executeVaultSecretsUpdateTest(t *testing.T, encryptedSecret, secretID, owne
 		require.True(t, ok, "missing update response for namespace %s", namespace)
 		require.Empty(t, result.GetError())
 		require.Equal(t, secretID, result.GetId().Key)
-		require.Equal(t, owner, result.GetId().Owner)
+		require.Equal(t, expectedResponseOwner, result.GetId().Owner)
 	}
 
 	framework.L.Info().Msgf("Secrets updated successfully (namespaces=%v)", namespaces)
 }
 
-func executeVaultSecretsListTest(t *testing.T, secretID, owner, gatewayURL, namespace string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
+func executeVaultSecretsListTest(t *testing.T, secretID, requestOwner, expectedOwner, gatewayURL, namespace string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
 	framework.L.Info().Msgf("Listing secrets (namespace=%s)...", namespace)
 	uniqueRequestID := uuid.New().String()
 	secretsListRequest := vault_helpers.ListSecretIdentifiersRequest{
 		RequestId: uniqueRequestID,
-		Owner:     owner,
+		Owner:     requestOwner,
 		Namespace: namespace,
 	}
 	secretsListRequestBody, err := json.Marshal(secretsListRequest) //nolint:govet // The lock field is not set on this proto
@@ -346,13 +829,13 @@ func executeVaultSecretsListTest(t *testing.T, secretID, owner, gatewayURL, name
 		Method:  vaulttypes.MethodSecretsList,
 		Params:  &secretsUpdateRequestBodyJSON,
 	}
-	allowlistRequest(t, owner, jsonRequest, sethClient, wfRegistryContract)
+	allowlistRequest(t, requestOwner, jsonRequest, sethClient, wfRegistryContract)
 
 	// Ensure that multiple requests can be allowlisted
 	uniqueRequestIDTwo := uuid.New().String()
 	secretsListRequestTwo := vault_helpers.ListSecretIdentifiersRequest{
 		RequestId: uniqueRequestIDTwo,
-		Owner:     owner,
+		Owner:     requestOwner,
 		Namespace: namespace,
 	}
 	secretsListRequestBodyTwo, err := json.Marshal(secretsListRequestTwo) //nolint:govet // The lock field is not set on this proto
@@ -364,7 +847,7 @@ func executeVaultSecretsListTest(t *testing.T, secretID, owner, gatewayURL, name
 		Method:  vaulttypes.MethodSecretsList,
 		Params:  &secretsUpdateRequestBodyJSONTwo,
 	}
-	allowlistRequest(t, owner, jsonRequestTwo, sethClient, wfRegistryContract)
+	allowlistRequest(t, requestOwner, jsonRequestTwo, sethClient, wfRegistryContract)
 
 	// Request 1
 	requestBody, err := json.Marshal(jsonRequest)
@@ -417,14 +900,14 @@ func executeVaultSecretsListTest(t *testing.T, secretID, owner, gatewayURL, name
 	var keys = make([]string, 0, len(listSecretsResponse.Identifiers))
 	for _, identifier := range listSecretsResponse.Identifiers {
 		keys = append(keys, identifier.Key)
-		require.Equal(t, owner, identifier.Owner)
+		require.Equal(t, expectedOwner, identifier.Owner)
 		require.Equal(t, namespace, identifier.Namespace)
 	}
 	require.Contains(t, keys, secretID)
 	framework.L.Info().Msgf("Secrets listed successfully (namespace=%s)", namespace)
 }
 
-func executeVaultSecretsDeleteTest(t *testing.T, secretID, owner, gatewayURL string, namespaces []string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
+func executeVaultSecretsDeleteTest(t *testing.T, secretID, requestOwner, expectedResponseOwner, gatewayURL string, namespaces []string, sethClient *seth.Client, wfRegistryContract *workflow_registry_v2_wrapper.WorkflowRegistry) {
 	framework.L.Info().Msgf("Deleting secrets (namespaces=%v)...", namespaces)
 	uniqueRequestID := uuid.New().String()
 
@@ -432,13 +915,13 @@ func executeVaultSecretsDeleteTest(t *testing.T, secretID, owner, gatewayURL str
 	for _, namespace := range namespaces {
 		deleteIDs = append(deleteIDs, &vault_helpers.SecretIdentifier{
 			Key:       secretID,
-			Owner:     owner,
+			Owner:     requestOwner,
 			Namespace: namespace,
 		})
 	}
 	deleteIDs = append(deleteIDs, &vault_helpers.SecretIdentifier{
 		Key:       "invalid",
-		Owner:     owner,
+		Owner:     requestOwner,
 		Namespace: namespaces[0],
 	})
 
@@ -455,7 +938,7 @@ func executeVaultSecretsDeleteTest(t *testing.T, secretID, owner, gatewayURL str
 		Method:  vaulttypes.MethodSecretsDelete,
 		Params:  &secretsDeleteRequestBodyJSON,
 	}
-	allowlistRequest(t, owner, jsonRequest, sethClient, wfRegistryContract)
+	allowlistRequest(t, requestOwner, jsonRequest, sethClient, wfRegistryContract)
 
 	requestBody, err := json.Marshal(jsonRequest)
 	require.NoError(t, err, "failed to marshal secrets request")
@@ -501,7 +984,7 @@ func executeVaultSecretsDeleteTest(t *testing.T, secretID, owner, gatewayURL str
 		result, ok := deleteRespByNs[namespace]
 		require.True(t, ok, "missing delete response for namespace %s", namespace)
 		require.True(t, result.Success, result.Error)
-		require.Equal(t, owner, result.Id.Owner)
+		require.Equal(t, expectedResponseOwner, result.Id.Owner)
 		require.Equal(t, secretID, result.Id.Key)
 	}
 

--- a/system-tests/tests/smoke/cre/v2_vault_don_test.go
+++ b/system-tests/tests/smoke/cre/v2_vault_don_test.go
@@ -492,6 +492,7 @@ func executeVaultJWTSecretsDeleteTest(t *testing.T, issuer *vault.TestJWTIssuer,
 
 func TestVaultStaticTopologies_LoadExpectedConfig(t *testing.T) {
 	t.Parallel()
+	dockerHost := strings.TrimPrefix(framework.HostDockerInternal(), "http://")
 
 	testCases := []struct {
 		name        string
@@ -536,7 +537,7 @@ func TestVaultStaticTopologies_LoadExpectedConfig(t *testing.T) {
 					}
 					if tc.wantLinking {
 						require.Contains(t, nodeSpec.Node.UserConfigOverrides, "[CRE.Linking]")
-						require.Contains(t, nodeSpec.Node.UserConfigOverrides, "host.docker.internal:18124")
+						require.Contains(t, nodeSpec.Node.UserConfigOverrides, dockerHost+":18124")
 						continue
 					}
 					require.Empty(t, nodeSpec.Node.UserConfigOverrides)
@@ -560,7 +561,7 @@ func TestVaultStaticTopologies_LoadExpectedConfig(t *testing.T) {
 
 			require.True(t, hasAuth0)
 			require.Equal(t, map[string]any{
-				"issuerURL": "http://host.docker.internal:18123/",
+				"issuerURL": framework.HostDockerInternal() + ":18123/",
 				"audience":  vault.DefaultJWTAudience,
 			}, auth0Value)
 		})

--- a/system-tests/tests/smoke/cre/v2_vault_don_test_helpers.go
+++ b/system-tests/tests/smoke/cre/v2_vault_don_test_helpers.go
@@ -57,6 +57,10 @@ func FetchVaultPublicKey(t *testing.T, gatewayURL string) (publicKey string) {
 }
 
 func sendVaultRequestToGateway(t *testing.T, gatewayURL string, requestBody []byte) (statusCode int, body []byte) {
+	return sendVaultRequestToGatewayWithHeaders(t, gatewayURL, requestBody, nil)
+}
+
+func sendVaultRequestToGatewayWithHeaders(t *testing.T, gatewayURL string, requestBody []byte, headers map[string]string) (statusCode int, body []byte) {
 	const maxRetries = 7
 	const retryInterval = 2 * time.Second
 
@@ -68,6 +72,9 @@ func sendVaultRequestToGateway(t *testing.T, gatewayURL string, requestBody []by
 
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
+		for key, value := range headers {
+			req.Header.Set(key, value)
+		}
 
 		client := &http.Client{}
 		resp, err := client.Do(req)


### PR DESCRIPTION
## Summary
- enable Vault JWT auth end to end for CRE gateway, node, OCR job spec, and deployment wiring
- add static Vault-enabled and Vault-disabled CRE topologies plus a fake JWKS issuer and linking service for deterministic local/CI coverage
- add Vault Bucket B smoke coverage for both `allowlist_auth` and `jwt_auth`, including workflow `GetSecret()` verification and `VaultOrgIdAsSecretOwnerEnabled` behavior
- normalize Vault CRUD response ownership to `org_id` when the org-owner flag is enabled and align the smoke assertions with that behavior
- harden local CRE and approval/retry paths uncovered by the new coverage, including job approval cleanup, duplicate-approval handling, and platform-specific Docker host resolution for static capability config URLs

## Why
Vault JWT auth needed full local CRE and CI coverage, but the existing Vault smoke path only exercised the allowlist flow and depended on topology/runtime assumptions that were not valid for JWT. Bringing JWT into Bucket B exposed a set of real issues:
- Vault auth/job wiring still needed to be carried through gateway and OCR job configuration
- static topology references to `host.docker.internal` in capability config did not work in CI, where Docker host resolution uses `172.17.0.1`
- with `VaultOrgIdAsSecretOwnerEnabled`, successful CRUD responses should return the canonical `org_id` owner, not the request workflow owner
- approval failures and retries could leave partially started jobs behind and re-hit Vault capability registration

This PR fixes those issues and leaves Vault e2e coverage running against a checked-in topology instead of ad hoc per-test config mutation.

## Validation
- `make gomodtidy`
- `go test ./core/capabilities/vault ./core/services/gateway/handlers/vault -count=1`
- `go test ./core/services/ocr2/plugins/vault -count=1`
- `go test ./deployment/cre/jobs/...`
- `go test ./system-tests/lib/cre/vault -count=1`
- `go test ./system-tests/lib/cre/features/vault -count=1`
- `go test ./system-tests/lib/cre/environment/config -count=1`
- `go test ./system-tests/tests/smoke/cre -run '^TestVaultStaticTopologies_LoadExpectedConfig$' -count=1`
- fresh local CRE start on `core/scripts/cre/environment/configs/workflow-gateway-capabilities-don-vault-flags-enabled.toml`
- `go test ./system-tests/tests/smoke/cre -timeout 45m -run 'Test_CRE_V2_Suite_Bucket_B/.*/jwt_auth' -count=1 -v`

## Notes
- the new PR branch points at the current signed head from the existing Vault JWT branch; no additional code change was needed beyond publishing a fresh branch/PR
- the sharding failure previously observed in CI is unrelated to this Vault diff and comes from the sharding path already present on `develop`
