### PR TITLE
chore: remove pointer.To in favour of new(T)

### DIFF
--- a/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config.go
@@ -11,15 +11,14 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	ccip_cs_common "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	ccip_cs_sol_v0_1_1 "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana_v0_1_1"
 	ccip_cs_evm_v1_5_1 "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1"
 	ccip_cs_evm_v1_6_0 "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
-
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 )
 
 var _ cldf.ChangeSetV2[SetTokenTransferFeeConfigInput] = SetTokenTransferFeeConfig
@@ -41,8 +40,8 @@ var _ cldf.ChangeSetV2[SetTokenTransferFeeConfigInput] = SetTokenTransferFeeConf
 var SetTokenTransferFeeConfig = cldf.CreateChangeSet(setTokenTransferFeeLogic, setTokenTransferFeePrecondition)
 
 var SetTokenTransferFeeLatestSupportedVersions = OptionalVersions{
-	Solana: pointer.To(ccip_cs_sol_v0_1_1.VersionSolanaV0_1_1),
-	Evm:    pointer.To(deployment.Version1_6_0.String()),
+	Solana: new(ccip_cs_sol_v0_1_1.VersionSolanaV0_1_1),
+	Evm:    new(deployment.Version1_6_0.String()),
 }
 
 type OptionalVersions struct {

--- a/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config_test.go
+++ b/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config_test.go
@@ -8,36 +8,30 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
+	"github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/require"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
-
-	"github.com/gagliardetto/solana-go"
-
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
+	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
 
 	solfq "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/fee_quoter"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
+	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	ccip_cs_sol_v0_1_1 "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana_v0_1_1"
+	solstateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 
 	solstate "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
-
+	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/crossfamily"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/v1_5"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-
-	solstateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
-
-	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/crossfamily"
-	ccip_cs_sol_v0_1_1 "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana_v0_1_1"
 )
 
 const SetTokenTransferFeePriceRegStalenessThreshold = 60 * 60 * 24 * 14 // two weeks in seconds
@@ -234,8 +228,8 @@ func TestSetTokenTransferFeeConfig_Validations(t *testing.T) {
 			MsgStr: "Unsupported EVM version hint fails fast",
 			Config: crossfamily.SetTokenTransferFeeConfigInput{
 				VersionHints: &crossfamily.OptionalVersions{
-					Solana: pointer.To(ccip_cs_sol_v0_1_1.VersionSolanaV0_1_1), // valid solana (doesn't matter)
-					Evm:    pointer.To("1.4.9"),                                // bogus/unsupported
+					Solana: new(ccip_cs_sol_v0_1_1.VersionSolanaV0_1_1), // valid solana (doesn't matter)
+					Evm:    new("1.4.9"),                                // bogus/unsupported
 				},
 				InputsByChain: map[uint64]map[uint64]crossfamily.TokenTransferFeeConfigArgs{
 					evmSrc: {
@@ -254,8 +248,8 @@ func TestSetTokenTransferFeeConfig_Validations(t *testing.T) {
 			MsgStr: "Unsupported Solana version hint fails fast",
 			Config: crossfamily.SetTokenTransferFeeConfigInput{
 				VersionHints: &crossfamily.OptionalVersions{
-					Evm:    pointer.To(deployment.Version1_6_0.String()),
-					Solana: pointer.To("v0_0_9"), // bogus/unsupported
+					Evm:    new(deployment.Version1_6_0.String()),
+					Solana: new("v0_0_9"), // bogus/unsupported
 				},
 				InputsByChain: map[uint64]map[uint64]crossfamily.TokenTransferFeeConfigArgs{
 					solSrc: {
@@ -329,15 +323,15 @@ func TestSetTokenTransferFeeConfig_EVM_V1_6_0_Only(t *testing.T) {
 					TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
 						link.Hex(): {
 							// partial fields: defaults should be auto-filled by the EVM changeset when none exist
-							MinFeeUsdCents:  pointer.To(uint32(800)),
-							DestGasOverhead: pointer.To(uint32(100)),
+							MinFeeUsdCents:  new(uint32(800)),
+							DestGasOverhead: new(uint32(100)),
 						},
 					},
 				},
 			},
 		},
 		VersionHints: &crossfamily.OptionalVersions{
-			Evm: pointer.To(deployment.Version1_6_0.String()),
+			Evm: new(deployment.Version1_6_0.String()),
 		},
 		MCMS: &SetTokenTransferFeeMcmsConfig,
 	}
@@ -420,19 +414,19 @@ func TestSetTokenTransferFeeConfig_EVM_V1_5_1_Only(t *testing.T) {
 				dst: {
 					TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
 						link.Hex(): {
-							DestBytesOverhead: pointer.To(uint32(32)),
-							DestGasOverhead:   pointer.To(uint32(10)),
-							MaxFeeUsdCents:    pointer.To(uint32(math.MaxUint32)),
-							MinFeeUsdCents:    pointer.To(uint32(800)),
-							DeciBps:           pointer.To(uint16(0)),
-							IsEnabled:         pointer.To(true),
+							DestBytesOverhead: new(uint32(32)),
+							DestGasOverhead:   new(uint32(10)),
+							MaxFeeUsdCents:    new(uint32(math.MaxUint32)),
+							MinFeeUsdCents:    new(uint32(800)),
+							DeciBps:           new(uint16(0)),
+							IsEnabled:         new(true),
 						},
 					},
 				},
 			},
 		},
 		VersionHints: &crossfamily.OptionalVersions{
-			Evm: pointer.To(deployment.Version1_5_1.String()),
+			Evm: new(deployment.Version1_5_1.String()),
 		},
 		MCMS: &SetTokenTransferFeeMcmsConfig,
 	}
@@ -507,19 +501,19 @@ func TestSetTokenTransferFeeConfig_Solana_V0_1_0_Only(t *testing.T) {
 					TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
 						tokenAddressX.String(): {
 							// partial fields: defaults should be auto-filled by the SOL changeset when none exist
-							DestGasOverhead: pointer.To(uint32(10)),
+							DestGasOverhead: new(uint32(10)),
 						},
 						tokenAddressY.String(): {
 							// partial fields: defaults should be auto-filled by the SOL changeset when none exist
-							DestBytesOverhead: pointer.To(uint32(64)),
-							DestGasOverhead:   pointer.To(uint32(10)),
+							DestBytesOverhead: new(uint32(64)),
+							DestGasOverhead:   new(uint32(10)),
 						},
 					},
 				},
 			},
 		},
 		VersionHints: &crossfamily.OptionalVersions{
-			Solana: pointer.To(ccip_cs_sol_v0_1_1.VersionSolanaV0_1_1),
+			Solana: new(ccip_cs_sol_v0_1_1.VersionSolanaV0_1_1),
 		},
 		MCMS: &SetTokenTransferFeeMcmsConfig,
 	}
@@ -605,11 +599,11 @@ func TestSetTokenTransferFeeConfig_MixedFamilies_SingleApply(t *testing.T) {
 				evmDst: {
 					TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
 						link.Hex(): {
-							MinFeeUsdCents:    pointer.To(uint32(12)),
-							DeciBps:           pointer.To(uint16(7)),
-							DestGasOverhead:   pointer.To(uint32(222)),
-							DestBytesOverhead: pointer.To(uint32(512)),
-							IsEnabled:         pointer.To(true),
+							MinFeeUsdCents:    new(uint32(12)),
+							DeciBps:           new(uint16(7)),
+							DestGasOverhead:   new(uint32(222)),
+							DestBytesOverhead: new(uint32(512)),
+							IsEnabled:         new(true),
 						},
 					},
 				},
@@ -620,9 +614,9 @@ func TestSetTokenTransferFeeConfig_MixedFamilies_SingleApply(t *testing.T) {
 					TokenAddressToFeeConfig: map[string]crossfamily.OptionalTokenTransferFeeConfig{
 						mint.String(): {
 							// partial: defaults will fill any omitted fields
-							MinFeeUsdCents:    pointer.To(uint32(900)),
-							DestGasOverhead:   pointer.To(uint32(100)),
-							DestBytesOverhead: pointer.To(uint32(128)),
+							MinFeeUsdCents:    new(uint32(900)),
+							DestGasOverhead:   new(uint32(100)),
+							DestBytesOverhead: new(uint32(128)),
 							// DeciBps/IsEnabled left nil -> defaults (0 / true)
 						},
 					},
@@ -630,8 +624,8 @@ func TestSetTokenTransferFeeConfig_MixedFamilies_SingleApply(t *testing.T) {
 			},
 		},
 		VersionHints: &crossfamily.OptionalVersions{
-			Solana: pointer.To(ccip_cs_sol_v0_1_1.VersionSolanaV0_1_1),
-			Evm:    pointer.To(deployment.Version1_6_0.String()),
+			Solana: new(ccip_cs_sol_v0_1_1.VersionSolanaV0_1_1),
+			Evm:    new(deployment.Version1_6_0.String()),
 		},
 		MCMS: &SetTokenTransferFeeMcmsConfig,
 	}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_chain_contracts_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	solanastateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -415,10 +414,10 @@ func doTestBilling(t *testing.T, mcms bool) {
 							evmChain: {
 								TokenAddressToFeeConfig: map[solana.PublicKey]ccipChangesetSolana.OptionalFeeQuoterTokenTransferFeeConfig{
 									tokenAddressB: {
-										MinFeeUsdcents:    pointer.To(uint32(800)),
-										MaxFeeUsdcents:    pointer.To(uint32(1600)),
-										DestGasOverhead:   pointer.To(uint32(100)),
-										DestBytesOverhead: pointer.To(uint32(100)),
+										MinFeeUsdcents:    new(uint32(800)),
+										MaxFeeUsdcents:    new(uint32(1600)),
+										DestGasOverhead:   new(uint32(100)),
+										DestBytesOverhead: new(uint32(100)),
 										IsEnabled:         nil, // auto-filled
 										DeciBps:           nil, // auto-filled
 									},
@@ -430,10 +429,10 @@ func doTestBilling(t *testing.T, mcms bool) {
 							evmChain2: {
 								TokenAddressToFeeConfig: map[solana.PublicKey]ccipChangesetSolana.OptionalFeeQuoterTokenTransferFeeConfig{
 									tokenAddressB: {
-										MinFeeUsdcents:    pointer.To(uint32(800)),
-										MaxFeeUsdcents:    pointer.To(uint32(1600)),
-										DestGasOverhead:   pointer.To(uint32(100)),
-										DestBytesOverhead: pointer.To(uint32(100)),
+										MinFeeUsdcents:    new(uint32(800)),
+										MaxFeeUsdcents:    new(uint32(1600)),
+										DestGasOverhead:   new(uint32(100)),
+										DestBytesOverhead: new(uint32(100)),
 										IsEnabled:         nil, // auto-filled
 										DeciBps:           nil, // auto-filled
 									},

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config_test.go
@@ -26,7 +26,6 @@ import (
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 )
 
 // Two weeks in seconds
@@ -167,12 +166,12 @@ func TestSetTokenTransferFeeConfig_Validations(t *testing.T) {
 							TokensToUseDefaultFeeConfigs: []common.Address{tokenB},
 							TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
 								tokenB: {
-									MinFeeUSDCents:            pointer.To(uint32(1)),
-									MaxFeeUSDCents:            pointer.To(uint32(2)),
-									DeciBps:                   pointer.To(uint16(10)),
-									DestGasOverhead:           pointer.To(uint32(100)),
-									DestBytesOverhead:         pointer.To(uint32(200)),
-									AggregateRateLimitEnabled: pointer.To(true),
+									MinFeeUSDCents:            new(uint32(1)),
+									MaxFeeUSDCents:            new(uint32(2)),
+									DeciBps:                   new(uint16(10)),
+									DestGasOverhead:           new(uint32(100)),
+									DestBytesOverhead:         new(uint32(200)),
+									AggregateRateLimitEnabled: new(true),
 								},
 							},
 						},
@@ -276,12 +275,12 @@ func TestSetTokenTransferFeeConfig_Execution_WithoutMCMS(t *testing.T) {
 							TokensToUseDefaultFeeConfigs: []common.Address{},
 							TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
 								tokenA: {
-									MinFeeUSDCents:            pointer.To(uint32(100)),
-									MaxFeeUSDCents:            pointer.To(uint32(5000)),
-									DeciBps:                   pointer.To(uint16(25)),
-									DestGasOverhead:           pointer.To(uint32(100_000)),
-									DestBytesOverhead:         pointer.To(uint32(1200)),
-									AggregateRateLimitEnabled: pointer.To(true),
+									MinFeeUSDCents:            new(uint32(100)),
+									MaxFeeUSDCents:            new(uint32(5000)),
+									DeciBps:                   new(uint16(25)),
+									DestGasOverhead:           new(uint32(100_000)),
+									DestBytesOverhead:         new(uint32(1200)),
+									AggregateRateLimitEnabled: new(true),
 								},
 							},
 						},
@@ -347,12 +346,12 @@ func TestSetTokenTransferFeeConfig_Execution_WithMCMS(t *testing.T) {
 						TokensToUseDefaultFeeConfigs: []common.Address{},
 						TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
 							tokenA: {
-								MinFeeUSDCents:            pointer.To(uint32(100)),
-								MaxFeeUSDCents:            pointer.To(uint32(5000)),
-								DeciBps:                   pointer.To(uint16(25)),
-								DestGasOverhead:           pointer.To(uint32(100_000)),
-								DestBytesOverhead:         pointer.To(uint32(1200)),
-								AggregateRateLimitEnabled: pointer.To(true),
+								MinFeeUSDCents:            new(uint32(100)),
+								MaxFeeUSDCents:            new(uint32(5000)),
+								DeciBps:                   new(uint16(25)),
+								DestGasOverhead:           new(uint32(100_000)),
+								DestBytesOverhead:         new(uint32(1200)),
+								AggregateRateLimitEnabled: new(true),
 							},
 						},
 					},
@@ -390,12 +389,12 @@ func TestSetTokenTransferFeeConfig_Execution_WithMCMS(t *testing.T) {
 						TokensToUseDefaultFeeConfigs: []common.Address{tokenB},
 						TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
 							tokenA: {
-								MinFeeUSDCents:            nil,                    // keep current
-								MaxFeeUSDCents:            nil,                    // keep current
-								DeciBps:                   pointer.To(uint16(30)), // change
-								DestGasOverhead:           nil,                    // keep current
-								DestBytesOverhead:         nil,                    // keep current
-								AggregateRateLimitEnabled: nil,                    // keep current
+								MinFeeUSDCents:            nil,             // keep current
+								MaxFeeUSDCents:            nil,             // keep current
+								DeciBps:                   new(uint16(30)), // change
+								DestGasOverhead:           nil,             // keep current
+								DestBytesOverhead:         nil,             // keep current
+								AggregateRateLimitEnabled: nil,             // keep current
 							},
 						},
 					},
@@ -461,12 +460,12 @@ func TestSetTokenTransferFeeConfig_MultipleChains(t *testing.T) {
 					TokensToUseDefaultFeeConfigs: []common.Address{tokenB},
 					TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
 						tokenA: {
-							MinFeeUSDCents:            pointer.To(uint32(101)),
-							MaxFeeUSDCents:            pointer.To(uint32(5001)),
-							DeciBps:                   pointer.To(uint16(26)),
-							DestGasOverhead:           pointer.To(uint32(110_000)),
-							DestBytesOverhead:         pointer.To(uint32(1300)),
-							AggregateRateLimitEnabled: pointer.To(true),
+							MinFeeUSDCents:            new(uint32(101)),
+							MaxFeeUSDCents:            new(uint32(5001)),
+							DeciBps:                   new(uint16(26)),
+							DestGasOverhead:           new(uint32(110_000)),
+							DestBytesOverhead:         new(uint32(1300)),
+							AggregateRateLimitEnabled: new(true),
 						},
 					},
 				},
@@ -476,12 +475,12 @@ func TestSetTokenTransferFeeConfig_MultipleChains(t *testing.T) {
 					TokensToUseDefaultFeeConfigs: []common.Address{tokenD},
 					TokenTransferFeeConfigArgs: map[common.Address]v1_5_1.TokenTransferFeeArgs{
 						tokenC: {
-							MinFeeUSDCents:            pointer.To(uint32(202)),
-							MaxFeeUSDCents:            pointer.To(uint32(6002)),
-							DeciBps:                   pointer.To(uint16(31)),
-							DestGasOverhead:           pointer.To(uint32(120_000)),
-							DestBytesOverhead:         pointer.To(uint32(1400)),
-							AggregateRateLimitEnabled: pointer.To(false),
+							MinFeeUSDCents:            new(uint32(202)),
+							MaxFeeUSDCents:            new(uint32(6002)),
+							DeciBps:                   new(uint16(31)),
+							DestGasOverhead:           new(uint32(120_000)),
+							DestBytesOverhead:         new(uint32(1400)),
+							AggregateRateLimitEnabled: new(false),
 						},
 					},
 				},

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts_test.go
@@ -34,7 +34,6 @@ import (
 	ccipseq "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm/v1_6"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -1537,12 +1536,12 @@ func TestApplyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2(t *testing.T) {
 								src: {
 									TokenTransferFeeConfigArgs: map[common.Address]v1_6.OptionalFeeQuoterTokenTransferFeeConfig{
 										dstLinkTokenAddress: {
-											MinFeeUSDCents:    pointer.To(uint32(1)),
-											MaxFeeUSDCents:    pointer.To(uint32(1)),
-											DeciBps:           pointer.To(uint16(1)),
-											DestGasOverhead:   pointer.To(uint32(1)),
-											DestBytesOverhead: pointer.To(uint32(1)),
-											IsEnabled:         pointer.To(true),
+											MinFeeUSDCents:    new(uint32(1)),
+											MaxFeeUSDCents:    new(uint32(1)),
+											DeciBps:           new(uint16(1)),
+											DestGasOverhead:   new(uint32(1)),
+											DestBytesOverhead: new(uint32(1)),
+											IsEnabled:         new(true),
 										},
 									},
 								},
@@ -1581,12 +1580,12 @@ func TestApplyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2(t *testing.T) {
 								src: {
 									TokenTransferFeeConfigArgs: map[common.Address]v1_6.OptionalFeeQuoterTokenTransferFeeConfig{
 										dstLinkTokenAddress: {
-											MinFeeUSDCents:    pointer.To(uint32(1)),
-											MaxFeeUSDCents:    pointer.To(uint32(2)),
-											DeciBps:           pointer.To(uint16(1)),
-											DestGasOverhead:   pointer.To(uint32(1)),
-											DestBytesOverhead: pointer.To(uint32(64)),
-											IsEnabled:         pointer.To(true),
+											MinFeeUSDCents:    new(uint32(1)),
+											MaxFeeUSDCents:    new(uint32(2)),
+											DeciBps:           new(uint16(1)),
+											DestGasOverhead:   new(uint32(1)),
+											DestBytesOverhead: new(uint32(64)),
+											IsEnabled:         new(true),
 										},
 									},
 								},

--- a/deployment/cre/jobs/operations/propose_std_cap_job.go
+++ b/deployment/cre/jobs/operations/propose_std_cap_job.go
@@ -22,7 +22,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/cre/jobs/pkg"
 	job_types "github.com/smartcontractkit/chainlink/deployment/cre/jobs/types"
 	"github.com/smartcontractkit/chainlink/deployment/cre/pkg/offchain"
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 )
 
 type ProposeStandardCapabilityJobDeps struct {
@@ -83,7 +82,7 @@ var ProposeStandardCapabilityJob = operations.NewSequence[
 				{
 					Key:   "type",
 					Op:    ptypes.SelectorOp_EQ,
-					Value: pointer.To(PluginNodeType),
+					Value: new(PluginNodeType),
 				},
 			},
 		}

--- a/deployment/cre/pkg/offchain/nodes.go
+++ b/deployment/cre/pkg/offchain/nodes.go
@@ -11,8 +11,6 @@ import (
 	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 	nodeapiv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
-
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 )
 
 // labels used in JD to identify nodes and jobs
@@ -79,18 +77,18 @@ func RegisterNode(
 	for _, key := range extraLabelKeys {
 		labels = append(labels, &ptypes.Label{
 			Key:   key,
-			Value: pointer.To(extraLabels[key]),
+			Value: new(extraLabels[key]),
 		})
 	}
 	if isBootstrap {
 		labels = append(labels, &ptypes.Label{
 			Key:   labelNodeTypeKey,
-			Value: pointer.To(labelNodeTypeValueBootstrap),
+			Value: new(labelNodeTypeValueBootstrap),
 		})
 	} else {
 		labels = append(labels, &ptypes.Label{
 			Key:   labelNodeTypeKey,
-			Value: pointer.To(labelNodeTypeValuePlugin),
+			Value: new(labelNodeTypeValuePlugin),
 		})
 	}
 	resp, err := jd.RegisterNode(ctx, &nodeapiv1.RegisterNodeRequest{

--- a/deployment/cre/pkg/offchain/propose_job.go
+++ b/deployment/cre/pkg/offchain/propose_job.go
@@ -10,8 +10,6 @@ import (
 	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
-
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 )
 
 // ProposeJobRequest contains parameters for proposing a job to nodes in JD.
@@ -76,7 +74,7 @@ func ProposeJob(ctx context.Context, req ProposeJobRequest) error {
 		selectors = append(selectors, &ptypes.Selector{
 			Key:   key,
 			Op:    ptypes.SelectorOp_EQ,
-			Value: pointer.To(value),
+			Value: new(value),
 		})
 	}
 	selectors = append(selectors, req.ExtraSelectors...)

--- a/deployment/data-feeds/changeset/jd_register_nodes.go
+++ b/deployment/data-feeds/changeset/jd_register_nodes.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 )
 
 // RegisterNodesToJDChangeset is a changeset that reads node info from a JSON file and registers them in Job Distributor
@@ -44,36 +43,36 @@ func registerNodesToJDLogic(env cldf.Environment, c types.RegisterNodeConfig) (c
 
 			// base labels
 			labels := []*ptypes.Label{
-				&ptypes.Label{
+				{
 					Key:   "product",
-					Value: pointer.To(productLabel),
+					Value: new(productLabel),
 				},
-				&ptypes.Label{
+				{
 					Key:   "domain",
-					Value: pointer.To(productLabel),
+					Value: new(productLabel),
 				},
-				&ptypes.Label{
+				{
 					Key:   productLabel,
-					Value: pointer.To(""),
+					Value: new(""),
 				},
-				&ptypes.Label{
+				{
 					Key:   "environment",
-					Value: pointer.To(env.Name),
+					Value: new(env.Name),
 				},
-				&ptypes.Label{
+				{
 					Key:   "don_id",
-					Value: pointer.To(strconv.Itoa(don.ID)),
+					Value: new(strconv.Itoa(don.ID)),
 				},
 			}
 			if node.IsBootstrap {
 				labels = append(labels, &ptypes.Label{
 					Key:   devenv.LabelNodeTypeKey,
-					Value: pointer.To(devenv.LabelNodeTypeValueBootstrap),
+					Value: new(devenv.LabelNodeTypeValueBootstrap),
 				})
 			} else {
 				labels = append(labels, &ptypes.Label{
 					Key:   devenv.LabelNodeTypeKey,
-					Value: pointer.To(devenv.LabelNodeTypeValuePlugin),
+					Value: new(devenv.LabelNodeTypeValuePlugin),
 				})
 			}
 			// extra labels

--- a/deployment/data-feeds/offchain/jd.go
+++ b/deployment/data-feeds/offchain/jd.go
@@ -13,7 +13,6 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 )
 
 type NodesFilter struct {
@@ -33,7 +32,7 @@ func (f *NodesFilter) filter() *nodeapiv1.ListNodesRequest_Filter {
 		{
 			Key:   "don_id",
 			Op:    jdtypesv1.SelectorOp_EQ,
-			Value: pointer.To(strconv.FormatUint(f.DONID, 10)),
+			Value: new(strconv.FormatUint(f.DONID, 10)),
 		},
 		{
 			Key:   "environment",
@@ -51,13 +50,13 @@ func (f *NodesFilter) filter() *nodeapiv1.ListNodesRequest_Filter {
 		selectors = append(selectors, &jdtypesv1.Selector{
 			Key:   devenv.LabelNodeTypeKey,
 			Op:    jdtypesv1.SelectorOp_EQ,
-			Value: pointer.To(devenv.LabelNodeTypeValueBootstrap),
+			Value: new(devenv.LabelNodeTypeValueBootstrap),
 		})
 	} else {
 		selectors = append(selectors, &jdtypesv1.Selector{
 			Key:   devenv.LabelNodeTypeKey,
 			Op:    jdtypesv1.SelectorOp_EQ,
-			Value: pointer.To(devenv.LabelNodeTypeValuePlugin),
+			Value: new(devenv.LabelNodeTypeValuePlugin),
 		})
 	}
 
@@ -130,15 +129,15 @@ func ProposeJobs(ctx context.Context, env cldf.Environment, workflowJobSpec stri
 
 	// Propose jobs
 	jobLabels := []*ptypes.Label{
-		&ptypes.Label{
+		{
 			Key:   "don_id",
-			Value: pointer.To(strconv.FormatUint(nodeFilters.DONID, 10)),
+			Value: new(strconv.FormatUint(nodeFilters.DONID, 10)),
 		},
-		&ptypes.Label{
+		{
 			Key:   "environment",
 			Value: &nodeFilters.EnvLabel,
 		},
-		&ptypes.Label{
+		{
 			Key:   "zone",
 			Value: &nodeFilters.Zone,
 		},

--- a/deployment/environment/test/job_service_client_test.go
+++ b/deployment/environment/test/job_service_client_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
 	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
-
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 )
 
 func TestNewJobServiceClient(t *testing.T) {
@@ -842,14 +840,14 @@ func TestMatchesSelectors(t *testing.T) {
 				{
 					Key:   "label1",
 					Op:    ptypes.SelectorOp_EQ,
-					Value: pointer.To("value1"),
+					Value: new("value1"),
 				},
 			},
 			job: &jobv1.Job{
 				Labels: []*ptypes.Label{
 					{
 						Key:   "label1",
-						Value: pointer.To("value1"),
+						Value: new("value1"),
 					},
 				},
 			},
@@ -861,14 +859,14 @@ func TestMatchesSelectors(t *testing.T) {
 				{
 					Key:   "label1",
 					Op:    ptypes.SelectorOp_EQ,
-					Value: pointer.To("value1"),
+					Value: new("value1"),
 				},
 			},
 			job: &jobv1.Job{
 				Labels: []*ptypes.Label{
 					{
 						Key:   "label1",
-						Value: pointer.To("NOT THE VALUE WE NEED"),
+						Value: new("NOT THE VALUE WE NEED"),
 					},
 				},
 			},
@@ -880,7 +878,7 @@ func TestMatchesSelectors(t *testing.T) {
 				{
 					Key:   "label1",
 					Op:    ptypes.SelectorOp_EQ,
-					Value: pointer.To("value1"),
+					Value: new("value1"),
 				},
 			},
 			job:      &jobv1.Job{},
@@ -893,14 +891,14 @@ func TestMatchesSelectors(t *testing.T) {
 				{
 					Key:   "label1",
 					Op:    ptypes.SelectorOp_NOT_EQ,
-					Value: pointer.To("value1"),
+					Value: new("value1"),
 				},
 			},
 			job: &jobv1.Job{
 				Labels: []*ptypes.Label{
 					{
 						Key:   "label1",
-						Value: pointer.To("value1"),
+						Value: new("value1"),
 					},
 				},
 			},
@@ -912,14 +910,14 @@ func TestMatchesSelectors(t *testing.T) {
 				{
 					Key:   "label1",
 					Op:    ptypes.SelectorOp_NOT_EQ,
-					Value: pointer.To("value1"),
+					Value: new("value1"),
 				},
 			},
 			job: &jobv1.Job{
 				Labels: []*ptypes.Label{
 					{
 						Key:   "label1",
-						Value: pointer.To("NOT THE VALUE WE NEED"),
+						Value: new("NOT THE VALUE WE NEED"),
 					},
 				},
 			},
@@ -931,7 +929,7 @@ func TestMatchesSelectors(t *testing.T) {
 				{
 					Key:   "label1",
 					Op:    ptypes.SelectorOp_NOT_EQ,
-					Value: pointer.To("value1"),
+					Value: new("value1"),
 				},
 			},
 			job:      &jobv1.Job{},
@@ -944,14 +942,14 @@ func TestMatchesSelectors(t *testing.T) {
 				{
 					Key:   "label1",
 					Op:    ptypes.SelectorOp_IN,
-					Value: pointer.To("value1,value2"),
+					Value: new("value1,value2"),
 				},
 			},
 			job: &jobv1.Job{
 				Labels: []*ptypes.Label{
 					{
 						Key:   "label1",
-						Value: pointer.To("value1"),
+						Value: new("value1"),
 					},
 				},
 			},
@@ -963,14 +961,14 @@ func TestMatchesSelectors(t *testing.T) {
 				{
 					Key:   "label1",
 					Op:    ptypes.SelectorOp_IN,
-					Value: pointer.To("value1,value2"),
+					Value: new("value1,value2"),
 				},
 			},
 			job: &jobv1.Job{
 				Labels: []*ptypes.Label{
 					{
 						Key:   "label1",
-						Value: pointer.To("NOT THE VALUE WE NEED"),
+						Value: new("NOT THE VALUE WE NEED"),
 					},
 				},
 			},
@@ -982,7 +980,7 @@ func TestMatchesSelectors(t *testing.T) {
 				{
 					Key:   "label1",
 					Op:    ptypes.SelectorOp_IN,
-					Value: pointer.To("value1"),
+					Value: new("value1"),
 				},
 			},
 			job:      &jobv1.Job{},
@@ -995,14 +993,14 @@ func TestMatchesSelectors(t *testing.T) {
 				{
 					Key:   "label1",
 					Op:    ptypes.SelectorOp_NOT_IN,
-					Value: pointer.To("value1,value2"),
+					Value: new("value1,value2"),
 				},
 			},
 			job: &jobv1.Job{
 				Labels: []*ptypes.Label{
 					{
 						Key:   "label1",
-						Value: pointer.To("value1"),
+						Value: new("value1"),
 					},
 				},
 			},
@@ -1014,14 +1012,14 @@ func TestMatchesSelectors(t *testing.T) {
 				{
 					Key:   "label1",
 					Op:    ptypes.SelectorOp_NOT_IN,
-					Value: pointer.To("value1,value2"),
+					Value: new("value1,value2"),
 				},
 			},
 			job: &jobv1.Job{
 				Labels: []*ptypes.Label{
 					{
 						Key:   "label1",
-						Value: pointer.To("NOT THE VALUE WE NEED"),
+						Value: new("NOT THE VALUE WE NEED"),
 					},
 				},
 			},
@@ -1033,7 +1031,7 @@ func TestMatchesSelectors(t *testing.T) {
 				{
 					Key:   "label1",
 					Op:    ptypes.SelectorOp_NOT_IN,
-					Value: pointer.To("value1"),
+					Value: new("value1"),
 				},
 			},
 			job:      &jobv1.Job{},

--- a/deployment/helpers/pointer/pointer.go
+++ b/deployment/helpers/pointer/pointer.go
@@ -6,7 +6,3 @@ func Coalesce[T any](p *T, fallback T) T {
 	}
 	return fallback
 }
-
-func To[T any](v T) *T {
-	return &v
-}

--- a/deployment/internal/jdtestutils/client.go
+++ b/deployment/internal/jdtestutils/client.go
@@ -16,7 +16,6 @@ import (
 	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/test"
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 	"github.com/smartcontractkit/chainlink/deployment/utils/nodetestutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/feeds"
 )
@@ -221,7 +220,7 @@ func (j JobClient) ListNodes(ctx context.Context, in *nodev1.ListNodesRequest, o
 	for id, n := range j.asMap() {
 		p2pIDLabel := &ptypes.Label{
 			Key:   "p2p_id",
-			Value: pointer.To(n.Keys.PeerID.String()),
+			Value: new(n.Keys.PeerID.String()),
 		}
 		node := &nodev1.Node{
 			Id:          id,

--- a/deployment/internal/jdtestutils/client_test.go
+++ b/deployment/internal/jdtestutils/client_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 	"github.com/smartcontractkit/chainlink/deployment/utils/nodetestutils"
 )
 
@@ -161,7 +160,7 @@ func TestJobClientJobAPI(t *testing.T) {
 		Labels: []*ptypes.Label{
 			{
 				Key:   "label-key",
-				Value: pointer.To("label-value"),
+				Value: new("label-value"),
 			},
 		},
 	}

--- a/deployment/keystone/changeset/internal/remove_dons_test.go
+++ b/deployment/keystone/changeset/internal/remove_dons_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/p2pkey"
 	"github.com/smartcontractkit/chainlink/deployment"
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 	kstest "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/test"
 )
@@ -197,7 +196,7 @@ func TestRemoveDONs(t *testing.T) {
 			useMCMS:         false,
 			wantErr:         true,
 			validateRemoval: false,
-			donToRemove:     pointer.To(uint32(2839748937)),
+			donToRemove:     new(uint32(2839748937)),
 		},
 	}
 

--- a/deployment/utils/nodetestutils/node.go
+++ b/deployment/utils/nodetestutils/node.go
@@ -45,7 +45,6 @@ import (
 	sollptesting "github.com/smartcontractkit/chainlink-solana/pkg/solana/logpoller/testing"
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
-	"github.com/smartcontractkit/chainlink/deployment/helpers/pointer"
 	"github.com/smartcontractkit/chainlink/deployment/internal/evmtestutils"
 	"github.com/smartcontractkit/chainlink/deployment/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
@@ -327,7 +326,7 @@ func (n Node) JDChainConfigs() ([]*nodev1.ChainConfig, error) {
 				OcrKeyBundle:     keyBundle,
 				Multiaddr:        n.MultiAddr(),
 				Plugins:          nil, // TODO: programmatic way to list these from the embedded chainlink.Application?
-				ForwarderAddress: pointer.To(""),
+				ForwarderAddress: new(""),
 			},
 		})
 	}
@@ -344,7 +343,7 @@ func WithFinalityDepths(finalityDepths map[uint64]uint32) ConfigOpt {
 			chainIDBig := sqlutil.New(new(big.Int).SetUint64(chainID))
 			for _, evmChainConfig := range c.EVM {
 				if evmChainConfig.ChainID.ToInt().Cmp(chainIDBig.ToInt()) == 0 {
-					evmChainConfig.FinalityDepth = pointer.To(depth)
+					evmChainConfig.FinalityDepth = new(depth)
 				}
 			}
 		}
@@ -392,30 +391,30 @@ func NewNode(
 	// Do not want to load fixtures as they contain a dummy chainID.
 	// Create database and initial configuration.
 	cfg, db := heavyweight.FullTestDBNoFixturesV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-		c.Insecure.OCRDevelopmentMode = pointer.To(true) // Disables ocr spec validation so we can have fast polling for the test.
+		c.Insecure.OCRDevelopmentMode = new(true) // Disables ocr spec validation so we can have fast polling for the test.
 
-		c.Feature.LogPoller = pointer.To(true)
+		c.Feature.LogPoller = new(true)
 
 		// P2P V2 configs.
-		c.P2P.V2.Enabled = pointer.To(true)
+		c.P2P.V2.Enabled = new(true)
 		c.P2P.V2.DeltaDial = config.MustNewDuration(500 * time.Millisecond)
 		c.P2P.V2.DeltaReconcile = config.MustNewDuration(5 * time.Second)
 		c.P2P.V2.ListenAddresses = &[]string{fmt.Sprintf("127.0.0.1:%d", nodecfg.Port)}
 
 		// Enable Capabilities, This is a pre-requisite for registrySyncer to work.
 		if nodecfg.RegistryConfig.Contract != common.HexToAddress("0x0") {
-			c.Capabilities.ExternalRegistry.NetworkID = pointer.To(relay.NetworkEVM)
-			c.Capabilities.ExternalRegistry.ChainID = pointer.To(strconv.FormatUint(nodecfg.RegistryConfig.EVMChainID, 10))
-			c.Capabilities.ExternalRegistry.Address = pointer.To(nodecfg.RegistryConfig.Contract.String())
+			c.Capabilities.ExternalRegistry.NetworkID = new(relay.NetworkEVM)
+			c.Capabilities.ExternalRegistry.ChainID = new(strconv.FormatUint(nodecfg.RegistryConfig.EVMChainID, 10))
+			c.Capabilities.ExternalRegistry.Address = new(nodecfg.RegistryConfig.Contract.String())
 		}
 
 		// OCR configs
-		c.OCR.Enabled = pointer.To(false)
-		c.OCR.DefaultTransactionQueueDepth = pointer.To(uint32(200))
-		c.OCR2.Enabled = pointer.To(true)
+		c.OCR.Enabled = new(false)
+		c.OCR.DefaultTransactionQueueDepth = new(uint32(200))
+		c.OCR2.Enabled = new(true)
 		c.OCR2.ContractPollInterval = config.MustNewDuration(5 * time.Second)
 
-		c.Log.Level = pointer.To(configv2.LogLevel(nodecfg.LogLevel))
+		c.Log.Level = new(configv2.LogLevel(nodecfg.LogLevel))
 
 		var evmConfigs v2toml.EVMConfigs
 		for chainID := range evmchains {
@@ -536,12 +535,12 @@ func NewNode(
 	if nodecfg.Bootstrap {
 		nodeLabels[0] = &ptypes.Label{
 			Key:   devenv.LabelNodeTypeKey,
-			Value: pointer.To(devenv.LabelNodeTypeValueBootstrap),
+			Value: new(devenv.LabelNodeTypeValueBootstrap),
 		}
 	} else {
 		nodeLabels[0] = &ptypes.Label{
 			Key:   devenv.LabelNodeTypeKey,
-			Value: pointer.To(devenv.LabelNodeTypeValuePlugin),
+			Value: new(devenv.LabelNodeTypeValuePlugin),
 		}
 	}
 
@@ -762,13 +761,13 @@ func CreateKeys(t *testing.T,
 func createConfigV2Chain(chainID uint64) *v2toml.EVMConfig {
 	chainIDBig := sqlutil.NewI(int64(chainID))
 	chain := v2toml.Defaults(chainIDBig)
-	chain.GasEstimator.LimitDefault = pointer.To(uint64(5e6))
+	chain.GasEstimator.LimitDefault = new(uint64(5e6))
 	chain.LogPollInterval = config.MustNewDuration(500 * time.Millisecond)
-	chain.Transactions.ForwardersEnabled = pointer.To(false)
-	chain.FinalityDepth = pointer.To(uint32(2))
+	chain.Transactions.ForwardersEnabled = new(false)
+	chain.FinalityDepth = new(uint32(2))
 	return &v2toml.EVMConfig{
 		ChainID: chainIDBig,
-		Enabled: pointer.To(true),
+		Enabled: new(true),
 		Chain:   chain,
 		Nodes:   v2toml.EVMNodes{&v2toml.Node{}},
 	}


### PR DESCRIPTION
This is a cleanup of the `deployment` codebase to remove the use of `pointer.To` in favour of `new(T)`.
