### PR TITLE
Add privacy as CODEOWNER for confidentialrelay paths in core

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,7 @@
 /core/capabilities/ccip/ccipsolana/ @smartcontractkit/bix-build
 /core/capabilities/ccip/ccipnoop/ @smartcontractkit/bix-build
 /core/capabilities/ccip/ccipton/ @smartcontractkit/bix-build
+/core/capabilities/confidentialrelay/ @smartcontractkit/privacy @smartcontractkit/keystone @smartcontractkit/capabilities-team
 
 # To be deprecated in Chainlink V3
 /core/services/job/ @smartcontractkit/foundations @smartcontractkit/core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@
 /core/capabilities/ccip/ccipsolana/ @smartcontractkit/bix-build
 /core/capabilities/ccip/ccipnoop/ @smartcontractkit/bix-build
 /core/capabilities/ccip/ccipton/ @smartcontractkit/bix-build
-/core/capabilities/confidentialrelay/ @smartcontractkit/privacy @smartcontractkit/keystone @smartcontractkit/capabilities-team
+/core/capabilities/confidentialrelay/ @smartcontractkit/privacy
 
 # To be deprecated in Chainlink V3
 /core/services/job/ @smartcontractkit/foundations @smartcontractkit/core
@@ -64,6 +64,7 @@
 /core/services/registrysyncer/ @smartcontractkit/keystone
 /core/services/workflows/ @smartcontractkit/keystone
 /core/services/standardcapabilities/ @smartcontractkit/keystone
+/core/services/gateway/handlers/confidentialrelay/ @smartcontractkit/privacy
 /core/scripts/keystone/ @smartcontractkit/keystone
 
 # GQL API

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,6 +65,7 @@
 /core/services/workflows/ @smartcontractkit/keystone
 /core/services/standardcapabilities/ @smartcontractkit/keystone
 /core/services/gateway/handlers/confidentialrelay/ @smartcontractkit/privacy
+/system-tests/lib/cre/features/confidentialrelay/ @smartcontractkit/privacy
 /core/scripts/keystone/ @smartcontractkit/keystone
 
 # GQL API


### PR DESCRIPTION
The confidentialrelay code (relay-DON authorization logic, PRIV-433, PRIV-458) is privacy-owned security code spread across three paths, none of which had a privacy CODEOWNERS entry:

- /core/capabilities/confidentialrelay/ (inherited /core/capabilities/ -> keystone + capabilities-team)
- /core/services/gateway/handlers/confidentialrelay/
- /system-tests/lib/cre/features/confidentialrelay/

Privacy could not approve changes there as a code owner (e.g. #22516, #22703). This adds @smartcontractkit/privacy for all three.

Note: GitHub only honors these entries if the @smartcontractkit/privacy team has write access to this repo. https://smartcontract-it.atlassian.net/servicedesk/customer/portal/4/SECHD-31726