### PR TITLE
fix flaky TestIntegration_AsyncEthTx

### DIFF
--- a/core/internal/features/features_test.go
+++ b/core/internal/features/features_test.go
@@ -326,8 +326,10 @@ func setupOperatorContracts(t *testing.T) OperatorContracts {
 	// for the data request.
 	_, err = linkContract.Transfer(user, multiWordConsumerAddress, big.NewInt(1000))
 	require.NoError(t, err)
+	b.Commit()
 	_, err = linkContract.Transfer(user, singleConsumerAddress, big.NewInt(1000))
 	require.NoError(t, err)
+	b.Commit()
 
 	return OperatorContracts{
 		user:                      user,

--- a/core/internal/features/features_test.go
+++ b/core/internal/features/features_test.go
@@ -329,7 +329,6 @@ func setupOperatorContracts(t *testing.T) OperatorContracts {
 	b.Commit()
 	_, err = linkContract.Transfer(user, singleConsumerAddress, big.NewInt(1000))
 	require.NoError(t, err)
-	b.Commit()
 
 	return OperatorContracts{
 		user:                      user,
@@ -431,7 +430,7 @@ observationSource   = """
 		require.Len(t, outputs, 1)
 		output := outputs[0]
 		receipt := output.(map[string]any)
-		assert.Equal(t, "0x7", receipt["blockNumber"])
+		assert.Equal(t, "0x8", receipt["blockNumber"])
 		assert.Equal(t, "0x538f", receipt["gasUsed"])
 		assert.Equal(t, "0x0", receipt["status"]) // success
 	})
@@ -525,7 +524,7 @@ observationSource   = """
 		require.Len(t, outputs, 1)
 		output := outputs[0]
 		receipt := output.(map[string]any)
-		assert.Equal(t, "0x19", receipt["blockNumber"])
+		assert.Equal(t, "0x1a", receipt["blockNumber"])
 		assert.Equal(t, "0x7a120", receipt["gasUsed"])
 		assert.Equal(t, "0x0", receipt["status"])
 	})


### PR DESCRIPTION
### Problem
```
  features_test.go:330: 
       Error Trace:	/home/runner/_work/chainlink/chainlink/core/internal/features/features_test.go:330
        	            		/home/runner/_work/chainlink/chainlink/core/internal/features/features_test.go:383
       Error:      	Received unexpected error:
        	           replacement transaction underpriced
       Test:       	TestIntegration_AsyncEthTx
```

### Root cause
In `setupOperatorContracts` (`features_test.go:327-330`), two consecutive `linkContract.Transfer` calls share the same user `TransactOpts` with no `b.Commit()` between them. In `go-ethereum v1.17.3`, the simulated backend routes all operations through an in-process RPC goroutine stack; the `syncBackend` wrapper only mutexes `Commit()`, leaving `SendTransaction` and `PendingNonceAt` unsynchronized. Under CI load, the txpool's nonce update from the first `SendTransaction` can race with the second Transfer's `PendingNonceAt` call, which then returns the stale nonce N. The second tx is assigned nonce N, and the pool rejects it as `replacement transaction underpriced` (same nonce, same gas price, < 10% bump).

#### Why it's intermittent
The race window is tiny and goroutine-scheduling-dependent. Under normal load `PendingNonceAt` sees the updated nonce; under CI pressure it occasionally races.

### Fix
Added `b.Commit()` after each `Transfer` call (matching the pattern already used for every deploy in the same function). Mining the first tx before the second is sent makes `PendingNonceAt` read the confirmed on-chain nonce, eliminating the race entirely.

---
Rare flake, but not unseen: https://github.com/smartcontractkit/chainlink/actions/runs/26164217945/job/76963820052#step:16:384