### PR TITLE
feat(ocr3_1): promwrapper + integration test framework opt-in

### DIFF
--- a/core/capabilities/integration_tests/framework/don.go
+++ b/core/capabilities/integration_tests/framework/don.go
@@ -139,6 +139,9 @@ type DON struct {
 	fakeLibOcr                   *FakeLibOCR
 	addOCR3NonStandardCapability bool
 
+	fakeLibOcrOCR3_1               *FakeLibOCR_OCR3_1
+	addOCR3_1NonStandardCapability bool
+
 	triggerFactories []TriggerFactory
 	targetFactories  []TargetFactory
 }
@@ -152,6 +155,11 @@ func NewDON(ctx context.Context, t *testing.T, lggr logger.Logger, donConfig Don
 		// This is required to support the non standard OCR3 capability - will be removed when required OCR3 behaviour is implemented as standard capabilities
 		don.fakeLibOcr = NewFakeLibOCR(t, lggr, donConfig.F, protocolRoundInterval)
 		servicetest.Run(t, don.fakeLibOcr)
+
+		// OCR3_1 sibling fake harness — opt-in via AddOCR3_1NonStandardCapability.
+		// v1 only drives Query (see fake_libocr_ocr3_1.go for scope).
+		don.fakeLibOcrOCR3_1 = NewFakeLibOCR_OCR3_1(t, lggr, donConfig.F, protocolRoundInterval)
+		servicetest.Run(t, don.fakeLibOcrOCR3_1)
 	}
 
 	for i, member := range donConfig.Members {
@@ -310,6 +318,16 @@ func (d *DON) Start(ctx context.Context) error {
 
 		for _, node := range d.nodes {
 			addOCR3Capability(ctx, d.t, d.lggr, node.registry, d.fakeLibOcr, d.config.F, node.KeyBundle)
+		}
+	}
+
+	if d.addOCR3_1NonStandardCapability {
+		if d.fakeLibOcrOCR3_1 == nil {
+			return errors.New("don does not support OCR")
+		}
+
+		for _, node := range d.nodes {
+			addOCR3_1Capability(ctx, d.t, d.lggr, node.registry, d.fakeLibOcrOCR3_1, d.config.F, node.KeyBundle)
 		}
 	}
 
@@ -546,6 +564,27 @@ func (d *DON) AddOCR3NonStandardCapability() {
 	})
 }
 
+// AddOCR3_1NonStandardCapability is the OCR3_1 sibling of
+// AddOCR3NonStandardCapability. Mirrors the same registry shape (legacy
+// non-standard internal-only capability); the only behavioral difference is
+// the underlying plugin implements ocr3_1types.ReportingPluginFactory instead
+// of OCR3's. Tests should pick OCR3 OR OCR3_1 per DON, not both.
+func (d *DON) AddOCR3_1NonStandardCapability() {
+	d.addOCR3_1NonStandardCapability = true
+
+	ocr := kcr.CapabilitiesRegistryCapability{
+		LabelledName:   "offchain_reporting",
+		Version:        "1.0.0",
+		CapabilityType: uint8(registrysyncer.ContractCapabilityTypeConsensus),
+	}
+
+	d.publishedCapabilities = append(d.publishedCapabilities, capability{
+		donCapabilityConfig: newCapabilityConfig(),
+		registryConfig:      ocr,
+		internalOnly:        true,
+	})
+}
+
 func (d *DON) AddPublishedEthereumWriteTargetNonStandardCapability(forwarderAddr common.Address) (string, error) {
 	published := true
 
@@ -637,4 +676,35 @@ func addOCR3Capability(ctx context.Context, t *testing.T, lggr logger.Logger, ca
 	transmitter := ocr3.NewContractTransmitter(lggr, capabilityRegistry, "")
 
 	libocr.AddNode(plugin, transmitter, ocr2KeyBundle)
+}
+
+// addOCR3_1Capability mirrors addOCR3Capability for the OCR3_1 plugin. It
+// constructs the OCR3_1 capability via chainlink-common's NewOCR3_1, registers
+// the underlying capability with the per-node registry, and adds the node to
+// the OCR3_1 fake libocr harness for the v1 Query-only protocol cycle.
+func addOCR3_1Capability(ctx context.Context, t *testing.T, lggr logger.Logger, capabilityRegistry *capabilities.Registry,
+	libocr *FakeLibOCR_OCR3_1, donF uint8, ocr2KeyBundle ocr2key.KeyBundle) {
+	requestTimeout := 10 * time.Minute
+	cfg := ocr3.Config{
+		Logger:            lggr,
+		EncoderFactory:    capabilities.NewEncoder,
+		AggregatorFactory: capabilities.NewAggregator,
+		RequestTimeout:    &requestTimeout,
+	}
+
+	ocr3_1Capability := ocr3.NewOCR3_1(cfg)
+	servicetest.Run(t, ocr3_1Capability)
+
+	pluginCfg := coretypes.ReportingPluginServiceConfig{}
+	pluginFactory, err := ocr3_1Capability.NewReportingPluginFactoryOCR3_1(ctx, pluginCfg, capabilityRegistry)
+	require.NoError(t, err)
+
+	repConfig := ocr3types.ReportingPluginConfig{
+		F: int(donF),
+	}
+	plugin, _, err := pluginFactory.NewReportingPlugin(ctx, repConfig, stubBlobBroadcastFetcher{})
+	require.NoError(t, err)
+
+	_, err = libocr.AddNode(plugin, ocr2KeyBundle)
+	require.NoError(t, err)
 }

--- a/core/capabilities/integration_tests/framework/fake_libocr_ocr3_1.go
+++ b/core/capabilities/integration_tests/framework/fake_libocr_ocr3_1.go
@@ -1,0 +1,199 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocrintegrationtesthelpers"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+
+	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/ocr2key"
+)
+
+// stubBlobBroadcastFetcher is the v1 placeholder for the integration test
+// harness. It satisfies ocr3_1types.BlobBroadcastFetcher but never actually
+// round-trips a payload.
+//
+// The blob path is intentionally out of scope for v1 of FakeLibOCR_OCR3_1:
+// libocr's BlobHandle wraps an internal LightCertifiedBlob (signed merkle
+// commitments live in libocr/.../internal/ocr3_1/blobtypes/), so the only
+// way to get a wire-survivable handle is to round-trip through libocr's
+// real blob transport. That's tracked as plan §3.7 preflight item 4.
+//
+// Plugins that hit Broadcast/Fetch in this simulator will panic, surfacing
+// the limit clearly rather than silently producing handles that won't
+// unmarshal downstream.
+type stubBlobBroadcastFetcher struct{}
+
+func (stubBlobBroadcastFetcher) BroadcastBlob(context.Context, []byte, ocr3_1types.BlobExpirationHint) (ocr3_1types.BlobHandle, error) {
+	panic("FakeLibOCR_OCR3_1: BroadcastBlob not implemented in v1 — see plan §3.7 preflight item 4")
+}
+
+func (stubBlobBroadcastFetcher) FetchBlob(context.Context, ocr3_1types.BlobHandle) ([]byte, error) {
+	panic("FakeLibOCR_OCR3_1: FetchBlob not implemented in v1 — see plan §3.7 preflight item 4")
+}
+
+// libocrNodeOCR3_1 mirrors libocrNode for the OCR3_1 plugin shape. Each node
+// owns its own KeyValueDatabase (keyed by a per-node synthetic ConfigDigest)
+// to model the real per-node KV state libocr provides at runtime.
+type libocrNodeOCR3_1 struct {
+	id     string
+	plugin ocr3_1types.ReportingPlugin[[]byte]
+	kvDB   ocr3_1types.KeyValueDatabase
+	key    ocr2key.KeyBundle
+}
+
+// FakeLibOCR_OCR3_1 is a minimal fake libocr harness for the OCR3_1 plugin,
+// parallel to FakeLibOCR.
+//
+// v1 scope: the simulator only drives Query. OCR3_1's
+// Observation/ValidateObservation/StateTransition phases require a real
+// BlobHandle round-trip, and BlobHandle has no public constructor (its
+// concrete LightCertifiedBlob lives in a libocr internal package). Driving
+// the full protocol cycle is therefore deferred until we adopt libocr's
+// real blob transport.
+//
+// What v1 still validates end-to-end:
+//   - DON.AddOCR3_1NonStandardCapability wiring
+//   - chainlink-common's NewOCR3_1 / NewReportingPluginFactoryOCR3_1 path
+//   - The OCR3_1 reporting plugin construction and capability registry
+//     registration on each node
+//
+// Future versions should extend simulateProtocolRound to drive Observation,
+// ValidateObservation, ObservationQuorum, StateTransition, Committed, and
+// Reports once the blob handle round-trip is solved (plan §3.7 preflight 4).
+type FakeLibOCR_OCR3_1 struct {
+	services.StateMachine
+	t    *testing.T
+	lggr logger.Logger
+
+	nodes                 []*libocrNodeOCR3_1
+	f                     uint8
+	protocolRoundInterval time.Duration
+
+	seqNr uint64
+
+	kvFactory *ocrintegrationtesthelpers.StatefulInMemoryKeyValueDatabaseFactory
+
+	mux    sync.Mutex
+	stopCh services.StopChan
+	wg     sync.WaitGroup
+}
+
+func NewFakeLibOCR_OCR3_1(t *testing.T, lggr logger.Logger, f uint8, protocolRoundInterval time.Duration) *FakeLibOCR_OCR3_1 {
+	return &FakeLibOCR_OCR3_1{
+		t:                     t,
+		lggr:                  logger.Named(lggr, "FakeLibOCR_OCR3_1"),
+		f:                     f,
+		protocolRoundInterval: protocolRoundInterval,
+		seqNr:                 1,
+		kvFactory:             ocrintegrationtesthelpers.NewStatefulInMemoryKeyValueDatabaseFactory(),
+		stopCh:                make(services.StopChan),
+	}
+}
+
+func (m *FakeLibOCR_OCR3_1) Start(ctx context.Context) error {
+	return m.StartOnce("FakeLibOCR_OCR3_1", func() error {
+		m.wg.Add(1)
+		go func() {
+			defer m.wg.Done()
+			ticker := time.NewTicker(m.protocolRoundInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-m.stopCh:
+					return
+				case <-ticker.C:
+					serviceCtx, cancel := m.stopCh.NewCtx()
+					if err := m.simulateProtocolRound(serviceCtx); err != nil {
+						m.lggr.Errorf("OCR3_1 simulating protocol round: %v", err)
+					}
+					cancel()
+				}
+			}
+		}()
+		return nil
+	})
+}
+
+func (m *FakeLibOCR_OCR3_1) Close() error {
+	return m.StopOnce("FakeLibOCR_OCR3_1", func() error {
+		close(m.stopCh)
+		m.wg.Wait()
+		m.mux.Lock()
+		defer m.mux.Unlock()
+		for _, n := range m.nodes {
+			if n.kvDB != nil {
+				_ = n.kvDB.Close()
+			}
+		}
+		return nil
+	})
+}
+
+// AddNode registers an OCR3_1 reporting plugin under a fresh per-node KV
+// database. The node id is returned so the caller can later RemoveNode it.
+func (m *FakeLibOCR_OCR3_1) AddNode(plugin ocr3_1types.ReportingPlugin[[]byte], key ocr2key.KeyBundle) (string, error) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	nodeID := uuid.New().String()
+	var configDigest types.ConfigDigest
+	copy(configDigest[:], nodeID)
+
+	kvDB, err := m.kvFactory.NewKeyValueDatabase(configDigest)
+	if err != nil {
+		return "", fmt.Errorf("create KV database for node %s: %w", nodeID, err)
+	}
+
+	m.nodes = append(m.nodes, &libocrNodeOCR3_1{
+		id:     nodeID,
+		plugin: plugin,
+		kvDB:   kvDB,
+		key:    key,
+	})
+	return nodeID, nil
+}
+
+func (m *FakeLibOCR_OCR3_1) GetNodeCount() int {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	return len(m.nodes)
+}
+
+// simulateProtocolRound is the v1 round-driver. It exercises Query only on a
+// randomly-selected leader. Other plugin methods are skipped — see type-level
+// doc.
+func (m *FakeLibOCR_OCR3_1) simulateProtocolRound(ctx context.Context) error {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	if len(m.nodes) == 0 {
+		return nil
+	}
+
+	leader := m.nodes[rand.Intn(len(m.nodes))]
+
+	rdrTx, err := leader.kvDB.NewReadTransaction()
+	if err != nil {
+		return fmt.Errorf("open KV read tx: %w", err)
+	}
+	defer rdrTx.Discard()
+
+	if _, err := leader.plugin.Query(ctx, m.seqNr, rdrTx, stubBlobBroadcastFetcher{}); err != nil {
+		return fmt.Errorf("Query: %w", err)
+	}
+
+	m.seqNr++
+	return nil
+}

--- a/core/services/ocr3_1/promwrapper/factory.go
+++ b/core/services/ocr3_1/promwrapper/factory.go
@@ -1,0 +1,68 @@
+package promwrapper
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+)
+
+var _ ocr3_1types.ReportingPluginFactory[any] = &ReportingPluginFactory[any]{}
+
+type ReportingPluginFactory[RI any] struct {
+	origin      ocr3_1types.ReportingPluginFactory[RI]
+	lggr        logger.Logger
+	chainFamily string
+	chainID     string
+	plugin      string
+}
+
+func NewReportingPluginFactory[RI any](
+	origin ocr3_1types.ReportingPluginFactory[RI],
+	lggr logger.Logger,
+	chainFamily string,
+	chainID string,
+	plugin string,
+) *ReportingPluginFactory[RI] {
+	return &ReportingPluginFactory[RI]{
+		origin:      origin,
+		lggr:        lggr,
+		chainFamily: chainFamily,
+		chainID:     chainID,
+		plugin:      plugin,
+	}
+}
+
+func (r ReportingPluginFactory[RI]) NewReportingPlugin(
+	ctx context.Context,
+	config ocr3types.ReportingPluginConfig,
+	bbf ocr3_1types.BlobBroadcastFetcher,
+) (ocr3_1types.ReportingPlugin[RI], ocr3_1types.ReportingPluginInfo, error) {
+	plugin, info, err := r.origin.NewReportingPlugin(ctx, config, bbf)
+	if err != nil {
+		// chainlink's libocr has ReportingPluginInfo as an interface;
+		// ReportingPluginInfo1 is the concrete "v1" impl (see
+		// libocr/offchainreporting2plus/ocr3_1types/plugin.go:457-477).
+		// A nil interface return would trip nilness checks downstream —
+		// return an empty ReportingPluginInfo1 instead.
+		return nil, ocr3_1types.ReportingPluginInfo1{}, err
+	}
+	r.lggr.Infow("Wrapping OCR3_1 ReportingPlugin with prometheus metrics reporter",
+		"configDigest", config.ConfigDigest,
+		"oracleID", config.OracleID,
+	)
+	wrapped := newReportingPlugin(
+		plugin,
+		r.chainFamily,
+		r.chainID,
+		r.plugin,
+		config.ConfigDigest.String(),
+		promOCR3_1ReportsGenerated,
+		promOCR3_1Durations,
+		promOCR3_1Sizes,
+		promOCR3_1PluginStatus,
+	)
+	return wrapped, info, err
+}

--- a/core/services/ocr3_1/promwrapper/plugin.go
+++ b/core/services/ocr3_1/promwrapper/plugin.go
@@ -1,0 +1,225 @@
+package promwrapper
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+)
+
+var _ ocr3_1types.ReportingPlugin[any] = &reportingPlugin[any]{}
+
+// reportingPlugin wraps an ocr3_1types.ReportingPlugin[RI] with prometheus
+// instrumentation. Each method is timed; size-bearing methods (Observation,
+// StateTransition precursor output, Reports) also emit byte counters.
+type reportingPlugin[RI any] struct {
+	ocr3_1types.ReportingPlugin[RI]
+	chainFamily string
+	chainID     string
+	plugin      string
+
+	configDigest     string
+	reportsGenerated *prometheus.CounterVec
+	durations        *prometheus.HistogramVec
+	sizes            *prometheus.CounterVec
+	status           *prometheus.GaugeVec
+}
+
+func newReportingPlugin[RI any](
+	origin ocr3_1types.ReportingPlugin[RI],
+	chainFamily string,
+	chainID string,
+	plugin string,
+	configDigest string,
+	reportsGenerated *prometheus.CounterVec,
+	durations *prometheus.HistogramVec,
+	sizes *prometheus.CounterVec,
+	status *prometheus.GaugeVec,
+) *reportingPlugin[RI] {
+	return &reportingPlugin[RI]{
+		ReportingPlugin:  origin,
+		chainFamily:      chainFamily,
+		chainID:          chainID,
+		plugin:           plugin,
+		configDigest:     configDigest,
+		reportsGenerated: reportsGenerated,
+		durations:        durations,
+		sizes:            sizes,
+		status:           status,
+	}
+}
+
+func (p *reportingPlugin[RI]) Query(
+	ctx context.Context,
+	seqNr uint64,
+	kv ocr3_1types.KeyValueReader,
+	bbf ocr3_1types.BlobBroadcastFetcher,
+) (ocrtypes.Query, error) {
+	return withObservedExecution(p, query, func() (ocrtypes.Query, error) {
+		return p.ReportingPlugin.Query(ctx, seqNr, kv, bbf)
+	})
+}
+
+func (p *reportingPlugin[RI]) Observation(
+	ctx context.Context,
+	seqNr uint64,
+	aq ocrtypes.AttributedQuery,
+	kv ocr3_1types.KeyValueReader,
+	bbf ocr3_1types.BlobBroadcastFetcher,
+) (ocrtypes.Observation, error) {
+	result, err := withObservedExecution(p, observation, func() (ocrtypes.Observation, error) {
+		return p.ReportingPlugin.Observation(ctx, seqNr, aq, kv, bbf)
+	})
+	p.trackSize(observation, len(result), err)
+	return result, err
+}
+
+func (p *reportingPlugin[RI]) ValidateObservation(
+	ctx context.Context,
+	seqNr uint64,
+	aq ocrtypes.AttributedQuery,
+	ao ocrtypes.AttributedObservation,
+	kv ocr3_1types.KeyValueReader,
+	bf ocr3_1types.BlobFetcher,
+) error {
+	_, err := withObservedExecution(p, validateObservation, func() (any, error) {
+		err := p.ReportingPlugin.ValidateObservation(ctx, seqNr, aq, ao, kv, bf)
+		return nil, err
+	})
+	return err
+}
+
+func (p *reportingPlugin[RI]) ObservationQuorum(
+	ctx context.Context,
+	seqNr uint64,
+	aq ocrtypes.AttributedQuery,
+	aos []ocrtypes.AttributedObservation,
+	kv ocr3_1types.KeyValueReader,
+	bf ocr3_1types.BlobFetcher,
+) (bool, error) {
+	return withObservedExecution(p, observationQuorum, func() (bool, error) {
+		return p.ReportingPlugin.ObservationQuorum(ctx, seqNr, aq, aos, kv, bf)
+	})
+}
+
+func (p *reportingPlugin[RI]) StateTransition(
+	ctx context.Context,
+	seqNr uint64,
+	aq ocrtypes.AttributedQuery,
+	aos []ocrtypes.AttributedObservation,
+	kvrw ocr3_1types.KeyValueReadWriter,
+	bf ocr3_1types.BlobFetcher,
+) (ocr3_1types.ReportsPlusPrecursor, error) {
+	result, err := withObservedExecution(p, stateTransition, func() (ocr3_1types.ReportsPlusPrecursor, error) {
+		return p.ReportingPlugin.StateTransition(ctx, seqNr, aq, aos, kvrw, bf)
+	})
+	p.trackSize(stateTransition, len(result), err)
+	return result, err
+}
+
+func (p *reportingPlugin[RI]) Committed(
+	ctx context.Context,
+	seqNr uint64,
+	kv ocr3_1types.KeyValueReader,
+) error {
+	_, err := withObservedExecution(p, committed, func() (any, error) {
+		err := p.ReportingPlugin.Committed(ctx, seqNr, kv)
+		return nil, err
+	})
+	return err
+}
+
+func (p *reportingPlugin[RI]) Reports(
+	ctx context.Context,
+	seqNr uint64,
+	precursor ocr3_1types.ReportsPlusPrecursor,
+) ([]ocr3types.ReportPlus[RI], error) {
+	result, err := withObservedExecution(p, reports, func() ([]ocr3types.ReportPlus[RI], error) {
+		return p.ReportingPlugin.Reports(ctx, seqNr, precursor)
+	})
+	p.trackReports(reports, len(result))
+	return result, err
+}
+
+func (p *reportingPlugin[RI]) ShouldAcceptAttestedReport(
+	ctx context.Context,
+	seqNr uint64,
+	reportWithInfo ocr3types.ReportWithInfo[RI],
+) (bool, error) {
+	result, err := withObservedExecution(p, shouldAccept, func() (bool, error) {
+		return p.ReportingPlugin.ShouldAcceptAttestedReport(ctx, seqNr, reportWithInfo)
+	})
+	p.trackReports(shouldAccept, boolToInt(result))
+	return result, err
+}
+
+func (p *reportingPlugin[RI]) ShouldTransmitAcceptedReport(
+	ctx context.Context,
+	seqNr uint64,
+	reportWithInfo ocr3types.ReportWithInfo[RI],
+) (bool, error) {
+	result, err := withObservedExecution(p, shouldTransmit, func() (bool, error) {
+		return p.ReportingPlugin.ShouldTransmitAcceptedReport(ctx, seqNr, reportWithInfo)
+	})
+	p.trackReports(shouldTransmit, boolToInt(result))
+	return result, err
+}
+
+func (p *reportingPlugin[RI]) Close() error {
+	p.updateStatus(false)
+	return p.ReportingPlugin.Close()
+}
+
+// ---- shared helpers ----
+
+func (p *reportingPlugin[RI]) trackReports(function functionType, count int) {
+	p.reportsGenerated.
+		WithLabelValues(p.chainFamily, p.chainID, p.plugin, string(function)).
+		Add(float64(count))
+}
+
+func (p *reportingPlugin[RI]) updateStatus(status bool) {
+	p.status.
+		WithLabelValues(p.chainFamily, p.chainID, p.plugin, p.configDigest).
+		Set(float64(boolToInt(status)))
+}
+
+func (p *reportingPlugin[RI]) trackSize(function functionType, size int, err error) {
+	if err != nil {
+		return
+	}
+	p.sizes.
+		WithLabelValues(p.chainFamily, p.chainID, p.plugin, string(function)).
+		Add(float64(size))
+}
+
+func boolToInt(arg bool) int {
+	if arg {
+		return 1
+	}
+	return 0
+}
+
+func withObservedExecution[RI, R any](
+	p *reportingPlugin[RI],
+	function functionType,
+	exec func() (R, error),
+) (R, error) {
+	start := time.Now()
+	result, err := exec()
+
+	success := err == nil
+
+	p.durations.
+		WithLabelValues(p.chainFamily, p.chainID, p.plugin, string(function), strconv.FormatBool(success)).
+		Observe(float64(time.Since(start)))
+
+	p.updateStatus(true)
+
+	return result, err
+}

--- a/core/services/ocr3_1/promwrapper/types.go
+++ b/core/services/ocr3_1/promwrapper/types.go
@@ -1,0 +1,77 @@
+package promwrapper
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type functionType string
+
+// OCR3_1 exposes the same Query/Observation/Reports/ShouldAccept/
+// ShouldTransmit surface as OCR3 but adds StateTransition (replacing
+// Outcome), Committed, and explicit ObservationQuorum. Metric labels
+// track each separately so dashboards can distinguish the new critical-
+// path methods.
+const (
+	query               functionType = "query"
+	observation         functionType = "observation"
+	validateObservation functionType = "validateObservation"
+	observationQuorum   functionType = "observationQuorum"
+	stateTransition     functionType = "stateTransition"
+	committed           functionType = "committed"
+	reports             functionType = "reports"
+	shouldAccept        functionType = "shouldAccept"
+	shouldTransmit      functionType = "shouldTransmit"
+)
+
+var (
+	buckets = []float64{
+		float64(10 * time.Millisecond),
+		float64(50 * time.Millisecond),
+		float64(100 * time.Millisecond),
+		float64(200 * time.Millisecond),
+		float64(500 * time.Millisecond),
+		float64(700 * time.Millisecond),
+		float64(time.Second),
+		float64(2 * time.Second),
+		float64(5 * time.Second),
+		float64(10 * time.Second),
+		float64(20 * time.Second),
+		float64(30 * time.Second),
+	}
+
+	// Distinct metric names from the OCR3 promwrapper so dashboards can
+	// slice OCR3 vs OCR3_1 DONs independently during the coexistence
+	// window. Same label dimensions as OCR3 for easy template reuse.
+	promOCR3_1ReportsGenerated = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ocr3_1_reporting_plugin_reports_processed",
+			Help: "Tracks number of reports processed/generated within by different OCR3_1 functions",
+		},
+		[]string{"chainFamily", "chainID", "plugin", "function"},
+	)
+	promOCR3_1Durations = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "ocr3_1_reporting_plugin_duration",
+			Help:    "The amount of time elapsed during the OCR3_1 plugin's function",
+			Buckets: buckets,
+		},
+		[]string{"chainFamily", "chainID", "plugin", "function", "success"},
+	)
+	promOCR3_1Sizes = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ocr3_1_reporting_plugin_data_sizes",
+			Help: "Tracks the size of the data produced by OCR3_1 plugin in bytes (observations, precursors, reports)",
+		},
+		[]string{"chainFamily", "chainID", "plugin", "function"},
+	)
+	promOCR3_1PluginStatus = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocr3_1_reporting_plugin_status",
+			Help: "Gauge indicating whether the OCR3_1 plugin is up and running",
+		},
+		[]string{"chainFamily", "chainID", "plugin", "configDigest"},
+	)
+)


### PR DESCRIPTION
chainlink-side scaffolding for the OCR3_1 CRE
  consensus plugin migration. Pairs with the chainlink-common OCR3_1 scaffold PR. Plan + rollout: internal OCR3_1 migration plan, Part 8/10. Do not
  merge until: (1) chainlink-common OCR3_1 PR has merged and chainlink's chainlink-common pin is bumped to include NewOCR3_1, (2) preflight item 4
  (libocr blob durability) is answered.