### PR TITLE
chore(ci): bump reusable-docker-build-publish ref

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -98,7 +98,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@f4ff50d0f4713ed7b247dbd8a58316484907f958 # 2026-01-13
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@f7223bc10928ba2ac7028fe3fae1d435b3bbbf6a # reusable-docker-build-publish/1.2.0
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-east-1
@@ -113,14 +113,14 @@ jobs:
       docker-cache-behaviour: "disable"
       docker-manifest-sign: true
       docker-registry-url-override: public.ecr.aws/chainlink
-      github-runner-arm64: ${{ github.repository != 'smartcontractkit/chainlink' &&
-        'ubuntu-24.04-4cores-16GB-ARM' || 'ubuntu-24.04-arm' }}
+      github-runner-arm64: ${{ github.repository != 'smartcontractkit/chainlink' && 'ubuntu-24.04-4cores-16GB-ARM' || 'ubuntu-24.04-arm' }}
       docker-image-tag-strip-prefix: v # strip out the "v" prefix from the git tag for the image tag.
       git-sha: ${{ github.sha }}
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
       github-ref-type: ${{ github.ref_type}}
       github-workflow-repository: ${{ github.repository }}
+      allow-overwrites: "false"
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
       AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_SDLC_BUILD_PUBLISH_ARN }}
@@ -135,7 +135,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@f4ff50d0f4713ed7b247dbd8a58316484907f958 # 2026-01-13
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@f7223bc10928ba2ac7028fe3fae1d435b3bbbf6a # reusable-docker-build-publish/1.2.0
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-east-1
@@ -153,14 +153,14 @@ jobs:
       docker-cache-behaviour: "disable"
       docker-manifest-sign: true
       docker-registry-url-override: public.ecr.aws/chainlink
-      github-runner-arm64: ${{ github.repository != 'smartcontractkit/chainlink' &&
-        'ubuntu-24.04-4cores-16GB-ARM' || 'ubuntu-24.04-arm' }}
+      github-runner-arm64: ${{ github.repository != 'smartcontractkit/chainlink' && 'ubuntu-24.04-4cores-16GB-ARM' || 'ubuntu-24.04-arm' }}
       docker-image-tag-override: ${{ needs.checks.outputs.ccip-image-tag }}
       git-sha: ${{ github.sha }}
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
       github-ref-type: ${{ github.ref_type}}
       github-workflow-repository: ${{ github.repository }}
+      allow-overwrites: "false"
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
       AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_SDLC_BUILD_PUBLISH_ARN }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -88,7 +88,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@f4ff50d0f4713ed7b247dbd8a58316484907f958 # 2026-01-13
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@reusable-docker-build-publish/v1
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -120,7 +120,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@f4ff50d0f4713ed7b247dbd8a58316484907f958 # 2026-01-13
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@reusable-docker-build-publish/v1
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -154,7 +154,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@f4ff50d0f4713ed7b247dbd8a58316484907f958 # 2026-01-13
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@reusable-docker-build-publish/v1
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -189,7 +189,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@f4ff50d0f4713ed7b247dbd8a58316484907f958 # 2026-01-13
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@reusable-docker-build-publish/v1
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2
@@ -224,7 +224,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@f4ff50d0f4713ed7b247dbd8a58316484907f958 # 2026-01-13
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@reusable-docker-build-publish/v1
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2


### PR DESCRIPTION
Bumps `resuable-docker-build-publish` to the newest ref (https://github.com/smartcontractkit/.github/pull/1533).
New input documented here: https://github.com/smartcontractkit/.github/pull/1526

### Changes

* Bumps resuable workflow to latest SHA-ref for release workflow `build-publish`
  * Adds `allow-ovewrites: "false"` which ensures that we cannot overwrite existing images in the public ECR
  * Public ECRs do not support immutable tags like private ECRs
* Bumps resuable workflow to mutable major version tag for `docker-build`

### Notes

We do not set `allow-overwrites` for the `docker-build` workflow, as the role that publishes the images doesn't have the proper permissions to query the private ECR. Republishing in the private ECR is also not a problem, but we shouldn't do it in the public ECR (which doesn't support immutability)