### PR TITLE
Fix value 0 erc20 transfer changeset error

### DIFF
--- a/deployment/vault/changeset/operations.go
+++ b/deployment/vault/changeset/operations.go
@@ -27,10 +27,8 @@ import (
 
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/vault/changeset/types"
-	evmsdk "github.com/smartcontractkit/mcms/sdk/evm"
-
 )
-typeTest evmsdk
+
 type VaultDeps struct {
 	Chain       cldf_evm.Chain
 	Auth        *bind.TransactOpts

--- a/deployment/vault/changeset/operations.go
+++ b/deployment/vault/changeset/operations.go
@@ -27,8 +27,10 @@ import (
 
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/vault/changeset/types"
-)
+	evmsdk "github.com/smartcontractkit/mcms/sdk/evm"
 
+)
+typeTest evmsdk
 type VaultDeps struct {
 	Chain       cldf_evm.Chain
 	Auth        *bind.TransactOpts
@@ -560,7 +562,7 @@ func generateERC20MCMSProposals(b operations.Bundle, deps VaultDeps, input Trans
 				chainSelector,
 				tr.Token,
 				data,
-				nil,
+				big.NewInt(0),
 				"ERC20Transfer",
 				[]string{"vault", "erc20-transfer"},
 			)


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->

We are receiving [this](https://github.com/smartcontractkit/chainlink-deployments/actions/runs/27159733625/job/80172084299) error on a CLD pipeline because a `nil` value at changeset level. This change fix that issue so we can run erc20 changesets