### PR TITLE
chore(logging): adjust log levels for core-foundations (232 changes)

### DIFF
--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -874,7 +874,7 @@ func (t *promptingAPIInitializer) Initialize(ctx context.Context, orm sessions.B
 			// On a fresh DB, create an admin user
 			user, err2 := sessions.NewUser(email, pwd, sessions.UserRoleAdmin)
 			if err2 != nil {
-				lggr.Errorw("Error creating API user", "err", err2)
+				lggr.Warnw("Error creating API user", "err", err2)
 				continue
 			}
 			if err = orm.CreateUser(ctx, &user); err != nil {

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -473,7 +473,7 @@ func tryRunServerUntilCancelled(ctx context.Context, lggr logger.Logger, timeout
 		// try calling runServer() and log error if any
 		if err := runServer(); err != nil {
 			if !errors.Is(err, http.ErrServerClosed) {
-				lggr.Criticalf("Error starting server: %v", err)
+				lggr.Errorf("Error starting server: %v", err)
 			}
 		}
 		// if ctx is cancelled, we must leave the loop

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -92,7 +92,7 @@ func initGlobals(cfgProm config.Prometheus, cfgTracing config.Tracing, cfgTeleme
 			grpcOpts = loop.NewGRPCOpts(nil) // default prometheus.Registerer
 
 			otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
-				lggr.Errorw("Telemetry error", "err", err)
+				lggr.Warnw("Telemetry error", "err", err)
 			}))
 
 			tracingCfg := loop.TracingConfig{

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -101,7 +101,7 @@ func initGlobals(cfgProm config.Prometheus, cfgTracing config.Tracing, cfgTeleme
 				NodeAttributes:  cfgTracing.Attributes(),
 				SamplingRatio:   cfgTracing.SamplingRatio(),
 				TLSCertPath:     cfgTracing.TLSCertPath(),
-				OnDialError:     func(error) { lggr.Errorw("Failed to dial", "err", err) },
+				OnDialError:     func(error) { lggr.Warnw("Failed to dial", "err", err) },
 			}
 			if !cfgTelemetry.Enabled() {
 				return loop.SetupTracing(tracingCfg)

--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -669,7 +669,7 @@ func checkFilePermissions(lggr logger.Logger, rootDir string) error {
 	// Ensure tls sub directory (and children) permissions are <= `ownerPermsMask``
 	tlsDir := filepath.Join(rootDir, "tls")
 	if _, err := os.Stat(tlsDir); err != nil && !os.IsNotExist(err) {
-		lggr.Errorf("error checking perms of 'tls' directory: %v", err)
+		lggr.Warnf("error checking perms of 'tls' directory: %v", err)
 	} else if err == nil {
 		err := utils.EnsureDirAndMaxPerms(tlsDir, ownerPermsMask)
 		if err != nil {

--- a/core/logger/audit/audit_logger.go
+++ b/core/logger/audit/audit_logger.go
@@ -149,7 +149,7 @@ func (l *AuditLoggerService) Close() error {
 		return errors.New("The audit logger is not enabled")
 	}
 
-	l.logger.Warnf("Disabled the audit logger service")
+	l.logger.Infof("Disabled the audit logger service")
 	close(l.chStop)
 	<-l.chDone
 

--- a/core/logger/audit/audit_logger.go
+++ b/core/logger/audit/audit_logger.go
@@ -188,7 +188,7 @@ func (l *AuditLoggerService) runLoop() {
 	for {
 		select {
 		case <-l.chStop:
-			l.logger.Warn("The audit logger is shutting down")
+			l.logger.Info("The audit logger is shutting down")
 			return
 		case event := <-l.loggingChannel:
 			l.postLogToLogService(event.eventID, event.data)

--- a/core/scripts/ccip/shared/helpers.go
+++ b/core/scripts/ccip/shared/helpers.go
@@ -28,7 +28,7 @@ func WaitForMined(lggr logger.Logger, client ethereum.TransactionReader, hash co
 
 		if receipt != nil {
 			if shouldSucceed && receipt.Status == 0 {
-				lggr.Infof("[MINING] ERROR tx reverted %s", hash.Hex())
+				lggr.Errorf("[MINING] ERROR tx reverted %s", hash.Hex())
 				panic(receipt)
 			} else if !shouldSucceed && receipt.Status != 0 {
 				lggr.Infof("[MINING] ERROR expected tx to revert %s", hash.Hex())

--- a/core/scripts/ccip/shared/helpers.go
+++ b/core/scripts/ccip/shared/helpers.go
@@ -31,7 +31,7 @@ func WaitForMined(lggr logger.Logger, client ethereum.TransactionReader, hash co
 				lggr.Errorf("[MINING] ERROR tx reverted %s", hash.Hex())
 				panic(receipt)
 			} else if !shouldSucceed && receipt.Status != 0 {
-				lggr.Infof("[MINING] ERROR expected tx to revert %s", hash.Hex())
+				lggr.Errorf("[MINING] ERROR expected tx to revert %s", hash.Hex())
 				panic(receipt)
 			}
 			lggr.Infof("[MINING] tx mined %s successful %t", hash.Hex(), shouldSucceed)

--- a/core/scripts/ccip/shared/helpers.go
+++ b/core/scripts/ccip/shared/helpers.go
@@ -23,7 +23,7 @@ const TxInclusionTimout = 3 * time.Minute
 func WaitForMined(lggr logger.Logger, client ethereum.TransactionReader, hash common.Hash, shouldSucceed bool) error {
 	maxIterations := TxInclusionTimout / RetryTiming
 	for i := 0; i < int(maxIterations); i++ {
-		lggr.Info("[MINING] waiting for tx to be mined...")
+		lggr.Debug("[MINING] waiting for tx to be mined...")
 		receipt, _ := client.TransactionReceipt(context.Background(), hash)
 
 		if receipt != nil {

--- a/core/scripts/chaincli/handler/scrape_node_config.go
+++ b/core/scripts/chaincli/handler/scrape_node_config.go
@@ -100,7 +100,7 @@ func (h *baseHandler) ScrapeNodes() {
 }
 
 func (h *baseHandler) scrapeNodes(ctx context.Context, log logger.Logger) {
-	log.Warn("This scrapes node address, peer ID, CSA node address, CSA public key, OCR2 ID, OCR2 config pub key, OCR2 onchain pub key, and OCR2 offchain pub key.")
+	log.Info("This scrapes node address, peer ID, CSA node address, CSA public key, OCR2 ID, OCR2 config pub key, OCR2 onchain pub key, and OCR2 offchain pub key.")
 	log.Warn("This does NOT scrape for payee address, admin address etc. Please verify that manually.")
 	cls := make([]cmd.HTTPClient, len(h.cfg.KeeperURLs))
 	for i := range h.cfg.KeeperURLs {

--- a/core/scripts/chaincli/handler/scrape_node_config.go
+++ b/core/scripts/chaincli/handler/scrape_node_config.go
@@ -101,7 +101,7 @@ func (h *baseHandler) ScrapeNodes() {
 
 func (h *baseHandler) scrapeNodes(ctx context.Context, log logger.Logger) {
 	log.Info("This scrapes node address, peer ID, CSA node address, CSA public key, OCR2 ID, OCR2 config pub key, OCR2 onchain pub key, and OCR2 offchain pub key.")
-	log.Warn("This does NOT scrape for payee address, admin address etc. Please verify that manually.")
+	log.Info("This does NOT scrape for payee address, admin address etc. Please verify that manually.")
 	cls := make([]cmd.HTTPClient, len(h.cfg.KeeperURLs))
 	for i := range h.cfg.KeeperURLs {
 		url := h.cfg.KeeperURLs[i]

--- a/core/scripts/cre/environment/environment/beholder.go
+++ b/core/scripts/cre/environment/environment/beholder.go
@@ -857,7 +857,7 @@ func parseConfigsAndRegisterProtos(ctx context.Context, schemaSets []chipingress
 
 	for _, protoSchemaSet := range schemaSets {
 		framework.L.Info().Msgf("Registering and fetching proto from %s", protoSchemaSet.URI)
-		framework.L.Info().Msgf("Proto schema set config: %+v", protoSchemaSet)
+		framework.L.Debug().Msgf("Proto schema set config: %+v", protoSchemaSet)
 	}
 
 	reposErr := chipingressset.FetchAndRegisterProtos(

--- a/core/scripts/cre/environment/environment/setup.go
+++ b/core/scripts/cre/environment/environment/setup.go
@@ -580,7 +580,7 @@ func RunSetup(ctx context.Context, config SetupConfig, noPrompt, purge, withBill
 			return
 		}
 	} else {
-		logger.Warn().Str("config file", config.ConfigPath).Msgf("Skipping Atlas Chip Ingress setup, because configuration is not provided in the config file")
+		logger.Info().Str("config file", config.ConfigPath).Msgf("Skipping Atlas Chip Ingress setup, because configuration is not provided in the config file")
 	}
 
 	var chipConfigLocalImage string

--- a/core/scripts/cre/environment/environment/setup.go
+++ b/core/scripts/cre/environment/environment/setup.go
@@ -563,7 +563,7 @@ func RunSetup(ctx context.Context, config SetupConfig, noPrompt, purge, withBill
 			return
 		}
 	} else {
-		logger.Warn().Str("config file", config.ConfigPath).Msg("Skipping Chip Router setup, because configuration is not provided in the config file")
+		logger.Info().Str("config file", config.ConfigPath).Msg("Skipping Chip Router setup, because configuration is not provided in the config file")
 	}
 
 	var chipIngressLocalImage string

--- a/core/scripts/cre/environment/environment/setup.go
+++ b/core/scripts/cre/environment/environment/setup.go
@@ -597,7 +597,7 @@ func RunSetup(ctx context.Context, config SetupConfig, noPrompt, purge, withBill
 			return
 		}
 	} else {
-		logger.Warn().Str("config file", config.ConfigPath).Msgf("Skipping Atlas Chip Config setup, because configuration is not provided in the config file")
+		logger.Info().Str("config file", config.ConfigPath).Msgf("Skipping Atlas Chip Config setup, because configuration is not provided in the config file")
 	}
 
 	var billingLocalImage string

--- a/core/scripts/cre/environment/environment/setup.go
+++ b/core/scripts/cre/environment/environment/setup.go
@@ -620,7 +620,7 @@ func RunSetup(ctx context.Context, config SetupConfig, noPrompt, purge, withBill
 			return
 		}
 	} else {
-		logger.Warn().Msgf("Skipping Billing Platform Service setup, because the --with-billing flag was not provided")
+		logger.Info().Msgf("Skipping Billing Platform Service setup, because the --with-billing flag was not provided")
 	}
 
 	if err := runGHSetupGit(ctx); err != nil {

--- a/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
+++ b/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
@@ -162,7 +162,7 @@ func onTrigger(config types.WorkflowConfig, runtime cre.Runtime, payload *cron.P
 }
 
 func getReadBalancesContractABI(runtime cre.Runtime) (*abi.ABI, error) {
-	runtime.Logger().Info("getting Balance Reader contract ABI")
+	runtime.Logger().Debug("getting Balance Reader contract ABI")
 	readBalancesABI, abiErr := balance_reader.BalanceReaderMetaData.GetAbi()
 	if abiErr != nil {
 		runtime.Logger().Error("failed to get Balance Reader contract ABI", "error", abiErr)

--- a/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
+++ b/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
@@ -64,7 +64,7 @@ func onTrigger(config types.WorkflowConfig, runtime cre.Runtime, payload *cron.P
 		runtime.Logger().Error(fmt.Sprintf("[logger] failed to get on-chain balance: %v", err))
 		return "", fmt.Errorf("failed to get on-chain balance: %w", err)
 	}
-	runtime.Logger().With().Info(fmt.Sprintf("[logger] Got on-chain balance with BalanceAt() for address %s: %s", addressToRead1, balanceAtOutput.Balance.String()))
+	runtime.Logger().With().Debug(fmt.Sprintf("[logger] Got on-chain balance with BalanceAt() for address %s: %s", addressToRead1, balanceAtOutput.Balance.String()))
 	// Convert protobuf BigInt to big.Int manually to avoid import conflicts
 	balanceAtResult := values.ProtoToBigInt(balanceAtOutput.Balance)
 	runtime.Logger().With().Info(fmt.Sprintf("[logger] Got on-chain balance with BalanceAt() for address %s: %s", addressToRead1, balanceAtResult.String()))

--- a/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
+++ b/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
@@ -46,7 +46,7 @@ func onTrigger(config types.WorkflowConfig, runtime cre.Runtime, payload *cron.P
 
 	// get balance with BalanceAt()
 	evmClient := evm.Client{ChainSelector: config.ChainSelector}
-	runtime.Logger().Info("Got EVM client", "chainSelector", evmClient.ChainSelector)
+	runtime.Logger().Debug("Got EVM client", "chainSelector", evmClient.ChainSelector)
 	addressesToRead := config.BalanceReaderConfig.AddressesToRead
 	runtime.Logger().Info("Got addresses to read", "addresses", addressesToRead)
 

--- a/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
+++ b/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
@@ -48,7 +48,7 @@ func onTrigger(config types.WorkflowConfig, runtime cre.Runtime, payload *cron.P
 	evmClient := evm.Client{ChainSelector: config.ChainSelector}
 	runtime.Logger().Debug("Got EVM client", "chainSelector", evmClient.ChainSelector)
 	addressesToRead := config.BalanceReaderConfig.AddressesToRead
-	runtime.Logger().Info("Got addresses to read", "addresses", addressesToRead)
+	runtime.Logger().Debug("Got addresses to read", "addresses", addressesToRead)
 
 	// For testing purposes, there is no handling of index out of range or nil cases.
 	// It allows for the configuration of empty addresses, a single address, or zero balances.

--- a/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
+++ b/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
@@ -67,7 +67,7 @@ func onTrigger(config types.WorkflowConfig, runtime cre.Runtime, payload *cron.P
 	runtime.Logger().With().Debug(fmt.Sprintf("[logger] Got on-chain balance with BalanceAt() for address %s: %s", addressToRead1, balanceAtOutput.Balance.String()))
 	// Convert protobuf BigInt to big.Int manually to avoid import conflicts
 	balanceAtResult := values.ProtoToBigInt(balanceAtOutput.Balance)
-	runtime.Logger().With().Info(fmt.Sprintf("[logger] Got on-chain balance with BalanceAt() for address %s: %s", addressToRead1, balanceAtResult.String()))
+	runtime.Logger().With().Debug(fmt.Sprintf("[logger] Got on-chain balance with BalanceAt() for address %s: %s", addressToRead1, balanceAtResult.String()))
 
 	// get balance with CallContract
 	readBalancesParsedABI, err := getReadBalancesContractABI(runtime)

--- a/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
+++ b/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
@@ -93,7 +93,7 @@ func onTrigger(config types.WorkflowConfig, runtime cre.Runtime, payload *cron.P
 		runtime.Logger().Error(fmt.Sprintf("failed to read CallContract output: %v", err))
 		return "", fmt.Errorf("failed to read CallContract output: %w", err)
 	}
-	runtime.Logger().With().Info(fmt.Sprintf("Read on-onchain balances for addresses %v: %v", addressesToRead, &readBalancePrices))
+	runtime.Logger().With().Debug(fmt.Sprintf("Read on-onchain balances for addresses %v: %v", addressesToRead, &readBalancePrices))
 
 	// get total on-chain balance
 	allOnchainBalances := append(readBalancePrices, balanceAtResult)

--- a/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
+++ b/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
@@ -251,7 +251,7 @@ func getHTTPPrice(config types.WorkflowConfig, runtime cre.NodeRuntime) (priceOu
 		return priceOutput{}, fmt.Errorf("failed to unmarshal price response: %w", err)
 	}
 
-	runtime.Logger().With().Info(fmt.Sprintf("Response is account name: %s, totalTrust: %.10f, ripcord: %v, updatedAt: %s", resp.AccountName, resp.TotalTrust, resp.Ripcord, resp.UpdatedAt.String()))
+	runtime.Logger().With().Debug(fmt.Sprintf("Response is account name: %s, totalTrust: %.10f, ripcord: %v, updatedAt: %s", resp.AccountName, resp.TotalTrust, resp.Ripcord, resp.UpdatedAt.String()))
 
 	if resp.Ripcord {
 		runtime.Logger().With(

--- a/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
+++ b/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
@@ -101,7 +101,7 @@ func onTrigger(config types.WorkflowConfig, runtime cre.Runtime, payload *cron.P
 	for _, balance := range allOnchainBalances {
 		totalOnChainBalance = *totalOnChainBalance.Add(&totalOnChainBalance, balance)
 	}
-	runtime.Logger().With().Info(fmt.Sprintf("Total on-chain balance for addresses %v", &totalOnChainBalance))
+	runtime.Logger().With().Debug(fmt.Sprintf("Total on-chain balance for addresses %v", &totalOnChainBalance))
 
 	totalPriceOutput, err := cre.RunInNodeMode(config, runtime,
 		func(config types.WorkflowConfig, nodeRuntime cre.NodeRuntime) (priceOutput, error) {

--- a/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
+++ b/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
@@ -189,7 +189,7 @@ func readBalancesFromContract(addresses []common.Address, readBalancesABI *abi.A
 		runtime.Logger().Error(fmt.Sprintf("[logger] failed to get balances %v: %v", addresses, err))
 		return nil, fmt.Errorf("failed to get balances for addresses %v: %w", addresses, err)
 	}
-	runtime.Logger().With().Info(fmt.Sprintf("Got raw CallContract output: %s", hex.EncodeToString(readBalancesOutput.Data)))
+	runtime.Logger().With().Debug(fmt.Sprintf("Got raw CallContract output: %s", hex.EncodeToString(readBalancesOutput.Data)))
 	return readBalancesOutput, nil
 }
 

--- a/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
+++ b/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
@@ -168,7 +168,7 @@ func getReadBalancesContractABI(runtime cre.Runtime) (*abi.ABI, error) {
 		runtime.Logger().Error("failed to get Balance Reader contract ABI", "error", abiErr)
 		return nil, fmt.Errorf("failed to get Balance Reader contract ABI: %w", abiErr)
 	}
-	runtime.Logger().Info("successfully got Balance Reader contract ABI")
+	runtime.Logger().Debug("successfully got Balance Reader contract ABI")
 	return readBalancesABI, nil
 }
 

--- a/core/services/arbiter/arbiter_scaler.go
+++ b/core/services/arbiter/arbiter_scaler.go
@@ -67,7 +67,7 @@ func (h *RingArbiterHandler) ConsensusWantShards(ctx context.Context, req *ringp
 		)
 	}
 
-	h.lggr.Infow("Consensus wants shards",
+	h.lggr.Debugw("Consensus wants shards",
 		"nShards", nShards,
 	)
 

--- a/core/services/arbiter/shardconfig.go
+++ b/core/services/arbiter/shardconfig.go
@@ -178,7 +178,7 @@ func (s *shardConfigSyncer) initContractReader(ctx context.Context) error {
 		case <-ticker.C:
 			reader, err := s.newContractReader(ctx)
 			if err != nil {
-				s.lggr.Infow("Contract reader unavailable, retrying", "error", err)
+				s.lggr.Debugw("Contract reader unavailable, retrying", "error", err)
 				continue
 			}
 			s.contractReader = reader

--- a/core/services/beholder/config_recorder.go
+++ b/core/services/beholder/config_recorder.go
@@ -32,7 +32,7 @@ func (s *ConfigRecorder) start(ctx context.Context) error {
 	ticker := services.TickerConfig{}.NewTicker(s.interval)
 	s.eng.GoTick(ticker, func(ctx context.Context) {
 		if err := beholder.GetClient().RecordConfigMetric(ctx); err != nil {
-			s.eng.Errorf("failed to record beholder config metric: %v", err)
+			s.eng.Warnf("failed to record beholder config metric: %v", err)
 		}
 	})
 	return nil

--- a/core/services/ccv/ccvcommitteeverifier/delegate.go
+++ b/core/services/ccv/ccvcommitteeverifier/delegate.go
@@ -70,7 +70,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) (services 
 		return nil, fmt.Errorf("failed to unmarshal committeeVerifierConfig into the verifier config struct: %w", err)
 	}
 
-	d.delegateLogger.Infow("validating committee verifier config", "config", decodedCfg, "raw", spec.CCVCommitteeVerifierSpec.CommitteeVerifierConfig)
+	d.delegateLogger.Debugw("validating committee verifier config", "config", decodedCfg, "raw", spec.CCVCommitteeVerifierSpec.CommitteeVerifierConfig)
 
 	err = decodedCfg.Validate()
 	if err != nil {

--- a/core/services/ccv/ccvcommon/common.go
+++ b/core/services/ccv/ccvcommon/common.go
@@ -36,7 +36,7 @@ func GetLegacyChains(ctx context.Context, lggr logger.Logger, chainServices []co
 		}
 
 		if !slices.Contains(chainsInConfig, protocol.ChainSelector(chain2.Selector)) {
-			lggr.Infow("skipping chain not in config", "chain", chain2.Selector, "chainID", id.String())
+			lggr.Debugw("skipping chain not in config", "chain", chain2.Selector, "chainID", id.String())
 			continue
 		}
 

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -410,7 +410,7 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 
 	var profiler *pyroscope.Profiler
 	if cfg.Pyroscope().ServerAddress() != "" {
-		globalLogger.Debug("Pyroscope (automatic pprof profiling) is enabled")
+		globalLogger.Info("Pyroscope (automatic pprof profiling) is enabled")
 		var err error
 		profiler, err = logger.StartPyroscope(cfg.Pyroscope(), cfg.AutoPprof())
 		if err != nil {

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -740,7 +740,7 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 			cfg.EVMConfigs(),
 		)
 	} else {
-		globalLogger.Debug("Off-chain reporting v2 disabled")
+		globalLogger.Info("Off-chain reporting v2 disabled")
 	}
 
 	bridgeStatusReporter := bridgestatus.NewBridgeStatusReporter(

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -265,7 +265,7 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 			globalLogger.Infow("ShardOrchestrator gRPC client created", "shardID", shardIdx, "serverAddress", shardOrchestratorAddr.String())
 		}
 	} else {
-		globalLogger.Debug("Sharding not enabled, running without shard orchestrator client")
+		globalLogger.Info("Sharding not enabled, running without shard orchestrator client")
 	}
 
 	creSettingsTOML, err := toml.Marshal(commoncresettings.Default)

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -677,7 +677,7 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 			mailMon,
 		)
 	} else {
-		globalLogger.Debug("Off-chain reporting disabled")
+		globalLogger.Info("Off-chain reporting disabled")
 	}
 
 	if cfg.OCR2().Enabled() {

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -953,7 +953,7 @@ func (app *ChainlinkApplication) stop() (err error) {
 		// Stop services in the reverse order from which they were started
 		for i := len(app.srvcs) - 1; i >= 0; i-- {
 			service := app.srvcs[i]
-			app.logger.Debugw("Closing service...", "name", service.Name())
+			app.logger.Infow("Closing service...", "name", service.Name())
 			err = stderrors.Join(err, service.Close())
 		}
 

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -681,7 +681,7 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 	}
 
 	if cfg.OCR2().Enabled() {
-		globalLogger.Debug("Off-chain reporting v2 enabled")
+		globalLogger.Info("Off-chain reporting v2 enabled")
 
 		ocr2DelegateConfig := ocr2.NewDelegateConfig(cfg.OCR2(), cfg.Mercury(), cfg.Threshold(), cfg.Insecure(), cfg.JobPipeline(), loopRegistrarConfig, cfg.Sharding(), ringStoreForShard0)
 

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -429,7 +429,7 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 			)
 		}
 	} else {
-		globalLogger.Debug("Pyroscope (automatic pprof profiling) is disabled")
+		globalLogger.Info("Pyroscope (automatic pprof profiling) is disabled")
 	}
 
 	ap := cfg.AutoPprof()

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -1190,7 +1190,7 @@ func (app *ChainlinkApplication) GetWebAuthnConfiguration() sessions.WebAuthnCon
 	}
 
 	if rporigin == "" {
-		app.GetLogger().Errorf("RPOrigin is not set, WebAuthn will likely not work as intended")
+		app.GetLogger().Warnf("RPOrigin is not set, WebAuthn will likely not work as intended")
 	}
 
 	return sessions.WebAuthnConfiguration{

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -970,7 +970,7 @@ func (app *ChainlinkApplication) stop() (err error) {
 			err = stderrors.Join(err, app.profiler.Stop())
 		}
 
-		app.logger.Debugf("Closed application in %v", time.Since(shutdownStart))
+		app.logger.Infof("Closed application in %v", time.Since(shutdownStart))
 
 		app.started = false
 	})

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -1186,7 +1186,7 @@ func (app *ChainlinkApplication) GetWebAuthnConfiguration() sessions.WebAuthnCon
 	rpid := app.Config.WebServer().MFA().RPID()
 	rporigin := app.Config.WebServer().MFA().RPOrigin()
 	if rpid == "" {
-		app.GetLogger().Errorf("RPID is not set, WebAuthn will likely not work as intended")
+		app.GetLogger().Warnf("RPID is not set, WebAuthn will likely not work as intended")
 	}
 
 	if rporigin == "" {

--- a/core/services/chainlink/node_platform.go
+++ b/core/services/chainlink/node_platform.go
@@ -258,7 +258,7 @@ func (s *NodePlatformJobInfoService) submitterAddresses(ctx context.Context) []*
 	for offset := 0; ; {
 		jobs, count, err := s.opts.JobReader.FindJobs(ctx, offset, nodePlatformJobInfoPageSize)
 		if err != nil {
-			s.eng.Warnw("failed to resolve node-platform submitter addresses", "offset", offset, "limit", nodePlatformJobInfoPageSize, "err", err)
+			s.eng.Errorw("failed to resolve node-platform submitter addresses", "offset", offset, "limit", nodePlatformJobInfoPageSize, "err", err)
 			return nil
 		}
 

--- a/core/services/chainlink/relayer_factory.go
+++ b/core/services/chainlink/relayer_factory.go
@@ -203,7 +203,7 @@ func (r *RelayerFactory) NewLOOPRelayer(name string, network string, plugin env.
 
 		// skip disabled chains from further processing
 		if !chainCfg.IsEnabled() {
-			lggr.Warnw("Skipping disabled chain", "id", relayID.ChainID)
+			lggr.Infow("Skipping disabled chain", "id", relayID.ChainID)
 			continue
 		}
 

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -1135,7 +1135,7 @@ func newWorkflowRegistrySyncer(
 
 	billingClient, err := newBillingClient(lggr, cfg, opts)
 	if err != nil {
-		lggr.Infof("failed to create billing client: %s", err)
+		lggr.Errorf("failed to create billing client: %s", err)
 	}
 
 	major, vErr := workflowRegistrySemverMajor(capCfg.WorkflowRegistry().ContractVersion())

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -865,7 +865,7 @@ func newWorkflowRegistrySyncerV1(
 	}
 
 	srvcs = append(srvcs, wfSyncer)
-	lggr.Debugw("Created WorkflowRegistrySyncer V1")
+	lggr.Infow("Created WorkflowRegistrySyncer V1")
 	return srvcs, nil
 }
 

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -1109,7 +1109,7 @@ func newWorkflowRegistrySyncerV2(
 	}
 
 	srvcs = append(srvcs, workflowRegistrySyncerV2)
-	lggr.Debugw("Created WorkflowRegistrySyncer V2")
+	lggr.Infow("Created WorkflowRegistrySyncer V2")
 	return workflowRegistrySyncerV2, srvcs, nil
 }
 

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -229,7 +229,7 @@ func (s *Services) newSubservices(
 		s.OrgResolver = fallbackResolver
 		srvs = append(srvs, fallbackResolver)
 	} else {
-		lggr.Warn("Skipping orgResolver, no linking service configured")
+		lggr.Info("Skipping orgResolver, no linking service configured")
 	}
 
 	dispatcherWrapper, err := newDispatcherWrapper(cfg, opts, keyStore, ds, singletonPeerWrapper, lggr)

--- a/core/services/cron/cron.go
+++ b/core/services/cron/cron.go
@@ -47,7 +47,7 @@ func NewCronFromJobSpec(
 
 // Start implements the job.Service interface.
 func (cr *Cron) Start(context.Context) error {
-	cr.logger.Debug("Starting")
+	cr.logger.Info("Starting")
 
 	_, err := cr.cronRunner.AddFunc(cr.jobSpec.CronSpec.CronSchedule, cr.runPipeline)
 	if err != nil {

--- a/core/services/cron/cron.go
+++ b/core/services/cron/cron.go
@@ -61,7 +61,7 @@ func (cr *Cron) Start(context.Context) error {
 // Close implements the job.Service interface. It stops this job from
 // running and cleans up resources.
 func (cr *Cron) Close() error {
-	cr.logger.Debug("Closing")
+	cr.logger.Info("Closing")
 	cr.cronRunner.Stop()
 	return nil
 }

--- a/core/services/gateway/connectionmanager.go
+++ b/core/services/gateway/connectionmanager.go
@@ -392,7 +392,7 @@ func (m *donConnectionManager) keepaliveLoop(intervalSec uint32) {
 				}
 			}
 			promKeepalivesSent.WithLabelValues(m.donConfig.DonId).Set(float64(len(m.nodes) - errorCount))
-			m.lggr.Infow("sent keepalive pings to nodes", "donID", m.donConfig.DonId, "errCount", errorCount)
+			m.lggr.Debugw("sent keepalive pings to nodes", "donID", m.donConfig.DonId, "errCount", errorCount)
 		}
 	}
 }

--- a/core/services/gateway/connectionmanager.go
+++ b/core/services/gateway/connectionmanager.go
@@ -357,7 +357,7 @@ func (m *donConnectionManager) readLoop(nodeAddress string, nodeState *nodeState
 			m.gMetrics.RecordNodeMsgHandlerInvocation(ctx, nodeAddress, nodeState.name, err == nil)
 			m.gMetrics.RecordNodeMsgHandlerDuration(ctx, nodeAddress, nodeState.name, time.Since(startTime), err == nil)
 			if err != nil {
-				m.lggr.Errorw("error when calling HandleNodeMessage", "err", err, "nodeAddress", nodeAddress, "nodeState", nodeState.name, "responseID", resp.ID)
+				m.lggr.Warnw("error when calling HandleNodeMessage", "err", err, "nodeAddress", nodeAddress, "nodeState", nodeState.name, "responseID", resp.ID)
 			}
 		}
 	}

--- a/core/services/gateway/connectionmanager.go
+++ b/core/services/gateway/connectionmanager.go
@@ -349,7 +349,7 @@ func (m *donConnectionManager) readLoop(nodeAddress string, nodeState *nodeState
 			}
 			handler, err := m.getHandler(resp.Method)
 			if err != nil {
-				m.lggr.Errorw("no handler for node message", "nodeAddress", nodeAddress, "method", resp.Method, "err", err)
+				m.lggr.Warnw("no handler for node message", "nodeAddress", nodeAddress, "method", resp.Method, "err", err)
 				break
 			}
 			startTime := time.Now()

--- a/core/services/gateway/connectionmanager.go
+++ b/core/services/gateway/connectionmanager.go
@@ -344,7 +344,7 @@ func (m *donConnectionManager) readLoop(nodeAddress string, nodeState *nodeState
 			var resp jsonrpc.Response[json.RawMessage]
 			err := json.Unmarshal(item.Data, &resp)
 			if err != nil {
-				m.lggr.Errorw("parse error when reading from node", "nodeAddress", nodeAddress, "err", err)
+				m.lggr.Warnw("parse error when reading from node", "nodeAddress", nodeAddress, "err", err)
 				break
 			}
 			handler, err := m.getHandler(resp.Method)

--- a/core/services/gateway/connectionmanager.go
+++ b/core/services/gateway/connectionmanager.go
@@ -369,7 +369,7 @@ func (m *donConnectionManager) keepaliveLoop(intervalSec uint32) {
 	defer cancel()
 
 	if intervalSec == 0 {
-		m.lggr.Errorw("keepalive interval is 0, keepalive disabled", "donID", m.donConfig.DonId)
+		m.lggr.Warnw("keepalive interval is 0, keepalive disabled", "donID", m.donConfig.DonId)
 		return
 	}
 	m.lggr.Infow("starting keepalive loop", "donID", m.donConfig.DonId)

--- a/core/services/gateway/connector/connector.go
+++ b/core/services/gateway/connector/connector.go
@@ -238,7 +238,7 @@ func (c *gatewayConnector) readLoop(gatewayState *gatewayState) {
 			}
 			handler, exists := c.handlers[req.Method]
 			if !exists {
-				c.lggr.Errorw("no handler for method", "id", gatewayState.config.Id, "method", req.Method)
+				c.lggr.Warnw("no handler for method", "id", gatewayState.config.Id, "method", req.Method)
 				break
 			}
 			// do not break on error. HandleGatewayMessage handles errors

--- a/core/services/gateway/connector/connector.go
+++ b/core/services/gateway/connector/connector.go
@@ -280,7 +280,7 @@ func (c *gatewayConnector) reconnectLoop(gatewayState *gatewayState) {
 			c.closeWait.Done()
 			return
 		case <-time.After(redialBackoff.Duration()):
-			c.lggr.Info("reconnecting ...")
+			c.lggr.Debug("reconnecting ...")
 		}
 	}
 }

--- a/core/services/gateway/connector/connector.go
+++ b/core/services/gateway/connector/connector.go
@@ -233,7 +233,7 @@ func (c *gatewayConnector) readLoop(gatewayState *gatewayState) {
 			var req jsonrpc.Request[json.RawMessage]
 			err := json.Unmarshal(item.Data, &req)
 			if err != nil {
-				c.lggr.Errorw("parse error when reading from Gateway", "id", gatewayState.config.Id, "err", err)
+				c.lggr.Warnw("parse error when reading from Gateway", "id", gatewayState.config.Id, "err", err)
 				break
 			}
 			handler, exists := c.handlers[req.Method]

--- a/core/services/gateway/connector/connector.go
+++ b/core/services/gateway/connector/connector.go
@@ -259,7 +259,7 @@ func (c *gatewayConnector) reconnectLoop(gatewayState *gatewayState) {
 	for {
 		conn, err := gatewayState.wsClient.Connect(ctx, gatewayState.url)
 		if err != nil {
-			c.lggr.Errorw("connection error", "url", gatewayState.url, "err", err)
+			c.lggr.Warnw("connection error", "url", gatewayState.url, "err", err)
 		} else {
 			c.lggr.Infow("connected successfully", "url", gatewayState.url)
 			closeCh := gatewayState.conn.Reset(conn)

--- a/core/services/gateway/handlers/capabilities/handler.go
+++ b/core/services/gateway/handlers/capabilities/handler.go
@@ -231,7 +231,7 @@ func (h *handler) handleWebAPIOutgoingMessage(ctx context.Context, msg *api.Mess
 		}
 		err = h.don.SendToNode(newCtx, nodeAddr, req)
 		if err != nil {
-			l.Errorw("failed to send to node", "err", err, "to", nodeAddr)
+			l.Warnw("failed to send to node", "err", err, "to", nodeAddr)
 			return
 		}
 		l.Debugw("sent response to node", "to", nodeAddr)

--- a/core/services/gateway/handlers/capabilities/handler.go
+++ b/core/services/gateway/handlers/capabilities/handler.go
@@ -226,7 +226,7 @@ func (h *handler) handleWebAPIOutgoingMessage(ctx context.Context, msg *api.Mess
 		respMsg.Signature = msg.Signature
 		req, err := common.ValidatedRequestFromMessage(respMsg)
 		if err != nil {
-			l.Errorw(ErrTransformingMessageToRequest, "err", err)
+			l.Warnw(ErrTransformingMessageToRequest, "err", err)
 			return
 		}
 		err = h.don.SendToNode(newCtx, nodeAddr, req)

--- a/core/services/gateway/handlers/capabilities/handler.go
+++ b/core/services/gateway/handlers/capabilities/handler.go
@@ -373,7 +373,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 	}
 
 	if uint(time.Now().Unix())-h.config.MaxAllowedMessageAgeSec > uint(payload.Timestamp) {
-		h.lggr.Errorw("stale message")
+		h.lggr.Warnw("stale message")
 		return callback.SendResponse(handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,

--- a/core/services/gateway/handlers/capabilities/handler.go
+++ b/core/services/gateway/handlers/capabilities/handler.go
@@ -386,7 +386,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 	}
 	// TODO: apply allowlist and rate-limiting here
 	if msg.Body.Method != MethodWebAPITrigger {
-		h.lggr.Errorw("unsupported method", "method", body.Method)
+		h.lggr.Warnw("unsupported method", "method", body.Method)
 		return callback.SendResponse(handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,

--- a/core/services/gateway/handlers/capabilities/handler.go
+++ b/core/services/gateway/handlers/capabilities/handler.go
@@ -195,7 +195,7 @@ func (h *handler) handleWebAPIOutgoingMessage(ctx context.Context, msg *api.Mess
 		l.Debug("Sending request to client")
 		respMsg, err := h.sendHTTPMessageToClient(newCtx, req, msg)
 		if err != nil {
-			l.Errorw("error while sending HTTP request to external endpoint", "err", err)
+			l.Warnw("error while sending HTTP request to external endpoint", "err", err)
 			payload := Response{
 				ExecutionError: true,
 				ErrorMessage:   err.Error(),

--- a/core/services/gateway/handlers/capabilities/handler.go
+++ b/core/services/gateway/handlers/capabilities/handler.go
@@ -399,7 +399,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 	}
 	req, err := common.ValidatedRequestFromMessage(msg)
 	if err != nil {
-		h.lggr.Errorw(ErrTransformingMessageToRequest)
+		h.lggr.Warnw(ErrTransformingMessageToRequest)
 		return callback.SendResponse(handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,

--- a/core/services/gateway/handlers/capabilities/handler.go
+++ b/core/services/gateway/handlers/capabilities/handler.go
@@ -360,7 +360,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 	}
 
 	if payload.Timestamp == 0 {
-		h.lggr.Errorw(ErrDecodingPayload)
+		h.lggr.Warnw(ErrDecodingPayload)
 		return callback.SendResponse(handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,

--- a/core/services/gateway/handlers/capabilities/handler.go
+++ b/core/services/gateway/handlers/capabilities/handler.go
@@ -347,7 +347,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 	codec := api.JsonRPCCodec{}
 	err := json.Unmarshal(body.Payload, &payload)
 	if err != nil {
-		h.lggr.Errorw(ErrDecodingPayload, "err", err)
+		h.lggr.Warnw(ErrDecodingPayload, "err", err)
 		return callback.SendResponse(handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,

--- a/core/services/gateway/handlers/capabilities/v2/http_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_handler.go
@@ -222,7 +222,7 @@ func (h *gatewayHandler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Re
 	// Any messages without "/" is assumed to be a trigger response to a prior user request.
 	if strings.Contains(resp.ID, "/") {
 		if resp.Result == nil {
-			h.lggr.Errorw("received response with empty result from node", "nodeAddr", nodeAddr, "error", resp.Error)
+			h.lggr.Warnw("received response with empty result from node", "nodeAddr", nodeAddr, "error", resp.Error)
 			return fmt.Errorf("received response with empty result from node %s", nodeAddr)
 		}
 		parts := strings.Split(resp.ID, "/")

--- a/core/services/gateway/handlers/capabilities/v2/http_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_handler.go
@@ -314,7 +314,7 @@ func (h *gatewayHandler) HandleJSONRPCUserMessage(ctx context.Context, req jsonr
 	h.metrics.IncrementTriggerRequestCount(ctx, h.lggr)
 	err := h.triggerHandler.HandleUserTriggerRequest(ctx, &req, callback, time.Now())
 	if err != nil {
-		h.lggr.Errorw("failed to handle user trigger request", "requestID",
+		h.lggr.Warnw("failed to handle user trigger request", "requestID",
 			req.ID, "err", err)
 		// error response is sent to the response channel by the trigger handler
 		// so return nil after logging

--- a/core/services/gateway/handlers/capabilities/v2/http_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_handler.go
@@ -370,7 +370,7 @@ func (h *gatewayHandler) makeOutgoingRequest(ctx context.Context, resp *jsonrpc.
 		defer sendCancel()
 		err := h.sendResponseToNode(sendCtx, requestID, outboundResp, nodeAddr)
 		if err != nil {
-			l.Errorw("error sending response to node", "err", err, "nodeAddr", nodeAddr, "requestID", requestID)
+			l.Warnw("error sending response to node", "err", err, "nodeAddr", nodeAddr, "requestID", requestID)
 			h.metrics.IncrementActionCapabilityFailures(ctx, nodeAddr, h.lggr)
 		}
 	}()

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -539,7 +539,7 @@ func (h *httpTriggerHandler) handleUserError(ctx context.Context, requestID stri
 		ErrorCode:   errorCode,
 	})
 	if err != nil {
-		h.lggr.Errorw("failed to send user callback", "err", err, "requestID", requestID)
+		h.lggr.Warnw("failed to send user callback", "err", err, "requestID", requestID)
 		return
 	}
 }

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -591,7 +591,7 @@ func (h *httpTriggerHandler) sendWithRetries(ctx context.Context, executionID st
 		}
 
 		if allNodesSucceeded {
-			h.lggr.Infow("Successfully sent trigger request to all nodes",
+			h.lggr.Debugw("Successfully sent trigger request to all nodes",
 				"executionID", executionID,
 				"nodeCount", len(h.donConfig.Members))
 			return nil

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -366,7 +366,7 @@ func (h *httpTriggerHandler) checkRateLimit(ctx context.Context, workflowID, req
 		if errors.As(err, &errLimited) {
 			switch errLimited.Scope {
 			case settings.ScopeWorkflow:
-				lggr.Errorf("failed to start execution: per workflow rate limit exceeded")
+				lggr.Warnf("failed to start execution: per workflow rate limit exceeded")
 				h.metrics.IncrementWorkflowThrottled(ctx, h.lggr)
 			default:
 				lggr.Errorf("failed to start execution: unexpected rate limit for scope %s", errLimited.Scope)

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -605,7 +605,7 @@ func (h *httpTriggerHandler) sendWithRetries(ctx context.Context, executionID st
 
 		select {
 		case <-doneCh:
-			h.lggr.Infow("Callback already responded to, stopping retries",
+			h.lggr.Debugw("Callback already responded to, stopping retries",
 				"executionID", executionID,
 				"requestID", req.ID,
 				"successNodes", len(successfulNodes),

--- a/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
@@ -86,7 +86,7 @@ func (h *WorkflowMetadataHandler) Authorize(workflowID string, token string, req
 
 	keys, exists := h.authorizedKeys[workflowID]
 	if !exists {
-		h.lggr.Errorw("Workflow ID not found in authorized keys", "workflowID", workflowID)
+		h.lggr.Warnw("Workflow ID not found in authorized keys", "workflowID", workflowID)
 		return nil, fmt.Errorf("workflow ID %s not found", workflowID)
 	}
 	key := gateway.AuthorizedKey{

--- a/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
@@ -75,7 +75,7 @@ func NewWorkflowMetadataHandler(lggr logger.Logger, cfg ServiceConfig, don handl
 func (h *WorkflowMetadataHandler) Authorize(workflowID string, token string, req *jsonrpc.Request[json.RawMessage]) (*gateway.AuthorizedKey, error) {
 	claims, signer, err := utils.VerifyRequestJWT(token, *req)
 	if err != nil {
-		h.lggr.Errorw("Failed to verify JWT", "error", err)
+		h.lggr.Warnw("Failed to verify JWT", "error", err)
 		return nil, err
 	}
 

--- a/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
@@ -234,7 +234,7 @@ func (h *WorkflowMetadataHandler) Start(ctx context.Context) error {
 		h.runTicker(time.Duration(h.config.MetadataPullIntervalMs)*time.Millisecond, func(ctx context.Context) {
 			err2 := h.sendMetadataPullRequest()
 			if err2 != nil {
-				h.lggr.Errorw("Failed to send pull request", "error", err2)
+				h.lggr.Warnw("Failed to send pull request", "error", err2)
 			}
 		})
 		h.runTicker(time.Duration(h.config.MetadataAggregationIntervalMs)*time.Millisecond, h.syncMetadata)

--- a/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
@@ -94,7 +94,7 @@ func (h *WorkflowMetadataHandler) Authorize(workflowID string, token string, req
 		PublicKey: strings.ToLower(signer.Hex()),
 	}
 	if _, exists = keys[key]; !exists {
-		h.lggr.Errorw("Signer not found in authorized keys", "signer", signer.Hex())
+		h.lggr.Warnw("Signer not found in authorized keys", "signer", signer.Hex())
 		return nil, fmt.Errorf("signer '%s' is not authorized for workflow '%s'. Ensure that the signer is registered in the workflow definition", signer.Hex(), workflowID)
 	}
 	h.jwtCache.recordUsage(claims.ID)

--- a/core/services/gateway/handlers/confidentialrelay/aggregator.go
+++ b/core/services/gateway/handlers/confidentialrelay/aggregator.go
@@ -100,7 +100,7 @@ func (a *aggregator) Aggregate(req jsonrpc.Request[json.RawMessage], resps map[s
 
 	remainingResponses := donMembersCount - len(resps)
 	if maxBucketSigs+remainingResponses < requiredQuorum {
-		l.Warnw("quorum unattainable for request",
+		l.Debugw("quorum unattainable for request",
 			"requiredQuorum", requiredQuorum,
 			"remainingResponses", remainingResponses,
 			"maxBucketSigs", maxBucketSigs,

--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -323,7 +323,7 @@ func (h *handler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Response[
 
 	added := ar.addResponseForNode(nodeAddr, resp)
 	if !added {
-		l.Errorw("duplicate response from node, ignoring", "nodeAddr", nodeAddr)
+		l.Warnw("duplicate response from node, ignoring", "nodeAddr", nodeAddr)
 		return nil
 	}
 

--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -363,7 +363,7 @@ func (h *handler) fanOutToNodes(ctx context.Context, l logger.Logger, ar *active
 			err := h.don.SendToNode(ctx, node.Address, &ar.req)
 			if err != nil {
 				nodeErrors.Add(1)
-				l.Errorw("error sending request to node", "node", node.Address, "error", err)
+				l.Warnw("error sending request to node", "node", node.Address, "error", err)
 			}
 			return nil
 		})

--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -279,7 +279,7 @@ func (h *handler) newActiveRequest(req jsonrpc.Request[json.RawMessage], callbac
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.activeRequests[req.ID] != nil {
-		h.lggr.Errorw("request id already exists", "requestID", req.ID)
+		h.lggr.Warnw("request id already exists", "requestID", req.ID)
 		return nil, errors.New("request ID already exists: " + req.ID)
 	}
 	ar := &activeRequest{

--- a/core/services/gateway/handlers/functions/allowlist/allowlist.go
+++ b/core/services/gateway/handlers/functions/allowlist/allowlist.go
@@ -349,7 +349,7 @@ func (a *onchainAllowlist) updateAllowedSendersBatch(
 		snapshot[k] = v
 	}
 	a.allowlist.Store(&snapshot)
-	a.lggr.Infow("allowlist updated in batches successfully", "len", len(currentAllowedSenderList))
+	a.lggr.Debugw("allowlist updated in batches successfully", "len", len(currentAllowedSenderList))
 
 	// persist each batch to the underalying orm layer
 	err = a.orm.CreateAllowedSenders(ctx, allowedSendersBatch)

--- a/core/services/gateway/handlers/functions/subscriptions/subscriptions.go
+++ b/core/services/gateway/handlers/functions/subscriptions/subscriptions.go
@@ -152,7 +152,7 @@ func (s *onchainSubscriptions) queryLoop() {
 		if lastKnownCount == 0 || start > lastKnownCount {
 			count, err := s.getSubscriptionsCount(ctx, blockNumber)
 			if err != nil {
-				s.lggr.Errorw("Error getting new subscriptions count", "err", err)
+				s.lggr.Warnw("Error getting new subscriptions count", "err", err)
 			} else {
 				s.lggr.Infow("Updated subscriptions count", "count", count, "blockNumber", blockNumber.Int64())
 				lastKnownCount = count

--- a/core/services/gateway/handlers/functions/subscriptions/subscriptions.go
+++ b/core/services/gateway/handlers/functions/subscriptions/subscriptions.go
@@ -143,7 +143,7 @@ func (s *onchainSubscriptions) queryLoop() {
 
 		latestBlockHeight, err := s.client.LatestBlockHeight(ctx)
 		if err != nil || latestBlockHeight == nil {
-			s.lggr.Errorw("Error calling LatestBlockHeight", "err", err, "latestBlockHeight", latestBlockHeight)
+			s.lggr.Warnw("Error calling LatestBlockHeight", "err", err, "latestBlockHeight", latestBlockHeight)
 			return
 		}
 

--- a/core/services/gateway/handlers/functions/subscriptions/subscriptions.go
+++ b/core/services/gateway/handlers/functions/subscriptions/subscriptions.go
@@ -154,7 +154,7 @@ func (s *onchainSubscriptions) queryLoop() {
 			if err != nil {
 				s.lggr.Warnw("Error getting new subscriptions count", "err", err)
 			} else {
-				s.lggr.Infow("Updated subscriptions count", "count", count, "blockNumber", blockNumber.Int64())
+				s.lggr.Debugw("Updated subscriptions count", "count", count, "blockNumber", blockNumber.Int64())
 				lastKnownCount = count
 			}
 		}

--- a/core/services/gateway/handlers/functions/subscriptions/subscriptions.go
+++ b/core/services/gateway/handlers/functions/subscriptions/subscriptions.go
@@ -170,7 +170,7 @@ func (s *onchainSubscriptions) queryLoop() {
 
 		end := min(start+uint64(s.config.UpdateRangeSize)-1, lastKnownCount)
 		if err := s.querySubscriptionsRange(ctx, blockNumber, start, end); err != nil {
-			s.lggr.Errorw("Error querying subscriptions", "err", err, "start", start, "end", end)
+			s.lggr.Warnw("Error querying subscriptions", "err", err, "start", start, "end", end)
 			return
 		}
 

--- a/core/services/gateway/handlers/functions/subscriptions/subscriptions.go
+++ b/core/services/gateway/handlers/functions/subscriptions/subscriptions.go
@@ -160,7 +160,7 @@ func (s *onchainSubscriptions) queryLoop() {
 		}
 
 		if lastKnownCount == 0 {
-			s.lggr.Info("Router has no subscriptions yet")
+			s.lggr.Debug("Router has no subscriptions yet")
 			return
 		}
 

--- a/core/services/gateway/handlers/vault/aggregator.go
+++ b/core/services/gateway/handlers/vault/aggregator.go
@@ -121,7 +121,7 @@ func (a *baseAggregator) validateUsingQuorum(don capabilities.DON, resps map[str
 	for _, r := range resps {
 		sha, err := a.sha(&r)
 		if err != nil {
-			l.Errorw("failed to compute digest of response during quorum validation, skipping...", "error", err)
+			l.Warnw("failed to compute digest of response during quorum validation, skipping...", "error", err)
 			continue
 		}
 		shaToCount[sha]++

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -870,7 +870,7 @@ func (h *handler) errorResponse(
 		// Intentionally hide the error from the user
 		err = errors.New(errorCode.String())
 	case api.InvalidParamsError:
-		h.lggr.Errorw("invalid params", "requestID", req.ID, "params", string(*req.Params))
+		h.lggr.Debugw("invalid params", "requestID", req.ID, "params", string(*req.Params))
 		err = errors.New("invalid params error: " + err.Error())
 	case api.UnsupportedMethodError:
 		h.lggr.Errorw("unsupported method", "requestID", req.ID, "method", req.Method, "error", err.Error())

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -511,7 +511,7 @@ func (h *handler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Response[
 
 	ok := ar.addResponseForNode(nodeAddr, resp)
 	if !ok {
-		l.Errorw("duplicate response from node, ignoring", "nodeAddr", nodeAddr)
+		l.Warnw("duplicate response from node, ignoring", "nodeAddr", nodeAddr)
 		return nil
 	}
 

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -876,7 +876,7 @@ func (h *handler) errorResponse(
 		h.lggr.Debugw("unsupported method", "requestID", req.ID, "method", req.Method, "error", err.Error())
 		err = errors.New("unsupported method(" + req.Method + "): " + err.Error())
 	case api.UserMessageParseError:
-		h.lggr.Errorw("user message parse error", "requestID", req.ID, "error", err.Error())
+		h.lggr.Debugw("user message parse error", "requestID", req.ID, "error", err.Error())
 		err = errors.New("user message parse error: " + err.Error())
 	case api.NoError:
 	case api.UnsupportedDONIdError:

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -313,7 +313,7 @@ func (h *handler) Start(_ context.Context) error {
 
 func (h *handler) Close() error {
 	return h.StopOnce("VaultHandler", func() error {
-		h.lggr.Debug("closing vault handler")
+		h.lggr.Info("closing vault handler")
 		close(h.stopCh)
 		var jwtAuthErr error
 		if h.jwtAuth != nil {

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -647,7 +647,7 @@ func (h *handler) handleSecretsCreate(ctx context.Context, ar *activeRequest) er
 	}
 	err = h.ValidateCreateSecretsRequest(ctx, cachedPublicKey, validationRequest, skipLabelValidation)
 	if err != nil {
-		l.Warnw("failed to validate create secrets request", "error", err)
+		l.Debugw("failed to validate create secrets request", "error", err)
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, fmt.Errorf("failed to validate create secrets request: %w", err), nil))
 	}
 

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -769,7 +769,7 @@ func (h *handler) handleSecretsList(ctx context.Context, ar *activeRequest) erro
 	}
 	err := h.ValidateListSecretIdentifiersRequest(ctx, req)
 	if err != nil {
-		l.Warnw("failed to validate list secret identifiers request", "error", err)
+		l.Debugw("failed to validate list secret identifiers request", "error", err)
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, fmt.Errorf("failed to validate list secret identifiers request: %w", err), nil))
 	}
 

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -741,7 +741,7 @@ func (h *handler) handleSecretsDelete(ctx context.Context, ar *activeRequest) er
 	}
 	err = h.ValidateDeleteSecretsRequest(ctx, deleteSecretsRequest)
 	if err != nil {
-		l.Warnw("failed to validate delete secrets request", "error", err)
+		l.Debugw("failed to validate delete secrets request", "error", err)
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, fmt.Errorf("failed to validate delete secrets request: %w", err), nil))
 	}
 

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -434,7 +434,7 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 
 	authResult, authErr := h.authorizer.AuthorizeRequest(ctx, req)
 	if authErr != nil {
-		h.lggr.Errorw("request not authorized", "method", req.Method, "requestID", req.ID, "hasAuth", req.Auth != "", "error", authErr)
+		h.lggr.Warnw("request not authorized", "method", req.Method, "requestID", req.ID, "hasAuth", req.Auth != "", "error", authErr)
 		return errors.New("request not authorized: " + authErr.Error())
 	}
 	normalizedReq, normalizeErr := vaultcap.NormalizeRequestWithIdentity(req, authResult.OrgID(), authResult.WorkflowOwner())

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -702,7 +702,7 @@ func (h *handler) handleSecretsUpdate(ctx context.Context, ar *activeRequest) er
 	}
 	vaultCapErr := h.ValidateUpdateSecretsRequest(ctx, cachedPublicKey, validationRequest, skipLabelValidation)
 	if vaultCapErr != nil {
-		l.Warnw("failed to validate update secrets request", "error", vaultCapErr)
+		l.Debugw("failed to validate update secrets request", "error", vaultCapErr)
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, fmt.Errorf("failed to validate update secrets request: %w", vaultCapErr), nil))
 	}
 

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -873,7 +873,7 @@ func (h *handler) errorResponse(
 		h.lggr.Debugw("invalid params", "requestID", req.ID, "params", string(*req.Params))
 		err = errors.New("invalid params error: " + err.Error())
 	case api.UnsupportedMethodError:
-		h.lggr.Errorw("unsupported method", "requestID", req.ID, "method", req.Method, "error", err.Error())
+		h.lggr.Debugw("unsupported method", "requestID", req.ID, "method", req.Method, "error", err.Error())
 		err = errors.New("unsupported method(" + req.Method + "): " + err.Error())
 	case api.UserMessageParseError:
 		h.lggr.Errorw("user message parse error", "requestID", req.ID, "error", err.Error())

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -282,7 +282,7 @@ func newHandlerWithAuthorizer(methodConfig json.RawMessage, donConfig *config.DO
 
 func (h *handler) Start(_ context.Context) error {
 	return h.StartOnce("VaultHandler", func() error {
-		h.lggr.Debug("starting vault handler")
+		h.lggr.Info("starting vault handler")
 		if h.jwtAuth != nil {
 			if err := h.jwtAuth.Start(context.Background()); err != nil {
 				return fmt.Errorf("failed to start JWTBasedAuth: %w", err)

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -845,7 +845,7 @@ func (h *handler) fanOutToVaultNodes(ctx context.Context, l logger.Logger, ar *a
 		err := h.don.SendToNode(ctx, node.Address, &ar.req)
 		if err != nil {
 			nodeErrors = append(nodeErrors, err)
-			l.Errorw("error sending request to node", "node", node.Address, "error", err)
+			l.Warnw("error sending request to node", "node", node.Address, "error", err)
 		}
 	}
 

--- a/core/services/gateway/network/httpclient.go
+++ b/core/services/gateway/network/httpclient.go
@@ -324,7 +324,7 @@ func (c *httpClient) Send(ctx context.Context, req HTTPRequest) (*HTTPResponse, 
 	reader := http.MaxBytesReader(nil, resp.Body, int64(n))
 	body, err := io.ReadAll(reader)
 	if err != nil {
-		c.lggr.Errorw("failed to read HTTP response body", "err", err)
+		c.lggr.Debugw("failed to read HTTP response body", "err", err)
 		return nil, errors.Join(err, ErrHTTPRead)
 	}
 

--- a/core/services/gateway/network/httpclient.go
+++ b/core/services/gateway/network/httpclient.go
@@ -313,7 +313,7 @@ func (c *httpClient) Send(ctx context.Context, req HTTPRequest) (*HTTPResponse, 
 			c.lggr.Warnw("HTTP request blocked", "err", err)
 			return nil, fmt.Errorf("%w: %w", ErrBlockedRequest, err)
 		}
-		c.lggr.Errorw("failed to send HTTP request", "err", err)
+		c.lggr.Debugw("failed to send HTTP request", "err", err)
 		return nil, errors.Join(err, ErrHTTPSend)
 	}
 	defer resp.Body.Close()

--- a/core/services/gateway/network/httpserver.go
+++ b/core/services/gateway/network/httpserver.go
@@ -203,7 +203,7 @@ func (s *httpServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 	source := http.MaxBytesReader(nil, r.Body, int64(maxRequestBytes))
 	rawMessage, err := io.ReadAll(source)
 	if err != nil {
-		s.lggr.Error("error reading request", err)
+		s.lggr.Debug("error reading request", err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/core/services/gateway/network/httpserver.go
+++ b/core/services/gateway/network/httpserver.go
@@ -225,7 +225,7 @@ func (s *httpServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(httpStatusCode)
 	_, err = w.Write(rawResponse)
 	if err != nil {
-		s.lggr.Error("error when writing response", err)
+		s.lggr.Debug("error when writing response", err)
 	}
 }
 

--- a/core/services/gateway/network/wsclient.go
+++ b/core/services/gateway/network/wsclient.go
@@ -64,7 +64,7 @@ func (c *webSocketClient) Connect(ctx context.Context, url *url.URL) (*websocket
 	}
 	challenge, err := base64.StdEncoding.DecodeString(challengeStr)
 	if err != nil {
-		c.lggr.Errorf("WebSocketClient: couldn't decode challenge: %s: %v", challengeStr, err)
+		c.lggr.Debugf("WebSocketClient: couldn't decode challenge: %s: %v", challengeStr, err)
 		c.tryCloseConn(conn)
 		return nil, err
 	}

--- a/core/services/gateway/network/wsclient.go
+++ b/core/services/gateway/network/wsclient.go
@@ -71,7 +71,7 @@ func (c *webSocketClient) Connect(ctx context.Context, url *url.URL) (*websocket
 
 	response, err := c.initiator.ChallengeResponse(ctx, url, challenge)
 	if err != nil {
-		c.lggr.Errorw("WebSocketClient: couldn't generate challenge response", "err", err)
+		c.lggr.Debugw("WebSocketClient: couldn't generate challenge response", "err", err)
 		c.tryCloseConn(conn)
 		return nil, err
 	}

--- a/core/services/gateway/network/wsclient.go
+++ b/core/services/gateway/network/wsclient.go
@@ -51,7 +51,7 @@ func (c *webSocketClient) Connect(ctx context.Context, url *url.URL) (*websocket
 	conn, resp, err := c.dialer.DialContext(ctx, url.String(), hdr)
 
 	if err != nil {
-		c.lggr.Errorf("WebSocketClient: couldn't connect to %s: %v", url.String(), err)
+		c.lggr.Debugf("WebSocketClient: couldn't connect to %s: %v", url.String(), err)
 		c.tryCloseConn(conn)
 		return nil, err
 	}

--- a/core/services/gateway/network/wsclient.go
+++ b/core/services/gateway/network/wsclient.go
@@ -58,7 +58,7 @@ func (c *webSocketClient) Connect(ctx context.Context, url *url.URL) (*websocket
 
 	challengeStr := resp.Header.Get(WsServerHandshakeChallengeHeaderName)
 	if challengeStr == "" {
-		c.lggr.Error("WebSocketClient: empty challenge")
+		c.lggr.Debug("WebSocketClient: empty challenge")
 		c.tryCloseConn(conn)
 		return nil, err
 	}

--- a/core/services/gateway/network/wsclient.go
+++ b/core/services/gateway/network/wsclient.go
@@ -77,7 +77,7 @@ func (c *webSocketClient) Connect(ctx context.Context, url *url.URL) (*websocket
 	}
 
 	if err = conn.WriteMessage(websocket.BinaryMessage, response); err != nil {
-		c.lggr.Errorw("WebSocketClient: couldn't send challenge response", "err", err)
+		c.lggr.Debugw("WebSocketClient: couldn't send challenge response", "err", err)
 		c.tryCloseConn(conn)
 		return nil, err
 	}

--- a/core/services/gateway/network/wsclient.go
+++ b/core/services/gateway/network/wsclient.go
@@ -88,7 +88,7 @@ func (c *webSocketClient) tryCloseConn(conn *websocket.Conn) {
 	if conn != nil {
 		err := conn.Close()
 		if err != nil {
-			c.lggr.Errorf("WebSocketClient: error closing connection %v", err)
+			c.lggr.Debugf("WebSocketClient: error closing connection %v", err)
 		}
 	}
 }

--- a/core/services/gateway/network/wsconnection.go
+++ b/core/services/gateway/network/wsconnection.go
@@ -197,7 +197,7 @@ func (c *wsConnectionWrapper) readPump(conn *websocket.Conn, closeCh chan<- erro
 		case <-c.shutdownCh:
 			closeErr := conn.Close()
 			if closeErr != nil {
-				c.lggr.Errorw("error closing connection during shutdown", "error", closeErr)
+				c.lggr.Debugw("error closing connection during shutdown", "error", closeErr)
 			}
 			closeCh <- closeErr
 			close(closeCh)

--- a/core/services/gateway/network/wsconnection.go
+++ b/core/services/gateway/network/wsconnection.go
@@ -183,7 +183,7 @@ func (c *wsConnectionWrapper) readPump(conn *websocket.Conn, closeCh chan<- erro
 	for {
 		msgType, data, err := conn.ReadMessage()
 		if err != nil {
-			c.lggr.Errorw("failed to read message, closing connection", "error", err)
+			c.lggr.Debugw("failed to read message, closing connection", "error", err)
 			closeErr := conn.Close()
 			if closeErr != nil {
 				c.lggr.Errorw("error closing connection", "error", closeErr)

--- a/core/services/gateway/network/wsconnection.go
+++ b/core/services/gateway/network/wsconnection.go
@@ -186,7 +186,7 @@ func (c *wsConnectionWrapper) readPump(conn *websocket.Conn, closeCh chan<- erro
 			c.lggr.Debugw("failed to read message, closing connection", "error", err)
 			closeErr := conn.Close()
 			if closeErr != nil {
-				c.lggr.Errorw("error closing connection", "error", closeErr)
+				c.lggr.Debugw("error closing connection", "error", closeErr)
 			}
 			closeCh <- closeErr
 			close(closeCh)

--- a/core/services/gateway/network/wsconnection.go
+++ b/core/services/gateway/network/wsconnection.go
@@ -168,7 +168,7 @@ func (c *wsConnectionWrapper) writePump() {
 			}
 			err := conn.WriteMessage(wsMsg.MsgType, wsMsg.Data)
 			if err != nil {
-				c.lggr.Errorw("failed to write message", "msgType", wsMsg.MsgType, "dataLen", len(wsMsg.Data), "error", err)
+				c.lggr.Debugw("failed to write message", "msgType", wsMsg.MsgType, "dataLen", len(wsMsg.Data), "error", err)
 			}
 			wsMsg.ErrCh <- err
 			close(wsMsg.ErrCh)

--- a/core/services/gateway/network/wsserver.go
+++ b/core/services/gateway/network/wsserver.go
@@ -122,7 +122,7 @@ func (s *webSocketServer) handleRequest(w http.ResponseWriter, r *http.Request) 
 	hdr.Add(WsServerHandshakeChallengeHeaderName, challengeStr)
 	conn, err := s.upgrader.Upgrade(w, r, hdr)
 	if err != nil {
-		s.lggr.Errorw("failed websocket upgrade", "err", err)
+		s.lggr.Debugw("failed websocket upgrade", "err", err)
 		if conn != nil {
 			conn.Close()
 		}

--- a/core/services/gateway/network/wsserver.go
+++ b/core/services/gateway/network/wsserver.go
@@ -146,7 +146,7 @@ func (s *webSocketServer) handleRequest(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err = s.acceptor.FinalizeHandshake(attemptId, response, conn); err != nil {
-		s.lggr.Errorw("unable to finalize handshake", "err", err)
+		s.lggr.Debugw("unable to finalize handshake", "err", err)
 		conn.Close()
 		s.acceptor.AbortHandshake(attemptId)
 		return

--- a/core/services/gateway/network/wsserver.go
+++ b/core/services/gateway/network/wsserver.go
@@ -139,7 +139,7 @@ func (s *webSocketServer) handleRequest(w http.ResponseWriter, r *http.Request) 
 	conn.SetReadLimit(int64(maxRequestBytes))
 	msgType, response, err := conn.ReadMessage()
 	if err != nil || msgType != websocket.BinaryMessage {
-		s.lggr.Errorw("invalid handshake message", "msgType", msgType, "err", err, "remoteAddr", conn.RemoteAddr())
+		s.lggr.Debugw("invalid handshake message", "msgType", msgType, "err", err, "remoteAddr", conn.RemoteAddr())
 		conn.Close()
 		s.acceptor.AbortHandshake(attemptId)
 		return

--- a/core/services/headreporter/head_reporter.go
+++ b/core/services/headreporter/head_reporter.go
@@ -101,7 +101,7 @@ func (hrd *HeadReporterService) eventLoop() {
 			for _, reporter := range hrd.reporters {
 				err := reporter.ReportPeriodic(ctx)
 				if err != nil && ctx.Err() == nil {
-					hrd.lggr.Errorw("Error in periodic report", "err", err)
+					hrd.lggr.Warnw("Error in periodic report", "err", err)
 				}
 			}
 			after = time.After(hrd.reportPeriod)

--- a/core/services/headreporter/head_reporter.go
+++ b/core/services/headreporter/head_reporter.go
@@ -94,7 +94,7 @@ func (hrd *HeadReporterService) eventLoop() {
 			for _, reporter := range hrd.reporters {
 				err := reporter.ReportNewHead(ctx, head)
 				if err != nil && ctx.Err() == nil {
-					hrd.lggr.Errorw("Error reporting new head", "err", err)
+					hrd.lggr.Warnw("Error reporting new head", "err", err)
 				}
 			}
 		case <-after:

--- a/core/services/headreporter/telemetry_reporter.go
+++ b/core/services/headreporter/telemetry_reporter.go
@@ -67,7 +67,7 @@ func (t *legacyEVMTelemetryReporter) ReportNewHead(ctx context.Context, head *ev
 	}
 	monitoringEndpoint.SendLog(bytes)
 	if finalized == nil {
-		t.lggr.Infow("No finalized block was found", "chainID", head.EVMChainID.ToInt().Int64(),
+		t.lggr.Debugw("No finalized block was found", "chainID", head.EVMChainID.ToInt().Int64(),
 			"head.number", head.Number, "chainLength", head.ChainLength())
 	}
 	return nil

--- a/core/services/job/spawner.go
+++ b/core/services/job/spawner.go
@@ -247,7 +247,7 @@ func (js *spawner) StartService(ctx context.Context, jb Job) error {
 	for _, srv := range srvs {
 		err = ms.Start(ctx, srv)
 		if err != nil {
-			lggr.Criticalw("Error starting service for job", "err", err)
+			lggr.Errorw("Error starting service for job", "err", err)
 			return err
 		}
 		if c, ok := srv.(services.HealthReporter); ok {

--- a/core/services/job/spawner.go
+++ b/core/services/job/spawner.go
@@ -205,7 +205,7 @@ func (js *spawner) stopService(jobID int32) {
 			}
 		}
 		if err := service.Close(); err != nil {
-			sLggr.Criticalw("Error stopping job service", "err", err)
+			sLggr.Errorw("Error stopping job service", "err", err)
 			js.SvcErrBuffer.Append(pkgerrors.Wrap(err, "error stopping job service"))
 		}
 	}

--- a/core/services/nodestatusreporter/bridgestatus/bridge_status_reporter.go
+++ b/core/services/nodestatusreporter/bridgestatus/bridge_status_reporter.go
@@ -127,7 +127,7 @@ func (s *Service) pollAllBridges(ctx context.Context) {
 
 // handleBridgeError handles errors during bridge polling, either skipping or emitting empty telemetry
 func (s *Service) handleBridgeError(ctx context.Context, bridgeName string, jobs []JobInfo, logMsg string, logFields ...any) {
-	s.eng.Debugw(logMsg, logFields...)
+	s.eng.Warnw(logMsg, logFields...)
 	if s.config.IgnoreInvalidBridges() {
 		return
 	}

--- a/core/services/nodestatusreporter/bridgestatus/bridge_status_reporter.go
+++ b/core/services/nodestatusreporter/bridgestatus/bridge_status_reporter.go
@@ -89,7 +89,7 @@ func (s *Service) pollAllBridges(ctx context.Context) {
 	for {
 		bridgeList, _, err := s.bridgeORM.BridgeTypes(ctx, offset, bridgePollPageSize)
 		if err != nil {
-			s.eng.Debugw("Failed to fetch bridges", "error", err, "offset", offset)
+			s.eng.Warnw("Failed to fetch bridges", "error", err, "offset", offset)
 			return
 		}
 

--- a/core/services/nurse.go
+++ b/core/services/nurse.go
@@ -85,7 +85,7 @@ func (n *Nurse) start(_ context.Context) error {
 		runtime.MemProfileRate = n.cfg.BlockProfileRate()
 	}
 
-	n.eng.Debugf("Starting nurse with config %+v", n.cfg)
+	n.eng.Infof("Starting nurse with config %+v", n.cfg)
 	runtime.SetCPUProfileRate(n.cfg.CPUProfileRate())
 	runtime.SetBlockProfileRate(n.cfg.BlockProfileRate())
 	runtime.SetMutexProfileFraction(n.cfg.MutexProfileFraction())

--- a/core/services/nurse.go
+++ b/core/services/nurse.go
@@ -167,7 +167,7 @@ func (n *Nurse) checkGoroutines() (bool, Meta) {
 func (n *Nurse) gatherVitals(reason string, meta Meta) {
 	loggerFields := (logger.Fields{"reason": reason}).Merge(logger.Fields(meta))
 
-	n.eng.Debugw("Nurse is gathering vitals", loggerFields.Slice()...)
+	n.eng.Infow("Nurse is gathering vitals", loggerFields.Slice()...)
 
 	size, err := n.totalProfileBytes()
 	if err != nil {

--- a/core/services/nurse.go
+++ b/core/services/nurse.go
@@ -184,7 +184,7 @@ func (n *Nurse) gatherVitals(reason string, meta Meta) {
 
 	err = n.appendLog(now, reason, meta)
 	if err != nil {
-		n.eng.Warnw("cannot write pprof profile", loggerFields.With("err", err).Slice()...)
+		n.eng.Errorw("cannot write pprof profile", loggerFields.With("err", err).Slice()...)
 		return
 	}
 	var wg sync.WaitGroup

--- a/core/services/ocr/config_overrider.go
+++ b/core/services/ocr/config_overrider.go
@@ -111,7 +111,7 @@ func (c *ConfigOverriderImpl) eventLoop() {
 			return
 		case <-c.pollTicker.Ticks():
 			if err := c.updateFlagsStatus(); err != nil {
-				c.logger.Errorw("OCRConfigOverrider: Error updating hibernation status", "err", err)
+				c.logger.Warnw("OCRConfigOverrider: Error updating hibernation status", "err", err)
 			}
 		}
 	}

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -1632,7 +1632,7 @@ func (d *Delegate) newServicesLLO(
 			if len(kbs) == 0 {
 				return nil, fmt.Errorf("no on-chain signing keys found for report format %s", "evm")
 			} else if len(kbs) > 1 {
-				lggr.Debugf("Multiple on-chain signing keys found for report format %s, using the first", rf.String())
+				lggr.Warnf("Multiple on-chain signing keys found for report format %s, using the first", rf.String())
 			}
 			kbm[rf] = kbs[0]
 		}

--- a/core/services/ocr2/plugins/vault/kvstore_wrapper.go
+++ b/core/services/ocr2/plugins/vault/kvstore_wrapper.go
@@ -356,7 +356,7 @@ func mergeMetadata(orgMd, woMd *vault.StoredMetadata, orgID string, lggr logger.
 		for _, id := range md.SecretIdentifiers {
 			dk := deduplicationKey(id)
 			if seen[dk] {
-				lggr.Criticalw(
+				lggr.Errorw(
 					"duplicate secret identifier found during owner migration metadata merge",
 					"orgID", orgID,
 					"duplicateKey", dk,

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -1593,7 +1593,7 @@ func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq 
 			r.stateTransitionListSecretIdentifiers(ctx, wrappedStore.WithRequest(req.OrgId, req.WorkflowOwner), chosen, o)
 			os.Outcomes = append(os.Outcomes, o)
 		default:
-			r.lggr.Debugw("unknown request type, skipping...", "requestType", first.RequestType, "id", id)
+			r.lggr.Errorw("unknown request type, skipping...", "requestType", first.RequestType, "id", id)
 			continue
 		}
 	}

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -275,7 +275,7 @@ func (r *ReportingPluginFactory) NewReportingPlugin(ctx context.Context, config 
 	cfg.PublicKey = publicKey
 	cfg.PrivateKeyShare = privateKeyShare
 
-	r.lggr.Debugw("instantiating VaultReportingPlugin with config",
+	r.lggr.Infow("instantiating VaultReportingPlugin with config",
 		"maxSecretsPerOwner", logLimit(ctx, r.lggr, cfg.MaxSecretsPerOwner),
 		"maxCiphertextLengthBytes", logLimit(ctx, r.lggr, cfg.MaxCiphertextLengthBytes),
 		"maxIdentifierKeyLengthBytes", logLimit(ctx, r.lggr, cfg.MaxIdentifierKeyLengthBytes),

--- a/core/services/ocrcommon/data_source.go
+++ b/core/services/ocrcommon/data_source.go
@@ -179,7 +179,7 @@ func (ds *inMemoryDataSource) currentAnswer() (*big.Int, *big.Int) {
 func (ds *inMemoryDataSource) executeRun(ctx context.Context) (*pipeline.Run, pipeline.TaskRunResults, error) {
 	md, err := bridges.MarshalBridgeMetaData(ds.currentAnswer())
 	if err != nil {
-		ds.lggr.Warnf("unable to attach metadata for run, err: %v", err)
+		ds.lggr.Debugf("unable to attach metadata for run, err: %v", err)
 	}
 
 	vars := pipeline.NewVarsFrom(map[string]any{

--- a/core/services/ocrcommon/data_source.go
+++ b/core/services/ocrcommon/data_source.go
@@ -155,7 +155,7 @@ func setEATelemetry(ds *inMemoryDataSource, finalResult pipeline.FinalResult, tr
 			RepTimestamp:   timestamp,
 		})
 	} else {
-		ds.lggr.Infow("Enhanced telemetry is disabled for job", "job", ds.jb.Name)
+		ds.lggr.Debugw("Enhanced telemetry is disabled for job", "job", ds.jb.Name)
 	}
 }
 

--- a/core/services/ocrcommon/telemetry.go
+++ b/core/services/ocrcommon/telemetry.go
@@ -597,7 +597,7 @@ func getPricesFromBridgeTaskByTelemetryField(lggr logger.Logger, bridgeTask pipe
 	for _, trr := range tasksWithTags {
 		attributes, err := parseTelemetryAttributes(trr.Task.TaskTags())
 		if err != nil {
-			lggr.Warnw("found telemetry attributes but cannot them, taskTags="+trr.Task.TaskTags(), "err", err)
+			lggr.Debugw("found telemetry attributes but cannot them, taskTags="+trr.Task.TaskTags(), "err", err)
 			continue
 		}
 

--- a/core/services/ocrcommon/telemetry.go
+++ b/core/services/ocrcommon/telemetry.go
@@ -613,7 +613,7 @@ func getPricesFromBridgeTaskByTelemetryField(lggr logger.Logger, bridgeTask pipe
 				price := parsePriceFromTask(lggr, trr)
 				benchmarkPrice, bidPrice, askPrice = price, price, price
 			case "":
-				lggr.Warnw(fmt.Sprintf("no priceType found in attributes, parsedAttributes=%+v, id %s", attributes, trr.Task.DotID()))
+				lggr.Debugw(fmt.Sprintf("no priceType found in attributes, parsedAttributes=%+v, id %s", attributes, trr.Task.DotID()))
 			}
 		}
 	}

--- a/core/services/ocrcommon/telemetry.go
+++ b/core/services/ocrcommon/telemetry.go
@@ -168,7 +168,7 @@ func ParseMercuryEATelemetry(lggr logger.Logger, trrs pipeline.TaskRunResults, f
 		}
 		eaTelem, err := parseEATelemetry([]byte(bridgeRawResponse))
 		if err != nil {
-			lggr.Warnw(fmt.Sprintf("cannot parse EA telemetry, id=%s, name=%q", trr.Task.DotID(), bridgeName), "err", err, "dotID", trr.Task.DotID(), "bridgeName", bridgeName)
+			lggr.Debugw(fmt.Sprintf("cannot parse EA telemetry, id=%s, name=%q", trr.Task.DotID(), bridgeName), "err", err, "dotID", trr.Task.DotID(), "bridgeName", bridgeName)
 		}
 		eaTelem.BridgeRequestData = bridgeTask.RequestData
 		eaTelem.DpBenchmarkPrice, eaTelem.DpBid, eaTelem.DpAsk = getPricesFromBridgeTask(lggr, trr, trrs, feedVersion)

--- a/core/services/p2p/peer.go
+++ b/core/services/p2p/peer.go
@@ -191,7 +191,7 @@ func (p *peer) Start(ctx context.Context) error {
 }
 
 func (p *peer) recvLoopSingle(pid ragetypes.PeerID, ch <-chan []byte) {
-	p.lggr.Infow("starting recvLoopSingle", "peerID", pid)
+	p.lggr.Debugw("starting recvLoopSingle", "peerID", pid)
 	defer p.wg.Done()
 	for {
 		select {

--- a/core/services/p2p/peer.go
+++ b/core/services/p2p/peer.go
@@ -196,7 +196,7 @@ func (p *peer) recvLoopSingle(pid ragetypes.PeerID, ch <-chan []byte) {
 	for {
 		select {
 		case <-p.stopCh:
-			p.lggr.Infow("stopped - exiting recvLoopSingle", "peerID", pid)
+			p.lggr.Debugw("stopped - exiting recvLoopSingle", "peerID", pid)
 			return
 		case msg, ok := <-ch:
 			if !ok {

--- a/core/services/p2p/peer.go
+++ b/core/services/p2p/peer.go
@@ -200,7 +200,7 @@ func (p *peer) recvLoopSingle(pid ragetypes.PeerID, ch <-chan []byte) {
 			return
 		case msg, ok := <-ch:
 			if !ok {
-				p.lggr.Infow("channel closed - exiting recvLoopSingle", "peerID", pid)
+				p.lggr.Debugw("channel closed - exiting recvLoopSingle", "peerID", pid)
 				return
 			}
 			p.recvCh <- p2ptypes.Message{Sender: pid, Payload: msg}

--- a/core/services/p2p/shared_peer.go
+++ b/core/services/p2p/shared_peer.go
@@ -323,7 +323,7 @@ func (sp *don2DonSharedPeer) updateConnections(donPairs []p2ptypes.DonPair, desi
 }
 
 func (sp *don2DonSharedPeer) recvLoopSingle(ctx context.Context, pid ragetypes.PeerID, ch <-chan []byte) {
-	sp.lggr.Infow("starting recvLoopSingle", "peerID", pid)
+	sp.lggr.Debugw("starting recvLoopSingle", "peerID", pid)
 	for {
 		select {
 		case <-ctx.Done():

--- a/core/services/p2p/shared_peer.go
+++ b/core/services/p2p/shared_peer.go
@@ -160,7 +160,7 @@ func (sp *don2DonSharedPeer) UpdateConnections(peers map[ragetypes.PeerID]p2ptyp
 }
 
 func (sp *don2DonSharedPeer) UpdateConnectionsByDONs(ctx context.Context, donPairs []p2ptypes.DonPair, streamConfig p2ptypes.StreamConfig) error {
-	sp.lggr.Infow("UpdateConnectionsByDONs", "numDonPairs", len(donPairs))
+	sp.lggr.Debugw("UpdateConnectionsByDONs", "numDonPairs", len(donPairs))
 	startTs := time.Now().UnixMilli()
 
 	desiredDONPairsIDs := make(map[string]struct{})

--- a/core/services/p2p/shared_peer.go
+++ b/core/services/p2p/shared_peer.go
@@ -327,7 +327,7 @@ func (sp *don2DonSharedPeer) recvLoopSingle(ctx context.Context, pid ragetypes.P
 	for {
 		select {
 		case <-ctx.Done():
-			sp.lggr.Infow("stopped - exiting recvLoopSingle", "peerID", pid)
+			sp.lggr.Debugw("stopped - exiting recvLoopSingle", "peerID", pid)
 			return
 		case msg, ok := <-ch:
 			if !ok {

--- a/core/services/p2p/shared_peer.go
+++ b/core/services/p2p/shared_peer.go
@@ -331,7 +331,7 @@ func (sp *don2DonSharedPeer) recvLoopSingle(ctx context.Context, pid ragetypes.P
 			return
 		case msg, ok := <-ch:
 			if !ok {
-				sp.lggr.Infow("channel closed - exiting recvLoopSingle", "peerID", pid)
+				sp.lggr.Debugw("channel closed - exiting recvLoopSingle", "peerID", pid)
 				return
 			}
 			sp.recvCh <- p2ptypes.Message{Sender: pid, Payload: msg}

--- a/core/services/p2p/shared_peer.go
+++ b/core/services/p2p/shared_peer.go
@@ -199,7 +199,7 @@ func (sp *don2DonSharedPeer) UpdateConnectionsByDONs(ctx context.Context, donPai
 	sp.metrics.discoveryGroups.Record(ctx, int64(len(sp.discoveryGroups)))
 	sp.metrics.messagingGroups.Record(ctx, int64(len(sp.remotePeers)))
 	sp.metrics.groupUpdateDurationMs.Record(ctx, time.Now().UnixMilli()-startTs)
-	sp.lggr.Info("UpdateConnectionsByDONs done")
+	sp.lggr.Debug("UpdateConnectionsByDONs done")
 	return nil
 }
 

--- a/core/services/periodicbackup/backup.go
+++ b/core/services/periodicbackup/backup.go
@@ -142,7 +142,7 @@ func (backup *databaseBackup) RunBackup(version string) error {
 	result, err := backup.runBackup(version)
 	duration := time.Since(startAt)
 	if err != nil {
-		backup.logger.Criticalw("Backup failed", "duration", duration, "err", err)
+		backup.logger.Errorw("Backup failed", "duration", duration, "err", err)
 		backup.SvcErrBuffer.Append(err)
 		return err
 	}

--- a/core/services/pg/lease_lock.go
+++ b/core/services/pg/lease_lock.go
@@ -86,7 +86,7 @@ func NewLeaseLock(db *sqlx.DB, appID uuid.UUID, lggr logger.Logger, cfg LeaseLoc
 // Release() function must be used to release the acquired lock.
 // NOT THREAD SAFE
 func (l *leaseLock) TakeAndHold(ctx context.Context) (err error) {
-	l.logger.Debug("Taking initial lease...")
+	l.logger.Info("Taking initial lease...")
 	retryCount := 0
 	isInitial := true
 

--- a/core/services/pg/lease_lock.go
+++ b/core/services/pg/lease_lock.go
@@ -136,7 +136,7 @@ func (l *leaseLock) TakeAndHold(ctx context.Context) (err error) {
 		case <-time.After(utils.WithJitter(l.cfg.LeaseRefreshInterval)):
 		}
 	}
-	l.logger.Debug("Got exclusive lease on database")
+	l.logger.Info("Got exclusive lease on database")
 
 	lctx, cancel := context.WithCancel(context.Background())
 	l.stop = cancel

--- a/core/services/pg/locked_db.go
+++ b/core/services/pg/locked_db.go
@@ -82,7 +82,7 @@ func (l *lockedDb) Open(ctx context.Context) (err error) {
 
 		// Step 3: acquire DB locks
 		lockingMode := l.lockCfg.LockingMode()
-		l.lggr.Debugf("Using database locking mode: %s", lockingMode)
+		l.lggr.Infof("Using database locking mode: %s", lockingMode)
 
 		// Take the lease before any other DB operations
 		switch lockingMode {

--- a/core/services/relay/evm/evm_service.go
+++ b/core/services/relay/evm/evm_service.go
@@ -273,7 +273,7 @@ func (e *evmService) SubmitTransaction(ctx context.Context, txRequest evm.Submit
 	})
 
 	if err != nil {
-		e.logger.Warnw("Failed getting transaction status", "txID", txID, "lastErr", lastStatusErr, "retryErr", err)
+		e.logger.Errorw("Failed getting transaction status", "txID", txID, "lastErr", lastStatusErr, "retryErr", err)
 		return &evm.TransactionResult{TxStatus: evm.TxFatal, TxIdempotencyKey: txID}, fmt.Errorf("last err: %w retry err: %w", lastStatusErr, err)
 	}
 

--- a/core/services/relay/evm/llo_provider.go
+++ b/core/services/relay/evm/llo_provider.go
@@ -119,7 +119,7 @@ func NewLLOProvider(
 
 	var transmitter LLOTransmitter
 	if lloCfg.BenchmarkMode {
-		lggr.Info("Benchmark mode enabled, using dummy transmitter. NOTE: THIS WILL NOT TRANSMIT ANYTHING")
+		lggr.Warn("Benchmark mode enabled, using dummy transmitter. NOTE: THIS WILL NOT TRANSMIT ANYTHING")
 		transmitter = bm.NewTransmitter(lggr, csaPub)
 	} else {
 		clients := make(map[string]rpc.Client)

--- a/core/services/relay/evm/target_strategy.go
+++ b/core/services/relay/evm/target_strategy.go
@@ -128,7 +128,7 @@ func (t *evmTargetStrategy) QueryTransmissionState(ctx context.Context, reportID
 	// TODO: Want to confirm these states are correct - invalid receiver and failed with sufficient gas are fatal.
 	switch transmissionInfo.State {
 	case TransmissionStateNotAttempted:
-		t.lggr.Infow("non-empty report - transmission not attempted", "request", request, "reportLen", len(r.Inputs.SignedReport.Report), "reportContextLen", len(r.Inputs.SignedReport.Context), "nSignatures", len(r.Inputs.SignedReport.Signatures), "executionID", request.Metadata.WorkflowExecutionID)
+		t.lggr.Debugw("non-empty report - transmission not attempted", "request", request, "reportLen", len(r.Inputs.SignedReport.Report), "reportContextLen", len(r.Inputs.SignedReport.Context), "nSignatures", len(r.Inputs.SignedReport.Signatures), "executionID", request.Metadata.WorkflowExecutionID)
 		return &writetarget.TransmissionState{
 			Status:      writetarget.TransmissionStateNotAttempted,
 			Transmitter: transmissionInfo.Transmitter.String(),

--- a/core/services/relay/evm/target_strategy.go
+++ b/core/services/relay/evm/target_strategy.go
@@ -154,7 +154,7 @@ func (t *evmTargetStrategy) QueryTransmissionState(ctx context.Context, reportID
 			receiverGasMinimum = *r.Config.GasLimit - ForwarderContractLogicGasCost
 		}
 		if transmissionInfo.GasLimit.Uint64() > receiverGasMinimum {
-			t.lggr.Infow("returning without a transmission attempt - transmission already attempted and failed, sufficient gas was provided", "executionID", request.Metadata.WorkflowExecutionID, "receiverGasMinimum", receiverGasMinimum, "transmissionGasLimit", transmissionInfo.GasLimit)
+			t.lggr.Warnw("returning without a transmission attempt - transmission already attempted and failed, sufficient gas was provided", "executionID", request.Metadata.WorkflowExecutionID, "receiverGasMinimum", receiverGasMinimum, "transmissionGasLimit", transmissionInfo.GasLimit)
 			return &writetarget.TransmissionState{
 				Status:      writetarget.TransmissionStateFatal,
 				Transmitter: transmissionInfo.Transmitter.String(),

--- a/core/services/relay/evm/target_strategy.go
+++ b/core/services/relay/evm/target_strategy.go
@@ -161,7 +161,7 @@ func (t *evmTargetStrategy) QueryTransmissionState(ctx context.Context, reportID
 				Err:         ErrTxFailed,
 			}, nil
 		}
-		t.lggr.Infow("non-empty report - transmission should be retried", "request", request, "reportLen", len(r.Inputs.SignedReport.Report), "reportContextLen", len(r.Inputs.SignedReport.Context), "nSignatures", len(r.Inputs.SignedReport.Signatures), "executionID", request.Metadata.WorkflowExecutionID, "receiverGasMinimum", receiverGasMinimum, "transmissionGasLimit", transmissionInfo.GasLimit)
+		t.lggr.Debugw("non-empty report - transmission should be retried", "request", request, "reportLen", len(r.Inputs.SignedReport.Report), "reportContextLen", len(r.Inputs.SignedReport.Context), "nSignatures", len(r.Inputs.SignedReport.Signatures), "executionID", request.Metadata.WorkflowExecutionID, "receiverGasMinimum", receiverGasMinimum, "transmissionGasLimit", transmissionInfo.GasLimit)
 		return &writetarget.TransmissionState{
 			Status:      writetarget.TransmissionStateFailed,
 			Transmitter: transmissionInfo.Transmitter.String(),

--- a/core/services/relay/evm/target_strategy.go
+++ b/core/services/relay/evm/target_strategy.go
@@ -142,7 +142,7 @@ func (t *evmTargetStrategy) QueryTransmissionState(ctx context.Context, reportID
 			Err:         nil,
 		}, nil
 	case TransmissionStateInvalidReceiver:
-		t.lggr.Infow("returning without a transmission attempt - transmission already attempted, receiver was marked as invalid", "executionID", request.Metadata.WorkflowExecutionID)
+		t.lggr.Warnw("returning without a transmission attempt - transmission already attempted, receiver was marked as invalid", "executionID", request.Metadata.WorkflowExecutionID)
 		return &writetarget.TransmissionState{
 			Status:      writetarget.TransmissionStateFatal,
 			Transmitter: transmissionInfo.Transmitter.String(),

--- a/core/services/relay/evm/target_strategy.go
+++ b/core/services/relay/evm/target_strategy.go
@@ -135,7 +135,7 @@ func (t *evmTargetStrategy) QueryTransmissionState(ctx context.Context, reportID
 			Err:         nil,
 		}, nil
 	case TransmissionStateSucceeded:
-		t.lggr.Infow("returning without a transmission attempt - report already onchain ", "executionID", request.Metadata.WorkflowExecutionID)
+		t.lggr.Debugw("returning without a transmission attempt - report already onchain ", "executionID", request.Metadata.WorkflowExecutionID)
 		return &writetarget.TransmissionState{
 			Status:      writetarget.TransmissionStateSucceeded,
 			Transmitter: transmissionInfo.Transmitter.String(),

--- a/core/services/ring/plugin.go
+++ b/core/services/ring/plugin.go
@@ -103,7 +103,7 @@ func (p *Plugin) Observation(ctx context.Context, _ ocr3types.OutcomeContext, _ 
 	}
 
 	pendingAllocs := p.store.GetPendingAllocations()
-	p.lggr.Infow("RingOCR Observation pending allocations", "pendingAllocs", pendingAllocs)
+	p.lggr.Debugw("RingOCR Observation pending allocations", "pendingAllocs", pendingAllocs)
 
 	allWorkflowIDs = append(allWorkflowIDs, pendingAllocs...)
 	allWorkflowIDs = uniqueSorted(allWorkflowIDs)

--- a/core/services/ring/plugin.go
+++ b/core/services/ring/plugin.go
@@ -176,7 +176,7 @@ func (p *Plugin) Outcome(_ context.Context, outctx ocr3types.OutcomeContext, _ t
 		return nil, errors.New("RingOCR Outcome: no attributed observations")
 	}
 	currentShardHealth, allWorkflows, nows, wantShardVotes := p.collectShardInfo(aos)
-	p.lggr.Infow("RingOCR Outcome collect shard info", "currentShardHealth", currentShardHealth, "wantShardVotes", wantShardVotes)
+	p.lggr.Debugw("RingOCR Outcome collect shard info", "currentShardHealth", currentShardHealth, "wantShardVotes", wantShardVotes)
 
 	// Use the median timestamp to determine the current time
 	slices.SortFunc(nows, time.Time.Compare)

--- a/core/services/ring/plugin.go
+++ b/core/services/ring/plugin.go
@@ -107,7 +107,7 @@ func (p *Plugin) Observation(ctx context.Context, _ ocr3types.OutcomeContext, _ 
 
 	allWorkflowIDs = append(allWorkflowIDs, pendingAllocs...)
 	allWorkflowIDs = uniqueSorted(allWorkflowIDs)
-	p.lggr.Infow("RingOCR Observation all workflow IDs unique", "allWorkflowIDs", allWorkflowIDs, "wantShards", wantShards)
+	p.lggr.Debugw("RingOCR Observation all workflow IDs unique", "allWorkflowIDs", allWorkflowIDs, "wantShards", wantShards)
 
 	observation := &ringpb.Observation{
 		ShardStatus: shardStatus,

--- a/core/services/ring/plugin.go
+++ b/core/services/ring/plugin.go
@@ -89,7 +89,7 @@ func (p *Plugin) Observation(ctx context.Context, _ ocr3types.OutcomeContext, _ 
 	status, err := p.arbiterScaler.Status(ctx, &emptypb.Empty{})
 	if err != nil {
 		// NOTE: consider a fallback data source if Arbiter is not available
-		p.lggr.Errorw("RingOCR failed to get arbiter scaler status", "error", err)
+		p.lggr.Warnw("RingOCR failed to get arbiter scaler status", "error", err)
 		return nil, err
 	}
 	wantShards = status.WantShards

--- a/core/services/ring/plugin.go
+++ b/core/services/ring/plugin.go
@@ -226,7 +226,7 @@ func (p *Plugin) Outcome(_ context.Context, outctx ocr3types.OutcomeContext, _ t
 		Routes: routes,
 	}
 
-	p.lggr.Infow("RingOCR Outcome", "healthyShards", len(healthyShards), "totalObservations", len(aos), "workflowCount", len(routes))
+	p.lggr.Debugw("RingOCR Outcome", "healthyShards", len(healthyShards), "totalObservations", len(aos), "workflowCount", len(routes))
 
 	return proto.MarshalOptions{Deterministic: true}.Marshal(outcome)
 }

--- a/core/services/ring/transmitter.go
+++ b/core/services/ring/transmitter.go
@@ -77,7 +77,7 @@ func (t *Transmitter) notifyArbiter(ctx context.Context, state *ringpb.RoutingSt
 		t.lggr.Debugw("Transmitting shard routing", "routableShards", nShards)
 	case *ringpb.RoutingState_Transition:
 		nShards = s.Transition.WantShards
-		t.lggr.Infow("Transmitting shard routing (in transition)", "wantShards", nShards)
+		t.lggr.Debugw("Transmitting shard routing (in transition)", "wantShards", nShards)
 	}
 
 	if t.arbiterScaler != nil && nShards > 0 {

--- a/core/services/ring/transmitter.go
+++ b/core/services/ring/transmitter.go
@@ -74,7 +74,7 @@ func (t *Transmitter) notifyArbiter(ctx context.Context, state *ringpb.RoutingSt
 	switch s := state.State.(type) {
 	case *ringpb.RoutingState_RoutableShards:
 		nShards = s.RoutableShards
-		t.lggr.Infow("Transmitting shard routing", "routableShards", nShards)
+		t.lggr.Debugw("Transmitting shard routing", "routableShards", nShards)
 	case *ringpb.RoutingState_Transition:
 		nShards = s.Transition.WantShards
 		t.lggr.Infow("Transmitting shard routing (in transition)", "wantShards", nShards)

--- a/core/services/shardorchestrator/service.go
+++ b/core/services/shardorchestrator/service.go
@@ -99,7 +99,7 @@ func (s *Server) ReportWorkflowTriggerRegistration(_ context.Context, req *ringp
 
 	s.ringStore.RegisterWorkflowsFromShard(req.SourceShardId, workflowIDs)
 
-	s.logger.Infow("Successfully registered workflows",
+	s.logger.Debugw("Successfully registered workflows",
 		"shardID", req.SourceShardId,
 		"workflowCount", len(workflowIDs),
 	)

--- a/core/services/shardorchestrator/shard_orchestrator.go
+++ b/core/services/shardorchestrator/shard_orchestrator.go
@@ -76,7 +76,7 @@ func (o *orchestrator) runGRPCServer(ctx context.Context) {
 	var lc net.ListenConfig
 	lis, err := lc.Listen(ctx, "tcp", o.grpcAddr)
 	if err != nil {
-		o.lggr.Errorw("Failed to listen for gRPC", "addr", o.grpcAddr, "error", err)
+		o.lggr.Criticalw("Failed to listen for gRPC", "addr", o.grpcAddr, "error", err)
 		return
 	}
 

--- a/core/services/shardorchestrator/shard_orchestrator.go
+++ b/core/services/shardorchestrator/shard_orchestrator.go
@@ -90,7 +90,7 @@ func (o *orchestrator) runGRPCServer(ctx context.Context) {
 		select {
 		case <-o.stopCh:
 			// Normal shutdown, don't log as error
-			o.lggr.Debug("gRPC server stopped")
+			o.lggr.Info("gRPC server stopped")
 		default:
 			o.lggr.Errorw("gRPC server error", "error", err)
 		}

--- a/core/services/shardorchestrator/shard_orchestrator.go
+++ b/core/services/shardorchestrator/shard_orchestrator.go
@@ -92,7 +92,7 @@ func (o *orchestrator) runGRPCServer(ctx context.Context) {
 			// Normal shutdown, don't log as error
 			o.lggr.Info("gRPC server stopped")
 		default:
-			o.lggr.Errorw("gRPC server error", "error", err)
+			o.lggr.Criticalw("gRPC server error", "error", err)
 		}
 	}
 }

--- a/core/services/synchronization/chip_ingress_batch_worker.go
+++ b/core/services/synchronization/chip_ingress_batch_worker.go
@@ -72,7 +72,7 @@ func (cw *chipIngressBatchWorker) Send(ctx context.Context) {
 
 	_, err := cw.chipClient.PublishBatch(ctx, batch)
 	if err != nil {
-		cw.lggr.Warnf("Could not send telemetry via ChIP ingress: %v", err)
+		cw.lggr.Debugf("Could not send telemetry via ChIP ingress: %v", err)
 		TelemetryClientMessagesSendErrors.WithLabelValues(chipIngress, string(cw.telemType)).Inc()
 		return
 	}

--- a/core/services/synchronization/chip_ingress_batch_worker.go
+++ b/core/services/synchronization/chip_ingress_batch_worker.go
@@ -102,7 +102,7 @@ func (cw *chipIngressBatchWorker) BuildCloudEventBatch() *chipingress.CloudEvent
 		payload := <-cw.chTelemetry
 		event, err := cw.payloadToEvent(payload)
 		if err != nil {
-			cw.lggr.Warnw("failed to build CloudEvent for ChIP ingress", "error", err, "contractID", payload.ContractID, "telemType", payload.TelemType)
+			cw.lggr.Debugw("failed to build CloudEvent for ChIP ingress", "error", err, "contractID", payload.ContractID, "telemType", payload.TelemType)
 			TelemetryClientMessagesDropped.WithLabelValues(chipIngress, string(cw.telemType)).Inc()
 			continue
 		}

--- a/core/services/synchronization/telemetry_ingress_batch_client.go
+++ b/core/services/synchronization/telemetry_ingress_batch_client.go
@@ -132,7 +132,7 @@ func (tc *telemetryIngressBatchClient) start(ctx context.Context) error {
 					if ctx.Err() != nil {
 						tc.eng.Warnw("gave up connecting to telemetry endpoint", "err", err)
 					} else {
-						tc.eng.Criticalw("telemetry endpoint dial errored unexpectedly", "err", err, "server pubkey", tc.serverPubKeyHex)
+						tc.eng.Errorw("telemetry endpoint dial errored unexpectedly", "err", err, "server pubkey", tc.serverPubKeyHex)
 						tc.eng.EmitHealthErr(err)
 					}
 					return

--- a/core/services/synchronization/telemetry_ingress_batch_client.go
+++ b/core/services/synchronization/telemetry_ingress_batch_client.go
@@ -200,7 +200,7 @@ func (tc *telemetryIngressBatchClient) close() (err error) {
 // and a warning is logged.
 func (tc *telemetryIngressBatchClient) Send(ctx context.Context, telemData []byte, contractID string, telemType TelemetryType) {
 	if tc.useUniConn && !tc.connected.Load() {
-		tc.eng.Warnw("not connected to telemetry endpoint", "endpoint", tc.url.String())
+		tc.eng.Debugw("not connected to telemetry endpoint", "endpoint", tc.url.String())
 		return
 	}
 	payload := TelemPayload{

--- a/core/services/synchronization/telemetry_ingress_batch_worker.go
+++ b/core/services/synchronization/telemetry_ingress_batch_worker.go
@@ -69,7 +69,7 @@ func (tw *telemetryIngressBatchWorker) Send(ctx context.Context) {
 	cancel()
 
 	if err != nil {
-		tw.lggr.Warnf("Could not send telemetry: %v", err)
+		tw.lggr.Debugf("Could not send telemetry: %v", err)
 		TelemetryClientMessagesSendErrors.WithLabelValues(tw.endpointURL, string(tw.telemType)).Inc()
 		return
 	}

--- a/core/services/synchronization/telemetry_ingress_client.go
+++ b/core/services/synchronization/telemetry_ingress_client.go
@@ -130,7 +130,7 @@ func (tc *telemetryIngressClient) handleTelemetry() {
 				}
 				_, err := tc.telemClient.Telem(ctx, telemReq)
 				if err != nil {
-					tc.eng.Errorf("Could not send telemetry: %v", err)
+					tc.eng.Warnf("Could not send telemetry: %v", err)
 					continue
 				}
 				if tc.logging {

--- a/core/services/synchronization/telemetry_ingress_client.go
+++ b/core/services/synchronization/telemetry_ingress_client.go
@@ -94,7 +94,7 @@ func (tc *telemetryIngressClient) start(context.Context) error {
 			if ctx.Err() != nil {
 				tc.eng.Infow("gave up connecting to telemetry endpoint", "err", err)
 			} else {
-				tc.eng.Criticalw("telemetry endpoint dial errored unexpectedly", "err", err)
+				tc.eng.Errorw("telemetry endpoint dial errored unexpectedly", "err", err)
 				tc.eng.EmitHealthErr(err)
 			}
 			return

--- a/core/services/synchronization/telemetry_ingress_client.go
+++ b/core/services/synchronization/telemetry_ingress_client.go
@@ -92,7 +92,7 @@ func (tc *telemetryIngressClient) start(context.Context) error {
 		}()
 		if err != nil {
 			if ctx.Err() != nil {
-				tc.eng.Warnw("gave up connecting to telemetry endpoint", "err", err)
+				tc.eng.Infow("gave up connecting to telemetry endpoint", "err", err)
 			} else {
 				tc.eng.Criticalw("telemetry endpoint dial errored unexpectedly", "err", err)
 				tc.eng.EmitHealthErr(err)

--- a/core/sessions/ldapauth/ldap.go
+++ b/core/sessions/ldapauth/ldap.go
@@ -653,7 +653,7 @@ func (l *ldapAuthenticator) validateUsersActive(emails []string) ([]bool, error)
 
 	conn, err := l.ldapClient.CreateEphemeralConnection()
 	if err != nil {
-		l.lggr.Error("error in LDAP dial: ", err)
+		l.lggr.Warn("error in LDAP dial: ", err)
 		return validUsers, errors.New("unable to establish connection to LDAP server with provided URL and credentials")
 	}
 	defer conn.Close()

--- a/core/sessions/ldapauth/ldap.go
+++ b/core/sessions/ldapauth/ldap.go
@@ -124,7 +124,7 @@ func (l *ldapAuthenticator) FindUser(ctx context.Context, email string) (session
 	// If error is not nil, there was either an issue or no local users found
 	if !errors.Is(checkErr, sql.ErrNoRows) {
 		// If the error is not that no local user was found, log and exit
-		l.lggr.Errorf("error searching users table: %v", checkErr)
+		l.lggr.Warnf("error searching users table: %v", checkErr)
 		return sessions.User{}, errors.New("error Finding user")
 	}
 

--- a/core/sessions/ldapauth/ldap.go
+++ b/core/sessions/ldapauth/ldap.go
@@ -415,7 +415,7 @@ func (l *ldapAuthenticator) CreateSession(ctx context.Context, sr sessions.Sessi
 	// with cached user email and role
 	foundUser, err := l.FindUser(ctx, escapedEmail)
 	if err != nil {
-		l.lggr.Infof("Successful user login, but error querying for user groups: user: %s, error %v", escapedEmail, err)
+		l.lggr.Warnf("Successful user login, but error querying for user groups: user: %s, error %v", escapedEmail, err)
 		returnErr = errors.New("log in successful, but no assigned groups to assume role")
 	}
 

--- a/core/sessions/ldapauth/ldap.go
+++ b/core/sessions/ldapauth/ldap.go
@@ -166,7 +166,7 @@ func (l *ldapAuthenticator) FindUser(ctx context.Context, email string) (session
 	// Query the server
 	result, err := conn.Search(searchRequest)
 	if err != nil {
-		l.lggr.Errorf("error searching users in LDAP query: %v", err)
+		l.lggr.Warnf("error searching users in LDAP query: %v", err)
 		return sessions.User{}, errors.New("error searching users in LDAP directory")
 	}
 

--- a/core/sessions/ldapauth/ldap.go
+++ b/core/sessions/ldapauth/ldap.go
@@ -362,7 +362,7 @@ func (l *ldapAuthenticator) AuthorizedUserWithSession(ctx context.Context, sessi
 	if !foundSession.Valid {
 		// Sessions expired, purge
 		if _, execErr := l.ds.ExecContext(ctx, "DELETE FROM ldap_sessions WHERE id = $1", sessionID); execErr != nil {
-			l.lggr.Errorf("error purging stale ldap session: %v", execErr)
+			l.lggr.Warnf("error purging stale ldap session: %v", execErr)
 		}
 		return sessions.User{}, sessions.ErrUserSessionExpired
 	}

--- a/core/sessions/ldapauth/ldap.go
+++ b/core/sessions/ldapauth/ldap.go
@@ -143,7 +143,7 @@ func (l *ldapAuthenticator) FindUser(ctx context.Context, email string) (session
 
 	conn, err := l.ldapClient.CreateEphemeralConnection()
 	if err != nil {
-		l.lggr.Errorf("error in LDAP dial: %v", err)
+		l.lggr.Warnf("error in LDAP dial: %v", err)
 		return sessions.User{}, errors.New("unable to establish connection to LDAP server with provided URL and credentials")
 	}
 	defer conn.Close()

--- a/core/sessions/ldapauth/ldap.go
+++ b/core/sessions/ldapauth/ldap.go
@@ -134,7 +134,7 @@ func (l *ldapAuthenticator) FindUser(ctx context.Context, email string) (session
 		if errors.Is(err, ErrUserNotInUpstream) {
 			return sessions.User{}, ErrUserNotInUpstream
 		}
-		l.lggr.Errorf("error in validateUsers call: %v", err)
+		l.lggr.Warnf("error in validateUsers call: %v", err)
 		return sessions.User{}, errors.New("error running query to validate user active")
 	}
 	if !usersActive[0] {

--- a/core/sessions/ldapauth/ldap.go
+++ b/core/sessions/ldapauth/ldap.go
@@ -677,7 +677,7 @@ func (l *ldapAuthenticator) validateUsersActive(emails []string) ([]bool, error)
 	// Query LDAP server for the ActiveAttribute property of each specified user
 	results, err := conn.Search(searchRequest)
 	if err != nil {
-		l.lggr.Errorf("error searching user in LDAP query: %v", err)
+		l.lggr.Warnf("error searching user in LDAP query: %v", err)
 		return validUsers, errors.New("error searching users in LDAP directory")
 	}
 

--- a/core/sessions/ldapauth/ldap.go
+++ b/core/sessions/ldapauth/ldap.go
@@ -224,7 +224,7 @@ func (l *ldapAuthenticator) FindUserByAPIToken(ctx context.Context, apiToken str
 	}
 	if !foundUserToken.Valid { // API Token expired, purge
 		if _, execErr := l.ds.ExecContext(ctx, "DELETE FROM ldap_user_api_tokens WHERE token_key = $1", apiToken); execErr != nil {
-			l.lggr.Errorf("error purging stale ldap API token session: %v", execErr)
+			l.lggr.Warnf("error purging stale ldap API token session: %v", execErr)
 		}
 		return sessions.User{}, sessions.ErrUserSessionExpired
 	}

--- a/core/sessions/ldapauth/ldap.go
+++ b/core/sessions/ldapauth/ldap.go
@@ -406,7 +406,7 @@ func (l *ldapAuthenticator) CreateSession(ctx context.Context, sr sessions.Sessi
 	escapedEmail := ldap.EscapeFilter(strings.ToLower(sr.Email))
 	searchBaseDN := fmt.Sprintf("%s=%s,%s,%s", l.config.BaseUserAttr(), escapedEmail, l.config.UsersDN(), l.config.BaseDN())
 	if err = conn.Bind(searchBaseDN, sr.Password); err != nil {
-		l.lggr.Infof("Error binding user authentication request in LDAP Bind: %v", err)
+		l.lggr.Debugf("Error binding user authentication request in LDAP Bind: %v", err)
 		returnErr = errors.New("unable to log in with LDAP server. Check credentials")
 	}
 

--- a/core/sessions/ldapauth/ldap.go
+++ b/core/sessions/ldapauth/ldap.go
@@ -511,7 +511,7 @@ func (l *ldapAuthenticator) TestPassword(ctx context.Context, email string, pass
 	if err == nil {
 		return nil
 	}
-	l.lggr.Infof("Error binding user authentication request in TestPassword call LDAP Bind: %v", err)
+	l.lggr.Debugf("Error binding user authentication request in TestPassword call LDAP Bind: %v", err)
 
 	// Fall back to test local users table in case of supported local CLI users as well
 	var hashedPassword string

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -278,7 +278,7 @@ func (l *LDAPServerStateSyncer) Work(ctx context.Context) {
 		return nil
 	})
 	if err != nil {
-		l.lggr.Error("Error syncing local database state: ", err)
+		l.lggr.Warn("Error syncing local database state: ", err)
 	}
 	l.lggr.Info("Upstream LDAP sync complete")
 }

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -151,7 +151,7 @@ func (l *LDAPServerStateSyncer) Work(ctx context.Context) {
 	// Query for list of uniqueMember IDs present in Edit group
 	readUsers, err := l.ldapGroupMembersListToUser(conn, l.config.ReadUserGroupCN(), sessions.UserRoleView)
 	if err != nil {
-		l.lggr.Error("Error in ldapGroupMembersListToUser: ", err)
+		l.lggr.Warn("Error in ldapGroupMembersListToUser: ", err)
 		return
 	}
 

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -303,7 +303,7 @@ func (l *LDAPServerStateSyncer) ldapGroupMembersListToUser(conn LDAPConn, groupN
 		l.lggr,
 	)
 	if err != nil {
-		l.lggr.Errorf("Error listing members of group (%s): %v", groupNameCN, err)
+		l.lggr.Warnf("Error listing members of group (%s): %v", groupNameCN, err)
 		return users, errors.New("error searching group members in LDAP directory")
 	}
 	return users, nil

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -175,7 +175,7 @@ func (l *LDAPServerStateSyncer) Work(ctx context.Context) {
 	// list group members that are no longer marked as active
 	usersActiveFlags, err := l.validateUsersActive(dedupedEmails, conn)
 	if err != nil {
-		l.lggr.Error("Error validating supplied user list: ", err)
+		l.lggr.Warn("Error validating supplied user list: ", err)
 	}
 	// Remove users in the upstreamUserStateMap source of truth who are part of groups but marked as deactivated/no-active
 	for i, active := range usersActiveFlags {

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -342,7 +342,7 @@ func (l *LDAPServerStateSyncer) validateUsersActive(emails []string, conn LDAPCo
 	// Query LDAP server for the ActiveAttribute property of each specified user
 	results, err := conn.Search(searchRequest)
 	if err != nil {
-		l.lggr.Errorf("Error searching user in LDAP query: %v", err)
+		l.lggr.Warnf("Error searching user in LDAP query: %v", err)
 		return validUsers, errors.New("error searching users in LDAP directory")
 	}
 	// Ensure user response entries

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -126,7 +126,7 @@ func (l *LDAPServerStateSyncer) Work(ctx context.Context) {
 	// Root level root user auth with credentials provided from config
 	bindStr := l.config.BaseUserAttr() + "=" + l.config.ReadOnlyUserLogin() + "," + l.config.BaseDN()
 	if err = conn.Bind(bindStr, l.config.ReadOnlyUserPass()); err != nil {
-		l.lggr.Error("Unable to login as initial root LDAP user: ", err)
+		l.lggr.Warn("Unable to login as initial root LDAP user: ", err)
 	}
 	defer conn.Close()
 

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -133,7 +133,7 @@ func (l *LDAPServerStateSyncer) Work(ctx context.Context) {
 	// Query for list of uniqueMember IDs present in Admin group
 	adminUsers, err := l.ldapGroupMembersListToUser(conn, l.config.AdminUserGroupCN(), sessions.UserRoleAdmin)
 	if err != nil {
-		l.lggr.Error("Error in ldapGroupMembersListToUser: ", err)
+		l.lggr.Warn("Error in ldapGroupMembersListToUser: ", err)
 		return
 	}
 	// Query for list of uniqueMember IDs present in Edit group

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -113,7 +113,7 @@ func (l *LDAPServerStateSyncer) Work(ctx context.Context) {
 		l.nextSyncTime = time.Now().Add(l.config.UpstreamSyncRateLimit().Duration())
 	}
 
-	l.lggr.Info("Begin Upstream LDAP provider state sync after checking time against config UpstreamSyncInterval and UpstreamSyncRateLimit")
+	l.lggr.Debug("Begin Upstream LDAP provider state sync after checking time against config UpstreamSyncInterval and UpstreamSyncRateLimit")
 
 	// For each defined role/group, query for the list of group members to gather the full list of possible users
 	users := []sessions.User{}

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -280,7 +280,7 @@ func (l *LDAPServerStateSyncer) Work(ctx context.Context) {
 	if err != nil {
 		l.lggr.Warn("Error syncing local database state: ", err)
 	}
-	l.lggr.Info("Upstream LDAP sync complete")
+	l.lggr.Debug("Upstream LDAP sync complete")
 }
 
 // deleteStaleSessions deletes all ldap_sessions before the passed time.

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -145,7 +145,7 @@ func (l *LDAPServerStateSyncer) Work(ctx context.Context) {
 	// Query for list of uniqueMember IDs present in Edit group
 	runUsers, err := l.ldapGroupMembersListToUser(conn, l.config.RunUserGroupCN(), sessions.UserRoleRun)
 	if err != nil {
-		l.lggr.Error("Error in ldapGroupMembersListToUser: ", err)
+		l.lggr.Warn("Error in ldapGroupMembersListToUser: ", err)
 		return
 	}
 	// Query for list of uniqueMember IDs present in Edit group

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -139,7 +139,7 @@ func (l *LDAPServerStateSyncer) Work(ctx context.Context) {
 	// Query for list of uniqueMember IDs present in Edit group
 	editUsers, err := l.ldapGroupMembersListToUser(conn, l.config.EditUserGroupCN(), sessions.UserRoleEdit)
 	if err != nil {
-		l.lggr.Error("Error in ldapGroupMembersListToUser: ", err)
+		l.lggr.Warn("Error in ldapGroupMembersListToUser: ", err)
 		return
 	}
 	// Query for list of uniqueMember IDs present in Edit group

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -95,7 +95,7 @@ func (l *LDAPServerStateSyncer) Work(ctx context.Context) {
 	recordCreationStaleThreshold := l.config.SessionTimeout().Before(time.Now())
 	err := l.deleteStaleSessions(ctx, recordCreationStaleThreshold)
 	if err != nil {
-		l.lggr.Error("unable to expire local LDAP sessions: ", err)
+		l.lggr.Warn("unable to expire local LDAP sessions: ", err)
 	}
 	recordCreationStaleThreshold = l.config.UserAPITokenDuration().Before(time.Now())
 	err = l.deleteStaleAPITokens(ctx, recordCreationStaleThreshold)

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -274,7 +274,7 @@ func (l *LDAPServerStateSyncer) Work(ctx context.Context) {
 			}
 		}
 
-		l.lggr.Info("local ldap_sessions and ldap_user_api_tokens table successfully synced with upstream LDAP state")
+		l.lggr.Debug("local ldap_sessions and ldap_user_api_tokens table successfully synced with upstream LDAP state")
 		return nil
 	})
 	if err != nil {

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -120,7 +120,7 @@ func (l *LDAPServerStateSyncer) Work(ctx context.Context) {
 
 	conn, err := l.ldapClient.CreateEphemeralConnection()
 	if err != nil {
-		l.lggr.Error("Failed to Dial LDAP Server: ", err)
+		l.lggr.Warn("Failed to Dial LDAP Server: ", err)
 		return
 	}
 	// Root level root user auth with credentials provided from config

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -100,7 +100,7 @@ func (l *LDAPServerStateSyncer) Work(ctx context.Context) {
 	recordCreationStaleThreshold = l.config.UserAPITokenDuration().Before(time.Now())
 	err = l.deleteStaleAPITokens(ctx, recordCreationStaleThreshold)
 	if err != nil {
-		l.lggr.Error("unable to expire user API tokens: ", err)
+		l.lggr.Warn("unable to expire user API tokens: ", err)
 	}
 
 	// Optional rate limiting check to limit the amount of upstream LDAP server queries performed

--- a/core/sessions/localauth/orm.go
+++ b/core/sessions/localauth/orm.go
@@ -182,7 +182,7 @@ func (o *orm) CreateSession(ctx context.Context, sr sessions.SessionRequest) (st
 	// if not, return a 401 error for the frontend to prompt the user to provide this
 	// data in the next round trip request (tap key to include webauthn data on the login page)
 	if sr.WebAuthnData == "" {
-		lggr.Warnf("Attempted login to MFA user. Generating challenge for user.")
+		lggr.Debugf("Attempted login to MFA user. Generating challenge for user.")
 		options, webauthnError := sessions.BeginWebAuthnLogin(user, uwas, sr)
 		if webauthnError != nil {
 			lggr.Errorf("Could not begin WebAuthn verification: %v", webauthnError)

--- a/core/sessions/localauth/orm.go
+++ b/core/sessions/localauth/orm.go
@@ -210,7 +210,7 @@ func (o *orm) CreateSession(ctx context.Context, sr sessions.SessionRequest) (st
 		return "", pkgerrors.New("MFA Error")
 	}
 
-	lggr.Infof("User passed MFA authentication and login will proceed")
+	lggr.Debugf("User passed MFA authentication and login will proceed")
 	// This is a success so we can create the sessions
 	session := sessions.NewSession()
 	_, err = o.ds.ExecContext(ctx, "INSERT INTO sessions (id, email, last_used, created_at) VALUES ($1, $2, now(), now())", session.ID, user.Email)

--- a/core/sessions/localauth/orm.go
+++ b/core/sessions/localauth/orm.go
@@ -171,7 +171,7 @@ func (o *orm) CreateSession(ctx context.Context, sr sessions.SessionRequest) (st
 
 	// No webauthn tokens registered for the current user, so normal authentication is now complete
 	if len(uwas) == 0 {
-		lggr.Infof("No MFA for user. Creating Session")
+		lggr.Debugf("No MFA for user. Creating Session")
 		session := sessions.NewSession()
 		_, err = o.ds.ExecContext(ctx, "INSERT INTO sessions (id, email, last_used, created_at) VALUES ($1, $2, now(), now())", session.ID, user.Email)
 		o.auditLogger.Audit(audit.AuthLoginSuccessNo2FA, map[string]any{"email": sr.Email})

--- a/core/sessions/localauth/orm.go
+++ b/core/sessions/localauth/orm.go
@@ -221,7 +221,7 @@ func (o *orm) CreateSession(ctx context.Context, sr sessions.SessionRequest) (st
 	// Forward registered credentials for audit logs
 	uwasj, err := json.Marshal(uwas)
 	if err != nil {
-		lggr.Errorf("error in Marshal credentials: %s", err)
+		lggr.Warnf("error in Marshal credentials: %s", err)
 	} else {
 		o.auditLogger.Audit(audit.AuthLoginSuccessWith2FA, map[string]any{"email": sr.Email, "credential": string(uwasj)})
 	}

--- a/core/sessions/localauth/orm.go
+++ b/core/sessions/localauth/orm.go
@@ -206,7 +206,7 @@ func (o *orm) CreateSession(ctx context.Context, sr sessions.SessionRequest) (st
 	if err != nil {
 		// The user does have WebAuthn enabled but failed the check
 		o.auditLogger.Audit(audit.AuthLoginFailed2FA, map[string]any{"email": sr.Email, "error": err})
-		lggr.Errorf("User sent an invalid attestation: %v", err)
+		lggr.Warnf("User sent an invalid attestation: %v", err)
 		return "", pkgerrors.New("MFA Error")
 	}
 

--- a/core/sessions/localauth/orm.go
+++ b/core/sessions/localauth/orm.go
@@ -68,7 +68,7 @@ func (o *orm) ListUsers(ctx context.Context) (users []sessions.User, err error) 
 // findValidSession finds an unexpired session by its ID and returns the associated email.
 func (o *orm) findValidSession(ctx context.Context, sessionID string) (email string, err error) {
 	if err := o.ds.GetContext(ctx, &email, "SELECT email FROM sessions WHERE id = $1 AND last_used + $2 >= now() FOR UPDATE", sessionID, o.sessionDuration); err != nil {
-		o.lggr.Infof("query result: %v", email)
+		o.lggr.Debugf("query result: %v", email)
 		return email, pkgerrors.Wrap(err, "no matching user for provided session token")
 	}
 	return email, nil

--- a/core/sessions/localauth/reaper.go
+++ b/core/sessions/localauth/reaper.go
@@ -37,7 +37,7 @@ func (sr *sessionReaper) Work(ctx context.Context) {
 		sr.config.SessionTimeout().Before(time.Now()))
 	err := sr.deleteStaleSessions(ctx, recordCreationStaleThreshold)
 	if err != nil {
-		sr.lggr.Error("unable to reap stale sessions: ", err)
+		sr.lggr.Warn("unable to reap stale sessions: ", err)
 	}
 }
 

--- a/core/sessions/oidcauth/oidc.go
+++ b/core/sessions/oidcauth/oidc.go
@@ -239,7 +239,7 @@ func (oi *oidcAuthenticator) handleTokenExchange(c *gin.Context) {
 		oi.config.ReadClaim(),
 	)
 	if err != nil {
-		oi.lggr.Errorf("Failed to map configured RBAC role name against received list of group claims: %v", err)
+		oi.lggr.Warnf("Failed to map configured RBAC role name against received list of group claims: %v", err)
 		c.String(http.StatusBadRequest, "No matching role within attested user group claims")
 		return
 	}

--- a/core/sessions/oidcauth/oidc.go
+++ b/core/sessions/oidcauth/oidc.go
@@ -460,7 +460,7 @@ func (oi *oidcAuthenticator) SetPassword(ctx context.Context, user *clsessions.U
 	// Ensure specified user is part of the local admins user table
 	var localAdminUser clsessions.User
 	if err := oi.ds.GetContext(ctx, &localAdminUser, SQLSelectUserbyEmail, user.Email); err != nil {
-		oi.lggr.Infof("Can not change password, local user with email not found in users table: %s, err: %v", user.Email, err)
+		oi.lggr.Debugf("Can not change password, local user with email not found in users table: %s, err: %v", user.Email, err)
 		return clsessions.ErrNotSupported
 	}
 

--- a/core/sessions/oidcauth/oidc.go
+++ b/core/sessions/oidcauth/oidc.go
@@ -382,7 +382,7 @@ func (oi *oidcAuthenticator) AuthorizedUserWithSession(ctx context.Context, sess
 	if err != nil {
 		if errors.Is(err, clsessions.ErrUserSessionExpired) {
 			if _, execErr := oi.ds.ExecContext(ctx, "DELETE FROM oidc_sessions WHERE id = $1", sessionID); execErr != nil {
-				oi.lggr.Errorf("error purging stale OIDC session: %v", execErr)
+				oi.lggr.Warnf("error purging stale OIDC session: %v", execErr)
 			}
 		}
 		return clsessions.User{}, err

--- a/core/sessions/oidcauth/oidc.go
+++ b/core/sessions/oidcauth/oidc.go
@@ -329,7 +329,7 @@ func (oi *oidcAuthenticator) FindUserByAPIToken(ctx context.Context, apiToken st
 		if errors.Is(err, clsessions.ErrUserSessionExpired) {
 			// API Token expired, purge
 			if _, execErr := oi.ds.ExecContext(ctx, "DELETE FROM oidc_user_api_tokens WHERE token_key = $1", apiToken); execErr != nil {
-				oi.lggr.Errorf("error purging stale oidc API token session: %v", execErr)
+				oi.lggr.Warnf("error purging stale oidc API token session: %v", execErr)
 			}
 		}
 		return clsessions.User{}, err

--- a/core/web/auth/gql.go
+++ b/core/web/auth/gql.go
@@ -36,7 +36,7 @@ func AuthenticateGQL(authenticator Authenticator, lggr logger.Logger) gin.Handle
 		user, err := authenticator.AuthorizedUserWithSession(ctx, sessionID)
 		if err != nil {
 			if errors.Is(err, clsessions.ErrUserSessionExpired) {
-				lggr.Warnw("Failed to authenticate session", "err", err)
+				lggr.Debugw("Failed to authenticate session", "err", err)
 			} else {
 				lggr.Errorw("Failed call to AuthorizedUserWithSession, unable to get user", "err", err)
 			}

--- a/core/web/eth_keys_controller.go
+++ b/core/web/eth_keys_controller.go
@@ -415,7 +415,7 @@ func (ekc *ETHKeysController) getKeyMaxGasPriceWei(state ethkey.State, keyAddres
 	}
 	chain, ok := chainService.(legacyevm.Chain)
 	if !ok {
-		ekc.lggr.Errorw("EVM Chain in LOOPP mode", "chainID", chainID, "err", err)
+		ekc.lggr.Debugw("EVM Chain in LOOPP mode", "chainID", chainID, "err", err)
 		return nil
 	}
 	return chain.Config().EVM().GasEstimator().PriceMaxKey(keyAddress)

--- a/core/web/eth_keys_controller.go
+++ b/core/web/eth_keys_controller.go
@@ -361,7 +361,7 @@ func (ekc *ETHKeysController) getEthBalance(ctx context.Context, state ethkey.St
 	ethClient := chain.Client()
 	bal, err := ethClient.BalanceAt(ctx, state.Address.Address(), nil)
 	if err != nil {
-		ekc.lggr.Errorw("Failed to get ETH balance", "chainID", chainID, "address", state.Address, "err", err)
+		ekc.lggr.Warnw("Failed to get ETH balance", "chainID", chainID, "address", state.Address, "err", err)
 		return nil
 	}
 

--- a/core/web/eth_keys_controller.go
+++ b/core/web/eth_keys_controller.go
@@ -354,7 +354,7 @@ func (ekc *ETHKeysController) getEthBalance(ctx context.Context, state ethkey.St
 	}
 	chain, ok := chainService.(legacyevm.Chain)
 	if !ok {
-		ekc.lggr.Errorw("EVM Chain in LOOPP mode", "chainID", chainID, "err", err)
+		ekc.lggr.Debugw("EVM Chain in LOOPP mode", "chainID", chainID, "err", err)
 		return nil
 	}
 

--- a/core/web/eth_keys_controller.go
+++ b/core/web/eth_keys_controller.go
@@ -384,7 +384,7 @@ func (ekc *ETHKeysController) getLinkBalance(ctx context.Context, state ethkey.S
 	}
 	chain, ok := chainService.(legacyevm.Chain)
 	if !ok {
-		ekc.lggr.Errorw("EVM Chain in LOOPP mode", "chainID", chainID, "err", err)
+		ekc.lggr.Debugw("EVM Chain in LOOPP mode", "chainID", chainID, "err", err)
 		return nil
 	}
 	ethClient := chain.Client()

--- a/core/web/eth_keys_controller.go
+++ b/core/web/eth_keys_controller.go
@@ -391,7 +391,7 @@ func (ekc *ETHKeysController) getLinkBalance(ctx context.Context, state ethkey.S
 	addr := common.HexToAddress(chain.Config().EVM().LinkContractAddress())
 	bal, err := ethClient.LINKBalance(ctx, state.Address.Address(), addr)
 	if err != nil {
-		ekc.lggr.Errorw("Failed to get LINK balance", "chainID", chainID, "address", state.Address, "err", err)
+		ekc.lggr.Warnw("Failed to get LINK balance", "chainID", chainID, "address", state.Address, "err", err)
 		return nil
 	}
 	return bal

--- a/core/web/health_controller.go
+++ b/core/web/health_controller.go
@@ -116,7 +116,7 @@ func (hc *HealthController) Health(c *gin.Context) {
 
 	case gin.MIMEPlain:
 		if err := writeTextTo(c.Writer, checks); err != nil {
-			hc.App.GetLogger().Errorw("Failed to write plaintext health report", "err", err)
+			hc.App.GetLogger().Warnw("Failed to write plaintext health report", "err", err)
 			c.AbortWithStatus(http.StatusInternalServerError)
 		}
 		return

--- a/core/web/health_controller.go
+++ b/core/web/health_controller.go
@@ -109,7 +109,7 @@ func (hc *HealthController) Health(c *gin.Context) {
 
 	case gin.MIMEHTML:
 		if err := newCheckTree(checks).WriteHTMLTo(c.Writer); err != nil {
-			hc.App.GetLogger().Errorw("Failed to write HTML health report", "err", err)
+			hc.App.GetLogger().Warnw("Failed to write HTML health report", "err", err)
 			c.AbortWithStatus(http.StatusInternalServerError)
 		}
 		return

--- a/core/web/middleware.go
+++ b/core/web/middleware.go
@@ -215,7 +215,7 @@ func (f *gzipFileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	f.lggr.Infof("could not find file: %s", fpath)
+	f.lggr.Debugf("could not find file: %s", fpath)
 	http.NotFound(w, r)
 }
 

--- a/core/web/presenters/vrf_key.go
+++ b/core/web/presenters/vrf_key.go
@@ -20,7 +20,7 @@ func (VRFKeyResource) GetName() string {
 func NewVRFKeyResource(key vrfkey.KeyV2, lggr logger.Logger) *VRFKeyResource {
 	uncompressed, err := key.PublicKey.StringUncompressed()
 	if err != nil {
-		lggr.Errorw("Unable to get uncompressed pk", "err", err)
+		lggr.Warnw("Unable to get uncompressed pk", "err", err)
 	}
 	return &VRFKeyResource{
 		JAID:         NewJAID(key.PublicKey.String()),

--- a/core/web/resolver/query.go
+++ b/core/web/resolver/query.go
@@ -302,7 +302,7 @@ func (r *Resolver) Node(ctx context.Context, args struct{ ID graphql.ID }) (*Nod
 		}
 	}
 
-	r.App.GetLogger().Errorw("resolver getting node status", "err", chains.ErrNotFound)
+	r.App.GetLogger().Debugw("resolver getting node status", "err", chains.ErrNotFound)
 	return NewNodePayloadResolver(nil, chains.ErrNotFound)
 }
 

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -585,7 +585,7 @@ func readBody(reader io.Reader, lggr logger.Logger) string {
 	buf := new(bytes.Buffer)
 	_, err := buf.ReadFrom(reader)
 	if err != nil {
-		lggr.Warn("unable to read from body for sanitization: ", err)
+		lggr.Debug("unable to read from body for sanitization: ", err)
 		return "*FAILED TO READ BODY*"
 	}
 

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -595,7 +595,7 @@ func readBody(reader io.Reader, lggr logger.Logger) string {
 
 	s, err := readSanitizedJSON(buf)
 	if err != nil {
-		lggr.Warn("unable to sanitize json for logging: ", err)
+		lggr.Debug("unable to sanitize json for logging: ", err)
 		return "*FAILED TO READ BODY*"
 	}
 	return s

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -531,7 +531,7 @@ func loggerFunc(lggr logger.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		buf, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			lggr.Error("Web request log error: ", err.Error())
+			lggr.Warn("Web request log error: ", err.Error())
 			// Implicitly relies on limits.RequestSizeLimiter
 			// overriding of c.Request.Body to abort gin's Context
 			// inside io.ReadAll.

--- a/core/web/webauthn_controller.go
+++ b/core/web/webauthn_controller.go
@@ -80,7 +80,7 @@ func (w *WebAuthnController) FinishRegistration(c *gin.Context) {
 
 	credential, err := w.inProgressRegistrationsStore.FinishWebAuthnRegistration(*user, uwas, c.Request, webAuthnConfig)
 	if err != nil {
-		w.App.GetLogger().Errorf("error in FinishWebAuthnRegistration: %s", err)
+		w.App.GetLogger().Warnf("error in FinishWebAuthnRegistration: %s", err)
 		jsonAPIError(c, http.StatusBadRequest, errors.New("registration was unsuccessful"))
 		return
 	}

--- a/plugins/cmd/capabilities/log-event-trigger/main.go
+++ b/plugins/cmd/capabilities/log-event-trigger/main.go
@@ -87,7 +87,7 @@ func (cs *LogEventTriggerGRPCService) Initialise(
 	ctx context.Context,
 	dependencies core.StandardCapabilitiesDependencies,
 ) error {
-	cs.s.Logger.Debugf("Initialising %s", serviceName)
+	cs.s.Logger.Infof("Initialising %s", serviceName)
 
 	var logEventConfig logevent.Config
 	err := json.Unmarshal([]byte(dependencies.Config), &logEventConfig)

--- a/plugins/loop_registry.go
+++ b/plugins/loop_registry.go
@@ -161,7 +161,7 @@ func (m *LoopRegistry) Register(id string) (*RegisteredLoop, error) {
 		envCfg.TelemetryLogExportInterval = m.cfgTelemetry.LogExportInterval()
 		envCfg.TelemetryLogMaxQueueSize = m.cfgTelemetry.LogMaxQueueSize()
 	}
-	m.lggr.Debugf("Registered loopp %q with port %d", id, envCfg.PrometheusPort)
+	m.lggr.Infof("Registered loopp %q with port %d", id, envCfg.PrometheusPort)
 
 	// Add auth header after logging config
 	if m.cfgTelemetry != nil {

--- a/plugins/loop_registry.go
+++ b/plugins/loop_registry.go
@@ -193,7 +193,7 @@ func (m *LoopRegistry) Unregister(id string) {
 
 	freeport.Return([]int{loop.EnvCfg.PrometheusPort})
 	delete(m.registry, id)
-	m.lggr.Debugf("Unregistered loopp %q", id)
+	m.lggr.Infof("Unregistered loopp %q", id)
 }
 
 // Return slice sorted by plugin name. Safe for concurrent use.

--- a/plugins/medianpoc/data_source.go
+++ b/plugins/medianpoc/data_source.go
@@ -28,7 +28,7 @@ type DataSource struct {
 func (d *DataSource) Observe(ctx context.Context, reportTimestamp ocrtypes.ReportTimestamp) (*big.Int, error) {
 	md, err := bridges.MarshalBridgeMetaData(d.currentAnswer())
 	if err != nil {
-		d.lggr.Warnw("unable to attach metadata for run", "err", err)
+		d.lggr.Debugw("unable to attach metadata for run", "err", err)
 	}
 
 	// NOTE: job metadata is automatically attached by the pipeline runner service


### PR DESCRIPTION
## Summary

Automated log-level adjustments produced by an LLM audit against a [logging-level-rubric](https://github.com/smartcontractkit/logging-audit-mzhang/blob/main/docs/logging-level-rubric.md). Audit baseline: chainlink `807f2928c65c`.

- Code owners: @smartcontractkit/core @smartcontractkit/foundations
- Changes applied: **232** (192 downgrade, 40 upgrade)
- Recommendations not applied (upstream removed or rewrote the line since the audit baseline): 23
- One commit per change. Inline review comments contain per-change rationale.

## Files touched

- `core/cmd/shell.go` (4 changes)
- `core/cmd/shell_local.go` (1 change)
- `core/logger/audit/audit_logger.go` (2 changes)
- `core/scripts/ccip/shared/helpers.go` (3 changes)
- `core/scripts/chaincli/handler/scrape_node_config.go` (2 changes)
- `core/scripts/cre/environment/environment/beholder.go` (1 change)
- `core/scripts/cre/environment/environment/setup.go` (4 changes)
- `core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go` (10 changes)
- `core/services/arbiter/arbiter_scaler.go` (1 change)
- `core/services/arbiter/shardconfig.go` (1 change)
- `core/services/beholder/config_recorder.go` (1 change)
- `core/services/ccv/ccvcommitteeverifier/delegate.go` (1 change)
- `core/services/ccv/ccvcommon/common.go` (1 change)
- `core/services/chainlink/application.go` (10 changes)
- `core/services/chainlink/node_platform.go` (1 change)
- `core/services/chainlink/relayer_factory.go` (1 change)
- `core/services/cre/cre.go` (4 changes)
- `core/services/cron/cron.go` (2 changes)
- `core/services/gateway/connectionmanager.go` (5 changes)
- `core/services/gateway/connector/connector.go` (4 changes)
- `core/services/gateway/handlers/capabilities/handler.go` (8 changes)
- `core/services/gateway/handlers/capabilities/v2/http_handler.go` (3 changes)
- `core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go` (4 changes)
- `core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go` (4 changes)
- `core/services/gateway/handlers/confidentialrelay/aggregator.go` (1 change)
- `core/services/gateway/handlers/confidentialrelay/handler.go` (3 changes)
- `core/services/gateway/handlers/functions/allowlist/allowlist.go` (1 change)
- `core/services/gateway/handlers/functions/subscriptions/subscriptions.go` (5 changes)
- `core/services/gateway/handlers/vault/aggregator.go` (1 change)
- `core/services/gateway/handlers/vault/handler.go` (12 changes)
- `core/services/gateway/network/httpclient.go` (2 changes)
- `core/services/gateway/network/httpserver.go` (2 changes)
- `core/services/gateway/network/wsclient.go` (6 changes)
- `core/services/gateway/network/wsconnection.go` (4 changes)
- `core/services/gateway/network/wsserver.go` (3 changes)
- `core/services/headreporter/head_reporter.go` (2 changes)
- `core/services/headreporter/telemetry_reporter.go` (1 change)
- `core/services/job/spawner.go` (2 changes)
- `core/services/nodestatusreporter/bridgestatus/bridge_status_reporter.go` (2 changes)
- `core/services/nurse.go` (3 changes)
- `core/services/ocr/config_overrider.go` (1 change)
- `core/services/ocr2/delegate.go` (1 change)
- `core/services/ocr2/plugins/vault/kvstore_wrapper.go` (1 change)
- `core/services/ocr2/plugins/vault/plugin.go` (2 changes)
- `core/services/ocrcommon/data_source.go` (2 changes)
- `core/services/ocrcommon/telemetry.go` (3 changes)
- `core/services/p2p/peer.go` (3 changes)
- `core/services/p2p/shared_peer.go` (5 changes)
- `core/services/periodicbackup/backup.go` (1 change)
- `core/services/pg/lease_lock.go` (2 changes)
- `core/services/pg/locked_db.go` (1 change)
- `core/services/relay/evm/evm_service.go` (1 change)
- `core/services/relay/evm/llo_provider.go` (1 change)
- `core/services/relay/evm/target_strategy.go` (5 changes)
- `core/services/ring/plugin.go` (5 changes)
- `core/services/ring/transmitter.go` (2 changes)
- `core/services/shardorchestrator/service.go` (1 change)
- `core/services/shardorchestrator/shard_orchestrator.go` (3 changes)
- `core/services/synchronization/chip_ingress_batch_worker.go` (2 changes)
- `core/services/synchronization/telemetry_ingress_batch_client.go` (2 changes)
- `core/services/synchronization/telemetry_ingress_batch_worker.go` (1 change)
- `core/services/synchronization/telemetry_ingress_client.go` (3 changes)
- `core/sessions/ldapauth/ldap.go` (11 changes)
- `core/sessions/ldapauth/sync.go` (15 changes)
- `core/sessions/localauth/orm.go` (6 changes)
- `core/sessions/localauth/reaper.go` (1 change)
- `core/sessions/oidcauth/oidc.go` (4 changes)
- `core/web/auth/gql.go` (1 change)
- `core/web/eth_keys_controller.go` (5 changes)
- `core/web/health_controller.go` (2 changes)
- `core/web/middleware.go` (1 change)
- `core/web/presenters/vrf_key.go` (1 change)
- `core/web/resolver/query.go` (1 change)
- `core/web/router.go` (3 changes)
- `core/web/webauthn_controller.go` (1 change)
- `plugins/cmd/capabilities/log-event-trigger/main.go` (1 change)
- `plugins/loop_registry.go` (2 changes)
- `plugins/medianpoc/data_source.go` (1 change)

## Not applied

These recommendations did not land on this PR — the audited line has been removed or rewritten upstream since `807f2928c65c`, so the recommendation is no longer actionable as a mechanical method-name swap.

- `core/services/fluxmonitorv2/flux_monitor.go:349` Warn→Error (upgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:454` Error→Debug (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:502` Error→Warn (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:527` Error→Warn (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:563` Error→Warn (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:644` Error→Warn (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:650` Error→Warn (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:686` Info→Debug (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:693` Error→Warn (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:700` Info→Debug (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:710` Warn→Debug (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:714` Warn→Debug (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:818` Warn→Debug (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:841` Error→Warn (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:856` Info→Debug (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:861` Error→Warn (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:888` Error→Warn (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:896` Info→Debug (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:904` Info→Debug (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:912` Warn→Debug (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:916` Warn→Debug (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:1073` Error→Debug (downgrade)
- `core/services/fluxmonitorv2/flux_monitor.go:1090` Error→Debug (downgrade)

---

Generated by [`scripts/apply-and-pr.py`](https://github.com/smartcontractkit/logging-audit-mzhang/blob/main/scripts/apply-and-pr.py).