### PR TITLE
test(ccip): skip flaky TestRMN_TwoMessagesOneSourceChainCursed

### DIFF
--- a/.changeset/skip-flaky-rmn-cursed-18031.md
+++ b/.changeset/skip-flaky-rmn-cursed-18031.md
@@ -1,0 +1,7 @@
+---
+"chainlink": patch
+---
+
+#internal
+
+Skip flaky `TestRMN_TwoMessagesOneSourceChainCursed` in `integration-tests/smoke/ccip/ccip_rmn_test.go`. The test is tracked at #18031 and matches the pattern already used for other quarantined RMN tests in the same file.

--- a/integration-tests/smoke/ccip/ccip_rmn_test.go
+++ b/integration-tests/smoke/ccip/ccip_rmn_test.go
@@ -267,6 +267,7 @@ func TestRMN_DifferentRmnNodesForDifferentChains(t *testing.T) {
 }
 
 func TestRMN_TwoMessagesOneSourceChainCursed(t *testing.T) {
+	t.Skipf("Skipping due to flakiness, see https://github.com/smartcontractkit/chainlink/issues/18031")
 	runRmnTestCase(t, rmnTestCase{
 		name:                "two messages, one source chain is cursed the other chain was cursed but curse is revoked",
 		passIfNoCommitAfter: 15 * time.Second,


### PR DESCRIPTION
### Description

Closes #18031.

`TestRMN_TwoMessagesOneSourceChainCursed` in `integration-tests/smoke/ccip/ccip_rmn_test.go` is consistently flaky in CI. The same file already skips a sibling test (`TestRMN_TwoMessagesOnTwoLanesIncludingBatching`, line 75) using a `t.Skipf` with a link to the failure context.

This PR adds the same one-line skip to keep the CCIP smoke suite green while #18031 is investigated.

```go
func TestRMN_TwoMessagesOneSourceChainCursed(t *testing.T) {
    t.Skipf("Skipping due to flakiness, see https://github.com/smartcontractkit/chainlink/issues/18031")
    runRmnTestCase(t, rmnTestCase{
        ...
```

### Risk

None at runtime: the skip executes before any test setup, so the test simply reports as `SKIP` instead of running. No production code touched.