### PR TITLE
Add Zone to CRE User Workflow Metrics Payload

### DIFF
--- a/.changeset/cre-workflow-user-metric-zone.md
+++ b/.changeset/cre-workflow-user-metric-zone.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Propagate operational zone from Telemetry.ResourceAttributes into CRE workflow user metric CreInfo payloads.

--- a/core/platform/monitoring.go
+++ b/core/platform/monitoring.go
@@ -25,6 +25,9 @@ const (
 	KeyDonN                = "N"
 	KeyDonQ                = "Q"
 	KeyP2PID               = "p2pID"
+	// KeyZone identifies the operational zone (e.g., "zone-a") of the DON
+	// this node belongs to. Sourced from Telemetry.ResourceAttributes.zone.
+	KeyZone                = "zone"
 	ValueWorkflowVersion   = "1.0.0"
 	ValueWorkflowVersionV2 = "2.0.0"
 	KeyCapabilityErrorCode = "capabilityErrorCode"

--- a/core/services/cre/confidential_relay_peerid_test.go
+++ b/core/services/cre/confidential_relay_peerid_test.go
@@ -51,6 +51,7 @@ func (s stubConfig) Workflows() config.Workflows       { return nil }
 func (s stubConfig) CRE() config.CRE                   { return nil }
 func (s stubConfig) P2P() config.P2P                   { return s.p2p }
 func (s stubConfig) Sharding() config.Sharding         { return nil }
+func (s stubConfig) Telemetry() config.Telemetry         { return nil }
 
 func peerIDFromByte(b byte) p2pkey.PeerID {
 	var id p2pkey.PeerID

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -323,6 +323,7 @@ type Config interface {
 	CRE() config.CRE
 	P2P() config.P2P
 	Sharding() config.Sharding
+	Telemetry() config.Telemetry
 }
 
 // RelayerChainInterops is the minimal interface needed for relayer chain interops
@@ -1000,6 +1001,7 @@ func newWorkflowRegistrySyncerV2(
 	handlerOpts := []syncerV2.EventHandlerOption{
 		syncerV2.WithBillingClient(billingClient),
 		syncerV2.WithWorkflowRegistry(capCfg.WorkflowRegistry().Address(), selector),
+		syncerV2.WithZone(cfg.Telemetry().ResourceAttributes()["zone"]),
 		syncerV2.WithOrgResolver(orgResolver),
 		syncerV2.WithDebugMode(cfg.CRE().DebugMode()),
 		syncerV2.WithLocalSecretOverrides(lggr, cfg.CRE().LocalSecretOverrides()),

--- a/core/services/workflows/events/emit.go
+++ b/core/services/workflows/events/emit.go
@@ -532,6 +532,7 @@ func buildCREMetadataV2(kvs map[string]string) *eventsv2.CreInfo {
 	m.CapabilitiesRegistryVersion = kvs[platform.CapabilitiesRegistryVersion]
 	m.DonVersion = kvs[platform.DonVersion]
 	m.WorkflowSource = kvs[platform.KeyWorkflowSource]
+	m.Zone = kvs[platform.KeyZone]
 
 	return m
 }

--- a/core/services/workflows/events/emit_metadata_test.go
+++ b/core/services/workflows/events/emit_metadata_test.go
@@ -1,0 +1,38 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/platform"
+)
+
+func TestBuildCREMetadataV2_IncludesZone(t *testing.T) {
+	t.Parallel()
+
+	labels := map[string]string{
+		platform.KeyDonID:  "5",
+		platform.KeyP2PID:  "12D3KooWRp2Gdj1JPot5425NshLBeyJJPno95GAIrzTNUm6cgx3B",
+		platform.KeyZone:   "zone-a",
+		platform.KeyDonF:   "1",
+		platform.KeyDonN:   "4",
+	}
+
+	creInfo := buildCREMetadataV2(labels)
+	require.NotNil(t, creInfo)
+	assert.Equal(t, int32(5), creInfo.DonID)
+	assert.Equal(t, "12D3KooWRp2Gdj1JPot5425NshLBeyJJPno95GAIrzTNUm6cgx3B", creInfo.P2PID)
+	assert.Equal(t, "zone-a", creInfo.Zone)
+}
+
+func TestBuildCREMetadataV2_EmptyZoneWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	creInfo := buildCREMetadataV2(map[string]string{
+		platform.KeyDonID: "2",
+	})
+	require.NotNil(t, creInfo)
+	assert.Empty(t, creInfo.Zone)
+}

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -101,6 +101,10 @@ type eventHandler struct {
 	// WorkflowRegistryChainSelector is the chain selector for the workflow registry
 	workflowRegistryChainSelector string
 
+	// zone identifies the operational zone (e.g., "zone-a") of the DON this
+	// node belongs to. Sourced from Telemetry.ResourceAttributes.zone.
+	zone string
+
 	// debugMode enables additional OTel tracing for workflow engines and syncer.
 	// When enabled, traces are created for workflow execution and syncer events.
 	debugMode bool
@@ -169,6 +173,14 @@ func WithWorkflowRegistry(address, chainSelector string) func(*eventHandler) {
 	return func(e *eventHandler) {
 		e.workflowRegistryAddress = address
 		e.workflowRegistryChainSelector = chainSelector
+	}
+}
+
+// WithZone sets the operational zone label propagated to engine telemetry
+// (e.g., "zone-a"). Sourced from Telemetry.ResourceAttributes.zone.
+func WithZone(zone string) func(*eventHandler) {
+	return func(e *eventHandler) {
+		e.zone = zone
 	}
 }
 
@@ -1061,6 +1073,7 @@ func (h *eventHandler) newV2EngineConfig(
 
 		WorkflowRegistryAddress:       h.workflowRegistryAddress,
 		WorkflowRegistryChainSelector: h.workflowRegistryChainSelector,
+		Zone:                          h.zone,
 		OrgResolver:                   h.orgResolver,
 		SecretsFetcher:                h.secretsFetcher,
 		OverrideFetcher:               h.overrideFetcherForOwner(owner),

--- a/core/services/workflows/v2/config.go
+++ b/core/services/workflows/v2/config.go
@@ -64,6 +64,10 @@ type EngineConfig struct {
 	// WorkflowRegistryChainSelector is the chain selector for the workflow registry
 	WorkflowRegistryChainSelector string
 
+	// Zone identifies the operational zone (e.g., "zone-a") of the DON this
+	// node belongs to. Sourced from Telemetry.ResourceAttributes.zone.
+	Zone string
+
 	// OrgResolver is used to resolve organization IDs from workflow owners
 	OrgResolver orgresolver.OrgResolver
 

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -130,6 +130,7 @@ func (e *Engine) buildLabels(localNode *capabilities.Node) []any {
 			int(localNode.WorkflowDON.F),
 		)),
 		platform.KeyP2PID, localNode.PeerID.String(),
+		platform.KeyZone, e.cfg.Zone,
 		platform.WorkflowRegistryAddress, e.cfg.WorkflowRegistryAddress,
 		platform.WorkflowRegistryChainSelector, e.cfg.WorkflowRegistryChainSelector,
 		platform.EngineVersion, platform.ValueWorkflowVersionV2,

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.10.0
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260331131315-f08a616d8dcd
 	github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0
-	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260323124644-faea187e6997
+	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260601174453-7d26523f8217
 	github.com/smartcontractkit/chainlink-solana v1.3.1-0.20260522172305-f71b70a4d020
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260527160341-aa3adc0abf67
 	github.com/smartcontractkit/chainlink-ton v1.0.5-0.20260520103847-15ca4de9dba9

--- a/go.sum
+++ b/go.sum
@@ -1229,8 +1229,8 @@ github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0 h1:B7itmjy+C
 github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0/go.mod h1:h6kqaGajbNRrezm56zhx03p0mVmmA2xxj7E/M4ytLUA=
 github.com/smartcontractkit/chainlink-protos/svr v1.2.0 h1:7jjgqRgORQS/ikL3z0ZgJy95pzjhR9LuU1TVWg4BZ78=
 github.com/smartcontractkit/chainlink-protos/svr v1.2.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
-github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260323124644-faea187e6997 h1:W0HKHO8eE8BckTRnhSdqjHKbJcnk068nEWYnWRu6tJY=
-github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260323124644-faea187e6997/go.mod h1:GTpDgyK0OObf7jpch6p8N281KxN92wbB8serZhU9yRc=
+github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260601174453-7d26523f8217 h1:77TdkLxkCh7ofUaRwEKflYhw5UHLCIKId/f7rgjLWow=
+github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260601174453-7d26523f8217/go.mod h1:GTpDgyK0OObf7jpch6p8N281KxN92wbB8serZhU9yRc=
 github.com/smartcontractkit/chainlink-solana v1.3.1-0.20260522172305-f71b70a4d020 h1:8bMEgrIdrff6CequbqHQOACd3ktgwlLf1XmQ6giPfNk=
 github.com/smartcontractkit/chainlink-solana v1.3.1-0.20260522172305-f71b70a4d020/go.mod h1:5uWu39vXphl2Ug0WyHqpB2UfltClSANBVenvGMpsDS8=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260527160341-aa3adc0abf67 h1:NNvPOgvf5vbOYVLxLST+5E88iPOAnpmzZGPihEx8DFc=

--- a/system-tests/lib/cre/don/config/config.go
+++ b/system-tests/lib/cre/don/config/config.go
@@ -287,18 +287,22 @@ func baseNodeConfig(commonInputs *commonInputs, donMetadata *cre.DonMetadata, no
 
 	if commonInputs.provider.IsDocker() {
 		nodeIdentifier := donMetadata.Name + "-node-" + strconv.Itoa(nodeMetadata.Index)
+		resourceAttributes := map[string]string{
+			"service.name":     "chainlink-node",
+			"service.instance": nodeIdentifier,
+			"node.don":         donMetadata.Name,
+			"node.index":       strconv.Itoa(nodeMetadata.Index),
+		}
+		if zone := zoneFromDonName(donMetadata.Name); zone != "" {
+			resourceAttributes["zone"] = zone
+		}
 		c.Telemetry = coretoml.Telemetry{
 			Enabled:             new(true),
 			Endpoint:            new(strings.TrimPrefix(framework.HostDockerInternal(), "http://") + ":4317"),
 			InsecureConnection:  new(true),
 			LogStreamingEnabled: new(true),
 			TraceSampleRatio:    new(0.0), // Set to > 0 to enable tracing
-			ResourceAttributes: map[string]string{
-				"service.name":     "chainlink-node",
-				"service.instance": nodeIdentifier,
-				"node.don":         donMetadata.Name,
-				"node.index":       strconv.Itoa(nodeMetadata.Index),
-			},
+			ResourceAttributes:  resourceAttributes,
 		}
 		// Note: OTEL_SERVICE_NAME env var should also be set on nodes to ensure
 		// the service name is applied correctly. The ResourceAttributes above may
@@ -313,6 +317,17 @@ func baseNodeConfig(commonInputs *commonInputs, donMetadata *cre.DonMetadata, no
 	}
 
 	return c
+}
+
+// zoneFromDonName extracts an operational zone label from local CRE DON names
+// (e.g. feeds-zone-a, gateway-zone-b). Returns empty when no zone suffix is present.
+func zoneFromDonName(donName string) string {
+	for _, zone := range []string{"zone-a", "zone-b"} {
+		if strings.HasSuffix(donName, zone) {
+			return zone
+		}
+	}
+	return ""
 }
 
 func addBootstrapNodeConfig(
@@ -541,8 +556,12 @@ func addWorkerNodeConfig(
 		}
 
 		gateways := []coretoml.ConnectorGateway{}
-		if topology != nil && topology.GatewayConnectors != nil && len(topology.GatewayConnectors.Configurations) > 0 {
-			for _, gateway := range topology.GatewayConnectors.Configurations {
+		connectors := cre.GatewayConnectors{}
+		if topology != nil && topology.GatewayConnectors != nil {
+			connectors = topology.GatewayConnectorsForWorkflow(donMetadata.Name)
+		}
+		if len(connectors.Configurations) > 0 {
+			for _, gateway := range connectors.Configurations {
 				gateways = append(gateways, coretoml.ConnectorGateway{
 					ID: new(gateway.AuthGatewayID),
 					URL: new(fmt.Sprintf("ws://%s:%d%s",


### PR DESCRIPTION
Adds Zone to CRE User Workflow Metrics Payload, so we don't have to maintain an external mapping of `(don_id, env) => zone`