### PR TITLE
fix(keeper): prevent mock race in Test_RegistrySynchronizer1_2_UpkeepReceivedLog

### DIFF
--- a/core/services/keeper/registry1_2_synchronizer_test.go
+++ b/core/services/keeper/registry1_2_synchronizer_test.go
@@ -534,7 +534,7 @@ func Test_RegistrySynchronizer1_2_UpkeepReceivedLog(t *testing.T) {
 	cltest.WaitForCount(t, db, "upkeep_registrations", 1)
 
 	registryMock := cltest.NewContractMockReceiver(t, ethMock, keeper.Registry1_2ABI, contractAddress)
-	registryMock.MockResponse("getUpkeep", upkeepConfig1_2).Once()
+	registryMock.MockResponse("getUpkeep", upkeepConfig1_2).Maybe()
 
 	head := cltest.MustInsertHead(t, db, 1)
 	rawLog := types.Log{BlockHash: head.Hash}


### PR DESCRIPTION
## Summary

- Fixes flaky test `Test_RegistrySynchronizer1_2_UpkeepReceivedLog` in `core/services/keeper/` ([CRE-3895](https://smartcontract-it.atlassian.net/browse/CRE-3895))
- Changes `registryMock.MockResponse("getUpkeep", upkeepConfig1_2).Once()` → `.Maybe()` at `registry1_2_synchronizer_test.go:537`
- The `fullSync` goroutine (configured with `getActiveUpkeepIDsTime=2`) can make a second `getUpkeep` call after `WaitForCount(upkeep_registrations, 1)` returns, consuming the `.Once()` mock intended for the log handler — leaving `handleUpkeepReceived` without a response and causing `WaitForCount(upkeep_registrations, 2)` to time out
- `.Maybe()` makes the mock a permanent fallback; the `WaitForCount(..., 2)` assertion still fully validates correctness

## Test plan

- [ ] CI runs `Test_RegistrySynchronizer1_2_UpkeepReceivedLog` with `-race -shuffle=on` (requires `CL_DATABASE_URL` — not runnable locally without a full DB setup)
- [ ] Verify no regressions in sibling keeper synchronizer tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CRE-3895]: https://smartcontract-it.atlassian.net/browse/CRE-3895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ