### PR TITLE
chore: align package.json with release/2.41.3 patch line (RANE-4725)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.41.4",
+  "version": "2.41.3",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Beta/pre-GA builds from `release/2.41.3` should keep the root `package.json` version on **2.41.3** until RANE intentionally advances the shipped patch (e.g. GA hotfix as 2.41.4).

[#22229](https://github.com/smartcontractkit/chainlink/pull/22229) merged the cl-common rollback but also bumped `package.json` to 2.41.4; this PR sets it back to **2.41.3** so beta tags/images match the branch line.

## Ticket

[RANE-4725](https://smartcontract-it.atlassian.net/browse/RANE-4725)

## Testing

N/A (version field only).

[RANE-4725]: https://smartcontract-it.atlassian.net/browse/RANE-4725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ