### PR TITLE
feat(deployment): Add aptos regulated token changesets

### DIFF
--- a/deployment/ccip/changeset/aptos/config/deploy_regulated_token.go
+++ b/deployment/ccip/changeset/aptos/config/deploy_regulated_token.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"errors"
+
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+)
+
+// DeployRegulatedTokenConfig drives the regulated token publish + initialize +
+// transfer_ownership + transfer_admin to the MCMS registry owner, and emits an MCMS
+// proposal with accept_ownership and accept_admin. Note: regulated_token cannot be
+// deployed via MCMS due to DFA re-entrancy; those steps are signed directly by the
+// deployer.
+type DeployRegulatedTokenConfig struct {
+	ChainSelector uint64
+	TokenParams   TokenParams
+	TokenMint     *TokenMint
+	// RegistrarPreregister is passed to DeployMCMSRegistrarToExistingObject (default true).
+	RegistrarPreregister *bool
+	MCMSConfig           *proposalutils.TimelockConfig
+}
+
+func (c DeployRegulatedTokenConfig) Validate() error {
+	var errs []error
+	if c.MCMSConfig == nil {
+		errs = append(errs, errors.New("MCMSConfig is required"))
+	}
+	if err := c.TokenParams.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+// RegistrarPreregisterOrDefault returns true when unset (matches test helper default).
+func (c DeployRegulatedTokenConfig) RegistrarPreregisterOrDefault() bool {
+	if c.RegistrarPreregister == nil {
+		return true
+	}
+	return *c.RegistrarPreregister
+}

--- a/deployment/ccip/changeset/aptos/config/deploy_regulated_token.go
+++ b/deployment/ccip/changeset/aptos/config/deploy_regulated_token.go
@@ -3,6 +3,8 @@ package config
 import (
 	"errors"
 
+	"github.com/aptos-labs/aptos-go-sdk"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
 
@@ -27,6 +29,17 @@ func (c DeployRegulatedTokenConfig) Validate() error {
 	}
 	if err := c.TokenParams.Validate(); err != nil {
 		errs = append(errs, err)
+	}
+	// The deploy sequence grants MINTER_ROLE to the deployer and calls Mint via direct EOA
+	// transactions before the MCMS proposal is built; reject invalid TokenMint up front so
+	// we don't fail after partial on-chain side effects.
+	if c.TokenMint != nil {
+		if (c.TokenMint.To == aptos.AccountAddress{}) {
+			errs = append(errs, errors.New("TokenMint.To address is empty"))
+		}
+		if c.TokenMint.Amount == 0 {
+			errs = append(errs, errors.New("TokenMint.Amount is 0"))
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/deployment/ccip/changeset/aptos/cs_add_token_pool.go
+++ b/deployment/ccip/changeset/aptos/cs_add_token_pool.go
@@ -101,6 +101,19 @@ func (cs AddTokenPool) VerifyPreconditions(env cldf.Environment, cfg config.AddT
 			errs = append(errs, fmt.Errorf("pool %s already exists with a different token address %s", pool.StringLong(), token.StringLong()))
 		}
 	}
+	// Validate regulated token ownership finalization preconditions: when adding a regulated
+	// token pool against a pre-existing regulated token, a pending ownership transfer to MCMS
+	// (if any) must be in a state where the deployer EOA can finalize it.
+	if cfg.PoolType == shared.AptosRegulatedTokenPoolType && cfg.TokenCodeObjAddress != (aptos.AccountAddress{}) {
+		deps := dependency.AptosDeps{
+			AptosChain:       env.BlockChains.AptosChains()[cfg.ChainSelector],
+			CCIPOnChainState: state,
+		}
+		mcmsAddress := state.AptosChains[cfg.ChainSelector].MCMSAddress
+		if err := seq.VerifyFinalizeRegulatedTokenOwnership(deps, cfg.TokenCodeObjAddress, mcmsAddress); err != nil {
+			errs = append(errs, fmt.Errorf("regulated token ownership finalize precondition: %w", err))
+		}
+	}
 	return errors.Join(errs...)
 }
 
@@ -120,6 +133,22 @@ func (cs AddTokenPool) Apply(env cldf.Environment, cfg config.AddTokenPoolConfig
 		AB:               ab,
 		AptosChain:       aptosChain,
 		CCIPOnChainState: state,
+	}
+
+	// Finalize the regulated_token 3-step ownership handoff if needed: when MCMS has accepted
+	// ownership but the original deployer hasn't called execute_ownership_transfer yet, the
+	// token object still belongs to the deployer and isTokenOwnedByMCMS would return false.
+	if cfg.PoolType == shared.AptosRegulatedTokenPoolType && cfg.TokenCodeObjAddress != (aptos.AccountAddress{}) {
+		finalizeReport, err := operations.ExecuteSequence(
+			env.OperationsBundle,
+			seq.FinalizeRegulatedTokenOwnershipSequence,
+			deps,
+			cfg.TokenCodeObjAddress,
+		)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to finalize regulated token ownership: %w", err)
+		}
+		seqReports = append(seqReports, finalizeReport.ExecutionReports...)
 	}
 
 	// Deploy Aptos Token

--- a/deployment/ccip/changeset/aptos/cs_deploy_regulated_token.go
+++ b/deployment/ccip/changeset/aptos/cs_deploy_regulated_token.go
@@ -1,0 +1,121 @@
+package aptos
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/smartcontractkit/mcms"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/dependency"
+	seq "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/sequence"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/utils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+)
+
+var _ cldf.ChangeSetV2[config.DeployRegulatedTokenConfig] = DeployRegulatedToken{}
+
+// DeployRegulatedToken deploys and initializes a regulated token directly with the
+// deployer signer (regulated_token cannot be deployed via MCMS due to DFA re-entrancy),
+// transfers ownership and admin role to the MCMS registry owner, and returns a
+// timelock proposal containing accept_ownership and accept_admin.
+type DeployRegulatedToken struct{}
+
+func (cs DeployRegulatedToken) VerifyPreconditions(env cldf.Environment, cfg config.DeployRegulatedTokenConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	state, err := stateview.LoadOnchainState(env)
+	if err != nil {
+		return fmt.Errorf("failed to load onchain state: %w", err)
+	}
+	var errs []error
+	if _, ok := state.SupportedChains()[cfg.ChainSelector]; !ok {
+		errs = append(errs, fmt.Errorf("unsupported chain: %d", cfg.ChainSelector))
+	}
+	aptosState, ok := state.AptosChains[cfg.ChainSelector]
+	if !ok {
+		errs = append(errs, fmt.Errorf("aptos chain %d not in state", cfg.ChainSelector))
+	} else {
+		if aptosState.CCIPAddress == (aptos.AccountAddress{}) {
+			errs = append(errs, fmt.Errorf("CCIP is not deployed on Aptos chain %d", cfg.ChainSelector))
+		}
+		if aptosState.MCMSAddress == (aptos.AccountAddress{}) {
+			errs = append(errs, fmt.Errorf("MCMS is not deployed on Aptos chain %d", cfg.ChainSelector))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (cs DeployRegulatedToken) Apply(env cldf.Environment, cfg config.DeployRegulatedTokenConfig) (cldf.ChangesetOutput, error) {
+	state, err := stateview.LoadOnchainState(env)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
+	}
+
+	aptosChain := env.BlockChains.AptosChains()[cfg.ChainSelector]
+	mcmsAddress := state.AptosChains[cfg.ChainSelector].MCMSAddress
+
+	ab := cldf.NewMemoryAddressBook()
+	deps := dependency.AptosDeps{
+		AB:               ab,
+		AptosChain:       aptosChain,
+		CCIPOnChainState: state,
+	}
+
+	seqReport, err := operations.ExecuteSequence(
+		env.OperationsBundle,
+		seq.DeployRegulatedTokenSequence,
+		deps,
+		seq.DeployRegulatedTokenSeqInput{
+			MCMSAddress:          mcmsAddress,
+			TokenParams:          cfg.TokenParams,
+			TokenMint:            cfg.TokenMint,
+			RegistrarPreregister: cfg.RegistrarPreregisterOrDefault(),
+		},
+	)
+	if err != nil {
+		return cldf.ChangesetOutput{}, err
+	}
+
+	out := seqReport.Output
+	typeAndVersion := cldf.NewTypeAndVersion(shared.AptosRegulatedTokenType, deployment.Version1_6_0)
+	typeAndVersion.AddLabel(string(cfg.TokenParams.Symbol))
+	if err := ab.Save(aptosChain.Selector, out.TokenCodeObjectAddress.StringLong(), typeAndVersion); err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("save regulated token code object: %w", err)
+	}
+	typeAndVersion = cldf.NewTypeAndVersion(cldf.ContractType(cfg.TokenParams.Symbol), deployment.Version1_6_0)
+	if err := ab.Save(aptosChain.Selector, out.TokenMetadataAddress.StringLong(), typeAndVersion); err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("save token metadata address: %w", err)
+	}
+
+	proposal, err := utils.GenerateProposal(
+		env,
+		mcmsAddress,
+		cfg.ChainSelector,
+		out.MCMSOperations,
+		"Accept regulated token ownership and admin role (after direct deploy)",
+		*cfg.MCMSConfig,
+	)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("generate MCMS proposal: %w", err)
+	}
+
+	ds, err := shared.PopulateDataStore(ab)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("populate datastore: %w", err)
+	}
+
+	return cldf.ChangesetOutput{
+		AddressBook:           ab,
+		DataStore:             ds,
+		MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
+		Reports:               seqReport.ExecutionReports,
+	}, nil
+}

--- a/deployment/ccip/changeset/aptos/cs_deploy_regulated_token_test.go
+++ b/deployment/ccip/changeset/aptos/cs_deploy_regulated_token_test.go
@@ -1,0 +1,57 @@
+package aptos_test
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/require"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	aptoscs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
+	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+)
+
+func TestDeployRegulatedToken_Apply(t *testing.T) {
+	t.Parallel()
+	deployedEnvironment, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithAptosChains(1))
+	env := deployedEnvironment.Env
+
+	aptosSelectors := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyAptos))
+	require.Len(t, aptosSelectors, 1)
+	aptosSelector := aptosSelectors[0]
+
+	cfg := config.DeployRegulatedTokenConfig{
+		ChainSelector: aptosSelector,
+		TokenParams: config.TokenParams{
+			MaxSupply: big.NewInt(1_000_000),
+			Name:      "RegDeploy",
+			Symbol:    "RDT",
+			Decimals:  8,
+			Icon:      "",
+			Project:   "",
+		},
+		MCMSConfig: &proposalutils.TimelockConfig{
+			MinDelay:     time.Second,
+			MCMSAction:   mcmstypes.TimelockActionSchedule,
+			OverrideRoot: false,
+		},
+	}
+
+	_, outputs, err := commonchangeset.ApplyChangesets(t, env, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(aptoscs.DeployRegulatedToken{}, cfg),
+	})
+	require.NoError(t, err)
+	require.Len(t, outputs, 1)
+	output := outputs[0]
+	require.Len(t, output.MCMSTimelockProposals, 1)
+	require.NotEmpty(t, output.Reports)
+	ops := output.MCMSTimelockProposals[0].Operations
+	require.NotEmpty(t, ops)
+	require.Len(t, ops[0].Transactions, 2)
+}

--- a/deployment/ccip/changeset/aptos/operation/regulated_token.go
+++ b/deployment/ccip/changeset/aptos/operation/regulated_token.go
@@ -1,0 +1,277 @@
+package operation
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+
+	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	"github.com/smartcontractkit/chainlink-aptos/bindings/regulated_token"
+	module_regulated_token "github.com/smartcontractkit/chainlink-aptos/bindings/regulated_token/regulated_token"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/dependency"
+)
+
+// regulated_token cannot be deployed via MCMS: MCMS dispatches calls through
+// dispatchable_fungible_asset (DFA), and regulated_token::initialize itself calls
+// dispatchable_fungible_asset::register_dispatch_functions, which Aptos rejects as
+// nested DFA dispatch (re-entrancy). Every operation in this file is therefore
+// signed directly by the deployer and confirmed on chain — they do not produce
+// MCMS transactions and must not be wrapped in an MCMS proposal.
+
+// DeployRegulatedTokenObjectOp publishes the regulated_token package to a new code object (one tx).
+var DeployRegulatedTokenObjectOp = operations.NewOperation(
+	"deploy-regulated-token-object-op",
+	Version1_0_0,
+	"Deploy regulated_token package to a new object",
+	deployRegulatedTokenObject,
+)
+
+func deployRegulatedTokenObject(
+	b operations.Bundle,
+	deps dependency.AptosDeps,
+	_ operations.EmptyInput,
+) (aptos.AccountAddress, error) {
+	_ = b
+	signer := deps.AptosChain.DeployerSigner
+	client := deps.AptosChain.Client
+	adminAddress := signer.AccountAddress()
+
+	tokenAddress, tx, _, err := regulated_token.DeployToObject(signer, client, adminAddress)
+	if err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("DeployToObject: %w", err)
+	}
+	if err := deps.AptosChain.Confirm(tx.Hash); err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("confirm DeployToObject: %w", err)
+	}
+	return tokenAddress, nil
+}
+
+// DeployRegulatedTokenMCMSRegistrarInput is input for DeployRegulatedTokenMCMSRegistrarOp.
+type DeployRegulatedTokenMCMSRegistrarInput struct {
+	TokenCodeObjectAddress aptos.AccountAddress
+	MCMSAddress            aptos.AccountAddress
+	RegistrarPreregister   bool
+}
+
+// DeployRegulatedTokenMCMSRegistrarOp attaches the MCMS registrar to the token code object (one tx).
+var DeployRegulatedTokenMCMSRegistrarOp = operations.NewOperation(
+	"deploy-regulated-token-mcms-registrar-op",
+	Version1_0_0,
+	"Deploy MCMS registrar on existing regulated token code object",
+	deployRegulatedTokenMCMSRegistrar,
+)
+
+func deployRegulatedTokenMCMSRegistrar(
+	b operations.Bundle,
+	deps dependency.AptosDeps,
+	in DeployRegulatedTokenMCMSRegistrarInput,
+) (aptos.AccountAddress, error) {
+	_ = b
+	signer := deps.AptosChain.DeployerSigner
+	client := deps.AptosChain.Client
+	adminAddress := signer.AccountAddress()
+
+	tx, _, err := regulated_token.DeployMCMSRegistrarToExistingObject(
+		signer, client, in.TokenCodeObjectAddress, adminAddress, in.MCMSAddress, in.RegistrarPreregister,
+	)
+	if err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("DeployMCMSRegistrarToExistingObject: %w", err)
+	}
+	if err := deps.AptosChain.Confirm(tx.Hash); err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("confirm DeployMCMSRegistrarToExistingObject: %w", err)
+	}
+	return in.TokenCodeObjectAddress, nil
+}
+
+// InitializeRegulatedTokenInput is input for InitializeRegulatedTokenOp.
+type InitializeRegulatedTokenInput struct {
+	TokenCodeObjectAddress aptos.AccountAddress
+	TokenParams            config.TokenParams
+}
+
+// InitializeRegulatedTokenOp runs regulated_token::initialize (one tx).
+var InitializeRegulatedTokenOp = operations.NewOperation(
+	"initialize-regulated-token-op",
+	Version1_0_0,
+	"Initialize regulated token metadata and hooks",
+	initializeRegulatedToken,
+)
+
+func initializeRegulatedToken(
+	b operations.Bundle,
+	deps dependency.AptosDeps,
+	in InitializeRegulatedTokenInput,
+) (aptos.AccountAddress, error) {
+	_ = b
+	signer := deps.AptosChain.DeployerSigner
+	client := deps.AptosChain.Client
+	opts := &bind.TransactOpts{Signer: signer}
+
+	token := regulated_token.Bind(in.TokenCodeObjectAddress, client)
+
+	var maxSupply **big.Int
+	if in.TokenParams.MaxSupply != nil {
+		p := in.TokenParams.MaxSupply
+		maxSupply = &p
+	}
+	tx, err := token.RegulatedToken().Initialize(
+		opts,
+		maxSupply,
+		in.TokenParams.Name,
+		string(in.TokenParams.Symbol),
+		in.TokenParams.Decimals,
+		in.TokenParams.Icon,
+		in.TokenParams.Project,
+	)
+	if err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("Initialize: %w", err)
+	}
+	if err := deps.AptosChain.Confirm(tx.Hash); err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("confirm Initialize: %w", err)
+	}
+	return in.TokenCodeObjectAddress, nil
+}
+
+// GrantRegulatedTokenMinterRoleInput is input for GrantRegulatedTokenMinterRoleOp.
+type GrantRegulatedTokenMinterRoleInput struct {
+	TokenCodeObjectAddress aptos.AccountAddress
+	Grantee                aptos.AccountAddress
+}
+
+// GrantRegulatedTokenMinterRoleOp grants MINTER_ROLE to one account (one tx).
+var GrantRegulatedTokenMinterRoleOp = operations.NewOperation(
+	"grant-regulated-token-minter-role-op",
+	Version1_0_0,
+	"Grant regulated token minter role",
+	grantRegulatedTokenMinterRole,
+)
+
+func grantRegulatedTokenMinterRole(
+	b operations.Bundle,
+	deps dependency.AptosDeps,
+	in GrantRegulatedTokenMinterRoleInput,
+) (aptos.AccountAddress, error) {
+	_ = b
+	signer := deps.AptosChain.DeployerSigner
+	client := deps.AptosChain.Client
+	opts := &bind.TransactOpts{Signer: signer}
+	token := regulated_token.Bind(in.TokenCodeObjectAddress, client)
+
+	tx, err := token.RegulatedToken().GrantRole(opts, module_regulated_token.MINTER_ROLE, in.Grantee)
+	if err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("GrantRole minter: %w", err)
+	}
+	if err := deps.AptosChain.Confirm(tx.Hash); err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("confirm GrantRole: %w", err)
+	}
+	return in.TokenCodeObjectAddress, nil
+}
+
+// MintRegulatedTokenInput is input for MintRegulatedTokenOp.
+type MintRegulatedTokenInput struct {
+	TokenCodeObjectAddress aptos.AccountAddress
+	To                     aptos.AccountAddress
+	Amount                 uint64
+}
+
+// MintRegulatedTokenOp mints to an address (one tx).
+var MintRegulatedTokenOp = operations.NewOperation(
+	"mint-regulated-token-op",
+	Version1_0_0,
+	"Mint regulated token to an account",
+	mintRegulatedToken,
+)
+
+func mintRegulatedToken(
+	b operations.Bundle,
+	deps dependency.AptosDeps,
+	in MintRegulatedTokenInput,
+) (aptos.AccountAddress, error) {
+	_ = b
+	signer := deps.AptosChain.DeployerSigner
+	client := deps.AptosChain.Client
+	opts := &bind.TransactOpts{Signer: signer}
+	token := regulated_token.Bind(in.TokenCodeObjectAddress, client)
+
+	tx, err := token.RegulatedToken().Mint(opts, in.To, in.Amount)
+	if err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("Mint: %w", err)
+	}
+	if err := deps.AptosChain.Confirm(tx.Hash); err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("confirm Mint: %w", err)
+	}
+	return in.TokenCodeObjectAddress, nil
+}
+
+// TransferRegulatedTokenOwnershipInput is input for TransferRegulatedTokenOwnershipOp.
+type TransferRegulatedTokenOwnershipInput struct {
+	TokenCodeObjectAddress aptos.AccountAddress
+	To                     aptos.AccountAddress
+}
+
+// TransferRegulatedTokenOwnershipOp starts ownership transfer to the given address (one tx).
+var TransferRegulatedTokenOwnershipOp = operations.NewOperation(
+	"transfer-regulated-token-ownership-op",
+	Version1_0_0,
+	"Transfer regulated token ownership to the given address",
+	transferRegulatedTokenOwnership,
+)
+
+func transferRegulatedTokenOwnership(
+	b operations.Bundle,
+	deps dependency.AptosDeps,
+	in TransferRegulatedTokenOwnershipInput,
+) (aptos.AccountAddress, error) {
+	_ = b
+	signer := deps.AptosChain.DeployerSigner
+	client := deps.AptosChain.Client
+	opts := &bind.TransactOpts{Signer: signer}
+	token := regulated_token.Bind(in.TokenCodeObjectAddress, client)
+
+	tx, err := token.RegulatedToken().TransferOwnership(opts, in.To)
+	if err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("TransferOwnership: %w", err)
+	}
+	if err := deps.AptosChain.Confirm(tx.Hash); err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("confirm TransferOwnership: %w", err)
+	}
+	return in.TokenCodeObjectAddress, nil
+}
+
+// TransferRegulatedTokenAdminInput is input for TransferRegulatedTokenAdminOp.
+type TransferRegulatedTokenAdminInput struct {
+	TokenCodeObjectAddress aptos.AccountAddress
+	NewAdmin               aptos.AccountAddress
+}
+
+// TransferRegulatedTokenAdminOp proposes admin role transfer to the given address (one tx).
+var TransferRegulatedTokenAdminOp = operations.NewOperation(
+	"transfer-regulated-token-admin-op",
+	Version1_0_0,
+	"Transfer regulated token admin role to the given address",
+	transferRegulatedTokenAdmin,
+)
+
+func transferRegulatedTokenAdmin(
+	b operations.Bundle,
+	deps dependency.AptosDeps,
+	in TransferRegulatedTokenAdminInput,
+) (aptos.AccountAddress, error) {
+	_ = b
+	signer := deps.AptosChain.DeployerSigner
+	client := deps.AptosChain.Client
+	opts := &bind.TransactOpts{Signer: signer}
+	token := regulated_token.Bind(in.TokenCodeObjectAddress, client)
+
+	tx, err := token.RegulatedToken().TransferAdmin(opts, in.NewAdmin)
+	if err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("TransferAdmin: %w", err)
+	}
+	if err := deps.AptosChain.Confirm(tx.Hash); err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("confirm TransferAdmin: %w", err)
+	}
+	return in.TokenCodeObjectAddress, nil
+}

--- a/deployment/ccip/changeset/aptos/operation/regulated_token.go
+++ b/deployment/ccip/changeset/aptos/operation/regulated_token.go
@@ -127,10 +127,10 @@ func initializeRegulatedToken(
 		in.TokenParams.Project,
 	)
 	if err != nil {
-		return aptos.AccountAddress{}, fmt.Errorf("Initialize: %w", err)
+		return aptos.AccountAddress{}, fmt.Errorf("initialize: %w", err)
 	}
 	if err := deps.AptosChain.Confirm(tx.Hash); err != nil {
-		return aptos.AccountAddress{}, fmt.Errorf("confirm Initialize: %w", err)
+		return aptos.AccountAddress{}, fmt.Errorf("confirm initialize: %w", err)
 	}
 	return in.TokenCodeObjectAddress, nil
 }
@@ -198,10 +198,10 @@ func mintRegulatedToken(
 
 	tx, err := token.RegulatedToken().Mint(opts, in.To, in.Amount)
 	if err != nil {
-		return aptos.AccountAddress{}, fmt.Errorf("Mint: %w", err)
+		return aptos.AccountAddress{}, fmt.Errorf("mint: %w", err)
 	}
 	if err := deps.AptosChain.Confirm(tx.Hash); err != nil {
-		return aptos.AccountAddress{}, fmt.Errorf("confirm Mint: %w", err)
+		return aptos.AccountAddress{}, fmt.Errorf("confirm mint: %w", err)
 	}
 	return in.TokenCodeObjectAddress, nil
 }
@@ -237,6 +237,43 @@ func transferRegulatedTokenOwnership(
 	}
 	if err := deps.AptosChain.Confirm(tx.Hash); err != nil {
 		return aptos.AccountAddress{}, fmt.Errorf("confirm TransferOwnership: %w", err)
+	}
+	return in.TokenCodeObjectAddress, nil
+}
+
+// ExecuteRegulatedTokenOwnershipTransferInput is input for ExecuteRegulatedTokenOwnershipTransferOp.
+type ExecuteRegulatedTokenOwnershipTransferInput struct {
+	TokenCodeObjectAddress aptos.AccountAddress
+	To                     aptos.AccountAddress
+}
+
+// ExecuteRegulatedTokenOwnershipTransferOp finalizes the 3-step ownable handoff by calling
+// regulated_token::execute_ownership_transfer with the original deployer (one tx). It must
+// be called after the new owner has accepted ownership.
+var ExecuteRegulatedTokenOwnershipTransferOp = operations.NewOperation(
+	"execute-regulated-token-ownership-transfer-op",
+	Version1_0_0,
+	"Execute regulated token ownership transfer (finalize 3-step handoff)",
+	executeRegulatedTokenOwnershipTransfer,
+)
+
+func executeRegulatedTokenOwnershipTransfer(
+	b operations.Bundle,
+	deps dependency.AptosDeps,
+	in ExecuteRegulatedTokenOwnershipTransferInput,
+) (aptos.AccountAddress, error) {
+	_ = b
+	signer := deps.AptosChain.DeployerSigner
+	client := deps.AptosChain.Client
+	opts := &bind.TransactOpts{Signer: signer}
+	token := regulated_token.Bind(in.TokenCodeObjectAddress, client)
+
+	tx, err := token.RegulatedToken().ExecuteOwnershipTransfer(opts, in.To)
+	if err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("execute ownership transfer: %w", err)
+	}
+	if err := deps.AptosChain.Confirm(tx.Hash); err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("confirm execute ownership transfer: %w", err)
 	}
 	return in.TokenCodeObjectAddress, nil
 }

--- a/deployment/ccip/changeset/aptos/operation/regulated_token.go
+++ b/deployment/ccip/changeset/aptos/operation/regulated_token.go
@@ -170,6 +170,41 @@ func grantRegulatedTokenMinterRole(
 	return in.TokenCodeObjectAddress, nil
 }
 
+// RevokeRegulatedTokenMinterRoleInput is input for RevokeRegulatedTokenMinterRoleOp.
+type RevokeRegulatedTokenMinterRoleInput struct {
+	TokenCodeObjectAddress aptos.AccountAddress
+	Account                aptos.AccountAddress
+}
+
+// RevokeRegulatedTokenMinterRoleOp revokes MINTER_ROLE from one account (one tx).
+var RevokeRegulatedTokenMinterRoleOp = operations.NewOperation(
+	"revoke-regulated-token-minter-role-op",
+	Version1_0_0,
+	"Revoke regulated token minter role from an account",
+	revokeRegulatedTokenMinterRole,
+)
+
+func revokeRegulatedTokenMinterRole(
+	b operations.Bundle,
+	deps dependency.AptosDeps,
+	in RevokeRegulatedTokenMinterRoleInput,
+) (aptos.AccountAddress, error) {
+	_ = b
+	signer := deps.AptosChain.DeployerSigner
+	client := deps.AptosChain.Client
+	opts := &bind.TransactOpts{Signer: signer}
+	token := regulated_token.Bind(in.TokenCodeObjectAddress, client)
+
+	tx, err := token.RegulatedToken().RevokeRole(opts, module_regulated_token.MINTER_ROLE, in.Account)
+	if err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("revoke role minter: %w", err)
+	}
+	if err := deps.AptosChain.Confirm(tx.Hash); err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("confirm revoke role: %w", err)
+	}
+	return in.TokenCodeObjectAddress, nil
+}
+
 // MintRegulatedTokenInput is input for MintRegulatedTokenOp.
 type MintRegulatedTokenInput struct {
 	TokenCodeObjectAddress aptos.AccountAddress

--- a/deployment/ccip/changeset/aptos/operation/token.go
+++ b/deployment/ccip/changeset/aptos/operation/token.go
@@ -22,6 +22,13 @@ import (
 const managedTokenStateSeed = "managed_token::managed_token::token_state"
 
 var TokenOperations = []*operations.Operation[any, any, any]{
+	DeployRegulatedTokenObjectOp.AsUntypedRelaxed(),
+	DeployRegulatedTokenMCMSRegistrarOp.AsUntypedRelaxed(),
+	InitializeRegulatedTokenOp.AsUntypedRelaxed(),
+	GrantRegulatedTokenMinterRoleOp.AsUntypedRelaxed(),
+	MintRegulatedTokenOp.AsUntypedRelaxed(),
+	TransferRegulatedTokenOwnershipOp.AsUntypedRelaxed(),
+	TransferRegulatedTokenAdminOp.AsUntypedRelaxed(),
 	DeployTokenMCMSRegistrarOp.AsUntypedRelaxed(),
 	InitializeTokenOp.AsUntypedRelaxed(),
 	MintTokensOp.AsUntypedRelaxed(),

--- a/deployment/ccip/changeset/aptos/operation/token.go
+++ b/deployment/ccip/changeset/aptos/operation/token.go
@@ -21,15 +21,8 @@ import (
 
 const managedTokenStateSeed = "managed_token::managed_token::token_state"
 
+// TokenOperations contains the token operations whose output is consumed by MCMS proposals.
 var TokenOperations = []*operations.Operation[any, any, any]{
-	DeployRegulatedTokenObjectOp.AsUntypedRelaxed(),
-	DeployRegulatedTokenMCMSRegistrarOp.AsUntypedRelaxed(),
-	InitializeRegulatedTokenOp.AsUntypedRelaxed(),
-	GrantRegulatedTokenMinterRoleOp.AsUntypedRelaxed(),
-	MintRegulatedTokenOp.AsUntypedRelaxed(),
-	TransferRegulatedTokenOwnershipOp.AsUntypedRelaxed(),
-	ExecuteRegulatedTokenOwnershipTransferOp.AsUntypedRelaxed(),
-	TransferRegulatedTokenAdminOp.AsUntypedRelaxed(),
 	DeployTokenMCMSRegistrarOp.AsUntypedRelaxed(),
 	InitializeTokenOp.AsUntypedRelaxed(),
 	MintTokensOp.AsUntypedRelaxed(),

--- a/deployment/ccip/changeset/aptos/operation/token.go
+++ b/deployment/ccip/changeset/aptos/operation/token.go
@@ -28,6 +28,7 @@ var TokenOperations = []*operations.Operation[any, any, any]{
 	GrantRegulatedTokenMinterRoleOp.AsUntypedRelaxed(),
 	MintRegulatedTokenOp.AsUntypedRelaxed(),
 	TransferRegulatedTokenOwnershipOp.AsUntypedRelaxed(),
+	ExecuteRegulatedTokenOwnershipTransferOp.AsUntypedRelaxed(),
 	TransferRegulatedTokenAdminOp.AsUntypedRelaxed(),
 	DeployTokenMCMSRegistrarOp.AsUntypedRelaxed(),
 	InitializeTokenOp.AsUntypedRelaxed(),

--- a/deployment/ccip/changeset/aptos/sequence/deploy_regulated_token.go
+++ b/deployment/ccip/changeset/aptos/sequence/deploy_regulated_token.go
@@ -1,0 +1,152 @@
+package sequence
+
+import (
+	"fmt"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+
+	mcmsbind "github.com/smartcontractkit/chainlink-aptos/bindings/mcms"
+	"github.com/smartcontractkit/chainlink-aptos/bindings/regulated_token"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/dependency"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/operation"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
+)
+
+// DeployRegulatedTokenSeqInput is input for DeployRegulatedTokenSequence.
+type DeployRegulatedTokenSeqInput struct {
+	MCMSAddress          aptos.AccountAddress
+	TokenParams          config.TokenParams
+	TokenMint            *config.TokenMint
+	RegistrarPreregister bool
+}
+
+// DeployRegulatedTokenSeqOutput contains token addresses and MCMS batch operations
+// (accept_ownership + accept_admin) to be wrapped in a timelock proposal.
+type DeployRegulatedTokenSeqOutput struct {
+	TokenCodeObjectAddress aptos.AccountAddress
+	TokenMetadataAddress   aptos.AccountAddress
+	MCMSOperations         []mcmstypes.BatchOperation
+}
+
+var DeployRegulatedTokenSequence = operations.NewSequence(
+	"deploy-regulated-token-aptos-sequence",
+	operation.Version1_0_0,
+	"Deploy regulated token directly (regulated_token cannot be deployed via MCMS due to DFA re-entrancy) then build MCMS accept_ownership + accept_admin batch",
+	deployRegulatedTokenSequence,
+)
+
+func deployRegulatedTokenSequence(
+	b operations.Bundle,
+	deps dependency.AptosDeps,
+	in DeployRegulatedTokenSeqInput,
+) (DeployRegulatedTokenSeqOutput, error) {
+	objReport, err := operations.ExecuteOperation(b, operation.DeployRegulatedTokenObjectOp, deps, operations.EmptyInput{})
+	if err != nil {
+		return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("DeployRegulatedTokenObjectOp: %w", err)
+	}
+	codeObj := objReport.Output
+
+	_, err = operations.ExecuteOperation(b, operation.DeployRegulatedTokenMCMSRegistrarOp, deps, operation.DeployRegulatedTokenMCMSRegistrarInput{
+		TokenCodeObjectAddress: codeObj,
+		MCMSAddress:            in.MCMSAddress,
+		RegistrarPreregister:   in.RegistrarPreregister,
+	})
+	if err != nil {
+		return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("DeployRegulatedTokenMCMSRegistrarOp: %w", err)
+	}
+
+	_, err = operations.ExecuteOperation(b, operation.InitializeRegulatedTokenOp, deps, operation.InitializeRegulatedTokenInput{
+		TokenCodeObjectAddress: codeObj,
+		TokenParams:            in.TokenParams,
+	})
+	if err != nil {
+		return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("InitializeRegulatedTokenOp: %w", err)
+	}
+
+	if in.TokenMint != nil {
+		grantee := deps.AptosChain.DeployerSigner.AccountAddress()
+		_, err = operations.ExecuteOperation(b, operation.GrantRegulatedTokenMinterRoleOp, deps, operation.GrantRegulatedTokenMinterRoleInput{
+			TokenCodeObjectAddress: codeObj,
+			Grantee:                grantee,
+		})
+		if err != nil {
+			return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("GrantRegulatedTokenMinterRoleOp: %w", err)
+		}
+		_, err = operations.ExecuteOperation(b, operation.MintRegulatedTokenOp, deps, operation.MintRegulatedTokenInput{
+			TokenCodeObjectAddress: codeObj,
+			To:                     in.TokenMint.To,
+			Amount:                 in.TokenMint.Amount,
+		})
+		if err != nil {
+			return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("MintRegulatedTokenOp: %w", err)
+		}
+	}
+
+	mcmsContract := mcmsbind.Bind(in.MCMSAddress, deps.AptosChain.Client)
+	tokenOwnerAddress, err := mcmsContract.MCMSRegistry().GetPreexistingCodeObjectOwnerAddress(nil, codeObj)
+	if err != nil {
+		return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("GetPreexistingCodeObjectOwnerAddress: %w", err)
+	}
+	_, err = operations.ExecuteOperation(b, operation.TransferRegulatedTokenOwnershipOp, deps, operation.TransferRegulatedTokenOwnershipInput{
+		TokenCodeObjectAddress: codeObj,
+		To:                     tokenOwnerAddress,
+	})
+	if err != nil {
+		return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("TransferRegulatedTokenOwnershipOp: %w", err)
+	}
+
+	_, err = operations.ExecuteOperation(b, operation.TransferRegulatedTokenAdminOp, deps, operation.TransferRegulatedTokenAdminInput{
+		TokenCodeObjectAddress: codeObj,
+		NewAdmin:               tokenOwnerAddress,
+	})
+	if err != nil {
+		return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("TransferRegulatedTokenAdminOp: %w", err)
+	}
+
+	token := regulated_token.Bind(codeObj, deps.AptosChain.Client)
+	tokenMetadata, err := token.RegulatedToken().TokenMetadata(nil)
+	if err != nil {
+		return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("TokenMetadata: %w", err)
+	}
+
+	acceptOwnershipReport, err := operations.ExecuteOperation(
+		b,
+		operation.AcceptTokenOwnershipOp,
+		deps,
+		operation.AcceptTokenOwnershipInput{
+			TokenCodeObjectAddress: codeObj,
+			TokenType:              shared.AptosRegulatedTokenType,
+		},
+	)
+	if err != nil {
+		return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("AcceptTokenOwnershipOp: %w", err)
+	}
+
+	acceptAdminReport, err := operations.ExecuteOperation(
+		b,
+		operation.AcceptTokenAdminOp,
+		deps,
+		operation.AcceptTokenAdminInput{
+			TokenCodeObjectAddress: codeObj,
+		},
+	)
+	if err != nil {
+		return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("AcceptTokenAdminOp: %w", err)
+	}
+
+	mcmsOperations := []mcmstypes.BatchOperation{
+		{
+			ChainSelector: mcmstypes.ChainSelector(deps.AptosChain.Selector),
+			Transactions:  []mcmstypes.Transaction{acceptOwnershipReport.Output, acceptAdminReport.Output},
+		},
+	}
+
+	return DeployRegulatedTokenSeqOutput{
+		TokenCodeObjectAddress: codeObj,
+		TokenMetadataAddress:   tokenMetadata,
+		MCMSOperations:         mcmsOperations,
+	}, nil
+}

--- a/deployment/ccip/changeset/aptos/sequence/regulated_token.go
+++ b/deployment/ccip/changeset/aptos/sequence/regulated_token.go
@@ -1,6 +1,7 @@
 package sequence
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/aptos-labs/aptos-go-sdk"
@@ -149,4 +150,105 @@ func deployRegulatedTokenSequence(
 		TokenMetadataAddress:   tokenMetadata,
 		MCMSOperations:         mcmsOperations,
 	}, nil
+}
+
+// FinalizeRegulatedTokenOwnershipSequence runs regulated_token::execute_ownership_transfer
+// (EOA) to finalize the 3-step ownable handoff after MCMS has accepted ownership. The full
+// validation (transfer is to MCMS, accepted, deployer is current owner) lives in
+// VerifyFinalizeRegulatedTokenOwnership and must be invoked by the calling changeset's
+// VerifyPreconditions;
+var FinalizeRegulatedTokenOwnershipSequence = operations.NewSequence(
+	"finalize-regulated-token-ownership-sequence",
+	operation.Version1_0_0,
+	"Run regulated_token::execute_ownership_transfer (EOA) when a pending transfer exists",
+	finalizeRegulatedTokenOwnershipSequence,
+)
+
+func finalizeRegulatedTokenOwnershipSequence(
+	b operations.Bundle,
+	deps dependency.AptosDeps,
+	tokenCodeObjectAddress aptos.AccountAddress,
+) (aptos.AccountAddress, error) {
+	token := regulated_token.Bind(tokenCodeObjectAddress, deps.AptosChain.Client)
+	hasPending, err := token.RegulatedToken().HasPendingTransfer(nil)
+	if err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("query has_pending_transfer: %w", err)
+	}
+	if !hasPending {
+		return aptos.AccountAddress{}, nil
+	}
+	pendingTo, err := token.RegulatedToken().PendingTransferTo(nil)
+	if err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("query pending_transfer_to: %w", err)
+	}
+	if pendingTo == nil {
+		return aptos.AccountAddress{}, errors.New("pending_transfer_to is empty despite has_pending_transfer=true")
+	}
+	_, err = operations.ExecuteOperation(
+		b,
+		operation.ExecuteRegulatedTokenOwnershipTransferOp,
+		deps,
+		operation.ExecuteRegulatedTokenOwnershipTransferInput{
+			TokenCodeObjectAddress: tokenCodeObjectAddress,
+			To:                     *pendingTo,
+		},
+	)
+	if err != nil {
+		return aptos.AccountAddress{}, fmt.Errorf("ExecuteRegulatedTokenOwnershipTransferOp: %w", err)
+	}
+	return *pendingTo, nil
+}
+
+// VerifyFinalizeRegulatedTokenOwnership validates that the regulated token is in a state where
+// the deployer EOA can run execute_ownership_transfer to finalize the 3-step handoff to MCMS.
+func VerifyFinalizeRegulatedTokenOwnership(
+	deps dependency.AptosDeps,
+	tokenCodeObjectAddress aptos.AccountAddress,
+	mcmsAddress aptos.AccountAddress,
+) error {
+	token := regulated_token.Bind(tokenCodeObjectAddress, deps.AptosChain.Client)
+
+	hasPending, err := token.RegulatedToken().HasPendingTransfer(nil)
+	if err != nil {
+		return fmt.Errorf("query has_pending_transfer: %w", err)
+	}
+	if !hasPending {
+		return nil
+	}
+
+	mcmsContract := mcmsbind.Bind(mcmsAddress, deps.AptosChain.Client)
+	expectedOwner, err := mcmsContract.MCMSRegistry().GetPreexistingCodeObjectOwnerAddress(nil, tokenCodeObjectAddress)
+	if err != nil {
+		return fmt.Errorf("get mcms preexisting code object owner: %w", err)
+	}
+
+	pendingTo, err := token.RegulatedToken().PendingTransferTo(nil)
+	if err != nil {
+		return fmt.Errorf("query pending_transfer_to: %w", err)
+	}
+	if pendingTo == nil {
+		return errors.New("pending_transfer_to is empty despite has_pending_transfer=true")
+	}
+	if *pendingTo != expectedOwner {
+		return fmt.Errorf("pending_transfer_to %s does not match MCMS registry owner %s", pendingTo.StringLong(), expectedOwner.StringLong())
+	}
+
+	accepted, err := token.RegulatedToken().PendingTransferAccepted(nil)
+	if err != nil {
+		return fmt.Errorf("query pending_transfer_accepted: %w", err)
+	}
+	if accepted == nil || !*accepted {
+		return errors.New("pending transfer has not been accepted by MCMS")
+	}
+
+	currentOwner, err := token.RegulatedToken().Owner(nil)
+	if err != nil {
+		return fmt.Errorf("query owner: %w", err)
+	}
+	deployerAddress := deps.AptosChain.DeployerSigner.AccountAddress()
+	if currentOwner != deployerAddress {
+		return fmt.Errorf("current owner %s is not the deployer EOA %s; only the original owner can execute the ownership transfer", currentOwner.StringLong(), deployerAddress.StringLong())
+	}
+
+	return nil
 }

--- a/deployment/ccip/changeset/aptos/sequence/regulated_token.go
+++ b/deployment/ccip/changeset/aptos/sequence/regulated_token.go
@@ -252,6 +252,19 @@ func VerifyFinalizeRegulatedTokenOwnership(
 		return errors.New("pending transfer has not been accepted by MCMS")
 	}
 
+	// The DeployRegulatedToken changeset emits accept_ownership and accept_admin in the same
+	// MCMS proposal, so once ownership is accepted we expect admin to be MCMS as well. The
+	// regulated pool deployment later emits an MCMS GrantRole for BRIDGE_MINTER_OR_BURNER_ROLE
+	// that requires MCMS to be admin at execution time; finalizing ownership here without that
+	// would produce a pool proposal that fails at execution.
+	currentAdmin, err := token.RegulatedToken().Admin(nil)
+	if err != nil {
+		return fmt.Errorf("query admin: %w", err)
+	}
+	if currentAdmin != expectedOwner {
+		return fmt.Errorf("admin %s has not been transferred to MCMS registry owner %s; accept_admin from the deploy proposal must execute before finalizing ownership", currentAdmin.StringLong(), expectedOwner.StringLong())
+	}
+
 	currentOwner, err := token.RegulatedToken().Owner(nil)
 	if err != nil {
 		return fmt.Errorf("query owner: %w", err)

--- a/deployment/ccip/changeset/aptos/sequence/regulated_token.go
+++ b/deployment/ccip/changeset/aptos/sequence/regulated_token.go
@@ -67,11 +67,12 @@ func deployRegulatedTokenSequence(
 		return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("InitializeRegulatedTokenOp: %w", err)
 	}
 
+	// To be used for tests, staging and testnet
 	if in.TokenMint != nil {
-		grantee := deps.AptosChain.DeployerSigner.AccountAddress()
+		deployerAddress := deps.AptosChain.DeployerSigner.AccountAddress()
 		_, err = operations.ExecuteOperation(b, operation.GrantRegulatedTokenMinterRoleOp, deps, operation.GrantRegulatedTokenMinterRoleInput{
 			TokenCodeObjectAddress: codeObj,
-			Grantee:                grantee,
+			Grantee:                deployerAddress,
 		})
 		if err != nil {
 			return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("GrantRegulatedTokenMinterRoleOp: %w", err)
@@ -83,6 +84,16 @@ func deployRegulatedTokenSequence(
 		})
 		if err != nil {
 			return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("MintRegulatedTokenOp: %w", err)
+		}
+		// Revoke the deployer's MINTER_ROLE so it doesn't retain mint authority once admin
+		// is handed over to MCMS. Must happen while the deployer is still admin (i.e., before
+		// MCMS executes accept_admin from the proposal generated below).
+		_, err = operations.ExecuteOperation(b, operation.RevokeRegulatedTokenMinterRoleOp, deps, operation.RevokeRegulatedTokenMinterRoleInput{
+			TokenCodeObjectAddress: codeObj,
+			Account:                deployerAddress,
+		})
+		if err != nil {
+			return DeployRegulatedTokenSeqOutput{}, fmt.Errorf("RevokeRegulatedTokenMinterRoleOp: %w", err)
 		}
 	}
 

--- a/deployment/ccip/changeset/testhelpers/test_helpers_aptos.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers_aptos.go
@@ -32,7 +32,6 @@ import (
 	"github.com/smartcontractkit/chainlink-aptos/bindings/helpers"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/mcms"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/regulated_token"
-	module_regulated_token "github.com/smartcontractkit/chainlink-aptos/bindings/regulated_token/regulated_token"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/test_token/bnm_registrar"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/test_token/lnr_registrar"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/test_token/test_token"
@@ -393,8 +392,6 @@ func DeployRegulatedTransferableTokenAptos(
 	signer := e.BlockChains.AptosChains()[aptosChainSel].DeployerSigner
 	client := e.BlockChains.AptosChains()[aptosChainSel].Client
 	opts := &aptosBind.TransactOpts{Signer: signer}
-	aptosAddresses, err := e.ExistingAddresses.AddressesForChain(aptosChainSel)
-	require.NoError(t, err)
 	// helper function to wait for a transaction to be mined
 	assertTxSuccess := func(err error, tx *api.PendingTransaction, msg string, args ...any) {
 		require.NoError(t, err)
@@ -402,6 +399,30 @@ func DeployRegulatedTransferableTokenAptos(
 		require.NoError(t, err)
 		require.True(t, data.Success, "%s: %s", fmt.Sprintf(msg, args...), data.VmStatus)
 	}
+
+	// Deploy + initialize regulated token, transfer ownership/admin to mcms via the changeset.
+	const tokenSymbol shared.TokenSymbol = "TKN"
+	e, err = commoncs.Apply(t, e,
+		commoncs.Configure(aptoscs.DeployRegulatedToken{},
+			config.DeployRegulatedTokenConfig{
+				ChainSelector: aptosChainSel,
+				TokenParams: config.TokenParams{
+					Name:     tokenName,
+					Symbol:   tokenSymbol,
+					Decimals: 8,
+				},
+				TokenMint: mintAmount,
+				MCMSConfig: &proposalutils.TimelockConfig{
+					MinDelay: time.Second,
+				},
+			},
+		),
+	)
+	require.NoError(t, err)
+
+	// Lookup deployed addresses (saved by the changeset).
+	aptosAddresses, err := e.ExistingAddresses.AddressesForChain(aptosChainSel)
+	require.NoError(t, err)
 	mcmsAddress := aptosstate.FindAptosAddress(
 		cldf.TypeAndVersion{
 			Type:    shared.AptosMCMSType,
@@ -410,84 +431,33 @@ func DeployRegulatedTransferableTokenAptos(
 		aptosAddresses,
 	)
 	require.NotEqualf(t, aptos.AccountAddress{}, mcmsAddress, "Aptos mcms address not found")
+	tokenAddress := aptosstate.FindAptosAddress(
+		cldf.TypeAndVersion{
+			Type:    shared.AptosRegulatedTokenType,
+			Version: deployment.Version1_6_0,
+			Labels:  cldf.NewLabelSet(string(tokenSymbol)),
+		},
+		aptosAddresses,
+	)
+	require.NotEqualf(t, aptos.AccountAddress{}, tokenAddress, "regulated token code object address not found")
+	tokenMetadata := aptosstate.FindAptosAddress(
+		cldf.TypeAndVersion{
+			Type:    cldf.ContractType(tokenSymbol),
+			Version: deployment.Version1_6_0,
+		},
+		aptosAddresses,
+	)
+	require.NotEqualf(t, aptos.AccountAddress{}, tokenMetadata, "regulated token metadata address not found")
 
-	// Deploy the token and token registrar, setting the deployer as the administrator
-	adminAddress := signer.AccountAddress()
-	tokenAddress, tx, token, err := regulated_token.DeployToObject(signer, client, adminAddress)
-	assertTxSuccess(err, tx, "failed to deploy regulated token")
-	tx, _, err = regulated_token.DeployMCMSRegistrarToExistingObject(signer, client, tokenAddress, adminAddress, mcmsAddress, true)
-	assertTxSuccess(err, tx, "failed to deploy regulated token MCMS registrar")
-
-	// Initialize the token
-	tx, err = token.RegulatedToken().Initialize(opts, nil, tokenName, "TKN", 8, "", "")
-	assertTxSuccess(err, tx, "failed to initialize regulated token")
-
-	// If requested, set the deployer as an allowed minter and mint the requested tokens
-	if mintAmount != nil {
-		lggr.Infof("Minting %v tokens to %v...", mintAmount.Amount, mintAmount.To)
-		tx, err = token.RegulatedToken().GrantRole(opts, module_regulated_token.MINTER_ROLE, adminAddress)
-		assertTxSuccess(err, tx, "failed to grant mint role to deployer")
-		tx, err = token.RegulatedToken().Mint(opts, mintAmount.To, mintAmount.Amount)
-		assertTxSuccess(err, tx, "failed to mint %d token to %s", mintAmount.Amount, mintAmount.To)
-	}
-
-	// Save token addresses in address book
-	tokenMetadata, err := token.RegulatedToken().TokenMetadata(nil)
-	require.NoError(t, err)
-	typeAndVersion := cldf.NewTypeAndVersion(shared.AptosRegulatedTokenType, deployment.Version1_6_0)
-	typeAndVersion.AddLabel("TKN")
-	err = e.ExistingAddresses.Save(aptosChainSel, tokenAddress.StringLong(), typeAndVersion)
-	require.NoError(t, err)
-	typeAndVersion = cldf.NewTypeAndVersion("TKN", deployment.Version1_6_0)
-	err = e.ExistingAddresses.Save(aptosChainSel, tokenMetadata.StringLong(), typeAndVersion)
-	require.NoError(t, err)
-
-	// Transfer token ownership to mcms
+	// Finalize the 3-step ownable handoff: original deployer must call execute_ownership_transfer
+	// after MCMS has accepted ownership. Not part of the changeset because it requires the
+	// original deployer signer.
 	mcmsContract := mcms.Bind(mcmsAddress, client)
 	tokenOwnerAddress, err := mcmsContract.MCMSRegistry().GetPreexistingCodeObjectOwnerAddress(nil, tokenAddress)
 	require.NoError(t, err)
-	tx, err = token.RegulatedToken().TransferOwnership(opts, tokenOwnerAddress)
-	assertTxSuccess(err, tx, "failed to propose ownership transfer to mcms %v", tokenOwnerAddress)
-	_, err = commoncs.Apply(t, e,
-		commoncs.Configure(aptoscs.AcceptTokenOwnership{},
-			config.AcceptTokenOwnershipInput{
-				ChainSelector: aptosChainSel,
-				Accepts: []config.TokenAcceptInput{
-					{
-						TokenCodeObjectAddress: tokenAddress,
-						TokenType:              shared.AptosRegulatedTokenType,
-					},
-				},
-				MCMSConfig: &proposalutils.TimelockConfig{
-					MinDelay: time.Second,
-				},
-			},
-		),
-	)
-	require.NoError(t, err)
-	tx, err = token.RegulatedToken().ExecuteOwnershipTransfer(opts, tokenOwnerAddress)
+	token := regulated_token.Bind(tokenAddress, client)
+	tx, err := token.RegulatedToken().ExecuteOwnershipTransfer(opts, tokenOwnerAddress)
 	assertTxSuccess(err, tx, "failed to execute ownership transfer to mcms %v", tokenOwnerAddress)
-
-	// Transfer admin role to mcms
-	tx, err = token.RegulatedToken().TransferAdmin(opts, tokenOwnerAddress)
-	assertTxSuccess(err, tx, "failed to propose admin transfer to mcms %v", tokenOwnerAddress)
-	_, err = commoncs.Apply(t, e,
-		commoncs.Configure(aptoscs.AcceptTokenAdmin{},
-			config.AcceptTokenAdminInput{
-				ChainSelector: aptosChainSel,
-				Accepts: []config.TokenAcceptInput{
-					{
-						TokenCodeObjectAddress: tokenAddress,
-						TokenType:              shared.AptosRegulatedTokenType,
-					},
-				},
-				MCMSConfig: &proposalutils.TimelockConfig{
-					MinDelay: time.Second,
-				},
-			},
-		),
-	)
-	require.NoError(t, err)
 
 	// Deploy lane
 	e, err = commoncs.Apply(t, e,
@@ -522,32 +492,24 @@ func DeployRegulatedTransferableTokenAptos(
 	)
 	require.NoError(t, err)
 
+	lggr.Debugf("Deployed Regulated Token on Aptos: %v", tokenMetadata.StringLong())
 	aptosAddresses, err = e.ExistingAddresses.AddressesForChain(aptosChainSel)
 	require.NoError(t, err)
-	tokenMetadataAddress := aptosstate.FindAptosAddress(
-		cldf.TypeAndVersion{
-			Type:    "TKN", // Regulated Token symbol
-			Version: deployment.Version1_6_0,
-			Labels:  nil,
-		},
-		aptosAddresses,
-	)
-	lggr.Debugf("Deployed Regulated Token on Aptos: %v", tokenMetadataAddress.StringLong())
 	tokenPoolAddress := aptosstate.FindAptosAddress(
 		cldf.TypeAndVersion{
 			Type:    shared.AptosRegulatedTokenPoolType,
 			Version: deployment.Version1_6_0,
-			Labels:  cldf.NewLabelSet(tokenMetadataAddress.StringLong()),
+			Labels:  cldf.NewLabelSet(tokenMetadata.StringLong()),
 		},
 		aptosAddresses,
 	)
 	aptosTokenPool := regulated_token_pool.Bind(tokenPoolAddress, e.BlockChains.AptosChains()[aptosChainSel].Client)
-	lggr.Debugf("Deployed Regulated Token Pool for %v to %v", tokenMetadataAddress.StringLong(), tokenPoolAddress.StringLong())
-	err = setTokenPoolCounterPart(e.BlockChains.EVMChains()[evmChainSel], evmPool, evmDeployerKey, aptosChainSel, tokenMetadataAddress[:], tokenPoolAddress[:])
+	lggr.Debugf("Deployed Regulated Token Pool for %v to %v", tokenMetadata.StringLong(), tokenPoolAddress.StringLong())
+	err = setTokenPoolCounterPart(e.BlockChains.EVMChains()[evmChainSel], evmPool, evmDeployerKey, aptosChainSel, tokenMetadata[:], tokenPoolAddress[:])
 	require.NoError(t, err)
 	err = grantMintBurnPermissions(lggr, e.BlockChains.EVMChains()[evmChainSel], evmToken, evmDeployerKey, evmPool.Address())
 	require.NoError(t, err)
-	return evmToken, evmPool, tokenMetadataAddress, aptosTokenPool, nil
+	return evmToken, evmPool, tokenMetadata, aptosTokenPool, nil
 }
 
 // DeployAptosCCIPReceiver deploys the ccip_dummy_receiver package to all Aptos chains, saving the resulting address in the address book for future use

--- a/deployment/ccip/changeset/testhelpers/test_helpers_aptos.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers_aptos.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/aptos-labs/aptos-go-sdk"
-	"github.com/aptos-labs/aptos-go-sdk/api"
 	"github.com/aptos-labs/aptos-go-sdk/bcs"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	chainsel "github.com/smartcontractkit/chain-selectors"
@@ -31,7 +30,6 @@ import (
 	"github.com/smartcontractkit/chainlink-aptos/bindings/ccip_token_pools/token_pool"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/helpers"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/mcms"
-	"github.com/smartcontractkit/chainlink-aptos/bindings/regulated_token"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/test_token/bnm_registrar"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/test_token/lnr_registrar"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/test_token/test_token"
@@ -353,10 +351,10 @@ func DeployTransferableTokenAptos(
 	return evmToken, evmPool, tokenMetadataAddress, aptosTokenPool, nil
 }
 
-// DeployRegulatedTransferableTokenAptos deploys two tokens onto the EVM and Aptos chain and sets up a lane between them
-// For Aptos, the regulated_token will be used along with the regulated_token_pool token pool.
-// Since the regulated_token must be initialized from an EOA, not mcms, it will be deployed from the deployer account
-// and then transferred over to mcms
+// DeployRegulatedTransferableTokenAptos deploys two tokens onto the EVM and Aptos chain and sets up a lane between them.
+// For Aptos, the regulated_token is deployed via the DeployRegulatedToken changeset (regulated_token
+// cannot be deployed via MCMS due to DFA re-entrancy). The AddTokenPool changeset then finalizes
+// the 3-step ownership handoff (execute_ownership_transfer) and deploys the regulated_token_pool.
 func DeployRegulatedTransferableTokenAptos(
 	t *testing.T,
 	lggr logger.Logger,
@@ -388,18 +386,6 @@ func DeployRegulatedTransferableTokenAptos(
 	err = attachTokenToTheRegistry(e.BlockChains.EVMChains()[evmChainSel], state.MustGetEVMChainState(evmChainSel), evmDeployerKey, evmToken.Address(), evmPool.Address())
 	require.NoError(t, err)
 
-	// Regulated token must be initialized via EOA, not mcms
-	signer := e.BlockChains.AptosChains()[aptosChainSel].DeployerSigner
-	client := e.BlockChains.AptosChains()[aptosChainSel].Client
-	opts := &aptosBind.TransactOpts{Signer: signer}
-	// helper function to wait for a transaction to be mined
-	assertTxSuccess := func(err error, tx *api.PendingTransaction, msg string, args ...any) {
-		require.NoError(t, err)
-		data, err := client.WaitForTransaction(tx.Hash)
-		require.NoError(t, err)
-		require.True(t, data.Success, "%s: %s", fmt.Sprintf(msg, args...), data.VmStatus)
-	}
-
 	// Deploy + initialize regulated token, transfer ownership/admin to mcms via the changeset.
 	const tokenSymbol shared.TokenSymbol = "TKN"
 	e, err = commoncs.Apply(t, e,
@@ -423,14 +409,6 @@ func DeployRegulatedTransferableTokenAptos(
 	// Lookup deployed addresses (saved by the changeset).
 	aptosAddresses, err := e.ExistingAddresses.AddressesForChain(aptosChainSel)
 	require.NoError(t, err)
-	mcmsAddress := aptosstate.FindAptosAddress(
-		cldf.TypeAndVersion{
-			Type:    shared.AptosMCMSType,
-			Version: deployment.Version1_6_0,
-		},
-		aptosAddresses,
-	)
-	require.NotEqualf(t, aptos.AccountAddress{}, mcmsAddress, "Aptos mcms address not found")
 	tokenAddress := aptosstate.FindAptosAddress(
 		cldf.TypeAndVersion{
 			Type:    shared.AptosRegulatedTokenType,
@@ -449,17 +427,7 @@ func DeployRegulatedTransferableTokenAptos(
 	)
 	require.NotEqualf(t, aptos.AccountAddress{}, tokenMetadata, "regulated token metadata address not found")
 
-	// Finalize the 3-step ownable handoff: original deployer must call execute_ownership_transfer
-	// after MCMS has accepted ownership. Not part of the changeset because it requires the
-	// original deployer signer.
-	mcmsContract := mcms.Bind(mcmsAddress, client)
-	tokenOwnerAddress, err := mcmsContract.MCMSRegistry().GetPreexistingCodeObjectOwnerAddress(nil, tokenAddress)
-	require.NoError(t, err)
-	token := regulated_token.Bind(tokenAddress, client)
-	tx, err := token.RegulatedToken().ExecuteOwnershipTransfer(opts, tokenOwnerAddress)
-	assertTxSuccess(err, tx, "failed to execute ownership transfer to mcms %v", tokenOwnerAddress)
-
-	// Deploy lane
+	// Deploy lane (also finalizes the 3-step ownership handoff via FinalizeRegulatedTokenOwnershipSequence).
 	e, err = commoncs.Apply(t, e,
 		commoncs.Configure(aptoscs.AddTokenPool{},
 			config.AddTokenPoolConfig{


### PR DESCRIPTION
## Summary
Implements support for Aptos Regulated Token deployment. This token cannot be deployed via MCMS, so the flow will require 2 changesets. 
- 1: Deploy > transfers ownership > sets admin > generate accept ownership proposal
after accept proposal is executed the regular add_token_pool changeset can be run to
- 2: Finalize ownership transfer > deploy pool

## Testing
- The test helper now uses changeset, so `Test_CCIP_RegulatedTokenTransfer_EVM2Aptos` on `integration-tests/smoke/ccip/ccip_aptos_regulated_token_transfer_test.go` is testing the whole flow