### PR TITLE
Gate vault workflow ID metadata

### DIFF
--- a/core/services/workflows/v2/secrets.go
+++ b/core/services/workflows/v2/secrets.go
@@ -193,13 +193,15 @@ func (s *secretsFetcher) getSecretsForBatch(ctx context.Context, request *sdkpb.
 		return nil, fmt.Errorf("failed to evaluate vault org_id gate: %w", err)
 	}
 	metadata := capabilities.RequestMetadata{
-		WorkflowID:          s.workflowID,
 		WorkflowOwner:       s.workflowOwner,
 		WorkflowName:        s.workflowName,
 		WorkflowExecutionID: sha(s.phaseID, strconv.FormatInt(int64(request.CallbackId), 10)),
 		ReferenceID:         strconv.FormatInt(int64(request.CallbackId), 10),
 	}
 	if orgIDGateEnabled {
+		// WorkflowID is under this gate because the previous release skipped
+		// setting workflowID on SecretsFetcher entirely.
+		metadata.WorkflowID = s.workflowID
 		metadata.OrgID = s.orgID
 	}
 

--- a/core/services/workflows/v2/secrets_test.go
+++ b/core/services/workflows/v2/secrets_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
 	"github.com/smartcontractkit/tdh2/go/tdh2/tdh2easy"
@@ -48,6 +49,44 @@ func testVaultOrgIDAsSecretOwnerGate(t *testing.T, enabled bool) limits.GateLimi
 	gate, err := limits.MakeGateLimiter(limits.Factory{Settings: getter, Logger: logger.TestLogger(t)}, cresettings.Default.VaultOrgIdAsSecretOwnerEnabled)
 	require.NoError(t, err)
 	return gate
+}
+
+type metadataCapturingVault struct {
+	metadata capabilities.RequestMetadata
+	response *vault.GetSecretsResponse
+}
+
+func (m *metadataCapturingVault) Info(ctx context.Context) (capabilities.CapabilityInfo, error) {
+	return capabilities.CapabilityInfo{
+		ID:             vault.CapabilityID,
+		CapabilityType: capabilities.CapabilityTypeAction,
+		IsLocal:        true,
+	}, nil
+}
+
+func (m *metadataCapturingVault) Execute(ctx context.Context, req capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+	vr := &vault.GetSecretsRequest{}
+	if err := req.Payload.UnmarshalTo(vr); err != nil {
+		return capabilities.CapabilityResponse{}, errors.New("received unexpected payload: want *vault.GetSecretsRequest")
+	}
+	if req.Method != vault.MethodGetSecrets {
+		return capabilities.CapabilityResponse{}, errors.New("received unexpected method: want vault.MethodGetSecrets")
+	}
+	m.metadata = req.Metadata
+
+	anyvresp, err := anypb.New(m.response)
+	if err != nil {
+		return capabilities.CapabilityResponse{}, err
+	}
+	return capabilities.CapabilityResponse{Payload: anyvresp}, nil
+}
+
+func (m *metadataCapturingVault) RegisterToWorkflow(ctx context.Context, request capabilities.RegisterToWorkflowRequest) error {
+	return errors.New("not used")
+}
+
+func (m *metadataCapturingVault) UnregisterFromWorkflow(ctx context.Context, request capabilities.UnregisterFromWorkflowRequest) error {
+	return errors.New("not used")
 }
 
 func TestSecretsFetcher_BulkFetchesSecretsFromCapability(t *testing.T) {
@@ -310,6 +349,87 @@ func TestSecretsFetcher_ReturnsErrorIfCapabilityErrors(t *testing.T) {
 		},
 	})
 	require.ErrorContains(t, err, "could not authorize the request")
+}
+
+func TestSecretsFetcher_WorkflowIDMetadataFollowsOrgIDGate(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		gateEnabled    bool
+		wantWorkflowID string
+		wantOrgID      string
+	}{
+		{
+			name:        "gate disabled",
+			gateEnabled: false,
+		},
+		{
+			name:           "gate enabled",
+			gateEnabled:    true,
+			wantWorkflowID: "workflowID",
+			wantOrgID:      "org-123",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lggr := logger.TestLogger(t)
+			reg := coreCap.NewRegistry(lggr)
+			peer := coreCap.RandomUTF8BytesWord()
+
+			workflowEncryptionKey := workflowkey.MustNewXXXTestingOnly(big.NewInt(1))
+			_, vaultPublicKey, _, err := tdh2easy.GenerateKeys(2, 3)
+			require.NoError(t, err)
+			vaultPublicKeyBytes, err := vaultPublicKey.Marshal()
+			require.NoError(t, err)
+			reg.SetLocalRegistry(CreateLocalRegistryWith1Node(t, peer, workflowEncryptionKey.PublicKey(), vaultPublicKeyBytes))
+
+			owner := "1234567890abcdef1234567890abcdef12345678"
+			normalizedOwner, err := normalizeOwner(owner)
+			require.NoError(t, err)
+
+			capture := &metadataCapturingVault{
+				response: &vault.GetSecretsResponse{
+					Responses: []*vault.SecretResponse{
+						{
+							Id: &vault.SecretIdentifier{
+								Key:       "Foo",
+								Namespace: "Bar",
+								Owner:     normalizedOwner,
+							},
+							Result: &vault.SecretResponse_Error{Error: "not found"},
+						},
+					},
+				},
+			}
+			err = reg.Add(t.Context(), capture)
+			require.NoError(t, err)
+
+			sf := NewSecretsFetcher(
+				MetricsLabelerTest(t),
+				reg,
+				lggr,
+				limits.WorkflowResourcePoolLimiter[int](5),
+				limits.NewUpperBoundLimiter[int](5),
+				testVaultOrgIDAsSecretOwnerGate(t, tc.gateEnabled),
+				"org-123",
+				owner,
+				"workflowName",
+				"workflowID",
+				"workflowExecID",
+				workflowEncryptionKey,
+			)
+
+			_, err = sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
+				Requests: []*sdkpb.SecretRequest{
+					{
+						Id:        "Foo",
+						Namespace: "Bar",
+					},
+				},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantWorkflowID, capture.metadata.WorkflowID)
+			assert.Equal(t, tc.wantOrgID, capture.metadata.OrgID)
+		})
+	}
 }
 
 func TestSecretsFetcher_ForwardsOrgIDAndWorkflowOwner(t *testing.T) {


### PR DESCRIPTION
## summary

- Fixes a mixed-version Vault request metadata regression in the workflow DON to Vault DON request path.
- Keeps `metadata.workflow_id` omitted while the Vault org ID gate is disabled, matching the previous release behavior where `SecretsFetcher` did not populate `workflowID`.
- Preserves the new JWT auth metadata behavior when the org ID gate is enabled by setting both `workflow_id` and `org_id` under the same gate.
- Adds test coverage for the gated metadata behavior so old and new workflow callers produce compatible Vault requests during rollout.