### PR TITLE
fix(pipeline): reject partially-consumed input in JSONWithVarExprs

### DIFF
--- a/.changeset/fix-ethtx-from-literal-address.md
+++ b/.changeset/fix-ethtx-from-literal-address.md
@@ -1,0 +1,11 @@
+---
+"chainlink": patch
+---
+
+#bugfix Reject inputs that the JSON decoder only partially consumes in the
+pipeline `JSONWithVarExprs` getter. Previously, a literal Ethereum address
+like `0x...` in an `ethtx` task's `from` field would be parsed as the JSON
+number `0`, returned as `int64(0)`, and fail downstream with
+`AddressSliceParam: cannot convert int64`. The getter now requires the
+decoder to consume the entire input, letting `NonemptyString` handle the
+literal address as intended. Resolves #21768.

--- a/core/services/pipeline/getters.go
+++ b/core/services/pipeline/getters.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	stderrors "errors"
 	"strings"
 	"time"
 
@@ -132,6 +134,15 @@ func JSONWithVarExprs(jsExpr string, vars Vars, allowErrors bool) GetterFunc {
 		jd.UseNumber()
 		if err := jd.Decode(&val); err != nil {
 			return nil, errors.Wrapf(ErrBadInput, "while unmarshalling JSON: %v; js: %s", err, string(replaced))
+		}
+		// Reject inputs that the decoder only partially consumed. Without
+		// this check, json.Decoder happily reads "0" out of an Ethereum
+		// address like "0x..." (since "0" is itself a complete JSON number)
+		// and returns int64(0), with the trailing characters silently
+		// discarded. The next getter (e.g. NonemptyString) never gets a
+		// chance to handle the literal address. See issue #21768.
+		if _, err := jd.Token(); !stderrors.Is(err, io.EOF) {
+			return nil, errors.Wrapf(ErrBadInput, "trailing data after JSON value; js: %s", string(replaced))
 		}
 		reinterpreted, err := jsonserializable.ReinterpretJSONNumbers(val)
 		if err != nil {

--- a/core/services/pipeline/getters_test.go
+++ b/core/services/pipeline/getters_test.go
@@ -95,6 +95,14 @@ func TestGetters_JSONWithVarExprs(t *testing.T) {
 		{`{ "$(foo.bar)": $(zet) }`, "value", 123, pipeline.ErrBadInput, false},
 		{`{ "x": { "__chainlink_key_path__": 0 } }`, "", nil, pipeline.ErrBadInput, false},
 		{`{ "e": $(err)`, "e", nil, pipeline.ErrBadInput, false},
+		// Inputs that look like a JSON token followed by trailing data must be
+		// rejected so that the next getter (NonemptyString, etc.) gets a
+		// chance to handle them. Otherwise json.Decoder happily reads "0"
+		// out of an Ethereum address and discards the rest. See #21768.
+		{`0x1234567890abcdef1234567890abcdef12345678`, "", nil, pipeline.ErrBadInput, false},
+		{`0xdeadbeef`, "", nil, pipeline.ErrBadInput, false},
+		{`123abc`, "", nil, pipeline.ErrBadInput, false},
+		{`{"a":1} extra`, "", nil, pipeline.ErrBadInput, false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description

Closes #21768.

The pipeline `JSONWithVarExprs` getter (`core/services/pipeline/getters.go`) uses a streaming `json.Decoder` that reads only one top-level token. For a literal Ethereum address in an `ethtx` task's `from` field the decoder reads the leading `0` as a complete JSON number, returns `int64(0)`, and discards the rest of the address:

```toml
perform [type="ethtx"
         from="0xAaAa...AAAA"
         ...]
```

```
fatal=true
run.FatalErrors=["from: AddressSliceParam: cannot convert int64: bad input for task"]
```

Because `JSONWithVarExprs` successfully returns `int64(0)`, the next getter in the `From` chain (`NonemptyString`) is never tried, and `AddressSliceParam.UnmarshalPipelineParam` hits its `default` branch and errors out.

Issue author Beam already traced this in the report; root cause is that the decoder doesn't validate that it consumed the entire input.

## Fix

Tighten `JSONWithVarExprs` to require the decoder to consume the full input. After `jd.Decode(...)` returns, call `jd.Token()` once and require `io.EOF`; anything else means there's trailing data, which the getter rejects with `ErrBadInput` so the next getter in the `From` chain (e.g. `NonemptyString`) gets its turn.

```go
if _, err := jd.Token(); !stderrors.Is(err, io.EOF) {
    return nil, errors.Wrapf(ErrBadInput, "trailing data after JSON value; js: %s", string(replaced))
}
```

Wire-observable behavior:
- Valid JSON (objects, arrays, complete numbers, strings, `null`) — unchanged. All existing `TestGetters_JSONWithVarExprs` cases still pass.
- Literal `0xABCD...` and similar partially-consumable inputs — now correctly fall through to the next getter, so `from = "0x..."` resolves via `NonemptyString` and the `ethtx` task succeeds.

## Tests

Added regression cases to the existing `TestGetters_JSONWithVarExprs` table:
- `0x1234567890abcdef1234567890abcdef12345678` (full 20-byte address)
- `0xdeadbeef`
- `123abc` (number prefix + garbage suffix)
- `{"a":1} extra` (valid JSON + trailing junk)

All four assert `pipeline.ErrBadInput`, matching the next-getter-falls-through contract.

```
$ go test -count=1 -run "TestGetters_JSONWithVarExprs" ./core/services/pipeline/
ok   github.com/smartcontractkit/chainlink/v2/core/services/pipeline   2.142s
```

DB-backed tests in this package (`TestETHTxTask`, `TestETHCallTask`) require `CL_DATABASE_URL` and a Postgres test database, which I don't have set up locally; happy to add a focused `TestETHTxTask_FromLiteralAddress` if a maintainer can either point me at the right setup or run those checks in CI.

## Diff

```
 .changeset/fix-ethtx-from-literal-address.md    | +9
 core/services/pipeline/getters.go               | +11
 core/services/pipeline/getters_test.go          | +8
```