### PR TITLE
fix(ci): cre workflow example cron

### DIFF
--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -179,19 +179,19 @@ jobs:
           total_seconds=$(echo "$minutes * 60 + $seconds" | bc)
           echo "execution_time=$total_seconds" >> "${GITHUB_OUTPUT}"
 
-      - name: Deploy v2 Cron workflow (Go)
+      - name: Deploy Cron workflow (Go)
         shell: bash
         working-directory: core/scripts/cre/environment
         run: |
-          go run . env workflow deploy --compile --workflow-file-path ./examples/workflows/v2/cron/main.go --name cronv2workflow
+          go run . env workflow deploy --compile --workflow-file-path ./examples/workflows/cron/main.go --name cronworkflow
 
-      - name: Delete v2 Cron workflow (Go)
+      - name: Delete Cron workflow (Go)
         shell: bash
         working-directory: core/scripts/cre/environment
         run: |
-          go run . env workflow delete --name cronv2workflow
+          go run . env workflow delete --name cronworkflow
 
-      - name: Deploy v2 Cron workflow (TypeScript)
+      - name: Deploy Cron workflow (TypeScript)
         shell: bash
         working-directory: core/scripts/cre/environment
         run: |


### PR DESCRIPTION
ce66ee61298c05d017311b704ec367f73683934a changed the path for the cron workflow, and now this workflow is failing. 

Example: https://github.com/smartcontractkit/chainlink/actions/runs/25880460612/job/76058892047?pr=22475

```
⚙️ Compiling workflow from ./examples/workflows/v2/cron/main.go
Error: ❌ failed to compile workflow: ❌ failed to compile workflow: failed to compile go workflow: failed to run go mod tidy: : chdir examples/workflows/v2/cron: no such file or directory
Usage:
  local_cre env workflow deploy [flags]

Flags:
      --capabilities-registry-address string   Capabilities registry address for vault config update (if not provided, address from the state file will be used)
  -x, --compile                                Compiles the workflow before deploying it
  -c, --config-file-path string                Path to the workflow config file
  -p, --container-name-pattern string          Pattern to match Docker containers workkflow DON containers (e.g. 'workflow-node') (default "workflow-node")
  -t, --container-target-dir string            Path to the target directory in the Docker container (default "/home/chainlink/workflows")
  -l, --delete-workflow-file                   Deletes the workflow file after deployment
  -e, --don-id uint32                          donID used in the workflow registry contract (integer starting with 1) (default 1)
  -g, --gateway-url string                     Gateway URL for vault secrets (if not provided, URL from the state file will be used)
  -h, --help                                   help for deploy
  -n, --name string                            Workflow name
  -r, --rpc-url string                         RPC URL (default "http://localhost:8545")
  -s, --secrets-file-path string               Path to the vault secrets YAML file (keys, env var names, namespaces)
  -o, --secrets-output-file-path string        Path to encrypted vault secrets output file (default "./vault_secrets.json")
  -w, --workflow-file-path string              Path to a base64-encoded workflow WASM file or to a Go file that contains the workflow (if --compile flag is used)
  -d, --workflow-owner-address string          Workflow owner address (default "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266")
  -a, --workflow-registry-address string       Workflow registry address (if not provided, address from the state file will be used)

Error: ❌ failed to compile workflow: ❌ failed to compile workflow: failed to compile go workflow: failed to run go mod tidy: : chdir examples/workflows/v2/cron: no such file or directory
exit status 1
Error: Process completed with exit code 1.

```

