### PR TITLE
Added in normalization of namespace

### DIFF
--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -1267,6 +1267,11 @@ func (r *ReportingPlugin) validateSecretIdentifier(ctx context.Context, id *vaul
 		return nil, newUserError("secret identifier cannot be nil")
 	}
 
+	namespace := id.Namespace
+	if namespace == "" {
+		namespace = vaulttypes.DefaultNamespace
+	}
+
 	if err := r.validator.ValidateSecretIdentifier(ctx, id.Key, id.Owner, id.Namespace); err != nil {
 		return nil, newUserError(err.Error())
 	}

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -1272,14 +1272,14 @@ func (r *ReportingPlugin) validateSecretIdentifier(ctx context.Context, id *vaul
 		namespace = vaulttypes.DefaultNamespace
 	}
 
-	if err := r.validator.ValidateSecretIdentifier(ctx, id.Key, id.Owner, id.Namespace); err != nil {
+	if err := r.validator.ValidateSecretIdentifier(ctx, id.Key, id.Owner, namespace); err != nil {
 		return nil, newUserError(err.Error())
 	}
 
 	newID := &vaultcommon.SecretIdentifier{
 		Key:       id.Key,
 		Owner:     id.Owner,
-		Namespace: id.Namespace,
+		Namespace: namespace,
 	}
 
 	return newID, nil


### PR DESCRIPTION
Without this normalization, things fail during a mixed rollout of a new release.
Previous release had this normalization, so new release also needs to.
