### PR TITLE
fix(chainlink): deterministic ordering for /nodes pagination

### DIFF
--- a/.changeset/stable-nodes-pagination.md
+++ b/.changeset/stable-nodes-pagination.md
@@ -1,0 +1,7 @@
+---
+"chainlink": patch
+---
+
+Sort aggregated NodeStatuses by (ChainID, Name) so the /nodes dashboard paginates deterministically across reloads when more than 100 nodes are configured.
+
+#bugfix

--- a/core/services/chainlink/relayer_chain_interoperators.go
+++ b/core/services/chainlink/relayer_chain_interoperators.go
@@ -408,6 +408,12 @@ func (rs *CoreRelayerChainInteroperators) NodeStatuses(ctx context.Context, offs
 	if totalErr != nil {
 		return nil, 0, totalErr
 	}
+	// Per-relayer node ordering is whatever the underlying chain implementation
+	// returns and is not guaranteed to be stable across calls (#18263). Sort
+	// the aggregated slice by (ChainID, Name) so the API surface is paginated
+	// deterministically and operators can find the same node on the same page
+	// across reloads.
+	sortNodeStatuses(result)
 	if len(result) < offset {
 		return nil, 0, nil
 	}
@@ -416,6 +422,20 @@ func (rs *CoreRelayerChainInteroperators) NodeStatuses(ctx context.Context, offs
 		return result[:limit], count, nil
 	}
 	return result, count, nil
+}
+
+// sortNodeStatuses orders node statuses by (ChainID, Name) in place so the
+// /nodes dashboard surface paginates deterministically. SortStableFunc keeps
+// the input order on equal (ChainID, Name) pairs so the aggregate is fully
+// reproducible. Extracted for unit testing without standing up a full
+// relayer; see #18263.
+func sortNodeStatuses(nodes []types.NodeStatus) {
+	slices.SortStableFunc(nodes, func(a, b types.NodeStatus) int {
+		if c := strings.Compare(a.ChainID, b.ChainID); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
 }
 
 type FilterFn func(id types.RelayID) bool

--- a/core/services/chainlink/relayer_chain_interoperators_internal_test.go
+++ b/core/services/chainlink/relayer_chain_interoperators_internal_test.go
@@ -1,0 +1,112 @@
+package chainlink
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSortNodeStatuses is a regression test for #18263. The /nodes dashboard
+// page was reordering every render because per-relayer node iteration is not
+// guaranteed to be stable. The aggregator now sorts by (ChainID, Name) so
+// repeated calls with the same inputs return the same page.
+func TestSortNodeStatuses(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   []types.NodeStatus
+		want []types.NodeStatus
+	}{
+		{
+			name: "shuffled within a chain sorts by name",
+			in: []types.NodeStatus{
+				{ChainID: "1", Name: "zebra"},
+				{ChainID: "1", Name: "alpha"},
+				{ChainID: "1", Name: "mango"},
+			},
+			want: []types.NodeStatus{
+				{ChainID: "1", Name: "alpha"},
+				{ChainID: "1", Name: "mango"},
+				{ChainID: "1", Name: "zebra"},
+			},
+		},
+		{
+			name: "groups by chain id then sorts by name",
+			in: []types.NodeStatus{
+				{ChainID: "2", Name: "bear"},
+				{ChainID: "1", Name: "zebra"},
+				{ChainID: "2", Name: "ant"},
+				{ChainID: "1", Name: "alpha"},
+			},
+			want: []types.NodeStatus{
+				{ChainID: "1", Name: "alpha"},
+				{ChainID: "1", Name: "zebra"},
+				{ChainID: "2", Name: "ant"},
+				{ChainID: "2", Name: "bear"},
+			},
+		},
+		{
+			name: "lexicographic chain ids (string compare, not numeric)",
+			in: []types.NodeStatus{
+				{ChainID: "10", Name: "n1"},
+				{ChainID: "2", Name: "n2"},
+				{ChainID: "1", Name: "n3"},
+			},
+			// ChainID is a string in NodeStatus, so "10" sorts before "2"
+			// lexicographically. The sort intentionally mirrors that — chain
+			// id space is opaque (EVM, Solana, dummy, ...) so a numeric sort
+			// would be wrong for non-EVM chains.
+			want: []types.NodeStatus{
+				{ChainID: "1", Name: "n3"},
+				{ChainID: "10", Name: "n1"},
+				{ChainID: "2", Name: "n2"},
+			},
+		},
+		{
+			name: "already sorted is a no-op",
+			in: []types.NodeStatus{
+				{ChainID: "1", Name: "a"},
+				{ChainID: "1", Name: "b"},
+				{ChainID: "2", Name: "c"},
+			},
+			want: []types.NodeStatus{
+				{ChainID: "1", Name: "a"},
+				{ChainID: "1", Name: "b"},
+				{ChainID: "2", Name: "c"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := append([]types.NodeStatus(nil), tc.in...)
+			sortNodeStatuses(got)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("empty and nil slices are no-ops", func(t *testing.T) {
+		empty := []types.NodeStatus{}
+		sortNodeStatuses(empty)
+		assert.Empty(t, empty)
+		sortNodeStatuses(nil)
+	})
+}
+
+// TestSortNodeStatusesStable asserts equal keys preserve input order so the
+// aggregator output stays predictable even when two relayers happen to use
+// the same (ChainID, Name) pair (e.g. dev fixtures, multi-relayer dummy
+// chains).
+func TestSortNodeStatusesStable(t *testing.T) {
+	t.Parallel()
+
+	in := []types.NodeStatus{
+		{ChainID: "1", Name: "same", Config: "first"},
+		{ChainID: "1", Name: "same", Config: "second"},
+		{ChainID: "1", Name: "same", Config: "third"},
+	}
+	got := append([]types.NodeStatus(nil), in...)
+	sortNodeStatuses(got)
+	assert.Equal(t, in, got, "equal-key entries must keep their original order")
+}


### PR DESCRIPTION
## Problem

The **Nodes** tab in the operator UI reorders on every render. With more than 100 nodes configured (now routine for CCIP), the same chain's nodes flip across pages between refreshes, making the page unusable for locating a specific node by sight.

The root cause is in `(*CoreRelayerChainInteroperators).NodeStatuses`: per-relayer node ordering is whatever the underlying chain implementation returns, and several relayer implementations build the list from map iteration. The outer relayer keys are already sorted by `(Network, ChainID)`, but the aggregated `[]types.NodeStatus` slice has no stable order, so pagination is non-deterministic.

## Fix

Extract a package-private `sortNodeStatuses` helper and apply it in `NodeStatuses` right after aggregation, before the offset/size slicing happens. The sort key is `(ChainID, Name)` using `slices.SortStableFunc` so equal keys (e.g. dev fixtures or multi-relayer dummy chains) keep their input order and the result is fully reproducible.

## Test

`relayer_chain_interoperators_internal_test.go` covers:

- Shuffled input within a single chain comes out lexicographic by `Name`.
- Nodes are grouped across chains, with chain IDs in lexicographic order.
- Stability: pre-sorted equal-key pairs keep their original order.

The test lives in an internal `_test.go` so it can exercise the helper without standing up the full `loop.Relayer` interface.

Fixes #18263