### PR TITLE
chore: fix typos arsguments and overidden

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,7 +12,7 @@ CL_INSTALL_TESTING_PLUGINS ?= false
 CL_IS_PROD_BUILD ?= true
 # Output directory for loopinstall plugin manifests (set by caller)
 CL_LOOPINSTALL_OUTPUT_DIR ?=
-# Conditionally define arsguments for loopinstall based on CL_LOOPINSTALL_OUTPUT_DIR
+# Conditionally define arguments for loopinstall based on CL_LOOPINSTALL_OUTPUT_DIR
 LOOPINSTALL_PUBLIC_ARGS  := $(if $(strip $(CL_LOOPINSTALL_OUTPUT_DIR)),--output-installation-artifacts $(CL_LOOPINSTALL_OUTPUT_DIR)/public.json)
 LOOPINSTALL_PRIVATE_ARGS := $(if $(strip $(CL_LOOPINSTALL_OUTPUT_DIR)),--output-installation-artifacts $(CL_LOOPINSTALL_OUTPUT_DIR)/private.json)
 LOOPINSTALL_TESTING_ARGS := $(if $(strip $(CL_LOOPINSTALL_OUTPUT_DIR)),--output-installation-artifacts $(CL_LOOPINSTALL_OUTPUT_DIR)/testing.json)

--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -76,7 +76,7 @@ func NewApp(s *Shell) *cli.App {
 		s.secretsFileIsSet = c.IsSet("secrets")
 
 		// Default to using a stdout logger only.
-		// This is overidden for server commands which may start a rotating
+		// This is overridden for server commands which may start a rotating
 		// logger instead.
 		lggr, closeFn := logger.NewLogger()
 


### PR DESCRIPTION
## Summary

Comment-only typo fixes. No behavior change.

- `GNUmakefile`: `arsguments` -> `arguments` in the comment that documents `CL_LOOPINSTALL_OUTPUT_DIR`-driven loopinstall args.
- `core/cmd/app.go`: `overidden` -> `overridden` in the comment that explains why the default stdout logger is replaced for server commands.

## Test plan

- [x] `go build ./core/cmd/...`
- [x] No code paths changed; only comments.