### PR TITLE
fix artifact name in ci deployments

### DIFF
--- a/.github/workflows/ci-deployments.yml
+++ b/.github/workflows/ci-deployments.yml
@@ -309,7 +309,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.logs-artifact-name }}
+          name: ${{ matrix.logs-artifact-name }}-always-logs
           path: |
             ./deployment/coverage.txt
             ./postgres_logs.txt


### PR DESCRIPTION
Fixes:
<img width="320" height="119" alt="image" src="https://github.com/user-attachments/assets/140cca11-df79-4f13-9983-a5d914bb5acd" />

Why is there a problem?
- branch-out action uploads artifact on failure
- but we want to upload artifacts on success as well

Solution:
- use unique artifact names

Current impact:
- small really, because that only happens if unquarantined tests failed, so the job would fail anyway, but with unclear reason