### PR TITLE
aggregate confidential-relay responses by logical hash

### DIFF
--- a/core/services/gateway/handlers/confidentialrelay/aggregator.go
+++ b/core/services/gateway/handlers/confidentialrelay/aggregator.go
@@ -1,12 +1,13 @@
 package confidentialrelay
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
-	"slices"
+	"sort"
 
+	relaytypes "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialrelay"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -14,11 +15,22 @@ import (
 var (
 	errInsufficientResponsesForQuorum = errors.New("insufficient valid responses to reach quorum")
 	errQuorumUnobtainable             = errors.New("quorum unobtainable")
+	errUnknownMethod                  = errors.New("unknown relay method")
 )
 
 type aggregator struct{}
 
-func (a *aggregator) Aggregate(resps map[string]jsonrpc.Response[json.RawMessage], donF int, donMembersCount int, l logger.Logger) (*jsonrpc.Response[json.RawMessage], error) {
+// Aggregate buckets per-node signed responses by their canonical logical hash and, once F+1
+// unique signers vouch for the same hash, returns a single envelope carrying the shared logical
+// result with the merged signature set. Transport-level JSON-RPC errors and undecodable
+// responses are skipped without counting toward quorum.
+//
+// Defense-in-depth: when the gateway gains access to the relay-DON signer set (e.g., via the
+// capability registry or an extended NodeConfig), each incoming RelayResponseSignature should
+// be verified against the logical hash here before being merged into a bucket, mirroring the
+// untrusted-host signature filter in confidential-compute (host.go). Trust anchor remains the
+// enclave; verification at this layer is an early filter only.
+func (a *aggregator) Aggregate(req jsonrpc.Request[json.RawMessage], resps map[string]jsonrpc.Response[json.RawMessage], donF int, donMembersCount int, l logger.Logger) (*jsonrpc.Response[json.RawMessage], error) {
 	// F+1 (QuorumFPlusOne) is sufficient because each relay node calls the
 	// target DON (Vault or capability) through CRE's standard capability
 	// dispatch, which includes DON-level consensus. Every honest relay node
@@ -31,47 +43,135 @@ func (a *aggregator) Aggregate(resps map[string]jsonrpc.Response[json.RawMessage
 		return nil, errInsufficientResponsesForQuorum
 	}
 
-	shaToCount := map[string]int{}
-	maxShaToCount := 0
-	for _, r := range resps {
-		sha, err := r.Digest()
-		if err != nil {
-			l.Errorw("failed to compute digest of response during quorum validation, skipping...", "error", err)
+	buckets := map[[32]byte]*responseBucket{}
+	maxBucketSigs := 0
+	contributingResponses := 0
+
+	for nodeAddr, r := range resps {
+		if r.Error != nil || r.Result == nil {
 			continue
 		}
-		shaToCount[sha]++
-		if shaToCount[sha] > maxShaToCount {
-			maxShaToCount = shaToCount[sha]
+
+		hash, sigs, raw, err := decodeSignedResponse(req, *r.Result)
+		if err != nil {
+			l.Warnw("failed to decode signed relay response, skipping", "nodeAddr", nodeAddr, "error", err)
+			continue
+		}
+
+		b, ok := buckets[hash]
+		if !ok {
+			b = &responseBucket{result: raw, signers: map[string]struct{}{}}
+			buckets[hash] = b
+		}
+		for _, sig := range sigs {
+			key := string(sig.Signer)
+			if _, dup := b.signers[key]; dup {
+				continue
+			}
+			b.signers[key] = struct{}{}
+			b.signatures = append(b.signatures, sig)
+		}
+		contributingResponses++
+		if len(b.signatures) > maxBucketSigs {
+			maxBucketSigs = len(b.signatures)
 		}
 	}
 
-	var qualifiedDigests []string
-	for sha, n := range shaToCount {
-		if n >= requiredQuorum {
-			qualifiedDigests = append(qualifiedDigests, sha)
+	var qualified [][32]byte
+	for h, b := range buckets {
+		if len(b.signatures) >= requiredQuorum {
+			qualified = append(qualified, h)
 		}
 	}
-	if len(qualifiedDigests) > 0 {
-		slices.Sort(qualifiedDigests)
-		want := qualifiedDigests[0]
-		for _, k := range slices.Sorted(maps.Keys(resps)) {
-			r := resps[k]
-			sha, err := r.Digest()
-			if err != nil {
-				continue
-			}
-			if sha == want {
-				out := r
-				return &out, nil
-			}
+	if len(qualified) > 0 {
+		sort.Slice(qualified, func(i, j int) bool { return bytes.Compare(qualified[i][:], qualified[j][:]) < 0 })
+		b := buckets[qualified[0]]
+		merged, err := encodeMergedResponse(req, b.result, b.signatures)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode merged signed response: %w", err)
 		}
+		return &jsonrpc.Response[json.RawMessage]{
+			Version: req.Version,
+			ID:      req.ID,
+			Method:  req.Method,
+			Result:  &merged,
+		}, nil
 	}
 
 	remainingResponses := donMembersCount - len(resps)
-	if maxShaToCount+remainingResponses < requiredQuorum {
-		l.Warnw("quorum unattainable for request", "requiredQuorum", requiredQuorum, "remainingResponses", remainingResponses, "maxShaToCount", maxShaToCount)
-		return nil, fmt.Errorf("%w: requiredQuorum=%d, maxShaToCount=%d, remainingResponses=%d", errQuorumUnobtainable, requiredQuorum, maxShaToCount, remainingResponses)
+	if maxBucketSigs+remainingResponses < requiredQuorum {
+		l.Warnw("quorum unattainable for request",
+			"requiredQuorum", requiredQuorum,
+			"remainingResponses", remainingResponses,
+			"maxBucketSigs", maxBucketSigs,
+			"contributingResponses", contributingResponses,
+		)
+		return nil, fmt.Errorf("%w: requiredQuorum=%d, maxBucketSigs=%d, remainingResponses=%d", errQuorumUnobtainable, requiredQuorum, maxBucketSigs, remainingResponses)
 	}
-
 	return nil, errInsufficientResponsesForQuorum
+}
+
+type responseBucket struct {
+	// result holds the typed logical result for this hash, kept around so the merged envelope
+	// can be re-encoded canonically without depending on byte-for-byte equality of the input.
+	result     interface{}
+	signatures []relaytypes.RelayResponseSignature
+	signers    map[string]struct{}
+}
+
+// decodeSignedResponse unmarshals one node's signed response, computes the canonical logical
+// hash for the request, and returns the per-node signatures plus the typed logical result for
+// later re-encoding.
+func decodeSignedResponse(req jsonrpc.Request[json.RawMessage], rawResult json.RawMessage) ([32]byte, []relaytypes.RelayResponseSignature, interface{}, error) {
+	switch req.Method {
+	case relaytypes.MethodSecretsGet:
+		var params relaytypes.SecretsRequestParams
+		if req.Params != nil {
+			if err := json.Unmarshal(*req.Params, &params); err != nil {
+				return [32]byte{}, nil, nil, fmt.Errorf("decode secrets request params: %w", err)
+			}
+		}
+		var signed relaytypes.SignedSecretsResponseResult
+		if err := json.Unmarshal(rawResult, &signed); err != nil {
+			return [32]byte{}, nil, nil, fmt.Errorf("decode signed secrets response: %w", err)
+		}
+		return signed.Result.Hash(params), signed.Signatures, signed.Result, nil
+	case relaytypes.MethodCapabilityExec:
+		var params relaytypes.CapabilityRequestParams
+		if req.Params != nil {
+			if err := json.Unmarshal(*req.Params, &params); err != nil {
+				return [32]byte{}, nil, nil, fmt.Errorf("decode capability request params: %w", err)
+			}
+		}
+		var signed relaytypes.SignedCapabilityResponseResult
+		if err := json.Unmarshal(rawResult, &signed); err != nil {
+			return [32]byte{}, nil, nil, fmt.Errorf("decode signed capability response: %w", err)
+		}
+		return signed.Result.Hash(params), signed.Signatures, signed.Result, nil
+	default:
+		return [32]byte{}, nil, nil, fmt.Errorf("%w: %q", errUnknownMethod, req.Method)
+	}
+}
+
+// encodeMergedResponse builds the final aggregated envelope from the shared logical result and
+// the merged signature set. Signatures are sorted by signer for determinism.
+func encodeMergedResponse(req jsonrpc.Request[json.RawMessage], result interface{}, sigs []relaytypes.RelayResponseSignature) (json.RawMessage, error) {
+	sort.Slice(sigs, func(i, j int) bool { return bytes.Compare(sigs[i].Signer, sigs[j].Signer) < 0 })
+
+	switch req.Method {
+	case relaytypes.MethodSecretsGet:
+		typed, ok := result.(relaytypes.SecretsResponseResult)
+		if !ok {
+			return nil, fmt.Errorf("internal: expected SecretsResponseResult, got %T", result)
+		}
+		return json.Marshal(relaytypes.SignedSecretsResponseResult{Result: typed, Signatures: sigs})
+	case relaytypes.MethodCapabilityExec:
+		typed, ok := result.(relaytypes.CapabilityResponseResult)
+		if !ok {
+			return nil, fmt.Errorf("internal: expected CapabilityResponseResult, got %T", result)
+		}
+		return json.Marshal(relaytypes.SignedCapabilityResponseResult{Result: typed, Signatures: sigs})
+	default:
+		return nil, fmt.Errorf("%w: %q", errUnknownMethod, req.Method)
+	}
 }

--- a/core/services/gateway/handlers/confidentialrelay/aggregator_test.go
+++ b/core/services/gateway/handlers/confidentialrelay/aggregator_test.go
@@ -1,63 +1,258 @@
 package confidentialrelay
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	relaytypes "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialrelay"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
-func TestAggregator_tiedMajoritiesPickDigestDeterministically(t *testing.T) {
-	t.Parallel()
+func capExecRequest(t *testing.T, id string, params relaytypes.CapabilityRequestParams) jsonrpc.Request[json.RawMessage] {
+	t.Helper()
+	raw, err := json.Marshal(params)
+	require.NoError(t, err)
+	rm := json.RawMessage(raw)
+	return jsonrpc.Request[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      id,
+		Method:  MethodCapabilityExec,
+		Params:  &rm,
+	}
+}
 
+func capExecSignedResponse(t *testing.T, id string, result relaytypes.CapabilityResponseResult, signer []byte) jsonrpc.Response[json.RawMessage] {
+	t.Helper()
+	signed := relaytypes.SignedCapabilityResponseResult{
+		Result: result,
+		Signatures: []relaytypes.RelayResponseSignature{{
+			Signer:    signer,
+			Signature: append([]byte("sig-"), signer...),
+		}},
+	}
+	raw, err := json.Marshal(signed)
+	require.NoError(t, err)
+	rm := json.RawMessage(raw)
+	return jsonrpc.Response[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      id,
+		Method:  MethodCapabilityExec,
+		Result:  &rm,
+	}
+}
+
+func decodeSignedCapability(t *testing.T, resp *jsonrpc.Response[json.RawMessage]) relaytypes.SignedCapabilityResponseResult {
+	t.Helper()
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Result)
+	var out relaytypes.SignedCapabilityResponseResult
+	require.NoError(t, json.Unmarshal(*resp.Result, &out))
+	return out
+}
+
+func TestAggregator_capabilityExec_quorumMergesSignatures(t *testing.T) {
+	t.Parallel()
 	lggr := logger.Test(t)
 	agg := &aggregator{}
 
-	const id = "req-tie"
-	makeResp := func(payload string) jsonrpc.Response[json.RawMessage] {
-		buf, err := json.Marshal(map[string]string{"payload": payload})
+	params := relaytypes.CapabilityRequestParams{WorkflowID: "wf-1", CapabilityID: "cap-1", Payload: "in"}
+	req := capExecRequest(t, "req-1", params)
+	result := relaytypes.CapabilityResponseResult{Payload: "out-A"}
+
+	resps := map[string]jsonrpc.Response[json.RawMessage]{
+		"n0": capExecSignedResponse(t, "req-1", result, []byte("signer-0")),
+		"n1": capExecSignedResponse(t, "req-1", result, []byte("signer-1")),
+		"n2": capExecSignedResponse(t, "req-1", result, []byte("signer-2")),
+		"n3": capExecSignedResponse(t, "req-1", result, []byte("signer-3")),
+	}
+
+	out, err := agg.Aggregate(req, resps, 1, 4, lggr)
+	require.NoError(t, err)
+	got := decodeSignedCapability(t, out)
+	require.Equal(t, result, got.Result)
+	require.Len(t, got.Signatures, 4)
+	for i := 0; i < len(got.Signatures)-1; i++ {
+		require.Negative(t, bytes.Compare(got.Signatures[i].Signer, got.Signatures[i+1].Signer),
+			"signatures should be sorted by signer for determinism")
+	}
+}
+
+func TestAggregator_capabilityExec_dedupesDuplicateSigner(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+	agg := &aggregator{}
+
+	params := relaytypes.CapabilityRequestParams{WorkflowID: "wf-1", CapabilityID: "cap-1", Payload: "in"}
+	req := capExecRequest(t, "req-dup", params)
+	result := relaytypes.CapabilityResponseResult{Payload: "out-A"}
+
+	// Three responses, two carrying the same signer bytes (defensive dedupe path).
+	resps := map[string]jsonrpc.Response[json.RawMessage]{
+		"n0": capExecSignedResponse(t, "req-dup", result, []byte("signer-shared")),
+		"n1": capExecSignedResponse(t, "req-dup", result, []byte("signer-shared")),
+		"n2": capExecSignedResponse(t, "req-dup", result, []byte("signer-2")),
+	}
+
+	out, err := agg.Aggregate(req, resps, 1, 3, lggr)
+	require.NoError(t, err)
+	got := decodeSignedCapability(t, out)
+	require.Len(t, got.Signatures, 2, "duplicates by signer must collapse")
+}
+
+func TestAggregator_capabilityExec_tiedMajoritiesDeterministic(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+	agg := &aggregator{}
+
+	params := relaytypes.CapabilityRequestParams{WorkflowID: "wf-1", CapabilityID: "cap-1", Payload: "in"}
+	req := capExecRequest(t, "req-tie", params)
+
+	resultA := relaytypes.CapabilityResponseResult{Payload: "out-A"}
+	resultB := relaytypes.CapabilityResponseResult{Payload: "out-B"}
+	hashA := resultA.Hash(params)
+	hashB := resultB.Hash(params)
+	require.NotEqual(t, hashA, hashB)
+
+	wantResult := resultA
+	if bytes.Compare(hashB[:], hashA[:]) < 0 {
+		wantResult = resultB
+	}
+
+	// Each pair has F+1 sigs at F=1; map iteration order must not change the winner.
+	for range 100 {
+		resps := map[string]jsonrpc.Response[json.RawMessage]{
+			"n0": capExecSignedResponse(t, "req-tie", resultA, []byte("signer-0")),
+			"n1": capExecSignedResponse(t, "req-tie", resultA, []byte("signer-1")),
+			"n2": capExecSignedResponse(t, "req-tie", resultB, []byte("signer-2")),
+			"n3": capExecSignedResponse(t, "req-tie", resultB, []byte("signer-3")),
+		}
+		out, err := agg.Aggregate(req, resps, 1, 4, lggr)
 		require.NoError(t, err)
-		rd := make(json.RawMessage, len(buf))
-		copy(rd, buf)
+		got := decodeSignedCapability(t, out)
+		require.Equal(t, wantResult, got.Result,
+			"tied majorities must resolve to the lex-smallest logical hash regardless of map order")
+		require.Len(t, got.Signatures, 2)
+	}
+}
+
+func TestAggregator_skipsTransportErrorsFromQuorum(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+	agg := &aggregator{}
+
+	params := relaytypes.CapabilityRequestParams{WorkflowID: "wf-1", CapabilityID: "cap-1", Payload: "in"}
+	req := capExecRequest(t, "req-err", params)
+	result := relaytypes.CapabilityResponseResult{Payload: "out-A"}
+
+	errResp := jsonrpc.Response[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "req-err",
+		Method:  MethodCapabilityExec,
+		Error:   &jsonrpc.WireError{Code: -32000, Message: "node failure"},
+	}
+
+	// 2 transport errors + 2 valid signed responses. F=1 -> F+1=2; signed pair forms quorum.
+	resps := map[string]jsonrpc.Response[json.RawMessage]{
+		"n0": errResp,
+		"n1": errResp,
+		"n2": capExecSignedResponse(t, "req-err", result, []byte("signer-2")),
+		"n3": capExecSignedResponse(t, "req-err", result, []byte("signer-3")),
+	}
+
+	out, err := agg.Aggregate(req, resps, 1, 4, lggr)
+	require.NoError(t, err)
+	got := decodeSignedCapability(t, out)
+	require.Equal(t, result, got.Result)
+	require.Len(t, got.Signatures, 2)
+}
+
+func TestAggregator_quorumUnobtainable(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+	agg := &aggregator{}
+
+	params := relaytypes.CapabilityRequestParams{WorkflowID: "wf-1", CapabilityID: "cap-1", Payload: "in"}
+	req := capExecRequest(t, "req-uno", params)
+
+	// 4 distinct logical results means no bucket reaches F+1=2; remaining=0; unattainable.
+	resps := map[string]jsonrpc.Response[json.RawMessage]{
+		"n0": capExecSignedResponse(t, "req-uno", relaytypes.CapabilityResponseResult{Payload: "p-0"}, []byte("s-0")),
+		"n1": capExecSignedResponse(t, "req-uno", relaytypes.CapabilityResponseResult{Payload: "p-1"}, []byte("s-1")),
+		"n2": capExecSignedResponse(t, "req-uno", relaytypes.CapabilityResponseResult{Payload: "p-2"}, []byte("s-2")),
+		"n3": capExecSignedResponse(t, "req-uno", relaytypes.CapabilityResponseResult{Payload: "p-3"}, []byte("s-3")),
+	}
+
+	out, err := agg.Aggregate(req, resps, 1, 4, lggr)
+	require.Nil(t, out)
+	require.ErrorIs(t, err, errQuorumUnobtainable)
+}
+
+func TestAggregator_secretsGet_quorumMergesSignatures(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+	agg := &aggregator{}
+
+	params := relaytypes.SecretsRequestParams{
+		WorkflowID:  "wf-1",
+		Owner:       "0xabc",
+		ExecutionID: "exec-1",
+		Secrets: []relaytypes.SecretIdentifier{
+			{Key: "k1", Namespace: "ns"},
+		},
+		EnclavePublicKey: "pk",
+	}
+	rawParams, err := json.Marshal(params)
+	require.NoError(t, err)
+	rm := json.RawMessage(rawParams)
+	req := jsonrpc.Request[json.RawMessage]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "req-secrets",
+		Method:  MethodSecretsGet,
+		Params:  &rm,
+	}
+
+	result := relaytypes.SecretsResponseResult{
+		Secrets: []relaytypes.SecretEntry{{
+			ID:              relaytypes.SecretIdentifier{Key: "k1", Namespace: "ns"},
+			Ciphertext:      "ct",
+			EncryptedShares: []string{"sh-0", "sh-1"},
+		}},
+	}
+	signed := func(signer []byte) jsonrpc.Response[json.RawMessage] {
+		raw, mErr := json.Marshal(relaytypes.SignedSecretsResponseResult{
+			Result: result,
+			Signatures: []relaytypes.RelayResponseSignature{{
+				Signer:    signer,
+				Signature: append([]byte("sig-"), signer...),
+			}},
+		})
+		require.NoError(t, mErr)
+		rmsg := json.RawMessage(raw)
 		return jsonrpc.Response[json.RawMessage]{
 			Version: jsonrpc.JsonRpcVersion,
-			ID:      id,
-			Method:  MethodCapabilityExec,
-			Result:  &rd,
+			ID:      "req-secrets",
+			Method:  MethodSecretsGet,
+			Result:  &rmsg,
 		}
 	}
 
-	a := makeResp("aaa")
-	b := makeResp("zzz")
-	digestA, err := a.Digest()
-	require.NoError(t, err)
-	digestB, err := b.Digest()
-	require.NoError(t, err)
-	require.NotEqual(t, digestA, digestB, "fixtures must produce distinct digests")
-
-	wantWinnerDigest := digestA
-	if digestB < digestA {
-		wantWinnerDigest = digestB
+	resps := map[string]jsonrpc.Response[json.RawMessage]{
+		"n0": signed([]byte("signer-0")),
+		"n1": signed([]byte("signer-1")),
+		"n2": signed([]byte("signer-2")),
 	}
 
-	// Two nodes report A, two report B: each side has F+1 when F=1. Map iteration order
-	// must not change which digest wins.
-	for range 300 {
-		m := map[string]jsonrpc.Response[json.RawMessage]{
-			"n0": a,
-			"n1": a,
-			"n2": b,
-			"n3": b,
-		}
-		got, err := agg.Aggregate(m, 1, 4, lggr)
-		require.NoError(t, err)
-		require.NotNil(t, got)
-		gotDigest, derr := got.Digest()
-		require.NoError(t, derr)
-		require.Equal(t, wantWinnerDigest, gotDigest,
-			"with tied majorities the chosen digest must be order-independent (lexicographically smallest qualifying digest)")
-	}
+	out, err := agg.Aggregate(req, resps, 1, 3, lggr)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.Result)
+
+	var got relaytypes.SignedSecretsResponseResult
+	require.NoError(t, json.Unmarshal(*out.Result, &got))
+	require.Equal(t, result, got.Result)
+	require.Len(t, got.Signatures, 3)
 }

--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -110,7 +110,7 @@ func (ar *activeRequest) copiedResponses() map[string]jsonrpc.Response[json.RawM
 }
 
 type relayAggregator interface {
-	Aggregate(resps map[string]jsonrpc.Response[json.RawMessage], donF int, donMembersCount int, l logger.Logger) (*jsonrpc.Response[json.RawMessage], error)
+	Aggregate(req jsonrpc.Request[json.RawMessage], resps map[string]jsonrpc.Response[json.RawMessage], donF int, donMembersCount int, l logger.Logger) (*jsonrpc.Response[json.RawMessage], error)
 }
 
 type Config struct {
@@ -328,7 +328,7 @@ func (h *handler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Response[
 	}
 
 	copiedResponses := ar.copiedResponses()
-	aggregatedResp, err := h.aggregator.Aggregate(copiedResponses, h.donConfig.F, len(h.donConfig.Members), l)
+	aggregatedResp, err := h.aggregator.Aggregate(ar.req, copiedResponses, h.donConfig.F, len(h.donConfig.Members), l)
 	switch {
 	case errors.Is(err, errInsufficientResponsesForQuorum):
 		l.Debugw("aggregating responses, waiting for other nodes...", "error", err)

--- a/core/services/gateway/handlers/confidentialrelay/handler_test.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 
+	relaytypes "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialrelay"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
@@ -101,13 +102,13 @@ type mockAggregator struct {
 	err error
 }
 
-func (m *mockAggregator) Aggregate(_ map[string]jsonrpc.Response[json.RawMessage], _ int, _ int, _ logger.Logger) (*jsonrpc.Response[json.RawMessage], error) {
+func (m *mockAggregator) Aggregate(_ jsonrpc.Request[json.RawMessage], _ map[string]jsonrpc.Response[json.RawMessage], _ int, _ int, _ logger.Logger) (*jsonrpc.Response[json.RawMessage], error) {
 	return nil, m.err
 }
 
 type respondingMockAggregator struct{}
 
-func (m *respondingMockAggregator) Aggregate(resps map[string]jsonrpc.Response[json.RawMessage], _ int, _ int, _ logger.Logger) (*jsonrpc.Response[json.RawMessage], error) {
+func (m *respondingMockAggregator) Aggregate(_ jsonrpc.Request[json.RawMessage], resps map[string]jsonrpc.Response[json.RawMessage], _ int, _ int, _ logger.Logger) (*jsonrpc.Response[json.RawMessage], error) {
 	if len(resps) == 0 {
 		return nil, errInsufficientResponsesForQuorum
 	}
@@ -210,15 +211,22 @@ func TestConfidentialRelayHandler_QuorumWithRealAggregator(t *testing.T) {
 		Params: &params,
 	}
 
-	resultData := json.RawMessage(`{"payload":"result"}`)
-	makeResp := func() *jsonrpc.Response[json.RawMessage] {
-		rd := make(json.RawMessage, len(resultData))
-		copy(rd, resultData)
+	makeSignedResp := func(signer string) *jsonrpc.Response[json.RawMessage] {
+		signed := relaytypes.SignedCapabilityResponseResult{
+			Result: relaytypes.CapabilityResponseResult{Payload: "result"},
+			Signatures: []relaytypes.RelayResponseSignature{{
+				Signer:    []byte(signer),
+				Signature: []byte("sig-" + signer),
+			}},
+		}
+		raw, mErr := json.Marshal(signed)
+		require.NoError(t, mErr)
+		rm := json.RawMessage(raw)
 		return &jsonrpc.Response[json.RawMessage]{
 			Version: jsonrpc.JsonRpcVersion,
 			ID:      "req-quorum",
 			Method:  MethodCapabilityExec,
-			Result:  &rd,
+			Result:  &rm,
 		}
 	}
 
@@ -234,9 +242,9 @@ func TestConfidentialRelayHandler_QuorumWithRealAggregator(t *testing.T) {
 	err := h.HandleJSONRPCUserMessage(t.Context(), req, cb)
 	require.NoError(t, err)
 
-	// Send 2 matching responses (F+1 = 2)
+	// Send F+1 = 2 matching signed responses with distinct signers.
 	for i := range 2 {
-		err = h.HandleNodeMessage(t.Context(), makeResp(), fmt.Sprintf("0x%04d", i))
+		err = h.HandleNodeMessage(t.Context(), makeSignedResp(fmt.Sprintf("signer-%d", i)), fmt.Sprintf("0x%04d", i))
 		require.NoError(t, err)
 	}
 	wg.Wait()
@@ -266,27 +274,41 @@ func TestConfidentialRelayHandler_QuorumWithDivergentResponses(t *testing.T) {
 	err := h.HandleJSONRPCUserMessage(t.Context(), req, cb)
 	require.NoError(t, err)
 
-	// One divergent response
-	divergentResult := json.RawMessage(`{"secrets":[],"master_public_key":"DIFFERENT","threshold":1}`)
+	// One divergent response.
+	divergent, err := json.Marshal(relaytypes.SignedCapabilityResponseResult{
+		Result: relaytypes.CapabilityResponseResult{Payload: "DIVERGENT"},
+		Signatures: []relaytypes.RelayResponseSignature{{
+			Signer:    []byte("signer-divergent"),
+			Signature: []byte("sig-divergent"),
+		}},
+	})
+	require.NoError(t, err)
+	divergentRaw := json.RawMessage(divergent)
 	divergentResp := &jsonrpc.Response[json.RawMessage]{
 		Version: jsonrpc.JsonRpcVersion,
 		ID:      "req-diverge",
 		Method:  MethodCapabilityExec,
-		Result:  &divergentResult,
+		Result:  &divergentRaw,
 	}
 	err = h.HandleNodeMessage(t.Context(), divergentResp, "0x0000")
 	require.NoError(t, err)
 
-	// Two matching responses (quorum = F+1 = 2)
-	matchingResult := json.RawMessage(`{"secrets":[],"master_public_key":"mpk","threshold":1}`)
+	// F+1 = 2 matching signed responses; distinct signers form the quorum.
 	for i := 1; i <= 2; i++ {
-		rd := make(json.RawMessage, len(matchingResult))
-		copy(rd, matchingResult)
+		matching, mErr := json.Marshal(relaytypes.SignedCapabilityResponseResult{
+			Result: relaytypes.CapabilityResponseResult{Payload: "match"},
+			Signatures: []relaytypes.RelayResponseSignature{{
+				Signer:    []byte(fmt.Sprintf("signer-%d", i)),
+				Signature: []byte(fmt.Sprintf("sig-%d", i)),
+			}},
+		})
+		require.NoError(t, mErr)
+		rm := json.RawMessage(matching)
 		resp := &jsonrpc.Response[json.RawMessage]{
 			Version: jsonrpc.JsonRpcVersion,
 			ID:      "req-diverge",
 			Method:  MethodCapabilityExec,
-			Result:  &rd,
+			Result:  &rm,
 		}
 		err = h.HandleNodeMessage(t.Context(), resp, fmt.Sprintf("0x%04d", i))
 		require.NoError(t, err)


### PR DESCRIPTION
## What changed
- Confidential-relay gateway aggregator now buckets per-node signed responses by their canonical logical hash (via `Hash(params)` helpers in chainlink-common) and merges signatures into a single envelope once F+1 unique signers vouch for the same hash.
- Aggregator dispatches on `req.Method` to handle both `confidential.secrets.get` and `confidential.capability.execute`.
- Transport-level JSON-RPC error responses are dropped from quorum counting per the design doc; only signed logical responses count.
- Defense-in-depth comment in `aggregator.go` describes the future signature-verification hook for when the gateway has access to the relay-DON signer set; the trust anchor remains the enclave.

## Why
PR #22302 made each relay-DON node sign its response (Step 2 of the E9 plan, PRIV-432). The previous aggregator bucketed by full-envelope digest, which broke once each honest node's envelope started carrying a different signature for identical logical content. Step 3 makes the gateway aggregate-and-pass-through correctly, so the enclave can verify F+1 unique relay signatures over a shared logical payload at E9.

## Stacked on
Stacked on #22302 (`tejaswi/relay-response-signatures`). Once that lands, this rebases onto develop.

## Validation
- `go test ./core/services/gateway/handlers/confidentialrelay`