### PR TITLE
core/services: fix race in TestNewStartupHealthReport

### DIFF
--- a/core/services/health_test.go
+++ b/core/services/health_test.go
@@ -16,15 +16,18 @@ func TestNewStartUpHealthReport(t *testing.T) {
 	lggr, observed := logger.TestLoggerObserved(t, zapcore.InfoLevel)
 	ibhr := services.NewStartUpHealthReport(1234, lggr)
 
-	ibhr.Start()
-	require.Eventually(t, func() bool { return observed.Len() >= 1 }, time.Second*5, time.Millisecond*100)
-	require.Equal(t, "Starting StartUpHealthReport", observed.TakeAll()[0].Message)
+	func() {
+		ibhr.Start()
+		defer ibhr.Stop()
+		require.Eventually(t, func() bool { return observed.Len() >= 1 }, time.Second*5, time.Millisecond*100)
+		require.Equal(t, "Starting StartUpHealthReport", observed.TakeAll()[0].Message)
 
-	req, err := http.NewRequestWithContext(t.Context(), "GET", "http://localhost:1234/health", nil)
-	require.NoError(t, err)
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusNoContent, res.StatusCode)
+		req, err := http.NewRequestWithContext(t.Context(), "GET", "http://localhost:1234/health", nil)
+		require.NoError(t, err)
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNoContent, res.StatusCode)
+	}()
 
 	ibhr.Stop()
 	require.Eventually(t, func() bool { return observed.Len() >= 1 }, time.Second*5, time.Millisecond*100)


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/actions/runs/25594426366/job/75137781201
```
==================
WARNING: DATA RACE
Read at 0x00c0002d56d3 by goroutine 1407:
  testing.(*common).destination()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:1064 +0x1cc
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:1036 +0xbe
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:1200 +0x8e
  go.uber.org/zap/zaptest.TestingWriter.Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.28.0/zaptest/logger.go:146 +0x119
  go.uber.org/zap/zaptest.(*TestingWriter).Write()
      <autogenerated>:1 +0x68
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.28.0/zapcore/core.go:99 +0x201
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.28.0/zapcore/entry.go:276 +0x567
  go.uber.org/zap.(*SugaredLogger).log()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.28.0/sugar.go:355 +0x12c
  go.uber.org/zap.(*SugaredLogger).Errorf()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.28.0/sugar.go:216 +0x8f
  github.com/smartcontractkit/chainlink/v2/core/logger.(*zapLogger).Errorf()
      <autogenerated>:1 +0x12
  github.com/smartcontractkit/chainlink/v2/core/logger.(*sugared).Errorf()
      <autogenerated>:1 +0x72
  github.com/smartcontractkit/chainlink/v2/core/services.(*StartUpHealthReport).Start.func1()
      /home/runner/_work/chainlink/chainlink/core/services/health.go:57 +0x1e1

Previous write at 0x00c0002d56d3 by main goroutine:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2023 +0x904
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.26.2/x64/src/runtime/panic.go:668 +0x5d
  testing.runTests()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2583 +0x9e9
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2443 +0xf4b
  main.main()
      _testmain.go:50 +0x164

Goroutine 1407 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/services.(*StartUpHealthReport).Start()
      /home/runner/_work/chainlink/chainlink/core/services/health.go:51 +0x8a
  github.com/smartcontractkit/chainlink/v2/core/services_test.TestNewStartUpHealthReport()
      /home/runner/_work/chainlink/chainlink/core/services/health_test.go:19 +0x64
  testing.tRunner()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2101 +0x38
==================
```