### PR TITLE
chore: remove deprecated common MCMSWithTimelockState

### DIFF
--- a/deployment/ccip/changeset/save_existing_test.go
+++ b/deployment/ccip/changeset/save_existing_test.go
@@ -5,15 +5,16 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	evmstate "github.com/smartcontractkit/cld-changesets/legacy/pkg/family/evm"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-	changeset2 "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
@@ -138,7 +139,7 @@ func TestSaveExistingMCMSAddressWithLabels(t *testing.T) {
 	require.True(t, exists)
 	require.Len(t, addressForChain1, 1)
 	// load mcms state
-	mcmsState, err := changeset2.MaybeLoadMCMSWithTimelockChainState(dummyEnv.BlockChains.EVMChains()[chainsel.TEST_90000001.Selector], addressForChain1)
+	mcmsState, err := evmstate.MaybeLoadMCMSWithTimelockChainState(dummyEnv.BlockChains.EVMChains()[chainsel.TEST_90000001.Selector], addressForChain1)
 	require.NoError(t, err)
 	require.NotNil(t, mcmsState)
 	require.NotNil(t, mcmsState.ProposerMcm)

--- a/deployment/keystone/changeset/internal/contract_set.go
+++ b/deployment/keystone/changeset/internal/contract_set.go
@@ -8,12 +8,6 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
-type deployContractsRequest struct {
-	chain           cldf_evm.Chain
-	isRegistryChain bool
-	ad              cldf.AddressBook
-}
-
 // DeployCapabilitiesRegistry deploys the CapabilitiesRegistry contract to the chain
 // and saves the address in the address book. This mutates the address book.
 func DeployCapabilitiesRegistry(_ context.Context, chain cldf_evm.Chain, ab cldf.AddressBook) (*DeployResponse, error) {

--- a/deployment/keystone/changeset/internal/state.go
+++ b/deployment/keystone/changeset/internal/state.go
@@ -12,7 +12,6 @@ import (
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal/addrbook"
 
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
@@ -40,7 +39,7 @@ type GetContractSetsResponse struct {
 //
 // TODO: remove after CRE-227
 type ContractSet struct {
-	commonchangeset.MCMSWithTimelockState
+	MCMSWithTimelockState
 	OCR3                 map[common.Address]*ocr3_capability.OCR3Capability
 	Forwarder            *forwarder.KeystoneForwarder
 	CapabilitiesRegistry *capabilities_registry.CapabilitiesRegistry
@@ -94,7 +93,7 @@ func loadContractSet(
 	addresses map[string]cldf.TypeAndVersion,
 ) (*ContractSet, error) {
 	var out ContractSet
-	mcmsWithTimelock, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
+	mcmsWithTimelock, err := MaybeLoadMCMSWithTimelockChainState(chain, addresses)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load mcms contract: %w", err)
 	}

--- a/deployment/keystone/changeset/internal/state_mcms.go
+++ b/deployment/keystone/changeset/internal/state_mcms.go
@@ -1,9 +1,10 @@
-package changeset
+package internal
 
 import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	owner_helpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
-	"github.com/smartcontractkit/chainlink/deployment/common/view/v1_0"
 )
 
 // MCMSWithTimelockState holds the Go bindings
@@ -23,64 +23,6 @@ import (
 // if you are changing this, please make the similar changes in deployment/common/changeset/state
 type MCMSWithTimelockState struct {
 	*cldfproposalutils.MCMSWithTimelockContracts
-}
-
-// Deprecated: use GenerateMCMSWithTimelockView from deployment/common/changeset/state/evm.go instead
-// if you are changing this, please make the similar changes in deployment/common/changeset/state
-func (state MCMSWithTimelockState) GenerateMCMSWithTimelockView() (v1_0.MCMSWithTimelockView, error) {
-	if err := state.Validate(); err != nil {
-		return v1_0.MCMSWithTimelockView{}, err
-	}
-	timelockView, err := v1_0.GenerateTimelockView(*state.Timelock)
-	if err != nil {
-		return v1_0.MCMSWithTimelockView{}, nil
-	}
-	callProxyView, err := v1_0.GenerateCallProxyView(*state.CallProxy)
-	if err != nil {
-		return v1_0.MCMSWithTimelockView{}, nil
-	}
-	bypasserView, err := v1_0.GenerateMCMSView(*state.BypasserMcm)
-	if err != nil {
-		return v1_0.MCMSWithTimelockView{}, nil
-	}
-	proposerView, err := v1_0.GenerateMCMSView(*state.ProposerMcm)
-	if err != nil {
-		return v1_0.MCMSWithTimelockView{}, nil
-	}
-	cancellerView, err := v1_0.GenerateMCMSView(*state.CancellerMcm)
-	if err != nil {
-		return v1_0.MCMSWithTimelockView{}, nil
-	}
-	return v1_0.MCMSWithTimelockView{
-		Timelock:  timelockView,
-		Bypasser:  bypasserView,
-		Proposer:  proposerView,
-		Canceller: cancellerView,
-		CallProxy: callProxyView,
-	}, nil
-}
-
-// MaybeLoadMCMSWithTimelockState loads the MCMSWithTimelockState state for each chain in the given environment.
-// Deprecated: use MaybeLoadMCMSWithTimelockState from deployment/common/changeset/state/evm.go instead
-// if you are changing this, please make the similar changes in deployment/common/changeset/state
-func MaybeLoadMCMSWithTimelockState(env cldf.Environment, chainSelectors []uint64) (map[uint64]*MCMSWithTimelockState, error) {
-	result := map[uint64]*MCMSWithTimelockState{}
-	for _, chainSelector := range chainSelectors {
-		chain, ok := env.BlockChains.EVMChains()[chainSelector]
-		if !ok {
-			return nil, fmt.Errorf("chain %d not found", chainSelector)
-		}
-		addressesChain, err := env.ExistingAddresses.AddressesForChain(chainSelector)
-		if err != nil {
-			return nil, err
-		}
-		state, err := MaybeLoadMCMSWithTimelockChainState(chain, addressesChain)
-		if err != nil {
-			return nil, err
-		}
-		result[chainSelector] = state
-	}
-	return result, nil
 }
 
 // MaybeLoadMCMSWithTimelockChainState looks for the addresses corresponding to

--- a/deployment/keystone/changeset/internal/state_mcms_test.go
+++ b/deployment/keystone/changeset/internal/state_mcms_test.go
@@ -1,4 +1,4 @@
-package changeset
+package internal
 
 import (
 	"testing"

--- a/deployment/keystone/changeset/internal/state_test.go
+++ b/deployment/keystone/changeset/internal/state_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 )
 
 func Test_GetContractSet(t *testing.T) {
@@ -68,7 +67,7 @@ func Test_GetContractSet(t *testing.T) {
 			wantResp: &GetContractSetsResponse{
 				ContractSets: map[uint64]ContractSet{
 					chain.Selector: {
-						MCMSWithTimelockState: commonchangeset.MCMSWithTimelockState{
+						MCMSWithTimelockState: MCMSWithTimelockState{
 							MCMSWithTimelockContracts: &cldfproposalutils.MCMSWithTimelockContracts{},
 						},
 						CapabilitiesRegistry: func() *kcr.CapabilitiesRegistry {
@@ -116,7 +115,7 @@ func Test_GetContractSet(t *testing.T) {
 			wantResp: &GetContractSetsResponse{
 				ContractSets: map[uint64]ContractSet{
 					chain.Selector: {
-						MCMSWithTimelockState: commonchangeset.MCMSWithTimelockState{
+						MCMSWithTimelockState: MCMSWithTimelockState{
 							MCMSWithTimelockContracts: &cldfproposalutils.MCMSWithTimelockContracts{},
 						},
 						CapabilitiesRegistry: func() *kcr.CapabilitiesRegistry {

--- a/deployment/keystone/changeset/state.go
+++ b/deployment/keystone/changeset/state.go
@@ -12,7 +12,6 @@ import (
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal/addrbook"
 
@@ -37,7 +36,7 @@ type GetContractSetsResponse struct {
 }
 
 type ContractSet struct {
-	commonchangeset.MCMSWithTimelockState
+	internal.MCMSWithTimelockState
 	OCR3                 map[common.Address]*ocr3_capability.OCR3Capability
 	Forwarder            *forwarder.KeystoneForwarder
 	CapabilitiesRegistry *capabilities_registry.CapabilitiesRegistry
@@ -46,7 +45,7 @@ type ContractSet struct {
 
 func (cs ContractSet) Convert() internal.ContractSet {
 	return internal.ContractSet{
-		MCMSWithTimelockState: commonchangeset.MCMSWithTimelockState{
+		MCMSWithTimelockState: internal.MCMSWithTimelockState{
 			MCMSWithTimelockContracts: cs.MCMSWithTimelockContracts,
 		},
 		Forwarder:            cs.Forwarder,
@@ -117,7 +116,7 @@ func GetContractSets(lggr logger.Logger, req *GetContractSetsRequest) (*GetContr
 
 func loadContractSet(lggr logger.Logger, chain cldf_evm.Chain, addresses map[string]cldf.TypeAndVersion) (*ContractSet, error) {
 	var out ContractSet
-	mcmsWithTimelock, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
+	mcmsWithTimelock, err := internal.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load mcms contract: %w", err)
 	}

--- a/deployment/vault/changeset/validation.go
+++ b/deployment/vault/changeset/validation.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	chainSel "github.com/smartcontractkit/chain-selectors"
-
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	proposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
+	evmstate "github.com/smartcontractkit/cld-changesets/legacy/pkg/family/evm"
 
-	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
-
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+
 	"github.com/smartcontractkit/chainlink/deployment/vault/changeset/types"
 )
 
@@ -160,7 +160,7 @@ func validateMCMSConfig(e cldf.Environment, mcmsConfig *proposalutils.TimelockCo
 		}
 
 		chain := e.BlockChains.EVMChains()[chainSelector]
-		_, err = changeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
+		_, err = evmstate.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
 		if err != nil {
 			return fmt.Errorf("failed to load MCMS state for chain %d: %w", chainSelector, err)
 		}
@@ -287,7 +287,7 @@ func validateDeployEthBalMonMCMSInDatastore(e cldf.Environment, chainSelector ui
 	}
 
 	chain := e.BlockChains.EVMChains()[chainSelector]
-	_, err = changeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
+	_, err = evmstate.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
 	if err != nil {
 		return fmt.Errorf("failed to load MCMS with timelock state: %w", err)
 	}


### PR DESCRIPTION
Drop the deprecated `MCMSWithTimelockState` and
`MaybeLoadMCMSWithTimelock*` helpers from `deployment/common/changeset`.

The keystone changeset was the last internal consumer, so moved the struct into deployment/keystone/changeset/internal as a private type. Other callers (vault, ccip save_existing_test) now use the canonical `cld-changesets/legacy/pkg/family/evm` package.
