### PR TITLE
chore(logging): adjust log levels for ccip-offchain-ccip-tooling-core-operations-platform (184 changes)

### DIFF
--- a/deployment/ccip/changeset/ccip-attestation-solana/cs_idl.go
+++ b/deployment/ccip/changeset/ccip-attestation-solana/cs_idl.go
@@ -98,7 +98,7 @@ func BaseUploadIDLChangeset(e cldf.Environment, c BaseIDLConfig) (cldf.Changeset
 
 	e.Logger.Infow("Uploading IDL", "programName", solutils.ProgBaseSignerRegistry)
 	args := []string{"idl", "init", "--filepath", idlFile, signer_registry.ProgramID.String()}
-	e.Logger.Info(args)
+	e.Logger.Debug(args)
 	output, err := cs_solana.RunCommand("anchor", args, chain.ProgramsPath)
 	e.Logger.Debugw("IDL init output", "output", output)
 	if err != nil {

--- a/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config.go
@@ -71,7 +71,7 @@ type SetTokenTransferFeeConfigInput struct {
 
 func (cfg SetTokenTransferFeeConfigInput) buildOrchestrateChangesetsConfig(env cldf.Environment) (ccip_cs_common.OrchestrateChangesetsConfig, error) {
 	// Make sure MCMS config is specified
-	env.Logger.Info("building orchestrate changesets config")
+	env.Logger.Debug("building orchestrate changesets config")
 	if cfg.MCMS == nil {
 		return ccip_cs_common.OrchestrateChangesetsConfig{}, errors.New("MCMS config is required")
 	}

--- a/deployment/ccip/changeset/crossfamily/v1_6/cs_add_evm_solana_lane.go
+++ b/deployment/ccip/changeset/crossfamily/v1_6/cs_add_evm_solana_lane.go
@@ -516,7 +516,7 @@ func addEVMAndSolanaLaneLogic(env cldf.Environment, input AddMultiEVMSolanaLaneC
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
-	env.Logger.Infow("router input", "input", changesetInputs.solanaRouterInput)
+	env.Logger.Debugw("router input", "input", changesetInputs.solanaRouterInput)
 	deps := Dependencies{
 		Env:          env,
 		EVMMCMSState: evmState.EVMMCMSStateByChain(),

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_billing.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_billing.go
@@ -224,7 +224,7 @@ func (cfg TokenTransferFeeForRemoteChainConfig) Validate(e cldf.Environment, sta
 		return fmt.Errorf("fee quoter validation failed: %w", err)
 	}
 	if cfg.Config.DestBytesOverhead < 32 {
-		e.Logger.Infow("dest bytes overhead is less than minimum. Setting to minimum value",
+		e.Logger.Warnw("dest bytes overhead is less than minimum. Setting to minimum value",
 			"destBytesOverhead", cfg.Config.DestBytesOverhead,
 			"minDestBytesOverhead", MinDestBytesOverhead)
 		cfg.Config.DestBytesOverhead = MinDestBytesOverhead

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_build_solana.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_build_solana.go
@@ -351,7 +351,7 @@ func BuildSolana(e cldf.Environment, config BuildSolanaConfig) error {
 			return fmt.Errorf("error downloading solana ccip program artifacts: %w", err)
 		}
 	} else {
-		e.Logger.Debug("Building Solana CCIP program artifacts locally...")
+		e.Logger.Info("Building Solana CCIP program artifacts locally...")
 		err := buildLocally(e, config)
 		if err != nil {
 			return fmt.Errorf("error building solana ccip program artifacts: %w", err)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_build_solana.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_build_solana.go
@@ -345,7 +345,7 @@ func buildLocally(e cldf.Environment, config BuildSolanaConfig) error {
 
 func BuildSolana(e cldf.Environment, config BuildSolanaConfig) error {
 	if !config.LocalBuild.BuildLocally {
-		e.Logger.Debug("Downloading Solana CCIP program artifacts...")
+		e.Logger.Info("Downloading Solana CCIP program artifacts...")
 		err := solutils.DownloadChainlinkCCIPProgramArtifacts(e.GetContext(), config.DestinationDir, config.GitCommitSha, e.Logger)
 		if err != nil {
 			return fmt.Errorf("error downloading solana ccip program artifacts: %w", err)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_deploy_chain.go
@@ -186,7 +186,7 @@ func DeployChainContractsChangeset(e cldf.Environment, c DeployChainContractsCon
 	// artifacts will already exist if running locally as chain spin up fetches them
 	// on CI they wont be present and we want to fetch them here
 	if c.BuildConfig != nil {
-		e.Logger.Debugw("Building solana artifacts", "gitCommitSha", c.BuildConfig.GitCommitSha)
+		e.Logger.Infow("Building solana artifacts", "gitCommitSha", c.BuildConfig.GitCommitSha)
 		err = BuildSolana(e, *c.BuildConfig)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build solana: %w", err)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_idl.go
@@ -227,7 +227,7 @@ func writeBuffer(e cldf.Environment, programsPath, programID, programName string
 	}
 	e.Logger.Infow("Writing IDL buffer", "programID", programID)
 	args := []string{"idl", "write-buffer", "--filepath", idlFile, programID}
-	e.Logger.Info(args)
+	e.Logger.Debug(args)
 	output, err := runCommand("anchor", args, programsPath)
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("error writing IDL buffer: %w", err)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_idl.go
@@ -232,7 +232,7 @@ func writeBuffer(e cldf.Environment, programsPath, programID, programName string
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("error writing IDL buffer: %w", err)
 	}
-	e.Logger.Infow("Parsing IDL buffer", "programID", programID)
+	e.Logger.Debugw("Parsing IDL buffer", "programID", programID)
 	buffer, err := parseIdlBuffer(output)
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("error parsing IDL buffer: %w", err)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_idl.go
@@ -173,7 +173,7 @@ func idlInit(e cldf.Environment, programsPath, programID, programName string) er
 	}
 	e.Logger.Infow("Uploading IDL", "programName", programName)
 	args := []string{"idl", "init", "--filepath", idlFile, programID}
-	e.Logger.Info(args)
+	e.Logger.Debug(args)
 	output, err := runCommand("anchor", args, programsPath)
 	e.Logger.Debugw("IDL init output", "output", output)
 	if err != nil {

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_idl.go
@@ -192,7 +192,7 @@ func setIdlAuthority(e cldf.Environment, newAuthority, programsPath, programID, 
 		e.Logger.Infow("Setting IDL authority for buffer", "bufferAccount", bufferAccount)
 		args = append(args, bufferAccount)
 	}
-	e.Logger.Info(args)
+	e.Logger.Debug(args)
 	_, err := runCommand("anchor", args, programsPath)
 	if err != nil {
 		return fmt.Errorf("error setting idl authority: %w", err)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_ops.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_ops.go
@@ -431,7 +431,7 @@ func DeployReceiverForTest(e cldf.Environment, cfg DeployForTestConfig) (cldf.Ch
 	}
 
 	if cfg.BuildConfig != nil {
-		e.Logger.Debugw("Building solana artifacts", "gitCommitSha", cfg.BuildConfig.GitCommitSha)
+		e.Logger.Infow("Building solana artifacts", "gitCommitSha", cfg.BuildConfig.GitCommitSha)
 		err := BuildSolana(e, *cfg.BuildConfig)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build solana: %w", err)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go
@@ -217,7 +217,7 @@ func isOCR3ConfigSetOnOffRampSolana(
 	for _, newState := range args {
 		existingState := configAccount.Ocr3[newState.OCRPluginType]
 		if existingState.ConfigInfo.ConfigDigest != newState.ConfigDigest {
-			e.Logger.Infof("OCR3 config digest mismatch")
+			e.Logger.Debugf("OCR3 config digest mismatch")
 			return false, nil
 		}
 		if existingState.ConfigInfo.F != newState.F {

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go
@@ -225,7 +225,7 @@ func isOCR3ConfigSetOnOffRampSolana(
 			return false, nil
 		}
 		if existingState.ConfigInfo.IsSignatureVerificationEnabled != btoi(newState.IsSignatureVerificationEnabled) {
-			e.Logger.Infof("OCR3 config signature verification mismatch")
+			e.Logger.Debugf("OCR3 config signature verification mismatch")
 			return false, nil
 		}
 		if newState.OCRPluginType == OcrCommitPlugin {

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go
@@ -242,7 +242,7 @@ func isOCR3ConfigSetOnOffRampSolana(
 			}
 		}
 		if len(existingState.Transmitters) != len(newState.Transmitters) {
-			e.Logger.Infof("OCR3 config transmitters length mismatch")
+			e.Logger.Debugf("OCR3 config transmitters length mismatch")
 			return false, nil
 		}
 		for i := range len(existingState.Transmitters) {

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go
@@ -221,7 +221,7 @@ func isOCR3ConfigSetOnOffRampSolana(
 			return false, nil
 		}
 		if existingState.ConfigInfo.F != newState.F {
-			e.Logger.Infof("OCR3 config F mismatch")
+			e.Logger.Debugf("OCR3 config F mismatch")
 			return false, nil
 		}
 		if existingState.ConfigInfo.IsSignatureVerificationEnabled != btoi(newState.IsSignatureVerificationEnabled) {

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go
@@ -231,7 +231,7 @@ func isOCR3ConfigSetOnOffRampSolana(
 		if newState.OCRPluginType == OcrCommitPlugin {
 			// only commit will set signers, exec doesn't need them.
 			if len(existingState.Signers) != len(newState.Signers) {
-				e.Logger.Infof("OCR3 config signers length mismatch")
+				e.Logger.Debugf("OCR3 config signers length mismatch")
 				return false, nil
 			}
 			for i := range len(existingState.Signers) {

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go
@@ -247,7 +247,7 @@ func isOCR3ConfigSetOnOffRampSolana(
 		}
 		for i := range len(existingState.Transmitters) {
 			if existingState.Transmitters[i] != newState.Transmitters[i] {
-				e.Logger.Infof("OCR3 config transmitters mismatch")
+				e.Logger.Debugf("OCR3 config transmitters mismatch")
 				return false, nil
 			}
 		}

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go
@@ -236,7 +236,7 @@ func isOCR3ConfigSetOnOffRampSolana(
 			}
 			for i := range len(existingState.Signers) {
 				if existingState.Signers[i] != newState.Signers[i] {
-					e.Logger.Infof("OCR3 config signers mismatch")
+					e.Logger.Debugf("OCR3 config signers mismatch")
 					return false, nil
 				}
 			}

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
@@ -379,7 +379,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 		if !metadata.UpdateAuthority.IsZero() {
 			e.Logger.Infow("Updating token metadata authority", "tokenPubkey", metadata.TokenPubkey.String())
 			args := []string{"set", "update-authority", "--account", metadata.TokenPubkey.String(), "--new-update-authority", metadata.UpdateAuthority.String()}
-			e.Logger.Info(args)
+			e.Logger.Debug(args)
 			output, err := runCommand("metaboss", args, chain.ProgramsPath)
 			e.Logger.Debugw("metaboss output", "output", output)
 			if err != nil {

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
@@ -383,7 +383,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 			output, err := runCommand("metaboss", args, chain.ProgramsPath)
 			e.Logger.Debugw("metaboss output", "output", output)
 			if err != nil {
-				e.Logger.Debugw("metaboss set error", "error", err)
+				e.Logger.Errorw("metaboss set error", "error", err)
 				return cldf.ChangesetOutput{}, fmt.Errorf("error uploading token metadata: %w", err)
 			}
 			e.Logger.Infow("Token metadata update authority set", "tokenPubkey", metadata.TokenPubkey.String(), "updateAuthority", metadata.UpdateAuthority.String())

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
@@ -365,7 +365,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 		if metadata.MetadataJSONPath != "" {
 			e.Logger.Infow("Uploading token metadata", "tokenPubkey", metadata.TokenPubkey.String())
 			args := []string{"create", "metadata", "--mint", metadata.TokenPubkey.String(), "--metadata", metadata.MetadataJSONPath}
-			e.Logger.Info(args)
+			e.Logger.Debug(args)
 			output, err := runCommand("metaboss", args, chain.ProgramsPath)
 			e.Logger.Debugw("metaboss output", "output", output)
 			if err != nil {

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
@@ -350,7 +350,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 		return cldf.ChangesetOutput{}, fmt.Errorf("error setting solana url: %w", err1)
 	}
 	out2, err2 := runCommand("solana", []string{"config", "set", "--keypair", chain.KeypairPath}, chain.ProgramsPath)
-	e.Logger.Infow("solana config set keypair output", "output", out2)
+	e.Logger.Debugw("solana config set keypair output", "output", out2)
 	if err2 != nil {
 		e.Logger.Errorw("solana config set keypair error", "error", err2)
 		return cldf.ChangesetOutput{}, fmt.Errorf("error setting solana keypair: %w", err2)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
@@ -397,7 +397,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 			output, err := runCommand("metaboss", args, chain.ProgramsPath)
 			e.Logger.Debugw("metaboss output", "output", output)
 			if err != nil {
-				e.Logger.Debugw("metaboss update name error", "error", err)
+				e.Logger.Errorw("metaboss update name error", "error", err)
 				return cldf.ChangesetOutput{}, fmt.Errorf("error uploading token metadata: %w", err)
 			}
 			e.Logger.Infow("Token metadata name set", "tokenPubkey", metadata.TokenPubkey.String(), "name", metadata.UpdateName)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
@@ -411,7 +411,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 			output, err := runCommand("metaboss", args, chain.ProgramsPath)
 			e.Logger.Debugw("metaboss output", "output", output)
 			if err != nil {
-				e.Logger.Debugw("metaboss update symbol error", "error", err)
+				e.Logger.Errorw("metaboss update symbol error", "error", err)
 				return cldf.ChangesetOutput{}, fmt.Errorf("error uploading token metadata: %w", err)
 			}
 			e.Logger.Infow("Token metadata symbol set", "tokenPubkey", metadata.TokenPubkey.String(), "symbol", metadata.UpdateSymbol)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
@@ -421,7 +421,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 		if metadata.MetadataJSONPath == "" && metadata.UpdateURI != "" {
 			e.Logger.Infow("Updating token metadata uri", "tokenPubkey", metadata.TokenPubkey.String())
 			args := []string{"update", "uri", "--account", metadata.TokenPubkey.String(), "--new-uri", metadata.UpdateURI}
-			e.Logger.Info(args)
+			e.Logger.Debug(args)
 			output, err := runCommand("metaboss", args, chain.ProgramsPath)
 			e.Logger.Debugw("metaboss output", "output", output)
 			if err != nil {

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
@@ -369,7 +369,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 			output, err := runCommand("metaboss", args, chain.ProgramsPath)
 			e.Logger.Debugw("metaboss output", "output", output)
 			if err != nil {
-				e.Logger.Debugw("metaboss create error", "error", err)
+				e.Logger.Errorw("metaboss create error", "error", err)
 				return cldf.ChangesetOutput{}, fmt.Errorf("error uploading token metadata: %w", err)
 			}
 			e.Logger.Infow("Token metadata uploaded", "tokenPubkey", metadata.TokenPubkey.String())

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
@@ -407,7 +407,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 		if metadata.MetadataJSONPath == "" && metadata.UpdateSymbol != "" {
 			e.Logger.Infow("Updating token metadata symbol", "tokenPubkey", metadata.TokenPubkey.String())
 			args := []string{"update", "symbol", "--account", metadata.TokenPubkey.String(), "--new-symbol", metadata.UpdateSymbol}
-			e.Logger.Info(args)
+			e.Logger.Debug(args)
 			output, err := runCommand("metaboss", args, chain.ProgramsPath)
 			e.Logger.Debugw("metaboss output", "output", output)
 			if err != nil {

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
@@ -344,7 +344,7 @@ type UploadTokenMetadataConfig struct {
 func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cldf.ChangesetOutput, error) {
 	chain := e.BlockChains.SolanaChains()[cfg.ChainSelector]
 	out1, err1 := runCommand("solana", []string{"config", "set", "--url", chain.URL}, chain.ProgramsPath)
-	e.Logger.Infow("solana config set url output", "output", out1)
+	e.Logger.Debugw("solana config set url output", "output", out1)
 	if err1 != nil {
 		e.Logger.Errorw("solana config set url error", "error", err1)
 		return cldf.ChangesetOutput{}, fmt.Errorf("error setting solana url: %w", err1)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
@@ -425,7 +425,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 			output, err := runCommand("metaboss", args, chain.ProgramsPath)
 			e.Logger.Debugw("metaboss output", "output", output)
 			if err != nil {
-				e.Logger.Debugw("metaboss update uri error", "error", err)
+				e.Logger.Errorw("metaboss update uri error", "error", err)
 				return cldf.ChangesetOutput{}, fmt.Errorf("error uploading token metadata: %w", err)
 			}
 			e.Logger.Infow("Token metadata uri set", "tokenPubkey", metadata.TokenPubkey.String(), "uri", metadata.UpdateURI)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
@@ -393,7 +393,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 		if metadata.MetadataJSONPath == "" && metadata.UpdateName != "" {
 			e.Logger.Infow("Updating token metadata name", "tokenPubkey", metadata.TokenPubkey.String())
 			args := []string{"update", "name", "--account", metadata.TokenPubkey.String(), "--new-name", metadata.UpdateName}
-			e.Logger.Info(args)
+			e.Logger.Debug(args)
 			output, err := runCommand("metaboss", args, chain.ProgramsPath)
 			e.Logger.Debugw("metaboss output", "output", output)
 			if err != nil {

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
@@ -866,7 +866,7 @@ func getInstructionsForLockRelease(
 	evmChainSelector uint64,
 	evmRemoteConfig EVMRemoteConfig,
 ) ([]solana.Instruction, error) {
-	e.Logger.Infow("getInstructionsForLockRelease", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
+	e.Logger.Debugw("getInstructionsForLockRelease", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
 	tokenPubKey := cfg.SolTokenPubKey
 	tokenPool := solChainState.GetActiveTokenPool(cfg.SolPoolType, cfg.Metadata)
 	poolConfigPDA, remoteChainConfigPDA := getPoolPDAs(tokenPubKey, tokenPool, evmChainSelector)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
@@ -269,7 +269,7 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 					"deployer", chain.DeployerKey.PublicKey().String(), "poolSigner", poolSigner.String())
 			}
 		} else {
-			e.Logger.Warnw("PoolType is not a BurnMintTokenPool, skipping setting poolSigner as mint authority",
+			e.Logger.Debugw("PoolType is not a BurnMintTokenPool, skipping setting poolSigner as mint authority",
 				"poolType", tokenPoolCfg.PoolType, "mintAuthority", mintAuthority,
 				"deployer", chain.DeployerKey.PublicKey().String(), "poolSigner", poolSigner.String())
 		}

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
@@ -572,7 +572,7 @@ func getNewSetuptInstructionsForBurnMint(
 	rateLimiterConfig RateLimiterConfig,
 	onChainEVMPoolConfig solBaseTokenPool.RemoteConfig,
 ) ([]solana.Instruction, error) {
-	e.Logger.Infow("getNewSetuptInstructionsForBurnMint", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
+	e.Logger.Debugw("getNewSetuptInstructionsForBurnMint", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
 	tokenPool := chainState.GetActiveTokenPool(cfg.SolPoolType, cfg.Metadata)
 	tokenPubKey := cfg.SolTokenPubKey
 	poolConfigPDA, remoteChainConfigPDA := getPoolPDAs(tokenPubKey, tokenPool, evmChainSelector)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
@@ -769,7 +769,7 @@ func getNewSetuptInstructionsForLockRelease(
 	rateLimiterConfig RateLimiterConfig,
 	onChainEVMPoolConfig solBaseTokenPool.RemoteConfig,
 ) ([]solana.Instruction, error) {
-	e.Logger.Infow("getNewSetuptInstructionsForLockRelease", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
+	e.Logger.Debugw("getNewSetuptInstructionsForLockRelease", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
 	tokenPubKey := cfg.SolTokenPubKey
 	tokenPool := chainState.GetActiveTokenPool(cfg.SolPoolType, cfg.Metadata)
 	poolConfigPDA, remoteChainConfigPDA := getPoolPDAs(tokenPubKey, tokenPool, evmChainSelector)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
@@ -673,7 +673,7 @@ func getInstructionsForBurnMint(
 	evmChainSelector uint64,
 	evmRemoteConfig EVMRemoteConfig,
 ) ([]solana.Instruction, error) {
-	e.Logger.Infow("getInstructionsForBurnMint", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
+	e.Logger.Debugw("getInstructionsForBurnMint", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
 	tokenPubKey := cfg.SolTokenPubKey
 	tokenPool := solChainState.GetActiveTokenPool(cfg.SolPoolType, cfg.Metadata)
 	poolConfigPDA, remoteChainConfigPDA := getPoolPDAs(tokenPubKey, tokenPool, evmChainSelector)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
@@ -782,7 +782,7 @@ func getNewSetuptInstructionsForLockRelease(
 		tokenPubKey,
 		cfg.Metadata,
 	)
-	e.Logger.Infow("getNewSetuptInstructionsForLockRelease", "authority", authority.String())
+	e.Logger.Debugw("getNewSetuptInstructionsForLockRelease", "authority", authority.String())
 	onChainEVMPoolConfigWithoutPoolAddress := solBaseTokenPool.RemoteConfig{
 		TokenAddress:  onChainEVMPoolConfig.TokenAddress,
 		PoolAddresses: []solBaseTokenPool.RemoteAddress{},

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
@@ -138,7 +138,7 @@ func runSolanaVerifyWithoutMCMS(e cldf.Environment,
 	}
 
 	output, err := runCommand("solana-verify", cmdArgs, ".")
-	e.Logger.Infow("verify-from-repo output", "output", output)
+	e.Logger.Debugw("verify-from-repo output", "output", output)
 	if err != nil {
 		return fmt.Errorf("solana program verification failed: %s %w", output, err)
 	}

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
@@ -111,7 +111,7 @@ func runSolanaVerifyMCMS(e cldf.Environment,
 		return fmt.Errorf("failed to build upgrade transaction: %w", err)
 	}
 	if upgradeTx != nil {
-		e.Logger.Infow("upgradeTx", "tx", upgradeTx)
+		e.Logger.Debugw("upgradeTx", "tx", upgradeTx)
 		*mcmsTxs = append(*mcmsTxs, *upgradeTx)
 	}
 	return nil

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
@@ -383,7 +383,7 @@ func VerifyBuild(e cldf.Environment, cfg VerifyBuildConfig) (cldf.ChangesetOutpu
 			continue
 		}
 
-		e.Logger.Debugw("Verifying program", "name", v.name, "programID", v.programID, "programLib", v.programLib)
+		e.Logger.Infow("Verifying program", "name", v.name, "programID", v.programID, "programLib", v.programLib)
 		err := runSolanaVerify(
 			e,
 			cfg,

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
@@ -208,7 +208,7 @@ func getIxnFromEncodedTx(e cldf.Environment, output string, timelockSignerPDA so
 	if base58EncodedTx == "" {
 		return nil, errors.New("failed to extract base58-encoded transaction")
 	}
-	e.Logger.Infow("base58-encoded transaction", "tx", base58EncodedTx)
+	e.Logger.Debugw("base58-encoded transaction", "tx", base58EncodedTx)
 
 	// create a transaction object from the base58EncodedTx
 	tx, err := solana.TransactionFromBase58(base58EncodedTx)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
@@ -70,7 +70,7 @@ func runSolanaVerifyMCMS(e cldf.Environment,
 			"--program-id", programID,
 		}
 		output, err := runCommand("solana-verify", cmdArgs, chain.ProgramsPath)
-		e.Logger.Infow("remote submit-job output", "output", output)
+		e.Logger.Debugw("remote submit-job output", "output", output)
 		if err != nil {
 			return fmt.Errorf("solana program verification failed: %s %w", output, err)
 		}

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
@@ -151,7 +151,7 @@ func runSolanaVerifyWithoutMCMS(e cldf.Environment,
 			"--program-id", programID,
 		}
 		output, err := runCommand("solana-verify", cmdArgs, chain.ProgramsPath)
-		e.Logger.Infow("remote submit-job output", "output", output)
+		e.Logger.Debugw("remote submit-job output", "output", output)
 		if err != nil {
 			return fmt.Errorf("solana program verification failed: %s %w", output, err)
 		}

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
@@ -89,7 +89,7 @@ func runSolanaVerifyMCMS(e cldf.Environment,
 		"--mount-path", mountPath,
 		"--uploader", timelockSignerPDA.String(),
 	}
-	e.Logger.Infow("export-pda-tx cmdArgs", "cmdArgs", cmdArgs)
+	e.Logger.Debugw("export-pda-tx cmdArgs", "cmdArgs", cmdArgs)
 	output, err := runCommand("solana-verify", cmdArgs, ".")
 	e.Logger.Infow("export-pda-tx output", "output", output)
 	if err != nil {

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
@@ -91,7 +91,7 @@ func runSolanaVerifyMCMS(e cldf.Environment,
 	}
 	e.Logger.Debugw("export-pda-tx cmdArgs", "cmdArgs", cmdArgs)
 	output, err := runCommand("solana-verify", cmdArgs, ".")
-	e.Logger.Infow("export-pda-tx output", "output", output)
+	e.Logger.Debugw("export-pda-tx output", "output", output)
 	if err != nil {
 		return fmt.Errorf("solana program verification failed: %s %w", output, err)
 	}

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
@@ -178,7 +178,7 @@ func runSolanaVerify(e cldf.Environment,
 	if err != nil {
 		return err
 	}
-	e.Logger.Infow("solana verify params", "params", string(log))
+	e.Logger.Debugw("solana verify params", "params", string(log))
 
 	// if timelock signer exists
 	// and user has set the upgrade authority to the timelock signer

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
@@ -295,7 +295,7 @@ func setConfig(e cldf.Environment, chain cldf_solana.Chain) error {
 		"--keypair", chain.KeypairPath,
 	}
 	output, err := runCommand("solana", cmdArgs, ".")
-	e.Logger.Infow("solana config set output", "output", output)
+	e.Logger.Debugw("solana config set output", "output", output)
 	if err != nil {
 		return fmt.Errorf("failed to set keypair during program verification: %s %w", output, err)
 	}

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go
@@ -305,7 +305,7 @@ func setConfig(e cldf.Environment, chain cldf_solana.Chain) error {
 		"--url", chain.URL,
 	}
 	output, err = runCommand("solana", cmdArgs, ".")
-	e.Logger.Infow("solana config set output", "output", output)
+	e.Logger.Debugw("solana config set output", "output", output)
 	if err != nil {
 		return fmt.Errorf("failed to set url during program verification: %s %w", output, err)
 	}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
@@ -857,7 +857,7 @@ func (cfg TokenTransferFeeForRemoteChainConfigV2) buildOrchestrateChangesetsConf
 					feeConfig.DestGasOverhead = &destGasOverhead
 					feeConfig.DestBytesOverhead = &destBytesOverhead
 					feeConfig.IsEnabled = &isEnabled
-					env.Logger.Infof("missing fields in user input have been auto-filled with sensible defaults: %+v", feeConfig)
+					env.Logger.Debugf("missing fields in user input have been auto-filled with sensible defaults: %+v", feeConfig)
 				}
 
 				// at this point, we're either using inputs from the user (highest precedence), fallback values from the chain, or pre-defined sensible defaults

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
@@ -813,7 +813,7 @@ func (cfg TokenTransferFeeForRemoteChainConfigV2) buildOrchestrateChangesetsConf
 			// build the config map
 			for tokenAddress, feeConfig := range dstConfig.TokenAddressToFeeConfig {
 				// get the remote billing PDA for the given (token, dst) pair
-				env.Logger.Infof("processing inputs src = %d, dst = %d, token = %s", srcSelector, dstSelector, tokenAddress.String())
+				env.Logger.Debugf("processing inputs src = %d, dst = %d, token = %s", srcSelector, dstSelector, tokenAddress.String())
 				remoteBillingPDA, _, err := solState.FindFqPerChainPerTokenConfigPDA(dstSelector, tokenAddress, solChainState.FeeQuoter)
 				if err != nil {
 					return ccipcommoncs.OrchestrateChangesetsConfig{}, fmt.Errorf("failed to find remote billing token config pda (src = %d, dst = %d, token = %s): %w", srcSelector, dstSelector, tokenAddress.String(), err)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
@@ -800,7 +800,7 @@ func (cfg TokenTransferFeeForRemoteChainConfigV2) buildOrchestrateChangesetsConf
 		)
 
 		// 1st pass -> populate remote chain configs for each (token, dst) pair
-		env.Logger.Infof("building remote chain configs for chain %d", srcSelector)
+		env.Logger.Debugf("building remote chain configs for chain %d", srcSelector)
 		for dstSelector, dstConfig := range dst {
 			// perform basic validations on the first pass
 			if srcSelector == dstSelector {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
@@ -766,7 +766,7 @@ type OptionalFeeQuoterTokenTransferFeeConfig struct {
 }
 
 func (cfg TokenTransferFeeForRemoteChainConfigV2) buildOrchestrateChangesetsConfig(env cldf.Environment) (ccipcommoncs.OrchestrateChangesetsConfig, error) {
-	env.Logger.Info("building orchestrate changesets config")
+	env.Logger.Debug("building orchestrate changesets config")
 	if cfg.MCMS == nil {
 		return ccipcommoncs.OrchestrateChangesetsConfig{}, errors.New("MCMS config is required")
 	}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
@@ -828,7 +828,7 @@ func (cfg TokenTransferFeeForRemoteChainConfigV2) buildOrchestrateChangesetsConf
 				}
 
 				// if the config has not been set yet, we auto-fill any missing input fields with sensible defaults
-				env.Logger.Infof("current config = %+v", curConfig)
+				env.Logger.Debugf("current config = %+v", curConfig)
 				if !curConfig.TokenTransferConfig.IsEnabled {
 					// this config is dynamically adjusted (ethereum is very expensive)
 					minFeeUsdCentsVal := uint32(25)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
@@ -848,7 +848,7 @@ func (cfg TokenTransferFeeForRemoteChainConfigV2) buildOrchestrateChangesetsConf
 					destBytesOverhead := pointer.Coalesce(feeConfig.DestBytesOverhead, uint32(32))
 					deciBps := pointer.Coalesce(feeConfig.DeciBps, uint16(0))
 					isEnabled := pointer.Coalesce(feeConfig.IsEnabled, true)
-					env.Logger.Infof("config is not set - populating missing fields in user input with sensible defaults: %+v", feeConfig)
+					env.Logger.Debugf("config is not set - populating missing fields in user input with sensible defaults: %+v", feeConfig)
 
 					// fill in the missing values in-place
 					feeConfig.MinFeeUsdcents = &minFeeUsdCents

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
@@ -229,7 +229,7 @@ func (cfg TokenTransferFeeForRemoteChainConfig) Validate(e cldf.Environment, sta
 	}
 	for _, config := range cfg.RemoteChainConfigs {
 		if config.DestBytesOverhead < 32 {
-			e.Logger.Infow("dest bytes overhead is less than minimum. Setting to minimum value",
+			e.Logger.Warnw("dest bytes overhead is less than minimum. Setting to minimum value",
 				"destBytesOverhead", config.DestBytesOverhead,
 				"minDestBytesOverhead", MinDestBytesOverhead)
 			config.DestBytesOverhead = MinDestBytesOverhead

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
@@ -820,7 +820,7 @@ func (cfg TokenTransferFeeForRemoteChainConfigV2) buildOrchestrateChangesetsConf
 				}
 
 				// get the token transfer fee config from the fee quoter - if it doesn't exist, then the zero struct will be returned and `IsEnabled` will be `false`
-				env.Logger.Infof("remote billing PDA = %s", remoteBillingPDA.String())
+				env.Logger.Debugf("remote billing PDA = %s", remoteBillingPDA.String())
 				var curConfig solFeeQuoter.PerChainPerTokenConfig
 				err = solChain.GetAccountDataBorshInto(env.GetContext(), remoteBillingPDA, &curConfig)
 				if !errors.Is(err, rpc.ErrNotFound) && err != nil {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
@@ -884,7 +884,7 @@ func (cfg TokenTransferFeeForRemoteChainConfigV2) buildOrchestrateChangesetsConf
 					newConfig.IsEnabled != curConfig.TokenTransferConfig.IsEnabled
 
 				// only perform an update if the new config is different from the on-chain config
-				env.Logger.Infof("constructed new token transfer fee config: %+v", newConfig)
+				env.Logger.Debugf("constructed new token transfer fee config: %+v", newConfig)
 				if !isDifferent {
 					env.Logger.Infof(
 						"skipping update since input config is the same as on-chain config (src=%d, dst=%d, token=%s): %+v",

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_billing.go
@@ -794,7 +794,7 @@ func (cfg TokenTransferFeeForRemoteChainConfigV2) buildOrchestrateChangesetsConf
 
 		// prepare for iteration
 		remoteChainConfigsByToken := map[solana.PublicKey]map[uint64]solFeeQuoter.TokenTransferFeeConfig{}
-		env.Logger.Infof(
+		env.Logger.Debugf(
 			"successfully found Solana fee quoter in state for selector %d: %s",
 			srcSelector, solChainState.FeeQuoter.String(),
 		)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -399,7 +399,7 @@ func SetAuthorityIDLByCLI(e cldf.Environment, newAuthority, programsPath, progra
 		e.Logger.Infow("Setting IDL authority for buffer", "bufferAccount", bufferAccount)
 		args = append(args, bufferAccount)
 	}
-	e.Logger.Info(args)
+	e.Logger.Debug(args)
 	_, err := RunCommand("anchor", args, programsPath)
 	if err != nil {
 		return fmt.Errorf("error setting idl authority: %w", err)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -380,7 +380,7 @@ func writeBuffer(e cldf.Environment, programsPath, programID, programName string
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("error writing IDL buffer: %w", err)
 	}
-	e.Logger.Infow("Parsing IDL buffer", "programID", programID)
+	e.Logger.Debugw("Parsing IDL buffer", "programID", programID)
 	buffer, err := parseIdlBuffer(output)
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("error parsing IDL buffer: %w", err)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -337,7 +337,7 @@ func IdlInit(e cldf.Environment, programsPath, programID, programName string) er
 	}
 	e.Logger.Infow("Uploading IDL", "programName", programName)
 	args := []string{"idl", "init", "--filepath", idlFile, programID}
-	e.Logger.Info(args)
+	e.Logger.Debug(args)
 	output, err := RunCommand("anchor", args, programsPath)
 	e.Logger.Debugw("IDL init output", "output", output)
 	if err != nil {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -375,7 +375,7 @@ func writeBuffer(e cldf.Environment, programsPath, programID, programName string
 	}
 	e.Logger.Infow("Writing IDL buffer", "programID", programID)
 	args := []string{"idl", "write-buffer", "--filepath", idlFile, programID}
-	e.Logger.Info(args)
+	e.Logger.Debug(args)
 	output, err := RunCommand("anchor", args, programsPath)
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("error writing IDL buffer: %w", err)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -352,7 +352,7 @@ func IdlInit(e cldf.Environment, programsPath, programID, programName string) er
 func getIDLAddress(e cldf.Environment, programID solana.PublicKey) (solana.PublicKey, error) {
 	base, _, _ := solana.FindProgramAddress([][]byte{}, programID)
 	idlAddress, _ := solana.CreateWithSeed(base, "anchor:idl", programID)
-	e.Logger.Infof("IDL Address:  %s", idlAddress.String())
+	e.Logger.Debugf("IDL Address:  %s", idlAddress.String())
 	return idlAddress, nil
 }
 

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go
@@ -207,7 +207,7 @@ func isOCR3ConfigSetOnOffRampSolana(
 			return false, nil
 		}
 		if existingState.ConfigInfo.F != newState.F {
-			e.Logger.Infof("OCR3 config F mismatch")
+			e.Logger.Debugf("OCR3 config F mismatch")
 			return false, nil
 		}
 		if existingState.ConfigInfo.IsSignatureVerificationEnabled != btoi(newState.IsSignatureVerificationEnabled) {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go
@@ -217,7 +217,7 @@ func isOCR3ConfigSetOnOffRampSolana(
 		if newState.OCRPluginType == OcrCommitPlugin {
 			// only commit will set signers, exec doesn't need them.
 			if len(existingState.Signers) != len(newState.Signers) {
-				e.Logger.Infof("OCR3 config signers length mismatch")
+				e.Logger.Debugf("OCR3 config signers length mismatch")
 				return false, nil
 			}
 			for i := range len(existingState.Signers) {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go
@@ -228,7 +228,7 @@ func isOCR3ConfigSetOnOffRampSolana(
 			}
 		}
 		if len(existingState.Transmitters) != len(newState.Transmitters) {
-			e.Logger.Infof("OCR3 config transmitters length mismatch")
+			e.Logger.Debugf("OCR3 config transmitters length mismatch")
 			return false, nil
 		}
 		for i := range len(existingState.Transmitters) {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go
@@ -211,7 +211,7 @@ func isOCR3ConfigSetOnOffRampSolana(
 			return false, nil
 		}
 		if existingState.ConfigInfo.IsSignatureVerificationEnabled != btoi(newState.IsSignatureVerificationEnabled) {
-			e.Logger.Infof("OCR3 config signature verification mismatch")
+			e.Logger.Debugf("OCR3 config signature verification mismatch")
 			return false, nil
 		}
 		if newState.OCRPluginType == OcrCommitPlugin {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go
@@ -233,7 +233,7 @@ func isOCR3ConfigSetOnOffRampSolana(
 		}
 		for i := range len(existingState.Transmitters) {
 			if existingState.Transmitters[i] != newState.Transmitters[i] {
-				e.Logger.Infof("OCR3 config transmitters mismatch")
+				e.Logger.Debugf("OCR3 config transmitters mismatch")
 				return false, nil
 			}
 		}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go
@@ -222,7 +222,7 @@ func isOCR3ConfigSetOnOffRampSolana(
 			}
 			for i := range len(existingState.Signers) {
 				if existingState.Signers[i] != newState.Signers[i] {
-					e.Logger.Infof("OCR3 config signers mismatch")
+					e.Logger.Debugf("OCR3 config signers mismatch")
 					return false, nil
 				}
 			}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go
@@ -203,7 +203,7 @@ func isOCR3ConfigSetOnOffRampSolana(
 	for _, newState := range args {
 		existingState := configAccount.Ocr3[newState.OCRPluginType]
 		if existingState.ConfigInfo.ConfigDigest != newState.ConfigDigest {
-			e.Logger.Infof("OCR3 config digest mismatch")
+			e.Logger.Debugf("OCR3 config digest mismatch")
 			return false, nil
 		}
 		if existingState.ConfigInfo.F != newState.F {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
@@ -439,7 +439,7 @@ func (cfg UploadTokenMetadataConfig) Validate(e cldf.Environment) error {
 		if err = e.BlockChains.SolanaChains()[cfg.ChainSelector].GetAccountDataBorshInto(context.Background(), metadataPDA, &tokenMetadata); err != nil {
 			// PDA does not exist. We need to create it. Validate fields
 			if metadata.MetadataJSONPath == "" {
-				e.Logger.Infow("Metadata JSON path is empty", "tokenPubkey", metadata.TokenPubkey.String())
+				e.Logger.Errorw("Metadata JSON path is empty", "tokenPubkey", metadata.TokenPubkey.String())
 				return errors.New("metadata JSON path is empty")
 			}
 		}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
@@ -345,7 +345,7 @@ func SetTokenAuthority(e cldf.Environment, cfg SetTokenAuthorityConfig) (cldf.Ch
 		if err = chain.GetAccountDataBorshInto(e.GetContext(), tokenAuthorityConfig.TokenPubkey, &tokenMint); err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
-		e.Logger.Infow("Fetched token mint", "MintAuthority", tokenMint.MintAuthority.String(), "tokenMintFreezeAuthority", tokenMint.FreezeAuthority.String())
+		e.Logger.Debugw("Fetched token mint", "MintAuthority", tokenMint.MintAuthority.String(), "tokenMintFreezeAuthority", tokenMint.FreezeAuthority.String())
 		authority := chain.DeployerKey.PublicKey()
 		switch tokenAuthorityConfig.AuthorityType {
 		case solToken.AuthorityMintTokens:

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
@@ -333,7 +333,7 @@ func SetTokenAuthority(e cldf.Environment, cfg SetTokenAuthorityConfig) (cldf.Ch
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("error loading timelockSignerPDA: %w", err)
 	}
-	e.Logger.Infow("Fetched timelock signer PDA", "timelockSignerPDA", timelockSignerPDA.String())
+	e.Logger.Debugw("Fetched timelock signer PDA", "timelockSignerPDA", timelockSignerPDA.String())
 	mcmsTxs := []mcmsTypes.Transaction{}
 
 	for _, tokenAuthorityConfig := range cfg.TokenAuthorityConfigs {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
@@ -582,7 +582,7 @@ func DisableFreezeAuthority(e cldf.Environment, cfg DisableFreezeAuthorityConfig
 		return cldf.ChangesetOutput{}, fmt.Errorf("error setting solana url: %w", err1)
 	}
 	out2, err2 := RunCommand("solana", []string{"config", "set", "--keypair", chain.KeypairPath}, chain.ProgramsPath)
-	e.Logger.Infow("solana config set keypair output", "output", out2)
+	e.Logger.Debugw("solana config set keypair output", "output", out2)
 	if err2 != nil {
 		e.Logger.Errorw("solana config set keypair error", "error", err2)
 		return cldf.ChangesetOutput{}, fmt.Errorf("error setting solana keypair: %w", err2)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
@@ -591,7 +591,7 @@ func DisableFreezeAuthority(e cldf.Environment, cfg DisableFreezeAuthorityConfig
 	for _, tokenPubkey := range cfg.TokenPubkeys {
 		e.Logger.Infow("Disabling freeze authority", "tokenPubkey", tokenPubkey.String())
 		args := []string{"authorize", tokenPubkey.String(), "freeze", "--disable"}
-		e.Logger.Info(args)
+		e.Logger.Debug(args)
 		output, err := RunCommand("spl-token", args, chain.ProgramsPath)
 		e.Logger.Debugw("spl-token output", "output", output)
 		if err != nil {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
@@ -595,7 +595,7 @@ func DisableFreezeAuthority(e cldf.Environment, cfg DisableFreezeAuthorityConfig
 		output, err := RunCommand("spl-token", args, chain.ProgramsPath)
 		e.Logger.Debugw("spl-token output", "output", output)
 		if err != nil {
-			e.Logger.Debugw("spl-token authorize error", "error", err)
+			e.Logger.Errorw("spl-token authorize error", "error", err)
 			return cldf.ChangesetOutput{}, fmt.Errorf("error disabling freeze authority: %w", err)
 		}
 		e.Logger.Infow("Token freeze authority disabled", "tokenPubkey", tokenPubkey.String())

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
@@ -461,7 +461,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 		return cldf.ChangesetOutput{}, fmt.Errorf("error setting solana url: %w", err1)
 	}
 	out2, err2 := RunCommand("solana", []string{"config", "set", "--keypair", chain.KeypairPath}, chain.ProgramsPath)
-	e.Logger.Infow("solana config set keypair output", "output", out2)
+	e.Logger.Debugw("solana config set keypair output", "output", out2)
 	if err2 != nil {
 		e.Logger.Errorw("solana config set keypair error", "error", err2)
 		return cldf.ChangesetOutput{}, fmt.Errorf("error setting solana keypair: %w", err2)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
@@ -475,7 +475,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 		if metadata.MetadataJSONPath != "" {
 			e.Logger.Infow("Uploading token metadata", "tokenPubkey", metadata.TokenPubkey.String())
 			args := []string{"create", "metadata", "--mint", metadata.TokenPubkey.String(), "--metadata", metadata.MetadataJSONPath}
-			e.Logger.Info(args)
+			e.Logger.Debug(args)
 			output, err := RunCommand("metaboss", args, chain.ProgramsPath)
 			e.Logger.Infow("metaboss output", "output", output)
 			if err != nil {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
@@ -477,7 +477,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 			args := []string{"create", "metadata", "--mint", metadata.TokenPubkey.String(), "--metadata", metadata.MetadataJSONPath}
 			e.Logger.Debug(args)
 			output, err := RunCommand("metaboss", args, chain.ProgramsPath)
-			e.Logger.Infow("metaboss output", "output", output)
+			e.Logger.Debugw("metaboss output", "output", output)
 			if err != nil {
 				e.Logger.Errorw("metaboss create error", "error", err)
 				return cldf.ChangesetOutput{}, fmt.Errorf("error uploading token metadata: %w", err)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
@@ -576,7 +576,7 @@ func DisableFreezeAuthority(e cldf.Environment, cfg DisableFreezeAuthorityConfig
 	}
 	chain := e.BlockChains.SolanaChains()[cfg.ChainSelector]
 	out1, err1 := RunCommand("solana", []string{"config", "set", "--url", chain.URL}, chain.ProgramsPath)
-	e.Logger.Infow("solana config set url output", "output", out1)
+	e.Logger.Debugw("solana config set url output", "output", out1)
 	if err1 != nil {
 		e.Logger.Errorw("solana config set url error", "error", err1)
 		return cldf.ChangesetOutput{}, fmt.Errorf("error setting solana url: %w", err1)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
@@ -455,7 +455,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 	mcmsTxs := make([]mcmsTypes.Transaction, 0)
 
 	out1, err1 := RunCommand("solana", []string{"config", "set", "--url", chain.URL}, chain.ProgramsPath)
-	e.Logger.Infow("solana config set url output", "output", out1)
+	e.Logger.Debugw("solana config set url output", "output", out1)
 	if err1 != nil {
 		e.Logger.Errorw("solana config set url error", "error", err1)
 		return cldf.ChangesetOutput{}, fmt.Errorf("error setting solana url: %w", err1)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
@@ -494,7 +494,7 @@ func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cld
 		}
 		fmt.Println("Metadata", metadataPDA)
 		if err := e.BlockChains.SolanaChains()[cfg.ChainSelector].GetAccountDataBorshInto(context.Background(), metadataPDA, &mintMetadata); err != nil {
-			e.Logger.Errorw("Token metadata account does not exist. Cannot update", "tokenPubkey", metadata.TokenPubkey.String())
+			e.Logger.Warnw("Token metadata account does not exist. Cannot update", "tokenPubkey", metadata.TokenPubkey.String())
 			continue
 		}
 		newUpdateAuthority := mintMetadata.UpdateAuthority

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -1532,7 +1532,7 @@ func getNewSetupInstructionsForLockRelease(
 		tokenPubKey,
 		cfg.Metadata,
 	)
-	e.Logger.Infow("getNewSetupInstructionsForLockRelease", "authority", authority.String())
+	e.Logger.Debugw("getNewSetupInstructionsForLockRelease", "authority", authority.String())
 	onChainEVMPoolConfigWithoutPoolAddress := solBaseTokenPool.RemoteConfig{
 		TokenAddress:  onChainEVMPoolConfig.TokenAddress,
 		PoolAddresses: []solBaseTokenPool.RemoteAddress{},

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -876,7 +876,7 @@ func CreateTokenMultisig(e cldf.Environment, cfg CreateTokenMultisigConfig) (cld
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
-	e.Logger.Infow("Using tokenPoolSignerPDA as signer", "tokenPoolSignerPDA", tokenPoolSignerPDA, "tokenPoolProgramID", tokenPoolProgramID, "TokenMint", cfg.TokenMint)
+	e.Logger.Debugw("Using tokenPoolSignerPDA as signer", "tokenPoolSignerPDA", tokenPoolSignerPDA, "tokenPoolProgramID", tokenPoolProgramID, "TokenMint", cfg.TokenMint)
 	newMultisig, err := createMultisig(e, cfg.ChainSelector, tokenPoolSignerPDA, cfg.CustomerMintAuthorities, tokenProgramID)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -905,7 +905,7 @@ func createMultisig(e cldf.Environment, chainSelector uint64, tokenPoolSignerPDA
 		authoritiesStr[i] = auth.String()
 	}
 	args = append(args, authoritiesStr...)
-	e.Logger.Info(args)
+	e.Logger.Debug(args)
 	output, err := RunCommand("spl-token", args, ".")
 	e.Logger.Debugw("spl-token create-multisig output", "output", output)
 	if err != nil {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -1815,7 +1815,7 @@ func getInstructionsForCCTP(
 	evmChainSelector uint64,
 	evmRemoteConfig EVMRemoteConfig,
 ) ([]solana.Instruction, error) {
-	e.Logger.Infow("getInstructionsForCCTP", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String())
+	e.Logger.Debugw("getInstructionsForCCTP", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String())
 	tokenPubKey := cfg.SolTokenPubKey
 	tokenPool := solChainState.CCTPTokenPool
 	contractType := shared.CCTPTokenPool

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -914,7 +914,7 @@ func createMultisig(e cldf.Environment, chainSelector uint64, tokenPoolSignerPDA
 	}
 	multisigAddress, err := parseMultisigAddress(output)
 	if err != nil {
-		e.Logger.Debugw("spl-token create-multisig error", "error", err)
+		e.Logger.Errorw("spl-token create-multisig error", "error", err)
 	}
 	e.Logger.Infow("Created Token Multisig ", "tokenProgramId", tokenProgramID)
 	return solana.MustPublicKeyFromBase58(multisigAddress), nil

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -372,7 +372,7 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 					"deployer", chain.DeployerKey.PublicKey().String(), "poolSigner", poolSigner.String())
 			}
 		} else {
-			e.Logger.Warnw("PoolType is not a BurnMintTokenPool, skipping setting poolSigner as mint authority",
+			e.Logger.Debugw("PoolType is not a BurnMintTokenPool, skipping setting poolSigner as mint authority",
 				"poolType", tokenPoolCfg.PoolType, "mintAuthority", mintAuthority,
 				"deployer", chain.DeployerKey.PublicKey().String(), "poolSigner", poolSigner.String())
 		}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -1415,7 +1415,7 @@ func getInstructionsForBurnMint(
 	evmChainSelector uint64,
 	evmRemoteConfig EVMRemoteConfig,
 ) ([]solana.Instruction, error) {
-	e.Logger.Infow("getInstructionsForBurnMint", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
+	e.Logger.Debugw("getInstructionsForBurnMint", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
 	tokenPubKey := cfg.SolTokenPubKey
 	tokenPool := solChainState.GetActiveTokenPool(cfg.SolPoolType, cfg.Metadata)
 	poolConfigPDA, remoteChainConfigPDA := getPoolPDAs(tokenPubKey, tokenPool, evmChainSelector)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -1314,7 +1314,7 @@ func getNewSetupInstructionsForBurnMint(
 	rateLimiterConfig RateLimiterConfig,
 	onChainEVMPoolConfig solBaseTokenPool.RemoteConfig,
 ) ([]solana.Instruction, error) {
-	e.Logger.Infow("getNewSetupInstructionsForBurnMint", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
+	e.Logger.Debugw("getNewSetupInstructionsForBurnMint", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
 	tokenPool := chainState.GetActiveTokenPool(cfg.SolPoolType, cfg.Metadata)
 	tokenPubKey := cfg.SolTokenPubKey
 	poolConfigPDA, remoteChainConfigPDA := getPoolPDAs(tokenPubKey, tokenPool, evmChainSelector)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -1717,7 +1717,7 @@ func getNewSetupInstructionsForCCTP(
 	rateLimiterConfig RateLimiterConfig,
 	onChainEVMPoolConfig cctp_token_pool.RemoteConfig,
 ) ([]solana.Instruction, error) {
-	e.Logger.Infow("getNewSetupInstructionsForCCTP", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String())
+	e.Logger.Debugw("getNewSetupInstructionsForCCTP", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String())
 	tokenPubKey := cfg.SolTokenPubKey
 	tokenPool := chainState.CCTPTokenPool
 	contractType := shared.CCTPTokenPool

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -1731,7 +1731,7 @@ func getNewSetupInstructionsForCCTP(
 		tokenPubKey,
 		cfg.Metadata,
 	)
-	e.Logger.Infow("getNewSetupInstructionsForCCTP", "authority", authority.String())
+	e.Logger.Debugw("getNewSetupInstructionsForCCTP", "authority", authority.String())
 	onChainEVMPoolConfigWithoutPoolAddress := cctp_token_pool.RemoteConfig{
 		TokenAddress:  onChainEVMPoolConfig.TokenAddress,
 		PoolAddresses: []cctp_token_pool.RemoteAddress{},

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -1616,7 +1616,7 @@ func getInstructionsForLockRelease(
 	evmChainSelector uint64,
 	evmRemoteConfig EVMRemoteConfig,
 ) ([]solana.Instruction, error) {
-	e.Logger.Infow("getInstructionsForLockRelease", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
+	e.Logger.Debugw("getInstructionsForLockRelease", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
 	tokenPubKey := cfg.SolTokenPubKey
 	tokenPool := solChainState.GetActiveTokenPool(cfg.SolPoolType, cfg.Metadata)
 	poolConfigPDA, remoteChainConfigPDA := getPoolPDAs(tokenPubKey, tokenPool, evmChainSelector)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -1519,7 +1519,7 @@ func getNewSetupInstructionsForLockRelease(
 	rateLimiterConfig RateLimiterConfig,
 	onChainEVMPoolConfig solBaseTokenPool.RemoteConfig,
 ) ([]solana.Instruction, error) {
-	e.Logger.Infow("getNewSetupInstructionsForLockRelease", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
+	e.Logger.Debugw("getNewSetupInstructionsForLockRelease", "remote_chain_selector", evmChainSelector, "token_pubkey", cfg.SolTokenPubKey.String(), "pool_type", cfg.SolPoolType)
 	tokenPubKey := cfg.SolTokenPubKey
 	tokenPool := chainState.GetActiveTokenPool(cfg.SolPoolType, cfg.Metadata)
 	poolConfigPDA, remoteChainConfigPDA := getPoolPDAs(tokenPubKey, tokenPool, evmChainSelector)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_verify_contracts.go
@@ -385,7 +385,7 @@ func VerifyBuild(e cldf.Environment, cfg VerifyBuildConfig) (cldf.ChangesetOutpu
 			continue
 		}
 
-		e.Logger.Debugw("Verifying program", "name", v.name, "programID", v.programID, "programLib", v.programLib)
+		e.Logger.Infow("Verifying program", "name", v.name, "programID", v.programID, "programLib", v.programLib)
 		err := runSolanaVerify(
 			e,
 			cfg,

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_verify_contracts.go
@@ -209,7 +209,7 @@ func getIxnFromEncodedTx(e cldf.Environment, output string, timelockSignerPDA so
 	if base58EncodedTx == "" {
 		return nil, errors.New("failed to extract base58-encoded transaction")
 	}
-	e.Logger.Infow("base58-encoded transaction", "tx", base58EncodedTx)
+	e.Logger.Debugw("base58-encoded transaction", "tx", base58EncodedTx)
 
 	// create a transaction object from the base58EncodedTx
 	tx, err := solana.TransactionFromBase58(base58EncodedTx)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_verify_contracts.go
@@ -90,7 +90,7 @@ func runSolanaVerifyMCMS(e cldf.Environment,
 		"--mount-path", mountPath,
 		"--uploader", timelockSignerPDA.String(),
 	}
-	e.Logger.Infow("export-pda-tx cmdArgs", "cmdArgs", cmdArgs)
+	e.Logger.Debugw("export-pda-tx cmdArgs", "cmdArgs", cmdArgs)
 	output, err := RunCommand("solana-verify", cmdArgs, ".")
 	e.Logger.Infow("export-pda-tx output", "output", output)
 	if err != nil {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_verify_contracts.go
@@ -296,7 +296,7 @@ func setConfig(e cldf.Environment, chain cldf_solana.Chain) error {
 		"--keypair", chain.KeypairPath,
 	}
 	output, err := RunCommand("solana", cmdArgs, ".")
-	e.Logger.Infow("solana config set output", "output", output)
+	e.Logger.Debugw("solana config set output", "output", output)
 	if err != nil {
 		return fmt.Errorf("failed to set keypair during program verification: %s %w", output, err)
 	}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_verify_contracts.go
@@ -306,7 +306,7 @@ func setConfig(e cldf.Environment, chain cldf_solana.Chain) error {
 		"--url", chain.URL,
 	}
 	output, err = RunCommand("solana", cmdArgs, ".")
-	e.Logger.Infow("solana config set output", "output", output)
+	e.Logger.Debugw("solana config set output", "output", output)
 	if err != nil {
 		return fmt.Errorf("failed to set url during program verification: %s %w", output, err)
 	}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_verify_contracts.go
@@ -112,7 +112,7 @@ func runSolanaVerifyMCMS(e cldf.Environment,
 		return fmt.Errorf("failed to build upgrade transaction: %w", err)
 	}
 	if upgradeTx != nil {
-		e.Logger.Infow("upgradeTx", "tx", upgradeTx)
+		e.Logger.Debugw("upgradeTx", "tx", upgradeTx)
 		*mcmsTxs = append(*mcmsTxs, *upgradeTx)
 	}
 	return nil

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
@@ -223,7 +223,7 @@ func setTokenTransferFeeConfigLogic(env cldf.Environment, cfg SetTokenTransferFe
 				// If no custom config already exists on-chain for the token, then use sensible defaults for any missing fields
 				env.Logger.Debugf("fetched token transfer fee config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), curConfig)
 				if !curConfig.IsEnabled {
-					env.Logger.Infof("no token transfer fee config exists on chain - filling in missing values (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
+					env.Logger.Debugf("no token transfer fee config exists on chain - filling in missing values (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
 					args = args.FillMissingValues(srcSelector, dstSelector)
 					env.Logger.Infof("missing values have been filled in with sensible defaults (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
 				}

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
@@ -96,7 +96,7 @@ func (args TokenTransferFeeArgs) FillMissingValues(srcSelector uint64, dstSelect
 
 func setTokenTransferFeeConfigPrecondition(env cldf.Environment, cfg SetTokenTransferFeeConfig) error {
 	if len(cfg.InputsByChain) == 0 {
-		env.Logger.Warn("no inputs were provided - exiting precondition stage gracefully")
+		env.Logger.Info("no inputs were provided - exiting precondition stage gracefully")
 		return nil
 	}
 

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
@@ -225,7 +225,7 @@ func setTokenTransferFeeConfigLogic(env cldf.Environment, cfg SetTokenTransferFe
 				if !curConfig.IsEnabled {
 					env.Logger.Debugf("no token transfer fee config exists on chain - filling in missing values (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
 					args = args.FillMissingValues(srcSelector, dstSelector)
-					env.Logger.Infof("missing values have been filled in with sensible defaults (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
+					env.Logger.Debugf("missing values have been filled in with sensible defaults (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
 				}
 
 				// At this point, we're either using inputs from the user (highest precedence), fallback values from the chain, or pre-defined sensible defaults

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
@@ -158,7 +158,7 @@ func setTokenTransferFeeConfigPrecondition(env cldf.Environment, cfg SetTokenTra
 
 func setTokenTransferFeeConfigLogic(env cldf.Environment, cfg SetTokenTransferFeeConfig) (cldf.ChangesetOutput, error) {
 	if len(cfg.InputsByChain) == 0 {
-		env.Logger.Warn("no inputs were provided - exiting apply stage gracefully")
+		env.Logger.Info("no inputs were provided - exiting apply stage gracefully")
 		return cldf.ChangesetOutput{}, nil
 	}
 

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
@@ -253,7 +253,7 @@ func setTokenTransferFeeConfigLogic(env cldf.Environment, cfg SetTokenTransferFe
 					newConfig.AggregateRateLimitEnabled != curConfig.AggregateRateLimitEnabled
 
 				// Only perform an update if the new config is different from the on-chain config
-				env.Logger.Infof("constructed token transfer fee config (src = %s, dst = %s, token = %s, new_cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), newConfig)
+				env.Logger.Debugf("constructed token transfer fee config (src = %s, dst = %s, token = %s, new_cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), newConfig)
 				if isDifferent {
 					tokenTransferFeeConfigArgs = append(tokenTransferFeeConfigArgs, newConfig)
 				} else {

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
@@ -221,7 +221,7 @@ func setTokenTransferFeeConfigLogic(env cldf.Environment, cfg SetTokenTransferFe
 				}
 
 				// If no custom config already exists on-chain for the token, then use sensible defaults for any missing fields
-				env.Logger.Infof("fetched token transfer fee config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), curConfig)
+				env.Logger.Debugf("fetched token transfer fee config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), curConfig)
 				if !curConfig.IsEnabled {
 					env.Logger.Infof("no token transfer fee config exists on chain - filling in missing values (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
 					args = args.FillMissingValues(srcSelector, dstSelector)

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
@@ -214,7 +214,7 @@ func setTokenTransferFeeConfigLogic(env cldf.Environment, cfg SetTokenTransferFe
 			tokenTransferFeeConfigArgs := []evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs{}
 			for tokenAddress, args := range input.TokenTransferFeeConfigArgs {
 				// This gets the token transfer fee config for the given token - if it doesn't exist, then the zero struct will be returned and `IsEnabled` will be `false`
-				env.Logger.Infof("fetching token transfer fee config (src = %s, dst = %s, token = %s)", srcChain.String(), dstChain.String(), tokenAddress.Hex())
+				env.Logger.Debugf("fetching token transfer fee config (src = %s, dst = %s, token = %s)", srcChain.String(), dstChain.String(), tokenAddress.Hex())
 				curConfig, err := onramp.GetTokenTransferFeeConfig(&bind.CallOpts{Context: env.GetContext()}, tokenAddress)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to fetch token transfer fee config (src = %s, dst = %s, token = %s): %w", srcChain.String(), dstChain.String(), tokenAddress.Hex(), err)

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
@@ -257,7 +257,7 @@ func setTokenTransferFeeConfigLogic(env cldf.Environment, cfg SetTokenTransferFe
 				if isDifferent {
 					tokenTransferFeeConfigArgs = append(tokenTransferFeeConfigArgs, newConfig)
 				} else {
-					env.Logger.Infof("skipping update since input config is the same as on-chain config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), curConfig)
+					env.Logger.Debugf("skipping update since input config is the same as on-chain config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), curConfig)
 				}
 			}
 

--- a/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go
@@ -205,7 +205,7 @@ func setTokenTransferFeeConfigLogic(env cldf.Environment, cfg SetTokenTransferFe
 				return cldf.ChangesetOutput{}, fmt.Errorf("no EVM2EVMOnRamp (src = %s, dst = %s)", srcChain.String(), dstChain.String())
 			}
 
-			env.Logger.Infof("found OnRamp on source chain (src = %s, dst = %s, onramp = %s)",
+			env.Logger.Debugf("found OnRamp on source chain (src = %s, dst = %s, onramp = %s)",
 				srcChain.String(),
 				dstChain.String(),
 				onramp.Address().Hex(),

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -219,7 +219,7 @@ func updateAdminRolePrecondition(e cldf.Environment, cfg UpdateAdminRoleConfig) 
 func updateAdminRoleLogic(e cldf.Environment, cfg UpdateAdminRoleConfig) (cldf.ChangesetOutput, error) {
 	result := cldf.ChangesetOutput{}
 	if len(cfg.ChainUpdates) == 0 {
-		e.Logger.Warn("no chain updates were provided - exiting apply stage gracefully")
+		e.Logger.Info("no chain updates were provided - exiting apply stage gracefully")
 		return cldf.ChangesetOutput{}, nil
 	}
 

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -47,7 +47,7 @@ type updateAdminRoleConfigs struct {
 
 func (cfg *UpdateAdminRoleConfig) populate(e cldf.Environment) (updateAdminRoleConfigs, error) {
 	if cfg.configs != nil {
-		e.Logger.Info("using cached configs")
+		e.Logger.Debug("using cached configs")
 		return *cfg.configs, nil
 	}
 

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -90,7 +90,7 @@ func (cfg *UpdateAdminRoleConfig) populate(e cldf.Environment) (updateAdminRoleC
 				continue
 			}
 
-			e.Logger.Infof(
+			e.Logger.Debugf(
 				"fetching token config for token '%s' from token admin registry at '%s' (chain selector = '%d')",
 				info.TokenAddress.Hex(),
 				chainState.TokenAdminRegistry.Address().Hex(),

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -186,7 +186,7 @@ func updateAdminRolePrecondition(e cldf.Environment, cfg UpdateAdminRoleConfig) 
 	}
 
 	if configs.orchestrateChangesetsConfig == nil && configs.transferAdminRoleConfig == nil && configs.proposeAdminRoleConfig == nil {
-		e.Logger.Warn("no operations to perform - exiting precondition stage gracefully")
+		e.Logger.Info("no operations to perform - exiting precondition stage gracefully")
 		return nil
 	}
 

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -230,7 +230,7 @@ func updateAdminRoleLogic(e cldf.Environment, cfg UpdateAdminRoleConfig) (cldf.C
 	}
 
 	if configs.orchestrateChangesetsConfig == nil && configs.transferAdminRoleConfig == nil && configs.proposeAdminRoleConfig == nil {
-		e.Logger.Warn("no operations to perform - exiting apply stage gracefully")
+		e.Logger.Info("no operations to perform - exiting apply stage gracefully")
 		return cldf.ChangesetOutput{}, nil
 	}
 

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -107,7 +107,7 @@ func (cfg *UpdateAdminRoleConfig) populate(e cldf.Environment) (updateAdminRoleC
 			}
 
 			tokenAddrSet[info.TokenAddress] = true
-			e.Logger.Infof(
+			e.Logger.Debugf(
 				"found token config for token '%s' in token admin registry at '%s' (chain selector = '%d'): %+v",
 				info.TokenAddress.Hex(),
 				chainState.TokenAdminRegistry.Address().Hex(),

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -175,7 +175,7 @@ func (cfg *UpdateAdminRoleConfig) populate(e cldf.Environment) (updateAdminRoleC
 
 func updateAdminRolePrecondition(e cldf.Environment, cfg UpdateAdminRoleConfig) error {
 	if len(cfg.ChainUpdates) == 0 {
-		e.Logger.Warn("no chain updates were provided - exiting precondition stage gracefully")
+		e.Logger.Info("no chain updates were provided - exiting precondition stage gracefully")
 		return nil
 	}
 

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -1732,7 +1732,7 @@ func isOCR3ConfigSetOnOffRamp(
 		}
 		for i, transmitter := range mapOfframpOCR3Configs[pluginType].Transmitters {
 			if !bytes.Equal(transmitter.Bytes(), ocrConfig.Transmitters[i].Bytes()) {
-				lggr.Infow("OCR3 config transmitter mismatch", "pluginType", pluginType.String())
+				lggr.Debugw("OCR3 config transmitter mismatch", "pluginType", pluginType.String())
 				return false, nil
 			}
 		}

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -2556,7 +2556,7 @@ func applyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2Logic(env cldf.Enviro
 					newConfig.TokenTransferFeeConfig.IsEnabled != curConfig.IsEnabled
 
 				// Only perform an update if the new config is different from the on-chain config
-				env.Logger.Infof("constructed token transfer fee config (src = %s, dst = %s, token = %s, new_cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), newConfig)
+				env.Logger.Debugf("constructed token transfer fee config (src = %s, dst = %s, token = %s, new_cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), newConfig)
 				if isDifferent {
 					tokenTransferFeeConfigs = append(tokenTransferFeeConfigs, newConfig)
 				} else {

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -1718,7 +1718,7 @@ func isOCR3ConfigSetOnOffRamp(
 			return false, nil
 		}
 		if mapOfframpOCR3Configs[pluginType].IsSignatureVerificationEnabled != ocrConfig.ConfigInfo.IsSignatureVerificationEnabled {
-			lggr.Infow("OCR3 config signature verification mismatch", "pluginType", pluginType.String())
+			lggr.Debugw("OCR3 config signature verification mismatch", "pluginType", pluginType.String())
 			return false, nil
 		}
 		if pluginType == cctypes.PluginTypeCCIPCommit {

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -2519,7 +2519,7 @@ func applyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2Logic(env cldf.Enviro
 				}
 
 				// If no custom config already exists on-chain for the token, then use sensible defaults for any missing fields
-				env.Logger.Infof("fetched token transfer fee config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), curConfig)
+				env.Logger.Debugf("fetched token transfer fee config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), curConfig)
 				if !curConfig.IsEnabled {
 					env.Logger.Infof("no token transfer fee config exists on chain - filling in missing values (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
 					args = args.FillMissingValues(srcSelector, dstSelector)

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -1714,7 +1714,7 @@ func isOCR3ConfigSetOnOffRamp(
 			return false, nil
 		}
 		if mapOfframpOCR3Configs[pluginType].F != ocrConfig.ConfigInfo.F {
-			lggr.Infow("OCR3 config F mismatch", "pluginType", pluginType.String())
+			lggr.Debugw("OCR3 config F mismatch", "pluginType", pluginType.String())
 			return false, nil
 		}
 		if mapOfframpOCR3Configs[pluginType].IsSignatureVerificationEnabled != ocrConfig.ConfigInfo.IsSignatureVerificationEnabled {

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -2503,7 +2503,7 @@ func applyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2Logic(env cldf.Enviro
 				tokensToUseDefaultFeeConfigs[i] = fee_quoter.FeeQuoterTokenTransferFeeConfigRemoveArgs{DestChainSelector: dstSelector, Token: tokenAddress}
 			}
 
-			env.Logger.Infof("found fee quoter on source chain (src = %s, dst = %s, fq = %s)",
+			env.Logger.Debugf("found fee quoter on source chain (src = %s, dst = %s, fq = %s)",
 				srcChain.String(),
 				dstChain.String(),
 				chainState.FeeQuoter.Address().Hex(),

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -2521,7 +2521,7 @@ func applyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2Logic(env cldf.Enviro
 				// If no custom config already exists on-chain for the token, then use sensible defaults for any missing fields
 				env.Logger.Debugf("fetched token transfer fee config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), curConfig)
 				if !curConfig.IsEnabled {
-					env.Logger.Infof("no token transfer fee config exists on chain - filling in missing values (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
+					env.Logger.Debugf("no token transfer fee config exists on chain - filling in missing values (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
 					args = args.FillMissingValues(srcSelector, dstSelector)
 					env.Logger.Infof("missing values have been filled in with sensible defaults (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
 				}

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -1586,7 +1586,7 @@ func (cfg UpdateDynamicConfigOffRampConfig) Validate(e cldf.Environment) error {
 			return fmt.Errorf("missing fee quoter for chain %d", chainSel)
 		}
 		if params.GasForCallExactCheck > 0 {
-			e.Logger.Infow(
+			e.Logger.Warnw(
 				"GasForCallExactCheck is set, please note it's a static config and will be ignored for this changeset",
 				"chain", chainSel, "gas", params.GasForCallExactCheck)
 		}

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -2523,7 +2523,7 @@ func applyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2Logic(env cldf.Enviro
 				if !curConfig.IsEnabled {
 					env.Logger.Debugf("no token transfer fee config exists on chain - filling in missing values (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
 					args = args.FillMissingValues(srcSelector, dstSelector)
-					env.Logger.Infof("missing values have been filled in with sensible defaults (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
+					env.Logger.Debugf("missing values have been filled in with sensible defaults (src = %s, dst = %s, token = %s, input = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), args)
 				}
 
 				// At this point, we're either using inputs from the user (highest precedence), fallback values from the chain, or pre-defined sensible defaults

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -2560,7 +2560,7 @@ func applyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2Logic(env cldf.Enviro
 				if isDifferent {
 					tokenTransferFeeConfigs = append(tokenTransferFeeConfigs, newConfig)
 				} else {
-					env.Logger.Infof("skipping update since input config is the same as on-chain config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), curConfig)
+					env.Logger.Debugf("skipping update since input config is the same as on-chain config (src = %s, dst = %s, token = %s, cfg = %+v)", srcChain.String(), dstChain.String(), tokenAddress.Hex(), curConfig)
 				}
 			}
 

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -2512,7 +2512,7 @@ func applyTokenTransferFeeConfigUpdatesFeeQuoterChangesetV2Logic(env cldf.Enviro
 			tokenTransferFeeConfigs := []fee_quoter.FeeQuoterTokenTransferFeeConfigSingleTokenArgs{}
 			for tokenAddress, args := range input.TokenTransferFeeConfigArgs {
 				// This gets the token transfer fee config for the given token - if it doesn't exist, then the zero struct will be returned and `IsEnabled` will be `false`
-				env.Logger.Infof("fetching token transfer fee config (src = %s, dst = %s, token = %s)", srcChain.String(), dstChain.String(), tokenAddress.Hex())
+				env.Logger.Debugf("fetching token transfer fee config (src = %s, dst = %s, token = %s)", srcChain.String(), dstChain.String(), tokenAddress.Hex())
 				curConfig, err := chainState.FeeQuoter.GetTokenTransferFeeConfig(&bind.CallOpts{Context: env.GetContext()}, dstSelector, tokenAddress)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to fetch token transfer fee config (src = %s, dst = %s, token = %s): %w", srcChain.String(), dstChain.String(), tokenAddress.Hex(), err)

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -1725,7 +1725,7 @@ func isOCR3ConfigSetOnOffRamp(
 			// only commit will set signers, exec doesn't need them.
 			for i, signer := range mapOfframpOCR3Configs[pluginType].Signers {
 				if !bytes.Equal(signer.Bytes(), ocrConfig.Signers[i].Bytes()) {
-					lggr.Infow("OCR3 config signer mismatch", "pluginType", pluginType.String())
+					lggr.Debugw("OCR3 config signer mismatch", "pluginType", pluginType.String())
 					return false, nil
 				}
 			}

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -1710,7 +1710,7 @@ func isOCR3ConfigSetOnOffRamp(
 		// TODO: assertions to be done as part of full state
 		// resprentation validation CCIP-3047
 		if mapOfframpOCR3Configs[pluginType].ConfigDigest != ocrConfig.ConfigInfo.ConfigDigest {
-			lggr.Infow("OCR3 config digest mismatch", "pluginType", pluginType.String())
+			lggr.Debugw("OCR3 config digest mismatch", "pluginType", pluginType.String())
 			return false, nil
 		}
 		if mapOfframpOCR3Configs[pluginType].F != ocrConfig.ConfigInfo.F {

--- a/deployment/ccip/changeset/v1_6/cs_home_chain.go
+++ b/deployment/ccip/changeset/v1_6/cs_home_chain.go
@@ -289,7 +289,7 @@ func deployHomeChain(
 			lggr.Errorw("Failed to get RMNHome active digest", "chain", chain.String(), "err", err)
 			return nil, err
 		}
-		lggr.Infow("Got rmn home active digest", "digest", rmnActiveDigest)
+		lggr.Debugw("Got rmn home active digest", "digest", rmnActiveDigest)
 
 		if rmnActiveDigest != rmnCandidateDigest {
 			lggr.Errorw("RMNHome active digest does not match previously candidate digest",

--- a/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes.go
+++ b/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes.go
@@ -447,7 +447,7 @@ func FilterOutExistingDestChainConfigs[T destChainConfigType](
 				chainSel, destSel, err)
 		}
 		if enabled {
-			e.Logger.Infow("skipping dest chain config already present on FeeQuoter",
+			e.Logger.Debugw("skipping dest chain config already present on FeeQuoter",
 				"sourceChain", chainSel,
 				"destChain", destSel,
 			)

--- a/deployment/ccip/changeset/v1_6_1/cs_transparent_upgradeable_proxy.go
+++ b/deployment/ccip/changeset/v1_6_1/cs_transparent_upgradeable_proxy.go
@@ -338,7 +338,7 @@ func GrantRoleTransparentUpgradeableProxy(e cldf.Environment, c TransparentUpgra
 				if hasRole, err := transparent.HasRole(&bind.CallOpts{Context: e.GetContext()}, r, config.Account); err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to check if account %s has role %s on TransparentUpgradeableProxy at %s for %s token on %s: %w", config.Account, config.Role, proxy.Address(), token, chain.Name(), err)
 				} else if hasRole {
-					e.Logger.Infof("Account %s already has role %s on TransparentUpgradeableProxy at %s for %s token on %s, skipping grantRole", config.Account, config.Role, proxy.Address(), token, chain.Name())
+					e.Logger.Debugf("Account %s already has role %s on TransparentUpgradeableProxy at %s for %s token on %s, skipping grantRole", config.Account, config.Role, proxy.Address(), token, chain.Name())
 					continue
 				}
 

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -189,7 +189,7 @@ func findCommitRoot(
 ) (offramp.InternalMerkleRoot, bool) {
 	for _, root := range roots {
 		if root.SourceChainSelector == srcChainSel {
-			lggr.Infow("checking commit root",
+			lggr.Debugw("checking commit root",
 				"minSeqNr", root.MinSeqNr,
 				"maxSeqNr", root.MaxSeqNr,
 				"txHash", txHash.Hex(),

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -387,7 +387,7 @@ func manuallyExecuteSingle(
 		for start := merkleRoot.MinSeqNr; start <= merkleRoot.MaxSeqNr; start++ {
 			message, ok := messageSentCache.Get(start)
 			if !ok {
-				lggr.Infow("message not found in cache, fetching from the chain", "msgSeqNr", start)
+				lggr.Debugw("message not found in cache, fetching from the chain", "msgSeqNr", start)
 				break
 			}
 			ccipMessageSentEvents = append(ccipMessageSentEvents, message)

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -477,7 +477,7 @@ func manuallyExecuteSingle(
 		return fmt.Errorf("failed to get merkle proof: %w", err)
 	}
 
-	lggr.Infow("got hashes and flags", "hashes", hashes, "flags", flags)
+	lggr.Debugw("got hashes and flags", "hashes", hashes, "flags", flags)
 
 	// since we're only executing one message, we need to only include that message
 	// in the report.

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -134,7 +134,7 @@ func getCommitRootAcceptedEvent(
 
 	start := getStartBlock(srcChainSel, hdr.Number.Uint64(), lookbackDuration)
 	if cachedBlockNumber != 0 {
-		lggr.Infow("using cached block number to start search for root", "cachedBlockNumber", cachedBlockNumber)
+		lggr.Debugw("using cached block number to start search for root", "cachedBlockNumber", cachedBlockNumber)
 		start = cachedBlockNumber
 	}
 	step := durationToBlocks(destChainSel, stepDuration)

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -370,7 +370,7 @@ func manuallyExecuteSingle(
 		})
 		commitRootCache.Build()
 	} else {
-		lggr.Infow("found merkle root in cache", "msgSeqNr", msgSeqNr, "merkleRoot", merkleRoot)
+		lggr.Debugw("found merkle root in cache", "msgSeqNr", msgSeqNr, "merkleRoot", merkleRoot)
 	}
 
 	lggr.Infow("merkle root",

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -426,7 +426,7 @@ func manuallyExecuteSingle(
 		}
 	} else {
 		latestBlockNumber := messageSentCache.GetLatestBlockNumber()
-		lggr.Infow("not found in cache, fetching from the chain", "msgSeqNr", msgSeqNr, "latestBlockNumber", latestBlockNumber)
+		lggr.Debugw("not found in cache, fetching from the chain", "msgSeqNr", msgSeqNr, "latestBlockNumber", latestBlockNumber)
 		var err error
 		var blockNumbers []uint64
 		ccipMessageSentEvents, blockNumbers, err = getCCIPMessageSentEvents(

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -142,7 +142,7 @@ func getCommitRootAcceptedEvent(
 	lggr.Debugw("Getting commit root accepted event", "startBlock", start, "step", step)
 	for start <= hdr.Number.Uint64() {
 		end := min(start+step, hdr.Number.Uint64())
-		lggr.Infow("Querying with", "startBlock", start, "endBlock", end, "step", step)
+		lggr.Debugw("Querying with", "startBlock", start, "endBlock", end, "step", step)
 
 		iter, err := state.Chains[destChainSel].OffRamp.FilterCommitReportAccepted(
 			&bind.FilterOpts{

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -238,7 +238,7 @@ func getCCIPMessageSentEvents(
 		seqNrs = append(seqNrs, i)
 	}
 
-	lggr.Infow("would query with",
+	lggr.Debugw("would query with",
 		"seqNrs", seqNrs,
 		"minSeqNr", merkleRoot.MinSeqNr,
 		"maxSeqNr", merkleRoot.MaxSeqNr,

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -228,7 +228,7 @@ func getCCIPMessageSentEvents(
 
 	start := getStartBlock(srcChainSel, hdr.Number.Uint64(), lookbackDuration)
 	if cachedBlockNumber != 0 {
-		lggr.Infow("using cached block number to start search for messages", "cachedBlockNumber", cachedBlockNumber)
+		lggr.Debugw("using cached block number to start search for messages", "cachedBlockNumber", cachedBlockNumber)
 		start = cachedBlockNumber
 	}
 	step := durationToBlocks(srcChainSel, stepDuration)

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -341,7 +341,7 @@ func manuallyExecuteSingle(
 	merkleRoot, inCache := commitRootCache.Get(msgSeqNr)
 	if !inCache {
 		latestBlockNumber := commitRootCache.GetLatestBlockNumber()
-		lggr.Infow("merkle root not found in cache, fetching from the chain",
+		lggr.Debugw("merkle root not found in cache, fetching from the chain",
 			"msgSeqNr", msgSeqNr,
 			"latestBlockNumber", latestBlockNumber,
 		)

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -139,7 +139,7 @@ func getCommitRootAcceptedEvent(
 	}
 	step := durationToBlocks(destChainSel, stepDuration)
 
-	lggr.Infow("Getting commit root accepted event", "startBlock", start, "step", step)
+	lggr.Debugw("Getting commit root accepted event", "startBlock", start, "step", step)
 	for start <= hdr.Number.Uint64() {
 		end := min(start+step, hdr.Number.Uint64())
 		lggr.Infow("Querying with", "startBlock", start, "endBlock", end, "step", step)

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -373,7 +373,7 @@ func manuallyExecuteSingle(
 		lggr.Debugw("found merkle root in cache", "msgSeqNr", msgSeqNr, "merkleRoot", merkleRoot)
 	}
 
-	lggr.Infow("merkle root",
+	lggr.Debugw("merkle root",
 		"merkleRoot", hexutil.Encode(merkleRoot.MerkleRoot[:]),
 		"minSeqNr", merkleRoot.MinSeqNr,
 		"maxSeqNr", merkleRoot.MaxSeqNr,

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -258,7 +258,7 @@ func getCCIPMessageSentEvents(
 	var blockNumbers []uint64
 	for uint64(len(ret)) < merkleRootSize && start <= hdr.Number.Uint64() {
 		end := min(start+step, hdr.Number.Uint64())
-		lggr.Infow("Querying for messages with", "startBlock", start, "endBlock", end, "stepBlocks", step)
+		lggr.Debugw("Querying for messages with", "startBlock", start, "endBlock", end, "stepBlocks", step)
 		iter, err := state.Chains[srcChainSel].OnRamp.FilterCCIPMessageSent(
 			&bind.FilterOpts{
 				Start: start,

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -395,7 +395,7 @@ func manuallyExecuteSingle(
 
 		if uint64(len(ccipMessageSentEvents)) != merkleRootSize {
 			latestBlockNumber := messageSentCache.GetLatestBlockNumber()
-			lggr.Infow("not all messages found in cache, fetching from the chain", "msgSeqNr", msgSeqNr, "latestBlockNumber", latestBlockNumber)
+			lggr.Debugw("not all messages found in cache, fetching from the chain", "msgSeqNr", msgSeqNr, "latestBlockNumber", latestBlockNumber)
 			var err error
 			var blockNumbers []uint64
 			ccipMessageSentEvents, blockNumbers, err = getCCIPMessageSentEvents(

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -383,7 +383,7 @@ func manuallyExecuteSingle(
 	merkleRootSize := merkleRoot.MaxSeqNr - merkleRoot.MinSeqNr + 1
 	var ccipMessageSentEvents []onramp.OnRampCCIPMessageSent
 	if _, ok := messageSentCache.Get(msgSeqNr); ok {
-		lggr.Infow("found message in cache, fetching the rest", "msgSeqNr", msgSeqNr)
+		lggr.Debugw("found message in cache, fetching the rest", "msgSeqNr", msgSeqNr)
 		for start := merkleRoot.MinSeqNr; start <= merkleRoot.MaxSeqNr; start++ {
 			message, ok := messageSentCache.Get(start)
 			if !ok {

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -332,7 +332,7 @@ func manuallyExecuteSingle(
 		return nil
 	}
 
-	lggr.Infow("contract addresses",
+	lggr.Debugw("contract addresses",
 		"offRampAddress", state.Chains[destChainSel].OffRamp.Address(),
 		"onRampAddress", onRampAddress,
 		"execState", execState,

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -273,7 +273,7 @@ func getCCIPMessageSentEvents(
 
 		for iter.Next() {
 			if iter.Event.DestChainSelector == destChainSel {
-				lggr.Infow("checking message",
+				lggr.Debugw("checking message",
 					"seqNr", iter.Event.SequenceNumber,
 					"destChain", iter.Event.DestChainSelector,
 					"txHash", iter.Event.Raw.TxHash.String())

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -174,7 +174,7 @@ func getCommitRootAcceptedEvent(
 		start = end + 1
 	}
 
-	lggr.Infow("didn't find commit root, maybe increase lookback duration")
+	lggr.Warnw("didn't find commit root, maybe increase lookback duration")
 
 	return offramp.InternalMerkleRoot{}, 0, errors.New("commit root not found")
 }

--- a/deployment/ccip/shared/deployergroup/deployer_group.go
+++ b/deployment/ccip/shared/deployergroup/deployer_group.go
@@ -252,7 +252,7 @@ func (d *DeployerGroup) GetDeployer(chain uint64) (*bind.TransactOpts, error) {
 			}
 			decodedCall, err := d.txDecoder.Analyze(tx.To().String(), &_abi, tx.Data())
 			if err != nil {
-				d.e.Logger.Errorw("could not analyze transaction",
+				d.e.Logger.Warnw("could not analyze transaction",
 					"chain", chain, "address", tx.To().Hex(), "nonce", currentNonce, "error", err)
 			} else {
 				description = decodedCall.Describe(d.describeContext)

--- a/deployment/ccip/shared/stateview/aptos/state.go
+++ b/deployment/ccip/shared/stateview/aptos/state.go
@@ -251,7 +251,7 @@ func (s CCIPChainState) GenerateView(e *cldf.Environment, selector uint64, chain
 				chainView.Tokens[symbol.String()] = tokenView
 			}
 			chainView.UpdateMu.Unlock()
-			lggr.Infow("generated token view", "tokenAddress", address.StringLong(), "symbol", symbol, "chain", chainName)
+			lggr.Debugw("generated token view", "tokenAddress", address.StringLong(), "symbol", symbol, "chain", chainName)
 		}
 		return nil
 	})

--- a/deployment/ccip/shared/stateview/aptos/state.go
+++ b/deployment/ccip/shared/stateview/aptos/state.go
@@ -314,7 +314,7 @@ func (s CCIPChainState) GenerateView(e *cldf.Environment, selector uint64, chain
 		chainView.UpdateMu.Lock()
 		chainView.OffRamp[s.CCIPAddress.StringLong()] = offRampView
 		chainView.UpdateMu.Unlock()
-		lggr.Infow("gneerated offRamp view", "offRampAddress", s.CCIPAddress.StringLong(), "chain", chainName)
+		lggr.Debugw("gneerated offRamp view", "offRampAddress", s.CCIPAddress.StringLong(), "chain", chainName)
 		return nil
 	})
 

--- a/deployment/ccip/shared/stateview/aptos/state.go
+++ b/deployment/ccip/shared/stateview/aptos/state.go
@@ -265,7 +265,7 @@ func (s CCIPChainState) GenerateView(e *cldf.Environment, selector uint64, chain
 		chainView.UpdateMu.Lock()
 		chainView.MCMSWithTimelock = mcmsView
 		chainView.UpdateMu.Unlock()
-		lggr.Infow("generated MCMS with timelock view", "MCMSAddress", s.MCMSAddress.StringLong(), "chain", chainName)
+		lggr.Debugw("generated MCMS with timelock view", "MCMSAddress", s.MCMSAddress.StringLong(), "chain", chainName)
 		return nil
 	})
 

--- a/deployment/ccip/shared/stateview/aptos/state.go
+++ b/deployment/ccip/shared/stateview/aptos/state.go
@@ -290,7 +290,7 @@ func (s CCIPChainState) GenerateView(e *cldf.Environment, selector uint64, chain
 		chainView.UpdateMu.Lock()
 		chainView.Router[s.CCIPAddress.StringLong()] = routerView
 		chainView.UpdateMu.Unlock()
-		lggr.Infow("generated router view", "routerAddress", s.CCIPAddress.StringLong(), "chain", chainName)
+		lggr.Debugw("generated router view", "routerAddress", s.CCIPAddress.StringLong(), "chain", chainName)
 		return nil
 	})
 

--- a/deployment/ccip/shared/stateview/aptos/state.go
+++ b/deployment/ccip/shared/stateview/aptos/state.go
@@ -302,7 +302,7 @@ func (s CCIPChainState) GenerateView(e *cldf.Environment, selector uint64, chain
 		chainView.UpdateMu.Lock()
 		chainView.OnRamp[s.CCIPAddress.StringLong()] = onRampView
 		chainView.UpdateMu.Unlock()
-		lggr.Infow("generated onRamp view", "onRampAddress", s.CCIPAddress.StringLong(), "chain", chainName)
+		lggr.Debugw("generated onRamp view", "onRampAddress", s.CCIPAddress.StringLong(), "chain", chainName)
 		return nil
 	})
 

--- a/deployment/ccip/shared/stateview/aptos/state.go
+++ b/deployment/ccip/shared/stateview/aptos/state.go
@@ -278,7 +278,7 @@ func (s CCIPChainState) GenerateView(e *cldf.Environment, selector uint64, chain
 		chainView.UpdateMu.Lock()
 		chainView.CCIP = ccipView
 		chainView.UpdateMu.Unlock()
-		lggr.Infow("generated CCIP view", "CCIPAddress", s.CCIPAddress.StringLong(), "chain", chainName)
+		lggr.Debugw("generated CCIP view", "CCIPAddress", s.CCIPAddress.StringLong(), "chain", chainName)
 		return nil
 	})
 

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -1069,7 +1069,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.RMNProxy[c.RMNProxy.Address().Hex()] = rmnProxyView
-			lggr.Infow("generated rmn proxy view", "rmnProxy", c.RMNProxy.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated rmn proxy view", "rmnProxy", c.RMNProxy.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -865,7 +865,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), v1_5_1.PoolView{
 					TokenPoolView: tokenPoolView,
 				})
-				lggr.Infow("generated burn mint token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
+				lggr.Debugw("generated burn mint token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
 				return nil
 			}
 		}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -1162,7 +1162,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 				return fmt.Errorf("failed to generate registry module view for registry module %s: %w", registryModule.Address().Hex(), err)
 			}
 			chainView.UpdateRegistryModuleView(registryModule.Address().Hex(), registryModuleView)
-			lggr.Infow("generated registry module view", "registryModule", registryModule.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated registry module view", "registryModule", registryModule.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -834,7 +834,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.TokenPoolFactory[c.TokenPoolFactory.Address().Hex()] = tpfView
-			lggr.Infow("generated token pool factory view", "tokenPoolFactory", c.TokenPoolFactory.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated token pool factory view", "tokenPoolFactory", c.TokenPoolFactory.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -1134,7 +1134,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.StaticLinkToken = staticLinkTokenView
-			lggr.Infow("generated static link token view", "staticLinkToken", c.StaticLinkToken.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated static link token view", "staticLinkToken", c.StaticLinkToken.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -941,7 +941,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 					return nil
 				}
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), tokenPoolView)
-				lggr.Infow("generated lock release token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
+				lggr.Debugw("generated lock release token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
 				return nil
 			}
 		}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -927,7 +927,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 					return nil
 				}
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), tokenPoolView)
-				lggr.Infow("generated lock release token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
+				lggr.Debugw("generated lock release token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
 				return nil
 			}
 		}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -981,7 +981,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.RMNRemote[c.RMNRemote.Address().Hex()] = rmnView
-			lggr.Infow("generated rmn remote view", "rmnRemote", c.RMNRemote.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated rmn remote view", "rmnRemote", c.RMNRemote.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -1018,7 +1018,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.FeeQuoter[c.FeeQuoter.Address().Hex()] = fqView
-			lggr.Infow("generated fee quoter view", "feeQuoter", c.FeeQuoter.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated fee quoter view", "feeQuoter", c.FeeQuoter.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -792,7 +792,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.Router[c.Router.Address().Hex()] = routerView
-			lggr.Infow("generated router view", "router", c.Router.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated router view", "router", c.Router.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -1082,7 +1082,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.CCIPHome[c.CCIPHome.Address().Hex()] = chView
-			lggr.Infow("generated CCIP home view", "CCIPHome", c.CCIPHome.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated CCIP home view", "CCIPHome", c.CCIPHome.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -913,7 +913,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), v1_5_1.PoolView{
 					TokenPoolView: tokenPoolView,
 				})
-				lggr.Infow("generated burn from mint token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
+				lggr.Debugw("generated burn from mint token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
 				return nil
 			}
 		}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -897,7 +897,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), v1_5_1.PoolView{
 					TokenPoolView: tokenPoolView,
 				})
-				lggr.Infow("generated burn with from mint token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
+				lggr.Debugw("generated burn with from mint token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
 				return nil
 			}
 		}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -849,7 +849,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), v1_5_1.PoolView{
 					TokenPoolView: tokenPoolView,
 				})
-				lggr.Infow("generated burn mint token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
+				lggr.Debugw("generated burn mint token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
 				return nil
 			}
 		}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -1095,7 +1095,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.CapabilityRegistry[c.CapabilityRegistry.Address().Hex()] = capRegView
-			lggr.Infow("generated capability registry view", "capabilityRegistry", c.CapabilityRegistry.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated capability registry view", "capabilityRegistry", c.CapabilityRegistry.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -1037,7 +1037,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.OnRamp[c.OnRamp.Address().Hex()] = onRampView
-			lggr.Infow("generated on ramp view", "onRamp", c.OnRamp.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated on ramp view", "onRamp", c.OnRamp.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -1176,7 +1176,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.PriceRegistry[c.PriceRegistry.Address().String()] = priceRegistryView
-			lggr.Infow("generated price registry view", "priceRegistry", c.PriceRegistry.Address().String(), "chain", chain)
+			lggr.Debugw("generated price registry view", "priceRegistry", c.PriceRegistry.Address().String(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -806,7 +806,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.Router[c.TestRouter.Address().Hex()] = testRouterView
-			lggr.Infow("generated test router view", "testRouter", c.TestRouter.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated test router view", "testRouter", c.TestRouter.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -955,7 +955,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 				return nil
 			}
 			chainView.UpdateTokenPool(string(shared.USDCSymbol), pool.Address().Hex(), tokenPoolView)
-			lggr.Infow("generated USDC token pool view", "tokenPool", pool.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated USDC token pool view", "tokenPool", pool.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -1190,7 +1190,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.RMN[c.RMN.Address().Hex()] = rmnView
-			lggr.Infow("generated rmn view", "rmn", c.RMN.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated rmn view", "rmn", c.RMN.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -1108,7 +1108,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.MCMSWithTimelock = mcmsView
-			lggr.Infow("generated MCMS with timelock view", "MCMSWithTimelock", c.MCMSWithTimelockState.Timelock.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated MCMS with timelock view", "MCMSWithTimelock", c.MCMSWithTimelockState.Timelock.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -1150,7 +1150,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 				return fmt.Errorf("failed to generate registry module view for registry module %s: %w", registryModule.Address().Hex(), err)
 			}
 			chainView.UpdateRegistryModuleView(registryModule.Address().Hex(), registryModuleView)
-			lggr.Infow("generated registry module view", "registryModule", registryModule.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated registry module view", "registryModule", registryModule.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -1121,7 +1121,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.LinkToken = linkTokenView
-			lggr.Infow("generated link token view", "linkToken", c.LinkToken.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated link token view", "linkToken", c.LinkToken.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -995,7 +995,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.RMNHome[c.RMNHome.Address().Hex()] = rmnHomeView
-			lggr.Infow("generated rmn home view", "rmnHome", c.RMNHome.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated rmn home view", "rmnHome", c.RMNHome.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -1055,7 +1055,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.OffRamp[c.OffRamp.Address().Hex()] = offRampView
-			lggr.Infow("generated off ramp view", "offRamp", c.OffRamp.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated off ramp view", "offRamp", c.OffRamp.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -968,7 +968,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
 			chainView.NonceManager[c.NonceManager.Address().Hex()] = nmView
-			lggr.Infow("generated nonce manager view", "nonceManager", c.NonceManager.Address().Hex(), "chain", chain)
+			lggr.Debugw("generated nonce manager view", "nonceManager", c.NonceManager.Address().Hex(), "chain", chain)
 			return nil
 		}
 	}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -881,7 +881,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), v1_5_1.PoolView{
 					TokenPoolView: tokenPoolView,
 				})
-				lggr.Infow("generated burn mint token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
+				lggr.Debugw("generated burn mint token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
 				return nil
 			}
 		}


### PR DESCRIPTION
## Summary

Automated log-level adjustments produced by an LLM audit against a [logging-level-rubric](https://github.com/smartcontractkit/logging-audit-mzhang/blob/main/docs/logging-level-rubric.md). Audit baseline: chainlink `807f2928c65c`.

- Code owners: @smartcontractkit/ccip-offchain @smartcontractkit/ccip-tooling @smartcontractkit/core @smartcontractkit/operations-platform
- Changes applied: **184** (166 downgrade, 18 upgrade)
- Recommendations not applied (upstream removed or rewrote the line since the audit baseline): 0
- One commit per change. Inline review comments contain per-change rationale.

## Files touched

- `deployment/ccip/changeset/ccip-attestation-solana/cs_idl.go` (1 change)
- `deployment/ccip/changeset/crossfamily/cs_set_token_transfer_fee_config.go` (1 change)
- `deployment/ccip/changeset/crossfamily/v1_6/cs_add_evm_solana_lane.go` (1 change)
- `deployment/ccip/changeset/solana_v0_1_0/cs_billing.go` (1 change)
- `deployment/ccip/changeset/solana_v0_1_0/cs_build_solana.go` (2 changes)
- `deployment/ccip/changeset/solana_v0_1_0/cs_deploy_chain.go` (1 change)
- `deployment/ccip/changeset/solana_v0_1_0/cs_idl.go` (4 changes)
- `deployment/ccip/changeset/solana_v0_1_0/cs_ops.go` (1 change)
- `deployment/ccip/changeset/solana_v0_1_0/cs_set_ocr3.go` (7 changes)
- `deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go` (12 changes)
- `deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go` (6 changes)
- `deployment/ccip/changeset/solana_v0_1_0/cs_verify_contracts.go` (11 changes)
- `deployment/ccip/changeset/solana_v0_1_1/cs_billing.go` (10 changes)
- `deployment/ccip/changeset/solana_v0_1_1/cs_idl.go` (5 changes)
- `deployment/ccip/changeset/solana_v0_1_1/cs_set_ocr3.go` (7 changes)
- `deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go` (12 changes)
- `deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go` (12 changes)
- `deployment/ccip/changeset/solana_v0_1_1/cs_verify_contracts.go` (6 changes)
- `deployment/ccip/changeset/v1_5_1/cs_set_token_transfer_fee_config.go` (9 changes)
- `deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go` (7 changes)
- `deployment/ccip/changeset/v1_6/cs_chain_contracts.go` (13 changes)
- `deployment/ccip/changeset/v1_6/cs_home_chain.go` (1 change)
- `deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes.go` (1 change)
- `deployment/ccip/changeset/v1_6_1/cs_transparent_upgradeable_proxy.go` (1 change)
- `deployment/ccip/manualexechelpers/exec.go` (18 changes)
- `deployment/ccip/shared/deployergroup/deployer_group.go` (1 change)
- `deployment/ccip/shared/stateview/aptos/state.go` (6 changes)
- `deployment/ccip/shared/stateview/evm/state.go` (27 changes)

---

Generated by [`scripts/apply-and-pr.py`](https://github.com/smartcontractkit/logging-audit-mzhang/blob/main/scripts/apply-and-pr.py).