### PR TITLE
system-tests: plumb workflow attributes through RegisterWithContract

### DIFF
--- a/core/scripts/cre/environment/environment/workflow.go
+++ b/core/scripts/cre/environment/environment/workflow.go
@@ -475,7 +475,7 @@ func deployWorkflow(
 
 	fmt.Printf("\n⚙️ Registering workflow '%s' with the workflow registry\n\n", workflowNameFlag)
 
-	workflowID, registerErr := creworkflow.RegisterWithContract(ctx, sethClient, common.HexToAddress(workflowRegistryAddress), workflowRegistryVersion, uint64(donIDFlag), workflowNameFlag, "file://"+wasmWorkflowFilePathFlag, configPath, secretsPath, &containerTargetDirFlag)
+	workflowID, registerErr := creworkflow.RegisterWithContract(ctx, sethClient, common.HexToAddress(workflowRegistryAddress), workflowRegistryVersion, uint64(donIDFlag), workflowNameFlag, "file://"+wasmWorkflowFilePathFlag, configPath, secretsPath, &containerTargetDirFlag, nil)
 	if registerErr != nil {
 		return errors.Wrapf(registerErr, "❌ failed to register workflow %s", workflowNameFlag)
 	}

--- a/core/scripts/cre/environment/environment/workflow.go
+++ b/core/scripts/cre/environment/environment/workflow.go
@@ -475,7 +475,7 @@ func deployWorkflow(
 
 	fmt.Printf("\n⚙️ Registering workflow '%s' with the workflow registry\n\n", workflowNameFlag)
 
-	workflowID, registerErr := creworkflow.RegisterWithContract(ctx, sethClient, common.HexToAddress(workflowRegistryAddress), workflowRegistryVersion, uint64(donIDFlag), workflowNameFlag, "file://"+wasmWorkflowFilePathFlag, configPath, secretsPath, &containerTargetDirFlag, nil)
+	workflowID, registerErr := creworkflow.RegisterWithContract(ctx, sethClient, common.HexToAddress(workflowRegistryAddress), workflowRegistryVersion, uint64(donIDFlag), workflowNameFlag, "file://"+wasmWorkflowFilePathFlag, configPath, secretsPath, nil, &containerTargetDirFlag)
 	if registerErr != nil {
 		return errors.Wrapf(registerErr, "❌ failed to register workflow %s", workflowNameFlag)
 	}

--- a/system-tests/lib/cre/workflow/workflow.go
+++ b/system-tests/lib/cre/workflow/workflow.go
@@ -56,6 +56,7 @@ func RegisterWithContract(
 	donID uint64, workflowName, binaryURL string,
 	configURL, secretsURL *string,
 	artifactsDirInContainer *string,
+	attributes []byte,
 ) (string, error) {
 	// Download and decode workflow binary
 	workflowData, err := libnet.DownloadAndDecodeBase64(ctx, binaryURL)
@@ -92,7 +93,7 @@ func RegisterWithContract(
 	// Register workflow based on version
 	switch version.Major() {
 	case 2:
-		if err := registerWorkflowV2(sc, workflowRegistryAddr, version, workflowName, workflowID, binaryURLToUse, configURLToUse); err != nil {
+		if err := registerWorkflowV2(sc, workflowRegistryAddr, version, workflowName, workflowID, binaryURLToUse, configURLToUse, attributes); err != nil {
 			return "", err
 		}
 	default:
@@ -227,6 +228,7 @@ func registerWorkflowV2(
 	workflowRegistryAddr common.Address,
 	version *semver.Version,
 	workflowName, workflowID, binaryURL, configURL string,
+	attributes []byte,
 ) error {
 	registry, err := getRegistryV2Instance(sc, workflowRegistryAddr, version)
 	if err != nil {
@@ -251,7 +253,7 @@ func registerWorkflowV2(
 		contracts.DonFamily,
 		binaryURL,
 		configURL,
-		nil,
+		attributes,
 		false,
 	))
 	if err != nil {

--- a/system-tests/lib/cre/workflow/workflow.go
+++ b/system-tests/lib/cre/workflow/workflow.go
@@ -55,8 +55,8 @@ func RegisterWithContract(
 	version *semver.Version,
 	donID uint64, workflowName, binaryURL string,
 	configURL, secretsURL *string,
-	artifactsDirInContainer *string,
 	attributes []byte,
+	artifactsDirInContainer *string,
 ) (string, error) {
 	// Download and decode workflow binary
 	workflowData, err := libnet.DownloadAndDecodeBase64(ctx, binaryURL)

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -750,10 +750,11 @@ func WithArtifactCopyDONTypes(donTypes ...cre.CapabilityFlag) CompileAndDeployWo
 
 // WithAttributes sets the workflow attributes byte blob (JSON) written to the
 // WorkflowRegistry contract on upsert. The CRE syncer reads this to decide
-// routing (e.g. confidential execution via ConfidentialModule).
+// routing (e.g. confidential execution via ConfidentialModule). The input is
+// cloned so later caller mutations don't affect stored config.
 func WithAttributes(attributes []byte) CompileAndDeployWorkflowOpt {
 	return func(cfg *compileAndDeployWorkflowCfg) {
-		cfg.attributes = attributes
+		cfg.attributes = slices.Clone(attributes)
 	}
 }
 

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -336,6 +336,7 @@ type WorkflowRegistrationConfig struct {
 	DonID                   uint64
 	ContainerTargetDir      string
 	SethClient              *seth.Client
+	Attributes              []byte
 }
 
 /*
@@ -645,6 +646,7 @@ func registerWorkflow(ctx context.Context, t *testing.T,
 		configURL,
 		nil, // no secrets yet
 		containerTargetDir,
+		wfRegCfg.Attributes,
 	)
 	require.NoError(t, registerErr, "failed to register workflow '%s'", wfRegCfg.WorkflowName)
 	testLogger.Info().Msgf("Workflow registered successfully: '%s'", workflowID)
@@ -721,6 +723,7 @@ func CompileAndDeployWorkflow[T WorkflowConfig](t *testing.T,
 		DonID:                   testEnv.Dons.MustWorkflowDON().ID,
 		ContainerTargetDir:      creworkflow.DefaultWorkflowTargetDir,
 		SethClient:              testEnv.CreEnvironment.Blockchains[0].(*evm.Blockchain).SethClient,
+		Attributes:              cfg.attributes,
 	}
 	require.IsType(t, &evm.Blockchain{}, testEnv.CreEnvironment.Blockchains[0], "expected EVM blockchain type")
 	workflowID := registerWorkflow(t.Context(), t, workflowRegConfig, testEnv.CreEnvironment.Blockchains[0].(*evm.Blockchain).SethClient, testLogger)
@@ -729,6 +732,7 @@ func CompileAndDeployWorkflow[T WorkflowConfig](t *testing.T,
 
 type compileAndDeployWorkflowCfg struct {
 	artifactCopyDONTypes []cre.CapabilityFlag
+	attributes           []byte
 }
 
 // CompileAndDeployWorkflowOpt customizes workflow compilation/deployment behavior.
@@ -741,6 +745,15 @@ func WithArtifactCopyDONTypes(donTypes ...cre.CapabilityFlag) CompileAndDeployWo
 			return
 		}
 		cfg.artifactCopyDONTypes = append([]cre.CapabilityFlag{}, donTypes...)
+	}
+}
+
+// WithAttributes sets the workflow attributes byte blob (JSON) written to the
+// WorkflowRegistry contract on upsert. The CRE syncer reads this to decide
+// routing (e.g. confidential execution via ConfidentialModule).
+func WithAttributes(attributes []byte) CompileAndDeployWorkflowOpt {
+	return func(cfg *compileAndDeployWorkflowCfg) {
+		cfg.attributes = attributes
 	}
 }
 

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -645,8 +645,8 @@ func registerWorkflow(ctx context.Context, t *testing.T,
 		binaryURL,
 		configURL,
 		nil, // no secrets yet
-		containerTargetDir,
 		wfRegCfg.Attributes,
+		containerTargetDir,
 	)
 	require.NoError(t, registerErr, "failed to register workflow '%s'", wfRegCfg.WorkflowName)
 	testLogger.Info().Msgf("Workflow registered successfully: '%s'", workflowID)


### PR DESCRIPTION
## Summary
Thread an `attributes []byte` parameter through the `system-tests` workflow registration chain so tests can set `WorkflowSpec.Attributes` on the WorkflowRegistry v2 contract.

CRE's syncer reads `spec.Attributes` (via `v2.IsConfidential`) to decide whether a workflow runs locally or via `ConfidentialModule`. Today every `system-tests` caller of `registry.UpsertWorkflow` hard-codes attributes to `nil`, so no test can exercise the confidential-execution path end-to-end.

## Changes
- `system-tests/lib/cre/workflow/workflow.go`: `RegisterWithContract` and `registerWorkflowV2` accept `attributes []byte` and forward to `UpsertWorkflow`.
- `system-tests/tests/test-helpers/t_helpers.go`: `WithAttributes(attrs []byte)` option on `CompileAndDeployWorkflow`; `WorkflowRegistrationConfig.Attributes` field.
- `core/scripts/cre/environment/environment/workflow.go`: pass `nil` at the one non-test caller.

V1 path unaffected. All existing callers behave identically.