### PR TITLE
Clean up token description price feeds

### DIFF
--- a/deployment/ccip/shared/token_info.go
+++ b/deployment/ccip/shared/token_info.go
@@ -159,7 +159,7 @@ var (
 		FTMUSD:                        {WSSymbol},
 		BTCUSD:                        {WBTCNSymbol, WBTCSymbol},
 		LTCUSD:                        {WHYPESymbol},
-		USDCUSD:                       {WAPESymbol, WHSKSymbol, WSBYSymbol, WCROSymbol},
+		USDCUSD:                       {WAPESymbol, WHSKSymbol, WCROSymbol},
 		ARBUSD:                        {WCoreSymbol},
 		XTZUSD:                        {XTZSymbol},
 	}


### PR DESCRIPTION
SBY token is mapped wrongly to USDC feeds, fixing that