### PR TITLE
fix(cmd): enforce TLS 1.2 minimum in shell HTTP client

### DIFF
--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -554,9 +554,14 @@ func NewAuthenticatedHTTPClient(lggr logger.Logger, clientOpts ClientOpts, cooki
 
 func newHttpClient(lggr logger.Logger, insecureSkipVerify bool) *http.Client {
 	tr := &http.Transport{
-		// User enables this at their own risk!
+		// User enables InsecureSkipVerify at their own risk; the explicit
+		// MinVersion still enforces a TLS 1.2 floor regardless of the
+		// platform default crypto policy.
 		// #nosec G402
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: insecureSkipVerify,
+			MinVersion:         tls.VersionTLS12,
+		},
 	}
 	if insecureSkipVerify {
 		lggr.Warn("InsecureSkipVerify is on, skipping SSL certificate verification.")


### PR DESCRIPTION
## Description

Closes #21004.

`newHttpClient` in `core/cmd/shell.go` builds the HTTPS transport for the CLI shell using a default \`tls.Config\` and inherits whatever minimum TLS version the host platform's crypto policy selects. On runtimes / distributions that still permit TLS 1.0 / 1.1 negotiation, this is a downgrade risk and out of step with current industry baselines.

This PR sets \`MinVersion: tls.VersionTLS12\` unconditionally on the embedded \`TLSClientConfig\` so the floor is the same in every environment.

### Why unconditional

The existing \`InsecureSkipVerify\` knob only affects certificate verification — it is orthogonal to protocol-version negotiation. Keeping \`MinVersion\` in effect when that knob is on still blocks a protocol-version downgrade even in trusted-network test setups, which is the safer default. (The previous attempt at this fix in #21347 gated \`MinVersion\` on \`!InsecureSkipVerify\`; this version drops that gate.)

## Changes

- \`core/cmd/shell.go\`: add \`MinVersion: tls.VersionTLS12\` to the \`TLSClientConfig\` constructed in \`newHttpClient\`.

## Testing

\`go build ./core/cmd/...\` and \`go vet ./core/cmd/...\` both clean. \`newHttpClient\` is unexported and only constructs config — no behavioural unit test added; the change is a single-field static configuration matching what a similar TLS-floor PR in the SDK ecosystem typically ships without dedicated tests.

## Relation to prior attempts

- #20775 (closed stale, no review)
- #21347 (closed stale; only added \`MinVersion\` when \`InsecureSkipVerify == false\`)

Both attempts went stale waiting on CI approval. The fix is uncontroversial and well-understood; this re-raises with the broader (always-on) MinVersion guard.