### PR TITLE
[CRE-3674] fix: flaky Test_RegistrySynchronizer1_3_UpkeepCheckDataUpdatedLog

### DIFF
--- a/core/services/keeper/registry1_3_synchronizer_test.go
+++ b/core/services/keeper/registry1_3_synchronizer_test.go
@@ -707,9 +707,16 @@ func Test_RegistrySynchronizer1_3_UpkeepCheckDataUpdatedLog(t *testing.T) {
 	cltest.WaitForCount(t, db, "keeper_registries", 1)
 	cltest.WaitForCount(t, db, "upkeep_registrations", 1)
 
+	// Verify initial check data before proceeding to ensure fullSync is complete
+	g.Eventually(func() []byte {
+		var upkeep keeper.UpkeepRegistration
+		err := db.Get(&upkeep, `SELECT * FROM upkeep_registrations WHERE upkeep_id = $1`, sqlutil.New(upkeepId))
+		require.NoError(t, err)
+		return upkeep.CheckData
+	}, testutils.WaitTimeout(t), cltest.DBPollingInterval).Should(gomega.Equal(upkeepConfig1_3.CheckData))
+
 	head := cltest.MustInsertHead(t, db, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
-	_ = logmocks.NewBroadcast(t)
 	newCheckData := []byte("Chainlink")
 	registryMock := cltest.NewContractMockReceiver(t, ethMock, keeper.Registry1_3ABI, contractAddress)
 	newConfig := upkeepConfig1_3


### PR DESCRIPTION
## Summary
- Add initial check data verification (`g.Eventually`) before the log handling phase to ensure `fullSync` has fully completed and the run loop is in the `select` statement — matches the pattern used in the stable `UpkeepGasLimitSetLog` test
- Remove unused `logmocks.NewBroadcast(t)` (dead code)

Fixes: [CRE-3674](https://smartcontract-it.atlassian.net/browse/CRE-3674)

## Root cause
`WaitForCount` succeeds as soon as `UpsertUpkeep` commits, but `fullSync` may still be running (goroutines in `batchSyncUpkeepsOnRegistry` haven't finished). Under CI load, this delays when the run loop enters `select` and picks up the log notification from `HandleLog`, causing the test to hang or fail.

## Test plan
- [x] `go test -race -count=5 -run Test_RegistrySynchronizer1_3_UpkeepCheckDataUpdatedLog` — 5/5 passes
- [x] Full keeper package test suite passes with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CRE-3674]: https://smartcontract-it.atlassian.net/browse/CRE-3674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ