### PR TITLE
Bump package.json version to 2.49.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.49.0",
+  "version": "2.49.1",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps `package.json` version from `2.49.0` to `2.49.1` so release builds and CI version checks target the correct patch release.
