### PR TITLE
Log vault secrets request metadata

### DIFF
--- a/core/services/workflows/v2/secrets.go
+++ b/core/services/workflows/v2/secrets.go
@@ -238,7 +238,7 @@ func (s *secretsFetcher) getSecretsForBatch(ctx context.Context, request *sdkpb.
 		return nil, fmt.Errorf("failed to convert vault request to any: %w", err)
 	}
 
-	lggr := logger.With(s.lggr, "requestedKeys", logKeys)
+	lggr := logger.With(s.lggr, "requestedKeys", logKeys, "metadata", metadata)
 	lggr.Debug("fetching secrets...")
 
 	capabilityResponse, err := vaultCap.Execute(ctx, capabilities.CapabilityRequest{


### PR DESCRIPTION
## Summary

- Include `RequestMetadata` in the workflow Vault GetSecrets logger context.
- Keeps the existing requested key logging intact while making sender-side logs easier to correlate with Vault and Don2Don request metadata.

