### PR TITLE
make the test loop less race'y

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -210,7 +209,7 @@ func TestLogEventProvider_ScheduleReadJobs(t *testing.T) {
 			got := map[string]int{}
 
 		readLoop:
-			for {
+			for len(got) < len(ids) {
 				select {
 				case <-timeoutTicker.C:
 					break readLoop
@@ -220,12 +219,7 @@ func TestLogEventProvider_ScheduleReadJobs(t *testing.T) {
 					}
 				case <-ctx.Done():
 					break readLoop
-				default:
-					if p.CurrentPartitionIdx() > uint64(batches+1) {
-						break readLoop
-					}
 				}
-				runtime.Gosched()
 			}
 
 			require.Len(t, got, len(ids))


### PR DESCRIPTION
### Suspect
Race between Go async preemption and the test's default branch. The select could pick `default` (reads buffer empty), and before `p.CurrentPartitionIdx()` was called — a function-call safe point — the goroutine could be preempted. During that suspension, `scheduleReadJobs` fired all 3 ticks (30ms), incrementing `currentPartitionIdx` to 3 and sending items to reads. On resume, the test loaded `partitionIdx = 3`, broke immediately, and never ran another select — leaving items in reads unconsumed and got empty.

### Fix
Replaced the racy busy-wait `default` case with a blocking loop that exits only when all expected IDs appear in `reads`.
