### PR TITLE
fix Test_CachedInMemoryDataSourceErrHandling

### DIFF
--- a/core/services/ocrcommon/data_source_test.go
+++ b/core/services/ocrcommon/data_source_test.go
@@ -79,14 +79,18 @@ func Test_CachedInMemoryDataSourceErrHandling(t *testing.T) {
 		mockKVStore := mocks.KVStore{}
 		mockKVStore.On("Store", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockKVStore.On("Get", mock.Anything, mock.Anything).Return(nil, nil)
+
+		mockVal := int64(1)
+		// Must register before servicetest.Run: updater() calls updateCache() immediately on Start(),
+		// before the ticker fires, so the expectation must exist when the goroutine is created.
+		changeResultValue(runner, strconv.FormatInt(mockVal, 10), false, true)
+
 		dsCache, err := ocrcommon.NewInMemoryDataSourceCache(ds, &mockKVStore, &config.JuelsPerFeeCoinCache{UpdateInterval: sqlutil.Interval(time.Second * 2)})
 		require.NoError(t, err)
 		servicetest.Run(t, dsCache)
 
-		mockVal := int64(1)
 		// Test if Observe notices that cache updater failed and can refresh the cache on its own
-		// 1. Set initial value
-		changeResultValue(runner, strconv.FormatInt(mockVal, 10), false, true)
+		// 1. Initial value already registered above; wait for the first cache update to land
 		time.Sleep(time.Millisecond * 100)
 		val, err := dsCache.Observe(testutils.Context(t), types.ReportTimestamp{})
 		require.NoError(t, err)

--- a/core/services/ocrcommon/data_source_test.go
+++ b/core/services/ocrcommon/data_source_test.go
@@ -91,10 +91,13 @@ func Test_CachedInMemoryDataSourceErrHandling(t *testing.T) {
 
 		// Test if Observe notices that cache updater failed and can refresh the cache on its own
 		// 1. Initial value already registered above; wait for the first cache update to land
-		time.Sleep(time.Millisecond * 100)
-		val, err := dsCache.Observe(testutils.Context(t), types.ReportTimestamp{})
-		require.NoError(t, err)
-		assert.Equal(t, mockVal, val.Int64())
+		var val *big.Int
+		require.Eventually(t, func() bool {
+			var valErr error
+			val, valErr = dsCache.Observe(testutils.Context(t), types.ReportTimestamp{})
+			return valErr == nil && val.Int64() == mockVal
+		}, time.Second*2, time.Millisecond*100)
+
 		// 2. Set values again, but make it error in updater
 		changeResultValue(runner, strconv.FormatInt(mockVal+1, 10), true, true)
 		time.Sleep(time.Second*2 + time.Millisecond*100)


### PR DESCRIPTION
`inMemoryDataSourceCache.Start()` triggers an immediate `updateCache()` call before the ticker loop begins. The test was starting the service before registering the first `ExecuteRun` mock expectation, so the background goroutine fired on an empty mock — testify panicked, the goroutine died without closing chDone, and
`Close()` blocked forever causing a 15-minute timeout.

Fix: register the initial mock expectation before calling `servicetest.Run`.

Failed run: https://github.com/smartcontractkit/chainlink/actions/runs/26099195822