### PR TITLE
[CRE-3630] fix: flaky TestSyncer_DBIntegration

### DIFF
--- a/core/services/registrysyncer/syncer_test.go
+++ b/core/services/registrysyncer/syncer_test.go
@@ -23,8 +23,6 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	p2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
-	"github.com/smartcontractkit/quarantine"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
@@ -375,7 +373,6 @@ func TestReader_Integration(t *testing.T) {
 }
 
 func TestSyncer_DBIntegration(t *testing.T) {
-	quarantine.Flaky(t, "DX-1925")
 	ctx := testutils.Context(t)
 	reg, regAddress, owner, sim := startNewChainWithRegistry(t)
 
@@ -474,14 +471,15 @@ func TestSyncer_DBIntegration(t *testing.T) {
 	syncerORM.ormMock.On("AddLocalRegistry", mock.Anything, mock.Anything).Return(nil)
 	syncer, err := newTestSyncer(logger.TestLogger(t), func() (p2ptypes.PeerID, error) { return p2ptypes.PeerID{}, nil }, factory, regAddress.Hex(), syncerORM)
 	require.NoError(t, err)
-	require.NoError(t, syncer.Start(ctx))
-	t.Cleanup(func() {
-		syncerORM.Cleanup()
-		require.NoError(t, syncer.Close())
-	})
 
 	l := &launcher{}
 	syncer.AddListener(l)
+
+	require.NoError(t, syncer.Start(ctx))
+	t.Cleanup(func() {
+		require.NoError(t, syncer.Close())
+		syncerORM.Cleanup()
+	})
 
 	var latestLocalRegistryCalled, addLocalRegistryCalled bool
 	timeout := time.After(testutils.WaitTimeout(t))


### PR DESCRIPTION
## Summary
- Fix race condition where `syncer.Start()` launched `syncLoop()` goroutine that could run the initial `Sync(ctx, true)` before `AddListener()` was called, causing it to no-op (empty listeners check) and never trigger `LatestLocalRegistry`
- Fix cleanup ordering: stop syncer goroutines before closing ORM signal channels to prevent panics from sending on closed channels
- Remove `quarantine.Flaky` annotation now that root cause is fixed

Fixes: [CRE-3630](https://smartcontract-it.atlassian.net/browse/CRE-3630)

## Test plan
- [x] `go test -race -count=5 -run TestSyncer_DBIntegration ./core/services/registrysyncer/` — 5/5 passes
- [x] Full package test suite passes with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CRE-3630]: https://smartcontract-it.atlassian.net/browse/CRE-3630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ