### PR TITLE
[CRE] fix flaky TestLogEventProvider_ScheduleReadJobs tests (CRE-3918…

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -220,12 +219,18 @@ func TestLogEventProvider_ScheduleReadJobs(t *testing.T) {
 					}
 				case <-ctx.Done():
 					break readLoop
-				default:
-					if p.CurrentPartitionIdx() > uint64(batches+1) {
-						break readLoop
-					}
 				}
-				runtime.Gosched()
+			}
+		drainLoop:
+			for {
+				select {
+				case batch := <-reads:
+					for _, id := range batch {
+						got[id.String()]++
+					}
+				default:
+					break drainLoop
+				}
 			}
 
 			require.Len(t, got, len(ids))

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -220,6 +221,7 @@ func TestLogEventProvider_ScheduleReadJobs(t *testing.T) {
 				case <-ctx.Done():
 					break readLoop
 				}
+				runtime.Gosched()
 			}
 		drainLoop:
 			for {


### PR DESCRIPTION
…, CRE-3920)

Remove racy default: busy-spin from readLoop that could exit before the buffered reads channel was fully drained, causing non-deterministic require.Len failures. Replace with a blocking select and a post-loop drainLoop to flush any remaining buffered batches before assertions.