### PR TITLE
Log payload diffs for duplicate executable message IDs

### DIFF
--- a/core/capabilities/remote/executable/server.go
+++ b/core/capabilities/remote/executable/server.go
@@ -39,6 +39,7 @@ type server struct {
 
 	// Used to detect messages with the same message id but different payloads
 	messageIDToRequestIDsCount map[string]map[string]int
+	messageIDToPayloads        map[string]map[string][]byte
 
 	receiveLock sync.Mutex
 	stopCh      services.StopChan
@@ -82,6 +83,7 @@ func NewServer(capabilityID, methodName string, peerID p2ptypes.PeerID, dispatch
 		lggr:                       logger.With(logger.Named(lggr, "ExecutableCapabilityServer"), "capabilityID", capabilityID, "capMethodName", methodName),
 		requestIDToRequest:         map[string]requestAndMsgID{},
 		messageIDToRequestIDsCount: map[string]map[string]int{},
+		messageIDToPayloads:        map[string]map[string][]byte{},
 		stopCh:                     make(services.StopChan),
 	}
 }
@@ -233,6 +235,7 @@ func (r *server) expireRequests() {
 		if executeReq.request.Evictable(commoncap.DefaultExecutableRequestTimeout) {
 			delete(r.requestIDToRequest, requestID)
 			delete(r.messageIDToRequestIDsCount, executeReq.messageID)
+			delete(r.messageIDToPayloads, executeReq.messageID)
 		}
 	}
 }
@@ -260,6 +263,12 @@ func (r *server) Receive(ctx context.Context, msg *types.MessageBody) {
 		return
 	}
 
+	callingDon, ok := cfg.workflowDONs[msg.CallerDonId]
+	if !ok {
+		r.lggr.Errorw("received request from unregistered don", "donId", msg.CallerDonId)
+		return
+	}
+
 	msgHash, err := cfg.hasher.Hash(msg)
 	if err != nil {
 		r.lggr.Errorw("failed to get message hash", "err", err)
@@ -277,21 +286,34 @@ func (r *server) Receive(ctx context.Context, msg *types.MessageBody) {
 	} else {
 		r.messageIDToRequestIDsCount[messageID] = map[string]int{requestID: 1}
 	}
+	if payloads, ok := r.messageIDToPayloads[messageID]; ok {
+		if _, exists := payloads[requestID]; !exists {
+			payloads[requestID] = append([]byte(nil), msg.Payload...)
+		}
+	} else {
+		r.messageIDToPayloads[messageID] = map[string][]byte{requestID: append([]byte(nil), msg.Payload...)}
+	}
 
 	requestIDs := r.messageIDToRequestIDsCount[messageID]
 	if len(requestIDs) > 1 {
 		// This is a potential attack vector as well as a situation that will occur if the client is sending non-deterministic payloads
 		// so a warning is logged
-		r.lggr.Warnw("received messages with the same id and different payloads", "messageID", messageID, "lenRequestIDs", len(requestIDs))
+		comparedRequestID, comparedPayload, ok := r.payloadForDifferentRequestID(messageID, requestID)
+		if ok {
+			payloadDiff, payloadDiffTruncated := diffPayloads(comparedPayload, msg.Payload)
+			r.lggr.Warnw("received messages with the same id and different payloads",
+				"messageID", messageID,
+				"lenRequestIDs", len(requestIDs),
+				"currentRequestID", requestID,
+				"comparedRequestID", comparedRequestID,
+				"payloadDiff", payloadDiff,
+				"payloadDiffTruncated", payloadDiffTruncated)
+		} else {
+			r.lggr.Warnw("received messages with the same id and different payloads", "messageID", messageID, "lenRequestIDs", len(requestIDs))
+		}
 	}
 
 	if _, ok := r.requestIDToRequest[requestID]; !ok {
-		callingDon, ok := cfg.workflowDONs[msg.CallerDonId]
-		if !ok {
-			r.lggr.Errorw("received request from unregistered don", "donId", msg.CallerDonId)
-			return
-		}
-
 		sr, ierr := request.NewServerRequest(cfg.underlying, msg.Method, cfg.capInfo.ID, cfg.localDonInfo.ID, r.peerID,
 			callingDon, messageID, r.dispatcher, cfg.remoteExecutableConfig.RequestTimeout, r.capMethodName, r.lggr)
 		if ierr != nil {
@@ -315,6 +337,15 @@ func (r *server) Receive(ctx context.Context, msg *types.MessageBody) {
 		}); executeTaskErr != nil {
 		r.lggr.Errorw("failed to execute on message task", "messageID", messageID, "err", executeTaskErr)
 	}
+}
+
+func (r *server) payloadForDifferentRequestID(messageID, requestID string) (string, []byte, bool) {
+	for otherRequestID, payload := range r.messageIDToPayloads[messageID] {
+		if otherRequestID != requestID {
+			return otherRequestID, payload, true
+		}
+	}
+	return "", nil, false
 }
 
 func GetMessageID(msg *types.MessageBody) (string, error) {

--- a/core/capabilities/remote/executable/server_payload_diff.go
+++ b/core/capabilities/remote/executable/server_payload_diff.go
@@ -1,0 +1,123 @@
+package executable
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	maxPayloadDiffBytes       = 64 * 1024
+	maxPayloadDiffMatrixCells = 4_000_000
+)
+
+func diffPayloads(previousPayload, currentPayload []byte) (string, bool) {
+	previous := formatPayloadForDiff(previousPayload)
+	current := formatPayloadForDiff(currentPayload)
+	if previous == current {
+		return "", false
+	}
+
+	diff, truncated := lineDiff(previous, current)
+	if len(diff) <= maxPayloadDiffBytes {
+		return diff, truncated
+	}
+	return diff[:maxPayloadDiffBytes] + "\n... payload diff truncated ...", true
+}
+
+func formatPayloadForDiff(payload []byte) string {
+	var req capabilitiespb.CapabilityRequest
+	if err := proto.Unmarshal(payload, &req); err != nil {
+		return fmt.Sprintf("unable to decode CapabilityRequest payload: %v\nraw_payload_hex:\n%s", err, hex.Dump(payload))
+	}
+
+	jsonPayload, jsonErr := protojson.MarshalOptions{
+		UseProtoNames: true,
+		Multiline:     true,
+		Indent:        "  ",
+	}.Marshal(&req)
+	if jsonErr == nil {
+		return string(jsonPayload)
+	}
+
+	textPayload, textErr := prototext.MarshalOptions{
+		Multiline: true,
+		Indent:    "  ",
+	}.Marshal(&req)
+	if textErr == nil {
+		return string(textPayload)
+	}
+
+	return fmt.Sprintf("unable to format CapabilityRequest payload as JSON (%v) or text (%v)\nraw_payload_hex:\n%s",
+		jsonErr, textErr, hex.Dump(payload))
+}
+
+func lineDiff(previous, current string) (string, bool) {
+	previousLines := splitDiffLines(previous)
+	currentLines := splitDiffLines(current)
+	if len(previousLines)*len(currentLines) > maxPayloadDiffMatrixCells {
+		return oversizedDiff(previousLines, currentLines), true
+	}
+
+	lcs := make([][]int, len(previousLines)+1)
+	for i := range lcs {
+		lcs[i] = make([]int, len(currentLines)+1)
+	}
+	for i := len(previousLines) - 1; i >= 0; i-- {
+		for j := len(currentLines) - 1; j >= 0; j-- {
+			if previousLines[i] == currentLines[j] {
+				lcs[i][j] = lcs[i+1][j+1] + 1
+			} else if lcs[i+1][j] >= lcs[i][j+1] {
+				lcs[i][j] = lcs[i+1][j]
+			} else {
+				lcs[i][j] = lcs[i][j+1]
+			}
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("--- previous_payload\n+++ current_payload\n")
+	for i, j := 0, 0; i < len(previousLines) || j < len(currentLines); {
+		switch {
+		case i < len(previousLines) && j < len(currentLines) && previousLines[i] == currentLines[j]:
+			i++
+			j++
+		case j >= len(currentLines) || (i < len(previousLines) && lcs[i+1][j] >= lcs[i][j+1]):
+			writeDiffLine(&b, '-', previousLines[i])
+			i++
+		default:
+			writeDiffLine(&b, '+', currentLines[j])
+			j++
+		}
+	}
+	return b.String(), false
+}
+
+func oversizedDiff(previousLines, currentLines []string) string {
+	return fmt.Sprintf("--- previous_payload\n+++ current_payload\npayload diff omitted: formatted payloads are too large to diff safely (previousLines=%d, currentLines=%d)\n",
+		len(previousLines), len(currentLines))
+}
+
+func splitDiffLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	lines := strings.SplitAfter(s, "\n")
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+func writeDiffLine(b *strings.Builder, prefix byte, line string) {
+	b.WriteByte(prefix)
+	b.WriteString(line)
+	if !strings.HasSuffix(line, "\n") {
+		b.WriteByte('\n')
+	}
+}

--- a/core/capabilities/remote/executable/server_test.go
+++ b/core/capabilities/remote/executable/server_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
@@ -150,6 +151,75 @@ func Test_Server_ExcludesNonDeterministicInputAttributes(t *testing.T) {
 		}
 	}
 	closeServices(t, srvcs)
+}
+
+func Test_Server_Receive_LogsPayloadDiffForSameMessageIDDifferentPayloads(t *testing.T) {
+	ctx := testutils.Context(t)
+	lggr, observedLogs := logger.TestObserved(t, zapcore.WarnLevel)
+
+	capabilityPeer := NewP2PPeerID(t)
+	workflowPeer := NewP2PPeerID(t)
+	broker := newTestAsyncMessageBroker(t, 100)
+	dispatcher := broker.NewDispatcherForNode(capabilityPeer)
+
+	capDonInfo := commoncap.DON{
+		ID:      1,
+		Members: []p2ptypes.PeerID{capabilityPeer},
+		F:       0,
+	}
+	capInfo := commoncap.CapabilityInfo{
+		ID:             "cap_id@1.0.0",
+		CapabilityType: commoncap.CapabilityTypeTarget,
+		Description:    "Remote Target",
+		DON:            &capDonInfo,
+	}
+	workflowDONs := map[uint32]commoncap.DON{
+		2: {
+			ID:      2,
+			Members: []p2ptypes.PeerID{workflowPeer},
+			F:       1,
+		},
+	}
+
+	srv := executable.NewServer(capInfo.ID, "", capabilityPeer, dispatcher, lggr)
+	require.NoError(t, srv.SetConfig(&commoncap.RemoteExecutableConfig{
+		RequestTimeout:            10 * time.Second,
+		ServerMaxParallelRequests: 1,
+	}, &TestCapability{}, capInfo, capDonInfo, workflowDONs, nil))
+	require.NoError(t, srv.Start(ctx))
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+	payloadA := marshalTestCapabilityRequest(t, "payload-a")
+	payloadB := marshalTestCapabilityRequest(t, "payload-b")
+
+	msg := &remotetypes.MessageBody{
+		CapabilityId:    capInfo.ID,
+		CapabilityDonId: capDonInfo.ID,
+		CallerDonId:     2,
+		Method:          remotetypes.MethodExecute,
+		Payload:         payloadA,
+		MessageId:       []byte("Execute:payload-diff"),
+		Sender:          workflowPeer[:],
+		Receiver:        capabilityPeer[:],
+	}
+	srv.Receive(ctx, msg)
+
+	msgWithDifferentPayload := *msg
+	msgWithDifferentPayload.Payload = payloadB
+	srv.Receive(ctx, &msgWithDifferentPayload)
+
+	logs := observedLogs.FilterMessage("received messages with the same id and different payloads").All()
+	require.Len(t, logs, 1)
+
+	fields := logs[0].ContextMap()
+	assert.Equal(t, "Execute:payload-diff", fields["messageID"])
+	payloadDiff, ok := fields["payloadDiff"].(string)
+	require.True(t, ok)
+	assert.Contains(t, payloadDiff, "--- previous_payload")
+	assert.Contains(t, payloadDiff, "+++ current_payload")
+	assert.Contains(t, payloadDiff, "payload-a")
+	assert.Contains(t, payloadDiff, "payload-b")
+	assert.Equal(t, false, fields["payloadDiffTruncated"])
 }
 
 func Test_Server_Execute_RespondsAfterSufficientRequests(t *testing.T) {
@@ -391,6 +461,20 @@ func closeServices(t *testing.T, srvcs []services.Service) {
 	for _, srv := range srvcs {
 		require.NoError(t, srv.Close())
 	}
+}
+
+func marshalTestCapabilityRequest(t *testing.T, executeValue string) []byte {
+	inputs, err := values.NewMap(map[string]any{"executeValue1": executeValue})
+	require.NoError(t, err)
+	payload, err := pb.MarshalCapabilityRequest(commoncap.CapabilityRequest{
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID:          workflowID1,
+			WorkflowExecutionID: workflowExecutionID1,
+		},
+		Inputs: inputs,
+	})
+	require.NoError(t, err)
+	return payload
 }
 
 type serverTestClient struct {


### PR DESCRIPTION
## Summary

- Adds diagnostic logging for duplicate executable messages that reuse a message ID with different payloads, so the warning shows what changed instead of only reporting the number of request IDs.
- Stores one representative payload per request hash while the request is retained, then removes those payloads through the existing eviction path.
- Formats decoded capability request payloads and logs a bounded line diff with truncation metadata for large payloads.