### PR TITLE
fix(chainlink): deterministic ordering for /nodes pagination

### DIFF
--- a/core/services/chainlink/relayer_chain_interoperators.go
+++ b/core/services/chainlink/relayer_chain_interoperators.go
@@ -408,6 +408,12 @@ func (rs *CoreRelayerChainInteroperators) NodeStatuses(ctx context.Context, offs
 	if totalErr != nil {
 		return nil, 0, totalErr
 	}
+	// Per-relayer node ordering is whatever the underlying chain implementation
+	// returns and is not guaranteed to be stable across calls (#18263). Sort
+	// the aggregated slice by (ChainID, Name) so the API surface is paginated
+	// deterministically and operators can find the same node on the same page
+	// across reloads.
+	sortNodeStatuses(result)
 	if len(result) < offset {
 		return nil, 0, nil
 	}
@@ -416,6 +422,20 @@ func (rs *CoreRelayerChainInteroperators) NodeStatuses(ctx context.Context, offs
 		return result[:limit], count, nil
 	}
 	return result, count, nil
+}
+
+// sortNodeStatuses orders node statuses by (ChainID, Name) in place so the
+// /nodes dashboard surface paginates deterministically. SortStableFunc keeps
+// the input order on equal (ChainID, Name) pairs so the aggregate is fully
+// reproducible. Extracted for unit testing without standing up a full
+// relayer; see #18263.
+func sortNodeStatuses(nodes []types.NodeStatus) {
+	slices.SortStableFunc(nodes, func(a, b types.NodeStatus) int {
+		if c := strings.Compare(a.ChainID, b.ChainID); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
 }
 
 type FilterFn func(id types.RelayID) bool

--- a/core/services/chainlink/relayer_chain_interoperators_internal_test.go
+++ b/core/services/chainlink/relayer_chain_interoperators_internal_test.go
@@ -1,0 +1,112 @@
+package chainlink
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSortNodeStatuses is a regression test for #18263. The /nodes dashboard
+// page was reordering every render because per-relayer node iteration is not
+// guaranteed to be stable. The aggregator now sorts by (ChainID, Name) so
+// repeated calls with the same inputs return the same page.
+func TestSortNodeStatuses(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   []types.NodeStatus
+		want []types.NodeStatus
+	}{
+		{
+			name: "shuffled within a chain sorts by name",
+			in: []types.NodeStatus{
+				{ChainID: "1", Name: "zebra"},
+				{ChainID: "1", Name: "alpha"},
+				{ChainID: "1", Name: "mango"},
+			},
+			want: []types.NodeStatus{
+				{ChainID: "1", Name: "alpha"},
+				{ChainID: "1", Name: "mango"},
+				{ChainID: "1", Name: "zebra"},
+			},
+		},
+		{
+			name: "groups by chain id then sorts by name",
+			in: []types.NodeStatus{
+				{ChainID: "2", Name: "bear"},
+				{ChainID: "1", Name: "zebra"},
+				{ChainID: "2", Name: "ant"},
+				{ChainID: "1", Name: "alpha"},
+			},
+			want: []types.NodeStatus{
+				{ChainID: "1", Name: "alpha"},
+				{ChainID: "1", Name: "zebra"},
+				{ChainID: "2", Name: "ant"},
+				{ChainID: "2", Name: "bear"},
+			},
+		},
+		{
+			name: "lexicographic chain ids (string compare, not numeric)",
+			in: []types.NodeStatus{
+				{ChainID: "10", Name: "n1"},
+				{ChainID: "2", Name: "n2"},
+				{ChainID: "1", Name: "n3"},
+			},
+			// ChainID is a string in NodeStatus, so "10" sorts before "2"
+			// lexicographically. The sort intentionally mirrors that — chain
+			// id space is opaque (EVM, Solana, dummy, ...) so a numeric sort
+			// would be wrong for non-EVM chains.
+			want: []types.NodeStatus{
+				{ChainID: "1", Name: "n3"},
+				{ChainID: "10", Name: "n1"},
+				{ChainID: "2", Name: "n2"},
+			},
+		},
+		{
+			name: "already sorted is a no-op",
+			in: []types.NodeStatus{
+				{ChainID: "1", Name: "a"},
+				{ChainID: "1", Name: "b"},
+				{ChainID: "2", Name: "c"},
+			},
+			want: []types.NodeStatus{
+				{ChainID: "1", Name: "a"},
+				{ChainID: "1", Name: "b"},
+				{ChainID: "2", Name: "c"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := append([]types.NodeStatus(nil), tc.in...)
+			sortNodeStatuses(got)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("empty and nil slices are no-ops", func(t *testing.T) {
+		empty := []types.NodeStatus{}
+		sortNodeStatuses(empty)
+		assert.Empty(t, empty)
+		sortNodeStatuses(nil)
+	})
+}
+
+// TestSortNodeStatusesStable asserts equal keys preserve input order so the
+// aggregator output stays predictable even when two relayers happen to use
+// the same (ChainID, Name) pair (e.g. dev fixtures, multi-relayer dummy
+// chains).
+func TestSortNodeStatusesStable(t *testing.T) {
+	t.Parallel()
+
+	in := []types.NodeStatus{
+		{ChainID: "1", Name: "same", Config: "first"},
+		{ChainID: "1", Name: "same", Config: "second"},
+		{ChainID: "1", Name: "same", Config: "third"},
+	}
+	got := append([]types.NodeStatus(nil), in...)
+	sortNodeStatuses(got)
+	assert.Equal(t, in, got, "equal-key entries must keep their original order")
+}


### PR DESCRIPTION
## Summary

Fixes #18263. The Nodes tab reorders on every render because the aggregated `NodeStatuses()` slice inherits whatever per-relayer order the underlying chain returned, which is map-iteration order for several implementations. With more than 100 nodes (now the case for CCIP) the same chain's nodes flip across pages between refreshes, making the page unusable for locating a specific node.

The outer relayer keys are already sorted by `(Network, ChainID)` in `CoreRelayerChainInteroperators.NodeStatuses` (`relayer_chain_interoperators.go`, around the `slices.Collect(maps.Keys(rs.loopRelayers))` block). The missing layer is a stable sort of the aggregated `[]types.NodeStatus` slice by `(ChainID, Name)` before applying offset/limit pagination.

## Approach

- Add a private `sortNodeStatuses([]types.NodeStatus)` helper that calls `slices.SortStableFunc` over `(ChainID, Name)`.
- Call it in `NodeStatuses()` after collecting from all relayers, before applying offset/limit. Pagination therefore sees a deterministic slice and the same node lands on the same page across refreshes.
- `SortStableFunc` (not `SortFunc`) so equal-key entries — dev fixtures or multi-relayer dummy chains that legitimately share `(ChainID, Name)` — preserve input order and stay reproducible too.

## Why string sort on `ChainID`

`NodeStatus.ChainID` is `string` and the chain-id namespace is opaque (EVM numeric ids, Solana base58, dummy strings, ...). A numeric sort would be wrong for non-EVM relayers. The lexicographic order matches what the outer relayer key sort already uses, so the two layers compose without surprise: chains land in `(Network, ChainID)` order, nodes within a chain land in `Name` order.

The test pins this explicitly — see `TestSortNodeStatuses/lexicographic_chain_ids_(string_compare,_not_numeric)`. Happy to switch to numeric sort for the EVM subset only if maintainers prefer that direction.

## Test

Added `core/services/chainlink/relayer_chain_interoperators_internal_test.go` (internal `package chainlink`) so the regression doesn't need to stub the 15+ method `loop.Relayer` interface just to exercise the sort. Coverage:

- shuffled within a chain → sorted by `Name`
- grouped across chains → `(ChainID, Name)` order
- lexicographic chain-id behavior pinned explicitly
- already-sorted input is a no-op
- empty and `nil` slices are no-ops
- equal `(ChainID, Name)` entries preserve input order (stability)

```
$ go test -count=1 -run TestSortNodeStatuses ./core/services/chainlink/
ok  	github.com/smartcontractkit/chainlink/v2/core/services/chainlink	1.886s
```

The existing `TestCoreRelayerChainInteroperators` integration test requires `CL_DATABASE_URL` (Postgres) and was not run locally; CI will exercise it end-to-end. The sort change is on the aggregator output only and does not touch any DB-backed code path.

Fixes #18263