### PR TITLE
Update to Go 1.26.4 + modernize lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - loggercheck
     - mirror
     - misspell
+    - modernize
     - noctx
     - nolintlint
     - perfsprint
@@ -63,16 +64,16 @@ linters:
               desc: Use gopkg.in/guregu/null.v4 instead
             - pkg: github.com/go-gorm/gorm
               desc: Use github.com/jmoiron/sqlx directly instead
-#            - pkg: github.com/smartcontractkit/chainlink-aptos
-#              desc: Aptos only runs as a LOOPP
+            #  - pkg: github.com/smartcontractkit/chainlink-aptos
+            #   desc: Aptos only runs as a LOOPP
             - pkg: github.com/smartcontractkit/chainlink-cosmos
               desc: Cosmos only runs as a LOOPP
             - pkg: github.com/smartcontractkit/chainlink-integrations/evm
               desc: Use github.com/smartcontractkit/chainlink-evm instead
             - pkg: github.com/smartcontractkit/chainlink-starknet/relayer
               desc: Starknet only runs as a LOOPP
-#            - pkg: github.com/smartcontractkit/chainlink-tron
-#              desc: Tron only runs as a LOOPP
+            #  - pkg: github.com/smartcontractkit/chainlink-tron
+            #  desc: Tron only runs as a LOOPP
             - pkg: github.com/consul/sdk/freeport
               desc: Use github.com/smartcontractkit/freeport instead
         keystore:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.26.3
+golang 1.26.4
 mockery 2.53.0
 nodejs 20.13.1
 pnpm 10.6.5

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ regarding Chainlink social accounts, news, and networking.
 
 ## Build Chainlink
 
-1. [Install Go 1.23](https://golang.org/doc/install), and add your GOPATH's [bin directory to your PATH](https://golang.org/doc/code.html#GOPATH)
+1. [Install Go 1.26.4](https://golang.org/doc/install), and add your GOPATH's [bin directory to your PATH](https://golang.org/doc/code.html#GOPATH)
    - Example Path for macOS `export PATH=$GOPATH/bin:$PATH` & `export GOPATH=/Users/$USER/go`
 2. Install [NodeJS v20](https://nodejs.org/en/download/package-manager/) & [pnpm v10 via npm](https://pnpm.io/installation#using-npm).
    - It might be easier long term to use [nvm](https://nodejs.org/en/download/package-manager/#nvm) to switch between node versions for different projects. For example, assuming $NODE_VERSION was set to a valid version of NodeJS, you could run: `nvm install $NODE_VERSION && nvm use $NODE_VERSION`

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -5,7 +5,7 @@
 # Stage: deps-base — module downloads, no source tree.
 # Stages that don't need the full source (remote plugins, delve) branch from
 # here so that source-only changes never invalidate their layer cache.
-FROM golang:1.26.3-bookworm AS deps-base
+FROM golang:1.26.4-bookworm AS deps-base
 RUN go version
 RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
 

--- a/core/scripts/cre/environment/examples/workflows/cron/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/cron/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/cron
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.5.0

--- a/core/scripts/cre/environment/examples/workflows/http/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/http/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.5.0

--- a/core/scripts/cre/environment/examples/workflows/http_simple/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/http_simple/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.5.0

--- a/core/scripts/cre/environment/examples/workflows/node-mode/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/node-mode/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0

--- a/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/ethereum/go-ethereum v1.17.1

--- a/core/scripts/cre/environment/examples/workflows/time/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/time/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.5.0

--- a/core/scripts/cre/environment/examples/workflows/time_consensus/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/time_consensus/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.5.0

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/core/scripts
 
-go 1.26.3
+go 1.26.4
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../../

--- a/deployment/.golangci.yml
+++ b/deployment/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - loggercheck
     - mirror
     - misspell
+    - modernize
     - noctx
     - nolintlint
     - perfsprint

--- a/deployment/environment/web/sdk/README.md
+++ b/deployment/environment/web/sdk/README.md
@@ -14,7 +14,7 @@ internal/        # GraphQL queries/mutations and generated code
 ### Prerequisites
 
 - [go-task](https://taskfile.dev/) (`task` CLI)
-- Go 1.21+
+- Go 1.26.4+
 
 ### Extending the Client
 

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/deployment
 
-go 1.26.3
+go 1.26.4
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../

--- a/devenv/.golangci.yml
+++ b/devenv/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - loggercheck
     - mirror
     - misspell
+    - modernize
     - noctx
     - nolintlint
     - perfsprint

--- a/devenv/fakes/Dockerfile
+++ b/devenv/fakes/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-bookworm AS builder
+FROM golang:1.26 AS builder
 
 ENV GOPRIVATE=github.com/smartcontractkit/*
 

--- a/devenv/fakes/Dockerfile
+++ b/devenv/fakes/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 ENV GOPRIVATE=github.com/smartcontractkit/*
 

--- a/devenv/fakes/go.mod
+++ b/devenv/fakes/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/devenv/fakes
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/gin-gonic/gin v1.12.0

--- a/devenv/go.mod
+++ b/devenv/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/devenv
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/BurntSushi/toml v1.5.0

--- a/integration-tests/.golangci.yml
+++ b/integration-tests/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - loggercheck
     - mirror
     - misspell
+    - modernize
     - noctx
     - nolintlint
     - perfsprint

--- a/integration-tests/.tool-versions
+++ b/integration-tests/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.26.3
+golang 1.26.4
 k3d 5.4.6
 kubectl 1.25.5
 nodejs 20.13.1

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/integration-tests
 
-go 1.26.3
+go 1.26.4
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../

--- a/integration-tests/load/.golangci.yml
+++ b/integration-tests/load/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - loggercheck
     - mirror
     - misspell
+    - modernize
     - noctx
     - nolintlint
     - perfsprint

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/load-tests
 
-go 1.26.3
+go 1.26.4
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../../

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -7,7 +7,7 @@
 # Stage: deps-base — module downloads, no source tree.
 # Stages that don't need the full source (remote plugins, delve) branch from
 # here so that source-only changes never invalidate their layer cache.
-FROM golang:1.26.3-bookworm AS deps-base
+FROM golang:1.26.4-bookworm AS deps-base
 RUN go version
 RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
 

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/lib
 
-go 1.26.3
+go 1.26.4
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../../

--- a/system-tests/tests/canaries_sentinels/proof-of-reserve/cron-based/go.mod
+++ b/system-tests/tests/canaries_sentinels/proof-of-reserve/cron-based/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/ethereum/go-ethereum v1.17.1

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests
 
-go 1.26.3
+go 1.26.4
 
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../../

--- a/system-tests/tests/regression/cre/consensus/go.mod
+++ b/system-tests/tests/regression/cre/consensus/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/consensus
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/ethereum/go-ethereum v1.17.1

--- a/system-tests/tests/regression/cre/evm/evmread-negative/go.mod
+++ b/system-tests/tests/regression/cre/evm/evmread-negative/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/evm/evmread-negative
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/ethereum/go-ethereum v1.17.1

--- a/system-tests/tests/regression/cre/evm/evmwrite-negative/go.mod
+++ b/system-tests/tests/regression/cre/evm/evmwrite-negative/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/evm/evmwrite-negative
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/ethereum/go-ethereum v1.17.1

--- a/system-tests/tests/regression/cre/evm/logtrigger-negative/go.mod
+++ b/system-tests/tests/regression/cre/evm/logtrigger-negative/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/evm/logtrigger-negative
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.5.0

--- a/system-tests/tests/regression/cre/http/go.mod
+++ b/system-tests/tests/regression/cre/http/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/http
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.5.0

--- a/system-tests/tests/regression/cre/httpaction-negative/go.mod
+++ b/system-tests/tests/regression/cre/httpaction-negative/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/httpaction-negative
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.5.0

--- a/system-tests/tests/smoke/cre/aptos/aptosread/go.mod
+++ b/system-tests/tests/smoke/cre/aptos/aptosread/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/aptos/aptosread
 
-go 1.25.7
+go 1.26.4
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.4.1-0.20260312154349-ecb4cb615f37

--- a/system-tests/tests/smoke/cre/aptos/aptoswrite/go.mod
+++ b/system-tests/tests/smoke/cre/aptos/aptoswrite/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/aptos/aptoswrite
 
-go 1.25.7
+go 1.26.4
 
 require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260505131349-78e491b80735

--- a/system-tests/tests/smoke/cre/aptos/aptoswriteroundtrip/go.mod
+++ b/system-tests/tests/smoke/cre/aptos/aptoswriteroundtrip/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/aptos/aptoswriteroundtrip
 
-go 1.25.7
+go 1.26.4
 
 require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260505131349-78e491b80735

--- a/system-tests/tests/smoke/cre/evm/evmread/go.mod
+++ b/system-tests/tests/smoke/cre/evm/evmread/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evm/evmread
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/ethereum/go-ethereum v1.17.1

--- a/system-tests/tests/smoke/cre/evm/logtrigger/go.mod
+++ b/system-tests/tests/smoke/cre/evm/logtrigger/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evm/logtrigger
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/ethereum/go-ethereum v1.17.1

--- a/system-tests/tests/smoke/cre/httpaction/go.mod
+++ b/system-tests/tests/smoke/cre/httpaction/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/httpaction
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.5.0

--- a/system-tests/tests/smoke/cre/solana/sollogtrigger/go.mod
+++ b/system-tests/tests/smoke/cre/solana/sollogtrigger/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/solana/sollogtrigger
 
-go 1.25.5
+go 1.26.4
 
 require (
 	github.com/gagliardetto/solana-go v1.14.0

--- a/system-tests/tests/smoke/cre/solana/solwrite/go.mod
+++ b/system-tests/tests/smoke/cre/solana/solwrite/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/solana/solwrite
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/gagliardetto/anchor-go v1.0.0

--- a/system-tests/tests/smoke/cre/vaultsecret/go.mod
+++ b/system-tests/tests/smoke/cre/vaultsecret/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/vaultsecret
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/smartcontractkit/cre-sdk-go v1.5.0

--- a/tools/ci/install_wasmd
+++ b/tools/ci/install_wasmd
@@ -11,4 +11,4 @@ BUILD_DIR="${HOME}/wasmd-build"
 git clone https://github.com/CosmWasm/wasmd --branch "${GIT_TAG}" "${CHECKOUT_DIR}"
 cd "${CHECKOUT_DIR}"
 git checkout "${GIT_TAG}"
-GOTOOLCHAIN=go1.25.8 GOPATH="${BUILD_DIR}" make install
+GOTOOLCHAIN=go1.26.4 GOPATH="${BUILD_DIR}" make install

--- a/tools/test/go.mod
+++ b/tools/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/v2/tools/test
 
-go 1.26.3
+go 1.26.4
 
 require (
 	charm.land/fang/v2 v2.0.1


### PR DESCRIPTION
* Updates go `1.26.3 -> 1.26.4`
* Adds the [modernize](https://golangci-lint.run/docs/linters/configuration/#modernize) linter to default golangci-lint