### PR TITLE
fix: abort if latest tag cannot be retrieved from GitHub API

### DIFF
--- a/operator_ui/check.sh
+++ b/operator_ui/check.sh
@@ -18,6 +18,11 @@ release=$(gh release view -R $repo --json 'tagName,body')
 latest_tag=$(echo "$release" | jq -r '.tagName')
 body=$(echo "$release" | jq -r '.body')
 
+if [ -z "$latest_tag" ] || [ "$latest_tag" = "null" ]; then
+  echo "Error: could not retrieve latest tag from release" >&2
+  exit 1
+fi
+    
 if [ "$current_tag" = "$latest_tag" ]; then
   echo "Tag $current_tag is up to date."
   exit 0


### PR DESCRIPTION
Prevent writing a literal null string to the TAG file when jq returns no value. The script now exits with an error instead of silently corrupting the pinned tag.