### PR TITLE
chore: bump package.json version to 2.44.2 on release/2.44.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.44.0",
+  "version": "2.44.2",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump root `package.json` **`version`** from **`2.44.0`** → **`2.44.2`** so it matches the **`release/2.44.2`** branch line.

## Motivation

`chainlink-releases` **Release (Pre)** derives **`VERSION`** from this field. With **`2.44.0`** on `release/2.44.2`, the last prerelease cut resolved to the **2.44.0** train (e.g. **`v2.44.0-beta.1`**) instead of a **2.44.2** prerelease. Aligning semver here fixes that for the next cut ([RANE-4708](https://smartcontract-it.atlassian.net/browse/RANE-4708)).

## Testing

- N/A (single-field semver alignment).

[RANE-4708]: https://smartcontract-it.atlassian.net/browse/RANE-4708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ