### PR TITLE
core/capabilities/ccip/ocrimpls: data race in contract transmitter test

### DIFF
--- a/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient/simulated"
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
@@ -109,6 +110,7 @@ func testTransmitter(
 	expectedSigsEnabled bool,
 	report []byte,
 ) {
+	ctx := t.Context()
 	uni := newTestUniverse(t, nil)
 
 	c, err := uni.wrapper.LatestConfigDetails(nil, pluginType)
@@ -131,48 +133,40 @@ func testTransmitter(
 	seqNr := uint64(1)
 	attributedSigs := uni.SignReport(t, configDigest, rwi, seqNr)
 
-	account, err := uni.transmitterWithSigs.FromAccount(t.Context())
+	account, err := uni.transmitterWithSigs.FromAccount(ctx)
 	require.NoError(t, err, "failed to get from account")
 	require.Equal(t, ocrtypes.Account(uni.transmitters[0].Hex()), account, "from account mismatch")
 	if withSigs {
-		err = uni.transmitterWithSigs.Transmit(testutils.Context(t), configDigest, seqNr, rwi, attributedSigs)
+		err = uni.transmitterWithSigs.Transmit(ctx, configDigest, seqNr, rwi, attributedSigs)
 	} else {
-		err = uni.transmitterWithoutSigs.Transmit(testutils.Context(t), configDigest, seqNr, rwi, attributedSigs)
+		err = uni.transmitterWithoutSigs.Transmit(ctx, configDigest, seqNr, rwi, attributedSigs)
 	}
 	require.NoError(t, err, "failed to transmit")
 	uni.backend.Commit()
 
 	var txStatus uint64
-	require.Eventually(t, func() bool {
+	// testing.T should not be used within the callbacks below, as it may cause a race.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		uni.backend.Commit()
-		rows, err := uni.db.QueryContext(testutils.Context(t), `SELECT hash FROM evm.tx_attempts LIMIT 1`)
-		require.NoError(t, err, "failed to query txes")
+		rows, err := uni.db.QueryContext(ctx, `SELECT hash FROM evm.tx_attempts LIMIT 1`)
+		require.NoError(c, err, "failed to query txes")
 		defer rows.Close()
 		var txHash []byte
 		for rows.Next() {
-			require.NoError(t, rows.Scan(&txHash), "failed to scan")
+			require.NoError(c, rows.Scan(&txHash), "failed to scan")
 		}
-		t.Log("txHash:", txHash)
-		receipt, err := uni.simClient.TransactionReceipt(testutils.Context(t), common.BytesToHash(txHash))
-		if err != nil {
-			t.Log("tx not found yet:", hexutil.Encode(txHash))
-			return false
-		}
-		t.Log("tx found:", hexutil.Encode(txHash), "status:", receipt.Status)
+		receipt, err := uni.simClient.TransactionReceipt(ctx, common.BytesToHash(txHash))
+		require.NoError(c, err)
 		txStatus = receipt.Status
-		return true
 	}, testutils.WaitTimeout(t), 1*time.Second)
 
 	// wait for receipt to be written to the db
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		uni.backend.Commit()
 		var count uint32
-		err := uni.db.GetContext(testutils.Context(t), &count, `SELECT count(*) as cnt FROM evm.receipts LIMIT 1`)
-		require.NoError(t, err)
-		if count == 1 {
-			t.Log("tx receipt found in db")
-		}
-		return count == 1
+		err := uni.db.GetContext(ctx, &count, `SELECT count(*) as cnt FROM evm.receipts LIMIT 1`)
+		require.NoError(c, err)
+		require.Equal(c, uint32(1), count)
 	}, testutils.WaitTimeout(t), 2*time.Second)
 
 	require.Equal(t, uint64(1), txStatus, "tx status should be success")


### PR DESCRIPTION
testify's require.Eventually runs its callback in a background
goroutine. The test used require.NoError(t, ...) and t.Log inside
those callbacks, which races with *testing.T teardown under
-race.

Switch to require.EventuallyWithT and assert on *assert.CollectT
instead of t inside the polling closures. Capture t.Context() once
before Eventually so the callbacks do not read t at all.

### Test plan
- [x] `go test -race -count=50 -run Test_ContractTransmitter_TransmitWithoutSignatures ./core/capabilities/ccip/ocrimpls/...`


<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
