### PR TITLE
Bump version and update CHANGELOG for v2.49.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog Chainlink Core
 
+## 2.49.1
+
+### Patch Changes
+
+- [#22666](https://github.com/smartcontractkit/chainlink/pull/22666) [`a2808a6`](https://github.com/smartcontractkit/chainlink/commit/a2808a6b275994649ef797486fbfde9c76757bfe) - Cherry-pick vault reliability fixes onto the `2.49.1` patch line for the CRE prod release train:
+  - [#22595](https://github.com/smartcontractkit/chainlink/pull/22595) [`7d2ffe7`](https://github.com/smartcontractkit/chainlink/commit/7d2ffe7965ac472649e161c70e00f3f0ef8b188c) - Optimize vault from load test
+  - [#22662](https://github.com/smartcontractkit/chainlink/pull/22662) [`068777e`](https://github.com/smartcontractkit/chainlink/commit/068777eee9e5f639069f8249c23cc000cdb4daab) - Bump confidential-compute ref to support vault changes
+
 ## 2.49.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.49.0",
+  "version": "2.49.1",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Sets `package.json` to **2.49.1** on the `release/2.49.1` patch line so `release-pre` tags pre-releases as `v2.49.1-beta.0` / `v2.49.1-rc.0` (not `v2.49.0-*`).

Prior `release-pre` runs read `package.json` = `2.49.0` and created erroneous tags `v2.49.0-beta.1` and `v2.49.0-rc.1`; build/publish on those tags was cancelled.

## Changes

- `package.json`: `2.49.0` → `2.49.1`
- `CHANGELOG.md`: add `2.49.1` patch section documenting vault cherry-picks ([#22666](https://github.com/smartcontractkit/chainlink/pull/22666))

## Tracking

- [RANE-4792](https://smartcontract-it.atlassian.net/browse/RANE-4792)

## After merge

1. Delete erroneous tags `v2.49.0-beta.1` and `v2.49.0-rc.1` (ProdSec / SECHD if protected)
2. Re-dispatch `release-pre` from `release/2.49.1` for beta and RC
3. Let build/publish complete for `2.49.1-beta.0` / `2.49.1-rc.0`

[RANE-4792]: https://smartcontract-it.atlassian.net/browse/RANE-4792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ