### PR TITLE
use longer local CRE startup timeout

### DIFF
--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -837,7 +837,7 @@ func StartCLIEnvironment(
 		ContractVersions:        env.ContractVersions(),
 	}
 
-	ctx, cancel := context.WithTimeout(cmdContext, 10*time.Minute)
+	ctx, cancel := context.WithTimeout(cmdContext, 20*time.Minute)
 	defer cancel()
 	universalSetupOutput, setupErr := creenv.SetupTestEnvironment(ctx, testLogger, singleFileLogger, universalSetupInput, relativePathToRepoRoot)
 	if setupErr != nil {

--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -140,25 +140,38 @@ var StartCmdRecoverHandlerFunc = func(p any, persistedBeholderState *envconfig.C
 	if p != nil {
 		fmt.Println("Panicked when starting environment")
 
+		stack := debug.Stack()
+		stackStr := string(stack)
+
 		var errText string
+		var panicErr error
 		if err, ok := p.(error); ok {
 			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-			fmt.Fprintf(os.Stderr, "Stack trace: %s\n", string(debug.Stack()))
+			fmt.Fprintf(os.Stderr, "Stack trace: %s\n", stackStr)
+			panicErr = err
 
-			errText = strings.SplitN(err.Error(), "\n", 1)[0]
+			errText = strings.SplitN(err.Error(), "\n", 2)[0]
 		} else {
 			fmt.Fprintf(os.Stderr, "panic: %v\n", p)
-			fmt.Fprintf(os.Stderr, "Stack trace: %s\n", string(debug.Stack()))
+			fmt.Fprintf(os.Stderr, "Stack trace: %s\n", stackStr)
 
-			errText = strings.SplitN(fmt.Sprintf("%v", p), "\n", 1)[0]
+			errText = strings.SplitN(fmt.Sprintf("%v", p), "\n", 2)[0]
 		}
 
-		tracingErr := dxTracker.Track(MetricStartupResult, map[string]any{
+		meta := map[string]any{
 			"success":  false,
 			"error":    errText,
 			"panicked": true,
 			"topology": os.Getenv("CTF_CONFIGS"),
-		})
+		}
+
+		if loc := errorLocationForTracking(panicErr, stack); loc != "" {
+			meta["error_location"] = loc
+		}
+
+		fmt.Println("Error location: ", meta["error_location"])
+
+		tracingErr := dxTracker.Track(MetricStartupResult, meta)
 
 		if tracingErr != nil {
 			fmt.Fprintf(os.Stderr, "failed to track startup: %s\n", tracingErr)
@@ -344,7 +357,7 @@ func startCmd() *cobra.Command {
 				fmt.Fprintf(os.Stderr, "Error: %s\n", startErr)
 				fmt.Fprintf(os.Stderr, "Stack trace: %s\n", string(debug.Stack()))
 
-				dxErr := trackStartup(false, hasBuiltDockerImage(in), in.Infra.Type, new(strings.SplitN(startErr.Error(), "\n", 1)[0]), new(false))
+				dxErr := trackStartup(false, hasBuiltDockerImage(in), in.Infra.Type, new(strings.SplitN(startErr.Error(), "\n", 2)[0]), new(false), errorLocationForTracking(startErr, nil))
 				if dxErr != nil {
 					fmt.Fprintf(os.Stderr, "failed to track startup: %s\n", dxErr)
 				}
@@ -380,7 +393,7 @@ func startCmd() *cobra.Command {
 
 			registryChainOut := output.CreEnvironment.Blockchains[0]
 
-			dxErr := trackStartup(true, hasBuiltDockerImage(in), output.CreEnvironment.Provider.Type, nil, nil)
+			dxErr := trackStartup(true, hasBuiltDockerImage(in), output.CreEnvironment.Provider.Type, nil, nil, "")
 			if dxErr != nil {
 				fmt.Fprintf(os.Stderr, "failed to track startup: %s\n", dxErr)
 			}
@@ -588,7 +601,7 @@ func setupDashboards(ctx context.Context, setupCfg SetupConfig) error {
 	return nil
 }
 
-func trackStartup(success, hasBuiltDockerImage bool, infraType string, errorMessage *string, panicked *bool) error {
+func trackStartup(success, hasBuiltDockerImage bool, infraType string, errorMessage *string, panicked *bool, errorLocation string) error {
 	metadata := map[string]any{
 		"success":  success,
 		"infra":    infraType,
@@ -601,6 +614,10 @@ func trackStartup(success, hasBuiltDockerImage bool, infraType string, errorMess
 
 	if panicked != nil {
 		metadata["panicked"] = *panicked
+	}
+
+	if errorLocation != "" {
+		metadata["error_location"] = errorLocation
 	}
 
 	dxStartupErr := dxTracker.Track(MetricStartupResult, metadata)
@@ -975,10 +992,10 @@ func hasBuiltDockerImage(in *envconfig.Config) bool {
 
 func oneLineErrorMessage(errOrPanic any) string {
 	if err, ok := errOrPanic.(error); ok {
-		return strings.SplitN(err.Error(), "\n", 1)[0]
+		return strings.SplitN(err.Error(), "\n", 2)[0]
 	}
 
-	return strings.SplitN(fmt.Sprintf("%v", errOrPanic), "\n", 1)[0]
+	return strings.SplitN(fmt.Sprintf("%v", errOrPanic), "\n", 2)[0]
 }
 
 func initDxTracker() {

--- a/core/scripts/cre/environment/environment/error_location.go
+++ b/core/scripts/cre/environment/environment/error_location.go
@@ -1,0 +1,93 @@
+package environment
+
+import (
+	stderrors "errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+var (
+	goStackFileLine     = regexp.MustCompile(`^\t(.*?\.go):(\d+)\s+`)
+	pkgErrFramePathLine = regexp.MustCompile(`.+\.go:\d+$`)
+)
+
+// errorLocationForTracking returns a file:line suitable for DX telemetry.
+// When panicStack is non-empty (e.g. from debug.Stack()), it is parsed first so the
+// reported location reflects the panic site. Otherwise, or when parsing yields nothing,
+// it falls back to the innermost github.com/pkg/errors stack attached on the unwrap chain.
+func errorLocationForTracking(err error, panicStack []byte) string {
+	if loc := innermostUserFrameFromGoStack(panicStack); loc != "" {
+		return loc
+	}
+	return errorLocationFromWrappedErrors(err)
+}
+
+func innermostUserFrameFromGoStack(stack []byte) string {
+	if len(stack) == 0 {
+		return ""
+	}
+	for _, line := range strings.Split(string(stack), "\n") {
+		m := goStackFileLine.FindStringSubmatch(line)
+		if len(m) != 3 {
+			continue
+		}
+		path := m[1]
+		lineNo := m[2]
+		if skipRuntimeStackPath(path) {
+			continue
+		}
+		return path + ":" + lineNo
+	}
+	return ""
+}
+
+func skipRuntimeStackPath(path string) bool {
+	return strings.Contains(path, "/runtime/") ||
+		strings.Contains(path, `\runtime\`) ||
+		strings.Contains(path, "/reflect/") ||
+		strings.Contains(path, `\reflect\`)
+}
+
+type stackTracer interface {
+	StackTrace() pkgerrors.StackTrace
+}
+
+// errorLocationFromWrappedErrors returns the call site (file:line) from the innermost
+// error in the unwrap chain that carries a non-empty pkg/errors stack trace.
+func errorLocationFromWrappedErrors(err error) string {
+	if err == nil {
+		return ""
+	}
+	var innermost pkgerrors.StackTrace
+	for e := err; e != nil; e = stderrors.Unwrap(e) {
+		var st stackTracer
+		if !stderrors.As(e, &st) {
+			continue
+		}
+		frames := st.StackTrace()
+		if len(frames) == 0 {
+			continue
+		}
+		innermost = frames
+	}
+	if len(innermost) == 0 {
+		return ""
+	}
+	return formatPkgErrorsFrameFileLine(innermost[0])
+}
+
+// formatPkgErrorsFrameFileLine returns absolute (or module) path and line only.
+// fmt.Sprintf("%%+v", frame) also prints the qualified function name on a separate line.
+func formatPkgErrorsFrameFileLine(fr pkgerrors.Frame) string {
+	raw := fmt.Sprintf("%+v", fr)
+	for _, ln := range strings.Split(raw, "\n") {
+		t := strings.TrimSpace(ln)
+		if pkgErrFramePathLine.MatchString(t) {
+			return t
+		}
+	}
+	return strings.TrimSpace(fmt.Sprintf("%v", fr))
+}


### PR DESCRIPTION
- use longer local CRE startup timeout
- send error fine + line to getDX if startup fails