### PR TITLE
chore: bump chainlink-common for chip ingress batching

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.100
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260506144252-c100eabfda74
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8
 	github.com/smartcontractkit/chainlink-common/keystore v1.1.0
 	github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec
 	github.com/smartcontractkit/chainlink-deployments-framework v0.101.1
@@ -484,7 +484,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7 // indirect
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260504204047-af9826978b72 // indirect
 	github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd // indirect
-	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4 // indirect
+	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482 // indirect
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20260423135514-5b1a7565a99c // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1643,12 +1643,12 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd/go.mod h1:SBN8Urnh5sQvrQRbSo1Nr8coWatHg8LZoPw3R/42sho=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23 h1:1Rt4HLpwbRN1YtBFcbsxSJYIiUP2wJ11qizevOEeCrs=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23/go.mod h1:V+wrhuNve+JiFwoBr25d6y0lL1rYSCSJhTFyloL3ueo=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf h1:Ai7bHctBPlhYwGn3+NIH/jXachC1eOpvDxQWLLjmjpY=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf/go.mod h1:B+eYJSQmOc28kzs7OwJjwo0DEV2f01HnUk89r9R1d/Y=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8 h1:P1GwU1MzwU4hYVRLuyUvSCncUmeQ4qajljsSQJJWgg0=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8/go.mod h1:IkMLZ56R+9DpxOT99DzGCeiVVxg81sjZwbNUloXWXu8=
 github.com/smartcontractkit/chainlink-common/keystore v1.1.0 h1:2wzySccgk2fpWusPKO0bpeAZzfSU9eq6CS5U+JwYaVo=
 github.com/smartcontractkit/chainlink-common/keystore v1.1.0/go.mod h1:6JexOOhPhknQ0QMuppFIlOpm6wCp54yZMxai+tWugwY=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4 h1:NOUsjsMzNecbjiPWUQGlRSRAutEvCFrqqyETDJeh5q4=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4/go.mod h1:Zpvul9sTcZNAZOVzt5vBl1XZGNvQebFpnpn3/KOQvOQ=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482 h1:CpuTkw3SooswiRubVfKl5AeLASN34QwnU8UuYMMcqbE=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482/go.mod h1:HmUyH2oD9m+GRpKq7q3vuRnm1F2Uczf/Nd1v3ipMSK8=
 github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec h1:ey01SlGfe0zSWAWDZmFEgQ52trcwQFfjoLiWzrk7GTM=
 github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec/go.mod h1:LXRm6NpaJOsobRs8zEjO0Qm45TnkVavLtHvlZlcNH8w=
 github.com/smartcontractkit/chainlink-deployments-framework v0.101.1 h1:qrDRItygGaDbhJZt1cvyqkMDYQkPGx0K6FQ0u2hZGoY=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260504204047-af9826978b72
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8
 	github.com/smartcontractkit/chainlink-common/keystore v1.1.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.101.1
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260512150409-b4068bf735e6
@@ -417,7 +417,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
 	github.com/smartcontractkit/chainlink-ccip/ccv/chains/evm v0.0.0-20260408145530-22e2d05695cd // indirect
 	github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd // indirect
-	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
+	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20260423135514-5b1a7565a99c // indirect

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1383,12 +1383,12 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd/go.mod h1:SBN8Urnh5sQvrQRbSo1Nr8coWatHg8LZoPw3R/42sho=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23 h1:1Rt4HLpwbRN1YtBFcbsxSJYIiUP2wJ11qizevOEeCrs=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23/go.mod h1:V+wrhuNve+JiFwoBr25d6y0lL1rYSCSJhTFyloL3ueo=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf h1:Ai7bHctBPlhYwGn3+NIH/jXachC1eOpvDxQWLLjmjpY=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf/go.mod h1:B+eYJSQmOc28kzs7OwJjwo0DEV2f01HnUk89r9R1d/Y=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8 h1:P1GwU1MzwU4hYVRLuyUvSCncUmeQ4qajljsSQJJWgg0=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8/go.mod h1:IkMLZ56R+9DpxOT99DzGCeiVVxg81sjZwbNUloXWXu8=
 github.com/smartcontractkit/chainlink-common/keystore v1.1.0 h1:2wzySccgk2fpWusPKO0bpeAZzfSU9eq6CS5U+JwYaVo=
 github.com/smartcontractkit/chainlink-common/keystore v1.1.0/go.mod h1:6JexOOhPhknQ0QMuppFIlOpm6wCp54yZMxai+tWugwY=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482 h1:CpuTkw3SooswiRubVfKl5AeLASN34QwnU8UuYMMcqbE=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482/go.mod h1:HmUyH2oD9m+GRpKq7q3vuRnm1F2Uczf/Nd1v3ipMSK8=
 github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec h1:ey01SlGfe0zSWAWDZmFEgQ52trcwQFfjoLiWzrk7GTM=
 github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec/go.mod h1:LXRm6NpaJOsobRs8zEjO0Qm45TnkVavLtHvlZlcNH8w=
 github.com/smartcontractkit/chainlink-deployments-framework v0.101.1 h1:qrDRItygGaDbhJZt1cvyqkMDYQkPGx0K6FQ0u2hZGoY=

--- a/go.mod
+++ b/go.mod
@@ -85,9 +85,9 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8
 	github.com/smartcontractkit/chainlink-common/keystore v1.1.0
-	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10
+	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482
 	github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260512150409-b4068bf735e6
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501

--- a/go.sum
+++ b/go.sum
@@ -1184,12 +1184,12 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd h1:IMopuENFVS63AerRELdfWo6o60UNUidcldJOxJLmk24=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd/go.mod h1:SBN8Urnh5sQvrQRbSo1Nr8coWatHg8LZoPw3R/42sho=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf h1:Ai7bHctBPlhYwGn3+NIH/jXachC1eOpvDxQWLLjmjpY=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf/go.mod h1:B+eYJSQmOc28kzs7OwJjwo0DEV2f01HnUk89r9R1d/Y=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8 h1:P1GwU1MzwU4hYVRLuyUvSCncUmeQ4qajljsSQJJWgg0=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8/go.mod h1:IkMLZ56R+9DpxOT99DzGCeiVVxg81sjZwbNUloXWXu8=
 github.com/smartcontractkit/chainlink-common/keystore v1.1.0 h1:2wzySccgk2fpWusPKO0bpeAZzfSU9eq6CS5U+JwYaVo=
 github.com/smartcontractkit/chainlink-common/keystore v1.1.0/go.mod h1:6JexOOhPhknQ0QMuppFIlOpm6wCp54yZMxai+tWugwY=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482 h1:CpuTkw3SooswiRubVfKl5AeLASN34QwnU8UuYMMcqbE=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482/go.mod h1:HmUyH2oD9m+GRpKq7q3vuRnm1F2Uczf/Nd1v3ipMSK8=
 github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec h1:ey01SlGfe0zSWAWDZmFEgQ52trcwQFfjoLiWzrk7GTM=
 github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec/go.mod h1:LXRm6NpaJOsobRs8zEjO0Qm45TnkVavLtHvlZlcNH8w=
 github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260512150409-b4068bf735e6 h1:XQr7oODxrpssu4OL2QReo8CJSGo7KF99xV3NLCFFIJk=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260506144252-c100eabfda74
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8
 	github.com/smartcontractkit/chainlink-common/keystore v1.1.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.101.1
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260512150409-b4068bf735e6
@@ -397,7 +397,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/ccv/chains/evm v0.0.0-20260408145530-22e2d05695cd // indirect
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260504204047-af9826978b72 // indirect
 	github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd // indirect
-	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
+	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec // indirect
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1369,12 +1369,12 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd/go.mod h1:SBN8Urnh5sQvrQRbSo1Nr8coWatHg8LZoPw3R/42sho=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23 h1:1Rt4HLpwbRN1YtBFcbsxSJYIiUP2wJ11qizevOEeCrs=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23/go.mod h1:V+wrhuNve+JiFwoBr25d6y0lL1rYSCSJhTFyloL3ueo=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf h1:Ai7bHctBPlhYwGn3+NIH/jXachC1eOpvDxQWLLjmjpY=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf/go.mod h1:B+eYJSQmOc28kzs7OwJjwo0DEV2f01HnUk89r9R1d/Y=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8 h1:P1GwU1MzwU4hYVRLuyUvSCncUmeQ4qajljsSQJJWgg0=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8/go.mod h1:IkMLZ56R+9DpxOT99DzGCeiVVxg81sjZwbNUloXWXu8=
 github.com/smartcontractkit/chainlink-common/keystore v1.1.0 h1:2wzySccgk2fpWusPKO0bpeAZzfSU9eq6CS5U+JwYaVo=
 github.com/smartcontractkit/chainlink-common/keystore v1.1.0/go.mod h1:6JexOOhPhknQ0QMuppFIlOpm6wCp54yZMxai+tWugwY=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482 h1:CpuTkw3SooswiRubVfKl5AeLASN34QwnU8UuYMMcqbE=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482/go.mod h1:HmUyH2oD9m+GRpKq7q3vuRnm1F2Uczf/Nd1v3ipMSK8=
 github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec h1:ey01SlGfe0zSWAWDZmFEgQ52trcwQFfjoLiWzrk7GTM=
 github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec/go.mod h1:LXRm6NpaJOsobRs8zEjO0Qm45TnkVavLtHvlZlcNH8w=
 github.com/smartcontractkit/chainlink-deployments-framework v0.101.1 h1:qrDRItygGaDbhJZt1cvyqkMDYQkPGx0K6FQ0u2hZGoY=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260506144252-c100eabfda74
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8
 	github.com/smartcontractkit/chainlink-deployments-framework v0.101.1
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260512150409-b4068bf735e6
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.16.1
@@ -477,7 +477,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260504204047-af9826978b72 // indirect
 	github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd // indirect
 	github.com/smartcontractkit/chainlink-common/keystore v1.1.0 // indirect
-	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
+	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec // indirect
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501 // indirect
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20260421142741-9c7fbaf7c828 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1639,12 +1639,12 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd/go.mod h1:SBN8Urnh5sQvrQRbSo1Nr8coWatHg8LZoPw3R/42sho=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23 h1:1Rt4HLpwbRN1YtBFcbsxSJYIiUP2wJ11qizevOEeCrs=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23/go.mod h1:V+wrhuNve+JiFwoBr25d6y0lL1rYSCSJhTFyloL3ueo=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf h1:Ai7bHctBPlhYwGn3+NIH/jXachC1eOpvDxQWLLjmjpY=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf/go.mod h1:B+eYJSQmOc28kzs7OwJjwo0DEV2f01HnUk89r9R1d/Y=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8 h1:P1GwU1MzwU4hYVRLuyUvSCncUmeQ4qajljsSQJJWgg0=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8/go.mod h1:IkMLZ56R+9DpxOT99DzGCeiVVxg81sjZwbNUloXWXu8=
 github.com/smartcontractkit/chainlink-common/keystore v1.1.0 h1:2wzySccgk2fpWusPKO0bpeAZzfSU9eq6CS5U+JwYaVo=
 github.com/smartcontractkit/chainlink-common/keystore v1.1.0/go.mod h1:6JexOOhPhknQ0QMuppFIlOpm6wCp54yZMxai+tWugwY=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482 h1:CpuTkw3SooswiRubVfKl5AeLASN34QwnU8UuYMMcqbE=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482/go.mod h1:HmUyH2oD9m+GRpKq7q3vuRnm1F2Uczf/Nd1v3ipMSK8=
 github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec h1:ey01SlGfe0zSWAWDZmFEgQ52trcwQFfjoLiWzrk7GTM=
 github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec/go.mod h1:LXRm6NpaJOsobRs8zEjO0Qm45TnkVavLtHvlZlcNH8w=
 github.com/smartcontractkit/chainlink-deployments-framework v0.101.1 h1:qrDRItygGaDbhJZt1cvyqkMDYQkPGx0K6FQ0u2hZGoY=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.100
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20260507123701-77fc93b573bb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8
 	github.com/smartcontractkit/chainlink-common/keystore v1.1.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.101.1
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260512150409-b4068bf735e6
@@ -450,7 +450,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7 // indirect
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260504204047-af9826978b72 // indirect
 	github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd // indirect
-	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4 // indirect
+	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec // indirect
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1612,12 +1612,12 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd/go.mod h1:SBN8Urnh5sQvrQRbSo1Nr8coWatHg8LZoPw3R/42sho=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23 h1:1Rt4HLpwbRN1YtBFcbsxSJYIiUP2wJ11qizevOEeCrs=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23/go.mod h1:V+wrhuNve+JiFwoBr25d6y0lL1rYSCSJhTFyloL3ueo=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf h1:Ai7bHctBPlhYwGn3+NIH/jXachC1eOpvDxQWLLjmjpY=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf/go.mod h1:B+eYJSQmOc28kzs7OwJjwo0DEV2f01HnUk89r9R1d/Y=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8 h1:P1GwU1MzwU4hYVRLuyUvSCncUmeQ4qajljsSQJJWgg0=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8/go.mod h1:IkMLZ56R+9DpxOT99DzGCeiVVxg81sjZwbNUloXWXu8=
 github.com/smartcontractkit/chainlink-common/keystore v1.1.0 h1:2wzySccgk2fpWusPKO0bpeAZzfSU9eq6CS5U+JwYaVo=
 github.com/smartcontractkit/chainlink-common/keystore v1.1.0/go.mod h1:6JexOOhPhknQ0QMuppFIlOpm6wCp54yZMxai+tWugwY=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4 h1:NOUsjsMzNecbjiPWUQGlRSRAutEvCFrqqyETDJeh5q4=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4/go.mod h1:Zpvul9sTcZNAZOVzt5vBl1XZGNvQebFpnpn3/KOQvOQ=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482 h1:CpuTkw3SooswiRubVfKl5AeLASN34QwnU8UuYMMcqbE=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482/go.mod h1:HmUyH2oD9m+GRpKq7q3vuRnm1F2Uczf/Nd1v3ipMSK8=
 github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec h1:ey01SlGfe0zSWAWDZmFEgQ52trcwQFfjoLiWzrk7GTM=
 github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec/go.mod h1:LXRm6NpaJOsobRs8zEjO0Qm45TnkVavLtHvlZlcNH8w=
 github.com/smartcontractkit/chainlink-deployments-framework v0.101.1 h1:qrDRItygGaDbhJZt1cvyqkMDYQkPGx0K6FQ0u2hZGoY=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
 	github.com/smartcontractkit/chain-selectors v1.0.100
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8
 	github.com/smartcontractkit/chainlink-common/keystore v1.1.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.101.1
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501
@@ -515,7 +515,7 @@ require (
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20260507123701-77fc93b573bb
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20260428205619-2db1389501a1 // indirect
-	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4
+	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260512150409-b4068bf735e6 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20260423135514-5b1a7565a99c // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1625,12 +1625,12 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd/go.mod h1:SBN8Urnh5sQvrQRbSo1Nr8coWatHg8LZoPw3R/42sho=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23 h1:1Rt4HLpwbRN1YtBFcbsxSJYIiUP2wJ11qizevOEeCrs=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23/go.mod h1:V+wrhuNve+JiFwoBr25d6y0lL1rYSCSJhTFyloL3ueo=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf h1:Ai7bHctBPlhYwGn3+NIH/jXachC1eOpvDxQWLLjmjpY=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260514144456-29b2f52c4fcf/go.mod h1:B+eYJSQmOc28kzs7OwJjwo0DEV2f01HnUk89r9R1d/Y=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8 h1:P1GwU1MzwU4hYVRLuyUvSCncUmeQ4qajljsSQJJWgg0=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260515051533-0f95004f50c8/go.mod h1:IkMLZ56R+9DpxOT99DzGCeiVVxg81sjZwbNUloXWXu8=
 github.com/smartcontractkit/chainlink-common/keystore v1.1.0 h1:2wzySccgk2fpWusPKO0bpeAZzfSU9eq6CS5U+JwYaVo=
 github.com/smartcontractkit/chainlink-common/keystore v1.1.0/go.mod h1:6JexOOhPhknQ0QMuppFIlOpm6wCp54yZMxai+tWugwY=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4 h1:NOUsjsMzNecbjiPWUQGlRSRAutEvCFrqqyETDJeh5q4=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20251211140724-319861e514c4/go.mod h1:Zpvul9sTcZNAZOVzt5vBl1XZGNvQebFpnpn3/KOQvOQ=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482 h1:CpuTkw3SooswiRubVfKl5AeLASN34QwnU8UuYMMcqbE=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260514213647-fddcb86b6482/go.mod h1:HmUyH2oD9m+GRpKq7q3vuRnm1F2Uczf/Nd1v3ipMSK8=
 github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec h1:ey01SlGfe0zSWAWDZmFEgQ52trcwQFfjoLiWzrk7GTM=
 github.com/smartcontractkit/chainlink-data-streams v0.1.14-0.20260512145107-b41c0e2855ec/go.mod h1:LXRm6NpaJOsobRs8zEjO0Qm45TnkVavLtHvlZlcNH8w=
 github.com/smartcontractkit/chainlink-deployments-framework v0.101.1 h1:qrDRItygGaDbhJZt1cvyqkMDYQkPGx0K6FQ0u2hZGoY=


### PR DESCRIPTION
## Summary
- bump `github.com/smartcontractkit/chainlink-common/pkg/chipingress` to `infoplat-3436-chipingress-batching-part-1`
- bump `github.com/smartcontractkit/chainlink-common` to `infoplat-3436-chipingress-batching-part-2`
- run `make gomodtidy` to propagate module and checksum updates across workspace go modules

## Testing
- make gomodtidy