### PR TITLE
bugfix WriteReport internal errors to users

### DIFF
--- a/core/capabilities/remote/executable/client_test.go
+++ b/core/capabilities/remote/executable/client_test.go
@@ -174,6 +174,44 @@ func Test_Client_TimesOutIfInsufficientCapabilityPeerResponses(t *testing.T) {
 		})
 }
 
+func Test_Client_WaitsForResponsesWithinAggregationGrace(t *testing.T) {
+	ctx := testutils.Context(t)
+	requestTimeout := 500 * time.Millisecond
+
+	responseTest := func(t *testing.T, response commoncap.CapabilityResponse, responseError error) {
+		require.NoError(t, responseError)
+		mp, err := response.Value.Unwrap()
+		require.NoError(t, err)
+		assert.Equal(t, "2s", mp.(map[string]any)["response"].(string))
+	}
+
+	// Capability execution exceeds requestTimeout (500ms) but completes within
+	// requestTimeout + defaultResponseAggregationGrace (10s).
+	// Use a single workflow peer so the mock cap server executes as soon as it
+	// receives one request; with multiple workflow peers the mock waits for all
+	// peers and blocks the test broker while executing, which exceeds the grace window.
+	capability := &TestSlowExecutionCapability{
+		workflowIDToPause: map[string]time.Duration{
+			workflowID1: 2 * time.Second,
+		},
+	}
+
+	transmissionSchedule, err := values.NewMap(map[string]any{
+		"schedule":   transmission.Schedule_AllAtOnce,
+		"deltaStage": "10ms",
+	})
+	require.NoError(t, err)
+
+	testClient(t, 1, requestTimeout, 4, 3,
+		capability,
+		func(caller commoncap.ExecutableCapability) {
+			executeInputs, err := values.NewMap(map[string]any{"executeValue1": "aValue1"})
+			if assert.NoError(t, err) {
+				executeMethod(ctx, caller, transmissionSchedule, executeInputs, responseTest, t)
+			}
+		})
+}
+
 func Test_Client_ConsensusFailedIfInsufficientCapabilityPeerResponses(t *testing.T) {
 	ctx := testutils.Context(t)
 

--- a/core/capabilities/remote/executable/request/client_request.go
+++ b/core/capabilities/remote/executable/request/client_request.go
@@ -137,7 +137,12 @@ func NewClientExecuteRequest(ctx context.Context, lggr logger.Logger, req common
 	return newClientRequest(ctx, lggr, requestID, remoteCapabilityInfo, localDonInfo, dispatcher, requestTimeout, tc, types.MethodExecute, rawRequest, workflowExecutionID, req.Metadata.ReferenceID, capMethodName, signers)
 }
 
-var defaultDelayMargin = 10 * time.Second
+var (
+	defaultDelayMargin = 10 * time.Second
+	// Extra time the workflow DON client waits beyond requestTimeout for P2P responses
+	// after remote capability nodes hit their execution deadline.
+	defaultResponseAggregationGrace = 10 * time.Second
+)
 
 func newClientRequest(ctx context.Context, lggr logger.Logger, requestID string, remoteCapabilityInfo commoncap.CapabilityInfo,
 	localDonInfo commoncap.DON, dispatcher types.Dispatcher, requestTimeout time.Duration,
@@ -308,7 +313,7 @@ func (c *ClientRequest) ResponseChan() <-chan clientResponse {
 }
 
 func (c *ClientRequest) Expired() bool {
-	return time.Since(c.createdAt) > c.requestTimeout
+	return time.Since(c.createdAt) > c.requestTimeout+defaultResponseAggregationGrace
 }
 
 func (c *ClientRequest) Cancel(err error) {

--- a/core/capabilities/remote/executable/request/client_request_internal_test.go
+++ b/core/capabilities/remote/executable/request/client_request_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"testing"
+	"time"
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/stretchr/testify/assert"
@@ -19,6 +20,29 @@ import (
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 )
+
+func TestClientRequest_Expired_aggregationGrace(t *testing.T) {
+	t.Parallel()
+
+	requestTimeout := 100 * time.Millisecond
+	t.Run("not expired before requestTimeout plus grace", func(t *testing.T) {
+		t.Parallel()
+		c := &ClientRequest{
+			createdAt:      time.Now().Add(-requestTimeout - time.Millisecond), //less than defaultResponseAggregationGrace
+			requestTimeout: requestTimeout,
+		}
+		require.False(t, c.Expired())
+	})
+
+	t.Run("expired after requestTimeout plus grace", func(t *testing.T) {
+		t.Parallel()
+		c := &ClientRequest{
+			createdAt:      time.Now().Add(-requestTimeout - defaultResponseAggregationGrace - time.Millisecond),
+			requestTimeout: requestTimeout,
+		}
+		require.True(t, c.Expired())
+	})
+}
 
 func Test_ClientRequest_VerifyAttestation(t *testing.T) {
 	const workflowExecutionID = "95ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0abbadeed"

--- a/core/capabilities/remote/executable/request/client_request_internal_test.go
+++ b/core/capabilities/remote/executable/request/client_request_internal_test.go
@@ -28,7 +28,7 @@ func TestClientRequest_Expired_aggregationGrace(t *testing.T) {
 	t.Run("not expired before requestTimeout plus grace", func(t *testing.T) {
 		t.Parallel()
 		c := &ClientRequest{
-			createdAt:      time.Now().Add(-requestTimeout - time.Millisecond), //less than defaultResponseAggregationGrace
+			createdAt:      time.Now().Add(-requestTimeout - time.Millisecond), // less than defaultResponseAggregationGrace
 			requestTimeout: requestTimeout,
 		}
 		require.False(t, c.Expired())


### PR DESCRIPTION
This PR ensures that specific WriteReport execution failures (such as downstream RPC or transmission timeouts) are propagated as explicit capability errors instead of being masked by a generic internal error message. This change preserves the detailed error payload if it reaches to 2F+1 instead of timing out and returning the generic error [failed to execute capability](https://github.com/smartcontractkit/chainlink/blob/544f9aac5455092c0fa03c150344bf55d73e7f7e/core/capabilities/remote/executable/request/server_request.go#L355)

This could also benefit other remote actions, but as they are currently using [ClientRequest#hasValidAttestation()](https://github.com/smartcontractkit/chainlink/blob/d74c9fe5c4e034f02b1ae747434ab33473c6d363/core/capabilities/remote/executable/request/client_request.go#L497) short circuit it won't be likely impacted, but WR for sure will and will improve error reporting to the user.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
