### PR TITLE
chore: fix 'priviledges' typo in core/store/migrate/README.md

### DIFF
--- a/core/store/migrate/README.md
+++ b/core/store/migrate/README.md
@@ -1,3 +1,3 @@
 # Notes
 - Node operators do not always run their migrations with 
-super user priviledges so you cannot use ```CREATE EXTENSION```
+super user privileges so you cannot use ```CREATE EXTENSION```


### PR DESCRIPTION
### Summary

`core/store/migrate/README.md` notes that node operators do not always run migrations with **super user priviledges** — should be "privileges".

### Change

Single-character typo fix on the only line that mentions it.

```diff
-super user priviledges so you cannot use ```CREATE EXTENSION```
+super user privileges so you cannot use ```CREATE EXTENSION```
```

No semantic change.