### PR TITLE
chore: 2.45.1 — package.json version + CHANGELOG (Operator UI hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog Chainlink Core
 
+## 2.45.1
+
+### Patch Changes
+
+- [#22303](https://github.com/smartcontractkit/chainlink/pull/22303) [`77dc29f`](https://github.com/smartcontractkit/chainlink/commit/77dc29f13fc7880388882107f26a860579b05b48) - Fix Operator UI jobs management after legacy Keepers v1 removal: bump bundled Operator UI so GraphQL no longer queries removed KeeperSpec types. #bugfix #nops
+
 ## 2.45.0
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.45.0",
+  "version": "2.45.1",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Set root `package.json` **version** to **2.45.1** on `release/2.45.1` so `chainlink-releases` **Release (Pre)** resolves `VERSION` correctly (avoids failing `Check for final release` against existing **v2.45.0**).
- **CHANGELOG:** add `## 2.45.1` **Patch** entry for [#22303](https://github.com/smartcontractkit/chainlink/pull/22303) — Operator UI Jobs view (`KeeperSpec` / bundled UI after Keepers v1 removal). #bugfix #nops

## Notes
Changelog text produced via changesets (`pnpm changeset version`, PR link in summary).