### PR TITLE
[CRE] WF Reg syncer v2 fix (#22352)

### DIFF
--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/uuid"
@@ -126,6 +127,36 @@ func (s *Services) close() error {
 	return s.WorkflowLimits.Close()
 }
 
+// workflowRegistryConfigured is true when the workflow registry syncer should start.
+// v1 is on-chain only (non-empty contract address). v2 allows on-chain address and/or
+// additional (e.g. gRPC) sources with a non-empty URL.
+func workflowRegistryConfigured(workflowRegistry config.CapabilitiesWorkflowRegistry, major uint64) bool {
+	if strings.TrimSpace(workflowRegistry.Address()) != "" {
+		return true
+	}
+	if major != 2 {
+		return false
+	}
+	if len(workflowRegistry.AdditionalSources()) > 0 {
+		return true
+	}
+	return false
+}
+
+// workflowRegistrySemverMajor returns the major contract version used to pick the workflow registry syncer.
+// Empty or whitespace-only version defaults to 2 (v2 syncer).
+func workflowRegistrySemverMajor(version string) (major uint64, err error) {
+	v := strings.TrimSpace(version)
+	if v == "" {
+		return 2, nil
+	}
+	sv, err := semver.NewVersion(v)
+	if err != nil {
+		return 0, err
+	}
+	return sv.Major(), nil
+}
+
 // newSubservices initializes and returns all CRE child services
 func (s *Services) newSubservices(
 	lggr logger.Logger,
@@ -211,7 +242,7 @@ func (s *Services) newSubservices(
 	}
 
 	if capCfg.ExternalRegistry().Address() == "" {
-		lggr.Warn("Skipping capabilities and workflow registry syncer, none configured")
+		lggr.Warn("Skipping capabilities registry syncer, not configured")
 		return srvs, nil
 	}
 
@@ -228,8 +259,22 @@ func (s *Services) newSubservices(
 	}
 	srvs = append(srvs, registrySyncerServices...)
 
+	major, majorErr := workflowRegistrySemverMajor(capCfg.WorkflowRegistry().ContractVersion())
+	if majorErr != nil {
+		return nil, majorErr
+	}
+	// WorkflowRegistrySyncer v2 supports offchain-only sources (e.g. gRPC/file) and can
+	// start without an on-chain registry address. v1 is on-chain only, so we only skip
+	// initialization when using v1.
 	if capCfg.WorkflowRegistry().Address() == "" {
-		lggr.Warn("Skipping capabilities and workflow registry syncer, none configured")
+		if major == 1 {
+			lggr.Warn("Skipping workflow registry syncer (v1 requires on-chain address)")
+			return srvs, nil
+		}
+	}
+
+	if !workflowRegistryConfigured(capCfg.WorkflowRegistry(), major) {
+		lggr.Warn("Skipping workflow registry syncer, not configured")
 		return srvs, nil
 	}
 
@@ -1047,12 +1092,12 @@ func newWorkflowRegistrySyncer(
 		lggr.Infof("failed to create billing client: %s", err)
 	}
 
-	wrVersion, vErr := semver.NewVersion(capCfg.WorkflowRegistry().ContractVersion())
+	major, vErr := workflowRegistrySemverMajor(capCfg.WorkflowRegistry().ContractVersion())
 	if vErr != nil {
 		return nil, nil, nil, vErr
 	}
 
-	switch wrVersion.Major() {
+	switch major {
 	case 1:
 		srvcs, err := newWorkflowRegistrySyncerV1(
 			capCfg,
@@ -1087,7 +1132,7 @@ func newWorkflowRegistrySyncer(
 		)
 		return syncer, billingClient, srvcs, err
 	default:
-		return nil, nil, nil, fmt.Errorf("unsupported WorkflowRegistry contract version %s", wrVersion)
+		return nil, nil, nil, fmt.Errorf("unsupported WorkflowRegistry contract version %d", major)
 	}
 }
 

--- a/core/services/cre/cre_test.go
+++ b/core/services/cre/cre_test.go
@@ -5,9 +5,53 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
+
 	capStreams "github.com/smartcontractkit/chainlink/v2/core/capabilities/streams"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
+
+// wfRegTestStub implements config.CapabilitiesWorkflowRegistry for tests.
+type wfRegTestStub struct {
+	addr           string
+	additionalURLs []string
+}
+
+type wfRegAddSrcStub struct{ u string }
+
+func (a wfRegAddSrcStub) GetURL() string      { return a.u }
+func (a wfRegAddSrcStub) GetTLSEnabled() bool { return false }
+func (a wfRegAddSrcStub) GetName() string     { return "" }
+
+type wfRegStorageStub struct{}
+
+func (wfRegStorageStub) ArtifactStorageHost() string { return "" }
+func (wfRegStorageStub) URL() string                 { return "" }
+func (wfRegStorageStub) TLSEnabled() bool            { return false }
+
+func (w wfRegTestStub) Address() string                         { return w.addr }
+func (w wfRegTestStub) NetworkID() string                       { return "" }
+func (w wfRegTestStub) ChainID() string                         { return "" }
+func (w wfRegTestStub) ContractVersion() string                 { return "" }
+func (w wfRegTestStub) MaxEncryptedSecretsSize() utils.FileSize { return 0 }
+func (w wfRegTestStub) MaxBinarySize() utils.FileSize           { return 0 }
+func (w wfRegTestStub) MaxConfigSize() utils.FileSize           { return 0 }
+func (w wfRegTestStub) RelayID() commontypes.RelayID            { return commontypes.RelayID{} }
+func (w wfRegTestStub) SyncStrategy() string                    { return "" }
+func (w wfRegTestStub) MaxConcurrency() int                     { return 0 }
+func (w wfRegTestStub) WorkflowStorage() config.WorkflowStorage { return wfRegStorageStub{} }
+func (w wfRegTestStub) AdditionalSources() []config.AdditionalWorkflowSource {
+	out := make([]config.AdditionalWorkflowSource, len(w.additionalURLs))
+	for i, u := range w.additionalURLs {
+		out[i] = wfRegAddSrcStub{u: u}
+	}
+	return out
+}
+
+func testWorkflowRegistry(addr string, urls ...string) config.CapabilitiesWorkflowRegistry {
+	return wfRegTestStub{addr: addr, additionalURLs: urls}
+}
 
 type testLocalCapabilities struct {
 	cfgs map[string]config.CapabilityNodeConfig
@@ -41,6 +85,42 @@ func (testCapabilityNodeConfig) BinaryPathOverride() string {
 
 func (testCapabilityNodeConfig) Config() map[string]string {
 	return nil
+}
+
+func TestWorkflowRegistrySemverMajor(t *testing.T) {
+	t.Parallel()
+
+	major, err := workflowRegistrySemverMajor("")
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), major)
+
+	major, err = workflowRegistrySemverMajor("   ")
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), major)
+
+	major, err = workflowRegistrySemverMajor("2.0.0")
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), major)
+
+	major, err = workflowRegistrySemverMajor("1.0.0")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), major)
+
+	_, err = workflowRegistrySemverMajor("not-a-version")
+	require.Error(t, err)
+}
+
+func TestWorkflowRegistryConfigured(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, workflowRegistryConfigured(testWorkflowRegistry(""), 1))
+	require.False(t, workflowRegistryConfigured(testWorkflowRegistry("", "", "  "), 1))
+	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("0xabc"), 1))
+
+	require.False(t, workflowRegistryConfigured(testWorkflowRegistry(""), 2))
+	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("0xdef"), 2))
+	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("", "https://example"), 2))
+	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("", "", "grpc://x"), 2))
 }
 
 func TestNewLocalTestMetadataRegistry(t *testing.T) {


### PR DESCRIPTION
* Allows offchain registry to start without on-chain address (v1 only)

* Defaults to syncer v2

* Improves validation logic for workflow registry syncer initialization

* Improves validation logic for workflow registry syncer initialization

* Fixes test

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
