### PR TITLE
cre-4403: (pt.2) extra defensive path writable check

### DIFF
--- a/core/services/workflows/artifacts/v2/file_module_store.go
+++ b/core/services/workflows/artifacts/v2/file_module_store.go
@@ -33,7 +33,27 @@ func NewFileModuleStore(cacheDir string, cleanOnStartup bool) (*FileModuleStore,
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create module cache directory: %w", err)
 	}
+	if err := checkCacheDirWritable(cacheDir); err != nil {
+		return nil, err
+	}
 	return &FileModuleStore{cacheDir: cacheDir}, nil
+}
+
+func checkCacheDirWritable(dir string) error {
+	f, err := os.CreateTemp(dir, ".writecheck-*")
+	if err != nil {
+		return fmt.Errorf("module cache directory is not writable: %w", err)
+	}
+	name := f.Name()
+	defer os.Remove(name)
+	if _, err := f.Write([]byte{0}); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("module cache directory is not writable: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("module cache directory is not writable: %w", err)
+	}
+	return nil
 }
 
 // CacheDir returns the resolved on-disk root for the module cache.

--- a/core/services/workflows/artifacts/v2/file_module_store_test.go
+++ b/core/services/workflows/artifacts/v2/file_module_store_test.go
@@ -168,3 +168,13 @@ func TestFileModuleStore_CacheDir(t *testing.T) {
 		assert.Equal(t, filepath.Join(os.TempDir(), defaultCacheSubdir), s.CacheDir())
 	})
 }
+
+func TestNewFileModuleStore_NotWritable(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	_, err := NewFileModuleStore(dir, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not writable")
+}


### PR DESCRIPTION
extra defensive checks for the path being writable

[cre-4403](https://smartcontract-it.atlassian.net/browse/cre-4403)