### PR TITLE
fix(tools/benchmark): drop unnecessary $ on arithmetic variables (SC2004)

### DIFF
--- a/tools/benchmark/job_spec_delete_v2.sh
+++ b/tools/benchmark/job_spec_delete_v2.sh
@@ -131,7 +131,7 @@ chainlink admin login --file tools/clroot/apicredentials
 number=${#CONTRACT_ADDRESSES[@]}
 echo "Adding jobs..."
 time {
-  for (( i=1; i<$number; i++ )) do
+  for (( i=1; i<number; i++ )) do
     job_spec=`make_spec $i`
     chainlink jobs create "$job_spec"
   done
@@ -140,7 +140,7 @@ time {
 
 echo "Deleting jobs..."
 time {
-  for (( i=1; i<$number; i++ )) do
+  for (( i=1; i<number; i++ )) do
     chainlink jobs delete $i
   done
 }


### PR DESCRIPTION
## Description

Closes #14512.

Inside \`(( ... ))\` arithmetic context, regular variables are evaluated as expressions and do not need the \`\$\` prefix. The \`\$\` prefix expands the variable to a string *before* evaluation, which can produce subtle precedence bugs if the variable ever holds an expression rather than a plain integer:

\`\`\`
\$ a='1+1'
\$ echo \$((\$a * 5))    # becomes 1+1*5
6
\$ echo \$((a * 5))     # evaluates as (1+1)*5
10
\`\`\`

See [ShellCheck SC2004](https://www.shellcheck.net/wiki/SC2004).

## Changes

\`tools/benchmark/job_spec_delete_v2.sh\` — both \`for (( i=1; i<\$number; i++ ))\` loops at lines 134 and 143 now use \`for (( i=1; i<number; i++ ))\`. No behavioural change for the integer-only \`\$number\` actually used here; the fix is purely to silence the lint warning and remove the foot-gun.

## Testing

\`bash -n tools/benchmark/job_spec_delete_v2.sh\` — clean.