### PR TITLE
Fix two races

### DIFF
--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	gethCommon "github.com/ethereum/go-ethereum/common"
@@ -394,18 +395,18 @@ func (s *Shell) runNode(c *cli.Context) error {
 
 	// cleanExit is used to skip "fail fast" routine
 	cleanExit := make(chan struct{})
-	var shutdownStartTime time.Time
+	var shutdownStartTime atomic.Value // time.Time
 	defer func() {
 		close(cleanExit)
-		if !shutdownStartTime.IsZero() {
-			log.Printf("Graceful shutdown time: %s", time.Since(shutdownStartTime))
+		if val := shutdownStartTime.Load(); val != nil {
+			log.Printf("Graceful shutdown time: %s", time.Since(val.(time.Time)))
 		}
 	}()
 
 	go shutdown.HandleShutdown(func(sig string) {
 		lggr.Infof("Shutting down due to %s signal received...", sig)
 
-		shutdownStartTime = time.Now()
+		shutdownStartTime.Store(time.Now())
 		cancelRootCtx()
 
 		select {

--- a/core/services/pg/lease_lock_test.go
+++ b/core/services/pg/lease_lock_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/jmoiron/sqlx"
 
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
@@ -177,6 +176,7 @@ func Test_LeaseLock(t *testing.T) {
 	})
 
 	t.Run("cancel TakeAndHold with ctx", func(t *testing.T) {
+		ctx := t.Context()
 		cfg := pg.LeaseLockConfig{
 			DefaultQueryTimeout:  cfg.Database().DefaultQueryTimeout(),
 			LeaseDuration:        15 * time.Second,
@@ -185,23 +185,14 @@ func Test_LeaseLock(t *testing.T) {
 		leaseLock1 := newLeaseLock(t, db, cfg)
 		leaseLock2 := newLeaseLock(t, db, cfg)
 
-		err := leaseLock1.TakeAndHold(testutils.Context(t))
+		err := leaseLock1.TakeAndHold(ctx)
 		require.NoError(t, err)
+		t.Cleanup(leaseLock1.Release)
 
-		awaiter := cltest.NewAwaiter()
-		go func() {
-			ctx, cancel := context.WithCancel(testutils.Context(t))
-			go func() {
-				<-time.After(3 * time.Second)
-				cancel()
-			}()
-			err := leaseLock2.TakeAndHold(ctx)
-			require.Error(t, err)
-			awaiter.ItHappened()
-		}()
-
-		awaiter.AwaitOrFail(t)
-		leaseLock1.Release()
+		ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+		require.Error(t, leaseLock2.TakeAndHold(ctx))
+		t.Cleanup(leaseLock2.Release)
 	})
 
 	require.NoError(t, db.Close())


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Read at 0x00c000215b48 by main goroutine:
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).runNode.func1()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:400 +0x49
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.26.2/x64/src/runtime/panic.go:668 +0x5d
  github.com/smartcontractkit/chainlink/v2/core/sessions/localauth.(*orm).ListUsers()
      /home/runner/_work/chainlink/chainlink/core/sessions/localauth/orm.go:64 +0xaa
  github.com/smartcontractkit/chainlink/v2/core/cmd.fileAPIInitializer.Initialize()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell.go:918 +0x1ba
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).runNode()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:623 +0x3f04
  github.com/smartcontractkit/chainlink/v2/core/services/keystore.(*solana).EnsureKey()
      /home/runner/_work/chainlink/chainlink/core/services/keystore/solana.go:166 +0x385
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).runNode()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:543 +0x5e8b
  github.com/smartcontractkit/chainlink/v2/core/services/keystore.(*p2p).EnsureKey()
      /home/runner/_work/chainlink/chainlink/core/services/keystore/p2p.go:149 +0x39c
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).runNode()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:518 +0x27c1
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*ChainlinkAppFactory).NewApplication()
      <autogenerated>:1 +0xf4
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).runNode()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:425 +0x11e8
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).RunNode()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:359 +0x34
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).RunNode-fm()
      <autogenerated>:1 +0x34
  github.com/urfave/cli.HandleAction()
      /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.14/app.go:524 +0xe2
  github.com/urfave/cli.Command.Run()
      /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.14/command.go:175 +0xd4d
  github.com/smartcontractkit/chainlink/v2/core/cmd.TerminalKeyStoreAuthenticator.Authenticate()
      /home/runner/_work/chainlink/chainlink/core/cmd/key_store_authenticator.go:38 +0x141
  github.com/smartcontractkit/chainlink/v2/core/cmd.TerminalKeyStoreAuthenticator.Authenticate()
      /home/runner/_work/chainlink/chainlink/core/cmd/key_store_authenticator.go:38 +0x141
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).beforeNode()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:1188 +0x1297
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).TakeAndHold()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:112 +0x124
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).beforeNode.(*lockedDb).Open.func1()
      /home/runner/_work/chainlink/chainlink/core/services/pg/locked_db.go:96 +0x674
  github.com/smartcontractkit/chainlink-common/pkg/services.(*StateMachine).StartOnce()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260422075950-29f37fa83c8a/pkg/services/state.go:93 +0x101
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*lockedDb).Open()
      /home/runner/_work/chainlink/chainlink/core/services/pg/locked_db.go:65 +0x927
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).beforeNode()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:1170 +0x85b
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).BeforeNode()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:1228 +0x34
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).BeforeNode-fm()
      <autogenerated>:1 +0x34
  github.com/urfave/cli.Command.Run()
      /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.14/command.go:164 +0xc4c
  github.com/urfave/cli.(*App).RunAsSubcommand()
      /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.14/app.go:405 +0x1f04
  github.com/urfave/cli.Command.startApp()
      /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.14/command.go:380 +0x1985
  github.com/urfave/cli.Command.Run()
      /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.14/command.go:103 +0x1012
  github.com/urfave/cli.(*App).Run()
      /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.14/app.go:277 +0x124c
  github.com/smartcontractkit/chainlink/v2/core.Main.func1()
      /home/runner/_work/chainlink/chainlink/core/main.go:31 +0x64
  github.com/smartcontractkit/chainlink/v2/core/recovery.HandleFn()
      /home/runner/_work/chainlink/chainlink/core/recovery/recover.go:40 +0x73
  github.com/smartcontractkit/chainlink/v2/core/recovery.ReportPanics()
      /home/runner/_work/chainlink/chainlink/core/recovery/recover.go:12 +0x64
  github.com/smartcontractkit/chainlink/v2/core.Main()
      /home/runner/_work/chainlink/chainlink/core/main.go:29 +0x21
  github.com/rogpeppe/go-internal/testscript.RunMain.func1()
      /home/runner/go/pkg/mod/github.com/rogpeppe/go-internal@v1.14.1/testscript/exe.go:109 +0x2e
  github.com/rogpeppe/go-internal/testscript.Main()
      /home/runner/go/pkg/mod/github.com/rogpeppe/go-internal@v1.14.1/testscript/exe.go:57 +0x123
  github.com/rogpeppe/go-internal/testscript.RunMain()
      /home/runner/go/pkg/mod/github.com/rogpeppe/go-internal@v1.14.1/testscript/exe.go:111 +0x2b4
  github.com/smartcontractkit/chainlink/v2.TestMain()
      /home/runner/_work/chainlink/chainlink/main_test.go:43 +0x144
  main.main()
      _testmain.go:50 +0x171

Previous write at 0x00c000215b48 by goroutine 424:
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).runNode.func2()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:408 +0x177
  github.com/smartcontractkit/chainlink/v2/core/shutdown.HandleShutdown()
      /home/runner/_work/chainlink/chainlink/core/shutdown/shutdown.go:15 +0x121
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).runNode.gowrap2()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:405 +0x2e

Goroutine 424 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).runNode()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:405 +0x105d
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).RunNode()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:359 +0x34
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).RunNode-fm()
      <autogenerated>:1 +0x34
  github.com/urfave/cli.HandleAction()
      /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.14/app.go:524 +0xe2
  github.com/urfave/cli.Command.Run()
      /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.14/command.go:175 +0xd4d
  github.com/smartcontractkit/chainlink/v2/core/cmd.TerminalKeyStoreAuthenticator.Authenticate()
      /home/runner/_work/chainlink/chainlink/core/cmd/key_store_authenticator.go:38 +0x141
  github.com/smartcontractkit/chainlink/v2/core/cmd.TerminalKeyStoreAuthenticator.Authenticate()
      /home/runner/_work/chainlink/chainlink/core/cmd/key_store_authenticator.go:38 +0x141
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).beforeNode()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:1188 +0x1297
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).TakeAndHold()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:112 +0x124
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).beforeNode.(*lockedDb).Open.func1()
      /home/runner/_work/chainlink/chainlink/core/services/pg/locked_db.go:96 +0x674
  github.com/smartcontractkit/chainlink-common/pkg/services.(*StateMachine).StartOnce()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260422075950-29f37fa83c8a/pkg/services/state.go:93 +0x101
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*lockedDb).Open()
      /home/runner/_work/chainlink/chainlink/core/services/pg/locked_db.go:65 +0x927
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).beforeNode()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:1170 +0x85b
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).BeforeNode()
      /home/runner/_work/chainlink/chainlink/core/cmd/shell_local.go:1228 +0x34
  github.com/smartcontractkit/chainlink/v2/core/cmd.(*Shell).BeforeNode-fm()
      <autogenerated>:1 +0x34
  github.com/urfave/cli.Command.Run()
      /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.14/command.go:164 +0xc4c
  github.com/urfave/cli.(*App).RunAsSubcommand()
      /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.14/app.go:405 +0x1f04
  github.com/urfave/cli.Command.startApp()
      /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.14/command.go:380 +0x1985
  github.com/urfave/cli.Command.Run()
      /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.14/command.go:103 +0x1012
  github.com/urfave/cli.(*App).Run()
      /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.14/app.go:277 +0x124c
  github.com/smartcontractkit/chainlink/v2/core.Main.func1()
      /home/runner/_work/chainlink/chainlink/core/main.go:31 +0x64
  github.com/smartcontractkit/chainlink/v2/core/recovery.HandleFn()
      /home/runner/_work/chainlink/chainlink/core/recovery/recover.go:40 +0x73
  github.com/smartcontractkit/chainlink/v2/core/recovery.ReportPanics()
      /home/runner/_work/chainlink/chainlink/core/recovery/recover.go:12 +0x64
  github.com/smartcontractkit/chainlink/v2/core.Main()
      /home/runner/_work/chainlink/chainlink/core/main.go:29 +0x21
  github.com/rogpeppe/go-internal/testscript.RunMain.func1()
      /home/runner/go/pkg/mod/github.com/rogpeppe/go-internal@v1.14.1/testscript/exe.go:109 +0x2e
  github.com/rogpeppe/go-internal/testscript.Main()
      /home/runner/go/pkg/mod/github.com/rogpeppe/go-internal@v1.14.1/testscript/exe.go:57 +0x123
  github.com/rogpeppe/go-internal/testscript.RunMain()
      /home/runner/go/pkg/mod/github.com/rogpeppe/go-internal@v1.14.1/testscript/exe.go:111 +0x2b4
  github.com/smartcontractkit/chainlink/v2.TestMain()
      /home/runner/_work/chainlink/chainlink/main_test.go:43 +0x144
  main.main()
      _testmain.go:50 +0x171
==================
```

```
==================
WARNING: DATA RACE
Read at 0x00c00093d913 by goroutine 4243:
  testing.(*common).destination()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:1064 +0x1cc
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:1036 +0xbe
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:1200 +0x8e
  go.uber.org/zap/zaptest.TestingWriter.Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.1/zaptest/logger.go:146 +0x119
  go.uber.org/zap/zaptest.(*TestingWriter).Write()
      <autogenerated>:1 +0x68
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.1/zapcore/core.go:99 +0x201
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.1/zapcore/entry.go:258 +0x215
  go.uber.org/zap.(*SugaredLogger).log()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.1/sugar.go:355 +0x12c
  go.uber.org/zap.(*SugaredLogger).Warnw()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.1/sugar.go:263 +0x97
  github.com/smartcontractkit/chainlink/v2/core/logger.(*zapLogger).Warnw()
      <autogenerated>:1 +0x12
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).loop()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:216 +0x3e9
  github.com/smartcontractkit/chainlink-common/pkg/sqlutil.TransactConn[go.shape.e645a83d9852ec3868f84a2e5cc1247fd20f418916940935d1fc75edcf035ee5]()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260422075950-29f37fa83c8a/pkg/sqlutil/sqlutil.go:84 +0x32f
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).getLease()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:252 +0x330
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).loop()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:214 +0x264
  github.com/smartcontractkit/chainlink-common/pkg/sqlutil.TransactConn[go.shape.e645a83d9852ec3868f84a2e5cc1247fd20f418916940935d1fc75edcf035ee5]()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260422075950-29f37fa83c8a/pkg/sqlutil/sqlutil.go:84 +0x32f
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).getLease()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:252 +0x330
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).loop()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:214 +0x264
  github.com/smartcontractkit/chainlink-common/pkg/sqlutil.TransactConn[go.shape.e645a83d9852ec3868f84a2e5cc1247fd20f418916940935d1fc75edcf035ee5]()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260422075950-29f37fa83c8a/pkg/sqlutil/sqlutil.go:84 +0x32f
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).getLease()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:252 +0x330
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).loop()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:214 +0x264
  github.com/smartcontractkit/chainlink-common/pkg/sqlutil.TransactConn[go.shape.e645a83d9852ec3868f84a2e5cc1247fd20f418916940935d1fc75edcf035ee5]()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260422075950-29f37fa83c8a/pkg/sqlutil/sqlutil.go:84 +0x32f
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).getLease()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:252 +0x330
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).loop()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:214 +0x264
  github.com/smartcontractkit/chainlink-common/pkg/sqlutil.TransactConn[go.shape.e645a83d9852ec3868f84a2e5cc1247fd20f418916940935d1fc75edcf035ee5]()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260422075950-29f37fa83c8a/pkg/sqlutil/sqlutil.go:84 +0x32f
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).getLease()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:252 +0x330
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2101 +0x38

Goroutine 4243 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).TakeAndHold()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:147 +0x63c
  github.com/smartcontractkit/chainlink-common/pkg/sqlutil.transact[go.shape.e645a83d9852ec3868f84a2e5cc1247fd20f418916940935d1fc75edcf035ee5]()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260422075950-29f37fa83c8a/pkg/sqlutil/sqlutil.go:127 +0x303
  github.com/smartcontractkit/chainlink-common/pkg/sqlutil.TransactConn[go.shape.e645a83d9852ec3868f84a2e5cc1247fd20f418916940935d1fc75edcf035ee5]()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260422075950-29f37fa83c8a/pkg/sqlutil/sqlutil.go:84 +0x32f
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).getLease()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:252 +0x330
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).TakeAndHold.func1()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:105 +0x190
  github.com/smartcontractkit/chainlink/v2/core/services/pg.(*leaseLock).TakeAndHold()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock.go:112 +0x124
  github.com/smartcontractkit/chainlink/v2/core/services/pg_test.Test_LeaseLock.func6()
      /home/runner/_work/chainlink/chainlink/core/services/pg/lease_lock_test.go:188 +0x12a
  testing.tRunner()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2101 +0x38

Goroutine 4046 (finished) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2101 +0xb12
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2585 +0x85
  testing.tRunner()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2036 +0x21c
  testing.runTests()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2583 +0x9e9
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2443 +0xf4b
  main.main()
      _testmain.go:60 +0x164
==================
```