### PR TITLE
chore(tools/benchmark): drop $ on arithmetic vars in job_spec_delete_v2.sh

### DIFF
--- a/tools/benchmark/job_spec_delete_v2.sh
+++ b/tools/benchmark/job_spec_delete_v2.sh
@@ -131,7 +131,7 @@ chainlink admin login --file tools/clroot/apicredentials
 number=${#CONTRACT_ADDRESSES[@]}
 echo "Adding jobs..."
 time {
-  for (( i=1; i<$number; i++ )) do
+  for (( i=1; i<number; i++ )) do
     job_spec=`make_spec $i`
     chainlink jobs create "$job_spec"
   done
@@ -140,7 +140,7 @@ time {
 
 echo "Deleting jobs..."
 time {
-  for (( i=1; i<$number; i++ )) do
+  for (( i=1; i<number; i++ )) do
     chainlink jobs delete $i
   done
 }


### PR DESCRIPTION
## Summary

Fixes #14512.

Inside `(( ... ))` Bash first expands the body to a string and *then* evaluates that string as an arithmetic expression. Referencing variables with a leading `$` therefore inserts the textual value before evaluation, which is fine for plain integers but produces silently-wrong results for anything compound. ShellCheck flags this as [SC2004](https://www.shellcheck.net/wiki/SC2004).

`tools/benchmark/job_spec_delete_v2.sh` does this twice — once on each of the two `for (( i=1; i<$number; i++ ))` loop guards. Today `number` is `${#CONTRACT_ADDRESSES[@]}`, an integer, so the bug is dormant; but the anti-pattern is exactly the one the upstream issue called out, and the trivially correct form (`i<number`) is what ShellCheck and `bash` itself want here.

## Changes

- `tools/benchmark/job_spec_delete_v2.sh:134` — `i<$number` → `i<number`
- `tools/benchmark/job_spec_delete_v2.sh:143` — same

No behavior change for the supported input set. Just removes the SC2004 hit and aligns the script with the other arithmetic uses in the repo.

## Validation

- `bash -n tools/benchmark/job_spec_delete_v2.sh` — clean
- `git diff` shows two single-character edits, both on the same construct

Fixes #14512