### PR TITLE
recycling workflow store map to fix mem leak

### DIFF
--- a/.changeset/fix-workflow-store-mem-leak.md
+++ b/.changeset/fix-workflow-store-mem-leak.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix Rebuild the in-memory workflow execution store's map when pruning so old bucket storage becomes eligible for GC. Go maps never shrink after deletes, which stranded memory as the store churned through millions of executions.

--- a/core/services/workflows/store/store.go
+++ b/core/services/workflows/store/store.go
@@ -3,12 +3,15 @@ package store
 import (
 	"context"
 	"errors"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 )
 
 // ErrDuplicateExecution is returned by Add when the execution ID already exists.
 var ErrDuplicateExecution = errors.New("duplicate execution")
 
 type Store interface {
+	services.Service
 	Add(ctx context.Context, steps map[string]*WorkflowExecutionStep,
 		executionID string, workflowID string, status string) (WorkflowExecution, error)
 	UpsertStep(ctx context.Context, step *WorkflowExecutionStep) (WorkflowExecution, error)

--- a/core/services/workflows/store/store_memory.go
+++ b/core/services/workflows/store/store_memory.go
@@ -16,6 +16,10 @@ const (
 	// defaultPruneInterval is the default interval between pruning completed executions
 	defaultPruneInterval = 30 * time.Second
 
+	// defaultRecycleMapForGCInterval is the default interval between rebuilding the execution
+	// map so its old bucket storage becomes eligible for GC, even when no entries are deleted.
+	defaultRecycleMapForGCInterval = 1 * time.Hour
+
 	// maximumExecutionAge is the default maximum age of an execution before it is considered expired and eligible for pruning
 	// regardless of its status
 	maximumExecutionAge = 24 * time.Hour
@@ -42,16 +46,22 @@ type InMemoryStore struct {
 	// maximumExecutionAge is the maximum age of an execution before it is considered expired and eligible for pruning
 	// regardless of its status
 	maximumExecutionAge time.Duration
+
+	// recycleMapForGCInterval is the interval between rebuilding the execution map so old
+	// bucket storage becomes eligible for GC, independent of entry deletion.
+	recycleMapForGCInterval time.Duration
 }
 
 func NewInMemoryStore(lggr logger.Logger, clock clockwork.Clock) *InMemoryStore {
-	return NewInMemoryStoreWithPruneConfiguration(lggr, clock, defaultPruneInterval, maximumExecutionAge)
+	return NewInMemoryStoreWithPruneConfiguration(lggr, clock, defaultPruneInterval, maximumExecutionAge,
+		defaultRecycleMapForGCInterval)
 }
 
 func NewInMemoryStoreWithPruneConfiguration(lggr logger.Logger, clock clockwork.Clock, pruneFrequency time.Duration,
-	maximumExecutionAge time.Duration) *InMemoryStore {
+	maximumExecutionAge time.Duration, recycleMapForGCInterval time.Duration) *InMemoryStore {
 	return &InMemoryStore{lggr: lggr, idToExecution: map[string]*WorkflowExecution{}, clock: clock, chStop: make(chan struct{}),
-		pruneInterval: pruneFrequency, maximumExecutionAge: maximumExecutionAge}
+		pruneInterval: pruneFrequency, maximumExecutionAge: maximumExecutionAge,
+		recycleMapForGCInterval: recycleMapForGCInterval}
 }
 
 // Add adds a new execution state under the given executionID
@@ -180,38 +190,86 @@ func (s *InMemoryStore) DeleteByWorkflowID(_ context.Context, workflowID string)
 	return nil
 }
 
+// recycleMapLocked copies all entries into a fresh map and swaps it in.
+// Caller must hold s.mu.
+func (s *InMemoryStore) recycleMapLocked() {
+	if len(s.idToExecution) == 0 {
+		return
+	}
+	newMap := make(map[string]*WorkflowExecution, len(s.idToExecution))
+	for id, state := range s.idToExecution {
+		newMap[id] = state
+	}
+	s.idToExecution = newMap
+}
+
 func (s *InMemoryStore) pruneExpiredExecutionEntries() {
 	defer s.shutdownWaitGroup.Done()
-	ticker := s.clock.NewTicker(s.pruneInterval)
-	defer ticker.Stop()
+	pruneTicker := s.clock.NewTicker(s.pruneInterval)
+	defer pruneTicker.Stop()
+	recycleTicker := s.clock.NewTicker(s.recycleMapForGCInterval)
+	defer recycleTicker.Stop()
 	for {
 		select {
 		case <-s.chStop:
 			return
-		case <-ticker.Chan():
-			expirationTime := s.clock.Now().Add(-s.maximumExecutionAge)
-			s.mu.Lock()
-			for id, state := range s.idToExecution {
-				if isCompletedStatus(state.Status) {
-					delete(s.idToExecution, id)
-				}
-			}
-
-			// Prune non-terminated executions that are older than the maximum expiration time
-			// This shouldn't be necessary - erring on the side of caution for now as this pruning logic
-			// existed in the old store.
-			var prunedNonTerminatedExecutionIDs []string
-			for id, state := range s.idToExecution {
-				if state.UpdatedAt.Before(expirationTime) {
-					delete(s.idToExecution, id)
-					prunedNonTerminatedExecutionIDs = append(prunedNonTerminatedExecutionIDs, id)
-				}
-			}
-			s.mu.Unlock()
-			if len(prunedNonTerminatedExecutionIDs) > 0 {
-				s.lggr.Warnw("Found and pruned non completed workflow executions older than the maximum execution age",
-					"maximumExecutionAge", s.maximumExecutionAge, "pruned execution ids", prunedNonTerminatedExecutionIDs)
-			}
+		case <-pruneTicker.Chan():
+			s.pruneCompletedAndExpiredExecutions()
+		case <-recycleTicker.Chan():
+			s.recycleExecutionMapForGC()
 		}
+	}
+}
+
+func (s *InMemoryStore) pruneCompletedAndExpiredExecutions() {
+	expirationTime := s.clock.Now().Add(-s.maximumExecutionAge)
+	s.mu.Lock()
+	newMap := make(map[string]*WorkflowExecution, len(s.idToExecution))
+	prunedCompletedCount := 0
+
+	// Prune non-terminated executions that are older than the maximum expiration time
+	// This shouldn't be necessary - erring on the side of caution for now as this pruning logic
+	// existed in the old store.
+	var prunedNonTerminatedExecutionIDs []string
+	for id, state := range s.idToExecution {
+		if isCompletedStatus(state.Status) {
+			prunedCompletedCount++
+			continue
+		}
+		if state.UpdatedAt.Before(expirationTime) {
+			prunedNonTerminatedExecutionIDs = append(prunedNonTerminatedExecutionIDs, id)
+			continue
+		}
+		newMap[id] = state
+	}
+	prunedAny := prunedCompletedCount > 0 || len(prunedNonTerminatedExecutionIDs) > 0
+	if prunedAny {
+		// Rebuild the map to let old buckets become GC-eligible after churn-heavy periods.
+		s.idToExecution = newMap
+	}
+	remainingExecutions := len(s.idToExecution)
+	s.mu.Unlock()
+	if prunedAny {
+		s.lggr.Infow("Pruned workflow execution entries",
+			"prunedCompletedCount", prunedCompletedCount,
+			"prunedNonCompletedCount", len(prunedNonTerminatedExecutionIDs),
+			"remainingExecutions", remainingExecutions)
+	}
+	if len(prunedNonTerminatedExecutionIDs) > 0 {
+		s.lggr.Warnw("Found and pruned non completed workflow executions older than the maximum execution age",
+			"maximumExecutionAge", s.maximumExecutionAge, "pruned execution ids", prunedNonTerminatedExecutionIDs)
+	}
+}
+
+func (s *InMemoryStore) recycleExecutionMapForGC() {
+	s.mu.Lock()
+	remainingExecutions := len(s.idToExecution)
+	if remainingExecutions > 0 {
+		s.recycleMapLocked()
+	}
+	s.mu.Unlock()
+	if remainingExecutions > 0 {
+		s.lggr.Infow("Recycled workflow execution map for GC",
+			"remainingExecutions", remainingExecutions)
 	}
 }

--- a/core/services/workflows/store/store_memory.go
+++ b/core/services/workflows/store/store_memory.go
@@ -16,10 +16,6 @@ const (
 	// defaultPruneInterval is the default interval between pruning completed executions
 	defaultPruneInterval = 30 * time.Second
 
-	// defaultRecycleMapForGCInterval is the default interval between rebuilding the execution
-	// map so its old bucket storage becomes eligible for GC, even when no entries are deleted.
-	defaultRecycleMapForGCInterval = 1 * time.Hour
-
 	// maximumExecutionAge is the default maximum age of an execution before it is considered expired and eligible for pruning
 	// regardless of its status
 	maximumExecutionAge = 24 * time.Hour
@@ -46,22 +42,16 @@ type InMemoryStore struct {
 	// maximumExecutionAge is the maximum age of an execution before it is considered expired and eligible for pruning
 	// regardless of its status
 	maximumExecutionAge time.Duration
-
-	// recycleMapForGCInterval is the interval between rebuilding the execution map so old
-	// bucket storage becomes eligible for GC, independent of entry deletion.
-	recycleMapForGCInterval time.Duration
 }
 
 func NewInMemoryStore(lggr logger.Logger, clock clockwork.Clock) *InMemoryStore {
-	return NewInMemoryStoreWithPruneConfiguration(lggr, clock, defaultPruneInterval, maximumExecutionAge,
-		defaultRecycleMapForGCInterval)
+	return NewInMemoryStoreWithPruneConfiguration(lggr, clock, defaultPruneInterval, maximumExecutionAge)
 }
 
 func NewInMemoryStoreWithPruneConfiguration(lggr logger.Logger, clock clockwork.Clock, pruneFrequency time.Duration,
-	maximumExecutionAge time.Duration, recycleMapForGCInterval time.Duration) *InMemoryStore {
+	maximumExecutionAge time.Duration) *InMemoryStore {
 	return &InMemoryStore{lggr: lggr, idToExecution: map[string]*WorkflowExecution{}, clock: clock, chStop: make(chan struct{}),
-		pruneInterval: pruneFrequency, maximumExecutionAge: maximumExecutionAge,
-		recycleMapForGCInterval: recycleMapForGCInterval}
+		pruneInterval: pruneFrequency, maximumExecutionAge: maximumExecutionAge}
 }
 
 // Add adds a new execution state under the given executionID
@@ -190,86 +180,59 @@ func (s *InMemoryStore) DeleteByWorkflowID(_ context.Context, workflowID string)
 	return nil
 }
 
-// recycleMapLocked copies all entries into a fresh map and swaps it in.
-// Caller must hold s.mu.
-func (s *InMemoryStore) recycleMapLocked() {
-	if len(s.idToExecution) == 0 {
-		return
-	}
-	newMap := make(map[string]*WorkflowExecution, len(s.idToExecution))
-	for id, state := range s.idToExecution {
-		newMap[id] = state
-	}
-	s.idToExecution = newMap
-}
-
 func (s *InMemoryStore) pruneExpiredExecutionEntries() {
 	defer s.shutdownWaitGroup.Done()
-	pruneTicker := s.clock.NewTicker(s.pruneInterval)
-	defer pruneTicker.Stop()
-	recycleTicker := s.clock.NewTicker(s.recycleMapForGCInterval)
-	defer recycleTicker.Stop()
+	ticker := s.clock.NewTicker(s.pruneInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-s.chStop:
 			return
-		case <-pruneTicker.Chan():
+		case <-ticker.Chan():
 			s.pruneCompletedAndExpiredExecutions()
-		case <-recycleTicker.Chan():
-			s.recycleExecutionMapForGC()
 		}
 	}
 }
 
+// pruneCompletedAndExpiredExecutions removes completed executions and non-completed executions
+// older than maximumExecutionAge. When it prunes anything it rebuilds the map rather than
+// deleting in place, so the old bucket storage becomes eligible for GC: Go maps never shrink
+// after deletes, which strands memory once the store has churned through many executions.
+// See https://100go.co/28-maps-memory-leaks/
 func (s *InMemoryStore) pruneCompletedAndExpiredExecutions() {
 	expirationTime := s.clock.Now().Add(-s.maximumExecutionAge)
-	s.mu.Lock()
-	newMap := make(map[string]*WorkflowExecution, len(s.idToExecution))
-	prunedCompletedCount := 0
 
-	// Prune non-terminated executions that are older than the maximum expiration time
-	// This shouldn't be necessary - erring on the side of caution for now as this pruning logic
-	// existed in the old store.
-	var prunedNonTerminatedExecutionIDs []string
+	s.mu.Lock()
+	remaining := make(map[string]*WorkflowExecution, len(s.idToExecution))
+	prunedCompletedCount := 0
+	// Non-terminated executions older than the maximum age shouldn't normally exist; we prune
+	// them out of caution, preserving the behaviour of the old store.
+	var prunedExpiredIDs []string
 	for id, state := range s.idToExecution {
-		if isCompletedStatus(state.Status) {
+		switch {
+		case isCompletedStatus(state.Status):
 			prunedCompletedCount++
-			continue
+		case state.UpdatedAt.Before(expirationTime):
+			prunedExpiredIDs = append(prunedExpiredIDs, id)
+		default:
+			remaining[id] = state
 		}
-		if state.UpdatedAt.Before(expirationTime) {
-			prunedNonTerminatedExecutionIDs = append(prunedNonTerminatedExecutionIDs, id)
-			continue
-		}
-		newMap[id] = state
 	}
-	prunedAny := prunedCompletedCount > 0 || len(prunedNonTerminatedExecutionIDs) > 0
-	if prunedAny {
-		// Rebuild the map to let old buckets become GC-eligible after churn-heavy periods.
-		s.idToExecution = newMap
+	prunedCount := prunedCompletedCount + len(prunedExpiredIDs)
+	if prunedCount > 0 {
+		s.idToExecution = remaining
 	}
 	remainingExecutions := len(s.idToExecution)
 	s.mu.Unlock()
-	if prunedAny {
+
+	if prunedCount > 0 {
 		s.lggr.Infow("Pruned workflow execution entries",
 			"prunedCompletedCount", prunedCompletedCount,
-			"prunedNonCompletedCount", len(prunedNonTerminatedExecutionIDs),
+			"prunedExpiredCount", len(prunedExpiredIDs),
 			"remainingExecutions", remainingExecutions)
 	}
-	if len(prunedNonTerminatedExecutionIDs) > 0 {
+	if len(prunedExpiredIDs) > 0 {
 		s.lggr.Warnw("Found and pruned non completed workflow executions older than the maximum execution age",
-			"maximumExecutionAge", s.maximumExecutionAge, "pruned execution ids", prunedNonTerminatedExecutionIDs)
-	}
-}
-
-func (s *InMemoryStore) recycleExecutionMapForGC() {
-	s.mu.Lock()
-	remainingExecutions := len(s.idToExecution)
-	if remainingExecutions > 0 {
-		s.recycleMapLocked()
-	}
-	s.mu.Unlock()
-	if remainingExecutions > 0 {
-		s.lggr.Infow("Recycled workflow execution map for GC",
-			"remainingExecutions", remainingExecutions)
+			"maximumExecutionAge", s.maximumExecutionAge, "prunedExecutionIDs", prunedExpiredIDs)
 	}
 }

--- a/core/services/workflows/store/store_memory_test.go
+++ b/core/services/workflows/store/store_memory_test.go
@@ -65,7 +65,7 @@ func TestInMemoryStore_Get(t *testing.T) {
 
 func TestInMemoryStore_FinishedExecution(t *testing.T) {
 	store := NewInMemoryStoreWithPruneConfiguration(logger.TestLogger(t), clockwork.NewRealClock(),
-		10*time.Millisecond, 1*time.Hour)
+		10*time.Millisecond, 1*time.Hour, 24*time.Hour)
 	servicetest.Run(t, store)
 
 	_, err := store.Add(t.Context(), map[string]*WorkflowExecutionStep{
@@ -111,7 +111,7 @@ func TestInMemoryStore_ExpiresNonCompletedExecutions(t *testing.T) {
 	expirationDuration := 50 * time.Millisecond
 
 	store := NewInMemoryStoreWithPruneConfiguration(logger.TestLogger(t), clockwork.NewRealClock(),
-		10*time.Millisecond, expirationDuration)
+		10*time.Millisecond, expirationDuration, 24*time.Hour)
 
 	servicetest.Run(t, store)
 
@@ -128,7 +128,7 @@ func TestInMemoryStore_ExpiresNonCompletedExecutions(t *testing.T) {
 
 	// Now repeat the test but with a longer expiration duration and check that the state is not expired
 	store = NewInMemoryStoreWithPruneConfiguration(logger.TestLogger(t), clockwork.NewRealClock(),
-		10*time.Millisecond, 30*time.Second)
+		10*time.Millisecond, 30*time.Second, 24*time.Hour)
 
 	_, err = store.Add(t.Context(), map[string]*WorkflowExecutionStep{
 		"step-1": {Ref: "step-1"},
@@ -139,4 +139,45 @@ func TestInMemoryStore_ExpiresNonCompletedExecutions(t *testing.T) {
 		_, err2 := store.Get(t.Context(), "test-id")
 		return err2 != nil
 	}, 300*time.Millisecond, 50*time.Millisecond)
+}
+
+func TestInMemoryStore_DefaultRecycleMapForGCInterval(t *testing.T) {
+	assert.Equal(t, time.Hour, defaultRecycleMapForGCInterval)
+}
+
+func TestInMemoryStore_RecycleMapWithoutPruning(t *testing.T) {
+	fakeClock := clockwork.NewFakeClock()
+	store := NewInMemoryStoreWithPruneConfiguration(logger.TestLogger(t), fakeClock,
+		30*time.Second, 24*time.Hour, 50*time.Millisecond)
+	servicetest.Run(t, store)
+
+	_, err := store.Add(t.Context(), map[string]*WorkflowExecutionStep{
+		"step-1": {Ref: "step-1"},
+	}, "exec-1", "wf-1", StatusStarted)
+	require.NoError(t, err)
+
+	fakeClock.Advance(100 * time.Millisecond)
+
+	got, err := store.Get(t.Context(), "exec-1")
+	require.NoError(t, err)
+	assert.Equal(t, "exec-1", got.ExecutionID)
+	assert.Equal(t, StatusStarted, got.Status)
+}
+
+func TestInMemoryStore_PruneIntervalIndependentOfRecycleInterval(t *testing.T) {
+	fakeClock := clockwork.NewFakeClock()
+	store := NewInMemoryStoreWithPruneConfiguration(logger.TestLogger(t), fakeClock,
+		50*time.Millisecond, 24*time.Hour, time.Hour)
+	servicetest.Run(t, store)
+
+	_, err := store.Add(t.Context(), nil, "exec-1", "wf-1", StatusStarted)
+	require.NoError(t, err)
+	_, err = store.FinishExecution(t.Context(), "exec-1", StatusCompleted)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		fakeClock.Advance(60 * time.Millisecond)
+		_, getErr := store.Get(t.Context(), "exec-1")
+		return getErr != nil
+	}, 2*time.Second, 10*time.Millisecond)
 }

--- a/core/services/workflows/store/store_memory_test.go
+++ b/core/services/workflows/store/store_memory_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -65,7 +66,7 @@ func TestInMemoryStore_Get(t *testing.T) {
 
 func TestInMemoryStore_FinishedExecution(t *testing.T) {
 	store := NewInMemoryStoreWithPruneConfiguration(logger.TestLogger(t), clockwork.NewRealClock(),
-		10*time.Millisecond, 1*time.Hour, 24*time.Hour)
+		10*time.Millisecond, 1*time.Hour)
 	servicetest.Run(t, store)
 
 	_, err := store.Add(t.Context(), map[string]*WorkflowExecutionStep{
@@ -111,7 +112,7 @@ func TestInMemoryStore_ExpiresNonCompletedExecutions(t *testing.T) {
 	expirationDuration := 50 * time.Millisecond
 
 	store := NewInMemoryStoreWithPruneConfiguration(logger.TestLogger(t), clockwork.NewRealClock(),
-		10*time.Millisecond, expirationDuration, 24*time.Hour)
+		10*time.Millisecond, expirationDuration)
 
 	servicetest.Run(t, store)
 
@@ -128,7 +129,7 @@ func TestInMemoryStore_ExpiresNonCompletedExecutions(t *testing.T) {
 
 	// Now repeat the test but with a longer expiration duration and check that the state is not expired
 	store = NewInMemoryStoreWithPruneConfiguration(logger.TestLogger(t), clockwork.NewRealClock(),
-		10*time.Millisecond, 30*time.Second, 24*time.Hour)
+		10*time.Millisecond, 30*time.Second)
 
 	_, err = store.Add(t.Context(), map[string]*WorkflowExecutionStep{
 		"step-1": {Ref: "step-1"},
@@ -141,43 +142,38 @@ func TestInMemoryStore_ExpiresNonCompletedExecutions(t *testing.T) {
 	}, 300*time.Millisecond, 50*time.Millisecond)
 }
 
-func TestInMemoryStore_DefaultRecycleMapForGCInterval(t *testing.T) {
-	assert.Equal(t, time.Hour, defaultRecycleMapForGCInterval)
-}
+// TestInMemoryStore_PruneRebuildsMapOnlyWhenPruning verifies that pruning drops completed and
+// expired executions while retaining active ones, and that the backing map is rebuilt only when
+// something is actually pruned. Rebuilding is what lets stranded bucket storage become
+// GC-eligible (Go maps never shrink after deletes); skipping it on a no-op prune avoids a
+// needless full copy of the map every interval.
+func TestInMemoryStore_PruneRebuildsMapOnlyWhenPruning(t *testing.T) {
+	t.Parallel()
 
-func TestInMemoryStore_RecycleMapWithoutPruning(t *testing.T) {
-	fakeClock := clockwork.NewFakeClock()
-	store := NewInMemoryStoreWithPruneConfiguration(logger.TestLogger(t), fakeClock,
-		30*time.Second, 24*time.Hour, 50*time.Millisecond)
-	servicetest.Run(t, store)
+	store := NewInMemoryStoreWithPruneConfiguration(logger.TestLogger(t), clockwork.NewFakeClock(),
+		defaultPruneInterval, 24*time.Hour)
 
-	_, err := store.Add(t.Context(), map[string]*WorkflowExecutionStep{
-		"step-1": {Ref: "step-1"},
-	}, "exec-1", "wf-1", StatusStarted)
+	// active stays; done is completed and should be pruned.
+	_, err := store.Add(t.Context(), nil, "active", "wf-1", StatusStarted)
+	require.NoError(t, err)
+	_, err = store.Add(t.Context(), nil, "done", "wf-1", StatusStarted)
+	require.NoError(t, err)
+	_, err = store.FinishExecution(t.Context(), "done", StatusCompleted)
 	require.NoError(t, err)
 
-	fakeClock.Advance(100 * time.Millisecond)
+	mapBefore := reflect.ValueOf(store.idToExecution).Pointer()
+	store.pruneCompletedAndExpiredExecutions()
+	mapAfterPrune := reflect.ValueOf(store.idToExecution).Pointer()
 
-	got, err := store.Get(t.Context(), "exec-1")
+	_, err = store.Get(t.Context(), "done")
+	require.Error(t, err)
+	got, err := store.Get(t.Context(), "active")
 	require.NoError(t, err)
-	assert.Equal(t, "exec-1", got.ExecutionID)
-	assert.Equal(t, StatusStarted, got.Status)
-}
+	assert.Equal(t, "active", got.ExecutionID)
+	assert.NotEqual(t, mapBefore, mapAfterPrune, "map should be rebuilt when entries are pruned")
 
-func TestInMemoryStore_PruneIntervalIndependentOfRecycleInterval(t *testing.T) {
-	fakeClock := clockwork.NewFakeClock()
-	store := NewInMemoryStoreWithPruneConfiguration(logger.TestLogger(t), fakeClock,
-		50*time.Millisecond, 24*time.Hour, time.Hour)
-	servicetest.Run(t, store)
-
-	_, err := store.Add(t.Context(), nil, "exec-1", "wf-1", StatusStarted)
-	require.NoError(t, err)
-	_, err = store.FinishExecution(t.Context(), "exec-1", StatusCompleted)
-	require.NoError(t, err)
-
-	require.Eventually(t, func() bool {
-		fakeClock.Advance(60 * time.Millisecond)
-		_, getErr := store.Get(t.Context(), "exec-1")
-		return getErr != nil
-	}, 2*time.Second, 10*time.Millisecond)
+	// A prune that removes nothing must leave the same backing map in place.
+	store.pruneCompletedAndExpiredExecutions()
+	assert.Equal(t, mapAfterPrune, reflect.ValueOf(store.idToExecution).Pointer(),
+		"map should not be rebuilt when nothing is pruned")
 }

--- a/core/services/workflows/syncer/handler_test.go
+++ b/core/services/workflows/syncer/handler_test.go
@@ -1344,4 +1344,3 @@ func TestEngineFactoryFn_SuccessfulCreation(t *testing.T) {
 		require.NotNil(t, engine)
 	})
 }
-

--- a/core/services/workflows/syncer/handler_test.go
+++ b/core/services/workflows/syncer/handler_test.go
@@ -1344,3 +1344,4 @@ func TestEngineFactoryFn_SuccessfulCreation(t *testing.T) {
 		require.NotNil(t, engine)
 	})
 }
+

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -895,21 +895,25 @@ func (h *eventHandler) workflowDeletedEvent(
 // tryEngineCleanup attempts to stop the workflow engine for the given workflow ID.  Does nothing if the
 // workflow engine is not running.
 func (h *eventHandler) tryEngineCleanup(workflowID types.WorkflowID) error {
-	// Pop first so the engine is removed from the registry atomically: it can then only be
-	// closed once, avoiding a double Close (and the resulting ErrAlreadyStopped) if this runs
-	// concurrently with, or is retried after, another cleanup for the same workflow.
-	e, err := h.engineRegistry.Pop(workflowID)
-	if errors.Is(err, ErrNotFound) {
+	e, ok := h.engineRegistry.Get(workflowID)
+	if !ok {
 		return nil
 	}
-	if err != nil {
-		return fmt.Errorf("failed to remove workflow engine: %w", err)
-	}
 
-	if err := e.Close(); err != nil {
+	// Close the engine, then remove it from the registry only once cleanup has succeeded. The
+	// registry entry is what tells us this workflow still needs cleanup, so if a step fails we
+	// leave it in place and return the error, allowing a future attempt to retry in case the
+	// failure was spurious. Close is idempotent, so ErrAlreadyStopped means the engine was
+	// already closed on a prior attempt and is treated as success rather than a failure.
+	if err := e.Close(); err != nil && !errors.Is(err, services.ErrAlreadyStopped) {
 		return fmt.Errorf("failed to close workflow engine: %w", err)
 	}
+
 	h.cleanupModuleCache(workflowID.Hex())
+
+	if _, err := h.engineRegistry.Pop(workflowID); err != nil {
+		return fmt.Errorf("failed to remove workflow engine: %w", err)
+	}
 	return nil
 }
 

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -328,8 +328,10 @@ func NewEventHandler(
 }
 
 func (h *eventHandler) start(ctx context.Context) error {
-	if err := h.workflowStore.Start(ctx); err != nil {
-		return fmt.Errorf("failed to start workflow store: %w", err)
+	if h.workflowStore != nil {
+		if err := h.workflowStore.Start(ctx); err != nil {
+			return fmt.Errorf("failed to start workflow store: %w", err)
+		}
 	}
 	if h.moduleLRU != nil {
 		h.moduleLRU.Start()
@@ -346,7 +348,9 @@ func (h *eventHandler) close() error {
 	for _, e := range es {
 		cs = append(cs, e)
 	}
-	cs = append(cs, h.workflowStore)
+	if h.workflowStore != nil {
+		cs = append(cs, h.workflowStore)
+	}
 	cs = append(cs, h.engineLimiters)
 	return services.CloseAll(cs...)
 }

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -327,7 +327,10 @@ func NewEventHandler(
 	return eh, nil
 }
 
-func (h *eventHandler) start(_ context.Context) error {
+func (h *eventHandler) start(ctx context.Context) error {
+	if err := h.workflowStore.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start workflow store: %w", err)
+	}
 	if h.moduleLRU != nil {
 		h.moduleLRU.Start()
 	}
@@ -339,11 +342,12 @@ func (h *eventHandler) close() error {
 		h.moduleLRU.Close()
 	}
 	es := h.engineRegistry.PopAll()
-	cs := make([]io.Closer, 0, len(es)+1)
-	cs = append(cs, h.engineLimiters)
+	cs := make([]io.Closer, 0, len(es)+2)
 	for _, e := range es {
 		cs = append(cs, e)
 	}
+	cs = append(cs, h.workflowStore)
+	cs = append(cs, h.engineLimiters)
 	return services.CloseAll(cs...)
 }
 
@@ -891,7 +895,7 @@ func (h *eventHandler) tryEngineCleanup(workflowID types.WorkflowID) error {
 	e, ok := h.engineRegistry.Get(workflowID)
 	if ok {
 		// Stop the engine
-		if err := e.Close(); err != nil {
+		if err := e.Close(); err != nil && !errors.Is(err, services.ErrAlreadyStopped) {
 			return fmt.Errorf("failed to close workflow engine: %w", err)
 		}
 

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -319,7 +319,14 @@ func NewEventHandler(
 	}
 
 	eh.Service, eh.eng = services.Config{
-		Name:  "EventHandler",
+		Name: "EventHandler",
+		// The workflow store is started and stopped alongside the handler.
+		NewSubServices: func(logger.Logger) []services.Service {
+			if eh.workflowStore == nil {
+				return nil
+			}
+			return []services.Service{eh.workflowStore}
+		},
 		Start: eh.start,
 		Close: eh.close,
 	}.NewServiceEngine(lggr)
@@ -327,12 +334,7 @@ func NewEventHandler(
 	return eh, nil
 }
 
-func (h *eventHandler) start(ctx context.Context) error {
-	if h.workflowStore != nil {
-		if err := h.workflowStore.Start(ctx); err != nil {
-			return fmt.Errorf("failed to start workflow store: %w", err)
-		}
-	}
+func (h *eventHandler) start(_ context.Context) error {
 	if h.moduleLRU != nil {
 		h.moduleLRU.Start()
 	}
@@ -344,14 +346,11 @@ func (h *eventHandler) close() error {
 		h.moduleLRU.Close()
 	}
 	es := h.engineRegistry.PopAll()
-	cs := make([]io.Closer, 0, len(es)+2)
+	cs := make([]io.Closer, 0, len(es)+1)
+	cs = append(cs, h.engineLimiters)
 	for _, e := range es {
 		cs = append(cs, e)
 	}
-	if h.workflowStore != nil {
-		cs = append(cs, h.workflowStore)
-	}
-	cs = append(cs, h.engineLimiters)
 	return services.CloseAll(cs...)
 }
 
@@ -896,21 +895,21 @@ func (h *eventHandler) workflowDeletedEvent(
 // tryEngineCleanup attempts to stop the workflow engine for the given workflow ID.  Does nothing if the
 // workflow engine is not running.
 func (h *eventHandler) tryEngineCleanup(workflowID types.WorkflowID) error {
-	e, ok := h.engineRegistry.Get(workflowID)
-	if ok {
-		// Stop the engine
-		if err := e.Close(); err != nil && !errors.Is(err, services.ErrAlreadyStopped) {
-			return fmt.Errorf("failed to close workflow engine: %w", err)
-		}
-
-		h.cleanupModuleCache(workflowID.Hex())
-
-		// Remove the engine from the registry
-		_, err := h.engineRegistry.Pop(workflowID)
-		if err != nil {
-			return fmt.Errorf("failed to remove workflow engine: %w", err)
-		}
+	// Pop first so the engine is removed from the registry atomically: it can then only be
+	// closed once, avoiding a double Close (and the resulting ErrAlreadyStopped) if this runs
+	// concurrently with, or is retried after, another cleanup for the same workflow.
+	e, err := h.engineRegistry.Pop(workflowID)
+	if errors.Is(err, ErrNotFound) {
+		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("failed to remove workflow engine: %w", err)
+	}
+
+	if err := e.Close(); err != nil {
+		return fmt.Errorf("failed to close workflow engine: %w", err)
+	}
+	h.cleanupModuleCache(workflowID.Hex())
 	return nil
 }
 

--- a/core/services/workflows/syncer/v2/handler_test.go
+++ b/core/services/workflows/syncer/v2/handler_test.go
@@ -1374,28 +1374,36 @@ func Test_workflowDeletedEvent_IgnoresErrAlreadyStopped(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func Test_eventHandlerStart_StartsWorkflowStorePruning(t *testing.T) {
+func Test_eventHandler_StartsAndStopsWorkflowStore(t *testing.T) {
 	t.Parallel()
 
 	lggr := logger.TestLogger(t)
 	lf := limits.Factory{Logger: lggr}
+	emitter := custmsg.NewLabeler()
+	registry := capabilities.NewRegistry(lggr)
+	registry.SetLocalRegistry(&capabilities.TestMetadataRegistry{})
+	workflowEncryptionKey := workflowkey.MustNewXXXTestingOnly(big.NewInt(1))
 	limiters, err := v2.NewLimiters(lf, nil)
 	require.NoError(t, err)
+	rl, err := ratelimiter.NewRateLimiter(rlConfig)
+	require.NoError(t, err)
+	workflowLimits, err := syncerlimiter.NewWorkflowLimits(lggr, syncerlimiter.Config{Global: 200, PerOwner: 200}, lf)
+	require.NoError(t, err)
 
+	// Short prune interval on a fake clock so pruning is only observable once the store has been
+	// started as a sub-service of the handler.
 	fakeClock := clockwork.NewFakeClock()
-	wfStore := store.NewInMemoryStoreWithPruneConfiguration(lggr, fakeClock, 100*time.Millisecond, time.Hour, 24*time.Hour)
-	h := &eventHandler{
-		lggr:           lggr,
-		workflowStore:  wfStore,
-		engineRegistry: NewEngineRegistry(),
-		engineLimiters: limiters,
-	}
-	ctx := testutils.Context(t)
-	require.NoError(t, h.start(ctx))
-	t.Cleanup(func() {
-		require.NoError(t, h.close())
-	})
+	wfStore := store.NewInMemoryStoreWithPruneConfiguration(lggr, fakeClock, 100*time.Millisecond, time.Hour)
 
+	h, err := NewEventHandler(lggr, wfStore, nil, true, registry, &confidentialrelay.ExecutionHandlers{},
+		NewEngineRegistry(), emitter, limiters, nil, rl, workflowLimits, &stubWorkflowArtifactsStore{},
+		workflowEncryptionKey, &testDonNotifier{})
+	require.NoError(t, err)
+	// servicetest.Run starts the handler (and its sub-services, including the store) and closes
+	// them on cleanup.
+	servicetest.Run(t, h)
+
+	ctx := t.Context()
 	_, err = wfStore.Add(ctx, nil, "exec-1", "wf-1", store.StatusStarted)
 	require.NoError(t, err)
 	_, err = wfStore.FinishExecution(ctx, "exec-1", store.StatusCompleted)
@@ -1408,11 +1416,11 @@ func Test_eventHandlerStart_StartsWorkflowStorePruning(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 }
 
-func Test_tryEngineCleanup_IgnoresErrAlreadyStopped(t *testing.T) {
+func Test_tryEngineCleanup_ClosesEngineOnceAndIsIdempotent(t *testing.T) {
 	t.Parallel()
 
 	workflowID := types.WorkflowID{9}
-	engine := &mockEngine{CloseErr: services.ErrAlreadyStopped}
+	engine := &mockDrainableEngine{}
 	registry := NewEngineRegistry()
 	require.NoError(t, registry.Add(workflowID, "test-source", engine))
 
@@ -1421,10 +1429,16 @@ func Test_tryEngineCleanup_IgnoresErrAlreadyStopped(t *testing.T) {
 		engineRegistry: registry,
 	}
 
-	err := h.tryEngineCleanup(workflowID)
-	require.NoError(t, err)
+	// First cleanup pops the engine from the registry and closes it exactly once.
+	require.NoError(t, h.tryEngineCleanup(workflowID))
 	_, ok := registry.Get(workflowID)
 	assert.False(t, ok)
+	assert.Equal(t, int32(1), engine.closeCalls.Load())
+
+	// A repeated cleanup for the same workflow is a no-op: the engine is already gone, so it is
+	// never closed a second time — there is no double close to swallow.
+	require.NoError(t, h.tryEngineCleanup(workflowID))
+	assert.Equal(t, int32(1), engine.closeCalls.Load())
 }
 
 func Test_workflowRegisteredEvent_DrainingEngineNotTreatedAsHealthy(t *testing.T) {

--- a/core/services/workflows/syncer/v2/handler_test.go
+++ b/core/services/workflows/syncer/v2/handler_test.go
@@ -1374,6 +1374,59 @@ func Test_workflowDeletedEvent_IgnoresErrAlreadyStopped(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func Test_eventHandlerStart_StartsWorkflowStorePruning(t *testing.T) {
+	t.Parallel()
+
+	lggr := logger.TestLogger(t)
+	lf := limits.Factory{Logger: lggr}
+	limiters, err := v2.NewLimiters(lf, nil)
+	require.NoError(t, err)
+
+	fakeClock := clockwork.NewFakeClock()
+	wfStore := store.NewInMemoryStoreWithPruneConfiguration(lggr, fakeClock, 100*time.Millisecond, time.Hour, 24*time.Hour)
+	h := &eventHandler{
+		lggr:           lggr,
+		workflowStore:  wfStore,
+		engineRegistry: NewEngineRegistry(),
+		engineLimiters: limiters,
+	}
+	ctx := testutils.Context(t)
+	require.NoError(t, h.start(ctx))
+	t.Cleanup(func() {
+		require.NoError(t, h.close())
+	})
+
+	_, err = wfStore.Add(ctx, nil, "exec-1", "wf-1", store.StatusStarted)
+	require.NoError(t, err)
+	_, err = wfStore.FinishExecution(ctx, "exec-1", store.StatusCompleted)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		fakeClock.Advance(200 * time.Millisecond)
+		_, getErr := wfStore.Get(ctx, "exec-1")
+		return getErr != nil
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func Test_tryEngineCleanup_IgnoresErrAlreadyStopped(t *testing.T) {
+	t.Parallel()
+
+	workflowID := types.WorkflowID{9}
+	engine := &mockEngine{CloseErr: services.ErrAlreadyStopped}
+	registry := NewEngineRegistry()
+	require.NoError(t, registry.Add(workflowID, "test-source", engine))
+
+	h := &eventHandler{
+		lggr:           logger.TestLogger(t),
+		engineRegistry: registry,
+	}
+
+	err := h.tryEngineCleanup(workflowID)
+	require.NoError(t, err)
+	_, ok := registry.Get(workflowID)
+	assert.False(t, ok)
+}
+
 func Test_workflowRegisteredEvent_DrainingEngineNotTreatedAsHealthy(t *testing.T) {
 	t.Parallel()
 

--- a/core/services/workflows/syncer/v2/handler_test.go
+++ b/core/services/workflows/syncer/v2/handler_test.go
@@ -1416,7 +1416,7 @@ func Test_eventHandler_StartsAndStopsWorkflowStore(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 }
 
-func Test_tryEngineCleanup_ClosesEngineOnceAndIsIdempotent(t *testing.T) {
+func Test_tryEngineCleanup_ClosesEngineThenRemovesFromRegistry(t *testing.T) {
 	t.Parallel()
 
 	workflowID := types.WorkflowID{9}
@@ -1429,16 +1429,62 @@ func Test_tryEngineCleanup_ClosesEngineOnceAndIsIdempotent(t *testing.T) {
 		engineRegistry: registry,
 	}
 
-	// First cleanup pops the engine from the registry and closes it exactly once.
+	require.NoError(t, h.tryEngineCleanup(workflowID))
+	assert.Equal(t, int32(1), engine.closeCalls.Load())
+	_, ok := registry.Get(workflowID)
+	assert.False(t, ok, "engine should be removed from the registry after a successful close")
+
+	// Cleanup for an already-removed workflow is a no-op and does not close again.
+	require.NoError(t, h.tryEngineCleanup(workflowID))
+	assert.Equal(t, int32(1), engine.closeCalls.Load())
+}
+
+func Test_tryEngineCleanup_KeepsEngineInRegistryOnCloseFailure(t *testing.T) {
+	t.Parallel()
+
+	workflowID := types.WorkflowID{9}
+	engine := &mockDrainableEngine{}
+	engine.CloseErr = assert.AnError
+	registry := NewEngineRegistry()
+	require.NoError(t, registry.Add(workflowID, "test-source", engine))
+
+	h := &eventHandler{
+		lggr:           logger.TestLogger(t),
+		engineRegistry: registry,
+	}
+
+	// A failing close leaves the engine in the registry so the cleanup can be retried later.
+	require.Error(t, h.tryEngineCleanup(workflowID))
+	_, ok := registry.Get(workflowID)
+	require.True(t, ok, "engine must remain in the registry so the close can be retried")
+
+	// Once the (spurious) failure clears, the retry succeeds and only then is the engine removed.
+	engine.CloseErr = nil
+	require.NoError(t, h.tryEngineCleanup(workflowID))
+	assert.Equal(t, int32(2), engine.closeCalls.Load())
+	_, ok = registry.Get(workflowID)
+	assert.False(t, ok)
+}
+
+func Test_tryEngineCleanup_ToleratesErrAlreadyStopped(t *testing.T) {
+	t.Parallel()
+
+	workflowID := types.WorkflowID{9}
+	engine := &mockDrainableEngine{}
+	engine.CloseErr = services.ErrAlreadyStopped
+	registry := NewEngineRegistry()
+	require.NoError(t, registry.Add(workflowID, "test-source", engine))
+
+	h := &eventHandler{
+		lggr:           logger.TestLogger(t),
+		engineRegistry: registry,
+	}
+
+	// ErrAlreadyStopped means the engine was already closed on a prior attempt; treat it as
+	// success and remove the registry entry.
 	require.NoError(t, h.tryEngineCleanup(workflowID))
 	_, ok := registry.Get(workflowID)
 	assert.False(t, ok)
-	assert.Equal(t, int32(1), engine.closeCalls.Load())
-
-	// A repeated cleanup for the same workflow is a no-op: the engine is already gone, so it is
-	// never closed a second time — there is no double close to swallow.
-	require.NoError(t, h.tryEngineCleanup(workflowID))
-	assert.Equal(t, int32(1), engine.closeCalls.Load())
 }
 
 func Test_workflowRegisteredEvent_DrainingEngineNotTreatedAsHealthy(t *testing.T) {


### PR DESCRIPTION
While deleting entries from maps frees up the memory associated with those elements, it doesn't remove parts of the structure of the map that still live on the heap. We don't think about this for most maps as the number of items is low. The workflow store, however, can accrue millions of entries very quickly, and is one of the biggest users of memory currently. I identified this from pprof flame graphs and container level memory usage metrics.

For further reading, please refer to https://100go.co/28-maps-memory-leaks/

