### PR TITLE
.github/workflows/integration-in-memory.yml: shorten CCIP test name

### DIFF
--- a/.github/workflows/integration-in-memory-tests.yml
+++ b/.github/workflows/integration-in-memory-tests.yml
@@ -92,7 +92,7 @@ jobs:
           check-label: "runs-on-opt-out"
 
   run-ccip-integration-in-memory-tests-for-pr:
-    name: Run CCIP integration In Memory Tests For PR
+    name: Run CCIP Tests For PR
     permissions:
       actions: read
       checks: write


### PR DESCRIPTION
Shortening the name of this test because it is redundant and hides the interesting part:
<img width="713" height="292" alt="Screenshot 2026-04-20 at 3 06 27 PM" src="https://github.com/user-attachments/assets/7ad77f81-cc27-4dc2-8221-a97b35a72280" />
