### PR TITLE
fix(utils): accept json.Number in ToDecimal

### DIFF
--- a/.changeset/utils-todecimal-jsonnumber.md
+++ b/.changeset/utils-todecimal-jsonnumber.md
@@ -1,0 +1,7 @@
+---
+"chainlink": patch
+---
+
+Teach `utils.ToDecimal` to convert `json.Number` so pipeline tasks that consume HTTP JSON payloads (ethabiencode, fluxmonitor, OCR data sources) no longer fail with "type json.Number cannot be converted to decimal.Decimal".
+
+#bugfix

--- a/core/utils/decimal.go
+++ b/core/utils/decimal.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"math"
 	"math/big"
 
@@ -14,6 +15,14 @@ import (
 // https://github.com/smartcontractkit/chainlink/pull/14841
 func ToDecimal(input any) (decimal.Decimal, error) {
 	switch v := input.(type) {
+	case json.Number:
+		// json.Number is what encoding/json returns when Decoder.UseNumber()
+		// has been set, which is how the pipeline parses HTTP / JSON payloads
+		// containing numeric values. Without this case any downstream task
+		// that receives a json.Number (e.g. ethabiencode with a uint256[]
+		// argument, fluxmonitor, OCR data sources) fails the conversion with
+		// "type json.Number cannot be converted to decimal.Decimal".
+		return decimal.NewFromString(string(v))
 	case string:
 		return decimal.NewFromString(v)
 	case int:

--- a/core/utils/decimal_test.go
+++ b/core/utils/decimal_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"math"
 	"math/big"
 	"testing"
@@ -46,6 +47,12 @@ func TestDecimal(t *testing.T) {
 		{math.NaN(), true},
 		{float32(math.NaN()), true},
 		{true, true},
+		// json.Number is produced by Decoder.UseNumber, which the pipeline
+		// uses when decoding JSON HTTP responses. Both integer and floating
+		// point forms have to be accepted; see #8504.
+		{json.Number("123"), false},
+		{json.Number("-1.1"), false},
+		{json.Number("not-a-number"), true},
 	}
 	for _, tc := range tt {
 		_, err := ToDecimal(tc.v)


### PR DESCRIPTION
## Problem

`utils.ToDecimal` is used wherever the node has to coerce a pipeline value into a `decimal.Decimal`: `pipeline/task_params.go`, `pipeline/common_eth.go`, `ocrcommon/data_source.go`, `ocrcommon/telemetry.go`, `fluxmonitorv2/flux_monitor.go`, etc.

The pipeline JSON decoder uses `Decoder.UseNumber()` (see `core/services/pipeline/getters.go:132` and `task.jsonparse.go:64`), so any value coming from an HTTP JSON payload arrives downstream as `json.Number`, not `float64`. `ToDecimal`'s type switch handled `string`, all `int*`/`uint*`, `float32`/`float64`, `big.Int`, `decimal.Decimal` - but not `json.Number`. Result: every task that pulled a numeric value out of an HTTP response and tried to turn it into a decimal blew up with:

    type json.Number cannot be converted to decimal.Decimal: bad input for task

The user-visible case in #8504 is `ethabiencode` with a `uint256[]` argument, but `fluxmonitor`, OCR `data_source`, and OCR `telemetry` all sit on the same code path.

## Fix

Add a `json.Number` case at the top of the type switch in `ToDecimal`:

```go
case json.Number:
    return decimal.NewFromString(string(v))
```

`json.Number` is a `string` alias under the hood, so `decimal.NewFromString` parses integer and floating point forms identically and surfaces bad input as a regular parse error instead of the previous misleading type-mismatch message.

## Test

`core/utils/decimal_test.go` is extended with three cases:

- `json.Number("123")` succeeds
- `json.Number("-1.1")` succeeds
- `json.Number("not-a-number")` returns an error

Both successful cases fail on `develop` without this patch.

Fixes #8504