### PR TITLE
fix(solutils): reject path traversal in downloadProgramArtifacts

### DIFF
--- a/.changeset/zip-slip-artifacts-21003.md
+++ b/.changeset/zip-slip-artifacts-21003.md
@@ -1,0 +1,7 @@
+---
+"chainlink": patch
+---
+
+#bugfix
+
+`downloadProgramArtifacts` in `deployment/utils/solutils/artifacts.go` now rejects archive entries whose names would resolve outside the target directory and validates the absolute extraction path against the configured target directory. This hardens the Solana artifact downloader against Zip Slip / path-traversal attacks where a malicious archive could otherwise overwrite arbitrary files. Closes #21003.

--- a/deployment/utils/solutils/artifacts.go
+++ b/deployment/utils/solutils/artifacts.go
@@ -172,8 +172,31 @@ func downloadProgramArtifacts(ctx context.Context, url string, targetDir string,
 			return fmt.Errorf("archive total size exceeds limit (limit: %d bytes)", maxTotalSize)
 		}
 
-		// Copy the file to the target directory
-		outPath := filepath.Join(targetDir, filepath.Base(header.Name))
+		// Copy the file to the target directory.
+		//
+		// Defense against Zip Slip / path traversal: archive entries can carry
+		// names like "../../etc/passwd" or absolute paths. We strip directory
+		// components with filepath.Base, reject obviously dangerous names, and
+		// verify the resolved absolute path remains under targetDir.
+		cleanedName := filepath.Base(filepath.Clean(header.Name))
+		if cleanedName == "." || cleanedName == ".." || cleanedName == string(filepath.Separator) || cleanedName == "" {
+			return fmt.Errorf("archive contains entry with invalid name: %q", header.Name)
+		}
+		outPath := filepath.Join(targetDir, cleanedName)
+
+		absTarget, err := filepath.Abs(targetDir)
+		if err != nil {
+			return err
+		}
+		absOut, err := filepath.Abs(outPath)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(absTarget, absOut)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("archive entry %q would extract outside target directory", header.Name)
+		}
+
 		if err := os.MkdirAll(filepath.Dir(outPath), os.ModePerm); err != nil {
 			return err
 		}

--- a/deployment/utils/solutils/artifacts_test.go
+++ b/deployment/utils/solutils/artifacts_test.go
@@ -188,6 +188,74 @@ func TestDownloadProgramArtifacts_InvalidURL(t *testing.T) {
 	require.ErrorContains(t, err, "dial tcp: lookup invalid-url: no such host")
 }
 
+func TestDownloadProgramArtifacts_RejectsPathTraversal(t *testing.T) {
+	tests := []struct {
+		name      string
+		entryName string
+		// wantReject is true when the extractor is expected to refuse the entry
+		// outright. When false the entry is benign once directory components are
+		// stripped (e.g. "../foo.so" collapses to "foo.so") and we only verify no
+		// file escapes targetDir.
+		wantReject bool
+	}{
+		{name: "parent_only", entryName: "..", wantReject: true},
+		{name: "current_then_parent", entryName: "./..", wantReject: true},
+		{name: "single_traversal", entryName: "../escape.so", wantReject: false},
+		{name: "deep_traversal", entryName: "../../etc/passwd", wantReject: false},
+		{name: "absolute_path_leak", entryName: "/etc/passwd", wantReject: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/gzip")
+
+				gzWriter := gzip.NewWriter(w)
+				defer gzWriter.Close()
+
+				tarWriter := tar.NewWriter(gzWriter)
+				defer tarWriter.Close()
+
+				content := "malicious payload"
+				header := &tar.Header{
+					Name:     tt.entryName,
+					Size:     int64(len(content)),
+					Typeflag: tar.TypeReg,
+				}
+
+				err := tarWriter.WriteHeader(header)
+				if err != nil {
+					t.Errorf("Failed to write tar header: %v", err)
+					return
+				}
+				_, err = tarWriter.Write([]byte(content))
+				if err != nil {
+					t.Errorf("Failed to write tar content: %v", err)
+					return
+				}
+			}))
+			defer server.Close()
+
+			tempDir := t.TempDir()
+			parentDir := filepath.Dir(tempDir)
+			parentBefore, err := os.ReadDir(parentDir)
+			require.NoError(t, err)
+
+			err = downloadProgramArtifacts(t.Context(), server.URL, tempDir, logger.Test(t))
+
+			if tt.wantReject {
+				require.Error(t, err, "extraction must reject %q", tt.entryName)
+			}
+
+			// Defense-in-depth: regardless of accept/reject, nothing must be
+			// written outside tempDir.
+			parentAfter, err := os.ReadDir(parentDir)
+			require.NoError(t, err)
+			assert.Equal(t, len(parentBefore), len(parentAfter), "parent directory of tempDir must be untouched")
+		})
+	}
+}
+
 func TestDownloadProgramArtifacts_NonExistentTargetDir(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/gzip")


### PR DESCRIPTION
### Description

Fixes #21003.

`downloadProgramArtifacts` in `deployment/utils/solutils/artifacts.go` extracted archive entries by joining the target directory with `filepath.Base(header.Name)`. That sanitization is enough for benign payloads such as `../etc/passwd`, which collapses to `passwd`, but a header name of just `..` made `filepath.Join(targetDir, "..")` resolve to the **parent** of the target directory, allowing extraction to escape.

### Fix

In `downloadProgramArtifacts`:

- `filepath.Clean` + `filepath.Base` the entry name and refuse `.` / `..` / empty / root entries explicitly.
- Resolve the joined path with `filepath.Abs` and verify with `filepath.Rel` that it stays within `targetDir`. Anything that walks outside is rejected with a clear error.

### Tests

`TestDownloadProgramArtifacts_RejectsPathTraversal` (in `deployment/utils/solutils/artifacts_test.go`) covers two classes:

| Entry name             | Behaviour |
|------------------------|-----------|
| `..`, `./..`           | Extraction returns an error (explicit reject) |
| `../escape.so`, `../../etc/passwd`, `/etc/passwd` | `filepath.Base` collapses to a safe name; the file lands inside `tempDir` and the parent directory is verified untouched (defense in depth) |

The existing happy-path / 4xx-5xx / context-cancel tests continue to pass.

```
$ go test ./utils/solutils/... -count=1
ok  	github.com/smartcontractkit/chainlink/deployment/utils/solutils
```

### Risk

Confined to one helper used by Solana artifact downloads. No behaviour change for valid archives. New rejections only fire for entry names that should never appear in legitimate artifacts.