### PR TITLE
[DX-3862] remove event trigger from post-release tests

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -239,45 +239,6 @@ jobs:
           }
           JSON
 
-  emit-release-image-tagged-event:
-    name: Emit release image tagged event
-    needs: [ checks ]
-    if: needs.checks.outputs.is-release == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Compute image tag
-        id: compute-image-tag
-        shell: bash
-        env:
-          GIT_TAG: ${{ github.ref_name }}
-        run: |
-          # Compute image tag by removing 'v' prefix
-          # Examples:
-          #   v2.34.0   -> 2.34.0
-          tag_without_v="${GIT_TAG#v}"
-          echo "image-tag=$tag_without_v" | tee -a "$GITHUB_OUTPUT"
-      - name: Emit release image tagged event
-        env:
-          DOCKER_IMAGE_TAG: ${{ steps.compute-image-tag.outputs.image-tag }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${GITHUB_REPOSITORY}/dispatches" \
-            --input - <<JSON
-          {
-            "event_type": "release-image-tagged",
-            "client_payload": {
-              "chainlink_image_tag": "${DOCKER_IMAGE_TAG}",
-              "chainlink_version": "${GITHUB_REF_NAME}"
-            }
-          }
-          JSON
-
   # Notify Slack channel for new git tags associated with pre-releases.
   # Final release notifications originate from the release coordinator repo.
   slack-notify:

--- a/.github/workflows/post-image-released.yml
+++ b/.github/workflows/post-image-released.yml
@@ -1,34 +1,11 @@
-name: "Post Release Image Tagged"
+name: "Post Image Released"
 on:
     # to be used with post release tests
-    repository_dispatch:
-        types: [ release-image-tagged ]
+    workflow_dispatch:
 
 permissions: {}
 
 jobs:
-    validate-trigger:
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-        steps:
-            - name: Validate trigger
-              env:
-                  CHAINLINK_IMAGE_TAG: ${{ github.event.client_payload.chainlink_image_tag }}
-                  CHAINLINK_VERSION: ${{ github.event.client_payload.chainlink_version }}
-              run: |
-                  echo "Image Tag: $CHAINLINK_IMAGE_TAG"
-                  echo "Chainlink Version: $CHAINLINK_VERSION"
-                  if [ -z "$CHAINLINK_IMAGE_TAG" ]; then
-                      echo "Chainlink image tag is required, but 'client_payload.chainlink_image_tag' is empty"
-                      exit 1
-                  fi
-                  if [ -z "$CHAINLINK_VERSION" ]; then
-                      echo "Chainlink Version is required, but 'client_payload.chainlink_version' is empty"
-                      exit 1
-                  fi
-                  echo "Trigger validated successfully"
-
     # Upgrade compatibility tests
     # Run on images excluding beta and release candidate versions
     df1-compat:


### PR DESCRIPTION
- do not trigger tests after `check` has run, because at that point image won't be available yet
- instead switch the workflow to `workflow_dispatch` and trigger it from the release repository once the image has been pushed to the ECR