### PR TITLE
(feat): Use per owner max ciphertext size

### DIFF
--- a/core/capabilities/vault/capability.go
+++ b/core/capabilities/vault/capability.go
@@ -342,7 +342,7 @@ func NewCapability(
 	if err != nil {
 		return nil, fmt.Errorf("could not create request batch size limiter: %w", err)
 	}
-	ciphertextLimiter, err := limits.MakeUpperBoundLimiter(limitsFactory, cresettings.Default.VaultCiphertextSizeLimit)
+	ciphertextLimiter, err := limits.MakeUpperBoundLimiter(limitsFactory, cresettings.Default.PerOwner.VaultCiphertextSizeLimit)
 	if err != nil {
 		return nil, fmt.Errorf("could not create ciphertext size limiter: %w", err)
 	}

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -231,7 +231,7 @@ func newHandlerWithAuthorizer(methodConfig json.RawMessage, donConfig *config.DO
 	if err != nil {
 		return nil, fmt.Errorf("could not create request batch size limiter: %w", err)
 	}
-	ciphertextLimiter, err := limits.MakeUpperBoundLimiter(limitsFactory, cresettings.Default.VaultCiphertextSizeLimit)
+	ciphertextLimiter, err := limits.MakeUpperBoundLimiter(limitsFactory, cresettings.Default.PerOwner.VaultCiphertextSizeLimit)
 	if err != nil {
 		return nil, fmt.Errorf("could not create ciphertext size limiter: %w", err)
 	}

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -174,7 +174,7 @@ func (r *ReportingPluginFactory) pollForKeyMaterial(ctx context.Context, instanc
 }
 
 func newReportingPluginConfigLimiters(factory limits.Factory) (*ReportingPluginConfig, error) {
-	maxCiphertextLengthBytesLimiter, err := limits.MakeUpperBoundLimiter(factory, cresettings.Default.VaultCiphertextSizeLimit)
+	maxCiphertextLengthBytesLimiter, err := limits.MakeUpperBoundLimiter(factory, cresettings.Default.PerOwner.VaultCiphertextSizeLimit)
 	if err != nil {
 		return nil, fmt.Errorf("VaultCiphertextSizeLimit: %w", err)
 	}

--- a/core/services/ocr2/plugins/vault/plugin_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_test.go
@@ -7921,7 +7921,7 @@ func TestPlugin_broadcastBlobPayloads(t *testing.T) {
 
 func TestProperty_broadcastBlobPayloads_MaxSizePayloadsWithinBlobLimit(t *testing.T) {
 	maxRequestBatchSize := cresettings.Default.VaultRequestBatchSizeLimit.DefaultValue
-	maxCiphertextBytes := cresettings.Default.VaultCiphertextSizeLimit.DefaultValue
+	maxCiphertextBytes := cresettings.Default.PerOwner.VaultCiphertextSizeLimit.DefaultValue
 	maxIDKeySize := cresettings.Default.VaultIdentifierKeySizeLimit.DefaultValue
 	maxIDOwnerSize := cresettings.Default.VaultIdentifierOwnerSizeLimit.DefaultValue
 	maxIDNamespaceSize := cresettings.Default.VaultIdentifierNamespaceSizeLimit.DefaultValue


### PR DESCRIPTION
Carrying https://github.com/smartcontractkit/chainlink-common/pull/2121 through