### PR TITLE
Support array inputs in length pipeline task

### DIFF
--- a/core/services/pipeline/task.length.go
+++ b/core/services/pipeline/task.length.go
@@ -2,7 +2,7 @@ package pipeline
 
 import (
 	"context"
-	stderrors "errors"
+	"reflect"
 
 	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
@@ -30,14 +30,28 @@ func (t *LengthTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs [
 		return Result{Error: errors.Wrap(err, "task inputs")}, runInfo
 	}
 
-	var input BytesParam
-
-	err = stderrors.Join(
-		errors.Wrap(ResolveParam(&input, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
-	)
+	input, err := resolveParamValue(From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0)))
 	if err != nil {
-		return Result{Error: err}, runInfo
+		return Result{Error: errors.Wrap(err, "input")}, runInfo
 	}
 
-	return Result{Value: decimal.NewFromInt(int64(len(input)))}, runInfo
+	if input != nil {
+		v := reflect.ValueOf(input)
+		switch v.Kind() {
+		case reflect.Array, reflect.Slice:
+			return Result{Value: decimal.NewFromInt(int64(v.Len()))}, runInfo
+		}
+	}
+
+	var sliceInput SliceParam
+	if err = sliceInput.UnmarshalPipelineParam(input); err == nil {
+		return Result{Value: decimal.NewFromInt(int64(len(sliceInput)))}, runInfo
+	}
+
+	var bytesInput BytesParam
+	if err = bytesInput.UnmarshalPipelineParam(input); err != nil {
+		return Result{Error: errors.Wrap(err, "input")}, runInfo
+	}
+
+	return Result{Value: decimal.NewFromInt(int64(len(bytesInput)))}, runInfo
 }

--- a/core/services/pipeline/task.length_test.go
+++ b/core/services/pipeline/task.length_test.go
@@ -1,6 +1,7 @@
 package pipeline_test
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/shopspring/decimal"
@@ -16,15 +17,21 @@ func TestLengthTask(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		input any
-		want  decimal.Decimal
+		name       string
+		input      any
+		inputParam string
+		want       decimal.Decimal
 	}{
-		{"normal bytes", []byte{0xaa, 0xbb, 0xcc, 0xdd}, decimal.NewFromInt(4)},
-		{"empty bytes", []byte{}, decimal.NewFromInt(0)},
-		{"string as bytes", []byte("stevetoshi sergeymoto"), decimal.NewFromInt(21)},
-		{"string input gets converted to bytes", "stevetoshi sergeymoto", decimal.NewFromInt(21)},
-		{"empty string", "", decimal.NewFromInt(0)},
+		{"normal bytes", []byte{0xaa, 0xbb, 0xcc, 0xdd}, string([]byte{0xaa, 0xbb, 0xcc, 0xdd}), decimal.NewFromInt(4)},
+		{"empty bytes", []byte{}, "", decimal.NewFromInt(0)},
+		{"string as bytes", []byte("stevetoshi sergeymoto"), "stevetoshi sergeymoto", decimal.NewFromInt(21)},
+		{"string input gets converted to bytes", "stevetoshi sergeymoto", "stevetoshi sergeymoto", decimal.NewFromInt(21)},
+		{"empty string", "", "", decimal.NewFromInt(0)},
+		{"array input", []any{1, 2, 3}, "[1,2,3]", decimal.NewFromInt(3)},
+		{"empty array input", []any{}, "[]", decimal.NewFromInt(0)},
+		{"typed slice input", []*big.Int{big.NewInt(3), big.NewInt(11)}, "", decimal.NewFromInt(2)},
+		{"JSON array string", "[1,2,3]", "[1,2,3]", decimal.NewFromInt(3)},
+		{"empty JSON array string", "[]", "[]", decimal.NewFromInt(0)},
 	}
 
 	for _, test := range tests {
@@ -41,13 +48,7 @@ func TestLengthTask(t *testing.T) {
 				assertOK(task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{{Value: test.input}}))
 			})
 			t.Run("without vars through input param", func(t *testing.T) {
-				var inputStr string
-				if _, ok := test.input.([]byte); ok {
-					inputStr = string(test.input.([]byte))
-				} else {
-					inputStr = test.input.(string)
-				}
-				if inputStr == "" {
+				if test.inputParam == "" {
 					// empty input parameter is indistinguishable from not providing it at all
 					// in that case the task will use an input defined by the job DAG
 					return
@@ -55,7 +56,7 @@ func TestLengthTask(t *testing.T) {
 				vars := pipeline.NewVarsFrom(nil)
 				task := pipeline.LengthTask{
 					BaseTask: pipeline.NewBaseTask(0, "task", nil, nil, 0),
-					Input:    inputStr,
+					Input:    test.inputParam,
 				}
 				assertOK(task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{}))
 			})

--- a/core/services/pipeline/task_params.go
+++ b/core/services/pipeline/task_params.go
@@ -22,6 +22,19 @@ type PipelineParamUnmarshaler interface {
 }
 
 func ResolveParam(out PipelineParamUnmarshaler, getters []GetterFunc) error {
+	val, err := resolveParamValue(getters)
+	if err != nil {
+		return err
+	}
+
+	err = out.UnmarshalPipelineParam(val)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func resolveParamValue(getters []GetterFunc) (any, error) {
 	var val any
 	var err error
 	var found bool
@@ -30,20 +43,16 @@ func ResolveParam(out PipelineParamUnmarshaler, getters []GetterFunc) error {
 		if errors.Is(errors.Cause(err), ErrParameterEmpty) {
 			continue
 		} else if err != nil {
-			return err
+			return nil, err
 		}
 		found = true
 		break
 	}
 	if !found {
-		return ErrParameterEmpty
+		return nil, ErrParameterEmpty
 	}
 
-	err = out.UnmarshalPipelineParam(val)
-	if err != nil {
-		return err
-	}
-	return nil
+	return val, nil
 }
 
 type StringParam string


### PR DESCRIPTION
## Summary

- update the length pipeline task to return element counts for array/slice inputs
- support JSON array strings such as `[1,2,3]`
- preserve existing string and bytes length behavior

Fixes #7926

## Tests

- `go test ./core/services/pipeline -count=1`