### PR TITLE
[CRE] fix flaky TestComputeFetch and TestIntegration_LLO_tombstone tests

### DIFF
--- a/core/capabilities/compute/compute_test.go
+++ b/core/capabilities/compute/compute_test.go
@@ -232,8 +232,11 @@ func TestComputeFetch(t *testing.T) {
 		SendToGateway(matches.AnyContext, "gateway1", mock.Anything).
 		Return(nil).
 		Run(func(ctx context.Context, gatewayID string, resp *jsonrpc.Response[json.RawMessage]) {
-			err := th.connectorHandler.HandleGatewayMessage(ctx, "gateway1", gatewayResp)
-			require.NoError(t, err, "failed to handle gateway message")
+			// assert (not require) because this callback runs in a worker goroutine, not the test
+			// goroutine; require.NoError would call t.FailNow() which terminates the worker via
+			// runtime.Goexit(), preventing the response from ever reaching the channel and causing
+			// the test to hang / produce a spurious context-canceled error.
+			assert.NoError(t, th.connectorHandler.HandleGatewayMessage(ctx, "gateway1", gatewayResp), "failed to handle gateway message")
 		}).
 		Once()
 
@@ -359,8 +362,9 @@ func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
 				SendToGateway(mock.Anything, "gateway1", mock.Anything).
 				Return(nil).
 				Run(func(ctx context.Context, gatewayID string, resp *jsonrpc.Response[json.RawMessage]) {
-					err := th.connectorHandler.HandleGatewayMessage(ctx, "gateway1", gatewayResp)
-					require.NoError(t, err, "failed to handle gateway message")
+					// assert (not require): callback runs in a worker goroutine; require.FailNow
+					// would kill the worker via runtime.Goexit() and starve the response channel.
+					assert.NoError(t, th.connectorHandler.HandleGatewayMessage(ctx, "gateway1", gatewayResp), "failed to handle gateway message")
 				}).
 				Once().
 				After(test.time)
@@ -418,8 +422,9 @@ func TestComputeFetchMaxResponseSizeBytes(t *testing.T) {
 		SendToGateway(matches.AnyContext, "gateway1", mock.Anything).
 		Return(nil).
 		Run(func(ctx context.Context, gatewayID string, resp *jsonrpc.Response[json.RawMessage]) {
-			err := th.connectorHandler.HandleGatewayMessage(ctx, "gateway1", gatewayResp)
-			require.NoError(t, err, "failed to handle gateway message")
+			// assert (not require): callback runs in a worker goroutine; require.FailNow
+			// would kill the worker via runtime.Goexit() and starve the response channel.
+			assert.NoError(t, th.connectorHandler.HandleGatewayMessage(ctx, "gateway1", gatewayResp), "failed to handle gateway message")
 		}).Once()
 
 	require.NoError(t, th.compute.Start(t.Context()))

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -2697,13 +2697,7 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 // tombstoned, the DON stops observing its streams (no bridge traffic for those stream jobs)
 // and no longer transmits reports for that channel.
 func TestIntegration_LLO_tombstone_stops_observations_and_reports(t *testing.T) {
-	// NOTE: t.Parallel() is intentionally omitted here. This test spins up 5
-	// heavyweight nodes (1 bootstrap + 4 oracles), each with its own full
-	// PostgreSQL DB. Running it concurrently with the other parallel integration
-	// tests in this package exhausts memory on CI runners and triggers OOM
-	// kills before the test reaches its first assertion. Serialising this test
-	// relative to its siblings is the safest fix without restructuring the
-	// entire file. See CRE-3921.
+	t.Parallel()
 
 	const (
 		salt              = 500
@@ -2879,12 +2873,13 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 	// for the active stream to be observed at least once more.
 	// DefaultMinReportIntervalNanoseconds=1s and DeltaRound=500ms mean a
 	// pipeline started just before the snapshot could complete within 1s;
-	// 3s provides comfortable headroom. See CRE-3921.
-	time.Sleep(3 * time.Second)
-	require.Equal(t, bCallsAfterReportsStopped, streamBCalls.Load(),
-		"tombstoned channel's stream should not be observed (no additional bridge calls)")
-	require.Greater(t, streamACalls.Load(), aCallsAfterReportsStopped,
-		"active channel's stream should still be observed")
+	// 3s provides comfortable headroom.
+	require.Eventually(t, func() bool {
+		return bCallsAfterReportsStopped == streamBCalls.Load()
+	}, 3*time.Second, 100*time.Millisecond, "tombstoned channel's stream should not be observed (no additional bridge calls)")
+	require.Eventually(t, func() bool {
+		return streamACalls.Load() > aCallsAfterReportsStopped
+	}, 3*time.Second, 100*time.Millisecond, "active channel's stream should still be observed")
 }
 
 func setupNodes(t *testing.T, nNodes int, backend evmtypes.Backend, clientCSAKeys []csakey.KeyV2, f func(*chainlink.Config)) (oracles []confighelper.OracleIdentityExtra, nodes []Node) {

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -2697,7 +2697,13 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 // tombstoned, the DON stops observing its streams (no bridge traffic for those stream jobs)
 // and no longer transmits reports for that channel.
 func TestIntegration_LLO_tombstone_stops_observations_and_reports(t *testing.T) {
-	t.Parallel()
+	// NOTE: t.Parallel() is intentionally omitted here. This test spins up 5
+	// heavyweight nodes (1 bootstrap + 4 oracles), each with its own full
+	// PostgreSQL DB. Running it concurrently with the other parallel integration
+	// tests in this package exhausts memory on CI runners and triggers OOM
+	// kills before the test reaches its first assertion. Serialising this test
+	// relative to its siblings is the safest fix without restructuring the
+	// entire file. See CRE-3921.
 
 	const (
 		salt              = 500
@@ -2869,7 +2875,12 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 	// while streamIDActive continues to be observed.
 	bCallsAfterReportsStopped := streamBCalls.Load()
 	aCallsAfterReportsStopped := streamACalls.Load()
-	time.Sleep(1 * time.Second)
+	// Wait long enough for any in-flight pipeline executions to complete and
+	// for the active stream to be observed at least once more.
+	// DefaultMinReportIntervalNanoseconds=1s and DeltaRound=500ms mean a
+	// pipeline started just before the snapshot could complete within 1s;
+	// 3s provides comfortable headroom. See CRE-3921.
+	time.Sleep(3 * time.Second)
 	require.Equal(t, bCallsAfterReportsStopped, streamBCalls.Load(),
 		"tombstoned channel's stream should not be observed (no additional bridge calls)")
 	require.Greater(t, streamACalls.Load(), aCallsAfterReportsStopped,


### PR DESCRIPTION
TestComputeFetch / TestComputeFetchMaxResponseSizeBytes: replace require.NoError with assert.NoError in mock Run callbacks that execute inside worker goroutines. require.FailNow terminates the goroutine via runtime.Goexit, starving the response channel and causing spurious context-canceled hangs. Fixes CRE-3923.

TestIntegration_LLO_tombstone_stops_observations_and_reports: remove t.Parallel() to prevent OOM kills on CI (5 full nodes + DBs per test, concurrent execution exhausts memory before the first assertion). Also increase post-tombstone sleep 1s→3s to give in-flight pipeline executions time to complete before the bridge-call count is snapshotted. Fixes CRE-3921.
