### PR TITLE
(fix): Gateway connection manager: set a deadline to close stalled handshakes

### DIFF
--- a/core/services/gateway/config/config.go
+++ b/core/services/gateway/config/config.go
@@ -27,6 +27,10 @@ type ConnectionManagerConfig struct {
 	AuthTimestampToleranceSec uint32
 	AuthChallengeLen          uint32
 	HeartbeatIntervalSec      uint32
+	// PongTimeoutSec is the maximum time to wait for a pong response before
+	// considering the connection dead. When 0 (default), read deadline enforcement
+	// is disabled and connections may remain half-open indefinitely.
+	PongTimeoutSec uint32
 }
 
 type DONConfig struct {

--- a/core/services/gateway/config/config.go
+++ b/core/services/gateway/config/config.go
@@ -82,13 +82,12 @@ type Shard struct {
 }
 
 func (c *GatewayConfig) Validate() error {
-	if c.ConnectionManagerConfig.PongTimeoutSec != 0 {
-		if c.ConnectionManagerConfig.HeartbeatIntervalSec == 0 {
+	if pong := c.ConnectionManagerConfig.PongTimeoutSec; pong != 0 {
+		if heartbeat := c.ConnectionManagerConfig.HeartbeatIntervalSec; heartbeat == 0 {
 			return errors.New("PongTimeoutSec requires HeartbeatIntervalSec > 0 (pong deadline needs periodic pings)")
-		}
-		if c.ConnectionManagerConfig.PongTimeoutSec <= c.ConnectionManagerConfig.HeartbeatIntervalSec {
+		} else if pong <= heartbeat {
 			return fmt.Errorf("PongTimeoutSec (%d) must be greater than HeartbeatIntervalSec (%d)",
-				c.ConnectionManagerConfig.PongTimeoutSec, c.ConnectionManagerConfig.HeartbeatIntervalSec)
+				pong, heartbeat)
 		}
 	}
 

--- a/core/services/gateway/config/config.go
+++ b/core/services/gateway/config/config.go
@@ -82,6 +82,16 @@ type Shard struct {
 }
 
 func (c *GatewayConfig) Validate() error {
+	if c.ConnectionManagerConfig.PongTimeoutSec != 0 {
+		if c.ConnectionManagerConfig.HeartbeatIntervalSec == 0 {
+			return errors.New("PongTimeoutSec requires HeartbeatIntervalSec > 0 (pong deadline needs periodic pings)")
+		}
+		if c.ConnectionManagerConfig.PongTimeoutSec <= c.ConnectionManagerConfig.HeartbeatIntervalSec {
+			return fmt.Errorf("PongTimeoutSec (%d) must be greater than HeartbeatIntervalSec (%d)",
+				c.ConnectionManagerConfig.PongTimeoutSec, c.ConnectionManagerConfig.HeartbeatIntervalSec)
+		}
+	}
+
 	if len(c.Dons) > 0 && (len(c.Services) > 0 || len(c.ShardedDONs) > 0) {
 		return errors.New("legacy Dons config and Services/ShardedDONs cannot be used together")
 	}

--- a/core/services/gateway/config/config_test.go
+++ b/core/services/gateway/config/config_test.go
@@ -267,6 +267,54 @@ func TestGatewayConfig_Validate(t *testing.T) {
 			},
 			wantErr: "legacy Dons config and Services/ShardedDONs cannot be used together",
 		},
+		{
+			name: "PongTimeoutSec less than HeartbeatIntervalSec",
+			config: GatewayConfig{
+				ConnectionManagerConfig: ConnectionManagerConfig{
+					HeartbeatIntervalSec: 20,
+					PongTimeoutSec:       10,
+				},
+			},
+			wantErr: "PongTimeoutSec (10) must be greater than HeartbeatIntervalSec (20)",
+		},
+		{
+			name: "PongTimeoutSec equal to HeartbeatIntervalSec",
+			config: GatewayConfig{
+				ConnectionManagerConfig: ConnectionManagerConfig{
+					HeartbeatIntervalSec: 20,
+					PongTimeoutSec:       20,
+				},
+			},
+			wantErr: "PongTimeoutSec (20) must be greater than HeartbeatIntervalSec (20)",
+		},
+		{
+			name: "PongTimeoutSec zero is valid (disabled)",
+			config: GatewayConfig{
+				ConnectionManagerConfig: ConnectionManagerConfig{
+					HeartbeatIntervalSec: 20,
+					PongTimeoutSec:       0,
+				},
+			},
+		},
+		{
+			name: "PongTimeoutSec greater than HeartbeatIntervalSec is valid",
+			config: GatewayConfig{
+				ConnectionManagerConfig: ConnectionManagerConfig{
+					HeartbeatIntervalSec: 20,
+					PongTimeoutSec:       60,
+				},
+			},
+		},
+		{
+			name: "PongTimeoutSec enabled without heartbeat",
+			config: GatewayConfig{
+				ConnectionManagerConfig: ConnectionManagerConfig{
+					HeartbeatIntervalSec: 0,
+					PongTimeoutSec:       60,
+				},
+			},
+			wantErr: "PongTimeoutSec requires HeartbeatIntervalSec > 0",
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/services/gateway/connectionmanager.go
+++ b/core/services/gateway/connectionmanager.go
@@ -273,14 +273,21 @@ func (m *connectionManager) FinalizeHandshake(attemptId string, response []byte,
 	}
 	if conn != nil {
 		// Set a read deadline so that half-open connections are detected and closed.
-		// Use 3x the heartbeat interval to tolerate up to 2 missed pongs.
-		pongWait := time.Duration(m.config.HeartbeatIntervalSec) * time.Second * 3
+		// The deadline is reset every time a pong is received. If PongTimeoutSec is
+		// 0, deadline enforcement is disabled (backward-compatible default).
+		pongWait := time.Duration(m.config.PongTimeoutSec) * time.Second
 		if pongWait > 0 {
-			conn.SetReadDeadline(time.Now().Add(pongWait))
+			if err := conn.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
+				m.lggr.Warnw("failed to set initial read deadline, connection may be unusable",
+					"nodeAddress", attempt.nodeAddress, "err", err)
+			}
 		}
 		conn.SetPongHandler(func(data string) error {
 			if pongWait > 0 {
-				conn.SetReadDeadline(time.Now().Add(pongWait))
+				if err := conn.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
+					m.lggr.Warnw("failed to reset read deadline on pong",
+						"nodeAddress", attempt.nodeAddress, "err", err)
+				}
 			}
 			m.lggr.Debugw("received keepalive pong from node", "nodeAddress", attempt.nodeAddress)
 			m.gMetrics.RecordKeepalivePongsReceived(context.Background(), attempt.nodeAddress, attempt.nodeState.name)
@@ -288,6 +295,16 @@ func (m *connectionManager) FinalizeHandshake(attemptId string, response []byte,
 		})
 	}
 	attempt.nodeState.conn.Reset(conn)
+	if conn != nil {
+		// Send an immediate ping so the first pong arrives quickly (within
+		// milliseconds on a healthy connection) rather than waiting up to one
+		// full heartbeat interval for the keepalive ticker to fire.
+		ctx := context.Background()
+		if err := attempt.nodeState.conn.Write(ctx, websocket.PingMessage, []byte{}); err != nil {
+			m.lggr.Debugw("unable to send post-handshake ping to node",
+				"nodeAddress", attempt.nodeAddress, "name", attempt.nodeState.name, "err", err)
+		}
+	}
 	m.lggr.Infof("node %s connected", attempt.nodeAddress)
 	m.gMetrics.RecordNodeConnectedEvent(context.Background(), attempt.nodeAddress, attempt.nodeState.name)
 	return nil

--- a/core/services/gateway/connectionmanager.go
+++ b/core/services/gateway/connectionmanager.go
@@ -272,7 +272,16 @@ func (m *connectionManager) FinalizeHandshake(attemptId string, response []byte,
 		return network.ErrChallengeInvalidSignature
 	}
 	if conn != nil {
+		// Set a read deadline so that half-open connections are detected and closed.
+		// Use 3x the heartbeat interval to tolerate up to 2 missed pongs.
+		pongWait := time.Duration(m.config.HeartbeatIntervalSec) * time.Second * 3
+		if pongWait > 0 {
+			conn.SetReadDeadline(time.Now().Add(pongWait))
+		}
 		conn.SetPongHandler(func(data string) error {
+			if pongWait > 0 {
+				conn.SetReadDeadline(time.Now().Add(pongWait))
+			}
 			m.lggr.Debugw("received keepalive pong from node", "nodeAddress", attempt.nodeAddress)
 			m.gMetrics.RecordKeepalivePongsReceived(context.Background(), attempt.nodeAddress, attempt.nodeState.name)
 			return nil

--- a/core/services/gateway/connectionmanager.go
+++ b/core/services/gateway/connectionmanager.go
@@ -271,11 +271,11 @@ func (m *connectionManager) FinalizeHandshake(attemptId string, response []byte,
 	if err != nil || attempt.nodeAddress != "0x"+hex.EncodeToString(signer) {
 		return network.ErrChallengeInvalidSignature
 	}
+	// Set a read deadline so that half-open connections are detected and closed.
+	// The deadline is reset every time a pong is received. If PongTimeoutSec is
+	// 0, deadline enforcement is disabled.
+	pongWait := time.Duration(m.config.PongTimeoutSec) * time.Second
 	if conn != nil {
-		// Set a read deadline so that half-open connections are detected and closed.
-		// The deadline is reset every time a pong is received. If PongTimeoutSec is
-		// 0, deadline enforcement is disabled (backward-compatible default).
-		pongWait := time.Duration(m.config.PongTimeoutSec) * time.Second
 		if pongWait > 0 {
 			if err := conn.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
 				m.lggr.Warnw("failed to set initial read deadline, connection may be unusable",
@@ -295,7 +295,7 @@ func (m *connectionManager) FinalizeHandshake(attemptId string, response []byte,
 		})
 	}
 	attempt.nodeState.conn.Reset(conn)
-	if conn != nil {
+	if conn != nil && pongWait > 0 {
 		// Send an immediate ping so the first pong arrives quickly (within
 		// milliseconds on a healthy connection) rather than waiting up to one
 		// full heartbeat interval for the keepalive ticker to fire.

--- a/core/services/gateway/connectionmanager_test.go
+++ b/core/services/gateway/connectionmanager_test.go
@@ -464,7 +464,8 @@ func TestConnectionManager_ReadDeadline_ClosesIdleConnection(t *testing.T) {
 	t.Parallel()
 
 	cfg, nodes := newTestConfig(t, 1)
-	cfg.ConnectionManagerConfig.HeartbeatIntervalSec = 1 // pongWait = 3s
+	cfg.ConnectionManagerConfig.HeartbeatIntervalSec = 1
+	cfg.ConnectionManagerConfig.PongTimeoutSec = 3
 	clock := clockwork.NewRealClock()
 	mgr := newConnectionManager(t, cfg, clock)
 
@@ -478,7 +479,7 @@ func TestConnectionManager_ReadDeadline_ClosesIdleConnection(t *testing.T) {
 
 	doHandshake(t, mgr, clock, nodes[0], serverConn)
 
-	// After pongWait (3s) the read deadline fires, readPump closes the conn.
+	// After PongTimeoutSec (3s) the read deadline fires, readPump closes the conn.
 	// SendToNode should eventually fail because the underlying conn is closed.
 	donMgr := mgr.DONConnectionManager("my_don_1")
 	require.NotNil(t, donMgr)
@@ -493,7 +494,8 @@ func TestConnectionManager_ReadDeadline_ConnectionAliveWithPongs(t *testing.T) {
 	t.Parallel()
 
 	cfg, nodes := newTestConfig(t, 1)
-	cfg.ConnectionManagerConfig.HeartbeatIntervalSec = 1 // pongWait = 3s
+	cfg.ConnectionManagerConfig.HeartbeatIntervalSec = 1
+	cfg.ConnectionManagerConfig.PongTimeoutSec = 3
 	clock := clockwork.NewRealClock()
 	mgr := newConnectionManager(t, cfg, clock)
 
@@ -503,7 +505,7 @@ func TestConnectionManager_ReadDeadline_ConnectionAliveWithPongs(t *testing.T) {
 
 	serverConn, clientConn := newWebSocketPair(t)
 
-	// Client reads in a loop — gorilla/websocket's default ping handler
+	// Client reads in a loop - gorilla/websocket's default ping handler
 	// automatically responds with pongs, which resets the server's read deadline.
 	go func() {
 		for {
@@ -516,18 +518,44 @@ func TestConnectionManager_ReadDeadline_ConnectionAliveWithPongs(t *testing.T) {
 
 	doHandshake(t, mgr, clock, nodes[0], serverConn)
 
-	// Wait significantly longer than pongWait (3s) to ensure multiple keepalive
-	// cycles have completed. With HeartbeatIntervalSec=1, by t=5s we expect 4-5
-	// pong cycles, each extending the deadline well past our check time.
-	// This avoids a race where the check lands exactly as a deadline expires.
-	time.Sleep(5 * time.Second)
-
+	// Assert the connection never dies during a period longer than PongTimeoutSec.
+	// With HeartbeatIntervalSec=1, pongs arrive every ~1s resetting the 3s deadline.
 	donMgr := mgr.DONConnectionManager("my_don_1")
 	require.NotNil(t, donMgr)
 
-	msg := &jsonrpc.Request[json.RawMessage]{ID: "alive-check"}
-	err = donMgr.SendToNode(testutils.Context(t), nodes[0].Address, msg)
-	require.NoError(t, err, "connection should still be alive when pongs are received")
+	assert.Never(t, func() bool {
+		msg := &jsonrpc.Request[json.RawMessage]{ID: "alive-check"}
+		return donMgr.SendToNode(testutils.Context(t), nodes[0].Address, msg) != nil
+	}, 5*time.Second, 500*time.Millisecond, "connection should stay alive when pongs are received")
+}
+
+func TestConnectionManager_ReadDeadline_DisabledWhenZero(t *testing.T) {
+	t.Parallel()
+
+	cfg, nodes := newTestConfig(t, 1)
+	cfg.ConnectionManagerConfig.HeartbeatIntervalSec = 1
+	// PongTimeoutSec = 0 (default) - deadline enforcement disabled
+	clock := clockwork.NewRealClock()
+	mgr := newConnectionManager(t, cfg, clock)
+
+	err := mgr.Start(testutils.Context(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, mgr.Close()) })
+
+	serverConn, _ := newWebSocketPair(t)
+	// Client does NOT read - no pongs sent back.
+
+	doHandshake(t, mgr, clock, nodes[0], serverConn)
+
+	// Even without pongs, the connection should remain alive because
+	// PongTimeoutSec=0 means no read deadline is set.
+	donMgr := mgr.DONConnectionManager("my_don_1")
+	require.NotNil(t, donMgr)
+
+	assert.Never(t, func() bool {
+		msg := &jsonrpc.Request[json.RawMessage]{ID: "test"}
+		return donMgr.SendToNode(testutils.Context(t), nodes[0].Address, msg) != nil
+	}, 4*time.Second, 500*time.Millisecond, "connection should stay alive when deadline enforcement is disabled")
 }
 
 func newConnectionManager(t *testing.T, gwConfig *config.GatewayConfig, clock clockwork.Clock) gateway.ConnectionManager {

--- a/core/services/gateway/connectionmanager_test.go
+++ b/core/services/gateway/connectionmanager_test.go
@@ -4,10 +4,15 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
@@ -414,6 +419,115 @@ Address = "0x0001020304050607080900010203040506070809"
 
 	err = mgr.Close()
 	require.NoError(t, err)
+}
+
+// newWebSocketPair creates an httptest server with a WebSocket upgrader and dials it.
+// Returns the server-side conn (to pass to FinalizeHandshake) and the client-side conn
+// (simulating the node). The httptest server is closed on test cleanup.
+func newWebSocketPair(t *testing.T) (serverConn, clientConn *websocket.Conn) {
+	t.Helper()
+	upgrader := websocket.Upgrader{}
+	connCh := make(chan *websocket.Conn, 1)
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		connCh <- c
+	}))
+	t.Cleanup(s.Close)
+
+	clientConn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(s.URL, "http"), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { clientConn.Close() })
+
+	serverConn = <-connCh
+	return serverConn, clientConn
+}
+
+// doHandshake performs StartHandshake + FinalizeHandshake with the given conn.
+func doHandshake(t *testing.T, mgr gateway.ConnectionManager, clock clockwork.Clock, node gc.TestNode, conn *websocket.Conn) {
+	t.Helper()
+	authHeaderElems := network.AuthHeaderElems{
+		Timestamp: uint32(clock.Now().Unix()),
+		DonId:     "my_don_1",
+		GatewayId: "my_gateway_no_3",
+	}
+	attemptId, challenge, err := mgr.StartHandshake(signAndPackAuthHeader(t, &authHeaderElems, node.PrivateKey))
+	require.NoError(t, err)
+	response, err := gc.SignData(node.PrivateKey, challenge)
+	require.NoError(t, err)
+	require.NoError(t, mgr.FinalizeHandshake(attemptId, response, conn))
+}
+
+func TestConnectionManager_ReadDeadline_ClosesIdleConnection(t *testing.T) {
+	t.Parallel()
+
+	cfg, nodes := newTestConfig(t, 1)
+	cfg.ConnectionManagerConfig.HeartbeatIntervalSec = 1 // pongWait = 3s
+	clock := clockwork.NewRealClock()
+	mgr := newConnectionManager(t, cfg, clock)
+
+	err := mgr.Start(testutils.Context(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, mgr.Close()) })
+
+	serverConn, _ := newWebSocketPair(t)
+	// Client does NOT read from its connection, so pings from the gateway
+	// are never processed and pongs are never sent back.
+
+	doHandshake(t, mgr, clock, nodes[0], serverConn)
+
+	// After pongWait (3s) the read deadline fires, readPump closes the conn.
+	// SendToNode should eventually fail because the underlying conn is closed.
+	donMgr := mgr.DONConnectionManager("my_don_1")
+	require.NotNil(t, donMgr)
+
+	assert.Eventually(t, func() bool {
+		msg := &jsonrpc.Request[json.RawMessage]{ID: "test"}
+		return donMgr.SendToNode(testutils.Context(t), nodes[0].Address, msg) != nil
+	}, 6*time.Second, 200*time.Millisecond, "connection should be closed by read deadline")
+}
+
+func TestConnectionManager_ReadDeadline_ConnectionAliveWithPongs(t *testing.T) {
+	t.Parallel()
+
+	cfg, nodes := newTestConfig(t, 1)
+	cfg.ConnectionManagerConfig.HeartbeatIntervalSec = 1 // pongWait = 3s
+	clock := clockwork.NewRealClock()
+	mgr := newConnectionManager(t, cfg, clock)
+
+	err := mgr.Start(testutils.Context(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, mgr.Close()) })
+
+	serverConn, clientConn := newWebSocketPair(t)
+
+	// Client reads in a loop — gorilla/websocket's default ping handler
+	// automatically responds with pongs, which resets the server's read deadline.
+	go func() {
+		for {
+			_, _, err := clientConn.ReadMessage()
+			if err != nil {
+				return // connection closed
+			}
+		}
+	}()
+
+	doHandshake(t, mgr, clock, nodes[0], serverConn)
+
+	// Wait significantly longer than pongWait (3s) to ensure multiple keepalive
+	// cycles have completed. With HeartbeatIntervalSec=1, by t=5s we expect 4-5
+	// pong cycles, each extending the deadline well past our check time.
+	// This avoids a race where the check lands exactly as a deadline expires.
+	time.Sleep(5 * time.Second)
+
+	donMgr := mgr.DONConnectionManager("my_don_1")
+	require.NotNil(t, donMgr)
+
+	msg := &jsonrpc.Request[json.RawMessage]{ID: "alive-check"}
+	err = donMgr.SendToNode(testutils.Context(t), nodes[0].Address, msg)
+	require.NoError(t, err, "connection should still be alive when pongs are received")
 }
 
 func newConnectionManager(t *testing.T, gwConfig *config.GatewayConfig, clock clockwork.Clock) gateway.ConnectionManager {

--- a/core/services/gateway/connectionmanager_test.go
+++ b/core/services/gateway/connectionmanager_test.go
@@ -449,15 +449,15 @@ func newWebSocketPair(t *testing.T) (serverConn, clientConn *websocket.Conn) {
 func doHandshake(t *testing.T, mgr gateway.ConnectionManager, clock clockwork.Clock, node gc.TestNode, conn *websocket.Conn) {
 	t.Helper()
 	authHeaderElems := network.AuthHeaderElems{
-		Timestamp: uint32(clock.Now().Unix()),
+		Timestamp: uint32(clock.Now().Unix()), //nolint:gosec // test clock is always small positive
 		DonId:     "my_don_1",
 		GatewayId: "my_gateway_no_3",
 	}
-	attemptId, challenge, err := mgr.StartHandshake(signAndPackAuthHeader(t, &authHeaderElems, node.PrivateKey))
+	attemptID, challenge, err := mgr.StartHandshake(signAndPackAuthHeader(t, &authHeaderElems, node.PrivateKey))
 	require.NoError(t, err)
 	response, err := gc.SignData(node.PrivateKey, challenge)
 	require.NoError(t, err)
-	require.NoError(t, mgr.FinalizeHandshake(attemptId, response, conn))
+	require.NoError(t, mgr.FinalizeHandshake(attemptID, response, conn))
 }
 
 func TestConnectionManager_ReadDeadline_ClosesIdleConnection(t *testing.T) {

--- a/core/services/gateway/connectionmanager_test.go
+++ b/core/services/gateway/connectionmanager_test.go
@@ -441,7 +441,12 @@ func newWebSocketPair(t *testing.T) (serverConn, clientConn *websocket.Conn) {
 	require.NoError(t, err)
 	t.Cleanup(func() { clientConn.Close() })
 
-	serverConn = <-connCh
+	select {
+	case serverConn = <-connCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for WebSocket upgrade")
+	}
+	t.Cleanup(func() { serverConn.Close() })
 	return serverConn, clientConn
 }
 
@@ -483,6 +488,10 @@ func TestConnectionManager_ReadDeadline_ClosesIdleConnection(t *testing.T) {
 	// SendToNode should eventually fail because the underlying conn is closed.
 	donMgr := mgr.DONConnectionManager("my_don_1")
 	require.NotNil(t, donMgr)
+
+	// Verify connection works initially.
+	msg := &jsonrpc.Request[json.RawMessage]{ID: "pre-check"}
+	require.NoError(t, donMgr.SendToNode(testutils.Context(t), nodes[0].Address, msg))
 
 	assert.Eventually(t, func() bool {
 		msg := &jsonrpc.Request[json.RawMessage]{ID: "test"}

--- a/deployment/cre/jobs/pkg/gateway_job.go
+++ b/deployment/cre/jobs/pkg/gateway_job.go
@@ -391,6 +391,7 @@ type connectionManagerConfig struct {
 	AuthGatewayID             string `toml:"AuthGatewayId"`
 	AuthTimestampToleranceSec int    `toml:"AuthTimestampToleranceSec"`
 	HeartbeatIntervalSec      int    `toml:"HeartbeatIntervalSec"`
+	PongTimeoutSec            int    `toml:"PongTimeoutSec,omitempty"`
 }
 
 type handler struct {


### PR DESCRIPTION
Set a read deadline so that half-open connections are detected and closed.
The deadline is reset every time a keepalive pong is received.
If no pongarrives within the deadline, ReadMessage() in the readPump returns an error, the connection is closed, and the node can reconnect.