### PR TITLE
feat(confidentialhttp fake): invoke signer

### DIFF
--- a/core/capabilities/fakes/confidential_http_action.go
+++ b/core/capabilities/fakes/confidential_http_action.go
@@ -22,6 +22,7 @@ import (
 	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialhttp"
 	httpserver "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialhttp/server"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialhttp/signer"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
@@ -55,11 +56,13 @@ type DirectConfidentialHTTPAction struct {
 
 	secretsConfig SecretsConfig
 	lggr          logger.Logger
+	signerBuilder *signer.Builder
 }
 
 func NewDirectConfidentialHTTPAction(lggr logger.Logger, secretsPath string) *DirectConfidentialHTTPAction {
 	fc := &DirectConfidentialHTTPAction{
-		lggr: lggr,
+		lggr:          lggr,
+		signerBuilder: signer.NewBuilder(http.DefaultClient),
 	}
 
 	// Load secrets
@@ -178,6 +181,31 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 
 				httpReq.Header.Add(name, processedHeader.String())
 			}
+		}
+	}
+
+	// Apply request signing if an AuthConfig is set. The fake uses the same
+	// signer package as the enclave so signed requests are byte-identical
+	// in both environments.
+	if input.GetAuth() != nil {
+		s, sErr := fh.signerBuilder.Build(input.GetAuth())
+		if sErr != nil {
+			return nil, caperrors.NewPublicUserError(fmt.Errorf("build signer: %w", sErr), caperrors.InvalidArgument)
+		}
+		if s != nil {
+			stringSecrets := make(map[string]string, len(fh.secretsConfig.SecretsNames))
+			for k, vals := range fh.secretsConfig.SecretsNames {
+				if len(vals) > 0 {
+					stringSecrets[k] = vals[0]
+				}
+			}
+			if sErr := s.Sign(ctx, httpReq, stringSecrets); sErr != nil {
+				return nil, caperrors.NewPublicUserError(fmt.Errorf("sign request: %w", sErr), caperrors.InvalidArgument)
+			}
+		}
+		// Signed requests must not follow redirects.
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -179,6 +179,8 @@ require (
 	github.com/apache/arrow-go/v18 v18.3.1 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/atombender/go-jsonschema v0.16.1-0.20240916205339-a74cd4e2851c // indirect
+	github.com/aws/aws-sdk-go-v2 v1.41.6 // indirect
+	github.com/aws/smithy-go v1.25.0 // indirect
 	github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beevik/ntp v1.5.0 // indirect
@@ -440,3 +442,5 @@ replace github.com/fbsobreira/gotron-sdk => github.com/smartcontractkit/chainlin
 tool github.com/smartcontractkit/chainlink-common/pkg/loop/cmd/loopinstall
 
 tool github.com/smartcontractkit/chainlink-common/script/cmd/dependabot
+
+replace github.com/smartcontractkit/chainlink-common => ../chainlink-common

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,10 @@ github.com/avast/retry-go/v4 v4.7.0 h1:yjDs35SlGvKwRNSykujfjdMxMhMQQM0TnIjJaHB+Z
 github.com/avast/retry-go/v4 v4.7.0/go.mod h1:ZMPDa3sY2bKgpLtap9JRUgk2yTAba7cgiFhqxY2Sg6Q=
 github.com/aws/aws-sdk-go v1.22.1/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=
+github.com/aws/aws-sdk-go-v2 v1.41.6/go.mod h1:dy0UzBIfwSeot4grGvY1AqFWN5zgziMmWGzysDnHFcQ=
+github.com/aws/smithy-go v1.25.0 h1:Sz/XJ64rwuiKtB6j98nDIPyYrV1nVNJ4YU74gttcl5U=
+github.com/aws/smithy-go v1.25.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59 h1:WWB576BN5zNSZc/M9d/10pqEx5VHNhaQ/yOVAkmj5Yo=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
@@ -1239,8 +1243,6 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260408181529-b5080e662563 h1:1sYQ2lG3zbAG2vASNF5kLke8DhGk5lNaJirwPDx3Vi4=
 github.com/smartcontractkit/chainlink-ccv v0.0.0-20260408181529-b5080e662563/go.mod h1:nEuyjUh4wrK6mNXEAaOncl/AhCl31oaxOS160gNW0vc=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260417081611-8bdbd9f45629 h1:YZCgnZteDIaV+Jrb6DDk4NQVJJ/ZwwYUaX9De/XUoCA=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260417081611-8bdbd9f45629/go.mod h1:RnNTmxoheJYec/Gl/9t3wPLtFIHrlYjmWDdwZZJjchw=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2 h1:AWisx4JT3QV8tcgh6J5NCrex+wAgTYpWyHsyNPSXzsQ=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2/go.mod h1:rSkIHdomyak3YnUtXLenl6poIq8q0V3UZPiiyYqPdGA=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=


### PR DESCRIPTION
## Summary
- `DirectConfidentialHTTPAction` fake now runs the signer package, keeping `cre simulate` byte-identical to production.

Blocked by: chainlink-common signingExpansion PR.

## Remove-before-merge
- `replace` directive in go.mod pointing at local chainlink-common.