### PR TITLE
chore: remove MCMS view from vault deployment

### DIFF
--- a/deployment/vault/view/view.go
+++ b/deployment/vault/view/view.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"slices"
 
-	evmstate "github.com/smartcontractkit/cld-changesets/legacy/pkg/family/evm"
-	mcmsv10 "github.com/smartcontractkit/cld-changesets/pkg/contract/mcms/view/v1_0"
-
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/vault/changeset"
@@ -19,7 +16,6 @@ var _ cldf.ViewStateV2 = Vault
 type VaultView struct {
 	TimelockBalances     map[uint64]*types.TimelockNativeBalanceInfo `json:"timelock_balances"`
 	WhitelistedAddresses map[uint64][]changeset.WhitelistEntry       `json:"whitelisted_addresses"`
-	MCMSWithTimelock     map[uint64]mcmsv10.MCMSWithTimelockView     `json:"mcms_with_timelock,omitempty"`
 }
 
 func (v *VaultView) MarshalJSON() ([]byte, error) {
@@ -53,7 +49,6 @@ func Vault(e cldf.Environment, _ json.Marshaler) (json.Marshaler, error) {
 func GenerateVaultView(e cldf.Environment, chainSelectors []uint64) (*VaultView, error) {
 	view := &VaultView{
 		WhitelistedAddresses: make(map[uint64][]changeset.WhitelistEntry),
-		MCMSWithTimelock:     make(map[uint64]mcmsv10.MCMSWithTimelockView),
 	}
 
 	balances, err := changeset.GetTimelockBalances(e, chainSelectors)
@@ -67,22 +62,6 @@ func GenerateVaultView(e cldf.Environment, chainSelectors []uint64) (*VaultView,
 		return nil, fmt.Errorf("failed to get whitelisted addresses: %w", err)
 	}
 	view.WhitelistedAddresses = addresses
-
-	mcmsStates, err := evmstate.MaybeLoadMCMSWithTimelockStateDataStore(e, chainSelectors)
-	if err != nil {
-		e.Logger.Warnf("Failed to load MCMS state (this may be expected if MCMS is not deployed): %v", err)
-	} else {
-		for chainSelector, mcmsState := range mcmsStates {
-			if mcmsState != nil {
-				mcmsView, err := mcmsState.GenerateMCMSWithTimelockView()
-				if err != nil {
-					e.Logger.Warnf("Failed to generate MCMS view for chain %d: %v", chainSelector, err)
-				} else {
-					view.MCMSWithTimelock[chainSelector] = mcmsView
-				}
-			}
-		}
-	}
 
 	return view, nil
 }

--- a/deployment/vault/view/view_test.go
+++ b/deployment/vault/view/view_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	chainselectors "github.com/smartcontractkit/chain-selectors"
-	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
 	"github.com/stretchr/testify/require"
 
-	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
-	cldftesthelpers "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils/testhelpers"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
+	cldftesthelpers "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils/testhelpers"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
@@ -32,7 +32,6 @@ func TestVault_NoChains(t *testing.T) {
 	view := viewMarshaler.(*VaultView)
 	require.Empty(t, view.TimelockBalances)
 	require.Empty(t, view.WhitelistedAddresses)
-	require.Empty(t, view.MCMSWithTimelock)
 }
 
 func TestGenerateVaultView_WithoutTimelock(t *testing.T) {
@@ -54,8 +53,6 @@ func TestGenerateVaultView_WithoutTimelock(t *testing.T) {
 	for _, sel := range selectors {
 		require.Empty(t, view.WhitelistedAddresses[sel])
 	}
-
-	require.Empty(t, view.MCMSWithTimelock)
 }
 
 func TestGenerateVaultView_WithMCMSAndWhitelist(t *testing.T) {
@@ -101,7 +98,6 @@ func TestGenerateVaultView_WithMCMSAndWhitelist(t *testing.T) {
 		require.Len(t, entries, 1)
 		require.Equal(t, whitelistByChain[sel][0].Address, entries[0].Address)
 	}
-	require.Len(t, view.MCMSWithTimelock, len(selectors))
 }
 
 func setupMCMS(t *testing.T, rt *runtime.Runtime, chainSelectors []uint64) {


### PR DESCRIPTION
This removes the MCMS view from the vault deployment as is not used.
