### PR TITLE
chore(scripts): fix 'Datbase' typo in setup_testdb.sh success message

### DIFF
--- a/core/scripts/setup_testdb.sh
+++ b/core/scripts/setup_testdb.sh
@@ -63,7 +63,7 @@ popd
 # Set the database URL in the .dbenv file
 dbenv=$repo/.dbenv
 echo "\n!Success!\n"
-echo "Datbase URL: $db_url"
+echo "Database URL: $db_url"
 
 echo "export $db_url" >> $dbenv
 echo "Has been set in the $dbenv file"


### PR DESCRIPTION
## Summary

`core/scripts/setup_testdb.sh` printed `Datbase URL: ...` instead of `Database URL: ...` after a successful setup. Cosmetic only; no behavior change.

## Test plan

- [x] Single-character typo fix in an `echo` line; no code paths altered.