### PR TITLE
Fake HTTP Trigger - Implement local gateway

### DIFF
--- a/core/capabilities/fakes/gateway/local.go
+++ b/core/capabilities/fakes/gateway/local.go
@@ -1,0 +1,88 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	httptypedapi "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/triggers/http"
+)
+
+type JSONRPCRequest struct {
+	Input json.RawMessage `json:"input"`
+}
+
+type Config struct {
+	Port uint16
+}
+
+type LocalGateway struct {
+	config Config
+}
+
+func NewLocalGateway(config Config) *LocalGateway {
+	return &LocalGateway{config: config}
+}
+
+func (g *LocalGateway) ListenForTriggerPayload(ctx context.Context) (*httptypedapi.Payload, error) {
+	payloadCh := make(chan *httptypedapi.Payload, 1)
+	errorCh := make(chan error, 1)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/trigger", func(w http.ResponseWriter, r *http.Request) {
+		input, err := parseRequest(r)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("error processing request: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		payloadCh <- &httptypedapi.Payload{
+			Input: input,
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	server := &http.Server{
+		Addr:              fmt.Sprintf(":%d", g.config.Port),
+		Handler:           mux,
+		ReadHeaderTimeout: time.Second,
+	}
+	defer server.Close()
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errorCh <- err
+		}
+	}()
+
+	select {
+	case payload := <-payloadCh:
+		return payload, nil
+	case err := <-errorCh:
+		return nil, err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func parseRequest(req *http.Request) ([]byte, error) {
+	if req.Method != http.MethodPost {
+		return nil, errors.New("gateway expects POST request")
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	var rpcRequest JSONRPCRequest
+	if err := json.Unmarshal(body, &rpcRequest); err != nil {
+		return nil, fmt.Errorf("failed to parse request body: %w", err)
+	}
+
+	return rpcRequest.Input, nil
+}

--- a/core/capabilities/fakes/gateway/local_test.go
+++ b/core/capabilities/fakes/gateway/local_test.go
@@ -64,7 +64,7 @@ func TestListenForTriggerPayload_HappyPath(t *testing.T) {
 	// directly, the []byte field would be base64-encoded by json.Marshal,
 	// which is not what a real HTTP client sends.
 	inputJSON := json.RawMessage(`{"order":"pizza","size":"large"}`)
-	rawBody := map[string]interface{}{
+	rawBody := map[string]any{
 		"input": inputJSON,
 	}
 	body, err := json.Marshal(rawBody)

--- a/core/capabilities/fakes/gateway/local_test.go
+++ b/core/capabilities/fakes/gateway/local_test.go
@@ -1,0 +1,91 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	httptypedapi "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/triggers/http"
+)
+
+// waitForPort polls until the TCP port is reachable or the deadline passes.
+func waitForPort(t *testing.T, port uint16, timeout time.Duration) {
+	t.Helper()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		dialer := &net.Dialer{Timeout: 50 * time.Millisecond}
+		conn, err := dialer.DialContext(context.Background(), "tcp", addr)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("server on port %d did not become ready within %s", port, timeout)
+}
+
+// TestListenForTriggerPayload_HappyPath is an integration test that verifies
+// the full round-trip of ListenForTriggerPayload:
+//  1. A LocalGateway is started on an ephemeral port.
+//  2. A valid POST request carrying a signed JWT and a JSON-RPC body is sent.
+//  3. The method returns a Payload whose Input and Key match the request.
+func TestListenForTriggerPayload_HappyPath(t *testing.T) {
+	var port uint16 = 30123
+	gw := NewLocalGateway(Config{Port: port})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	type result struct {
+		payload *httptypedapi.Payload
+		err     error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		p, err := gw.ListenForTriggerPayload(ctx)
+		resultCh <- result{p, err}
+	}()
+
+	// Wait for the HTTP server to be ready before sending the request.
+	waitForPort(t, port, 2*time.Second)
+
+	// Build the JSON-RPC request body containing input data.
+	// We construct the body manually using a map so that the "input" field is
+	// embedded as a raw JSON object on the wire.  If we used JsonRpcRequest
+	// directly, the []byte field would be base64-encoded by json.Marshal,
+	// which is not what a real HTTP client sends.
+	inputJSON := json.RawMessage(`{"order":"pizza","size":"large"}`)
+	rawBody := map[string]interface{}{
+		"input": inputJSON,
+	}
+	body, err := json.Marshal(rawBody)
+	require.NoError(t, err)
+
+	// Send the POST request to the gateway.
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("http://127.0.0.1:%d/trigger", port), bytes.NewReader(body))
+	require.NoError(t, err)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// ListenForTriggerPayload should return exactly one payload.
+	res := <-resultCh
+	require.NoError(t, res.err)
+	require.NotNil(t, res.payload)
+
+	// The payload input must match what was sent in Params.Input.
+	assert.Equal(t, []byte(inputJSON), res.payload.Input)
+}

--- a/core/capabilities/fakes/manual_http_trigger.go
+++ b/core/capabilities/fakes/manual_http_trigger.go
@@ -2,6 +2,8 @@ package fakes
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
@@ -10,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/fakes/gateway"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/events"
 )
@@ -28,24 +31,34 @@ var manualHTTPTriggerInfo = capabilities.MustNewCapabilityInfo(
 
 type ManualHTTPTriggerService struct {
 	capabilities.CapabilityInfo
-	lggr        logger.Logger
+
+	lggr    logger.Logger
+	gateway *gateway.LocalGateway
+
 	callbackCh  map[string]chan capabilities.TriggerAndId[*httptypedapi.Payload]
 	workflowIDs map[string]string // triggerID -> workflowID mapping
+	inputs      map[string]*httptypedapi.Config
 }
 
-func NewManualHTTPTriggerService(parentLggr logger.Logger) *ManualHTTPTriggerService {
+func NewManualHTTPTriggerService(parentLggr logger.Logger, gatewayConfig gateway.Config) *ManualHTTPTriggerService {
 	lggr := logger.Named(parentLggr, "HTTPTriggerService")
+	localGateway := gateway.NewLocalGateway(gatewayConfig)
 
 	return &ManualHTTPTriggerService{
 		CapabilityInfo: manualHTTPTriggerInfo,
-		lggr:           lggr,
-		callbackCh:     make(map[string]chan capabilities.TriggerAndId[*httptypedapi.Payload]),
-		workflowIDs:    make(map[string]string),
+
+		lggr:    lggr,
+		gateway: localGateway,
+
+		callbackCh:  make(map[string]chan capabilities.TriggerAndId[*httptypedapi.Payload]),
+		workflowIDs: make(map[string]string),
+		inputs:      make(map[string]*httptypedapi.Config),
 	}
 }
 
 // HTTPCapability interface methods
 func (f *ManualHTTPTriggerService) RegisterTrigger(ctx context.Context, triggerID string, metadata capabilities.RequestMetadata, input *httptypedapi.Config) (<-chan capabilities.TriggerAndId[*httptypedapi.Payload], caperrors.Error) {
+	f.inputs[triggerID] = input
 	f.callbackCh[triggerID] = make(chan capabilities.TriggerAndId[*httptypedapi.Payload])
 	f.workflowIDs[triggerID] = metadata.WorkflowID
 	return f.callbackCh[triggerID], nil
@@ -65,16 +78,32 @@ func (f *ManualHTTPTriggerService) Initialise(ctx context.Context, dependencies 
 }
 
 // ManualTriggerCapability interface method
-func (f *ManualHTTPTriggerService) ManualTrigger(ctx context.Context, triggerID string, payload *httptypedapi.Payload) error {
-	triggerEvent := f.createManualTriggerEvent(payload)
-
-	triggerEventID := triggerEvent.Id
-
+func (f *ManualHTTPTriggerService) ManualTrigger(ctx context.Context, triggerID string, payload *httptypedapi.Payload) (err error) {
 	workflowID, exists := f.workflowIDs[triggerID]
 	if !exists {
 		f.lggr.Errorw("workflowID not found for triggerID", "triggerID", triggerID)
 		workflowID = "unknownWorkflow"
 	}
+
+	input, exists := f.inputs[triggerID]
+	if !exists {
+		f.lggr.Errorw("input not found for triggerID", "triggerID", triggerID)
+		return errors.New("input not found for triggerID")
+	}
+	if input == nil {
+		f.lggr.Errorw("input is nil for triggerID", "triggerID", triggerID)
+		return errors.New("input is nil for triggerID")
+	}
+
+	if payload == nil {
+		payload, err = f.gateway.ListenForTriggerPayload(ctx)
+		if err != nil {
+			return fmt.Errorf("gateway: %w", err)
+		}
+	}
+
+	triggerEvent := f.createManualTriggerEvent(payload)
+	triggerEventID := triggerEvent.Id
 
 	workflowExecutionID, err := events.GenerateExecutionID(workflowID, triggerEventID)
 	if err != nil {


### PR DESCRIPTION
This pull request introduces a local JWT-authenticated HTTP gateway for the manual HTTP trigger capability. The main changes include the addition of a local gateway implementation, and integration of these components into the `ManualHTTPTriggerService`.