### PR TITLE
[CRE-3579] fix: flaky Test_StratReconciliation_RetriesWithBackoff

### DIFF
--- a/core/services/workflows/syncer/workflow_syncer_test.go
+++ b/core/services/workflows/syncer/workflow_syncer_test.go
@@ -12,6 +12,7 @@ import (
 	rand2 "math/rand/v2"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -838,10 +839,9 @@ func Test_StratReconciliation_RetriesWithBackoff(t *testing.T) {
 	workflow.ID = workflowID
 	registerWorkflow(t, backendTH, wfRegistryC, workflow)
 
-	var retryCount int
+	var retryCount atomic.Int32
 	testEventHandler := newTestEvtHandler(func() error {
-		if retryCount <= 1 {
-			retryCount++
+		if retryCount.Add(1) <= 2 {
 			return errors.New("error handling event")
 		}
 		return nil
@@ -866,20 +866,24 @@ func Test_StratReconciliation_RetriesWithBackoff(t *testing.T) {
 			err: nil,
 		},
 		NewEngineRegistry(),
-		WithRetryInterval(1*time.Second),
+		WithTicker(time.NewTicker(1*time.Second).C),
+		WithRetryInterval(100*time.Millisecond),
 	)
 	require.NoError(t, err)
 
 	servicetest.Run(t, worker)
 
+	// Wait for the handler to be called 3 times: 2 failures with backoff + 1 success
 	require.Eventually(t, func() bool {
-		return len(testEventHandler.GetEvents()) == 1
+		return retryCount.Load() >= 3
 	}, 30*time.Second, 1*time.Second)
 
-	event := testEventHandler.GetEvents()[0]
-	assert.Equal(t, WorkflowRegisteredEvent, event.EventType)
-
-	assert.Equal(t, 1, retryCount)
+	// All 3 calls (2 failures + 1 success) should have appended events
+	events := testEventHandler.GetEvents()
+	require.GreaterOrEqual(t, len(events), 3)
+	for _, event := range events {
+		assert.Equal(t, WorkflowRegisteredEvent, event.EventType)
+	}
 }
 
 func updateAuthorizedAddress(


### PR DESCRIPTION
## Summary

[CRE-3579](https://smartcontract-it.atlassian.net/browse/CRE-3579) - Fix flaky Test_StratReconciliation_RetriesWithBackoff

- Fix data race on `retryCount` variable (plain `int` accessed across goroutines without synchronization) by using `atomic.Int32`
- Fix test to actually verify retry behavior: wait for the full retry cycle (2 failures + 1 success) instead of exiting after the first failed attempt
- Use a faster ticker (`1s`) and shorter retry interval (`100ms`) to reduce test duration and timing sensitivity

## Test plan
- [x] Passes locally with `-race -count=5`
- [ ] CI passes with race detector enabled
- [ ] `Test_StratReconciliation_RetriesWithBackoff` no longer flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CRE-3579]: https://smartcontract-it.atlassian.net/browse/CRE-3579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ