### PR TITLE
[RANE-4694] ci: skip dependency-check and lint-gh-workflows on mirror repos

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   changes:
     name: Detect changes
+    if: github.repository == 'smartcontractkit/chainlink'
     runs-on: ubuntu-latest
     outputs:
       changes: ${{ steps.changes.outputs.src }}
@@ -21,6 +22,7 @@ jobs:
               - '**/*go.mod'
               - '.github/workflows/dependency-check.yml'
   Go:
+    if: github.repository == 'smartcontractkit/chainlink'
     runs-on: ubuntu-latest
     needs: [changes]
     steps:

--- a/.github/workflows/lint-gh-workflows.yml
+++ b/.github/workflows/lint-gh-workflows.yml
@@ -4,6 +4,8 @@ on:
 jobs:
   lint_workflows:
     name: Validate Github Action Workflows
+    # Avoid fan-out on mirror repos that sync many branches from chainlink.
+    if: github.repository == 'smartcontractkit/chainlink'
     runs-on: ubuntu-latest
     steps:
       - name: Check out Code


### PR DESCRIPTION
## Tracking

**[RANE-4694](https://smartcontract-it.atlassian.net/browse/RANE-4694)** — Sub-task under **[RANE-4462](https://smartcontract-it.atlassian.net/browse/RANE-4462)**. Umbrella epic: **[RANE-4695](https://smartcontract-it.atlassian.net/browse/RANE-4695)** (Private release improvements). Program context: **[RANE-4443](https://smartcontract-it.atlassian.net/browse/RANE-4443)**.

## Summary

Add `if: github.repository == 'smartcontractkit/chainlink'` to the **Dependency Vulnerability Check** and **Lint GitHub Workflows** workflows so they only run on the primary repository.

## Why

Forks and mirror repos (for example repos that replay or carry copies of the same workflows and SHAs) otherwise schedule the same jobs twice: once on `smartcontractkit/chainlink` and again on the mirror. That adds noise, duplicate results, and unnecessary Actions usage without changing outcomes for the canonical repo.

## Changes

- `.github/workflows/dependency-check.yml` — guard `changes` and `Go` jobs.
- `.github/workflows/lint-gh-workflows.yml` — guard `lint_workflows` job.

## Notes

- **SigScanner**: `develop` no longer includes `.github/workflows/sigscanner.yml`; this PR does not reintroduce it.

## Test plan

- [ ] Confirm workflows still run on pushes to `smartcontractkit/chainlink` (guards evaluate true).
- [ ] On a fork or mirror, confirm these workflows are skipped (guards evaluate false), if you have a repro repo.


[RANE-4694]: https://smartcontract-it.atlassian.net/browse/RANE-4694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RANE-4462]: https://smartcontract-it.atlassian.net/browse/RANE-4462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RANE-4695]: https://smartcontract-it.atlassian.net/browse/RANE-4695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RANE-4443]: https://smartcontract-it.atlassian.net/browse/RANE-4443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ