### PR TITLE
chore: move link state to ccip shared stateview

### DIFF
--- a/deployment/ccip/changeset/cs_grant_and_mint_link_token.go
+++ b/deployment/ccip/changeset/cs_grant_and_mint_link_token.go
@@ -10,8 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
-	evmstate "github.com/smartcontractkit/cld-changesets/legacy/pkg/family/evm"
-
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
@@ -21,6 +19,7 @@ import (
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm"
 	ccipseqs "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+	evmstateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/evm"
 )
 
 var (
@@ -90,7 +89,7 @@ func GrantMintRoleAndMintLogic(e cldf.Environment, cfg GrantMintRoleAndMintConfi
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get addresses for chain %d: %w", cfg.Selector, err)
 	}
 
-	linkState, err := evmstate.MaybeLoadLinkTokenChainState(chain, addresses)
+	linkState, err := evmstateview.MaybeLoadLinkTokenChainState(chain, addresses)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load LINK token state: %w", err)
 	}

--- a/deployment/ccip/shared/stateview/evm/link.go
+++ b/deployment/ccip/shared/stateview/evm/link.go
@@ -1,0 +1,52 @@
+package evm
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	linkviewv10 "github.com/smartcontractkit/cld-changesets/pkg/contract/link/view/v10"
+
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/link_token"
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/types"
+)
+
+type LinkTokenState struct {
+	LinkToken *link_token.LinkToken
+}
+
+func (s LinkTokenState) GenerateLinkView() (linkviewv10.LinkTokenView, error) {
+	if s.LinkToken == nil {
+		return linkviewv10.LinkTokenView{}, errors.New("link token not found")
+	}
+	return linkviewv10.GenerateLinkTokenView(s.LinkToken)
+}
+
+func MaybeLoadLinkTokenChainState(chain cldf_evm.Chain, addresses map[string]cldf.TypeAndVersion) (*LinkTokenState, error) {
+	state := LinkTokenState{}
+	linkToken := cldf.NewTypeAndVersion(types.LinkToken, deployment.Version1_0_0)
+
+	// Convert map keys to a slice
+	wantTypes := []cldf.TypeAndVersion{linkToken}
+
+	// Ensure we either have the bundle or not.
+	_, err := cldf.EnsureDeduped(addresses, wantTypes)
+	if err != nil {
+		return nil, fmt.Errorf("unable to check link token on chain %s error: %w", chain.Name(), err)
+	}
+
+	for address, tvStr := range addresses {
+		if tvStr.Type == linkToken.Type && tvStr.Version.String() == linkToken.Version.String() {
+			lt, err := link_token.NewLinkToken(common.HexToAddress(address), chain.Client)
+			if err != nil {
+				return nil, err
+			}
+			state.LinkToken = lt
+		}
+	}
+	return &state, nil
+}

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -92,7 +92,7 @@ import (
 // on a chain. If a binding is nil, it means there is no such contract on the chain.
 type CCIPChainState struct {
 	evmstate.MCMSWithTimelockState
-	evmstate.LinkTokenState
+	LinkTokenState
 	evmstate.StaticLinkTokenState
 	ABIByAddress       map[string]string
 	OnRamp             onramp.OnRampInterface

--- a/deployment/ccip/shared/stateview/state.go
+++ b/deployment/ccip/shared/stateview/state.go
@@ -1094,7 +1094,7 @@ func LoadChainState(ctx context.Context, chain cldf_evm.Chain, addresses map[str
 	}
 	state.MCMSWithTimelockState = *mcmsWithTimelock
 
-	linkState, err := evmstate.MaybeLoadLinkTokenChainState(chain, addresses)
+	linkState, err := evm.MaybeLoadLinkTokenChainState(chain, addresses)
 	if err != nil {
 		return state, err
 	}

--- a/deployment/common/changeset/test_helpers.go
+++ b/deployment/common/changeset/test_helpers.go
@@ -2,20 +2,13 @@ package changeset
 
 import (
 	"fmt"
-	"math/big"
 	"testing"
 
 	mapset "github.com/deckarep/golang-set/v2"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
-	evmstate "github.com/smartcontractkit/cld-changesets/legacy/pkg/family/evm"
-	"github.com/stretchr/testify/require"
 
 	cldftesthelpers "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils/testhelpers"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-
-	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
@@ -187,44 +180,4 @@ func ApplyChangesets(t *testing.T, e cldf.Environment, changesetApplications []C
 		}
 	}
 	return currentEnv, outputs, nil
-}
-
-func MustFundAddressWithLink(t *testing.T, e cldf.Environment, chain cldf_evm.Chain, to common.Address, amount int64) {
-	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
-	require.NoError(t, err)
-
-	linkState, err := evmstate.MaybeLoadLinkTokenChainState(chain, addresses)
-	require.NoError(t, err)
-	require.NotNil(t, linkState.LinkToken)
-
-	// grant minter permissions - only owner can call this function
-	e.Logger.Info("granting minter permissions for chain", chain.DeployerKey)
-	tx, err := linkState.LinkToken.GrantMintRole(chain.DeployerKey, chain.DeployerKey.From)
-	require.NoError(t, err)
-	_, err = cldf.ConfirmIfNoError(chain, tx, err)
-	require.NoError(t, err)
-
-	// Mint 'To' address some tokens
-	tx, err = linkState.LinkToken.Mint(chain.DeployerKey, to, big.NewInt(amount))
-	require.NoError(t, err)
-	_, err = cldf.ConfirmIfNoError(chain, tx, err)
-	require.NoError(t, err)
-
-	// 'To' address should have the tokens
-	ctx := e.GetContext()
-	endBalance, err := linkState.LinkToken.BalanceOf(&bind.CallOpts{Context: ctx}, to)
-	require.NoError(t, err)
-	expectedBalance := big.NewInt(amount)
-	require.Equal(t, expectedBalance, endBalance)
-}
-
-// MaybeGetLinkBalance returns the LINK balance of the given address on the given chain.
-func MaybeGetLinkBalance(t *testing.T, e cldf.Environment, chain cldf_evm.Chain, linkAddr common.Address) *big.Int {
-	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
-	require.NoError(t, err)
-	linkState, err := evmstate.MaybeLoadLinkTokenChainState(chain, addresses)
-	require.NoError(t, err)
-	endBalance, err := linkState.LinkToken.BalanceOf(&bind.CallOpts{Context: chain.DeployerKey.Context}, linkAddr)
-	require.NoError(t, err)
-	return endBalance
 }


### PR DESCRIPTION
This is a refactor to move the link state to the ccip shared stateview.

CCIP is is the only directory using this helper.
