### PR TITLE
ci(build-publish): amd64 runners for mirror repos (canary tag builds)

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -114,6 +114,7 @@ jobs:
       docker-cache-behaviour: "disable"
       docker-manifest-sign: true
       docker-registry-url-override: public.ecr.aws/chainlink
+      github-runner-amd64: ${{ github.repository != 'smartcontractkit/chainlink' && 'ubuntu24.04-4cores-16GB' || 'ubuntu-24.04' }}
       github-runner-arm64: ${{ github.repository != 'smartcontractkit/chainlink' && 'ubuntu-24.04-4cores-16GB-ARM' || 'ubuntu-24.04-arm' }}
       docker-image-tag-strip-prefix: v # strip out the "v" prefix from the git tag for the image tag.
       free-disk-space: "true"
@@ -156,6 +157,7 @@ jobs:
       docker-cache-behaviour: "disable"
       docker-manifest-sign: true
       docker-registry-url-override: public.ecr.aws/chainlink
+      github-runner-amd64: ${{ github.repository != 'smartcontractkit/chainlink' && 'ubuntu24.04-4cores-16GB' || 'ubuntu-24.04' }}
       github-runner-arm64: ${{ github.repository != 'smartcontractkit/chainlink' && 'ubuntu-24.04-4cores-16GB-ARM' || 'ubuntu-24.04-arm' }}
       docker-image-tag-override: ${{ needs.checks.outputs.ccip-image-tag }}
       free-disk-space: "true"


### PR DESCRIPTION
## Summary

Adds **amd64** runner sizing and **`free-disk-space`** to `build-publish` for non-primary repos, matching the existing **arm64** / **`CL_GOPRIVATE`** pattern.

Tag-triggered builds on **chainlink-canary** run the workflow file **at the tag SHA** (usually mirrored from chainlink). Canary `main` edits do not affect those jobs — this change must live on **chainlink** (per Erik/Chad).

## Changes

For `docker-core` and `docker-ccip` when `github.repository != 'smartcontractkit/chainlink'`:

| Input | Mirror repos (canary, etc.) | `smartcontractkit/chainlink` |
|-------|-----------------------------|------------------------------|
| `github-runner-amd64` | `ubuntu24.04-4cores-16GB` | `ubuntu-24.04` (default) |
| `free-disk-space` | `true` | `false` |
| `github-runner-arm64` | (unchanged) `ubuntu-24.04-4cores-16GB-ARM` | `ubuntu-24.04-arm` |

## Context

- **RANE-4676** — amd64 disk exhaustion on default runners ([run 24488497332](https://github.com/smartcontractkit/chainlink-canary/actions/runs/24488497332))
- Chad: use org SKU from [canary runners](https://github.com/smartcontractkit/chainlink-canary/actions/runners) (`ubuntu24.04-4cores-16GB`)
- GATI / runner enablement: [SECHD-31475](https://smartcontract-it.atlassian.net/servicedesk/customer/portal/4/SECHD-31475)
- Canary-only runner overrides removed from [chainlink-canary#19](https://github.com/smartcontractkit/chainlink-canary/pull/19) (supersedes closed #20)

## Coordination

Merge **before or with** private-release work that tags canary from SHAs that include this workflow. **#22242** closed — not needed per Erik.

## Test plan

- [ ] CI green on this PR (workflow-only)
- [ ] After merge to `develop`, confirm next canary pre-release tag build schedules amd64 on `ubuntu24.04-4cores-16GB`

[SECHD-31475]: https://smartcontract-it.atlassian.net/browse/SECHD-31475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ