### PR TITLE
fix(plugins): bump capabilities plugins off orphaned libs revision

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -9,41 +9,41 @@ defaults:
 plugins:
   cron:
     - moduleURI: "github.com/smartcontractkit/capabilities/cron"
-      gitRef: "9dd7b288b86797ffae90cafe438370e098452c81"
+      gitRef: "3fad562d65996bf447372023b5123c0c6e8850c7"
       installPath: "."
       flags: "-tags timetzdata"
   readcontract:
     - moduleURI: "github.com/smartcontractkit/capabilities/readcontract"
-      gitRef: "9dd7b288b86797ffae90cafe438370e098452c81"
+      gitRef: "3fad562d65996bf447372023b5123c0c6e8850c7"
       installPath: "."
   consensus:
     - moduleURI: "github.com/smartcontractkit/capabilities/consensus"
-      gitRef: "9dd7b288b86797ffae90cafe438370e098452c81"
+      gitRef: "3fad562d65996bf447372023b5123c0c6e8850c7"
       installPath: "."
   workflowevent:
     - enabled: false
       moduleURI: "github.com/smartcontractkit/capabilities/workflowevent"
-      gitRef: "9dd7b288b86797ffae90cafe438370e098452c81"
+      gitRef: "3fad562d65996bf447372023b5123c0c6e8850c7"
       installPath: "."
   httpaction:
     - moduleURI: "github.com/smartcontractkit/capabilities/http_action"
-      gitRef: "9dd7b288b86797ffae90cafe438370e098452c81"
+      gitRef: "3fad562d65996bf447372023b5123c0c6e8850c7"
       installPath: "."
   httptrigger:
     - moduleURI: "github.com/smartcontractkit/capabilities/http_trigger"
-      gitRef: "9dd7b288b86797ffae90cafe438370e098452c81"
+      gitRef: "3fad562d65996bf447372023b5123c0c6e8850c7"
       installPath: "."
   evm:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
-      gitRef: "9dd7b288b86797ffae90cafe438370e098452c81"
+      gitRef: "3fad562d65996bf447372023b5123c0c6e8850c7"
       installPath: "."
   solana:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/solana"
-      gitRef: "9dd7b288b86797ffae90cafe438370e098452c81"
+      gitRef: "3fad562d65996bf447372023b5123c0c6e8850c7"
       installPath: "."
   aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "9dd7b288b86797ffae90cafe438370e098452c81"
+      gitRef: "3fad562d65996bf447372023b5123c0c6e8850c7"
       installPath: "."
   confidential-http:
     - moduleURI:


### PR DESCRIPTION
The capabilities plugins were pinned at 9dd7b288 (#22686). Its
chain_capabilities/* (and cron/consensus/http_*/readcontract/
workflowevent) modules require
github.com/smartcontractkit/capabilities/libs@...c4b42d8c0edf, a revision
that was force-pushed out of the capabilities repo and no longer exists.
So `make install-plugins-*` fails on every fresh chainlink image build
with "unknown revision c4b42d8c0edf".

Builds that ran before the force-push are stale-green (e.g. #22687's
image build completed 2026-05-29, merged June 1), so develop currently
has no passing image build despite the recent merges.

Bump all nine capabilities module gitRefs from 9dd7b288 to 3fad562d
(current capabilities main), whose transitive libs/common references
resolve to existing commits (verified for evm/solana/consensus/http_trigger/cron).

Unblocks the chainlink image build (and the ETH Smoke / Integration /
CCIP smoke jobs that gate on it) for all PRs.