### PR TITLE
Bump package.json to 2.46.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.46.0",
+  "version": "2.46.2",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps root `package.json` from `2.46.0` to `2.46.2` so `release-pre.yaml` can compute the correct `VERSION` for the upcoming `v2.46.2-rc.0` tag.

Matches the same single-line pattern used for `release/2.46.1` (commit `157ee774d7`). No changeset added — the release-pre workflow reads the version directly from `package.json`.

Tracks [RANE-4781](https://smartcontract-it.atlassian.net/browse/RANE-4781) (Aptos config revert hotfix).

## Why
The current `release-pre.yaml` dispatch on `release/2.46.2` failed because the workflow reads `VERSION=2.46.0` from `package.json`, then aborts with *"Final release tag v2.46.0 already exists. This release has already been finalized."* — see [failed run](https://github.com/smartcontractkit/chainlink-releases/actions/runs/26048399594/job/76578571422).

## Test plan
- [ ] Merge to `release/2.46.2`.
- [ ] Re-dispatch `release-pre.yaml` with `source-ref=release/2.46.2 release-phase=rc`.
- [ ] Verify the workflow reads `VERSION=2.46.2` and creates `v2.46.2-rc.0`.

[RANE-4781]: https://smartcontract-it.atlassian.net/browse/RANE-4781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ