### PR TITLE
[codex] backport vault get-secrets workflow owner to 2.43.1

### DIFF
--- a/core/capabilities/vault/capability.go
+++ b/core/capabilities/vault/capability.go
@@ -138,6 +138,12 @@ func (s *Capability) Execute(ctx context.Context, request capabilities.Capabilit
 	}
 	id := fmt.Sprintf("%s::%s::%s", md.WorkflowID, phaseOrExecution, md.ReferenceID)
 
+	// When VaultOrgIdAsSecretOwnerEnabled is disabled, request.WorkflowOwner is
+	// not populated, so it has to be fetched from the first request's secret owner.
+	if r.WorkflowOwner == "" && len(r.Requests) > 0 && r.Requests[0] != nil && r.Requests[0].Id != nil {
+		r.WorkflowOwner = r.Requests[0].Id.Owner
+	}
+
 	resp, err := s.handleRequest(ctx, id, r)
 	if err != nil {
 		return capabilities.CapabilityResponse{}, err

--- a/core/capabilities/vault/capability_test.go
+++ b/core/capabilities/vault/capability_test.go
@@ -552,6 +552,104 @@ func TestCapability_CapabilityCall_ForwardsRequestGetSecretsIdentity(t *testing.
 	assert.Empty(t, resolver.calledWith)
 }
 
+func TestCapability_CapabilityCall_BackfillsGetSecretsWorkflowOwnerFromFirstSecretOwner(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	clock := clockwork.NewFakeClock()
+	expiry := 10 * time.Second
+	store := requests.NewStore[*vaulttypes.Request]()
+	handler := requests.NewHandler[*vaulttypes.Request, *vaulttypes.Response](lggr, store, clock, expiry)
+	reg := coreCapabilities.NewRegistry(lggr)
+	lf := newVaultOrgIDAsSecretOwnerLimitsFactory(t, true)
+	resolver := &testOrgResolver{orgID: "org-123"}
+	capability, err := NewCapability(lggr, clock, expiry, handler, reg, nil, resolver, lf)
+	require.NoError(t, err)
+	servicetest.Run(t, capability)
+
+	requestID := "wf-id::exec-id::ref-id"
+	workflowOwner := "0xABCDef1234567890abcdef1234567890abcdef12"
+	gsr := &vault.GetSecretsRequest{
+		Requests: []*vault.SecretRequest{
+			{
+				Id: &vault.SecretIdentifier{
+					Key:       "Foo",
+					Namespace: "Bar",
+					Owner:     workflowOwner,
+				},
+				EncryptionKeys: []string{"key"},
+			},
+		},
+	}
+
+	anyproto, err := anypb.New(gsr)
+	require.NoError(t, err)
+	responsePayload, err := proto.Marshal(&vault.GetSecretsResponse{
+		Responses: []*vault.SecretResponse{
+			{
+				Id: &vault.SecretIdentifier{
+					Key:       "Foo",
+					Namespace: "Bar",
+					Owner:     workflowOwner,
+				},
+				Result: &vault.SecretResponse_Data{
+					Data: &vault.SecretData{EncryptedValue: "encrypted-value"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var (
+		wg          sync.WaitGroup
+		forward     *vault.GetSecretsRequest
+		forwardedOK bool
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-t.Context().Done():
+				return
+			default:
+				reqs := store.GetByIDs([]string{requestID})
+				if len(reqs) != 1 {
+					continue
+				}
+				payload, ok := reqs[0].Payload.(*vault.GetSecretsRequest)
+				if !ok {
+					return
+				}
+				cloned, ok := proto.Clone(payload).(*vault.GetSecretsRequest)
+				if !ok {
+					return
+				}
+				forward = cloned
+				forwardedOK = true
+				reqs[0].SendResponse(t.Context(), &vaulttypes.Response{ID: requestID, Payload: responsePayload})
+				return
+			}
+		}
+	}()
+
+	_, err = capability.Execute(t.Context(), capabilities.CapabilityRequest{
+		Payload: anyproto,
+		Method:  vault.MethodGetSecrets,
+		Metadata: capabilities.RequestMetadata{
+			WorkflowOwner:       workflowOwner,
+			WorkflowID:          "wf-id",
+			WorkflowExecutionID: "exec-id",
+			ReferenceID:         "ref-id",
+		},
+	})
+	require.NoError(t, err)
+	wg.Wait()
+	require.True(t, forwardedOK)
+	require.NotNil(t, forward)
+	assert.Empty(t, forward.OrgId)
+	assert.Equal(t, workflowOwner, forward.WorkflowOwner)
+	assert.Empty(t, resolver.calledWith)
+}
+
 func TestCapability_CapabilityCall_ReturnsIncorrectType(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	clock := clockwork.NewFakeClock()

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -1625,7 +1625,7 @@ func TestSecretsFetcher_Integration(t *testing.T) {
 	// received.
 	res := <-resultReceivedCh
 	require.NotNil(t, capturedVaultReq)
-	require.Equal(t, cfg.WorkflowOwner, capturedVaultReq.WorkflowOwner) // WorkflowOwner is always set for label validation
+	require.Empty(t, capturedVaultReq.WorkflowOwner)
 	require.Empty(t, capturedVaultReq.OrgId)
 	switch output := res.Result.(type) {
 	case *sdkpb.ExecutionResult_Value:

--- a/core/services/workflows/v2/secrets.go
+++ b/core/services/workflows/v2/secrets.go
@@ -204,11 +204,11 @@ func (s *secretsFetcher) getSecretsForBatch(ctx context.Context, request *sdkpb.
 	}
 
 	vp := &vault.GetSecretsRequest{
-		Requests:      make([]*vault.SecretRequest, 0),
-		WorkflowOwner: s.workflowOwner, // Always set for label validation
+		Requests: make([]*vault.SecretRequest, 0),
 	}
 	if orgIDGateEnabled {
 		vp.OrgId = s.orgID
+		vp.WorkflowOwner = s.workflowOwner
 	}
 
 	owner, err := normalizeOwner(s.workflowOwner)

--- a/core/services/workflows/v2/secrets_test.go
+++ b/core/services/workflows/v2/secrets_test.go
@@ -378,7 +378,7 @@ func TestSecretsFetcher_ForwardsOrgIDAndWorkflowOwner(t *testing.T) {
 	assert.Equal(t, owner, capturedReq.WorkflowOwner)
 }
 
-func TestSecretsFetcher_OmitsOrgIDWhenGateDisabled(t *testing.T) {
+func TestSecretsFetcher_OmitsOrgIDAndWorkflowOwnerWhenGateDisabled(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	reg := coreCap.NewRegistry(lggr)
 	peer := coreCap.RandomUTF8BytesWord()
@@ -441,7 +441,7 @@ func TestSecretsFetcher_OmitsOrgIDWhenGateDisabled(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, capturedReq)
 	assert.Empty(t, capturedReq.OrgId)
-	assert.Equal(t, owner, capturedReq.WorkflowOwner) // WorkflowOwner is always set for label validation
+	assert.Empty(t, capturedReq.WorkflowOwner)
 }
 
 func TestSecretsFetcher_ReturnsErrorIfNoResponseForRequest(t *testing.T) {


### PR DESCRIPTION
## What changed
This is a fresh backport of [#22112](https://github.com/smartcontractkit/chainlink/pull/22112) onto `release/2.43.1`.

It includes the same release-line change set:
- backfill `vault.GetSecretsRequest.WorkflowOwner` in the vault capability `Execute()` path from `request.Requests[0].Id.Owner` when the request omits it
- stop populating `GetSecretsRequest.WorkflowOwner` in `workflows/v2/secrets.go` unless `VaultOrgIdAsSecretOwnerEnabled` is enabled
- align workflow tests, including `TestSecretsFetcher_Integration`, with the disabled-gate request shape
- keep the regression coverage for the omitted-owner and disabled-gate cases

## Why
We are backporting the already-reviewed fix from `develop` so the same behavior is available on the `2.43.1` release line.

This PR is intended to replace [#22116](https://github.com/smartcontractkit/chainlink/pull/22116) with a completely fresh branch and freshly signed commit history.

## Validation
- `go test ./core/capabilities/vault -run 'TestCapability_CapabilityCall_(ForwardsRequestGetSecretsIdentity|BackfillsGetSecretsWorkflowOwnerFromFirstSecretOwner|UsesMetadataWorkflowOwner|DuringSubscriptionPhase|SecretIdentifierOwnerMismatch|CapabilityCall)$'`
- `go test ./core/services/workflows/v2 -run 'TestSecretsFetcher_Integration|TestSecretsFetcher_(ForwardsOrgIDAndWorkflowOwner|OmitsOrgIDAndWorkflowOwnerWhenGateDisabled)$'`