### PR TITLE
[CRE-491] Prepare evmregistry/v21 to be moved to chainlink-evm

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry_test.go
@@ -18,7 +18,6 @@ import (
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 
 	"github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 )
 
 func TestGetActiveUpkeepKeys(t *testing.T) {
@@ -56,7 +55,7 @@ func TestGetActiveUpkeepKeys(t *testing.T) {
 				active: actives,
 			}
 
-			keys, err := rg.GetActiveUpkeepIDs(testutils.Context(t))
+			keys, err := rg.GetActiveUpkeepIDs(t.Context())
 
 			if test.ExpectedErr != nil {
 				assert.ErrorIs(t, err, test.ExpectedErr)
@@ -187,7 +186,7 @@ func TestPollLogs(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			ctx := testutils.Context(t)
+			ctx := t.Context()
 			mp := mocks.NewLogPoller(t)
 
 			if test.LatestBlock != nil {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/autotelemetry21/custom_telemetry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/autotelemetry21/custom_telemetry.go
@@ -11,14 +11,13 @@ import (
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/services"
-
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol"
 	"github.com/smartcontractkit/chainlink/v2/core/services/synchronization/telem"
 	"github.com/smartcontractkit/chainlink/v2/core/static"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 type AutomationCustomTelemetryService struct {
@@ -26,7 +25,7 @@ type AutomationCustomTelemetryService struct {
 	monitoringEndpoint    commontypes.MonitoringEndpoint
 	blockSubscriber       ocr2keepers.BlockSubscriber
 	blockSubChanID        int
-	threadCtrl            utils.ThreadControl
+	threadCtrl            threadcontrol.ThreadControl
 	lggr                  logger.Logger
 	configDigest          [32]byte
 	contractConfigTracker types.ContractConfigTracker
@@ -38,8 +37,8 @@ func NewAutomationCustomTelemetryService(me commontypes.MonitoringEndpoint,
 	lggr logger.Logger, blocksub ocr2keepers.BlockSubscriber, configTracker types.ContractConfigTracker) (*AutomationCustomTelemetryService, error) {
 	return &AutomationCustomTelemetryService{
 		monitoringEndpoint:    me,
-		threadCtrl:            utils.NewThreadControl(),
-		lggr:                  lggr.Named("AutomationCustomTelem"),
+		threadCtrl:            threadcontrol.NewThreadControl(),
+		lggr:                  logger.Named(lggr, "AutomationCustomTelem"),
 		contractConfigTracker: configTracker,
 		blockSubscriber:       blocksub,
 	}, nil

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/autotelemetry21/custom_telemetry_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/autotelemetry21/custom_telemetry_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	evm "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21"
 )
 
@@ -20,7 +20,7 @@ const finality = uint32(4)
 
 func TestNewAutomationCustomTelemetryService(t *testing.T) {
 	me := &MockMonitoringEndpoint{}
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	var hb heads.Broadcaster
 	var lp logpoller.LogPoller
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/block_subscriber.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/block_subscriber.go
@@ -17,7 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol"
 )
 
 const (
@@ -37,7 +37,7 @@ var (
 
 type BlockSubscriber struct {
 	services.StateMachine
-	threadCtrl utils.ThreadControl
+	threadCtrl threadcontrol.ThreadControl
 
 	mu               sync.RWMutex
 	hb               heads.Broadcaster
@@ -64,7 +64,7 @@ var _ ocr2keepers.BlockSubscriber = &BlockSubscriber{}
 
 func NewBlockSubscriber(hb heads.Broadcaster, lp logpoller.LogPoller, finalityDepth uint32, lggr logger.Logger) *BlockSubscriber {
 	return &BlockSubscriber{
-		threadCtrl:       utils.NewThreadControl(),
+		threadCtrl:       threadcontrol.NewThreadControl(),
 		hb:               hb,
 		lp:               lp,
 		headC:            make(chan *types.Head, channelSize),

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/block_subscriber_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/block_subscriber_test.go
@@ -11,14 +11,13 @@ import (
 
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads"
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads/headstest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 
 	"github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 const historySize = 4
@@ -26,7 +25,7 @@ const blockSize = int64(4)
 const finality = uint32(4)
 
 func TestBlockSubscriber_Subscribe(t *testing.T) {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	var hb heads.Broadcaster
 	var lp logpoller.LogPoller
 
@@ -102,7 +101,7 @@ func TestBlockSubscriber_GetBlockRange(t *testing.T) {
 			bs := NewBlockSubscriber(hb, lp, finality, lggr)
 			bs.blockHistorySize = historySize
 			bs.blockSize = blockSize
-			blocks, err := bs.getBlockRange(testutils.Context(t))
+			blocks, err := bs.getBlockRange(t.Context())
 
 			if tc.LatestBlockErr != nil {
 				assert.Equal(t, tc.LatestBlockErr.Error(), err.Error())
@@ -160,7 +159,7 @@ func TestBlockSubscriber_InitializeBlocks(t *testing.T) {
 			bs := NewBlockSubscriber(hb, lp, finality, lggr)
 			bs.blockHistorySize = historySize
 			bs.blockSize = blockSize
-			err := bs.initializeBlocks(testutils.Context(t), tc.Blocks)
+			err := bs.initializeBlocks(t.Context(), tc.Blocks)
 
 			if tc.Error != nil {
 				assert.Equal(t, tc.Error.Error(), err.Error())
@@ -305,7 +304,7 @@ func TestBlockSubscriber_Start(t *testing.T) {
 	bs := NewBlockSubscriber(hb, lp, finality, lggr)
 	bs.blockHistorySize = historySize
 	bs.blockSize = blockSize
-	err := bs.Start(testutils.Context(t))
+	err := bs.Start(t.Context())
 	assert.NoError(t, err)
 
 	h97 := evmtypes.Head{

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/block_subscriber_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/block_subscriber_test.go
@@ -44,7 +44,7 @@ func TestBlockSubscriber_Subscribe(t *testing.T) {
 }
 
 func TestBlockSubscriber_Unsubscribe(t *testing.T) {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	var hb heads.Broadcaster
 	var lp logpoller.LogPoller
 
@@ -62,7 +62,7 @@ func TestBlockSubscriber_Unsubscribe(t *testing.T) {
 }
 
 func TestBlockSubscriber_Unsubscribe_Failure(t *testing.T) {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	var hb heads.Broadcaster
 	var lp logpoller.LogPoller
 
@@ -74,7 +74,7 @@ func TestBlockSubscriber_Unsubscribe_Failure(t *testing.T) {
 }
 
 func TestBlockSubscriber_GetBlockRange(t *testing.T) {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	var hb heads.Broadcaster
 
 	tests := []struct {
@@ -113,7 +113,7 @@ func TestBlockSubscriber_GetBlockRange(t *testing.T) {
 }
 
 func TestBlockSubscriber_InitializeBlocks(t *testing.T) {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	var hb heads.Broadcaster
 
 	tests := []struct {
@@ -176,7 +176,7 @@ func TestBlockSubscriber_InitializeBlocks(t *testing.T) {
 }
 
 func TestBlockSubscriber_BuildHistory(t *testing.T) {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	var hb heads.Broadcaster
 	lp := mocks.NewLogPoller(t)
 
@@ -226,7 +226,7 @@ func TestBlockSubscriber_BuildHistory(t *testing.T) {
 }
 
 func TestBlockSubscriber_Cleanup(t *testing.T) {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	var hb heads.Broadcaster
 	lp := mocks.NewLogPoller(t)
 
@@ -274,7 +274,7 @@ func TestBlockSubscriber_Cleanup(t *testing.T) {
 }
 
 func TestBlockSubscriber_Start(t *testing.T) {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	hb := headstest.NewBroadcaster[*evmtypes.Head, common.Hash](t)
 	hb.On("Subscribe", mock.Anything).Return(&evmtypes.Head{Number: 42}, func() {})
 	lp := mocks.NewLogPoller(t)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core/utils_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core/utils_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 )
 
 func TestUtils_GetTxBlock(t *testing.T) {
@@ -60,7 +59,7 @@ func TestUtils_GetTxBlock(t *testing.T) {
 			}
 		})
 
-		bn, bh, err := GetTxBlock(testutils.Context(t), client, tt.txHash)
+		bn, bh, err := GetTxBlock(t.Context(), client, tt.txHash)
 		if tt.ethCallError != nil {
 			assert.Equal(t, tt.ethCallError, err)
 		} else {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/gasprice/gasprice_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/gasprice/gasprice_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas"
 	gasMocks "github.com/smartcontractkit/chainlink-evm/pkg/gas/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding"
 )
 
@@ -22,7 +22,7 @@ type WrongOffchainConfig struct {
 }
 
 func TestGasPrice_Check(t *testing.T) {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	uid, _ := new(big.Int).SetString("1843548457736589226156809205796175506139185429616502850435279853710366065936", 10)
 
 	tests := []struct {
@@ -83,7 +83,7 @@ func TestGasPrice_Check(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			ctx := testutils.Context(t)
+			ctx := t.Context()
 			ge := gasMocks.NewEvmFeeEstimator(t)
 			if test.FailedToGetFee {
 				ge.On("GetFee", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/block_time_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/block_time_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	lpmocks "github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 )
 
 func TestBlockTimeResolver_BlockTime(t *testing.T) {
@@ -63,7 +62,7 @@ func TestBlockTimeResolver_BlockTime(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := testutils.Context(t)
+			ctx := t.Context()
 
 			lp := new(lpmocks.LogPoller)
 			resolver := newBlockTimeResolver(lp)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
@@ -210,7 +210,7 @@ func TestLogEventBufferV1_Dequeue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			buf := NewLogBuffer(logger.Test(t), uint32(tc.lookback), uint32(tc.args.blockRate), uint32(tc.args.upkeepLimit))
+			buf := NewLogBuffer(logger.Test(t), uint32(tc.lookback), uint32(tc.args.blockRate), uint32(tc.args.upkeepLimit)) //nolint:gosec // G115
 			for id, logs := range tc.logsInBuffer {
 				added, dropped := buf.Enqueue(id, logs...)
 				require.Equal(t, len(logs), added+dropped)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func TestLogEventBufferV1(t *testing.T) {
-	buf := NewLogBuffer(logger.TestLogger(t), 10, 20, 1)
+	buf := NewLogBuffer(logger.Test(t), 10, 20, 1)
 
 	buf.Enqueue(big.NewInt(1),
 		logpoller.Log{BlockNumber: 2, TxHash: common.HexToHash("0x1"), LogIndex: 0},
@@ -33,7 +33,7 @@ func TestLogEventBufferV1(t *testing.T) {
 }
 
 func TestLogEventBufferV1_SyncFilters(t *testing.T) {
-	buf := NewLogBuffer(logger.TestLogger(t), 10, 20, 1)
+	buf := NewLogBuffer(logger.Test(t), 10, 20, 1)
 
 	buf.Enqueue(big.NewInt(1),
 		logpoller.Log{BlockNumber: 2, TxHash: common.HexToHash("0x1"), LogIndex: 0},
@@ -72,7 +72,7 @@ func TestLogEventBufferV1_EnqueueViolations(t *testing.T) {
 	t.Run("enqueuing logs for a block older than latest seen logs a message", func(t *testing.T) {
 		logReceived := false
 		readableLogger := &readableLogger{
-			Logger: logger.TestLogger(t),
+			Logger: logger.Test(t),
 			DebugwFn: func(msg string, keysAndValues ...any) {
 				if msg == "enqueuing logs from a block older than latest seen block" {
 					logReceived = true
@@ -102,7 +102,7 @@ func TestLogEventBufferV1_EnqueueViolations(t *testing.T) {
 	t.Run("enqueuing logs for the same block over multiple calls logs a message", func(t *testing.T) {
 		logReceived := false
 		readableLogger := &readableLogger{
-			Logger: logger.TestLogger(t),
+			Logger: logger.Test(t),
 			DebugwFn: func(msg string, keysAndValues ...any) {
 				if msg == "enqueuing logs again for a previously seen block" {
 					logReceived = true
@@ -210,7 +210,7 @@ func TestLogEventBufferV1_Dequeue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			buf := NewLogBuffer(logger.TestLogger(t), uint32(tc.lookback), uint32(tc.args.blockRate), uint32(tc.args.upkeepLimit))
+			buf := NewLogBuffer(logger.Test(t), uint32(tc.lookback), uint32(tc.args.blockRate), uint32(tc.args.upkeepLimit))
 			for id, logs := range tc.logsInBuffer {
 				added, dropped := buf.Enqueue(id, logs...)
 				require.Equal(t, len(logs), added+dropped)
@@ -324,7 +324,7 @@ func TestLogEventBufferV1_Enqueue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			buf := NewLogBuffer(logger.TestLogger(t), tc.lookback, tc.blockRate, tc.upkeepLimit)
+			buf := NewLogBuffer(logger.Test(t), tc.lookback, tc.blockRate, tc.upkeepLimit)
 			for id, logs := range tc.logsToAdd {
 				added, dropped := buf.Enqueue(id, logs...)
 				sid := id.String()
@@ -348,7 +348,7 @@ func TestLogEventBufferV1_Enqueue(t *testing.T) {
 
 func TestLogEventBufferV1_UpkeepQueue(t *testing.T) {
 	t.Run("enqueue dequeue", func(t *testing.T) {
-		q := newUpkeepLogQueue(logger.TestLogger(t), big.NewInt(1), newLogBufferOptions(10, 1, 1))
+		q := newUpkeepLogQueue(logger.Test(t), big.NewInt(1), newLogBufferOptions(10, 1, 1))
 
 		added, dropped := q.enqueue(10, logpoller.Log{BlockNumber: 20, TxHash: common.HexToHash("0x1"), LogIndex: 0})
 		require.Equal(t, 0, dropped)
@@ -360,7 +360,7 @@ func TestLogEventBufferV1_UpkeepQueue(t *testing.T) {
 	})
 
 	t.Run("enqueue with limits", func(t *testing.T) {
-		q := newUpkeepLogQueue(logger.TestLogger(t), big.NewInt(1), newLogBufferOptions(10, 1, 1))
+		q := newUpkeepLogQueue(logger.Test(t), big.NewInt(1), newLogBufferOptions(10, 1, 1))
 
 		added, dropped := q.enqueue(10,
 			createDummyLogSequence(15, 0, 20, common.HexToHash("0x20"))...,
@@ -370,7 +370,7 @@ func TestLogEventBufferV1_UpkeepQueue(t *testing.T) {
 	})
 
 	t.Run("dequeue with limits", func(t *testing.T) {
-		q := newUpkeepLogQueue(logger.TestLogger(t), big.NewInt(1), newLogBufferOptions(10, 1, 3))
+		q := newUpkeepLogQueue(logger.Test(t), big.NewInt(1), newLogBufferOptions(10, 1, 3))
 
 		added, dropped := q.enqueue(10,
 			logpoller.Log{BlockNumber: 20, TxHash: common.HexToHash("0x1"), LogIndex: 0},
@@ -388,13 +388,13 @@ func TestLogEventBufferV1_UpkeepQueue(t *testing.T) {
 
 func TestLogEventBufferV1_UpkeepQueue_sizeOfRange(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		q := newUpkeepLogQueue(logger.TestLogger(t), big.NewInt(1), newLogBufferOptions(10, 1, 1))
+		q := newUpkeepLogQueue(logger.Test(t), big.NewInt(1), newLogBufferOptions(10, 1, 1))
 
 		require.Equal(t, 0, q.sizeOfRange(1, 10))
 	})
 
 	t.Run("happy path", func(t *testing.T) {
-		q := newUpkeepLogQueue(logger.TestLogger(t), big.NewInt(1), newLogBufferOptions(10, 1, 1))
+		q := newUpkeepLogQueue(logger.Test(t), big.NewInt(1), newLogBufferOptions(10, 1, 1))
 
 		added, dropped := q.enqueue(10, logpoller.Log{BlockNumber: 20, TxHash: common.HexToHash("0x1"), LogIndex: 0})
 		require.Equal(t, 0, dropped)
@@ -406,13 +406,13 @@ func TestLogEventBufferV1_UpkeepQueue_sizeOfRange(t *testing.T) {
 
 func TestLogEventBufferV1_UpkeepQueue_clean(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		q := newUpkeepLogQueue(logger.TestLogger(t), big.NewInt(1), newLogBufferOptions(10, 1, 1))
+		q := newUpkeepLogQueue(logger.Test(t), big.NewInt(1), newLogBufferOptions(10, 1, 1))
 
 		q.clean(10)
 	})
 
 	t.Run("happy path", func(t *testing.T) {
-		buf := NewLogBuffer(logger.TestLogger(t), 10, 5, 1)
+		buf := NewLogBuffer(logger.Test(t), 10, 5, 1)
 
 		buf.Enqueue(big.NewInt(1),
 			logpoller.Log{BlockNumber: 2, TxHash: common.HexToHash("0x1"), LogIndex: 0},

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/integration_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/integration_test.go
@@ -12,13 +12,15 @@ import (
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/quarantine"
 
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/log_upkeep_counter_wrapper"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	evmclient "github.com/smartcontractkit/chainlink-evm/pkg/client"
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads/headstest"
@@ -26,10 +28,7 @@ import (
 	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/log_upkeep_counter_wrapper"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	evmregistry21 "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider"
@@ -37,7 +36,7 @@ import (
 )
 
 func TestIntegration_LogEventProvider(t *testing.T) {
-	ctx, cancel := context.WithCancel(testutils.Context(t))
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	backend, stopMining, accounts := setupBackend(t)
@@ -53,7 +52,7 @@ func TestIntegration_LogEventProvider(t *testing.T) {
 
 	lp, ethClient := setupDependencies(t, db, backend)
 	filterStore := logprovider.NewUpkeepFilterStore()
-	provider, _ := setup(logger.TestLogger(t), lp, nil, nil, filterStore, &opts)
+	provider, _ := setup(logger.Test(t), lp, nil, nil, filterStore, &opts)
 	logProvider := provider.(logprovider.LogEventProviderTest)
 
 	n := 10
@@ -93,7 +92,7 @@ func TestIntegration_LogEventProvider(t *testing.T) {
 		// assuming that our service was closed and restarted,
 		// we should be able to backfill old logs and fetch new ones
 		filterStore := logprovider.NewUpkeepFilterStore()
-		logProvider2 := logprovider.NewLogProvider(logger.TestLogger(t), lp, big.NewInt(1), logprovider.NewLogEventsPacker(), filterStore, opts)
+		logProvider2 := logprovider.NewLogProvider(logger.Test(t), lp, big.NewInt(1), logprovider.NewLogEventsPacker(), filterStore, opts)
 
 		poll(backend.Commit())
 		go func() {
@@ -127,7 +126,7 @@ func TestIntegration_LogEventProvider(t *testing.T) {
 
 func TestIntegration_LogEventProvider_UpdateConfig(t *testing.T) {
 	quarantine.Flaky(t, "DX-1779")
-	ctx := testutils.Context(t)
+	ctx := t.Context()
 
 	backend, stopMining, accounts := setupBackend(t)
 	defer stopMining()
@@ -141,7 +140,7 @@ func TestIntegration_LogEventProvider_UpdateConfig(t *testing.T) {
 	}
 	lp, ethClient := setupDependencies(t, db, backend)
 	filterStore := logprovider.NewUpkeepFilterStore()
-	provider, _ := setup(logger.TestLogger(t), lp, nil, nil, filterStore, opts)
+	provider, _ := setup(logger.Test(t), lp, nil, nil, filterStore, opts)
 	logProvider := provider.(logprovider.LogEventProviderTest)
 
 	backend.Commit()
@@ -200,7 +199,7 @@ func TestIntegration_LogEventProvider_UpdateConfig(t *testing.T) {
 }
 
 func TestIntegration_LogEventProvider_Backfill(t *testing.T) {
-	ctx, cancel := context.WithTimeout(testutils.Context(t), testutils.WaitTimeout(t))
+	ctx, cancel := context.WithTimeout(t.Context(), tests.WaitTimeout(t))
 	defer cancel()
 
 	backend, stopMining, accounts := setupBackend(t)
@@ -216,7 +215,7 @@ func TestIntegration_LogEventProvider_Backfill(t *testing.T) {
 
 	lp, ethClient := setupDependencies(t, db, backend)
 	filterStore := logprovider.NewUpkeepFilterStore()
-	provider, _ := setup(logger.TestLogger(t), lp, nil, nil, filterStore, &opts)
+	provider, _ := setup(logger.Test(t), lp, nil, nil, filterStore, &opts)
 	logProvider := provider.(logprovider.LogEventProviderTest)
 
 	n := 10
@@ -253,7 +252,7 @@ func TestIntegration_LogEventProvider_Backfill(t *testing.T) {
 
 func TestIntegration_LogRecoverer_Backfill(t *testing.T) {
 	quarantine.Flaky(t, "DX-1889")
-	ctx := testutils.Context(t)
+	ctx := t.Context()
 
 	backend, stopMining, accounts := setupBackend(t)
 	defer stopMining()
@@ -274,7 +273,7 @@ func TestIntegration_LogRecoverer_Backfill(t *testing.T) {
 	defer func() {
 		logprovider.RecoveryInterval = origDefaultRecoveryInterval
 	}()
-	provider, recoverer := setup(logger.TestLogger(t), lp, nil, &mockUpkeepStateStore{}, filterStore, opts)
+	provider, recoverer := setup(logger.Test(t), lp, nil, &mockUpkeepStateStore{}, filterStore, opts)
 	logProvider := provider.(logprovider.LogEventProviderTest)
 
 	backend.Commit()
@@ -350,7 +349,7 @@ func waitLogProvider(ctx context.Context, t *testing.T, logProvider logprovider.
 		if currentPartition > partition { // make sure we went over all items
 			break
 		}
-		time.Sleep(testutils.TestInterval)
+		time.Sleep(tests.TestInterval)
 	}
 	require.Greater(t, logProvider.CurrentPartitionIdx(), partition,
 		"timed out waiting for log provider to pass partition %d", partition)
@@ -463,8 +462,7 @@ func newPlainLogTriggerConfig(upkeepAddr common.Address) logprovider.LogTriggerC
 
 func setupDependencies(t *testing.T, db *sqlx.DB, backend evmtypes.Backend) (logpoller.LogPollerTest, *evmclient.SimulatedBackendClient) {
 	ethClient := evmclient.NewSimulatedBackendClient(t, backend, big.NewInt(1337))
-	pollerLggr := logger.TestLogger(t)
-	pollerLggr.SetLogLevel(zapcore.WarnLevel)
+	pollerLggr := logger.Test(t)
 	lorm := logpoller.NewORM(big.NewInt(1337), db, pollerLggr)
 	lpOpts := logpoller.Opts{
 		PollPeriod:               100 * time.Millisecond,

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -19,12 +19,12 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
-
 	ac "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/automation_compatible_utils"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol"
 )
 
 var (
@@ -86,7 +86,7 @@ var _ LogEventProviderTest = &logEventProvider{}
 // logEventProvider manages log filters for upkeeps and enables to read the log events.
 type logEventProvider struct {
 	services.StateMachine
-	threadCtrl utils.ThreadControl
+	threadCtrl threadcontrol.ThreadControl
 
 	lggr logger.Logger
 
@@ -109,7 +109,7 @@ type logEventProvider struct {
 
 func NewLogProvider(lggr logger.Logger, poller logpoller.LogPoller, chainID *big.Int, packer LogDataPacker, filterStore UpkeepFilterStore, opts LogTriggersOptions) *logEventProvider {
 	return &logEventProvider{
-		threadCtrl:  utils.NewThreadControl(),
+		threadCtrl:  threadcontrol.NewThreadControl(),
 		lggr:        logger.Named(lggr, "KeepersRegistry.LogEventProvider"),
 		packer:      packer,
 		buffer:      NewLogBuffer(lggr, uint32(opts.LookbackBlocks), opts.BlockRate, opts.LogLimit),

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_life_cycle_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_life_cycle_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
+
 	"github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
 )
 
@@ -101,11 +101,11 @@ func TestLogEventProvider_LifeCycle(t *testing.T) {
 		},
 	}
 
-	p := NewLogProvider(logger.TestLogger(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
+	p := NewLogProvider(logger.Test(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := testutils.Context(t)
+			ctx := t.Context()
 
 			if tc.mockPoller {
 				lp := mocks.NewLogPoller(t)
@@ -140,14 +140,14 @@ func TestLogEventProvider_LifeCycle(t *testing.T) {
 }
 
 func TestEventLogProvider_RefreshActiveUpkeeps(t *testing.T) {
-	ctx := testutils.Context(t)
+	ctx := t.Context()
 	mp := mocks.NewLogPoller(t)
 	mp.On("RegisterFilter", mock.Anything, mock.Anything).Return(nil)
 	mp.On("HasFilter", mock.Anything).Return(false)
 	mp.On("LatestBlock", mock.Anything).Return(logpoller.Block{}, nil)
 	mp.On("ReplayAsync", mock.Anything).Return(nil)
 
-	p := NewLogProvider(logger.TestLogger(t), mp, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
+	p := NewLogProvider(logger.Test(t), mp, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
 
 	require.NoError(t, p.RegisterFilter(ctx, FilterOptions{
 		UpkeepID: core.GenUpkeepID(types.LogTrigger, "1111").BigInt(),
@@ -226,7 +226,7 @@ func TestLogEventProvider_ValidateLogTriggerConfig(t *testing.T) {
 		},
 	}
 
-	p := NewLogProvider(logger.TestLogger(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
+	p := NewLogProvider(logger.Test(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := p.validateLogTriggerConfig(tc.cfg)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -16,14 +16,14 @@ import (
 
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
+
 	"github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func TestLogEventProvider_GetFilters(t *testing.T) {
-	p := NewLogProvider(logger.TestLogger(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
+	p := NewLogProvider(logger.Test(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
 
 	_, f := newEntry(p, 1)
 	p.filterStore.AddActiveUpkeeps(f)
@@ -65,7 +65,7 @@ func TestLogEventProvider_GetFilters(t *testing.T) {
 }
 
 func TestLogEventProvider_UpdateEntriesLastPoll(t *testing.T) {
-	p := NewLogProvider(logger.TestLogger(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
+	p := NewLogProvider(logger.Test(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
 
 	n := 10
 
@@ -175,13 +175,13 @@ func TestLogEventProvider_ScheduleReadJobs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := testutils.Context(t)
+			ctx := t.Context()
 
 			readInterval := 10 * time.Millisecond
 			opts := NewOptions(200, big.NewInt(1))
 			opts.ReadInterval = readInterval
 
-			p := NewLogProvider(logger.TestLogger(t), mp, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), opts)
+			p := NewLogProvider(logger.Test(t), mp, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), opts)
 
 			var ids []*big.Int
 			for i, id := range tc.ids {
@@ -239,7 +239,7 @@ func TestLogEventProvider_ScheduleReadJobs(t *testing.T) {
 }
 
 func TestLogEventProvider_ReadLogs(t *testing.T) {
-	ctx := testutils.Context(t)
+	ctx := t.Context()
 
 	mp := mocks.NewLogPoller(t)
 
@@ -256,7 +256,7 @@ func TestLogEventProvider_ReadLogs(t *testing.T) {
 	}, nil).Maybe()
 
 	filterStore := NewUpkeepFilterStore()
-	p := NewLogProvider(logger.TestLogger(t), mp, big.NewInt(1), &mockedPacker{}, filterStore, NewOptions(200, big.NewInt(1)))
+	p := NewLogProvider(logger.Test(t), mp, big.NewInt(1), &mockedPacker{}, filterStore, NewOptions(200, big.NewInt(1)))
 
 	for i := range 10 {
 		cfg, f := newEntry(p, i+1)
@@ -326,7 +326,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 			},
 		}
 
-		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
+		provider := NewLogProvider(logger.Test(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
 		ctx := t.Context()
 
@@ -344,7 +344,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 			},
 		}
 
-		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
+		provider := NewLogProvider(logger.Test(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
 		ctx := t.Context()
 
@@ -366,7 +366,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 			},
 		}
 
-		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
+		provider := NewLogProvider(logger.Test(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
 		ctx := t.Context()
 
@@ -391,7 +391,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 			},
 		}
 
-		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
+		provider := NewLogProvider(logger.Test(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
 		ctx := t.Context()
 
@@ -419,7 +419,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 			},
 		}
 
-		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
+		provider := NewLogProvider(logger.Test(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
 		ctx := t.Context()
 
@@ -470,7 +470,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 			},
 		}
 
-		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
+		provider := NewLogProvider(logger.Test(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
 		ctx := t.Context()
 
@@ -529,7 +529,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 			},
 		}
 
-		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
+		provider := NewLogProvider(logger.Test(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
 		ctx := t.Context()
 
@@ -583,7 +583,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 			},
 		}
 
-		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
+		provider := NewLogProvider(logger.Test(t), logPoller, big.NewInt(42161), &mockedPacker{}, nil, opts)
 
 		ctx := t.Context()
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer.go
@@ -17,18 +17,18 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/random"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
-
-	"github.com/smartcontractkit/chainlink-automation/pkg/v3/random"
-	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
-
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol"
 )
 
 var (
@@ -69,7 +69,7 @@ type visitedRecord struct {
 
 type logRecoverer struct {
 	services.StateMachine
-	threadCtrl utils.ThreadControl
+	threadCtrl threadcontrol.ThreadControl
 
 	lggr logger.SugaredLogger
 
@@ -98,7 +98,7 @@ func NewLogRecoverer(lggr logger.Logger, poller logpoller.LogPoller, client clie
 	rec := &logRecoverer{
 		lggr: logger.Sugared(lggr).Named(LogRecovererServiceName),
 
-		threadCtrl: utils.NewThreadControl(),
+		threadCtrl: threadcontrol.NewThreadControl(),
 
 		blockTime:      new(atomic.Int64),
 		lookbackBlocks: new(atomic.Int64),

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer_test.go
@@ -18,21 +18,21 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
+
 	lpmocks "github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core/mocks"
 )
 
 func TestLogRecoverer_GetRecoverables(t *testing.T) {
-	ctx := testutils.Context(t)
+	ctx := t.Context()
 	lp := &lpmocks.LogPoller{}
 	lp.On("LatestBlock", mock.Anything).Return(logpoller.Block{BlockNumber: 100}, nil)
-	r := NewLogRecoverer(logger.TestLogger(t), lp, nil, nil, nil, nil, NewOptions(200, big.NewInt(1)))
+	r := NewLogRecoverer(logger.Test(t), lp, nil, nil, nil, nil, NewOptions(200, big.NewInt(1)))
 
 	tests := []struct {
 		name    string
@@ -173,7 +173,7 @@ func TestLogRecoverer_Clean(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(testutils.Context(t))
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			lookbackBlocks := int64(100)
@@ -212,7 +212,7 @@ func TestLogRecoverer_Clean(t *testing.T) {
 }
 
 func TestLogRecoverer_Recover(t *testing.T) {
-	ctx := testutils.Context(t)
+	ctx := t.Context()
 
 	tests := []struct {
 		name             string
@@ -1077,7 +1077,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 				recoverer.states = tc.stateReader
 			}
 
-			b, err := recoverer.GetProposalData(testutils.Context(t), tc.proposal)
+			b, err := recoverer.GetProposalData(t.Context(), tc.proposal)
 			if tc.expectErr {
 				assert.Error(t, err)
 				assert.Equal(t, tc.wantErr.Error(), err.Error())
@@ -1150,7 +1150,7 @@ func TestLogRecoverer_pending(t *testing.T) {
 				maxPendingPayloadsPerUpkeep = origMaxPendingPayloadsPerUpkeep
 			}()
 
-			r := NewLogRecoverer(logger.TestLogger(t), nil, nil, nil, nil, nil, NewOptions(200, big.NewInt(1)))
+			r := NewLogRecoverer(logger.Test(t), nil, nil, nil, nil, nil, NewOptions(200, big.NewInt(1)))
 			r.lock.Lock()
 			r.pending = tc.exist
 			for i, p := range tc.new {
@@ -1234,6 +1234,6 @@ func setupTestRecoverer(t *testing.T, interval time.Duration, lookbackBlocks int
 	opts := NewOptions(lookbackBlocks, big.NewInt(1))
 	opts.ReadInterval = interval / 5
 	opts.LookbackBlocks = lookbackBlocks
-	recoverer := NewLogRecoverer(logger.TestLogger(t), lp, nil, statesReader, &mockedPacker{}, filterStore, opts)
+	recoverer := NewLogRecoverer(logger.Test(t), lp, nil, statesReader, &mockedPacker{}, filterStore, opts)
 	return recoverer, filterStore, lp, statesReader
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/streams/streams.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/streams/streams.go
@@ -20,15 +20,15 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
-
 	autov2common "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/i_automation_v21_plus_common"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury"
 	v02 "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v02"
 	v03 "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v03"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol"
 )
 
 const (
@@ -62,7 +62,7 @@ type streams struct {
 	registry        streamRegistry
 	client          contextCaller
 	lggr            logger.Logger
-	threadCtrl      utils.ThreadControl
+	threadCtrl      threadcontrol.ThreadControl
 	v02Client       mercury.MercuryClient
 	v03Client       mercury.MercuryClient
 }
@@ -80,7 +80,7 @@ func NewStreamsLookup(
 	registry streamRegistry,
 	lggr logger.Logger) *streams {
 	httpClient := http.DefaultClient
-	threadCtrl := utils.NewThreadControl()
+	threadCtrl := threadcontrol.NewThreadControl()
 	packer := mercury.NewAbiPacker()
 
 	return &streams{

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/streams/streams_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/streams/streams_test.go
@@ -12,27 +12,24 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
+	autov2common "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/i_automation_v21_plus_common"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury"
 	v02 "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v02"
 	v03 "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v03"
-
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/mock"
-
-	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
-
-	autov2common "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/i_automation_v21_plus_common"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 type MockMercuryConfigProvider struct {
@@ -103,7 +100,7 @@ func (r *mockRegistry) CheckCallback(opts *bind.CallOpts, id *big.Int, values []
 
 // setups up a streams object for tests.
 func setupStreams(t *testing.T) *streams {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	mercuryConfig := new(MockMercuryConfigProvider)
 	blockSubscriber := new(MockBlockSubscriber)
 	registry := &mockRegistry{}
@@ -255,7 +252,7 @@ func TestStreams_CheckErrorHandler(t *testing.T) {
 				}).Once()
 			s.client = client
 
-			err = s.CheckErrorHandler(testutils.Context(t), tt.errCode, tt.lookup, tt.checkResults, 0)
+			err = s.CheckErrorHandler(t.Context(), tt.errCode, tt.lookup, tt.checkResults, 0)
 			tt.wantErr(t, err, fmt.Sprintf("Error assertion failed: %v", tt.name))
 			assert.Equal(t, uint8(tt.state), tt.checkResults[0].PipelineExecutionState)
 			assert.Equal(t, tt.retryable, tt.checkResults[0].Retryable)
@@ -410,7 +407,7 @@ func TestStreams_CheckCallback(t *testing.T) {
 				}).Once()
 			s.client = client
 
-			err = s.CheckCallback(testutils.Context(t), tt.values, tt.lookup, tt.input, 0)
+			err = s.CheckCallback(t.Context(), tt.values, tt.lookup, tt.input, 0)
 			tt.wantErr(t, err, fmt.Sprintf("Error assertion failed: %v", tt.name))
 			assert.Equal(t, uint8(tt.state), tt.input[0].PipelineExecutionState)
 			assert.Equal(t, tt.retryable, tt.input[0].Retryable)
@@ -966,7 +963,7 @@ func TestStreams_StreamsLookup(t *testing.T) {
 					}).Once()
 			}
 
-			got := s.Lookup(testutils.Context(t), tt.input)
+			got := s.Lookup(t.Context(), tt.input)
 			assert.Equal(t, tt.expectedResults, got, tt.name)
 		})
 	}

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v02/request.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v02/request.go
@@ -22,7 +22,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol"
 )
 
 const (
@@ -43,11 +43,11 @@ type client struct {
 	services.StateMachine
 	mercuryConfig mercury.MercuryConfigProvider
 	httpClient    mercury.HttpClient
-	threadCtrl    utils.ThreadControl
+	threadCtrl    threadcontrol.ThreadControl
 	lggr          logger.Logger
 }
 
-func NewClient(mercuryConfig mercury.MercuryConfigProvider, httpClient mercury.HttpClient, threadCtrl utils.ThreadControl, lggr logger.Logger) *client {
+func NewClient(mercuryConfig mercury.MercuryConfigProvider, httpClient mercury.HttpClient, threadCtrl threadcontrol.ThreadControl, lggr logger.Logger) *client {
 	return &client{
 		mercuryConfig: mercuryConfig,
 		httpClient:    httpClient,

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v02/v02_request_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v02/v02_request_test.go
@@ -17,15 +17,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/patrickmn/go-cache"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol"
 )
 
 const (
@@ -86,10 +85,10 @@ func (mock *MockHttpClient) Do(req *http.Request) (*http.Response, error) {
 
 // setups up a client object for tests.
 func setupClient(t *testing.T) *client {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	mockHttpClient := new(MockHttpClient)
 	mercuryConfig := NewMockMercuryConfigProvider()
-	threadCtl := utils.NewThreadControl()
+	threadCtl := threadcontrol.NewThreadControl()
 
 	client := NewClient(
 		mercuryConfig,
@@ -361,7 +360,7 @@ func TestV02_SingleFeedRequest(t *testing.T) {
 			c.httpClient = hc
 
 			ch := make(chan mercury.MercuryData, 1)
-			c.singleFeedRequest(testutils.Context(t), ch, tt.index, tt.lookup)
+			c.singleFeedRequest(t.Context(), ch, tt.index, tt.lookup)
 
 			m := <-ch
 			assert.Equal(t, tt.index, m.Index)
@@ -609,7 +608,7 @@ func TestV02_DoMercuryRequestV02(t *testing.T) {
 			}
 			c.httpClient = hc
 
-			state, values, errCode, retryable, retryInterval, reqErr := c.DoRequest(testutils.Context(t), tt.lookup, tt.upkeepType, pluginRetryKey)
+			state, values, errCode, retryable, retryInterval, reqErr := c.DoRequest(t.Context(), tt.lookup, tt.upkeepType, pluginRetryKey)
 			assert.Equal(t, tt.expectedValues, values)
 			assert.Equal(t, tt.expectedRetryable, retryable)
 			if retryable {
@@ -662,7 +661,7 @@ func TestV02_DoMercuryRequestV02_MultipleFeedsSuccess(t *testing.T) {
 		UpkeepId: upkeepId,
 	}
 
-	state, _, errCode, retryable, retryInterval, _ := c.DoRequest(testutils.Context(t), lookup, automationTypes.ConditionTrigger, pluginRetryKey)
+	state, _, errCode, retryable, retryInterval, _ := c.DoRequest(t.Context(), lookup, automationTypes.ConditionTrigger, pluginRetryKey)
 	assert.False(t, retryable)
 	assert.Equal(t, 0*time.Second, retryInterval)
 	assert.Equal(t, encoding.ErrCodeNil, errCode)
@@ -714,7 +713,7 @@ func TestV02_DoMercuryRequestV02_Timeout(t *testing.T) {
 	}
 
 	start := time.Now()
-	state, values, errCode, retryable, retryInterval, _ := c.DoRequest(testutils.Context(t), lookup, automationTypes.ConditionTrigger, pluginRetryKey)
+	state, values, errCode, retryable, retryInterval, _ := c.DoRequest(t.Context(), lookup, automationTypes.ConditionTrigger, pluginRetryKey)
 	elapsed := time.Since(start)
 	assert.Less(t, elapsed, serverTimeout)
 	assert.False(t, retryable)
@@ -764,7 +763,7 @@ func TestV02_DoMercuryRequestV02_OneFeedSuccessOneFeedPipelineError(t *testing.T
 		UpkeepId: upkeepId,
 	}
 
-	state, values, errCode, retryable, retryInterval, _ := c.DoRequest(testutils.Context(t), lookup, automationTypes.LogTrigger, pluginRetryKey)
+	state, values, errCode, retryable, retryInterval, _ := c.DoRequest(t.Context(), lookup, automationTypes.LogTrigger, pluginRetryKey)
 	assert.True(t, retryable)
 	assert.Equal(t, 1*time.Second, retryInterval)
 	assert.Equal(t, encoding.ErrCodeStreamsServiceUnavailable, errCode)
@@ -812,7 +811,7 @@ func TestV02_DoMercuryRequestV02_OneFeedSuccessOneFeedErrCode(t *testing.T) {
 		UpkeepId: upkeepId,
 	}
 
-	state, values, errCode, retryable, retryInterval, _ := c.DoRequest(testutils.Context(t), lookup, automationTypes.LogTrigger, pluginRetryKey)
+	state, values, errCode, retryable, retryInterval, _ := c.DoRequest(t.Context(), lookup, automationTypes.LogTrigger, pluginRetryKey)
 	assert.Equal(t, [][]byte(nil), values)
 	assert.False(t, retryable)
 	assert.Equal(t, 0*time.Second, retryInterval)
@@ -860,7 +859,7 @@ func TestV02_DoMercuryRequestV02_OneFeedSuccessOneFeedPipelineErrorConvertedErro
 		UpkeepId: upkeepId,
 	}
 
-	state, values, errCode, retryable, retryInterval, _ := c.DoRequest(testutils.Context(t), lookup, automationTypes.ConditionTrigger, pluginRetryKey)
+	state, values, errCode, retryable, retryInterval, _ := c.DoRequest(t.Context(), lookup, automationTypes.ConditionTrigger, pluginRetryKey)
 	assert.False(t, retryable)
 	assert.Equal(t, 0*time.Second, retryInterval)
 	assert.Equal(t, encoding.ErrCodeStreamsStatusGatewayTimeout, errCode)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v03/request.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v03/request.go
@@ -21,7 +21,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol"
 )
 
 const (
@@ -51,11 +51,11 @@ type client struct {
 	services.StateMachine
 	mercuryConfig mercury.MercuryConfigProvider
 	httpClient    mercury.HttpClient
-	threadCtrl    utils.ThreadControl
+	threadCtrl    threadcontrol.ThreadControl
 	lggr          logger.Logger
 }
 
-func NewClient(mercuryConfig mercury.MercuryConfigProvider, httpClient mercury.HttpClient, threadCtrl utils.ThreadControl, lggr logger.Logger) *client {
+func NewClient(mercuryConfig mercury.MercuryConfigProvider, httpClient mercury.HttpClient, threadCtrl threadcontrol.ThreadControl, lggr logger.Logger) *client {
 	return &client{
 		mercuryConfig: mercuryConfig,
 		httpClient:    httpClient,

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v03/v03_request_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/v03/v03_request_test.go
@@ -9,21 +9,19 @@ import (
 	"testing"
 	"time"
 
-	automationTypes "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
-
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	automationTypes "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol"
 )
 
 const (
@@ -84,10 +82,10 @@ func (mock *MockHttpClient) Do(req *http.Request) (*http.Response, error) {
 
 // setups up a client object for tests.
 func setupClient(t *testing.T) *client {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	mockHttpClient := new(MockHttpClient)
 	mercuryConfig := NewMockMercuryConfigProvider()
-	threadCtl := utils.NewThreadControl()
+	threadCtl := threadcontrol.NewThreadControl()
 
 	client := NewClient(
 		mercuryConfig,
@@ -165,7 +163,7 @@ func TestV03_DoMercuryRequestV03(t *testing.T) {
 			}
 			c.httpClient = hc
 
-			state, values, errCode, retryable, retryInterval, reqErr := c.DoRequest(testutils.Context(t), tt.lookup, automationTypes.ConditionTrigger, tt.pluginRetryKey)
+			state, values, errCode, retryable, retryInterval, reqErr := c.DoRequest(t.Context(), tt.lookup, automationTypes.ConditionTrigger, tt.pluginRetryKey)
 
 			assert.Equal(t, tt.expectedValues, values)
 			assert.Equal(t, tt.expectedRetryable, retryable)
@@ -224,7 +222,7 @@ func TestV03_DoMercuryRequestV03_MultipleFeedsSuccess(t *testing.T) {
 		UpkeepId: upkeepId,
 	}
 
-	state, _, errCode, retryable, retryInterval, _ := c.DoRequest(testutils.Context(t), lookup, automationTypes.ConditionTrigger, pluginRetryKey)
+	state, _, errCode, retryable, retryInterval, _ := c.DoRequest(t.Context(), lookup, automationTypes.ConditionTrigger, pluginRetryKey)
 	assert.False(t, retryable)
 	assert.Equal(t, 0*time.Second, retryInterval)
 	assert.Equal(t, encoding.ErrCodeNil, errCode)
@@ -279,7 +277,7 @@ func TestV03_DoMercuryRequestV03_Timeout(t *testing.T) {
 	}
 
 	start := time.Now()
-	state, values, errCode, retryable, retryInterval, _ := c.DoRequest(testutils.Context(t), lookup, automationTypes.ConditionTrigger, pluginRetryKey)
+	state, values, errCode, retryable, retryInterval, _ := c.DoRequest(t.Context(), lookup, automationTypes.ConditionTrigger, pluginRetryKey)
 	elapsed := time.Since(start)
 	assert.Less(t, elapsed, serverTimeout)
 	assert.False(t, retryable)
@@ -338,7 +336,7 @@ func TestV03_DoMercuryRequestV03_OneFeedSuccessOneFeedPipelineError(t *testing.T
 		UpkeepId: upkeepId,
 	}
 
-	state, values, errCode, retryable, retryInterval, _ := c.DoRequest(testutils.Context(t), lookup, automationTypes.LogTrigger, pluginRetryKey)
+	state, values, errCode, retryable, retryInterval, _ := c.DoRequest(t.Context(), lookup, automationTypes.LogTrigger, pluginRetryKey)
 	assert.True(t, retryable)
 	assert.Equal(t, 1*time.Second, retryInterval)
 	assert.Equal(t, encoding.ErrCodeStreamsBadGateway, errCode)
@@ -409,7 +407,7 @@ func TestV03_DoMercuryRequestV03_OneFeedSuccessOneFeedErrCode(t *testing.T) {
 		UpkeepId: upkeepId,
 	}
 
-	state, values, errCode, retryable, retryInterval, _ := c.DoRequest(testutils.Context(t), lookup, automationTypes.LogTrigger, pluginRetryKey)
+	state, values, errCode, retryable, retryInterval, _ := c.DoRequest(t.Context(), lookup, automationTypes.LogTrigger, pluginRetryKey)
 	assert.Equal(t, [][]byte(nil), values)
 	assert.False(t, retryable)
 	assert.Equal(t, 0*time.Second, retryInterval)
@@ -875,7 +873,7 @@ func TestV03_MultiFeedRequest(t *testing.T) {
 			c.httpClient = hc
 
 			ch := make(chan mercury.MercuryData, 1)
-			c.multiFeedsRequest(testutils.Context(t), ch, tt.lookup)
+			c.multiFeedsRequest(t.Context(), ch, tt.lookup)
 
 			m := <-ch
 			assert.Equal(t, 0, m.Index)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/payload_builder_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/payload_builder_test.go
@@ -191,7 +191,7 @@ func TestNewPayloadBuilder(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			lggr, _ := logger.NewLogger()
+			lggr := logger.Test(t)
 			builder := NewPayloadBuilder(tc.activeList, tc.recoverer, lggr)
 			payloads, err := builder.BuildPayloads(t.Context(), tc.proposals...)
 			assert.NoError(t, err)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/payload_builder_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/payload_builder_test.go
@@ -9,10 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider"
 )
@@ -194,7 +193,7 @@ func TestNewPayloadBuilder(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			lggr, _ := logger.NewLogger()
 			builder := NewPayloadBuilder(tc.activeList, tc.recoverer, lggr)
-			payloads, err := builder.BuildPayloads(testutils.Context(t), tc.proposals...)
+			payloads, err := builder.BuildPayloads(t.Context(), tc.proposals...)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.wantPayloads, payloads)
 		})

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry.go
@@ -17,13 +17,11 @@ import (
 	coreTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/patrickmn/go-cache"
 
+	autotypes "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
-
-	autotypes "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
-
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated"
 	ac "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/i_automation_v21_plus_common"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
@@ -31,11 +29,12 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mercury/streams"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol"
 )
 
 const (
@@ -93,7 +92,7 @@ func NewEvmRegistry(
 
 	return &EvmRegistry{
 		stopCh:           make(chan struct{}),
-		threadCtrl:       utils.NewThreadControl(),
+		threadCtrl:       threadcontrol.NewThreadControl(),
 		lggr:             logger.Sugared(lggr).Named(RegistryServiceName),
 		poller:           client.LogPoller(),
 		addr:             addr,
@@ -170,7 +169,7 @@ func (c *MercuryConfig) SetPluginRetry(k string, v any, d time.Duration) {
 
 type EvmRegistry struct {
 	services.StateMachine
-	threadCtrl       utils.ThreadControl
+	threadCtrl       threadcontrol.ThreadControl
 	lggr             logger.SugaredLogger
 	poller           logpoller.LogPoller
 	addr             common.Address

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_check_pipeline_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_check_pipeline_test.go
@@ -27,7 +27,7 @@ import (
 	gasMocks "github.com/smartcontractkit/chainlink-evm/pkg/gas/mocks"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/mocks"
@@ -204,7 +204,7 @@ func TestRegistry_VerifyCheckBlock(t *testing.T) {
 				e.client = client
 			}
 
-			state, retryable := e.verifyCheckBlock(testutils.Context(t), tc.checkBlock, tc.upkeepId, tc.checkHash)
+			state, retryable := e.verifyCheckBlock(t.Context(), tc.checkBlock, tc.upkeepId, tc.checkHash)
 			assert.Equal(t, tc.state, state)
 			assert.Equal(t, tc.retryable, retryable)
 		})
@@ -343,7 +343,7 @@ func TestRegistry_VerifyLogExists(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := testutils.Context(t)
+			ctx := t.Context()
 			bs := &BlockSubscriber{
 				blocks: tc.blocks,
 			}
@@ -529,7 +529,7 @@ func TestRegistry_CheckUpkeeps(t *testing.T) {
 			}
 			e.client = client
 
-			results, err := e.checkUpkeeps(testutils.Context(t), tc.inputs)
+			results, err := e.checkUpkeeps(t.Context(), tc.inputs)
 			assert.Equal(t, tc.results, results)
 			assert.Equal(t, tc.err, err)
 		})
@@ -657,7 +657,7 @@ func TestRegistry_SimulatePerformUpkeeps(t *testing.T) {
 			).Times(2)
 			e.registry = mockReg
 
-			results, err := e.simulatePerformUpkeeps(testutils.Context(t), tc.inputs)
+			results, err := e.simulatePerformUpkeeps(t.Context(), tc.inputs)
 			assert.Equal(t, tc.results, results)
 			assert.Equal(t, tc.err, err)
 		})

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_test.go
@@ -19,15 +19,14 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated"
+	ac "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/automation_compatible_utils"
+	autov2common "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/i_automation_v21_plus_common"
 	evmheads "github.com/smartcontractkit/chainlink-evm/pkg/heads"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated"
-	ac "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/automation_compatible_utils"
-	autov2common "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/i_automation_v21_plus_common"
 	"github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/encoding"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider"
@@ -188,7 +187,7 @@ func TestPollLogs(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			ctx := testutils.Context(t)
+			ctx := t.Context()
 			mp := mocks.NewLogPoller(t)
 
 			if test.LatestBlock != nil {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol/thread_control.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol/thread_control.go
@@ -1,4 +1,4 @@
-package utils
+package threadcontrol
 
 import (
 	"context"

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol/thread_control_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol/thread_control_test.go
@@ -1,4 +1,4 @@
-package utils
+package threadcontrol
 
 import (
 	"context"

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/transmit/event_provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/transmit/event_provider_test.go
@@ -13,24 +13,24 @@ import (
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	ac "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/i_automation_v21_plus_common"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
+
 	"github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
 )
 
 func TestTransmitEventProvider_Sanity(t *testing.T) {
-	ctx := testutils.Context(t)
+	ctx := t.Context()
 
 	lp := mocks.NewLogPoller(t)
 
 	lp.On("RegisterFilter", mock.Anything, mock.Anything).Return(nil)
 
-	provider, err := NewTransmitEventProvider(ctx, logger.TestLogger(t), lp, common.HexToAddress("0x"), client.NewNullClient(big.NewInt(1), logger.TestLogger(t)), 32)
+	provider, err := NewTransmitEventProvider(ctx, logger.Test(t), lp, common.HexToAddress("0x"), client.NewNullClient(big.NewInt(1), logger.Test(t)), 32)
 	require.NoError(t, err)
 	require.NotNil(t, provider)
 
@@ -104,9 +104,9 @@ func TestTransmitEventProvider_ProcessLogs(t *testing.T) {
 	lp := mocks.NewLogPoller(t)
 	lp.On("RegisterFilter", mock.Anything, mock.Anything).Return(nil)
 	client := clienttest.NewClient(t)
-	ctx := testutils.Context(t)
+	ctx := t.Context()
 
-	provider, err := NewTransmitEventProvider(ctx, logger.TestLogger(t), lp, common.HexToAddress("0x"), client, 250)
+	provider, err := NewTransmitEventProvider(ctx, logger.Test(t), lp, common.HexToAddress("0x"), client, 250)
 	require.NoError(t, err)
 
 	id := core.GenUpkeepID(types.LogTrigger, "1111111111111111")

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeep_provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeep_provider_test.go
@@ -10,14 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
-
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
 )
 
 func TestUpkeepProvider_GetActiveUpkeeps(t *testing.T) {
-	ctx := testutils.Context(t)
+	ctx := t.Context()
 
 	var lp logpoller.LogPoller
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/orm_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/orm_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
+
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 )
 
 func TestInsertSelectDelete(t *testing.T) {
-	ctx := testutils.Context(t)
+	ctx := t.Context()
 	chainID := testutils.FixtureChainID
 	db := pgtest.NewSqlxDB(t)
 	orm := NewORM(chainID, db)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/scanner_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/scanner_test.go
@@ -9,17 +9,17 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	ac "github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/i_automation_v21_plus_common"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
+
 	"github.com/smartcontractkit/chainlink/v2/common/logpoller/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func TestPerformedEventsScanner(t *testing.T) {
-	ctx := testutils.Context(t)
+	ctx := t.Context()
 	registryAddr := common.HexToAddress("0x12345")
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 
 	tests := []struct {
 		name           string
@@ -112,9 +112,9 @@ func TestPerformedEventsScanner(t *testing.T) {
 }
 
 func TestPerformedEventsScanner_Batch(t *testing.T) {
-	ctx := testutils.Context(t)
+	ctx := t.Context()
 	registryAddr := common.HexToAddress("0x12345")
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	lp := mocks.NewLogPoller(t)
 	scanner := NewPerformedEventsScanner(lggr, lp, registryAddr, 100)
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/store.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/store.go
@@ -12,9 +12,10 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/threadcontrol"
 )
 
 const (
@@ -61,7 +62,7 @@ type upkeepStateRecord struct {
 // In addition, performed events are fetched by the scanner on demand.
 type upkeepStateStore struct {
 	services.StateMachine
-	threadCtrl utils.ThreadControl
+	threadCtrl threadcontrol.ThreadControl
 
 	orm     ORM
 	lggr    logger.Logger
@@ -87,7 +88,7 @@ func NewUpkeepStateStore(orm ORM, lggr logger.Logger, scanner PerformedLogsScann
 		scanner:        scanner,
 		retention:      CacheExpiration,
 		cleanCadence:   GCInterval,
-		threadCtrl:     utils.NewThreadControl(),
+		threadCtrl:     threadcontrol.NewThreadControl(),
 		pendingRecords: []persistedStateRecord{},
 		sem:            make(chan struct{}, concurrentBatchCalls),
 		batchSize:      batchSize,

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/store_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/store_test.go
@@ -326,7 +326,7 @@ func TestUpkeepStateStore_SetSelectIntegration(t *testing.T) {
 				batchSize = oldFlushSize
 			}()
 
-			lggr, observedLogs := logger.TestLoggerObserved(t, zapcore.ErrorLevel)
+			lggr, observedLogs := logger.TestObserved(t, zapcore.ErrorLevel)
 			chainID := testutils.FixtureChainID
 			db := pgtest.NewSqlxDB(t)
 			realORM := NewORM(chainID, db)
@@ -388,7 +388,7 @@ func (u *upkeepStateStore) clearCache() {
 
 func TestUpkeepStateStore_emptyDB(t *testing.T) {
 	t.Run("querying non-stored workIDs on empty db returns unknown state results", func(t *testing.T) {
-		lggr, observedLogs := logger.TestLoggerObserved(t, zapcore.ErrorLevel)
+		lggr, observedLogs := logger.TestObserved(t, zapcore.ErrorLevel)
 		chainID := testutils.FixtureChainID
 		db := pgtest.NewSqlxDB(t)
 		realORM := NewORM(chainID, db)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/store_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/upkeepstate/store_test.go
@@ -14,10 +14,11 @@ import (
 
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
+
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func TestUpkeepStateStore(t *testing.T) {
@@ -164,8 +165,8 @@ func TestUpkeepStateStore(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := testutils.Context(t)
-			lggr := logger.TestLogger(t)
+			ctx := t.Context()
+			lggr := logger.Test(t)
 
 			scanner := &mockScanner{}
 			scanner.addWorkID(tc.workIDsFromScanner...)
@@ -308,7 +309,7 @@ func TestUpkeepStateStore_SetSelectIntegration(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := testutils.Context(t)
+			ctx := t.Context()
 
 			tickerCh := make(chan time.Time)
 
@@ -404,7 +405,7 @@ func TestUpkeepStateStore_emptyDB(t *testing.T) {
 		scanner := &mockScanner{}
 		store := NewUpkeepStateStore(orm, lggr, scanner)
 
-		states, err := store.SelectByWorkIDs(testutils.Context(t), []string{"0x1", "0x2", "0x3", "0x4"}...)
+		states, err := store.SelectByWorkIDs(t.Context(), []string{"0x1", "0x2", "0x3", "0x4"}...)
 		assert.NoError(t, err)
 		assert.Equal(t, []ocr2keepers.UpkeepState{
 			ocr2keepers.UnknownState,
@@ -421,8 +422,8 @@ func TestUpkeepStateStore_emptyDB(t *testing.T) {
 
 func TestUpkeepStateStore_Upsert(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	ctx := testutils.Context(t)
-	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+	lggr := logger.Test(t)
 	chainID := testutils.FixtureChainID
 	orm := NewORM(chainID, db)
 
@@ -450,7 +451,7 @@ func TestUpkeepStateStore_Upsert(t *testing.T) {
 }
 
 func TestUpkeepStateStore_Service(t *testing.T) {
-	ctx := testutils.Context(t)
+	ctx := t.Context()
 	orm := &mockORM{
 		onDelete: func(tm time.Time) {
 
@@ -458,7 +459,7 @@ func TestUpkeepStateStore_Service(t *testing.T) {
 	}
 	scanner := &mockScanner{}
 
-	store := NewUpkeepStateStore(orm, logger.TestLogger(t), scanner)
+	store := NewUpkeepStateStore(orm, logger.Test(t), scanner)
 
 	store.retention = 500 * time.Millisecond
 	store.cleanCadence = 100 * time.Millisecond


### PR DESCRIPTION
Made the following update:
 - Used `t.Context()` instead of `testutils.Context(t)`
 - Used `logger.Test(t)` from common instead of core's `logger.TestLogger(t)`
 - Used `WithJitter` and `TestTimeout` from common instead of core
 - Moved threadcontrol from utils to its own package under v21 folder.