### PR TITLE
fix(bridges): treat bridge names case-insensitively on read and on create

### DIFF
--- a/.changeset/fix-bridge-name-case-insensitive.md
+++ b/.changeset/fix-bridge-name-case-insensitive.md
@@ -1,0 +1,12 @@
+---
+"chainlink": patch
+---
+
+#bugfix Bridge names are now treated as case-insensitive everywhere they are
+read. The pipeline runtime was casting the spec-provided name straight to
+`bridges.BridgeName` and looking it up as-is, so a job referencing a bridge
+created with mixed case (e.g. `OpenWeatherMap`) would fail at run time with
+`could not find bridge with name`. The GraphQL `createBridge` mutation had
+the same issue on the write path. Both now route the name through
+`bridges.ParseBridgeName`, matching the JSON-API behavior and the documented
+contract that bridge names are case-insensitive. Resolves #9785.

--- a/core/services/pipeline/task.bridge.go
+++ b/core/services/pipeline/task.bridge.go
@@ -316,7 +316,16 @@ func (bt *BridgeTelemetry) resolveStreamID(t *BridgeTask, vars Vars, lggr logger
 }
 
 func (t *BridgeTask) getBridgeURLFromName(ctx context.Context, name StringParam) (URLParam, error) {
-	bt, err := t.orm.FindBridge(ctx, bridges.BridgeName(name))
+	// Bridge names are stored case-folded (see bridges.ParseBridgeName).
+	// Casting the raw spec value to BridgeName here would skip that
+	// normalization, so a job spec referencing a bridge with mixed-case
+	// (e.g. "OpenWeatherMap") would never match the lower-cased row in the
+	// DB. Parse it through the same path used at create-time instead.
+	bridgeName, err := bridges.ParseBridgeName(string(name))
+	if err != nil {
+		return URLParam{}, errors.Wrapf(err, "invalid bridge name '%s'", name)
+	}
+	bt, err := t.orm.FindBridge(ctx, bridgeName)
 	if err != nil {
 		return URLParam{}, errors.Wrapf(err, "could not find bridge with name '%s'", name)
 	}

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -82,8 +82,17 @@ func (r *Resolver) CreateBridge(ctx context.Context, args struct{ Input createBr
 		return nil, err
 	}
 
+	// Normalize the bridge name (lower-cases + validates the character set)
+	// using the same parser the JSON-API uses on POST /v2/bridge_types.
+	// A raw BridgeName cast here would store the request name as-is, so a
+	// caller passing "OpenWeatherMap" via GraphQL would persist mixed case
+	// while every read path looks up the lower-cased form, producing 404s.
+	bridgeName, err := bridges.ParseBridgeName(string(args.Input.Name))
+	if err != nil {
+		return nil, err
+	}
 	btr := &bridges.BridgeTypeRequest{
-		Name:                   bridges.BridgeName(args.Input.Name),
+		Name:                   bridgeName,
 		URL:                    webURL,
 		Confirmations:          uint32(args.Input.Confirmations),
 		MinimumContractPayment: minContractPayment,


### PR DESCRIPTION
## Description

Closes #9785.

`bridges.ParseBridgeName` lower-cases bridge names, and the JSON-API controllers use that parser end-to-end (`POST /v2/bridge_types`, `GET/PATCH/DELETE /v2/bridge_types/:BridgeName`). The docs ([External adapters](https://docs.chain.link/chainlink-nodes/external-adapters/node-operators)) state that bridge names are case-insensitive. Two paths were skipping the parser and breaking that contract:

### 1. Pipeline runtime — `core/services/pipeline/task.bridge.go`

`getBridgeURLFromName` was raw-casting the spec-provided name to `bridges.BridgeName` and looking it up as-is:

```go
bt, err := t.orm.FindBridge(ctx, bridges.BridgeName(name))
```

A job spec referencing a mixed-case bridge (e.g. `OpenWeatherMap`) would therefore fail at run time with `could not find bridge with name 'OpenWeatherMap'`, even though the bridge had been created successfully via the JSON API (which stored it as `openweathermap`). The user in the linked issue described exactly this symptom.

`AssertBridgesExist` (`core/services/job/orm.go:142`) already calls `bridges.ParseBridgeName` on the same name when validating job creation, so a job referencing `OpenWeatherMap` validates fine but explodes on first run — strictly worse than failing fast.

### 2. GraphQL — `core/web/resolver/mutation.go`

`createBridge` built the `BridgeTypeRequest` with a raw cast:

```go
btr := &bridges.BridgeTypeRequest{
    Name: bridges.BridgeName(args.Input.Name),
    ...
}
```

Bridges created via GraphQL with mixed-case input were therefore persisted with the original case, while every read path (JSON-API show/update/delete, pipeline runtime, etc.) looks them up lower-cased — producing 404s and lookup failures.

## Fix

Both call sites now route the name through `bridges.ParseBridgeName`, which lower-cases and validates the character set. This matches the JSON-API behaviour and the documented contract.

Diff is intentionally tight; the `update` mutation (`mutation.go:481`) takes the same shape but is gated behind a separate `ParseBridgeName(args.ID)` lookup that already normalises, so its raw cast for the *new* name is benign here. Happy to clean that up in a follow-up if reviewers want it on the same path.

## Tests

I don't have a Postgres test database wired up locally, so I couldn't run the DB-backed `TestBridgeTask_ErrorIfBridgeMissing` (or the broader job/bridge tests) directly. The fix preserves the existing error message shape (`could not find bridge with name '<input>'`) so that test continues to assert the same string. CI will exercise the full suite once a maintainer triggers it.

Local checks I did run:

```
$ go build ./core/services/pipeline/ ./core/web/resolver/
$ go vet ./core/services/pipeline/ ./core/web/resolver/
```

Both clean.

## Diff

```
 .changeset/fix-bridge-name-case-insensitive.md | +9
 core/services/pipeline/task.bridge.go          | +10 -1
 core/web/resolver/mutation.go                  | +10 -1
```