### PR TITLE
feat: adds metrics to sufficiently track trigger drops

### DIFF
--- a/core/platform/monitoring.go
+++ b/core/platform/monitoring.go
@@ -10,7 +10,7 @@ import (
 const (
 	KeyCapabilityID        = "capabilityID"
 	KeyTriggerID           = "triggerID"
-	KeyTriggerDropReason   = "drop_reason"
+	KeyTriggerDropReason   = "dropReason"
 	KeyWorkflowID          = "workflowID"
 	KeyWorkflowExecutionID = "workflowExecutionID"
 	KeyWorkflowName        = "workflowName"

--- a/core/platform/monitoring.go
+++ b/core/platform/monitoring.go
@@ -10,6 +10,7 @@ import (
 const (
 	KeyCapabilityID        = "capabilityID"
 	KeyTriggerID           = "triggerID"
+	KeyTriggerDropReason   = "drop_reason"
 	KeyWorkflowID          = "workflowID"
 	KeyWorkflowExecutionID = "workflowExecutionID"
 	KeyWorkflowName        = "workflowName"

--- a/core/services/workflows/monitoring/monitoring.go
+++ b/core/services/workflows/monitoring/monitoring.go
@@ -63,6 +63,8 @@ type EngineMetrics struct {
 	shardExecutionDeniedOrchestratorCounter metric.Int64Counter
 
 	triggerEventReceivedCounter         metric.Int64Counter
+	triggerEventAckSuccessCounter       metric.Int64Counter
+	triggerEventAckFailureCounter       metric.Int64Counter
 	triggerEventEnqueuedCounter         metric.Int64Counter
 	triggerEventEnqueueDroppedCounter   metric.Int64Counter
 	triggerEventDequeueDroppedCounter   metric.Int64Counter
@@ -296,6 +298,22 @@ func InitMonitoringResources() (em *EngineMetrics, err error) {
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to register trigger event received counter: %w", err)
+	}
+
+	em.triggerEventAckSuccessCounter, err = beholder.GetMeter().Int64Counter(
+		"platform_engine_trigger_event_ack_success_total",
+		metric.WithDescription("Trigger events successfully acknowledged to the trigger capability"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register trigger event ack success counter: %w", err)
+	}
+
+	em.triggerEventAckFailureCounter, err = beholder.GetMeter().Int64Counter(
+		"platform_engine_trigger_event_ack_failure_total",
+		metric.WithDescription("Trigger event ACK attempts that failed (registration missing or capability AckEvent error)"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register trigger event ack failure counter: %w", err)
 	}
 
 	em.triggerEventEnqueuedCounter, err = beholder.GetMeter().Int64Counter(
@@ -656,6 +674,16 @@ func (c WorkflowsMetricLabeler) IncrementShardExecutionDeniedOrchestratorErrorCo
 func (c WorkflowsMetricLabeler) IncrementTriggerEventReceivedCounter(ctx context.Context) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
 	c.em.triggerEventReceivedCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
+}
+
+func (c WorkflowsMetricLabeler) IncrementTriggerEventAckSuccessCounter(ctx context.Context) {
+	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
+	c.em.triggerEventAckSuccessCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
+}
+
+func (c WorkflowsMetricLabeler) IncrementTriggerEventAckFailureCounter(ctx context.Context) {
+	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
+	c.em.triggerEventAckFailureCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
 }
 
 func (c WorkflowsMetricLabeler) IncrementTriggerEventEnqueuedCounter(ctx context.Context) {

--- a/core/services/workflows/monitoring/monitoring.go
+++ b/core/services/workflows/monitoring/monitoring.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/metrics"
 
 	monutils "github.com/smartcontractkit/chainlink/v2/core/monitoring"
+	"github.com/smartcontractkit/chainlink/v2/core/platform"
 )
 
 // em AKA "engine metrics" is to locally scope these instruments to avoid
@@ -64,6 +65,7 @@ type EngineMetrics struct {
 	triggerEventEnqueuedCounter         metric.Int64Counter
 	triggerEventEnqueueDroppedCounter   metric.Int64Counter
 	triggerEventDequeueDroppedCounter   metric.Int64Counter
+	triggerEventDroppedTotal            metric.Int64Counter
 	triggerEventExpiredCounter          metric.Int64Counter
 	triggerExecutionDeduplicatedCounter metric.Int64Counter
 	triggerEventQueueWaitSeconds        metric.Float64Histogram
@@ -309,6 +311,14 @@ func InitMonitoringResources() (em *EngineMetrics, err error) {
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to register trigger event dequeue dropped counter: %w", err)
+	}
+
+	em.triggerEventDroppedTotal, err = beholder.GetMeter().Int64Counter(
+		"platform_engine_trigger_event_dropped_total",
+		metric.WithDescription("Trigger events that never reached Module.Execute, by drop_reason"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register trigger event dropped total counter: %w", err)
 	}
 
 	em.triggerEventExpiredCounter, err = beholder.GetMeter().Int64Counter(
@@ -642,6 +652,17 @@ func (c WorkflowsMetricLabeler) IncrementTriggerEventEnqueuedCounter(ctx context
 func (c WorkflowsMetricLabeler) IncrementTriggerEventEnqueueDroppedCounter(ctx context.Context) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
 	c.em.triggerEventEnqueueDroppedCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
+}
+
+// IncrementTriggerEventDroppedTotal records one dropped trigger event before Module.Execute.
+// dropReason must be a low-cardinality value; use TriggerDropReason* constants.
+func (c WorkflowsMetricLabeler) IncrementTriggerEventDroppedTotal(ctx context.Context, dropReason string) {
+	if dropReason == "" {
+		dropReason = TriggerDropReasonUnknown
+	}
+	lc := c.With(platform.KeyTriggerDropReason, dropReason)
+	otelLabels := beholder.OtelAttributes(lc.Labels).AsStringAttributes()
+	lc.em.triggerEventDroppedTotal.Add(ctx, 1, metric.WithAttributes(otelLabels...))
 }
 
 func (c WorkflowsMetricLabeler) IncrementTriggerEventDequeueDroppedCounter(ctx context.Context) {

--- a/core/services/workflows/monitoring/monitoring.go
+++ b/core/services/workflows/monitoring/monitoring.go
@@ -62,6 +62,7 @@ type EngineMetrics struct {
 	shardExecutionDeniedNotOwnerCounter     metric.Int64Counter
 	shardExecutionDeniedOrchestratorCounter metric.Int64Counter
 
+	triggerEventReceivedCounter         metric.Int64Counter
 	triggerEventEnqueuedCounter         metric.Int64Counter
 	triggerEventEnqueueDroppedCounter   metric.Int64Counter
 	triggerEventDequeueDroppedCounter   metric.Int64Counter
@@ -287,6 +288,14 @@ func InitMonitoringResources() (em *EngineMetrics, err error) {
 	em.shardExecutionDeniedOrchestratorCounter, err = beholder.GetMeter().Int64Counter("platform_engine_shard_execution_denied_orchestrator_error")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register shard execution denied orchestrator error counter: %w", err)
+	}
+
+	em.triggerEventReceivedCounter, err = beholder.GetMeter().Int64Counter(
+		"platform_engine_trigger_event_received_total",
+		metric.WithDescription("Trigger events read from the capability trigger channel (one per receive)"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register trigger event received counter: %w", err)
 	}
 
 	em.triggerEventEnqueuedCounter, err = beholder.GetMeter().Int64Counter(
@@ -642,6 +651,11 @@ func (c WorkflowsMetricLabeler) IncrementShardExecutionDeniedNotOwnerCounter(ctx
 func (c WorkflowsMetricLabeler) IncrementShardExecutionDeniedOrchestratorErrorCounter(ctx context.Context) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
 	c.em.shardExecutionDeniedOrchestratorCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
+}
+
+func (c WorkflowsMetricLabeler) IncrementTriggerEventReceivedCounter(ctx context.Context) {
+	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
+	c.em.triggerEventReceivedCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
 }
 
 func (c WorkflowsMetricLabeler) IncrementTriggerEventEnqueuedCounter(ctx context.Context) {

--- a/core/services/workflows/monitoring/trigger_drop_reason.go
+++ b/core/services/workflows/monitoring/trigger_drop_reason.go
@@ -1,0 +1,24 @@
+package monitoring
+
+// Drop reason values for platform_engine_trigger_event_dropped_total (low cardinality).
+const (
+	TriggerDropReasonTriggerResponseError             = "trigger_response_error"
+	TriggerDropReasonEnqueueDraining                  = "enqueue_draining"
+	TriggerDropReasonEnqueueQueueFull                 = "enqueue_queue_full"
+	TriggerDropReasonEnqueueFailed                    = "enqueue_failed"
+	TriggerDropReasonDequeueDraining                  = "dequeue_draining"
+	TriggerDropReasonQueueAgeLimitReadFailed          = "queue_age_limit_read_failed"
+	TriggerDropReasonExpired                          = "expired"
+	TriggerDropReasonExecutionSemaphoreWaitFailed     = "execution_semaphore_wait_failed"
+	TriggerDropReasonExecutionIDGenerationFailed      = "execution_id_generation_failed"
+	TriggerDropReasonDuplicateExecution               = "duplicate_execution"
+	TriggerDropReasonShardDeniedOrchestrator          = "shard_denied_orchestrator"
+	TriggerDropReasonShardDeniedNotOwner              = "shard_denied_not_owner"
+	TriggerDropReasonMeteringReserveFailed            = "metering_reserve_failed"
+	TriggerDropReasonExecutionTimeLimitReadFailed     = "execution_time_limit_read_failed"
+	TriggerDropReasonLogEventLimitReadFailed          = "log_event_limit_read_failed"
+	TriggerDropReasonTriggerIndexInvalid              = "trigger_index_invalid"
+	TriggerDropReasonExecutionResponseLimitReadFailed = "execution_response_limit_read_failed"
+	TriggerDropReasonExecutionResponseLimitInvalid    = "execution_response_limit_invalid"
+	TriggerDropReasonUnknown                          = "unknown"
+)

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -582,6 +582,7 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 					}
 					triggerID := subs.Subscriptions[idx].Id
 					eventID := event.Event.ID
+					e.metrics.With(platform.KeyTriggerID, triggerID).IncrementTriggerEventReceivedCounter(ctx)
 					e.logger().Debugw("Processing trigger event", "triggerID", triggerID, "eventID", eventID)
 					if event.Err != nil {
 						e.logger().Errorw("Received a trigger event with error, dropping", "triggerID", triggerID, "err", event.Err)

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -752,7 +752,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 			tm.IncrementWorkflowTriggerEventErrorCounter(ctx)
 			tm.IncrementTriggerEventDroppedTotal(ctx, monitoring.TriggerDropReasonDuplicateExecution)
 			registrationID := TriggerRegistrationID(e.cfg.WorkflowID, wrappedTriggerEvent.triggerIndex)
-			err = e.ackTriggerEvent(ctx, registrationID, &triggerEvent)
+			err = e.ackTriggerEvent(ctx, wrappedTriggerEvent.triggerCapID, registrationID, &triggerEvent)
 			if err != nil {
 				e.lggr.Errorw("failed to re-ACK trigger event", "eventID", triggerEvent.ID, "err", err)
 			}
@@ -782,7 +782,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 			triggerDrop(monitoring.TriggerDropReasonShardDeniedOrchestrator)
 			executionStatus = store.StatusErrored
 			registrationID := TriggerRegistrationID(e.cfg.WorkflowID, wrappedTriggerEvent.triggerIndex)
-			if ackErr := e.ackTriggerEvent(ctx, registrationID, &triggerEvent); ackErr != nil {
+			if ackErr := e.ackTriggerEvent(ctx, wrappedTriggerEvent.triggerCapID, registrationID, &triggerEvent); ackErr != nil {
 				e.logger().Errorw("failed to ACK trigger after shard ownership orchestrator error", "eventID", triggerEvent.ID, "err", ackErr)
 			}
 			return
@@ -801,7 +801,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 			triggerDrop(monitoring.TriggerDropReasonShardDeniedNotOwner)
 			executionStatus = store.StatusErrored
 			registrationID := TriggerRegistrationID(e.cfg.WorkflowID, wrappedTriggerEvent.triggerIndex)
-			if ackErr := e.ackTriggerEvent(ctx, registrationID, &triggerEvent); ackErr != nil {
+			if ackErr := e.ackTriggerEvent(ctx, wrappedTriggerEvent.triggerCapID, registrationID, &triggerEvent); ackErr != nil {
 				e.logger().Errorw("failed to ACK trigger after shard ownership denial", "eventID", triggerEvent.ID, "err", ackErr)
 			}
 			return
@@ -865,7 +865,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	_ = events.EmitExecutionStartedEvent(ctx, loggerLabels, triggerEvent.ID, executionID)
 
 	registrationID := TriggerRegistrationID(e.cfg.WorkflowID, wrappedTriggerEvent.triggerIndex)
-	err = e.ackTriggerEvent(ctx, registrationID, &triggerEvent)
+	err = e.ackTriggerEvent(ctx, wrappedTriggerEvent.triggerCapID, registrationID, &triggerEvent)
 	if err != nil {
 		e.lggr.Errorf("failed to ACK trigger event (eventID=%s): %v", triggerEvent.ID, err)
 	}
@@ -975,17 +975,26 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	e.cfg.Hooks.OnResultReceived(result)
 }
 
-func (e *Engine) ackTriggerEvent(ctx context.Context, triggerRegistrationID string, te *capabilities.TriggerEvent) error {
+func (e *Engine) ackTriggerEvent(ctx context.Context, triggerCapID, triggerRegistrationID string, te *capabilities.TriggerEvent) error {
 	e.logger().Infow("ACKing trigger event", "triggerRegistrationID", triggerRegistrationID, "eventID", te.ID)
+
+	tm := e.metrics.With(platform.KeyTriggerID, triggerCapID)
 
 	e.triggersRegMu.Lock()
 	trigger, ok := e.triggers[triggerRegistrationID]
 	e.triggersRegMu.Unlock()
 
 	if !ok {
+		tm.IncrementTriggerEventAckFailureCounter(ctx)
 		return fmt.Errorf("failed to find trigger %s", triggerRegistrationID)
 	}
-	return trigger.AckEvent(ctx, triggerRegistrationID, te.ID, trigger.method)
+	err := trigger.AckEvent(ctx, triggerRegistrationID, te.ID, trigger.method)
+	if err != nil {
+		tm.IncrementTriggerEventAckFailureCounter(ctx)
+		return err
+	}
+	tm.IncrementTriggerEventAckSuccessCounter(ctx)
+	return nil
 }
 
 func (e *Engine) secretsFetcher(phaseID string) SecretsFetcher {

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -585,12 +585,16 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 					e.logger().Debugw("Processing trigger event", "triggerID", triggerID, "eventID", eventID)
 					if event.Err != nil {
 						e.logger().Errorw("Received a trigger event with error, dropping", "triggerID", triggerID, "err", event.Err)
-						e.metrics.With(platform.KeyTriggerID, triggerID).IncrementWorkflowTriggerEventErrorCounter(ctx)
+						tm := e.metrics.With(platform.KeyTriggerID, triggerID)
+						tm.IncrementWorkflowTriggerEventErrorCounter(ctx)
+						tm.IncrementTriggerEventDroppedTotal(ctx, monitoring.TriggerDropReasonTriggerResponseError)
 						continue
 					}
 					if e.draining.Load() {
 						e.logger().Infow("Engine is draining, dropping trigger event before enqueue", "triggerID", triggerID, "eventID", eventID)
-						e.metrics.With(platform.KeyTriggerID, triggerID).IncrementTriggerEventEnqueueDroppedCounter(ctx)
+						tm := e.metrics.With(platform.KeyTriggerID, triggerID)
+						tm.IncrementTriggerEventEnqueueDroppedCounter(ctx)
+						tm.IncrementTriggerEventDroppedTotal(ctx, monitoring.TriggerDropReasonEnqueueDraining)
 						e.cfg.Hooks.OnTriggerEventDropped(triggerID, eventID, "draining")
 						continue
 					}
@@ -600,15 +604,19 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 						timestamp:    e.cfg.Clock.Now(),
 						event:        event,
 					}); err != nil {
-						e.metrics.With(platform.KeyTriggerID, triggerID).IncrementTriggerEventEnqueueDroppedCounter(ctx)
+						tm := e.metrics.With(platform.KeyTriggerID, triggerID)
+						tm.IncrementTriggerEventEnqueueDroppedCounter(ctx)
 						var errFull limits.ErrorQueueFull
 						if errors.As(err, &errFull) {
 							// queue full, drop the event
 							e.logger().Errorw("Trigger event queue is full, dropping event", "triggerID", triggerID, "triggerIndex", idx, "err", err)
-							e.metrics.With(platform.KeyTriggerID, triggerID).IncrementWorkflowTriggerEventQueueFullCounter(ctx)
+							tm.IncrementWorkflowTriggerEventQueueFullCounter(ctx)
+							tm.IncrementTriggerEventDroppedTotal(ctx, monitoring.TriggerDropReasonEnqueueQueueFull)
+						} else {
+							tm.IncrementTriggerEventDroppedTotal(ctx, monitoring.TriggerDropReasonEnqueueFailed)
 						}
 						e.logger().Errorw("Failed to enqueue trigger event", "triggerID", triggerID, "triggerIndex", idx, "err", err)
-						e.metrics.With(platform.KeyTriggerID, triggerID).IncrementWorkflowTriggerEventErrorCounter(ctx)
+						tm.IncrementWorkflowTriggerEventErrorCounter(ctx)
 						continue
 					}
 					e.metrics.With(platform.KeyTriggerID, triggerID).IncrementTriggerEventEnqueuedCounter(ctx)
@@ -633,6 +641,7 @@ func (e *Engine) handleAllTriggerEvents(ctx context.Context) {
 		triggerMetricLabels := e.metrics.With(platform.KeyTriggerID, queueHead.triggerCapID)
 		if e.draining.Load() {
 			triggerMetricLabels.IncrementTriggerEventDequeueDroppedCounter(ctx)
+			triggerMetricLabels.IncrementTriggerEventDroppedTotal(ctx, monitoring.TriggerDropReasonDequeueDraining)
 			e.cfg.Hooks.OnTriggerEventDropped(queueHead.triggerCapID, eventID, "draining")
 			e.logger().Infow("Engine is draining, stopping trigger handling loop", "eventID", eventID, "triggerID", queueHead.triggerCapID)
 			return
@@ -643,11 +652,13 @@ func (e *Engine) handleAllTriggerEvents(ctx context.Context) {
 		triggerEventMaxAge, err := e.cfg.LocalLimiters.TriggerEventQueueTime.Limit(ctx)
 		if err != nil {
 			e.logger().Errorw("Failed to get trigger event queue time limit", "err", err)
+			triggerMetricLabels.IncrementTriggerEventDroppedTotal(ctx, monitoring.TriggerDropReasonQueueAgeLimitReadFailed)
 			continue
 		}
 		if eventAge > triggerEventMaxAge {
 			e.logger().Warnw("Trigger event is too old, skipping execution", "triggerID", queueHead.triggerCapID, "eventID", eventID, "eventAgeMs", eventAge.Milliseconds())
 			triggerMetricLabels.IncrementTriggerEventExpiredCounter(ctx)
+			triggerMetricLabels.IncrementTriggerEventDroppedTotal(ctx, monitoring.TriggerDropReasonExpired)
 			continue
 		}
 		semWaitStart := e.cfg.Clock.Now()
@@ -655,6 +666,7 @@ func (e *Engine) handleAllTriggerEvents(ctx context.Context) {
 		triggerMetricLabels.RecordExecutionSemaphoreWaitSeconds(ctx, e.cfg.Clock.Now().Sub(semWaitStart).Seconds())
 		if err != nil {
 			e.logger().Errorw("Failed to acquire executions semaphore", "err", err)
+			triggerMetricLabels.IncrementTriggerEventDroppedTotal(ctx, monitoring.TriggerDropReasonExecutionSemaphoreWaitFailed)
 			continue
 		}
 		e.activeExecutions.Add(1)
@@ -680,9 +692,14 @@ func (e *Engine) handleAllTriggerEvents(ctx context.Context) {
 
 // startExecution initiates a new workflow execution, blocking until completed
 func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueuedTriggerEvent) {
+	triggerDrop := func(reason string) {
+		e.metrics.With(platform.KeyTriggerID, wrappedTriggerEvent.triggerCapID).IncrementTriggerEventDroppedTotal(ctx, reason)
+	}
+
 	fullExecutionID, err := events.GenerateExecutionIDWithTriggerIndex(e.cfg.WorkflowID, wrappedTriggerEvent.event.Event.ID, wrappedTriggerEvent.triggerIndex)
 	if err != nil {
 		e.logger().Errorw("Failed to generate execution ID", "err", err, "triggerID", wrappedTriggerEvent.triggerCapID)
+		triggerDrop(monitoring.TriggerDropReasonExecutionIDGenerationFailed)
 		return
 	}
 
@@ -717,6 +734,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		executionID, err = events.GenerateExecutionID(e.cfg.WorkflowID, triggerEvent.ID)
 		if err != nil {
 			e.logger().Errorw("Failed to generate execution ID", "err", err, "triggerID", wrappedTriggerEvent.triggerCapID)
+			triggerDrop(monitoring.TriggerDropReasonExecutionIDGenerationFailed)
 			return
 		}
 		e.metrics.IncrementExecutionIDLegacyCounter(ctx)
@@ -728,8 +746,10 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	if addErr != nil {
 		if errors.Is(addErr, store.ErrDuplicateExecution) {
 			lggr.Infow("Skipping duplicate execution", "executionID", executionID, "triggerID", wrappedTriggerEvent.triggerCapID, "triggerIndex", wrappedTriggerEvent.triggerIndex)
-			e.metrics.With(platform.KeyTriggerID, wrappedTriggerEvent.triggerCapID).IncrementTriggerExecutionDeduplicatedCounter(ctx)
-			e.metrics.With(platform.KeyTriggerID, wrappedTriggerEvent.triggerCapID).IncrementWorkflowTriggerEventErrorCounter(ctx)
+			tm := e.metrics.With(platform.KeyTriggerID, wrappedTriggerEvent.triggerCapID)
+			tm.IncrementTriggerExecutionDeduplicatedCounter(ctx)
+			tm.IncrementWorkflowTriggerEventErrorCounter(ctx)
+			tm.IncrementTriggerEventDroppedTotal(ctx, monitoring.TriggerDropReasonDuplicateExecution)
 			registrationID := TriggerRegistrationID(e.cfg.WorkflowID, wrappedTriggerEvent.triggerIndex)
 			err = e.ackTriggerEvent(ctx, registrationID, &triggerEvent)
 			if err != nil {
@@ -758,6 +778,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		case shardownership.DenyOrchestratorError:
 			lggr.Warnw("Shard ownership check failed (orchestrator error); skipping execution", "err", ownErr)
 			e.metrics.IncrementShardExecutionDeniedOrchestratorErrorCounter(ctx)
+			triggerDrop(monitoring.TriggerDropReasonShardDeniedOrchestrator)
 			executionStatus = store.StatusErrored
 			registrationID := TriggerRegistrationID(e.cfg.WorkflowID, wrappedTriggerEvent.triggerIndex)
 			if ackErr := e.ackTriggerEvent(ctx, registrationID, &triggerEvent); ackErr != nil {
@@ -776,6 +797,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 			}
 			lggr.Infow("Skipping execution: workflow not owned by this shard per orchestrator", logFields...)
 			e.metrics.IncrementShardExecutionDeniedNotOwnerCounter(ctx)
+			triggerDrop(monitoring.TriggerDropReasonShardDeniedNotOwner)
 			executionStatus = store.StatusErrored
 			registrationID := TriggerRegistrationID(e.cfg.WorkflowID, wrappedTriggerEvent.triggerIndex)
 			if ackErr := e.ackTriggerEvent(ctx, registrationID, &triggerEvent); ackErr != nil {
@@ -800,6 +822,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		mrErr := meteringReport.Reserve(ctx)
 		if mrErr != nil {
 			lggr.Errorw("could not reserve metering", "err", mrErr)
+			triggerDrop(monitoring.TriggerDropReasonMeteringReserveFailed)
 			return
 		}
 
@@ -809,6 +832,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	execCtx, execCancel, err := e.cfg.LocalLimiters.ExecutionTime.WithTimeout(ctx)
 	if err != nil {
 		lggr.Errorw("Failed to get execution time limit", "err", err)
+		triggerDrop(monitoring.TriggerDropReasonExecutionTimeLimitReadFailed)
 		return
 	}
 	defer execCancel()
@@ -818,6 +842,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	maxUserLogEventsPerExecution, err := e.cfg.LocalLimiters.LogEvent.Limit(ctx)
 	if err != nil {
 		lggr.Errorw("Failed to get log event limit", "err", err)
+		triggerDrop(monitoring.TriggerDropReasonLogEventLimitReadFailed)
 		return
 	}
 	userLogChan := make(chan *protoevents.LogLine, maxUserLogEventsPerExecution)
@@ -829,6 +854,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	tid, err := safe.IntToUint64(wrappedTriggerEvent.triggerIndex)
 	if err != nil {
 		executionLogger.Errorw("Failed to convert trigger index to uint64", "err", err)
+		triggerDrop(monitoring.TriggerDropReasonTriggerIndexInvalid)
 		return
 	}
 
@@ -864,12 +890,14 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		lggr.Errorw("Failed to get execution response size limit", "err", err)
 		executionStatus = store.StatusErrored
 		execErr = err
+		triggerDrop(monitoring.TriggerDropReasonExecutionResponseLimitReadFailed)
 		return
 	}
 	if moduleExecuteMaxResponseSizeBytes < 0 {
 		execErr = fmt.Errorf("invalid moduleExecuteMaxResponseSizeBytes; must not be negative: %d", moduleExecuteMaxResponseSizeBytes)
 		lggr.Errorw(execErr.Error())
 		executionStatus = store.StatusErrored
+		triggerDrop(monitoring.TriggerDropReasonExecutionResponseLimitInvalid)
 		return
 	}
 	execHelper := &ExecutionHelper{


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
Enables trigger based SLOs like: "99.9% of triggers acknowledged per wf DON" or "99.9% of triggers start workflow executions"

* all engine failure modes that drop a trigger are tracked as a counter with a `dropReason`  
* adds a metric to count each seen trigger.  allows us to query what fraction of seen triggers are dropped.
* adds metrics to track success/failure to ack a trigger

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
