### PR TITLE
chore: bump confidential http gitref

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -47,5 +47,5 @@ plugins:
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "e035ae9a8ae76a0a74cd7a91d786fe8b69ae010f"
+      gitRef: "6d1558cbc5afda7c3b1aee6436b3dcc372617d8a"
       installPath: "./cmd/confidential-http"


### PR DESCRIPTION
## Summary

Cherry-pick to `release/2.44.1`: bumps the confidential http gitref in `plugins/plugins.private.yaml`.
