### PR TITLE
Log JWT token validation details

### DIFF
--- a/core/capabilities/vault/jwt_based_auth.go
+++ b/core/capabilities/vault/jwt_based_auth.go
@@ -39,6 +39,7 @@ const ClaimVaultSecretManagementEnabled = "urn:chainlink:claim_vault_secret_mana
 const (
 	defaultJWKSRefreshInterval = 15 * time.Minute
 	defaultHTTPTimeout         = 5 * time.Second
+	tokenLogPrefixLen          = 20
 )
 
 // Auth0Config captures the Vault JWT issuer settings shared by gateway and node handlers.
@@ -203,9 +204,8 @@ func (v *jwtBasedAuth) AuthorizeRequest(ctx context.Context, req jsonrpc.Request
 		return nil, errors.New("JWTBasedAuth is disabled")
 	}
 
-	claims, err := v.validateToken(ctx, req.Auth)
+	claims, err := v.validateToken(ctx, req.Auth, req.ID, req.Method)
 	if err != nil {
-		v.lggr.Debugw("JWTBasedAuth token validation failed", "method", req.Method, "requestID", req.ID, "error", err)
 		return nil, fmt.Errorf("invalid JWT auth token: %w", err)
 	}
 
@@ -232,24 +232,24 @@ func (v *jwtBasedAuth) AuthorizeRequest(ctx context.Context, req jsonrpc.Request
 // validateToken verifies the JWT signature via Auth0 JWKS, validates
 // standard claims (iss, aud, exp), and extracts Vault-specific claims
 // (org_id, workflow_owner, request_digest).
-func (v *jwtBasedAuth) validateToken(ctx context.Context, tokenString string) (*JWTClaims, error) {
+func (v *jwtBasedAuth) validateToken(ctx context.Context, tokenString, requestID, method string) (*JWTClaims, error) {
 	if tokenString == "" {
-		return nil, ErrMissingToken
+		return v.tokenValidationError(requestID, method, tokenString, nil, ErrMissingToken)
 	}
 
 	unverified, _, err := jwt.NewParser().ParseUnverified(tokenString, jwt.MapClaims{})
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrInvalidToken, err)
+		return v.tokenValidationError(requestID, method, tokenString, unverified, fmt.Errorf("%w: %w", ErrInvalidToken, err))
 	}
 
 	kid, ok := unverified.Header["kid"].(string)
 	if !ok || kid == "" {
-		return nil, fmt.Errorf("%w: missing kid header", ErrInvalidToken)
+		return v.tokenValidationError(requestID, method, tokenString, unverified, fmt.Errorf("%w: missing kid header", ErrInvalidToken))
 	}
 
 	rsaKey, err := v.resolveSigningKey(ctx, kid)
 	if err != nil {
-		return nil, err
+		return v.tokenValidationError(requestID, method, tokenString, unverified, err)
 	}
 
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
@@ -264,15 +264,55 @@ func (v *jwtBasedAuth) validateToken(ctx context.Context, tokenString string) (*
 		jwt.WithIssuedAt(),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrInvalidToken, err)
+		return v.tokenValidationError(requestID, method, tokenString, token, fmt.Errorf("%w: %w", ErrInvalidToken, err))
 	}
 
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok || !token.Valid {
-		return nil, ErrInvalidToken
+		return v.tokenValidationError(requestID, method, tokenString, token, ErrInvalidToken)
 	}
 
-	return extractVaultClaims(claims)
+	vaultClaims, err := extractVaultClaims(claims)
+	if err != nil {
+		return v.tokenValidationError(requestID, method, tokenString, token, err)
+	}
+
+	return vaultClaims, nil
+}
+
+func (v *jwtBasedAuth) tokenValidationError(requestID, method, tokenString string, token *jwt.Token, err error) (*JWTClaims, error) {
+	var claims interface{}
+	var parsedToken interface{}
+	if token != nil {
+		claims = token.Claims
+		alg := ""
+		if token.Method != nil {
+			alg = token.Method.Alg()
+		}
+		parsedToken = map[string]interface{}{
+			"alg":    alg,
+			"header": token.Header,
+			"claims": token.Claims,
+			"valid":  token.Valid,
+		}
+	}
+
+	v.lggr.Debugw("JWTBasedAuth token validation failed with token details",
+		"method", method,
+		"requestID", requestID,
+		"error", err,
+		"tokenPrefix", safeTokenPrefix(tokenString, tokenLogPrefixLen),
+		"parsedToken", parsedToken,
+		"claims", claims,
+	)
+	return nil, err
+}
+
+func safeTokenPrefix(tokenString string, maxLen int) string {
+	if len(tokenString) <= maxLen {
+		return tokenString
+	}
+	return tokenString[:maxLen]
 }
 
 func extractVaultClaims(claims jwt.MapClaims) (*JWTClaims, error) {
@@ -351,8 +391,7 @@ func (v *jwtBasedAuth) resolveSigningKey(ctx context.Context, kid string) (*rsa.
 	}
 
 	if refreshErr := v.refreshJWKS(ctx); refreshErr != nil {
-		v.lggr.Warnw("JWKS refresh failed", "error", refreshErr, "kid", kid)
-		return nil, fmt.Errorf("%w: kid=%s", ErrJWKSKeyNotFound, kid)
+		return nil, fmt.Errorf("%w: kid=%s: %w", ErrJWKSKeyNotFound, kid, refreshErr)
 	}
 
 	key, err = v.findCachedKey(kid)

--- a/core/capabilities/vault/jwt_based_auth_test.go
+++ b/core/capabilities/vault/jwt_based_auth_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings"
@@ -117,11 +118,11 @@ func createTestJWT(t *testing.T, key testRSAKey, claims jwt.MapClaims) string {
 
 func validTestClaims(issuer, audience string) jwt.MapClaims {
 	return jwt.MapClaims{
-		"iss":    issuer,
-		"aud":    audience,
-		"exp":    jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
-		"iat":    jwt.NewNumericDate(time.Now()),
-		"org_id": "org_test123",
+		"iss":                             issuer,
+		"aud":                             audience,
+		"exp":                             jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+		"iat":                             jwt.NewNumericDate(time.Now()),
+		"org_id":                          "org_test123",
 		ClaimVaultSecretManagementEnabled: "true",
 		"authorization_details": []interface{}{
 			map[string]interface{}{
@@ -159,7 +160,7 @@ func TestJWTBasedAuth_ValidToken(t *testing.T) {
 
 	tokenString := createTestJWT(t, rsaKey, validTestClaims(issuer, audience))
 
-	result, err := v.validateToken(context.Background(), tokenString)
+	result, err := v.validateToken(context.Background(), tokenString, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "org_test123", result.OrgID)
 	assert.Equal(t, "0xAbCdEf0123456789AbCdEf0123456789AbCdEf01", result.WorkflowOwner)
@@ -176,11 +177,11 @@ func TestJWTBasedAuth_RejectsTokenWithoutWorkflowOwner(t *testing.T) {
 	v := newTestValidator(t, issuer, audience)
 
 	claims := jwt.MapClaims{
-		"iss":    issuer,
-		"aud":    audience,
-		"exp":    jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
-		"iat":    jwt.NewNumericDate(time.Now()),
-		"org_id": "org_no_wfowner",
+		"iss":                             issuer,
+		"aud":                             audience,
+		"exp":                             jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+		"iat":                             jwt.NewNumericDate(time.Now()),
+		"org_id":                          "org_no_wfowner",
 		ClaimVaultSecretManagementEnabled: "true",
 		"authorization_details": []interface{}{
 			map[string]interface{}{
@@ -191,7 +192,7 @@ func TestJWTBasedAuth_RejectsTokenWithoutWorkflowOwner(t *testing.T) {
 	}
 	tokenString := createTestJWT(t, rsaKey, claims)
 
-	result, err := v.validateToken(context.Background(), tokenString)
+	result, err := v.validateToken(context.Background(), tokenString, "", "")
 	require.Nil(t, result)
 	require.ErrorIs(t, err, ErrMissingWorkflowOwner)
 }
@@ -208,7 +209,7 @@ func TestJWTBasedAuth_ExpiredToken(t *testing.T) {
 	claims["exp"] = jwt.NewNumericDate(time.Now().Add(-1 * time.Minute))
 	tokenString := createTestJWT(t, rsaKey, claims)
 
-	_, err := v.validateToken(context.Background(), tokenString)
+	_, err := v.validateToken(context.Background(), tokenString, "", "")
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrInvalidToken)
 	assert.Contains(t, err.Error(), "expired")
@@ -225,7 +226,7 @@ func TestJWTBasedAuth_WrongIssuer(t *testing.T) {
 	claims := validTestClaims("https://wrong-issuer.auth0.com/", audience)
 	tokenString := createTestJWT(t, rsaKey, claims)
 
-	_, err := v.validateToken(context.Background(), tokenString)
+	_, err := v.validateToken(context.Background(), tokenString, "", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrInvalidToken)
 }
@@ -241,7 +242,7 @@ func TestJWTBasedAuth_WrongAudience(t *testing.T) {
 	claims := validTestClaims(issuer, "https://wrong-audience.com")
 	tokenString := createTestJWT(t, rsaKey, claims)
 
-	_, err := v.validateToken(context.Background(), tokenString)
+	_, err := v.validateToken(context.Background(), tokenString, "", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrInvalidToken)
 }
@@ -258,9 +259,57 @@ func TestJWTBasedAuth_MissingOrgID(t *testing.T) {
 	delete(claims, "org_id")
 	tokenString := createTestJWT(t, rsaKey, claims)
 
-	_, err := v.validateToken(context.Background(), tokenString)
+	_, err := v.validateToken(context.Background(), tokenString, "", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrMissingOrgID)
+}
+
+func TestJWTBasedAuth_LogsTokenDetailsOnValidationFailure(t *testing.T) {
+	rsaKey := generateTestRSAKey(t, "key-1")
+	jwksServer := newTestJWKSServer(t, rsaKey)
+
+	issuer := jwksServer.URL() + "/"
+	audience := "https://api.test.chain.link"
+	lggr, observed := logger.TestLoggerObserved(t, zapcore.DebugLevel)
+	v, err := NewJWTBasedAuth(JWTBasedAuthConfig{
+		IssuerURL:           issuer,
+		Audience:            audience,
+		JWKSRefreshInterval: time.Millisecond,
+	}, limits.Factory{Settings: cresettings.DefaultGetter}, lggr, WithJWTBasedAuthGateLimiter(limits.NewGateLimiter(true)))
+	require.NoError(t, err)
+
+	claims := validTestClaims(issuer, audience)
+	delete(claims, "org_id")
+	tokenString := createTestJWT(t, rsaKey, claims)
+
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-logs-token-details",
+		Method: vaulttypes.MethodSecretsList,
+		Auth:   tokenString,
+	}
+	_, err = v.AuthorizeRequest(t.Context(), req)
+	require.ErrorIs(t, err, ErrMissingOrgID)
+
+	logs := observed.FilterMessage("JWTBasedAuth token validation failed with token details").All()
+	require.Len(t, logs, 1)
+	logFields := logs[0].ContextMap()
+	assert.Equal(t, req.Method, logFields["method"])
+	assert.Equal(t, req.ID, logFields["requestID"])
+	assert.Equal(t, tokenString[:tokenLogPrefixLen], logFields["tokenPrefix"])
+	assert.NotContains(t, logFields, "rawToken")
+	parsedToken, ok := logFields["parsedToken"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "RS256", parsedToken["alg"])
+	assert.Contains(t, parsedToken, "header")
+	assert.Contains(t, parsedToken, "claims")
+	assert.NotContains(t, parsedToken, "raw")
+	assert.NotContains(t, parsedToken, "signature")
+
+	loggedClaims, ok := logFields["claims"].(jwt.MapClaims)
+	require.True(t, ok)
+	assert.Equal(t, issuer, loggedClaims["iss"])
+	assert.Equal(t, audience, loggedClaims["aud"])
+	assert.Equal(t, "true", loggedClaims[ClaimVaultSecretManagementEnabled])
 }
 
 func TestJWTBasedAuth_MissingVaultSecretManagementClaim(t *testing.T) {
@@ -275,7 +324,7 @@ func TestJWTBasedAuth_MissingVaultSecretManagementClaim(t *testing.T) {
 	delete(claims, ClaimVaultSecretManagementEnabled)
 	tokenString := createTestJWT(t, rsaKey, claims)
 
-	_, err := v.validateToken(context.Background(), tokenString)
+	_, err := v.validateToken(context.Background(), tokenString, "", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrVaultSecretManagementNotEnabled)
 }
@@ -292,7 +341,7 @@ func TestJWTBasedAuth_VaultSecretManagementClaimNotTrue(t *testing.T) {
 	claims[ClaimVaultSecretManagementEnabled] = "false"
 	tokenString := createTestJWT(t, rsaKey, claims)
 
-	_, err := v.validateToken(context.Background(), tokenString)
+	_, err := v.validateToken(context.Background(), tokenString, "", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrVaultSecretManagementNotEnabled)
 }
@@ -314,7 +363,7 @@ func TestJWTBasedAuth_MissingRequestDigest(t *testing.T) {
 	}
 	tokenString := createTestJWT(t, rsaKey, claims)
 
-	_, err := v.validateToken(context.Background(), tokenString)
+	_, err := v.validateToken(context.Background(), tokenString, "", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrMissingRequestDigest)
 }
@@ -331,7 +380,7 @@ func TestJWTBasedAuth_MissingAuthorizationDetails(t *testing.T) {
 	delete(claims, "authorization_details")
 	tokenString := createTestJWT(t, rsaKey, claims)
 
-	_, err := v.validateToken(context.Background(), tokenString)
+	_, err := v.validateToken(context.Background(), tokenString, "", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrMissingRequestDigest)
 }
@@ -348,7 +397,7 @@ func TestJWTBasedAuth_InvalidSignature(t *testing.T) {
 	claims := validTestClaims(issuer, audience)
 	tokenString := createTestJWT(t, badKey, claims) // signed with wrong private key
 
-	_, err := v.validateToken(context.Background(), tokenString)
+	_, err := v.validateToken(context.Background(), tokenString, "", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrInvalidToken)
 }
@@ -360,7 +409,7 @@ func TestJWTBasedAuth_EmptyToken(t *testing.T) {
 	}, limits.Factory{Settings: cresettings.DefaultGetter}, logger.TestLogger(t), WithJWTBasedAuthGateLimiter(limits.NewGateLimiter(true)))
 	require.NoError(t, err)
 
-	_, err = v.validateToken(context.Background(), "")
+	_, err = v.validateToken(context.Background(), "", "", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrMissingToken)
 }
@@ -378,7 +427,7 @@ func TestJWTBasedAuth_JWKSKeyRotation(t *testing.T) {
 	// Token signed with key-A succeeds
 	claimsA := validTestClaims(issuer, audience)
 	tokenA := createTestJWT(t, keyA, claimsA)
-	resultA, err := v.validateToken(context.Background(), tokenA)
+	resultA, err := v.validateToken(context.Background(), tokenA, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "org_test123", resultA.OrgID)
 
@@ -392,7 +441,7 @@ func TestJWTBasedAuth_JWKSKeyRotation(t *testing.T) {
 	claimsB := validTestClaims(issuer, audience)
 	claimsB["org_id"] = "org_after_rotation"
 	tokenB := createTestJWT(t, keyB, claimsB)
-	resultB, err := v.validateToken(context.Background(), tokenB)
+	resultB, err := v.validateToken(context.Background(), tokenB, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "org_after_rotation", resultB.OrgID)
 }
@@ -406,11 +455,11 @@ func TestJWTBasedAuth_AuthorizationDetailsFromTypedArray(t *testing.T) {
 	v := newTestValidator(t, issuer, audience)
 
 	claims := jwt.MapClaims{
-		"iss":    issuer,
-		"aud":    audience,
-		"exp":    jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
-		"iat":    jwt.NewNumericDate(time.Now()),
-		"org_id": "org_single",
+		"iss":                             issuer,
+		"aud":                             audience,
+		"exp":                             jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+		"iat":                             jwt.NewNumericDate(time.Now()),
+		"org_id":                          "org_single",
 		ClaimVaultSecretManagementEnabled: "true",
 		"authorization_details": []interface{}{
 			map[string]interface{}{"type": "request_digest", "value": "single_digest"},
@@ -419,7 +468,7 @@ func TestJWTBasedAuth_AuthorizationDetailsFromTypedArray(t *testing.T) {
 	}
 	tokenString := createTestJWT(t, rsaKey, claims)
 
-	result, err := v.validateToken(context.Background(), tokenString)
+	result, err := v.validateToken(context.Background(), tokenString, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "org_single", result.OrgID)
 	assert.Equal(t, "single_digest", result.RequestDigest)
@@ -441,7 +490,7 @@ func TestJWTBasedAuth_UnsupportedAlgorithm(t *testing.T) {
 	tokenString, err := token.SignedString([]byte("hmac-secret"))
 	require.NoError(t, err)
 
-	_, err = v.validateToken(context.Background(), tokenString)
+	_, err = v.validateToken(context.Background(), tokenString, "", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrInvalidToken)
 }
@@ -463,9 +512,11 @@ func TestJWTBasedAuth_JWKSServerUnavailable(t *testing.T) {
 	claims := validTestClaims(issuer, audience)
 	tokenString := createTestJWT(t, rsaKey, claims)
 
-	_, err := v.validateToken(context.Background(), tokenString)
+	_, err := v.validateToken(context.Background(), tokenString, "", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrJWKSKeyNotFound)
+	assert.ErrorIs(t, err, ErrJWKSFetchFailed)
+	assert.Contains(t, err.Error(), "HTTP 500")
 }
 
 func TestJWTBasedAuth_StartRefreshesJWKSPeriodically(t *testing.T) {
@@ -558,11 +609,11 @@ func TestJWTBasedAuth_AuthorizeCreateRequestFromRawJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	token := createTestJWT(t, rsaKey, jwt.MapClaims{
-		"iss":    issuer,
-		"aud":    audience,
-		"exp":    jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
-		"iat":    jwt.NewNumericDate(time.Now()),
-		"org_id": "org-123",
+		"iss":                             issuer,
+		"aud":                             audience,
+		"exp":                             jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+		"iat":                             jwt.NewNumericDate(time.Now()),
+		"org_id":                          "org-123",
 		ClaimVaultSecretManagementEnabled: "true",
 		"authorization_details": []interface{}{
 			map[string]interface{}{


### PR DESCRIPTION
## Summary

- Adds request-scoped debug logging for JWT validation failures so operators can inspect sanitized token context, parsed header and claims, and the validation error when auth fails.
- Threads the JSON-RPC request ID and method into token validation so diagnostic logs can be correlated with the failing request.
- Avoids logging replayable JWT material by recording only a short token prefix and a sanitized parsed token without raw token or signature fields.
- Adds regression coverage through the authorize path to verify sanitized token details, method, and request ID are emitted on validation failure.