### PR TITLE
chip ingress smoke test: verify PublishBatch via dedicated callback

### DIFF
--- a/system-tests/tests/smoke/cre/chip_ingress_batching_test.go
+++ b/system-tests/tests/smoke/cre/chip_ingress_batching_test.go
@@ -1,11 +1,100 @@
 package cre
 
 import (
+	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/cloudevents/sdk-go/binding/format/protobuf/v2/pb"
+	chippb "github.com/smartcontractkit/chainlink-common/pkg/chipingress/pb"
+
+	crontypes "github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/cron/types"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+	t_helpers "github.com/smartcontractkit/chainlink/system-tests/tests/test-helpers"
 	ttypes "github.com/smartcontractkit/chainlink/system-tests/tests/test-helpers/configuration"
+
+	commonevents "github.com/smartcontractkit/chainlink-protos/workflows/go/common"
+	workflowevents "github.com/smartcontractkit/chainlink-protos/workflows/go/events"
+	"github.com/stretchr/testify/require"
 )
 
-func ExecuteChipIngressBatchingTest(t *testing.T, _ *ttypes.TestEnvironment) {
-	t.Skip("chip ingress batching test is not implemented yet")
+func ExecuteChipIngressBatchingTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
+	t.Helper()
+
+	testLogger := framework.L
+	const workflowFileLocation = "../../../../core/scripts/cre/environment/examples/workflows/cron/main.go"
+
+	userLogsCh := make(chan *workflowevents.UserLogs, 1000)
+	baseMessageCh := make(chan *commonevents.BaseMessage, 1000)
+
+	var publishCalls atomic.Int64
+	var publishBatchCalls atomic.Int64
+	var publishBatchEventCount atomic.Int64
+
+	basePublishFn := t_helpers.GetPublishFn(testLogger, userLogsCh, baseMessageCh)
+
+	// PublishFunc handles individual Publish RPCs.
+	publishFn := func(ctx context.Context, event *pb.CloudEvent) (*chippb.PublishResponse, error) {
+		publishCalls.Add(1)
+		return basePublishFn(ctx, event)
+	}
+
+	// PublishBatchFunc handles PublishBatch RPCs directly, then fans out to basePublishFn per event.
+	publishBatchFn := func(ctx context.Context, batch *chippb.CloudEventBatch) (*chippb.PublishResponse, error) {
+		publishBatchCalls.Add(1)
+		publishBatchEventCount.Add(int64(len(batch.Events)))
+
+		for _, event := range batch.Events {
+			if _, err := basePublishFn(ctx, event); err != nil {
+				return nil, fmt.Errorf("publish batch: event %s: %w", event.GetId(), err)
+			}
+		}
+		return &chippb.PublishResponse{}, nil
+	}
+
+	server := t_helpers.StartChipTestSink(t, publishFn, t_helpers.WithPublishBatchFunc(publishBatchFn))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		t_helpers.ShutdownChipSinkWithDrain(ctx, server, userLogsCh, baseMessageCh)
+	})
+
+	const workflowCount = 3
+	workflowIDs := make([]string, 0, workflowCount)
+	for i := range workflowCount {
+		workflowName := fmt.Sprintf("chip-ingress-batching-%d-%d", i, time.Now().UnixNano())
+		workflowID := t_helpers.CompileAndDeployWorkflow(t, testEnv, testLogger, workflowName, &crontypes.WorkflowConfig{
+			Schedule: "*/30 * * * * *",
+		}, workflowFileLocation)
+		workflowIDs = append(workflowIDs, workflowID)
+	}
+
+	for _, workflowID := range workflowIDs {
+		t_helpers.WatchWorkflowLogs(
+			t,
+			testLogger,
+			userLogsCh,
+			baseMessageCh,
+			t_helpers.WorkflowEngineInitErrorLog,
+			"Amazing workflow user log",
+			4*time.Minute,
+			t_helpers.WithUserLogWorkflowID(workflowID),
+		)
+	}
+
+	// Verify batching occurred.
+	batchCalls := publishBatchCalls.Load()
+	batchEvents := publishBatchEventCount.Load()
+	singleCalls := publishCalls.Load()
+
+	require.Greater(t, batchCalls, int64(0),
+		"expected at least one PublishBatch RPC call, got 0 (single Publish calls: %d)", singleCalls)
+
+	testLogger.Info().
+		Int64("publish_calls", singleCalls).
+		Int64("publish_batch_calls", batchCalls).
+		Int64("publish_batch_events", batchEvents).
+		Msg("CHiP ingress batching verified")
 }

--- a/system-tests/tests/test-helpers/chip-testsink/server.go
+++ b/system-tests/tests/test-helpers/chip-testsink/server.go
@@ -17,6 +17,8 @@ import (
 
 type PublishFn = func(ctx context.Context, event *pb.CloudEvent) (*chippb.PublishResponse, error)
 
+type PublishBatchFn = func(ctx context.Context, batch *chippb.CloudEventBatch) (*chippb.PublishResponse, error)
+
 const listenerReadyTimeout = 5 * time.Second
 
 // Config defines how the test sink listens.
@@ -29,6 +31,10 @@ type Config struct {
 	UpstreamEndpoint string
 
 	PublishFunc PublishFn
+
+	// PublishBatchFunc is called for PublishBatch RPCs when set.
+	// If nil, PublishBatch falls back to calling PublishFunc per event.
+	PublishBatchFunc PublishBatchFn
 
 	// Started optionally receives a signal once the gRPC listener is bound.
 	Started chan<- struct{}
@@ -142,6 +148,10 @@ func (s *Server) PublishBatch(ctx context.Context, batch *chippb.CloudEventBatch
 			log.Printf("failed to forward batch to upstream: %v", err)
 		}
 	}()
+
+	if s.cfg.PublishBatchFunc != nil {
+		return s.cfg.PublishBatchFunc(ctx, batch)
+	}
 
 	for _, event := range batch.Events {
 		if _, err := s.cfg.PublishFunc(ctx, event); err != nil {

--- a/system-tests/tests/test-helpers/chip_testsink_helpers.go
+++ b/system-tests/tests/test-helpers/chip_testsink_helpers.go
@@ -598,17 +598,31 @@ func GetLoggingPublishFn(
 	}
 }
 
+// ChipTestSinkOpt is a functional option for StartChipTestSink.
+type ChipTestSinkOpt func(*chiptestsink.Config)
+
+// WithPublishBatchFunc sets a PublishBatchFunc on the test sink config.
+func WithPublishBatchFunc(fn chiptestsink.PublishBatchFn) ChipTestSinkOpt {
+	return func(cfg *chiptestsink.Config) {
+		cfg.PublishBatchFunc = fn
+	}
+}
+
 // StartChipTestSink boots a per-test CHiP sink on an ephemeral port and registers it with the
 // shared chip ingress router, which owns the default ingress port.
-func StartChipTestSink(t *testing.T, publishFn chiptestsink.PublishFn) ChipSink {
+func StartChipTestSink(t *testing.T, publishFn chiptestsink.PublishFn, opts ...ChipTestSinkOpt) ChipSink {
 	startCh := make(chan struct{}, 1)
 	addrCh := make(chan string, 1)
-	server, sErr := chiptestsink.NewServer(chiptestsink.Config{
+	cfg := chiptestsink.Config{
 		PublishFunc: publishFn,
 		GRPCListen:  "0.0.0.0:0",
 		Started:     startCh,
 		ActualAddr:  addrCh,
-	})
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	server, sErr := chiptestsink.NewServer(cfg)
 	require.NoError(t, sErr, "failed to create new test sink server")
 
 	errCh := make(chan error, 1)


### PR DESCRIPTION
## Summary

Add `PublishBatchFunc` to the CHiP test sink so the smoke test can directly observe `PublishBatch` RPCs without relying on `grpc.Method(ctx)` inspection.

### Changes

- **`chip-testsink/server.go`** — Add `PublishBatchFn` type and `PublishBatchFunc` field to `Config`. When set, `PublishBatch` delegates to it; otherwise falls back to per-event `PublishFunc`.
- **`chip_testsink_helpers.go`** — Add `ChipTestSinkOpt` functional option and `WithPublishBatchFunc` helper. `StartChipTestSink` now accepts variadic opts.
- **`chip_ingress_batching_test.go`** — Use `PublishBatchFunc` to count batch RPCs and total batched events directly. Removes `grpc.Method` string matching.

### Testing

Builds cleanly via `go build ./...` in `system-tests/tests`.