### PR TITLE
[CRE-4280] Fix flaky Test_ChannelDefinitionCache_OwnerAndAdderMerging/multiple_adders_can_add_different_channels

### DIFF
--- a/core/services/ocr2/plugins/llo/onchain_channel_definition_cache_integration_test.go
+++ b/core/services/ocr2/plugins/llo/onchain_channel_definition_cache_integration_test.go
@@ -1431,6 +1431,8 @@ func Test_ChannelDefinitionCache_OwnerAndAdderMerging(t *testing.T) {
 		testutils.WaitForLogMessageWithField(t, observedLogs, "Got new logs",
 			"url", url)
 
+		testutils.WaitForLogMessageWithField(t, observedLogs, "Set channel definitions for source", "source", strconv.FormatUint(uint64(adder1ID), 10))
+
 		// Adder2 adds different channels
 		observedLogs.TakeAll()
 
@@ -1461,6 +1463,8 @@ func Test_ChannelDefinitionCache_OwnerAndAdderMerging(t *testing.T) {
 
 		testutils.WaitForLogMessageWithField(t, observedLogs, "Got new logs",
 			"url", url2)
+
+		testutils.WaitForLogMessageWithField(t, observedLogs, "Set channel definitions for source", "source", strconv.FormatUint(uint64(adder2ID), 10))
 
 		require.Eventually(t, func() bool {
 			defs := cdc.Definitions(llotypes.ChannelDefinitions{})


### PR DESCRIPTION
## Summary

- Fixes flaky `Test_ChannelDefinitionCache_OwnerAndAdderMerging/multiple_adders_can_add_different_channels` in the LLO channel definition cache integration test.

## Root cause

`WaitForLogMessageWithField` returns when `"Got new logs"` is emitted in `processLogs`, which fires **before** the blocking send to `fetchTriggerCh` and before `fetchAndSetChannelDefinitions` completes and stores the result under `definitionsMu`. The `require.Eventually` assertion could therefore poll before either adder's definition was stored in memory.

This race is specific to the two-adder scenario: both triggers must independently traverse `fetchTriggerCh → fetchLatestLoop → fetchAndSetChannelDefinitions → definitionsMu`, and the test was asserting the combined result before both goroutines completed.

## Fix

Added two `WaitForLogMessageWithField` calls synchronizing on `"Set channel definitions for source"` (emitted inside `fetchAndSetChannelDefinitions` after the `definitionsMu.Lock()` store) — one for `adder1ID` before `TakeAll()`, one for `adder2ID` before `require.Eventually`. The existing `require.Eventually` is kept as a safety-net fallback.

## Flaky test fixes

| Issue | Test | Trunk |
|-------|------|-------|
| [CRE-4280](https://smartcontract-it.atlassian.net/browse/CRE-4280) | `Test_ChannelDefinitionCache_OwnerAndAdderMerging/multiple_adders_can_add_different_channels` | [Trunk test case](https://app.trunk.io/chainlink/flaky-tests/repo/0ec8ac39-2bf0-42e2-baaf-3f6cce784097/test/c4fc7e77-6eb8-5b3e-87c4-f0002ade2e1f) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CRE-4280]: https://smartcontract-it.atlassian.net/browse/CRE-4280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ