### PR TITLE
if port collision is detected use lsof to check what is running there

### DIFF
--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"runtime/debug"
 	"slices"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -106,7 +107,9 @@ func waitToCleanUp(d time.Duration) {
 }
 
 func describePortUsage(ctx context.Context, port int) (string, error) {
-	cmd := exec.CommandContext(ctx, "lsof", "-nP", fmt.Sprintf("-iTCP:%d", port)) //nolint:gosec //G204-- we control the value of the cmd so the lint/sec error is a false positive
+	lsofCtx, lsofCtxCancel := context.WithTimeout(ctx, 20*time.Second)
+	defer lsofCtxCancel()
+	cmd := exec.CommandContext(lsofCtx, "lsof", "-nP", fmt.Sprintf("-iTCP:%d", port)) //nolint:gosec //G204-- we control the value of the cmd so the lint/sec error is a false positive
 	output, err := cmd.CombinedOutput()
 	trimmedOutput := strings.TrimSpace(string(output))
 
@@ -891,12 +894,14 @@ func StartCLIEnvironment(
 			regex := regexp.MustCompile(`:(\d+)`)
 			matches := regex.FindStringSubmatch(setupErr.Error())
 			if len(matches) > 1 {
-				port := mustStringToInt(matches[1])
-				portUsage, err := describePortUsage(cmdContext, port)
-				if err != nil {
-					return nil, fmt.Errorf("failed to describe port usage: %w", err)
+				port, pErr := strconv.Atoi(matches[1])
+				// ignore errors from now on, so that we don't overwrite the original error
+				if pErr == nil {
+					portUsage, err := describePortUsage(cmdContext, port)
+					if err == nil {
+						fmt.Printf("Port %d is already in use by:\n%s\n\n", port, portUsage)
+					}
 				}
-				fmt.Printf("Port %d is already in use by:\n%s\n\n", port, portUsage)
 			}
 		}
 		return nil, fmt.Errorf("failed to setup test environment: %w", setupErr)

--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"runtime/debug"
 	"slices"
 	"strings"
@@ -102,6 +103,30 @@ func init() {
 func waitToCleanUp(d time.Duration) {
 	fmt.Printf("Waiting %s before cleanup\n", d)
 	time.Sleep(d)
+}
+
+func describePortUsage(ctx context.Context, port int) (string, error) {
+	cmd := exec.CommandContext(ctx, "lsof", "-nP", fmt.Sprintf("-iTCP:%d", port)) //nolint:gosec //G204-- we control the value of the cmd so the lint/sec error is a false positive
+	output, err := cmd.CombinedOutput()
+	trimmedOutput := strings.TrimSpace(string(output))
+
+	if err == nil {
+		if trimmedOutput == "" {
+			return fmt.Sprintf("no processes found on TCP port %d", port), nil
+		}
+		return trimmedOutput, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return fmt.Sprintf("no processes found on TCP port %d", port), nil
+	}
+
+	if trimmedOutput == "" {
+		return "", fmt.Errorf("failed to inspect TCP port %d with lsof: %w", port, err)
+	}
+
+	return "", fmt.Errorf("failed to inspect TCP port %d with lsof: %w\n%s", port, err, trimmedOutput)
 }
 
 var StartCmdPreRunFunc = func(cmd *cobra.Command, args []string) {
@@ -862,6 +887,18 @@ func StartCLIEnvironment(
 	defer cancel()
 	universalSetupOutput, setupErr := creenv.SetupTestEnvironment(ctx, testLogger, singleFileLogger, universalSetupInput, relativePathToRepoRoot)
 	if setupErr != nil {
+		if strings.Contains(setupErr.Error(), "address already in use") {
+			regex := regexp.MustCompile(`:(\d+)`)
+			matches := regex.FindStringSubmatch(setupErr.Error())
+			if len(matches) > 1 {
+				port := mustStringToInt(matches[1])
+				portUsage, err := describePortUsage(cmdContext, port)
+				if err != nil {
+					return nil, fmt.Errorf("failed to describe port usage: %w", err)
+				}
+				fmt.Printf("Port %d is already in use by:\n%s\n\n", port, portUsage)
+			}
+		}
 		return nil, fmt.Errorf("failed to setup test environment: %w", setupErr)
 	}
 


### PR DESCRIPTION
We want to discover what is causing these intermittent failures in CI:
```
Error: failed to setup test environment: failed to start chip router: 
start container: container start: Error response from daemon: 
failed to set up container networking: 
driver failed programming external connectivity on endpoint chip-router-ab0bb (5b2409a1b1a565e38e9a367f2c088bd158089e2c62cb82c73612f509446db9bc): 
failed to bind host port for 0.0.0.0:50050:172.18.0.2:50050/tcp: address already in use
```