### PR TITLE
fix: remove delve from public images

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -105,6 +105,7 @@ jobs:
       aws-region-gati: us-west-2
       dockerfile: core/chainlink.Dockerfile
       docker-build-context: .
+      docker-target: final
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
@@ -142,6 +143,7 @@ jobs:
       aws-region-gati: us-west-2
       dockerfile: core/chainlink.Dockerfile
       docker-build-context: .
+      docker-target: final
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -95,6 +95,7 @@ jobs:
       aws-region-gati: us-west-2
       dockerfile: core/chainlink.Dockerfile
       docker-build-context: .
+      docker-target: debug
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ needs.init.outputs.checked-out-sha }}
@@ -127,6 +128,7 @@ jobs:
       aws-region-gati: us-west-2
       dockerfile: plugins/chainlink.Dockerfile
       docker-build-context: .
+      docker-target: debug
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ needs.init.outputs.checked-out-sha }}
@@ -161,6 +163,7 @@ jobs:
       aws-region-gati: us-west-2
       dockerfile: plugins/chainlink.Dockerfile
       docker-build-context: .
+      docker-target: debug
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ needs.init.outputs.checked-out-sha }}
@@ -196,6 +199,7 @@ jobs:
       aws-region-gati: us-west-2
       dockerfile: core/chainlink.Dockerfile
       docker-build-context: .
+      docker-target: debug
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ needs.init.outputs.checked-out-sha }}
@@ -231,6 +235,7 @@ jobs:
       aws-region-gati: us-west-2
       dockerfile: plugins/chainlink.Dockerfile
       docker-build-context: .
+      docker-target: debug
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ needs.init.outputs.checked-out-sha }}

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -95,7 +95,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=go-build-chainlink \
 ##
 # Final Image
 ##
-FROM ubuntu:24.04
+FROM ubuntu:24.04 AS final
 
 ARG CHAINLINK_USER=root
 ENV DEBIAN_FRONTEND=noninteractive
@@ -133,8 +133,6 @@ COPY --from=build-local-plugins /gobins/ /usr/local/bin/
 COPY --from=build-chainlink /gobins/ /usr/local/bin/
 # Copy shared libraries from the remote plugins build stage.
 COPY --from=build-remote-plugins /tmp/lib /usr/lib/
-COPY --from=build-delve /go/bin/dlv /usr/local/bin/
-
 
 WORKDIR /home/${CHAINLINK_USER}
 
@@ -151,3 +149,7 @@ EXPOSE 6688
 ENTRYPOINT ["chainlink"]
 HEALTHCHECK CMD curl -f http://localhost:6688/health || exit 1
 CMD ["local", "node"]
+
+FROM final AS debug
+
+COPY --from=build-delve /go/bin/dlv /usr/local/bin/

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -95,7 +95,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=go-build-chainlink \
 ##
 # Final Image
 ##
-FROM ubuntu:24.04
+FROM ubuntu:24.04 AS final
 
 ARG CHAINLINK_USER=root
 ENV DEBIAN_FRONTEND=noninteractive
@@ -109,8 +109,6 @@ RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
 
 RUN if [ ${CHAINLINK_USER} != root ]; then useradd --uid 14933 --create-home ${CHAINLINK_USER}; fi
 USER ${CHAINLINK_USER}
-
-COPY --from=build-delve /go/bin/dlv /usr/local/bin/dlv
 
 # Expose image metadata to the running node.
 ARG CL_AUTO_DOCKER_TAG=unset
@@ -146,3 +144,7 @@ EXPOSE 6688
 ENTRYPOINT ["chainlink"]
 HEALTHCHECK CMD curl -f http://localhost:6688/health || exit 1
 CMD ["local", "node"]
+
+FROM final AS debug
+
+COPY --from=build-delve /go/bin/dlv /usr/local/bin/dlv


### PR DESCRIPTION
Removes unneeded dep for our publicly released images.

### Changes

* Adds 2 targets to the dockerfiles (`final`, `debug`)
    * Ensures that `delve` is only copied to the image when `debug` is target is chosen
* Updates `build-publish` pipeline to target `final`, whereas `docker-build` pipeline targets `debug`

### Testing

Builds (debug) are successful: https://github.com/smartcontractkit/chainlink/actions/runs/25699227711?pr=22389


### Notes

Sonarqube is complaining with:

```
FROM final AS debug
^
This image might run with "root" as the default user. Make sure it is safe here.
```

This is not true as it inherits from `final`. Leaving as is.

---

DX-4135
