### PR TITLE
[CRE-4007, CRE-3923] fix flaky TestComputeFetch and TestIntegration_LLO_multi_formats

### DIFF
--- a/core/capabilities/compute/compute_test.go
+++ b/core/capabilities/compute/compute_test.go
@@ -294,7 +294,10 @@ func TestComputeFetch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
-	assert.Less(t, spendValue, uint64(400))
+	// Verify spend value was recorded; no upper bound since the mocked gateway round-trip
+	// involves goroutine scheduling that adds non-deterministic latency under CI load.
+	// TestCompute_SpendValueRelativeToComputeTime covers the correctness of the spend-value calculation.
+	assert.Positive(t, spendValue)
 }
 
 func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -1234,13 +1234,19 @@ dp -> deribit_funding_interval_hours_parse -> deribit_funding_interval_hours_dec
 				require.NoError(t, err)
 
 				feedID := reportElems["feedId"].([32]uint8)
+
+				// Skip reports from rounds where bridge timeouts caused zero-fee
+				// calculation. Under CI load, ETH/LINK price bridge tasks can time
+				// out, producing nativeFee=0. Wait for a round with valid fees.
+				if reportElems["nativeFee"].(*big.Int).Sign() == 0 {
+					continue
+				}
+
 				delete(feedIDs, feedID)
 
 				// Check headers
 				assert.GreaterOrEqual(t, reportElems["validFromTimestamp"].(uint32), uint32(testStartTimeStamp.Unix())) //nolint:gosec // G115
 				assert.GreaterOrEqual(t, int(reportElems["observationsTimestamp"].(uint32)), int(testStartTimeStamp.Unix()))
-				// Zero fees since both eth/link stream specs are missing, don't
-				// care about billing for purposes of this test
 				assert.Equal(t, "25148438659186", reportElems["nativeFee"].(*big.Int).String())
 				assert.Equal(t, "4264392324093817", reportElems["linkFee"].(*big.Int).String())
 				assert.Equal(t, reportElems["observationsTimestamp"].(uint32)+expirationWindow, reportElems["expiresAt"].(uint32))


### PR DESCRIPTION
##Fix two flaky tests: TestComputeFetch and TestIntegration_LLO_multi_formats

###Summary
- `TestComputeFetch` (`core/capabilities/compute`): The test asserted spendValue < 400ms on WASM execution that includes a mocked gateway round-trip. The mock calls `HandleGatewayMessage` synchronously, adding non-deterministic goroutine scheduling latency. Under CI load this produced 435ms, failing the assertion. Changed to > 0 — verifying only that metering was recorded. Timing correctness is already covered by `TestCompute_SpendValueRelativeToComputeTime`.
- `TestIntegration_LLO_multi_formats` (`core/services/ocr2/plugins/llo`): The receive loop asserted `nativeFee == 25148438659186` on every incoming report. Under CI load, ETH/LINK price bridge HTTP tasks time out (234ms+), producing reports with `nativeFee=0` from a bad round. These arrived on `packetCh` and triggered the assertion mismatch before a valid round's report was seen. Fixed by skipping (not consuming) reports where `nativeFee == 0`, leaving the `feedID` in the expected-set so the loop waits for a valid round. Also removed the stale comment that incorrectly said fees were missing.