### PR TITLE
cre-4403: separation of the caching feature flags

### DIFF
--- a/core/config/capabilities_config.go
+++ b/core/config/capabilities_config.go
@@ -48,6 +48,7 @@ type WorkflowStorage interface {
 
 type ModuleCache interface {
 	Enabled() bool
+	DiskMonitorEnabled() bool
 	IdleEviction() bool
 	IdleTimeout() time.Duration
 	MaxLoaded() int

--- a/core/config/docs/core.toml
+++ b/core/config/docs/core.toml
@@ -545,6 +545,10 @@ Name = 'my-workflow-source' # Example
 # Enabled activates the two-level module cache (LRU + disk). When true, compiled WASM modules
 # are kept in memory and persisted to disk, avoiding recompilation on subsequent activations.
 Enabled = false # Default
+# DiskMonitorEnabled exposes platform_workflow_module_cache_disk_usage_bytes for CacheDir without
+# enabling LRU/disk persistence. Set CacheDir to the production path during rollout; then set
+# Enabled = true for the full cache. Enabled = true also starts the disk monitor when this is false.
+DiskMonitorEnabled = false # Default
 # IdleEviction enables time-based eviction of modules unused for IdleTimeout.
 IdleEviction = true # Default
 # IdleTimeout is how long a module can remain idle before being evicted from memory.

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -2339,12 +2339,12 @@ func (a AdditionalWorkflowSource) GetName() string {
 }
 
 type ModuleCache struct {
-	Enabled              *bool
-	DiskMonitorEnabled   *bool
-	IdleEviction         *bool
-	IdleTimeout          *commonconfig.Duration
-	MaxLoaded            *int
-	CacheDir             *string
+	Enabled            *bool
+	DiskMonitorEnabled *bool
+	IdleEviction       *bool
+	IdleTimeout        *commonconfig.Duration
+	MaxLoaded          *int
+	CacheDir           *string
 }
 
 func (m *ModuleCache) setFrom(f *ModuleCache) {
@@ -2852,27 +2852,27 @@ func (t *Tracing) ValidateConfig() (err error) {
 }
 
 type Telemetry struct {
-	Enabled                       *bool
-	CACertFile                    *string
-	Endpoint                      *string
-	InsecureConnection            *bool
-	ResourceAttributes            map[string]string `toml:",omitempty"`
-	TraceSampleRatio              *float64
-	EmitterBatchProcessor         *bool
-	EmitterExportTimeout          *commonconfig.Duration
-	AuthHeadersTTL                *commonconfig.Duration
-	ChipIngressEndpoint           *string
+	Enabled                        *bool
+	CACertFile                     *string
+	Endpoint                       *string
+	InsecureConnection             *bool
+	ResourceAttributes             map[string]string `toml:",omitempty"`
+	TraceSampleRatio               *float64
+	EmitterBatchProcessor          *bool
+	EmitterExportTimeout           *commonconfig.Duration
+	AuthHeadersTTL                 *commonconfig.Duration
+	ChipIngressEndpoint            *string
 	ChipIngressInsecureConnection  *bool
 	ChipIngressBatchEmitterEnabled *bool
 	DurableEmitterEnabled          *bool
 	HeartbeatInterval              *commonconfig.Duration
-	LogLevel                      *string
-	LogStreamingEnabled           *bool
-	LogBatchProcessor             *bool
-	LogExportTimeout              *commonconfig.Duration
-	LogExportMaxBatchSize         *int
-	LogExportInterval             *commonconfig.Duration
-	LogMaxQueueSize               *int
+	LogLevel                       *string
+	LogStreamingEnabled            *bool
+	LogBatchProcessor              *bool
+	LogExportTimeout               *commonconfig.Duration
+	LogExportMaxBatchSize          *int
+	LogExportInterval              *commonconfig.Duration
+	LogMaxQueueSize                *int
 }
 
 func (b *Telemetry) setFrom(f *Telemetry) {

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -2339,16 +2339,20 @@ func (a AdditionalWorkflowSource) GetName() string {
 }
 
 type ModuleCache struct {
-	Enabled      *bool
-	IdleEviction *bool
-	IdleTimeout  *commonconfig.Duration
-	MaxLoaded    *int
-	CacheDir     *string
+	Enabled              *bool
+	DiskMonitorEnabled   *bool
+	IdleEviction         *bool
+	IdleTimeout          *commonconfig.Duration
+	MaxLoaded            *int
+	CacheDir             *string
 }
 
 func (m *ModuleCache) setFrom(f *ModuleCache) {
 	if f.Enabled != nil {
 		m.Enabled = f.Enabled
+	}
+	if f.DiskMonitorEnabled != nil {
+		m.DiskMonitorEnabled = f.DiskMonitorEnabled
 	}
 	if f.IdleEviction != nil {
 		m.IdleEviction = f.IdleEviction

--- a/core/services/chainlink/config_capabilities.go
+++ b/core/services/chainlink/config_capabilities.go
@@ -279,6 +279,13 @@ func (m *moduleCacheConfig) Enabled() bool {
 	return *m.c.Enabled
 }
 
+func (m *moduleCacheConfig) DiskMonitorEnabled() bool {
+	if m.c.DiskMonitorEnabled == nil {
+		return false
+	}
+	return *m.c.DiskMonitorEnabled
+}
+
 func (m *moduleCacheConfig) IdleEviction() bool {
 	if m.c.IdleEviction == nil {
 		return true

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -467,8 +467,9 @@ func TestConfig_Marshal(t *testing.T) {
 				TLSEnabled:          ptr(true),
 			},
 			ModuleCache: toml.ModuleCache{
-				Enabled:      ptr(false),
-				IdleEviction: ptr(true),
+				Enabled:            ptr(false),
+				DiskMonitorEnabled: ptr(false),
+				IdleEviction:       ptr(true),
 				IdleTimeout:  commoncfg.MustNewDuration(10 * time.Minute),
 				MaxLoaded:    ptr(200),
 				CacheDir:     ptr(""),

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -322,6 +322,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -331,6 +331,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -322,6 +322,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -1008,51 +1008,60 @@ func newWorkflowRegistrySyncerV2(
 	}
 
 	mc := capCfg.WorkflowRegistry().ModuleCache()
-	if mc.Enabled() {
-		cm, cmErr := syncerV2.NewCacheMetrics()
-		if cmErr != nil {
-			return nil, nil, fmt.Errorf("unable to create module cache metrics: %w", cmErr)
-		}
+	cacheEnabled := mc.Enabled()
+	diskMonitorEnabled := mc.DiskMonitorEnabled() || cacheEnabled
 
-		fileStore, fsErr := artifactsV2.NewFileModuleStore(mc.CacheDir(), true)
+	if diskMonitorEnabled || cacheEnabled {
+		fileStore, fsErr := artifactsV2.NewFileModuleStore(mc.CacheDir(), cacheEnabled)
 		if fsErr != nil {
 			return nil, nil, fmt.Errorf("unable to create file module store: %w", fsErr)
 		}
 
-		dm, dmErr := diskmonitor.NewDiskMonitor(
-			lggr,
-			fileStore.CacheDir(),
-			syncerV2.GaugeWorkflowModuleCacheDiskUsageBytes,
-			syncerV2.WorkflowModuleCacheDiskMonitorTickInterval,
-		)
-		if dmErr != nil {
-			return nil, nil, fmt.Errorf("unable to create module cache disk monitor: %w", dmErr)
-		}
-		srvcs = append(srvcs, dm)
+		if diskMonitorEnabled {
+			dm, dmErr := diskmonitor.NewDiskMonitor(
+				lggr,
+				fileStore.CacheDir(),
+				syncerV2.GaugeWorkflowModuleCacheDiskUsageBytes,
+				syncerV2.WorkflowModuleCacheDiskMonitorTickInterval,
+			)
+			if dmErr != nil {
+				return nil, nil, fmt.Errorf("unable to create module cache disk monitor: %w", dmErr)
+			}
+			srvcs = append(srvcs, dm)
 
-		lruOpts := []func(*syncerV2.ModuleLRU){
-			syncerV2.WithMaxLoadedModules(mc.MaxLoaded()),
-			syncerV2.WithCacheMetrics(cm),
+			lggr.Infow("Module cache disk monitor enabled", "cacheDir", fileStore.CacheDir())
 		}
-		if mc.IdleEviction() {
-			lruOpts = append(lruOpts, syncerV2.WithIdleTimeout(mc.IdleTimeout()))
-		} else {
-			lruOpts = append(lruOpts, syncerV2.WithIdleTimeout(0))
+
+		if cacheEnabled {
+			cm, cmErr := syncerV2.NewCacheMetrics()
+			if cmErr != nil {
+				return nil, nil, fmt.Errorf("unable to create module cache metrics: %w", cmErr)
+			}
+
+			lruOpts := []func(*syncerV2.ModuleLRU){
+				syncerV2.WithMaxLoadedModules(mc.MaxLoaded()),
+				syncerV2.WithCacheMetrics(cm),
+			}
+			if mc.IdleEviction() {
+				lruOpts = append(lruOpts, syncerV2.WithIdleTimeout(mc.IdleTimeout()))
+			} else {
+				lruOpts = append(lruOpts, syncerV2.WithIdleTimeout(0))
+			}
+			moduleLRU := syncerV2.NewModuleLRU(clockwork.NewRealClock(), lruOpts...)
+
+			handlerOpts = append(handlerOpts,
+				syncerV2.WithModuleLRU(moduleLRU),
+				syncerV2.WithModuleStore(fileStore),
+				syncerV2.WithModuleCacheMetrics(cm),
+			)
+
+			lggr.Infow("Module cache enabled",
+				"idleEviction", mc.IdleEviction(),
+				"idleTimeout", mc.IdleTimeout(),
+				"maxLoaded", mc.MaxLoaded(),
+				"cacheDir", fileStore.CacheDir(),
+			)
 		}
-		moduleLRU := syncerV2.NewModuleLRU(clockwork.NewRealClock(), lruOpts...)
-
-		handlerOpts = append(handlerOpts,
-			syncerV2.WithModuleLRU(moduleLRU),
-			syncerV2.WithModuleStore(fileStore),
-			syncerV2.WithModuleCacheMetrics(cm),
-		)
-
-		lggr.Infow("Module cache enabled",
-			"idleEviction", mc.IdleEviction(),
-			"idleTimeout", mc.IdleTimeout(),
-			"maxLoaded", mc.MaxLoaded(),
-			"cacheDir", mc.CacheDir(),
-		)
 	}
 
 	eventHandler, err := syncerV2.NewEventHandler(

--- a/core/services/cre/cre_test.go
+++ b/core/services/cre/cre_test.go
@@ -34,6 +34,7 @@ func (wfRegStorageStub) TLSEnabled() bool            { return false }
 type wfRegModuleCacheStub struct{}
 
 func (wfRegModuleCacheStub) Enabled() bool              { return false }
+func (wfRegModuleCacheStub) DiskMonitorEnabled() bool   { return false }
 func (wfRegModuleCacheStub) IdleEviction() bool         { return true }
 func (wfRegModuleCacheStub) IdleTimeout() time.Duration { return 10 * time.Minute }
 func (wfRegModuleCacheStub) MaxLoaded() int             { return 200 }

--- a/core/web/resolver/testdata/config-empty-effective.toml
+++ b/core/web/resolver/testdata/config-empty-effective.toml
@@ -322,6 +322,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -332,6 +332,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -322,6 +322,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1525,6 +1525,7 @@ Name is a required unique identifier for this workflow source. Each additional s
 ```toml
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false # Default
+DiskMonitorEnabled = false # Default
 IdleEviction = true # Default
 IdleTimeout = '10m' # Default
 MaxLoaded = 200 # Default
@@ -1538,6 +1539,14 @@ Enabled = false # Default
 ```
 Enabled activates the two-level module cache (LRU + disk). When true, compiled WASM modules
 are kept in memory and persisted to disk, avoiding recompilation on subsequent activations.
+
+### DiskMonitorEnabled
+```toml
+DiskMonitorEnabled = false # Default
+```
+DiskMonitorEnabled exposes platform_workflow_module_cache_disk_usage_bytes for CacheDir without
+enabling LRU/disk persistence. Set CacheDir to the production path during rollout; then set
+Enabled = true for the full cache. Enabled = true also starts the disk monitor when this is false.
 
 ### IdleEviction
 ```toml

--- a/testdata/scripts/config/merge_raw_configs.txtar
+++ b/testdata/scripts/config/merge_raw_configs.txtar
@@ -469,6 +469,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/testdata/scripts/node/validate/default.txtar
+++ b/testdata/scripts/node/validate/default.txtar
@@ -334,6 +334,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/testdata/scripts/node/validate/defaults-override.txtar
+++ b/testdata/scripts/node/validate/defaults-override.txtar
@@ -395,6 +395,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
@@ -378,6 +378,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
@@ -378,6 +378,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/testdata/scripts/node/validate/disk-based-logging.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging.txtar
@@ -378,6 +378,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/testdata/scripts/node/validate/fallback-override.txtar
+++ b/testdata/scripts/node/validate/fallback-override.txtar
@@ -480,6 +480,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
+++ b/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
@@ -363,6 +363,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/testdata/scripts/node/validate/invalid.txtar
+++ b/testdata/scripts/node/validate/invalid.txtar
@@ -374,6 +374,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/testdata/scripts/node/validate/valid.txtar
+++ b/testdata/scripts/node/validate/valid.txtar
@@ -375,6 +375,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200

--- a/testdata/scripts/node/validate/warnings.txtar
+++ b/testdata/scripts/node/validate/warnings.txtar
@@ -357,6 +357,7 @@ TLSEnabled = true
 
 [Capabilities.WorkflowRegistry.ModuleCache]
 Enabled = false
+DiskMonitorEnabled = false
 IdleEviction = true
 IdleTimeout = '10m0s'
 MaxLoaded = 200


### PR DESCRIPTION
separation of feature flags, so that we can observe drive accessibility before enabling caching

[cre-4403](https://smartcontract-it.atlassian.net/browse/cre-4403)