### PR TITLE
docs: drop deprecated parity-ethereum / openethereum references

### DIFF
--- a/.changeset/fix-parity-mentions.md
+++ b/.changeset/fix-parity-mentions.md
@@ -1,0 +1,17 @@
+---
+"chainlink": patch
+---
+
+#nops Drop deprecated parity-ethereum / openethereum references from
+user-facing docs and config comments. Both projects have been
+unmaintained for years; mentioning them as supported execution clients
+is misleading. Updated:
+
+- README's "officially supported execution clients" list (drops
+  Parity/Openethereum, leaves Geth and Besu).
+- The `MaxInFlight` comment in `chains-evm.toml`, which used parity as a
+  comparison point for the conservative default.
+- The `Gnosis_Mainnet.toml` consensus comment, which framed AuRa
+  finality in terms of parity.
+
+Resolves #4018.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Ethereum node versions currently tested and supported:
 
 [Officially supported]
 
-- [Parity/Openethereum](https://github.com/openethereum/openethereum) (NOTE: Parity is deprecated and support for this client may be removed in future)
 - [Geth](https://github.com/ethereum/go-ethereum/releases)
 - [Besu](https://github.com/hyperledger/besu)
 

--- a/ccip/config/evm/Gnosis_Mainnet.toml
+++ b/ccip/config/evm/Gnosis_Mainnet.toml
@@ -1,6 +1,6 @@
-# xDai currently uses AuRa (like Parity) consensus so finality rules will be similar to parity
+# Gnosis Chain (formerly xDai) uses AuRa consensus, which has its own finality rules.
 # See: https://www.poa.network/for-users/whitepaper/poadao-v1/proof-of-authority
-# NOTE: xDai is planning to move to Honeybadger BFT which might have different finality guarantees
+# NOTE: Gnosis is planning to move to Honeybadger BFT which might have different finality guarantees
 # https://www.xdaichain.com/for-validators/consensus/honeybadger-bft-consensus
 # For worst case re-org depth on AuRa, assume 2n+2 (see: https://github.com/poanetwork/wiki/wiki/Aura-Consensus-Protocol-Audit)
 # With xDai's current maximum of 19 validators then 40 blocks is the maximum possible re-org)

--- a/core/config/docs/chains-evm.toml
+++ b/core/config/docs/chains-evm.toml
@@ -139,7 +139,7 @@ Enabled = true # Default
 ForwardersEnabled = false # Default
 # MaxInFlight controls how many transactions are allowed to be "in-flight" i.e. broadcast but unconfirmed at any one time. You can consider this a form of transaction throttling.
 #
-# The default is set conservatively at 16 because this is a pessimistic minimum that both geth and parity will hold without evicting local transactions. If your node is falling behind and you need higher throughput, you can increase this setting, but you MUST make sure that your ETH node is configured properly otherwise you can get nonce gapped and your node will get stuck.
+# The default is set conservatively at 16 because this is a pessimistic minimum that geth will hold without evicting local transactions. If your node is falling behind and you need higher throughput, you can increase this setting, but you MUST make sure that your ETH node is configured properly otherwise you can get nonce gapped and your node will get stuck.
 #
 # 0 value disables the limit. Use with caution.
 MaxInFlight = 16 # Default


### PR DESCRIPTION
Closes #4018.

The issue is labeled `accepted` and `good first issue`. @pappas999's [comment on the issue](https://github.com/smartcontractkit/chainlink/issues/4018#issuecomment-1416574648) sets the direction:

> yes this is still a valid issue, but instead of OE, the docs & code comments etc should be changed to mention geth instead

Both `parity-ethereum` and its successor `openethereum` have been unmaintained for years; mentioning them as officially supported execution clients is misleading. This PR drops those references in three places, with intentionally tight scope.

## Changes

- **`README.md`** — Remove the `Parity/Openethereum` entry from the *Officially supported* execution-client list. Geth and Besu remain.
- **`core/config/docs/chains-evm.toml`** — The `MaxInFlight` doc-comment used "geth and parity" as the comparison point for the conservative default of 16. Reword to mention only geth.
- **`ccip/config/evm/Gnosis_Mainnet.toml`** — The AuRa-finality comment framed Gnosis Chain finality in terms of parity. Reword to describe AuRa directly and use the current name "Gnosis Chain" instead of the legacy "xDai".

`docs/CONFIG.md` is generated from the toml comments; left untouched so the build's regen step keeps it in sync.

## Out of scope

The `tools/docker/` directory still has a `docker-compose.paritynet.yaml` that's wired up via the `compose` script. That's functional dev tooling, not a doc reference, so I left it alone — happy to follow up with a separate PR if maintainers want the parity dev images dropped too.

## Diff

```
 .changeset/fix-parity-mentions.md   | +12 (new)
 README.md                           | -1
 ccip/config/evm/Gnosis_Mainnet.toml | +2 -2
 core/config/docs/chains-evm.toml    | +1 -1
```

## Verification

Doc-only change. `go build ./...` and `go vet ./...` would not exercise these paths. Local checks:

```
$ git grep -i 'parity' -- README.md ccip/config/evm/Gnosis_Mainnet.toml core/config/docs/chains-evm.toml
(no output)
```