### PR TITLE
[CRE] Per-owner local secrets overrides

### DIFF
--- a/.changeset/cre-per-owner-local-secrets.md
+++ b/.changeset/cre-per-owner-local-secrets.md
@@ -1,0 +1,6 @@
+---
+"chainlink": patch
+---
+
+#added
+CRE: per-owner local secret overrides (`CRE.LocalSecretOverrides`) allow static per-workflow-owner secret maps to take precedence over the Vault capability.

--- a/.changeset/cre-per-owner-local-secrets.md
+++ b/.changeset/cre-per-owner-local-secrets.md
@@ -1,6 +1,0 @@
----
-"chainlink": patch
----
-
-#added
-CRE: per-owner local secret overrides (`CRE.LocalSecretOverrides`) allow static per-workflow-owner secret maps to take precedence over the Vault capability.

--- a/core/config/cre_config.go
+++ b/core/config/cre_config.go
@@ -12,7 +12,7 @@ type CRE interface {
 	// DebugMode returns true if debug mode is enabled for workflow engines.
 	// When enabled, additional OTel tracing and logging is performed.
 	DebugMode() bool
-	LocalSecrets() map[string]string
+	LocalSecretOverrides() map[string]map[string]string
 	ConfidentialRelay() CREConfidentialRelay
 }
 

--- a/core/config/docs/secrets.toml
+++ b/core/config/docs/secrets.toml
@@ -71,6 +71,6 @@ ApiKey = "streams-api-key" # Example
 ApiSecret = "streams-api-secret" # Example
 
 # LocalSecretOverrides maps workflow owner to (secret id -> secret value) map.
-# When non-empty, workflow secrets are served from this map first, before calling the Vault capability.
+# When non-empty, overrides are used as fallback when Vault calls fail.
 [CRE.LocalSecretOverrides]
 # "0000000000000000000000000000000000000000" = { "my-secret-id" = "my-plaintext-value" } # Example

--- a/core/config/docs/secrets.toml
+++ b/core/config/docs/secrets.toml
@@ -70,8 +70,7 @@ ApiKey = "streams-api-key" # Example
 # ApiSecret is the API secret used for authenticating with the CLL Data Streams SDK.
 ApiSecret = "streams-api-secret" # Example
 
-# LocalSecrets is a static map of secret ID to plaintext value.
-# When non-empty, all workflow secrets are served from this map instead of calling the vault capability.
-# Only use when the vault capability is not available.
-[CRE.LocalSecrets]
-# "my-secret-id" = "my-secret-value" # Example
+# LocalSecretOverrides maps workflow owner to (secret id -> secret value) map.
+# When non-empty, workflow secrets are served from this map first, before calling the Vault capability.
+[CRE.LocalSecretOverrides]
+# "0000000000000000000000000000000000000000" = { "my-secret-id" = "my-plaintext-value" } # Example

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -2117,8 +2117,18 @@ type StreamsSecretConfig struct {
 }
 
 type CreSecrets struct {
-	Streams      *StreamsSecretConfig `toml:",omitempty"`
-	LocalSecrets map[string]string    `toml:",omitempty"`
+	Streams              *StreamsSecretConfig         `toml:",omitempty"`
+	LocalSecretOverrides map[string]map[string]string `toml:",omitempty"`
+}
+
+// normalizeCRELocalSecretOwnerKey lowercases a workflow owner string and strips a "0x" / "0X"
+// prefix for LocalSecretOverrides map key lookup.
+func normalizeCRELocalSecretOwnerKey(k string) (string, error) {
+	s := strings.TrimSpace(k)
+	if s == "" {
+		return "", errors.New("empty owner key in LocalSecretOverrides")
+	}
+	return strings.TrimPrefix(strings.ToLower(s), "0x"), nil
 }
 
 func (c *CreSecrets) SetFrom(f *CreSecrets) (err error) {
@@ -2139,9 +2149,15 @@ func (c *CreSecrets) SetFrom(f *CreSecrets) (err error) {
 		}
 	}
 
-	if f.LocalSecrets != nil {
-		c.LocalSecrets = make(map[string]string, len(f.LocalSecrets))
-		maps.Copy(c.LocalSecrets, f.LocalSecrets)
+	if f.LocalSecretOverrides != nil {
+		c.LocalSecretOverrides = make(map[string]map[string]string, len(f.LocalSecretOverrides))
+		for k, v := range f.LocalSecretOverrides {
+			nk, nerr := normalizeCRELocalSecretOwnerKey(k)
+			if nerr != nil {
+				return nerr
+			}
+			c.LocalSecretOverrides[nk] = maps.Clone(v)
+		}
 	}
 
 	return nil
@@ -2156,8 +2172,8 @@ func (c *CreSecrets) validateMerge(f *CreSecrets) (err error) {
 			err = errors.Join(err, configutils.ErrOverride{Name: "Streams.APISecret"})
 		}
 	}
-	if len(c.LocalSecrets) > 0 && len(f.LocalSecrets) > 0 {
-		err = errors.Join(err, configutils.ErrOverride{Name: "LocalSecrets"})
+	if len(c.LocalSecretOverrides) > 0 && len(f.LocalSecretOverrides) > 0 {
+		err = errors.Join(err, configutils.ErrOverride{Name: "LocalSecretOverrides"})
 	}
 	return err
 }

--- a/core/services/chainlink/config_cre.go
+++ b/core/services/chainlink/config_cre.go
@@ -122,6 +122,6 @@ func (c *creConfig) ConfidentialRelay() config.CREConfidentialRelay {
 	return &confidentialRelayConfig{enabled: enabled}
 }
 
-func (c *creConfig) LocalSecrets() map[string]string {
-	return c.s.LocalSecrets
+func (c *creConfig) LocalSecretOverrides() map[string]map[string]string {
+	return c.s.LocalSecretOverrides
 }

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -965,7 +965,7 @@ func newWorkflowRegistrySyncerV2(
 		syncerV2.WithWorkflowRegistry(wfReg.Address(), selector),
 		syncerV2.WithOrgResolver(orgResolver),
 		syncerV2.WithDebugMode(cfg.CRE().DebugMode()),
-		syncerV2.WithLocalSecrets(lggr, cfg.CRE().LocalSecrets()),
+		syncerV2.WithLocalSecretOverrides(lggr, cfg.CRE().LocalSecretOverrides()),
 		syncerV2.WithShardExecutionGuard(shardOrchestratorClient, shardingEnabled, shardIndex),
 		syncerV2.WithShardRoutingSteady(shardRoutingSteady),
 	)

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"sync"
 	"time"
 
@@ -86,6 +87,8 @@ type eventHandler struct {
 	billingClient          metering.BillingClient
 	orgResolver            orgresolver.OrgResolver
 	secretsFetcher         v2.SecretsFetcher
+	// localSecretOverrides is keyed by owner address; values are secret id -> secret value
+	localSecretOverrides map[string]map[string]string
 
 	// WorkflowRegistryAddress is the address of the workflow registry contract
 	workflowRegistryAddress string
@@ -189,13 +192,23 @@ func WithSecretsFetcher(sf v2.SecretsFetcher) func(*eventHandler) {
 	}
 }
 
-func WithLocalSecrets(lggr logger.Logger, secrets map[string]string) func(*eventHandler) {
+// WithLocalSecretOverrides wires [CRE.LocalSecretOverrides]: per-workflow-owner name->secret map
+func WithLocalSecretOverrides(lggr logger.Logger, perOwner map[string]map[string]string) func(*eventHandler) {
 	return func(e *eventHandler) {
-		if len(secrets) == 0 {
+		if len(perOwner) == 0 {
 			return
 		}
-		lggr.Warnw("Local secrets override is active, vault capability will not be used for secrets", "numSecrets", len(secrets))
-		e.secretsFetcher = v2.NewLocalSecretsFetcher(secrets)
+		e.localSecretOverrides = make(map[string]map[string]string, len(perOwner))
+		for k, m := range perOwner {
+			e.localSecretOverrides[k] = maps.Clone(m)
+		}
+		owners := make([]string, 0, len(e.localSecretOverrides))
+		for owner := range e.localSecretOverrides {
+			owners = append(owners, owner)
+		}
+		lggr.Warnw("Per-owner local secret overrides are active; vault is used for secret IDs not listed under each owner",
+			"numOwners", len(e.localSecretOverrides),
+			"owners", owners)
 	}
 }
 
@@ -914,6 +927,22 @@ func (h *eventHandler) tryEngineCreate(ctx context.Context, spec *job.WorkflowSp
 	return nil
 }
 
+func (h *eventHandler) overrideFetcherForOwner(owner string) v2.SecretsFetcher {
+	if h.localSecretOverrides == nil {
+		return nil
+	}
+	key, err := v2.LocalSecretOverrideOwnerKey(owner)
+	if err != nil {
+		h.lggr.Errorw("invalid workflow owner for local secret overrides", "owner", owner, "err", err)
+		return nil
+	}
+	m := h.localSecretOverrides[key]
+	if len(m) == 0 {
+		return nil
+	}
+	return v2.NewLocalSecretsFetcher(m)
+}
+
 // newV2EngineConfig builds the common EngineConfig shared by both the normal
 // WASM engine and the confidential engine paths. Caller supplies the module.
 func (h *eventHandler) newV2EngineConfig(
@@ -953,6 +982,7 @@ func (h *eventHandler) newV2EngineConfig(
 		WorkflowRegistryChainSelector: h.workflowRegistryChainSelector,
 		OrgResolver:                   h.orgResolver,
 		SecretsFetcher:                h.secretsFetcher,
+		OverrideFetcher:               h.overrideFetcherForOwner(owner),
 		DebugMode:                     h.debugMode,
 		SdkName:                       sdkName,
 

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -936,11 +936,11 @@ func (h *eventHandler) overrideFetcherForOwner(owner string) v2.SecretsFetcher {
 		h.lggr.Errorw("invalid workflow owner for local secret overrides", "owner", owner, "err", err)
 		return nil
 	}
-	m := h.localSecretOverrides[key]
-	if len(m) == 0 {
+	overrides := h.localSecretOverrides[key]
+	if len(overrides) == 0 {
 		return nil
 	}
-	return v2.NewLocalSecretsFetcher(m)
+	return v2.NewLocalSecretsFetcher(owner, overrides)
 }
 
 // newV2EngineConfig builds the common EngineConfig shared by both the normal

--- a/core/services/workflows/v2/config.go
+++ b/core/services/workflows/v2/config.go
@@ -39,6 +39,7 @@ type EngineConfig struct {
 	ExecutionsStore      store.Store
 	Clock                clockwork.Clock
 	SecretsFetcher       SecretsFetcher
+	OverrideFetcher      SecretsFetcher // Optional local secrets overrides
 	DonSubscriber        capabilities.DonSubscriber
 
 	WorkflowID            string // hex-encoded [32]byte, no "0x" prefix

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -973,6 +973,7 @@ func (e *Engine) secretsFetcher(phaseID string) SecretsFetcher {
 		// or the workflowID if called during trigger subscription
 		phaseID,
 		e.cfg.WorkflowEncryptionKey,
+		e.cfg.OverrideFetcher,
 	)
 }
 

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -1721,6 +1721,7 @@ func TestSecretsFetcher_Integration(t *testing.T) {
 		cfg.WorkflowID,
 		"",
 		cfg.WorkflowEncryptionKey,
+		nil,
 	)
 	cfg.SecretsFetcher = secretsFetcher
 	engine, err := v2.NewEngine(cfg)

--- a/core/services/workflows/v2/local_secrets_fetcher.go
+++ b/core/services/workflows/v2/local_secrets_fetcher.go
@@ -3,18 +3,42 @@ package v2
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 )
 
 type localSecretsFetcher struct {
-	secrets map[string]string
+	secrets      map[string]string
+	owner        string
+	callsCounter metric.Int64Counter
 }
 
-func NewLocalSecretsFetcher(secrets map[string]string) SecretsFetcher {
-	return &localSecretsFetcher{secrets: secrets}
+func NewLocalSecretsFetcher(owner string, secrets map[string]string) SecretsFetcher {
+	var callsCounter metric.Int64Counter
+	if c, err := beholder.GetMeter().Int64Counter(
+		"platform_engine_local_secrets_getsecrets_total",
+		metric.WithUnit("1"),
+		metric.WithDescription("Workflow local secrets override fetcher batch GetSecrets invocations"),
+	); err == nil {
+		callsCounter = c
+	}
+	resolvedOwner := owner
+	if n, err := normalizeOwner(owner); err == nil {
+		resolvedOwner = n
+	}
+	return &localSecretsFetcher{
+		secrets:      secrets,
+		owner:        resolvedOwner,
+		callsCounter: callsCounter,
+	}
 }
 
-func (f *localSecretsFetcher) GetSecrets(_ context.Context, request *sdkpb.GetSecretsRequest) ([]*sdkpb.SecretResponse, error) {
+func (f *localSecretsFetcher) GetSecrets(ctx context.Context, request *sdkpb.GetSecretsRequest) ([]*sdkpb.SecretResponse, error) {
+	if f.callsCounter != nil {
+		f.callsCounter.Add(ctx, 1)
+	}
 	responses := make([]*sdkpb.SecretResponse, 0, len(request.Requests))
 	for _, req := range request.Requests {
 		value, ok := f.secrets[req.Id]
@@ -22,8 +46,10 @@ func (f *localSecretsFetcher) GetSecrets(_ context.Context, request *sdkpb.GetSe
 			responses = append(responses, &sdkpb.SecretResponse{
 				Response: &sdkpb.SecretResponse_Error{
 					Error: &sdkpb.SecretError{
-						Id:    req.Id,
-						Error: "secret not found in local secrets",
+						Id:        req.Id,
+						Namespace: req.Namespace,
+						Owner:     f.owner,
+						Error:     "secret not found in local secrets",
 					},
 				},
 			})
@@ -35,6 +61,7 @@ func (f *localSecretsFetcher) GetSecrets(_ context.Context, request *sdkpb.GetSe
 				Secret: &sdkpb.Secret{
 					Id:        req.Id,
 					Namespace: req.Namespace,
+					Owner:     f.owner,
 					Value:     value,
 				},
 			},

--- a/core/services/workflows/v2/local_secrets_fetcher_test.go
+++ b/core/services/workflows/v2/local_secrets_fetcher_test.go
@@ -10,11 +10,15 @@ import (
 )
 
 func TestLocalSecretsFetcher_GetSecrets(t *testing.T) {
+	testOwner := "1234567890abcdef1234567890abcdef12345678"
+	wantOwner, err := normalizeOwner(testOwner)
+	require.NoError(t, err)
+
 	secrets := map[string]string{
 		"api-key":     "sk-abc123",
 		"db-password": "hunter2",
 	}
-	fetcher := NewLocalSecretsFetcher(secrets)
+	fetcher := NewLocalSecretsFetcher(testOwner, secrets)
 
 	t.Run("returns known secrets", func(t *testing.T) {
 		resp, err := fetcher.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
@@ -30,11 +34,13 @@ func TestLocalSecretsFetcher_GetSecrets(t *testing.T) {
 		require.NotNil(t, s0)
 		assert.Equal(t, "api-key", s0.Id)
 		assert.Equal(t, "default", s0.Namespace)
+		assert.Equal(t, wantOwner, s0.Owner)
 		assert.Equal(t, "sk-abc123", s0.Value)
 
 		s1 := resp[1].GetSecret()
 		require.NotNil(t, s1)
 		assert.Equal(t, "db-password", s1.Id)
+		assert.Equal(t, wantOwner, s1.Owner)
 		assert.Equal(t, "hunter2", s1.Value)
 	})
 
@@ -50,6 +56,7 @@ func TestLocalSecretsFetcher_GetSecrets(t *testing.T) {
 		errResp := resp[0].GetError()
 		require.NotNil(t, errResp)
 		assert.Equal(t, "nonexistent", errResp.Id)
+		assert.Equal(t, wantOwner, errResp.Owner)
 		assert.Contains(t, errResp.Error, "not found")
 	})
 
@@ -64,11 +71,13 @@ func TestLocalSecretsFetcher_GetSecrets(t *testing.T) {
 		require.Len(t, resp, 2)
 
 		assert.NotNil(t, resp[0].GetSecret())
+		assert.Equal(t, wantOwner, resp[0].GetSecret().GetOwner())
 		assert.NotNil(t, resp[1].GetError())
+		assert.Equal(t, wantOwner, resp[1].GetError().GetOwner())
 	})
 
 	t.Run("empty map returns errors for all", func(t *testing.T) {
-		emptyFetcher := NewLocalSecretsFetcher(map[string]string{})
+		emptyFetcher := NewLocalSecretsFetcher(testOwner, map[string]string{})
 		resp, err := emptyFetcher.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
 			Requests: []*sdkpb.SecretRequest{
 				{Id: "anything"},
@@ -77,5 +86,19 @@ func TestLocalSecretsFetcher_GetSecrets(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, resp, 1)
 		assert.NotNil(t, resp[0].GetError())
+		assert.Equal(t, wantOwner, resp[0].GetError().GetOwner())
+	})
+
+	t.Run("non-EVM owner is passed through", func(t *testing.T) {
+		raw := "not-an-evm-address"
+		f := NewLocalSecretsFetcher(raw, map[string]string{"k": "v"})
+		resp, err := f.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
+			Requests: []*sdkpb.SecretRequest{{Id: "k"}},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp, 1)
+		s := resp[0].GetSecret()
+		require.NotNil(t, s)
+		assert.Equal(t, raw, s.GetOwner())
 	})
 }

--- a/core/services/workflows/v2/secrets.go
+++ b/core/services/workflows/v2/secrets.go
@@ -54,8 +54,9 @@ type secretsFetcher struct {
 
 	metrics *monitoring.WorkflowsMetricLabeler
 
-	// overrideFetcher is an optional static map fetcher (e.g. NewLocalSecretsFetcher).
-	// When set, getSecretsForBatch tries it first before calling Vault.
+	// overrideFetcher is an optional static map fetcher.
+	// When set, Vault is called first; on whole-batch failure or per-secret SecretResponse errors,
+	// local overrides are tried for the failed request(s).
 	overrideFetcher SecretsFetcher
 }
 
@@ -161,56 +162,65 @@ func LocalSecretOverrideOwnerKey(owner string) (string, error) {
 	return owner, nil
 }
 
-// getSecretsForBatchWithLocalFallback tries all requests through overrideFetcher first;
-// any request not resolved locally falls through to vault.
+// getSecretsForBatchWithLocalFallback calls Vault first. If the batch fails entirely or any
+// SecretResponse carries an error, those request(s) are retried via overrideFetcher.
 func (s *secretsFetcher) getSecretsForBatchWithLocalFallback(ctx context.Context, request *sdkpb.GetSecretsRequest) ([]*sdkpb.SecretResponse, error) {
 	if s.overrideFetcher == nil {
 		return s.getVaultSecretsForBatch(ctx, request)
 	}
+	// overrideFetcher is set
 	if request == nil || len(request.Requests) == 0 {
 		return nil, nil
 	}
-	overrideResp, err := s.overrideFetcher.GetSecrets(ctx, request)
+	vaultResp, err := s.getVaultSecretsForBatch(ctx, request)
 	if err != nil {
-		return nil, err
+		s.lggr.Debugw("vault secrets batch failed, trying local override fetcher for full batch", "error", err)
+		return s.overrideFetcher.GetSecrets(ctx, request)
 	}
 
-	var forVault []*sdkpb.SecretRequest
+	var forLocal []*sdkpb.SecretRequest
+	var failedIdx []int
 	for i, r := range request.Requests {
 		ns := r.Namespace
 		if ns == "" {
 			ns = vaulttypes.DefaultNamespace
 		}
 		nsID := ns + "::" + r.Id
-		if overrideResp[i].GetError() != nil {
-			s.lggr.Debugw("failed to get secret from local override fetcher, falling back to vault", "error", overrideResp[i].GetError(), "nsID", nsID)
-			forVault = append(forVault, r)
-		} else {
-			s.lggr.Debugw("secret resolved from local override fetcher", "nsID", nsID)
+		if vaultResp[i].GetError() != nil {
+			s.lggr.Debugw("vault returned error for secret, trying local override fetcher", "error", vaultResp[i].GetError(), "nsID", nsID)
+			forLocal = append(forLocal, r)
+			failedIdx = append(failedIdx, i)
 		}
 	}
-	var vaultResp []*sdkpb.SecretResponse
-	if len(forVault) > 0 {
-		vaultResp, err = s.getVaultSecretsForBatch(ctx, &sdkpb.GetSecretsRequest{
-			Requests:   forVault,
-			CallbackId: request.CallbackId,
-		})
-		if err != nil {
-			return nil, err
-		}
+	if len(forLocal) == 0 {
+		return vaultResp, nil
 	}
 
-	combinedResp := make([]*sdkpb.SecretResponse, 0, len(request.Requests))
-	vaultRespIdx := 0
-	for i := range request.Requests {
-		if overrideResp[i].GetError() == nil {
-			combinedResp = append(combinedResp, overrideResp[i])
-		} else {
-			combinedResp = append(combinedResp, vaultResp[vaultRespIdx])
-			vaultRespIdx++
-		}
+	overrideResp, err := s.overrideFetcher.GetSecrets(ctx, &sdkpb.GetSecretsRequest{
+		Requests:   forLocal,
+		CallbackId: request.CallbackId,
+	})
+	if err != nil {
+		s.lggr.Errorw("local override fetcher failed - this should never happen", "error", err)
+		return nil, err
 	}
-	return combinedResp, nil
+
+	combined := make([]*sdkpb.SecretResponse, len(vaultResp))
+	copy(combined, vaultResp)
+	for j, origIdx := range failedIdx {
+		ns := forLocal[j].Namespace
+		if ns == "" {
+			ns = vaulttypes.DefaultNamespace
+		}
+		nsID := ns + "::" + forLocal[j].Id
+		if overrideResp[j].GetError() != nil {
+			s.lggr.Debugw("local override fetcher did not resolve secret after vault error", "error", overrideResp[j].GetError(), "nsID", nsID)
+		} else {
+			s.lggr.Debugw("secret resolved from local override fetcher after vault error", "nsID", nsID)
+		}
+		combined[origIdx] = overrideResp[j]
+	}
+	return combined, nil
 }
 
 func (s *secretsFetcher) getVaultSecretsForBatch(ctx context.Context, request *sdkpb.GetSecretsRequest) ([]*sdkpb.SecretResponse, error) {

--- a/core/services/workflows/v2/secrets.go
+++ b/core/services/workflows/v2/secrets.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
+	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/types"
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/workflowkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/monitoring"
@@ -51,6 +53,10 @@ type secretsFetcher struct {
 	workflowEncryptionKey workflowkey.Key
 
 	metrics *monitoring.WorkflowsMetricLabeler
+
+	// overrideFetcher is an optional static map fetcher (e.g. NewLocalSecretsFetcher).
+	// When set, getSecretsForBatch tries it first before calling Vault.
+	overrideFetcher SecretsFetcher
 }
 
 func NewSecretsFetcher(
@@ -66,6 +72,7 @@ func NewSecretsFetcher(
 	workflowID string,
 	phaseID string,
 	workflowEncryptionKey workflowkey.Key,
+	overrideFetcher SecretsFetcher,
 ) *secretsFetcher {
 	lggr = logger.Named(lggr, "WorkflowEngine.SecretsFetcher")
 	lggr = logger.With(lggr, "workflowID", workflowID, "workflowName", workflowName, "workflowOwner", workflowOwner, "phaseID", phaseID)
@@ -82,6 +89,7 @@ func NewSecretsFetcher(
 		phaseID:                        phaseID,
 		workflowEncryptionKey:          workflowEncryptionKey,
 		metrics:                        metrics,
+		overrideFetcher:                overrideFetcher,
 	}
 }
 
@@ -109,7 +117,7 @@ func (s *secretsFetcher) GetSecrets(ctx context.Context, request *sdkpb.GetSecre
 			return nil, err
 		}
 		defer free()
-		return s.getSecretsForBatch(ctx, request)
+		return s.getSecretsForBatchWithLocalFallback(ctx, request)
 	}()
 	getSecretsDuration := time.Since(start).Milliseconds()
 	if err != nil {
@@ -145,7 +153,70 @@ func normalizeOwner(owner string) (string, error) {
 	return common.HexToAddress(owner).Hex(), nil
 }
 
-func (s *secretsFetcher) getSecretsForBatch(ctx context.Context, request *sdkpb.GetSecretsRequest) ([]*sdkpb.SecretResponse, error) {
+func LocalSecretOverrideOwnerKey(owner string) (string, error) {
+	owner = strings.TrimPrefix(strings.ToLower(owner), "0x")
+	if err := types.ValidateWorkflowOwner(owner); err != nil {
+		return "", err
+	}
+	return owner, nil
+}
+
+// getSecretsForBatchWithLocalFallback tries all requests through overrideFetcher first;
+// any request not resolved locally falls through to vault.
+func (s *secretsFetcher) getSecretsForBatchWithLocalFallback(ctx context.Context, request *sdkpb.GetSecretsRequest) ([]*sdkpb.SecretResponse, error) {
+	if s.overrideFetcher == nil {
+		return s.getVaultSecretsForBatch(ctx, request)
+	}
+	if request == nil || len(request.Requests) == 0 {
+		return nil, nil
+	}
+	overrideResp, err := s.overrideFetcher.GetSecrets(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	var forVault []*sdkpb.SecretRequest
+	for i, r := range request.Requests {
+		ns := r.Namespace
+		if ns == "" {
+			ns = vaulttypes.DefaultNamespace
+		}
+		nsID := ns + "::" + r.Id
+		if overrideResp[i].GetError() != nil {
+			s.lggr.Debugw("failed to get secret from local override fetcher, falling back to vault", "error", overrideResp[i].GetError(), "nsID", nsID)
+			forVault = append(forVault, r)
+		} else {
+			s.lggr.Debugw("secret resolved from local override fetcher", "nsID", nsID)
+		}
+	}
+	var vaultResp []*sdkpb.SecretResponse
+	if len(forVault) > 0 {
+		vaultResp, err = s.getVaultSecretsForBatch(ctx, &sdkpb.GetSecretsRequest{
+			Requests:   forVault,
+			CallbackId: request.CallbackId,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	combinedResp := make([]*sdkpb.SecretResponse, 0, len(request.Requests))
+	vaultRespIdx := 0
+	for i := range request.Requests {
+		if overrideResp[i].GetError() == nil {
+			combinedResp = append(combinedResp, overrideResp[i])
+		} else {
+			combinedResp = append(combinedResp, vaultResp[vaultRespIdx])
+			vaultRespIdx++
+		}
+	}
+	return combinedResp, nil
+}
+
+func (s *secretsFetcher) getVaultSecretsForBatch(ctx context.Context, request *sdkpb.GetSecretsRequest) ([]*sdkpb.SecretResponse, error) {
+	if request == nil || len(request.Requests) == 0 {
+		return nil, nil
+	}
 	vaultCap, err := s.capRegistry.GetExecutable(ctx, vault.CapabilityID)
 	if err != nil {
 		return nil, errors.New("failed to get vault capability: " + err.Error())

--- a/core/services/workflows/v2/secrets_test.go
+++ b/core/services/workflows/v2/secrets_test.go
@@ -419,6 +419,7 @@ func TestSecretsFetcher_WorkflowIDMetadataFollowsOrgIDGate(t *testing.T) {
 				"workflowID",
 				"workflowExecID",
 				workflowEncryptionKey,
+				nil,
 			)
 
 			_, err = sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
@@ -542,6 +543,7 @@ func TestSecretsFetcher_RequiresOrgIDWhenGateEnabled(t *testing.T) {
 		"workflowID",
 		"workflowExecID",
 		workflowEncryptionKey,
+		nil,
 	)
 
 	_, err = sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
@@ -1027,7 +1029,7 @@ func TestSecretsFetcher_EnforcesSecretsCallsLimit(t *testing.T) {
 	require.ErrorContains(t, err, "limited: cannot use 2, limit is 1")
 }
 
-func TestSecretsFetcher_OverrideFetcherFallsBackToVaultForMissingSecrets(t *testing.T) {
+func TestSecretsFetcher_VaultFirstThenLocalOverridesForVaultFailures(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	reg := coreCap.NewRegistry(lggr)
 	peer := coreCap.RandomUTF8BytesWord()
@@ -1099,7 +1101,7 @@ func TestSecretsFetcher_OverrideFetcherFallsBackToVaultForMissingSecrets(t *test
 	err = reg.Add(t.Context(), mc)
 	require.NoError(t, err)
 
-	local := NewLocalSecretsFetcher(map[string]string{"local-only": "local-value"})
+	local := NewLocalSecretsFetcher(owner, map[string]string{"local-only": "local-value"})
 	sf := NewSecretsFetcher(
 		MetricsLabelerTest(t),
 		reg,
@@ -1127,14 +1129,18 @@ func TestSecretsFetcher_OverrideFetcherFallsBackToVaultForMissingSecrets(t *test
 	require.Len(t, resp, 2)
 
 	require.NotNil(t, gotVaultReq)
-	require.Len(t, gotVaultReq.Requests, 1)
-	require.Equal(t, "vault-only", gotVaultReq.Requests[0].GetId().GetKey())
+	require.Len(t, gotVaultReq.Requests, 2)
+	require.Equal(t, "local-only", gotVaultReq.Requests[0].GetId().GetKey())
 	require.Equal(t, vaulttypes.DefaultNamespace, gotVaultReq.Requests[0].GetId().GetNamespace())
 	require.Equal(t, normalizedOwner, gotVaultReq.Requests[0].GetId().GetOwner())
+	require.Equal(t, "vault-only", gotVaultReq.Requests[1].GetId().GetKey())
+	require.Equal(t, vaulttypes.DefaultNamespace, gotVaultReq.Requests[1].GetId().GetNamespace())
+	require.Equal(t, normalizedOwner, gotVaultReq.Requests[1].GetId().GetOwner())
 
 	localSecret := resp[0].GetSecret()
 	require.NotNil(t, localSecret)
 	require.Equal(t, "local-only", localSecret.GetId())
+	require.Equal(t, normalizedOwner, localSecret.GetOwner())
 	require.Equal(t, "local-value", localSecret.GetValue())
 
 	vaultSecret := resp[1].GetSecret()
@@ -1143,4 +1149,77 @@ func TestSecretsFetcher_OverrideFetcherFallsBackToVaultForMissingSecrets(t *test
 	require.Equal(t, vaulttypes.DefaultNamespace, vaultSecret.GetNamespace())
 	require.Equal(t, normalizedOwner, vaultSecret.GetOwner())
 	require.Equal(t, rawSecret, vaultSecret.GetValue())
+}
+
+func TestSecretsFetcher_LocalOverridesWhenVaultExecuteFails(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	reg := coreCap.NewRegistry(lggr)
+	peer := coreCap.RandomUTF8BytesWord()
+	workflowEncryptionKey := workflowkey.MustNewXXXTestingOnly(big.NewInt(1))
+
+	f, n := 2, 3
+	_, vaultPublicKey, _, err := tdh2easy.GenerateKeys(f, n)
+	require.NoError(t, err)
+	vaultPublicKeyBytes, err := vaultPublicKey.Marshal()
+	require.NoError(t, err)
+	reg.SetLocalRegistry(CreateLocalRegistryWith1Node(t, peer, workflowEncryptionKey.PublicKey(), vaultPublicKeyBytes))
+
+	var vaultCalls int
+	mc := vaultMock.Vault{
+		Fn: func(ctx context.Context, req *vault.GetSecretsRequest) (*vault.GetSecretsResponse, error) {
+			vaultCalls++
+			require.Len(t, req.Requests, 2)
+			require.Equal(t, "secret-a", req.Requests[0].GetId().GetKey())
+			require.Equal(t, "secret-b", req.Requests[1].GetId().GetKey())
+			return nil, errors.New("vault capability execute failed")
+		},
+	}
+	err = reg.Add(t.Context(), mc)
+	require.NoError(t, err)
+
+	owner := "1234567890abcdef1234567890abcdef12345678"
+	normalizedLocalOwner, err := normalizeOwner(owner)
+	require.NoError(t, err)
+	local := NewLocalSecretsFetcher(owner, map[string]string{
+		"secret-a": "value-a",
+		"secret-b": "value-b",
+	})
+	sf := NewSecretsFetcher(
+		MetricsLabelerTest(t),
+		reg,
+		lggr,
+		limits.WorkflowResourcePoolLimiter[int](5),
+		limits.NewUpperBoundLimiter[int](5),
+		testVaultOrgIDAsSecretOwnerGate(t, false),
+		"",
+		owner,
+		"workflowName",
+		"workflowID",
+		"phaseID",
+		workflowEncryptionKey,
+		local,
+	)
+
+	resp, err := sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
+		CallbackId: 7,
+		Requests: []*sdkpb.SecretRequest{
+			{Id: "secret-a"},
+			{Id: "secret-b"},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, vaultCalls)
+	require.Len(t, resp, 2)
+
+	s0 := resp[0].GetSecret()
+	require.NotNil(t, s0)
+	require.Equal(t, "secret-a", s0.GetId())
+	require.Equal(t, normalizedLocalOwner, s0.GetOwner())
+	require.Equal(t, "value-a", s0.GetValue())
+
+	s1 := resp[1].GetSecret()
+	require.NotNil(t, s1)
+	require.Equal(t, "secret-b", s1.GetId())
+	require.Equal(t, normalizedLocalOwner, s1.GetOwner())
+	require.Equal(t, "value-b", s1.GetValue())
 }

--- a/core/services/workflows/v2/secrets_test.go
+++ b/core/services/workflows/v2/secrets_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/workflowkey"
 	coreCap "github.com/smartcontractkit/chainlink/v2/core/capabilities"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 	"github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer"
@@ -222,7 +223,7 @@ func TestSecretsFetcher_BulkFetchesSecretsFromCapability(t *testing.T) {
 		reg,
 		lggr,
 		limits.WorkflowResourcePoolLimiter[int](5),
-		limits.NewBoundLimiter[int](5),
+		limits.NewUpperBoundLimiter[int](5),
 		testVaultOrgIDAsSecretOwnerGate(t, false),
 		"",
 		owner,
@@ -230,6 +231,7 @@ func TestSecretsFetcher_BulkFetchesSecretsFromCapability(t *testing.T) {
 		"workflowID",
 		"workflowExecID",
 		workflowEncryptionKey,
+		nil,
 	)
 
 	resp, err := sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
@@ -283,7 +285,7 @@ func TestSecretsFetcher_ReturnsErrorIfCapabilityNoFound(t *testing.T) {
 		reg,
 		lggr,
 		limits.WorkflowResourcePoolLimiter[int](5),
-		limits.NewBoundLimiter[int](5),
+		limits.NewUpperBoundLimiter[int](5),
 		testVaultOrgIDAsSecretOwnerGate(t, false),
 		"",
 		owner,
@@ -291,6 +293,7 @@ func TestSecretsFetcher_ReturnsErrorIfCapabilityNoFound(t *testing.T) {
 		"workflowID",
 		"workflowExecID",
 		workflowkey.MustNewXXXTestingOnly(big.NewInt(1)),
+		nil,
 	)
 
 	_, err = sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
@@ -330,7 +333,7 @@ func TestSecretsFetcher_ReturnsErrorIfCapabilityErrors(t *testing.T) {
 		reg,
 		lggr,
 		limits.WorkflowResourcePoolLimiter[int](5),
-		limits.NewBoundLimiter[int](5),
+		limits.NewUpperBoundLimiter[int](5),
 		testVaultOrgIDAsSecretOwnerGate(t, false),
 		"",
 		owner,
@@ -338,6 +341,7 @@ func TestSecretsFetcher_ReturnsErrorIfCapabilityErrors(t *testing.T) {
 		"workflowID",
 		"workflowExecID",
 		workflowkey.MustNewXXXTestingOnly(big.NewInt(1)),
+		nil,
 	)
 
 	_, err = sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
@@ -482,6 +486,7 @@ func TestSecretsFetcher_ForwardsOrgIDAndWorkflowOwner(t *testing.T) {
 		"workflowID",
 		"workflowExecID",
 		workflowEncryptionKey,
+		nil,
 	)
 
 	resp, err := sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
@@ -600,6 +605,7 @@ func TestSecretsFetcher_OmitsOrgIDAndWorkflowOwnerWhenGateDisabled(t *testing.T)
 		"workflowID",
 		"workflowExecID",
 		workflowEncryptionKey,
+		nil,
 	)
 
 	_, err = sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
@@ -646,7 +652,7 @@ func TestSecretsFetcher_ReturnsErrorIfNoResponseForRequest(t *testing.T) {
 		reg,
 		lggr,
 		limits.WorkflowResourcePoolLimiter[int](5),
-		limits.NewBoundLimiter[int](5),
+		limits.NewUpperBoundLimiter[int](5),
 		testVaultOrgIDAsSecretOwnerGate(t, false),
 		"",
 		owner,
@@ -654,6 +660,7 @@ func TestSecretsFetcher_ReturnsErrorIfNoResponseForRequest(t *testing.T) {
 		"workflowID",
 		"workflowExecID",
 		workflowkey.MustNewXXXTestingOnly(big.NewInt(1)),
+		nil,
 	)
 	resp, err := sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
 		Requests: []*sdkpb.SecretRequest{
@@ -720,7 +727,7 @@ func TestSecretsFetcher_ReturnsErrorIfMissingEncryptionSharesForNode(t *testing.
 		reg,
 		lggr,
 		limits.WorkflowResourcePoolLimiter[int](5),
-		limits.NewBoundLimiter[int](5),
+		limits.NewUpperBoundLimiter[int](5),
 		testVaultOrgIDAsSecretOwnerGate(t, false),
 		"",
 		owner,
@@ -728,6 +735,7 @@ func TestSecretsFetcher_ReturnsErrorIfMissingEncryptionSharesForNode(t *testing.
 		"workflowID",
 		"workflowExecID",
 		workflowkey.MustNewXXXTestingOnly(big.NewInt(1)),
+		nil,
 	)
 
 	resp, err := sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
@@ -822,7 +830,7 @@ func TestSecretsFetcher_ReturnsErrorIfCantCombineShares(t *testing.T) {
 		reg,
 		lggr,
 		limits.WorkflowResourcePoolLimiter[int](5),
-		limits.NewBoundLimiter[int](5),
+		limits.NewUpperBoundLimiter[int](5),
 		testVaultOrgIDAsSecretOwnerGate(t, false),
 		"",
 		owner,
@@ -830,6 +838,7 @@ func TestSecretsFetcher_ReturnsErrorIfCantCombineShares(t *testing.T) {
 		"workflowID",
 		"workflowExecID",
 		workflowEncryptionKey,
+		nil,
 	)
 
 	resp, err := sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
@@ -983,7 +992,7 @@ func TestSecretsFetcher_EnforcesSecretsCallsLimit(t *testing.T) {
 
 	semaphore := limits.WorkflowResourcePoolLimiter[int](5)
 	// bound limiter of 1 call allowed
-	secretsCallsLimit := limits.NewBoundLimiter[int](1)
+	secretsCallsLimit := limits.NewUpperBoundLimiter[int](1)
 
 	sf := NewSecretsFetcher(
 		MetricsLabelerTest(t),
@@ -998,6 +1007,7 @@ func TestSecretsFetcher_EnforcesSecretsCallsLimit(t *testing.T) {
 		"wfID",
 		"phaseID",
 		workflowkey.MustNewXXXTestingOnly(big.NewInt(1)),
+		nil,
 	)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -1015,4 +1025,122 @@ func TestSecretsFetcher_EnforcesSecretsCallsLimit(t *testing.T) {
 	// second call should fail due to exceeding the bound limiter (limit == 1)
 	_, err = sf.GetSecrets(ctx, req)
 	require.ErrorContains(t, err, "limited: cannot use 2, limit is 1")
+}
+
+func TestSecretsFetcher_OverrideFetcherFallsBackToVaultForMissingSecrets(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	reg := coreCap.NewRegistry(lggr)
+	peer := coreCap.RandomUTF8BytesWord()
+	workflowEncryptionKey := workflowkey.MustNewXXXTestingOnly(big.NewInt(1))
+	workflowKeyBytes := workflowEncryptionKey.PublicKey()
+
+	rawSecret := "vault-secret"
+	f, n := 2, 3
+	_, vaultPublicKey, privateShares, err := tdh2easy.GenerateKeys(f, n)
+	require.NoError(t, err)
+	vaultPublicKeyBytes, err := vaultPublicKey.Marshal()
+	require.NoError(t, err)
+	reg.SetLocalRegistry(CreateLocalRegistryWith1Node(t, peer, workflowEncryptionKey.PublicKey(), vaultPublicKeyBytes))
+
+	cipher, err := tdh2easy.Encrypt(vaultPublicKey, []byte(rawSecret))
+	require.NoError(t, err)
+	cipherBytes, err := cipher.Marshal()
+	require.NoError(t, err)
+
+	decryptionShare0, err := tdh2easy.Decrypt(cipher, privateShares[0])
+	require.NoError(t, err)
+	decryptionShare0Bytes, err := decryptionShare0.Marshal()
+	require.NoError(t, err)
+	decryptionShare1, err := tdh2easy.Decrypt(cipher, privateShares[1])
+	require.NoError(t, err)
+	decryptionShare1Bytes, err := decryptionShare1.Marshal()
+	require.NoError(t, err)
+
+	encryptedDecryptionShare0, err := workflowEncryptionKey.Encrypt(decryptionShare0Bytes)
+	require.NoError(t, err)
+	encryptedDecryptionShare1, err := workflowEncryptionKey.Encrypt(decryptionShare1Bytes)
+	require.NoError(t, err)
+
+	owner := "1234567890abcdef1234567890abcdef12345678"
+	normalizedOwner, err := normalizeOwner(owner)
+	require.NoError(t, err)
+
+	var gotVaultReq *vault.GetSecretsRequest
+	mc := vaultMock.Vault{
+		Fn: func(ctx context.Context, req *vault.GetSecretsRequest) (*vault.GetSecretsResponse, error) {
+			gotVaultReq = proto.Clone(req).(*vault.GetSecretsRequest)
+			return &vault.GetSecretsResponse{
+				Responses: []*vault.SecretResponse{
+					{
+						Id: &vault.SecretIdentifier{
+							Key:       "vault-only",
+							Namespace: vaulttypes.DefaultNamespace,
+							Owner:     normalizedOwner,
+						},
+						Result: &vault.SecretResponse_Data{
+							Data: &vault.SecretData{
+								EncryptedValue: hex.EncodeToString(cipherBytes),
+								EncryptedDecryptionKeyShares: []*vault.EncryptedShares{
+									{
+										Shares: []string{
+											hex.EncodeToString(encryptedDecryptionShare0),
+											hex.EncodeToString(encryptedDecryptionShare1),
+										},
+										EncryptionKey: hex.EncodeToString(workflowKeyBytes[:]),
+									},
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+	err = reg.Add(t.Context(), mc)
+	require.NoError(t, err)
+
+	local := NewLocalSecretsFetcher(map[string]string{"local-only": "local-value"})
+	sf := NewSecretsFetcher(
+		MetricsLabelerTest(t),
+		reg,
+		lggr,
+		limits.WorkflowResourcePoolLimiter[int](5),
+		limits.NewUpperBoundLimiter[int](5),
+		testVaultOrgIDAsSecretOwnerGate(t, false),
+		"",
+		owner,
+		"workflowName",
+		"workflowID",
+		"phaseID",
+		workflowEncryptionKey,
+		local,
+	)
+
+	resp, err := sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
+		CallbackId: 42,
+		Requests: []*sdkpb.SecretRequest{
+			{Id: "local-only"},
+			{Id: "vault-only"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp, 2)
+
+	require.NotNil(t, gotVaultReq)
+	require.Len(t, gotVaultReq.Requests, 1)
+	require.Equal(t, "vault-only", gotVaultReq.Requests[0].GetId().GetKey())
+	require.Equal(t, vaulttypes.DefaultNamespace, gotVaultReq.Requests[0].GetId().GetNamespace())
+	require.Equal(t, normalizedOwner, gotVaultReq.Requests[0].GetId().GetOwner())
+
+	localSecret := resp[0].GetSecret()
+	require.NotNil(t, localSecret)
+	require.Equal(t, "local-only", localSecret.GetId())
+	require.Equal(t, "local-value", localSecret.GetValue())
+
+	vaultSecret := resp[1].GetSecret()
+	require.NotNil(t, vaultSecret)
+	require.Equal(t, "vault-only", vaultSecret.GetId())
+	require.Equal(t, vaulttypes.DefaultNamespace, vaultSecret.GetNamespace())
+	require.Equal(t, normalizedOwner, vaultSecret.GetOwner())
+	require.Equal(t, rawSecret, vaultSecret.GetValue())
 }

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -212,13 +212,12 @@ ApiSecret = "streams-api-secret" # Example
 ```
 ApiSecret is the API secret used for authenticating with the CLL Data Streams SDK.
 
-## CRE.LocalSecrets
+## CRE.LocalSecretOverrides
 ```toml
-[CRE.LocalSecrets]
+[CRE.LocalSecretOverrides]
 ```
-LocalSecrets is a static map of secret ID to plaintext value.
-When non-empty, all workflow secrets are served from this map instead of calling the vault capability.
-Only use when the vault capability is not available.
+LocalSecretOverrides maps workflow owner to (secret id -> secret value) map.
+When non-empty, workflow secrets are served from this map first, before calling the Vault capability.
 
-"my-secret-id" = "my-secret-value" # Example
+"0000000000000000000000000000000000000000" = { "my-secret-id" = "my-plaintext-value" } # Example
 

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -217,7 +217,7 @@ ApiSecret is the API secret used for authenticating with the CLL Data Streams SD
 [CRE.LocalSecretOverrides]
 ```
 LocalSecretOverrides maps workflow owner to (secret id -> secret value) map.
-When non-empty, workflow secrets are served from this map first, before calling the Vault capability.
+When non-empty, overrides are used as fallback when Vault calls fail.
 
 "0000000000000000000000000000000000000000" = { "my-secret-id" = "my-plaintext-value" } # Example
 


### PR DESCRIPTION
Improve the existing local secrets override feature:
1. Overrides are now per-owner rather than global.
2. Vault is always queried first (if available) and local overrides are applied only for failed requests.