### PR TITLE
core: include original limit errors

### DIFF
--- a/core/capabilities/vault/validator.go
+++ b/core/capabilities/vault/validator.go
@@ -48,7 +48,7 @@ func (r *RequestValidator) validateWriteRequest(ctx context.Context, publicKey *
 	if err := r.MaxRequestBatchSizeLimiter.Check(ctx, len(encryptedSecrets)); err != nil {
 		var errBoundLimited limits.ErrorBoundLimited[int]
 		if errors.As(err, &errBoundLimited) {
-			return fmt.Errorf("request batch size exceeds maximum of %d", errBoundLimited.Limit)
+			return fmt.Errorf("request batch size exceeds maximum of %d: %w", errBoundLimited.Limit, err)
 		}
 		return fmt.Errorf("failed to check request batch size limit: %w", err)
 	}
@@ -111,7 +111,7 @@ func (r *RequestValidator) ValidateCiphertextSize(ctx context.Context, owner str
 	if err := r.MaxCiphertextLengthLimiter.Check(innerCtx, pkgconfig.Size(len(rawCiphertext))*pkgconfig.Byte); err != nil {
 		var errBoundLimited limits.ErrorBoundLimited[pkgconfig.Size]
 		if errors.As(err, &errBoundLimited) {
-			return fmt.Errorf("ciphertext size exceeds maximum allowed size: %s", errBoundLimited.Limit)
+			return fmt.Errorf("ciphertext size exceeds maximum allowed size: %s: %w", errBoundLimited.Limit, err)
 		}
 		return fmt.Errorf("failed to check ciphertext size limit: %w", err)
 	}
@@ -137,7 +137,7 @@ func (r *RequestValidator) ValidateSecretIdentifier(ctx context.Context, idKey s
 	if err := r.MaxIdentifierOwnerLengthLimiter.Check(ctx, pkgconfig.Size(len(idOwner))); err != nil {
 		var errBoundLimited limits.ErrorBoundLimited[pkgconfig.Size]
 		if errors.As(err, &errBoundLimited) {
-			return fmt.Errorf("owner exceeds maximum length of %s", errBoundLimited.Limit)
+			return fmt.Errorf("owner exceeds maximum length of %s: %w", errBoundLimited.Limit, err)
 		}
 		return fmt.Errorf("failed to check owner length limit: %w", err)
 	}
@@ -145,7 +145,7 @@ func (r *RequestValidator) ValidateSecretIdentifier(ctx context.Context, idKey s
 	if err := r.MaxIdentifierNamespaceLengthLimiter.Check(ctx, pkgconfig.Size(len(idNamespace))); err != nil {
 		var errBoundLimited limits.ErrorBoundLimited[pkgconfig.Size]
 		if errors.As(err, &errBoundLimited) {
-			return fmt.Errorf("namespace exceeds maximum length of %s", errBoundLimited.Limit)
+			return fmt.Errorf("namespace exceeds maximum length of %s: %w", errBoundLimited.Limit, err)
 		}
 		return fmt.Errorf("failed to check namespace length limit: %w", err)
 	}
@@ -153,7 +153,7 @@ func (r *RequestValidator) ValidateSecretIdentifier(ctx context.Context, idKey s
 	if err := r.MaxIdentifierKeyLengthLimiter.Check(ctx, pkgconfig.Size(len(idKey))); err != nil {
 		var errBoundLimited limits.ErrorBoundLimited[pkgconfig.Size]
 		if errors.As(err, &errBoundLimited) {
-			return fmt.Errorf("key exceeds maximum length of %s", errBoundLimited.Limit)
+			return fmt.Errorf("key exceeds maximum length of %s: %w", errBoundLimited.Limit, err)
 		}
 		return fmt.Errorf("failed to check key length limit: %w", err)
 	}

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -374,6 +374,7 @@ func (h *httpTriggerHandler) checkRateLimit(ctx context.Context, workflowID, req
 			h.handleUserError(ctx, requestID, jsonrpc.ErrLimitExceeded, "rate limit exceeded", callback)
 			return err
 		}
+		return fmt.Errorf("failed to check rate limit: %w", err)
 	}
 	return nil
 }

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -1489,7 +1489,7 @@ func (r *ReportingPlugin) validateListSecretIdentifiersObservation(ctx context.C
 		if err := r.cfg.MaxSecretsPerOwner.Check(ctx, len(listResp.Identifiers)); err != nil {
 			var errBoundLimited limits.ErrorBoundLimited[int]
 			if errors.As(err, &errBoundLimited) {
-				return fmt.Errorf("ListSecretIdentifiers response exceeds maximum number of secrets per owner (have=%d, limit=%d)", len(listResp.Identifiers), errBoundLimited.Limit)
+				return fmt.Errorf("ListSecretIdentifiers response exceeds maximum number of secrets per owner (have=%d, limit=%d): %w", len(listResp.Identifiers), errBoundLimited.Limit, err)
 			}
 			return fmt.Errorf("failed to check max secrets per owner limit: %w", err)
 		}

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -1101,7 +1101,7 @@ func (e *Engine) emitUserLogs(ctx context.Context, userLogChan chan *protoevents
 			if err != nil {
 				var errBoundLimited limits.ErrorBoundLimited[int]
 				if errors.As(err, &errBoundLimited) {
-					e.logger().Warnw("Max user log events per execution reached, dropping event", "maxEvents", errBoundLimited.Limit)
+					e.logger().Warnw("Max user log events per execution reached, dropping event", "maxEvents", errBoundLimited.Limit, "err", err)
 					return
 				}
 				e.logger().Errorw("Failed to get user log event limit", "err", err)


### PR DESCRIPTION
The underlying limit errors include critical information including the key, scope, and tenant that shouldn't be discarded.