### PR TITLE
[DX-4303] [DX-4148] Test_Service_syncNodeInfoWithRetry/update_chain

### DIFF
--- a/.antigravitycli/d2ba304a-a87e-48a9-a126-97b316fc2f50.json
+++ b/.antigravitycli/d2ba304a-a87e-48a9-a126-97b316fc2f50.json
@@ -1,1 +1,0 @@
-/Users/adamhamrick/.gemini/config/projects/d2ba304a-a87e-48a9-a126-97b316fc2f50.json

--- a/.antigravitycli/d2ba304a-a87e-48a9-a126-97b316fc2f50.json
+++ b/.antigravitycli/d2ba304a-a87e-48a9-a126-97b316fc2f50.json
@@ -1,0 +1,1 @@
+/Users/adamhamrick/.gemini/config/projects/d2ba304a-a87e-48a9-a126-97b316fc2f50.json

--- a/core/services/feeds/log_messages_test.go
+++ b/core/services/feeds/log_messages_test.go
@@ -1,0 +1,75 @@
+package feeds_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_isSyncNodeInfoLogMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		message string
+		want    bool
+	}{
+		{message: `failed to sync node info attempt="0" err="err"`, want: true},
+		{message: `failed to sync node info; aborting err="err"`, want: true},
+		{message: "successfully synced node info", want: true},
+		{message: "evm chain started", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.message, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isSyncNodeInfoLogMessage(tt.message))
+		})
+	}
+}
+
+func Test_filterSyncNodeInfoLogMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "keeps sync retry and success lines",
+			in: []string{
+				"evm chain started",
+				`failed to sync node info attempt="0" err="SyncNodeInfo.UpdateNode call partially failed: error chain 3"`,
+				`failed to sync node info attempt="1" err="SyncNodeInfo.UpdateNode call failed: error-4"`,
+				"successfully synced node info",
+			},
+			want: []string{
+				`failed to sync node info attempt="0" err="SyncNodeInfo.UpdateNode call partially failed: error chain 3"`,
+				`failed to sync node info attempt="1" err="SyncNodeInfo.UpdateNode call failed: error-4"`,
+				"successfully synced node info",
+			},
+		},
+		{
+			name: "keeps abort log",
+			in: []string{
+				"noise",
+				`failed to sync node info; aborting err="SyncNodeInfo.UpdateNode call partially failed: error chain 12"`,
+			},
+			want: []string{
+				`failed to sync node info; aborting err="SyncNodeInfo.UpdateNode call partially failed: error chain 12"`,
+			},
+		},
+		{
+			name: "empty when no sync logs",
+			in:   []string{"only unrelated logs"},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, filterSyncNodeInfoLogMessages(tt.in))
+		})
+	}
+}

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -2173,8 +2173,8 @@ func Test_Service_syncNodeInfoWithRetry(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				assert.Equal(collect, tt.wantLogs, logMessages(svc.logs.All()))
-			}, 1*time.Second, 50*time.Millisecond)
+				assert.Equal(collect, tt.wantLogs, syncNodeInfoLogMessages(svc.logs.All()))
+			}, 5*time.Second, 5*time.Millisecond)
 		})
 	}
 }
@@ -5227,6 +5227,27 @@ func logMessages(logEntries []observer.LoggedEntry) []string {
 	}
 
 	return messages
+}
+
+// filterSyncNodeInfoLogMessages keeps only logs emitted by syncNodeInfoWithRetry.
+func filterSyncNodeInfoLogMessages(messages []string) []string {
+	filtered := make([]string, 0, len(messages))
+	for _, message := range messages {
+		if isSyncNodeInfoLogMessage(message) {
+			filtered = append(filtered, message)
+		}
+	}
+
+	return filtered
+}
+
+func isSyncNodeInfoLogMessage(message string) bool {
+	return strings.Contains(message, "failed to sync node info") ||
+		strings.Contains(message, "successfully synced node info")
+}
+
+func syncNodeInfoLogMessages(logEntries []observer.LoggedEntry) []string {
+	return filterSyncNodeInfoLogMessages(logMessages(logEntries))
 }
 
 func Test_Service_GetJobRuns(t *testing.T) {

--- a/tools/test/.agents/skills/fix-flaky-tests/SKILL.md
+++ b/tools/test/.agents/skills/fix-flaky-tests/SKILL.md
@@ -47,6 +47,8 @@ If unknown, prompt user.
 
 <jira_reference>
 If JIRA issues are present read [jira.md](./references/jira.md) to understand how to claim tickets, find eligible flaky-test tickets, read and add comments and transition JIRA issues.
+
+After a FIXED outcome, the ticket must stay assigned to the investigator (`accountId` from `atlassianUserInfo`) when moved to In Review. Do not unassign on FIXED — see [transition-ticket.md](./references/transition-ticket.md) assignee policy.
 </jira_reference>
 
 <cli_reference>

--- a/tools/test/.agents/skills/fix-flaky-tests/SKILL.md
+++ b/tools/test/.agents/skills/fix-flaky-tests/SKILL.md
@@ -57,6 +57,19 @@ Base Command: `go -C tools/test run . diagnose [harness_flags] -- [go_test_flags
 - Help: `go -C tools/test run . diagnose -h`
 </cli_reference>
 
+<diagnose-iterations>
+Use this table to determine how many diagnose iterations you should use to confirm behavior
+
+| Iterations | Chance you missed a flake |
+| ---------- | ------------------------- |
+| 5          | 50%                       |
+| 30         | 10%                       |
+| 60         | 5%                        |
+| 150        | 2%                        |
+| 300        | 1%                        |
+| 500+       | < 1%                      |
+</diagnose-iterations>
+
 <loop>
 1. If user doesn't have recent results, run `diagnose` command with min 5 iterations to gather initial info. On sandbox errors, follow `<possible_execution_issues>`.
 2. If no issues, ask the user if they want to verify with more iterations. If not, end and output final report of findings, fixes, and lessons learned.

--- a/tools/test/.agents/skills/fix-flaky-tests/references/jira-mananger-subagent.md
+++ b/tools/test/.agents/skills/fix-flaky-tests/references/jira-mananger-subagent.md
@@ -3,7 +3,8 @@ You MUST configure the sub-agent with these exact initialization parameters:
 1. System Prompt: "You are a headless JIRA ticket manager. You read and update JIRA tickets via Atlassian MCP. You output raw JSON and nothing else — no prose, no markdown fences.
    - Read operations return a slim record (see ./references/slim-record.md).
    - Write operations (claim, transition, comment, abandon) return: {\"operation\": \"<name>\", \"jira_key\": \"...\", \"success\": true|false, \"details\": \"...\", \"slim_record\": {...} | null}.
-   Read the matching reference before executing: claim-ticket.md, transition-ticket.md, abandon-ticket.md, investigation-comment.md, fetch-flaky-tickets.md."
+   Read the matching reference before executing: claim-ticket.md, transition-ticket.md, abandon-ticket.md, investigation-comment.md, fetch-flaky-tickets.md.
+   FIXED → In Review: always set assignee to accountId; never unassign."
 2. Input contract — the caller MUST pass: `{operation, accountId, cloudId}` plus operation-specific fields (`jira_key` or `project_key`, `target`, `comment_body`, `original_assignee`, `slim_record`). Fail fast with `success: false` if required fields are missing.
 3. Allowed Tools: `mcp__atlassian__atlassianUserInfo`, `mcp__atlassian__getAccessibleAtlassianResources`, `mcp__atlassian__getJiraIssue`, `mcp__atlassian__editJiraIssue`, `mcp__atlassian__transitionJiraIssue`, `mcp__atlassian__addCommentToJiraIssue`, `mcp__atlassian__getTransitionsForJiraIssue`, `mcp__atlassian__searchJiraIssuesUsingJql`, `LSP`, `mcp__code-review-graph__*`, `Bash(grep, find, git remote get-url *)`, `Read` ONLY. Revoke filesystem writes (Edit, Write, NotebookEdit) and web search capabilities.
 4. Temperature: 0.0

--- a/tools/test/.agents/skills/fix-flaky-tests/references/jira.md
+++ b/tools/test/.agents/skills/fix-flaky-tests/references/jira.md
@@ -8,9 +8,8 @@ These files are **includable references**, not user-facing skills (no `SKILL.md`
 </when_to_use>
 
 <requirements>
-1. Atlassian MCP available.
-2. If MCP is unauthenticated prompt user to authenticate before proceeding.
-If Atlassian MCP is not available prompt the user to install it. If authentication fails STOP.
+1. Atlassian MCP available. If Atlassian/Jira MCP unavailable, STOP!. Prompt user to install it before proceeding.
+2. If MCP is unauthenticated, STOP! Prompt user to authenticate before proceeding.
 </requirements>
 
 <operation_requirements>

--- a/tools/test/.agents/skills/fix-flaky-tests/references/jira.md
+++ b/tools/test/.agents/skills/fix-flaky-tests/references/jira.md
@@ -40,8 +40,12 @@ You MUST use [this](./slim-record.md) JSON structure to pass data around in orde
 3. Prepare and return slim records.
 4. Once the work on flaky tests has finished, regardless of the result, for each ticket:
     a. Update the ticket with investigation comment
-    b. Transition the ticket to correct state — pass `original_assignee` AND `accountId` from the slim record so `transition-ticket.md` step 4 can handle reassignment:
-    - abandoned -> `Open`
-    - mismatch -> `Open`
-    - fixed -> `In Review` (transition-ticket.md step 4 will reassign back to `original_assignee`, or unassign if `original_assignee` is null or matches `accountId`)
+    b. Transition the ticket to correct state — always pass `accountId` from `atlassianUserInfo`; pass `original_assignee` from the slim record when abandoning or mismatching:
+    - abandoned -> `Open` (unassign via abandon-ticket.md)
+    - mismatch -> `Open` (restore `original_assignee` if set)
+    - fixed -> `In Review` (transition-ticket.md step 4 assigns to `accountId` — **never unassign** on FIXED)
 </logic>
+
+<assignee_rules>
+On FIXED, the investigator stays assignee through In Review. Unassigning when `original_assignee == accountId` was incorrect and left tickets with no owner after claim-and-fix.
+</assignee_rules>

--- a/tools/test/.agents/skills/fix-flaky-tests/references/transition-ticket.md
+++ b/tools/test/.agents/skills/fix-flaky-tests/references/transition-ticket.md
@@ -6,10 +6,19 @@ Generic transition operation for flaky-test JIRA tickets. Takes a semantic targe
 2. Match `target` to an available transition using the alias table below. Pick the **first alias that appears** in the response.
 3. Call `mcp__atlassian__transitionJiraIssue` with the matched transition ID.
    - For closing targets (`"Won't Do"`, `"Done"`): if the transition supports a `resolution` field, set `resolution = "Won't Do"` (fallback: `"Won't Fix"`) or
-4. **If `target = "In Review"` and `original_assignee` and `accountId` are provided:**
-   - If `original_assignee` is `null` or equals `accountId` → call `mcp__atlassian__editJiraIssue` to unassign the ticket (set `assignee` to `null`).
-   - If `original_assignee` differs from `accountId` → call `mcp__atlassian__editJiraIssue` to assign the ticket back to `original_assignee` (set `assignee.accountId = original_assignee`).
+4. **If `target = "In Review"` and `accountId` is provided** (FIXED handoff — investigator owns review):
+   - Call `mcp__atlassian__editJiraIssue` and set `assignee.accountId = accountId` (the investigator who fixed the flake).
+   - Do **not** unassign. The assignee must remain the current user so the ticket stays on their board until the PR merges.
+   - `original_assignee` is informational only for this target; do not restore or clear it on FIXED → In Review.
 </steps>
+
+<assignee_policy>
+| Outcome / target | Assignee after transition |
+|------------------|---------------------------|
+| FIXED → In Review | `accountId` (investigator) |
+| ABANDONED → Open | unassigned (`null`) — see abandon-ticket.md |
+| MISMATCH → Open | restore `original_assignee` if set; else unassigned |
+</assignee_policy>
 
 <target_alias_table>
 | Semantic target | Try these names in order |


### PR DESCRIPTION
Used the `fix-flaky-tests` skill to fix [DX-4303](https://smartcontract-it.atlassian.net/browse/DX-4303).

[DX-4303]: https://smartcontract-it.atlassian.net/browse/DX-4303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ