### PR TITLE
Fix CCIP-11061: Increase TON LogPoller query frequency

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_ton_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_ton_helpers.go
@@ -38,7 +38,7 @@ var (
 // TON blockchain polling configuration
 const (
 	clientRetries       = 3                      // Number of retries for TON client operations
-	queryInterval       = 500 * time.Millisecond // How often to query logpoller for new events
+	queryInterval       = 100 * time.Millisecond // How often to query logpoller for new events
 	progressLogInterval = 5 * time.Second        // How often to log "still waiting" progress updates
 )
 


### PR DESCRIPTION
Fixes CCIP-11061

  ## Problem
  Test `Test_CCIPMessaging_EVM2TON/message_to_contract_receiver` was timing out (995s) waiting for CommitReportAccepted event on
  TON blockchain.

  ## Root Cause
  TON LogPoller's polling interval (500ms) was too coarse-grained. Events were emitted between polling cycles and never detected in
  fast test environments.

  ## Solution
  Reduce LogPoller query interval from 500ms to 100ms (5x more aggressive) to ensure events are captured reliably.

  ## Changes
  - `deployment/ccip/changeset/testhelpers/test_ton_helpers.go` (line 41):
    Changed: `queryInterval = 500 * time.Millisecond` → `100 * time.Millisecond`

  ## Confidence
  Trunk.io: 0.81 (high)
  Trunk Analysis: https://app.trunk.io/chainlink/flaky-tests/repo/0ec8ac39-2bf0-42e2-baaf-3f6cce784097/test/0594e16a-7d3b-532d-9081-75c3aff38d02?tab=analysis