### PR TITLE
chore: refactor CRE tests to use the new TestHarness

### DIFF
--- a/deployment/cre/capabilities_registry/v2/changeset/add_capabilities_test.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/add_capabilities_test.go
@@ -132,7 +132,7 @@ func TestAddCapabilities_VerifyPreconditions(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func addNewCapability(t *testing.T, h *test.EnvWrapperV2, capID string) {
+func addNewCapability(t *testing.T, h *test.Harness, capID string) {
 	input := changeset.AddCapabilitiesInput{
 		RegistryChainSel:  h.RegistrySelector,
 		RegistryQualifier: test.RegistryQualifier,
@@ -155,7 +155,7 @@ func addNewCapability(t *testing.T, h *test.EnvWrapperV2, capID string) {
 	require.NoError(t, err)
 }
 
-func requireCapability(t *testing.T, h *test.EnvWrapperV2, capID string) {
+func requireCapability(t *testing.T, h *test.Harness, capID string) {
 	// Validate on-chain state
 	capReg, err := capabilities_registry_v2.NewCapabilitiesRegistry(
 		h.RegistryAddress,
@@ -270,7 +270,7 @@ func aptosTestCapabilityID(aptosChainSelector uint64) string {
 	return fmt.Sprintf("aptos:ChainSelector:%d@1.0.0", aptosChainSelector)
 }
 
-func addCapabilityWithModifier(t *testing.T, h *test.EnvWrapperV2) {
+func addCapabilityWithModifier(t *testing.T, h *test.Harness) {
 	t.Helper()
 
 	require.NotNil(t, h.Runtime.Environment().Offchain, "Aptos add-capabilities needs JD Offchain client")
@@ -298,7 +298,7 @@ func addCapabilityWithModifier(t *testing.T, h *test.EnvWrapperV2) {
 	require.NoError(t, err)
 }
 
-func requireCapabilityWithModifier(t *testing.T, h *test.EnvWrapperV2) {
+func requireCapabilityWithModifier(t *testing.T, h *test.Harness) {
 	t.Helper()
 
 	capReg, err := capabilities_registry_v2.NewCapabilitiesRegistry(

--- a/deployment/cre/capabilities_registry/v2/changeset/update_don_test.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/update_don_test.go
@@ -1,6 +1,7 @@
 package changeset_test
 
 import (
+	"crypto/ecdsa"
 	"encoding/json"
 	"testing"
 	"time"
@@ -23,7 +24,6 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
-	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/cre/capabilities_registry/v2/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/cre/capabilities_registry/v2/changeset/operations/contracts"
 	"github.com/smartcontractkit/chainlink/deployment/cre/capabilities_registry/v2/changeset/pkg"
@@ -42,7 +42,7 @@ const (
 )
 
 type updFixture struct {
-	env        cldf.Environment
+	rt         *runtime.Runtime
 	selector   uint64
 	qualifier  string
 	address    string
@@ -138,42 +138,44 @@ func setupRegistryForUpdateDON(t *testing.T, isWorkflow, useMCMS bool) *updFixtu
 	donName := "upd-don-v2"
 
 	// Register everything using ConfigureCapabilitiesRegistry (no MCMS)
-	_, err = changeset.ConfigureCapabilitiesRegistry{}.Apply(rt.Environment(), changeset.ConfigureCapabilitiesRegistryInput{
-		ChainSelector:               selector,
-		CapabilitiesRegistryAddress: addr,
-		Nops: []changeset.CapabilitiesRegistryNodeOperator{
-			{Admin: common.HexToAddress("0x01"), Name: nop1},
-			{Admin: common.HexToAddress("0x02"), Name: nop2},
-		},
-		Capabilities: []changeset.CapabilitiesRegistryCapability{
-			{CapabilityID: writeChain.CapabilityId, Metadata: writeChainMeta},
-			{CapabilityID: trigger.CapabilityId, Metadata: triggerMeta},
-			{CapabilityID: capWithModifierID.CapabilityId, Metadata: aptosWriteChainMeta},
-		},
-		Nodes: nodes,
-		DONs: []changeset.CapabilitiesRegistryNewDONParams{
-			{
-				Name:        donName,
-				DonFamilies: []string{"upd-family"},
-				Config: map[string]any{
-					"defaultConfig": map[string]any{},
-				},
-				CapabilityConfigurations: []changeset.CapabilitiesRegistryCapabilityConfiguration{
-					{CapabilityID: writeChain.CapabilityId, Config: cfg},
-					{CapabilityID: capWithModifierID.CapabilityId, Config: cfg},
-				},
-				Nodes:            nodeSet,
-				F:                1,
-				IsPublic:         true,
-				AcceptsWorkflows: isWorkflow,
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.ConfigureCapabilitiesRegistry{}, changeset.ConfigureCapabilitiesRegistryInput{
+			ChainSelector:               selector,
+			CapabilitiesRegistryAddress: addr,
+			Nops: []changeset.CapabilitiesRegistryNodeOperator{
+				{Admin: common.HexToAddress("0x01"), Name: nop1},
+				{Admin: common.HexToAddress("0x02"), Name: nop2},
 			},
-		},
-	})
+			Capabilities: []changeset.CapabilitiesRegistryCapability{
+				{CapabilityID: writeChain.CapabilityId, Metadata: writeChainMeta},
+				{CapabilityID: trigger.CapabilityId, Metadata: triggerMeta},
+				{CapabilityID: capWithModifierID.CapabilityId, Metadata: aptosWriteChainMeta},
+			},
+			Nodes: nodes,
+			DONs: []changeset.CapabilitiesRegistryNewDONParams{
+				{
+					Name:        donName,
+					DonFamilies: []string{"upd-family"},
+					Config: map[string]any{
+						"defaultConfig": map[string]any{},
+					},
+					CapabilityConfigurations: []changeset.CapabilitiesRegistryCapabilityConfiguration{
+						{CapabilityID: writeChain.CapabilityId, Config: cfg},
+						{CapabilityID: capWithModifierID.CapabilityId, Config: cfg},
+					},
+					Nodes:            nodeSet,
+					F:                1,
+					IsPublic:         true,
+					AcceptsWorkflows: isWorkflow,
+				},
+			},
+		}),
+	)
 	require.NoError(t, err)
 
 	if !useMCMS {
 		return &updFixture{
-			env:        rt.Environment(),
+			rt:         rt,
 			selector:   selector,
 			qualifier:  qualifier,
 			address:    addr,
@@ -188,26 +190,29 @@ func setupRegistryForUpdateDON(t *testing.T, isWorkflow, useMCMS bool) *updFixtu
 		selector: cldftesthelpers.SingleGroupTimelockConfig(t),
 	}
 
-	updatedEnv, mcmsErr := commonchangeset.Apply(t, rt.Environment(), commonchangeset.Configure(
-		cldf.CreateLegacyChangeSet(mcmschangesets.DeployMCMSWithTimelockV2),
-		timelockCfgs,
-	))
-	require.NoError(t, mcmsErr, "failed to deploy MCMS infrastructure")
+	err = rt.Exec(
+		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(mcmschangesets.DeployMCMSWithTimelockV2), timelockCfgs),
+	)
+	require.NoError(t, err, "failed to deploy MCMS infrastructure")
+
 	t.Log("MCMS infrastructure deployed successfully")
 
 	t.Log("Transferring ownership to MCMS...")
-	updatedEnv, mcmsErr = commonchangeset.Apply(t, updatedEnv, commonchangeset.Configure(
-		cldf.CreateLegacyChangeSet(keystonechangeset.AcceptAllOwnershipsProposal),
-		&keystonechangeset.AcceptAllOwnershipRequest{
-			ChainSelector: selector,
-			MinDelay:      0,
-		},
-	))
-	require.NoError(t, mcmsErr, "failed to transfer ownership to MCMS")
+	err = rt.Exec(
+		runtime.ChangesetTask(
+			cldf.CreateLegacyChangeSet(keystonechangeset.AcceptAllOwnershipsProposal),
+			&keystonechangeset.AcceptAllOwnershipRequest{
+				ChainSelector: selector,
+				MinDelay:      0,
+			},
+		),
+		runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{cldftesthelpers.TestXXXMCMSSigner}),
+	)
+	require.NoError(t, err, "failed to transfer ownership to MCMS")
 	t.Log("Ownership transferred to MCMS successfully")
 
 	return &updFixture{
-		env:        updatedEnv,
+		rt:         rt,
 		selector:   selector,
 		qualifier:  qualifier,
 		address:    addr,
@@ -238,7 +243,7 @@ func TestUpdateDONChangeset_ByName_Direct_Succeeds(t *testing.T) {
 
 	newName := fx.donName + "-renamed"
 
-	out, err := changeset.UpdateDON{}.Apply(fx.env, changeset.UpdateDONInput{
+	task := runtime.ChangesetTask(changeset.UpdateDON{}, changeset.UpdateDONInput{
 		RegistryQualifier: fx.qualifier,
 		RegistryChainSel:  fx.selector,
 		DONName:           fx.donName, // required current name
@@ -249,8 +254,13 @@ func TestUpdateDONChangeset_ByName_Direct_Succeeds(t *testing.T) {
 		Force:      false,
 		MCMSConfig: nil,
 	})
+
+	err = fx.rt.Exec(task)
 	require.NoError(t, err)
+
+	out := fx.rt.State().Outputs[task.ID()]
 	require.NotNil(t, out)
+
 	assert.Empty(t, out.MCMSTimelockProposals, "no MCMS → proposals must be empty")
 	require.NotEmpty(t, out.Reports)
 
@@ -285,7 +295,7 @@ func TestUpdateDONChangeset_ByName_Direct_Succeeds_MCMS(t *testing.T) {
 
 	newName := fx.donName + "-renamed"
 
-	out, err := changeset.UpdateDON{}.Apply(fx.env, changeset.UpdateDONInput{
+	task := runtime.ChangesetTask(changeset.UpdateDON{}, changeset.UpdateDONInput{
 		RegistryQualifier: fx.qualifier,
 		RegistryChainSel:  fx.selector,
 		DONName:           fx.donName, // required current name
@@ -301,8 +311,11 @@ func TestUpdateDONChangeset_ByName_Direct_Succeeds_MCMS(t *testing.T) {
 			},
 		},
 	})
+
+	err := fx.rt.Exec(task)
 	require.NoError(t, err)
 
+	out := fx.rt.State().Outputs[task.ID()]
 	assert.NotNil(t, out)
 	assert.NotEmpty(t, out.Reports)
 	assert.NotEmpty(t, out.MCMSTimelockProposals, "MCMS → proposals must not be empty")
@@ -326,7 +339,7 @@ func TestUpdateDONChangeset_ByName_Workflow_Force_Succeeds(t *testing.T) {
 	wantProto, err := pkg.CapabilityConfig(newCfg).MarshalProto()
 	require.NoError(t, err)
 
-	out, err := changeset.UpdateDON{}.Apply(fx.env, changeset.UpdateDONInput{
+	task := runtime.ChangesetTask(changeset.UpdateDON{}, changeset.UpdateDONInput{
 		RegistryQualifier: fx.qualifier,
 		RegistryChainSel:  fx.selector,
 		DONName:           fx.donName, // required
@@ -336,8 +349,14 @@ func TestUpdateDONChangeset_ByName_Workflow_Force_Succeeds(t *testing.T) {
 		Force: true, // override
 	})
 	require.NoError(t, err)
+
+	err = fx.rt.Exec(task)
+	require.NoError(t, err)
+
+	out := fx.rt.State().Outputs[task.ID()]
 	require.NotNil(t, out)
-	assert.Empty(t, out.MCMSTimelockProposals)
+	assert.Empty(t, out.MCMSTimelockProposals, "no MCMS → proposals must be empty")
+	require.NotEmpty(t, out.Reports)
 
 	got, err := fx.registry.GetDONByName(nil, fx.donName)
 	require.NoError(t, err)
@@ -357,7 +376,7 @@ func TestUpdateDONChangeset_VerifyPreconditions_EmptyName(t *testing.T) {
 		DONName:           "", // invalid
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must provide a non-empty DONName")
+	require.ErrorContains(t, err, "must provide a non-empty DONName")
 }
 
 // Chain not found: Apply should fail early with a clear message.
@@ -377,7 +396,7 @@ func TestUpdateDONChangeset_ByName_ChainNotFound(t *testing.T) {
 		CapabilityConfigs: nil,
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "chain not found for selector")
+	require.ErrorContains(t, err, "chain not found for selector")
 }
 
 // Qualifier not found in DataStore: Apply should fail when it cannot look up the registry address.
@@ -399,7 +418,7 @@ func TestUpdateDONChangeset_ByName_QualifierNotFound(t *testing.T) {
 		CapabilityConfigs: nil,
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to get registry address")
+	require.ErrorContains(t, err, "failed to get registry address")
 }
 
 // TestUpdateDON_FirstOCR3ConfigCapabilities exercises the first-config gate in
@@ -407,6 +426,7 @@ func TestUpdateDONChangeset_ByName_QualifierNotFound(t *testing.T) {
 func TestUpdateDON_FirstOCR3ConfigCapabilities(t *testing.T) {
 	t.Parallel()
 	fx := setupRegistryForUpdateDON(t, false, false)
+	env := fx.rt.Environment()
 
 	// A minimal ocr3Configs entry matching the proto structure: oracle config
 	// params are nested under the "offchainConfig" key.
@@ -439,13 +459,13 @@ func TestUpdateDON_FirstOCR3ConfigCapabilities(t *testing.T) {
 	}
 
 	t.Run("rejects when capability is not in FirstOCR3ConfigCapabilities", func(t *testing.T) {
-		_, err := changeset.UpdateDON{}.Apply(fx.env, makeInput(fx.capIDs[0], nil))
+		_, err := changeset.UpdateDON{}.Apply(env, makeInput(fx.capIDs[0], nil))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "firstOCR3ConfigCapabilities")
 	})
 
 	t.Run("passes first-config check when capability is listed", func(t *testing.T) {
-		_, err := changeset.UpdateDON{}.Apply(fx.env, makeInput(fx.capIDs[0], []string{fx.capIDs[0]}))
+		_, err := changeset.UpdateDON{}.Apply(env, makeInput(fx.capIDs[0], []string{fx.capIDs[0]}))
 		require.Error(t, err)
 		// Should fail later (e.g. ComputeOCR3Config), NOT at the first-config gate.
 		assert.NotContains(t, err.Error(), "firstOCR3ConfigCapabilities")
@@ -453,7 +473,7 @@ func TestUpdateDON_FirstOCR3ConfigCapabilities(t *testing.T) {
 
 	t.Run("rejects unlisted capability even when another is listed", func(t *testing.T) {
 		// List capIDs[0] but provide ocr3Configs for capIDs[1] → should fail
-		_, err := changeset.UpdateDON{}.Apply(fx.env, makeInput(fx.capIDs[1], []string{fx.capIDs[0]}))
+		_, err := changeset.UpdateDON{}.Apply(env, makeInput(fx.capIDs[1], []string{fx.capIDs[0]}))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "firstOCR3ConfigCapabilities")
 	})

--- a/deployment/cre/forwarder/configure_test.go
+++ b/deployment/cre/forwarder/configure_test.go
@@ -1,17 +1,22 @@
 package forwarder_test
 
 import (
+	"crypto/ecdsa"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
+	cldftesthelpers "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils/testhelpers"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations/optest"
 
-	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/cre/contracts"
 	"github.com/smartcontractkit/chainlink/deployment/cre/forwarder"
 	"github.com/smartcontractkit/chainlink/deployment/cre/test"
@@ -19,12 +24,12 @@ import (
 )
 
 func TestConfigureForwardersSeq(t *testing.T) {
-	envWrapper, donConfig := setupForwarderTest(t, false)
-	env := envWrapper.Env
+	h, donConfig := setupForwarderTest(t, false)
+	env := h.Runtime.Environment()
 
 	b := optest.NewBundle(t)
 	deps := forwarder.ConfigureSeqDeps{
-		Env: env,
+		Env: &env,
 	}
 	input := forwarder.ConfigureSeqInput{
 		DON:        donConfig,
@@ -41,35 +46,34 @@ func TestConfigureForwardersSeq(t *testing.T) {
 }
 
 func TestConfigureForwarders(t *testing.T) {
-	envWrapper, donConfig := setupForwarderTest(t, false)
-	env := envWrapper.Env
-	registryChainSel := envWrapper.RegistrySelector
+	h, donConfig := setupForwarderTest(t, false)
 
 	// Test the durable pipeline wrapper
 	t.Log("Starting configure changeset application...")
-	changesetOutput, err := forwarder.ConfigureForwarders{}.Apply(*env, forwarder.ConfigureSeqInput{
+	task := runtime.ChangesetTask(forwarder.ConfigureForwarders{}, forwarder.ConfigureSeqInput{
 		DON:        donConfig,
 		Qualifier:  "test-configure-forwarder",
 		MCMSConfig: nil, // Not using MCMS for this test
-		Chains:     map[uint64]struct{}{registryChainSel: {}},
+		Chains:     map[uint64]struct{}{h.RegistrySelector: {}},
 	})
+	err := h.Runtime.Exec(task)
 	require.NoError(t, err, "changeset apply failed")
-	require.NotNil(t, changesetOutput, "changeset output should not be nil")
+	out := h.Runtime.State().Outputs[task.ID()]
+	require.NotNil(t, out, "changeset output should not be nil")
 	t.Logf("Configure changeset applied successfully")
 
 	// Verify the changeset output
-	require.NotNil(t, changesetOutput.Reports, "reports should be present")
-	require.Empty(t, changesetOutput.MCMSTimelockProposals, "should not have MCMS proposals when not using MCMS")
+	require.NotNil(t, out.Reports, "reports should be present")
+	require.Empty(t, out.MCMSTimelockProposals, "should not have MCMS proposals when not using MCMS")
 }
 
 func TestConfigureForwarders_WithMCMS(t *testing.T) {
-	envWrapper, donConfig := setupForwarderTest(t, true)
-	env := envWrapper.Env
-	registryChainSel := envWrapper.RegistrySelector
+	h, donConfig := setupForwarderTest(t, true)
+	registryChainSel := h.RegistrySelector
 
 	// Test the durable pipeline wrapper
 	t.Log("Starting configure changeset application with MCMS...")
-	changesetOutput, err := forwarder.ConfigureForwarders{}.Apply(*env, forwarder.ConfigureSeqInput{
+	task := runtime.ChangesetTask(forwarder.ConfigureForwarders{}, forwarder.ConfigureSeqInput{
 		DON:       donConfig,
 		Qualifier: "test-configure-forwarder",
 		MCMSConfig: &contracts.MCMSConfig{
@@ -80,20 +84,22 @@ func TestConfigureForwarders_WithMCMS(t *testing.T) {
 		},
 		Chains: map[uint64]struct{}{registryChainSel: {}},
 	})
-	require.NoError(t, err, "changeset with MCMS apply failed")
-	require.NotNil(t, changesetOutput, "changeset output with MCMS should not be nil")
+	err := h.Runtime.Exec(task)
+	require.NoError(t, err, "changeset apply failed")
+	out := h.Runtime.State().Outputs[task.ID()]
+	require.NotNil(t, out, "changeset output should not be nil")
 	t.Logf("Configure changeset with MCMS applied successfully")
 
 	// Verify the changeset output
-	require.NotNil(t, changesetOutput.Reports, "reports should be present")
-	require.NotEmpty(t, changesetOutput.MCMSTimelockProposals, "should have MCMS proposals when using MCMS")
+	require.NotNil(t, out.Reports, "reports should be present")
+	require.NotEmpty(t, out.MCMSTimelockProposals, "should have MCMS proposals when using MCMS")
 }
 
 func TestConfigureForwarders_SpecificChains(t *testing.T) {
 	// This test needs a custom setup to deploy to multiple chains first
-	envWrapper := test.SetupEnvV2(t, false)
-	env := envWrapper.Env
-	registryChainSel := envWrapper.RegistrySelector
+	h := test.NewTestHarness(t)
+	env := h.Runtime.Environment()
+	registryChainSel := h.RegistrySelector
 
 	// Get all available chain selectors for multi-chain deployment
 	allChains := make([]uint64, 0)
@@ -104,7 +110,7 @@ func TestConfigureForwarders_SpecificChains(t *testing.T) {
 	// Deploy Keystone Forwarder contracts to ALL chains (unlike the helper which deploys to one)
 	b := optest.NewBundle(t)
 	deps := forwarder.DeploySequenceDeps{
-		Env: env,
+		Env: &env,
 	}
 	input := forwarder.DeploySequenceInput{
 		Targets:   allChains,
@@ -136,27 +142,32 @@ func TestConfigureForwarders_SpecificChains(t *testing.T) {
 		registryChainSel: {},
 	}
 
+	// We need to create a new runtime from the updated environment
+	h.Runtime = runtime.NewFromEnvironment(env)
+
 	// Apply the changeset to configure only specific chains
 	t.Log("Starting configure changeset application for specific chains...")
-	changesetOutput, err := forwarder.ConfigureForwarders{}.Apply(*env, forwarder.ConfigureSeqInput{
+	task := runtime.ChangesetTask(forwarder.ConfigureForwarders{}, forwarder.ConfigureSeqInput{
 		DON:        donConfig,
 		Qualifier:  "test-configure-specific-chains",
 		MCMSConfig: nil,
 		Chains:     specificChains, // Only configure for registry chain
 	})
+	err = h.Runtime.Exec(task)
 	require.NoError(t, err, "changeset apply failed")
-	require.NotNil(t, changesetOutput, "changeset output should not be nil")
+	out := h.Runtime.State().Outputs[task.ID()]
+	require.NotNil(t, out, "changeset output should not be nil")
 	t.Logf("Configure changeset for specific chains applied successfully")
 
 	// Verify the changeset output
-	require.NotNil(t, changesetOutput.Reports, "reports should be present")
-	require.Empty(t, changesetOutput.MCMSTimelockProposals, "should not have MCMS proposals when not using MCMS")
-	require.NotEmpty(t, changesetOutput.Reports, "should have at least one report for the configured chain")
+	require.NotNil(t, out.Reports, "reports should be present")
+	require.Empty(t, out.MCMSTimelockProposals, "should not have MCMS proposals when not using MCMS")
+	require.NotEmpty(t, out.Reports, "should have at least one report for the configured chain")
 }
 
 func TestConfigureForwarders_SameQualifierAcrossChains(t *testing.T) {
-	envWrapper := test.SetupEnvV2(t, false)
-	env := envWrapper.Env
+	h := test.NewTestHarness(t)
+	env := h.Runtime.Environment()
 
 	allChains := make([]uint64, 0)
 	for chainSel := range env.BlockChains.EVMChains() {
@@ -165,7 +176,7 @@ func TestConfigureForwarders_SameQualifierAcrossChains(t *testing.T) {
 
 	b := optest.NewBundle(t)
 	deps := forwarder.DeploySequenceDeps{
-		Env: env,
+		Env: &env,
 	}
 	input := forwarder.DeploySequenceInput{
 		Targets:   allChains,
@@ -190,27 +201,38 @@ func TestConfigureForwarders_SameQualifierAcrossChains(t *testing.T) {
 		NodeIDs: env.NodeIDs,
 	}
 
-	changesetOutput, err := forwarder.ConfigureForwarders{}.Apply(*env, forwarder.ConfigureSeqInput{
+	// We need to create a new runtime from the updated environment
+	h.Runtime = runtime.NewFromEnvironment(env)
+
+	task := runtime.ChangesetTask(forwarder.ConfigureForwarders{}, forwarder.ConfigureSeqInput{
 		DON:        donConfig,
 		Qualifier:  "test-configure-shared-qualifier",
 		MCMSConfig: nil,
 		Chains:     map[uint64]struct{}{},
 	})
+	err = h.Runtime.Exec(task)
 	require.NoError(t, err, "changeset apply failed")
-	require.NotNil(t, changesetOutput, "changeset output should not be nil")
-	require.NotEmpty(t, changesetOutput.Reports, "should have reports for configured chains")
+	out := h.Runtime.State().Outputs[task.ID()]
+
+	require.NotNil(t, out, "changeset output should not be nil")
+	require.NotEmpty(t, out.Reports, "should have reports for configured chains")
 }
 
 // setupForwarderTest is a helper function to reduce duplication in configure tests
-func setupForwarderTest(t *testing.T, enableMCMS bool) (*test.EnvWrapperV2, forwarder.DonConfiguration) {
+func setupForwarderTest(t *testing.T, enableMCMS bool) (*test.Harness, forwarder.DonConfiguration) {
+	hopts := []test.HarnessOpt{}
+	if enableMCMS {
+		hopts = append(hopts, test.WithMCMS())
+	}
+
 	// Setup test environment
-	envWrapper := test.SetupEnvV2(t, enableMCMS)
-	env := envWrapper.Env
-	registryChainSel := envWrapper.RegistrySelector
+	h := test.NewTestHarness(t, hopts...)
+	env := h.Runtime.Environment()
+	registryChainSel := h.RegistrySelector
 
 	// Deploy Keystone Forwarder contracts to the test chains
 	deps := forwarder.DeploySequenceDeps{
-		Env: env,
+		Env: &env,
 	}
 	input := forwarder.DeploySequenceInput{
 		Targets:   []uint64{registryChainSel},
@@ -232,26 +254,27 @@ func setupForwarderTest(t *testing.T, enableMCMS bool) (*test.EnvWrapperV2, forw
 	require.NoError(t, ds.Merge(prevDS), "failed to merge existing datastore")
 	require.NoError(t, ds.Merge(got.Output.Datastore), "failed to merge output datastore")
 
-	// Try and transfer ownership to MCMS if enabled
+	// We need to create a new runtime from the updated environment
+	env.DataStore = ds.Seal()
+	h.Runtime = runtime.NewFromEnvironment(env)
+
+	// Transfer ownership to MCMS if enabled
 	if enableMCMS {
-		env.DataStore = got.Output.Datastore // temporary override to perform ownership transfer of only the forwarder to MCMS
 		// We need to transfer forwarder ownership to MCMS
 		t.Log("Transferring forwarder ownership to MCMS...")
-		resultEnv, mcmsErr := changeset.Apply(t, *env, changeset.Configure(
-			cldf.CreateLegacyChangeSet(changeset3.AcceptAllOwnershipsProposal),
-			&changeset3.AcceptAllOwnershipRequest{
-				ChainSelector: registryChainSel,
-				MinDelay:      0,
-			},
-		))
-		require.NoError(t, mcmsErr, "failed to transfer forwarder ownership to MCMS")
+		err = h.Runtime.Exec(
+			runtime.ChangesetTask(
+				cldf.CreateLegacyChangeSet(acceptForwarderOwnershipProposal),
+				&changeset3.AcceptAllOwnershipRequest{
+					ChainSelector: registryChainSel,
+					MinDelay:      0,
+				},
+			),
+			runtime.SignAndExecuteProposalsTask([]*ecdsa.PrivateKey{cldftesthelpers.TestXXXMCMSSigner}),
+		)
+		require.NoError(t, err, "failed to transfer forwarder ownership to MCMS")
 		t.Log("Forwarder ownership transferred to MCMS successfully")
-
-		require.NoError(t, ds.Merge(env.DataStore), "failed to merge existing datastore")
-		require.NoError(t, ds.Merge(resultEnv.DataStore), "failed to merge existing datastore")
 	}
-
-	envWrapper.Env.DataStore = ds.Seal()
 
 	// Create test DON configuration
 	donConfig := forwarder.DonConfiguration{
@@ -262,5 +285,22 @@ func setupForwarderTest(t *testing.T, enableMCMS bool) (*test.EnvWrapperV2, forw
 		NodeIDs: env.NodeIDs,
 	}
 
-	return envWrapper, donConfig
+	return h, donConfig
+}
+
+// acceptForwarderOwnershipProposal is a test-only variant of
+// changeset3.AcceptAllOwnershipsProposal scoped to KeystoneForwarder contracts.
+//
+// This is used to accept ownership of only the KeystoneForwarder contracts to MCMS.
+func acceptForwarderOwnershipProposal(e cldf.Environment, req *changeset3.AcceptAllOwnershipRequest) (cldf.ChangesetOutput, error) {
+	var forwarders []common.Address
+	for _, addr := range e.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(req.ChainSelector)) {
+		if addr.Type == datastore.ContractType(changeset3.KeystoneForwarder) {
+			forwarders = append(forwarders, common.HexToAddress(addr.Address))
+		}
+	}
+	return mcmschangesets.TransferToMCMSWithTimelockV2(e, mcmschangesets.TransferToMCMSWithTimelockConfig{
+		ContractsByChain: map[uint64][]common.Address{req.ChainSelector: forwarders},
+		MCMSConfig:       cldfproposalutils.TimelockConfig{MinDelay: req.MinDelay},
+	})
 }

--- a/deployment/cre/forwarder/solana/deploy_forwarder_test.go
+++ b/deployment/cre/forwarder/solana/deploy_forwarder_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/onchain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
-	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	solanaMCMS "github.com/smartcontractkit/chainlink/deployment/common/changeset/solana/mcms"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/cre/forwarder"
@@ -39,50 +38,47 @@ const (
 // so we disable them in CI since it will take too long to run
 func TestDeployForwarder(t *testing.T) {
 	skipInCI(t)
+
 	t.Parallel()
 
 	selector := chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector
-	env, err := environment.New(t.Context(),
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
 		environment.WithSolanaContainer(t, []uint64{selector}, t.TempDir(), map[string]string{}),
 		environment.WithLogger(logger.Test(t)),
-	)
+	))
 	require.NoError(t, err)
 
-	chain := env.BlockChains.SolanaChains()[selector]
+	chain := rt.Environment().BlockChains.SolanaChains()[selector]
 
 	t.Run("should deploy forwarder", func(t *testing.T) {
-		configuredChangeset := commonchangeset.Configure(DeployForwarder{},
-			&DeployForwarderRequest{
-				ChainSel:  selector,
-				Qualifier: testQualifier,
-				Version:   "1.0.0",
-				BuildConfig: &helpers.BuildSolanaConfig{
-					GitCommitSha:   "3305b4d55b5469e110133e5a36e5600aadf436fb",
-					DestinationDir: chain.ProgramsPath,
-					LocalBuild:     helpers.LocalBuildConfig{BuildLocally: true, CreateDestinationDir: true},
+		err := rt.Exec(
+			runtime.ChangesetTask(DeployForwarder{},
+				&DeployForwarderRequest{
+					ChainSel:  selector,
+					Qualifier: testQualifier,
+					Version:   "1.0.0",
+					BuildConfig: &helpers.BuildSolanaConfig{
+						GitCommitSha:   "3305b4d55b5469e110133e5a36e5600aadf436fb",
+						DestinationDir: chain.ProgramsPath,
+						LocalBuild:     helpers.LocalBuildConfig{BuildLocally: true, CreateDestinationDir: true},
+					},
 				},
-			},
+			),
 		)
-
-		// deploy
-		var err error
-		_, _, err = commonchangeset.ApplyChangesets(t, *env, []commonchangeset.ConfiguredChangeSet{configuredChangeset})
 		require.NoError(t, err)
 	})
 
 	t.Run("should pass upgrade authority", func(t *testing.T) {
-		configuredChangeset := commonchangeset.Configure(SetForwarderUpgradeAuthority{},
-			&SetForwarderUpgradeAuthorityRequest{
-				ChainSel:            selector,
-				Qualifier:           testQualifier,
-				Version:             "1.0.0",
-				NewUpgradeAuthority: chain.DeployerKey.PublicKey(),
-			},
+		err := rt.Exec(
+			runtime.ChangesetTask(SetForwarderUpgradeAuthority{},
+				&SetForwarderUpgradeAuthorityRequest{
+					ChainSel:            selector,
+					Qualifier:           testQualifier,
+					Version:             "1.0.0",
+					NewUpgradeAuthority: chain.DeployerKey.PublicKey(),
+				},
+			),
 		)
-
-		// deploy
-		var err error
-		_, _, err = commonchangeset.ApplyChangesets(t, *env, []commonchangeset.ConfiguredChangeSet{configuredChangeset})
 		require.NoError(t, err)
 	})
 }

--- a/deployment/cre/jobs/propose_evm_cap_test.go
+++ b/deployment/cre/jobs/propose_evm_cap_test.go
@@ -11,18 +11,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink/deployment/cre/jobs/pkg"
-	"github.com/smartcontractkit/chainlink/deployment/cre/pkg/offchain"
 	tenv "github.com/smartcontractkit/chainlink/deployment/environment/test"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 	csav1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/csa"
 	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 	"github.com/smartcontractkit/chainlink/deployment/cre/jobs"
+	"github.com/smartcontractkit/chainlink/deployment/cre/jobs/pkg"
+	"github.com/smartcontractkit/chainlink/deployment/cre/pkg/offchain"
 	"github.com/smartcontractkit/chainlink/deployment/cre/test"
 
 	"github.com/smartcontractkit/chainlink/deployment/cre/ocr3"
@@ -35,7 +36,7 @@ const (
 )
 
 type evmCapTestSetup struct {
-	env          *cldf.Environment
+	rt           *runtime.Runtime
 	nodeIDs      []string
 	evmCapInputs []jobs.EVMCapabilityInput
 	baseInput    jobs.ProposeEVMCapJobSpecInput
@@ -43,15 +44,17 @@ type evmCapTestSetup struct {
 
 func setupEVMCapTest(t *testing.T) evmCapTestSetup {
 	t.Helper()
-	testEnv := test.SetupEnvV2(t, false)
 
-	selector := testEnv.RegistrySelector
 	ds := datastore.NewMemoryDataStore()
-	seedAddressesForSelector(t, ds, selector, "0xocr...", "0xfwd...")
-	env := testEnv.Env
-	env.DataStore = ds.Seal()
+	seedAddressesForSelector(t, ds, test.DefaultRegistrySelector, "0xocr...", "0xfwd...")
 
-	nodes, err := testEnv.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
+	var (
+		h        = test.NewTestHarness(t, test.WithDatastore(ds))
+		env      = h.Runtime.Environment()
+		selector = h.RegistrySelector
+	)
+
+	nodes, err := h.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
 	require.NoError(t, err)
 
 	var nodeIDs []string
@@ -68,7 +71,7 @@ func setupEVMCapTest(t *testing.T) evmCapTestSetup {
 
 	client := tenv.NewJobServiceClient(mockGetter)
 
-	testEnv.TestJD.JobServiceClient = client
+	h.TestJD.JobServiceClient = client
 
 	env.Offchain = struct {
 		jobv1.JobServiceClient
@@ -79,6 +82,8 @@ func setupEVMCapTest(t *testing.T) evmCapTestSetup {
 		NodeServiceClient: env.Offchain,
 		CSAServiceClient:  env.Offchain,
 	}
+
+	rt := runtime.NewFromEnvironment(env)
 
 	baseInput := jobs.ProposeEVMCapJobSpecInput{
 		Environment:             test.EnvironmentName,
@@ -96,7 +101,7 @@ func setupEVMCapTest(t *testing.T) evmCapTestSetup {
 	}
 
 	return evmCapTestSetup{
-		env:          env,
+		rt:           rt,
 		nodeIDs:      nodeIDs,
 		evmCapInputs: evmCapInputs,
 		baseInput:    baseInput,
@@ -338,7 +343,6 @@ func TestProposeEVMCapJobSpec_VerifyPreconditions_mismatchAndMinimums(t *testing
 
 func TestProposeEVMCapJobSpec_Apply_success(t *testing.T) {
 	setup := setupEVMCapTest(t)
-	env := setup.env
 
 	const (
 		inputLookback  int64 = 123 // non-zero input-level default
@@ -359,10 +363,12 @@ func TestProposeEVMCapJobSpec_Apply_success(t *testing.T) {
 	input.EVMCapabilityInputs[0].OverrideDefaultCfg.DeltaStage = 5 * time.Second
 
 	// Verify should pass
-	require.NoError(t, jobs.ProposeEVMCapJobSpec{}.VerifyPreconditions(*env, input))
-
-	out, err := jobs.ProposeEVMCapJobSpec{}.Apply(*env, input)
+	task := runtime.ChangesetTask(jobs.ProposeEVMCapJobSpec{}, input)
+	err := setup.rt.Exec(task)
 	require.NoError(t, err)
+
+	out := setup.rt.State().Outputs[task.ID()]
+	assert.NotNil(t, out, "changeset output should not be nil")
 	assert.Len(t, out.Reports, 1)
 
 	// Validate exactly one override and three defaults
@@ -377,7 +383,6 @@ func TestProposeEVMCapJobSpec_Apply_success(t *testing.T) {
 
 func TestProposeEVMCapJobSpec_Apply_duplicateNodeIDs(t *testing.T) {
 	setup := setupEVMCapTest(t)
-	env := setup.env
 
 	input := setup.baseInput
 	// duplicate
@@ -387,22 +392,22 @@ func TestProposeEVMCapJobSpec_Apply_duplicateNodeIDs(t *testing.T) {
 		setup.evmCapInputs[0],
 	}
 
-	_, err := jobs.ProposeEVMCapJobSpec{}.Apply(*env, input)
+	task := runtime.ChangesetTask(jobs.ProposeEVMCapJobSpec{}, input)
+	err := setup.rt.Exec(task)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate nodeID")
+	require.ErrorContains(t, err, "duplicate nodeID")
 }
 
 func TestProposeStandardCapabilityJob_ReusesUUIDForEvmCapabilitiesV2(t *testing.T) {
 	setup := setupEVMCapTest(t)
-	env := setup.env
 	nodeIDs := setup.nodeIDs
 	baseInput := setup.baseInput
 
 	verifyJobProposal := func(revision int64) {
-		jobProposals, err := env.Offchain.ListProposals(t.Context(), &jobv1.ListProposalsRequest{})
+		jobProposals, err := setup.rt.Environment().Offchain.ListProposals(t.Context(), &jobv1.ListProposalsRequest{})
 		require.NoError(t, err)
 
-		jobsList, err := env.Offchain.ListJobs(t.Context(), &jobv1.ListJobsRequest{Filter: &jobv1.ListJobsRequest_Filter{NodeIds: nodeIDs}})
+		jobsList, err := setup.rt.Environment().Offchain.ListJobs(t.Context(), &jobv1.ListJobsRequest{Filter: &jobv1.ListJobsRequest_Filter{NodeIds: nodeIDs}})
 		require.NoError(t, err)
 
 		proposalsAtRevision := 0
@@ -420,19 +425,26 @@ func TestProposeStandardCapabilityJob_ReusesUUIDForEvmCapabilitiesV2(t *testing.
 
 	// verify that the jobs have been distributed and accepted
 	input := baseInput
-	_, err := jobs.ProposeEVMCapJobSpec{}.Apply(*env, input)
+
+	err := setup.rt.Exec(
+		runtime.ChangesetTask(jobs.ProposeEVMCapJobSpec{}, input),
+	)
 	require.NoError(t, err)
 
 	verifyJobProposal(1)
 
 	// different config generates different uuid, but evm cap jobs should lookup the old id and reuse it
 	input.ForwarderLookbackBlocks = 999
-	_, err = jobs.ProposeEVMCapJobSpec{}.Apply(*env, input)
+
+	err = setup.rt.Exec(
+		runtime.ChangesetTask(jobs.ProposeEVMCapJobSpec{}, input),
+	)
 	require.NoError(t, err)
+
 	verifyJobProposal(2)
 
 	// Verify that jobs use the new name format (evm-cap-v2)
-	jobProposals, err := env.Offchain.ListProposals(t.Context(), &jobv1.ListProposalsRequest{})
+	jobProposals, err := setup.rt.Environment().Offchain.ListProposals(t.Context(), &jobv1.ListProposalsRequest{})
 	require.NoError(t, err)
 
 	hasNewFormat := false
@@ -449,7 +461,6 @@ func TestProposeStandardCapabilityJob_ReusesUUIDForEvmCapabilitiesV2(t *testing.
 
 func TestProposeStandardCapabilityJob_ReusesUUIDWithLegacyNameFormat(t *testing.T) {
 	setup := setupEVMCapTest(t)
-	env := setup.env
 	nodeIDs := setup.nodeIDs
 	baseInput := setup.baseInput
 
@@ -460,7 +471,7 @@ func TestProposeStandardCapabilityJob_ReusesUUIDWithLegacyNameFormat(t *testing.
 		Command:     "/usr/local/bin/evm",
 		DONName:     test.DONName,
 		Domain:      "cre",
-		Environment: env.Name,
+		Environment: test.EnvironmentName,
 		DONFilters: []offchain.TargetDONFilter{
 			{Key: "zone", Value: test.Zone},
 		},
@@ -470,19 +481,21 @@ func TestProposeStandardCapabilityJob_ReusesUUIDWithLegacyNameFormat(t *testing.
 		BootstrapPeers:        baseInput.BootstrapperOCR3Urls,
 	}
 
-	_, err := jobs.ProposeStandardCapabilityJob{}.Apply(*env, legacyJobInput)
+	err := setup.rt.Exec(
+		runtime.ChangesetTask(jobs.ProposeStandardCapabilityJob{}, legacyJobInput),
+	)
 	require.NoError(t, err)
 
 	// Get initial proposal count after creating legacy job
-	initialProposals, err := env.Offchain.ListProposals(t.Context(), &jobv1.ListProposalsRequest{})
+	initialProposals, err := setup.rt.Environment().Offchain.ListProposals(t.Context(), &jobv1.ListProposalsRequest{})
 	require.NoError(t, err)
 	initialCount := len(initialProposals.GetProposals())
 
 	verifyJobProposal := func(expectedNewProposals int) {
-		jobProposals, err := env.Offchain.ListProposals(t.Context(), &jobv1.ListProposalsRequest{})
+		jobProposals, err := setup.rt.Environment().Offchain.ListProposals(t.Context(), &jobv1.ListProposalsRequest{})
 		require.NoError(t, err)
 
-		jobsList, err := env.Offchain.ListJobs(t.Context(), &jobv1.ListJobsRequest{Filter: &jobv1.ListJobsRequest_Filter{NodeIds: nodeIDs}})
+		jobsList, err := setup.rt.Environment().Offchain.ListJobs(t.Context(), &jobv1.ListJobsRequest{Filter: &jobv1.ListJobsRequest_Filter{NodeIds: nodeIDs}})
 		require.NoError(t, err)
 
 		require.Len(t, jobsList.GetJobs(), len(nodeIDs))
@@ -492,19 +505,23 @@ func TestProposeStandardCapabilityJob_ReusesUUIDWithLegacyNameFormat(t *testing.
 	// Now propose again with ProposeEVMCapJobSpec (which uses new format evm-cap-v2)
 	// The system should detect the existing legacy job and handle it correctly
 	input := baseInput
-	_, err = jobs.ProposeEVMCapJobSpec{}.Apply(*env, input)
+	err = setup.rt.Exec(
+		runtime.ChangesetTask(jobs.ProposeEVMCapJobSpec{}, input),
+	)
 	require.NoError(t, err)
 
 	verifyJobProposal(len(nodeIDs))
 
 	// different config generates different uuid, but evm cap jobs should lookup the old id and reuse it
 	input.ForwarderLookbackBlocks = 999
-	_, err = jobs.ProposeEVMCapJobSpec{}.Apply(*env, input)
+	err = setup.rt.Exec(
+		runtime.ChangesetTask(jobs.ProposeEVMCapJobSpec{}, input),
+	)
 	require.NoError(t, err)
 	verifyJobProposal(len(nodeIDs) * 2)
 
 	// Verify that jobs use the legacy name format (evm-capabilities-v2) when UUIDs are reused
-	jobProposals, err := env.Offchain.ListProposals(t.Context(), &jobv1.ListProposalsRequest{})
+	jobProposals, err := setup.rt.Environment().Offchain.ListProposals(t.Context(), &jobv1.ListProposalsRequest{})
 	require.NoError(t, err)
 
 	hasLegacyFormat := false

--- a/deployment/cre/jobs/propose_job_spec_test.go
+++ b/deployment/cre/jobs/propose_job_spec_test.go
@@ -509,8 +509,8 @@ func TestProposeJobSpec_VerifyPreconditions_Aptos(t *testing.T) {
 }
 
 func TestProposeJobSpec_Apply(t *testing.T) {
-	testEnv := test.SetupEnvV2(t, false)
-	env := testEnv.Env
+	h := test.NewTestHarness(t)
+	env := new(h.Runtime.Environment())
 
 	t.Run("successful cron job distribution", func(t *testing.T) {
 		input := jobs.ProposeJobSpecInput{
@@ -534,7 +534,7 @@ func TestProposeJobSpec_Apply(t *testing.T) {
 			},
 		}
 
-		allNodes, err := testEnv.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
+		allNodes, err := h.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
 		require.NoError(t, err)
 
 		for _, n := range allNodes.Nodes {
@@ -545,7 +545,7 @@ func TestProposeJobSpec_Apply(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, out.Reports, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		filteredReqs := slices.DeleteFunc(reqs, func(s *job.ProposeJobRequest) bool {
@@ -589,7 +589,7 @@ perSenderBurst = 100
 			},
 		}
 
-		allNodes, err := testEnv.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
+		allNodes, err := h.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
 		require.NoError(t, err)
 
 		for _, n := range allNodes.Nodes {
@@ -600,7 +600,7 @@ perSenderBurst = 100
 		require.NoError(t, err)
 		assert.Len(t, out.Reports, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		filteredReqs := slices.DeleteFunc(reqs, func(s *job.ProposeJobRequest) bool {
@@ -643,7 +643,7 @@ perSenderBurst = 100
 			},
 		}
 
-		allNodes, err := testEnv.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
+		allNodes, err := h.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
 		require.NoError(t, err)
 
 		for _, n := range allNodes.Nodes {
@@ -654,7 +654,7 @@ perSenderBurst = 100
 		require.NoError(t, err)
 		assert.Len(t, out.Reports, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		filteredReqs := slices.DeleteFunc(reqs, func(s *job.ProposeJobRequest) bool {
@@ -696,7 +696,7 @@ PerSenderBurst = 100
 			},
 		}
 
-		allNodes, err := testEnv.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
+		allNodes, err := h.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
 		require.NoError(t, err)
 
 		for _, n := range allNodes.Nodes {
@@ -707,7 +707,7 @@ PerSenderBurst = 100
 		require.NoError(t, err)
 		assert.Len(t, out.Reports, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		filteredReqs := slices.DeleteFunc(reqs, func(s *job.ProposeJobRequest) bool {
@@ -756,7 +756,7 @@ PerSenderBurst = 100
 			},
 		}
 
-		allNodes, err := testEnv.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
+		allNodes, err := h.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
 		require.NoError(t, err)
 
 		for _, n := range allNodes.Nodes {
@@ -767,7 +767,7 @@ PerSenderBurst = 100
 		require.NoError(t, err)
 		assert.Len(t, out.Reports, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		filteredReqs := slices.DeleteFunc(reqs, func(s *job.ProposeJobRequest) bool {
@@ -810,7 +810,7 @@ PerSenderBurst = 100
 			},
 		}
 
-		allNodes, err := testEnv.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
+		allNodes, err := h.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
 		require.NoError(t, err)
 
 		for _, n := range allNodes.Nodes {
@@ -821,7 +821,7 @@ PerSenderBurst = 100
 		require.NoError(t, err)
 		assert.Len(t, out.Reports, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		filteredReqs := slices.DeleteFunc(reqs, func(s *job.ProposeJobRequest) bool {
@@ -839,7 +839,7 @@ PerSenderBurst = 100
 	})
 
 	t.Run("successful aptos job distribution includes oracle factory", func(t *testing.T) {
-		chainSelector := testEnv.RegistrySelector
+		chainSelector := h.RegistrySelector
 		ds := datastore.NewMemoryDataStore()
 
 		err := ds.Addresses().Add(datastore.AddressRef{
@@ -869,7 +869,7 @@ PerSenderBurst = 100
 				"config":           `{"chainId":"4","network":"aptos","creForwarderAddress":"0x1111111111111111111111111111111111111111111111111111111111111111"}`,
 				"chainSelectorEVM": strconv.FormatUint(chainSelector, 10),
 				"chainSelectorAptos": strconv.FormatUint(
-					testEnv.AptosSelector,
+					h.AptosSelector,
 					10,
 				),
 				"bootstrapPeers": []string{
@@ -884,7 +884,7 @@ PerSenderBurst = 100
 		require.NoError(t, err)
 		assert.Len(t, out.Reports, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		filteredReqs := slices.DeleteFunc(reqs, func(s *job.ProposeJobRequest) bool {
@@ -998,7 +998,7 @@ PerSenderBurst = 100
 		require.True(t, ok)
 		assert.Len(t, bootstrapOut.Specs, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		expectedChainID := chainsel.ETHEREUM_TESTNET_SEPOLIA.EvmChainID
@@ -1083,7 +1083,7 @@ PerSenderBurst = 100
 	})
 
 	t.Run("successful ocr3 job distribution", func(t *testing.T) {
-		chainSelector := testEnv.RegistrySelector
+		chainSelector := h.RegistrySelector
 		ds := datastore.NewMemoryDataStore()
 
 		err := ds.Addresses().Add(datastore.AddressRef{
@@ -1112,7 +1112,7 @@ PerSenderBurst = 100
 				"templateName":       "worker-ocr3",
 				"contractQualifier":  "ocr3-contract-qualifier",
 				"chainSelectorEVM":   strconv.FormatUint(chainSelector, 10),
-				"chainSelectorAptos": strconv.FormatUint(testEnv.AptosSelector, 10),
+				"chainSelectorAptos": strconv.FormatUint(h.AptosSelector, 10),
 				"bootstrapperOCR3Urls": []string{
 					"12D3KooWHfYFQ8hGttAYbMCevQVESEQhzJAqFZokMVtom8bNxwGq@127.0.0.1:5001",
 				},
@@ -1123,7 +1123,7 @@ PerSenderBurst = 100
 		require.NoError(t, err)
 		assert.Len(t, out.Reports, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		expectedChainID := chainsel.TEST_90000001.EvmChainID
@@ -1148,7 +1148,7 @@ PerSenderBurst = 100
 	})
 
 	t.Run("failed ocr3 job distribution", func(t *testing.T) {
-		chainSelector := testEnv.RegistrySelector
+		chainSelector := h.RegistrySelector
 		ds := datastore.NewMemoryDataStore()
 
 		err := ds.Addresses().Add(datastore.AddressRef{
@@ -1220,7 +1220,7 @@ PerSenderBurst = 100
 		require.NoError(t, err)
 		assert.Len(t, out.Reports, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		for _, req := range reqs {
@@ -1321,7 +1321,7 @@ PerSenderBurst = 100
 		require.NoError(t, err)
 		assert.Len(t, out.Reports, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		for _, req := range reqs {
@@ -1360,7 +1360,7 @@ PerSenderBurst = 100
 		require.NoError(t, err)
 		assert.Len(t, out.Reports, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 		for _, req := range reqs {
 			if !strings.Contains(req.Spec, `name = "http-action-job"`) {
@@ -1461,7 +1461,7 @@ PerSenderBurst = 100
 	})
 
 	t.Run("successful bootstrap distribution", func(t *testing.T) {
-		chainSelector := testEnv.RegistrySelector
+		chainSelector := h.RegistrySelector
 		ds := datastore.NewMemoryDataStore()
 
 		err := ds.Addresses().Add(datastore.AddressRef{
@@ -1528,7 +1528,7 @@ PerSenderBurst = 100
 			}
 		}
 
-		propJobs, err := testEnv.TestJD.ListProposedJobRequests()
+		propJobs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		foundSet := map[string]bool{}
@@ -1548,7 +1548,7 @@ PerSenderBurst = 100
 	})
 
 	t.Run("unsuccessful bootstrap distribution because contracts don't exist", func(t *testing.T) {
-		chainSelector := testEnv.RegistrySelector
+		chainSelector := h.RegistrySelector
 		ds := datastore.NewMemoryDataStore()
 
 		env.DataStore = ds.Seal()
@@ -1575,10 +1575,10 @@ PerSenderBurst = 100
 	})
 
 	t.Run("successful vault ocr3 job distribution", func(t *testing.T) {
-		testEnv := test.SetupEnvV2(t, false)
-		env := testEnv.Env
+		h2 := test.NewTestHarness(t)
+		env2 := new(h2.Runtime.Environment())
 
-		chainSelector := testEnv.RegistrySelector
+		chainSelector := h2.RegistrySelector
 		ds := datastore.NewMemoryDataStore()
 
 		err := ds.Addresses().Add(datastore.AddressRef{
@@ -1599,7 +1599,7 @@ PerSenderBurst = 100
 		})
 		require.NoError(t, err)
 
-		env.DataStore = ds.Seal()
+		env2.DataStore = ds.Seal()
 
 		input := jobs.ProposeJobSpecInput{
 			Environment: test.EnvironmentName,
@@ -1624,11 +1624,11 @@ PerSenderBurst = 100
 			},
 		}
 
-		out, err := jobs.ProposeJobSpec{}.Apply(*env, input)
+		out, err := jobs.ProposeJobSpec{}.Apply(*env2, input)
 		require.NoError(t, err)
 		assert.Len(t, out.Reports, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h2.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		expectedChainID := chainsel.TEST_90000001.EvmChainID
@@ -1650,7 +1650,7 @@ PerSenderBurst = 100
 	})
 
 	t.Run("successful consensus job distribution", func(t *testing.T) {
-		chainSelector := testEnv.RegistrySelector
+		chainSelector := h.RegistrySelector
 		ds := datastore.NewMemoryDataStore()
 
 		err := ds.Addresses().Add(datastore.AddressRef{
@@ -1689,7 +1689,7 @@ PerSenderBurst = 100
 		require.NoError(t, err)
 		assert.Len(t, out.Reports, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		expectedChainID := chainsel.TEST_90000001.EvmChainID
@@ -1716,7 +1716,7 @@ PerSenderBurst = 100
 	})
 
 	t.Run("successful consensus job distribution with aptos", func(t *testing.T) {
-		chainSelector := testEnv.RegistrySelector
+		chainSelector := h.RegistrySelector
 		ds := datastore.NewMemoryDataStore()
 
 		err := ds.Addresses().Add(datastore.AddressRef{
@@ -1745,7 +1745,7 @@ PerSenderBurst = 100
 				"command":            "consensus",
 				"contractQualifier":  "ocr3-contract-qualifier",
 				"chainSelectorEVM":   strconv.FormatUint(chainSelector, 10),
-				"chainSelectorAptos": strconv.FormatUint(testEnv.AptosSelector, 10),
+				"chainSelectorAptos": strconv.FormatUint(h.AptosSelector, 10),
 				"bootstrapPeers": []string{
 					"12D3KooWHfYFQ8hGttAYbMCevQVESEQhzJAqFZokMVtom8bNxwGq@127.0.0.1:5001",
 				},
@@ -1758,7 +1758,7 @@ PerSenderBurst = 100
 		require.NoError(t, err)
 		assert.Len(t, out.Reports, 1)
 
-		reqs, err := testEnv.TestJD.ListProposedJobRequests()
+		reqs, err := h.TestJD.ListProposedJobRequests()
 		require.NoError(t, err)
 
 		expectedChainID := chainsel.TEST_90000001.EvmChainID
@@ -1785,7 +1785,7 @@ PerSenderBurst = 100
 	})
 
 	t.Run("failed consensus job distribution", func(t *testing.T) {
-		chainSelector := testEnv.RegistrySelector
+		chainSelector := h.RegistrySelector
 		ds := datastore.NewMemoryDataStore()
 
 		err := ds.Addresses().Add(datastore.AddressRef{

--- a/deployment/cre/jobs/propose_solana_job_test.go
+++ b/deployment/cre/jobs/propose_solana_job_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 	csav1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/csa"
 	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
@@ -183,22 +184,26 @@ func TestProposeSolanaJobSpec_VerifyPreconditions_overrideMismatches(t *testing.
 }
 
 type solanaJobTestSetup struct {
-	env             *cldf.Environment
+	rt              *runtime.Runtime
 	solanaCapInputs []jobs.SolanaCapabilityInput
 	baseInput       jobs.ProposeSolanaJobSpecInput
 }
 
 func setupSolanaJobTest(t *testing.T) solanaJobTestSetup {
 	t.Helper()
-	testEnv := test.SetupEnvV2(t, false)
-	solSel := chainsel.SOLANA_DEVNET.Selector
 
-	ds := datastore.NewMemoryDataStore()
+	var (
+		solSel = chainsel.SOLANA_DEVNET.Selector
+		ds     = datastore.NewMemoryDataStore()
+	)
+
 	seedSolanaForwarderAddresses(t, ds, solSel, testSolSolanaFwdQualifier, testSolanaForwarderProgram, testSolanaForwarderState)
-	env := testEnv.Env
-	env.DataStore = ds.Seal()
 
-	nodes, err := testEnv.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
+	// Inject a new Job Distributor into the environment for testing
+	h := test.NewTestHarness(t, test.WithDatastore(ds))
+	env := h.Runtime.Environment()
+
+	nodes, err := h.TestJD.ListNodes(t.Context(), &node.ListNodesRequest{})
 	require.NoError(t, err)
 
 	var solanaCapInputs []jobs.SolanaCapabilityInput
@@ -212,7 +217,7 @@ func setupSolanaJobTest(t *testing.T) solanaJobTestSetup {
 	}
 
 	client := tenv.NewJobServiceClient(mockGetter)
-	testEnv.TestJD.JobServiceClient = client
+	h.TestJD.JobServiceClient = client
 
 	env.Offchain = struct {
 		jobv1.JobServiceClient
@@ -223,6 +228,9 @@ func setupSolanaJobTest(t *testing.T) solanaJobTestSetup {
 		NodeServiceClient: env.Offchain,
 		CSAServiceClient:  env.Offchain,
 	}
+
+	// We need to create a new runtime from the updated environment
+	h.Runtime = runtime.NewFromEnvironment(env)
 
 	baseInput := jobs.ProposeSolanaJobSpecInput{
 		Environment:            test.EnvironmentName,
@@ -237,7 +245,7 @@ func setupSolanaJobTest(t *testing.T) solanaJobTestSetup {
 	}
 
 	return solanaJobTestSetup{
-		env:             env,
+		rt:              h.Runtime,
 		solanaCapInputs: solanaCapInputs,
 		baseInput:       baseInput,
 	}
@@ -247,9 +255,11 @@ func TestProposeSolanaJobSpec_Apply_success(t *testing.T) {
 	setup := setupSolanaJobTest(t)
 	input := setup.baseInput
 
-	require.NoError(t, jobs.ProposeSolanaJobSpec{}.VerifyPreconditions(*setup.env, input))
+	task := runtime.ChangesetTask(jobs.ProposeSolanaJobSpec{}, input)
+	err := setup.rt.Exec(task)
+	require.NoError(t, err)
 
-	out, err := jobs.ProposeSolanaJobSpec{}.Apply(*setup.env, input)
+	out := setup.rt.State().Outputs[task.ID()]
 	require.NoError(t, err)
 	assert.Len(t, out.Reports, 1)
 }
@@ -263,7 +273,7 @@ func TestProposeSolanaJobSpec_Apply_duplicateNodeIDs(t *testing.T) {
 		setup.solanaCapInputs[0],
 	}
 
-	_, err := jobs.ProposeSolanaJobSpec{}.Apply(*setup.env, input)
+	_, err := jobs.ProposeSolanaJobSpec{}.Apply(setup.rt.Environment(), input)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "duplicate nodeID")
 }

--- a/deployment/cre/pkg/offchain/changeset/register_nodes_with_jd_test.go
+++ b/deployment/cre/pkg/offchain/changeset/register_nodes_with_jd_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/offchain/node"
 	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
@@ -26,7 +27,9 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 
 	t.Run("all ok", func(t *testing.T) {
 		t.Parallel()
-		env := test.SetupEnvV2(t, false)
+
+		h := test.NewTestHarness(t)
+
 		// Prepare input: one DON with two nodes
 		input := changeset.CsRegisterNodesWithJDInput{
 			Domain:      "test-domain",
@@ -55,11 +58,13 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 				},
 			},
 		}
-		cs := changeset.CsRegisterNodesWithJD{}
 
 		// Apply changeset
-		out, err := cs.Apply(*env.Env, input)
+		task := runtime.ChangesetTask(changeset.CsRegisterNodesWithJD{}, input)
+		err := h.Runtime.Exec(task)
 		require.NoError(t, err)
+		out := h.Runtime.State().Outputs[task.ID()]
+		require.NotNil(t, out, "changeset output should not be nil")
 
 		// Validate output reports
 		require.NotEmpty(t, out.Reports)
@@ -73,7 +78,7 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 			assert.Equal(t, o.Node.PublicKey, input.DONs[0].Nodes[i].CSAKey)
 			checkLabels(t, o.Node.Labels, map[string]string{
 				"product":             input.Domain,
-				"environment":         env.Env.Name,
+				"environment":         h.Runtime.Environment().Name,
 				"type":                "plugin",
 				"zone":                zone,
 				"don-" + test.DONName: "",
@@ -81,12 +86,17 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 			})
 		}
 	})
+
 	t.Run("register node error", func(t *testing.T) {
 		t.Parallel()
-		env := test.SetupEnvV2(t, false)
 
-		env.Env.Offchain = testJDClient{
-			env.TestJD,
+		var (
+			h   = test.NewTestHarness(t)
+			env = h.Runtime.Environment()
+		)
+
+		env.Offchain = testJDClient{
+			h.TestJD,
 		}
 
 		// Prepare input: one DON with one node that will trigger an error
@@ -110,8 +120,11 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 		}
 
 		// Apply changeset with test JD client that simulates error
+		//
+		// We cannot use the runtime Exec method here the runtime does not store output for failed changesets executions
+		// and the test is asserting on the output.
 		cs := changeset.CsRegisterNodesWithJD{}
-		out, err := cs.Apply(*env.Env, input)
+		out, err := cs.Apply(env, input)
 		require.Error(t, err)
 
 		// Validate output reports
@@ -128,14 +141,20 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 	// test with mixed valid and error nodes
 	t.Run("mixed valid and error nodes", func(t *testing.T) {
 		t.Parallel()
-		env := test.SetupEnvV2(t, false)
-		nodesReps, err := env.Env.Offchain.ListNodes(t.Context(), &nodev1.ListNodesRequest{})
+
+		var (
+			h   = test.NewTestHarness(t)
+			env = h.Runtime.Environment()
+		)
+
+		nodesReps, err := env.Offchain.ListNodes(t.Context(), &nodev1.ListNodesRequest{})
 		require.NoError(t, err)
 		nodes := nodesReps.GetNodes()
 
-		env.Env.Offchain = testJDClient{
-			env.TestJD,
+		env.Offchain = testJDClient{
+			h.TestJD,
 		}
+
 		// Prepare input: one DON with three nodes, one of which will trigger an error
 		input := changeset.CsRegisterNodesWithJDInput{
 			Domain:      "cre",
@@ -171,7 +190,7 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 
 		// Apply changeset with test JD client that simulates error
 		cs := changeset.CsRegisterNodesWithJD{}
-		out, err := cs.Apply(*env.Env, input)
+		out, err := cs.Apply(env, input)
 		require.Error(t, err)
 
 		// Validate output reports
@@ -198,7 +217,7 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 		}
 		checkLabels(t, o1.Node.Labels, map[string]string{
 			"product":             input.Domain,
-			"environment":         env.Env.Name,
+			"environment":         h.Runtime.Environment().Name,
 			"type":                typeLabel,
 			"zone":                zone,
 			"don-" + test.DONName: test.DONName,
@@ -232,7 +251,7 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 		assert.Equal(t, o3.Node.PublicKey, input.DONs[0].Nodes[2].CSAKey)
 		checkLabels(t, o3.Node.Labels, map[string]string{
 			"product":             input.Domain,
-			"environment":         env.Env.Name,
+			"environment":         h.Runtime.Environment().Name,
 			"type":                typeLabel,
 			"zone":                zone,
 			"don-" + test.DONName: test.DONName,
@@ -243,13 +262,14 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 	// test with valid node that gets updated
 	t.Run("valid node that gets updated", func(t *testing.T) {
 		t.Parallel()
-		env := test.SetupEnvV2(t, false)
 
-		nodes, err := env.Env.Offchain.ListNodes(t.Context(), &nodev1.ListNodesRequest{})
+		h := test.NewTestHarness(t)
+
+		nodes, err := h.Runtime.Environment().Offchain.ListNodes(t.Context(), &nodev1.ListNodesRequest{})
 		require.NoError(t, err)
 		firstNode := nodes.GetNodes()[0]
 
-		n, err := env.Env.Offchain.GetNode(t.Context(), &nodev1.GetNodeRequest{
+		n, err := h.Runtime.Environment().Offchain.GetNode(t.Context(), &nodev1.GetNodeRequest{
 			PublicKey: &firstNode.PublicKey,
 		})
 		require.NoError(t, err)
@@ -279,9 +299,11 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 		}
 
 		// Apply changeset with test JD client that simulates error
-		cs := changeset.CsRegisterNodesWithJD{}
-		out, err := cs.Apply(*env.Env, input)
+		task := runtime.ChangesetTask(changeset.CsRegisterNodesWithJD{}, input)
+		err = h.Runtime.Exec(task)
 		require.NoError(t, err)
+		out := h.Runtime.State().Outputs[task.ID()]
+		require.NotNil(t, out, "changeset output should not be nil")
 
 		// Validate output reports
 		require.Len(t, out.Reports, 1)
@@ -306,7 +328,7 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 			"don-" + test.DONName: test.DONName, // the label already existed
 			"product":             "cre",        // existing label should remain
 			"type":                typeLabel,
-			"environment":         env.Env.Name,
+			"environment":         h.Runtime.Environment().Name,
 			"zone":                zone,
 			"p2p_id":              p2pID,
 		})
@@ -315,13 +337,17 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 	// test with update node error
 	t.Run("update node error", func(t *testing.T) {
 		t.Parallel()
-		env := test.SetupEnvV2(t, false)
 
-		nodes, err := env.Env.Offchain.ListNodes(t.Context(), &nodev1.ListNodesRequest{})
+		var (
+			h   = test.NewTestHarness(t)
+			env = h.Runtime.Environment()
+		)
+
+		nodes, err := h.Runtime.Environment().Offchain.ListNodes(t.Context(), &nodev1.ListNodesRequest{})
 		require.NoError(t, err)
 		firstNode := nodes.GetNodes()[0]
 
-		n, err := env.Env.Offchain.GetNode(t.Context(), &nodev1.GetNodeRequest{
+		n, err := env.Offchain.GetNode(t.Context(), &nodev1.GetNodeRequest{
 			PublicKey: &firstNode.PublicKey,
 		})
 		require.NoError(t, err)
@@ -330,15 +356,15 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 		require.Equal(t, n.Node.Name, firstNode.Name)
 		require.Equal(t, n.Node.PublicKey, firstNode.PublicKey)
 
-		_, err = env.Env.Offchain.UpdateNode(t.Context(), &nodev1.UpdateNodeRequest{
+		_, err = env.Offchain.UpdateNode(t.Context(), &nodev1.UpdateNodeRequest{
 			Id:        firstNode.Id,
 			Name:      "update-node-error",
 			PublicKey: firstNode.PublicKey,
 		})
 		require.NoError(t, err)
 
-		env.Env.Offchain = testJDClient{
-			env.TestJD,
+		env.Offchain = testJDClient{
+			h.TestJD,
 		}
 
 		// Prepare input: one DON with one node that will trigger an update error
@@ -363,7 +389,7 @@ func TestCsRegisterNodesWithJD_Apply(t *testing.T) {
 
 		// Apply changeset with test JD client that simulates error
 		cs := changeset.CsRegisterNodesWithJD{}
-		out, err := cs.Apply(*env.Env, input)
+		out, err := cs.Apply(env, input)
 		require.Error(t, err)
 
 		// Validate output reports
@@ -402,11 +428,14 @@ func TestCsRegisterNodesWithJDV2_Apply(t *testing.T) {
 			},
 		}
 
-		env := test.SetupEnvV2(t, false)
-		cs := changeset.CsRegisterNodesWithJDV2{}
+		h := test.NewTestHarness(t)
 
-		out, err := cs.Apply(*env.Env, input)
+		task := runtime.ChangesetTask(changeset.CsRegisterNodesWithJDV2{}, input)
+		err := h.Runtime.Exec(task)
 		require.NoError(t, err)
+
+		out := h.Runtime.State().Outputs[task.ID()]
+		require.NotNil(t, out, "changeset output should not be nil")
 		require.Len(t, out.Reports, 2)
 		for i, report := range out.Reports {
 			assert.NotNil(t, report)
@@ -416,7 +445,7 @@ func TestCsRegisterNodesWithJDV2_Apply(t *testing.T) {
 			assert.Equal(t, input.DONs[0].Nodes[i].CSAKey, o.Node.PublicKey)
 			checkLabels(t, o.Node.Labels, map[string]string{
 				"product":             input.Domain,
-				"environment":         env.Env.Name,
+				"environment":         h.Runtime.Environment().Name,
 				"type":                "plugin",
 				"zone":                test.Zone,
 				"don-" + test.DONName: "",
@@ -431,9 +460,9 @@ func TestCsRegisterNodesWithJDV2_Apply(t *testing.T) {
 			DONs:        []offchain.DONConfig{},
 		}
 
-		env := test.SetupEnvV2(t, false)
+		h := test.NewTestHarness(t)
 		cs := changeset.CsRegisterNodesWithJDV2{}
-		err := cs.VerifyPreconditions(*env.Env, input)
+		err := cs.VerifyPreconditions(h.Runtime.Environment(), input)
 		require.Error(t, err)
 	})
 
@@ -454,18 +483,18 @@ func TestCsRegisterNodesWithJDV2_Apply(t *testing.T) {
 			},
 		}
 
-		env := test.SetupEnvV2(t, false)
+		h := test.NewTestHarness(t)
 		cs := changeset.CsRegisterNodesWithJDV2{}
-		err := cs.VerifyPreconditions(*env.Env, input)
+		err := cs.VerifyPreconditions(h.Runtime.Environment(), input)
 		require.Error(t, err)
 	})
 
 	t.Run("fails with already registered node", func(t *testing.T) {
 		t.Parallel()
 
-		env := test.SetupEnvV2(t, false)
+		h := test.NewTestHarness(t)
 
-		nodesReps, err := env.Env.Offchain.ListNodes(t.Context(), &nodev1.ListNodesRequest{})
+		nodesReps, err := h.Runtime.Environment().Offchain.ListNodes(t.Context(), &nodev1.ListNodesRequest{})
 		require.NoError(t, err)
 		nodes := nodesReps.GetNodes()
 
@@ -484,8 +513,9 @@ func TestCsRegisterNodesWithJDV2_Apply(t *testing.T) {
 				},
 			},
 		}
-		cs := changeset.CsRegisterNodesWithJDV2{}
-		_, err = cs.Apply(*env.Env, input)
+
+		task := runtime.ChangesetTask(changeset.CsRegisterNodesWithJDV2{}, input)
+		err = h.Runtime.Exec(task)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), operations2.ErrNodeAlreadyExists.Error())
 	})

--- a/deployment/cre/test/env_setup.go
+++ b/deployment/cre/test/env_setup.go
@@ -49,7 +49,7 @@ var (
 	DefaultAptosSelector    uint64 = chain_selectors.APTOS_LOCALNET.Selector
 )
 
-type EnvWrapperV2 struct {
+type Harness struct {
 	t *testing.T
 
 	Runtime *runtime.Runtime
@@ -57,7 +57,6 @@ type EnvWrapperV2 struct {
 
 	TestJD *envtest.JDNodeService
 
-	Env              *cldf.Environment
 	RegistrySelector uint64
 	RegistryAddress  common.Address
 	AptosSelector    uint64
@@ -72,6 +71,7 @@ type donConfig struct {
 	RegistryChainSel uint64
 }
 
+// HarnessConfig is used to configure the initialization of the test harness.
 type HarnessConfig struct {
 	WithMCMS      bool
 	DatastoreSeed *datastore.MemoryDataStore
@@ -109,7 +109,7 @@ func WithDatastore(ds *datastore.MemoryDataStore) HarnessOpt {
 // initHarness sets up the runtime and environment for the test harness.
 //
 // TODO CRE-999; aptos can be made optional
-func initHarness(t *testing.T, lggr logger.Logger, cfg *HarnessConfig) *EnvWrapperV2 {
+func initHarness(t *testing.T, lggr logger.Logger, cfg *HarnessConfig) *Harness {
 	var (
 		registryChainSel = chain_selectors.TEST_90000001.Selector
 		// by inspection, the only chain that is needed is evm, but some callers
@@ -143,7 +143,7 @@ func initHarness(t *testing.T, lggr logger.Logger, cfg *HarnessConfig) *EnvWrapp
 	))
 	require.NoError(t, err)
 
-	return &EnvWrapperV2{
+	return &Harness{
 		t:                t,
 		Runtime:          rt,
 		TestJD:           jd,
@@ -155,7 +155,7 @@ func initHarness(t *testing.T, lggr logger.Logger, cfg *HarnessConfig) *EnvWrapp
 
 // NewTestHarness starts a runtime with a single DON, 4 nodes and a capabilities registry v2
 // deployed and configured.
-func NewTestHarness(t *testing.T, opts ...HarnessOpt) *EnvWrapperV2 {
+func NewTestHarness(t *testing.T, opts ...HarnessOpt) *Harness {
 	t.Helper()
 
 	cfg := &HarnessConfig{}
@@ -187,29 +187,11 @@ func NewTestHarness(t *testing.T, opts ...HarnessOpt) *EnvWrapperV2 {
 		setupMCMSInfrastructure(t, h)
 	}
 
-	// Set the Environment because some changesets still use the Environment pointer
-	// To be removed once all changesets below use the runtime instead
-	h.Env = new(h.Runtime.Environment())
-
 	return h
 }
 
-// SetupEnvV2 is a deprecated function that is kept for backwards compatibility.
-//
-// Use NewTestHarness instead.
-func SetupEnvV2(t *testing.T, useMCMS bool) *EnvWrapperV2 {
-	t.Helper()
-
-	var opts []HarnessOpt
-	if useMCMS {
-		opts = append(opts, WithMCMS())
-	}
-
-	return NewTestHarness(t, opts...)
-}
-
 // configureCapabilitiesRegistry configures the capabilities registry in the runtime environment
-func configureCapabilitiesRegistry(t *testing.T, h *EnvWrapperV2) {
+func configureCapabilitiesRegistry(t *testing.T, h *Harness) {
 	t.Helper()
 
 	chainID, err := chain_selectors.GetChainIDFromSelector(h.RegistrySelector)
@@ -280,7 +262,7 @@ func configureCapabilitiesRegistry(t *testing.T, h *EnvWrapperV2) {
 }
 
 // capabilitiesRegistryClient returns a new capabilities registry client
-func capabilitiesRegistryClient(t *testing.T, h *EnvWrapperV2) *capabilities_registry_v2.CapabilitiesRegistry {
+func capabilitiesRegistryClient(t *testing.T, h *Harness) *capabilities_registry_v2.CapabilitiesRegistry {
 	t.Helper()
 
 	capReg, err := capabilities_registry_v2.NewCapabilitiesRegistry(
@@ -294,7 +276,7 @@ func capabilitiesRegistryClient(t *testing.T, h *EnvWrapperV2) *capabilities_reg
 }
 
 // assertCapabilitiesRegistryConfigured asserts that the capabilities registry is configured correctly
-func assertCapabilitiesRegistryConfigured(t *testing.T, h *EnvWrapperV2) {
+func assertCapabilitiesRegistryConfigured(t *testing.T, h *Harness) {
 	t.Helper()
 
 	capReg := capabilitiesRegistryClient(t, h)
@@ -313,7 +295,7 @@ func assertCapabilitiesRegistryConfigured(t *testing.T, h *EnvWrapperV2) {
 }
 
 // deployCapabilitiesRegistry deploys the capabilities registry in the runtime environment
-func deployCapabilitiesRegistry(t *testing.T, h *EnvWrapperV2) {
+func deployCapabilitiesRegistry(t *testing.T, h *Harness) {
 	t.Helper()
 
 	err := h.Runtime.Exec(
@@ -328,7 +310,7 @@ func deployCapabilitiesRegistry(t *testing.T, h *EnvWrapperV2) {
 }
 
 // setupMCMSInfrastructure sets up the MCMS infrastructure in the runtime environment
-func setupMCMSInfrastructure(t *testing.T, h *EnvWrapperV2) {
+func setupMCMSInfrastructure(t *testing.T, h *Harness) {
 	t.Helper()
 
 	t.Log("Setting up MCMS infrastructure...")


### PR DESCRIPTION
This completes the migration of the CRE tests to use the new TestHarness which uses the CLDF test engine under the hood.

This removes the dependency on legacy test helpers for applying changesets.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
