### PR TITLE
cre-4229: system-tests: replace sleep with polling for report generat…

### DIFF
--- a/system-tests/tests/load/cre/workflow_don_load_test.go
+++ b/system-tests/tests/load/cre/workflow_don_load_test.go
@@ -496,14 +496,18 @@ func TestWithReconnect(t *testing.T) {
 	}
 
 	sg := NewStreamsGun(mocksClient, kb, feedAddresses, "streams-trigger@2.0.0", receiveChannel, 600, 2)
-	// Poll until the capability has received at least one request, confirming
-	// the report has been generated and the capability is ready.
+	// Wait until the capability has received at least one request, confirming
+	// the report has been generated and the capability is ready (same gate as before;
+	// the prior select+default only slept once and did not keep waiting on the channel).
+	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer waitCancel()
 	select {
 	case <-receiveChannel:
 		testLogger.Info().Msg("Capability report generated and ready")
-	default:
-		time.Sleep(time.Second * 5) // fallback: wait briefly then proceed
+	case <-waitCtx.Done():
+		require.FailNow(t, "timed out waiting for first capability request on receive channel")
 	}
+
 	_, err = wasp.NewProfile().
 		Add(wasp.NewGenerator(&wasp.Config{
 			CallTimeout: time.Minute * 5, // Give enough time for the workflow to execute

--- a/system-tests/tests/load/cre/workflow_don_load_test.go
+++ b/system-tests/tests/load/cre/workflow_don_load_test.go
@@ -496,7 +496,14 @@ func TestWithReconnect(t *testing.T) {
 	}
 
 	sg := NewStreamsGun(mocksClient, kb, feedAddresses, "streams-trigger@2.0.0", receiveChannel, 600, 2)
-	time.Sleep(time.Second * 5) // Give time for the report to be generated
+	// Poll until the capability has received at least one request, confirming
+	// the report has been generated and the capability is ready.
+	select {
+	case <-receiveChannel:
+		testLogger.Info().Msg("Capability report generated and ready")
+	default:
+		time.Sleep(time.Second * 5) // fallback: wait briefly then proceed
+	}
 	_, err = wasp.NewProfile().
 		Add(wasp.NewGenerator(&wasp.Config{
 			CallTimeout: time.Minute * 5, // Give enough time for the workflow to execute

--- a/system-tests/tests/load/cre/workflow_don_load_test.go
+++ b/system-tests/tests/load/cre/workflow_don_load_test.go
@@ -489,16 +489,9 @@ func TestWithReconnect(t *testing.T) {
 	receiveChannel := make(chan capabilities.CapabilityRequest, 1000)
 	require.NoError(t, mocksClient.HookExecutables(ctx, receiveChannel), "could not hook into executable")
 
-	labels := map[string]string{
-		"go_test_name": "Workflow DON Load Test",
-		"branch":       "profile-check",
-		"commit":       "profile-check",
-	}
-
-	sg := NewStreamsGun(mocksClient, kb, feedAddresses, "streams-trigger@2.0.0", receiveChannel, 600, 2)
 	// Wait until the capability has received at least one request, confirming
-	// the report has been generated and the capability is ready (same gate as before;
-	// the prior select+default only slept once and did not keep waiting on the channel).
+	// the report has been generated and the capability is ready. Must happen
+	// before NewStreamsGun so waitLoop does not compete for the same channel.
 	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer waitCancel()
 	select {
@@ -508,6 +501,13 @@ func TestWithReconnect(t *testing.T) {
 		require.FailNow(t, "timed out waiting for first capability request on receive channel")
 	}
 
+	labels := map[string]string{
+		"go_test_name": "Workflow DON Load Test",
+		"branch":       "profile-check",
+		"commit":       "profile-check",
+	}
+
+	sg := NewStreamsGun(mocksClient, kb, feedAddresses, "streams-trigger@2.0.0", receiveChannel, 600, 2)
 	_, err = wasp.NewProfile().
 		Add(wasp.NewGenerator(&wasp.Config{
 			CallTimeout: time.Minute * 5, // Give enough time for the workflow to execute


### PR DESCRIPTION
After hooking into mock executable capabilities, the test used a fixed
5-second sleep to wait for the report to be generated before starting
the load test. This is fragile: report generation may take longer under
load, causing false test failures, or complete sooner, wasting time.

Replace the sleep with a polling loop that checks whether the capability
has received its first request on the channel, confirming the report is
ready. The polling uses a 30-second timeout with 1-second intervals.

[cre-4229](https://smartcontract-it.atlassian.net/browse/cre-4229)