### PR TITLE
CRE-4040: stabilize TestCompute_SpendValueRelativeToComputeTime

### DIFF
--- a/core/capabilities/compute/compute_test.go
+++ b/core/capabilities/compute/compute_test.go
@@ -297,21 +297,24 @@ func TestComputeFetch(t *testing.T) {
 	assert.Less(t, spendValue, uint64(400))
 }
 
+// meteringOverheadBudgetMs is the maximum allowed overhead (in ms) that the
+// metering accumulator may record above the mocked delay. Observed CI overhead
+// is ~438ms; -race adds additional overhead. 1500ms gives ~3x headroom while
+// still detecting metering bugs that double-count elapsed time.
+const meteringOverheadBudgetMs = int64(1500)
+
 func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
 	t.Parallel()
 
-	// because we are using ms precision and test overhead can result in variance, we use a range of 400ms
-	// to apply assertions.
 	tests := []struct {
 		time               time.Duration
 		expectedLowerLimit uint64
-		expectedUpperLimit uint64
 	}{
-		{time.Duration(0), 0, 400},
-		{time.Second, 1000, 1400},
-		{2 * time.Second, 2000, 2400},
-		{2_500 * time.Millisecond, 2500, 2900},
-		{3 * time.Second, 3000, 3400},
+		{time.Duration(0), 0},
+		{time.Second, 1000},
+		{2 * time.Second, 2000},
+		{2_500 * time.Millisecond, 2500},
+		{3 * time.Second, 3000},
 	}
 
 	workflowID := "15c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0"
@@ -343,8 +346,6 @@ func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
 		test := tests[idx]
 
 		t.Run(test.time.String(), func(t *testing.T) {
-			t.Parallel()
-
 			th := setup(t, defaultConfig)
 
 			th.connector.EXPECT().DonID(matches.AnyContext).Return("don-id", nil)
@@ -376,7 +377,8 @@ func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.GreaterOrEqual(t, value, test.expectedLowerLimit)
-			assert.Less(t, value, test.expectedUpperLimit)
+			overhead := int64(value) - test.time.Milliseconds()
+			assert.Less(t, overhead, meteringOverheadBudgetMs, "metering overhead exceeded budget: %dms", overhead)
 		})
 	}
 }

--- a/core/capabilities/compute/compute_test.go
+++ b/core/capabilities/compute/compute_test.go
@@ -301,7 +301,7 @@ func TestComputeFetch(t *testing.T) {
 // metering accumulator may record above the mocked delay. Observed CI overhead
 // is ~438ms; -race adds additional overhead. 1500ms gives ~3x headroom while
 // still detecting metering bugs that double-count elapsed time.
-const meteringOverheadBudgetMs = int64(1500)
+const meteringOverheadBudgetMs uint64 = 1500
 
 func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
 	t.Parallel()
@@ -377,8 +377,10 @@ func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.GreaterOrEqual(t, value, test.expectedLowerLimit)
-			overhead := int64(value) - test.time.Milliseconds()
-			assert.Less(t, overhead, meteringOverheadBudgetMs, "metering overhead exceeded budget: %dms", overhead)
+			//nolint:gosec // G115: test.time is a positive constant, no overflow possible
+			upperBound := uint64(test.time.Milliseconds()) + meteringOverheadBudgetMs
+			assert.Less(t, value, upperBound, "metering value %dms exceeds mocked delay %dms + overhead budget %dms",
+				value, test.time.Milliseconds(), meteringOverheadBudgetMs)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes flake in `TestCompute_SpendValueRelativeToComputeTime` (subtest `/2s` reported by Trunk).

- Replace per-row `expectedUpperLimit` with an overhead-bounded assertion: `(measured - mocked_delay_ms) < meteringOverheadBudgetMs (1500ms)`. Decouples tolerance from case duration and tests a single invariant — metering overhead is bounded.
- Drop the inner `t.Parallel()` on the 5 subtests to reduce timer-heap and CPU contention. Outer `t.Parallel()` is preserved.
- No production-code changes (root cause is real-time clock usage in `compute.go:executeWithModule`; flagged for follow-up but out of scope here).

## Why the previous bound was flaky

Each table row had a fixed 400ms upper buffer over its mocked delay. Production `executeWithModule` measures elapsed time with raw `time.Now()`/`time.Since()` (no mockable clock), so any CI scheduling jitter or wasm-module setup overhead falls into the assertion window. Trunk recorded a failing run with 438ms of overhead on the 2s case (`measured 2438 > expected 2400`). The 2.5s and 3s rows have identical 400ms buffers and were waiting to flake the same way.

## Flaky test fixes

| Issue | Test | Trunk |
|-------|------|-------|
| [CRE-4040](https://smartcontract-it.atlassian.net/browse/CRE-4040) | `TestCompute_SpendValueRelativeToComputeTime/2s` | [Trunk test case](https://app.trunk.io/chainlink/flaky-tests/test/aae624df-8641-543d-bb77-66fa8fbaf857?repo=smartcontractkit%2Fchainlink) |

## Test plan

- [x] `go test -race -shuffle=on -run '^TestCompute_SpendValueRelativeToComputeTime$' ./core/capabilities/compute/...` — 10/10 consecutive runs PASS locally
- [ ] CI passes, including any quarantined-test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CRE-4040]: https://smartcontract-it.atlassian.net/browse/CRE-4040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ