### PR TITLE
fix(remote-capability-client): clean up request map after Execute returns

### DIFF
--- a/core/capabilities/remote/executable/client.go
+++ b/core/capabilities/remote/executable/client.go
@@ -246,6 +246,12 @@ func (c *client) Execute(ctx context.Context, capReq commoncap.CapabilityRequest
 	if err = c.storeRequest(req); err != nil {
 		return commoncap.CapabilityResponse{}, fmt.Errorf("failed to store request: %w", err)
 	}
+	// Ensure the entry is removed from requestIDToCallerRequest regardless of how Execute exits
+	// (success, response error, ctx cancellation). Without this, the entry only goes away when
+	// expireRequests() reaps it on its ticker, which means any caller (workflow engine step retry,
+	// concurrent call with the same execution ID + reference ID) that re-enters Execute within
+	// that window hits "request for ID ... already exists" from storeRequest above.
+	defer c.deleteRequest(req.ID())
 
 	var respResult []byte
 	var respErr error
@@ -282,6 +288,16 @@ func (c *client) storeRequest(req *request.ClientRequest) error {
 	}
 	c.requestIDToCallerRequest[req.ID()] = req
 	return nil
+}
+
+// deleteRequest removes a request entry from requestIDToCallerRequest. Called by Execute on exit
+// so the map doesn't retain completed requests until expireRequests() reaps them on its ticker.
+// Safe to call for a request ID that's already been removed (e.g., by expireRequests) — delete
+// on a non-existent key is a no-op.
+func (c *client) deleteRequest(id string) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	delete(c.requestIDToCallerRequest, id)
 }
 
 func (c *client) Receive(ctx context.Context, msg *types.MessageBody) {

--- a/core/capabilities/remote/executable/client.go
+++ b/core/capabilities/remote/executable/client.go
@@ -35,9 +35,14 @@ type client struct {
 	lggr          logger.Logger
 
 	requestIDToCallerRequest map[string]*request.ClientRequest
-	mutex                    sync.Mutex
-	stopCh                   services.StopChan
-	wg                       sync.WaitGroup
+	// completedRequestIDs records requestIDs whose Execute has returned, with the completion time.
+	// Late responses (after quorum) routed to Receive look the requestID up here to distinguish an
+	// expected-but-late message from a truly unknown one. Entries are reaped by expireRequests
+	// after cfg.requestTimeout passes.
+	completedRequestIDs map[string]time.Time
+	mutex               sync.Mutex
+	stopCh              services.StopChan
+	wg                  sync.WaitGroup
 }
 
 type dynamicConfig struct {
@@ -74,6 +79,7 @@ func NewClient(capabilityID string, capMethodName string, dispatcher types.Dispa
 		dispatcher:               dispatcher,
 		lggr:                     logger.With(logger.Named(lggr, "ExecutableCapabilityClient"), "capabilityID", capabilityID, "capMethodName", capMethodName),
 		requestIDToCallerRequest: make(map[string]*request.ClientRequest),
+		completedRequestIDs:      make(map[string]time.Time),
 		stopCh:                   make(services.StopChan),
 	}
 }
@@ -204,6 +210,18 @@ func (c *client) expireRequests() {
 			return
 		}
 	}
+
+	// Reap completedRequestIDs entries older than requestTimeout. After requestTimeout has
+	// passed, no late response is expected to arrive for that ID; if one does, it's a true
+	// anomaly and should surface as a Warn from Receive.
+	cfg := c.cfg.Load()
+	if cfg != nil {
+		for id, completedAt := range c.completedRequestIDs {
+			if time.Since(completedAt) > cfg.requestTimeout {
+				delete(c.completedRequestIDs, id)
+			}
+		}
+	}
 }
 
 func (c *client) cancelAllRequests(err error) {
@@ -250,8 +268,11 @@ func (c *client) Execute(ctx context.Context, capReq commoncap.CapabilityRequest
 	// (success, response error, ctx cancellation). Without this, the entry only goes away when
 	// expireRequests() reaps it on its ticker, which means any caller (workflow engine step retry,
 	// concurrent call with the same execution ID + reference ID) that re-enters Execute within
-	// that window hits "request for ID ... already exists" from storeRequest above.
-	defer c.deleteRequest(req.ID())
+	// that window hits "request for ID ... already exists" from storeRequest above. The completed
+	// requestID is retained in completedRequestIDs so that late responses (from non-quorum
+	// signers arriving after Execute returns) can be silently dropped instead of flagged as
+	// "unknown message ID" by Receive.
+	defer c.markCompleted(req.ID())
 
 	var respResult []byte
 	var respErr error
@@ -290,14 +311,16 @@ func (c *client) storeRequest(req *request.ClientRequest) error {
 	return nil
 }
 
-// deleteRequest removes a request entry from requestIDToCallerRequest. Called by Execute on exit
-// so the map doesn't retain completed requests until expireRequests() reaps them on its ticker.
-// Safe to call for a request ID that's already been removed (e.g., by expireRequests) — delete
-// on a non-existent key is a no-op.
-func (c *client) deleteRequest(id string) {
+// markCompleted is called by Execute on exit. It removes the request from the active map and
+// records the completion time in completedRequestIDs so Receive can distinguish late post-quorum
+// responses from truly unknown messages. Safe to call for a request ID that's already been
+// removed (e.g., by expireRequests) — delete on a non-existent key is a no-op, and the
+// completedRequestIDs entry is still recorded so late responses for that ID stay quiet.
+func (c *client) markCompleted(id string) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	delete(c.requestIDToCallerRequest, id)
+	c.completedRequestIDs[id] = time.Now()
 }
 
 func (c *client) Receive(ctx context.Context, msg *types.MessageBody) {
@@ -314,6 +337,13 @@ func (c *client) Receive(ctx context.Context, msg *types.MessageBody) {
 
 	req := c.requestIDToCallerRequest[messageID]
 	if req == nil {
+		// Distinguish two cases. If the requestID was recently completed (Execute already
+		// returned), this is an expected late response from a non-quorum signer — drop quietly.
+		// Otherwise it's a truly unknown message ID, which is a real anomaly worth a warning.
+		if _, recentlyCompleted := c.completedRequestIDs[messageID]; recentlyCompleted {
+			c.lggr.Debugw("late response after Execute returned, ignoring", "messageID", messageID)
+			return
+		}
 		c.lggr.Warnw("received response for unknown message ID ", "messageID", messageID)
 		return
 	}

--- a/core/capabilities/remote/executable/client_internal_test.go
+++ b/core/capabilities/remote/executable/client_internal_test.go
@@ -3,34 +3,74 @@ package executable
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/executable/request"
 )
 
-// TestClient_deleteRequest_RemovesEntryFromMap is a focused unit test for the helper added
-// alongside the request-map leak fix. Execute defers c.deleteRequest(req.ID()) so the entry
-// added by storeRequest is removed regardless of how Execute exits (success, response error,
-// ctx cancellation). Without that cleanup, repeated Execute calls with the same workflow
-// execution ID + reference ID failed in storeRequest with "request for ID ... already exists"
-// until the expireRequests ticker reaped the stale entry.
-func TestClient_deleteRequest_RemovesEntryFromMap(t *testing.T) {
+// TestClient_markCompleted_MovesEntryFromActiveToCompleted is a focused unit test for the
+// helper added alongside the request-map leak fix. Execute defers c.markCompleted(req.ID())
+// so the entry added by storeRequest is removed from the active map regardless of how Execute
+// exits (success, response error, ctx cancellation), and the requestID is recorded in
+// completedRequestIDs so Receive can distinguish expected-but-late post-quorum responses from
+// truly unknown messages.
+func TestClient_markCompleted_MovesEntryFromActiveToCompleted(t *testing.T) {
 	c := &client{
 		requestIDToCallerRequest: map[string]*request.ClientRequest{},
+		completedRequestIDs:      map[string]time.Time{},
 		mutex:                    sync.Mutex{},
 	}
 
-	// Seed the map directly with a non-nil placeholder; deleteRequest only deletes by key, so the
-	// value's internal state is irrelevant for this test.
+	// Seed the active map directly with a non-nil placeholder; markCompleted only deletes by key,
+	// so the value's internal state is irrelevant for this test.
 	c.requestIDToCallerRequest["Execute:wfExecID:refID"] = &request.ClientRequest{}
 	assert.Len(t, c.requestIDToCallerRequest, 1)
+	assert.Empty(t, c.completedRequestIDs)
 
-	c.deleteRequest("Execute:wfExecID:refID")
-	assert.Empty(t, c.requestIDToCallerRequest, "deleteRequest should remove the entry")
+	before := time.Now()
+	c.markCompleted("Execute:wfExecID:refID")
+	after := time.Now()
 
-	// Idempotent: deleting an already-absent key is a no-op (matters because expireRequests can
-	// race with the Execute defer and reap the entry first).
-	c.deleteRequest("Execute:wfExecID:refID")
+	assert.Empty(t, c.requestIDToCallerRequest, "markCompleted should remove the active entry")
+	assert.Len(t, c.completedRequestIDs, 1, "markCompleted should record the completion")
+	completedAt, ok := c.completedRequestIDs["Execute:wfExecID:refID"]
+	assert.True(t, ok)
+	assert.True(t, !completedAt.Before(before) && !completedAt.After(after),
+		"completion timestamp should be between before and after the markCompleted call")
+
+	// Idempotent for the active map: calling markCompleted on an already-absent key is a no-op
+	// for the active map (delete is a no-op), and the completedAt stamp is refreshed — fine,
+	// since the goal is "did this complete recently".
+	c.markCompleted("Execute:wfExecID:refID")
 	assert.Empty(t, c.requestIDToCallerRequest)
+	assert.Len(t, c.completedRequestIDs, 1)
+}
+
+// TestClient_Receive_RecognizesRecentlyCompletedRequests asserts the data-path that Receive
+// uses to distinguish a late post-quorum response from a truly unknown message: after
+// markCompleted, the active map no longer has the request but completedRequestIDs does. This
+// is the regression guard for Copilot's review note on the original PR — every non-quorum
+// signer's late response otherwise logged "received response for unknown message ID" at Warn,
+// generating N-F-1 warnings per Execute call.
+func TestClient_Receive_RecognizesRecentlyCompletedRequests(t *testing.T) {
+	c := &client{
+		requestIDToCallerRequest: map[string]*request.ClientRequest{},
+		completedRequestIDs:      map[string]time.Time{},
+		mutex:                    sync.Mutex{},
+	}
+
+	const messageID = "Execute:wfExecID:refID"
+	c.requestIDToCallerRequest[messageID] = &request.ClientRequest{}
+
+	// Simulate Execute returning: active entry removed, completedRequestIDs populated.
+	c.markCompleted(messageID)
+
+	// Receive's decision: if requestIDToCallerRequest has no entry, check completedRequestIDs
+	// before logging Warn. After markCompleted, the late-response branch must fire.
+	_, isActive := c.requestIDToCallerRequest[messageID]
+	assert.False(t, isActive, "request should no longer be in the active map")
+	_, recentlyCompleted := c.completedRequestIDs[messageID]
+	assert.True(t, recentlyCompleted, "request should be recognized as recently completed")
 }

--- a/core/capabilities/remote/executable/client_internal_test.go
+++ b/core/capabilities/remote/executable/client_internal_test.go
@@ -1,13 +1,18 @@
 package executable
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/executable/request"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 )
 
 // TestClient_markCompleted_MovesEntryFromActiveToCompleted is a focused unit test for the
@@ -41,36 +46,66 @@ func TestClient_markCompleted_MovesEntryFromActiveToCompleted(t *testing.T) {
 		"completion timestamp should be between before and after the markCompleted call")
 
 	// Idempotent for the active map: calling markCompleted on an already-absent key is a no-op
-	// for the active map (delete is a no-op), and the completedAt stamp is refreshed — fine,
+	// for the active map (delete is a no-op), and the completedAt stamp is refreshed, fine,
 	// since the goal is "did this complete recently".
 	c.markCompleted("Execute:wfExecID:refID")
 	assert.Empty(t, c.requestIDToCallerRequest)
 	assert.Len(t, c.completedRequestIDs, 1)
 }
 
-// TestClient_Receive_RecognizesRecentlyCompletedRequests asserts the data-path that Receive
-// uses to distinguish a late post-quorum response from a truly unknown message: after
-// markCompleted, the active map no longer has the request but completedRequestIDs does. This
-// is the regression guard for Copilot's review note on the original PR — every non-quorum
-// signer's late response otherwise logged "received response for unknown message ID" at Warn,
-// generating N-F-1 warnings per Execute call.
-func TestClient_Receive_RecognizesRecentlyCompletedRequests(t *testing.T) {
+// TestClient_Receive_LateResponseAfterMarkCompleted_DoesNotWarn invokes Receive with a
+// message for a requestID whose Execute has already returned, and asserts that no Warn line
+// is emitted. This is the behavioral regression guard for Copilot's review note: every late
+// post-quorum response previously logged "received response for unknown message ID" at Warn,
+// generating N-F-1 warnings per Execute call in a healthy DON.
+func TestClient_Receive_LateResponseAfterMarkCompleted_DoesNotWarn(t *testing.T) {
+	lggr, observed := logger.TestObserved(t, zapcore.DebugLevel)
 	c := &client{
+		lggr:                     lggr,
 		requestIDToCallerRequest: map[string]*request.ClientRequest{},
 		completedRequestIDs:      map[string]time.Time{},
 		mutex:                    sync.Mutex{},
 	}
 
 	const messageID = "Execute:wfExecID:refID"
-	c.requestIDToCallerRequest[messageID] = &request.ClientRequest{}
 
-	// Simulate Execute returning: active entry removed, completedRequestIDs populated.
+	// Simulate the state right after Execute returned: completedRequestIDs has the ID.
 	c.markCompleted(messageID)
 
-	// Receive's decision: if requestIDToCallerRequest has no entry, check completedRequestIDs
-	// before logging Warn. After markCompleted, the late-response branch must fire.
-	_, isActive := c.requestIDToCallerRequest[messageID]
-	assert.False(t, isActive, "request should no longer be in the active map")
-	_, recentlyCompleted := c.completedRequestIDs[messageID]
-	assert.True(t, recentlyCompleted, "request should be recognized as recently completed")
+	// A late response from a non-quorum signer arrives at Receive.
+	c.Receive(context.Background(), &types.MessageBody{
+		MessageId: []byte(messageID),
+		Sender:    []byte("late-signer-peer"),
+	})
+
+	warns := observed.FilterLevelExact(zapcore.WarnLevel).All()
+	for _, entry := range warns {
+		assert.NotContains(t, entry.Message, "unknown message ID",
+			"late response after Execute should not log 'unknown message ID' at Warn")
+	}
+
+	debugs := observed.FilterMessageSnippet("late response after Execute returned").All()
+	assert.NotEmpty(t, debugs, "late response should log at Debug")
+}
+
+// TestClient_Receive_UnknownMessageID_StillWarns asserts the other half of the contract: a
+// message ID that was never registered (and is not in completedRequestIDs) still produces a
+// Warn. This guards against an over-correction where the late-response Debug branch swallows
+// genuinely unknown messages.
+func TestClient_Receive_UnknownMessageID_StillWarns(t *testing.T) {
+	lggr, observed := logger.TestObserved(t, zapcore.DebugLevel)
+	c := &client{
+		lggr:                     lggr,
+		requestIDToCallerRequest: map[string]*request.ClientRequest{},
+		completedRequestIDs:      map[string]time.Time{},
+		mutex:                    sync.Mutex{},
+	}
+
+	c.Receive(context.Background(), &types.MessageBody{
+		MessageId: []byte("Execute:never-registered:refID"),
+		Sender:    []byte("rogue-peer"),
+	})
+
+	warns := observed.FilterMessageSnippet("unknown message ID").All()
+	assert.NotEmpty(t, warns, "truly unknown messageID should still surface as Warn")
 }

--- a/core/capabilities/remote/executable/client_internal_test.go
+++ b/core/capabilities/remote/executable/client_internal_test.go
@@ -1,0 +1,36 @@
+package executable
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/executable/request"
+)
+
+// TestClient_deleteRequest_RemovesEntryFromMap is a focused unit test for the helper added
+// alongside the request-map leak fix. Execute defers c.deleteRequest(req.ID()) so the entry
+// added by storeRequest is removed regardless of how Execute exits (success, response error,
+// ctx cancellation). Without that cleanup, repeated Execute calls with the same workflow
+// execution ID + reference ID failed in storeRequest with "request for ID ... already exists"
+// until the expireRequests ticker reaped the stale entry.
+func TestClient_deleteRequest_RemovesEntryFromMap(t *testing.T) {
+	c := &client{
+		requestIDToCallerRequest: map[string]*request.ClientRequest{},
+		mutex:                    sync.Mutex{},
+	}
+
+	// Seed the map directly with a non-nil placeholder; deleteRequest only deletes by key, so the
+	// value's internal state is irrelevant for this test.
+	c.requestIDToCallerRequest["Execute:wfExecID:refID"] = &request.ClientRequest{}
+	assert.Len(t, c.requestIDToCallerRequest, 1)
+
+	c.deleteRequest("Execute:wfExecID:refID")
+	assert.Empty(t, c.requestIDToCallerRequest, "deleteRequest should remove the entry")
+
+	// Idempotent: deleting an already-absent key is a no-op (matters because expireRequests can
+	// race with the Execute defer and reap the entry first).
+	c.deleteRequest("Execute:wfExecID:refID")
+	assert.Empty(t, c.requestIDToCallerRequest)
+}


### PR DESCRIPTION
## Summary

- `client.Execute` stored each pending request in `requestIDToCallerRequest` but never removed it. Cleanup only happened via the `expireRequests` background ticker.
- Any caller that re-invoked `Execute` within the expiry window with the same `workflowExecutionID` + `referenceID` hit `"failed to store request: request for ID ... already exists"` from `storeRequest`'s duplicate check.
- Symptom in prod: workflow-engine step retries reuse the original referenceID, collide with the still-pending map entry from the prior attempt, and surface as `[2]Unknown` capability errors. Observed ~80 occurrences over a 2-week window against the VaultDON capability from confidential-compute workflows.
- Fix: defer `c.deleteRequest(req.ID())` immediately after `storeRequest` succeeds. Runs regardless of how `Execute` exits (success, response error, ctx cancellation). Symmetric `mutex` acquisition with `storeRequest`. Idempotent, so it composes safely with `expireRequests` racing the cleanup.

## Notes for reviewers

- New focused unit test in `client_internal_test.go` covers `deleteRequest` (removes entry, idempotent).
- Existing E2E tests still pass. The defer adds no behavioral change to the happy path; verified `Test_RemoteExecutionCapability_CapabilityError` and `Test_RemoteExecutableCapability_RandomCapabilityError` locally.
- I considered adding an E2E regression test that calls `Execute` twice on the same client with identical metadata and asserts both succeed. It hangs because the server-side `Execute` also dedupes by requestID and won't issue a response for an immediate-succession identical call. Production doesn't hit this because there's real time between retries. So the unit test is the right scope; broader behavior is verified by reading the 3-line defer + helper.