### PR TITLE
[DX-3716] Test timeout 25m -> 15m

### DIFF
--- a/tools/bin/go_core_ccip_deployment_tests
+++ b/tools/bin/go_core_ccip_deployment_tests
@@ -5,7 +5,7 @@ set +e
 SCRIPT_PATH=`dirname "$0"`; SCRIPT_PATH=`eval "cd \"$SCRIPT_PATH\" && pwd"`
 OUTPUT_FILE=${OUTPUT_FILE:-"./output.txt"}
 JUNIT_FILE=${JUNIT_FILE:-"./junit.xml"}
-GO_TEST_TIMEOUT=${GO_TEST_TIMEOUT:-"25m"}
+GO_TEST_TIMEOUT=${GO_TEST_TIMEOUT:-"15m"}
 # Adjusting freeport port block size for tests.
 export CL_RESERVE_PORTS=128
 

--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -5,7 +5,7 @@ set +e
 SCRIPT_PATH=`dirname "$0"`; SCRIPT_PATH=`eval "cd \"$SCRIPT_PATH\" && pwd"`
 OUTPUT_FILE=${OUTPUT_FILE:-"./output.txt"}
 JUNIT_FILE=${JUNIT_FILE:-"./junit.xml"}
-GO_TEST_TIMEOUT=${GO_TEST_TIMEOUT:-"25m"}
+GO_TEST_TIMEOUT=${GO_TEST_TIMEOUT:-"15m"}
 
 echo "Installing gotestsum..."
 go install gotest.tools/gotestsum@v1.13.0

--- a/tools/bin/go_core_tests_integration
+++ b/tools/bin/go_core_tests_integration
@@ -5,7 +5,7 @@ set +e
 SCRIPT_PATH=$(dirname "$0"); SCRIPT_PATH=$(eval "cd \"$SCRIPT_PATH\" && pwd")
 OUTPUT_FILE=${OUTPUT_FILE:-"./output.txt"}
 JUNIT_FILE=${JUNIT_FILE:-"./junit.xml"}
-GO_TEST_TIMEOUT=${GO_TEST_TIMEOUT:-"25m"}
+GO_TEST_TIMEOUT=${GO_TEST_TIMEOUT:-"15m"}
 EXTRA_FLAGS=""
 
 # Install gotestsum as test runner


### PR DESCRIPTION
Reverts https://github.com/smartcontractkit/chainlink/pull/21893 which set timeout to `25m` for unti test runs. We assumed the timing was too tight and timeouts were just unlucky. Turns out there's a hang, and we're just arbitrarily waiting longer to kill the hang.

There's separate, ongoing work to diagnose and fix the hang.