### PR TITLE
chore: fix 'dependants' and 'avaialable' comment typos

### DIFF
--- a/core/services/relay/evm/loop_impl.go
+++ b/core/services/relay/evm/loop_impl.go
@@ -8,7 +8,7 @@ import (
 )
 
 // RelayAdapter extends loop.Relayer with a method for accessing the internal legacy chain type.
-// Only avaialable in embedded mode, not LOOPP mode.
+// Only available in embedded mode, not LOOPP mode.
 type RelayAdapter interface {
 	loop.Relayer
 	Chain() types.ChainService

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -1133,7 +1133,7 @@ func (e *Engine) isWorkflowFullyProcessed(_ context.Context, state store.Workflo
 		}
 		statuses[s.Ref] = stateStep.Status
 		switch stateStep.Status {
-		// For each step with any of the following statuses, propagate the statuses to its dependants
+		// For each step with any of the following statuses, propagate the statuses to its dependents
 		// since they will not be executed.
 		case store.StatusErrored, store.StatusCompletedEarlyExit, store.StatusTimeout:
 			// Let's properly propagate the status to all dependents, not just direct dependents.


### PR DESCRIPTION
### Summary

Two unrelated comment typos found in adjacent core packages — both kept in a single PR because each is a one-character fix in a documentation comment and the diff stays well under five lines.

### Changes

`core/services/workflows/engine.go:1136`

`dependants` → `dependents`. The very next line already uses the correct spelling ("all dependents, not just direct dependents"), and the surrounding code calls `e.workflow.dependents(...)` / iterates over a `dependents` slice, so this aligns the comment with the rest of the block.

`core/services/relay/evm/loop_impl.go:11`

`avaialable` → `available` in the `RelayAdapter` doc comment.

### Verification

- Comments only; no semantic change.
- `gofmt -l` clean on both files.