### PR TITLE
[CRE-4206] Fix flaky TestIntegration_LLO_evm_premium_legacy nativeFee assertion

### DIFF
--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -570,6 +570,7 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 				// feedID will be deleted when all n oracles have reported
 				seen[opts.FeedID] = make(map[string]struct{}, nNodes)
 			}
+			warmupSkips := 0
 			for {
 				req, err := receiveWithTimeout(t, reqs, reportTimeout)
 				require.NoError(t, err)
@@ -604,10 +605,21 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 					t.Fatalf("unrecognized feedID: 0x%x", feedID)
 				}
 
+				nativeFee := reportElems["nativeFee"].(*big.Int)
+				linkFee := reportElems["linkFee"].(*big.Int)
+				if nativeFee.Sign() == 0 || linkFee.Sign() == 0 {
+					warmupSkips++
+					if warmupSkips > 100 {
+						t.Fatalf("too many warmup reports with zero fees (%d skipped) — stream bridges likely not producing values", warmupSkips)
+					}
+					t.Logf("skipping warmup report for feed 0x%x: nativeFee=%s linkFee=%s", feedID, nativeFee, linkFee)
+					continue
+				}
+
 				assert.GreaterOrEqual(t, reportElems["validFromTimestamp"].(uint32), uint32(testStartTimeStamp.Unix()))
 				assert.GreaterOrEqual(t, int(reportElems["observationsTimestamp"].(uint32)), int(testStartTimeStamp.Unix()))
-				assert.Equal(t, "33597747607000", reportElems["nativeFee"].(*big.Int).String())
-				assert.Equal(t, "7547169811320755", reportElems["linkFee"].(*big.Int).String())
+				assert.Equal(t, "33597747607000", nativeFee.String())
+				assert.Equal(t, "7547169811320755", linkFee.String())
 				assert.Equal(t, reportElems["observationsTimestamp"].(uint32)+uint32(expirationWindow), reportElems["expiresAt"].(uint32))
 				assert.Equal(t, expectedBm.String(), reportElems["benchmarkPrice"].(*big.Int).String())
 				assert.Equal(t, expectedBid.String(), reportElems["bid"].(*big.Int).String())


### PR DESCRIPTION
## Summary

- Skip warmup reports where `nativeFee` or `linkFee` is zero in `TestIntegration_LLO_evm_premium_legacy`
- Early OCR rounds can complete before ETH/LINK stream bridges produce their first observation, causing `CalculateFee` to return `0` for the fee fields
- Loop now discards incomplete warmup reports (bounded at 100) and only asserts on fully-populated ones, preserving the invariant that every *counted* report has correct fees

## Flaky test fixes

| Issue | Test | Trunk |
|-------|------|-------|
| [CRE-4206](https://smartcontract-it.atlassian.net/browse/CRE-4206) | `TestIntegration_LLO_evm_premium_legacy` | [Analysis](https://app.trunk.io/chainlink/flaky-tests/repo/0ec8ac39-2bf0-42e2-baaf-3f6cce784097/test/d502d60f-56bf-571f-aef1-368b2098e3f5?tab=history&sha=2281cafdf64d1756b16f78b32e1657412e4ad63b) |

## Root cause

`CalculateFee` (in `chainlink-data-streams`) correctly returns `0` when `tokenPriceInUSD` is zero. The ETH stream bridge may not have produced its first observation by the time the first OCR round fires, leaving `report.Values[0]` nil → `extractPrice` returns `decimal.Zero` → fee is `0`. The test was asserting `nativeFee == "33597747607000"` on every received report with no guard for this warmup window.

## Fix

Added before line 609 in `integration_test.go`:
```go
nativeFee := reportElems["nativeFee"].(*big.Int)
linkFee   := reportElems["linkFee"].(*big.Int)
if nativeFee.Sign() == 0 || linkFee.Sign() == 0 {
    warmupSkips++
    if warmupSkips > 100 {
        t.Fatalf("too many warmup reports with zero fees (%d skipped) — stream bridges likely not producing values", warmupSkips)
    }
    t.Logf("skipping warmup report for feed 0x%x: nativeFee=%s linkFee=%s", feedID, nativeFee, linkFee)
    continue
}
```

The `continue` is placed **before** the `seen[feedID]` tracking so warmup reports do not count toward per-oracle completion.

## Test plan

- [ ] CI passes `TestIntegration_LLO_evm_premium_legacy` (ProtocolVersion:0 and ProtocolVersion:1 subtests)
- [ ] No regressions in other LLO integration tests in `core/services/ocr2/plugins/llo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CRE-4206]: https://smartcontract-it.atlassian.net/browse/CRE-4206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ