### PR TITLE
fix(deployment): retry Solana artifact downloads and fix sync.Once cache poisoning (CCIP-11193)

### DIFF
--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -124,7 +124,7 @@ require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/atombender/go-jsonschema v0.16.1-0.20240916205339-a74cd4e2851c // indirect
 	github.com/avast/retry-go v3.0.0+incompatible // indirect
-	github.com/avast/retry-go/v4 v4.7.0 // indirect
+	github.com/avast/retry-go/v4 v4.7.0
 	github.com/awalterschulze/gographviz v2.0.3+incompatible // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.4 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.12 // indirect

--- a/deployment/internal/soltestutils/artifacts.go
+++ b/deployment/internal/soltestutils/artifacts.go
@@ -1,24 +1,36 @@
 package soltestutils
 
 import (
+	"context"
 	"path/filepath"
 	"runtime"
 	"sync"
 	"testing"
+	"time"
+
+	"golang.org/x/sync/singleflight"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/deployment/utils/solutils"
 )
 
+// Cross-process coordination (multiple `go test` invocations sharing the same
+// programs_cache directory) is out of scope. singleflight deduplicates concurrent
+// callers within a single test binary; separate processes should use isolated
+// cache directories or an external file lock.
 var (
-	// onceCCIP is used to ensure that the program artifacts from the chainlink-ccip repository are only downloaded once.
-	onceCCIP = &sync.Once{}
-	// onceSolana is used to ensure that the program artifacts from the chainlink-solana repository are only downloaded once.
-	onceSolana = &sync.Once{}
+	dlGroup singleflight.Group
+	dlMu    sync.RWMutex
+	dlDone  = map[string]bool{}
 )
 
-// downloadFunc is a function type for downloading program artifacts
+const (
+	ccipKey   = "ccip"
+	solanaKey = "solana"
+)
+
+// downloadFunc is a function type for downloading program artifacts.
 type downloadFunc func(t *testing.T) string
 
 // downloadChainlinkSolanaProgramArtifacts downloads the Chainlink Solana program artifacts.
@@ -27,14 +39,10 @@ type downloadFunc func(t *testing.T) string
 // this is called "CCIP" program artifacts).
 func downloadChainlinkSolanaProgramArtifacts(t *testing.T) string {
 	t.Helper()
-
 	cachePath := programsCachePath()
-
-	onceSolana.Do(func() {
-		err := solutils.DownloadChainlinkSolanaProgramArtifacts(t.Context(), cachePath, "", nil)
-		require.NoError(t, err)
+	doDownload(t, solanaKey, func(ctx context.Context) error {
+		return solutils.DownloadChainlinkSolanaProgramArtifacts(ctx, cachePath, "", nil)
 	})
-
 	return cachePath
 }
 
@@ -45,15 +53,57 @@ func downloadChainlinkSolanaProgramArtifacts(t *testing.T) string {
 // this is called "CCIP" program artifacts).
 func downloadChainlinkCCIPProgramArtifacts(t *testing.T) string {
 	t.Helper()
-
 	cachePath := programsCachePath()
+	doDownload(t, ccipKey, func(ctx context.Context) error {
+		return solutils.DownloadChainlinkCCIPProgramArtifacts(ctx, cachePath, "", nil)
+	})
+	return cachePath
+}
 
-	onceCCIP.Do(func() {
-		err := solutils.DownloadChainlinkCCIPProgramArtifacts(t.Context(), cachePath, "", nil)
-		require.NoError(t, err)
+// doDownload runs fn at most once per key per process via singleflight.
+//
+// The singleflight closure deliberately does NOT capture t or t.Context(): the
+// winning goroutine may outlive the test that triggered it, so it uses a bounded
+// background context. Each caller inspects the returned error against its own live
+// t and calls t.Fatalf in its own goroutine — never inside the closure.
+func doDownload(t *testing.T, key string, fn func(ctx context.Context) error) {
+	t.Helper()
+
+	dlMu.RLock()
+	already := dlDone[key]
+	dlMu.RUnlock()
+	if already {
+		return
+	}
+
+	_, err, _ := dlGroup.Do(key, func() (interface{}, error) {
+		// Re-check under the write lock in case another caller completed while we waited.
+		dlMu.RLock()
+		if dlDone[key] {
+			dlMu.RUnlock()
+			return nil, nil
+		}
+		dlMu.RUnlock()
+
+		// Use a bounded background context — never tied to *testing.T so the download
+		// is not cancelled if the winning goroutine's test finishes first.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+
+		if err := fn(ctx); err != nil {
+			return nil, err
+		}
+
+		// Mark success inside the closure, under the write lock, before returning nil
+		// so all waiting callers observe the completed state atomically.
+		dlMu.Lock()
+		dlDone[key] = true
+		dlMu.Unlock()
+		return nil, nil
 	})
 
-	return cachePath
+	// Each caller handles the error against its own live *testing.T.
+	require.NoError(t, err)
 }
 
 // programsCachePath returns the path to the cache directory for the program artifacts.

--- a/deployment/utils/solutils/artifacts.go
+++ b/deployment/utils/solutils/artifacts.go
@@ -12,7 +12,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
+	retry "github.com/avast/retry-go/v4"
 	"golang.org/x/mod/modfile"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -91,44 +93,91 @@ func DownloadChainlinkSolanaProgramArtifacts(ctx context.Context, targetDir stri
 }
 
 // downloadProgramArtifacts downloads and extracts program artifacts from a GitHub release URL.
-//
-// This internal function handles the HTTP download of a tar.gz archive and extracts all
-// regular files to the target directory. It creates parent directories as needed and
-// logs each extracted file if a logger is provided.
-//
-// The function performs the following steps:
-//  1. Downloads the tar.gz archive from the provided URL
-//  2. Decompresses the gzip stream
-//  3. Extracts each regular file from the tar archive
-//  4. Creates necessary parent directories
-//  5. Writes files to the target directory using only the base filename
-//
-// Parameters:
-//   - ctx: Context for cancellation and timeout control
-//   - url: Full URL to the tar.gz release asset
-//   - targetDir: Directory where extracted files will be stored
-//   - lggr: Logger for progress information. Can be nil to disable logging
-//
-// Returns an error if the download fails, decompression fails, or file extraction fails.
+// It retries up to 5 times with exponential backoff on transient errors (5xx, network failures).
+// 4xx responses are returned immediately as unrecoverable. Extraction happens into a sibling
+// temp directory and is atomically promoted via os.Rename only on full success.
 func downloadProgramArtifacts(ctx context.Context, url string, targetDir string, lggr logger.Logger) error {
-	// Download the artifact
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	const requestTimeout = 5 * time.Minute
+
+	parentDir := filepath.Dir(targetDir)
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return fmt.Errorf("creating parent dir %q: %w", parentDir, err)
+	}
+
+	client := &http.Client{Timeout: requestTimeout}
+
+	// tmpDir is reset on each attempt so partial extraction never bleeds into the next.
+	var tmpDir string
+
+	err := retry.Do(
+		func() error {
+			// Clean up any partial extraction from the previous attempt.
+			if tmpDir != "" {
+				_ = os.RemoveAll(tmpDir)
+			}
+			var mkErr error
+			tmpDir, mkErr = os.MkdirTemp(parentDir, ".artifacts-tmp-*")
+			if mkErr != nil {
+				return retry.Unrecoverable(fmt.Errorf("creating temp dir: %w", mkErr))
+			}
+
+			req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			if reqErr != nil {
+				return retry.Unrecoverable(reqErr)
+			}
+
+			res, doErr := client.Do(req)
+			if doErr != nil {
+				return doErr
+			}
+			defer func() {
+				_, _ = io.Copy(io.Discard, res.Body)
+				_ = res.Body.Close()
+			}()
+
+			if res.StatusCode >= 400 && res.StatusCode < 500 {
+				// 4xx: artifact doesn't exist or auth failed — retrying won't help.
+				return retry.Unrecoverable(fmt.Errorf("download failed with status %d - could not download tar.gz release artifact (url = %q)", res.StatusCode, url))
+			}
+			if res.StatusCode != http.StatusOK {
+				// 5xx or other — retryable.
+				return fmt.Errorf("download failed with status %d - could not download tar.gz release artifact (url = %q)", res.StatusCode, url)
+			}
+
+			return extractTarGz(res.Body, tmpDir, lggr)
+		},
+		retry.Attempts(5),
+		retry.Delay(500*time.Millisecond),
+		retry.DelayType(retry.BackOffDelay),
+		retry.MaxDelay(8*time.Second),
+		retry.Context(ctx),
+		retry.OnRetry(func(n uint, err error) {
+			if lggr != nil {
+				lggr.Infof("Artifact download attempt %d failed (%v), retrying", n+1, err)
+			}
+		}),
+	)
+
 	if err != nil {
+		_ = os.RemoveAll(tmpDir)
 		return err
 	}
 
-	res, err := (&http.Client{}).Do(req)
-	if err != nil {
-		return err
+	// Atomically promote tmpDir to targetDir (temp dir is a sibling, same filesystem).
+	if err := os.RemoveAll(targetDir); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return fmt.Errorf("removing existing target dir %q: %w", targetDir, err)
 	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("download failed with status %d - could not download tar.gz release artifact (url = '%s')", res.StatusCode, url)
+	if err := os.Rename(tmpDir, targetDir); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return fmt.Errorf("promoting artifacts dir %q -> %q: %w", tmpDir, targetDir, err)
 	}
+	return nil
+}
 
-	// Extract the artifact to the target directory
-	gzipReader, err := gzip.NewReader(res.Body)
+// extractTarGz decompresses a gzipped tar stream and writes regular files into outDir.
+func extractTarGz(r io.Reader, outDir string, lggr logger.Logger) error {
+	gzipReader, err := gzip.NewReader(r)
 	if err != nil {
 		return err
 	}
@@ -136,10 +185,11 @@ func downloadProgramArtifacts(ctx context.Context, url string, targetDir string,
 
 	tarReader := tar.NewReader(gzipReader)
 
-	// Protection against decompression bombs
+	// Protection against decompression bombs.
 	const (
-		maxFiles     = 1000              // Maximum number of files to extract
-		maxTotalSize = 500 * 1024 * 1024 // Maximum total extraction size (500MB)
+		maxFiles     = 1000
+		maxTotalSize = 500 * 1024 * 1024 // 500MB
+		maxFileSize  = 100 * 1024 * 1024 // 100MB per file
 	)
 	var (
 		fileCount int
@@ -148,32 +198,26 @@ func downloadProgramArtifacts(ctx context.Context, url string, targetDir string,
 
 	for {
 		header, err := tarReader.Next()
-		// End of tar archive
 		if errors.Is(err, io.EOF) {
 			break
 		}
-
 		if err != nil {
 			return err
 		}
 
-		// Skip non-regular files
 		if header.Typeflag != tar.TypeReg {
 			continue
 		}
 
-		// Check limits to prevent decompression bombs
 		fileCount++
 		if fileCount > maxFiles {
 			return fmt.Errorf("archive contains too many files (limit: %d)", maxFiles)
 		}
-
 		if totalSize+header.Size > maxTotalSize {
 			return fmt.Errorf("archive total size exceeds limit (limit: %d bytes)", maxTotalSize)
 		}
 
-		// Copy the file to the target directory
-		outPath := filepath.Join(targetDir, filepath.Base(header.Name))
+		outPath := filepath.Join(outDir, filepath.Base(header.Name))
 		if err := os.MkdirAll(filepath.Dir(outPath), os.ModePerm); err != nil {
 			return err
 		}
@@ -183,23 +227,16 @@ func downloadProgramArtifacts(ctx context.Context, url string, targetDir string,
 			return err
 		}
 
-		// Limit individual file size to 100MB to prevent decompression bombs
-		const maxFileSize = 100 * 1024 * 1024 // 100MB
-		limitedReader := io.LimitReader(tarReader, maxFileSize)
-		bytesWritten, err := io.Copy(outFile, limitedReader)
+		bytesWritten, err := io.Copy(outFile, io.LimitReader(tarReader, maxFileSize))
+		outFile.Close()
 		if err != nil {
-			outFile.Close()
 			return err
 		}
-
-		// Update total size counter
 		totalSize += bytesWritten
 
 		if lggr != nil {
-			lggr.Infof("Extracted Solana chainlink-solana artifact: %s", outPath)
+			lggr.Infof("Extracted Solana artifact: %s", outPath)
 		}
-
-		outFile.Close()
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- **Root cause**: `sync.Once` in `soltestutils/artifacts.go` marks itself done even when `require.NoError` triggers `runtime.Goexit()`, permanently poisoning the Solana artifact cache for all subsequent tests in the binary when a transient GitHub CDN 502 occurs at test startup.
- **Fix 1** (`deployment/internal/soltestutils/artifacts.go`): Replace `sync.Once` with `singleflight.Group` + `sync.RWMutex` + a success-only `dlDone` map so failed downloads can be retried by the next test. The singleflight closure uses `context.Background()` + 10min timeout — never tied to `*testing.T`.
- **Fix 2** (`deployment/utils/solutils/artifacts.go`): Add `http.Client{Timeout: 5min}`, 5-attempt exponential-backoff retry via `avast/retry-go/v4`, and atomic extraction through a sibling temp dir + `os.Rename`. 4xx → unrecoverable; 5xx/network errors → retried with backoff capped at 8s.

## Test plan

- [x] All existing `solutils` unit tests pass locally (`TestDownloadProgramArtifacts`, `TestDownloadProgramArtifacts_ContextCancellation`, `TestDownloadProgramArtifacts_InvalidURL`, `TestDownloadProgramArtifacts_NonExistentTargetDir`)
- [ ] `TestRMNCurseOneConnectedLanes` passes in CI (requires Solana/CCIP infrastructure — validates the flake fix)
- [ ] No regression in other Solana smoke tests that call `downloadChainlinkCCIPProgramArtifacts` / `downloadChainlinkSolanaProgramArtifacts`

Fixes [CCIP-11193](https://smartcontract-it.atlassian.net/browse/CCIP-11193)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCIP-11193]: https://smartcontract-it.atlassian.net/browse/CCIP-11193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ