### PR TITLE
chore: bump Aptos plugin ref for read observability

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -43,7 +43,7 @@ plugins:
       installPath: "."
   aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "bdb101f81480bc03a9fc57d03553ac39b5330fd9"
+      gitRef: "089b3aa6ddfda00177f1db42ca48f0b0890fa69f"
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -43,7 +43,7 @@ plugins:
       installPath: "."
   aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "089b3aa6ddfda00177f1db42ca48f0b0890fa69f"
+      gitRef: "089b3aa48f19ccffa83f4b8f4eac5d97b6406f5c"
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -43,7 +43,7 @@ plugins:
       installPath: "."
   aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "4608f9170a0fff492e65c69f2bf63803388d8d32"
+      gitRef: "b90ec8b75a6aab4ced0cd3ca667eae7c51ae0fde"
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -43,7 +43,7 @@ plugins:
       installPath: "."
   aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "8c1237cfc04530c1831a1187320bdf50bf403abb"
+      gitRef: "ece17debf084250135a9cfb98fe0289d92b0cb56"
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -43,7 +43,7 @@ plugins:
       installPath: "."
   aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "ce85a55223bbf5f82152e867c1a57a833d9d2bc9"
+      gitRef: "52245d5778d111fc35e4abc0a82f29cfef30142c"
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -43,7 +43,7 @@ plugins:
       installPath: "."
   aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "b90ec8b75a6aab4ced0cd3ca667eae7c51ae0fde"
+      gitRef: "ce85a55223bbf5f82152e867c1a57a833d9d2bc9"
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -43,7 +43,7 @@ plugins:
       installPath: "."
   aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "089b3aa48f19ccffa83f4b8f4eac5d97b6406f5c"
+      gitRef: "8c1237cfc04530c1831a1187320bdf50bf403abb"
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -43,7 +43,7 @@ plugins:
       installPath: "."
   aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "c1c2b4f6dde651a81af0b7890a4839f71bf842f9"
+      gitRef: "bdb101f81480bc03a9fc57d03553ac39b5330fd9"
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -43,7 +43,7 @@ plugins:
       installPath: "."
   aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "52245d5778d111fc35e4abc0a82f29cfef30142c"
+      gitRef: "c1c2b4f6dde651a81af0b7890a4839f71bf842f9"
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"


### PR DESCRIPTION
## Summary

Bump the private Aptos plugin pin in `plugins.private.yaml` so `chainlink` CI exercises the merged Aptos read observability changes from [smartcontractkit/capabilities#560](https://github.com/smartcontractkit/capabilities/pull/560).

The updated Aptos plugin ref is:
- `ece17debf084250135a9cfb98fe0289d92b0cb56`

## Why

Now that `capabilities#560` is merged, `chainlink` should validate the merged Aptos read capability changes end to end against the merged commit instead of the older branch pin.

## Validation

- parsed `plugins.private.yaml` after the ref bump
- reproduced that `go list -m github.com/smartcontractkit/capabilities/chain_capabilities/aptos@ece17debf084250135a9cfb98fe0289d92b0cb56` resolves successfully
