### PR TITLE
[DX-3778] Handle seconds=0 in the admin profile command

### DIFF
--- a/core/cmd/admin_commands.go
+++ b/core/cmd/admin_commands.go
@@ -332,16 +332,25 @@ func (s *Shell) Profile(c *cli.Context) error {
 	genDir := filepath.Join(baseDir, "debuginfo-"+time.Now().Format(time.RFC3339))
 
 	vitals := c.StringSlice("vitals")
-	allVitals := []string{
+	// supportsDeltaVitals contains profiles that can be run with or without seconds param.
+	// (see https://pkg.go.dev/net/http/pprof#hdr-Parameters)
+	supportsDeltaVitals := []string{
 		"allocs",       // A sampling of all past memory allocations
 		"block",        // Stack traces that led to blocking on synchronization primitives
 		"cmdline",      // The command line invocation of the current program
 		"goroutine",    // Stack traces of all current goroutines
 		"heap",         // A sampling of memory allocations of live objects.
 		"mutex",        // Stack traces of holders of contended mutexes
-		"profile",      // CPU profile.
 		"threadcreate", // Stack traces that led to the creation of new OS threads
-		"trace",        // A trace of execution of the current program.
+	}
+	// durationOnlyVitals contains profiles that can be run only with the seconds param.
+	durationOnlyVitals := []string{
+		"profile", // CPU profile.
+		"trace",   // A trace of execution of the current program.
+	}
+	allVitals := supportsDeltaVitals
+	if seconds > 0 {
+		allVitals = append(allVitals, durationOnlyVitals...)
 	}
 	if len(vitals) == 0 {
 		vitals = slices.Clone(allVitals)
@@ -436,7 +445,10 @@ func (s *Shell) profile(ctx context.Context, genDir string, name string, vitals 
 			defer wgPprof.Done()
 			ctx, cancel := context.WithTimeout(ctx, time.Duration(max(seconds, 0)+web.PPROFOverheadSeconds)*time.Second)
 			defer cancel()
-			uri := fmt.Sprintf(path+"/debug/pprof/%s?seconds=%d", vt, seconds)
+			uri := fmt.Sprintf(path+"/debug/pprof/%s", vt)
+			if seconds > 0 {
+				uri += fmt.Sprintf("?seconds=%d", seconds)
+			}
 			resp, err := s.HTTP.Get(ctx, uri)
 			if err != nil {
 				errs <- fmt.Errorf("error collecting %s: %w", uri, err)

--- a/testdata/scripts/admin/profile/multi-chain-loopp.txtar
+++ b/testdata/scripts/admin/profile/multi-chain-loopp.txtar
@@ -11,7 +11,7 @@ exec curl --retry 10 --retry-max-time 60 --retry-connrefused $NODEURL
 exec chainlink --remote-node-url $NODEURL admin login -file creds --bypass-version-check
 
 exec chainlink --remote-node-url $NODEURL admin profile -seconds 1 -output_dir ./profiles
-stderr 'Collecting profiles from host and 8 plugins: \[allocs block cmdline goroutine heap mutex profile threadcreate trace\]'
+stderr 'Collecting profiles from host and 8 plugins: \[allocs block cmdline goroutine heap mutex threadcreate profile trace\]'
 
 exec sh -c 'eval "ls -R $WORK"'
 

--- a/testdata/scripts/admin/profile/test-seconds.txtar
+++ b/testdata/scripts/admin/profile/test-seconds.txtar
@@ -1,0 +1,33 @@
+# start node
+exec sh -c 'eval "echo \"$(cat config.toml.tmpl)\" > config.toml"'
+exec chainlink node -c config.toml start -p password -a creds &
+
+# initialize client
+env NODEURL=http://localhost:$PORT
+exec curl --retry 10 --retry-max-time 60 --retry-connrefused $NODEURL
+exec chainlink --remote-node-url $NODEURL admin login -file creds --bypass-version-check
+
+# seconds=0: no CPU and trace profiles are created
+exec chainlink --remote-node-url $NODEURL admin profile -seconds 0 -output_dir ./profiles
+stderr 'Collecting profiles: \[allocs block cmdline goroutine heap mutex threadcreate\]'
+
+# seconds=1: CPU and trace profiles are created
+exec chainlink --remote-node-url $NODEURL admin profile -seconds 1 -output_dir ./profiles
+stderr 'Collecting profiles: \[allocs block cmdline goroutine heap mutex threadcreate profile trace\]'
+
+exec sh -c 'eval "ls -R $WORK"'
+
+-- testdb.txt --
+CL_DATABASE_URL
+-- testport.txt --
+PORT
+
+-- password --
+T.tLHkcmwePT/p,]sYuntjwHKAsrhm#4eRs4LuKHwvHejWYAC2JP4M8HimwgmbaZ
+-- creds --
+notreal@fakeemail.ch
+fj293fbBnlQ!f9vNs
+
+-- config.toml.tmpl --
+[Webserver]
+HTTPPort = $PORT


### PR DESCRIPTION
Before this PR we have always passed seconds as "?seconds=%d" arg to collect the corresponding profile.
After this PR we start to interpret seconds = 0 as "no seconds" argument.

This PR is required to obtain static (non-delta) heap profiles. Before this PR passing "seconds=0" would err in heap profiling - https://go.dev/src/net/http/pprof/pprof.go#L278. After this PR we can now obtain static heap profile. (To make things more complicated passing "seconds=0" to CPU profile would not err and reset profiling duration to 30 seconds.)