### PR TITLE
make dependabot: drop -r

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -299,7 +299,7 @@ endif
 dependabot: gomods
 	gh api --paginate -H "Accept: application/vnd.github+json" --method GET \
 	  '/repos/smartcontractkit/chainlink/dependabot/alerts?state=open&ecosystem=Go&severity=$(DEPENDABOT_SEVERITY)' \
-	  --jq -r '.[] | select(.security_vulnerability.first_patched_version != null) | .dependency.manifest_path |= rtrimstr("go.mod") | "./\(.dependency.manifest_path) \(.security_vulnerability.package.name) \(.security_vulnerability.first_patched_version.identifier)"' | \
+	  --jq '.[] | select(.security_vulnerability.first_patched_version != null) | .dependency.manifest_path |= rtrimstr("go.mod") | "./\(.dependency.manifest_path) \(.security_vulnerability.package.name) \(.security_vulnerability.first_patched_version.identifier)"' | \
 	  go tool dependabot && \
 	gomods tidy
 


### PR DESCRIPTION
It wasn't failing, but logged: `accepts 1 arg(s), received 2`