### PR TITLE
fix: secure PostgreSQL APT key installation in dockerfile

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -102,10 +102,16 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y ca-certificates gnupg lsb-release curl && rm -rf /var/lib/apt/lists/*
 
 # Install Postgres for CLI tools, needed specifically for DB backups
-RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-  && echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" |tee /etc/apt/sources.list.d/pgdg.list \
-  && apt-get update && apt-get install -y postgresql-client-16 \
-  && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+      | gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg \
+    && gpg --no-default-keyring \
+           --keyring /usr/share/keyrings/postgresql-archive-keyring.gpg \
+           --fingerprint B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
+    && echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] \
+       https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+       > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update && apt-get install -y postgresql-client-16 \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN if [ ${CHAINLINK_USER} != root ]; then useradd --uid 14933 --create-home ${CHAINLINK_USER}; fi
 USER ${CHAINLINK_USER}

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -102,10 +102,16 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y ca-certificates gnupg lsb-release curl && rm -rf /var/lib/apt/lists/*
 
 # Install Postgres for CLI tools, needed specifically for DB backups
-RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-  && echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" |tee /etc/apt/sources.list.d/pgdg.list \
-  && apt-get update && apt-get install -y postgresql-client-16 \
-  && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+      | gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg \
+    && gpg --no-default-keyring \
+           --keyring /usr/share/keyrings/postgresql-archive-keyring.gpg \
+           --fingerprint B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
+    && echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] \
+       https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+       > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update && apt-get install -y postgresql-client-16 \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN if [ ${CHAINLINK_USER} != root ]; then useradd --uid 14933 --create-home ${CHAINLINK_USER}; fi
 USER ${CHAINLINK_USER}


### PR DESCRIPTION
* Switches off of `apt-key add` as that is deprecated, and less secure
* Uses a per-repo keyring, and verifies the GPG key

### Testing

Builds are successful: https://github.com/smartcontractkit/chainlink/actions/runs/25699217695?pr=22391

### Notes

Sonarqube is complaining with:

```
RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc
^
Not enforcing HTTPS here might allow for redirections to insecure websites. Make sure it is safe here.
```

This is not that relevant as we are validating the fetched key with a known/static fingerprint baked into our Dockerfile. This means that we technically don't care if it ends up redirecting to http, because the key is still verified.

---

DX-4135