### PR TITLE
fix(vault): downgrade duplicate-response log from error to info

### DIFF
--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -875,7 +875,7 @@ func (h *handler) sendResponse(ctx context.Context, userRequest *activeRequest, 
 
 	err := userRequest.SendResponse(resp)
 	if err != nil {
-		h.lggr.Errorw("error sending response to user", "requestID", userRequest.req.ID, "error", err)
+		h.lggr.Infow("failed to send response to user", "requestID", userRequest.req.ID, "reason", err)
 		return err
 	}
 


### PR DESCRIPTION
## Summary                                    
  - Downgraded log level from `error` to `info` for the duplicate-response case in vault handler                                                                                                   
  - Renamed log message from "error sending response to user" to "failed to send response to user"                                                                                                 
  - This fires when a second node reaches quorum concurrently and tries to send an already-sent response — expected race, not a true error