### PR TITLE
llo: fix flaky test by adding require.Eventually for async cache assertion

### DIFF
--- a/core/services/ocr2/plugins/llo/onchain_channel_definition_cache_integration_test.go
+++ b/core/services/ocr2/plugins/llo/onchain_channel_definition_cache_integration_test.go
@@ -1362,9 +1362,13 @@ func Test_ChannelDefinitionCache_OwnerAndAdderMerging(t *testing.T) {
 			},
 		}
 
-		mergedOutcome := cdc.Definitions(prevSimulatingOCROutcome)
-		_, has600 := mergedOutcome[600]
-		require.False(t, has600, "merged outcome should not contain dropped tombstoned channel 600")
+		var mergedOutcome llotypes.ChannelDefinitions
+		require.Eventually(t, func() bool {
+			mergedOutcome = cdc.Definitions(prevSimulatingOCROutcome)
+			_, has600 := mergedOutcome[600]
+			return !has600
+		}, 5*time.Second, 100*time.Millisecond,
+			"merged outcome should not contain dropped tombstoned channel 600")
 		_, has601 := mergedOutcome[601]
 		require.True(t, has601, "merged outcome should still contain channel 601")
 		_, has602 := mergedOutcome[602]


### PR DESCRIPTION
## Summary

- Replaces a synchronous `cdc.Definitions()` call with `require.Eventually` in the `dropped_tombstoned_channel_stays_out_of_merged_outcome_after_cache_update` subtest
- The failing assertion was the only one in the test not using `require.Eventually`, despite testing async cache state that depends on background goroutines

## Flaky test fixes

| Issue | Test | Trunk |
|-------|------|-------|
| [CRE-4282](https://smartcontract-it.atlassian.net/browse/CRE-4282) | `Test_ChannelDefinitionCache_OwnerAndAdderMerging/dropped_tombstoned_channel_stays_out_of_merged_outcome_after_cache_update` | [Test case](https://app.trunk.io/chainlink/flaky-tests/repo/0ec8ac39-2bf0-42e2-baaf-3f6cce784097/test/064549a0-708d-568c-8bea-dc295bb8e9b7) |

## Test plan

- [ ] CI runs `Test_ChannelDefinitionCache_OwnerAndAdderMerging` with the race detector and shuffle enabled
- [ ] All subtests pass, including `dropped_tombstoned_channel_stays_out_of_merged_outcome_after_cache_update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CRE-4282]: https://smartcontract-it.atlassian.net/browse/CRE-4282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ