### PR TITLE
DF-24352 Reduce LimitDefault to 500_000 on Mantle

### DIFF
--- a/.changeset/clean-horses-hear.md
+++ b/.changeset/clean-horses-hear.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Mantle GasEstimator.LimitDefault now defaults to 500_000. #nops #changed

--- a/ccip/config/evm/Mantle_Mainnet.toml
+++ b/ccip/config/evm/Mantle_Mainnet.toml
@@ -12,9 +12,8 @@ HistoryDepth = 1250
 
 [GasEstimator]
 PriceMax = '120 gwei'
-# Limit values are high as Mantle's GasPrice is in native token (MNT) instead of ETH. Their proprietary TokenRatio parameter is used to adjust fees
-LimitDefault = 80_000_000_000
-LimitMax = 100_000_000_000
+# covers only L2 costs https://docs.mantle.xyz/network/system-information/fee-mechanism/fee-model-handbook-after-arsia
+LimitDefault = 500_000
 BumpMin = '100 wei'
 BumpThreshold = 60
 EIP1559DynamicFees = true

--- a/ccip/config/evm/Mantle_Sepolia.toml
+++ b/ccip/config/evm/Mantle_Sepolia.toml
@@ -12,15 +12,13 @@ HistoryDepth = 1250
 
 [GasEstimator]
 PriceMax = '120 gwei'
-# Limit values are high as Mantle's GasPrice is in native token (MNT) instead of ETH. Their proprietary TokenRatio parameter is used to adjust fees
-LimitDefault = 80000000000
-LimitMax = 100000000000
+# covers only L2 costs https://docs.mantle.xyz/network/system-information/fee-mechanism/fee-model-handbook-after-arsia
+LimitDefault = 500_000
 BumpMin = '100 wei'
-BumpPercent = 20
 BumpThreshold = 60
 EIP1559DynamicFees = true
 FeeCapDefault = '120 gwei'
-# Mantle reccomends setting Priority Fee to 0 in their docs linked here: https://docs-v2.mantle.xyz/devs/concepts/tx-fee/eip-1559#application-of-eip-1559-in-mantle-v2-tectonic
+# Mantle recommends setting Priority Fee to 0 in their docs linked here: https://docs-v2.mantle.xyz/devs/concepts/tx-fee/eip-1559#application-of-eip-1559-in-mantle-v2-tectonic
 TipCapDefault = '0 wei'
 TipCapMin = '0 wei'
 


### PR DESCRIPTION
Following the Mantle Arsia upgrade, `eth_estimateGas` now returns pure L2 execution gas (no amortised L1 data costs anymore). Our transactions use about ~117,600. NOPs are currently overriding `LimitDefault` to `500_000`.

Still overestimating, but to be in line with other EVMs that's what we're picking here.

- `BumpPercent` (`20`) dominates over `BumpMin` - no point in changing it. Removed pointless chain-override for testnet.
- `LimitMax` isn't used in `BlockHistoryEstimator` - its presence is misleading, so removed.
- Minor typo.

Bumping the chainlink-evm happened already in https://github.com/smartcontractkit/chainlink/pull/22337, this is for the remaining changes.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
https://github.com/smartcontractkit/chainlink-evm/pull/460
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[INCIDENT-2427]: https://smartcontract-it.atlassian.net/browse/INCIDENT-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ