### PR TITLE
fix(workflows): refresh org per execution and gate metadata OrgID

### DIFF
--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -1036,6 +1036,7 @@ func (h *eventHandler) confidentialEngineFactory(
 		binaryHash,
 		spec.WorkflowID, spec.WorkflowOwner, workflowName.String(), spec.WorkflowTag,
 		attrs.VaultDonSecrets,
+		h.engineLimiters.VaultOrgIDAsSecretOwnerEnabled,
 		lggr,
 	)
 

--- a/core/services/workflows/v2/capability_executor.go
+++ b/core/services/workflows/v2/capability_executor.go
@@ -31,8 +31,10 @@ var _ host.ExecutionHelper = (*ExecutionHelper)(nil)
 type ExecutionHelper struct {
 	*Engine
 	WorkflowExecutionID string
-	ExecutionTimestamp  time.Time
-	UserLogChan         chan<- *protoevents.LogLine
+	// ExecutionOrgID is resolved once per execution (see Engine.startExecution); used for capability metadata when the org gate is enabled.
+	ExecutionOrgID     string
+	ExecutionTimestamp time.Time
+	UserLogChan        chan<- *protoevents.LogLine
 	TimeProvider
 	SecretsFetcher
 
@@ -201,6 +203,10 @@ func (c *ExecutionHelper) callCapability(ctx context.Context, request *sdkpb.Cap
 			ExecutionTimestamp:       c.ExecutionTimestamp,
 		},
 		Config: values.EmptyMap(),
+	}
+
+	if err := c.enrichRequestMetadataOrg(ctx, &capReq.Metadata, c.ExecutionOrgID); err != nil {
+		return nil, fmt.Errorf("workflow capability metadata: %w", err)
 	}
 
 	execLogger.Debug("Executing capability ...")

--- a/core/services/workflows/v2/capability_executor.go
+++ b/core/services/workflows/v2/capability_executor.go
@@ -205,7 +205,7 @@ func (c *ExecutionHelper) callCapability(ctx context.Context, request *sdkpb.Cap
 		Config: values.EmptyMap(),
 	}
 
-	if err := c.enrichRequestMetadataOrg(ctx, &capReq.Metadata, c.ExecutionOrgID); err != nil {
+	if err = c.enrichRequestMetadataOrg(ctx, &capReq.Metadata, c.ExecutionOrgID); err != nil {
 		return nil, fmt.Errorf("workflow capability metadata: %w", err)
 	}
 

--- a/core/services/workflows/v2/confidential_module.go
+++ b/core/services/workflows/v2/confidential_module.go
@@ -168,7 +168,7 @@ func (m *ConfidentialModule) Execute(
 		WorkflowTag:         m.workflowTag,
 		WorkflowExecutionID: helper.GetWorkflowExecutionID(),
 	}
-	if err := m.enrichConfidentialOrgIdentity(ctx, &md, execPayload); err != nil {
+	if err = m.enrichConfidentialOrgIdentity(ctx, &md, execPayload); err != nil {
 		return nil, fmt.Errorf("confidential workflow org identity: %w", err)
 	}
 

--- a/core/services/workflows/v2/confidential_module.go
+++ b/core/services/workflows/v2/confidential_module.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/contexts"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host"
 
@@ -62,15 +63,16 @@ func IsConfidential(data []byte) (bool, error) {
 // Instead of running WASM locally, it delegates execution to the
 // confidential-workflows capability via the CapabilitiesRegistry.
 type ConfidentialModule struct {
-	capRegistry     core.CapabilitiesRegistry
-	binaryURL       string
-	binaryHash      []byte
-	workflowID      string
-	workflowOwner   string
-	workflowName    string
-	workflowTag     string
-	vaultDonSecrets []SecretIdentifier
-	lggr            logger.Logger
+	capRegistry                    core.CapabilitiesRegistry
+	binaryURL                      string
+	binaryHash                     []byte
+	workflowID                     string
+	workflowOwner                  string
+	workflowName                   string
+	workflowTag                    string
+	vaultDonSecrets                []SecretIdentifier
+	vaultOrgIDAsSecretOwnerEnabled limits.GateLimiter
+	lggr                           logger.Logger
 }
 
 var _ host.ModuleV2 = (*ConfidentialModule)(nil)
@@ -81,19 +83,41 @@ func NewConfidentialModule(
 	binaryHash []byte,
 	workflowID, workflowOwner, workflowName, workflowTag string,
 	vaultDonSecrets []SecretIdentifier,
+	vaultOrgIDAsSecretOwnerEnabled limits.GateLimiter,
 	lggr logger.Logger,
 ) *ConfidentialModule {
 	return &ConfidentialModule{
-		capRegistry:     capRegistry,
-		binaryURL:       binaryURL,
-		binaryHash:      binaryHash,
-		workflowID:      workflowID,
-		workflowOwner:   workflowOwner,
-		workflowName:    workflowName,
-		workflowTag:     workflowTag,
-		vaultDonSecrets: vaultDonSecrets,
-		lggr:            lggr,
+		capRegistry:                    capRegistry,
+		binaryURL:                      binaryURL,
+		binaryHash:                     binaryHash,
+		workflowID:                     workflowID,
+		workflowOwner:                  workflowOwner,
+		workflowName:                   workflowName,
+		workflowTag:                    workflowTag,
+		vaultDonSecrets:                vaultDonSecrets,
+		vaultOrgIDAsSecretOwnerEnabled: vaultOrgIDAsSecretOwnerEnabled,
+		lggr:                           lggr,
 	}
+}
+
+func (m *ConfidentialModule) enrichConfidentialOrgIdentity(ctx context.Context, md *capabilities.RequestMetadata, execPayload *confworkflowtypes.WorkflowExecution) error {
+	if m.vaultOrgIDAsSecretOwnerEnabled == nil {
+		return errors.New("vault org id gate is nil")
+	}
+	enabled, err := m.vaultOrgIDAsSecretOwnerEnabled.Limit(ctx)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		md.OrgID = ""
+		execPayload.OrgId = ""
+		return nil
+	}
+	org := contexts.CREValue(ctx).Org
+	md.OrgID = org
+	md.WorkflowID = m.workflowID
+	execPayload.OrgId = org
+	return nil
 }
 
 func (m *ConfidentialModule) Start()            {}
@@ -123,17 +147,29 @@ func (m *ConfidentialModule) Execute(
 		}
 	}
 
+	execPayload := &confworkflowtypes.WorkflowExecution{
+		WorkflowId:     m.workflowID,
+		BinaryUrl:      m.binaryURL,
+		BinaryHash:     m.binaryHash,
+		ExecuteRequest: execReqBytes,
+		Owner:          m.workflowOwner,
+		ExecutionId:    helper.GetWorkflowExecutionID(),
+	}
+
 	capInput := &confworkflowtypes.ConfidentialWorkflowRequest{
 		VaultDonSecrets: protoSecrets,
-		Execution: &confworkflowtypes.WorkflowExecution{
-			WorkflowId:     m.workflowID,
-			BinaryUrl:      m.binaryURL,
-			BinaryHash:     m.binaryHash,
-			ExecuteRequest: execReqBytes,
-			Owner:          m.workflowOwner,
-			ExecutionId:    helper.GetWorkflowExecutionID(),
-			OrgId:          contexts.CREValue(ctx).Org,
-		},
+		Execution:       execPayload,
+	}
+
+	md := capabilities.RequestMetadata{
+		WorkflowID:          m.workflowID,
+		WorkflowOwner:       m.workflowOwner,
+		WorkflowName:        m.workflowName,
+		WorkflowTag:         m.workflowTag,
+		WorkflowExecutionID: helper.GetWorkflowExecutionID(),
+	}
+	if err := m.enrichConfidentialOrgIdentity(ctx, &md, execPayload); err != nil {
+		return nil, fmt.Errorf("confidential workflow org identity: %w", err)
 	}
 
 	payload, err := anypb.New(capInput)
@@ -150,13 +186,7 @@ func (m *ConfidentialModule) Execute(
 		Payload:      payload,
 		Method:       "Execute",
 		CapabilityId: confidentialWorkflowsCapabilityID,
-		Metadata: capabilities.RequestMetadata{
-			WorkflowID:          m.workflowID,
-			WorkflowOwner:       m.workflowOwner,
-			WorkflowName:        m.workflowName,
-			WorkflowTag:         m.workflowTag,
-			WorkflowExecutionID: helper.GetWorkflowExecutionID(),
-		},
+		Metadata:     md,
 	}
 
 	capResp, err := executable.Execute(ctx, capReq)

--- a/core/services/workflows/v2/confidential_module_test.go
+++ b/core/services/workflows/v2/confidential_module_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -15,6 +16,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	regmocks "github.com/smartcontractkit/chainlink-common/pkg/types/core/mocks"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host"
 
@@ -25,7 +29,21 @@ import (
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 	valuespb "github.com/smartcontractkit/chainlink-protos/cre/go/values/pb"
 	wfpb "github.com/smartcontractkit/chainlink-protos/workflows/go/v2"
+
+	corelogger "github.com/smartcontractkit/chainlink/v2/core/logger"
 )
+
+func testConfidentialVaultOrgGate(t *testing.T, enabled bool) limits.GateLimiter {
+	t.Helper()
+	getter, err := settings.NewJSONGetter([]byte(fmt.Sprintf(`{"global":{"VaultOrgIdAsSecretOwnerEnabled":%t}}`, enabled)))
+	require.NoError(t, err)
+	gate, err := limits.MakeGateLimiter(limits.Factory{Settings: getter, Logger: corelogger.TestLogger(t)}, cresettings.Default.VaultOrgIdAsSecretOwnerEnabled)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, gate.Close())
+	})
+	return gate
+}
 
 // stubExecutionHelper implements host.ExecutionHelper for testing.
 type stubExecutionHelper struct {
@@ -176,6 +194,7 @@ func TestConfidentialModule_Execute(t *testing.T) {
 				{Key: "API_KEY"},
 				{Key: "SIGNING_KEY", Namespace: "custom-ns"},
 			},
+			testConfidentialVaultOrgGate(t, false),
 			lggr,
 		)
 
@@ -209,6 +228,7 @@ func TestConfidentialModule_Execute(t *testing.T) {
 			[]byte("hash"),
 			"wf-1", "owner", "name", "tag",
 			[]SecretIdentifier{{Key: "SECRET_A"}}, // no namespace
+			testConfidentialVaultOrgGate(t, false),
 			lggr,
 		)
 
@@ -229,7 +249,7 @@ func TestConfidentialModule_Execute(t *testing.T) {
 			Return(nil, errors.New("capability not found")).Once()
 
 		mod := NewConfidentialModule(
-			capReg, "", nil, "wf", "owner", "name", "tag", nil, lggr,
+			capReg, "", nil, "wf", "owner", "name", "tag", nil, testConfidentialVaultOrgGate(t, false), lggr,
 		)
 
 		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{})
@@ -247,7 +267,7 @@ func TestConfidentialModule_Execute(t *testing.T) {
 			Return(capabilities.CapabilityResponse{}, errors.New("enclave unavailable")).Once()
 
 		mod := NewConfidentialModule(
-			capReg, "", nil, "wf", "owner", "name", "tag", nil, lggr,
+			capReg, "", nil, "wf", "owner", "name", "tag", nil, testConfidentialVaultOrgGate(t, false), lggr,
 		)
 
 		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{})
@@ -265,7 +285,7 @@ func TestConfidentialModule_Execute(t *testing.T) {
 			Return(capabilities.CapabilityResponse{Payload: nil}, nil).Once()
 
 		mod := NewConfidentialModule(
-			capReg, "", nil, "wf", "owner", "name", "tag", nil, lggr,
+			capReg, "", nil, "wf", "owner", "name", "tag", nil, testConfidentialVaultOrgGate(t, false), lggr,
 		)
 
 		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{})
@@ -300,6 +320,7 @@ func TestConfidentialModule_Execute(t *testing.T) {
 				{Key: "K1", Namespace: "ns1"},
 				{Key: "K2"},
 			},
+			testConfidentialVaultOrgGate(t, false),
 			lggr,
 		)
 

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -246,9 +246,8 @@ func (e *Engine) start(ctx context.Context) error {
 	e.cfg.Module.Start()
 	ctx = context.WithoutCancel(ctx)
 
-	// Resolve the workflow owner's org once at engine startup and treat it as stable
-	// for the lifetime of this engine instance. If org membership/linking changes, the
-	// workflow must be restarted to pick up the new org mapping.
+	// Resolve the workflow owner's org at engine startup for logging, metrics, and CRE context.
+	// Subscribe and each execution re-resolve via resolveWorkflowOrgID for secrets wiring and metadata.
 	e.orgID = ""
 	if e.cfg.OrgResolver != nil {
 		orgID, gerr := e.cfg.OrgResolver.Get(ctx, e.cfg.WorkflowOwner)
@@ -415,11 +414,12 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 	if moduleExecuteMaxResponseSizeBytes < 0 {
 		return fmt.Errorf("invalid moduleExecuteMaxResponseSizeBytes; must not be negative: %d", moduleExecuteMaxResponseSizeBytes)
 	}
+	subscribeOrgID := e.resolveWorkflowOrgID(subCtx)
 	result, err := e.cfg.Module.Execute(subCtx, &sdkpb.ExecuteRequest{
 		Request:         &sdkpb.ExecuteRequest_Subscribe{},
 		MaxResponseSize: uint64(moduleExecuteMaxResponseSizeBytes),
 		Config:          e.cfg.WorkflowConfig,
-	}, NewDisallowedExecutionHelper(e.logger(), userLogChan, timeProvider, e.secretsFetcher(e.cfg.WorkflowID)))
+	}, NewDisallowedExecutionHelper(e.logger(), userLogChan, timeProvider, e.secretsFetcher(subCtx, e.cfg.WorkflowID, subscribeOrgID)))
 	if err != nil {
 		return fmt.Errorf("failed to execute subscribe: %w", err)
 	}
@@ -465,6 +465,7 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 		return err
 	}
 	defer regCancel()
+	subscribeOrgID = e.resolveWorkflowOrgID(regCtx)
 
 	// trigger registration results for use in concurrent trigger subscriptions
 	type triggerRegResult struct {
@@ -500,16 +501,8 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 				EngineVersion:                 platform.ValueWorkflowVersionV2,
 				// no WorkflowExecutionID needed (or available at this stage)
 			}
-			gate := e.cfg.LocalLimiters.VaultOrgIDAsSecretOwnerEnabled
-			if gate == nil {
-				return errors.New("vault org id gate is nil")
-			}
-			enabled, gateErr := gate.Limit(gCtx)
-			if gateErr != nil {
-				return gateErr
-			}
-			if enabled {
-				metadata.OrgID = e.orgID
+			if err := e.enrichRequestMetadataOrg(gCtx, &metadata, subscribeOrgID); err != nil {
+				return err
 			}
 			triggerEventCh, regErr := triggerCap.RegisterTrigger(gCtx, capabilities.TriggerRegistrationRequest{
 				TriggerID: registrationID,
@@ -683,8 +676,12 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		return
 	}
 
-	// Use the org resolved at engine startup for all executions in this engine instance.
-	executionOrgID := contexts.CREValue(ctx).Org
+	executionOrgID := e.resolveWorkflowOrgID(ctx)
+	ctx = contexts.WithCRE(ctx, contexts.CRE{Org: executionOrgID, Owner: e.cfg.WorkflowOwner, Workflow: e.cfg.WorkflowID})
+	if sp := trace.SpanFromContext(ctx); sp.SpanContext().IsValid() {
+		sp.SetAttributes(attribute.String("org_id", executionOrgID))
+	}
+
 	loggerLabels := maps.Clone(*e.loggerLabels.Load())
 	loggerLabels[platform.KeyOrganizationID] = executionOrgID
 	lggr := e.logger().With(platform.KeyOrganizationID, executionOrgID)
@@ -869,8 +866,9 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		return
 	}
 	execHelper := &ExecutionHelper{
-		Engine: e, WorkflowExecutionID: executionID, ExecutionTimestamp: executionTimestamp,
-		UserLogChan: userLogChan, TimeProvider: timeProvider, SecretsFetcher: e.secretsFetcher(executionID),
+		Engine: e, WorkflowExecutionID: executionID, ExecutionOrgID: executionOrgID,
+		ExecutionTimestamp: executionTimestamp,
+		UserLogChan:        userLogChan, TimeProvider: timeProvider, SecretsFetcher: e.secretsFetcher(execCtx, executionID, executionOrgID),
 	}
 	execHelper.initLimiters(e.cfg.LocalLimiters)
 	e.metrics.With(platform.KeyTriggerID, wrappedTriggerEvent.triggerCapID).RecordTriggerPayloadBytes(ctx, int64(proto.Size(triggerEvent.Payload)))
@@ -953,7 +951,41 @@ func (e *Engine) ackTriggerEvent(ctx context.Context, triggerRegistrationID stri
 	return trigger.AckEvent(ctx, triggerRegistrationID, te.ID, trigger.method)
 }
 
-func (e *Engine) secretsFetcher(phaseID string) SecretsFetcher {
+// resolveWorkflowOrgID returns the org ID for workflow wiring for this call path. When OrgResolver
+// is set, this queries linking (same as engine startup). The result is not written to e.orgID so
+// concurrent executions do not race on shared engine state.
+func (e *Engine) resolveWorkflowOrgID(ctx context.Context) string {
+	if e.cfg.OrgResolver == nil {
+		return e.orgID
+	}
+	orgID, err := e.cfg.OrgResolver.Get(ctx, e.cfg.WorkflowOwner)
+	if err != nil {
+		e.logger().Warnw("Failed to resolve organization ID for workflow wiring", "workflowOwner", e.cfg.WorkflowOwner, "err", err)
+		return ""
+	}
+	return orgID
+}
+
+// enrichRequestMetadataOrg sets RequestMetadata.OrgID when VaultOrgIdAsSecretOwnerEnabled is on,
+// and clears it when the gate is off.
+func (e *Engine) enrichRequestMetadataOrg(ctx context.Context, md *capabilities.RequestMetadata, resolvedOrgID string) error {
+	gate := e.cfg.LocalLimiters.VaultOrgIDAsSecretOwnerEnabled
+	if gate == nil {
+		return errors.New("vault org id gate is nil")
+	}
+	enabled, err := gate.Limit(ctx)
+	if err != nil {
+		return err
+	}
+	if enabled {
+		md.OrgID = resolvedOrgID
+	} else {
+		md.OrgID = ""
+	}
+	return nil
+}
+
+func (e *Engine) secretsFetcher(ctx context.Context, phaseID string, resolvedOrgID string) SecretsFetcher {
 	if e.cfg.SecretsFetcher != nil {
 		return e.cfg.SecretsFetcher
 	}
@@ -965,7 +997,7 @@ func (e *Engine) secretsFetcher(phaseID string) SecretsFetcher {
 		e.cfg.LocalLimiters.SecretsConcurrency,
 		e.cfg.LocalLimiters.SecretsCalls,
 		e.cfg.LocalLimiters.VaultOrgIDAsSecretOwnerEnabled,
-		e.orgID,
+		resolvedOrgID,
 		e.cfg.WorkflowOwner,
 		e.cfg.WorkflowName.String(),
 		e.cfg.WorkflowID,
@@ -1014,15 +1046,20 @@ func (e *Engine) close() error {
 // NOTE: needs to be called under the triggersRegMu lock
 func (e *Engine) unregisterAllTriggers(ctx context.Context) {
 	failCount := 0
+	unregisterOrgID := e.resolveWorkflowOrgID(ctx)
 	for registrationID, trigger := range e.triggers {
+		md := capabilities.RequestMetadata{
+			WorkflowID:    e.cfg.WorkflowID,
+			WorkflowDonID: e.localNode.Load().WorkflowDON.ID,
+		}
+		if err := e.enrichRequestMetadataOrg(ctx, &md, unregisterOrgID); err != nil {
+			e.logger().Warnw("Failed to apply org gate to unregister metadata", "registrationId", registrationID, "err", err)
+		}
 		err := trigger.UnregisterTrigger(ctx, capabilities.TriggerRegistrationRequest{
 			TriggerID: registrationID,
-			Metadata: capabilities.RequestMetadata{
-				WorkflowID:    e.cfg.WorkflowID,
-				WorkflowDonID: e.localNode.Load().WorkflowDON.ID,
-			},
-			Payload: trigger.payload,
-			Method:  trigger.method,
+			Metadata:  md,
+			Payload:   trigger.payload,
+			Method:    trigger.method,
 		})
 		if err != nil {
 			e.logger().Errorw("Failed to unregister trigger", "registrationId", registrationID, "err", err)

--- a/core/services/workflows/v2/secrets_test.go
+++ b/core/services/workflows/v2/secrets_test.go
@@ -49,6 +49,9 @@ func testVaultOrgIDAsSecretOwnerGate(t *testing.T, enabled bool) limits.GateLimi
 	require.NoError(t, err)
 	gate, err := limits.MakeGateLimiter(limits.Factory{Settings: getter, Logger: logger.TestLogger(t)}, cresettings.Default.VaultOrgIdAsSecretOwnerEnabled)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, gate.Close())
+	})
 	return gate
 }
 


### PR DESCRIPTION
Resolve workflow org at subscribe and at each execution start, thread it into SecretsFetcher and ExecutionHelper, and re-bind CRE for tracing and confidential execution. Add enrichRequestMetadataOrg for trigger register/unregister and capability calls; confidential-workflows sets OrgId and metadata OrgID only when VaultOrgIdAsSecretOwnerEnabled is on. Close gate limiters in tests via t.Cleanup.

This is fixing a regression caused by a previous PR here: https://github.com/smartcontractkit/chainlink/pull/21715/changes#diff-d217f82a818cadc25ef1cfd01b67b55b5ce2b86a5256af94d3472de4d4a24f56L619-L632
Then, we only resolved OrgID during engine startup.
