### PR TITLE
chore: move ocr parameters to ccip shared package

### DIFF
--- a/deployment/ccip/changeset/globals/ocr3.go
+++ b/deployment/ccip/changeset/globals/ocr3.go
@@ -6,7 +6,7 @@ import (
 
 	"dario.cat/mergo"
 
-	"github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 )
 
 // Intention of this file is to be a single source of the truth for OCR3 parameters used by CCIP plugins.
@@ -30,7 +30,7 @@ import (
 var (
 	// CommitOCRParams represents the default OCR3 parameters for all chains (beside Ethereum, see CommitOCRParamsForEthereum).
 	// Most of the intervals here should be generic enough (and chain agnostic) to be reused across different chains.
-	CommitOCRParams = types.OCRParameters{
+	CommitOCRParams = shared.OCRParameters{
 		DeltaProgress: 120 * time.Second,
 		DeltaResend:   30 * time.Second,
 		DeltaInitial:  20 * time.Second,
@@ -54,7 +54,7 @@ var (
 	// more expensive to other EVM compatible chains
 	CommitOCRParamsForEthereum = withOverrides(
 		CommitOCRParams,
-		types.OCRParameters{
+		shared.OCRParameters{
 			// Since a report produced every 2 rounds, whatever cadence we want to produce a report at we should divide by 2.
 			// If we want to produce a report every 12 seconds we would set DeltaRound to 6s.
 			// At a ~12s block time, this gives us a commit report every block.
@@ -65,7 +65,7 @@ var (
 
 var (
 	// ExecOCRParams represents the default OCR3 parameters for all chains (beside Ethereum, see ExecOCRParamsForEthereum).
-	ExecOCRParams = types.OCRParameters{
+	ExecOCRParams = shared.OCRParameters{
 		DeltaProgress:               120 * time.Second,
 		DeltaResend:                 30 * time.Second,
 		DeltaInitial:                20 * time.Second,
@@ -86,7 +86,7 @@ var (
 	// Similarly to Commit, it's here to accommodate Ethereum specific characteristics
 	ExecOCRParamsForEthereum = withOverrides(
 		ExecOCRParams,
-		types.OCRParameters{
+		shared.OCRParameters{
 			// Since exec produces a report every 3 rounds, and ideally we'd want to produce a report for every block
 			// in instances with high traffic, we do approximate block time (~15s) / 3 = 5s.
 			DeltaRound: 5 * time.Second,
@@ -94,7 +94,7 @@ var (
 	)
 )
 
-func withOverrides(base types.OCRParameters, overrides types.OCRParameters) types.OCRParameters {
+func withOverrides(base shared.OCRParameters, overrides shared.OCRParameters) shared.OCRParameters {
 	outcome := base
 	if err := mergo.Merge(&outcome, overrides, mergo.WithOverride); err != nil {
 		panic(fmt.Sprintf("error while building an OCR config %v", err))

--- a/deployment/ccip/changeset/internal/deploy_home_chain.go
+++ b/deployment/ccip/changeset/internal/deploy_home_chain.go
@@ -13,27 +13,24 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/gagliardetto/solana-go"
+	"github.com/xssnick/tonutils-go/address"
+
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-	"github.com/xssnick/tonutils-go/address"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/bytes"
-
-	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
-	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/ccip_home"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
-	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
-
+	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/bytes"
 	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
+	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
-	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipsolana"
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
@@ -461,7 +458,7 @@ func BuildOCR3ConfigForCCIPHome(
 	destSelector uint64,
 	nodes deployment.Nodes,
 	rmnHomeAddress common.Address,
-	ocrParams commontypes.OCRParameters,
+	ocrParams shared.OCRParameters,
 	commitOffchainCfg *pluginconfig.CommitOffchainConfig,
 	execOffchainCfg *pluginconfig.ExecuteOffchainConfig,
 	skipChainConfigValidation bool,

--- a/deployment/ccip/changeset/v1_6/config.go
+++ b/deployment/ccip/changeset/v1_6/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
-	"github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 )
 
 var (
@@ -36,7 +36,7 @@ var (
 
 	// Used for only testing with simulated chains
 	OcrParamsForTest = CCIPOCRParams{
-		OCRParameters: types.OCRParameters{
+		OCRParameters: shared.OCRParameters{
 			DeltaProgress:                           30 * time.Second, // Lower DeltaProgress can lead to timeouts when running tests locally
 			DeltaResend:                             10 * time.Second,
 			DeltaInitial:                            20 * time.Second,

--- a/deployment/ccip/changeset/v1_6/cs_ccip_home.go
+++ b/deployment/ccip/changeset/v1_6/cs_ccip_home.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
+	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
 	proposeutils "github.com/smartcontractkit/cld-changesets/legacy/mcms/proposeutils"
 
 	"github.com/smartcontractkit/chainlink-ccip/chainconfig"
@@ -39,8 +39,6 @@ import (
 	mcmsevmsdk "github.com/smartcontractkit/mcms/sdk/evm"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
-	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
-
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/internal"
 	opsutil "github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
@@ -48,7 +46,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 )
@@ -311,7 +308,7 @@ func refsByQualifier(refs []datastore.AddressRef) map[string]struct{} {
 
 type CCIPOCRParams struct {
 	// OCRParameters contains the parameters for the OCR plugin.
-	OCRParameters commontypes.OCRParameters `json:"ocrParameters"`
+	OCRParameters shared.OCRParameters `json:"ocrParameters"`
 	// CommitOffChainConfig contains pointers to Arb feeds for prices.
 	CommitOffChainConfig *pluginconfig.CommitOffchainConfig `json:"commitOffChainConfig,omitempty"`
 	// ExecuteOffChainConfig contains USDC config.

--- a/deployment/ccip/shared/types.go
+++ b/deployment/ccip/shared/types.go
@@ -1,6 +1,9 @@
 package shared
 
 import (
+	"errors"
+	"time"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
@@ -108,3 +111,58 @@ var (
 	ProxyAdmin                  deployment.ContractType = "ProxyAdmin"
 	TransparentUpgradeableProxy deployment.ContractType = "TransparentUpgradeableProxy"
 )
+
+type OCRParameters struct {
+	DeltaProgress                           time.Duration `json:"deltaProgress"`
+	DeltaResend                             time.Duration `json:"deltaResend"`
+	DeltaInitial                            time.Duration `json:"deltaInitial"`
+	DeltaRound                              time.Duration `json:"deltaRound"`
+	DeltaGrace                              time.Duration `json:"deltaGrace"`
+	DeltaCertifiedCommitRequest             time.Duration `json:"deltaCertifiedCommitRequest"`
+	DeltaStage                              time.Duration `json:"deltaStage"`
+	Rmax                                    uint64        `json:"rmax"`
+	MaxDurationQuery                        time.Duration `json:"maxDurationQuery"`
+	MaxDurationObservation                  time.Duration `json:"maxDurationObservation"`
+	MaxDurationShouldAcceptAttestedReport   time.Duration `json:"maxDurationShouldAcceptAttestedReport"`
+	MaxDurationShouldTransmitAcceptedReport time.Duration `json:"maxDurationShouldTransmitAcceptedReport"`
+}
+
+func (params OCRParameters) Validate() error {
+	if params.DeltaProgress <= 0 {
+		return errors.New("deltaProgress must be positive")
+	}
+	if params.DeltaResend <= 0 {
+		return errors.New("deltaResend must be positive")
+	}
+	if params.DeltaInitial <= 0 {
+		return errors.New("deltaInitial must be positive")
+	}
+	if params.DeltaRound <= 0 {
+		return errors.New("deltaRound must be positive")
+	}
+	if params.DeltaGrace <= 0 {
+		return errors.New("deltaGrace must be positive")
+	}
+	if params.DeltaCertifiedCommitRequest <= 0 {
+		return errors.New("deltaCertifiedCommitRequest must be positive")
+	}
+	if params.DeltaStage < 0 {
+		return errors.New("deltaStage must be positive or 0 for disabled")
+	}
+	if params.Rmax <= 0 {
+		return errors.New("rmax must be positive")
+	}
+	if params.MaxDurationQuery <= 0 {
+		return errors.New("maxDurationQuery must be positive")
+	}
+	if params.MaxDurationObservation <= 0 {
+		return errors.New("maxDurationObservation must be positive")
+	}
+	if params.MaxDurationShouldAcceptAttestedReport <= 0 {
+		return errors.New("maxDurationShouldAcceptAttestedReport must be positive")
+	}
+	if params.MaxDurationShouldTransmitAcceptedReport <= 0 {
+		return errors.New("maxDurationShouldTransmitAcceptedReport must be positive")
+	}
+	return nil
+}

--- a/deployment/common/types/types.go
+++ b/deployment/common/types/types.go
@@ -1,13 +1,14 @@
 package types
 
 import (
-	"errors"
-	"time"
-
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 type MCMSRole string
+
+func (role MCMSRole) String() string {
+	return string(role)
+}
 
 const (
 	BypasserManyChainMultisig  cldf.ContractType = "BypasserManyChainMultiSig"
@@ -41,62 +42,3 @@ const (
 	CancellerAccessControllerAccount cldf.ContractType = "CancellerAccessControllerAccount"
 	BypasserAccessControllerAccount  cldf.ContractType = "BypasserAccessControllerAccount"
 )
-
-func (role MCMSRole) String() string {
-	return string(role)
-}
-
-type OCRParameters struct {
-	DeltaProgress                           time.Duration `json:"deltaProgress"`
-	DeltaResend                             time.Duration `json:"deltaResend"`
-	DeltaInitial                            time.Duration `json:"deltaInitial"`
-	DeltaRound                              time.Duration `json:"deltaRound"`
-	DeltaGrace                              time.Duration `json:"deltaGrace"`
-	DeltaCertifiedCommitRequest             time.Duration `json:"deltaCertifiedCommitRequest"`
-	DeltaStage                              time.Duration `json:"deltaStage"`
-	Rmax                                    uint64        `json:"rmax"`
-	MaxDurationQuery                        time.Duration `json:"maxDurationQuery"`
-	MaxDurationObservation                  time.Duration `json:"maxDurationObservation"`
-	MaxDurationShouldAcceptAttestedReport   time.Duration `json:"maxDurationShouldAcceptAttestedReport"`
-	MaxDurationShouldTransmitAcceptedReport time.Duration `json:"maxDurationShouldTransmitAcceptedReport"`
-}
-
-func (params OCRParameters) Validate() error {
-	if params.DeltaProgress <= 0 {
-		return errors.New("deltaProgress must be positive")
-	}
-	if params.DeltaResend <= 0 {
-		return errors.New("deltaResend must be positive")
-	}
-	if params.DeltaInitial <= 0 {
-		return errors.New("deltaInitial must be positive")
-	}
-	if params.DeltaRound <= 0 {
-		return errors.New("deltaRound must be positive")
-	}
-	if params.DeltaGrace <= 0 {
-		return errors.New("deltaGrace must be positive")
-	}
-	if params.DeltaCertifiedCommitRequest <= 0 {
-		return errors.New("deltaCertifiedCommitRequest must be positive")
-	}
-	if params.DeltaStage < 0 {
-		return errors.New("deltaStage must be positive or 0 for disabled")
-	}
-	if params.Rmax <= 0 {
-		return errors.New("rmax must be positive")
-	}
-	if params.MaxDurationQuery <= 0 {
-		return errors.New("maxDurationQuery must be positive")
-	}
-	if params.MaxDurationObservation <= 0 {
-		return errors.New("maxDurationObservation must be positive")
-	}
-	if params.MaxDurationShouldAcceptAttestedReport <= 0 {
-		return errors.New("maxDurationShouldAcceptAttestedReport must be positive")
-	}
-	if params.MaxDurationShouldTransmitAcceptedReport <= 0 {
-		return errors.New("maxDurationShouldTransmitAcceptedReport must be positive")
-	}
-	return nil
-}


### PR DESCRIPTION
This moves the ocr parameters to the ccip shared package as the only users of this struct.
