### PR TITLE
fix flaky TestCompute_SpendValueRelativeToComputeTime

### DIFF
--- a/core/capabilities/compute/compute_test.go
+++ b/core/capabilities/compute/compute_test.go
@@ -303,18 +303,19 @@ func TestComputeFetch(t *testing.T) {
 func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
 	t.Parallel()
 
-	// because we are using ms precision and test overhead can result in variance, we use a range of 400ms
-	// to apply assertions.
+	// Maximum acceptable WASM execution and goroutine-scheduling overhead above the
+	// artificial gateway delay. Generous enough for loaded CI runners while still
+	// catching runaway regressions.
+	const overheadCap = uint64(1000)
+
 	tests := []struct {
-		time               time.Duration
-		expectedLowerLimit uint64
-		expectedUpperLimit uint64
+		delay time.Duration
 	}{
-		{time.Duration(0), 0, 400},
-		{time.Second, 1000, 1400},
-		{2 * time.Second, 2000, 2400},
-		{2_500 * time.Millisecond, 2500, 2900},
-		{3 * time.Second, 3000, 3400},
+		{0},
+		{time.Second},
+		{2 * time.Second},
+		{2_500 * time.Millisecond},
+		{3 * time.Second},
 	}
 
 	workflowID := "15c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0"
@@ -342,10 +343,10 @@ func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
 		},
 	}
 
-	for idx := range tests {
-		test := tests[idx]
+	for _, test := range tests {
+		test := test
 
-		t.Run(test.time.String(), func(t *testing.T) {
+		t.Run(test.delay.String(), func(t *testing.T) {
 			t.Parallel()
 
 			th := setup(t, defaultConfig)
@@ -366,7 +367,7 @@ func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
 					require.NoError(t, err, "failed to handle gateway message")
 				}).
 				Once().
-				After(test.time)
+				After(test.delay)
 
 			require.NoError(t, th.compute.Start(t.Context()))
 
@@ -378,8 +379,9 @@ func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
 			value, err := strconv.ParseUint(response.Metadata.Metering[0].SpendValue, 10, 64)
 			require.NoError(t, err)
 
-			assert.GreaterOrEqual(t, value, test.expectedLowerLimit)
-			assert.Less(t, value, test.expectedUpperLimit)
+			delayMS := uint64(test.delay.Milliseconds())
+			assert.GreaterOrEqual(t, value, delayMS)
+			assert.Less(t, value, delayMS+overheadCap)
 		})
 	}
 }

--- a/core/capabilities/compute/compute_test.go
+++ b/core/capabilities/compute/compute_test.go
@@ -306,7 +306,7 @@ func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
 	// Maximum acceptable WASM execution and goroutine-scheduling overhead above the
 	// artificial gateway delay. Generous enough for loaded CI runners while still
 	// catching runaway regressions.
-	const overheadCap = uint64(1000)
+	const overheadCap = int64(1000)
 
 	tests := []struct {
 		delay time.Duration
@@ -344,8 +344,6 @@ func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
-
 		t.Run(test.delay.String(), func(t *testing.T) {
 			t.Parallel()
 
@@ -376,12 +374,11 @@ func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
 
 			require.Len(t, response.Metadata.Metering, 1)
 
-			value, err := strconv.ParseUint(response.Metadata.Metering[0].SpendValue, 10, 64)
+			value, err := strconv.ParseInt(response.Metadata.Metering[0].SpendValue, 10, 64)
 			require.NoError(t, err)
 
-			delayMS := uint64(test.delay.Milliseconds())
-			assert.GreaterOrEqual(t, value, delayMS)
-			assert.Less(t, value, delayMS+overheadCap)
+			assert.GreaterOrEqual(t, value, test.delay.Milliseconds())
+			assert.Less(t, value, test.delay.Milliseconds()+overheadCap)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- `TestCompute_SpendValueRelativeToComputeTime` was flaking on loaded CI runners because the `0s` subtest asserted `SpendValue < 400ms` — a performance assertion that broke when WASM execution overhead exceeded that threshold (517ms observed)
- The 400ms window was never a functional requirement; the test's actual goal is to verify `SpendValue` tracks gateway response time proportionally
- Replaced per-case absolute bounds with a shared `overheadCap = 1000ms`: each subtest now asserts `delayMS <= SpendValue < delayMS + overheadCap`

CI failure: https://github.com/smartcontractkit/chainlink/actions/runs/25932659044/job/76230140891#step:16:414