### PR TITLE
try to stop node for 30s, if it timesout continue cleanup

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -81,6 +81,10 @@ const (
 	// NOTE: these are test values, real production values are configured in CLD.
 	DefaultGasPriceDeviationPPB   = 1000
 	DefaultDAGasPriceDeviationPPB = 1000
+
+	// appStopCleanupTimeout caps node App.Stop() during test teardown when OCR
+	// Close() can hang after on-chain DON removal.
+	appStopCleanupTimeout = 30 * time.Second
 )
 
 type EnvType string
@@ -536,11 +540,18 @@ func (m *MemoryEnvironment) StartNodes(t *testing.T, crConfig deployment.Capabil
 			// reclaimed when the test binary exits; they hold no locks or DB connections.
 			done := make(chan error, 1)
 			go func() { done <- node.App.Stop() }()
+
+			timer := time.NewTimer(appStopCleanupTimeout)
+			defer timer.Stop()
+
 			select {
 			case err := <-done:
+				if !timer.Stop() {
+					<-timer.C
+				}
 				require.NoError(t, err)
-			case <-time.After(30 * time.Second):
-				t.Logf("warning: node %s App.Stop() timed out after 30s, continuing cleanup", id)
+			case <-timer.C:
+				t.Logf("warning: node %s App.Stop() timed out after %s, continuing cleanup", id, appStopCleanupTimeout)
 			}
 		})
 		nodeIDs = append(nodeIDs, id)

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -530,7 +530,18 @@ func (m *MemoryEnvironment) StartNodes(t *testing.T, crConfig deployment.Capabil
 	for id, node := range nodes {
 		require.NoError(t, node.App.Start(ctx))
 		t.Cleanup(func() {
-			require.NoError(t, node.App.Stop())
+			// Timeout guard: tests that remove a DON on-chain mid-run leave OCR services in a
+			// confused state. Their Close() gets stuck inside libocr with no externally
+			// reachable cancel, so App.Stop() can hang indefinitely. Leaked goroutines are
+			// reclaimed when the test binary exits; they hold no locks or DB connections.
+			done := make(chan error, 1)
+			go func() { done <- node.App.Stop() }()
+			select {
+			case err := <-done:
+				require.NoError(t, err)
+			case <-time.After(30 * time.Second):
+				t.Logf("warning: node %s App.Stop() timed out after 30s, continuing cleanup", id)
+			}
 		})
 		nodeIDs = append(nodeIDs, id)
 	}


### PR DESCRIPTION
### Problem
`TestAddAndPromoteCandidatesForNewChain` removes a DON from CapabilityRegistry on-chain mid-test while nodes have active OCR jobs. This leaves OCR services in a confused state. At cleanup, `node.App.Stop()` blocks indefinitely in `spawner.stopAllServices()` — it waits on a `sync.WaitGroup` for each service's `Close()` to return, but the libocr oracle close chain gets stuck before it can cancel the `ragedisco.sendLoop` goroutine's context.

### Fix

Wrap `node.App.Stop()` in StartNodes's per-node cleanup with a 30-second timeout. If stop completes cleanly (the common case), the error is still asserted. If it hangs (the edge case after on-chain DON removal), cleanup logs a warning and continues — the leaked goroutines are reclaimed when the test binary exits.

### Trade-off
On timeout, goroutines from the stuck node remain alive for the rest of the test binary's lifetime. There is no available mechanism to force a clean shutdown: libocr does not expose a cancel context externally, and ChainlinkApplication has no force-stop path. The goroutines are stuck in a select with no locks or DB connections held, so they don't interfere with sibling tests. The alternative — deleting jobs before `App.Stop()` — hits the same hang since `spawner.DeleteJob` also calls `service.Close()` internally.

---
This is rare failure, so far I've seen it twice:
- https://github.com/smartcontractkit/chainlink/actions/runs/26164593699/job/76965177224
- https://github.com/smartcontractkit/chainlink/actions/runs/26114714261/job/76800877500