### PR TITLE
fix: increase Test_Server_CapabilityError timeout to prevent race wit…

### DIFF
--- a/core/capabilities/remote/executable/server_test.go
+++ b/core/capabilities/remote/executable/server_test.go
@@ -211,7 +211,7 @@ func Test_Server_CapabilityError(t *testing.T) {
 
 	numCapabilityPeers := 4
 
-	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{}, &TestErrorCapability{}, 10, 9, numCapabilityPeers, 3, 100*time.Millisecond, nil)
+	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{}, &TestErrorCapability{}, 10, 9, numCapabilityPeers, 3, 10*time.Second, nil)
 
 	for _, caller := range callers {
 		_, err := caller.Execute(t.Context(),


### PR DESCRIPTION
## Summary

- Increases `RequestTimeout` from `100ms` to `10s` in `Test_Server_CapabilityError` to eliminate a race condition between the server's expiry ticker and async message delivery.

## Root cause

`RequestTimeout=100ms` equalled the ticker interval returned by `getServerTickerInterval`. On loaded CI machines, the expiry goroutine fires `Cancel(Error_TIMEOUT)` before all 10 async messages from 10 workflow peers complete delivery through `testAsyncMessageBroker`'s serial `sendCh` consumer. The 10th `OnMessage` then finds `hasResponse()==true` (set by `Cancel`) and dispatches `Error_TIMEOUT` instead of the expected `Error_INTERNAL_ERROR`.

## Fix

Raise the timeout to `10s` — matching the convention used by other tests in this file. `TestErrorCapability` returns synchronously, so the test still completes in milliseconds; only the safety margin changes.

## Flaky test fixes

| Issue | Test | Trunk |
|-------|------|-------|
| [CRE-4319](https://smartcontract-it.atlassian.net/browse/CRE-4319) | `Test_Server_CapabilityError` | [Trunk test case](https://app.trunk.io/chainlink/flaky-tests/repo/0ec8ac39-2bf0-42e2-baaf-3f6cce784097/test/a5f13be6-4b2d-5c5c-abc2-2c49154f050d) |

## Test plan

- [x] `Test_Server_CapabilityError` passed 10/10 runs locally with `-race -shuffle=on`
- [x] `golangci-lint` clean for `./core/capabilities/remote/executable/...`
- [ ] CI green

[CRE-4319]: https://smartcontract-it.atlassian.net/browse/CRE-4319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ