### PR TITLE
Add plugout skip for indirectly-resolved plugin dependencies

### DIFF
--- a/tools/plugout/main.go
+++ b/tools/plugout/main.go
@@ -43,6 +43,7 @@ type ModuleVersion struct {
 	SHA       string // extracted commit SHA if available (7..40 lower-hex)
 	Tag       string // tag like v0.1.5 (without any subdir prefix)
 	TagPrefix string // if raw looked like "sub/dir/vX.Y.Z", TagPrefix is "sub/dir"
+	Indirect  bool   // true if go.mod resolves this module as an indirect dependency
 }
 
 func main() {
@@ -159,6 +160,15 @@ func runSync(opts Options) (bool, error) {
 			goModVersion, err := get(opts.GoModPath, module)
 			if err != nil || goModVersion.Raw == "" {
 				fmt.Printf("  - No version found in go.mod for %s: %v\n", module, err)
+				continue
+			}
+
+			// Indirect dependencies are resolved to the minimal version selected by
+			// the module graph, which has no authoritative relationship to the version
+			// this plugin should build against. Skip them entirely: don't sync and
+			// don't flag a mismatch.
+			if goModVersion.Indirect {
+				fmt.Printf("  - Skipping %s: resolved as an indirect dependency in go.mod\n", module)
 				continue
 			}
 
@@ -336,9 +346,10 @@ func getGoModVersion(goModPath, module string) (ModuleVersion, error) {
 	}
 
 	var m struct {
-		Path    string
-		Version string
-		Replace *struct {
+		Path     string
+		Version  string
+		Indirect bool
+		Replace  *struct {
 			Path    string
 			Version string
 		}
@@ -353,6 +364,7 @@ func getGoModVersion(goModPath, module string) (ModuleVersion, error) {
 	}
 
 	mv := normalizeVersion(version)
+	mv.Indirect = m.Indirect
 	fmt.Printf("  - Version in go.mod: %s (%s)\n", version, mv.toString())
 	return mv, nil
 }

--- a/tools/plugout/main_test.go
+++ b/tools/plugout/main_test.go
@@ -429,6 +429,51 @@ func TestRunSync_IgnoreModules_SkipsChecks(t *testing.T) {
 	}
 }
 
+func TestRunSync_SkipsIndirectDependencies(t *testing.T) {
+	dir := t.TempDir()
+	goMod := writeFile(t, dir, "go.mod", "module github.com/example/repo\n")
+
+	t.Run("CheckMode_NoMismatch", func(t *testing.T) {
+		plugins := writeFile(t, dir, "plugins-check.yaml", samplePluginsYAML())
+		opts := Options{
+			GoModPath:   goMod,
+			PluginPaths: []string{plugins},
+			Update:      false,
+			GetModVersion: func(goModPath, module string) (ModuleVersion, error) {
+				// All modules resolve to a different version, but as indirect deps
+				// they must be skipped rather than flagged as mismatches.
+				return ModuleVersion{Tag: "v9.9.9", Raw: "v9.9.9", Indirect: true}, nil
+			},
+		}
+		hasMismatch, err := runSync(opts)
+		if err != nil {
+			t.Fatalf("runSync error: %v", err)
+		}
+		if hasMismatch {
+			t.Fatalf("did not expect mismatch when all modules are indirect")
+		}
+	})
+
+	t.Run("UpdateMode_LeavesFileUnchanged", func(t *testing.T) {
+		plugins := writeFile(t, dir, "plugins-update.yaml", samplePluginsYAML())
+		before := readFile(t, plugins)
+		opts := Options{
+			GoModPath:   goMod,
+			PluginPaths: []string{plugins},
+			Update:      true,
+			GetModVersion: func(goModPath, module string) (ModuleVersion, error) {
+				return ModuleVersion{Tag: "v9.9.9", Raw: "v9.9.9", Indirect: true}, nil
+			},
+		}
+		if _, err := runSync(opts); err != nil {
+			t.Fatalf("runSync error: %v", err)
+		}
+		if after := readFile(t, plugins); after != before {
+			t.Fatalf("expected file unchanged for indirect deps, got:\n%s", after)
+		}
+	})
+}
+
 func TestRunSync_FileValidation(t *testing.T) {
 	dir := t.TempDir()
 	// Missing go.mod


### PR DESCRIPTION
`./tools/plugout/` will try to sync the version/revisions of modules defined in our `go.mod` with the plugin manifests in `./plugins/plugins.*.yaml` files (we use `go.mod` as the source of truth) but we only want this for direct dependencies.