### PR TITLE
fix(deployment/solutils): validate archive paths to prevent Zip Slip

### DIFF
--- a/deployment/utils/solutils/artifacts.go
+++ b/deployment/utils/solutils/artifacts.go
@@ -172,8 +172,22 @@ func downloadProgramArtifacts(ctx context.Context, url string, targetDir string,
 			return fmt.Errorf("archive total size exceeds limit (limit: %d bytes)", maxTotalSize)
 		}
 
-		// Copy the file to the target directory
+		// Reject archive entries with unsafe paths to prevent Zip Slip (CWE-22).
+		// filepath.IsLocal returns false for empty paths, ".", absolute paths, and any
+		// path that traverses outside the target via "..".
+		if !filepath.IsLocal(header.Name) {
+			return fmt.Errorf("archive entry %q has unsafe path: must be a relative path within target directory", header.Name)
+		}
+
+		// Copy the file to the target directory using only the base filename.
 		outPath := filepath.Join(targetDir, filepath.Base(header.Name))
+
+		// Defense-in-depth: ensure the cleaned output path is contained within targetDir.
+		cleanTarget := filepath.Clean(targetDir)
+		if rel, err := filepath.Rel(cleanTarget, filepath.Clean(outPath)); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("archive entry %q resolves outside target directory", header.Name)
+		}
+
 		if err := os.MkdirAll(filepath.Dir(outPath), os.ModePerm); err != nil {
 			return err
 		}

--- a/deployment/utils/solutils/artifacts_test.go
+++ b/deployment/utils/solutils/artifacts_test.go
@@ -159,6 +159,62 @@ func TestDownloadProgramArtifacts(t *testing.T) {
 	}
 }
 
+func TestDownloadProgramArtifacts_RejectsZipSlipEntries(t *testing.T) {
+	tests := []struct {
+		name      string
+		entryName string
+	}{
+		{name: "parent directory traversal", entryName: "../evil.so"},
+		{name: "nested parent traversal", entryName: "subdir/../../evil.so"},
+		{name: "absolute unix path", entryName: "/etc/passwd"},
+		{name: "empty entry", entryName: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/gzip")
+
+				gzWriter := gzip.NewWriter(w)
+				defer gzWriter.Close()
+
+				tarWriter := tar.NewWriter(gzWriter)
+				defer tarWriter.Close()
+
+				content := "malicious content"
+				header := &tar.Header{
+					Name:     tt.entryName,
+					Size:     int64(len(content)),
+					Typeflag: tar.TypeReg,
+				}
+				if err := tarWriter.WriteHeader(header); err != nil {
+					t.Errorf("Failed to write tar header: %v", err)
+					return
+				}
+				if _, err := tarWriter.Write([]byte(content)); err != nil {
+					t.Errorf("Failed to write tar content: %v", err)
+					return
+				}
+			}))
+			defer server.Close()
+
+			tempDir := t.TempDir()
+			err := downloadProgramArtifacts(t.Context(), server.URL, tempDir, logger.Test(t))
+			require.Error(t, err)
+			require.ErrorContains(t, err, "unsafe path")
+
+			// Verify no file was written outside or inside the target directory.
+			entries, readErr := os.ReadDir(tempDir)
+			require.NoError(t, readErr)
+			assert.Empty(t, entries, "no files should be extracted from a malicious archive")
+
+			// Ensure the traversal target was not created on disk.
+			_, statErr := os.Stat(filepath.Join(filepath.Dir(tempDir), "evil.so"))
+			assert.True(t, os.IsNotExist(statErr), "traversal target file must not exist")
+		})
+	}
+}
+
 func TestDownloadProgramArtifacts_ContextCancellation(t *testing.T) {
 	// Create a server that delays response
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Fixes #21003. `downloadProgramArtifacts` in `deployment/utils/solutils/artifacts.go` previously relied solely on `filepath.Base` when extracting tar entries. `filepath.Base` silently flattens path-traversal entries like `../../etc/passwd` to `passwd` instead of rejecting them, which can mask malicious archives and cause silent filename collisions.
- Reject any tar entry whose name is not local (`filepath.IsLocal` returns false for empty paths, absolute paths, and any path that traverses outside the target via `..`).
- Defense-in-depth: verify with `filepath.Rel` that the cleaned output path is contained within the cleaned `targetDir` before writing.
- Added `TestDownloadProgramArtifacts_RejectsZipSlipEntries` covering parent traversal, nested traversal, absolute paths, and empty entry names. Confirms no file is written inside or outside the target directory when a malicious archive is served.

## Test plan
- [x] `go test ./utils/solutils/... -count=1` from `deployment/` — all tests pass including the new Zip Slip cases and existing extraction/cancellation/URL/non-existent-dir tests.
- [x] `go vet ./utils/solutils/...` — clean.
- [x] `gofmt -l deployment/utils/solutils/` — clean.