### PR TITLE
[CRE-3578] use unique secret names to avoid DB locks

### DIFF
--- a/core/services/workflows/syncer/handler_test.go
+++ b/core/services/workflows/syncer/handler_test.go
@@ -894,7 +894,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 			binary        = wasmtest.CreateTestBinary(binaryCmd, true, t)
 			encodedBinary = []byte(base64.StdEncoding.EncodeToString(binary))
 			config        = []byte("")
-			secretsURL    = "http://example.com"
+			secretsURL    = "http://example.com/secrets/" + workflowName
 			binaryURL     = "http://example.com/binary"
 			configURL     = "http://example.com/config"
 		)
@@ -984,7 +984,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 			binary        = wasmtest.CreateTestBinary(binaryCmd, true, t)
 			encodedBinary = []byte(base64.StdEncoding.EncodeToString(binary))
 			config        = []byte("")
-			secretsURL    = "http://example.com"
+			secretsURL    = "http://example.com/secrets/" + workflowName
 			binaryURL     = "http://example.com/binary"
 			configURL     = "http://example.com/config"
 		)
@@ -1043,7 +1043,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 			binary        = wasmtest.CreateTestBinary(binaryCmd, true, t)
 			encodedBinary = []byte(base64.StdEncoding.EncodeToString(binary))
 			config        = []byte("")
-			secretsURL    = "http://example.com"
+			secretsURL    = "http://example.com/secrets/" + workflowName
 			binaryURL     = "http://example.com/binary"
 			configURL     = "http://example.com/config"
 
@@ -1141,7 +1141,7 @@ func Test_workflowPausedActivatedUpdatedHandler(t *testing.T) {
 			encodedBinary = []byte(base64.StdEncoding.EncodeToString(binary))
 			config        = []byte("")
 			updateConfig  = []byte("updated")
-			secretsURL    = "http://example.com"
+			secretsURL    = "http://example.com/secrets/" + workflowName
 			binaryURL     = "http://example.com/binary"
 			configURL     = "http://example.com/config"
 			newConfigURL  = "http://example.com/new-config"


### PR DESCRIPTION
Fix for CRE-3578 — `Test_workflowDeletedHandler/success_deleting_existing_engine_and_spec`

Root cause: All four Test_workflowDeletedHandler subtests used the same hardcoded `secretsURL = "http://example.com"`. Running in parallel, they all tried to upsert the same `workflow_secrets` row (keyed by `secrets_url_hash`), causing a PostgreSQL lock timeout.

Fix (handler_test.go lines 897, 987, 1046, 1144):
```
  // before
  secretsURL = "http://example.com"

  // after
  secretsURL = "http://example.com/secrets/" + workflowName
```
`workflowName` is already randomized per test via `testutils.RandomizeName(t.Name())`, so each parallel subtest now gets a distinct row.