### PR TITLE
chore(ci): migrate to setup-github-token

### DIFF
--- a/.github/workflows/operator-ui-ci.yml
+++ b/.github/workflows/operator-ui-ci.yml
@@ -16,20 +16,13 @@ jobs:
     name: Breaking Changes GQL Check
     runs-on: ubuntu-latest
     steps:
-      - name: Assume role capable of dispatching action
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        with:
-          role-to-assume: ${{ secrets.AWS_OIDC_CHAINLINK_CI_OPERATOR_UI_ACCESS_TOKEN_ISSUER_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 3600
-          role-session-name: operator-ui-ci.check-gql
-          mask-aws-account-id: true
-
-      - name: Get Github Token
+      - name: Setup Github Token
         id: get-gh-token
-        uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@5874ff7211cf5a5a2670bb010fbff914eaaae138 # v2.3.12
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
-          url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
+          aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_CI_OPERATOR_UI_ACCESS_TOKEN_ISSUER_ROLE_ARN }}
+          aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
### Changes

* Migrates to `smartcontractkit/.github/actions/setup-github-token`

### Testing

* https://github.com/smartcontractkit/chainlink/actions/runs/26921042193/job/79421352588?pr=22738
* https://github.com/smartcontractkit/operator-ui/actions/runs/26921063873

---

DX-3782