### PR TITLE
Forward port vault 2.44.1 fixes

### DIFF
--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -43,6 +43,11 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
+const (
+	blobBroadcastTimeout        = 2 * time.Second
+	maxConcurrentBlobBroadcasts = 10
+)
+
 var (
 	isValidIDComponent = regexp.MustCompile(`^[a-zA-Z0-9_]+$`).MatchString
 )
@@ -578,11 +583,12 @@ func (r *ReportingPlugin) Observation(ctx context.Context, seqNr uint64, aq type
 // broadcastBlobPayloads broadcasts each payload as a blob in parallel to reduce
 // Observation() latency (shortening this phase helps the OCR round finish within
 // DeltaProgress). Each call is given a 2-second timeout so that a single slow
-// broadcast cannot stall the entire batch. Individual broadcast failures are logged
-// and skipped rather than aborting the entire observation, so that one problematic
-// payload does not prevent the remaining items from being observed. Context
-// cancellation/deadline errors on the parent context are propagated immediately so
-// that expired rounds fail fast.
+// broadcast cannot stall the entire batch. No more than 10 broadcasts are allowed
+// in flight at a time. Individual broadcast failures are logged and skipped rather
+// than aborting the entire observation, so that one problematic payload does not
+// prevent the remaining items from being observed. Context cancellation/deadline
+// errors on the parent context are propagated immediately so that expired rounds
+// fail fast.
 func (r *ReportingPlugin) broadcastBlobPayloads(
 	ctx context.Context,
 	fetcher ocr3_1types.BlobBroadcastFetcher,
@@ -597,11 +603,12 @@ func (r *ReportingPlugin) broadcastBlobPayloads(
 		r.lggr.Debugw("observation blob broadcast finished", "seqNr", seqNr, "blobCount", len(payloads), "elapsed", time.Since(start))
 	}()
 
-	const perBlobTimeout = 2 * time.Second
 	var g errgroup.Group
+	g.SetLimit(maxConcurrentBlobBroadcasts)
 	for i, payload := range payloads {
+		requestID := requestIDs[i]
 		g.Go(func() error {
-			broadcastCtx, cancel := context.WithTimeout(ctx, perBlobTimeout)
+			broadcastCtx, cancel := context.WithTimeout(ctx, blobBroadcastTimeout)
 			defer cancel()
 
 			blobHandle, err := fetcher.BroadcastBlob(broadcastCtx, payload, ocr3_1types.BlobExpirationHintSequenceNumber{SeqNr: seqNr + 2})
@@ -611,7 +618,7 @@ func (r *ReportingPlugin) broadcastBlobPayloads(
 				}
 				r.lggr.Warnw("failed to broadcast pending queue item as blob, skipping",
 					"seqNr", seqNr,
-					"requestID", requestIDs[i],
+					"requestID", requestID,
 					"err", err)
 				return nil
 			}
@@ -620,7 +627,7 @@ func (r *ReportingPlugin) broadcastBlobPayloads(
 			if err != nil {
 				r.lggr.Warnw("failed to marshal blob handle, skipping",
 					"seqNr", seqNr,
-					"requestID", requestIDs[i],
+					"requestID", requestID,
 					"err", err)
 				return nil
 			}

--- a/core/services/ocr2/plugins/vault/plugin_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_test.go
@@ -7970,6 +7970,89 @@ func TestPlugin_broadcastBlobPayloads(t *testing.T) {
 		}
 	})
 
+	t.Run("does not exceed max concurrent broadcasts", func(t *testing.T) {
+		lggr := logger.TestLogger(t)
+		r := &ReportingPlugin{
+			lggr:    lggr,
+			metrics: newTestMetrics(t),
+			marshalBlob: func(ocr3_1types.BlobHandle) ([]byte, error) {
+				return []byte("handle"), nil
+			},
+		}
+
+		payloads := make([][]byte, maxConcurrentBlobBroadcasts*2+1)
+		ids := make([]string, len(payloads))
+		for i := range payloads {
+			payloads[i] = []byte(fmt.Sprintf("payload-%d", i))
+			ids[i] = fmt.Sprintf("req-%d", i)
+		}
+
+		var active atomic.Int32
+		var maxActive atomic.Int32
+		started := make(chan struct{}, len(payloads))
+		release := make(chan struct{})
+		released := atomic.Bool{}
+		releaseBroadcasts := func() {
+			if released.CompareAndSwap(false, true) {
+				close(release)
+			}
+		}
+		defer releaseBroadcasts()
+
+		fetcher := &ctxCallbackBlobFetcher{fn: func(ctx context.Context, _ []byte) error {
+			current := active.Add(1)
+			defer active.Add(-1)
+
+			for {
+				maxSeen := maxActive.Load()
+				if current <= maxSeen || maxActive.CompareAndSwap(maxSeen, current) {
+					break
+				}
+			}
+
+			started <- struct{}{}
+			select {
+			case <-release:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}}
+
+		type broadcastResult struct {
+			payloads [][]byte
+			err      error
+		}
+		done := make(chan broadcastResult, 1)
+		go func() {
+			result, err := r.broadcastBlobPayloads(t.Context(), fetcher, 1, payloads, ids)
+			done <- broadcastResult{payloads: result, err: err}
+		}()
+
+		for i := 0; i < maxConcurrentBlobBroadcasts; i++ {
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatalf("timed out waiting for broadcast %d to start", i+1)
+			}
+		}
+
+		assert.Never(t, func() bool {
+			return maxActive.Load() > int32(maxConcurrentBlobBroadcasts)
+		}, 100*time.Millisecond, 10*time.Millisecond)
+
+		releaseBroadcasts()
+
+		select {
+		case result := <-done:
+			require.NoError(t, result.err)
+			assert.Len(t, result.payloads, len(payloads))
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for broadcasts to complete")
+		}
+		assert.LessOrEqual(t, maxActive.Load(), int32(maxConcurrentBlobBroadcasts))
+	})
+
 	t.Run("failed broadcast is skipped and logged", func(t *testing.T) {
 		lggr, observed := logger.TestLoggerObserved(t, zapcore.WarnLevel)
 		r := &ReportingPlugin{

--- a/core/services/workflows/v2/secrets.go
+++ b/core/services/workflows/v2/secrets.go
@@ -193,13 +193,15 @@ func (s *secretsFetcher) getSecretsForBatch(ctx context.Context, request *sdkpb.
 		return nil, fmt.Errorf("failed to evaluate vault org_id gate: %w", err)
 	}
 	metadata := capabilities.RequestMetadata{
-		WorkflowID:          s.workflowID,
 		WorkflowOwner:       s.workflowOwner,
 		WorkflowName:        s.workflowName,
 		WorkflowExecutionID: sha(s.phaseID, strconv.FormatInt(int64(request.CallbackId), 10)),
 		ReferenceID:         strconv.FormatInt(int64(request.CallbackId), 10),
 	}
 	if orgIDGateEnabled {
+		// WorkflowID is under this gate because the previous release skipped
+		// setting workflowID on SecretsFetcher entirely.
+		metadata.WorkflowID = s.workflowID
 		metadata.OrgID = s.orgID
 	}
 

--- a/core/services/workflows/v2/secrets_test.go
+++ b/core/services/workflows/v2/secrets_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
 	"github.com/smartcontractkit/tdh2/go/tdh2/tdh2easy"
@@ -48,6 +49,44 @@ func testVaultOrgIDAsSecretOwnerGate(t *testing.T, enabled bool) limits.GateLimi
 	gate, err := limits.MakeGateLimiter(limits.Factory{Settings: getter, Logger: logger.TestLogger(t)}, cresettings.Default.VaultOrgIdAsSecretOwnerEnabled)
 	require.NoError(t, err)
 	return gate
+}
+
+type metadataCapturingVault struct {
+	metadata capabilities.RequestMetadata
+	response *vault.GetSecretsResponse
+}
+
+func (m *metadataCapturingVault) Info(ctx context.Context) (capabilities.CapabilityInfo, error) {
+	return capabilities.CapabilityInfo{
+		ID:             vault.CapabilityID,
+		CapabilityType: capabilities.CapabilityTypeAction,
+		IsLocal:        true,
+	}, nil
+}
+
+func (m *metadataCapturingVault) Execute(ctx context.Context, req capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+	vr := &vault.GetSecretsRequest{}
+	if err := req.Payload.UnmarshalTo(vr); err != nil {
+		return capabilities.CapabilityResponse{}, errors.New("received unexpected payload: want *vault.GetSecretsRequest")
+	}
+	if req.Method != vault.MethodGetSecrets {
+		return capabilities.CapabilityResponse{}, errors.New("received unexpected method: want vault.MethodGetSecrets")
+	}
+	m.metadata = req.Metadata
+
+	anyvresp, err := anypb.New(m.response)
+	if err != nil {
+		return capabilities.CapabilityResponse{}, err
+	}
+	return capabilities.CapabilityResponse{Payload: anyvresp}, nil
+}
+
+func (m *metadataCapturingVault) RegisterToWorkflow(ctx context.Context, request capabilities.RegisterToWorkflowRequest) error {
+	return errors.New("not used")
+}
+
+func (m *metadataCapturingVault) UnregisterFromWorkflow(ctx context.Context, request capabilities.UnregisterFromWorkflowRequest) error {
+	return errors.New("not used")
 }
 
 func TestSecretsFetcher_BulkFetchesSecretsFromCapability(t *testing.T) {
@@ -310,6 +349,87 @@ func TestSecretsFetcher_ReturnsErrorIfCapabilityErrors(t *testing.T) {
 		},
 	})
 	require.ErrorContains(t, err, "could not authorize the request")
+}
+
+func TestSecretsFetcher_WorkflowIDMetadataFollowsOrgIDGate(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		gateEnabled    bool
+		wantWorkflowID string
+		wantOrgID      string
+	}{
+		{
+			name:        "gate disabled",
+			gateEnabled: false,
+		},
+		{
+			name:           "gate enabled",
+			gateEnabled:    true,
+			wantWorkflowID: "workflowID",
+			wantOrgID:      "org-123",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lggr := logger.TestLogger(t)
+			reg := coreCap.NewRegistry(lggr)
+			peer := coreCap.RandomUTF8BytesWord()
+
+			workflowEncryptionKey := workflowkey.MustNewXXXTestingOnly(big.NewInt(1))
+			_, vaultPublicKey, _, err := tdh2easy.GenerateKeys(2, 3)
+			require.NoError(t, err)
+			vaultPublicKeyBytes, err := vaultPublicKey.Marshal()
+			require.NoError(t, err)
+			reg.SetLocalRegistry(CreateLocalRegistryWith1Node(t, peer, workflowEncryptionKey.PublicKey(), vaultPublicKeyBytes))
+
+			owner := "1234567890abcdef1234567890abcdef12345678"
+			normalizedOwner, err := normalizeOwner(owner)
+			require.NoError(t, err)
+
+			capture := &metadataCapturingVault{
+				response: &vault.GetSecretsResponse{
+					Responses: []*vault.SecretResponse{
+						{
+							Id: &vault.SecretIdentifier{
+								Key:       "Foo",
+								Namespace: "Bar",
+								Owner:     normalizedOwner,
+							},
+							Result: &vault.SecretResponse_Error{Error: "not found"},
+						},
+					},
+				},
+			}
+			err = reg.Add(t.Context(), capture)
+			require.NoError(t, err)
+
+			sf := NewSecretsFetcher(
+				MetricsLabelerTest(t),
+				reg,
+				lggr,
+				limits.WorkflowResourcePoolLimiter[int](5),
+				limits.NewUpperBoundLimiter[int](5),
+				testVaultOrgIDAsSecretOwnerGate(t, tc.gateEnabled),
+				"org-123",
+				owner,
+				"workflowName",
+				"workflowID",
+				"workflowExecID",
+				workflowEncryptionKey,
+			)
+
+			_, err = sf.GetSecrets(t.Context(), &sdkpb.GetSecretsRequest{
+				Requests: []*sdkpb.SecretRequest{
+					{
+						Id:        "Foo",
+						Namespace: "Bar",
+					},
+				},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantWorkflowID, capture.metadata.WorkflowID)
+			assert.Equal(t, tc.wantOrgID, capture.metadata.OrgID)
+		})
+	}
 }
 
 func TestSecretsFetcher_ForwardsOrgIDAndWorkflowOwner(t *testing.T) {


### PR DESCRIPTION
## Summary

- Forward-ports the Vault workflow ID metadata gate from #22238 so mixed-version workflow DON to Vault DON requests keep omitting `metadata.workflow_id` while the Vault org ID gate is disabled, preserving release behavior during rollout.
- Forward-ports the Vault blob broadcast concurrency limit from #22239 so observation blob broadcasts are bounded to 10 in-flight calls while preserving the existing per-blob timeout and graceful skip behavior.
- Includes the focused regression coverage from both release PRs for gated metadata behavior and bounded blob broadcast concurrency.