### PR TITLE
add listener before starting the service

### DIFF
--- a/core/services/registrysyncer/v2/syncer_test.go
+++ b/core/services/registrysyncer/v2/syncer_test.go
@@ -530,15 +530,15 @@ func TestSyncer_V2_DBIntegration(t *testing.T) {
 		syncerORM,
 	)
 	require.NoError(t, err)
+	l := &launcher{}
+	syncer.AddListener(l)
+
 	require.NoError(t, syncer.Start(ctx))
 
 	t.Cleanup(func() {
 		syncerORM.Cleanup()
 		require.NoError(t, syncer.Close())
 	})
-
-	l := &launcher{}
-	syncer.AddListener(l)
 
 	// Test that the syncer calls the ORM methods
 	var latestLocalRegistryCalled, addLocalRegistryCalled bool


### PR DESCRIPTION
### Problem
```
syncer_test.go:556: test timed out; channels did not received data
pgtest.go:38: pgtest: txdb connection held for a long time: 13m30s (opened at 2026-05-21T16:54:27Z). If tests are failing or hanging, there might be issues with how you're accessing the DB that lock out others. You can also consider increasing the lock timeout.
sqltest.go:34: 
     Error Trace:	/home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260520194751-11a4f360f4e2/pkg/sqlutil/sqltest/sqltest.go:34
        	            /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:1317
        	            /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:1667
        	            /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2030
        	            /opt/hostedtoolcache/go/1.26.2/x64/src/runtime/panic.go:694
        	            /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:1022
        	            /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:1221
        	            /home/runner/_work/chainlink/chainlink/core/services/registrysyncer/v2/syncer_test.go:556
     Error:      	Received unexpected error:
        	         FATAL: terminating connection due to idle-in-transaction timeout (SQLSTATE 25P03)
     Test:       	TestSyncer_V2_DBIntegration
```
Source: https://github.com/smartcontractkit/chainlink/actions/runs/26240219691/job/77224328330#step:16:586

### Root cause
`TestSyncer_V2_DBIntegration` called `syncer.Start(ctx)` before `syncer.AddListener(l)`. The syncLoop goroutine fires the initial sync immediately on start, hits the `len(s.listeners) == 0` guard in `Sync()`, and noops — never calling `orm.LatestLocalRegistry`. All subsequent 12-second ticks use `isInitialSync=false` and also skip `LatestLocalRegistry`. The test hung on `latestLocalRegistryCh` which could never receive, exhausting the 15-minute CI timeout.

The CI evidence of `AddLocalRegistry` being called (1 of 2 expectations met) confirmed `AddLocalRegistry` was working fine on the ticker ticks, while only `LatestLocalRegistry` was missing.

### Fix
Move `syncer.AddListener(l)` to before `syncer.Start(ctx)` so the initial sync sees the listener and takes the isInitialSync=true path.