### PR TITLE
Bump confidential-compute ref to support vault changes

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -48,5 +48,5 @@ plugins:
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confi\
         dential-http/capability"
-      gitRef: "e4977d6a6c993f99664b7f996357ffd4c645eaf4"
+      gitRef: "490ea72d7b66ea0b650528a0ca5e4c60cb04d423"
       installPath: "./cmd/confidential-http"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -48,5 +48,5 @@ plugins:
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confi\
         dential-http/capability"
-      gitRef: "2f08d370e6be1e35e036241cfd3cc37539a30d31"
+      gitRef: "e4977d6a6c993f99664b7f996357ffd4c645eaf4"
       installPath: "./cmd/confidential-http"


### PR DESCRIPTION
This PR in confidential-compute is needed for Vault Optimizations: https://github.com/smartcontractkit/confidential-compute/pull/344
