### PR TITLE
fix(scripts): make setup_testdb.sh runnable on Linux

### DIFF
--- a/core/scripts/setup_testdb.sh
+++ b/core/scripts/setup_testdb.sh
@@ -1,12 +1,16 @@
-#/bin/sh
+#!/bin/bash
+set -euo pipefail
 
-function exit_error {
-    echo "Error: $1"
+exit_error() {
+    echo "Error: $1" >&2
     exit 1
 }
 # Create a new user and database for development
 # This script is intended to be run on a local development machine
-tdir=$(mktemp -d -t db-dev-user)
+# Use an explicit template so mktemp works on both BSD (macOS) and GNU
+# coreutils (Linux), where `-t db-dev-user` rejects the template as
+# having too few X's.
+tdir=$(mktemp -d "${TMPDIR:-/tmp}/db-dev-user.XXXXXX")
 
 username="chainlink_dev"
 password="insecurepassword"
@@ -62,7 +66,7 @@ popd
 
 # Set the database URL in the .dbenv file
 dbenv=$repo/.dbenv
-echo "\n!Success!\n"
+printf '\n!Success!\n\n'
 echo "Datbase URL: $db_url"
 
 echo "export $db_url" >> $dbenv


### PR DESCRIPTION
## Description

Closes #16179.

`./core/scripts/setup_testdb.sh` currently fails out of the box on Linux with the errors reported in the issue:

```
./core/scripts/setup_testdb.sh: 3: function: not found
mktemp: too few X's in template 'db-dev-user'
```

Three problems combine to produce this:

1. The shebang on line 1 is `#/bin/sh` — the leading `!` is missing, so the kernel won't honor it and the file is interpreted by the calling shell (dash on Ubuntu), which then trips on the bash-only `function` keyword on line 3.
2. `mktemp -d -t db-dev-user` only works under BSD mktemp. GNU coreutils mktemp requires the template to contain `XXXXXX`, hence "too few X's".
3. The script also relies on bash builtins (`pushd`/`popd`), so reverting the shebang to plain `/bin/sh` would just shift the failure to those lines.

This PR:

- Switches the shebang to `/bin/bash` so bashisms (`pushd`, `popd`, `<<` heredocs with the existing escapes) keep working.
- Drops the redundant `function` keyword in `exit_error` and routes its message to stderr.
- Replaces `mktemp -d -t db-dev-user` with `mktemp -d "${TMPDIR:-/tmp}/db-dev-user.XXXXXX"`, which is accepted by both BSD and GNU mktemp.
- Replaces `echo "\n!Success!\n"` with `printf '\n!Success!\n\n'`. Bash's `echo` does not interpret `\n` without `-e`, so the original prints literal backslash-n.
- Adds `set -euo pipefail` so failures (e.g. a bad `psql` invocation) abort the script instead of continuing into the export step.

## Testing

```
$ bash -n core/scripts/setup_testdb.sh    # syntax check
$ tdir=$(mktemp -d "${TMPDIR:-/tmp}/db-dev-user.XXXXXX") && echo "$tdir" && rmdir "$tdir"
/var/folders/.../db-dev-user.XXXXXX
```

I do not have a Postgres-enabled CI environment locally to run `make setup-testdb` end-to-end, so I have not exercised the SQL path; the changes are limited to the failure modes described in the issue.

## Author Checklist

- [x] PR title uses Conventional Commits prefix
- [x] Targeted `develop`
- [x] Linked the relevant issue
- [x] Reviewed Files changed
- [ ] Unit tests — n/a, shell script with no test harness