### PR TITLE
[DX-4048] use dynamic ChIP Ingress/Router host port allocation

### DIFF
--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       chainlink_image_repository_path:
-        description: "ECR repository name used to compose image with chainlink_image_tag (for example: chainlink-integration-tests or chainlink or chainlink/chainlink)."
+        description: "ECR repository name used to compose image with chainlink_image_tag
+          (for example: chainlink-integration-tests or chainlink or
+          chainlink/chainlink)."
         required: true
         type: string
       chainlink_image_tag:
@@ -18,16 +20,20 @@ on:
           - "sdlc"
           - "public"
         default: "sdlc"
-        description: "Whether to use the SDLC or public ECR registry for the Chainlink image."
+        description: "Whether to use the SDLC or public ECR registry for the Chainlink
+          image."
       chainlink_version:
         required: false
         type: string
-        description: "The version of Chainlink repository to use for the tests. If empty, defaults to github.sha."
+        description: "The version of Chainlink repository to use for the tests. If
+          empty, defaults to github.sha."
         default: ""
   workflow_call:
     inputs:
       chainlink_image_repository_path:
-        description: "ECR repository name used to compose image with chainlink_image_tag (for example: chainlink-integration-tests or chainlink or chainlink/chainlink)."
+        description: "ECR repository name used to compose image with chainlink_image_tag
+          (for example: chainlink-integration-tests or chainlink or
+          chainlink/chainlink)."
         required: true
         type: string
       chainlink_image_tag:
@@ -38,16 +44,19 @@ on:
         type: string
         required: true
         default: "sdlc"
-        description: "Whether to use the SDLC (sdlc) or public ECR registry (public) for the Chainlink image."
+        description: "Whether to use the SDLC (sdlc) or public ECR registry (public) for
+          the Chainlink image."
       chainlink_version:
         required: false
         type: string
-        description: "The version of Chainlink repository to use for the tests. If empty, defaults to github.sha."
+        description: "The version of Chainlink repository to use for the tests. If
+          empty, defaults to github.sha."
         default: ""
 
 jobs:
   define-test-matrix:
-    runs-on: runs-on=${{ github.run_id }}/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs-on: runs-on=${{ github.run_id
+      }}/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
     permissions:
@@ -102,10 +111,12 @@ jobs:
       fail-fast: false
       matrix:
         tests: ${{fromJson(needs.define-test-matrix.outputs.matrix)}}
-    needs: [define-test-matrix]
+    needs: [ define-test-matrix ]
     # we need a `test_id` and `run_attempt` here to stop runner stealing
     # see: https://runs-on.com/guides/troubleshoot/#runner-stealing-and-matrix-jobs
-    runs-on: runs-on=${{ github.run_id }}-${{ matrix.tests.test_id }}-${{ github.run_attempt }}/cpu=16/ram=64/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs-on: runs-on=${{ github.run_id }}-${{ matrix.tests.test_id }}-${{
+      github.run_attempt
+      }}/cpu=16/ram=64/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     environment:
       # http://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments
       name: integration
@@ -115,10 +126,16 @@ jobs:
       ENABLE_AUTO_QUARANTINE: "true"
       # override Chip Ingress and Chip Config images with remote images. We have added this env var here, instead of the "Start local CRE" step, because
       # Beholder stack will be started only for the Beholder tests
-      CHIP_INGRESS_IMAGE: ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/atlas-chip-ingress:da84cb72d3a160e02896247d46ab4b9806ebee2f
-      CHIP_CONFIG_IMAGE: ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/atlas-chip-config:7b4e9ee68fd1c737dd3480b5a3ced0188f29b969
-      CTF_CHIP_ROUTER_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/local-cre-chip-router:v1.0.1"
-      BILLING_PLATFORM_SERVICE_IMAGE: ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/billing-platform-service:v1.45.0
+      CTF_CHIP_INGRESS_IMAGE: ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{
+        secrets.QA_AWS_REGION
+        }}.amazonaws.com/atlas-chip-ingress:da84cb72d3a160e02896247d46ab4b9806ebee2f
+      CTF_CHIP_CONFIG_IMAGE: ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{
+        secrets.QA_AWS_REGION
+        }}.amazonaws.com/atlas-chip-config:7b4e9ee68fd1c737dd3480b5a3ced0188f29b969
+      CTF_CHIP_ROUTER_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
+        secrets.QA_AWS_REGION }}.amazonaws.com/local-cre-chip-router:v1.0.1"
+      BILLING_PLATFORM_SERVICE_IMAGE: ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{
+        secrets.QA_AWS_REGION }}.amazonaws.com/billing-platform-service:v1.45.0
 
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners
@@ -153,7 +170,8 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
         with:
-          registries: ${{ format('{0},{1}', secrets.QA_AWS_ACCOUNT_NUMBER, secrets.AWS_ACCOUNT_ID_PROD) }}
+          registries: ${{ format('{0},{1}', secrets.QA_AWS_ACCOUNT_NUMBER,
+            secrets.AWS_ACCOUNT_ID_PROD) }}
         env:
           AWS_REGION: ${{ secrets.QA_AWS_REGION }}
 
@@ -192,7 +210,8 @@ jobs:
         shell: bash
         id: start-local-cre
         env:
-          CTF_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.22.1"
+          CTF_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{
+            secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.22.1"
           CTF_CHAINLINK_IMAGE: "${{ steps.resolve-chainlink-image.outputs.resolved_image }}"
           CTF_CONFIGS: configs/workflow-gateway-capabilities-don.toml
           CRE_VERSION: ${{ matrix.tests.cre_version }}
@@ -244,7 +263,8 @@ jobs:
           fi
           exit $exit_code
 
-      - name: Analyze and upload test results (${{ steps.run-regression-tests.outputs.tests_result }})
+      - name: Analyze and upload test results (${{
+          steps.run-regression-tests.outputs.tests_result }})
         if: ${{ !cancelled() }}
         uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/v1
         with:

--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -43,7 +43,6 @@ on:
       ecr:
         type: string
         required: true
-        default: "sdlc"
         description: "Whether to use the SDLC (sdlc) or public ECR registry (public) for
           the Chainlink image."
       chainlink_version:
@@ -253,15 +252,17 @@ jobs:
             --junitfile=/tmp/junit-report-regression.xml \
             --format=github-actions \
             -- \
-            -v -run "^(${TEST_NAME})$" -timeout ${TEST_TIMEOUT} -count=1 -parallel=${PARALLEL_COUNT} \
+            -v -run "^(${TEST_NAME})$" -timeout "${TEST_TIMEOUT}" -count=1 -parallel="${PARALLEL_COUNT}" \
             github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre
 
-          echo "⚠️⚠️⚠️ Add 'skip-e2e-regression' label to skip this step if necessary ⚠️⚠️⚠️"
           exit_code=$?
-          if [ $exit_code -eq 0 ]; then
+          if [ "$exit_code" -eq 0 ]; then
             echo "tests_result=✅ Tests passed" >> $GITHUB_OUTPUT
           fi
-          exit $exit_code
+
+          echo "⚠️⚠️⚠️ Add 'skip-e2e-regression' label to skip this step if necessary ⚠️⚠️⚠️"
+
+          exit "$exit_code"
 
       - name: Analyze and upload test results (${{
           steps.run-regression-tests.outputs.tests_result }})

--- a/.github/workflows/cre-soak-memory-leak.yml
+++ b/.github/workflows/cre-soak-memory-leak.yml
@@ -113,8 +113,6 @@ jobs:
         id: run-soak
         shell: bash
         working-directory: system-tests/tests
-        env:
-          GITHUB_TOKEN: ${{ steps.github-token.outputs.access-token || '' }}
         run: |
           gotestsum \
             --jsonfile=/tmp/gotest.log \

--- a/.github/workflows/cre-soak-memory-leak.yml
+++ b/.github/workflows/cre-soak-memory-leak.yml
@@ -28,7 +28,8 @@ jobs:
     environment:
       name: integration
       deployment: false
-    runs-on: runs-on=${{ github.run_id }}/cpu=32/ram=128/family=m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs-on: runs-on=${{ github.run_id
+      }}/cpu=32/ram=128/family=m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     timeout-minutes: 270 # 4h30m — test timeout is 4h20m
     permissions:
       contents: read
@@ -36,11 +37,21 @@ jobs:
     env:
       CTF_CONFIGS: configs/workflow-gateway-capabilities-don.toml
       CRE_SOAK_DURATION: "2h"
-      CTF_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.22.1"
-      CTF_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name || 'chainlink' }}:${{ inputs.chainlink_image_tag }}"
-      CHIP_INGRESS_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/atlas-chip-ingress:da84cb72d3a160e02896247d46ab4b9806ebee2f"
-      CHIP_CONFIG_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/atlas-chip-config:7b4e9ee68fd1c737dd3480b5a3ced0188f29b969"
-      CTF_CHIP_ROUTER_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/local-cre-chip-router:v1.0.1"
+      CTF_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{
+        secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.22.1"
+      CTF_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
+        secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name ||
+        'chainlink' }}:${{ inputs.chainlink_image_tag }}"
+      CTF_CHIP_INGRESS_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{
+        secrets.QA_AWS_REGION
+        }}.amazonaws.com/atlas-chip-ingress:da84cb72d3a160e02896247d46ab4b9806e\
+        bee2f"
+      CTF_CHIP_CONFIG_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{
+        secrets.QA_AWS_REGION
+        }}.amazonaws.com/atlas-chip-config:7b4e9ee68fd1c737dd3480b5a3ced0188f29\
+        b969"
+      CTF_CHIP_ROUTER_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
+        secrets.QA_AWS_REGION }}.amazonaws.com/local-cre-chip-router:v1.0.1"
 
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners
@@ -74,7 +85,8 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         with:
-          registries: ${{ format('{0},{1}', secrets.QA_AWS_ACCOUNT_NUMBER, secrets.AWS_ACCOUNT_ID_PROD) }}
+          registries: ${{ format('{0},{1}', secrets.QA_AWS_ACCOUNT_NUMBER,
+            secrets.AWS_ACCOUNT_ID_PROD) }}
         env:
           AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       - name: Start observability stack
@@ -134,7 +146,7 @@ jobs:
     name: Notify about test Failure
     #if: failure()
     if: false # TODO: Silence for now
-    needs: [soak]
+    needs: [ soak ]
     environment:
       name: integration
       deployment: false

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -43,7 +43,6 @@ on:
       ecr:
         type: string
         required: true
-        default: "sdlc"
         description: "Whether to use the SDLC (sdlc) or public ECR registry (public) for
           the Chainlink image."
       chainlink_version:

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       chainlink_image_repository_path:
-        description: "ECR repository name used to compose image with chainlink_image_tag (for example: chainlink-integration-tests or chainlink or chainlink/chainlink)."
+        description: "ECR repository name used to compose image with chainlink_image_tag
+          (for example: chainlink-integration-tests or chainlink or
+          chainlink/chainlink)."
         required: true
         type: string
       chainlink_image_tag:
@@ -18,16 +20,20 @@ on:
           - "sdlc"
           - "public"
         default: "sdlc"
-        description: "Whether to use the SDLC or public ECR registry for the Chainlink image."
+        description: "Whether to use the SDLC or public ECR registry for the Chainlink
+          image."
       chainlink_version:
         required: false
         type: string
-        description: "The version of Chainlink repository to use for the tests. If empty, defaults to github.sha."
+        description: "The version of Chainlink repository to use for the tests. If
+          empty, defaults to github.sha."
         default: ""
   workflow_call:
     inputs:
       chainlink_image_repository_path:
-        description: "ECR repository name used to compose image with chainlink_image_tag (for example: chainlink-integration-tests or chainlink or chainlink/chainlink)."
+        description: "ECR repository name used to compose image with chainlink_image_tag
+          (for example: chainlink-integration-tests or chainlink or
+          chainlink/chainlink)."
         required: true
         type: string
       chainlink_image_tag:
@@ -38,16 +44,19 @@ on:
         type: string
         required: true
         default: "sdlc"
-        description: "Whether to use the SDLC (sdlc) or public ECR registry (public) for the Chainlink image."
+        description: "Whether to use the SDLC (sdlc) or public ECR registry (public) for
+          the Chainlink image."
       chainlink_version:
         required: false
         type: string
-        description: "The version of Chainlink repository to use for the tests. If empty, defaults to github.sha."
+        description: "The version of Chainlink repository to use for the tests. If
+          empty, defaults to github.sha."
         default: ""
 
 jobs:
   define-test-matrix:
-    runs-on: runs-on=${{ github.run_id }}/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs-on: runs-on=${{ github.run_id
+      }}/cpu=8/ram=32/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
     permissions:
@@ -156,10 +165,12 @@ jobs:
       fail-fast: false
       matrix:
         tests: ${{fromJson(needs.define-test-matrix.outputs.matrix)}}
-    needs: [define-test-matrix]
+    needs: [ define-test-matrix ]
     # we need a `test_id` and `run_attempt` here to stop runner stealing
     # see: https://runs-on.com/guides/troubleshoot/#runner-stealing-and-matrix-jobs
-    runs-on: runs-on=${{ github.run_id }}-${{ matrix.tests.test_id }}-${{ github.run_attempt }}/cpu=16/ram=64/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs-on: runs-on=${{ github.run_id }}-${{ matrix.tests.test_id }}-${{
+      github.run_attempt
+      }}/cpu=16/ram=64/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     environment:
       # http://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments
       name: integration
@@ -169,9 +180,14 @@ jobs:
       ENABLE_AUTO_QUARANTINE: "true"
       # override Chip Ingress and Chip Config images with remote images. We have added this env var here, instead of the "Start local CRE" step, because
       # Beholder stack will be started only for the Beholder tests
-      CHIP_INGRESS_IMAGE: ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/atlas-chip-ingress:da84cb72d3a160e02896247d46ab4b9806ebee2f
-      CHIP_CONFIG_IMAGE: ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/atlas-chip-config:7b4e9ee68fd1c737dd3480b5a3ced0188f29b969
-      BILLING_PLATFORM_SERVICE_IMAGE: ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/billing-platform-service:v1.57.1
+      CTF_CHIP_INGRESS_IMAGE: ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{
+        secrets.QA_AWS_REGION
+        }}.amazonaws.com/atlas-chip-ingress:da84cb72d3a160e02896247d46ab4b9806ebee2f
+      CTF_CHIP_CONFIG_IMAGE: ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{
+        secrets.QA_AWS_REGION
+        }}.amazonaws.com/atlas-chip-config:7b4e9ee68fd1c737dd3480b5a3ced0188f29b969
+      BILLING_PLATFORM_SERVICE_IMAGE: ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{
+        secrets.QA_AWS_REGION }}.amazonaws.com/billing-platform-service:v1.57.1
 
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners
@@ -205,7 +221,8 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
         with:
-          registries: ${{ format('{0},{1}', secrets.QA_AWS_ACCOUNT_NUMBER, secrets.AWS_ACCOUNT_ID_PROD) }}
+          registries: ${{ format('{0},{1}', secrets.QA_AWS_ACCOUNT_NUMBER,
+            secrets.AWS_ACCOUNT_ID_PROD) }}
         env:
           AWS_REGION: ${{ secrets.QA_AWS_REGION }}
 
@@ -250,9 +267,11 @@ jobs:
         shell: bash
         id: start-local-cre
         env:
-          CTF_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.22.1"
+          CTF_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{
+            secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.22.1"
           CTF_CHAINLINK_IMAGE: "${{ steps.resolve-chainlink-image.outputs.resolved_image }}"
-          CTF_CHIP_ROUTER_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/local-cre-chip-router:v1.0.1"
+          CTF_CHIP_ROUTER_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
+            secrets.QA_AWS_REGION }}.amazonaws.com/local-cre-chip-router:v1.0.1"
           CTF_CONFIGS: ${{ matrix.tests.configs }}
           CRE_VERSION: ${{ matrix.tests.cre_version }}
           TEST_NAME: ${{ matrix.tests.test_name }}
@@ -353,7 +372,8 @@ jobs:
             echo "tests_result=✅ Tests passed" >> $GITHUB_OUTPUT
           fi
 
-      - name: Analyze and upload test results (${{ steps.run-tests.outputs.tests_result }})
+      - name: Analyze and upload test results (${{ steps.run-tests.outputs.tests_result
+          }})
         if: ${{ !cancelled() }}
         uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/v1
         with:

--- a/core/scripts/cre/environment/environment/beholder.go
+++ b/core/scripts/cre/environment/environment/beholder.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
-	ctfchiprouter "github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter"
 	chipingressset "github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose/chip_ingress_set"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/chiprouter"
 	envconfig "github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/config"
@@ -307,7 +306,7 @@ func startBeholderCmd() *cobra.Command {
 	}
 
 	cmd.Flags().DurationVarP(&timeout, "wait-on-error-timeout", "w", 15*time.Second, "Time to wait before removing Docker containers if environment fails to start (e.g. 10s, 1m, 1h)")
-	cmd.Flags().IntVarP(&port, "grpc-port", "g", ctfchiprouter.DefaultBeholderGRPCPort, "GRPC port for downstream Chip Ingress")
+	cmd.Flags().IntVarP(&port, "grpc-port", "g", 0, "GRPC port for downstream Chip Ingress")
 
 	return cmd
 }
@@ -709,23 +708,26 @@ If you want to use both together start ChIP Ingress on a different port with '--
 		// Set image version environment variables for docker-compose
 		if setupCfg.ChipIngress != nil {
 			if err := os.Setenv(chipingressset.ChipIngressImageEnvVar, setupCfg.ChipIngress.BuildConfig.LocalImage); err != nil {
-				return fmt.Errorf("failed to set CHIP_INGRESS_IMAGE environment variable: %w", err)
+				return fmt.Errorf("failed to set %s environment variable: %w", chipingressset.ChipIngressImageEnvVar, err)
 			}
 		}
 		if setupCfg.ChipConfig != nil {
 			if err := os.Setenv(chipingressset.ChipConfigImageEnvVar, setupCfg.ChipConfig.BuildConfig.LocalImage); err != nil {
-				return fmt.Errorf("failed to set CHIP_CONFIG_IMAGE environment variable: %w", err)
+				return fmt.Errorf("failed to set %s environment variable: %w", chipingressset.ChipConfigImageEnvVar, err)
 			}
 		}
 	}
 
-	// set both internal and external (host) ChIP Ingress GRPC port to the same value
-	if err := os.Setenv(chipingressset.ChipIngressGRPCHostPortEnvVar, strconv.Itoa(port)); err != nil {
-		return fmt.Errorf("failed to set %s environment variable: %w", chipingressset.ChipIngressGRPCHostPortEnvVar, err)
-	}
+	// only set the port, if specified by the user, otherwise it will be automatically assigned by Docker
+	if port != 0 {
+		// set both internal and external (host) ChIP Ingress GRPC port to the same value
+		if err := os.Setenv(chipingressset.ChipIngressGRPCHostPortEnvVar, strconv.Itoa(port)); err != nil {
+			return fmt.Errorf("failed to set %s environment variable: %w", chipingressset.ChipIngressGRPCHostPortEnvVar, err)
+		}
 
-	if err := os.Setenv(chipingressset.ChipIngressGRPCPortEnvVar, strconv.Itoa(port)); err != nil {
-		return fmt.Errorf("failed to set %s environment variable: %w", chipingressset.ChipIngressGRPCPortEnvVar, err)
+		if err := os.Setenv(chipingressset.ChipIngressGRPCPortEnvVar, strconv.Itoa(port)); err != nil {
+			return fmt.Errorf("failed to set %s environment variable: %w", chipingressset.ChipIngressGRPCPortEnvVar, err)
+		}
 	}
 
 	// we want to restore previous configs, because Beholder might be started within the context of a different command,
@@ -793,7 +795,7 @@ If you want to use both together start ChIP Ingress on a different port with '--
 	}
 
 	if routerErr := chiprouter.EnsureStarted(cmdContext); routerErr == nil {
-		if err := registerBeholderWithRouter(cmdContext, port); err != nil {
+		if err := registerBeholderWithRouter(cmdContext, out.ChipIngress); err != nil {
 			return errors.Wrap(err, "failed to register Beholder with chip ingress router")
 		}
 	}
@@ -807,8 +809,8 @@ If you want to use both together start ChIP Ingress on a different port with '--
 	return in.Store(envconfig.MustChipIngressStateFileAbsPath(relativePathToRepoRoot))
 }
 
-func registerBeholderWithRouter(ctx context.Context, port int) error {
-	return registerBeholderEndpointWithRouter(ctx, fmt.Sprintf("127.0.0.1:%d", port))
+func registerBeholderWithRouter(ctx context.Context, out *chipingressset.ChipIngressOutput) error {
+	return registerBeholderEndpointWithRouter(ctx, out.GRPCInternalURL)
 }
 
 func registerBeholderEndpointWithRouter(ctx context.Context, endpoint string) error {

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260420204255-a3f3bdd56877
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based v0.0.0-00010101000000-000000000000
@@ -517,7 +517,7 @@ require (
 	github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260421131224-c46cbfe7bc6c // indirect
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260427132612-76b9f754a556 // indirect
 	github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260427132612-76b9f754a556 // indirect
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5 // indirect
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-ton v0.0.0-20260423161209-5ce1dba9785e // indirect

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -54,8 +54,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260420204255-a3f3bdd56877
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.2
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.20
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/proof-of-reserve/cron-based v0.0.0-00010101000000-000000000000
@@ -518,6 +517,7 @@ require (
 	github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260421131224-c46cbfe7bc6c // indirect
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260427132612-76b9f754a556 // indirect
 	github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260427132612-76b9f754a556 // indirect
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-ton v0.0.0-20260423161209-5ce1dba9785e // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1723,10 +1723,10 @@ github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260427132612-76b9f
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260427132612-76b9f754a556/go.mod h1:LkUo0a46JWaCsLY4SCV5ZOESudehe2RR62C1S46iOqw=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18 h1:ZPYXn3VvaZhWOyVHFBsKC543EJbL2d4PthQbdL3WgHs=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18/go.mod h1:BALK9cj8sk12e15UF6uDhifHgIApa+6N11TcQfInEro=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5 h1:F18Mig85G5AABiVhNI/WqJpbjlbVrPYx/WoeEfZt0ok=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5/go.mod h1:MjUJAyU+kLvLLPRPBs3X7zYadds5umZcjTLHjfNhpUc=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5 h1:NmDvyjope1PrdPOo4ulP+ZC3OufMskNXn5QYfA9Xg2M=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5/go.mod h1:nDg9OE6IlGn6WO1xw+gqmGHIFPmeCG6ZSTq6o9KFUy0=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3 h1:57wap/rDhBcw6+Ld7MqwQmXt2BTyVeNGvvPFDJcO8jQ=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3/go.mod h1:MjUJAyU+kLvLLPRPBs3X7zYadds5umZcjTLHjfNhpUc=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22 h1:V+3clQPZ0/N8PJhJDkl00giFtsf9lv5XQJl0SCGWzcM=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22/go.mod h1:nDg9OE6IlGn6WO1xw+gqmGHIFPmeCG6ZSTq6o9KFUy0=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5 h1:jARz/SWbmWoGJJGVcAnWwGMb8JuHRTQQsM3m6ZwrAGk=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1723,10 +1723,10 @@ github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260427132612-76b9f
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260427132612-76b9f754a556/go.mod h1:LkUo0a46JWaCsLY4SCV5ZOESudehe2RR62C1S46iOqw=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18 h1:ZPYXn3VvaZhWOyVHFBsKC543EJbL2d4PthQbdL3WgHs=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18/go.mod h1:BALK9cj8sk12e15UF6uDhifHgIApa+6N11TcQfInEro=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.2 h1:c8T3cnZXrwOo6YU4A/VNj941mZo6n9VbfY3POP74OoA=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.2/go.mod h1:MjUJAyU+kLvLLPRPBs3X7zYadds5umZcjTLHjfNhpUc=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.20 h1:8D2DUnn7mLUZOLhPDGGFKKvBrgU6LQd00tq2VOprvfI=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.20/go.mod h1:98jNYBOPuKWJw9a8x0LgQuudp5enrHhQQP5Hq0YwRB8=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5 h1:F18Mig85G5AABiVhNI/WqJpbjlbVrPYx/WoeEfZt0ok=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5/go.mod h1:MjUJAyU+kLvLLPRPBs3X7zYadds5umZcjTLHjfNhpUc=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5 h1:NmDvyjope1PrdPOo4ulP+ZC3OufMskNXn5QYfA9Xg2M=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5/go.mod h1:nDg9OE6IlGn6WO1xw+gqmGHIFPmeCG6ZSTq6o9KFUy0=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5 h1:jARz/SWbmWoGJJGVcAnWwGMb8JuHRTQQsM3m6ZwrAGk=

--- a/system-tests/lib/cre/don/config/config.go
+++ b/system-tests/lib/cre/don/config/config.go
@@ -23,7 +23,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/chaintype"
 	evmconfigtoml "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
-	chipingressset "github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose/chip_ingress_set"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/ptr"
 
 	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -48,6 +47,7 @@ func PrepareNodeTOMLs(
 	nodeSets []*cre.NodeSet,
 	capabilities []cre.InstallableCapability, // Deprecated, use Features instead and modify node configs inside a Feature
 	nodeConfigTransformerFns []cre.NodeConfigTransformerFn,
+	chipRouterInternalGRPCURL string,
 ) ([]*cre.NodeSet, error) {
 	bt, hasBootstrap := topology.Bootstrap()
 	if !hasBootstrap {
@@ -104,16 +104,17 @@ func PrepareNodeTOMLs(
 		if configsFound == 0 {
 			config, configErr := generateNodeTomlConfig(
 				cre.GenerateConfigsInput{
-					Datastore:               creEnv.CldfEnvironment.DataStore,
-					ContractVersions:        creEnv.ContractVersions,
-					DonMetadata:             donMetadata,
-					Blockchains:             chainPerSelector,
-					Flags:                   donMetadata.Flags,
-					CapabilitiesPeeringData: capabilitiesPeeringData,
-					OCRPeeringData:          ocrPeeringData,
-					RegistryChainSelector:   creEnv.RegistryChainSelector,
-					Topology:                topology,
-					Provider:                creEnv.Provider,
+					Datastore:                 creEnv.CldfEnvironment.DataStore,
+					ContractVersions:          creEnv.ContractVersions,
+					DonMetadata:               donMetadata,
+					Blockchains:               chainPerSelector,
+					Flags:                     donMetadata.Flags,
+					CapabilitiesPeeringData:   capabilitiesPeeringData,
+					OCRPeeringData:            ocrPeeringData,
+					RegistryChainSelector:     creEnv.RegistryChainSelector,
+					Topology:                  topology,
+					Provider:                  creEnv.Provider,
+					ChipRouterInternalGRPCURL: chipRouterInternalGRPCURL,
 				},
 				configFactoryFunctions,
 			)
@@ -345,7 +346,7 @@ func addBootstrapNodeConfig(
 			URL: ptr.Ptr("file:///home/chainlink/workflows"),
 		}
 
-		existingConfig.Telemetry.ChipIngressEndpoint = ptr.Ptr(strings.TrimPrefix(framework.HostDockerInternal(), "http://") + ":" + chipingressset.DEFAULT_CHIP_INGRESS_GRPC_PORT)
+		existingConfig.Telemetry.ChipIngressEndpoint = ptr.Ptr(commonInputs.chipRouterInternalGRPCURL)
 		existingConfig.Telemetry.ChipIngressInsecureConnection = ptr.Ptr(true)
 		existingConfig.Telemetry.HeartbeatInterval = commonconfig.MustNewDuration(30 * time.Second)
 
@@ -433,7 +434,7 @@ func addWorkerNodeConfig(
 			URL: ptr.Ptr("file:///home/chainlink/workflows"),
 		}
 
-		existingConfig.Telemetry.ChipIngressEndpoint = ptr.Ptr(strings.TrimPrefix(framework.HostDockerInternal(), "http://") + ":" + chipingressset.DEFAULT_CHIP_INGRESS_GRPC_PORT)
+		existingConfig.Telemetry.ChipIngressEndpoint = ptr.Ptr(commonInputs.chipRouterInternalGRPCURL)
 		existingConfig.Telemetry.ChipIngressInsecureConnection = ptr.Ptr(true)
 		existingConfig.Telemetry.HeartbeatInterval = commonconfig.MustNewDuration(30 * time.Second)
 
@@ -660,6 +661,8 @@ type commonInputs struct {
 	aptosChains []*aptosChain
 
 	provider infra.Provider
+
+	chipRouterInternalGRPCURL string
 }
 
 func gatherCommonInputs(input cre.GenerateConfigsInput) (*commonInputs, error) {
@@ -696,7 +699,8 @@ func gatherCommonInputs(input cre.GenerateConfigsInput) (*commonInputs, error) {
 			address: capabilitiesRegistryAddress,
 			version: input.ContractVersions[keystone_changeset.CapabilitiesRegistry.String()],
 		},
-		provider: input.Provider,
+		provider:                  input.Provider,
+		chipRouterInternalGRPCURL: input.ChipRouterInternalGRPCURL,
 	}, nil
 }
 

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -179,6 +179,7 @@ func SetupTestEnvironment(
 		input.NodeSets,
 		input.Capabilities,
 		input.ConfigFactoryFunctions,
+		input.ChipRouterInput.Out.InternalGRPCURL,
 	)
 	if topoErr != nil {
 		return nil, pkgerrors.Wrap(topoErr, "failed to build topology")

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -515,7 +515,7 @@ func (g *GenerateConfigsInput) Validate() error {
 		return fmt.Errorf("no addresses found for home chain %d in datastore", g.RegistryChainSelector)
 	}
 	if g.ChipRouterInternalGRPCURL == "" {
-		return fmt.Errorf("chip router internal grpc url not set")
+		return errors.New("chip router internal grpc url not set")
 	}
 	return nil
 }

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -474,16 +474,17 @@ type (
 )
 
 type GenerateConfigsInput struct {
-	Datastore               datastore.DataStore
-	DonMetadata             *DonMetadata
-	Blockchains             map[uint64]blockchains.Blockchain
-	RegistryChainSelector   uint64
-	Flags                   []string
-	CapabilitiesPeeringData CapabilitiesPeeringData
-	OCRPeeringData          OCRPeeringData
-	ContractVersions        map[ContractType]*semver.Version
-	Topology                *Topology
-	Provider                infra.Provider
+	Datastore                 datastore.DataStore
+	DonMetadata               *DonMetadata
+	Blockchains               map[uint64]blockchains.Blockchain
+	RegistryChainSelector     uint64
+	Flags                     []string
+	CapabilitiesPeeringData   CapabilitiesPeeringData
+	OCRPeeringData            OCRPeeringData
+	ContractVersions          map[ContractType]*semver.Version
+	Topology                  *Topology
+	Provider                  infra.Provider
+	ChipRouterInternalGRPCURL string
 }
 
 func (g *GenerateConfigsInput) Validate() error {
@@ -513,7 +514,9 @@ func (g *GenerateConfigsInput) Validate() error {
 	if len(h) == 0 {
 		return fmt.Errorf("no addresses found for home chain %d in datastore", g.RegistryChainSelector)
 	}
-	// TODO check for required registry contracts by type and version
+	if g.ChipRouterInternalGRPCURL == "" {
+		return fmt.Errorf("chip router internal grpc url not set")
+	}
 	return nil
 }
 

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -43,8 +43,8 @@ require (
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260323124644-faea187e6997
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.2
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5
@@ -336,6 +336,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
+	github.com/jhump/protocompile v0.0.0-20221021153901-4f6f732835e8 // indirect
 	github.com/jinzhu/copier v0.4.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jmhodges/levigo v1.0.0 // indirect

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -43,8 +43,8 @@ require (
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260323124644-faea187e6997
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1690,10 +1690,10 @@ github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260427132612-76b9f
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260427132612-76b9f754a556/go.mod h1:LkUo0a46JWaCsLY4SCV5ZOESudehe2RR62C1S46iOqw=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18 h1:ZPYXn3VvaZhWOyVHFBsKC543EJbL2d4PthQbdL3WgHs=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18/go.mod h1:BALK9cj8sk12e15UF6uDhifHgIApa+6N11TcQfInEro=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5 h1:F18Mig85G5AABiVhNI/WqJpbjlbVrPYx/WoeEfZt0ok=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5/go.mod h1:MjUJAyU+kLvLLPRPBs3X7zYadds5umZcjTLHjfNhpUc=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5 h1:NmDvyjope1PrdPOo4ulP+ZC3OufMskNXn5QYfA9Xg2M=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5/go.mod h1:nDg9OE6IlGn6WO1xw+gqmGHIFPmeCG6ZSTq6o9KFUy0=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3 h1:57wap/rDhBcw6+Ld7MqwQmXt2BTyVeNGvvPFDJcO8jQ=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3/go.mod h1:MjUJAyU+kLvLLPRPBs3X7zYadds5umZcjTLHjfNhpUc=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22 h1:V+3clQPZ0/N8PJhJDkl00giFtsf9lv5XQJl0SCGWzcM=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22/go.mod h1:nDg9OE6IlGn6WO1xw+gqmGHIFPmeCG6ZSTq6o9KFUy0=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5 h1:jARz/SWbmWoGJJGVcAnWwGMb8JuHRTQQsM3m6ZwrAGk=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1102,6 +1102,8 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jhump/gopoet v0.0.0-20190322174617-17282ff210b3/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/gopoet v0.1.0/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/goprotoc v0.5.0/go.mod h1:VrbvcYrQOrTi3i0Vf+m+oqQWk9l72mjkJCYo7UvLHRQ=
+github.com/jhump/protocompile v0.0.0-20221021153901-4f6f732835e8 h1:Un1m8MEz6emotHqXiBkHX3G3afGDwO5oE6T7hZaNnbw=
+github.com/jhump/protocompile v0.0.0-20221021153901-4f6f732835e8/go.mod h1:qr2b5kx4HbFS7/g4uYO5qv9ei8303JMsC7ESbYiqr2Q=
 github.com/jhump/protoreflect v1.11.0/go.mod h1:U7aMIjN0NWq9swDP7xDdoMfRHb35uiuTd3Z9nFXJf5E=
 github.com/jhump/protoreflect v1.12.0/go.mod h1:JytZfP5d0r8pVNLZvai7U/MCuTWITgrI4tTg7puQFKI=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
@@ -1688,10 +1690,10 @@ github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260427132612-76b9f
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260427132612-76b9f754a556/go.mod h1:LkUo0a46JWaCsLY4SCV5ZOESudehe2RR62C1S46iOqw=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18 h1:ZPYXn3VvaZhWOyVHFBsKC543EJbL2d4PthQbdL3WgHs=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18/go.mod h1:BALK9cj8sk12e15UF6uDhifHgIApa+6N11TcQfInEro=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.2 h1:c8T3cnZXrwOo6YU4A/VNj941mZo6n9VbfY3POP74OoA=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.2/go.mod h1:MjUJAyU+kLvLLPRPBs3X7zYadds5umZcjTLHjfNhpUc=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15 h1:usf6YCNmSO8R1/rU28wUfIdp7zXlqGGOAttXW5mgkXU=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.15/go.mod h1:YqrpawYGRkT/jcvXcmaZeZPOtu0erIenrHl5Mb8+U/c=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5 h1:F18Mig85G5AABiVhNI/WqJpbjlbVrPYx/WoeEfZt0ok=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5/go.mod h1:MjUJAyU+kLvLLPRPBs3X7zYadds5umZcjTLHjfNhpUc=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5 h1:NmDvyjope1PrdPOo4ulP+ZC3OufMskNXn5QYfA9Xg2M=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5/go.mod h1:nDg9OE6IlGn6WO1xw+gqmGHIFPmeCG6ZSTq6o9KFUy0=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5 h1:jARz/SWbmWoGJJGVcAnWwGMb8JuHRTQQsM3m6ZwrAGk=
@@ -2544,6 +2546,7 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260331131315-f08a616d8dcd
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260323124644-faea187e6997
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.7
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
@@ -618,7 +618,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.2.0 // indirect
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260427132612-76b9f754a556 // indirect
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5 // indirect
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-ton v0.0.0-20260423161209-5ce1dba9785e // indirect

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260331131315-f08a616d8dcd
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260323124644-faea187e6997
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.2
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.7
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
@@ -618,7 +618,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.2.0 // indirect
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260427132612-76b9f754a556 // indirect
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.18 // indirect
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-ton v0.0.0-20260423161209-5ce1dba9785e // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1903,10 +1903,10 @@ github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260427132612-76b9f
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260427132612-76b9f754a556/go.mod h1:LkUo0a46JWaCsLY4SCV5ZOESudehe2RR62C1S46iOqw=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18 h1:ZPYXn3VvaZhWOyVHFBsKC543EJbL2d4PthQbdL3WgHs=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18/go.mod h1:BALK9cj8sk12e15UF6uDhifHgIApa+6N11TcQfInEro=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.2 h1:c8T3cnZXrwOo6YU4A/VNj941mZo6n9VbfY3POP74OoA=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.2/go.mod h1:MjUJAyU+kLvLLPRPBs3X7zYadds5umZcjTLHjfNhpUc=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.18 h1:1ng+p/+85zcVLHB050PiWUAjOcxyd4KjwkUlJy34rgE=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.18/go.mod h1:2+OrSz56pdgtY0Oc20nCS9LH/bEksFDBQjoR82De5PI=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5 h1:F18Mig85G5AABiVhNI/WqJpbjlbVrPYx/WoeEfZt0ok=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5/go.mod h1:MjUJAyU+kLvLLPRPBs3X7zYadds5umZcjTLHjfNhpUc=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5 h1:NmDvyjope1PrdPOo4ulP+ZC3OufMskNXn5QYfA9Xg2M=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5/go.mod h1:nDg9OE6IlGn6WO1xw+gqmGHIFPmeCG6ZSTq6o9KFUy0=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.7 h1:ANltXlvv6CbOXieasPD9erc4BewtCHm1tKDPAYvuWLw=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1903,10 +1903,10 @@ github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260427132612-76b9f
 github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260427132612-76b9f754a556/go.mod h1:LkUo0a46JWaCsLY4SCV5ZOESudehe2RR62C1S46iOqw=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18 h1:ZPYXn3VvaZhWOyVHFBsKC543EJbL2d4PthQbdL3WgHs=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.18/go.mod h1:BALK9cj8sk12e15UF6uDhifHgIApa+6N11TcQfInEro=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5 h1:F18Mig85G5AABiVhNI/WqJpbjlbVrPYx/WoeEfZt0ok=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3-0.20260506095219-9844f7980ce5/go.mod h1:MjUJAyU+kLvLLPRPBs3X7zYadds5umZcjTLHjfNhpUc=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5 h1:NmDvyjope1PrdPOo4ulP+ZC3OufMskNXn5QYfA9Xg2M=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22-0.20260506095219-9844f7980ce5/go.mod h1:nDg9OE6IlGn6WO1xw+gqmGHIFPmeCG6ZSTq6o9KFUy0=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3 h1:57wap/rDhBcw6+Ld7MqwQmXt2BTyVeNGvvPFDJcO8jQ=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.3/go.mod h1:MjUJAyU+kLvLLPRPBs3X7zYadds5umZcjTLHjfNhpUc=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22 h1:V+3clQPZ0/N8PJhJDkl00giFtsf9lv5XQJl0SCGWzcM=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.22/go.mod h1:nDg9OE6IlGn6WO1xw+gqmGHIFPmeCG6ZSTq6o9KFUy0=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.7 h1:ANltXlvv6CbOXieasPD9erc4BewtCHm1tKDPAYvuWLw=

--- a/system-tests/tests/test-helpers/beholder_provider.go
+++ b/system-tests/tests/test-helpers/beholder_provider.go
@@ -69,7 +69,8 @@ func NewBeholder(lggr zerolog.Logger, testConfig *configuration.TestConfig) (*Be
 	beholderStartupMu.Lock()
 	defer beholderStartupMu.Unlock()
 
-	if err := startBeholderIfNotRunning(testConfig.RelativePathToRepoRoot, testConfig.EnvironmentDirPath, testConfig.ChipIngressGRPCPort); err != nil {
+	// we don't need to pass the GRPC port here, because it will be automatically assigned by Docker
+	if err := startBeholderIfNotRunning(testConfig.RelativePathToRepoRoot, testConfig.EnvironmentDirPath); err != nil {
 		return nil, errors.Wrap(err, "Beholder failed to start")
 	}
 
@@ -82,7 +83,7 @@ func NewBeholder(lggr zerolog.Logger, testConfig *configuration.TestConfig) (*Be
 }
 
 // startBeholderIfNotRunning starts the Beholder stack if it's not already running.
-func startBeholderIfNotRunning(relativePathToRepoRoot, environmentDir, grpcPort string) error {
+func startBeholderIfNotRunning(relativePathToRepoRoot, environmentDir string) error {
 	if config.ChipIngressStateFileExists(relativePathToRepoRoot) {
 		framework.L.Info().Msg("No need to start Beholder - it is already running")
 		return nil
@@ -92,7 +93,7 @@ func startBeholderIfNotRunning(relativePathToRepoRoot, environmentDir, grpcPort 
 	ctx, cancel := context.WithTimeout(context.Background(), beholderStartTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "go", "run", ".", "env", "beholder", "start", "--grpc-port", grpcPort)
+	cmd := exec.CommandContext(ctx, "go", "run", ".", "env", "beholder", "start")
 	cmd.Dir = environmentDir
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 


### PR DESCRIPTION
Instead of using static ports ChIP Ingress and ChIP Router will now defer to Docker to select a free host port. That will allow us to avoid conflicts with GHA Runner Listener process like this one:
```
Error: failed to start environment: failed to setup test environment: failed to start chip router: start container: container start: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint chip-router-0f2f3 (f1100fb23598a5f9d398ba758663cc4f25d53872e3c7ce1552bca37eedd18e6a): failed to bind host port for 0.0.0.0:50050:172.18.0.2:50050/tcp: address already in use

Port 50050 is already in use by:
COMMAND    PID   USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
Runner.Li 1155 runner  143u  IPv6  10454      0t0  TCP 10.1.36.185:50050->20.85.130.105:443 (ESTABLISHED)
```