### PR TITLE
Move binary_url out of ConfidentialWorkflow hash envelope

### DIFF
--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -1005,6 +1005,7 @@ func newWorkflowRegistrySyncerV2(
 		syncerV2.WithLocalSecretOverrides(lggr, cfg.CRE().LocalSecretOverrides()),
 		syncerV2.WithShardExecutionGuard(shardOrchestratorClient, shardingEnabled, shardIndex),
 		syncerV2.WithShardRoutingSteady(shardRoutingSteady),
+		syncerV2.WithLocationRetriever(retrieverFunc),
 	}
 
 	mc := capCfg.WorkflowRegistry().ModuleCache()

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -88,6 +88,10 @@ type eventHandler struct {
 	billingClient          metering.BillingClient
 	orgResolver            orgresolver.OrgResolver
 	secretsFetcher         v2.SecretsFetcher
+	// retrieveURL mints a per-execution pre-signed download URL via the storage
+	// service for confidential workflows. Wired into ConfidentialModule so each
+	// run gets a fresh per-node URL.
+	retrieveURL types.LocationRetrieverFunc
 	// localSecretOverrides is keyed by owner address; values are secret id -> secret value
 	localSecretOverrides map[string]map[string]string
 
@@ -148,6 +152,16 @@ func WithStaticEngine(engine services.Service) func(*eventHandler) {
 func WithBillingClient(client metering.BillingClient) func(*eventHandler) {
 	return func(e *eventHandler) {
 		e.billingClient = client
+	}
+}
+
+// WithLocationRetriever installs the LocationRetrieverFunc used by
+// confidentialEngineFactory to mint per-execution pre-signed download URLs for
+// the confidential workflow path. Without it, ConfidentialModule.Execute fails
+// at runtime because there is no other way to obtain the URL.
+func WithLocationRetriever(fn types.LocationRetrieverFunc) func(*eventHandler) {
+	return func(e *eventHandler) {
+		e.retrieveURL = fn
 	}
 }
 
@@ -1102,11 +1116,6 @@ func (h *eventHandler) confidentialEngineFactory(
 	decodedBinary []byte,
 	initDone chan<- error,
 ) (services.Service, error) {
-	attrs, err := v2.ParseWorkflowAttributes(spec.Attributes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse workflow attributes: %w", err)
-	}
-
 	binaryHash := v2.ComputeBinaryHash(decodedBinary)
 
 	lggr := logger.Named(h.lggr, "WorkflowEngine.ConfidentialModule")
@@ -1129,10 +1138,9 @@ func (h *eventHandler) confidentialEngineFactory(
 
 	module := v2.NewConfidentialModule(
 		h.capRegistry,
-		spec.BinaryURL,
 		binaryHash,
 		spec.WorkflowID, spec.WorkflowOwner, workflowName.String(), spec.WorkflowTag,
-		attrs.VaultDonSecrets,
+		h.retrieveURL,
 		creGetter,
 		engineOrgID,
 		lggr,

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -43,6 +43,8 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/store"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/types"
 	v2 "github.com/smartcontractkit/chainlink/v2/core/services/workflows/v2"
+
+	storage_service "github.com/smartcontractkit/chainlink-protos/storage-service/go"
 )
 
 type ORM interface {
@@ -1136,11 +1138,24 @@ func (h *eventHandler) confidentialEngineFactory(
 		creGetter = h.engineLimiters.Settings
 	}
 
+	// The storage-service retriever mints per-node pre-signed URLs in
+	// production. When it is absent (e.g. a file-based workflow fetcher in
+	// local/E2E setups with no storage service), fall back to the workflow's
+	// on-chain binary URL so the enclave can still fetch the WASM. It remains
+	// per-node data outside the hashed ComputeRequest.
+	retrieveURL := h.retrieveURL
+	if retrieveURL == nil && spec.BinaryURL != "" {
+		binaryURL := spec.BinaryURL
+		retrieveURL = func(context.Context, *storage_service.DownloadArtifactRequest) (string, error) {
+			return binaryURL, nil
+		}
+	}
+
 	module := v2.NewConfidentialModule(
 		h.capRegistry,
 		binaryHash,
 		spec.WorkflowID, spec.WorkflowOwner, workflowName.String(), spec.WorkflowTag,
-		h.retrieveURL,
+		retrieveURL,
 		creGetter,
 		engineOrgID,
 		lggr,

--- a/core/services/workflows/v2/confidential_module.go
+++ b/core/services/workflows/v2/confidential_module.go
@@ -20,20 +20,16 @@ import (
 
 	confworkflowtypes "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialworkflow"
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
+	storage_service "github.com/smartcontractkit/chainlink-protos/storage-service/go"
+
+	workflowtypes "github.com/smartcontractkit/chainlink/v2/core/services/workflows/types"
 )
 
 const confidentialWorkflowsCapabilityID = "confidential-workflows@1.0.0-alpha"
 
 // WorkflowAttributes is the JSON structure stored in WorkflowSpec.Attributes.
 type WorkflowAttributes struct {
-	Confidential    bool               `json:"confidential"`
-	VaultDonSecrets []SecretIdentifier `json:"vault_don_secrets"`
-}
-
-// SecretIdentifier identifies a secret in VaultDON.
-type SecretIdentifier struct {
-	Key       string `json:"key"`
-	Namespace string `json:"namespace,omitempty"`
+	Confidential bool `json:"confidential"`
 }
 
 // ParseWorkflowAttributes parses the Attributes JSON from a WorkflowSpec.
@@ -64,14 +60,18 @@ func IsConfidential(data []byte) (bool, error) {
 // Instead of running WASM locally, it delegates execution to the
 // confidential-workflows capability via the CapabilitiesRegistry.
 type ConfidentialModule struct {
-	capRegistry       core.CapabilitiesRegistry
-	binaryURL         string
-	binaryHash        []byte
-	workflowID        string
-	workflowOwner     string
-	workflowName      string
-	workflowTag       string
-	vaultDonSecrets   []SecretIdentifier
+	capRegistry   core.CapabilitiesRegistry
+	binaryHash    []byte
+	workflowID    string
+	workflowOwner string
+	workflowName  string
+	workflowTag   string
+	// retrieveURL mints a fresh pre-signed CloudFront URL via the storage
+	// service's NodeService.DownloadArtifact at every Execute call. Each
+	// workflow DON node gets its own URL with its own signature and expiry,
+	// which is why the URL is carried on ConfidentialWorkflowRequest (outside
+	// the hashed WorkflowExecution) rather than inside it.
+	retrieveURL       workflowtypes.LocationRetrieverFunc
 	creSettingsGetter settings.Getter
 	orgID             string // resolved via org resolver at construction; stable for module lifetime
 	lggr              logger.Logger
@@ -81,23 +81,21 @@ var _ host.ModuleV2 = (*ConfidentialModule)(nil)
 
 func NewConfidentialModule(
 	capRegistry core.CapabilitiesRegistry,
-	binaryURL string,
 	binaryHash []byte,
 	workflowID, workflowOwner, workflowName, workflowTag string,
-	vaultDonSecrets []SecretIdentifier,
+	retrieveURL workflowtypes.LocationRetrieverFunc,
 	creSettingsGetter settings.Getter,
 	orgID string,
 	lggr logger.Logger,
 ) *ConfidentialModule {
 	return &ConfidentialModule{
 		capRegistry:       capRegistry,
-		binaryURL:         binaryURL,
 		binaryHash:        binaryHash,
 		workflowID:        workflowID,
 		workflowOwner:     workflowOwner,
 		workflowName:      workflowName,
 		workflowTag:       workflowTag,
-		vaultDonSecrets:   vaultDonSecrets,
+		retrieveURL:       retrieveURL,
 		creSettingsGetter: creSettingsGetter,
 		orgID:             orgID,
 		lggr:              lggr,
@@ -118,24 +116,25 @@ func (m *ConfidentialModule) Execute(
 		return nil, fmt.Errorf("failed to marshal ExecuteRequest: %w", err)
 	}
 
-	protoSecrets := make([]*confworkflowtypes.SecretIdentifier, len(m.vaultDonSecrets))
-	for i, s := range m.vaultDonSecrets {
-		// VaultDON treats "main" as the default namespace for secrets.
-		ns := s.Namespace
-		if ns == "" {
-			ns = "main"
-		}
-		protoSecrets[i] = &confworkflowtypes.SecretIdentifier{
-			Key:       s.Key,
-			Namespace: &ns,
-		}
+	if m.retrieveURL == nil {
+		return nil, errors.New("confidential module is missing a URL retriever; cannot fetch binary from storage service")
+	}
+	binaryURL, err := m.retrieveURL(ctx, &storage_service.DownloadArtifactRequest{
+		Id:   m.workflowID,
+		Type: storage_service.ArtifactType_ARTIFACT_TYPE_BINARY,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to mint pre-signed binary URL from storage service: %w", err)
 	}
 
 	capInput := &confworkflowtypes.ConfidentialWorkflowRequest{
-		VaultDonSecrets: protoSecrets,
+		// binary_url rides at the request level, outside the hashed
+		// WorkflowExecution. WorkflowExecution.binary_url is deprecated and
+		// intentionally left unset: it is inside ComputeRequest.PublicData
+		// (hashed for F+1 quorum), so a per-node value there would break quorum.
+		BinaryUrl: binaryURL,
 		Execution: &confworkflowtypes.WorkflowExecution{
 			WorkflowId:     m.workflowID,
-			BinaryUrl:      m.binaryURL,
 			BinaryHash:     m.binaryHash,
 			ExecuteRequest: execReqBytes,
 			Owner:          m.workflowOwner,

--- a/core/services/workflows/v2/confidential_module_test.go
+++ b/core/services/workflows/v2/confidential_module_test.go
@@ -20,12 +20,23 @@ import (
 
 	confworkflowtypes "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialworkflow"
 	capmocks "github.com/smartcontractkit/chainlink/v2/core/capabilities/mocks"
+	workflowtypes "github.com/smartcontractkit/chainlink/v2/core/services/workflows/types"
 	"github.com/smartcontractkit/chainlink/v2/core/utils/matches"
 
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
+	storage_service "github.com/smartcontractkit/chainlink-protos/storage-service/go"
 	valuespb "github.com/smartcontractkit/chainlink-protos/cre/go/values/pb"
 	wfpb "github.com/smartcontractkit/chainlink-protos/workflows/go/v2"
 )
+
+// stubRetrieveURL returns a LocationRetrieverFunc that always returns the given
+// URL, simulating the storage service's NodeService.DownloadArtifact presigned
+// URL response without a real storage backend.
+func stubRetrieveURL(url string) workflowtypes.LocationRetrieverFunc {
+	return func(context.Context, *storage_service.DownloadArtifactRequest) (string, error) {
+		return url, nil
+	}
+}
 
 // stubExecutionHelper implements host.ExecutionHelper for testing.
 type stubExecutionHelper struct {
@@ -49,23 +60,17 @@ func (s *stubExecutionHelper) EmitUserMetric(context.Context, *wfpb.WorkflowUser
 }
 
 func TestParseWorkflowAttributes(t *testing.T) {
-	t.Run("valid JSON with all fields", func(t *testing.T) {
-		data := []byte(`{"confidential":true,"vault_don_secrets":[{"key":"API_KEY"},{"key":"SIGNING_KEY","namespace":"custom-ns"}]}`)
+	t.Run("confidential true", func(t *testing.T) {
+		data := []byte(`{"confidential":true}`)
 		attrs, err := ParseWorkflowAttributes(data)
 		require.NoError(t, err)
 		assert.True(t, attrs.Confidential)
-		require.Len(t, attrs.VaultDonSecrets, 2)
-		assert.Equal(t, "API_KEY", attrs.VaultDonSecrets[0].Key)
-		assert.Empty(t, attrs.VaultDonSecrets[0].Namespace)
-		assert.Equal(t, "SIGNING_KEY", attrs.VaultDonSecrets[1].Key)
-		assert.Equal(t, "custom-ns", attrs.VaultDonSecrets[1].Namespace)
 	})
 
 	t.Run("empty data returns zero value", func(t *testing.T) {
 		attrs, err := ParseWorkflowAttributes(nil)
 		require.NoError(t, err)
 		assert.False(t, attrs.Confidential)
-		assert.Nil(t, attrs.VaultDonSecrets)
 
 		attrs, err = ParseWorkflowAttributes([]byte{})
 		require.NoError(t, err)
@@ -83,6 +88,15 @@ func TestParseWorkflowAttributes(t *testing.T) {
 		_, err := ParseWorkflowAttributes([]byte(`{not json}`))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse workflow attributes")
+	})
+
+	t.Run("unknown keys are ignored", func(t *testing.T) {
+		// vault_don_secrets is a leftover key from a previous schema. Parsing
+		// must tolerate it without failing.
+		data := []byte(`{"confidential":true,"vault_don_secrets":[{"key":"X"}]}`)
+		attrs, err := ParseWorkflowAttributes(data)
+		require.NoError(t, err)
+		assert.True(t, attrs.Confidential)
 	})
 }
 
@@ -166,16 +180,12 @@ func TestConfidentialModule_Execute(t *testing.T) {
 
 		mod := NewConfidentialModule(
 			capReg,
-			"https://example.com/binary.wasm",
 			[]byte("fakehash"),
 			"wf-123",
 			"owner-abc",
 			"my-workflow",
 			"v1",
-			[]SecretIdentifier{
-				{Key: "API_KEY"},
-				{Key: "SIGNING_KEY", Namespace: "custom-ns"},
-			},
+			stubRetrieveURL("https://example.com/binary.wasm"),
 			nil,
 			"",
 			lggr,
@@ -190,50 +200,13 @@ func TestConfidentialModule_Execute(t *testing.T) {
 		assert.Equal(t, "enclave-output", val.GetStringValue())
 	})
 
-	t.Run("default namespace is main", func(t *testing.T) {
-		capReg := regmocks.NewCapabilitiesRegistry(t)
-		execCap := capmocks.NewExecutableCapability(t)
-
-		capReg.EXPECT().GetExecutable(matches.AnyContext, confidentialWorkflowsCapabilityID).
-			Return(execCap, nil).Once()
-
-		// Capture the request to inspect proto secrets.
-		var capturedReq capabilities.CapabilityRequest
-		execCap.EXPECT().Execute(matches.AnyContext, mock.Anything).
-			Run(func(_ context.Context, req capabilities.CapabilityRequest) {
-				capturedReq = req
-			}).
-			Return(capabilities.CapabilityResponse{Payload: respPayload}, nil).Once()
-
-		mod := NewConfidentialModule(
-			capReg,
-			"https://example.com/binary.wasm",
-			[]byte("hash"),
-			"wf-1", "owner", "name", "tag",
-			[]SecretIdentifier{{Key: "SECRET_A"}}, // no namespace
-			nil,
-			"",
-			lggr,
-		)
-
-		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{executionID: "exec-1"})
-		require.NoError(t, err)
-
-		// Unmarshal the captured request payload and verify namespace defaulted to "main".
-		var confReq confworkflowtypes.ConfidentialWorkflowRequest
-		require.NoError(t, capturedReq.Payload.UnmarshalTo(&confReq))
-		require.Len(t, confReq.VaultDonSecrets, 1)
-		assert.Equal(t, "SECRET_A", confReq.VaultDonSecrets[0].Key)
-		assert.Equal(t, "main", confReq.VaultDonSecrets[0].GetNamespace())
-	})
-
 	t.Run("GetExecutable error", func(t *testing.T) {
 		capReg := regmocks.NewCapabilitiesRegistry(t)
 		capReg.EXPECT().GetExecutable(matches.AnyContext, confidentialWorkflowsCapabilityID).
 			Return(nil, errors.New("capability not found")).Once()
 
 		mod := NewConfidentialModule(
-			capReg, "", nil, "wf", "owner", "name", "tag", nil, nil, "", lggr,
+			capReg, nil, "wf", "owner", "name", "tag", stubRetrieveURL("https://example.com/x"), nil, "", lggr,
 		)
 
 		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{})
@@ -251,7 +224,7 @@ func TestConfidentialModule_Execute(t *testing.T) {
 			Return(capabilities.CapabilityResponse{}, errors.New("enclave unavailable")).Once()
 
 		mod := NewConfidentialModule(
-			capReg, "", nil, "wf", "owner", "name", "tag", nil, nil, "", lggr,
+			capReg, nil, "wf", "owner", "name", "tag", stubRetrieveURL("https://example.com/x"), nil, "", lggr,
 		)
 
 		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{})
@@ -269,12 +242,39 @@ func TestConfidentialModule_Execute(t *testing.T) {
 			Return(capabilities.CapabilityResponse{Payload: nil}, nil).Once()
 
 		mod := NewConfidentialModule(
-			capReg, "", nil, "wf", "owner", "name", "tag", nil, nil, "", lggr,
+			capReg, nil, "wf", "owner", "name", "tag", stubRetrieveURL("https://example.com/x"), nil, "", lggr,
 		)
 
 		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "returned nil payload")
+	})
+
+	t.Run("missing URL retriever errors", func(t *testing.T) {
+		capReg := regmocks.NewCapabilitiesRegistry(t)
+		mod := NewConfidentialModule(
+			capReg, nil, "wf", "owner", "name", "tag", nil, nil, "", lggr,
+		)
+
+		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing a URL retriever")
+	})
+
+	t.Run("retrieveURL error", func(t *testing.T) {
+		capReg := regmocks.NewCapabilitiesRegistry(t)
+		failingRetrieve := workflowtypes.LocationRetrieverFunc(
+			func(context.Context, *storage_service.DownloadArtifactRequest) (string, error) {
+				return "", errors.New("storage service down")
+			},
+		)
+		mod := NewConfidentialModule(
+			capReg, nil, "wf", "owner", "name", "tag", failingRetrieve, nil, "", lggr,
+		)
+
+		_, err := mod.Execute(ctx, execReq, &stubExecutionHelper{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to mint pre-signed binary URL")
 	})
 
 	t.Run("request fields are forwarded correctly", func(t *testing.T) {
@@ -294,16 +294,12 @@ func TestConfidentialModule_Execute(t *testing.T) {
 		binaryHash := ComputeBinaryHash([]byte("some-binary"))
 		mod := NewConfidentialModule(
 			capReg,
-			"https://example.com/wasm",
 			binaryHash,
 			"wf-abc",
 			"0xowner",
 			"my-workflow",
 			"v2",
-			[]SecretIdentifier{
-				{Key: "K1", Namespace: "ns1"},
-				{Key: "K2"},
-			},
+			stubRetrieveURL("https://presigned.cloudfront.example.com/wasm?sig=abc"),
 			nil,
 			"",
 			lggr,
@@ -326,20 +322,16 @@ func TestConfidentialModule_Execute(t *testing.T) {
 		require.NoError(t, capturedReq.Payload.UnmarshalTo(&confReq))
 
 		assert.Equal(t, "wf-abc", confReq.Execution.WorkflowId)
-		assert.Equal(t, "https://example.com/wasm", confReq.Execution.BinaryUrl)
+		// binary_url is the per-execution minted URL on the request (outside the
+		// hashed WorkflowExecution); the in-hash Execution.binary_url is left unset.
+		assert.Equal(t, "https://presigned.cloudfront.example.com/wasm?sig=abc", confReq.BinaryUrl)
+		assert.Empty(t, confReq.Execution.BinaryUrl)
 		assert.Equal(t, binaryHash, confReq.Execution.BinaryHash)
 
 		// Verify the serialized ExecuteRequest round-trips.
 		var roundTripped sdkpb.ExecuteRequest
 		require.NoError(t, proto.Unmarshal(confReq.Execution.ExecuteRequest, &roundTripped))
 		assert.Equal(t, execReq.GetConfig(), roundTripped.GetConfig())
-
-		// Verify secrets.
-		require.Len(t, confReq.VaultDonSecrets, 2)
-		assert.Equal(t, "K1", confReq.VaultDonSecrets[0].Key)
-		assert.Equal(t, "ns1", confReq.VaultDonSecrets[0].GetNamespace())
-		assert.Equal(t, "K2", confReq.VaultDonSecrets[1].Key)
-		assert.Equal(t, "main", confReq.VaultDonSecrets[1].GetNamespace())
 	})
 }
 

--- a/core/services/workflows/v2/confidential_module_test.go
+++ b/core/services/workflows/v2/confidential_module_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/utils/matches"
 
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
-	storage_service "github.com/smartcontractkit/chainlink-protos/storage-service/go"
 	valuespb "github.com/smartcontractkit/chainlink-protos/cre/go/values/pb"
+	storage_service "github.com/smartcontractkit/chainlink-protos/storage-service/go"
 	wfpb "github.com/smartcontractkit/chainlink-protos/workflows/go/v2"
 )
 


### PR DESCRIPTION
## Why

Confidential workflows need a per-node pre-signed binary URL (each workflow DON
node mints its own with a different AWS signature and expiry). The URL can't
live inside `WorkflowExecution.binary_url` because that's covered by
`ComputeRequest.Hash()` for F+1 quorum.

Adopts the additive `ConfidentialWorkflowRequest.binary_url` from
chainlink-common#2093 (merged). The deprecated `WorkflowExecution.binary_url`
stays in the proto for back-compat but is no longer populated.

## What

- `ConfidentialModule` mints a fresh per-execution URL via
  `NodeService.DownloadArtifact` and sets it on
  `ConfidentialWorkflowRequest.BinaryUrl`.
- `eventHandler` gains a `WithLocationRetriever(fn)` option; `cre.go` wires it
  from `newFetcherServiceV2`'s existing retriever.
- Chainlink-side `vault_don_secrets` handling is dropped. The enclave fetches
  secrets dynamically; proto fields remain unpopulated.

PRIV-389. The CC E2E (`confidential-compute/tests/e2e/`) currently serves WASM
over plain HTTP; wiring a storage-service stub to exercise the minting path is
a tracked follow-up.
