### PR TITLE
link token changeset update

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -509,7 +509,7 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-ton v1.0.5-0.20260520103847-15ca4de9dba9 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260408092456-3c6369888d4a // indirect
-	github.com/smartcontractkit/cld-changesets v0.4.0 // indirect
+	github.com/smartcontractkit/cld-changesets v0.5.0 // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect
 	github.com/smartcontractkit/mcms v0.45.0 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1667,8 +1667,8 @@ github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260408092456-3c63
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260408092456-3c6369888d4a/go.mod h1:1eaXR+Fe6TlpP+CKXozfYlFM8QgN/N5C7OMvTRWNT8I=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b h1:RarA5fTnBzQY9wHhl6g7Ac7Nv0d/izr2/zuSWhveB4c=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b/go.mod h1:ea1LESxlSSOgc2zZBqf1RTkXTMthHaspdqUHd7W4lF0=
-github.com/smartcontractkit/cld-changesets v0.4.0 h1:S6yNRj6FssyyKbxLHTbC9X9U4qsph17xiiBBT6DGyNE=
-github.com/smartcontractkit/cld-changesets v0.4.0/go.mod h1:4wOfnbSP8Ior/75QWLbtDntamSA/81SYcXzctBSx9CY=
+github.com/smartcontractkit/cld-changesets v0.5.0 h1:JfiS3k8uijw1zcoFBTAHOzI1LxkhZVjPT4YoxI7zTxQ=
+github.com/smartcontractkit/cld-changesets v0.5.0/go.mod h1:SYJTJw3tyi+bIVFApQ7RSe7jQD2cyEM1bmypbKF2dcg=
 github.com/smartcontractkit/cre-sdk-go v1.5.0 h1:kepW3QDKARrOOHjXwWAZ9j5KLk6bxLzvi6OMrLsFwVo=
 github.com/smartcontractkit/cre-sdk-go v1.5.0/go.mod h1:yYrQFz1UH7hhRbPO0q4fgo1tfsJNd4yXnI3oCZE0RzM=
 github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad h1:lgHxTHuzJIF3Vj6LSMOnjhqKgRqYW+0MV2SExtCYL1Q=

--- a/deployment/ccip/changeset/cs_grant_and_mint_link_token.go
+++ b/deployment/ccip/changeset/cs_grant_and_mint_link_token.go
@@ -85,8 +85,11 @@ func GrantMintRoleAndMintLogic(e cldf.Environment, cfg GrantMintRoleAndMintConfi
 	chain := e.BlockChains.EVMChains()[cfg.Selector]
 
 	addresses, err := e.ExistingAddresses.AddressesForChain(cfg.Selector)
-	if err != nil {
+	if err != nil && !errors.Is(err, cldf.ErrChainNotFound) {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get addresses for chain %d: %w", cfg.Selector, err)
+	}
+	if addresses == nil {
+		addresses = make(map[string]cldf.TypeAndVersion)
 	}
 
 	linkState, err := evmstateview.MaybeLoadLinkTokenChainState(chain, addresses)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_deploy_chain_test.go
@@ -10,10 +10,10 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	solstate "github.com/smartcontractkit/cld-changesets/legacy/pkg/family/solana"
 	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
-
-	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
 	"github.com/smartcontractkit/quarantine"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
 
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	cldftesthelpers "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils/testhelpers"

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_deploy_chain_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/gagliardetto/solana-go"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	solstate "github.com/smartcontractkit/cld-changesets/legacy/pkg/family/solana"
-	linkchangesets "github.com/smartcontractkit/cld-changesets/link/changesets"
+	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
 	"github.com/smartcontractkit/quarantine"
 	"github.com/stretchr/testify/require"
 
@@ -58,12 +60,10 @@ func initialDeployCS(t *testing.T, e cldf.Environment, buildConfig *ccipChangese
 			},
 		),
 		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(linkchangesets.DeploySolanaLinkToken),
-			linkchangesets.DeploySolanaLinkTokenConfig{
-				ChainSelector: solChainSelectors[0],
-				TokenPrivKey:  solLinkTokenPrivKey,
-				TokenDecimals: 9,
-			},
+			deploylink.DeployLinkTokenChangeset{},
+			linkchangesets.DeployLinkTokenInput{Solana: map[uint64]linkchangesets.SolanaLinkConfig{
+				solChainSelectors[0]: {TokenPrivKey: solLinkTokenPrivKey, TokenDecimals: 9},
+			}},
 		),
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token_test.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
-	linkchangesets "github.com/smartcontractkit/cld-changesets/link/changesets"
+	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
 
 	solTokenUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 
@@ -188,11 +190,9 @@ func TestDeployLinkToken(t *testing.T) {
 	solLinkTokenPrivKey, _ := solana.NewRandomPrivateKey()
 
 	err = rt.Exec(
-		runtime.ChangesetTask(cldf.CreateLegacyChangeSet(linkchangesets.DeploySolanaLinkToken), linkchangesets.DeploySolanaLinkTokenConfig{
-			ChainSelector: selector,
-			TokenPrivKey:  solLinkTokenPrivKey,
-			TokenDecimals: 9,
-		}),
+		runtime.ChangesetTask(deploylink.DeployLinkTokenChangeset{}, linkchangesets.DeployLinkTokenInput{Solana: map[uint64]linkchangesets.SolanaLinkConfig{
+			selector: {TokenPrivKey: solLinkTokenPrivKey, TokenDecimals: 9},
+		}}),
 	)
 	require.NoError(t, err)
 

--- a/deployment/ccip/changeset/solana_v0_1_1/transfer_ccip_to_mcms_with_timelock_test.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/transfer_ccip_to_mcms_with_timelock_test.go
@@ -16,7 +16,9 @@ import (
 
 	cldftesthelpers "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils/testhelpers"
 
-	linkchangesets "github.com/smartcontractkit/cld-changesets/link/changesets"
+	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/testutils"
 	burnmint "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/burnmint_token_pool"
@@ -239,12 +241,10 @@ func prepareEnvironmentForOwnershipTransfer(t *testing.T) (cldf.Environment, sta
 			},
 		),
 		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(linkchangesets.DeploySolanaLinkToken),
-			linkchangesets.DeploySolanaLinkTokenConfig{
-				ChainSelector: solChainSel,
-				TokenPrivKey:  solLinkTokenPrivKey,
-				TokenDecimals: 9,
-			},
+			deploylink.DeployLinkTokenChangeset{},
+			linkchangesets.DeployLinkTokenInput{Solana: map[uint64]linkchangesets.SolanaLinkConfig{
+				solChainSel: {TokenPrivKey: solLinkTokenPrivKey, TokenDecimals: 9},
+			}},
 		),
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -41,7 +41,9 @@ import (
 	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
 
-	linkchangesets "github.com/smartcontractkit/cld-changesets/link/changesets"
+	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
 
 	sui_cs "github.com/smartcontractkit/chainlink-sui/deployment/changesets"
 
@@ -709,17 +711,20 @@ func NewEnvironmentWithPrerequisitesContracts(t *testing.T, tEnv TestEnvironment
 			Opts:          opts,
 		})
 	}
-	deployLinkApp := commonchangeset.Configure(
-		cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-		evmChains,
-	)
-
+	evmLinkCfg := linkchangesets.EVMLinkConfig{}
 	if tc.IsStaticLink {
-		deployLinkApp = commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(linkchangesets.DeployStaticLinkToken),
-			evmChains,
-		)
+		evmLinkCfg.Variant = linkchangesets.EVMLinkStatic
 	}
+	evmLinkInput := linkchangesets.DeployLinkTokenInput{
+		EVM: make(map[uint64]linkchangesets.EVMLinkConfig, len(evmChains)),
+	}
+	for _, sel := range evmChains {
+		evmLinkInput.EVM[sel] = evmLinkCfg
+	}
+	deployLinkApp := commonchangeset.Configure(
+		deploylink.DeployLinkTokenChangeset{},
+		evmLinkInput,
+	)
 	e.Env, err = commonchangeset.Apply(t, e.Env, deployLinkApp, commonchangeset.Configure(
 		cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
 		changeset.DeployPrerequisiteConfig{
@@ -733,11 +738,14 @@ func NewEnvironmentWithPrerequisitesContracts(t *testing.T, tEnv TestEnvironment
 	if len(solChains) > 0 {
 		solLinkTokenPrivKey, _ := solanago.NewRandomPrivateKey()
 		deploySolanaLinkApp := commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(linkchangesets.DeploySolanaLinkToken),
-			linkchangesets.DeploySolanaLinkTokenConfig{
-				ChainSelector: solChains[0],
-				TokenPrivKey:  solLinkTokenPrivKey,
-				TokenDecimals: 9,
+			deploylink.DeployLinkTokenChangeset{},
+			linkchangesets.DeployLinkTokenInput{
+				Solana: map[uint64]linkchangesets.SolanaLinkConfig{
+					solChains[0]: {
+						TokenPrivKey:  solLinkTokenPrivKey,
+						TokenDecimals: 9,
+					},
+				},
 			},
 		)
 		e.Env, err = commonchangeset.Apply(t, e.Env,
@@ -876,7 +884,8 @@ func DeployChainContractsToSolChainCSV0_1_1(e DeployedEnv, solChainSelector uint
 				BuildConfig:            buildSolConfig,
 				MCMSWithTimelockConfig: mcmsCfg,
 			},
-		)}, nil
+		),
+	}, nil
 }
 
 func DeployChainContractsToSolChainCS(e DeployedEnv, solChainSelector uint64, preload bool, buildSolConfig *ccipChangeSetSolanaV0_1_1.BuildSolanaConfig) ([]commonchangeset.ConfiguredChangeSet, error) {
@@ -948,7 +957,8 @@ func DeployChainContractsToSolChainCS(e DeployedEnv, solChainSelector uint64, pr
 				BuildConfig:            buildSolConfig,
 				MCMSWithTimelockConfig: mcmsCfg,
 			},
-		)}, nil
+		),
+	}, nil
 }
 
 func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEnvironment, mcmsEnabled bool) DeployedEnv {
@@ -962,9 +972,7 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 	var apps []commonchangeset.ConfiguredChangeSet
 	evmContractParams := make(map[uint64]ccipseq.ChainContractParams)
 
-	var (
-		evmChains, solChains, aptosChains, suiChains []uint64
-	)
+	var evmChains, solChains, aptosChains, suiChains []uint64
 	for _, chain := range allChains {
 		if _, ok := e.Env.BlockChains.EVMChains()[chain]; ok {
 			evmChains = append(evmChains, chain)
@@ -1014,7 +1022,7 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 		programsPath := e.Env.BlockChains.SolanaChains()[solChains[0]].ProgramsPath
 
 		if tEnv.TestConfigs().CCIPSolanaContractVersion == ccipChangeSetSolanaV0_1_1.SolanaContractV0_1_1 {
-			var buildSolConfig = &ccipChangeSetSolanaV0_1_1.BuildSolanaConfig{
+			buildSolConfig := &ccipChangeSetSolanaV0_1_1.BuildSolanaConfig{
 				SolanaContractVersion: ccipChangeSetSolanaV0_1_1.VersionSolanaV0_1_1,
 				DestinationDir:        programsPath,
 			}
@@ -1098,7 +1106,8 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 					AttestationAPIInterval: commonconfig.MustNewDuration(500 * time.Millisecond),
 				},
 				Tokens: cctpContracts,
-			}})
+			},
+		})
 	}
 	if tc.IsLBTC {
 		endpoint := tEnv.MockLBTCAttestationServer(t, tc.IsUSDCAttestationMissing)
@@ -1118,7 +1127,8 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 					AttestationAPIInterval: commonconfig.MustNewDuration(500 * time.Millisecond),
 				},
 				SourcePoolAddressByChain: lbtcPools,
-			}})
+			},
+		})
 	}
 
 	nodeInfo, err := deployment.NodeInfo(e.Env.NodeIDs, e.Env.Offchain)

--- a/deployment/ccip/changeset/v1_6/cs_add_registry_module_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_registry_module_test.go
@@ -15,7 +15,9 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 
-	linkchangesets "github.com/smartcontractkit/cld-changesets/link/changesets"
+	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
@@ -42,8 +44,8 @@ func TestAddRegistryModuleChangeset(t *testing.T) {
 
 		*env, err = commonchangeset.Apply(t, *env,
 			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-				[]uint64{chain1},
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{EVM: map[uint64]linkchangesets.EVMLinkConfig{chain1: {}}},
 			),
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
@@ -138,8 +140,8 @@ func TestAddRegistryModuleChangeset(t *testing.T) {
 
 		*env, err = commonchangeset.Apply(t, *env,
 			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-				chainSelectors,
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{EVM: map[uint64]linkchangesets.EVMLinkConfig{chain1: {}, chain2: {}}},
 			),
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
@@ -223,8 +225,8 @@ func TestAddRegistryModuleChangeset(t *testing.T) {
 
 		*env, err = commonchangeset.Apply(t, *env,
 			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-				[]uint64{chain1},
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{EVM: map[uint64]linkchangesets.EVMLinkConfig{chain1: {}}},
 			),
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
@@ -309,8 +311,8 @@ func TestAddRegistryModuleChangeset(t *testing.T) {
 
 		*env, err = commonchangeset.Apply(t, *env,
 			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-				[]uint64{chain1},
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{EVM: map[uint64]linkchangesets.EVMLinkConfig{chain1: {}}},
 			),
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
@@ -414,8 +416,8 @@ func TestAddRegistryModuleConfig_Validate(t *testing.T) {
 
 		*env, err = commonchangeset.Apply(t, *env,
 			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-				[]uint64{chain1},
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{EVM: map[uint64]linkchangesets.EVMLinkConfig{chain1: {}}},
 			),
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
@@ -499,8 +501,8 @@ func TestAddRegistryModuleConfig_Validate(t *testing.T) {
 
 		*env, err = commonchangeset.Apply(t, *env,
 			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-				[]uint64{chain1},
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{EVM: map[uint64]linkchangesets.EVMLinkConfig{chain1: {}}},
 			),
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
@@ -539,8 +541,8 @@ func TestAddRegistryModuleConfig_Validate(t *testing.T) {
 
 		*env, err = commonchangeset.Apply(t, *env,
 			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-				[]uint64{chain1},
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{EVM: map[uint64]linkchangesets.EVMLinkConfig{chain1: {}}},
 			),
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),

--- a/deployment/ccip/changeset/v1_6/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_deploy_chain_test.go
@@ -22,7 +22,9 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
-	linkchangesets "github.com/smartcontractkit/cld-changesets/link/changesets"
+	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
@@ -91,6 +93,10 @@ func testDeployChainContractsChangesetWithEnv(t *testing.T, e cldf.Environment, 
 		})
 	}
 
+	evmLinkInputMap := make(map[uint64]linkchangesets.EVMLinkConfig, len(evmSelectors))
+	for _, sel := range evmSelectors {
+		evmLinkInputMap[sel] = linkchangesets.EVMLinkConfig{}
+	}
 	e, err = commonchangeset.Apply(t, e, commonchangeset.Configure(
 		cldf.CreateLegacyChangeSet(v1_6.DeployHomeChainChangeset),
 		v1_6.DeployHomeChainConfig{
@@ -103,8 +109,8 @@ func testDeployChainContractsChangesetWithEnv(t *testing.T, e cldf.Environment, 
 			},
 		},
 	), commonchangeset.Configure(
-		cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-		evmSelectors,
+		deploylink.DeployLinkTokenChangeset{},
+		linkchangesets.DeployLinkTokenInput{EVM: evmLinkInputMap},
 	), commonchangeset.Configure(
 		cldf.CreateLegacyChangeSet(mcmschangesets.DeployMCMSWithTimelockV2),
 		cfg,

--- a/deployment/ccip/changeset/v1_6/cs_deploy_registry_module_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_deploy_registry_module_test.go
@@ -14,7 +14,9 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 
-	linkchangesets "github.com/smartcontractkit/cld-changesets/link/changesets"
+	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
@@ -41,8 +43,8 @@ func TestDeployRegistryModuleChangeset(t *testing.T) {
 
 		*env, err = commonchangeset.Apply(t, *env,
 			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-				[]uint64{chain1},
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{EVM: map[uint64]linkchangesets.EVMLinkConfig{chain1: {}}},
 			),
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
@@ -103,8 +105,8 @@ func TestDeployRegistryModuleChangeset(t *testing.T) {
 
 		*env, err = commonchangeset.Apply(t, *env,
 			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-				chainSelectors,
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{EVM: map[uint64]linkchangesets.EVMLinkConfig{chain1: {}, chain2: {}}},
 			),
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
@@ -161,8 +163,8 @@ func TestDeployRegistryModuleChangeset(t *testing.T) {
 
 		*env, err = commonchangeset.Apply(t, *env,
 			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-				[]uint64{chain1},
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{EVM: map[uint64]linkchangesets.EVMLinkConfig{chain1: {}}},
 			),
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
@@ -247,8 +249,8 @@ func TestDeployRegistryModuleChangeset(t *testing.T) {
 
 		*env, err = commonchangeset.Apply(t, *env,
 			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-				[]uint64{chain1},
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{EVM: map[uint64]linkchangesets.EVMLinkConfig{chain1: {}}},
 			),
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
@@ -313,8 +315,8 @@ func TestDeployRegistryModuleChangeset(t *testing.T) {
 
 		*env, err = commonchangeset.Apply(t, *env,
 			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-				chainSelectors,
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{EVM: map[uint64]linkchangesets.EVMLinkConfig{chain1: {}, chain2: {}}},
 			),
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
@@ -467,8 +469,8 @@ func TestDeployRegistryModuleConfig_Validate(t *testing.T) {
 
 		*env, err = commonchangeset.Apply(t, *env,
 			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-				[]uint64{chain1},
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{EVM: map[uint64]linkchangesets.EVMLinkConfig{chain1: {}}},
 			),
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
@@ -509,8 +511,8 @@ func TestDeployRegistryModuleConfig_Validate(t *testing.T) {
 
 		*env, err = commonchangeset.Apply(t, *env,
 			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-				chainSelectors,
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{EVM: map[uint64]linkchangesets.EVMLinkConfig{chain1: {}, chain2: {}}},
 			),
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),

--- a/deployment/ccip/changeset/v1_6/cs_translate_onramp_to_feequoter_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_translate_onramp_to_feequoter_test.go
@@ -30,7 +30,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
 
-	linkchangesets "github.com/smartcontractkit/cld-changesets/link/changesets"
+	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
@@ -478,6 +480,10 @@ func DeployUtil(t *testing.T, e *cldf.Environment, homeChainSel uint64) {
 		})
 	}
 
+	evmLinkInputMap := make(map[uint64]linkchangesets.EVMLinkConfig, len(evmSelectors))
+	for _, sel := range evmSelectors {
+		evmLinkInputMap[sel] = linkchangesets.EVMLinkConfig{}
+	}
 	eVal, err := commonchangeset.Apply(t, *e, commonchangeset.Configure(
 		cldf.CreateLegacyChangeSet(v1_6.DeployHomeChainChangeset),
 		v1_6.DeployHomeChainConfig{
@@ -490,8 +496,8 @@ func DeployUtil(t *testing.T, e *cldf.Environment, homeChainSel uint64) {
 			},
 		},
 	), commonchangeset.Configure(
-		cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-		evmSelectors,
+		deploylink.DeployLinkTokenChangeset{},
+		linkchangesets.DeployLinkTokenInput{EVM: evmLinkInputMap},
 	), commonchangeset.Configure(
 		cldf.CreateLegacyChangeSet(mcmschangesets.DeployMCMSWithTimelockV2),
 		cfg,

--- a/deployment/ccip/shared/deploylink/deploy_link_token.go
+++ b/deployment/ccip/shared/deploylink/deploy_link_token.go
@@ -1,0 +1,46 @@
+package deploylink
+
+import (
+	"fmt"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
+	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
+)
+
+// DeployLinkTokenChangeset wraps the upstream DeployLinkTokenChangeset and
+// additionally writes deployed addresses to AddressBook for backward compatibility.
+type DeployLinkTokenChangeset struct{}
+
+var _ cldf.ChangeSetV2[linkchangesets.DeployLinkTokenInput] = DeployLinkTokenChangeset{}
+
+func (DeployLinkTokenChangeset) VerifyPreconditions(e cldf.Environment, input linkchangesets.DeployLinkTokenInput) error {
+	return (linkchangesets.DeployLinkTokenChangeset{}).VerifyPreconditions(e, input)
+}
+
+func (DeployLinkTokenChangeset) Apply(e cldf.Environment, input linkchangesets.DeployLinkTokenInput) (cldf.ChangesetOutput, error) {
+	out, err := (linkchangesets.DeployLinkTokenChangeset{}).Apply(e, input)
+	if err != nil {
+		return out, err
+	}
+
+	if out.DataStore != nil {
+		ab := cldf.NewMemoryAddressBook()
+		refs, fetchErr := out.DataStore.Addresses().Fetch()
+		if fetchErr != nil {
+			return out, fmt.Errorf("failed to fetch addresses from datastore: %w", fetchErr)
+		}
+		for _, ref := range refs {
+			if ref.Version == nil {
+				continue
+			}
+			tv := cldf.NewTypeAndVersion(cldf.ContractType(ref.Type), *ref.Version)
+			if addErr := ab.Save(ref.ChainSelector, ref.Address, tv); addErr != nil {
+				return out, fmt.Errorf("failed to save address to address book: %w", addErr)
+			}
+		}
+		out.AddressBook = ab
+	}
+
+	return out, nil
+}

--- a/deployment/ccip/shared/deploylink/deploy_link_token.go
+++ b/deployment/ccip/shared/deploylink/deploy_link_token.go
@@ -10,7 +10,7 @@ import (
 
 // DeployLinkTokenChangeset wraps the upstream DeployLinkTokenChangeset and
 // additionally writes deployed addresses to AddressBook for backward compatibility.
-type DeployLinkTokenChangeset struct{}
+type DeployLinkTokenChangeset struct{} //nolint:revive // intentional name match with upstream
 
 var _ cldf.ChangeSetV2[linkchangesets.DeployLinkTokenInput] = DeployLinkTokenChangeset{}
 
@@ -39,7 +39,7 @@ func (DeployLinkTokenChangeset) Apply(e cldf.Environment, input linkchangesets.D
 				return out, fmt.Errorf("failed to save address to address book: %w", addErr)
 			}
 		}
-		out.AddressBook = ab
+		out.AddressBook = ab //nolint:staticcheck // intentional use of deprecated AddressBook for backward compat
 	}
 
 	return out, nil

--- a/deployment/ccip/shared/stateview/evm/validate_feequoter_test.go
+++ b/deployment/ccip/shared/stateview/evm/validate_feequoter_test.go
@@ -32,7 +32,9 @@ import (
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 
-	linkchangesets "github.com/smartcontractkit/cld-changesets/link/changesets"
+	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
@@ -362,6 +364,10 @@ func deployV16Contracts(t *testing.T, tenv *cldf.Environment, homeChainSel uint6
 		prereqCfg = append(prereqCfg, changeset.DeployPrerequisiteConfigPerChain{ChainSelector: sel})
 	}
 
+	evmLinkInputMap := make(map[uint64]linkchangesets.EVMLinkConfig, len(evmSelectors))
+	for _, sel := range evmSelectors {
+		evmLinkInputMap[sel] = linkchangesets.EVMLinkConfig{}
+	}
 	eVal, err := commonchangeset.Apply(t, *tenv, commonchangeset.Configure(
 		cldf.CreateLegacyChangeSet(v1_6.DeployHomeChainChangeset),
 		v1_6.DeployHomeChainConfig{
@@ -374,8 +380,8 @@ func deployV16Contracts(t *testing.T, tenv *cldf.Environment, homeChainSel uint6
 			},
 		},
 	), commonchangeset.Configure(
-		cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-		evmSelectors,
+		deploylink.DeployLinkTokenChangeset{},
+		linkchangesets.DeployLinkTokenInput{EVM: evmLinkInputMap},
 	), commonchangeset.Configure(
 		cldf.CreateLegacyChangeSet(mcmschangesets.DeployMCMSWithTimelockV2),
 		cfg,

--- a/deployment/environment/crib/ccip_deployer.go
+++ b/deployment/environment/crib/ccip_deployer.go
@@ -55,7 +55,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 
-	linkchangesets "github.com/smartcontractkit/cld-changesets/link/changesets"
+	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -329,11 +331,14 @@ func setupChains(lggr logger.Logger, e *cldf.Environment, homeChainSel, feedChai
 				return *e, fmt.Errorf("failed to create the link token priv key: %w", err)
 			}
 			solLinkChangeset := commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(linkchangesets.DeploySolanaLinkToken),
-				linkchangesets.DeploySolanaLinkTokenConfig{
-					ChainSelector: chain,
-					TokenPrivKey:  privKey,
-					TokenDecimals: 9,
+				deploylink.DeployLinkTokenChangeset{},
+				linkchangesets.DeployLinkTokenInput{
+					Solana: map[uint64]linkchangesets.SolanaLinkConfig{
+						chain: {
+							TokenPrivKey:  privKey,
+							TokenDecimals: 9,
+						},
+					},
 				},
 			)
 			solLinkChangesets = append(solLinkChangesets, solLinkChangeset)
@@ -345,6 +350,13 @@ func setupChains(lggr logger.Logger, e *cldf.Environment, homeChainSel, feedChai
 		}
 	}
 
+	evmLinkInput := linkchangesets.DeployLinkTokenInput{
+		EVM: make(map[uint64]linkchangesets.EVMLinkConfig, len(evmChainSelectors)),
+	}
+	for _, sel := range evmChainSelectors {
+		evmLinkInput.EVM[sel] = linkchangesets.EVMLinkConfig{}
+	}
+
 	*e, err = commonchangeset.Apply(nil, *e,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(v1_6.UpdateChainConfigChangeset),
@@ -354,8 +366,8 @@ func setupChains(lggr logger.Logger, e *cldf.Environment, homeChainSel, feedChai
 			},
 		),
 		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(linkchangesets.DeployLinkToken),
-			evmChainSelectors,
+			deploylink.DeployLinkTokenChangeset{},
+			evmLinkInput,
 		),
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
@@ -479,7 +491,6 @@ func setupLinkPools(e *cldf.Environment) (cldf.Environment, error) {
 			Pools: pools,
 		},
 	))
-
 	if err != nil {
 		return *e, fmt.Errorf("failed to apply changesets: %w", err)
 	}
@@ -971,11 +982,11 @@ func mustOCR(e *cldf.Environment, homeChainSel uint64, feedChainSel uint64, newD
 	evmSelectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))
 	solSelectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))
 	// need to have extra definition here for golint
-	var allSelectors = make([]uint64, 0)
+	allSelectors := make([]uint64, 0)
 	allSelectors = append(allSelectors, evmSelectors...)
 	allSelectors = append(allSelectors, solSelectors...)
-	var commitOCRConfigPerSelector = make(map[uint64]v1_6.CCIPOCRParams)
-	var execOCRConfigPerSelector = make(map[uint64]v1_6.CCIPOCRParams)
+	commitOCRConfigPerSelector := make(map[uint64]v1_6.CCIPOCRParams)
+	execOCRConfigPerSelector := make(map[uint64]v1_6.CCIPOCRParams)
 	// Should be configured in the future based on the load test scenario
 	chainType := v1_6.Default
 	_, err := testhelpers.DeployFeeds(e.Logger, e.ExistingAddresses, e.BlockChains.EVMChains()[feedChainSel], testhelpers.DefaultLinkPrice, testhelpers.DefaultWethPrice)
@@ -1150,7 +1161,6 @@ func SetupRMNNodeOnAllChains(ctx context.Context, lggr logger.Logger, envConfig 
 	_, err = v1_6.UpdateOffRampSourcesChangeset(*e, v1_6.UpdateOffRampSourcesConfig{
 		UpdatesByChain: allUpdates,
 	})
-
 	if err != nil {
 		return DeployCCIPOutput{}, fmt.Errorf("failed to update dynamic off ramp config: %w", err)
 	}
@@ -1201,7 +1211,6 @@ func SetupRMNNodeOnAllChains(ctx context.Context, lggr logger.Logger, envConfig 
 	}
 
 	configDigest, err := state.Chains[homeChainSel].RMNHome.GetCandidateDigest(nil)
-
 	if err != nil {
 		return DeployCCIPOutput{}, fmt.Errorf("failed to get rmn home candidate digest: %w", err)
 	}
@@ -1255,7 +1264,8 @@ func SetupRMNNodeOnAllChains(ctx context.Context, lggr logger.Logger, envConfig 
 }
 
 func GenerateRMNNodeIdentities(rmnNodeCount uint, rageProxyImageURI, rageProxyImageTag, afn2proxyImageURI,
-	afn2proxyImageTag string, imagePlatform string) ([]RMNNodeConfig, error) {
+	afn2proxyImageTag string, imagePlatform string,
+) ([]RMNNodeConfig, error) {
 	lggr := zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout})
 	rmnNodeConfigs := make([]RMNNodeConfig, rmnNodeCount)
 

--- a/deployment/environment/crib/ccip_deployer.go
+++ b/deployment/environment/crib/ccip_deployer.go
@@ -56,9 +56,9 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 
 	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
-	mcmstypes "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.9
 	github.com/smartcontractkit/chainlink-ton v1.0.5-0.20260520103847-15ca4de9dba9
 	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260520103847-15ca4de9dba9
-	github.com/smartcontractkit/cld-changesets v0.4.0
+	github.com/smartcontractkit/cld-changesets v0.5.0
 	github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad
 	github.com/smartcontractkit/libocr v0.0.0-20260508200755-99940c85383c
 	github.com/smartcontractkit/mcms v0.45.0

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1462,8 +1462,8 @@ github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260408092456-3c63
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260408092456-3c6369888d4a/go.mod h1:1eaXR+Fe6TlpP+CKXozfYlFM8QgN/N5C7OMvTRWNT8I=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b h1:RarA5fTnBzQY9wHhl6g7Ac7Nv0d/izr2/zuSWhveB4c=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b/go.mod h1:ea1LESxlSSOgc2zZBqf1RTkXTMthHaspdqUHd7W4lF0=
-github.com/smartcontractkit/cld-changesets v0.4.0 h1:S6yNRj6FssyyKbxLHTbC9X9U4qsph17xiiBBT6DGyNE=
-github.com/smartcontractkit/cld-changesets v0.4.0/go.mod h1:4wOfnbSP8Ior/75QWLbtDntamSA/81SYcXzctBSx9CY=
+github.com/smartcontractkit/cld-changesets v0.5.0 h1:JfiS3k8uijw1zcoFBTAHOzI1LxkhZVjPT4YoxI7zTxQ=
+github.com/smartcontractkit/cld-changesets v0.5.0/go.mod h1:SYJTJw3tyi+bIVFApQ7RSe7jQD2cyEM1bmypbKF2dcg=
 github.com/smartcontractkit/cre-sdk-go v1.5.0 h1:kepW3QDKARrOOHjXwWAZ9j5KLk6bxLzvi6OMrLsFwVo=
 github.com/smartcontractkit/cre-sdk-go v1.5.0/go.mod h1:yYrQFz1UH7hhRbPO0q4fgo1tfsJNd4yXnI3oCZE0RzM=
 github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad h1:lgHxTHuzJIF3Vj6LSMOnjhqKgRqYW+0MV2SExtCYL1Q=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5
 	github.com/smartcontractkit/chainlink/deployment v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink/v2 v2.29.0
-	github.com/smartcontractkit/cld-changesets v0.4.0
+	github.com/smartcontractkit/cld-changesets v0.5.0
 	github.com/smartcontractkit/libocr v0.0.0-20260508200755-99940c85383c
 	github.com/smartcontractkit/mcms v0.45.0
 	github.com/smartcontractkit/quarantine v0.0.0-20251203215908-fd0551c6adf9

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1445,8 +1445,8 @@ github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260408092456-3c63
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260408092456-3c6369888d4a/go.mod h1:1eaXR+Fe6TlpP+CKXozfYlFM8QgN/N5C7OMvTRWNT8I=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b h1:RarA5fTnBzQY9wHhl6g7Ac7Nv0d/izr2/zuSWhveB4c=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b/go.mod h1:ea1LESxlSSOgc2zZBqf1RTkXTMthHaspdqUHd7W4lF0=
-github.com/smartcontractkit/cld-changesets v0.4.0 h1:S6yNRj6FssyyKbxLHTbC9X9U4qsph17xiiBBT6DGyNE=
-github.com/smartcontractkit/cld-changesets v0.4.0/go.mod h1:4wOfnbSP8Ior/75QWLbtDntamSA/81SYcXzctBSx9CY=
+github.com/smartcontractkit/cld-changesets v0.5.0 h1:JfiS3k8uijw1zcoFBTAHOzI1LxkhZVjPT4YoxI7zTxQ=
+github.com/smartcontractkit/cld-changesets v0.5.0/go.mod h1:SYJTJw3tyi+bIVFApQ7RSe7jQD2cyEM1bmypbKF2dcg=
 github.com/smartcontractkit/cre-sdk-go v1.5.0 h1:kepW3QDKARrOOHjXwWAZ9j5KLk6bxLzvi6OMrLsFwVo=
 github.com/smartcontractkit/cre-sdk-go v1.5.0/go.mod h1:yYrQFz1UH7hhRbPO0q4fgo1tfsJNd4yXnI3oCZE0RzM=
 github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad h1:lgHxTHuzJIF3Vj6LSMOnjhqKgRqYW+0MV2SExtCYL1Q=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -510,7 +510,7 @@ require (
 	github.com/smartcontractkit/chainlink-ton v1.0.5-0.20260520103847-15ca4de9dba9 // indirect
 	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260520103847-15ca4de9dba9 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260408092456-3c6369888d4a // indirect
-	github.com/smartcontractkit/cld-changesets v0.4.0 // indirect
+	github.com/smartcontractkit/cld-changesets v0.5.0 // indirect
 	github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect
 	github.com/smartcontractkit/libocr v0.0.0-20260508200755-99940c85383c // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1717,8 +1717,8 @@ github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260408092456-3c63
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260408092456-3c6369888d4a/go.mod h1:1eaXR+Fe6TlpP+CKXozfYlFM8QgN/N5C7OMvTRWNT8I=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b h1:RarA5fTnBzQY9wHhl6g7Ac7Nv0d/izr2/zuSWhveB4c=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b/go.mod h1:ea1LESxlSSOgc2zZBqf1RTkXTMthHaspdqUHd7W4lF0=
-github.com/smartcontractkit/cld-changesets v0.4.0 h1:S6yNRj6FssyyKbxLHTbC9X9U4qsph17xiiBBT6DGyNE=
-github.com/smartcontractkit/cld-changesets v0.4.0/go.mod h1:4wOfnbSP8Ior/75QWLbtDntamSA/81SYcXzctBSx9CY=
+github.com/smartcontractkit/cld-changesets v0.5.0 h1:JfiS3k8uijw1zcoFBTAHOzI1LxkhZVjPT4YoxI7zTxQ=
+github.com/smartcontractkit/cld-changesets v0.5.0/go.mod h1:SYJTJw3tyi+bIVFApQ7RSe7jQD2cyEM1bmypbKF2dcg=
 github.com/smartcontractkit/cre-sdk-go v1.5.0 h1:kepW3QDKARrOOHjXwWAZ9j5KLk6bxLzvi6OMrLsFwVo=
 github.com/smartcontractkit/cre-sdk-go v1.5.0/go.mod h1:yYrQFz1UH7hhRbPO0q4fgo1tfsJNd4yXnI3oCZE0RzM=
 github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad h1:lgHxTHuzJIF3Vj6LSMOnjhqKgRqYW+0MV2SExtCYL1Q=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5
 	github.com/smartcontractkit/chainlink/deployment v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink/v2 v2.29.0
-	github.com/smartcontractkit/cld-changesets v0.4.0
+	github.com/smartcontractkit/cld-changesets v0.5.0
 	github.com/smartcontractkit/libocr v0.0.0-20260508200755-99940c85383c
 	github.com/smartcontractkit/smdkg v0.0.0-20251029093710-c38905e58aeb
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20251120172354-e8ec0386b06c

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1634,8 +1634,8 @@ github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260408092456-3c63
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20260408092456-3c6369888d4a/go.mod h1:1eaXR+Fe6TlpP+CKXozfYlFM8QgN/N5C7OMvTRWNT8I=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b h1:RarA5fTnBzQY9wHhl6g7Ac7Nv0d/izr2/zuSWhveB4c=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b/go.mod h1:ea1LESxlSSOgc2zZBqf1RTkXTMthHaspdqUHd7W4lF0=
-github.com/smartcontractkit/cld-changesets v0.4.0 h1:S6yNRj6FssyyKbxLHTbC9X9U4qsph17xiiBBT6DGyNE=
-github.com/smartcontractkit/cld-changesets v0.4.0/go.mod h1:4wOfnbSP8Ior/75QWLbtDntamSA/81SYcXzctBSx9CY=
+github.com/smartcontractkit/cld-changesets v0.5.0 h1:JfiS3k8uijw1zcoFBTAHOzI1LxkhZVjPT4YoxI7zTxQ=
+github.com/smartcontractkit/cld-changesets v0.5.0/go.mod h1:SYJTJw3tyi+bIVFApQ7RSe7jQD2cyEM1bmypbKF2dcg=
 github.com/smartcontractkit/cre-sdk-go v1.5.0 h1:kepW3QDKARrOOHjXwWAZ9j5KLk6bxLzvi6OMrLsFwVo=
 github.com/smartcontractkit/cre-sdk-go v1.5.0/go.mod h1:yYrQFz1UH7hhRbPO0q4fgo1tfsJNd4yXnI3oCZE0RzM=
 github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad h1:lgHxTHuzJIF3Vj6LSMOnjhqKgRqYW+0MV2SExtCYL1Q=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/solana/sollogtrigger v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/solana/solwrite v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink/v2 v2.29.0
-	github.com/smartcontractkit/cld-changesets v0.4.0
+	github.com/smartcontractkit/cld-changesets v0.5.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.20.0
 	google.golang.org/protobuf v1.36.11

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1650,8 +1650,8 @@ github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.202602181
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b/go.mod h1:ea1LESxlSSOgc2zZBqf1RTkXTMthHaspdqUHd7W4lF0=
 github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evmread v0.0.0-20250917232237-c4ecf802c6f8 h1:ZhpUCMDFATsyS1B+6YaAxWYfh/WsVx9WWtYSOkl5V0g=
 github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evmread v0.0.0-20250917232237-c4ecf802c6f8/go.mod h1:96T5PZe9IRPcuMTnS2I2VGAtyDdkL5U9aWUykLtAYb8=
-github.com/smartcontractkit/cld-changesets v0.4.0 h1:S6yNRj6FssyyKbxLHTbC9X9U4qsph17xiiBBT6DGyNE=
-github.com/smartcontractkit/cld-changesets v0.4.0/go.mod h1:4wOfnbSP8Ior/75QWLbtDntamSA/81SYcXzctBSx9CY=
+github.com/smartcontractkit/cld-changesets v0.5.0 h1:JfiS3k8uijw1zcoFBTAHOzI1LxkhZVjPT4YoxI7zTxQ=
+github.com/smartcontractkit/cld-changesets v0.5.0/go.mod h1:SYJTJw3tyi+bIVFApQ7RSe7jQD2cyEM1bmypbKF2dcg=
 github.com/smartcontractkit/cre-sdk-go v1.9.0-capdev.1.0.20260526211007-043b75d05749 h1:1LLdmJdorKziQF1cYil445rpf4qFy9ShoYj1Q3/QTow=
 github.com/smartcontractkit/cre-sdk-go v1.9.0-capdev.1.0.20260526211007-043b75d05749/go.mod h1:6hAl5/hIfy4xUeevNvNf4vywdQ1pClGj4nbdMge4VRM=
 github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad h1:lgHxTHuzJIF3Vj6LSMOnjhqKgRqYW+0MV2SExtCYL1Q=


### PR DESCRIPTION
This pull request refactors how LINK token deployment changesets are referenced and configured throughout the CCIP deployment codebase. The main focus is to standardize the usage of the new `DeployLinkTokenChangeset` and its input configuration, replacing the older `DeploySolanaLinkToken` and `DeployLinkToken` patterns, and to update import paths accordingly. Additionally, there is an enhancement to the way LINK token addresses are merged from the DataStore.