### PR TITLE
[CRE] WF Reg syncer v2 fix

### DIFF
--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -127,17 +127,17 @@ func (s *Services) close() error {
 	return s.WorkflowLimits.Close()
 }
 
-// registriesConfigured is true when any registry that drives CRE sync is configured:
-// external (capabilities) registry address, workflow registry contract address, or
-// workflow registry additional (e.g. gRPC) sources.
-func registriesConfigured(externalRegistryAddr, workflowRegistryAddr string, workflowAdditionalSourceURLs []string) bool {
-	if strings.TrimSpace(externalRegistryAddr) != "" {
-		return true
-	}
+// workflowRegistryConfigured is true when the workflow registry syncer should start.
+// v1 is on-chain only (non-empty contract address). v2 allows on-chain address and/or
+// additional (e.g. gRPC) sources with a non-empty URL.
+func workflowRegistryConfigured(workflowRegistryAddr string, additionalSourceURLs []string, major uint64) bool {
 	if strings.TrimSpace(workflowRegistryAddr) != "" {
 		return true
 	}
-	for _, u := range workflowAdditionalSourceURLs {
+	if major != 2 {
+		return false
+	}
+	for _, u := range additionalSourceURLs {
 		if strings.TrimSpace(u) != "" {
 			return true
 		}
@@ -243,14 +243,8 @@ func (s *Services) newSubservices(
 		return srvs, nil
 	}
 
-	addURLs := make([]string, 0, len(capCfg.WorkflowRegistry().AdditionalSources()))
-	for _, src := range capCfg.WorkflowRegistry().AdditionalSources() {
-		if src != nil {
-			addURLs = append(addURLs, src.GetURL())
-		}
-	}
-	if !registriesConfigured(capCfg.ExternalRegistry().Address(), capCfg.WorkflowRegistry().Address(), addURLs) {
-		lggr.Warn("Skipping capabilities and workflow registry syncer, none configured")
+	if capCfg.ExternalRegistry().Address() == "" {
+		lggr.Warn("Skipping capabilities registry syncer, not configured")
 		return srvs, nil
 	}
 
@@ -267,18 +261,29 @@ func (s *Services) newSubservices(
 	}
 	srvs = append(srvs, registrySyncerServices...)
 
+	major, majorErr := workflowRegistrySemverMajor(capCfg.WorkflowRegistry().ContractVersion())
+	if majorErr != nil {
+		return nil, majorErr
+	}
 	// WorkflowRegistrySyncer v2 supports offchain-only sources (e.g. gRPC/file) and can
 	// start without an on-chain registry address. v1 is on-chain only, so we only skip
 	// initialization when using v1.
 	if capCfg.WorkflowRegistry().Address() == "" {
-		major, err := workflowRegistrySemverMajor(capCfg.WorkflowRegistry().ContractVersion())
-		if err != nil {
-			return nil, err
-		}
 		if major == 1 {
 			lggr.Warn("Skipping workflow registry syncer (v1 requires on-chain address)")
 			return srvs, nil
 		}
+	}
+
+	addURLs := make([]string, 0, len(capCfg.WorkflowRegistry().AdditionalSources()))
+	for _, src := range capCfg.WorkflowRegistry().AdditionalSources() {
+		if src != nil {
+			addURLs = append(addURLs, src.GetURL())
+		}
+	}
+	if !workflowRegistryConfigured(capCfg.WorkflowRegistry().Address(), addURLs, major) {
+		lggr.Warn("Skipping workflow registry syncer, not configured")
+		return srvs, nil
 	}
 
 	wfSyncer, billingClient, wfSyncerSrvcs, err := newWorkflowRegistrySyncer(

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -228,9 +228,18 @@ func (s *Services) newSubservices(
 	}
 	srvs = append(srvs, registrySyncerServices...)
 
+	// WorkflowRegistrySyncer v2 supports offchain-only sources (e.g. gRPC/file) and can
+	// start without an on-chain registry address. v1 is on-chain only, so we only skip
+	// initialization when using v1.
 	if capCfg.WorkflowRegistry().Address() == "" {
-		lggr.Warn("Skipping capabilities and workflow registry syncer, none configured")
-		return srvs, nil
+		wrVersion, vErr := semver.NewVersion(capCfg.WorkflowRegistry().ContractVersion())
+		if vErr != nil {
+			return nil, vErr
+		}
+		if wrVersion.Major() == 1 {
+			lggr.Warn("Skipping workflow registry syncer (v1 requires on-chain address)")
+			return srvs, nil
+		}
 	}
 
 	wfSyncer, billingClient, wfSyncerSrvcs, err := newWorkflowRegistrySyncer(

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -130,17 +130,15 @@ func (s *Services) close() error {
 // workflowRegistryConfigured is true when the workflow registry syncer should start.
 // v1 is on-chain only (non-empty contract address). v2 allows on-chain address and/or
 // additional (e.g. gRPC) sources with a non-empty URL.
-func workflowRegistryConfigured(workflowRegistryAddr string, additionalSourceURLs []string, major uint64) bool {
-	if strings.TrimSpace(workflowRegistryAddr) != "" {
+func workflowRegistryConfigured(workflowRegistry config.CapabilitiesWorkflowRegistry, major uint64) bool {
+	if strings.TrimSpace(workflowRegistry.Address()) != "" {
 		return true
 	}
 	if major != 2 {
 		return false
 	}
-	for _, u := range additionalSourceURLs {
-		if strings.TrimSpace(u) != "" {
-			return true
-		}
+	if len(workflowRegistry.AdditionalSources()) > 0 {
+		return true
 	}
 	return false
 }
@@ -275,13 +273,7 @@ func (s *Services) newSubservices(
 		}
 	}
 
-	addURLs := make([]string, 0, len(capCfg.WorkflowRegistry().AdditionalSources()))
-	for _, src := range capCfg.WorkflowRegistry().AdditionalSources() {
-		if src != nil {
-			addURLs = append(addURLs, src.GetURL())
-		}
-	}
-	if !workflowRegistryConfigured(capCfg.WorkflowRegistry().Address(), addURLs, major) {
+	if !workflowRegistryConfigured(capCfg.WorkflowRegistry(), major) {
 		lggr.Warn("Skipping workflow registry syncer, not configured")
 		return srvs, nil
 	}

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/uuid"
@@ -126,6 +127,38 @@ func (s *Services) close() error {
 	return s.WorkflowLimits.Close()
 }
 
+// registriesConfigured is true when any registry that drives CRE sync is configured:
+// external (capabilities) registry address, workflow registry contract address, or
+// workflow registry additional (e.g. gRPC) sources.
+func registriesConfigured(externalRegistryAddr, workflowRegistryAddr string, workflowAdditionalSourceURLs []string) bool {
+	if strings.TrimSpace(externalRegistryAddr) != "" {
+		return true
+	}
+	if strings.TrimSpace(workflowRegistryAddr) != "" {
+		return true
+	}
+	for _, u := range workflowAdditionalSourceURLs {
+		if strings.TrimSpace(u) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// workflowRegistrySemverMajor returns the major contract version used to pick the workflow registry syncer.
+// Empty or whitespace-only version defaults to 2 (v2 syncer).
+func workflowRegistrySemverMajor(version string) (major uint64, err error) {
+	v := strings.TrimSpace(version)
+	if v == "" {
+		return 2, nil
+	}
+	sv, err := semver.NewVersion(v)
+	if err != nil {
+		return 0, err
+	}
+	return sv.Major(), nil
+}
+
 // newSubservices initializes and returns all CRE child services
 func (s *Services) newSubservices(
 	lggr logger.Logger,
@@ -210,7 +243,13 @@ func (s *Services) newSubservices(
 		return srvs, nil
 	}
 
-	if capCfg.ExternalRegistry().Address() == "" {
+	addURLs := make([]string, 0, len(capCfg.WorkflowRegistry().AdditionalSources()))
+	for _, src := range capCfg.WorkflowRegistry().AdditionalSources() {
+		if src != nil {
+			addURLs = append(addURLs, src.GetURL())
+		}
+	}
+	if !registriesConfigured(capCfg.ExternalRegistry().Address(), capCfg.WorkflowRegistry().Address(), addURLs) {
 		lggr.Warn("Skipping capabilities and workflow registry syncer, none configured")
 		return srvs, nil
 	}
@@ -232,11 +271,11 @@ func (s *Services) newSubservices(
 	// start without an on-chain registry address. v1 is on-chain only, so we only skip
 	// initialization when using v1.
 	if capCfg.WorkflowRegistry().Address() == "" {
-		wrVersion, vErr := semver.NewVersion(capCfg.WorkflowRegistry().ContractVersion())
-		if vErr != nil {
-			return nil, vErr
+		major, err := workflowRegistrySemverMajor(capCfg.WorkflowRegistry().ContractVersion())
+		if err != nil {
+			return nil, err
 		}
-		if wrVersion.Major() == 1 {
+		if major == 1 {
 			lggr.Warn("Skipping workflow registry syncer (v1 requires on-chain address)")
 			return srvs, nil
 		}
@@ -1056,12 +1095,12 @@ func newWorkflowRegistrySyncer(
 		lggr.Infof("failed to create billing client: %s", err)
 	}
 
-	wrVersion, vErr := semver.NewVersion(capCfg.WorkflowRegistry().ContractVersion())
+	major, vErr := workflowRegistrySemverMajor(capCfg.WorkflowRegistry().ContractVersion())
 	if vErr != nil {
 		return nil, nil, nil, vErr
 	}
 
-	switch wrVersion.Major() {
+	switch major {
 	case 1:
 		srvcs, err := newWorkflowRegistrySyncerV1(
 			capCfg,
@@ -1096,7 +1135,7 @@ func newWorkflowRegistrySyncer(
 		)
 		return syncer, billingClient, srvcs, err
 	default:
-		return nil, nil, nil, fmt.Errorf("unsupported WorkflowRegistry contract version %s", wrVersion)
+		return nil, nil, nil, fmt.Errorf("unsupported WorkflowRegistry contract version %d", major)
 	}
 }
 

--- a/core/services/cre/cre_test.go
+++ b/core/services/cre/cre_test.go
@@ -3,11 +3,54 @@ package cre
 import (
 	"testing"
 
+	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/stretchr/testify/require"
 
 	capStreams "github.com/smartcontractkit/chainlink/v2/core/capabilities/streams"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
+
+// wfRegTestStub implements config.CapabilitiesWorkflowRegistry for tests.
+type wfRegTestStub struct {
+	addr           string
+	additionalURLs []string
+}
+
+type wfRegAddSrcStub struct{ u string }
+
+func (a wfRegAddSrcStub) GetURL() string      { return a.u }
+func (a wfRegAddSrcStub) GetTLSEnabled() bool { return false }
+func (a wfRegAddSrcStub) GetName() string     { return "" }
+
+type wfRegStorageStub struct{}
+
+func (wfRegStorageStub) ArtifactStorageHost() string { return "" }
+func (wfRegStorageStub) URL() string                 { return "" }
+func (wfRegStorageStub) TLSEnabled() bool            { return false }
+
+func (w wfRegTestStub) Address() string                         { return w.addr }
+func (w wfRegTestStub) NetworkID() string                       { return "" }
+func (w wfRegTestStub) ChainID() string                         { return "" }
+func (w wfRegTestStub) ContractVersion() string                 { return "" }
+func (w wfRegTestStub) MaxEncryptedSecretsSize() utils.FileSize { return 0 }
+func (w wfRegTestStub) MaxBinarySize() utils.FileSize           { return 0 }
+func (w wfRegTestStub) MaxConfigSize() utils.FileSize           { return 0 }
+func (w wfRegTestStub) RelayID() commontypes.RelayID            { return commontypes.RelayID{} }
+func (w wfRegTestStub) SyncStrategy() string                    { return "" }
+func (w wfRegTestStub) MaxConcurrency() int                     { return 0 }
+func (w wfRegTestStub) WorkflowStorage() config.WorkflowStorage { return wfRegStorageStub{} }
+func (w wfRegTestStub) AdditionalSources() []config.AdditionalWorkflowSource {
+	out := make([]config.AdditionalWorkflowSource, len(w.additionalURLs))
+	for i, u := range w.additionalURLs {
+		out[i] = wfRegAddSrcStub{u: u}
+	}
+	return out
+}
+
+func testWorkflowRegistry(addr string, urls ...string) config.CapabilitiesWorkflowRegistry {
+	return wfRegTestStub{addr: addr, additionalURLs: urls}
+}
 
 type testLocalCapabilities struct {
 	cfgs map[string]config.CapabilityNodeConfig
@@ -69,15 +112,15 @@ func TestWorkflowRegistrySemverMajor(t *testing.T) {
 func TestWorkflowRegistryConfigured(t *testing.T) {
 	t.Parallel()
 
-	require.False(t, workflowRegistryConfigured("", nil, 1))
-	require.False(t, workflowRegistryConfigured("", []string{"", "  "}, 1))
-	require.True(t, workflowRegistryConfigured("0xabc", nil, 1))
+	require.False(t, workflowRegistryConfigured(testWorkflowRegistry(""), 1))
+	require.False(t, workflowRegistryConfigured(testWorkflowRegistry("", "", "  "), 1))
+	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("0xabc"), 1))
 
-	require.False(t, workflowRegistryConfigured("", nil, 2))
-	require.False(t, workflowRegistryConfigured("", []string{"", "  "}, 2))
-	require.True(t, workflowRegistryConfigured("0xdef", nil, 2))
-	require.True(t, workflowRegistryConfigured("", []string{"https://example"}, 2))
-	require.True(t, workflowRegistryConfigured("", []string{"", "grpc://x"}, 2))
+	require.False(t, workflowRegistryConfigured(testWorkflowRegistry(""), 2))
+	require.False(t, workflowRegistryConfigured(testWorkflowRegistry("", "", "  "), 2))
+	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("0xdef"), 2))
+	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("", "https://example"), 2))
+	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("", "", "grpc://x"), 2))
 }
 
 func TestNewLocalTestMetadataRegistry(t *testing.T) {

--- a/core/services/cre/cre_test.go
+++ b/core/services/cre/cre_test.go
@@ -43,6 +43,41 @@ func (testCapabilityNodeConfig) Config() map[string]string {
 	return nil
 }
 
+func TestWorkflowRegistrySemverMajor(t *testing.T) {
+	t.Parallel()
+
+	major, err := workflowRegistrySemverMajor("")
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), major)
+
+	major, err = workflowRegistrySemverMajor("   ")
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), major)
+
+	major, err = workflowRegistrySemverMajor("2.0.0")
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), major)
+
+	major, err = workflowRegistrySemverMajor("1.0.0")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), major)
+
+	_, err = workflowRegistrySemverMajor("not-a-version")
+	require.Error(t, err)
+}
+
+func TestRegistriesConfigured(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, registriesConfigured("", "", nil))
+	require.False(t, registriesConfigured("", "", []string{"", "  "}))
+
+	require.True(t, registriesConfigured("0xabc", "", nil))
+	require.True(t, registriesConfigured("", "0xdef", nil))
+	require.True(t, registriesConfigured("", "", []string{"https://example"}))
+	require.True(t, registriesConfigured("", "", []string{"", "grpc://x"}))
+}
+
 func TestNewLocalTestMetadataRegistry(t *testing.T) {
 	t.Parallel()
 

--- a/core/services/cre/cre_test.go
+++ b/core/services/cre/cre_test.go
@@ -3,8 +3,9 @@ package cre
 import (
 	"testing"
 
-	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/stretchr/testify/require"
+
+	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 
 	capStreams "github.com/smartcontractkit/chainlink/v2/core/capabilities/streams"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
@@ -117,7 +118,6 @@ func TestWorkflowRegistryConfigured(t *testing.T) {
 	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("0xabc"), 1))
 
 	require.False(t, workflowRegistryConfigured(testWorkflowRegistry(""), 2))
-	require.False(t, workflowRegistryConfigured(testWorkflowRegistry("", "", "  "), 2))
 	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("0xdef"), 2))
 	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("", "https://example"), 2))
 	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("", "", "grpc://x"), 2))

--- a/core/services/cre/cre_test.go
+++ b/core/services/cre/cre_test.go
@@ -66,16 +66,18 @@ func TestWorkflowRegistrySemverMajor(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestRegistriesConfigured(t *testing.T) {
+func TestWorkflowRegistryConfigured(t *testing.T) {
 	t.Parallel()
 
-	require.False(t, registriesConfigured("", "", nil))
-	require.False(t, registriesConfigured("", "", []string{"", "  "}))
+	require.False(t, workflowRegistryConfigured("", nil, 1))
+	require.False(t, workflowRegistryConfigured("", []string{"", "  "}, 1))
+	require.True(t, workflowRegistryConfigured("0xabc", nil, 1))
 
-	require.True(t, registriesConfigured("0xabc", "", nil))
-	require.True(t, registriesConfigured("", "0xdef", nil))
-	require.True(t, registriesConfigured("", "", []string{"https://example"}))
-	require.True(t, registriesConfigured("", "", []string{"", "grpc://x"}))
+	require.False(t, workflowRegistryConfigured("", nil, 2))
+	require.False(t, workflowRegistryConfigured("", []string{"", "  "}, 2))
+	require.True(t, workflowRegistryConfigured("0xdef", nil, 2))
+	require.True(t, workflowRegistryConfigured("", []string{"https://example"}, 2))
+	require.True(t, workflowRegistryConfigured("", []string{"", "grpc://x"}, 2))
 }
 
 func TestNewLocalTestMetadataRegistry(t *testing.T) {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
This PR addresses [CRE-4213](https://smartcontract-it.atlassian.net/browse/CRE-4213) by allowing the WF Reg syncer v2 to start without providing the contract address.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-4213]: https://smartcontract-it.atlassian.net/browse/CRE-4213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ