### PR TITLE
move FinalizeLatest inside the tx sending loop

### DIFF
--- a/core/services/ocr2/plugins/functions/integration_tests/v1/internal/testutils.go
+++ b/core/services/ocr2/plugins/functions/integration_tests/v1/internal/testutils.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/freeport"
@@ -617,46 +619,19 @@ func ClientTestRequests(t *testing.T, owner *bind.TransactOpts, b evmtypes.Backe
 		require.NoError(t, err)
 		client.FinalizeLatest(t, b)
 	}
-
 	// validate that all client contracts got correct responses to their requests
-	type pollResult struct {
-		idx    int
-		answer [32]byte
-		err    error
-	}
-	results := make(chan pollResult, len(clientContracts))
+	var wg sync.WaitGroup
 	for i := range clientContracts {
 		ic := i
-		go func() {
-			ticker := time.NewTicker(time.Second)
-			defer ticker.Stop()
-			timer := time.NewTimer(timeout)
-			defer timer.Stop()
-			for {
+		wg.Go(func() {
+			assert.Eventually(t, func() bool {
 				answer, err := clientContracts[ic].Contract.SLastResponse(nil)
 				if err != nil {
-					results <- pollResult{ic, [32]byte{}, err}
-					return
+					return false
 				}
-				if answer == GetExpectedResponse(requestSources[ic]) {
-					results <- pollResult{ic, answer, nil}
-					return
-				}
-				select {
-				case <-ticker.C:
-				case <-timer.C:
-					results <- pollResult{ic, [32]byte{}, fmt.Errorf("contract %d response timed out after %s", ic, timeout)}
-					return
-				}
-			}
-		}()
+				return answer == GetExpectedResponse(requestSources[ic])
+			}, timeout, 1*time.Second, "unexpected response for client contract at index %d", ic)
+		})
 	}
-	// require/gomega assertions call t.FailNow which must run on the test goroutine;
-	// calling them from spawned goroutines panics or behaves unpredictably, so we
-	// poll without assertions in the goroutines and fail here on the main goroutine.
-	for range clientContracts {
-		r := <-results
-		require.NoError(t, r.err)
-		require.Equal(t, GetExpectedResponse(requestSources[r.idx]), r.answer)
-	}
+	wg.Wait()
 }

--- a/core/services/ocr2/plugins/functions/integration_tests/v1/internal/testutils.go
+++ b/core/services/ocr2/plugins/functions/integration_tests/v1/internal/testutils.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"sync"
 	"testing"
 	"time"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
-	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/freeport"
@@ -621,16 +619,44 @@ func ClientTestRequests(t *testing.T, owner *bind.TransactOpts, b evmtypes.Backe
 	}
 
 	// validate that all client contracts got correct responses to their requests
-	var wg sync.WaitGroup
+	type pollResult struct {
+		idx    int
+		answer [32]byte
+		err    error
+	}
+	results := make(chan pollResult, len(clientContracts))
 	for i := range clientContracts {
 		ic := i
-		wg.Go(func() {
-			gomega.NewGomegaWithT(t).Eventually(func() [32]byte {
+		go func() {
+			ticker := time.NewTicker(time.Second)
+			defer ticker.Stop()
+			timer := time.NewTimer(timeout)
+			defer timer.Stop()
+			for {
 				answer, err := clientContracts[ic].Contract.SLastResponse(nil)
-				require.NoError(t, err)
-				return answer
-			}, timeout, 1*time.Second).Should(gomega.Equal(GetExpectedResponse(requestSources[ic])))
-		})
+				if err != nil {
+					results <- pollResult{ic, [32]byte{}, err}
+					return
+				}
+				if answer == GetExpectedResponse(requestSources[ic]) {
+					results <- pollResult{ic, answer, nil}
+					return
+				}
+				select {
+				case <-ticker.C:
+				case <-timer.C:
+					results <- pollResult{ic, [32]byte{}, fmt.Errorf("contract %d response timed out after %s", ic, timeout)}
+					return
+				}
+			}
+		}()
 	}
-	wg.Wait()
+	// require/gomega assertions call t.FailNow which must run on the test goroutine;
+	// calling them from spawned goroutines panics or behaves unpredictably, so we
+	// poll without assertions in the goroutines and fail here on the main goroutine.
+	for range clientContracts {
+		r := <-results
+		require.NoError(t, r.err)
+		require.Equal(t, GetExpectedResponse(requestSources[r.idx]), r.answer)
+	}
 }

--- a/core/services/ocr2/plugins/functions/integration_tests/v1/internal/testutils.go
+++ b/core/services/ocr2/plugins/functions/integration_tests/v1/internal/testutils.go
@@ -603,12 +603,12 @@ func ClientTestRequests(t *testing.T, owner *bind.TransactOpts, b evmtypes.Backe
 	// send requests
 	requestSources := make([][]byte, len(clientContracts))
 	rnd := rand.New(rand.NewSource(666))
-	for i, client := range clientContracts {
+	for i, cc := range clientContracts {
 		requestSources[i] = make([]byte, requestLenBytes)
 		for j := range requestLenBytes {
 			requestSources[i][j] = byte(rnd.Uint32() % 256)
 		}
-		_, err := client.Contract.SendRequest(
+		_, err := cc.Contract.SendRequest(
 			owner,
 			hex.EncodeToString(requestSources[i]),
 			expectedSecrets,
@@ -617,22 +617,20 @@ func ClientTestRequests(t *testing.T, owner *bind.TransactOpts, b evmtypes.Backe
 			donId,
 		)
 		require.NoError(t, err)
+		client.FinalizeLatest(t, b)
 	}
-	client.FinalizeLatest(t, b)
 
 	// validate that all client contracts got correct responses to their requests
 	var wg sync.WaitGroup
 	for i := range clientContracts {
 		ic := i
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			gomega.NewGomegaWithT(t).Eventually(func() [32]byte {
 				answer, err := clientContracts[ic].Contract.SLastResponse(nil)
 				require.NoError(t, err)
 				return answer
 			}, timeout, 1*time.Second).Should(gomega.Equal(GetExpectedResponse(requestSources[ic])))
-		}()
+		})
 	}
 	wg.Wait()
 }


### PR DESCRIPTION
commit after each tx to avoid nonce collisions like this one:
```
Error Trace:	/home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/functions/integration_tests/v1/internal/testutils.go:619
        	            		/home/runner/_work/chainlink/chainlink/core/services/ocr2/plugins/functions/integration_tests/v1/functions_integration_test.go:50
Error:      	Received unexpected error:
         	    replacement transaction underpriced
Test:       	TestIntegration_Functions_MultipleV1Requests_Success
```
MQ failure: https://github.com/smartcontractkit/chainlink/actions/runs/26240637562/job/77225788271