### PR TITLE
fix(ci): version-file-bump and semver-compare ref

### DIFF
--- a/.github/actions/version-file-bump/action.yml
+++ b/.github/actions/version-file-bump/action.yml
@@ -15,28 +15,34 @@ runs:
     - name: Get latest release version
       id: get-latest-version
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
       run: |
         untrimmed_ver=$(
-          curl --header "Authorization: token ${{ inputs.github-token }}" \
+          curl --header "Authorization: token $GITHUB_TOKEN" \
             --request GET \
-            "https://api.github.com/repos/${{ github.repository }}/releases/latest?draft=false&prerelease=false" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest?draft=false&prerelease=false" \
             | jq -r .name
         )
         latest_version="${untrimmed_ver:1}"
         echo "latest_version=${latest_version}" | tee -a "$GITHUB_OUTPUT"
+
     - name: Get current version
       id: get-current-version
       shell: bash
       run: |
         current_version=$(jq -r '.version' ./package.json)
         echo "current_version=${current_version}" | tee -a "$GITHUB_OUTPUT"
+
     - name: Compare semantic versions
-      uses: smartcontractkit/chainlink-github-actions/semver-compare@75a9005952a9e905649cfb5a6971fd9429436acd # v2.3.25
+      uses: smartcontractkit/.github/actions/semver-compare@9e00ccc5cffd87902fe93948c7e4ef420910c918 # semver-compare/1.0.0
       id: compare
       with:
         version1: ${{ steps.get-current-version.outputs.current_version }}
         operator: eq
         version2: ${{ steps.get-latest-version.outputs.latest_version }}
+
     - name: Fail if version not bumped
       # XXX: The reason we are not checking if the current is greater than the
       # latest release is to account for hot fixes which may have been branched


### PR DESCRIPTION
This updates the `version-file-bump` action (referenced from `build-publish` workflow) to use env vars instead of templating, and uses the imported `semver-compare` action, now in `.github` repo.

### Changes

* Use env vars, not templating
* Migrate to `semver-compare` from `.github` repo: https://github.com/smartcontractkit/.github/tree/main/actions/semver-compare (https://github.com/smartcontractkit/.github/commit/9e00ccc5cffd87902fe93948c7e4ef420910c918)

