### PR TITLE
PLEX-3032: avoid context deadline when action returns all different p…

### DIFF
--- a/core/capabilities/remote/executable/client_test.go
+++ b/core/capabilities/remote/executable/client_test.go
@@ -179,9 +179,9 @@ func Test_Client_ConsensusFailedIfInsufficientCapabilityPeerResponses(t *testing
 
 	responseTest := func(t *testing.T, response commoncap.CapabilityResponse, responseError error) {
 		var capErr caperrors.Error
-		assert.ErrorAs(t, responseError, &capErr)
-		assert.Equal(t, caperrors.ConsensusFailed, capErr.Code())
-		assert.Contains(t, capErr.Error(), "[100]ConsensusFailed: response quorum unreachable: not enough matching capability responses: received 1/10 peer responses with 1 unique payloads; best match count 1, need 12 (9 responses pending)")
+		require.ErrorAs(t, responseError, &capErr)
+		require.Equal(t, caperrors.ConsensusFailed, capErr.Code())
+		require.Contains(t, capErr.Error(), "[100]ConsensusFailed: response quorum unreachable: not enough matching capability responses: received 1/10 peer responses with 1 unique payloads; best match count 1, need 12 (9 responses pending)")
 	}
 
 	capability := &TestCapability{}

--- a/core/capabilities/remote/executable/client_test.go
+++ b/core/capabilities/remote/executable/client_test.go
@@ -148,6 +148,36 @@ func Test_Client_TimesOutIfInsufficientCapabilityPeerResponses(t *testing.T) {
 	ctx := testutils.Context(t)
 
 	responseTest := func(t *testing.T, response commoncap.CapabilityResponse, responseError error) {
+		assert.ErrorIs(t, responseError, executable.ErrRequestExpired)
+	}
+
+	// Peers respond after requestTimeout; quorum (F+1=4) is still theoretically reachable.
+	capability := &TestSlowExecutionCapability{
+		workflowIDToPause: map[string]time.Duration{
+			workflowID1: 2 * time.Second,
+		},
+	}
+
+	transmissionSchedule, err := values.NewMap(map[string]any{
+		"schedule":   transmission.Schedule_AllAtOnce,
+		"deltaStage": "10ms",
+	})
+	require.NoError(t, err)
+
+	testClient(t, 10, 500*time.Millisecond, 10, 3,
+		capability,
+		func(caller commoncap.ExecutableCapability) {
+			executeInputs, err := values.NewMap(map[string]any{"executeValue1": "aValue1"})
+			if assert.NoError(t, err) {
+				executeMethod(ctx, caller, transmissionSchedule, executeInputs, responseTest, t)
+			}
+		})
+}
+
+func Test_Client_ConsensusFailedIfInsufficientCapabilityPeerResponses(t *testing.T) {
+	ctx := testutils.Context(t)
+
+	responseTest := func(t *testing.T, response commoncap.CapabilityResponse, responseError error) {
 		var capErr caperrors.Error
 		assert.ErrorAs(t, responseError, &capErr)
 		assert.Equal(t, caperrors.ConsensusFailed, capErr.Code())
@@ -162,7 +192,7 @@ func Test_Client_TimesOutIfInsufficientCapabilityPeerResponses(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// number of capability peers is less than F + 1
+	// F+1 exceeds peer count; first divergent response makes quorum unreachable.
 
 	testClient(t, 10, 1*time.Second, 10, 11,
 		capability,

--- a/core/capabilities/remote/executable/client_test.go
+++ b/core/capabilities/remote/executable/client_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
@@ -147,7 +148,10 @@ func Test_Client_TimesOutIfInsufficientCapabilityPeerResponses(t *testing.T) {
 	ctx := testutils.Context(t)
 
 	responseTest := func(t *testing.T, response commoncap.CapabilityResponse, responseError error) {
-		assert.ErrorIs(t, responseError, executable.ErrRequestExpired)
+		var capErr caperrors.Error
+		assert.ErrorAs(t, responseError, &capErr)
+		assert.Equal(t, caperrors.ConsensusFailed, capErr.Code())
+		assert.Contains(t, capErr.Error(), "[100]ConsensusFailed: response quorum unreachable: not enough matching capability responses: received 1/10 peer responses with 1 unique payloads; best match count 1, need 12 (9 responses pending)")
 	}
 
 	capability := &TestCapability{}

--- a/core/capabilities/remote/executable/request/client_request.go
+++ b/core/capabilities/remote/executable/request/client_request.go
@@ -55,6 +55,20 @@ func newRemoteCapabilityExecuteErrorWithMessage(display string, errMsg string) e
 	}
 }
 
+// newRemoteCapabilityExecuteErrorFromCapError wraps a capability error produced locally
+// (not deserialized from a remote payload). Unwrap returns caperrors.Error so
+// capability_executor can errors.As into caperrors.Error.
+func newRemoteCapabilityExecuteErrorFromCapError(capErr caperrors.Error) error {
+	return &errRemoteCapabilityExecuteError{
+		s:    capErr.Error(),
+		wrap: capErr,
+	}
+}
+
+// ErrResponseQuorumUnreachable is returned when enough peer responses have been
+// received that F+1 matching payloads are no longer mathematically possible.
+var ErrResponseQuorumUnreachable = errors.New("response quorum unreachable: not enough matching capability responses")
+
 type clientResponse struct {
 	Result []byte
 	Err    error
@@ -380,6 +394,8 @@ func (c *ClientRequest) OnMessage(_ context.Context, msg *types.MessageBody) err
 			}
 
 			c.sendResponse(clientResponse{Result: payload})
+		} else {
+			c.trySendQuorumUnreachableError()
 		}
 	} else {
 		c.lggr.Debugw("received error from peer", "error", msg.Error, "errorMsg", msg.ErrorMsg, "peer", sender)
@@ -410,6 +426,67 @@ func (c *ClientRequest) OnMessage(_ context.Context, msg *types.MessageBody) err
 		}
 	}
 	return nil
+}
+
+func (c *ClientRequest) responsesReceivedCount() int {
+	n := 0
+	for _, received := range c.responseReceived {
+		if received {
+			n++
+		}
+	}
+	return n
+}
+
+func (c *ClientRequest) maxMatchingResponseCount() int {
+	currentMax := 0
+	for _, count := range c.responseIDCount {
+		if count > currentMax {
+			currentMax = count
+		}
+	}
+	return currentMax
+}
+
+// quorumStillPossible reports whether requiredResponseConfirmations identical OK
+// responses can still be reached. Each pending peer can add at most one vote to
+// the current leading payload hash.
+func (c *ClientRequest) quorumStillPossible(pending int) bool {
+	return c.maxMatchingResponseCount()+pending >= c.requiredResponseConfirmations
+}
+
+func (c *ClientRequest) trySendQuorumUnreachableError() {
+	pending := c.pending()
+	if c.respSent || c.quorumStillPossible(pending) {
+		return
+	}
+	received := c.responsesReceivedCount()
+	unique := len(c.responseIDCount)
+	maxMatch := c.maxMatchingResponseCount()
+
+	detail := fmt.Errorf(
+		"received %d/%d peer responses with %d unique payloads; best match count %d, need %d (%d responses pending)",
+		received, c.remoteNodeCount, unique, maxMatch, c.requiredResponseConfirmations, pending,
+	)
+	capErr := caperrors.NewPublicSystemError(
+		fmt.Errorf("%w: %w", ErrResponseQuorumUnreachable, detail),
+		caperrors.ConsensusFailed,
+	)
+	c.lggr.Warnw("response quorum unreachable, failing early",
+		"responsesReceived", received,
+		"remoteNodeCount", c.remoteNodeCount,
+		"uniqueResponseCount", unique,
+		"maxMatchingResponseCount", maxMatch,
+		"requiredResponseConfirmations", c.requiredResponseConfirmations,
+		"pendingResponses", pending,
+	)
+	c.sendResponse(clientResponse{Err: newRemoteCapabilityExecuteErrorFromCapError(capErr)})
+}
+
+func (c *ClientRequest) pending() int {
+	received := c.responsesReceivedCount()
+	pending := c.remoteNodeCount - received
+	return pending
 }
 
 func (c *ClientRequest) hasValidAttestation(resp commoncap.CapabilityResponse) bool {

--- a/core/capabilities/remote/executable/request/client_request_internal_test.go
+++ b/core/capabilities/remote/executable/request/client_request_internal_test.go
@@ -2,9 +2,11 @@ package request
 
 import (
 	"crypto/rand"
+	"fmt"
 	"testing"
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -12,8 +14,10 @@ import (
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/ocr2key"
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
+	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 )
 
 func Test_ClientRequest_VerifyAttestation(t *testing.T) {
@@ -188,4 +192,115 @@ func Test_ClientRequest_VerifyAttestation(t *testing.T) {
 		err := c.verifyAttestation(validResp)
 		require.NoError(t, err)
 	})
+}
+
+func newReqForQuorumTest(t *testing.T, remoteNodeCount, required, responsesReceived int, responseIDCount map[[32]byte]int) *ClientRequest {
+	t.Helper()
+
+	responseReceived := make(map[p2ptypes.PeerID]bool, responsesReceived)
+	for i := 0; i < responsesReceived; i++ {
+		var peer p2ptypes.PeerID
+		peer[0] = byte(i)
+		responseReceived[peer] = true
+	}
+
+	return &ClientRequest{
+		lggr:                          logger.Test(t),
+		requiredResponseConfirmations: required,
+		remoteNodeCount:               remoteNodeCount,
+		responseIDCount:               responseIDCount,
+		responseReceived:              responseReceived,
+	}
+}
+
+func TestClientRequest_quorumStillPossible(t *testing.T) {
+	t.Parallel()
+
+	// 7-node DON, F+1 = 3: six unique responses, one pending → max 2 matches possible.
+	t.Run("7 DON 6 unique 1 pending unreachable", func(t *testing.T) {
+		t.Parallel()
+		counts := make(map[[32]byte]int)
+		for i := 0; i < 6; i++ {
+			counts[[32]byte{byte(i)}] = 1
+		}
+		c := newReqForQuorumTest(t, 7, 3, 6, counts)
+		pending := c.pending()
+		require.False(t, c.quorumStillPossible(pending))
+	})
+
+	t.Run("7 DON 5 unique 2 pending still possible", func(t *testing.T) {
+		t.Parallel()
+		counts := make(map[[32]byte]int)
+		for i := 0; i < 5; i++ {
+			counts[[32]byte{byte(i)}] = 1
+		}
+		c := newReqForQuorumTest(t, 7, 3, 5, counts)
+		pending := c.pending()
+		require.True(t, c.quorumStillPossible(pending))
+	})
+
+	t.Run("7 DON 7 unique all received unreachable", func(t *testing.T) {
+		t.Parallel()
+		counts := make(map[[32]byte]int)
+		for i := 0; i < 7; i++ {
+			counts[[32]byte{byte(i)}] = 1
+		}
+		c := newReqForQuorumTest(t, 7, 3, 7, counts)
+		pending := c.pending()
+		require.False(t, c.quorumStillPossible(pending))
+	})
+
+	t.Run("7 DON 2 matching 5 unique still possible with 2 pending", func(t *testing.T) {
+		t.Parallel()
+		counts := map[[32]byte]int{
+			{1}: 2,
+			{2}: 1,
+			{3}: 1,
+			{4}: 1,
+			{5}: 1,
+			{6}: 1,
+		}
+		c := newReqForQuorumTest(t, 7, 3, 6, counts)
+		pending := c.pending()
+		require.True(t, c.quorumStillPossible(pending))
+	})
+}
+
+func TestClientRequest_trySendQuorumUnreachableError(t *testing.T) {
+	t.Parallel()
+
+	counts := make(map[[32]byte]int)
+	for i := 0; i < 6; i++ {
+		counts[[32]byte{byte(i)}] = 1
+	}
+
+	c := newReqForQuorumTest(t, 7, 3, 6, counts)
+	c.responseCh = make(chan clientResponse, 1)
+
+	c.trySendQuorumUnreachableError()
+	require.True(t, c.respSent)
+
+	var respErr error
+	select {
+	case resp := <-c.responseCh:
+		require.Error(t, resp.Err)
+		respErr = resp.Err
+	default:
+		t.Fatal("expected error response on channel")
+	}
+
+	var capErr caperrors.Error
+	require.ErrorAs(t, respErr, &capErr)
+	require.Equal(t, caperrors.OriginSystem, capErr.Origin())
+	require.Equal(t, caperrors.ConsensusFailed, capErr.Code())
+	assert.Contains(t, capErr.Error(),
+		"[100]ConsensusFailed: response quorum unreachable: not enough matching capability responses: received 6/7 peer responses with 6 unique payloads; best match count 1, need 3 (1 responses pending)")
+
+	// Same unwrap chain as capability_executor after client.Execute wraps with %w.
+	wrapped := fmt.Errorf("error executing request: %w", respErr)
+	var capErrFromWrapped caperrors.Error
+	require.ErrorAs(t, wrapped, &capErrFromWrapped)
+	require.Equal(t, caperrors.ConsensusFailed, capErrFromWrapped.Code())
+	assert.Contains(t, capErrFromWrapped.Error(),
+		"[100]ConsensusFailed: response quorum unreachable: not enough matching capability responses: received 6/7 peer responses with 6 unique payloads; best match count 1, need 3 (1 responses pending)")
 }

--- a/core/capabilities/remote/executable/request/client_request_test.go
+++ b/core/capabilities/remote/executable/request/client_request_test.go
@@ -130,9 +130,17 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		require.NoError(t, err)
 
 		select {
-		case <-req.ResponseChan():
-			t.Fatal("expected no response")
+		case resp := <-req.ResponseChan():
+			require.Error(t, resp.Err)
+			var capErr caperrors.Error
+			require.ErrorAs(t, resp.Err, &capErr)
+			require.Equal(t, caperrors.OriginSystem, capErr.Origin())
+			require.Equal(t, caperrors.ConsensusFailed, capErr.Code())
+			assert.Contains(t, capErr.Error(),
+				"[100]ConsensusFailed: response quorum unreachable: not enough matching capability responses: received 2/2 peer responses with 2 unique payloads; best match count 1, need 2 (0 responses pending)")
+
 		default:
+			t.Fatal("expected early quorum unreachable response")
 		}
 	})
 


### PR DESCRIPTION
…ayloads and no quorum is reached

https://smartcontract-it.atlassian.net/browse/PLEX-3032

We noticed that the WR on andesite was not working as expected returning the following to the user

```
context done before remote client received a quorum of responses
context deadline exceeded
```

Which was wrong, at that time the engine got all responses but due to a bug on the action/WR all payloads were different, making impossible to aggregate.
This PR fixes this scenario making an early return even with payloads still incoming if quorum is unreachable, providing a better error to the user. 



<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
