### PR TITLE
chore: standardise using the shared mcms config in the framework

### DIFF
--- a/deployment/ccip/changeset/aptos/config/deploy_aptos_chain.go
+++ b/deployment/ccip/changeset/aptos/config/deploy_aptos_chain.go
@@ -9,13 +9,13 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
-	"github.com/smartcontractkit/chainlink/deployment/common/types"
 )
 
 // DeployAptosChainConfig is a configuration for deploying CCIP Package for Aptos chains
 type DeployAptosChainConfig struct {
-	MCMSDeployConfigPerChain   map[uint64]types.MCMSWithTimelockConfigV2
+	MCMSDeployConfigPerChain   map[uint64]cldfproposalutils.MCMSWithTimelockConfig
 	MCMSTimelockConfigPerChain map[uint64]cldfproposalutils.TimelockConfig
 	ContractParamsPerChain     map[uint64]ChainContractParams
 }

--- a/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
+++ b/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	aptosstate "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/aptos"
-	"github.com/smartcontractkit/chainlink/deployment/common/types"
 )
 
 func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
@@ -56,7 +55,7 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 					4457093679053095497: GetMockChainContractParams(t, 4457093679053095497),
 					743186221051783445:  GetMockChainContractParams(t, 743186221051783445),
 				},
-				MCMSDeployConfigPerChain: map[uint64]types.MCMSWithTimelockConfigV2{
+				MCMSDeployConfigPerChain: map[uint64]cldfproposalutils.MCMSWithTimelockConfig{
 					4457093679053095497: getMockMCMSConfig(t),
 					743186221051783445:  getMockMCMSConfig(t),
 				},
@@ -108,7 +107,7 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 				ContractParamsPerChain: map[uint64]config.ChainContractParams{
 					4457093679053095497: GetMockChainContractParams(t, 4457093679053095497),
 				},
-				MCMSDeployConfigPerChain: map[uint64]types.MCMSWithTimelockConfigV2{
+				MCMSDeployConfigPerChain: map[uint64]cldfproposalutils.MCMSWithTimelockConfig{
 					4457093679053095497: {
 						Canceller:        cldftesthelpers.SingleGroupMCMS(t),
 						Proposer:         cldftesthelpers.SingleGroupMCMS(t),
@@ -259,7 +258,7 @@ func TestDeployAptosChain_Apply(t *testing.T) {
 		ContractParamsPerChain: map[uint64]config.ChainContractParams{
 			selector: mockCCIPParams,
 		},
-		MCMSDeployConfigPerChain: map[uint64]types.MCMSWithTimelockConfigV2{
+		MCMSDeployConfigPerChain: map[uint64]cldfproposalutils.MCMSWithTimelockConfig{
 			selector: {
 				Canceller:        cldftesthelpers.SingleGroupMCMS(t),
 				Proposer:         cldftesthelpers.SingleGroupMCMS(t),

--- a/deployment/ccip/changeset/aptos/sequence/deploy_mcms.go
+++ b/deployment/ccip/changeset/aptos/sequence/deploy_mcms.go
@@ -5,10 +5,10 @@ import (
 	aptosmcms "github.com/smartcontractkit/mcms/sdk/aptos"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
+	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/dependency"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/operation"
-	"github.com/smartcontractkit/chainlink/deployment/common/types"
 )
 
 // Deploy MCMS Sequence
@@ -24,7 +24,7 @@ var DeployMCMSSequence = operations.NewSequence(
 	deployMCMSSequence,
 )
 
-func deployMCMSSequence(b operations.Bundle, deps dependency.AptosDeps, configMCMS types.MCMSWithTimelockConfigV2) (DeployMCMSSeqOutput, error) {
+func deployMCMSSequence(b operations.Bundle, deps dependency.AptosDeps, configMCMS cldfproposalutils.MCMSWithTimelockConfig) (DeployMCMSSeqOutput, error) {
 	// Check if MCMS package is already deployed
 	onChainState := deps.CCIPOnChainState.AptosChains[deps.AptosChain.Selector]
 	if onChainState.MCMSAddress != (aptos.AccountAddress{}) {

--- a/deployment/ccip/changeset/aptos/test_helpers.go
+++ b/deployment/ccip/changeset/aptos/test_helpers.go
@@ -9,13 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	cldftesthelpers "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils/testhelpers"
-
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
+	cldftesthelpers "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils/testhelpers"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
-	"github.com/smartcontractkit/chainlink/deployment/common/types"
 )
 
 const (
@@ -76,8 +75,8 @@ func GetMockChainContractParams(t *testing.T, chainSelector uint64) config.Chain
 	}
 }
 
-func getMockMCMSConfig(t *testing.T) types.MCMSWithTimelockConfigV2 {
-	return types.MCMSWithTimelockConfigV2{
+func getMockMCMSConfig(t *testing.T) cldfproposalutils.MCMSWithTimelockConfig {
+	return cldfproposalutils.MCMSWithTimelockConfig{
 		Canceller:        cldftesthelpers.SingleGroupMCMS(t),
 		Proposer:         cldftesthelpers.SingleGroupMCMS(t),
 		Bypasser:         cldftesthelpers.SingleGroupMCMS(t),

--- a/deployment/ccip/changeset/testhelpers/test_helpers_aptos.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers_aptos.go
@@ -16,9 +16,6 @@ import (
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
 
-	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
-	cldftesthelpers "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils/testhelpers"
-
 	aptosBind "github.com/smartcontractkit/chainlink-aptos/bindings/bind"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/ccip"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/ccip_dummy_receiver"
@@ -38,6 +35,8 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/burn_mint_token_pool"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
+	cldftesthelpers "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils/testhelpers"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc677"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -49,7 +48,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	aptosstate "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/aptos"
 	commoncs "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 )
 
 func DeployChainContractsToAptosCS(t *testing.T, e DeployedEnv, chainSelector uint64) commoncs.ConfiguredChangeSet {
@@ -80,7 +78,7 @@ func DeployChainContractsToAptosCS(t *testing.T, e DeployedEnv, chainSelector ui
 				},
 			},
 		},
-		MCMSDeployConfigPerChain: map[uint64]commontypes.MCMSWithTimelockConfigV2{
+		MCMSDeployConfigPerChain: map[uint64]cldfproposalutils.MCMSWithTimelockConfig{
 			chainSelector: {
 				Canceller:        cldftesthelpers.SingleGroupMCMS(t),
 				Proposer:         cldftesthelpers.SingleGroupMCMS(t),

--- a/deployment/common/changeset/solana/mcms/mcms.go
+++ b/deployment/common/changeset/solana/mcms/mcms.go
@@ -10,11 +10,10 @@ import (
 	"github.com/gagliardetto/solana-go/rpc"
 	solstate "github.com/smartcontractkit/cld-changesets/legacy/pkg/family/solana"
 
-	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
-
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/solana/mcms/sequence"
@@ -118,7 +117,7 @@ func DeployMCMSWithTimelockProgramsSolanaV2(
 	e cldf.Environment,
 	ds datastore.MutableDataStore,
 	chain cldf_solana.Chain,
-	config commontypes.MCMSWithTimelockConfigV2) (*solstate.MCMSWithTimelockState, error) {
+	config cldfproposalutils.MCMSWithTimelockConfig) (*solstate.MCMSWithTimelockState, error) {
 	chainstate, err := solstate.MaybeLoadMCMSWithTimelockChainStateV2(e.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(chain.Selector)))
 	if err != nil {
 		return nil, err

--- a/deployment/common/changeset/solana/mcms/sequence/sequence.go
+++ b/deployment/common/changeset/solana/mcms/sequence/sequence.go
@@ -18,6 +18,7 @@ import (
 	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/timelock"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/solana/mcms/sequence/operation"
@@ -37,7 +38,7 @@ var (
 
 type (
 	DeployMCMSWithTimelockInput struct {
-		MCMConfig        commontypes.MCMSWithTimelockConfigV2
+		MCMConfig        cldfproposalutils.MCMSWithTimelockConfig
 		TimelockMinDelay *big.Int
 	}
 
@@ -196,7 +197,7 @@ func deployMCM(b operations.Bundle, deps operation.Deps) error {
 	return nil
 }
 
-func initMCM(b operations.Bundle, deps operation.Deps, cfg commontypes.MCMSWithTimelockConfigV2) error {
+func initMCM(b operations.Bundle, deps operation.Deps, cfg cldfproposalutils.MCMSWithTimelockConfig) error {
 	configs := []struct {
 		ctype cldf.ContractType
 		cfg   mcmsTypes.Config

--- a/deployment/common/types/types.go
+++ b/deployment/common/types/types.go
@@ -2,12 +2,7 @@ package types
 
 import (
 	"errors"
-	"math/big"
 	"time"
-
-	mcmstypes "github.com/smartcontractkit/mcms/types"
-
-	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
@@ -49,18 +44,6 @@ const (
 
 func (role MCMSRole) String() string {
 	return string(role)
-}
-
-// MCMSWithTimelockConfigV2 holds the configuration for an MCMS with timelock.
-// Note that this type already exists in types.go, but this one is using the new lib version.
-type MCMSWithTimelockConfigV2 struct {
-	Canceller        mcmstypes.Config                  `json:"canceller"`
-	Bypasser         mcmstypes.Config                  `json:"bypasser"`
-	Proposer         mcmstypes.Config                  `json:"proposer"`
-	TimelockMinDelay *big.Int                          `json:"timelockMinDelay"`
-	Label            *string                           `json:"label"`
-	GasBoostConfig   *cldfproposalutils.GasBoostConfig `json:"gasBoostConfig"`
-	Qualifier        *string                           `json:"qualifier"`
 }
 
 type OCRParameters struct {

--- a/deployment/cre/forwarder/solana/deploy_forwarder_test.go
+++ b/deployment/cre/forwarder/solana/deploy_forwarder_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 
 	solanaMCMS "github.com/smartcontractkit/chainlink/deployment/common/changeset/solana/mcms"
-	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/cre/forwarder"
 	"github.com/smartcontractkit/chainlink/deployment/helpers"
 	"github.com/smartcontractkit/chainlink/deployment/internal/soltestutils"
@@ -209,7 +208,7 @@ func TestConfigureForwarder(t *testing.T) {
 			rt.Environment(),
 			ds,
 			solChain,
-			commontypes.MCMSWithTimelockConfigV2{
+			cldfproposalutils.MCMSWithTimelockConfig{
 				Canceller:        cldftesthelpers.SingleGroupMCMS(t),
 				Proposer:         cldftesthelpers.SingleGroupMCMS(t),
 				Bypasser:         cldftesthelpers.SingleGroupMCMS(t),

--- a/deployment/cre/mcms/pkg/profiles.go
+++ b/deployment/cre/mcms/pkg/profiles.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
-	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 )
 
 var (
@@ -15,10 +15,10 @@ var (
 )
 
 type MCMSConfigStore struct {
-	m map[string]*commontypes.MCMSWithTimelockConfigV2
+	m map[string]*cldfproposalutils.MCMSWithTimelockConfig
 }
 
-func (r *MCMSConfigStore) Get(profileID string) (*commontypes.MCMSWithTimelockConfigV2, error) {
+func (r *MCMSConfigStore) Get(profileID string) (*cldfproposalutils.MCMSWithTimelockConfig, error) {
 	profile, exists := r.m[profileID]
 	if !exists {
 		return nil, errors.New("mcms profile not found: " + profileID)
@@ -35,12 +35,12 @@ func (r *MCMSConfigStore) List() []string {
 	return profiles
 }
 
-func (r *MCMSConfigStore) Put(profileID string, config commontypes.MCMSWithTimelockConfigV2) {
+func (r *MCMSConfigStore) Put(profileID string, config cldfproposalutils.MCMSWithTimelockConfig) {
 	r.m[profileID] = &config
 }
 
 func init() {
-	ConfigStore = MCMSConfigStore{m: make(map[string]*commontypes.MCMSWithTimelockConfigV2)}
+	ConfigStore = MCMSConfigStore{m: make(map[string]*cldfproposalutils.MCMSWithTimelockConfig)}
 }
 
 func MustGetMCMSConfig(quorum uint8, signers []common.Address, groupSigners []mcmstypes.Config) mcmstypes.Config {

--- a/deployment/data-feeds/changeset/solana/deploy_cache_test.go
+++ b/deployment/data-feeds/changeset/solana/deploy_cache_test.go
@@ -22,7 +22,6 @@ import (
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	solanaMCMS "github.com/smartcontractkit/chainlink/deployment/common/changeset/solana/mcms"
-	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/helpers"
 	"github.com/smartcontractkit/chainlink/deployment/internal/soltestutils"
 )
@@ -285,7 +284,7 @@ func TestConfigureCache(t *testing.T) {
 
 		// deploy mcms
 		mcmsState, err := solanaMCMS.DeployMCMSWithTimelockProgramsSolanaV2(env, ds, chain,
-			commontypes.MCMSWithTimelockConfigV2{
+			cldfproposalutils.MCMSWithTimelockConfig{
 				Canceller:        cldftesthelpers.SingleGroupMCMS(t),
 				Proposer:         cldftesthelpers.SingleGroupMCMS(t),
 				Bypasser:         cldftesthelpers.SingleGroupMCMS(t),


### PR DESCRIPTION
This updates the changesets to use the shared mcms config in the framework, removing the local copy.
