### PR TITLE
Vault: enforce claim_vault_secret_management_enabled in JWT auth

### DIFF
--- a/core/capabilities/vault/jwt_based_auth.go
+++ b/core/capabilities/vault/jwt_based_auth.go
@@ -24,14 +24,14 @@ import (
 )
 
 var (
-	ErrMissingToken                        = errors.New("missing JWT token")
-	ErrInvalidToken                        = errors.New("invalid JWT token")
-	ErrMissingOrgID                        = errors.New("missing org_id claim")
-	ErrMissingWorkflowOwner                = errors.New("missing workflow_owner in authorization_details")
-	ErrMissingRequestDigest                = errors.New("missing request_digest in authorization_details")
-	ErrVaultSecretManagementNotEnabled     = errors.New("claim_vault_secret_management_enabled claim must be true")
-	ErrJWKSFetchFailed                     = errors.New("failed to fetch JWKS")
-	ErrJWKSKeyNotFound                     = errors.New("signing key not found in JWKS")
+	ErrMissingToken                    = errors.New("missing JWT token")
+	ErrInvalidToken                    = errors.New("invalid JWT token")
+	ErrMissingOrgID                    = errors.New("missing org_id claim")
+	ErrMissingWorkflowOwner            = errors.New("missing workflow_owner in authorization_details")
+	ErrMissingRequestDigest            = errors.New("missing request_digest in authorization_details")
+	ErrVaultSecretManagementNotEnabled = errors.New("claim_vault_secret_management_enabled claim must be true")
+	ErrJWKSFetchFailed                 = errors.New("failed to fetch JWKS")
+	ErrJWKSKeyNotFound                 = errors.New("signing key not found in JWKS")
 )
 
 const claimVaultSecretManagementEnabled = "urn:chainlink:claim_vault_secret_management_enabled"

--- a/core/capabilities/vault/jwt_based_auth.go
+++ b/core/capabilities/vault/jwt_based_auth.go
@@ -24,14 +24,17 @@ import (
 )
 
 var (
-	ErrMissingToken         = errors.New("missing JWT token")
-	ErrInvalidToken         = errors.New("invalid JWT token")
-	ErrMissingOrgID         = errors.New("missing org_id claim")
-	ErrMissingWorkflowOwner = errors.New("missing workflow_owner in authorization_details")
-	ErrMissingRequestDigest = errors.New("missing request_digest in authorization_details")
-	ErrJWKSFetchFailed      = errors.New("failed to fetch JWKS")
-	ErrJWKSKeyNotFound      = errors.New("signing key not found in JWKS")
+	ErrMissingToken                        = errors.New("missing JWT token")
+	ErrInvalidToken                        = errors.New("invalid JWT token")
+	ErrMissingOrgID                        = errors.New("missing org_id claim")
+	ErrMissingWorkflowOwner                = errors.New("missing workflow_owner in authorization_details")
+	ErrMissingRequestDigest                = errors.New("missing request_digest in authorization_details")
+	ErrVaultSecretManagementNotEnabled     = errors.New("claim_vault_secret_management_enabled claim must be true")
+	ErrJWKSFetchFailed                     = errors.New("failed to fetch JWKS")
+	ErrJWKSKeyNotFound                     = errors.New("signing key not found in JWKS")
 )
+
+const claimVaultSecretManagementEnabled = "urn:chainlink:claim_vault_secret_management_enabled"
 
 const (
 	defaultJWKSRefreshInterval = 15 * time.Minute
@@ -276,6 +279,10 @@ func extractVaultClaims(claims jwt.MapClaims) (*JWTClaims, error) {
 	orgID, _ := claims["org_id"].(string)
 	if orgID == "" {
 		return nil, ErrMissingOrgID
+	}
+
+	if claims[claimVaultSecretManagementEnabled] != "true" {
+		return nil, ErrVaultSecretManagementNotEnabled
 	}
 
 	exp, err := claims.GetExpirationTime()

--- a/core/capabilities/vault/jwt_based_auth.go
+++ b/core/capabilities/vault/jwt_based_auth.go
@@ -34,7 +34,7 @@ var (
 	ErrJWKSKeyNotFound                 = errors.New("signing key not found in JWKS")
 )
 
-const claimVaultSecretManagementEnabled = "urn:chainlink:claim_vault_secret_management_enabled"
+const ClaimVaultSecretManagementEnabled = "urn:chainlink:claim_vault_secret_management_enabled"
 
 const (
 	defaultJWKSRefreshInterval = 15 * time.Minute
@@ -281,7 +281,7 @@ func extractVaultClaims(claims jwt.MapClaims) (*JWTClaims, error) {
 		return nil, ErrMissingOrgID
 	}
 
-	if v, ok := claims[claimVaultSecretManagementEnabled].(string); !ok || v != "true" {
+	if v, ok := claims[ClaimVaultSecretManagementEnabled].(string); !ok || v != "true" {
 		return nil, ErrVaultSecretManagementNotEnabled
 	}
 

--- a/core/capabilities/vault/jwt_based_auth.go
+++ b/core/capabilities/vault/jwt_based_auth.go
@@ -281,7 +281,7 @@ func extractVaultClaims(claims jwt.MapClaims) (*JWTClaims, error) {
 		return nil, ErrMissingOrgID
 	}
 
-	if claims[claimVaultSecretManagementEnabled] != "true" {
+	if v, ok := claims[claimVaultSecretManagementEnabled].(string); !ok || v != "true" {
 		return nil, ErrVaultSecretManagementNotEnabled
 	}
 

--- a/core/capabilities/vault/jwt_based_auth_test.go
+++ b/core/capabilities/vault/jwt_based_auth_test.go
@@ -122,7 +122,7 @@ func validTestClaims(issuer, audience string) jwt.MapClaims {
 		"exp":    jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		"iat":    jwt.NewNumericDate(time.Now()),
 		"org_id": "org_test123",
-		"urn:chainlink:claim_vault_secret_management_enabled": "true",
+		ClaimVaultSecretManagementEnabled: "true",
 		"authorization_details": []interface{}{
 			map[string]interface{}{
 				"type":  "request_digest",
@@ -181,7 +181,7 @@ func TestJWTBasedAuth_RejectsTokenWithoutWorkflowOwner(t *testing.T) {
 		"exp":    jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		"iat":    jwt.NewNumericDate(time.Now()),
 		"org_id": "org_no_wfowner",
-		"urn:chainlink:claim_vault_secret_management_enabled": "true",
+		ClaimVaultSecretManagementEnabled: "true",
 		"authorization_details": []interface{}{
 			map[string]interface{}{
 				"type":  "request_digest",
@@ -272,7 +272,7 @@ func TestJWTBasedAuth_MissingVaultSecretManagementClaim(t *testing.T) {
 	v := newTestValidator(t, issuer, audience)
 
 	claims := validTestClaims(issuer, audience)
-	delete(claims, "urn:chainlink:claim_vault_secret_management_enabled")
+	delete(claims, ClaimVaultSecretManagementEnabled)
 	tokenString := createTestJWT(t, rsaKey, claims)
 
 	_, err := v.validateToken(context.Background(), tokenString)
@@ -289,7 +289,7 @@ func TestJWTBasedAuth_VaultSecretManagementClaimNotTrue(t *testing.T) {
 	v := newTestValidator(t, issuer, audience)
 
 	claims := validTestClaims(issuer, audience)
-	claims["urn:chainlink:claim_vault_secret_management_enabled"] = "false"
+	claims[ClaimVaultSecretManagementEnabled] = "false"
 	tokenString := createTestJWT(t, rsaKey, claims)
 
 	_, err := v.validateToken(context.Background(), tokenString)
@@ -411,7 +411,7 @@ func TestJWTBasedAuth_AuthorizationDetailsFromTypedArray(t *testing.T) {
 		"exp":    jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		"iat":    jwt.NewNumericDate(time.Now()),
 		"org_id": "org_single",
-		"urn:chainlink:claim_vault_secret_management_enabled": "true",
+		ClaimVaultSecretManagementEnabled: "true",
 		"authorization_details": []interface{}{
 			map[string]interface{}{"type": "request_digest", "value": "single_digest"},
 			map[string]interface{}{"type": "workflow_owner", "value": "0x1111"},
@@ -563,7 +563,7 @@ func TestJWTBasedAuth_AuthorizeCreateRequestFromRawJSON(t *testing.T) {
 		"exp":    jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		"iat":    jwt.NewNumericDate(time.Now()),
 		"org_id": "org-123",
-		"urn:chainlink:claim_vault_secret_management_enabled": "true",
+		ClaimVaultSecretManagementEnabled: "true",
 		"authorization_details": []interface{}{
 			map[string]interface{}{
 				"type":  "request_digest",

--- a/core/capabilities/vault/jwt_based_auth_test.go
+++ b/core/capabilities/vault/jwt_based_auth_test.go
@@ -122,6 +122,7 @@ func validTestClaims(issuer, audience string) jwt.MapClaims {
 		"exp":    jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		"iat":    jwt.NewNumericDate(time.Now()),
 		"org_id": "org_test123",
+		"urn:chainlink:claim_vault_secret_management_enabled": "true",
 		"authorization_details": []interface{}{
 			map[string]interface{}{
 				"type":  "request_digest",
@@ -180,6 +181,7 @@ func TestJWTBasedAuth_RejectsTokenWithoutWorkflowOwner(t *testing.T) {
 		"exp":    jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		"iat":    jwt.NewNumericDate(time.Now()),
 		"org_id": "org_no_wfowner",
+		"urn:chainlink:claim_vault_secret_management_enabled": "true",
 		"authorization_details": []interface{}{
 			map[string]interface{}{
 				"type":  "request_digest",
@@ -259,6 +261,40 @@ func TestJWTBasedAuth_MissingOrgID(t *testing.T) {
 	_, err := v.validateToken(context.Background(), tokenString)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrMissingOrgID)
+}
+
+func TestJWTBasedAuth_MissingVaultSecretManagementClaim(t *testing.T) {
+	rsaKey := generateTestRSAKey(t, "key-1")
+	jwksServer := newTestJWKSServer(t, rsaKey)
+
+	issuer := jwksServer.URL() + "/"
+	audience := "https://api.test.chain.link"
+	v := newTestValidator(t, issuer, audience)
+
+	claims := validTestClaims(issuer, audience)
+	delete(claims, "urn:chainlink:claim_vault_secret_management_enabled")
+	tokenString := createTestJWT(t, rsaKey, claims)
+
+	_, err := v.validateToken(context.Background(), tokenString)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrVaultSecretManagementNotEnabled)
+}
+
+func TestJWTBasedAuth_VaultSecretManagementClaimNotTrue(t *testing.T) {
+	rsaKey := generateTestRSAKey(t, "key-1")
+	jwksServer := newTestJWKSServer(t, rsaKey)
+
+	issuer := jwksServer.URL() + "/"
+	audience := "https://api.test.chain.link"
+	v := newTestValidator(t, issuer, audience)
+
+	claims := validTestClaims(issuer, audience)
+	claims["urn:chainlink:claim_vault_secret_management_enabled"] = "false"
+	tokenString := createTestJWT(t, rsaKey, claims)
+
+	_, err := v.validateToken(context.Background(), tokenString)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrVaultSecretManagementNotEnabled)
 }
 
 func TestJWTBasedAuth_MissingRequestDigest(t *testing.T) {
@@ -375,6 +411,7 @@ func TestJWTBasedAuth_AuthorizationDetailsFromTypedArray(t *testing.T) {
 		"exp":    jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		"iat":    jwt.NewNumericDate(time.Now()),
 		"org_id": "org_single",
+		"urn:chainlink:claim_vault_secret_management_enabled": "true",
 		"authorization_details": []interface{}{
 			map[string]interface{}{"type": "request_digest", "value": "single_digest"},
 			map[string]interface{}{"type": "workflow_owner", "value": "0x1111"},
@@ -526,6 +563,7 @@ func TestJWTBasedAuth_AuthorizeCreateRequestFromRawJSON(t *testing.T) {
 		"exp":    jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		"iat":    jwt.NewNumericDate(time.Now()),
 		"org_id": "org-123",
+		"urn:chainlink:claim_vault_secret_management_enabled": "true",
 		"authorization_details": []interface{}{
 			map[string]interface{}{
 				"type":  "request_digest",

--- a/system-tests/lib/cre/vault/jwt_auth.go
+++ b/system-tests/lib/cre/vault/jwt_auth.go
@@ -317,6 +317,7 @@ func SignTestJWT(privateKey *rsa.PrivateKey, claims JWTTokenClaims) (string, err
 		"iat":    jwt.NewNumericDate(claims.IssuedAt),
 		"exp":    jwt.NewNumericDate(claims.ExpiresAt),
 		"org_id": claims.OrgID,
+		"urn:chainlink:claim_vault_secret_management_enabled": "true",
 		"authorization_details": []map[string]string{
 			{
 				"type":  "request_digest",

--- a/system-tests/lib/cre/vault/jwt_auth.go
+++ b/system-tests/lib/cre/vault/jwt_auth.go
@@ -23,6 +23,7 @@ import (
 
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+	vaultcap "github.com/smartcontractkit/chainlink/v2/core/capabilities/vault"
 )
 
 const (
@@ -317,7 +318,7 @@ func SignTestJWT(privateKey *rsa.PrivateKey, claims JWTTokenClaims) (string, err
 		"iat":    jwt.NewNumericDate(claims.IssuedAt),
 		"exp":    jwt.NewNumericDate(claims.ExpiresAt),
 		"org_id": claims.OrgID,
-		"urn:chainlink:claim_vault_secret_management_enabled": "true",
+		vaultcap.ClaimVaultSecretManagementEnabled: "true",
 		"authorization_details": []map[string]string{
 			{
 				"type":  "request_digest",

--- a/system-tests/tests/smoke/cre/v2_vault_don_test.go
+++ b/system-tests/tests/smoke/cre/v2_vault_don_test.go
@@ -22,6 +22,7 @@ import (
 	crecontracts "github.com/smartcontractkit/chainlink/system-tests/lib/cre/contracts"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/blockchains/evm"
 	t_helpers "github.com/smartcontractkit/chainlink/system-tests/tests/test-helpers"
+	vaultcap "github.com/smartcontractkit/chainlink/v2/core/capabilities/vault"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaultutils"
 
@@ -222,8 +223,8 @@ func ExecuteVaultMixedAuthTest(t *testing.T, fixture *vaultScenarioFixture, test
 
 	t.Run("jwt_rejected_when_vault_secret_management_claim_false", func(t *testing.T) {
 		executeVaultJWTSecretsCreateUnauthorizedWithExtraClaimsTest(t, issuer, vaultPublicKey, orgID, workflowOwner, gwURL,
-			map[string]any{"urn:chainlink:claim_vault_secret_management_enabled": "false"},
-			"claim_vault_secret_management_enabled claim must be true",
+			map[string]any{vaultcap.ClaimVaultSecretManagementEnabled: "false"},
+			vaultcap.ErrVaultSecretManagementNotEnabled.Error(),
 		)
 	})
 }

--- a/system-tests/tests/smoke/cre/v2_vault_don_test.go
+++ b/system-tests/tests/smoke/cre/v2_vault_don_test.go
@@ -219,6 +219,13 @@ func ExecuteVaultMixedAuthTest(t *testing.T, fixture *vaultScenarioFixture, test
 	t.Run("jwt_rejected_when_workflow_owner_missing", func(t *testing.T) {
 		executeVaultJWTSecretsCreateUnauthorizedTest(t, issuer, vaultPublicKey, orgID, "", gwURL, "missing workflow_owner in authorization_details")
 	})
+
+	t.Run("jwt_rejected_when_vault_secret_management_claim_false", func(t *testing.T) {
+		executeVaultJWTSecretsCreateUnauthorizedWithExtraClaimsTest(t, issuer, vaultPublicKey, orgID, workflowOwner, gwURL,
+			map[string]any{"urn:chainlink:claim_vault_secret_management_enabled": "false"},
+			"claim_vault_secret_management_enabled claim must be true",
+		)
+	})
 }
 
 func ExecuteVaultJWTDisabledTest(t *testing.T, fixture *vaultScenarioFixture) {

--- a/system-tests/tests/smoke/cre/v2_vault_don_test_helpers.go
+++ b/system-tests/tests/smoke/cre/v2_vault_don_test_helpers.go
@@ -589,6 +589,11 @@ func executeVaultJWTSecretsDeleteTest(t *testing.T, issuer *vault.TestJWTIssuer,
 
 func mustMintVaultJWTForRequest(t *testing.T, issuer *vault.TestJWTIssuer, req jsonrpc.Request[json.RawMessage], orgID, workflowOwner string) string {
 	t.Helper()
+	return mustMintVaultJWTForRequestWithExtraClaims(t, issuer, req, orgID, workflowOwner, nil)
+}
+
+func mustMintVaultJWTForRequestWithExtraClaims(t *testing.T, issuer *vault.TestJWTIssuer, req jsonrpc.Request[json.RawMessage], orgID, workflowOwner string, extraClaims map[string]any) string {
+	t.Helper()
 
 	outboundReq := outboundRequestWithoutAuth(req)
 	requestDigest, err := outboundReq.Digest()
@@ -601,6 +606,7 @@ func mustMintVaultJWTForRequest(t *testing.T, issuer *vault.TestJWTIssuer, req j
 		OrgID:         orgID,
 		WorkflowOwner: workflowOwner,
 		RequestDigest: requestDigest,
+		ExtraClaims:   extraClaims,
 	})
 	require.NoError(t, err, "failed to mint JWT")
 
@@ -644,6 +650,17 @@ func executeVaultJWTSecretsCreateUnauthorizedTest(
 	expectedAuthError string,
 ) {
 	t.Helper()
+	executeVaultJWTSecretsCreateUnauthorizedWithExtraClaimsTest(t, issuer, vaultPublicKey, orgID, workflowOwner, gatewayURL, nil, expectedAuthError)
+}
+
+func executeVaultJWTSecretsCreateUnauthorizedWithExtraClaimsTest(
+	t *testing.T,
+	issuer *vault.TestJWTIssuer,
+	vaultPublicKey, orgID, workflowOwner, gatewayURL string,
+	extraClaims map[string]any,
+	expectedAuthError string,
+) {
+	t.Helper()
 
 	secretID := strconv.Itoa(rand.Intn(10000))
 	encryptedSecret, err := vaultutils.EncryptSecretWithOrgID("secret-jwt-disabled", mustVaultPublicKey(t, vaultPublicKey), orgID)
@@ -662,7 +679,7 @@ func executeVaultJWTSecretsCreateUnauthorizedTest(
 		}},
 	}
 	jsonRequest := newVaultJSONRequest(t, uniqueRequestID, vaulttypes.MethodSecretsCreate, &secretsCreateRequest)
-	jsonRequest.Auth = mustMintVaultJWTForRequest(t, issuer, jsonRequest, orgID, workflowOwner)
+	jsonRequest.Auth = mustMintVaultJWTForRequestWithExtraClaims(t, issuer, jsonRequest, orgID, workflowOwner, extraClaims)
 
 	jsonResponse := sendVaultJWTRequestToGatewayExpectError(t, gatewayURL, jsonRequest, http.StatusBadRequest)
 	require.Equal(t, uniqueRequestID, jsonResponse.ID)


### PR DESCRIPTION
## Summary

- Adds validation of the `urn:chainlink:claim_vault_secret_management_enabled` JWT claim in Vault's JWT-based auth (`extractVaultClaims`)
- Tokens missing this claim or with a value other than `"true"` are rejected with the new `ErrVaultSecretManagementNotEnabled` error
- Updates `SignTestJWT` in the system-test JWT helper to always include the claim, so all existing JWT system tests (`ExecuteVaultMixedAuthTest` and friends) continue to work without changes

## Context

The [cre-platform-graphql schema](https://github.com/smartcontractkit/cre-platform-graphql/blob/00b997f165c8025de0e04f56637ac05eff0a8fe3/pkg/graph/schemas/schema.graphqls#L335) gates the `createVaultAuthorizationUrl` mutation behind `@hasClaim(claimName: "claim_vault_secret_management_enabled", values: ["true"])`. The platform sets this claim (with the `urn:chainlink:` namespace prefix) when minting tokens for vault access. Chainlink nodes should enforce the same gate.
