### PR TITLE
Add redirects to the list of blocked requests

### DIFF
--- a/core/services/gateway/network/httpclient.go
+++ b/core/services/gateway/network/httpclient.go
@@ -204,8 +204,12 @@ func NewHTTPClient(config HTTPClientConfig, lggr logger.Logger) (HTTPClient, err
 }
 
 func disableRedirects(req *http.Request, via []*http.Request) error {
-	return errors.New("redirects are not allowed")
+	return &redirectsDisabledError{}
 }
+
+type redirectsDisabledError struct{}
+
+func (e *redirectsDisabledError) Error() string { return "redirects are not allowed" }
 
 // isBlockedRequest checks if an error is caused by blocked/invalid input (e.g., blocked IP, invalid scheme, blocked headers)
 // It checks for safeurl typed errors.
@@ -216,18 +220,20 @@ func isBlockedRequest(err error) bool {
 
 	// Check safeurl typed errors - use errors.As for type checking
 	var (
-		ipv6Err        *safeurl.IPv6BlockedError
-		portErr        *safeurl.AllowedPortError
-		schemeErr      *safeurl.AllowedSchemeError
-		invalidHostErr *safeurl.InvalidHostError
-		ipErr          *safeurl.AllowedIPError
+		ipv6Err              *safeurl.IPv6BlockedError
+		portErr              *safeurl.AllowedPortError
+		schemeErr            *safeurl.AllowedSchemeError
+		invalidHostErr       *safeurl.InvalidHostError
+		ipErr                *safeurl.AllowedIPError
+		redirectsDisabledErr *redirectsDisabledError
 	)
 
 	return errors.As(err, &ipv6Err) ||
 		errors.As(err, &portErr) ||
 		errors.As(err, &schemeErr) ||
 		errors.As(err, &invalidHostErr) ||
-		errors.As(err, &ipErr)
+		errors.As(err, &ipErr) ||
+		errors.As(err, &redirectsDisabledErr)
 }
 
 func (c *httpClient) validateMethod(method string) error {

--- a/core/services/gateway/network/httpclient_test.go
+++ b/core/services/gateway/network/httpclient_test.go
@@ -903,6 +903,44 @@ func TestHTTPClient_BlockedRequests_ReturnErrBlockedRequest(t *testing.T) {
 	}
 }
 
+func TestHTTPClient_RedirectIsErrBlockedRequest(t *testing.T) {
+	t.Parallel()
+
+	lggr := logger.Test(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirected", http.StatusMovedPermanently)
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	hostname, port := u.Hostname(), u.Port()
+	portInt, err := strconv.ParseInt(port, 10, 32)
+	require.NoError(t, err)
+
+	config := HTTPClientConfig{
+		AllowedIPs:   []string{hostname},
+		AllowedPorts: []int{int(portInt)},
+	}
+
+	client, err := NewHTTPClient(config, lggr)
+	require.NoError(t, err)
+
+	_, err = client.Send(t.Context(), HTTPRequest{
+		Method:  "GET",
+		URL:     server.URL + "/",
+		Headers: map[string]string{},
+		Body:    nil,
+		Timeout: 2 * time.Second,
+	})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrBlockedRequest, "redirect responses should be flagged as ErrBlockedRequest")
+	require.ErrorContains(t, err, "redirects are not allowed")
+}
+
 // verifyBackwardCompatibility checks that all keys in MultiHeaders are also present in Headers
 // with non-empty values.
 func verifyBackwardCompatibility(t *testing.T, headers map[string]string, multiHeaders map[string][]string) {


### PR DESCRIPTION
This should remove redirected requests from the metrics that have been noisy over the last few days.