### PR TITLE
Pair sharded gateway DONs to workflow DONs 1:1

### DIFF
--- a/system-tests/lib/cre/don/config/config.go
+++ b/system-tests/lib/cre/don/config/config.go
@@ -541,8 +541,12 @@ func addWorkerNodeConfig(
 		}
 
 		gateways := []coretoml.ConnectorGateway{}
-		if topology != nil && topology.GatewayConnectors != nil && len(topology.GatewayConnectors.Configurations) > 0 {
-			for _, gateway := range topology.GatewayConnectors.Configurations {
+		connectors := cre.GatewayConnectors{}
+		if topology != nil && topology.GatewayConnectors != nil {
+			connectors = topology.GatewayConnectorsForWorkflow(donMetadata.Name)
+		}
+		if len(connectors.Configurations) > 0 {
+			for _, gateway := range connectors.Configurations {
 				gateways = append(gateways, coretoml.ConnectorGateway{
 					ID: new(gateway.AuthGatewayID),
 					URL: new(fmt.Sprintf("ws://%s:%d%s",

--- a/system-tests/lib/cre/don/gateway/gateway.go
+++ b/system-tests/lib/cre/don/gateway/gateway.go
@@ -23,7 +23,7 @@ type WhitelistConfig struct {
 	ExtraAllowedIPsCIDR []string
 }
 
-func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, gatewayServiceConfigs []cre.GatewayServiceConfig, whitelistConfig WhitelistConfig) error {
+func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, topology *cre.Topology, gatewayServiceConfigs []cre.GatewayServiceConfig, whitelistConfig WhitelistConfig) error {
 	specs := make(map[string][]string)
 
 	if !dons.RequiresGateway() {
@@ -34,6 +34,11 @@ func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, ga
 		gatewayNode, ok := dons.NodeWithUUID(config.NodeUUID)
 		if !ok {
 			return fmt.Errorf("could not find gateway node with UUID %s in DON topology", config.NodeUUID)
+		}
+
+		services := gatewayServiceConfigs
+		if topology != nil {
+			services = topology.GatewayServiceConfigsForGateway(gatewayNode.DON.Name, gatewayServiceConfigs)
 		}
 
 		workerInput := cre_jobs.ProposeJobSpecInput{
@@ -52,7 +57,7 @@ func CreateJobs(ctx context.Context, creEnv *cre.Environment, dons *cre.Dons, ga
 				"gatewayKeyChainSelector":     creEnv.RegistryChainSelector,
 				"authGatewayID":               config.AuthGatewayID,
 				"serviceCentricFormatEnabled": true,
-				"services":                    gatewayServiceConfigs,
+				"services":                    services,
 			},
 		}
 

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -273,7 +273,7 @@ func SetupTestEnvironment(
 
 	fmt.Print(libformat.PurpleText("%s", input.StageGen.Wrap("Creating Jobs with Job Distributor")))
 
-	gJobErr := gateway.CreateJobs(ctx, creEnvironment, dons, topology.GatewayServiceConfigs, input.GatewayWhitelistConfig)
+	gJobErr := gateway.CreateJobs(ctx, creEnvironment, dons, topology, topology.GatewayServiceConfigs, input.GatewayWhitelistConfig)
 	if gJobErr != nil {
 		return nil, pkgerrors.Wrap(gJobErr, "failed to create gateway jobs with Job Distributor")
 	}

--- a/system-tests/lib/cre/features/confidentialrelay/confidentialrelay.go
+++ b/system-tests/lib/cre/features/confidentialrelay/confidentialrelay.go
@@ -40,7 +40,7 @@ func (o *ConfidentialRelay) PreEnvStartup(
 		return nil, errors.Wrapf(hErr, "failed to add gateway handlers to gateway config for don %s", don.Name)
 	}
 
-	cErr := don.ConfigureForGatewayAccess(registryChainID, *topology.GatewayConnectors)
+	cErr := don.ConfigureForGatewayAccess(registryChainID, topology.GatewayConnectorsForWorkflow(don.Name))
 	if cErr != nil {
 		return nil, errors.Wrapf(cErr, "failed to add gateway connectors to node's TOML config for don %s", don.Name)
 	}

--- a/system-tests/lib/cre/features/http_action/http_action.go
+++ b/system-tests/lib/cre/features/http_action/http_action.go
@@ -55,7 +55,7 @@ func (o *HTTPAction) PreEnvStartup(
 		return nil, errors.Wrapf(hErr, "failed to add gateway handlers to gateway config for don %s ", don.Name)
 	}
 
-	cErr := don.ConfigureForGatewayAccess(registryChainID, *topology.GatewayConnectors)
+	cErr := don.ConfigureForGatewayAccess(registryChainID, topology.GatewayConnectorsForWorkflow(don.Name))
 	if cErr != nil {
 		return nil, errors.Wrapf(cErr, "failed to add gateway connectors to node's TOML config in for don %s", don.Name)
 	}

--- a/system-tests/lib/cre/features/http_trigger/http_trigger.go
+++ b/system-tests/lib/cre/features/http_trigger/http_trigger.go
@@ -55,7 +55,7 @@ func (o *HTTPTrigger) PreEnvStartup(
 		return nil, errors.Wrapf(hErr, "failed to add gateway handlers to gateway config for don %s ", don.Name)
 	}
 
-	cErr := don.ConfigureForGatewayAccess(registryChainID, *topology.GatewayConnectors)
+	cErr := don.ConfigureForGatewayAccess(registryChainID, topology.GatewayConnectorsForWorkflow(don.Name))
 	if cErr != nil {
 		return nil, errors.Wrapf(cErr, "failed to add gateway connectors to node's TOML config in for don %s", don.Name)
 	}

--- a/system-tests/lib/cre/features/vault/vault.go
+++ b/system-tests/lib/cre/features/vault/vault.go
@@ -95,7 +95,7 @@ func (o *Vault) PreEnvStartup(
 		}
 	}
 
-	cErr := don.ConfigureForGatewayAccess(registryChainID, *topology.GatewayConnectors)
+	cErr := don.ConfigureForGatewayAccess(registryChainID, topology.GatewayConnectorsForWorkflow(don.Name))
 	if cErr != nil {
 		return nil, errors.Wrapf(cErr, "failed to add gateway connectors to node's TOML config in for don %s", don.Name)
 	}

--- a/system-tests/lib/cre/topology.go
+++ b/system-tests/lib/cre/topology.go
@@ -100,6 +100,77 @@ func NewTopology(nodeSet []*NodeSet, provider infra.Provider, capabilityConfigs 
 	return topology, nil
 }
 
+// gatewayAndWorkflowDONNames returns gateway and workflow DON names in topology list order.
+func (t *Topology) gatewayAndWorkflowDONNames() (gatewayNames, workflowNames []string) {
+	for _, d := range t.DonsMetadata.List() {
+		if _, hasGateway := d.Gateway(); hasGateway {
+			gatewayNames = append(gatewayNames, d.Name)
+		}
+	}
+
+	wfDONs, err := t.DonsMetadata.WorkflowDONs()
+	if err != nil {
+		return gatewayNames, nil
+	}
+	for _, d := range wfDONs {
+		workflowNames = append(workflowNames, d.Name)
+	}
+	return gatewayNames, workflowNames
+}
+
+// shardedGatewayPairingEnabled is true when multiple gateway DONs match workflow DON count 1:1.
+// Single-gateway topologies keep legacy behavior (one gateway serves all workflow DONs).
+func (t *Topology) shardedGatewayPairingEnabled() bool {
+	gatewayNames, workflowNames := t.gatewayAndWorkflowDONNames()
+	return len(gatewayNames) > 1 && len(gatewayNames) == len(workflowNames)
+}
+
+// GatewayConnectorsForWorkflow returns gateway connectors for a workflow DON.
+// When sharded pairing is enabled, only the paired gateway is included.
+func (t *Topology) GatewayConnectorsForWorkflow(workflowDONName string) GatewayConnectors {
+	if t.GatewayConnectors == nil {
+		return GatewayConnectors{}
+	}
+	if !t.shardedGatewayPairingEnabled() {
+		return *t.GatewayConnectors
+	}
+
+	_, workflowNames := t.gatewayAndWorkflowDONNames()
+	for i, name := range workflowNames {
+		if name == workflowDONName {
+			return GatewayConnectors{Configurations: []*DonGatewayConfiguration{t.GatewayConnectors.Configurations[i]}}
+		}
+	}
+	return *t.GatewayConnectors
+}
+
+// GatewayServiceConfigsForGateway scopes service DON lists to the workflow DON paired with
+// the given gateway DON when sharded pairing is enabled.
+func (t *Topology) GatewayServiceConfigsForGateway(gatewayDONName string, services []GatewayServiceConfig) []GatewayServiceConfig {
+	if !t.shardedGatewayPairingEnabled() {
+		return services
+	}
+
+	gatewayNames, workflowNames := t.gatewayAndWorkflowDONNames()
+	pairedWorkflow := ""
+	for i, name := range gatewayNames {
+		if name == gatewayDONName {
+			pairedWorkflow = workflowNames[i]
+			break
+		}
+	}
+	if pairedWorkflow == "" {
+		return services
+	}
+
+	out := make([]GatewayServiceConfig, len(services))
+	for i, svc := range services {
+		out[i] = svc
+		out[i].DONs = []string{pairedWorkflow}
+	}
+	return out
+}
+
 func (t *Topology) NodeSets() []*NodeSet {
 	sets := make([]*NodeSet, len(t.DonsMetadata.List()))
 	for i, d := range t.DonsMetadata.List() {

--- a/system-tests/lib/cre/topology_gateway_pairing_test.go
+++ b/system-tests/lib/cre/topology_gateway_pairing_test.go
@@ -1,0 +1,74 @@
+package cre
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/deployment/cre/jobs/pkg"
+)
+
+func TestGatewayConnectorsForWorkflow_shardedPairing(t *testing.T) {
+	t.Parallel()
+
+	topology := shardedGatewayTestTopology()
+
+	connA := topology.GatewayConnectorsForWorkflow("feeds-zone-a")
+	require.Len(t, connA.Configurations, 1)
+	require.Equal(t, "gateway-node-0", connA.Configurations[0].AuthGatewayID)
+
+	connB := topology.GatewayConnectorsForWorkflow("feeds-zone-b")
+	require.Len(t, connB.Configurations, 1)
+	require.Equal(t, "gateway-node-1", connB.Configurations[0].AuthGatewayID)
+}
+
+func TestGatewayConnectorsForWorkflow_singleGatewayLegacy(t *testing.T) {
+	t.Parallel()
+
+	topology := &Topology{
+		DonsMetadata: &DonsMetadata{dons: []*DonMetadata{
+			{Name: "feeds-zone-a", ns: &NodeSet{DONTypes: []string{WorkflowDON}}, Flags: []string{WorkflowDON}},
+			{Name: "feeds-zone-b", ns: &NodeSet{DONTypes: []string{WorkflowDON}}, Flags: []string{WorkflowDON}},
+			{Name: "gateway", ns: &NodeSet{}, NodesMetadata: []*NodeMetadata{{Roles: []string{GatewayNode}}}},
+		}},
+		GatewayConnectors: &GatewayConnectors{Configurations: []*DonGatewayConfiguration{
+			{GatewayConfiguration: &GatewayConfiguration{AuthGatewayID: "gateway-node-0"}},
+		}},
+	}
+
+	conn := topology.GatewayConnectorsForWorkflow("feeds-zone-b")
+	require.Len(t, conn.Configurations, 1)
+	require.Equal(t, "gateway-node-0", conn.Configurations[0].AuthGatewayID)
+}
+
+func TestGatewayServiceConfigsForGateway_shardedPairing(t *testing.T) {
+	t.Parallel()
+
+	topology := shardedGatewayTestTopology()
+	services := []GatewayServiceConfig{{
+		ServiceName: pkg.ServiceNameWorkflows,
+		Handlers:    []string{pkg.GatewayHandlerTypeWebAPICapabilities},
+		DONs:        []string{"feeds-zone-a", "feeds-zone-b"},
+	}}
+
+	scopedA := topology.GatewayServiceConfigsForGateway("gateway-zone-a", services)
+	require.Equal(t, []string{"feeds-zone-a"}, scopedA[0].DONs)
+
+	scopedB := topology.GatewayServiceConfigsForGateway("gateway-zone-b", services)
+	require.Equal(t, []string{"feeds-zone-b"}, scopedB[0].DONs)
+}
+
+func shardedGatewayTestTopology() *Topology {
+	return &Topology{
+		DonsMetadata: &DonsMetadata{dons: []*DonMetadata{
+			{Name: "feeds-zone-a", ns: &NodeSet{DONTypes: []string{WorkflowDON}}, Flags: []string{WorkflowDON}},
+			{Name: "feeds-zone-b", ns: &NodeSet{DONTypes: []string{WorkflowDON}}, Flags: []string{WorkflowDON}},
+			{Name: "gateway-zone-a", ns: &NodeSet{}, NodesMetadata: []*NodeMetadata{{Roles: []string{GatewayNode}}}},
+			{Name: "gateway-zone-b", ns: &NodeSet{}, NodesMetadata: []*NodeMetadata{{Roles: []string{GatewayNode}}}},
+		}},
+		GatewayConnectors: &GatewayConnectors{Configurations: []*DonGatewayConfiguration{
+			{GatewayConfiguration: &GatewayConfiguration{AuthGatewayID: "gateway-node-0"}},
+			{GatewayConfiguration: &GatewayConfiguration{AuthGatewayID: "gateway-node-1"}},
+		}},
+	}
+}


### PR DESCRIPTION
## Summary
- When multiple gateway DONs match the workflow DON count (1:1), pair them by topology list order at env configure time.
- Scope gateway worker job `Services.DONs` and workflow node `GatewayConnector.Gateways` to the paired zone only.
- Single-gateway topologies are unchanged (one gateway still serves all workflow DONs).

## Test plan
- [x] `go test -run 'TestGatewayConnectorsForWorkflow|TestGatewayServiceConfigsForGateway' ./system-tests/lib/cre/`
- [ ] Fresh local CRE bring-up with multi-zone topology — verify zone-b Data Streams fetch succeeds without post-start pairing workarounds