### PR TITLE
Rename Core E2E Tests -> CCIP v1.6 E2E Tests

### DIFF
--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -14,6 +14,7 @@ runner-test-matrix:
     runs_on: ubuntu-latest
     triggers:
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd integration-tests/smoke/ccip && \
@@ -34,6 +35,7 @@ runner-test-matrix:
     runs_on: ubuntu-latest
     triggers:
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd integration-tests/smoke/ccip && \
@@ -56,6 +58,7 @@ runner-test-matrix:
       - PR E2E CCIP v1.6 Tests
       - Merge Queue E2E CCIP v1.6 Tests
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -80,6 +83,7 @@ runner-test-matrix:
       - PR E2E CCIP v1.6 Tests
       - Merge Queue E2E CCIP v1.6 Tests
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -103,6 +107,7 @@ runner-test-matrix:
       - PR E2E CCIP v1.6 Tests
       - Merge Queue E2E CCIP v1.6 Tests
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -127,6 +132,7 @@ runner-test-matrix:
       - PR E2E CCIP v1.6 Tests
       - Merge Queue E2E CCIP v1.6 Tests
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -151,6 +157,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -175,6 +182,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -199,6 +207,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -223,6 +232,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -247,6 +257,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -271,6 +282,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -296,6 +308,7 @@ runner-test-matrix:
     triggers:
       - PR E2E CCIP v1.6 Tests
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -320,6 +333,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -344,6 +358,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -368,6 +383,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -392,6 +408,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -416,6 +433,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -441,6 +459,7 @@ runner-test-matrix:
       - PR E2E CCIP v1.6 Tests
       - Merge Queue E2E CCIP v1.6 Tests
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
@@ -465,6 +484,7 @@ runner-test-matrix:
       - PR E2E CCIP v1.6 Tests
       - Merge Queue E2E CCIP v1.6 Tests
       - Nightly E2E Tests
+      - Push E2E CCIP v1.6 Tests
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -14,8 +14,7 @@ runner-test-matrix:
     runs_on: ubuntu-latest
     triggers:
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd integration-tests/smoke/ccip && \
       gotestsum \
@@ -35,8 +34,7 @@ runner-test-matrix:
     runs_on: ubuntu-latest
     triggers:
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd integration-tests/smoke/ccip && \
       gotestsum \
@@ -55,11 +53,10 @@ runner-test-matrix:
     test_env_type: docker
     runs_on: ubuntu-latest
     triggers:
-      - PR E2E Core Tests
-      - Merge Queue E2E Core Tests
+      - PR E2E CCIP v1.6 Tests
+      - Merge Queue E2E CCIP v1.6 Tests
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -80,11 +77,10 @@ runner-test-matrix:
     test_env_type: docker
     runs_on: ubuntu-latest
     triggers:
-      - PR E2E Core Tests
-      - Merge Queue E2E Core Tests
+      - PR E2E CCIP v1.6 Tests
+      - Merge Queue E2E CCIP v1.6 Tests
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -104,11 +100,10 @@ runner-test-matrix:
     test_env_type: docker
     runs_on: ubuntu-latest
     triggers:
-      - PR E2E Core Tests
-      - Merge Queue E2E Core Tests
+      - PR E2E CCIP v1.6 Tests
+      - Merge Queue E2E CCIP v1.6 Tests
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -129,11 +124,10 @@ runner-test-matrix:
     runs_on: ubuntu24.04-16cores-64GB
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
-      - PR E2E Core Tests
-      - Merge Queue E2E Core Tests
+      - PR E2E CCIP v1.6 Tests
+      - Merge Queue E2E CCIP v1.6 Tests
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -157,7 +151,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -181,8 +175,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -206,7 +199,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -230,8 +223,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -255,7 +247,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -279,7 +271,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -302,10 +294,9 @@ runner-test-matrix:
     runs_on: ubuntu24.04-16cores-64GB
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
-      - PR E2E Core Tests
+      - PR E2E CCIP v1.6 Tests
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -329,8 +320,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -354,7 +344,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -378,7 +368,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -402,7 +392,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -426,8 +416,7 @@ runner-test-matrix:
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -449,11 +438,10 @@ runner-test-matrix:
     test_env_type: docker
     runs_on: ubuntu-latest
     triggers:
-      - PR E2E Core Tests
-      - Merge Queue E2E Core Tests
+      - PR E2E CCIP v1.6 Tests
+      - Merge Queue E2E CCIP v1.6 Tests
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -474,11 +462,10 @@ runner-test-matrix:
     test_env_type: docker
     runs_on: ubuntu-latest
     triggers:
-      - PR E2E Core Tests
-      - Merge Queue E2E Core Tests
+      - PR E2E CCIP v1.6 Tests
+      - Merge Queue E2E CCIP v1.6 Tests
       - Nightly E2E Tests
-      - Push E2E CCIP Tests
-      - Workflow Dispatch E2E CCIP Tests
+      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -530,7 +530,7 @@ jobs:
           echo "Core e2e test results:"
           echo "$results" | jq .
 
-          node_migration_tests_failed=$(echo $results | jq '[.[] | select(.id == "integration-tests/migration/upgrade_version_test.go:*" ) | select(.result != "success")] | length > 0')
+          node_migration_tests_failed=$(echo "$results" | jq '[.[] | select(.id == "integration-tests/migration/upgrade_version_test.go:*" ) | select(.result != "success")] | length > 0')
           echo "node_migration_tests_failed=$node_migration_tests_failed" | tee -a "$GITHUB_OUTPUT"
 
       - name: Fail the job if CCIP v1.6 E2E tests were not successful

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -430,7 +430,7 @@ jobs:
           RUN_E2E_TESTS_LABEL_FOUND: ${{ needs.labels.outputs.run-e2e-tests-label-found || 'false' }}
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == 'pull_request' ]]; then
-            # Run Core E2E tests on PRs only if the label "run-e2e-tests" is present, and there are relevant changes
+            # Run CCIP v1.6 E2E Tests on PRs only if the label "run-e2e-tests" is present, and there are relevant changes
             echo "workflow-name=Run CCIP v1.6 E2E Tests For PR" | tee -a "$GITHUB_OUTPUT"
             echo "test-trigger=PR E2E CCIP v1.6 Tests" | tee -a "$GITHUB_OUTPUT"
 
@@ -440,19 +440,19 @@ jobs:
             fi
 
           elif [[ "${GITHUB_EVENT_NAME}" == 'merge_group' ]]; then
-            # Run Core E2E tests in the merge queue, if there are relevant changes
+            # Run CCIP v1.6 E2E Tests in the merge queue, if there are relevant changes
             echo "workflow-name=Run CCIP v1.6 E2E Tests For Merge Queue" | tee -a "$GITHUB_OUTPUT"
             echo "test-trigger=Merge Queue E2E CCIP v1.6 Tests" | tee -a "$GITHUB_OUTPUT"
             echo "should-run=${CONTAINS_CHANGES}" | tee -a "$GITHUB_OUTPUT"
 
           elif [[ "${GITHUB_EVENT_NAME}" == 'workflow_dispatch' ]]; then
-            # Always run Core E2E tests on workflow dispatch
+            # Always Run CCIP v1.6 E2E Tests on workflow dispatch
             echo "workflow-name=Run CCIP v1.6 E2E Tests For Workflow Dispatch" | tee -a "$GITHUB_OUTPUT"
             echo "test-trigger=Workflow Dispatch E2E CCIP v1.6 Tests" | tee -a "$GITHUB_OUTPUT"
             echo "should-run=true" | tee -a "$GITHUB_OUTPUT"
 
           elif [[ "${GITHUB_EVENT_NAME}" == 'push' ]]; then
-            # Run Core E2E tests on push events, only if there are relevant changes or if it's a tag push
+            # Run CCIP v1.6 E2E Tests on push events, only if there are relevant changes or if it's a tag push
             echo "workflow-name=Run CCIP v1.6 E2E Tests For Push" | tee -a "$GITHUB_OUTPUT"
             echo "test-trigger=Push E2E CCIP v1.6 Tests" | tee -a "$GITHUB_OUTPUT"
             if [[ "${CONTAINS_CHANGES}" == 'true' || "${GITHUB_REF_TYPE}" == 'tag' ]]; then
@@ -522,7 +522,7 @@ jobs:
       ]
     steps:
       - name: Check Core test results
-        id: check_core_results
+        id: check_ccip_v1_6_results
         env:
           TEST_RESULTS: ${{ needs.run-ccip-v1-6-e2e-tests.outputs.test_results }}
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -521,17 +521,14 @@ jobs:
         run-core-cre-e2e-regression-tests,
       ]
     steps:
-      - name: Check Core test results
+      - name: Check CCIP v1.6 E2E test results
         id: check_ccip_v1_6_results
         env:
           TEST_RESULTS: ${{ needs.run-ccip-v1-6-e2e-tests.outputs.test_results }}
         run: |
           results="$TEST_RESULTS"
-          echo "Core e2e test results:"
+          echo "CCIP v1.6 E2E test results:"
           echo "$results" | jq .
-
-          node_migration_tests_failed=$(echo "$results" | jq '[.[] | select(.id == "integration-tests/migration/upgrade_version_test.go:*" ) | select(.result != "success")] | length > 0')
-          echo "node_migration_tests_failed=$node_migration_tests_failed" | tee -a "$GITHUB_OUTPUT"
 
       - name: Fail the job if CCIP v1.6 E2E tests were not successful
         if: always()
@@ -619,7 +616,7 @@ jobs:
             echo "should-run-solana-tests=false" | tee -a "$GITHUB_OUTPUT"
 
           elif [[ "${GITHUB_EVENT_NAME}" == 'pull_request' ]]; then
-            # Run Solana tests on PRs only if the label "run-e2e-tests" is present, and there are relevant changes
+            # Run Solana tests on PRs only if the label "run-e2e-tests" is present or if there are relevant changes
             if [[ "${RUN_E2E_TESTS_LABEL_FOUND}" == 'true' && "${CONTAINS_CHANGES}" == 'true' ]]; then
               echo "Solana tests will run on PR with label and relevant changes."
               echo "should-run-solana-tests=true" | tee -a "$GITHUB_OUTPUT"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,12 +1,11 @@
 # N/B: ci-core, which runs on PRs, will trigger linting for affected directories/modules
 # no need to run lint twice
 name: Integration Tests
-run-name: Integration Tests ${{ inputs.distinct_run_name &&
-  inputs.distinct_run_name || '' }}
+run-name: Integration Tests ${{ inputs.distinct_run_name && inputs.distinct_run_name || '' }}
 on:
   merge_group:
   pull_request:
-    types: [ opened, synchronize, reopened, labeled ]
+    types: [opened, synchronize, reopened, labeled]
   push:
     tags:
       - "*"
@@ -32,27 +31,20 @@ on:
         required: false
         type: string
       ecr_name:
-        description: "The name of the ECR repository to push the image to, defaults to
-          'chainlink'"
+        description: "The name of the ECR repository to push the image to, defaults to 'chainlink'"
         required: false
         type: string
         default: "chainlink"
 
 # Only run 1 of this workflow at a time per PR, but don't cancel runs on develop
 concurrency:
-  group: ${{ github.ref != 'refs/heads/develop' &&
-    format('{0}-{1}-{2}-e2e-tests-{3}', github.ref, github.repository,
-    github.event_name, inputs.distinct_run_name) || github.sha }}
+  group: ${{ github.ref != 'refs/heads/develop' && format('{0}-{1}-{2}-e2e-tests-{3}', github.ref, github.repository, github.event_name, inputs.distinct_run_name) || github.sha }}
   cancel-in-progress: true
 
 env:
   # for run-test variables and environment
-  ENV_JOB_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
-    secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests:${{ inputs.evm-ref ||
-    github.sha }}
-  CHAINLINK_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
-    secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name ||
-    'chainlink-integration-tests' }}
+  ENV_JOB_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests:${{ inputs.evm-ref || github.sha }}
+  CHAINLINK_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name || 'chainlink-integration-tests' }}
   CHAINLINK_REF: ${{ inputs.cl_ref || github.sha }}
   TEST_SUITE: smoke
   MOD_CACHE_VERSION: 2
@@ -150,17 +142,12 @@ jobs:
       contents: read
       pull-requests: write
     outputs:
-      builder-runner-label-core: ${{
-        steps.runner-labels.outputs.builder-runner-label-core ||
-        steps.runner-labels.outputs.builder-runner-label }}
-      builder-runner-label-plugins: ${{
-        steps.runner-labels.outputs.builder-runner-label-plugins ||
-        steps.runner-labels.outputs.builder-runner-label }}
+      builder-runner-label-core: ${{ steps.runner-labels.outputs.builder-runner-label-core || steps.runner-labels.outputs.builder-runner-label }}
+      builder-runner-label-plugins: ${{ steps.runner-labels.outputs.builder-runner-label-plugins || steps.runner-labels.outputs.builder-runner-label }}
       solana-runner-label: ${{ steps.runner-labels.outputs.solana-runner-label }}
       should-use-self-hosted-runners: ${{ steps.label-runs-on-opt-out.outputs.check-label-found == 'false' }}
       run-e2e-tests-label-found: ${{ steps.label-runs-e2e-tests.outputs.check-label-found || 'false' }}
-      skip-e2e-regression-label-found: ${{
-        steps.label-skip-e2e-regression.outputs.check-label-found || 'false' }}
+      skip-e2e-regression-label-found: ${{ steps.label-skip-e2e-regression.outputs.check-label-found || 'false' }}
     steps:
       - name: Get PR Labels (runs-on-opt-out)
         id: label-runs-on-opt-out
@@ -189,12 +176,9 @@ jobs:
           GH_BUILDER_RUNNER: ubuntu22.04-8cores-32GB
           GH_SOLANA_RUNNER: ubuntu22.04-8cores-32GB
           # include unique label (core/plugins/solana) to ensure jobs are not competing for the same runner
-          SH_BUILDER_RUNNER_CORE: runs-on=${{ github.run_id
-            }}-core/cpu=32+36/memory=64+72/family=c6i+c7i+c5.*/extras=s3-cache+tmpfs
-          SH_BUILDER_RUNNER_PLUGINS: runs-on=${{ github.run_id
-            }}-plugins/cpu=32+36/memory=64+72/family=c6i+c7i+c5.*/extras=s3-cache+tmpfs
-          SH_SOLANA_RUNNER: runs-on=${{ github.run_id
-            }}-solana/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+          SH_BUILDER_RUNNER_CORE: runs-on=${{ github.run_id }}-core/cpu=32+36/memory=64+72/family=c6i+c7i+c5.*/extras=s3-cache+tmpfs
+          SH_BUILDER_RUNNER_PLUGINS: runs-on=${{ github.run_id }}-plugins/cpu=32+36/memory=64+72/family=c6i+c7i+c5.*/extras=s3-cache+tmpfs
+          SH_SOLANA_RUNNER: runs-on=${{ github.run_id }}-solana/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
         run: |
           if [[ "${OPT_OUT}" == "true" ]]; then
             echo "builder-runner-label=${GH_BUILDER_RUNNER}" | tee -a "$GITHUB_OUTPUT"
@@ -228,8 +212,7 @@ jobs:
       matrix:
         image:
           - name: ""
-            runner: ${{ needs.labels.outputs.builder-runner-label-core ||
-              'ubuntu22.04-8cores-32GB' }}
+            runner: ${{ needs.labels.outputs.builder-runner-label-core || 'ubuntu22.04-8cores-32GB' }}
             dockerfile: core/chainlink.Dockerfile
             tag-suffix: ""
             cache-scope: core
@@ -242,8 +225,7 @@ jobs:
               }}
 
           - name: (plugins)
-            runner: ${{ needs.labels.outputs.builder-runner-label-plugins ||
-              'ubuntu22.04-8cores-32GB' }}
+            runner: ${{ needs.labels.outputs.builder-runner-label-plugins || 'ubuntu22.04-8cores-32GB' }}
             dockerfile: plugins/chainlink.Dockerfile
             tag-suffix: -plugins
             cache-scope: plugins
@@ -282,7 +264,7 @@ jobs:
           elif [[ "${ANY_SHOULD_RUN}" == "true" && "${IMAGE_EXISTS}" != "true" ]]; then
             echo "We will build the image because the matrix's any-should-run is true and the image does not already exist in ECR."
             echo "any-should-run is true when:"
-            echo "  - For the non-plugins image: the core tests or solana tests will be run."
+            echo "  - For the non-plugins image: the CCIP v1.6 tests or solana tests will be run."
             echo "  - For the plugins image: the core cre e2e tests will be run."
 
             echo "build-image=true" | tee -a "$GITHUB_OUTPUT"
@@ -303,11 +285,9 @@ jobs:
         if: steps.explain.outputs.build-image == 'true'
         uses: smartcontractkit/.github/actions/ctf-build-image@ctf-build-image/v1
         with:
-          image-tag: ${{ inputs.evm-ref || env.CHAINLINK_REF }}${{ matrix.image.tag-suffix
-            }}
+          image-tag: ${{ inputs.evm-ref || env.CHAINLINK_REF }}${{ matrix.image.tag-suffix }}
           dockerfile: ${{ matrix.image.dockerfile }}
-          docker-registry-url: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
-            secrets.QA_AWS_REGION }}.amazonaws.com
+          docker-registry-url: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com
           docker-repository-name: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
           aws-account-number: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
@@ -316,8 +296,7 @@ jobs:
             CL_IS_PROD_BUILD=false
           # go-get-overrides is empty when inputs.evm-ref is unset so ctf-build-image skips an unnecessary setup-go / go mod tidy.
           go-get-overrides: >-
-            ${{ inputs.evm-ref && format('chainlink-evm={0}', inputs.evm-ref) ||
-            '' }}
+            ${{ inputs.evm-ref && format('chainlink-evm={0}', inputs.evm-ref) || '' }}
           gati-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           gati-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
           cache-scope: ${{ matrix.image.cache-scope }}
@@ -325,7 +304,7 @@ jobs:
   run-core-cre-e2e-tests-setup:
     name: Run Core CRE E2E Tests Setup
     runs-on: ubuntu-latest
-    needs: [ changes, labels ]
+    needs: [changes, labels]
     permissions:
       contents: read
     outputs:
@@ -337,8 +316,7 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_TYPE: ${{ github.ref_type }}
-          CONTAINS_CHANGES: ${{ needs.changes.outputs.general-changes == 'true' ||
-            needs.changes.outputs.cre-changes == 'true' }}
+          CONTAINS_CHANGES: ${{ needs.changes.outputs.general-changes == 'true' || needs.changes.outputs.cre-changes == 'true' }}
           RUN_E2E_TESTS_LABEL_FOUND: ${{ needs.labels.outputs.run-e2e-tests-label-found }}
         run: |
           SHOULD_RUN="false"
@@ -398,7 +376,7 @@ jobs:
 
   run-core-cre-e2e-tests:
     name: Run Core CRE E2E Tests
-    needs: [ build-chainlink, run-core-cre-e2e-tests-setup ]
+    needs: [build-chainlink, run-core-cre-e2e-tests-setup]
     permissions:
       actions: read
       checks: write
@@ -411,36 +389,31 @@ jobs:
       ecr: "sdlc"
       chainlink_image_repository_path: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
-      chainlink_image_tag: ${{ inputs.evm-ref && format('{0}', inputs.evm-ref) ||
-        inputs.cl_ref && format('{0}', inputs.cl_ref) || format('{0}',
-        github.sha) }}
+      chainlink_image_tag: ${{ inputs.evm-ref && format('{0}', inputs.evm-ref) || inputs.cl_ref && format('{0}', inputs.cl_ref) || format('{0}', github.sha) }}
     secrets: inherit
 
   run-core-cre-e2e-regression-tests:
     name: Run Core CRE E2E Regression Tests
-    needs: [ build-chainlink, run-core-cre-e2e-tests-setup ]
+    needs: [build-chainlink, run-core-cre-e2e-tests-setup]
     permissions:
       actions: read
       checks: write
       pull-requests: write
       id-token: write
       contents: read
-    if: needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true' &&
-      needs.run-core-cre-e2e-tests-setup.outputs.with-regression == 'true'
+    if: needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true' && needs.run-core-cre-e2e-tests-setup.outputs.with-regression == 'true'
     uses: ./.github/workflows/cre-regression-system-tests.yaml
     with:
       ecr: "sdlc"
       chainlink_image_repository_path: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
-      chainlink_image_tag: ${{ inputs.evm-ref && format('{0}', inputs.evm-ref) ||
-        inputs.cl_ref && format('{0}', inputs.cl_ref) || format('{0}',
-        github.sha) }}
+      chainlink_image_tag: ${{ inputs.evm-ref && format('{0}', inputs.evm-ref) || inputs.cl_ref && format('{0}', inputs.cl_ref) || format('{0}', github.sha) }}
     secrets: inherit
 
   run-ccip-v1-6-e2e-tests-setup:
     name: Run CCIP v1.6 E2E Tests Setup
     runs-on: ubuntu-latest
-    needs: [ changes, labels ]
+    needs: [changes, labels]
     permissions:
       contents: read
     outputs:
@@ -453,8 +426,7 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_TYPE: ${{ github.ref_type }}
-          CONTAINS_CHANGES: ${{ needs.changes.outputs.general-changes == 'true' ||
-            needs.changes.outputs.core-changes == 'true' }}
+          CONTAINS_CHANGES: ${{ needs.changes.outputs.general-changes == 'true' || needs.changes.outputs.core-changes == 'true' }}
           RUN_E2E_TESTS_LABEL_FOUND: ${{ needs.labels.outputs.run-e2e-tests-label-found || 'false' }}
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == 'pull_request' ]]; then
@@ -494,7 +466,7 @@ jobs:
           fi
 
   run-ccip-v1-6-e2e-tests:
-    needs: [ run-ccip-v1-6-e2e-tests-setup, build-chainlink, changes, labels ]
+    needs: [run-ccip-v1-6-e2e-tests-setup, build-chainlink, changes, labels]
     name: ${{ needs.run-ccip-v1-6-e2e-tests-setup.outputs.workflow-name }}
     permissions:
       actions: read
@@ -510,9 +482,7 @@ jobs:
       test_path: .github/e2e-tests.yml
       test_trigger: ${{ needs.run-ccip-v1-6-e2e-tests-setup.outputs.test-trigger }}
       upload_cl_node_coverage_artifact: true
-      enable_otel_traces_for_ocr2_plugins: ${{
-        contains(join(github.event.pull_request.labels.*.name, ' '), 'enable
-        tracing') }}
+      enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
       use-self-hosted-runners: ${{ needs.labels.outputs.should-use-self-hosted-runners }}
       ecr_name: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
       quarantine: "true"
@@ -629,7 +599,7 @@ jobs:
     # We don't directly merge dependabot PRs, so let's not waste the resources
     if: ${{ github.actor != 'dependabot[bot]'  }}
     runs-on: ubuntu-latest
-    needs: [ changes, labels ]
+    needs: [changes, labels]
     permissions:
       contents: read
     outputs:
@@ -640,8 +610,7 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_TYPE: ${{ github.ref_type }}
-          CONTAINS_CHANGES: ${{ needs.changes.outputs.general-changes == 'true' ||
-            needs.changes.outputs.core-changes == 'true' }}
+          CONTAINS_CHANGES: ${{ needs.changes.outputs.general-changes == 'true' || needs.changes.outputs.core-changes == 'true' }}
           RUN_E2E_TESTS_LABEL_FOUND: ${{ needs.labels.outputs.run-e2e-tests-label-found || 'false' }}
           INPUTS_RUN_SOLANA: ${{ inputs.run_solana }}
         run: |
@@ -686,7 +655,7 @@ jobs:
       name: integration
       deployment: false
     runs-on: ubuntu-latest
-    needs: [ solana-smoke-tests-setup ]
+    needs: [solana-smoke-tests-setup]
     permissions:
       contents: read
     outputs:
@@ -739,7 +708,7 @@ jobs:
 
   run-solana-smoke-tests:
     name: Run Solana Smoke Tests
-    needs: [ build-chainlink, get-solana-sha, solana-smoke-tests-setup ]
+    needs: [build-chainlink, get-solana-sha, solana-smoke-tests-setup]
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,11 +1,12 @@
 # N/B: ci-core, which runs on PRs, will trigger linting for affected directories/modules
 # no need to run lint twice
 name: Integration Tests
-run-name: Integration Tests ${{ inputs.distinct_run_name && inputs.distinct_run_name || '' }}
+run-name: Integration Tests ${{ inputs.distinct_run_name &&
+  inputs.distinct_run_name || '' }}
 on:
   merge_group:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [ opened, synchronize, reopened, labeled ]
   push:
     tags:
       - "*"
@@ -31,20 +32,27 @@ on:
         required: false
         type: string
       ecr_name:
-        description: "The name of the ECR repository to push the image to, defaults to 'chainlink'"
+        description: "The name of the ECR repository to push the image to, defaults to
+          'chainlink'"
         required: false
         type: string
         default: "chainlink"
 
 # Only run 1 of this workflow at a time per PR, but don't cancel runs on develop
 concurrency:
-  group: ${{ github.ref != 'refs/heads/develop' && format('{0}-{1}-{2}-e2e-tests-{3}', github.ref, github.repository, github.event_name, inputs.distinct_run_name) || github.sha }}
+  group: ${{ github.ref != 'refs/heads/develop' &&
+    format('{0}-{1}-{2}-e2e-tests-{3}', github.ref, github.repository,
+    github.event_name, inputs.distinct_run_name) || github.sha }}
   cancel-in-progress: true
 
 env:
   # for run-test variables and environment
-  ENV_JOB_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests:${{ inputs.evm-ref || github.sha }}
-  CHAINLINK_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name || 'chainlink-integration-tests' }}
+  ENV_JOB_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
+    secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests:${{ inputs.evm-ref ||
+    github.sha }}
+  CHAINLINK_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
+    secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name ||
+    'chainlink-integration-tests' }}
   CHAINLINK_REF: ${{ inputs.cl_ref || github.sha }}
   TEST_SUITE: smoke
   MOD_CACHE_VERSION: 2
@@ -99,7 +107,6 @@ jobs:
       general-changes: ${{ steps.changes.outputs.general_changes }}
       core-changes: ${{ steps.changes.outputs.core_changes }}
       cre-changes: ${{ steps.changes.outputs.cre_changes }}
-      ccip-changes: ${{ steps.changes.outputs.ccip_changes }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v6
@@ -134,9 +141,6 @@ jobs:
               - 'system-tests/**'
               - 'plugins/plugins.private.yaml'
               - 'plugins/plugins.public.yaml'
-            ccip_changes:
-              - '**/*ccip*'
-              - '**/*ccip*/**'
 
   labels:
     name: Get PR labels and set runner labels
@@ -146,12 +150,17 @@ jobs:
       contents: read
       pull-requests: write
     outputs:
-      builder-runner-label-core: ${{ steps.runner-labels.outputs.builder-runner-label-core || steps.runner-labels.outputs.builder-runner-label }}
-      builder-runner-label-plugins: ${{ steps.runner-labels.outputs.builder-runner-label-plugins || steps.runner-labels.outputs.builder-runner-label }}
+      builder-runner-label-core: ${{
+        steps.runner-labels.outputs.builder-runner-label-core ||
+        steps.runner-labels.outputs.builder-runner-label }}
+      builder-runner-label-plugins: ${{
+        steps.runner-labels.outputs.builder-runner-label-plugins ||
+        steps.runner-labels.outputs.builder-runner-label }}
       solana-runner-label: ${{ steps.runner-labels.outputs.solana-runner-label }}
       should-use-self-hosted-runners: ${{ steps.label-runs-on-opt-out.outputs.check-label-found == 'false' }}
       run-e2e-tests-label-found: ${{ steps.label-runs-e2e-tests.outputs.check-label-found || 'false' }}
-      skip-e2e-regression-label-found: ${{ steps.label-skip-e2e-regression.outputs.check-label-found || 'false' }}
+      skip-e2e-regression-label-found: ${{
+        steps.label-skip-e2e-regression.outputs.check-label-found || 'false' }}
     steps:
       - name: Get PR Labels (runs-on-opt-out)
         id: label-runs-on-opt-out
@@ -180,9 +189,12 @@ jobs:
           GH_BUILDER_RUNNER: ubuntu22.04-8cores-32GB
           GH_SOLANA_RUNNER: ubuntu22.04-8cores-32GB
           # include unique label (core/plugins/solana) to ensure jobs are not competing for the same runner
-          SH_BUILDER_RUNNER_CORE: runs-on=${{ github.run_id }}-core/cpu=32+36/memory=64+72/family=c6i+c7i+c5.*/extras=s3-cache+tmpfs
-          SH_BUILDER_RUNNER_PLUGINS: runs-on=${{ github.run_id }}-plugins/cpu=32+36/memory=64+72/family=c6i+c7i+c5.*/extras=s3-cache+tmpfs
-          SH_SOLANA_RUNNER: runs-on=${{ github.run_id }}-solana/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+          SH_BUILDER_RUNNER_CORE: runs-on=${{ github.run_id
+            }}-core/cpu=32+36/memory=64+72/family=c6i+c7i+c5.*/extras=s3-cache+tmpfs
+          SH_BUILDER_RUNNER_PLUGINS: runs-on=${{ github.run_id
+            }}-plugins/cpu=32+36/memory=64+72/family=c6i+c7i+c5.*/extras=s3-cache+tmpfs
+          SH_SOLANA_RUNNER: runs-on=${{ github.run_id
+            }}-solana/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
         run: |
           if [[ "${OPT_OUT}" == "true" ]]; then
             echo "builder-runner-label=${GH_BUILDER_RUNNER}" | tee -a "$GITHUB_OUTPUT"
@@ -207,7 +219,6 @@ jobs:
         enforce-ctf-version,
         run-core-cre-e2e-tests-setup,
         run-core-e2e-tests-setup,
-        run-ccip-e2e-tests-setup,
         solana-smoke-tests-setup,
       ]
     permissions:
@@ -217,7 +228,8 @@ jobs:
       matrix:
         image:
           - name: ""
-            runner: ${{ needs.labels.outputs.builder-runner-label-core || 'ubuntu22.04-8cores-32GB' }}
+            runner: ${{ needs.labels.outputs.builder-runner-label-core ||
+              'ubuntu22.04-8cores-32GB' }}
             dockerfile: core/chainlink.Dockerfile
             tag-suffix: ""
             cache-scope: core
@@ -225,13 +237,13 @@ jobs:
             any-should-run: >-
               ${{
                 needs.run-core-e2e-tests-setup.outputs.should-run == 'true' ||
-                needs.run-ccip-e2e-tests-setup.outputs.should-run == 'true' ||
                 needs.solana-smoke-tests-setup.outputs.should-run-solana-tests == 'true' ||
                 needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'
               }}
 
           - name: (plugins)
-            runner: ${{ needs.labels.outputs.builder-runner-label-plugins || 'ubuntu22.04-8cores-32GB' }}
+            runner: ${{ needs.labels.outputs.builder-runner-label-plugins ||
+              'ubuntu22.04-8cores-32GB' }}
             dockerfile: plugins/chainlink.Dockerfile
             tag-suffix: -plugins
             cache-scope: plugins
@@ -239,7 +251,6 @@ jobs:
             any-should-run: >-
               ${{
                 needs.run-core-e2e-tests-setup.outputs.should-run == 'true' ||
-                needs.run-ccip-e2e-tests-setup.outputs.should-run == 'true' ||
                 needs.solana-smoke-tests-setup.outputs.should-run-solana-tests == 'true' ||
                 needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'
               }}
@@ -271,7 +282,7 @@ jobs:
           elif [[ "${ANY_SHOULD_RUN}" == "true" && "${IMAGE_EXISTS}" != "true" ]]; then
             echo "We will build the image because the matrix's any-should-run is true and the image does not already exist in ECR."
             echo "any-should-run is true when:"
-            echo "  - For the non-plugins image: the core tests, ccip tests, or solana tests will be run."
+            echo "  - For the non-plugins image: the core tests or solana tests will be run."
             echo "  - For the plugins image: the core cre e2e tests will be run."
 
             echo "build-image=true" | tee -a "$GITHUB_OUTPUT"
@@ -292,9 +303,11 @@ jobs:
         if: steps.explain.outputs.build-image == 'true'
         uses: smartcontractkit/.github/actions/ctf-build-image@ctf-build-image/v1
         with:
-          image-tag: ${{ inputs.evm-ref || env.CHAINLINK_REF }}${{ matrix.image.tag-suffix }}
+          image-tag: ${{ inputs.evm-ref || env.CHAINLINK_REF }}${{ matrix.image.tag-suffix
+            }}
           dockerfile: ${{ matrix.image.dockerfile }}
-          docker-registry-url: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com
+          docker-registry-url: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
+            secrets.QA_AWS_REGION }}.amazonaws.com
           docker-repository-name: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
           aws-account-number: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
@@ -303,7 +316,8 @@ jobs:
             CL_IS_PROD_BUILD=false
           # go-get-overrides is empty when inputs.evm-ref is unset so ctf-build-image skips an unnecessary setup-go / go mod tidy.
           go-get-overrides: >-
-            ${{ inputs.evm-ref && format('chainlink-evm={0}', inputs.evm-ref) || '' }}
+            ${{ inputs.evm-ref && format('chainlink-evm={0}', inputs.evm-ref) ||
+            '' }}
           gati-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           gati-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
           cache-scope: ${{ matrix.image.cache-scope }}
@@ -311,7 +325,7 @@ jobs:
   run-core-cre-e2e-tests-setup:
     name: Run Core CRE E2E Tests Setup
     runs-on: ubuntu-latest
-    needs: [changes, labels]
+    needs: [ changes, labels ]
     permissions:
       contents: read
     outputs:
@@ -323,7 +337,8 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_TYPE: ${{ github.ref_type }}
-          CONTAINS_CHANGES: ${{ needs.changes.outputs.general-changes == 'true' || needs.changes.outputs.cre-changes == 'true' }}
+          CONTAINS_CHANGES: ${{ needs.changes.outputs.general-changes == 'true' ||
+            needs.changes.outputs.cre-changes == 'true' }}
           RUN_E2E_TESTS_LABEL_FOUND: ${{ needs.labels.outputs.run-e2e-tests-label-found }}
         run: |
           SHOULD_RUN="false"
@@ -383,7 +398,7 @@ jobs:
 
   run-core-cre-e2e-tests:
     name: Run Core CRE E2E Tests
-    needs: [build-chainlink, run-core-cre-e2e-tests-setup]
+    needs: [ build-chainlink, run-core-cre-e2e-tests-setup ]
     permissions:
       actions: read
       checks: write
@@ -396,31 +411,36 @@ jobs:
       ecr: "sdlc"
       chainlink_image_repository_path: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
-      chainlink_image_tag: ${{ inputs.evm-ref && format('{0}', inputs.evm-ref) || inputs.cl_ref && format('{0}', inputs.cl_ref) || format('{0}', github.sha) }}
+      chainlink_image_tag: ${{ inputs.evm-ref && format('{0}', inputs.evm-ref) ||
+        inputs.cl_ref && format('{0}', inputs.cl_ref) || format('{0}',
+        github.sha) }}
     secrets: inherit
 
   run-core-cre-e2e-regression-tests:
     name: Run Core CRE E2E Regression Tests
-    needs: [build-chainlink, run-core-cre-e2e-tests-setup]
+    needs: [ build-chainlink, run-core-cre-e2e-tests-setup ]
     permissions:
       actions: read
       checks: write
       pull-requests: write
       id-token: write
       contents: read
-    if: needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true' && needs.run-core-cre-e2e-tests-setup.outputs.with-regression == 'true'
+    if: needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true' &&
+      needs.run-core-cre-e2e-tests-setup.outputs.with-regression == 'true'
     uses: ./.github/workflows/cre-regression-system-tests.yaml
     with:
       ecr: "sdlc"
       chainlink_image_repository_path: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
-      chainlink_image_tag: ${{ inputs.evm-ref && format('{0}', inputs.evm-ref) || inputs.cl_ref && format('{0}', inputs.cl_ref) || format('{0}', github.sha) }}
+      chainlink_image_tag: ${{ inputs.evm-ref && format('{0}', inputs.evm-ref) ||
+        inputs.cl_ref && format('{0}', inputs.cl_ref) || format('{0}',
+        github.sha) }}
     secrets: inherit
 
   run-core-e2e-tests-setup:
     name: Run Core E2E Tests Setup
     runs-on: ubuntu-latest
-    needs: [changes, labels]
+    needs: [ changes, labels ]
     permissions:
       contents: read
     outputs:
@@ -433,7 +453,8 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_TYPE: ${{ github.ref_type }}
-          CONTAINS_CHANGES: ${{ needs.changes.outputs.general-changes == 'true' || needs.changes.outputs.core-changes == 'true' }}
+          CONTAINS_CHANGES: ${{ needs.changes.outputs.general-changes == 'true' ||
+            needs.changes.outputs.core-changes == 'true' }}
           RUN_E2E_TESTS_LABEL_FOUND: ${{ needs.labels.outputs.run-e2e-tests-label-found || 'false' }}
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == 'pull_request' ]]; then
@@ -473,7 +494,7 @@ jobs:
           fi
 
   run-core-e2e-tests:
-    needs: [run-core-e2e-tests-setup, build-chainlink, changes, labels]
+    needs: [ run-core-e2e-tests-setup, build-chainlink, changes, labels ]
     name: ${{ needs.run-core-e2e-tests-setup.outputs.workflow-name }}
     permissions:
       actions: read
@@ -489,7 +510,9 @@ jobs:
       test_path: .github/e2e-tests.yml
       test_trigger: ${{ needs.run-core-e2e-tests-setup.outputs.test-trigger }}
       upload_cl_node_coverage_artifact: true
-      enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
+      enable_otel_traces_for_ocr2_plugins: ${{
+        contains(join(github.event.pull_request.labels.*.name, ' '), 'enable
+        tracing') }}
       use-self-hosted-runners: ${{ needs.labels.outputs.should-use-self-hosted-runners }}
       ecr_name: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
       quarantine: "true"
@@ -512,108 +535,6 @@ jobs:
       AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN }}
       AWS_API_GW_HOST_GRAFANA: ${{ secrets.AWS_API_GW_HOST_GRAFANA }}
       SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
-      OPTIONAL_GATI_AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
-      OPTIONAL_GATI_LAMBDA_URL: ${{  secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL}}
-      TRUNK_API_KEY: ${{ secrets.TRUNK_API_KEY }}
-
-  run-ccip-e2e-tests-setup:
-    name: Run CCIP E2E Tests Setup
-    runs-on: ubuntu-latest
-    needs: [changes, labels]
-    permissions:
-      contents: read
-    outputs:
-      should-run: ${{ steps.form-inputs.outputs.should-run }}
-      workflow-name: ${{ steps.form-inputs.outputs.workflow-name }}
-      test-trigger: ${{ steps.form-inputs.outputs.test-trigger }}
-    steps:
-      - name: Form Inputs for Core E2E Tests
-        id: form-inputs
-        env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF_TYPE: ${{ github.ref_type }}
-          CONTAINS_CHANGES: ${{ needs.changes.outputs.general-changes == 'true' || needs.changes.outputs.core-changes == 'true' }}
-          RUN_E2E_TESTS_LABEL_FOUND: ${{ needs.labels.outputs.run-e2e-tests-label-found || 'false' }}
-        run: |
-          if [[ "${GITHUB_EVENT_NAME}" == 'pull_request' ]]; then
-            # Run Core E2E tests on PRs only if the label "run-e2e-tests" is present, and there are relevant changes
-            echo "workflow-name=Run CCIP E2E Tests For PR" | tee -a "$GITHUB_OUTPUT"
-            echo "test-trigger=PR E2E CCIP Tests" | tee -a "$GITHUB_OUTPUT"
-
-            if [[ "${RUN_E2E_TESTS_LABEL_FOUND}" == 'true' ]]; then
-              # only run if the PR has the label "run-e2e-tests"
-              echo "should-run=true" | tee -a "$GITHUB_OUTPUT"
-            fi
-
-          elif [[ "${GITHUB_EVENT_NAME}" == 'merge_group' ]]; then
-            # Run Core E2E tests in the merge queue, if there are relevant changes
-            echo "workflow-name=Run CCIP E2E Tests For Merge Queue" | tee -a "$GITHUB_OUTPUT"
-            echo "test-trigger=Merge Queue E2E CCIP Tests" | tee -a "$GITHUB_OUTPUT"
-            echo "should-run=${CONTAINS_CHANGES}" | tee -a "$GITHUB_OUTPUT"
-
-          elif [[ "${GITHUB_EVENT_NAME}" == 'workflow_dispatch' ]]; then
-            # Always run Core E2E tests on workflow dispatch
-            echo "workflow-name=Run CCIP E2E Tests For Workflow Dispatch" | tee -a "$GITHUB_OUTPUT"
-            echo "test-trigger=Workflow Dispatch E2E CCIP Tests" | tee -a "$GITHUB_OUTPUT"
-            echo "should-run=true" | tee -a "$GITHUB_OUTPUT"
-
-          elif [[ "${GITHUB_EVENT_NAME}" == 'push' ]]; then
-            # Run Core E2E tests on push events, only if there are relevant changes or if it's a tag push
-            echo "workflow-name=Run CCIP E2E Tests For Push" | tee -a "$GITHUB_OUTPUT"
-            echo "test-trigger=Push E2E CCIP Tests" | tee -a "$GITHUB_OUTPUT"
-            if [[ "${CONTAINS_CHANGES}" == 'true' || "${GITHUB_REF_TYPE}" == 'tag' ]]; then
-              echo "should-run=true" | tee -a "$GITHUB_OUTPUT"
-            fi
-
-          else
-            echo "workflow-name=Run Core E2E Tests For Unknown Event" | tee -a "$GITHUB_OUTPUT"
-            echo "test-trigger=Unknown E2E Core Tests" | tee -a "$GITHUB_OUTPUT"
-            echo "should-run=false" | tee -a "$GITHUB_OUTPUT"
-          fi
-
-  run-ccip-e2e-tests:
-    name: ${{ needs.run-ccip-e2e-tests-setup.outputs.workflow-name }}
-    permissions:
-      actions: read
-      checks: write
-      pull-requests: write
-      id-token: write
-      contents: read
-    needs: [build-chainlink, run-ccip-e2e-tests-setup, changes, labels]
-    if: needs.run-ccip-e2e-tests-setup.outputs.should-run == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@fed09778ce127da5d37f902d8bee01387856550a # 2026-03-12
-    with:
-      workflow_name: ${{ needs.run-ccip-e2e-tests-setup.outputs.workflow-name }}
-      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
-      test_path: .github/e2e-tests.yml
-      test_trigger: ${{ needs.run-ccip-e2e-tests-setup.outputs.test-trigger }}
-      upload_cl_node_coverage_artifact: true
-      enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
-      use-self-hosted-runners: ${{ needs.labels.outputs.should-use-self-hosted-runners }}
-      ecr_name: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
-      team: "CCIP"
-      quarantine: "true"
-    secrets:
-      QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-      QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-      QA_AWS_ACCOUNT_NUMBER: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
-      PROD_AWS_ACCOUNT_NUMBER: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-      QA_PYROSCOPE_INSTANCE: ${{ secrets.QA_PYROSCOPE_INSTANCE }}
-      QA_PYROSCOPE_KEY: ${{ secrets.QA_PYROSCOPE_KEY }}
-      GRAFANA_INTERNAL_TENANT_ID: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-      GRAFANA_INTERNAL_BASIC_AUTH: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
-      GRAFANA_INTERNAL_HOST: ${{ secrets.GRAFANA_INTERNAL_HOST }}
-      GRAFANA_INTERNAL_URL_SHORTENER_TOKEN: ${{ secrets.GRAFANA_INTERNAL_URL_SHORTENER_TOKEN }}
-      LOKI_TENANT_ID: ${{ secrets.LOKI_TENANT_ID }}
-      LOKI_URL: ${{ secrets.LOKI_URL }}
-      LOKI_BASIC_AUTH: ${{ secrets.LOKI_BASIC_AUTH }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-      AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN }}
-      AWS_API_GW_HOST_GRAFANA: ${{ secrets.AWS_API_GW_HOST_GRAFANA }}
-      SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
-      MAIN_DNS_ZONE_PUBLIC_SDLC: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
-      AWS_K8S_CLUSTER_NAME_SDLC: ${{ secrets.AWS_K8S_CLUSTER_NAME_SDLC }}
       OPTIONAL_GATI_AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
       OPTIONAL_GATI_LAMBDA_URL: ${{  secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL}}
       TRUNK_API_KEY: ${{ secrets.TRUNK_API_KEY }}
@@ -626,7 +547,6 @@ jobs:
       [
         build-chainlink,
         run-core-e2e-tests,
-        run-ccip-e2e-tests,
         run-core-cre-e2e-tests,
         run-core-cre-e2e-regression-tests,
       ]
@@ -642,20 +562,6 @@ jobs:
 
           node_migration_tests_failed=$(echo $results | jq '[.[] | select(.id == "integration-tests/migration/upgrade_version_test.go:*" ) | select(.result != "success")] | length > 0')
           echo "node_migration_tests_failed=$node_migration_tests_failed" | tee -a "$GITHUB_OUTPUT"
-
-      - name: Check CCIP test results
-        id: check_ccip_results
-        env:
-          JOB_RESULT: ${{ needs.run-ccip-e2e-tests.result }}
-          TEST_RESULTS: ${{ needs.run-ccip-e2e-tests.outputs.test_results }}
-        run: |
-          if [[ "$JOB_RESULT" != "skipped" ]]; then
-            results="$TEST_RESULTS"
-            echo "CCIP test results:"
-            echo "$results" | jq .
-          else
-            echo "CCIP tests were skipped."
-          fi
 
       - name: Fail the job if core tests were not successful
         if: always()
@@ -702,19 +608,6 @@ jobs:
             echo "::warning::Core CRE E2E regression tests were skipped."
           fi
 
-      - name: Warn if CCIP tests were not successful
-        if: always()
-        env:
-          JOB_RESULT: ${{ needs.run-ccip-e2e-tests.result }}
-        run: |
-          if [[ "${JOB_RESULT}" == "failure" ]]; then
-            echo "::warning::CCIP E2E tests failed in one of the runs. Not failing as they are not mandatory."
-          elif [[ "${JOB_RESULT}" == "cancelled" ]]; then
-            echo "::warning::CCIP E2E tests were cancelled."
-          elif [[ "${JOB_RESULT}" == "skipped" ]]; then
-            echo "::warning::CCIP E2E tests were skipped."
-          fi
-
       - name: Fail the job if Chainlink image was cancelled or failed to build
         if: always()
         env:
@@ -730,35 +623,13 @@ jobs:
             echo "::warning::Chainlink image build was skipped."
           fi
 
-  show-chainlink-node-coverage:
-    name: Show Chainlink Node Go Coverage
-    if: false
-    # if: always()
-    needs: [run-core-e2e-tests, run-ccip-e2e-tests]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the repo
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-          repository: smartcontractkit/chainlink
-          ref: ${{ env.CHAINLINK_REF }}
-      - name: Download All Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: cl_node_coverage_data
-          pattern: cl_node_coverage_data_*
-          merge-multiple: true
-      - name: Show Coverage
-        run: go run ./integration-tests/scripts/show_coverage.go "${{ github.workspace }}/cl_node_coverage_data/*/merged"
-
   ## Solana Section
   solana-smoke-tests-setup:
     name: Solana Smoke Tests Setup
     # We don't directly merge dependabot PRs, so let's not waste the resources
     if: ${{ github.actor != 'dependabot[bot]'  }}
     runs-on: ubuntu-latest
-    needs: [changes, labels]
+    needs: [ changes, labels ]
     permissions:
       contents: read
     outputs:
@@ -769,7 +640,8 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_TYPE: ${{ github.ref_type }}
-          CONTAINS_CHANGES: ${{ needs.changes.outputs.general-changes == 'true' || needs.changes.outputs.core-changes == 'true' }}
+          CONTAINS_CHANGES: ${{ needs.changes.outputs.general-changes == 'true' ||
+            needs.changes.outputs.core-changes == 'true' }}
           RUN_E2E_TESTS_LABEL_FOUND: ${{ needs.labels.outputs.run-e2e-tests-label-found || 'false' }}
           INPUTS_RUN_SOLANA: ${{ inputs.run_solana }}
         run: |
@@ -814,7 +686,7 @@ jobs:
       name: integration
       deployment: false
     runs-on: ubuntu-latest
-    needs: [solana-smoke-tests-setup]
+    needs: [ solana-smoke-tests-setup ]
     permissions:
       contents: read
     outputs:
@@ -867,7 +739,7 @@ jobs:
 
   run-solana-smoke-tests:
     name: Run Solana Smoke Tests
-    needs: [build-chainlink, get-solana-sha, solana-smoke-tests-setup]
+    needs: [ build-chainlink, get-solana-sha, solana-smoke-tests-setup ]
     permissions:
       id-token: write
       contents: read
@@ -887,7 +759,7 @@ jobs:
     # TODO: uncomment this when we want to notify on test failures post-merge, if Phase 3 is necessary
     if: false
     # if: ${{ github.ref_name == 'develop' && failure() }}
-    needs: [check-e2e-test-results, run-solana-smoke-tests]
+    needs: [ check-e2e-test-results, run-solana-smoke-tests ]
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,7 +70,7 @@ jobs:
           SHOULD_ENFORCE="false"
           if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
               echo "We are in a merge_group event, now check if we are on the develop branch"
-              target_branch=$(cat $GITHUB_EVENT_PATH | jq -r .merge_group.base_ref)
+              target_branch=$(cat "$GITHUB_EVENT_PATH" | jq -r .merge_group.base_ref)
               if [[ "$target_branch" == "refs/heads/develop" ]]; then
                   echo "We are on the develop branch, we should enforce ctf version"
                   SHOULD_ENFORCE="true"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -218,7 +218,7 @@ jobs:
         labels,
         enforce-ctf-version,
         run-core-cre-e2e-tests-setup,
-        run-core-e2e-tests-setup,
+        run-ccip-v1-6-e2e-tests-setup,
         solana-smoke-tests-setup,
       ]
     permissions:
@@ -236,7 +236,7 @@ jobs:
             # todo: optimize this conditional
             any-should-run: >-
               ${{
-                needs.run-core-e2e-tests-setup.outputs.should-run == 'true' ||
+                needs.run-ccip-v1-6-e2e-tests-setup.outputs.should-run == 'true' ||
                 needs.solana-smoke-tests-setup.outputs.should-run-solana-tests == 'true' ||
                 needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'
               }}
@@ -250,7 +250,7 @@ jobs:
             # todo: optimize this conditional
             any-should-run: >-
               ${{
-                needs.run-core-e2e-tests-setup.outputs.should-run == 'true' ||
+                needs.run-ccip-v1-6-e2e-tests-setup.outputs.should-run == 'true' ||
                 needs.solana-smoke-tests-setup.outputs.should-run-solana-tests == 'true' ||
                 needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'
               }}
@@ -437,8 +437,8 @@ jobs:
         github.sha) }}
     secrets: inherit
 
-  run-core-e2e-tests-setup:
-    name: Run Core E2E Tests Setup
+  run-ccip-v1-6-e2e-tests-setup:
+    name: Run CCIP v1.6 E2E Tests Setup
     runs-on: ubuntu-latest
     needs: [ changes, labels ]
     permissions:
@@ -448,7 +448,7 @@ jobs:
       workflow-name: ${{ steps.form-inputs.outputs.workflow-name }}
       test-trigger: ${{ steps.form-inputs.outputs.test-trigger }}
     steps:
-      - name: Form Inputs for Core E2E Tests
+      - name: Form Inputs for CCIP v1.6 E2E Tests
         id: form-inputs
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
@@ -459,8 +459,8 @@ jobs:
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == 'pull_request' ]]; then
             # Run Core E2E tests on PRs only if the label "run-e2e-tests" is present, and there are relevant changes
-            echo "workflow-name=Run Core E2E Tests For PR" | tee -a "$GITHUB_OUTPUT"
-            echo "test-trigger=PR E2E Core Tests" | tee -a "$GITHUB_OUTPUT"
+            echo "workflow-name=Run CCIP v1.6 E2E Tests For PR" | tee -a "$GITHUB_OUTPUT"
+            echo "test-trigger=PR E2E CCIP v1.6 Tests" | tee -a "$GITHUB_OUTPUT"
 
             if [[ "${RUN_E2E_TESTS_LABEL_FOUND}" == 'true' ]]; then
               # only run if the PR has the label "run-e2e-tests"
@@ -469,46 +469,46 @@ jobs:
 
           elif [[ "${GITHUB_EVENT_NAME}" == 'merge_group' ]]; then
             # Run Core E2E tests in the merge queue, if there are relevant changes
-            echo "workflow-name=Run Core E2E Tests For Merge Queue" | tee -a "$GITHUB_OUTPUT"
-            echo "test-trigger=Merge Queue E2E Core Tests" | tee -a "$GITHUB_OUTPUT"
+            echo "workflow-name=Run CCIP v1.6 E2E Tests For Merge Queue" | tee -a "$GITHUB_OUTPUT"
+            echo "test-trigger=Merge Queue E2E CCIP v1.6 Tests" | tee -a "$GITHUB_OUTPUT"
             echo "should-run=${CONTAINS_CHANGES}" | tee -a "$GITHUB_OUTPUT"
 
           elif [[ "${GITHUB_EVENT_NAME}" == 'workflow_dispatch' ]]; then
             # Always run Core E2E tests on workflow dispatch
-            echo "workflow-name=Run Core E2E Tests For Workflow Dispatch" | tee -a "$GITHUB_OUTPUT"
-            echo "test-trigger=Workflow Dispatch E2E Core Tests" | tee -a "$GITHUB_OUTPUT"
+            echo "workflow-name=Run CCIP v1.6 E2E Tests For Workflow Dispatch" | tee -a "$GITHUB_OUTPUT"
+            echo "test-trigger=Workflow Dispatch E2E CCIP v1.6 Tests" | tee -a "$GITHUB_OUTPUT"
             echo "should-run=true" | tee -a "$GITHUB_OUTPUT"
 
           elif [[ "${GITHUB_EVENT_NAME}" == 'push' ]]; then
             # Run Core E2E tests on push events, only if there are relevant changes or if it's a tag push
-            echo "workflow-name=Run Core E2E Tests For Push" | tee -a "$GITHUB_OUTPUT"
-            echo "test-trigger=Push E2E Core Tests" | tee -a "$GITHUB_OUTPUT"
+            echo "workflow-name=Run CCIP v1.6 E2E Tests For Push" | tee -a "$GITHUB_OUTPUT"
+            echo "test-trigger=Push E2E CCIP v1.6 Tests" | tee -a "$GITHUB_OUTPUT"
             if [[ "${CONTAINS_CHANGES}" == 'true' || "${GITHUB_REF_TYPE}" == 'tag' ]]; then
               echo "should-run=true" | tee -a "$GITHUB_OUTPUT"
             fi
 
           else
-            echo "workflow-name=Run Core E2E Tests For Unknown Event" | tee -a "$GITHUB_OUTPUT"
-            echo "test-trigger=Unknown E2E Core Tests" | tee -a "$GITHUB_OUTPUT"
+            echo "workflow-name=Run CCIP v1.6 E2E Tests For Unknown Event" | tee -a "$GITHUB_OUTPUT"
+            echo "test-trigger=Unknown CCIP v1.6 E2E Tests" | tee -a "$GITHUB_OUTPUT"
             echo "should-run=false" | tee -a "$GITHUB_OUTPUT"
           fi
 
-  run-core-e2e-tests:
-    needs: [ run-core-e2e-tests-setup, build-chainlink, changes, labels ]
-    name: ${{ needs.run-core-e2e-tests-setup.outputs.workflow-name }}
+  run-ccip-v1-6-e2e-tests:
+    needs: [ run-ccip-v1-6-e2e-tests-setup, build-chainlink, changes, labels ]
+    name: ${{ needs.run-ccip-v1-6-e2e-tests-setup.outputs.workflow-name }}
     permissions:
       actions: read
       checks: write
       pull-requests: write
       id-token: write
       contents: read
-    if: needs.run-core-e2e-tests-setup.outputs.should-run == 'true'
+    if: needs.run-ccip-v1-6-e2e-tests-setup.outputs.should-run == 'true'
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@fed09778ce127da5d37f902d8bee01387856550a # 2026-03-12
     with:
-      workflow_name: ${{ needs.run-core-e2e-tests-setup.outputs.workflow-name }}
+      workflow_name: ${{ needs.run-ccip-v1-6-e2e-tests-setup.outputs.workflow-name }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
-      test_trigger: ${{ needs.run-core-e2e-tests-setup.outputs.test-trigger }}
+      test_trigger: ${{ needs.run-ccip-v1-6-e2e-tests-setup.outputs.test-trigger }}
       upload_cl_node_coverage_artifact: true
       enable_otel_traces_for_ocr2_plugins: ${{
         contains(join(github.event.pull_request.labels.*.name, ' '), 'enable
@@ -546,7 +546,7 @@ jobs:
     needs:
       [
         build-chainlink,
-        run-core-e2e-tests,
+        run-ccip-v1-6-e2e-tests,
         run-core-cre-e2e-tests,
         run-core-cre-e2e-regression-tests,
       ]
@@ -554,7 +554,7 @@ jobs:
       - name: Check Core test results
         id: check_core_results
         env:
-          TEST_RESULTS: ${{ needs.run-core-e2e-tests.outputs.test_results }}
+          TEST_RESULTS: ${{ needs.run-ccip-v1-6-e2e-tests.outputs.test_results }}
         run: |
           results="$TEST_RESULTS"
           echo "Core e2e test results:"
@@ -563,19 +563,19 @@ jobs:
           node_migration_tests_failed=$(echo $results | jq '[.[] | select(.id == "integration-tests/migration/upgrade_version_test.go:*" ) | select(.result != "success")] | length > 0')
           echo "node_migration_tests_failed=$node_migration_tests_failed" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Fail the job if core tests were not successful
+      - name: Fail the job if CCIP v1.6 E2E tests were not successful
         if: always()
         env:
-          JOB_RESULT: ${{ needs.run-core-e2e-tests.result }}
+          JOB_RESULT: ${{ needs.run-ccip-v1-6-e2e-tests.result }}
         run: |
           if [[ "${JOB_RESULT}" == "failure" ]]; then
-            echo "::error::Core E2E tests failed."
+            echo "::error::CCIP v1.6 E2E tests failed."
             exit 1
           elif [[ "${JOB_RESULT}" == "cancelled" ]]; then
-            echo "::error::Core E2E tests were cancelled."
+            echo "::error::CCIP v1.6 E2E tests were cancelled."
             exit 1
           elif [[ "${JOB_RESULT}" == "skipped" ]]; then
-            echo "::warning::Core E2E tests were skipped."
+            echo "::warning::CCIP v1.6 E2E tests were skipped."
           fi
 
       - name: Fail the job if core CRE tests were not successful
@@ -753,51 +753,3 @@ jobs:
       aws_account_id: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
       aws_region: ${{ secrets.QA_AWS_REGION }}
       aws_role_to_assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-
-  notify-test-failure:
-    name: Notify Test Failure
-    # TODO: uncomment this when we want to notify on test failures post-merge, if Phase 3 is necessary
-    if: false
-    # if: ${{ github.ref_name == 'develop' && failure() }}
-    needs: [ check-e2e-test-results, run-solana-smoke-tests ]
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - name: Send slack notification for failed migration tests
-        id: send-slack-notification
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
-        with:
-          errors: "true"
-          method: chat.postMessage
-          token: ${{ secrets.QA_SLACK_API_KEY }}
-          payload: |
-            {
-              "channel": "C023GJUSQ0H",
-              "text": "E2E Tests Failed Post-Merge, Immediate Action Required",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*:rotating_light: E2E Tests Failed Post-Merge, Immediate Action Required :rotating_light:*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Alerting <!subteam^S04SLH4V4JJ|devex-cicd-oncall> and <@U01Q4N37KFG>, E2E tests failed for commit <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> on run ID <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>. This commit was already merged to develop by user `${{ github.actor }}`. Please follow instructions below to remedy the issue."
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "1. Use the `/gh-lookup ${{ github.actor }}` command to find the who made the commit.\n2. <https://smartcontract-it.atlassian.net/wiki/spaces/ENG/pages/597262421/Raising+an+Incident|Raise a Pager Duty Incident> with that engineer to fix the issue.\n3. Start a 1 hour timer. If the E2E tests cannot be made passing on `develop` branch by then, please use `git revert <last-green-commit>` to revert the `develop` branch back to a happy state.\n4. Write a quick summary of the actions taken and post it in a thread to this message."
-                  }
-                }
-              ]
-            }


### PR DESCRIPTION
"Core" is no longer accurate identifier for these tests, as they're all CCIP v.16 tests. Also removes some dead code.