### PR TITLE
Stamp ownership on secrets

### DIFF
--- a/core/capabilities/vault/authorizer.go
+++ b/core/capabilities/vault/authorizer.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
+	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 )
 
 // AuthResult is the normalized authorization output shared by
@@ -106,6 +110,10 @@ func (a *authorizer) AuthorizeRequest(ctx context.Context, req jsonrpc.Request[j
 		a.lggr.Debugw("replay guard rejected request", "method", req.Method, "requestID", req.ID, "owner", authResult.AuthorizedOwner(), "digest", authResult.Digest(), "expiresAt", authResult.ExpiresAt(), "hasAuth", req.Auth != "", "error", err)
 		return nil, err
 	}
+	if ownerErr := validatePreparedVaultOwners(req, authResult.AuthorizedOwner()); ownerErr != nil {
+		a.lggr.Errorw("owner binding rejected request", "method", req.Method, "requestID", req.ID, "owner", authResult.AuthorizedOwner(), "hasAuth", req.Auth != "", "error", ownerErr)
+		return nil, ownerErr
+	}
 	a.lggr.Debugw("request authorized", "method", req.Method, "requestID", req.ID, "owner", authResult.AuthorizedOwner(), "digest", authResult.Digest(), "expiresAt", authResult.ExpiresAt(), "hasAuth", req.Auth != "")
 	return authResult, nil
 }
@@ -135,4 +143,71 @@ func (a *authorizer) authorizeJWTBasedAuth(ctx context.Context, req jsonrpc.Requ
 		return nil, err
 	}
 	return a.jwtBasedAuth.AuthorizeRequest(ctx, req)
+}
+
+// validatePreparedVaultOwners checks that every secret identifier in the request
+// payload belongs to workflowOwner. It runs after allowlist or JWT authentication
+// so neither path can be exploited to mutate another owner's secrets.
+func validatePreparedVaultOwners(req jsonrpc.Request[json.RawMessage], workflowOwner string) error {
+	switch req.Method {
+	case vaulttypes.MethodSecretsCreate:
+		parsed := &vaultcommon.CreateSecretsRequest{}
+		if err := json.Unmarshal(*req.Params, parsed); err != nil {
+			return fmt.Errorf("failed to parse create secrets request: %w", err)
+		}
+		return validateEncryptedSecretOwnersMatchWorkflowOwner(parsed.EncryptedSecrets, workflowOwner)
+	case vaulttypes.MethodSecretsUpdate:
+		parsed := &vaultcommon.UpdateSecretsRequest{}
+		if err := json.Unmarshal(*req.Params, parsed); err != nil {
+			return fmt.Errorf("failed to parse update secrets request: %w", err)
+		}
+		return validateEncryptedSecretOwnersMatchWorkflowOwner(parsed.EncryptedSecrets, workflowOwner)
+	case vaulttypes.MethodSecretsDelete:
+		parsed := &vaultcommon.DeleteSecretsRequest{}
+		if err := json.Unmarshal(*req.Params, parsed); err != nil {
+			return fmt.Errorf("failed to parse delete secrets request: %w", err)
+		}
+		return validateSecretIdentifierOwnersMatchWorkflowOwner(parsed.Ids, workflowOwner)
+	case vaulttypes.MethodSecretsList:
+		parsed := &vaultcommon.ListSecretIdentifiersRequest{}
+		if err := json.Unmarshal(*req.Params, parsed); err != nil {
+			return fmt.Errorf("failed to parse list secrets request: %w", err)
+		}
+		if normalizeOwner(parsed.Owner) != normalizeOwner(workflowOwner) {
+			return fmt.Errorf("list secrets owner %q does not match authorized workflow owner %q", parsed.Owner, workflowOwner)
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func validateEncryptedSecretOwnersMatchWorkflowOwner(encryptedSecrets []*vaultcommon.EncryptedSecret, workflowOwner string) error {
+	if len(encryptedSecrets) == 0 {
+		return errors.New("encrypted secrets must contain at least one identifier")
+	}
+	for idx, encryptedSecret := range encryptedSecrets {
+		if encryptedSecret == nil || encryptedSecret.Id == nil {
+			return fmt.Errorf("encrypted secret at index %d must include an identifier", idx)
+		}
+		if normalizeOwner(encryptedSecret.Id.Owner) != normalizeOwner(workflowOwner) {
+			return fmt.Errorf("encrypted secret owner at index %d %q does not match authorized workflow owner %q", idx, encryptedSecret.Id.Owner, workflowOwner)
+		}
+	}
+	return nil
+}
+
+func validateSecretIdentifierOwnersMatchWorkflowOwner(ids []*vaultcommon.SecretIdentifier, workflowOwner string) error {
+	if len(ids) == 0 {
+		return errors.New("secret identifiers must not be empty")
+	}
+	for idx, id := range ids {
+		if id == nil {
+			return fmt.Errorf("secret identifier at index %d must not be nil", idx)
+		}
+		if normalizeOwner(id.Owner) != normalizeOwner(workflowOwner) {
+			return fmt.Errorf("secret identifier owner at index %d %q does not match authorized workflow owner %q", idx, id.Owner, workflowOwner)
+		}
+	}
+	return nil
 }

--- a/core/capabilities/vault/authorizer.go
+++ b/core/capabilities/vault/authorizer.go
@@ -145,50 +145,67 @@ func (a *authorizer) authorizeJWTBasedAuth(ctx context.Context, req jsonrpc.Requ
 	return a.jwtBasedAuth.AuthorizeRequest(ctx, req)
 }
 
-// validatePreparedVaultOwners checks that every secret identifier in the request
-// payload belongs to workflowOwner. It runs after allowlist or JWT authentication
-// so neither path can be exploited to mutate another owner's secrets.
+// validatePreparedVaultOwners checks that secret identifiers in the request payload
+// belong to workflowOwner. It runs after allowlist or JWT authentication so neither
+// path can be exploited to mutate another owner's secrets.
+//
+// Param shape validation (empty batch, nil entries, parse errors) is left to the
+// gateway handler validators so clients receive the same InvalidParamsError codes
+// as before.
 func validatePreparedVaultOwners(req jsonrpc.Request[json.RawMessage], workflowOwner string) error {
+	// If the request has no params, there are no secret identifiers to validate.
+	// The gateway handler validates this case and returns InvalidParamsError.
+	if req.Params == nil {
+		return nil
+	}
+
 	switch req.Method {
 	case vaulttypes.MethodSecretsCreate:
 		parsed := &vaultcommon.CreateSecretsRequest{}
 		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse create secrets request: %w", err)
+			// InvalidParamsError is returned by the gateway handler for this case.
+			return nil
 		}
-		return validateEncryptedSecretOwnersMatchWorkflowOwner(parsed.EncryptedSecrets, workflowOwner)
+		return validateEncryptedSecretOwnerMismatch(parsed.EncryptedSecrets, workflowOwner)
 	case vaulttypes.MethodSecretsUpdate:
 		parsed := &vaultcommon.UpdateSecretsRequest{}
 		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse update secrets request: %w", err)
+			// InvalidParamsError is returned by the gateway handler for this case.
+			return nil
 		}
-		return validateEncryptedSecretOwnersMatchWorkflowOwner(parsed.EncryptedSecrets, workflowOwner)
+		return validateEncryptedSecretOwnerMismatch(parsed.EncryptedSecrets, workflowOwner)
 	case vaulttypes.MethodSecretsDelete:
 		parsed := &vaultcommon.DeleteSecretsRequest{}
 		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse delete secrets request: %w", err)
+			// InvalidParamsError is returned by the gateway handler for this case.
+			return nil
 		}
-		return validateSecretIdentifierOwnersMatchWorkflowOwner(parsed.Ids, workflowOwner)
+		return validateSecretIdentifierOwnerMismatch(parsed.Ids, workflowOwner)
 	case vaulttypes.MethodSecretsList:
 		parsed := &vaultcommon.ListSecretIdentifiersRequest{}
 		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse list secrets request: %w", err)
+			// InvalidParamsError is returned by the gateway handler for this case.
+			return nil
 		}
 		if normalizeOwner(parsed.Owner) != normalizeOwner(workflowOwner) {
 			return fmt.Errorf("list secrets owner %q does not match authorized workflow owner %q", parsed.Owner, workflowOwner)
 		}
+	case vaulttypes.MethodPublicKeyGet:
 		return nil
 	default:
+		// Fail open: this check only binds secret identifiers to the authorized owner.
+		// Unknown methods are rejected later with UnsupportedMethodError in the gateway
+		// handler (HandleJSONRPCUserMessage) and on vault nodes (GatewayHandler.HandleGatewayMessage).
 		return nil
 	}
+	return nil
 }
 
-func validateEncryptedSecretOwnersMatchWorkflowOwner(encryptedSecrets []*vaultcommon.EncryptedSecret, workflowOwner string) error {
-	if len(encryptedSecrets) == 0 {
-		return errors.New("encrypted secrets must contain at least one identifier")
-	}
+func validateEncryptedSecretOwnerMismatch(encryptedSecrets []*vaultcommon.EncryptedSecret, workflowOwner string) error {
 	for idx, encryptedSecret := range encryptedSecrets {
 		if encryptedSecret == nil || encryptedSecret.Id == nil {
-			return fmt.Errorf("encrypted secret at index %d must include an identifier", idx)
+			// InvalidParamsError is returned by the gateway handler for this case.
+			continue
 		}
 		if normalizeOwner(encryptedSecret.Id.Owner) != normalizeOwner(workflowOwner) {
 			return fmt.Errorf("encrypted secret owner at index %d %q does not match authorized workflow owner %q", idx, encryptedSecret.Id.Owner, workflowOwner)
@@ -197,13 +214,11 @@ func validateEncryptedSecretOwnersMatchWorkflowOwner(encryptedSecrets []*vaultco
 	return nil
 }
 
-func validateSecretIdentifierOwnersMatchWorkflowOwner(ids []*vaultcommon.SecretIdentifier, workflowOwner string) error {
-	if len(ids) == 0 {
-		return errors.New("secret identifiers must not be empty")
-	}
+func validateSecretIdentifierOwnerMismatch(ids []*vaultcommon.SecretIdentifier, workflowOwner string) error {
 	for idx, id := range ids {
 		if id == nil {
-			return fmt.Errorf("secret identifier at index %d must not be nil", idx)
+			// InvalidParamsError is returned by the gateway handler for this case.
+			continue
 		}
 		if normalizeOwner(id.Owner) != normalizeOwner(workflowOwner) {
 			return fmt.Errorf("secret identifier owner at index %d %q does not match authorized workflow owner %q", idx, id.Owner, workflowOwner)

--- a/core/capabilities/vault/authorizer.go
+++ b/core/capabilities/vault/authorizer.go
@@ -4,13 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 
-	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 )
 
 // AuthResult is the normalized authorization output shared by
@@ -110,10 +106,6 @@ func (a *authorizer) AuthorizeRequest(ctx context.Context, req jsonrpc.Request[j
 		a.lggr.Debugw("replay guard rejected request", "method", req.Method, "requestID", req.ID, "owner", authResult.AuthorizedOwner(), "digest", authResult.Digest(), "expiresAt", authResult.ExpiresAt(), "hasAuth", req.Auth != "", "error", err)
 		return nil, err
 	}
-	if ownerErr := validatePreparedVaultOwners(req, authResult.AuthorizedOwner()); ownerErr != nil {
-		a.lggr.Errorw("owner binding rejected request", "method", req.Method, "requestID", req.ID, "owner", authResult.AuthorizedOwner(), "hasAuth", req.Auth != "", "error", ownerErr)
-		return nil, ownerErr
-	}
 	a.lggr.Debugw("request authorized", "method", req.Method, "requestID", req.ID, "owner", authResult.AuthorizedOwner(), "digest", authResult.Digest(), "expiresAt", authResult.ExpiresAt(), "hasAuth", req.Auth != "")
 	return authResult, nil
 }
@@ -143,86 +135,4 @@ func (a *authorizer) authorizeJWTBasedAuth(ctx context.Context, req jsonrpc.Requ
 		return nil, err
 	}
 	return a.jwtBasedAuth.AuthorizeRequest(ctx, req)
-}
-
-// validatePreparedVaultOwners checks that secret identifiers in the request payload
-// belong to workflowOwner. It runs after allowlist or JWT authentication so neither
-// path can be exploited to mutate another owner's secrets.
-//
-// Param shape validation (empty batch, nil entries, parse errors) is left to the
-// gateway handler validators so clients receive the same InvalidParamsError codes
-// as before.
-func validatePreparedVaultOwners(req jsonrpc.Request[json.RawMessage], workflowOwner string) error {
-	// If the request has no params, there are no secret identifiers to validate.
-	// The gateway handler validates this case and returns InvalidParamsError.
-	if req.Params == nil {
-		return nil
-	}
-
-	switch req.Method {
-	case vaulttypes.MethodSecretsCreate:
-		parsed := &vaultcommon.CreateSecretsRequest{}
-		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			// InvalidParamsError is returned by the gateway handler for this case.
-			return nil
-		}
-		return validateEncryptedSecretOwnerMismatch(parsed.EncryptedSecrets, workflowOwner)
-	case vaulttypes.MethodSecretsUpdate:
-		parsed := &vaultcommon.UpdateSecretsRequest{}
-		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			// InvalidParamsError is returned by the gateway handler for this case.
-			return nil
-		}
-		return validateEncryptedSecretOwnerMismatch(parsed.EncryptedSecrets, workflowOwner)
-	case vaulttypes.MethodSecretsDelete:
-		parsed := &vaultcommon.DeleteSecretsRequest{}
-		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			// InvalidParamsError is returned by the gateway handler for this case.
-			return nil
-		}
-		return validateSecretIdentifierOwnerMismatch(parsed.Ids, workflowOwner)
-	case vaulttypes.MethodSecretsList:
-		parsed := &vaultcommon.ListSecretIdentifiersRequest{}
-		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			// InvalidParamsError is returned by the gateway handler for this case.
-			return nil
-		}
-		if normalizeOwner(parsed.Owner) != normalizeOwner(workflowOwner) {
-			return fmt.Errorf("list secrets owner %q does not match authorized workflow owner %q", parsed.Owner, workflowOwner)
-		}
-	case vaulttypes.MethodPublicKeyGet:
-		return nil
-	default:
-		// Fail open: this check only binds secret identifiers to the authorized owner.
-		// Unknown methods are rejected later with UnsupportedMethodError in the gateway
-		// handler (HandleJSONRPCUserMessage) and on vault nodes (GatewayHandler.HandleGatewayMessage).
-		return nil
-	}
-	return nil
-}
-
-func validateEncryptedSecretOwnerMismatch(encryptedSecrets []*vaultcommon.EncryptedSecret, workflowOwner string) error {
-	for idx, encryptedSecret := range encryptedSecrets {
-		if encryptedSecret == nil || encryptedSecret.Id == nil {
-			// InvalidParamsError is returned by the gateway handler for this case.
-			continue
-		}
-		if normalizeOwner(encryptedSecret.Id.Owner) != normalizeOwner(workflowOwner) {
-			return fmt.Errorf("encrypted secret owner at index %d %q does not match authorized workflow owner %q", idx, encryptedSecret.Id.Owner, workflowOwner)
-		}
-	}
-	return nil
-}
-
-func validateSecretIdentifierOwnerMismatch(ids []*vaultcommon.SecretIdentifier, workflowOwner string) error {
-	for idx, id := range ids {
-		if id == nil {
-			// InvalidParamsError is returned by the gateway handler for this case.
-			continue
-		}
-		if normalizeOwner(id.Owner) != normalizeOwner(workflowOwner) {
-			return fmt.Errorf("secret identifier owner at index %d %q does not match authorized workflow owner %q", idx, id.Owner, workflowOwner)
-		}
-	}
-	return nil
 }

--- a/core/capabilities/vault/authorizer_test.go
+++ b/core/capabilities/vault/authorizer_test.go
@@ -26,12 +26,13 @@ func TestAuthorizer_RejectsJWTBasedAuthWhenUnavailable(t *testing.T) {
 
 	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
 
-	authResult, err := a.AuthorizeRequest(t.Context(), jsonrpc.Request[json.RawMessage]{
+	req := jsonrpc.Request[json.RawMessage]{
 		ID:     "1",
 		Method: vaulttypes.MethodSecretsCreate,
 		Params: (*json.RawMessage)(&params),
 		Auth:   "jwt-token",
-	})
+	}
+	authResult, err := a.AuthorizeRequest(t.Context(), req)
 	require.Nil(t, authResult)
 	require.ErrorContains(t, err, "JWTBasedAuth is nil")
 	allowListBasedAuth.AssertNotCalled(t, "AuthorizeRequest", mock.Anything, mock.Anything)
@@ -110,7 +111,6 @@ func TestAuthorizer_RejectsJWTReplay(t *testing.T) {
 
 func TestAuthorizer_RejectsAllowListBasedAuthReplay(t *testing.T) {
 	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
-	// Use a method without secret identifiers so the owner-binding check is a no-op.
 	req := jsonrpc.Request[json.RawMessage]{ID: "1", Method: vaulttypes.MethodPublicKeyGet}
 	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, req).Return(vault.NewAuthResult("", "0xabc", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Twice()
 
@@ -128,7 +128,6 @@ func TestAuthorizer_RejectsAllowListBasedAuthReplay(t *testing.T) {
 }
 
 func TestAuthorizer_PropagatesJWTValidationErrors(t *testing.T) {
-	// JWT mock fails before owner binding; params are irrelevant here.
 	req := jsonrpc.Request[json.RawMessage]{
 		ID:     "1",
 		Method: vaulttypes.MethodSecretsCreate,
@@ -145,7 +144,7 @@ func TestAuthorizer_PropagatesJWTValidationErrors(t *testing.T) {
 	require.ErrorContains(t, err, "bad token")
 }
 
-func TestAuthorizer_AllowListPath_RejectsCreateOwnerMismatch(t *testing.T) {
+func TestAuthorizer_AllowListPath_DoesNotStampCreateOwnerMismatch(t *testing.T) {
 	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{
 		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
 			{Id: &vaultcommon.SecretIdentifier{Owner: "0xother", Namespace: "ns", Key: "k"}, EncryptedValue: "cipher"},
@@ -165,11 +164,15 @@ func TestAuthorizer_AllowListPath_RejectsCreateOwnerMismatch(t *testing.T) {
 	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
 
 	authResult, err := a.AuthorizeRequest(t.Context(), req)
-	require.Nil(t, authResult)
-	require.ErrorContains(t, err, "encrypted secret owner at index 0 \"0xother\" does not match authorized workflow owner \"0xauthorized\"")
+	require.NoError(t, err)
+	require.Equal(t, "0xauthorized", authResult.AuthorizedOwner())
+
+	parsed := &vaultcommon.CreateSecretsRequest{}
+	require.NoError(t, json.Unmarshal(*req.Params, parsed))
+	require.Equal(t, "0xother", parsed.EncryptedSecrets[0].Id.Owner)
 }
 
-func TestAuthorizer_AllowListPath_RejectsUpdateOwnerMismatch(t *testing.T) {
+func TestAuthorizer_AllowListPath_DoesNotStampUpdateOwnerMismatch(t *testing.T) {
 	params, err := json.Marshal(vaultcommon.UpdateSecretsRequest{
 		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
 			{Id: &vaultcommon.SecretIdentifier{Owner: "0xother", Namespace: "ns", Key: "k"}, EncryptedValue: "cipher"},
@@ -189,11 +192,15 @@ func TestAuthorizer_AllowListPath_RejectsUpdateOwnerMismatch(t *testing.T) {
 	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
 
 	authResult, err := a.AuthorizeRequest(t.Context(), req)
-	require.Nil(t, authResult)
-	require.ErrorContains(t, err, "encrypted secret owner at index 0 \"0xother\" does not match authorized workflow owner \"0xauthorized\"")
+	require.NoError(t, err)
+	require.Equal(t, "0xauthorized", authResult.AuthorizedOwner())
+
+	parsed := &vaultcommon.UpdateSecretsRequest{}
+	require.NoError(t, json.Unmarshal(*req.Params, parsed))
+	require.Equal(t, "0xother", parsed.EncryptedSecrets[0].Id.Owner)
 }
 
-func TestAuthorizer_AllowListPath_RejectsDeleteOwnerMismatch(t *testing.T) {
+func TestAuthorizer_AllowListPath_DoesNotStampDeleteOwnerMismatch(t *testing.T) {
 	params, err := json.Marshal(vaultcommon.DeleteSecretsRequest{
 		Ids: []*vaultcommon.SecretIdentifier{
 			{Owner: "0xother", Namespace: "ns", Key: "k"},
@@ -213,11 +220,15 @@ func TestAuthorizer_AllowListPath_RejectsDeleteOwnerMismatch(t *testing.T) {
 	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
 
 	authResult, err := a.AuthorizeRequest(t.Context(), req)
-	require.Nil(t, authResult)
-	require.ErrorContains(t, err, "secret identifier owner at index 0 \"0xother\" does not match authorized workflow owner \"0xauthorized\"")
+	require.NoError(t, err)
+	require.Equal(t, "0xauthorized", authResult.AuthorizedOwner())
+
+	parsed := &vaultcommon.DeleteSecretsRequest{}
+	require.NoError(t, json.Unmarshal(*req.Params, parsed))
+	require.Equal(t, "0xother", parsed.Ids[0].Owner)
 }
 
-func TestAuthorizer_AllowListPath_RejectsListOwnerMismatch(t *testing.T) {
+func TestAuthorizer_AllowListPath_DoesNotStampListOwnerMismatch(t *testing.T) {
 	params, err := json.Marshal(vaultcommon.ListSecretIdentifiersRequest{
 		Owner:     "0xother",
 		Namespace: "ns",
@@ -236,20 +247,26 @@ func TestAuthorizer_AllowListPath_RejectsListOwnerMismatch(t *testing.T) {
 	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
 
 	authResult, err := a.AuthorizeRequest(t.Context(), req)
-	require.Nil(t, authResult)
-	require.ErrorContains(t, err, "list secrets owner \"0xother\" does not match authorized workflow owner \"0xauthorized\"")
+	require.NoError(t, err)
+	require.Equal(t, "0xauthorized", authResult.AuthorizedOwner())
+
+	parsed := &vaultcommon.ListSecretIdentifiersRequest{}
+	require.NoError(t, json.Unmarshal(*req.Params, parsed))
+	require.Equal(t, "0xother", parsed.Owner)
 }
 
-func TestAuthorizer_SkipsOwnerBindingWhenParamsMissing(t *testing.T) {
+func TestAuthorizer_DoesNotStampWhenParamsMissing(t *testing.T) {
 	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
 	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Return(vault.NewAuthResult("", "0xauthorized", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Once()
 
 	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
 
-	authResult, err := a.AuthorizeRequest(t.Context(), jsonrpc.Request[json.RawMessage]{
+	req := jsonrpc.Request[json.RawMessage]{
 		ID:     "1",
 		Method: vaulttypes.MethodSecretsCreate,
-	})
+	}
+	authResult, err := a.AuthorizeRequest(t.Context(), req)
 	require.NoError(t, err)
 	require.Equal(t, "0xauthorized", authResult.AuthorizedOwner())
+	require.Nil(t, req.Params)
 }

--- a/core/capabilities/vault/authorizer_test.go
+++ b/core/capabilities/vault/authorizer_test.go
@@ -38,7 +38,11 @@ func TestAuthorizer_RejectsJWTBasedAuthWhenUnavailable(t *testing.T) {
 }
 
 func TestAuthorizer_UsesJWTWhenGateEnabled(t *testing.T) {
-	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{})
+	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{Id: &vaultcommon.SecretIdentifier{Owner: "0xworkflow", Namespace: "ns", Key: "k"}, EncryptedValue: "cipher"},
+		},
+	})
 	require.NoError(t, err)
 
 	req := jsonrpc.Request[json.RawMessage]{
@@ -63,13 +67,11 @@ func TestAuthorizer_UsesJWTWhenGateEnabled(t *testing.T) {
 }
 
 func TestAuthorizer_DelegatesDigestVerificationToJWTAuth(t *testing.T) {
-	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{})
-	require.NoError(t, err)
-
+	// Use a method that does not carry secret identifiers so the owner-binding
+	// check is a no-op; the test's focus is digest delegation, not owner binding.
 	req := jsonrpc.Request[json.RawMessage]{
 		ID:     "1",
-		Method: vaulttypes.MethodSecretsCreate,
-		Params: (*json.RawMessage)(&params),
+		Method: vaulttypes.MethodPublicKeyGet,
 		Auth:   "jwt-token",
 	}
 
@@ -86,13 +88,11 @@ func TestAuthorizer_DelegatesDigestVerificationToJWTAuth(t *testing.T) {
 }
 
 func TestAuthorizer_RejectsJWTReplay(t *testing.T) {
-	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{})
-	require.NoError(t, err)
-
+	// Use a method that does not carry secret identifiers so the owner-binding
+	// check is a no-op; the test's focus is replay protection.
 	req := jsonrpc.Request[json.RawMessage]{
 		ID:     "1",
-		Method: vaulttypes.MethodSecretsCreate,
-		Params: (*json.RawMessage)(&params),
+		Method: vaulttypes.MethodPublicKeyGet,
 		Auth:   "jwt-token",
 	}
 	digest, err := req.Digest()
@@ -114,7 +114,8 @@ func TestAuthorizer_RejectsJWTReplay(t *testing.T) {
 
 func TestAuthorizer_RejectsAllowListBasedAuthReplay(t *testing.T) {
 	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
-	req := jsonrpc.Request[json.RawMessage]{ID: "1", Method: vaulttypes.MethodSecretsCreate}
+	// Use a method without secret identifiers so the owner-binding check is a no-op.
+	req := jsonrpc.Request[json.RawMessage]{ID: "1", Method: vaulttypes.MethodPublicKeyGet}
 	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, req).Return(vault.NewAuthResult("", "0xabc", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Twice()
 
 	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))

--- a/core/capabilities/vault/authorizer_test.go
+++ b/core/capabilities/vault/authorizer_test.go
@@ -67,8 +67,6 @@ func TestAuthorizer_UsesJWTWhenGateEnabled(t *testing.T) {
 }
 
 func TestAuthorizer_DelegatesDigestVerificationToJWTAuth(t *testing.T) {
-	// Use a method that does not carry secret identifiers so the owner-binding
-	// check is a no-op; the test's focus is digest delegation, not owner binding.
 	req := jsonrpc.Request[json.RawMessage]{
 		ID:     "1",
 		Method: vaulttypes.MethodPublicKeyGet,
@@ -88,8 +86,6 @@ func TestAuthorizer_DelegatesDigestVerificationToJWTAuth(t *testing.T) {
 }
 
 func TestAuthorizer_RejectsJWTReplay(t *testing.T) {
-	// Use a method that does not carry secret identifiers so the owner-binding
-	// check is a no-op; the test's focus is replay protection.
 	req := jsonrpc.Request[json.RawMessage]{
 		ID:     "1",
 		Method: vaulttypes.MethodPublicKeyGet,
@@ -132,13 +128,10 @@ func TestAuthorizer_RejectsAllowListBasedAuthReplay(t *testing.T) {
 }
 
 func TestAuthorizer_PropagatesJWTValidationErrors(t *testing.T) {
-	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{})
-	require.NoError(t, err)
-
+	// JWT mock fails before owner binding; params are irrelevant here.
 	req := jsonrpc.Request[json.RawMessage]{
 		ID:     "1",
 		Method: vaulttypes.MethodSecretsCreate,
-		Params: (*json.RawMessage)(&params),
 		Auth:   "jwt-token",
 	}
 
@@ -150,4 +143,113 @@ func TestAuthorizer_PropagatesJWTValidationErrors(t *testing.T) {
 	authResult, err := a.AuthorizeRequest(t.Context(), req)
 	require.Nil(t, authResult)
 	require.ErrorContains(t, err, "bad token")
+}
+
+func TestAuthorizer_AllowListPath_RejectsCreateOwnerMismatch(t *testing.T) {
+	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{Id: &vaultcommon.SecretIdentifier{Owner: "0xother", Namespace: "ns", Key: "k"}, EncryptedValue: "cipher"},
+		},
+	})
+	require.NoError(t, err)
+
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "1",
+		Method: vaulttypes.MethodSecretsCreate,
+		Params: (*json.RawMessage)(&params),
+	}
+
+	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
+	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, req).Return(vault.NewAuthResult("", "0xauthorized", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Once()
+
+	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
+
+	authResult, err := a.AuthorizeRequest(t.Context(), req)
+	require.Nil(t, authResult)
+	require.ErrorContains(t, err, "encrypted secret owner at index 0 \"0xother\" does not match authorized workflow owner \"0xauthorized\"")
+}
+
+func TestAuthorizer_AllowListPath_RejectsUpdateOwnerMismatch(t *testing.T) {
+	params, err := json.Marshal(vaultcommon.UpdateSecretsRequest{
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{Id: &vaultcommon.SecretIdentifier{Owner: "0xother", Namespace: "ns", Key: "k"}, EncryptedValue: "cipher"},
+		},
+	})
+	require.NoError(t, err)
+
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "1",
+		Method: vaulttypes.MethodSecretsUpdate,
+		Params: (*json.RawMessage)(&params),
+	}
+
+	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
+	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, req).Return(vault.NewAuthResult("", "0xauthorized", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Once()
+
+	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
+
+	authResult, err := a.AuthorizeRequest(t.Context(), req)
+	require.Nil(t, authResult)
+	require.ErrorContains(t, err, "encrypted secret owner at index 0 \"0xother\" does not match authorized workflow owner \"0xauthorized\"")
+}
+
+func TestAuthorizer_AllowListPath_RejectsDeleteOwnerMismatch(t *testing.T) {
+	params, err := json.Marshal(vaultcommon.DeleteSecretsRequest{
+		Ids: []*vaultcommon.SecretIdentifier{
+			{Owner: "0xother", Namespace: "ns", Key: "k"},
+		},
+	})
+	require.NoError(t, err)
+
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "1",
+		Method: vaulttypes.MethodSecretsDelete,
+		Params: (*json.RawMessage)(&params),
+	}
+
+	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
+	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, req).Return(vault.NewAuthResult("", "0xauthorized", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Once()
+
+	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
+
+	authResult, err := a.AuthorizeRequest(t.Context(), req)
+	require.Nil(t, authResult)
+	require.ErrorContains(t, err, "secret identifier owner at index 0 \"0xother\" does not match authorized workflow owner \"0xauthorized\"")
+}
+
+func TestAuthorizer_AllowListPath_RejectsListOwnerMismatch(t *testing.T) {
+	params, err := json.Marshal(vaultcommon.ListSecretIdentifiersRequest{
+		Owner:     "0xother",
+		Namespace: "ns",
+	})
+	require.NoError(t, err)
+
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "1",
+		Method: vaulttypes.MethodSecretsList,
+		Params: (*json.RawMessage)(&params),
+	}
+
+	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
+	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, req).Return(vault.NewAuthResult("", "0xauthorized", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Once()
+
+	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
+
+	authResult, err := a.AuthorizeRequest(t.Context(), req)
+	require.Nil(t, authResult)
+	require.ErrorContains(t, err, "list secrets owner \"0xother\" does not match authorized workflow owner \"0xauthorized\"")
+}
+
+func TestAuthorizer_SkipsOwnerBindingWhenParamsMissing(t *testing.T) {
+	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
+	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Return(vault.NewAuthResult("", "0xauthorized", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Once()
+
+	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
+
+	authResult, err := a.AuthorizeRequest(t.Context(), jsonrpc.Request[json.RawMessage]{
+		ID:     "1",
+		Method: vaulttypes.MethodSecretsCreate,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "0xauthorized", authResult.AuthorizedOwner())
 }

--- a/core/capabilities/vault/gw_handler.go
+++ b/core/capabilities/vault/gw_handler.go
@@ -239,9 +239,6 @@ func (h *GatewayHandler) authorizeAndPrefixRequest(ctx context.Context, req *jso
 		h.lggr.Errorw("gateway request authorization failed", "method", req.Method, "requestID", originalRequestID, "hasAuth", req.Auth != "", "incomingOwner", incomingOwner, "error", authErr)
 		return nil, authErr
 	}
-	if authReq.Params != nil {
-		req.Params = authReq.Params
-	}
 	authorizedOwner := authResult.AuthorizedOwner()
 
 	req.ID = authorizedOwner + vaulttypes.RequestIDSeparator + originalRequestID
@@ -295,7 +292,9 @@ func (h *GatewayHandler) handleSecretsCreate(ctx context.Context, gatewayID stri
 	}
 
 	vaultCapRequest.RequestId = req.ID
-	StampAuthorizedOwnerFromRequestID(vaultCapRequest.RequestId, &vaultCapRequest)
+	if err := StampAuthorizedOwnerFromRequestID(vaultCapRequest.RequestId, &vaultCapRequest); err != nil {
+		return h.errorResponse(ctx, gatewayID, req, api.FatalError, err)
+	}
 
 	h.lggr.Debugw("Processing authorized create secrets request", "request", vaultCapRequest.String())
 	vaultCapResponse, err := h.secretsService.CreateSecrets(ctx, &vaultCapRequest)
@@ -316,7 +315,9 @@ func (h *GatewayHandler) handleSecretsUpdate(ctx context.Context, gatewayID stri
 		return h.errorResponse(ctx, gatewayID, req, api.UserMessageParseError, err)
 	}
 	vaultCapRequest.RequestId = req.ID
-	StampAuthorizedOwnerFromRequestID(vaultCapRequest.RequestId, &vaultCapRequest)
+	if err := StampAuthorizedOwnerFromRequestID(vaultCapRequest.RequestId, &vaultCapRequest); err != nil {
+		return h.errorResponse(ctx, gatewayID, req, api.FatalError, err)
+	}
 
 	h.lggr.Debugw("Processing authorized update secrets request", "request", vaultCapRequest.String())
 	vaultCapResponse, err := h.secretsService.UpdateSecrets(ctx, &vaultCapRequest)
@@ -337,7 +338,9 @@ func (h *GatewayHandler) handleSecretsDelete(ctx context.Context, gatewayID stri
 		return h.errorResponse(ctx, gatewayID, req, api.UserMessageParseError, err)
 	}
 	r.RequestId = req.ID
-	StampAuthorizedOwnerFromRequestID(r.RequestId, r)
+	if err := StampAuthorizedOwnerFromRequestID(r.RequestId, r); err != nil {
+		return h.errorResponse(ctx, gatewayID, req, api.FatalError, err)
+	}
 
 	h.lggr.Debugw("Processing authorized delete secrets request", "request", r.String())
 	resp, err := h.secretsService.DeleteSecrets(ctx, r)
@@ -364,7 +367,9 @@ func (h *GatewayHandler) handleSecretsList(ctx context.Context, gatewayID string
 		return h.errorResponse(ctx, gatewayID, req, api.UserMessageParseError, err)
 	}
 	r.RequestId = req.ID
-	StampAuthorizedOwnerFromRequestID(r.RequestId, r)
+	if err := StampAuthorizedOwnerFromRequestID(r.RequestId, r); err != nil {
+		return h.errorResponse(ctx, gatewayID, req, api.FatalError, err)
+	}
 
 	h.lggr.Debugw("Processing authorized list secrets request", "request", r.String())
 	resp, err := h.secretsService.ListSecretIdentifiers(ctx, r)

--- a/core/capabilities/vault/gw_handler.go
+++ b/core/capabilities/vault/gw_handler.go
@@ -241,6 +241,11 @@ func (h *GatewayHandler) authorizeAndPrefixRequest(ctx context.Context, req *jso
 	}
 	authorizedOwner := authResult.AuthorizedOwner()
 
+	if ownerErr := ValidatePreparedVaultOwners(authReq, authorizedOwner); ownerErr != nil {
+		h.lggr.Errorw("gateway request owner binding failed", "method", req.Method, "requestID", originalRequestID, "authorizedOwner", authorizedOwner, "error", ownerErr)
+		return nil, fmt.Errorf("request not authorized: %w", ownerErr)
+	}
+
 	req.ID = authorizedOwner + vaulttypes.RequestIDSeparator + originalRequestID
 	h.lggr.Debugw("authorized gateway request", "method", req.Method, "requestID", req.ID, "owner", authorizedOwner, "orgID", authResult.OrgID(), "workflowOwner", authResult.WorkflowOwner())
 	return authResult, nil

--- a/core/capabilities/vault/gw_handler.go
+++ b/core/capabilities/vault/gw_handler.go
@@ -239,6 +239,9 @@ func (h *GatewayHandler) authorizeAndPrefixRequest(ctx context.Context, req *jso
 		h.lggr.Errorw("gateway request authorization failed", "method", req.Method, "requestID", originalRequestID, "hasAuth", req.Auth != "", "incomingOwner", incomingOwner, "error", authErr)
 		return nil, authErr
 	}
+	if authReq.Params != nil {
+		req.Params = authReq.Params
+	}
 	authorizedOwner := authResult.AuthorizedOwner()
 
 	req.ID = authorizedOwner + vaulttypes.RequestIDSeparator + originalRequestID
@@ -285,16 +288,6 @@ func stripPrefixedRequestIDFromParams(req *jsonrpc.Request[json.RawMessage], ori
 	}
 }
 
-func rewriteRequestParams(req *jsonrpc.Request[json.RawMessage], payload any) error {
-	params, err := json.Marshal(payload)
-	if err != nil {
-		return err
-	}
-	raw := json.RawMessage(params)
-	req.Params = &raw
-	return nil
-}
-
 func (h *GatewayHandler) handleSecretsCreate(ctx context.Context, gatewayID string, req *jsonrpc.Request[json.RawMessage], authResult *AuthResult) *jsonrpc.Response[json.RawMessage] {
 	vaultCapRequest := vaultcommon.CreateSecretsRequest{}
 	if err := json.Unmarshal(*req.Params, &vaultCapRequest); err != nil {
@@ -302,6 +295,7 @@ func (h *GatewayHandler) handleSecretsCreate(ctx context.Context, gatewayID stri
 	}
 
 	vaultCapRequest.RequestId = req.ID
+	StampAuthorizedOwnerFromRequestID(vaultCapRequest.RequestId, &vaultCapRequest)
 
 	h.lggr.Debugw("Processing authorized create secrets request", "request", vaultCapRequest.String())
 	vaultCapResponse, err := h.secretsService.CreateSecrets(ctx, &vaultCapRequest)
@@ -322,6 +316,7 @@ func (h *GatewayHandler) handleSecretsUpdate(ctx context.Context, gatewayID stri
 		return h.errorResponse(ctx, gatewayID, req, api.UserMessageParseError, err)
 	}
 	vaultCapRequest.RequestId = req.ID
+	StampAuthorizedOwnerFromRequestID(vaultCapRequest.RequestId, &vaultCapRequest)
 
 	h.lggr.Debugw("Processing authorized update secrets request", "request", vaultCapRequest.String())
 	vaultCapResponse, err := h.secretsService.UpdateSecrets(ctx, &vaultCapRequest)
@@ -342,6 +337,7 @@ func (h *GatewayHandler) handleSecretsDelete(ctx context.Context, gatewayID stri
 		return h.errorResponse(ctx, gatewayID, req, api.UserMessageParseError, err)
 	}
 	r.RequestId = req.ID
+	StampAuthorizedOwnerFromRequestID(r.RequestId, r)
 
 	h.lggr.Debugw("Processing authorized delete secrets request", "request", r.String())
 	resp, err := h.secretsService.DeleteSecrets(ctx, r)
@@ -368,7 +364,7 @@ func (h *GatewayHandler) handleSecretsList(ctx context.Context, gatewayID string
 		return h.errorResponse(ctx, gatewayID, req, api.UserMessageParseError, err)
 	}
 	r.RequestId = req.ID
-	r.Owner = authResult.AuthorizedOwner()
+	StampAuthorizedOwnerFromRequestID(r.RequestId, r)
 
 	h.lggr.Debugw("Processing authorized list secrets request", "request", r.String())
 	resp, err := h.secretsService.ListSecretIdentifiers(ctx, r)

--- a/core/capabilities/vault/gw_handler.go
+++ b/core/capabilities/vault/gw_handler.go
@@ -241,11 +241,6 @@ func (h *GatewayHandler) authorizeAndPrefixRequest(ctx context.Context, req *jso
 	}
 	authorizedOwner := authResult.AuthorizedOwner()
 
-	if ownerErr := ValidatePreparedVaultOwners(authReq, authorizedOwner); ownerErr != nil {
-		h.lggr.Errorw("gateway request owner binding failed", "method", req.Method, "requestID", originalRequestID, "authorizedOwner", authorizedOwner, "error", ownerErr)
-		return nil, fmt.Errorf("request not authorized: %w", ownerErr)
-	}
-
 	req.ID = authorizedOwner + vaulttypes.RequestIDSeparator + originalRequestID
 	h.lggr.Debugw("authorized gateway request", "method", req.Method, "requestID", req.ID, "owner", authorizedOwner, "orgID", authResult.OrgID(), "workflowOwner", authResult.WorkflowOwner())
 	return authResult, nil

--- a/core/capabilities/vault/gw_handler_test.go
+++ b/core/capabilities/vault/gw_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,7 +90,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 				ss.EXPECT().CreateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.CreateSecretsRequest) bool {
 					return len(req.EncryptedSecrets) == 1 &&
 						req.EncryptedSecrets[0].Id.Key == "test-secret" &&
-						req.EncryptedSecrets[0].Id.Owner == "org-1" &&
+						req.EncryptedSecrets[0].Id.Owner == "0xworkflow" &&
 						req.RequestId == "0xworkflow"+vaulttypes.RequestIDSeparator+"1"
 				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
 
@@ -106,7 +107,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 							{
 								Id: &vaultcommon.SecretIdentifier{
 									Key:   "test-secret",
-									Owner: "org-1",
+									Owner: "0xworkflow",
 								},
 								EncryptedValue: "encrypted-value",
 							},
@@ -130,7 +131,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 				ss.EXPECT().CreateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.CreateSecretsRequest) bool {
 					return len(req.EncryptedSecrets) == 1 &&
 						req.EncryptedSecrets[0].Id.Key == "test-secret" &&
-						req.EncryptedSecrets[0].Id.Owner == "org-1" &&
+						req.EncryptedSecrets[0].Id.Owner == "0xworkflow" &&
 						req.RequestId == "0xworkflow"+vaulttypes.RequestIDSeparator+"1"
 				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
 
@@ -144,7 +145,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 				Params: func() *json.RawMessage {
 					rid := "org-1" + vaulttypes.RequestIDSeparator + "1"
 					raw := json.RawMessage(fmt.Sprintf(
-						`{"request_id":%q,"encrypted_secrets":[{"id":{"key":"test-secret","owner":"org-1"},"encrypted_value":"encrypted-value"}]}`,
+						`{"request_id":%q,"encrypted_secrets":[{"id":{"key":"test-secret","owner":"0xworkflow"},"encrypted_value":"encrypted-value"}]}`,
 						rid,
 					))
 					return &raw
@@ -264,7 +265,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 				ss.EXPECT().UpdateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.UpdateSecretsRequest) bool {
 					return len(req.EncryptedSecrets) == 1 &&
 						req.EncryptedSecrets[0].Id.Key == "updated-secret" &&
-						req.EncryptedSecrets[0].Id.Owner == "org-1" &&
+						req.EncryptedSecrets[0].Id.Owner == "0xworkflow" &&
 						req.RequestId == "0xworkflow"+vaulttypes.RequestIDSeparator+"1"
 				})).Return(&vaulttypes.Response{ID: "updated-secret"}, nil)
 
@@ -281,7 +282,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 							{
 								Id: &vaultcommon.SecretIdentifier{
 									Key:   "updated-secret",
-									Owner: "org-1",
+									Owner: "0xworkflow",
 								},
 								EncryptedValue: "encrypted-value",
 							},
@@ -303,7 +304,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 					return len(req.Ids) == 1 &&
 						req.Ids[0].Key == "Foo" &&
 						req.Ids[0].Namespace == "Bar" &&
-						req.Ids[0].Owner == "org-1" &&
+						req.Ids[0].Owner == "0xworkflow" &&
 						req.RequestId == "0xworkflow"+vaulttypes.RequestIDSeparator+"1"
 				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
 
@@ -320,7 +321,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 							{
 								Key:       "Foo",
 								Namespace: "Bar",
-								Owner:     "org-1",
+								Owner:     "0xworkflow",
 							},
 						},
 					})
@@ -351,7 +352,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 				ID:     "1",
 				Params: func() *json.RawMessage {
 					params, _ := json.Marshal(vaultcommon.ListSecretIdentifiersRequest{
-						Owner:     "user-supplied-owner",
+						Owner:     "0xworkflow",
 						Namespace: "ns",
 					})
 					raw := json.RawMessage(params)
@@ -440,19 +441,13 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "failure - capability rejects owner mismatch",
+			name: "failure - auth layer rejects cross-owner mutation",
 			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
 				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Return(authResult("", "0xdef"), nil)
-				ss.EXPECT().CreateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.CreateSecretsRequest) bool {
-					return len(req.EncryptedSecrets) == 1 &&
-						req.EncryptedSecrets[0].Id.Key == "test-secret" &&
-						req.EncryptedSecrets[0].Id.Owner == "0xabc" &&
-						req.RequestId == "0xdef"+vaulttypes.RequestIDSeparator+"1"
-				})).Return(nil, errors.New("capability owner validation failed"))
 				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
 					return resp.Error != nil &&
-						resp.Error.Code == api.ToJSONRPCErrorCode(api.FatalError) &&
-						resp.Error.Message == "capability owner validation failed"
+						resp.Error.Code == api.ToJSONRPCErrorCode(api.HandlerError) &&
+						strings.Contains(resp.Error.Message, "request not authorized")
 				})).Return(nil)
 			},
 			request: &jsonrpc.Request[json.RawMessage]{

--- a/core/capabilities/vault/gw_handler_test.go
+++ b/core/capabilities/vault/gw_handler_test.go
@@ -571,6 +571,73 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 	}
 }
 
+func TestGatewayHandler_NormalizesPrefixedRequestParamsBeforeAuthorization(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	ctx := t.Context()
+	authResult := vaultcap.NewAuthResult("", "0xabc", "digest-0xabc", time.Now().Add(time.Minute).Unix())
+
+	secretsService := vaulttypesmocks.NewSecretsService(t)
+	gwConnector := connector_mocks.NewGatewayConnector(t)
+	allowListBasedAuth := vaultcapmocks.NewAuthorizer(t)
+
+	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, mock.MatchedBy(func(req jsonrpc.Request[json.RawMessage]) bool {
+		if req.Method != vaulttypes.MethodSecretsCreate || req.ID != "1" || req.Params == nil {
+			return false
+		}
+		var parsed vaultcommon.CreateSecretsRequest
+		if err := json.Unmarshal(*req.Params, &parsed); err != nil {
+			return false
+		}
+		return parsed.RequestId == "1" &&
+			len(parsed.EncryptedSecrets) == 1 &&
+			parsed.EncryptedSecrets[0].Id != nil &&
+			parsed.EncryptedSecrets[0].Id.Owner == "0xAbC"
+	})).Return(authResult, nil).Once()
+
+	secretsService.EXPECT().CreateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.CreateSecretsRequest) bool {
+		return req.RequestId == "0xabc"+vaulttypes.RequestIDSeparator+"1" &&
+			req.EncryptedSecrets[0].Id.Owner == "0xabc"
+	})).Return(&vaulttypes.Response{ID: "test-secret"}, nil).Once()
+
+	gwConnector.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
+		return resp.Error == nil
+	})).Return(nil).Once()
+
+	handler, err := vaultcap.NewGatewayHandler(
+		secretsService,
+		gwConnector,
+		nil,
+		lggr,
+		limits.Factory{Settings: cresettings.DefaultGetter},
+		vaultcap.NewAuthorizer(allowListBasedAuth, nil, lggr),
+		nil,
+	)
+	require.NoError(t, err)
+
+	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{
+		RequestId: "0xDef" + vaulttypes.RequestIDSeparator + "1",
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{
+				Id: &vaultcommon.SecretIdentifier{
+					Key:   "test-secret",
+					Owner: "0xAbC",
+				},
+				EncryptedValue: "encrypted-value",
+			},
+		},
+	})
+	require.NoError(t, err)
+	raw := json.RawMessage(params)
+
+	req := &jsonrpc.Request[json.RawMessage]{
+		Method: vaulttypes.MethodSecretsCreate,
+		ID:     "0xDef" + vaulttypes.RequestIDSeparator + "1",
+		Params: &raw,
+	}
+
+	require.NoError(t, handler.HandleGatewayMessage(ctx, "gateway-1", req))
+}
+
 func TestGatewayHandler_Lifecycle(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	ctx := t.Context()

--- a/core/capabilities/vault/gw_handler_test.go
+++ b/core/capabilities/vault/gw_handler_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -51,7 +50,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 				ss.EXPECT().CreateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.CreateSecretsRequest) bool {
 					return len(req.EncryptedSecrets) == 1 &&
 						req.EncryptedSecrets[0].Id.Key == "test-secret" &&
-						req.EncryptedSecrets[0].Id.Owner == "0xAbC" &&
+						req.EncryptedSecrets[0].Id.Owner == "0xabc" &&
 						req.RequestId == "0xabc"+vaulttypes.RequestIDSeparator+"1"
 				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
 
@@ -228,7 +227,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 					return len(req.Ids) == 1 &&
 						req.Ids[0].Key == "Foo" &&
 						req.Ids[0].Namespace == "Bar" &&
-						req.Ids[0].Owner == "0xAbC" &&
+						req.Ids[0].Owner == "0xabc" &&
 						req.RequestId == "0xabc"+vaulttypes.RequestIDSeparator+"1"
 				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
 
@@ -362,6 +361,68 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name: "success - stamps cross-owner update to authorized owner",
+			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
+				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Return(authResult("", "0xdef"), nil)
+				ss.EXPECT().UpdateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.UpdateSecretsRequest) bool {
+					return len(req.EncryptedSecrets) == 1 &&
+						req.EncryptedSecrets[0].Id != nil &&
+						req.EncryptedSecrets[0].Id.Owner == "0xdef" &&
+						req.RequestId == "0xdef"+vaulttypes.RequestIDSeparator+"1"
+				})).Return(&vaulttypes.Response{ID: "updated-secret"}, nil)
+				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
+					return resp.Error == nil
+				})).Return(nil)
+			},
+			request: &jsonrpc.Request[json.RawMessage]{
+				Method: vaulttypes.MethodSecretsUpdate,
+				ID:     "1",
+				Params: func() *json.RawMessage {
+					params, _ := json.Marshal(vaultcommon.UpdateSecretsRequest{
+						EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+							{
+								Id: &vaultcommon.SecretIdentifier{
+									Key:   "updated-secret",
+									Owner: "0xabc",
+								},
+								EncryptedValue: "encrypted-value",
+							},
+						},
+					})
+					raw := json.RawMessage(params)
+					return &raw
+				}(),
+			},
+			expectedError: false,
+		},
+		{
+			name: "success - stamps cross-owner list to authorized owner",
+			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
+				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Return(authResult("", "0xdef"), nil)
+				ss.EXPECT().ListSecretIdentifiers(mock.Anything, mock.MatchedBy(func(req *vaultcommon.ListSecretIdentifiersRequest) bool {
+					return req.Owner == "0xdef" &&
+						req.Namespace == "ns" &&
+						req.RequestId == "0xdef"+vaulttypes.RequestIDSeparator+"1"
+				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
+				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
+					return resp.Error == nil
+				})).Return(nil)
+			},
+			request: &jsonrpc.Request[json.RawMessage]{
+				Method: vaulttypes.MethodSecretsList,
+				ID:     "1",
+				Params: func() *json.RawMessage {
+					params, _ := json.Marshal(vaultcommon.ListSecretIdentifiersRequest{
+						Owner:     "0xabc",
+						Namespace: "ns",
+					})
+					raw := json.RawMessage(params)
+					return &raw
+				}(),
+			},
+			expectedError: false,
+		},
+		{
 			name: "failure - unauthorized request",
 			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
 				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Return(nil, errors.New("not allowlisted"))
@@ -411,7 +472,10 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 						parsed.EncryptedSecrets[0].Id.Owner == "0xAbC"
 				})).Return(authResult("", "0xabc"), nil)
 				ss.EXPECT().CreateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.CreateSecretsRequest) bool {
-					return req.RequestId == "0xabc"+vaulttypes.RequestIDSeparator+"1"
+					return req.RequestId == "0xabc"+vaulttypes.RequestIDSeparator+"1" &&
+						len(req.EncryptedSecrets) == 1 &&
+						req.EncryptedSecrets[0].Id != nil &&
+						req.EncryptedSecrets[0].Id.Owner == "0xabc"
 				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
 
 				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
@@ -441,13 +505,17 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "failure - auth layer rejects cross-owner mutation",
+			name: "success - stamps cross-owner mutation to authorized owner",
 			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
 				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Return(authResult("", "0xdef"), nil)
+				ss.EXPECT().CreateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.CreateSecretsRequest) bool {
+					return len(req.EncryptedSecrets) == 1 &&
+						req.EncryptedSecrets[0].Id != nil &&
+						req.EncryptedSecrets[0].Id.Owner == "0xdef" &&
+						req.RequestId == "0xdef"+vaulttypes.RequestIDSeparator+"1"
+				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
 				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
-					return resp.Error != nil &&
-						resp.Error.Code == api.ToJSONRPCErrorCode(api.HandlerError) &&
-						strings.Contains(resp.Error.Message, "request not authorized")
+					return resp.Error == nil
 				})).Return(nil)
 			},
 			request: &jsonrpc.Request[json.RawMessage]{

--- a/core/capabilities/vault/jwt_based_auth.go
+++ b/core/capabilities/vault/jwt_based_auth.go
@@ -265,7 +265,7 @@ func (v *jwtBasedAuth) AuthorizeRequest(ctx context.Context, req jsonrpc.Request
 		return nil, fmt.Errorf("invalid JWT auth token: %w", err)
 	}
 
-	if ownerErr := validateJWTPreparedVaultOwners(req, derivedWorkflowOwner); ownerErr != nil {
+	if ownerErr := ValidatePreparedVaultOwners(req, derivedWorkflowOwner); ownerErr != nil {
 		v.lggr.Debugw("JWTBasedAuth secret owners rejected prepared request", "method", req.Method, "requestID", req.ID, "orgID", claims.OrgID, "workflowOwner", derivedWorkflowOwner, "error", ownerErr)
 		return nil, fmt.Errorf("invalid JWT auth token: %w", ownerErr)
 	}
@@ -442,7 +442,10 @@ func extractAuthorizationDetails(claims jwt.MapClaims) (workflowOwner, requestDi
 	return workflowOwner, requestDigest, nil
 }
 
-func validateJWTPreparedVaultOwners(req jsonrpc.Request[json.RawMessage], workflowOwner string) error {
+// ValidatePreparedVaultOwners checks that every secret identifier in the request
+// payload belongs to workflowOwner. It is used by both the JWT and allowlist auth
+// paths so that neither can be exploited to mutate another owner's secrets.
+func ValidatePreparedVaultOwners(req jsonrpc.Request[json.RawMessage], workflowOwner string) error {
 	switch req.Method {
 	case vaulttypes.MethodSecretsCreate:
 		parsed := &vaultcommon.CreateSecretsRequest{}

--- a/core/capabilities/vault/jwt_based_auth.go
+++ b/core/capabilities/vault/jwt_based_auth.go
@@ -18,13 +18,11 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 
-	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 )
 
 var (
@@ -265,11 +263,6 @@ func (v *jwtBasedAuth) AuthorizeRequest(ctx context.Context, req jsonrpc.Request
 		return nil, fmt.Errorf("invalid JWT auth token: %w", err)
 	}
 
-	if ownerErr := ValidatePreparedVaultOwners(req, derivedWorkflowOwner); ownerErr != nil {
-		v.lggr.Debugw("JWTBasedAuth secret owners rejected prepared request", "method", req.Method, "requestID", req.ID, "orgID", claims.OrgID, "workflowOwner", derivedWorkflowOwner, "error", ownerErr)
-		return nil, fmt.Errorf("invalid JWT auth token: %w", ownerErr)
-	}
-
 	v.lggr.Debugw("JWTBasedAuth authorization succeeded", "method", req.Method, "requestID", req.ID, "orgID", claims.OrgID, "workflowOwner", derivedWorkflowOwner, "digest", requestDigest, "expiresAt", claims.ExpiresAt.UTC().Unix())
 	return &AuthResult{
 		orgID:         claims.OrgID,
@@ -440,73 +433,6 @@ func extractAuthorizationDetails(claims jwt.MapClaims) (workflowOwner, requestDi
 	}
 
 	return workflowOwner, requestDigest, nil
-}
-
-// ValidatePreparedVaultOwners checks that every secret identifier in the request
-// payload belongs to workflowOwner. It is used by both the JWT and allowlist auth
-// paths so that neither can be exploited to mutate another owner's secrets.
-func ValidatePreparedVaultOwners(req jsonrpc.Request[json.RawMessage], workflowOwner string) error {
-	switch req.Method {
-	case vaulttypes.MethodSecretsCreate:
-		parsed := &vaultcommon.CreateSecretsRequest{}
-		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse create secrets request: %w", err)
-		}
-		return validateEncryptedSecretOwnersMatchWorkflowOwner(parsed.EncryptedSecrets, workflowOwner)
-	case vaulttypes.MethodSecretsUpdate:
-		parsed := &vaultcommon.UpdateSecretsRequest{}
-		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse update secrets request: %w", err)
-		}
-		return validateEncryptedSecretOwnersMatchWorkflowOwner(parsed.EncryptedSecrets, workflowOwner)
-	case vaulttypes.MethodSecretsDelete:
-		parsed := &vaultcommon.DeleteSecretsRequest{}
-		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse delete secrets request: %w", err)
-		}
-		return validateSecretIdentifierOwnersMatchWorkflowOwner(parsed.Ids, workflowOwner)
-	case vaulttypes.MethodSecretsList:
-		parsed := &vaultcommon.ListSecretIdentifiersRequest{}
-		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse list secrets request: %w", err)
-		}
-		if normalizeOwner(parsed.Owner) != normalizeOwner(workflowOwner) {
-			return fmt.Errorf("list secrets owner %q does not match authorized workflow owner %q", parsed.Owner, workflowOwner)
-		}
-		return nil
-	default:
-		return fmt.Errorf("method %q does not carry vault secret identifiers", req.Method)
-	}
-}
-
-func validateEncryptedSecretOwnersMatchWorkflowOwner(encryptedSecrets []*vaultcommon.EncryptedSecret, workflowOwner string) error {
-	if len(encryptedSecrets) == 0 {
-		return errors.New("encrypted secrets must contain at least one identifier")
-	}
-	for idx, encryptedSecret := range encryptedSecrets {
-		if encryptedSecret == nil || encryptedSecret.Id == nil {
-			return fmt.Errorf("encrypted secret at index %d must include an identifier", idx)
-		}
-		if normalizeOwner(encryptedSecret.Id.Owner) != normalizeOwner(workflowOwner) {
-			return fmt.Errorf("encrypted secret owner at index %d %q does not match authorized workflow owner %q", idx, encryptedSecret.Id.Owner, workflowOwner)
-		}
-	}
-	return nil
-}
-
-func validateSecretIdentifierOwnersMatchWorkflowOwner(ids []*vaultcommon.SecretIdentifier, workflowOwner string) error {
-	if len(ids) == 0 {
-		return errors.New("secret identifiers must not be empty")
-	}
-	for idx, id := range ids {
-		if id == nil {
-			return fmt.Errorf("secret identifier at index %d must not be nil", idx)
-		}
-		if normalizeOwner(id.Owner) != normalizeOwner(workflowOwner) {
-			return fmt.Errorf("secret identifier owner at index %d %q does not match authorized workflow owner %q", idx, id.Owner, workflowOwner)
-		}
-	}
-	return nil
 }
 
 // resolveSigningKey looks up the RSA public key for the given kid from the

--- a/core/capabilities/vault/jwt_based_auth_test.go
+++ b/core/capabilities/vault/jwt_based_auth_test.go
@@ -915,7 +915,9 @@ func TestJWTBasedAuth_RejectsCreateRequestWithoutWorkflowOwnerWhenIdentifierOwne
 	req, err = jsonrpc.DecodeRequest[json.RawMessage](rawRequest, token)
 	require.NoError(t, err)
 
-	authResult, err := v.AuthorizeRequest(t.Context(), req)
+	// Owner binding is enforced by the composite Authorizer, not the JWT layer directly.
+	a := NewAuthorizer(nil, v, logger.TestLogger(t))
+	authResult, err := a.AuthorizeRequest(t.Context(), req)
 	require.Nil(t, authResult)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "encrypted secret owner at index 0 \"0xAbCd\" does not match authorized workflow owner")

--- a/core/capabilities/vault/jwt_based_auth_test.go
+++ b/core/capabilities/vault/jwt_based_auth_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
@@ -880,7 +881,7 @@ func TestJWTBasedAuth_AuthorizeCreateRequestWithoutWorkflowOwnerWhenIdentifiersU
 	require.Equal(t, digest, authResult.Digest())
 }
 
-func TestJWTBasedAuth_RejectsCreateRequestWithoutWorkflowOwnerWhenIdentifierOwnerDiffers(t *testing.T) {
+func TestJWTBasedAuth_AuthorizesCreateRequestWhenIdentifierOwnerDiffers(t *testing.T) {
 	rsaKey := generateTestRSAKey(t, "key-1")
 	jwksServer := newTestJWKSServer(t, rsaKey)
 
@@ -915,12 +916,15 @@ func TestJWTBasedAuth_RejectsCreateRequestWithoutWorkflowOwnerWhenIdentifierOwne
 	req, err = jsonrpc.DecodeRequest[json.RawMessage](rawRequest, token)
 	require.NoError(t, err)
 
-	// Owner binding is enforced by the composite Authorizer, not the JWT layer directly.
+	// Owner stamping is enforced by gateway handlers and capability entrypoints, not the authorizer.
 	a := NewAuthorizer(nil, v, logger.TestLogger(t))
 	authResult, err := a.AuthorizeRequest(t.Context(), req)
-	require.Nil(t, authResult)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "encrypted secret owner at index 0 \"0xAbCd\" does not match authorized workflow owner")
+	require.NoError(t, err)
+	require.NotEmpty(t, authResult.AuthorizedOwner())
+
+	parsed := &vaultcommon.CreateSecretsRequest{}
+	require.NoError(t, json.Unmarshal(*req.Params, parsed))
+	require.Equal(t, "0xAbCd", parsed.EncryptedSecrets[0].Id.Owner)
 }
 
 func TestJWTBasedAuth_AuthorizeRequest_RejectsMissingTenantClaim(t *testing.T) {

--- a/core/capabilities/vault/ownership.go
+++ b/core/capabilities/vault/ownership.go
@@ -1,0 +1,94 @@
+package vault
+
+import (
+	"encoding/json"
+	"strings"
+
+	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
+	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
+
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
+)
+
+// StampAuthorizedOwnerOnCreate overwrites secret identifier owners in a create request.
+func StampAuthorizedOwnerOnCreate(request *vaultcommon.CreateSecretsRequest, authorizedOwner string) {
+	if request == nil || authorizedOwner == "" {
+		return
+	}
+	for _, encryptedSecret := range request.EncryptedSecrets {
+		if encryptedSecret != nil && encryptedSecret.Id != nil {
+			encryptedSecret.Id.Owner = authorizedOwner
+		}
+	}
+}
+
+// StampAuthorizedOwnerOnUpdate overwrites secret identifier owners in an update request.
+func StampAuthorizedOwnerOnUpdate(request *vaultcommon.UpdateSecretsRequest, authorizedOwner string) {
+	if request == nil || authorizedOwner == "" {
+		return
+	}
+	for _, encryptedSecret := range request.EncryptedSecrets {
+		if encryptedSecret != nil && encryptedSecret.Id != nil {
+			encryptedSecret.Id.Owner = authorizedOwner
+		}
+	}
+}
+
+// StampAuthorizedOwnerOnDelete overwrites secret identifier owners in a delete request.
+func StampAuthorizedOwnerOnDelete(request *vaultcommon.DeleteSecretsRequest, authorizedOwner string) {
+	if request == nil || authorizedOwner == "" {
+		return
+	}
+	for _, id := range request.Ids {
+		if id != nil {
+			id.Owner = authorizedOwner
+		}
+	}
+}
+
+// StampAuthorizedOwnerOnList overwrites the list request owner field.
+func StampAuthorizedOwnerOnList(request *vaultcommon.ListSecretIdentifiersRequest, authorizedOwner string) {
+	if request == nil || authorizedOwner == "" {
+		return
+	}
+	request.Owner = authorizedOwner
+}
+
+// StampAuthorizedOwnerFromRequestID stamps owner fields using the owner prefix in a
+// gateway-prefixed request ID (owner::userRequestID). No-op when the ID has no prefix.
+func StampAuthorizedOwnerFromRequestID(requestID string, request any) {
+	authorizedOwner := AuthorizedOwnerFromRequestID(requestID)
+	if authorizedOwner == "" {
+		return
+	}
+	switch r := request.(type) {
+	case *vaultcommon.CreateSecretsRequest:
+		StampAuthorizedOwnerOnCreate(r, authorizedOwner)
+	case *vaultcommon.UpdateSecretsRequest:
+		StampAuthorizedOwnerOnUpdate(r, authorizedOwner)
+	case *vaultcommon.DeleteSecretsRequest:
+		StampAuthorizedOwnerOnDelete(r, authorizedOwner)
+	case *vaultcommon.ListSecretIdentifiersRequest:
+		StampAuthorizedOwnerOnList(r, authorizedOwner)
+	}
+}
+
+// AuthorizedOwnerFromRequestID returns the owner prefix from a gateway request ID of the
+// form owner::userRequestID.
+func AuthorizedOwnerFromRequestID(prefixedID string) string {
+	idx := strings.Index(prefixedID, vaulttypes.RequestIDSeparator)
+	if idx == -1 {
+		return ""
+	}
+	return prefixedID[:idx]
+}
+
+func rewriteRequestParams(req *jsonrpc.Request[json.RawMessage], payload any) error {
+	params, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	raw := json.RawMessage(params)
+	req.Params = &raw
+	return nil
+}

--- a/core/capabilities/vault/ownership.go
+++ b/core/capabilities/vault/ownership.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
@@ -56,10 +57,10 @@ func StampAuthorizedOwnerOnList(request *vaultcommon.ListSecretIdentifiersReques
 
 // StampAuthorizedOwnerFromRequestID stamps owner fields using the owner prefix in a
 // gateway-prefixed request ID (owner::userRequestID). No-op when the ID has no prefix.
-func StampAuthorizedOwnerFromRequestID(requestID string, request any) {
+func StampAuthorizedOwnerFromRequestID(requestID string, request any) error {
 	authorizedOwner := AuthorizedOwnerFromRequestID(requestID)
 	if authorizedOwner == "" {
-		return
+		return nil
 	}
 	switch r := request.(type) {
 	case *vaultcommon.CreateSecretsRequest:
@@ -70,7 +71,10 @@ func StampAuthorizedOwnerFromRequestID(requestID string, request any) {
 		StampAuthorizedOwnerOnDelete(r, authorizedOwner)
 	case *vaultcommon.ListSecretIdentifiersRequest:
 		StampAuthorizedOwnerOnList(r, authorizedOwner)
+	default:
+		return fmt.Errorf("unsupported request type %T for owner stamping", request)
 	}
+	return nil
 }
 
 // AuthorizedOwnerFromRequestID returns the owner prefix from a gateway request ID of the

--- a/core/capabilities/vault/ownership_test.go
+++ b/core/capabilities/vault/ownership_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
+	pkgconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	vault "github.com/smartcontractkit/chainlink/v2/core/capabilities/vault"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 )
@@ -23,6 +25,30 @@ func TestStampAuthorizedOwnerOnCreate(t *testing.T) {
 	}
 	vault.StampAuthorizedOwnerOnCreate(req, "0xauthorized")
 	require.Equal(t, "0xauthorized", req.EncryptedSecrets[0].Id.Owner)
+}
+
+func TestStampAuthorizedOwnerOnCreate_SkipsNilId(t *testing.T) {
+	req := &vaultcommon.CreateSecretsRequest{
+		RequestId: "req-1",
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{EncryptedValue: "cipher"},
+		},
+	}
+	vault.StampAuthorizedOwnerOnCreate(req, "0xauthorized")
+	require.Nil(t, req.EncryptedSecrets[0].Id)
+
+	validator := newTestRequestValidator()
+	err := validator.ValidateCreateSecretsRequest(t.Context(), nil, req, true)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "secret ID must not be nil")
+}
+
+func TestStampAuthorizedOwnerOnCreate_EmptyEncryptedSecrets(t *testing.T) {
+	req := &vaultcommon.CreateSecretsRequest{
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{},
+	}
+	vault.StampAuthorizedOwnerOnCreate(req, "0xauthorized")
+	require.Empty(t, req.EncryptedSecrets)
 }
 
 func TestStampAuthorizedOwnerOnUpdate(t *testing.T) {
@@ -57,7 +83,7 @@ func TestStampAuthorizedOwnerFromRequestID_Create(t *testing.T) {
 			{Id: &vaultcommon.SecretIdentifier{Owner: "0xforeign", Key: "k"}, EncryptedValue: "cipher"},
 		},
 	}
-	vault.StampAuthorizedOwnerFromRequestID(req.RequestId, req)
+	require.NoError(t, vault.StampAuthorizedOwnerFromRequestID(req.RequestId, req))
 	require.Equal(t, authorized, req.EncryptedSecrets[0].Id.Owner)
 }
 
@@ -68,6 +94,37 @@ func TestStampAuthorizedOwnerFromRequestID_NoPrefixNoOp(t *testing.T) {
 			{Id: &vaultcommon.SecretIdentifier{Owner: "0xother", Key: "k"}, EncryptedValue: "cipher"},
 		},
 	}
-	vault.StampAuthorizedOwnerFromRequestID(req.RequestId, req)
+	require.NoError(t, vault.StampAuthorizedOwnerFromRequestID(req.RequestId, req))
 	require.Equal(t, "0xother", req.EncryptedSecrets[0].Id.Owner)
+}
+
+func TestStampAuthorizedOwnerFromRequestID_UnknownType(t *testing.T) {
+	requestID := "0xauthorized" + vaulttypes.RequestIDSeparator + "req-1"
+	err := vault.StampAuthorizedOwnerFromRequestID(requestID, struct{}{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unsupported request type")
+}
+
+func TestStampAuthorizedOwnerFromRequestID_EmptyEncryptedSecretsRejectedByValidator(t *testing.T) {
+	authorized := "0xauthorized"
+	req := &vaultcommon.CreateSecretsRequest{
+		RequestId:        authorized + vaulttypes.RequestIDSeparator + "req-1",
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{},
+	}
+	require.NoError(t, vault.StampAuthorizedOwnerFromRequestID(req.RequestId, req))
+
+	validator := newTestRequestValidator()
+	err := validator.ValidateCreateSecretsRequest(t.Context(), nil, req, true)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "request batch must contain at least 1 item")
+}
+
+func newTestRequestValidator() *vault.RequestValidator {
+	return vault.NewRequestValidator(
+		limits.NewUpperBoundLimiter(10),
+		limits.NewUpperBoundLimiter[pkgconfig.Size](1024*pkgconfig.Byte),
+		limits.NewUpperBoundLimiter[pkgconfig.Size](64*pkgconfig.Byte),
+		limits.NewUpperBoundLimiter[pkgconfig.Size](64*pkgconfig.Byte),
+		limits.NewUpperBoundLimiter[pkgconfig.Size](64*pkgconfig.Byte),
+	)
 }

--- a/core/capabilities/vault/ownership_test.go
+++ b/core/capabilities/vault/ownership_test.go
@@ -1,0 +1,73 @@
+package vault_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
+	vault "github.com/smartcontractkit/chainlink/v2/core/capabilities/vault"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
+)
+
+func TestAuthorizedOwnerFromRequestID(t *testing.T) {
+	require.Equal(t, "0xabc", vault.AuthorizedOwnerFromRequestID("0xabc"+vaulttypes.RequestIDSeparator+"req-1"))
+	require.Empty(t, vault.AuthorizedOwnerFromRequestID("req-1"))
+}
+
+func TestStampAuthorizedOwnerOnCreate(t *testing.T) {
+	req := &vaultcommon.CreateSecretsRequest{
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{Id: &vaultcommon.SecretIdentifier{Owner: "0xother", Key: "k"}, EncryptedValue: "cipher"},
+		},
+	}
+	vault.StampAuthorizedOwnerOnCreate(req, "0xauthorized")
+	require.Equal(t, "0xauthorized", req.EncryptedSecrets[0].Id.Owner)
+}
+
+func TestStampAuthorizedOwnerOnUpdate(t *testing.T) {
+	req := &vaultcommon.UpdateSecretsRequest{
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{Id: &vaultcommon.SecretIdentifier{Owner: "0xother", Key: "k"}, EncryptedValue: "cipher"},
+		},
+	}
+	vault.StampAuthorizedOwnerOnUpdate(req, "0xauthorized")
+	require.Equal(t, "0xauthorized", req.EncryptedSecrets[0].Id.Owner)
+}
+
+func TestStampAuthorizedOwnerOnDelete(t *testing.T) {
+	req := &vaultcommon.DeleteSecretsRequest{
+		Ids: []*vaultcommon.SecretIdentifier{{Owner: "0xother", Key: "k"}},
+	}
+	vault.StampAuthorizedOwnerOnDelete(req, "0xauthorized")
+	require.Equal(t, "0xauthorized", req.Ids[0].Owner)
+}
+
+func TestStampAuthorizedOwnerOnList(t *testing.T) {
+	req := &vaultcommon.ListSecretIdentifiersRequest{Owner: "0xother", Namespace: "ns"}
+	vault.StampAuthorizedOwnerOnList(req, "0xauthorized")
+	require.Equal(t, "0xauthorized", req.Owner)
+}
+
+func TestStampAuthorizedOwnerFromRequestID_Create(t *testing.T) {
+	authorized := "0xauthorized"
+	req := &vaultcommon.CreateSecretsRequest{
+		RequestId: authorized + vaulttypes.RequestIDSeparator + "req-1",
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{Id: &vaultcommon.SecretIdentifier{Owner: "0xforeign", Key: "k"}, EncryptedValue: "cipher"},
+		},
+	}
+	vault.StampAuthorizedOwnerFromRequestID(req.RequestId, req)
+	require.Equal(t, authorized, req.EncryptedSecrets[0].Id.Owner)
+}
+
+func TestStampAuthorizedOwnerFromRequestID_NoPrefixNoOp(t *testing.T) {
+	req := &vaultcommon.CreateSecretsRequest{
+		RequestId: "req-1",
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{Id: &vaultcommon.SecretIdentifier{Owner: "0xother", Key: "k"}, EncryptedValue: "cipher"},
+		},
+	}
+	vault.StampAuthorizedOwnerFromRequestID(req.RequestId, req)
+	require.Equal(t, "0xother", req.EncryptedSecrets[0].Id.Owner)
+}

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -604,10 +604,6 @@ func (h *handler) handleSecretsCreate(ctx context.Context, ar *activeRequest) er
 	if unmarshalErr := json.Unmarshal(*ar.req.Params, &createSecretsRequest); unmarshalErr != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, unmarshalErr, nil))
 	}
-	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
-		l.Errorw("owner binding failed", "error", ownerErr)
-		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
-	}
 	createSecretsRequest.RequestId = ar.req.ID
 	for _, secretItem := range createSecretsRequest.EncryptedSecrets {
 		if secretItem != nil && secretItem.Id != nil && secretItem.Id.Namespace == "" {
@@ -649,10 +645,6 @@ func (h *handler) handleSecretsUpdate(ctx context.Context, ar *activeRequest) er
 	if unmarshalErr := json.Unmarshal(*ar.req.Params, updateSecretsRequest); unmarshalErr != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, unmarshalErr, nil))
 	}
-	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
-		l.Errorw("owner binding failed", "error", ownerErr)
-		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
-	}
 	updateSecretsRequest.RequestId = ar.req.ID
 	for _, secretItem := range updateSecretsRequest.EncryptedSecrets {
 		if secretItem != nil && secretItem.Id != nil && secretItem.Id.Namespace == "" {
@@ -693,10 +685,6 @@ func (h *handler) handleSecretsDelete(ctx context.Context, ar *activeRequest) er
 	if unmarshalErr := json.Unmarshal(*ar.req.Params, deleteSecretsRequest); unmarshalErr != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, unmarshalErr, nil))
 	}
-	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
-		l.Errorw("owner binding failed", "error", ownerErr)
-		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
-	}
 	deleteSecretsRequest.RequestId = ar.req.ID
 	for _, id := range deleteSecretsRequest.Ids {
 		if id != nil && id.Namespace == "" {
@@ -725,10 +713,6 @@ func (h *handler) handleSecretsList(ctx context.Context, ar *activeRequest) erro
 	req := &vaultcommon.ListSecretIdentifiersRequest{}
 	if err := json.Unmarshal(*ar.req.Params, req); err != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, err, nil))
-	}
-	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
-		l.Errorw("owner binding failed", "error", ownerErr)
-		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
 	}
 	req.RequestId = ar.req.ID
 	if req.Namespace == "" {
@@ -871,16 +855,6 @@ func (h *handler) errorResponse(
 		),
 		ErrorCode: errorCode,
 	}
-}
-
-// authorizedOwnerFromRequestID extracts the owner prefix that was stamped onto
-// the request ID after authorization (format: "<owner>::<original-id>").
-func authorizedOwnerFromRequestID(requestID string) string {
-	idx := strings.Index(requestID, vaulttypes.RequestIDSeparator)
-	if idx == -1 {
-		return ""
-	}
-	return requestID[:idx]
 }
 
 func (h *handler) sendResponse(ctx context.Context, userRequest *activeRequest, resp gwhandlers.UserCallbackPayload) error {

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -425,6 +425,14 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 		return h.handlePublicKeyGetSynchronously(ctx, req, publicKeyResponseBytes, callback)
 	}
 
+	if !isSupportedAuthorizedVaultMethod(req.Method) {
+		ar, err := h.newActiveRequest(req, callback)
+		if err != nil {
+			return err
+		}
+		return h.sendResponse(ctx, ar, h.errorResponse(req, api.UnsupportedMethodError, fmt.Errorf("unsupported method(%s): this method is unsupported: %s", req.Method, req.Method), nil))
+	}
+
 	authResult, authErr := h.authorizer.AuthorizeRequest(ctx, req)
 	if authErr != nil {
 		h.lggr.Errorw("request not authorized", "method", req.Method, "requestID", req.ID, "hasAuth", req.Auth != "", "error", authErr)
@@ -453,7 +461,19 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 	case vaulttypes.MethodSecretsList:
 		return h.handleSecretsList(ctx, ar)
 	default:
-		return h.sendResponse(ctx, ar, h.errorResponse(req, api.UnsupportedMethodError, errors.New("this method is unsupported: "+req.Method), nil))
+		return h.sendResponse(ctx, ar, h.errorResponse(req, api.UnsupportedMethodError, fmt.Errorf("unsupported method(%s): this method is unsupported: %s", req.Method, req.Method), nil))
+	}
+}
+
+func isSupportedAuthorizedVaultMethod(method string) bool {
+	switch method {
+	case vaulttypes.MethodSecretsCreate,
+		vaulttypes.MethodSecretsUpdate,
+		vaulttypes.MethodSecretsDelete,
+		vaulttypes.MethodSecretsList:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -610,6 +630,7 @@ func (h *handler) handleSecretsCreate(ctx context.Context, ar *activeRequest) er
 			secretItem.Id.Namespace = vaulttypes.DefaultNamespace
 		}
 	}
+	vaultcap.StampAuthorizedOwnerFromRequestID(createSecretsRequest.RequestId, createSecretsRequest)
 	_, cachedPublicKey := h.getCachedPublicKey()
 	skipLabelValidation := cachedPublicKey == nil
 	err = h.ValidateCreateSecretsRequest(ctx, cachedPublicKey, createSecretsRequest, skipLabelValidation)
@@ -651,6 +672,7 @@ func (h *handler) handleSecretsUpdate(ctx context.Context, ar *activeRequest) er
 			secretItem.Id.Namespace = vaulttypes.DefaultNamespace
 		}
 	}
+	vaultcap.StampAuthorizedOwnerFromRequestID(updateSecretsRequest.RequestId, updateSecretsRequest)
 	_, cachedPublicKey := h.getCachedPublicKey()
 	skipLabelValidation := cachedPublicKey == nil
 	vaultCapErr := h.ValidateUpdateSecretsRequest(ctx, cachedPublicKey, updateSecretsRequest, skipLabelValidation)
@@ -691,6 +713,7 @@ func (h *handler) handleSecretsDelete(ctx context.Context, ar *activeRequest) er
 			id.Namespace = vaulttypes.DefaultNamespace
 		}
 	}
+	vaultcap.StampAuthorizedOwnerFromRequestID(deleteSecretsRequest.RequestId, deleteSecretsRequest)
 	err = h.ValidateDeleteSecretsRequest(ctx, deleteSecretsRequest)
 	if err != nil {
 		l.Warnw("failed to validate delete secrets request", "error", err)
@@ -718,6 +741,7 @@ func (h *handler) handleSecretsList(ctx context.Context, ar *activeRequest) erro
 	if req.Namespace == "" {
 		req.Namespace = vaulttypes.DefaultNamespace
 	}
+	vaultcap.StampAuthorizedOwnerFromRequestID(req.RequestId, req)
 	err := h.ValidateListSecretIdentifiersRequest(ctx, req)
 	if err != nil {
 		l.Warnw("failed to validate list secret identifiers request", "error", err)

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -431,6 +431,7 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 		return errors.New("request not authorized: " + authErr.Error())
 	}
 	authorizedOwner := authResult.AuthorizedOwner()
+
 	// Generate a unique ID for the request.
 	// Prefix request id with authorizedOwner, to ensure uniqueness across different owners
 	// We do this ourselves to ensure the ID is unique and can't be tampered with by the user.
@@ -603,6 +604,10 @@ func (h *handler) handleSecretsCreate(ctx context.Context, ar *activeRequest) er
 	if unmarshalErr := json.Unmarshal(*ar.req.Params, &createSecretsRequest); unmarshalErr != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, unmarshalErr, nil))
 	}
+	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
+		l.Errorw("owner binding failed", "error", ownerErr)
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
+	}
 	createSecretsRequest.RequestId = ar.req.ID
 	for _, secretItem := range createSecretsRequest.EncryptedSecrets {
 		if secretItem != nil && secretItem.Id != nil && secretItem.Id.Namespace == "" {
@@ -644,7 +649,10 @@ func (h *handler) handleSecretsUpdate(ctx context.Context, ar *activeRequest) er
 	if unmarshalErr := json.Unmarshal(*ar.req.Params, updateSecretsRequest); unmarshalErr != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, unmarshalErr, nil))
 	}
-
+	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
+		l.Errorw("owner binding failed", "error", ownerErr)
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
+	}
 	updateSecretsRequest.RequestId = ar.req.ID
 	for _, secretItem := range updateSecretsRequest.EncryptedSecrets {
 		if secretItem != nil && secretItem.Id != nil && secretItem.Id.Namespace == "" {
@@ -685,7 +693,10 @@ func (h *handler) handleSecretsDelete(ctx context.Context, ar *activeRequest) er
 	if unmarshalErr := json.Unmarshal(*ar.req.Params, deleteSecretsRequest); unmarshalErr != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, unmarshalErr, nil))
 	}
-
+	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
+		l.Errorw("owner binding failed", "error", ownerErr)
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
+	}
 	deleteSecretsRequest.RequestId = ar.req.ID
 	for _, id := range deleteSecretsRequest.Ids {
 		if id != nil && id.Namespace == "" {
@@ -715,7 +726,10 @@ func (h *handler) handleSecretsList(ctx context.Context, ar *activeRequest) erro
 	if err := json.Unmarshal(*ar.req.Params, req); err != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, err, nil))
 	}
-
+	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
+		l.Errorw("owner binding failed", "error", ownerErr)
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
+	}
 	req.RequestId = ar.req.ID
 	if req.Namespace == "" {
 		req.Namespace = vaulttypes.DefaultNamespace
@@ -857,6 +871,16 @@ func (h *handler) errorResponse(
 		),
 		ErrorCode: errorCode,
 	}
+}
+
+// authorizedOwnerFromRequestID extracts the owner prefix that was stamped onto
+// the request ID after authorization (format: "<owner>::<original-id>").
+func authorizedOwnerFromRequestID(requestID string) string {
+	idx := strings.Index(requestID, vaulttypes.RequestIDSeparator)
+	if idx == -1 {
+		return ""
+	}
+	return requestID[:idx]
 }
 
 func (h *handler) sendResponse(ctx context.Context, userRequest *activeRequest, resp gwhandlers.UserCallbackPayload) error {

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -430,7 +430,7 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 		if err != nil {
 			return err
 		}
-		return h.sendResponse(ctx, ar, h.errorResponse(req, api.UnsupportedMethodError, fmt.Errorf("unsupported method(%s): this method is unsupported: %s", req.Method, req.Method), nil))
+		return h.sendResponse(ctx, ar, h.errorResponse(req, api.UnsupportedMethodError, fmt.Errorf("this method is unsupported: %s", req.Method), nil))
 	}
 
 	authResult, authErr := h.authorizer.AuthorizeRequest(ctx, req)
@@ -461,7 +461,7 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 	case vaulttypes.MethodSecretsList:
 		return h.handleSecretsList(ctx, ar)
 	default:
-		return h.sendResponse(ctx, ar, h.errorResponse(req, api.UnsupportedMethodError, fmt.Errorf("unsupported method(%s): this method is unsupported: %s", req.Method, req.Method), nil))
+		return h.sendResponse(ctx, ar, h.errorResponse(req, api.UnsupportedMethodError, fmt.Errorf("this method is unsupported: %s", req.Method), nil))
 	}
 }
 
@@ -630,7 +630,10 @@ func (h *handler) handleSecretsCreate(ctx context.Context, ar *activeRequest) er
 			secretItem.Id.Namespace = vaulttypes.DefaultNamespace
 		}
 	}
-	vaultcap.StampAuthorizedOwnerFromRequestID(createSecretsRequest.RequestId, createSecretsRequest)
+	if err := vaultcap.StampAuthorizedOwnerFromRequestID(createSecretsRequest.RequestId, createSecretsRequest); err != nil {
+		l.Errorw("failed to stamp authorized owner on create secrets request", "error", err)
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.FatalError, fmt.Errorf("failed to stamp authorized owner: %w", err), nil))
+	}
 	_, cachedPublicKey := h.getCachedPublicKey()
 	skipLabelValidation := cachedPublicKey == nil
 	err = h.ValidateCreateSecretsRequest(ctx, cachedPublicKey, createSecretsRequest, skipLabelValidation)
@@ -672,7 +675,10 @@ func (h *handler) handleSecretsUpdate(ctx context.Context, ar *activeRequest) er
 			secretItem.Id.Namespace = vaulttypes.DefaultNamespace
 		}
 	}
-	vaultcap.StampAuthorizedOwnerFromRequestID(updateSecretsRequest.RequestId, updateSecretsRequest)
+	if err := vaultcap.StampAuthorizedOwnerFromRequestID(updateSecretsRequest.RequestId, updateSecretsRequest); err != nil {
+		l.Errorw("failed to stamp authorized owner on update secrets request", "error", err)
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.FatalError, fmt.Errorf("failed to stamp authorized owner: %w", err), nil))
+	}
 	_, cachedPublicKey := h.getCachedPublicKey()
 	skipLabelValidation := cachedPublicKey == nil
 	vaultCapErr := h.ValidateUpdateSecretsRequest(ctx, cachedPublicKey, updateSecretsRequest, skipLabelValidation)
@@ -713,7 +719,10 @@ func (h *handler) handleSecretsDelete(ctx context.Context, ar *activeRequest) er
 			id.Namespace = vaulttypes.DefaultNamespace
 		}
 	}
-	vaultcap.StampAuthorizedOwnerFromRequestID(deleteSecretsRequest.RequestId, deleteSecretsRequest)
+	if err := vaultcap.StampAuthorizedOwnerFromRequestID(deleteSecretsRequest.RequestId, deleteSecretsRequest); err != nil {
+		l.Errorw("failed to stamp authorized owner on delete secrets request", "error", err)
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.FatalError, fmt.Errorf("failed to stamp authorized owner: %w", err), nil))
+	}
 	err = h.ValidateDeleteSecretsRequest(ctx, deleteSecretsRequest)
 	if err != nil {
 		l.Warnw("failed to validate delete secrets request", "error", err)
@@ -741,7 +750,10 @@ func (h *handler) handleSecretsList(ctx context.Context, ar *activeRequest) erro
 	if req.Namespace == "" {
 		req.Namespace = vaulttypes.DefaultNamespace
 	}
-	vaultcap.StampAuthorizedOwnerFromRequestID(req.RequestId, req)
+	if err := vaultcap.StampAuthorizedOwnerFromRequestID(req.RequestId, req); err != nil {
+		l.Errorw("failed to stamp authorized owner on list secrets request", "error", err)
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.FatalError, fmt.Errorf("failed to stamp authorized owner: %w", err), nil))
+	}
 	err := h.ValidateListSecretIdentifiersRequest(ctx, req)
 	if err != nil {
 		l.Warnw("failed to validate list secret identifiers request", "error", err)

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -821,7 +821,11 @@ func (h *handler) errorResponse(
 		// Intentionally hide the error from the user
 		err = errors.New(errorCode.String())
 	case api.InvalidParamsError:
-		h.lggr.Errorw("invalid params", "requestID", req.ID, "params", string(*req.Params))
+		paramsStr := ""
+		if req.Params != nil {
+			paramsStr = string(*req.Params)
+		}
+		h.lggr.Errorw("invalid params", "requestID", req.ID, "params", paramsStr)
 		err = errors.New("invalid params error: " + err.Error())
 	case api.UnsupportedMethodError:
 		h.lggr.Errorw("unsupported method", "requestID", req.ID, "method", req.Method, "error", err.Error())

--- a/core/services/gateway/handlers/vault/handler_test.go
+++ b/core/services/gateway/handlers/vault/handler_test.go
@@ -445,6 +445,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 	})
 
 	t.Run("nil EncryptedSecrets inside CreateSecrets body", func(t *testing.T) {
+		var wg sync.WaitGroup
 		h, callback, _, _ := setupHandler(t)
 		emptyCreateSecretsRequest := &vaultcommon.CreateSecretsRequest{
 			RequestId: "test_request_id",
@@ -470,10 +471,22 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: (*json.RawMessage)(&emptyParams),
 		}
 
-		// A valid secret with matching owner precedes the nil entry so authorization
-		// passes owner binding and rejects the nil element at index 1.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err2 := callback.Wait(t.Context())
+			assert.NoError(t, err2)
+			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
+			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
+			assert.NoError(t, err2)
+			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
+			assert.Contains(t, secretsResponse.Error.Message, "encrypted secret must not be nil at index 1")
+			assert.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), secretsResponse.Error.Code, "Error code should match")
+		}()
+
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
-		require.ErrorContains(t, err, "encrypted secret at index 1 must include an identifier")
+		require.NoError(t, err)
+		wg.Wait()
 	})
 
 	t.Run("no id inside CreateSecrets.EncryptedSecrets body", func(t *testing.T) {
@@ -585,6 +598,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 	})
 
 	t.Run("nil id in delete secrets", func(t *testing.T) {
+		var wg sync.WaitGroup
 		h, callback, _, _ := setupHandler(t)
 
 		reqData := &vaultcommon.DeleteSecretsRequest{
@@ -603,10 +617,22 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: (*json.RawMessage)(&reqDataBytes),
 		}
 
-		// A valid identifier with matching owner precedes the nil entry so authorization
-		// passes owner binding and rejects the nil element at index 1.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err2 := callback.Wait(t.Context())
+			assert.NoError(t, err2)
+			var secretsResponse jsonrpc.Response[vaultcommon.DeleteSecretsResponse]
+			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
+			assert.NoError(t, err2)
+			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
+			assert.Contains(t, secretsResponse.Error.Message, "secret ID must not be nil at index 1")
+			assert.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), secretsResponse.Error.Code, "Error code should match")
+		}()
+
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
-		require.ErrorContains(t, err, "secret identifier at index 1 must not be nil")
+		require.NoError(t, err)
+		wg.Wait()
 	})
 
 	t.Run("happy path - list secret identifiers", func(t *testing.T) {
@@ -801,6 +827,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 	})
 
 	t.Run("empty params error", func(t *testing.T) {
+		var wg sync.WaitGroup
 		h, callback, don, _ := setupHandler(t)
 		// Don't expect SendToNode to be called for parse errors
 		don.AssertNotCalled(t, "SendToNode")
@@ -811,13 +838,26 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: &json.RawMessage{},
 		}
 
-		// Owner binding is enforced during authorization, before a callback is registered.
-		// HandleJSONRPCUserMessage returns the error directly.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := callback.Wait(t.Context())
+			assert.NoError(t, err)
+			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
+			err = json.Unmarshal(resp.RawResponse, &secretsResponse)
+			assert.NoError(t, err)
+			assert.Equal(t, emptyParamsRequest.ID, secretsResponse.ID, "Request ID should match")
+			assert.Equal(t, "user message parse error: unexpected end of JSON input", secretsResponse.Error.Message, "Error message should match")
+			assert.Equal(t, api.ToJSONRPCErrorCode(api.UserMessageParseError), secretsResponse.Error.Code, "Error code should match")
+		}()
+
 		err := h.HandleJSONRPCUserMessage(t.Context(), emptyParamsRequest, callback)
-		require.ErrorContains(t, err, "failed to parse create secrets request")
+		require.NoError(t, err)
+		wg.Wait()
 	})
 
 	t.Run("no request inside the batch request", func(t *testing.T) {
+		var wg sync.WaitGroup
 		h, callback, don, _ := setupHandler(t)
 		// Don't expect SendToNode to be called for invalid params
 		don.AssertNotCalled(t, "SendToNode")
@@ -829,10 +869,22 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: &invalidParams,
 		}
 
-		// Owner binding is enforced during authorization, before a callback is registered.
-		// HandleJSONRPCUserMessage returns the error directly.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := callback.Wait(t.Context())
+			assert.NoError(t, err)
+			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
+			err = json.Unmarshal(resp.RawResponse, &secretsResponse)
+			assert.NoError(t, err)
+			assert.Equal(t, invalidParamsRequest.ID, secretsResponse.ID, "Request ID should match")
+			assert.Equal(t, "invalid params error: failed to validate create secrets request: request batch must contain at least 1 item", secretsResponse.Error.Message, "Error message should match")
+			assert.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), secretsResponse.Error.Code, "Error code should match")
+		}()
+
 		err := h.HandleJSONRPCUserMessage(t.Context(), invalidParamsRequest, callback)
-		require.ErrorContains(t, err, "encrypted secrets must contain at least one identifier")
+		require.NoError(t, err)
+		wg.Wait()
 	})
 
 	t.Run("invalid params error", func(t *testing.T) {

--- a/core/services/gateway/handlers/vault/handler_test.go
+++ b/core/services/gateway/handlers/vault/handler_test.go
@@ -395,6 +395,165 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		require.Equal(t, owner+vaulttypes.RequestIDSeparator+req.ID, forwardedCreateRequest.RequestId)
 	})
 
+	t.Run("stamps mismatched identifier owner to authorized owner on forwarded create", func(t *testing.T) {
+		_, pk, _, err := tdh2easy.GenerateKeys(1, 3)
+		require.NoError(t, err)
+		foreignOwner := "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+		encryptedSecret, err := vaultutils.EncryptSecretWithWorkflowOwner("test_secret", pk, ethcommon.HexToAddress(owner))
+		require.NoError(t, err)
+
+		h, _, don, clock := setupHandlerWithLimitsFactory(t, limits.Factory{Settings: cresettings.DefaultGetter})
+		h.(*handler).authorizer = &stubAuthorizer{result: vaultcap.NewAuthResult("org-1", owner, "digest-1", clock.Now().Add(time.Minute).Unix())}
+		cacheVaultPublicKeyForTest(t, h.(*handler), pk)
+
+		reqData := &vaultcommon.CreateSecretsRequest{
+			EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+				{
+					Id: &vaultcommon.SecretIdentifier{
+						Key:   "test_id",
+						Owner: foreignOwner,
+					},
+					EncryptedValue: encryptedSecret,
+				},
+			},
+		}
+		reqDataBytes, err := json.Marshal(reqData)
+		require.NoError(t, err)
+
+		req := jsonrpc.Request[json.RawMessage]{
+			ID:     "stamp-create",
+			Method: vaulttypes.MethodSecretsCreate,
+			Params: (*json.RawMessage)(&reqDataBytes),
+		}
+
+		var forwarded jsonrpc.Request[json.RawMessage]
+		don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			forwarded = *args.Get(2).(*jsonrpc.Request[json.RawMessage])
+		}).Return(nil).Once()
+
+		err = h.HandleJSONRPCUserMessage(t.Context(), req, common.NewCallback())
+		require.NoError(t, err)
+		don.AssertExpectations(t)
+
+		var forwardedCreate vaultcommon.CreateSecretsRequest
+		require.NoError(t, json.Unmarshal(*forwarded.Params, &forwardedCreate))
+		require.Equal(t, owner, forwardedCreate.EncryptedSecrets[0].Id.Owner)
+		require.Equal(t, owner+vaulttypes.RequestIDSeparator+req.ID, forwardedCreate.RequestId)
+	})
+
+	t.Run("stamps mismatched identifier owner to authorized owner on forwarded update", func(t *testing.T) {
+		_, pk, _, err := tdh2easy.GenerateKeys(1, 3)
+		require.NoError(t, err)
+		foreignOwner := "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+		encryptedSecret, err := vaultutils.EncryptSecretWithWorkflowOwner("test_secret", pk, ethcommon.HexToAddress(owner))
+		require.NoError(t, err)
+
+		h, _, don, clock := setupHandlerWithLimitsFactory(t, limits.Factory{Settings: cresettings.DefaultGetter})
+		h.(*handler).authorizer = &stubAuthorizer{result: vaultcap.NewAuthResult("org-1", owner, "digest-1", clock.Now().Add(time.Minute).Unix())}
+		cacheVaultPublicKeyForTest(t, h.(*handler), pk)
+
+		reqData := &vaultcommon.UpdateSecretsRequest{
+			EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+				{
+					Id: &vaultcommon.SecretIdentifier{
+						Key:   "test_id",
+						Owner: foreignOwner,
+					},
+					EncryptedValue: encryptedSecret,
+				},
+			},
+		}
+		reqDataBytes, err := json.Marshal(reqData)
+		require.NoError(t, err)
+
+		req := jsonrpc.Request[json.RawMessage]{
+			ID:     "stamp-update",
+			Method: vaulttypes.MethodSecretsUpdate,
+			Params: (*json.RawMessage)(&reqDataBytes),
+		}
+
+		var forwarded jsonrpc.Request[json.RawMessage]
+		don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			forwarded = *args.Get(2).(*jsonrpc.Request[json.RawMessage])
+		}).Return(nil).Once()
+
+		err = h.HandleJSONRPCUserMessage(t.Context(), req, common.NewCallback())
+		require.NoError(t, err)
+		don.AssertExpectations(t)
+
+		var forwardedUpdate vaultcommon.UpdateSecretsRequest
+		require.NoError(t, json.Unmarshal(*forwarded.Params, &forwardedUpdate))
+		require.Equal(t, owner, forwardedUpdate.EncryptedSecrets[0].Id.Owner)
+		require.Equal(t, owner+vaulttypes.RequestIDSeparator+req.ID, forwardedUpdate.RequestId)
+	})
+
+	t.Run("stamps mismatched identifier owner to authorized owner on forwarded delete", func(t *testing.T) {
+		h, _, don, clock := setupHandlerWithLimitsFactory(t, limits.Factory{Settings: cresettings.DefaultGetter})
+		h.(*handler).authorizer = &stubAuthorizer{result: vaultcap.NewAuthResult("org-1", owner, "digest-1", clock.Now().Add(time.Minute).Unix())}
+
+		foreignOwner := "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+		reqData := &vaultcommon.DeleteSecretsRequest{
+			Ids: []*vaultcommon.SecretIdentifier{
+				{Key: "test_id", Namespace: "default", Owner: foreignOwner},
+			},
+		}
+		reqDataBytes, err := json.Marshal(reqData)
+		require.NoError(t, err)
+
+		req := jsonrpc.Request[json.RawMessage]{
+			ID:     "stamp-delete",
+			Method: vaulttypes.MethodSecretsDelete,
+			Params: (*json.RawMessage)(&reqDataBytes),
+		}
+
+		var forwarded jsonrpc.Request[json.RawMessage]
+		don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			forwarded = *args.Get(2).(*jsonrpc.Request[json.RawMessage])
+		}).Return(nil).Once()
+
+		err = h.HandleJSONRPCUserMessage(t.Context(), req, common.NewCallback())
+		require.NoError(t, err)
+		don.AssertExpectations(t)
+
+		var forwardedDelete vaultcommon.DeleteSecretsRequest
+		require.NoError(t, json.Unmarshal(*forwarded.Params, &forwardedDelete))
+		require.Equal(t, owner, forwardedDelete.Ids[0].Owner)
+		require.Equal(t, owner+vaulttypes.RequestIDSeparator+req.ID, forwardedDelete.RequestId)
+	})
+
+	t.Run("stamps mismatched list owner to authorized owner on forwarded list", func(t *testing.T) {
+		h, _, don, clock := setupHandlerWithLimitsFactory(t, limits.Factory{Settings: cresettings.DefaultGetter})
+		h.(*handler).authorizer = &stubAuthorizer{result: vaultcap.NewAuthResult("org-1", owner, "digest-1", clock.Now().Add(time.Minute).Unix())}
+
+		foreignOwner := "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+		reqData := &vaultcommon.ListSecretIdentifiersRequest{
+			Owner:     foreignOwner,
+			Namespace: "default",
+		}
+		reqDataBytes, err := json.Marshal(reqData)
+		require.NoError(t, err)
+
+		req := jsonrpc.Request[json.RawMessage]{
+			ID:     "stamp-list",
+			Method: vaulttypes.MethodSecretsList,
+			Params: (*json.RawMessage)(&reqDataBytes),
+		}
+
+		var forwarded jsonrpc.Request[json.RawMessage]
+		don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			forwarded = *args.Get(2).(*jsonrpc.Request[json.RawMessage])
+		}).Return(nil).Once()
+
+		err = h.HandleJSONRPCUserMessage(t.Context(), req, common.NewCallback())
+		require.NoError(t, err)
+		don.AssertExpectations(t)
+
+		var forwardedList vaultcommon.ListSecretIdentifiersRequest
+		require.NoError(t, json.Unmarshal(*forwarded.Params, &forwardedList))
+		require.Equal(t, owner, forwardedList.Owner)
+		require.Equal(t, owner+vaulttypes.RequestIDSeparator+req.ID, forwardedList.RequestId)
+	})
+
 	t.Run("rejects JWT create when ciphertext label does not match identifier owner", func(t *testing.T) {
 		_, pk, _, err := tdh2easy.GenerateKeys(1, 3)
 		require.NoError(t, err)

--- a/core/services/gateway/handlers/vault/handler_test.go
+++ b/core/services/gateway/handlers/vault/handler_test.go
@@ -285,7 +285,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		rawPayload := json.RawMessage(`{"request_id":"test_request_id","encrypted_secrets":[{"id":{"key":"test_id","owner":"org1","namespace":"default"},"encrypted_value":"abc123"}]}`)
+		rawPayload := json.RawMessage(`{"request_id":"test_request_id","encrypted_secrets":[{"id":{"key":"test_id","owner":"0xworkflow","namespace":"default"},"encrypted_value":"abc123"}]}`)
 
 		var forwarded jsonrpc.Request[json.RawMessage]
 		don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
@@ -395,17 +395,19 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		require.Equal(t, owner+vaulttypes.RequestIDSeparator+req.ID, forwardedCreateRequest.RequestId)
 	})
 
-	t.Run("rejects JWT create when secret identifier owner does not match ciphertext workflow owner label", func(t *testing.T) {
+	t.Run("rejects JWT create when ciphertext label does not match identifier owner", func(t *testing.T) {
 		_, pk, _, err := tdh2easy.GenerateKeys(1, 3)
 		require.NoError(t, err)
 		orgID := "org_2xAbCdEfGhIjKlMnOpQrStUvWxYz"
-		ciphertextOwner := "0x0001020304050607080900010203040506070809"
-		otherOwner := "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-		encryptedSecret, err := vaultutils.EncryptSecretWithWorkflowOwner("test_secret", pk, ethcommon.HexToAddress(ciphertextOwner))
+		// The authorized owner and Id.Owner match (passes owner-binding check).
+		// The ciphertext is encrypted for a different address so the label check fires.
+		authorizedOwner := "0x0001020304050607080900010203040506070809"
+		labelOwner := "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+		encryptedSecret, err := vaultutils.EncryptSecretWithWorkflowOwner("test_secret", pk, ethcommon.HexToAddress(labelOwner))
 		require.NoError(t, err)
 
 		h, callback, don, clock := setupHandlerWithLimitsFactory(t, limits.Factory{Settings: cresettings.DefaultGetter})
-		h.(*handler).authorizer = &stubAuthorizer{result: vaultcap.NewAuthResult(orgID, ciphertextOwner, "digest-1", clock.Now().Add(time.Minute).Unix())}
+		h.(*handler).authorizer = &stubAuthorizer{result: vaultcap.NewAuthResult(orgID, authorizedOwner, "digest-1", clock.Now().Add(time.Minute).Unix())}
 		cacheVaultPublicKeyForTest(t, h.(*handler), pk)
 
 		reqData := &vaultcommon.CreateSecretsRequest{
@@ -413,9 +415,9 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 				{
 					Id: &vaultcommon.SecretIdentifier{
 						Key:   "test_id",
-						Owner: otherOwner,
+						Owner: authorizedOwner, // matches authorized owner — owner-binding passes
 					},
-					EncryptedValue: encryptedSecret,
+					EncryptedValue: encryptedSecret, // labeled for labelOwner — label check fires
 				},
 			},
 		}
@@ -473,7 +475,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err2)
 			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.ErrorContains(t, secretsResponse.Error, "encrypted secret must not be nil")
+			assert.ErrorContains(t, secretsResponse.Error, "encrypted secret at index 0 must include an identifier")
 		}()
 
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
@@ -511,7 +513,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err2)
 			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.ErrorContains(t, secretsResponse.Error, "secret ID must not be nil")
+			assert.ErrorContains(t, secretsResponse.Error, "encrypted secret at index 0 must include an identifier")
 		}()
 
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
@@ -636,7 +638,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err2)
 			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.ErrorContains(t, secretsResponse.Error, "secret ID must not be nil")
+			assert.ErrorContains(t, secretsResponse.Error, "secret identifier at index 0 must not be nil")
 		}()
 
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
@@ -890,7 +892,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			err = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err)
 			assert.Equal(t, invalidParamsRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.Equal(t, "invalid params error: failed to validate create secrets request: request batch must contain at least 1 item", secretsResponse.Error.Message, "Error message should match")
+			assert.Equal(t, "invalid params error: encrypted secrets must contain at least one identifier", secretsResponse.Error.Message, "Error message should match")
 			assert.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), secretsResponse.Error.Code, "Error code should match")
 		}()
 
@@ -911,7 +913,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 				{
 					Id: &vaultcommon.SecretIdentifier{
 						Key:   "",
-						Owner: "test_owner",
+						Owner: owner, // matches authorized owner so key-validation error fires
 					},
 					EncryptedValue: "test_value",
 				},

--- a/core/services/gateway/handlers/vault/handler_test.go
+++ b/core/services/gateway/handlers/vault/handler_test.go
@@ -521,6 +521,68 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		require.Equal(t, owner+vaulttypes.RequestIDSeparator+req.ID, forwardedDelete.RequestId)
 	})
 
+	t.Run("rejects create with empty encrypted secrets after owner stamping", func(t *testing.T) {
+		h, callback, don, clock := setupHandlerWithLimitsFactory(t, limits.Factory{Settings: cresettings.DefaultGetter})
+		h.(*handler).authorizer = &stubAuthorizer{result: vaultcap.NewAuthResult("org-1", owner, "digest-1", clock.Now().Add(time.Minute).Unix())}
+
+		reqData := &vaultcommon.CreateSecretsRequest{
+			EncryptedSecrets: []*vaultcommon.EncryptedSecret{},
+		}
+		reqDataBytes, err := json.Marshal(reqData)
+		require.NoError(t, err)
+
+		req := jsonrpc.Request[json.RawMessage]{
+			ID:     "empty-create",
+			Method: vaulttypes.MethodSecretsCreate,
+			Params: (*json.RawMessage)(&reqDataBytes),
+		}
+
+		err = h.HandleJSONRPCUserMessage(t.Context(), req, callback)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		resp, err := callback.Wait(ctx)
+		require.NoError(t, err)
+		var createResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
+		require.NoError(t, json.Unmarshal(resp.RawResponse, &createResponse))
+		require.ErrorContains(t, createResponse.Error, "request batch must contain at least 1 item")
+		require.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), createResponse.Error.Code)
+		don.AssertNotCalled(t, "SendToNode", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("rejects create with nil secret identifier after owner stamping", func(t *testing.T) {
+		h, callback, don, clock := setupHandlerWithLimitsFactory(t, limits.Factory{Settings: cresettings.DefaultGetter})
+		h.(*handler).authorizer = &stubAuthorizer{result: vaultcap.NewAuthResult("org-1", owner, "digest-1", clock.Now().Add(time.Minute).Unix())}
+
+		reqData := &vaultcommon.CreateSecretsRequest{
+			EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+				{EncryptedValue: "abc123"},
+			},
+		}
+		reqDataBytes, err := json.Marshal(reqData)
+		require.NoError(t, err)
+
+		req := jsonrpc.Request[json.RawMessage]{
+			ID:     "nil-id-create",
+			Method: vaulttypes.MethodSecretsCreate,
+			Params: (*json.RawMessage)(&reqDataBytes),
+		}
+
+		err = h.HandleJSONRPCUserMessage(t.Context(), req, callback)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		resp, err := callback.Wait(ctx)
+		require.NoError(t, err)
+		var createResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
+		require.NoError(t, json.Unmarshal(resp.RawResponse, &createResponse))
+		require.ErrorContains(t, createResponse.Error, "secret ID must not be nil")
+		require.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), createResponse.Error.Code)
+		don.AssertNotCalled(t, "SendToNode", mock.Anything, mock.Anything, mock.Anything)
+	})
+
 	t.Run("stamps mismatched list owner to authorized owner on forwarded list", func(t *testing.T) {
 		h, _, don, clock := setupHandlerWithLimitsFactory(t, limits.Factory{Settings: cresettings.DefaultGetter})
 		h.(*handler).authorizer = &stubAuthorizer{result: vaultcap.NewAuthResult("org-1", owner, "digest-1", clock.Now().Add(time.Minute).Unix())}

--- a/core/services/gateway/handlers/vault/handler_test.go
+++ b/core/services/gateway/handlers/vault/handler_test.go
@@ -445,15 +445,19 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 	})
 
 	t.Run("nil EncryptedSecrets inside CreateSecrets body", func(t *testing.T) {
-		var wg sync.WaitGroup
 		h, callback, _, _ := setupHandler(t)
 		emptyCreateSecretsRequest := &vaultcommon.CreateSecretsRequest{
 			RequestId: "test_request_id",
 			EncryptedSecrets: []*vaultcommon.EncryptedSecret{
-				nil,
 				{
-					EncryptedValue: "abc123", // should be a valid hex string
+					Id: &vaultcommon.SecretIdentifier{
+						Key:       "k",
+						Namespace: "default",
+						Owner:     owner,
+					},
+					EncryptedValue: "abc123",
 				},
+				nil,
 			},
 		}
 		emptyParams, err := json.Marshal(emptyCreateSecretsRequest)
@@ -466,30 +470,24 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: (*json.RawMessage)(&emptyParams),
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			resp, err2 := callback.Wait(t.Context())
-			assert.NoError(t, err2)
-			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
-			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
-			assert.NoError(t, err2)
-			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.ErrorContains(t, secretsResponse.Error, "encrypted secret at index 0 must include an identifier")
-		}()
-
+		// A valid secret with matching owner precedes the nil entry so authorization
+		// passes owner binding and rejects the nil element at index 1.
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
-		require.NoError(t, err)
-		wg.Wait()
+		require.ErrorContains(t, err, "encrypted secret at index 1 must include an identifier")
 	})
 
 	t.Run("no id inside CreateSecrets.EncryptedSecrets body", func(t *testing.T) {
 		var wg sync.WaitGroup
-		h, callback, _, _ := setupHandler(t)
+		h, callback, don, _ := setupHandler(t)
+		don.AssertNotCalled(t, "SendToNode")
+
+		// Id is present with the authorized owner so authorization passes owner binding;
+		// key is omitted so validation fails on the incomplete identifier, not owner mismatch.
 		emptyCreateSecretsRequest := &vaultcommon.CreateSecretsRequest{
 			RequestId: "test_request_id",
 			EncryptedSecrets: []*vaultcommon.EncryptedSecret{
 				{
+					Id:             &vaultcommon.SecretIdentifier{Owner: owner},
 					EncryptedValue: "abc123", // should be a valid hex string
 				},
 			},
@@ -513,7 +511,8 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err2)
 			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.ErrorContains(t, secretsResponse.Error, "encrypted secret at index 0 must include an identifier")
+			assert.Contains(t, secretsResponse.Error.Message, "key cannot be empty")
+			assert.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), secretsResponse.Error.Code, "Error code should match")
 		}()
 
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
@@ -586,19 +585,13 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 	})
 
 	t.Run("nil id in delete secrets", func(t *testing.T) {
-		var wg sync.WaitGroup
 		h, callback, _, _ := setupHandler(t)
 
-		id := &vaultcommon.SecretIdentifier{
-			Key:       "foo",
-			Namespace: "default",
-			Owner:     owner,
-		}
 		reqData := &vaultcommon.DeleteSecretsRequest{
 			RequestId: "id",
 			Ids: []*vaultcommon.SecretIdentifier{
+				{Key: "foo", Namespace: "default", Owner: owner},
 				nil,
-				id,
 			},
 		}
 		reqDataBytes, err := json.Marshal(reqData)
@@ -610,43 +603,10 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: (*json.RawMessage)(&reqDataBytes),
 		}
 
-		responseData := &vaultcommon.DeleteSecretsResponse{
-			Responses: []*vaultcommon.DeleteSecretResponse{
-				{
-					Id:      id,
-					Success: true,
-				},
-			},
-		}
-		resultBytes, err := json.Marshal(responseData)
-		require.NoError(t, err)
-		expectedRequestID := owner + vaulttypes.RequestIDSeparator + requestID
-		response := jsonrpc.Response[json.RawMessage]{
-			ID:     expectedRequestID,
-			Result: (*json.RawMessage)(&resultBytes),
-			Method: vaulttypes.MethodSecretsDelete,
-		}
-		resultBytes, err = json.Marshal(responseData)
-		require.NoError(t, err)
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			resp, err2 := callback.Wait(t.Context())
-			assert.NoError(t, err2)
-			var secretsResponse jsonrpc.Response[vaultcommon.DeleteSecretsResponse]
-			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
-			assert.NoError(t, err2)
-			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.ErrorContains(t, secretsResponse.Error, "secret identifier at index 0 must not be nil")
-		}()
-
+		// A valid identifier with matching owner precedes the nil entry so authorization
+		// passes owner binding and rejects the nil element at index 1.
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
-		require.NoError(t, err)
-
-		err = h.HandleNodeMessage(t.Context(), &response, NodeOne.Address)
-		require.NoError(t, err)
-		wg.Wait()
+		require.ErrorContains(t, err, "secret identifier at index 1 must not be nil")
 	})
 
 	t.Run("happy path - list secret identifiers", func(t *testing.T) {
@@ -841,7 +801,6 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 	})
 
 	t.Run("empty params error", func(t *testing.T) {
-		var wg sync.WaitGroup
 		h, callback, don, _ := setupHandler(t)
 		// Don't expect SendToNode to be called for parse errors
 		don.AssertNotCalled(t, "SendToNode")
@@ -852,26 +811,13 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: &json.RawMessage{},
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			resp, err := callback.Wait(t.Context())
-			assert.NoError(t, err)
-			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
-			err = json.Unmarshal(resp.RawResponse, &secretsResponse)
-			assert.NoError(t, err)
-			assert.Equal(t, emptyParamsRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.Equal(t, "user message parse error: unexpected end of JSON input", secretsResponse.Error.Message, "Error message should match")
-			assert.Equal(t, api.ToJSONRPCErrorCode(api.UserMessageParseError), secretsResponse.Error.Code, "Error code should match")
-		}()
-
+		// Owner binding is enforced during authorization, before a callback is registered.
+		// HandleJSONRPCUserMessage returns the error directly.
 		err := h.HandleJSONRPCUserMessage(t.Context(), emptyParamsRequest, callback)
-		require.NoError(t, err)
-		wg.Wait()
+		require.ErrorContains(t, err, "failed to parse create secrets request")
 	})
 
 	t.Run("no request inside the batch request", func(t *testing.T) {
-		var wg sync.WaitGroup
 		h, callback, don, _ := setupHandler(t)
 		// Don't expect SendToNode to be called for invalid params
 		don.AssertNotCalled(t, "SendToNode")
@@ -883,22 +829,10 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: &invalidParams,
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			resp, err := callback.Wait(t.Context())
-			assert.NoError(t, err)
-			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
-			err = json.Unmarshal(resp.RawResponse, &secretsResponse)
-			assert.NoError(t, err)
-			assert.Equal(t, invalidParamsRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.Equal(t, "invalid params error: encrypted secrets must contain at least one identifier", secretsResponse.Error.Message, "Error message should match")
-			assert.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), secretsResponse.Error.Code, "Error code should match")
-		}()
-
+		// Owner binding is enforced during authorization, before a callback is registered.
+		// HandleJSONRPCUserMessage returns the error directly.
 		err := h.HandleJSONRPCUserMessage(t.Context(), invalidParamsRequest, callback)
-		require.NoError(t, err)
-		wg.Wait()
+		require.ErrorContains(t, err, "encrypted secrets must contain at least one identifier")
 	})
 
 	t.Run("invalid params error", func(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes a vault owner-mismatch vulnerability by stamping the authorized workflow owner onto secret mutation requests instead of rejecting mismatches at auth time. Owner fields in client-supplied params are overwritten from the auth-derived prefixed request ID (`owner::userRequestID`) at both the gateway handler and vault node handler, ensuring secrets are always stored under the identity that was actually authorized.
## Problem
An authenticated caller could include secret identifiers with an `Owner` field that did not match their authorized workflow owner. Depending on the code path, this could allow cross-owner secret access or mutation. The previous JWT auth path attempted to reject these mismatches during authorization, but the correct fix is to treat client-supplied owner fields as untrusted input and overwrite them after auth.
## Solution
- Introduce shared owner-stamping helpers in `core/capabilities/vault/ownership.go`.
- After authorization, derive the canonical owner from the prefixed request ID and stamp it onto create/update/delete/list request params.
- Apply stamping at two enforcement points:
  - **Gateway handler** (`core/services/gateway/handlers/vault/handler.go`) — overwrites untrusted client input before validation and fan-out.
  - **Vault node handler** (`core/capabilities/vault/gw_handler.go`) — re-authorizes, re-prefixes the request ID from auth, and stamps again before calling the capability (defense in depth against untrusted gateway-forwarded params).
- Remove JWT-time owner mismatch rejection from `jwt_based_auth.go`; authorization now only establishes identity, not param shape.
- Return an error from `StampAuthorizedOwnerFromRequestID` for unsupported request types instead of silently no-oping.
## Key changes
| Area | Change |
|------|--------|
| `ownership.go` | New stamping helpers + `AuthorizedOwnerFromRequestID` |
| `handler.go` | Stamp owners on create/update/delete/list after auth |
| `gw_handler.go` | Stamp owners on node-side handling; remove duplicate params rewrite |
| `jwt_based_auth.go` | Remove `validateJWTPreparedVaultOwners` and related helpers |
| Tests | Cross-owner stamping, allowlist path preserves unstamped params at auth layer, empty/nil identifier rejection, unknown type error, params normalization |
