### PR TITLE
fix(deployment/solutils): retry artifact downloads on transient 5xx errors

### DIFF
--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/Khan/genqlient v0.8.1
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/aptos-labs/aptos-go-sdk v1.12.1
+	github.com/avast/retry-go/v4 v4.7.0
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/block-vision/sui-go-sdk v1.2.1
 	github.com/deckarep/golang-set/v2 v2.8.0
@@ -124,7 +125,6 @@ require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/atombender/go-jsonschema v0.16.1-0.20240916205339-a74cd4e2851c // indirect
 	github.com/avast/retry-go v3.0.0+incompatible // indirect
-	github.com/avast/retry-go/v4 v4.7.0 // indirect
 	github.com/awalterschulze/gographviz v2.0.3+incompatible // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.4 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.12 // indirect

--- a/deployment/utils/solutils/artifacts.go
+++ b/deployment/utils/solutils/artifacts.go
@@ -12,7 +12,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
+	retry "github.com/avast/retry-go/v4"
 	"golang.org/x/mod/modfile"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -110,25 +112,53 @@ func DownloadChainlinkSolanaProgramArtifacts(ctx context.Context, targetDir stri
 //   - lggr: Logger for progress information. Can be nil to disable logging
 //
 // Returns an error if the download fails, decompression fails, or file extraction fails.
+// downloadRetryDelay is the base delay between download retry attempts.
+// Overridable in tests to avoid slow test runs.
+var downloadRetryDelay = time.Second
+
 func downloadProgramArtifacts(ctx context.Context, url string, targetDir string, lggr logger.Logger) error {
-	// Download the artifact
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	var body io.ReadCloser
+	err := retry.Do(
+		func() error {
+			req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+			if err != nil {
+				return retry.Unrecoverable(err)
+			}
+			res, err := (&http.Client{}).Do(req)
+			if err != nil {
+				// Network-level errors are not retried.
+				return retry.Unrecoverable(err)
+			}
+			if res.StatusCode == http.StatusOK {
+				body = res.Body
+				return nil
+			}
+			res.Body.Close()
+			if res.StatusCode < 500 {
+				// 4xx and other non-transient errors are not retried.
+				return retry.Unrecoverable(fmt.Errorf("download failed with status %d - could not download tar.gz release artifact (url = '%s')", res.StatusCode, url))
+			}
+			// 5xx: return retryable error.
+			return fmt.Errorf("download failed with status %d - could not download tar.gz release artifact (url = '%s')", res.StatusCode, url)
+		},
+		retry.Attempts(5),
+		retry.Delay(downloadRetryDelay),
+		retry.DelayType(retry.BackOffDelay),
+		retry.Context(ctx),
+		retry.LastErrorOnly(true),
+		retry.OnRetry(func(n uint, err error) {
+			if lggr != nil {
+				lggr.Infof("Download attempt %d failed (%v), retrying (url = '%s')", n+1, err, url)
+			}
+		}),
+	)
 	if err != nil {
 		return err
 	}
-
-	res, err := (&http.Client{}).Do(req)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("download failed with status %d - could not download tar.gz release artifact (url = '%s')", res.StatusCode, url)
-	}
+	defer body.Close()
 
 	// Extract the artifact to the target directory
-	gzipReader, err := gzip.NewReader(res.Body)
+	gzipReader, err := gzip.NewReader(body)
 	if err != nil {
 		return err
 	}

--- a/deployment/utils/solutils/artifacts_test.go
+++ b/deployment/utils/solutils/artifacts_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,11 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
+
+func TestMain(m *testing.M) {
+	downloadRetryDelay = 0 // skip backoff waits in tests
+	os.Exit(m.Run())
+}
 
 func TestDownloadProgramArtifacts(t *testing.T) {
 	tests := []struct {
@@ -76,7 +82,7 @@ func TestDownloadProgramArtifacts(t *testing.T) {
 			wantErr: "download failed with status 404",
 		},
 		{
-			name: "server returns 500",
+			name: "server always returns 500 — fails after all retries",
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusInternalServerError)
@@ -157,6 +163,32 @@ func TestDownloadProgramArtifacts(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDownloadProgramArtifacts_RetriesOn5xxThenSucceeds(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) < 3 {
+			w.WriteHeader(http.StatusBadGateway) // 502 — first two attempts fail
+			return
+		}
+		// Third attempt succeeds with a valid tar.gz
+		w.Header().Set("Content-Type", "application/gzip")
+		gzWriter := gzip.NewWriter(w)
+		tarWriter := tar.NewWriter(gzWriter)
+		content := "binary content"
+		_ = tarWriter.WriteHeader(&tar.Header{Name: "program.so", Size: int64(len(content)), Typeflag: tar.TypeReg})
+		_, _ = tarWriter.Write([]byte(content))
+		tarWriter.Close()
+		gzWriter.Close()
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	err := downloadProgramArtifacts(t.Context(), server.URL, tempDir, logger.Test(t))
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(tempDir, "program.so"))
+	assert.Equal(t, int32(3), attempts.Load(), "expected exactly 3 attempts (2 failures + 1 success)")
 }
 
 func TestDownloadProgramArtifacts_ContextCancellation(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds retry logic to `downloadProgramArtifacts` in `deployment/utils/solutils/artifacts.go` using `avast/retry-go/v4` (already a dependency)
- Retries up to 5 times with exponential backoff on transient 5xx HTTP errors (e.g. 502 Bad Gateway from GitHub release servers)
- Network errors and 4xx responses fail fast without retry
- Adds `TestDownloadProgramArtifacts_RetriesOn5xxThenSucceeds` to verify the retry-then-succeed path
- Introduces `downloadRetryDelay` package var set to 0 in `TestMain` so retry tests run instantly

## Flaky test fixes

| Issue | Test | Trunk |
|-------|------|-------|
| [CCIP-11193](https://smartcontract-it.atlassian.net/browse/CCIP-11193) | `TestRMNCurseOneConnectedLanes` | [Trunk test case](https://app.trunk.io/chainlink/flaky-tests/test/5e39d2e1-7b93-5940-971d-366bc34bfe39) |

## Root cause

The test fails during artifact preloading (in ~120ms) when GitHub's release server returns a transient 502 Bad Gateway. Because `downloadProgramArtifacts` had no retry logic, a single transient error caused the `sync.Once`-wrapped download to fail permanently for the entire test process.

## Test plan

- [x] `go test ./utils/solutils/...` — all 7 tests pass, retry path verified
- [ ] Integration test `TestRMNCurseOneConnectedLanes` requires Solana + EVM infrastructure (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCIP-11193]: https://smartcontract-it.atlassian.net/browse/CCIP-11193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ