### PR TITLE
Cherry-pick vault security fixes to release/2.51.1

### DIFF
--- a/core/capabilities/vault/authorizer.go
+++ b/core/capabilities/vault/authorizer.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
+	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 )
 
 // AuthResult is the normalized authorization output shared by
@@ -106,6 +110,10 @@ func (a *authorizer) AuthorizeRequest(ctx context.Context, req jsonrpc.Request[j
 		a.lggr.Debugw("replay guard rejected request", "method", req.Method, "requestID", req.ID, "owner", authResult.AuthorizedOwner(), "digest", authResult.Digest(), "expiresAt", authResult.ExpiresAt(), "hasAuth", req.Auth != "", "error", err)
 		return nil, err
 	}
+	if ownerErr := validatePreparedVaultOwners(req, authResult.AuthorizedOwner()); ownerErr != nil {
+		a.lggr.Errorw("owner binding rejected request", "method", req.Method, "requestID", req.ID, "owner", authResult.AuthorizedOwner(), "hasAuth", req.Auth != "", "error", ownerErr)
+		return nil, ownerErr
+	}
 	a.lggr.Debugw("request authorized", "method", req.Method, "requestID", req.ID, "owner", authResult.AuthorizedOwner(), "digest", authResult.Digest(), "expiresAt", authResult.ExpiresAt(), "hasAuth", req.Auth != "")
 	return authResult, nil
 }
@@ -135,4 +143,71 @@ func (a *authorizer) authorizeJWTBasedAuth(ctx context.Context, req jsonrpc.Requ
 		return nil, err
 	}
 	return a.jwtBasedAuth.AuthorizeRequest(ctx, req)
+}
+
+// validatePreparedVaultOwners checks that every secret identifier in the request
+// payload belongs to workflowOwner. It runs after allowlist or JWT authentication
+// so neither path can be exploited to mutate another owner's secrets.
+func validatePreparedVaultOwners(req jsonrpc.Request[json.RawMessage], workflowOwner string) error {
+	switch req.Method {
+	case vaulttypes.MethodSecretsCreate:
+		parsed := &vaultcommon.CreateSecretsRequest{}
+		if err := json.Unmarshal(*req.Params, parsed); err != nil {
+			return fmt.Errorf("failed to parse create secrets request: %w", err)
+		}
+		return validateEncryptedSecretOwnersMatchWorkflowOwner(parsed.EncryptedSecrets, workflowOwner)
+	case vaulttypes.MethodSecretsUpdate:
+		parsed := &vaultcommon.UpdateSecretsRequest{}
+		if err := json.Unmarshal(*req.Params, parsed); err != nil {
+			return fmt.Errorf("failed to parse update secrets request: %w", err)
+		}
+		return validateEncryptedSecretOwnersMatchWorkflowOwner(parsed.EncryptedSecrets, workflowOwner)
+	case vaulttypes.MethodSecretsDelete:
+		parsed := &vaultcommon.DeleteSecretsRequest{}
+		if err := json.Unmarshal(*req.Params, parsed); err != nil {
+			return fmt.Errorf("failed to parse delete secrets request: %w", err)
+		}
+		return validateSecretIdentifierOwnersMatchWorkflowOwner(parsed.Ids, workflowOwner)
+	case vaulttypes.MethodSecretsList:
+		parsed := &vaultcommon.ListSecretIdentifiersRequest{}
+		if err := json.Unmarshal(*req.Params, parsed); err != nil {
+			return fmt.Errorf("failed to parse list secrets request: %w", err)
+		}
+		if normalizeOwner(parsed.Owner) != normalizeOwner(workflowOwner) {
+			return fmt.Errorf("list secrets owner %q does not match authorized workflow owner %q", parsed.Owner, workflowOwner)
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func validateEncryptedSecretOwnersMatchWorkflowOwner(encryptedSecrets []*vaultcommon.EncryptedSecret, workflowOwner string) error {
+	if len(encryptedSecrets) == 0 {
+		return errors.New("encrypted secrets must contain at least one identifier")
+	}
+	for idx, encryptedSecret := range encryptedSecrets {
+		if encryptedSecret == nil || encryptedSecret.Id == nil {
+			return fmt.Errorf("encrypted secret at index %d must include an identifier", idx)
+		}
+		if normalizeOwner(encryptedSecret.Id.Owner) != normalizeOwner(workflowOwner) {
+			return fmt.Errorf("encrypted secret owner at index %d %q does not match authorized workflow owner %q", idx, encryptedSecret.Id.Owner, workflowOwner)
+		}
+	}
+	return nil
+}
+
+func validateSecretIdentifierOwnersMatchWorkflowOwner(ids []*vaultcommon.SecretIdentifier, workflowOwner string) error {
+	if len(ids) == 0 {
+		return errors.New("secret identifiers must not be empty")
+	}
+	for idx, id := range ids {
+		if id == nil {
+			return fmt.Errorf("secret identifier at index %d must not be nil", idx)
+		}
+		if normalizeOwner(id.Owner) != normalizeOwner(workflowOwner) {
+			return fmt.Errorf("secret identifier owner at index %d %q does not match authorized workflow owner %q", idx, id.Owner, workflowOwner)
+		}
+	}
+	return nil
 }

--- a/core/capabilities/vault/authorizer.go
+++ b/core/capabilities/vault/authorizer.go
@@ -145,50 +145,67 @@ func (a *authorizer) authorizeJWTBasedAuth(ctx context.Context, req jsonrpc.Requ
 	return a.jwtBasedAuth.AuthorizeRequest(ctx, req)
 }
 
-// validatePreparedVaultOwners checks that every secret identifier in the request
-// payload belongs to workflowOwner. It runs after allowlist or JWT authentication
-// so neither path can be exploited to mutate another owner's secrets.
+// validatePreparedVaultOwners checks that secret identifiers in the request payload
+// belong to workflowOwner. It runs after allowlist or JWT authentication so neither
+// path can be exploited to mutate another owner's secrets.
+//
+// Param shape validation (empty batch, nil entries, parse errors) is left to the
+// gateway handler validators so clients receive the same InvalidParamsError codes
+// as before.
 func validatePreparedVaultOwners(req jsonrpc.Request[json.RawMessage], workflowOwner string) error {
+	// If the request has no params, there are no secret identifiers to validate.
+	// The gateway handler validates this case and returns InvalidParamsError.
+	if req.Params == nil {
+		return nil
+	}
+
 	switch req.Method {
 	case vaulttypes.MethodSecretsCreate:
 		parsed := &vaultcommon.CreateSecretsRequest{}
 		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse create secrets request: %w", err)
+			// InvalidParamsError is returned by the gateway handler for this case.
+			return nil
 		}
-		return validateEncryptedSecretOwnersMatchWorkflowOwner(parsed.EncryptedSecrets, workflowOwner)
+		return validateEncryptedSecretOwnerMismatch(parsed.EncryptedSecrets, workflowOwner)
 	case vaulttypes.MethodSecretsUpdate:
 		parsed := &vaultcommon.UpdateSecretsRequest{}
 		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse update secrets request: %w", err)
+			// InvalidParamsError is returned by the gateway handler for this case.
+			return nil
 		}
-		return validateEncryptedSecretOwnersMatchWorkflowOwner(parsed.EncryptedSecrets, workflowOwner)
+		return validateEncryptedSecretOwnerMismatch(parsed.EncryptedSecrets, workflowOwner)
 	case vaulttypes.MethodSecretsDelete:
 		parsed := &vaultcommon.DeleteSecretsRequest{}
 		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse delete secrets request: %w", err)
+			// InvalidParamsError is returned by the gateway handler for this case.
+			return nil
 		}
-		return validateSecretIdentifierOwnersMatchWorkflowOwner(parsed.Ids, workflowOwner)
+		return validateSecretIdentifierOwnerMismatch(parsed.Ids, workflowOwner)
 	case vaulttypes.MethodSecretsList:
 		parsed := &vaultcommon.ListSecretIdentifiersRequest{}
 		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse list secrets request: %w", err)
+			// InvalidParamsError is returned by the gateway handler for this case.
+			return nil
 		}
 		if normalizeOwner(parsed.Owner) != normalizeOwner(workflowOwner) {
 			return fmt.Errorf("list secrets owner %q does not match authorized workflow owner %q", parsed.Owner, workflowOwner)
 		}
+	case vaulttypes.MethodPublicKeyGet:
 		return nil
 	default:
+		// Fail open: this check only binds secret identifiers to the authorized owner.
+		// Unknown methods are rejected later with UnsupportedMethodError in the gateway
+		// handler (HandleJSONRPCUserMessage) and on vault nodes (GatewayHandler.HandleGatewayMessage).
 		return nil
 	}
+	return nil
 }
 
-func validateEncryptedSecretOwnersMatchWorkflowOwner(encryptedSecrets []*vaultcommon.EncryptedSecret, workflowOwner string) error {
-	if len(encryptedSecrets) == 0 {
-		return errors.New("encrypted secrets must contain at least one identifier")
-	}
+func validateEncryptedSecretOwnerMismatch(encryptedSecrets []*vaultcommon.EncryptedSecret, workflowOwner string) error {
 	for idx, encryptedSecret := range encryptedSecrets {
 		if encryptedSecret == nil || encryptedSecret.Id == nil {
-			return fmt.Errorf("encrypted secret at index %d must include an identifier", idx)
+			// InvalidParamsError is returned by the gateway handler for this case.
+			continue
 		}
 		if normalizeOwner(encryptedSecret.Id.Owner) != normalizeOwner(workflowOwner) {
 			return fmt.Errorf("encrypted secret owner at index %d %q does not match authorized workflow owner %q", idx, encryptedSecret.Id.Owner, workflowOwner)
@@ -197,13 +214,11 @@ func validateEncryptedSecretOwnersMatchWorkflowOwner(encryptedSecrets []*vaultco
 	return nil
 }
 
-func validateSecretIdentifierOwnersMatchWorkflowOwner(ids []*vaultcommon.SecretIdentifier, workflowOwner string) error {
-	if len(ids) == 0 {
-		return errors.New("secret identifiers must not be empty")
-	}
+func validateSecretIdentifierOwnerMismatch(ids []*vaultcommon.SecretIdentifier, workflowOwner string) error {
 	for idx, id := range ids {
 		if id == nil {
-			return fmt.Errorf("secret identifier at index %d must not be nil", idx)
+			// InvalidParamsError is returned by the gateway handler for this case.
+			continue
 		}
 		if normalizeOwner(id.Owner) != normalizeOwner(workflowOwner) {
 			return fmt.Errorf("secret identifier owner at index %d %q does not match authorized workflow owner %q", idx, id.Owner, workflowOwner)

--- a/core/capabilities/vault/authorizer_test.go
+++ b/core/capabilities/vault/authorizer_test.go
@@ -38,7 +38,11 @@ func TestAuthorizer_RejectsJWTBasedAuthWhenUnavailable(t *testing.T) {
 }
 
 func TestAuthorizer_UsesJWTWhenGateEnabled(t *testing.T) {
-	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{})
+	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{Id: &vaultcommon.SecretIdentifier{Owner: "0xworkflow", Namespace: "ns", Key: "k"}, EncryptedValue: "cipher"},
+		},
+	})
 	require.NoError(t, err)
 
 	req := jsonrpc.Request[json.RawMessage]{
@@ -63,13 +67,11 @@ func TestAuthorizer_UsesJWTWhenGateEnabled(t *testing.T) {
 }
 
 func TestAuthorizer_DelegatesDigestVerificationToJWTAuth(t *testing.T) {
-	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{})
-	require.NoError(t, err)
-
+	// Use a method that does not carry secret identifiers so the owner-binding
+	// check is a no-op; the test's focus is digest delegation, not owner binding.
 	req := jsonrpc.Request[json.RawMessage]{
 		ID:     "1",
-		Method: vaulttypes.MethodSecretsCreate,
-		Params: (*json.RawMessage)(&params),
+		Method: vaulttypes.MethodPublicKeyGet,
 		Auth:   "jwt-token",
 	}
 
@@ -86,13 +88,11 @@ func TestAuthorizer_DelegatesDigestVerificationToJWTAuth(t *testing.T) {
 }
 
 func TestAuthorizer_RejectsJWTReplay(t *testing.T) {
-	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{})
-	require.NoError(t, err)
-
+	// Use a method that does not carry secret identifiers so the owner-binding
+	// check is a no-op; the test's focus is replay protection.
 	req := jsonrpc.Request[json.RawMessage]{
 		ID:     "1",
-		Method: vaulttypes.MethodSecretsCreate,
-		Params: (*json.RawMessage)(&params),
+		Method: vaulttypes.MethodPublicKeyGet,
 		Auth:   "jwt-token",
 	}
 	digest, err := req.Digest()
@@ -114,7 +114,8 @@ func TestAuthorizer_RejectsJWTReplay(t *testing.T) {
 
 func TestAuthorizer_RejectsAllowListBasedAuthReplay(t *testing.T) {
 	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
-	req := jsonrpc.Request[json.RawMessage]{ID: "1", Method: vaulttypes.MethodSecretsCreate}
+	// Use a method without secret identifiers so the owner-binding check is a no-op.
+	req := jsonrpc.Request[json.RawMessage]{ID: "1", Method: vaulttypes.MethodPublicKeyGet}
 	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, req).Return(vault.NewAuthResult("", "0xabc", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Twice()
 
 	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))

--- a/core/capabilities/vault/authorizer_test.go
+++ b/core/capabilities/vault/authorizer_test.go
@@ -67,8 +67,6 @@ func TestAuthorizer_UsesJWTWhenGateEnabled(t *testing.T) {
 }
 
 func TestAuthorizer_DelegatesDigestVerificationToJWTAuth(t *testing.T) {
-	// Use a method that does not carry secret identifiers so the owner-binding
-	// check is a no-op; the test's focus is digest delegation, not owner binding.
 	req := jsonrpc.Request[json.RawMessage]{
 		ID:     "1",
 		Method: vaulttypes.MethodPublicKeyGet,
@@ -88,8 +86,6 @@ func TestAuthorizer_DelegatesDigestVerificationToJWTAuth(t *testing.T) {
 }
 
 func TestAuthorizer_RejectsJWTReplay(t *testing.T) {
-	// Use a method that does not carry secret identifiers so the owner-binding
-	// check is a no-op; the test's focus is replay protection.
 	req := jsonrpc.Request[json.RawMessage]{
 		ID:     "1",
 		Method: vaulttypes.MethodPublicKeyGet,
@@ -132,13 +128,10 @@ func TestAuthorizer_RejectsAllowListBasedAuthReplay(t *testing.T) {
 }
 
 func TestAuthorizer_PropagatesJWTValidationErrors(t *testing.T) {
-	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{})
-	require.NoError(t, err)
-
+	// JWT mock fails before owner binding; params are irrelevant here.
 	req := jsonrpc.Request[json.RawMessage]{
 		ID:     "1",
 		Method: vaulttypes.MethodSecretsCreate,
-		Params: (*json.RawMessage)(&params),
 		Auth:   "jwt-token",
 	}
 
@@ -150,4 +143,113 @@ func TestAuthorizer_PropagatesJWTValidationErrors(t *testing.T) {
 	authResult, err := a.AuthorizeRequest(t.Context(), req)
 	require.Nil(t, authResult)
 	require.ErrorContains(t, err, "bad token")
+}
+
+func TestAuthorizer_AllowListPath_RejectsCreateOwnerMismatch(t *testing.T) {
+	params, err := json.Marshal(vaultcommon.CreateSecretsRequest{
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{Id: &vaultcommon.SecretIdentifier{Owner: "0xother", Namespace: "ns", Key: "k"}, EncryptedValue: "cipher"},
+		},
+	})
+	require.NoError(t, err)
+
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "1",
+		Method: vaulttypes.MethodSecretsCreate,
+		Params: (*json.RawMessage)(&params),
+	}
+
+	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
+	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, req).Return(vault.NewAuthResult("", "0xauthorized", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Once()
+
+	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
+
+	authResult, err := a.AuthorizeRequest(t.Context(), req)
+	require.Nil(t, authResult)
+	require.ErrorContains(t, err, "encrypted secret owner at index 0 \"0xother\" does not match authorized workflow owner \"0xauthorized\"")
+}
+
+func TestAuthorizer_AllowListPath_RejectsUpdateOwnerMismatch(t *testing.T) {
+	params, err := json.Marshal(vaultcommon.UpdateSecretsRequest{
+		EncryptedSecrets: []*vaultcommon.EncryptedSecret{
+			{Id: &vaultcommon.SecretIdentifier{Owner: "0xother", Namespace: "ns", Key: "k"}, EncryptedValue: "cipher"},
+		},
+	})
+	require.NoError(t, err)
+
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "1",
+		Method: vaulttypes.MethodSecretsUpdate,
+		Params: (*json.RawMessage)(&params),
+	}
+
+	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
+	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, req).Return(vault.NewAuthResult("", "0xauthorized", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Once()
+
+	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
+
+	authResult, err := a.AuthorizeRequest(t.Context(), req)
+	require.Nil(t, authResult)
+	require.ErrorContains(t, err, "encrypted secret owner at index 0 \"0xother\" does not match authorized workflow owner \"0xauthorized\"")
+}
+
+func TestAuthorizer_AllowListPath_RejectsDeleteOwnerMismatch(t *testing.T) {
+	params, err := json.Marshal(vaultcommon.DeleteSecretsRequest{
+		Ids: []*vaultcommon.SecretIdentifier{
+			{Owner: "0xother", Namespace: "ns", Key: "k"},
+		},
+	})
+	require.NoError(t, err)
+
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "1",
+		Method: vaulttypes.MethodSecretsDelete,
+		Params: (*json.RawMessage)(&params),
+	}
+
+	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
+	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, req).Return(vault.NewAuthResult("", "0xauthorized", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Once()
+
+	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
+
+	authResult, err := a.AuthorizeRequest(t.Context(), req)
+	require.Nil(t, authResult)
+	require.ErrorContains(t, err, "secret identifier owner at index 0 \"0xother\" does not match authorized workflow owner \"0xauthorized\"")
+}
+
+func TestAuthorizer_AllowListPath_RejectsListOwnerMismatch(t *testing.T) {
+	params, err := json.Marshal(vaultcommon.ListSecretIdentifiersRequest{
+		Owner:     "0xother",
+		Namespace: "ns",
+	})
+	require.NoError(t, err)
+
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "1",
+		Method: vaulttypes.MethodSecretsList,
+		Params: (*json.RawMessage)(&params),
+	}
+
+	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
+	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, req).Return(vault.NewAuthResult("", "0xauthorized", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Once()
+
+	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
+
+	authResult, err := a.AuthorizeRequest(t.Context(), req)
+	require.Nil(t, authResult)
+	require.ErrorContains(t, err, "list secrets owner \"0xother\" does not match authorized workflow owner \"0xauthorized\"")
+}
+
+func TestAuthorizer_SkipsOwnerBindingWhenParamsMissing(t *testing.T) {
+	allowListBasedAuth := vaultmocks.NewAuthorizer(t)
+	allowListBasedAuth.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Return(vault.NewAuthResult("", "0xauthorized", "digest-1", time.Now().Add(time.Minute).Unix()), nil).Once()
+
+	a := vault.NewAuthorizer(allowListBasedAuth, nil, logger.TestLogger(t))
+
+	authResult, err := a.AuthorizeRequest(t.Context(), jsonrpc.Request[json.RawMessage]{
+		ID:     "1",
+		Method: vaulttypes.MethodSecretsCreate,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "0xauthorized", authResult.AuthorizedOwner())
 }

--- a/core/capabilities/vault/gw_handler.go
+++ b/core/capabilities/vault/gw_handler.go
@@ -241,6 +241,11 @@ func (h *GatewayHandler) authorizeAndPrefixRequest(ctx context.Context, req *jso
 	}
 	authorizedOwner := authResult.AuthorizedOwner()
 
+	if ownerErr := ValidatePreparedVaultOwners(authReq, authorizedOwner); ownerErr != nil {
+		h.lggr.Errorw("gateway request owner binding failed", "method", req.Method, "requestID", originalRequestID, "authorizedOwner", authorizedOwner, "error", ownerErr)
+		return nil, fmt.Errorf("request not authorized: %w", ownerErr)
+	}
+
 	req.ID = authorizedOwner + vaulttypes.RequestIDSeparator + originalRequestID
 	h.lggr.Debugw("authorized gateway request", "method", req.Method, "requestID", req.ID, "owner", authorizedOwner, "orgID", authResult.OrgID(), "workflowOwner", authResult.WorkflowOwner())
 	return authResult, nil

--- a/core/capabilities/vault/gw_handler.go
+++ b/core/capabilities/vault/gw_handler.go
@@ -241,11 +241,6 @@ func (h *GatewayHandler) authorizeAndPrefixRequest(ctx context.Context, req *jso
 	}
 	authorizedOwner := authResult.AuthorizedOwner()
 
-	if ownerErr := ValidatePreparedVaultOwners(authReq, authorizedOwner); ownerErr != nil {
-		h.lggr.Errorw("gateway request owner binding failed", "method", req.Method, "requestID", originalRequestID, "authorizedOwner", authorizedOwner, "error", ownerErr)
-		return nil, fmt.Errorf("request not authorized: %w", ownerErr)
-	}
-
 	req.ID = authorizedOwner + vaulttypes.RequestIDSeparator + originalRequestID
 	h.lggr.Debugw("authorized gateway request", "method", req.Method, "requestID", req.ID, "owner", authorizedOwner, "orgID", authResult.OrgID(), "workflowOwner", authResult.WorkflowOwner())
 	return authResult, nil

--- a/core/capabilities/vault/gw_handler_test.go
+++ b/core/capabilities/vault/gw_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,7 +90,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 				ss.EXPECT().CreateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.CreateSecretsRequest) bool {
 					return len(req.EncryptedSecrets) == 1 &&
 						req.EncryptedSecrets[0].Id.Key == "test-secret" &&
-						req.EncryptedSecrets[0].Id.Owner == "org-1" &&
+						req.EncryptedSecrets[0].Id.Owner == "0xworkflow" &&
 						req.RequestId == "0xworkflow"+vaulttypes.RequestIDSeparator+"1"
 				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
 
@@ -106,7 +107,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 							{
 								Id: &vaultcommon.SecretIdentifier{
 									Key:   "test-secret",
-									Owner: "org-1",
+									Owner: "0xworkflow",
 								},
 								EncryptedValue: "encrypted-value",
 							},
@@ -130,7 +131,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 				ss.EXPECT().CreateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.CreateSecretsRequest) bool {
 					return len(req.EncryptedSecrets) == 1 &&
 						req.EncryptedSecrets[0].Id.Key == "test-secret" &&
-						req.EncryptedSecrets[0].Id.Owner == "org-1" &&
+						req.EncryptedSecrets[0].Id.Owner == "0xworkflow" &&
 						req.RequestId == "0xworkflow"+vaulttypes.RequestIDSeparator+"1"
 				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
 
@@ -144,7 +145,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 				Params: func() *json.RawMessage {
 					rid := "org-1" + vaulttypes.RequestIDSeparator + "1"
 					raw := json.RawMessage(fmt.Sprintf(
-						`{"request_id":%q,"encrypted_secrets":[{"id":{"key":"test-secret","owner":"org-1"},"encrypted_value":"encrypted-value"}]}`,
+						`{"request_id":%q,"encrypted_secrets":[{"id":{"key":"test-secret","owner":"0xworkflow"},"encrypted_value":"encrypted-value"}]}`,
 						rid,
 					))
 					return &raw
@@ -264,7 +265,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 				ss.EXPECT().UpdateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.UpdateSecretsRequest) bool {
 					return len(req.EncryptedSecrets) == 1 &&
 						req.EncryptedSecrets[0].Id.Key == "updated-secret" &&
-						req.EncryptedSecrets[0].Id.Owner == "org-1" &&
+						req.EncryptedSecrets[0].Id.Owner == "0xworkflow" &&
 						req.RequestId == "0xworkflow"+vaulttypes.RequestIDSeparator+"1"
 				})).Return(&vaulttypes.Response{ID: "updated-secret"}, nil)
 
@@ -281,7 +282,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 							{
 								Id: &vaultcommon.SecretIdentifier{
 									Key:   "updated-secret",
-									Owner: "org-1",
+									Owner: "0xworkflow",
 								},
 								EncryptedValue: "encrypted-value",
 							},
@@ -303,7 +304,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 					return len(req.Ids) == 1 &&
 						req.Ids[0].Key == "Foo" &&
 						req.Ids[0].Namespace == "Bar" &&
-						req.Ids[0].Owner == "org-1" &&
+						req.Ids[0].Owner == "0xworkflow" &&
 						req.RequestId == "0xworkflow"+vaulttypes.RequestIDSeparator+"1"
 				})).Return(&vaulttypes.Response{ID: "test-secret"}, nil)
 
@@ -320,7 +321,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 							{
 								Key:       "Foo",
 								Namespace: "Bar",
-								Owner:     "org-1",
+								Owner:     "0xworkflow",
 							},
 						},
 					})
@@ -351,7 +352,7 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 				ID:     "1",
 				Params: func() *json.RawMessage {
 					params, _ := json.Marshal(vaultcommon.ListSecretIdentifiersRequest{
-						Owner:     "user-supplied-owner",
+						Owner:     "0xworkflow",
 						Namespace: "ns",
 					})
 					raw := json.RawMessage(params)
@@ -440,19 +441,13 @@ func TestGatewayHandler_HandleGatewayMessage(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "failure - capability rejects owner mismatch",
+			name: "failure - auth layer rejects cross-owner mutation",
 			setupMocks: func(ss *vaulttypesmocks.SecretsService, gc *connector_mocks.GatewayConnector, ra *vaultcapmocks.Authorizer) {
 				ra.EXPECT().AuthorizeRequest(mock.Anything, mock.Anything).Return(authResult("", "0xdef"), nil)
-				ss.EXPECT().CreateSecrets(mock.Anything, mock.MatchedBy(func(req *vaultcommon.CreateSecretsRequest) bool {
-					return len(req.EncryptedSecrets) == 1 &&
-						req.EncryptedSecrets[0].Id.Key == "test-secret" &&
-						req.EncryptedSecrets[0].Id.Owner == "0xabc" &&
-						req.RequestId == "0xdef"+vaulttypes.RequestIDSeparator+"1"
-				})).Return(nil, errors.New("capability owner validation failed"))
 				gc.On("SendToGateway", mock.Anything, "gateway-1", mock.MatchedBy(func(resp *jsonrpc.Response[json.RawMessage]) bool {
 					return resp.Error != nil &&
-						resp.Error.Code == api.ToJSONRPCErrorCode(api.FatalError) &&
-						resp.Error.Message == "capability owner validation failed"
+						resp.Error.Code == api.ToJSONRPCErrorCode(api.HandlerError) &&
+						strings.Contains(resp.Error.Message, "request not authorized")
 				})).Return(nil)
 			},
 			request: &jsonrpc.Request[json.RawMessage]{

--- a/core/capabilities/vault/jwt_based_auth.go
+++ b/core/capabilities/vault/jwt_based_auth.go
@@ -265,7 +265,7 @@ func (v *jwtBasedAuth) AuthorizeRequest(ctx context.Context, req jsonrpc.Request
 		return nil, fmt.Errorf("invalid JWT auth token: %w", err)
 	}
 
-	if ownerErr := validateJWTPreparedVaultOwners(req, derivedWorkflowOwner); ownerErr != nil {
+	if ownerErr := ValidatePreparedVaultOwners(req, derivedWorkflowOwner); ownerErr != nil {
 		v.lggr.Debugw("JWTBasedAuth secret owners rejected prepared request", "method", req.Method, "requestID", req.ID, "orgID", claims.OrgID, "workflowOwner", derivedWorkflowOwner, "error", ownerErr)
 		return nil, fmt.Errorf("invalid JWT auth token: %w", ownerErr)
 	}
@@ -442,7 +442,10 @@ func extractAuthorizationDetails(claims jwt.MapClaims) (workflowOwner, requestDi
 	return workflowOwner, requestDigest, nil
 }
 
-func validateJWTPreparedVaultOwners(req jsonrpc.Request[json.RawMessage], workflowOwner string) error {
+// ValidatePreparedVaultOwners checks that every secret identifier in the request
+// payload belongs to workflowOwner. It is used by both the JWT and allowlist auth
+// paths so that neither can be exploited to mutate another owner's secrets.
+func ValidatePreparedVaultOwners(req jsonrpc.Request[json.RawMessage], workflowOwner string) error {
 	switch req.Method {
 	case vaulttypes.MethodSecretsCreate:
 		parsed := &vaultcommon.CreateSecretsRequest{}

--- a/core/capabilities/vault/jwt_based_auth.go
+++ b/core/capabilities/vault/jwt_based_auth.go
@@ -18,13 +18,11 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 
-	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 )
 
 var (
@@ -265,11 +263,6 @@ func (v *jwtBasedAuth) AuthorizeRequest(ctx context.Context, req jsonrpc.Request
 		return nil, fmt.Errorf("invalid JWT auth token: %w", err)
 	}
 
-	if ownerErr := ValidatePreparedVaultOwners(req, derivedWorkflowOwner); ownerErr != nil {
-		v.lggr.Debugw("JWTBasedAuth secret owners rejected prepared request", "method", req.Method, "requestID", req.ID, "orgID", claims.OrgID, "workflowOwner", derivedWorkflowOwner, "error", ownerErr)
-		return nil, fmt.Errorf("invalid JWT auth token: %w", ownerErr)
-	}
-
 	v.lggr.Debugw("JWTBasedAuth authorization succeeded", "method", req.Method, "requestID", req.ID, "orgID", claims.OrgID, "workflowOwner", derivedWorkflowOwner, "digest", requestDigest, "expiresAt", claims.ExpiresAt.UTC().Unix())
 	return &AuthResult{
 		orgID:         claims.OrgID,
@@ -440,73 +433,6 @@ func extractAuthorizationDetails(claims jwt.MapClaims) (workflowOwner, requestDi
 	}
 
 	return workflowOwner, requestDigest, nil
-}
-
-// ValidatePreparedVaultOwners checks that every secret identifier in the request
-// payload belongs to workflowOwner. It is used by both the JWT and allowlist auth
-// paths so that neither can be exploited to mutate another owner's secrets.
-func ValidatePreparedVaultOwners(req jsonrpc.Request[json.RawMessage], workflowOwner string) error {
-	switch req.Method {
-	case vaulttypes.MethodSecretsCreate:
-		parsed := &vaultcommon.CreateSecretsRequest{}
-		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse create secrets request: %w", err)
-		}
-		return validateEncryptedSecretOwnersMatchWorkflowOwner(parsed.EncryptedSecrets, workflowOwner)
-	case vaulttypes.MethodSecretsUpdate:
-		parsed := &vaultcommon.UpdateSecretsRequest{}
-		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse update secrets request: %w", err)
-		}
-		return validateEncryptedSecretOwnersMatchWorkflowOwner(parsed.EncryptedSecrets, workflowOwner)
-	case vaulttypes.MethodSecretsDelete:
-		parsed := &vaultcommon.DeleteSecretsRequest{}
-		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse delete secrets request: %w", err)
-		}
-		return validateSecretIdentifierOwnersMatchWorkflowOwner(parsed.Ids, workflowOwner)
-	case vaulttypes.MethodSecretsList:
-		parsed := &vaultcommon.ListSecretIdentifiersRequest{}
-		if err := json.Unmarshal(*req.Params, parsed); err != nil {
-			return fmt.Errorf("failed to parse list secrets request: %w", err)
-		}
-		if normalizeOwner(parsed.Owner) != normalizeOwner(workflowOwner) {
-			return fmt.Errorf("list secrets owner %q does not match authorized workflow owner %q", parsed.Owner, workflowOwner)
-		}
-		return nil
-	default:
-		return fmt.Errorf("method %q does not carry vault secret identifiers", req.Method)
-	}
-}
-
-func validateEncryptedSecretOwnersMatchWorkflowOwner(encryptedSecrets []*vaultcommon.EncryptedSecret, workflowOwner string) error {
-	if len(encryptedSecrets) == 0 {
-		return errors.New("encrypted secrets must contain at least one identifier")
-	}
-	for idx, encryptedSecret := range encryptedSecrets {
-		if encryptedSecret == nil || encryptedSecret.Id == nil {
-			return fmt.Errorf("encrypted secret at index %d must include an identifier", idx)
-		}
-		if normalizeOwner(encryptedSecret.Id.Owner) != normalizeOwner(workflowOwner) {
-			return fmt.Errorf("encrypted secret owner at index %d %q does not match authorized workflow owner %q", idx, encryptedSecret.Id.Owner, workflowOwner)
-		}
-	}
-	return nil
-}
-
-func validateSecretIdentifierOwnersMatchWorkflowOwner(ids []*vaultcommon.SecretIdentifier, workflowOwner string) error {
-	if len(ids) == 0 {
-		return errors.New("secret identifiers must not be empty")
-	}
-	for idx, id := range ids {
-		if id == nil {
-			return fmt.Errorf("secret identifier at index %d must not be nil", idx)
-		}
-		if normalizeOwner(id.Owner) != normalizeOwner(workflowOwner) {
-			return fmt.Errorf("secret identifier owner at index %d %q does not match authorized workflow owner %q", idx, id.Owner, workflowOwner)
-		}
-	}
-	return nil
 }
 
 // resolveSigningKey looks up the RSA public key for the given kid from the

--- a/core/capabilities/vault/jwt_based_auth_test.go
+++ b/core/capabilities/vault/jwt_based_auth_test.go
@@ -915,7 +915,9 @@ func TestJWTBasedAuth_RejectsCreateRequestWithoutWorkflowOwnerWhenIdentifierOwne
 	req, err = jsonrpc.DecodeRequest[json.RawMessage](rawRequest, token)
 	require.NoError(t, err)
 
-	authResult, err := v.AuthorizeRequest(t.Context(), req)
+	// Owner binding is enforced by the composite Authorizer, not the JWT layer directly.
+	a := NewAuthorizer(nil, v, logger.TestLogger(t))
+	authResult, err := a.AuthorizeRequest(t.Context(), req)
 	require.Nil(t, authResult)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "encrypted secret owner at index 0 \"0xAbCd\" does not match authorized workflow owner")

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -43,13 +43,13 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.101
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260506144252-c100eabfda74
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260522094612-5f9f748bd87a
 	github.com/smartcontractkit/chainlink-deployments-framework v0.105.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260609161557-8ceae53b8ab1
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20260521215851-3fdbb363496f
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.16.2
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.23

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1573,8 +1573,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd h1:IMopuENFVS63AerRELdfWo6o60UNUidcldJOxJLmk24=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd/go.mod h1:SBN8Urnh5sQvrQRbSo1Nr8coWatHg8LZoPw3R/42sho=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443 h1:uclvPWuit298UwfANmUUFWZdYX/pcQZLUosZVjwqs40=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443/go.mod h1:fP9RqD25/gTx3XqRstN8o4lAI3jp42vwJBLRZwRoOOM=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e h1:uTuCrOqBZeYfIl2QG70KuCG7xpubUETFJpHiip5+7FU=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e/go.mod h1:GlEVw7ziizXoMfzl1onNSwansrVBLHhj5gUJlGQpb4I=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0 h1:NExKM/D0HneOq/N5LGTbkV4VOa0UHCvfTNEb4GqYpto=
@@ -1609,8 +1609,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f h1:t+OoYaXLdH0WHK2pbWKjTSnSQa5JBQD1+gf0yISYfQk=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a h1:alnfvQgCKPFqsfijZQnr6Sbus2GT5YZ9BT/KzVrbszE=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 h1:SG+wAsNyAcA6Kk19ljuxi3HK9Ll2lpHik8OKoY4x7A0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0 h1:q+VDPcxWrj5k9QizSYfUOSMnDH3Sd5HvbPguZOgfXTY=

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -829,7 +829,11 @@ func (h *handler) errorResponse(
 		// Intentionally hide the error from the user
 		err = errors.New(errorCode.String())
 	case api.InvalidParamsError:
-		h.lggr.Errorw("invalid params", "requestID", req.ID, "params", string(*req.Params))
+		paramsStr := ""
+		if req.Params != nil {
+			paramsStr = string(*req.Params)
+		}
+		h.lggr.Errorw("invalid params", "requestID", req.ID, "params", paramsStr)
 		err = errors.New("invalid params error: " + err.Error())
 	case api.UnsupportedMethodError:
 		h.lggr.Errorw("unsupported method", "requestID", req.ID, "method", req.Method, "error", err.Error())

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -433,6 +433,7 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 		return errors.New("request not authorized: " + authErr.Error())
 	}
 	authorizedOwner := authResult.AuthorizedOwner()
+
 	// Generate a unique ID for the request.
 	// Prefix request id with authorizedOwner, to ensure uniqueness across different owners
 	// We do this ourselves to ensure the ID is unique and can't be tampered with by the user.
@@ -611,6 +612,10 @@ func (h *handler) handleSecretsCreate(ctx context.Context, ar *activeRequest) er
 	if unmarshalErr := json.Unmarshal(*ar.req.Params, &createSecretsRequest); unmarshalErr != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, unmarshalErr, nil))
 	}
+	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
+		l.Errorw("owner binding failed", "error", ownerErr)
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
+	}
 	createSecretsRequest.RequestId = ar.req.ID
 	for _, secretItem := range createSecretsRequest.EncryptedSecrets {
 		if secretItem != nil && secretItem.Id != nil && secretItem.Id.Namespace == "" {
@@ -652,7 +657,10 @@ func (h *handler) handleSecretsUpdate(ctx context.Context, ar *activeRequest) er
 	if unmarshalErr := json.Unmarshal(*ar.req.Params, updateSecretsRequest); unmarshalErr != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, unmarshalErr, nil))
 	}
-
+	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
+		l.Errorw("owner binding failed", "error", ownerErr)
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
+	}
 	updateSecretsRequest.RequestId = ar.req.ID
 	for _, secretItem := range updateSecretsRequest.EncryptedSecrets {
 		if secretItem != nil && secretItem.Id != nil && secretItem.Id.Namespace == "" {
@@ -693,7 +701,10 @@ func (h *handler) handleSecretsDelete(ctx context.Context, ar *activeRequest) er
 	if unmarshalErr := json.Unmarshal(*ar.req.Params, deleteSecretsRequest); unmarshalErr != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, unmarshalErr, nil))
 	}
-
+	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
+		l.Errorw("owner binding failed", "error", ownerErr)
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
+	}
 	deleteSecretsRequest.RequestId = ar.req.ID
 	for _, id := range deleteSecretsRequest.Ids {
 		if id != nil && id.Namespace == "" {
@@ -723,7 +734,10 @@ func (h *handler) handleSecretsList(ctx context.Context, ar *activeRequest) erro
 	if err := json.Unmarshal(*ar.req.Params, req); err != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, err, nil))
 	}
-
+	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
+		l.Errorw("owner binding failed", "error", ownerErr)
+		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
+	}
 	req.RequestId = ar.req.ID
 	if req.Namespace == "" {
 		req.Namespace = vaulttypes.DefaultNamespace
@@ -865,6 +879,16 @@ func (h *handler) errorResponse(
 		),
 		ErrorCode: errorCode,
 	}
+}
+
+// authorizedOwnerFromRequestID extracts the owner prefix that was stamped onto
+// the request ID after authorization (format: "<owner>::<original-id>").
+func authorizedOwnerFromRequestID(requestID string) string {
+	idx := strings.Index(requestID, vaulttypes.RequestIDSeparator)
+	if idx == -1 {
+		return ""
+	}
+	return requestID[:idx]
 }
 
 func (h *handler) sendResponse(ctx context.Context, userRequest *activeRequest, resp gwhandlers.UserCallbackPayload) error {

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -612,10 +612,6 @@ func (h *handler) handleSecretsCreate(ctx context.Context, ar *activeRequest) er
 	if unmarshalErr := json.Unmarshal(*ar.req.Params, &createSecretsRequest); unmarshalErr != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, unmarshalErr, nil))
 	}
-	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
-		l.Errorw("owner binding failed", "error", ownerErr)
-		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
-	}
 	createSecretsRequest.RequestId = ar.req.ID
 	for _, secretItem := range createSecretsRequest.EncryptedSecrets {
 		if secretItem != nil && secretItem.Id != nil && secretItem.Id.Namespace == "" {
@@ -657,10 +653,6 @@ func (h *handler) handleSecretsUpdate(ctx context.Context, ar *activeRequest) er
 	if unmarshalErr := json.Unmarshal(*ar.req.Params, updateSecretsRequest); unmarshalErr != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, unmarshalErr, nil))
 	}
-	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
-		l.Errorw("owner binding failed", "error", ownerErr)
-		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
-	}
 	updateSecretsRequest.RequestId = ar.req.ID
 	for _, secretItem := range updateSecretsRequest.EncryptedSecrets {
 		if secretItem != nil && secretItem.Id != nil && secretItem.Id.Namespace == "" {
@@ -701,10 +693,6 @@ func (h *handler) handleSecretsDelete(ctx context.Context, ar *activeRequest) er
 	if unmarshalErr := json.Unmarshal(*ar.req.Params, deleteSecretsRequest); unmarshalErr != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, unmarshalErr, nil))
 	}
-	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
-		l.Errorw("owner binding failed", "error", ownerErr)
-		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
-	}
 	deleteSecretsRequest.RequestId = ar.req.ID
 	for _, id := range deleteSecretsRequest.Ids {
 		if id != nil && id.Namespace == "" {
@@ -733,10 +721,6 @@ func (h *handler) handleSecretsList(ctx context.Context, ar *activeRequest) erro
 	req := &vaultcommon.ListSecretIdentifiersRequest{}
 	if err := json.Unmarshal(*ar.req.Params, req); err != nil {
 		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.UserMessageParseError, err, nil))
-	}
-	if ownerErr := vaultcap.ValidatePreparedVaultOwners(ar.req, authorizedOwnerFromRequestID(ar.req.ID)); ownerErr != nil {
-		l.Errorw("owner binding failed", "error", ownerErr)
-		return h.sendResponse(ctx, ar, h.errorResponse(ar.req, api.InvalidParamsError, ownerErr, nil))
 	}
 	req.RequestId = ar.req.ID
 	if req.Namespace == "" {
@@ -879,16 +863,6 @@ func (h *handler) errorResponse(
 		),
 		ErrorCode: errorCode,
 	}
-}
-
-// authorizedOwnerFromRequestID extracts the owner prefix that was stamped onto
-// the request ID after authorization (format: "<owner>::<original-id>").
-func authorizedOwnerFromRequestID(requestID string) string {
-	idx := strings.Index(requestID, vaulttypes.RequestIDSeparator)
-	if idx == -1 {
-		return ""
-	}
-	return requestID[:idx]
 }
 
 func (h *handler) sendResponse(ctx context.Context, userRequest *activeRequest, resp gwhandlers.UserCallbackPayload) error {

--- a/core/services/gateway/handlers/vault/handler_test.go
+++ b/core/services/gateway/handlers/vault/handler_test.go
@@ -445,6 +445,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 	})
 
 	t.Run("nil EncryptedSecrets inside CreateSecrets body", func(t *testing.T) {
+		var wg sync.WaitGroup
 		h, callback, _, _ := setupHandler(t)
 		emptyCreateSecretsRequest := &vaultcommon.CreateSecretsRequest{
 			RequestId: "test_request_id",
@@ -470,10 +471,22 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: (*json.RawMessage)(&emptyParams),
 		}
 
-		// A valid secret with matching owner precedes the nil entry so authorization
-		// passes owner binding and rejects the nil element at index 1.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err2 := callback.Wait(t.Context())
+			assert.NoError(t, err2)
+			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
+			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
+			assert.NoError(t, err2)
+			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
+			assert.Contains(t, secretsResponse.Error.Message, "encrypted secret must not be nil at index 1")
+			assert.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), secretsResponse.Error.Code, "Error code should match")
+		}()
+
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
-		require.ErrorContains(t, err, "encrypted secret at index 1 must include an identifier")
+		require.NoError(t, err)
+		wg.Wait()
 	})
 
 	t.Run("no id inside CreateSecrets.EncryptedSecrets body", func(t *testing.T) {
@@ -585,6 +598,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 	})
 
 	t.Run("nil id in delete secrets", func(t *testing.T) {
+		var wg sync.WaitGroup
 		h, callback, _, _ := setupHandler(t)
 
 		reqData := &vaultcommon.DeleteSecretsRequest{
@@ -603,10 +617,22 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: (*json.RawMessage)(&reqDataBytes),
 		}
 
-		// A valid identifier with matching owner precedes the nil entry so authorization
-		// passes owner binding and rejects the nil element at index 1.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err2 := callback.Wait(t.Context())
+			assert.NoError(t, err2)
+			var secretsResponse jsonrpc.Response[vaultcommon.DeleteSecretsResponse]
+			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
+			assert.NoError(t, err2)
+			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
+			assert.Contains(t, secretsResponse.Error.Message, "secret ID must not be nil at index 1")
+			assert.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), secretsResponse.Error.Code, "Error code should match")
+		}()
+
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
-		require.ErrorContains(t, err, "secret identifier at index 1 must not be nil")
+		require.NoError(t, err)
+		wg.Wait()
 	})
 
 	t.Run("happy path - list secret identifiers", func(t *testing.T) {
@@ -801,6 +827,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 	})
 
 	t.Run("empty params error", func(t *testing.T) {
+		var wg sync.WaitGroup
 		h, callback, don, _ := setupHandler(t)
 		// Don't expect SendToNode to be called for parse errors
 		don.AssertNotCalled(t, "SendToNode")
@@ -811,13 +838,26 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: &json.RawMessage{},
 		}
 
-		// Owner binding is enforced during authorization, before a callback is registered.
-		// HandleJSONRPCUserMessage returns the error directly.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := callback.Wait(t.Context())
+			assert.NoError(t, err)
+			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
+			err = json.Unmarshal(resp.RawResponse, &secretsResponse)
+			assert.NoError(t, err)
+			assert.Equal(t, emptyParamsRequest.ID, secretsResponse.ID, "Request ID should match")
+			assert.Equal(t, "user message parse error: unexpected end of JSON input", secretsResponse.Error.Message, "Error message should match")
+			assert.Equal(t, api.ToJSONRPCErrorCode(api.UserMessageParseError), secretsResponse.Error.Code, "Error code should match")
+		}()
+
 		err := h.HandleJSONRPCUserMessage(t.Context(), emptyParamsRequest, callback)
-		require.ErrorContains(t, err, "failed to parse create secrets request")
+		require.NoError(t, err)
+		wg.Wait()
 	})
 
 	t.Run("no request inside the batch request", func(t *testing.T) {
+		var wg sync.WaitGroup
 		h, callback, don, _ := setupHandler(t)
 		// Don't expect SendToNode to be called for invalid params
 		don.AssertNotCalled(t, "SendToNode")
@@ -829,10 +869,22 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: &invalidParams,
 		}
 
-		// Owner binding is enforced during authorization, before a callback is registered.
-		// HandleJSONRPCUserMessage returns the error directly.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := callback.Wait(t.Context())
+			assert.NoError(t, err)
+			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
+			err = json.Unmarshal(resp.RawResponse, &secretsResponse)
+			assert.NoError(t, err)
+			assert.Equal(t, invalidParamsRequest.ID, secretsResponse.ID, "Request ID should match")
+			assert.Equal(t, "invalid params error: failed to validate create secrets request: request batch must contain at least 1 item", secretsResponse.Error.Message, "Error message should match")
+			assert.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), secretsResponse.Error.Code, "Error code should match")
+		}()
+
 		err := h.HandleJSONRPCUserMessage(t.Context(), invalidParamsRequest, callback)
-		require.ErrorContains(t, err, "encrypted secrets must contain at least one identifier")
+		require.NoError(t, err)
+		wg.Wait()
 	})
 
 	t.Run("invalid params error", func(t *testing.T) {

--- a/core/services/gateway/handlers/vault/handler_test.go
+++ b/core/services/gateway/handlers/vault/handler_test.go
@@ -285,7 +285,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		rawPayload := json.RawMessage(`{"request_id":"test_request_id","encrypted_secrets":[{"id":{"key":"test_id","owner":"org1","namespace":"default"},"encrypted_value":"abc123"}]}`)
+		rawPayload := json.RawMessage(`{"request_id":"test_request_id","encrypted_secrets":[{"id":{"key":"test_id","owner":"0xworkflow","namespace":"default"},"encrypted_value":"abc123"}]}`)
 
 		var forwarded jsonrpc.Request[json.RawMessage]
 		don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
@@ -395,17 +395,19 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		require.Equal(t, owner+vaulttypes.RequestIDSeparator+req.ID, forwardedCreateRequest.RequestId)
 	})
 
-	t.Run("rejects JWT create when secret identifier owner does not match ciphertext workflow owner label", func(t *testing.T) {
+	t.Run("rejects JWT create when ciphertext label does not match identifier owner", func(t *testing.T) {
 		_, pk, _, err := tdh2easy.GenerateKeys(1, 3)
 		require.NoError(t, err)
 		orgID := "org_2xAbCdEfGhIjKlMnOpQrStUvWxYz"
-		ciphertextOwner := "0x0001020304050607080900010203040506070809"
-		otherOwner := "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-		encryptedSecret, err := vaultutils.EncryptSecretWithWorkflowOwner("test_secret", pk, ethcommon.HexToAddress(ciphertextOwner))
+		// The authorized owner and Id.Owner match (passes owner-binding check).
+		// The ciphertext is encrypted for a different address so the label check fires.
+		authorizedOwner := "0x0001020304050607080900010203040506070809"
+		labelOwner := "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+		encryptedSecret, err := vaultutils.EncryptSecretWithWorkflowOwner("test_secret", pk, ethcommon.HexToAddress(labelOwner))
 		require.NoError(t, err)
 
 		h, callback, don, clock := setupHandlerWithLimitsFactory(t, limits.Factory{Settings: cresettings.DefaultGetter})
-		h.(*handler).authorizer = &stubAuthorizer{result: vaultcap.NewAuthResult(orgID, ciphertextOwner, "digest-1", clock.Now().Add(time.Minute).Unix())}
+		h.(*handler).authorizer = &stubAuthorizer{result: vaultcap.NewAuthResult(orgID, authorizedOwner, "digest-1", clock.Now().Add(time.Minute).Unix())}
 		cacheVaultPublicKeyForTest(t, h.(*handler), pk)
 
 		reqData := &vaultcommon.CreateSecretsRequest{
@@ -413,9 +415,9 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 				{
 					Id: &vaultcommon.SecretIdentifier{
 						Key:   "test_id",
-						Owner: otherOwner,
+						Owner: authorizedOwner, // matches authorized owner — owner-binding passes
 					},
-					EncryptedValue: encryptedSecret,
+					EncryptedValue: encryptedSecret, // labeled for labelOwner — label check fires
 				},
 			},
 		}
@@ -473,7 +475,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err2)
 			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.ErrorContains(t, secretsResponse.Error, "encrypted secret must not be nil")
+			assert.ErrorContains(t, secretsResponse.Error, "encrypted secret at index 0 must include an identifier")
 		}()
 
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
@@ -511,7 +513,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err2)
 			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.ErrorContains(t, secretsResponse.Error, "secret ID must not be nil")
+			assert.ErrorContains(t, secretsResponse.Error, "encrypted secret at index 0 must include an identifier")
 		}()
 
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
@@ -636,7 +638,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err2)
 			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.ErrorContains(t, secretsResponse.Error, "secret ID must not be nil")
+			assert.ErrorContains(t, secretsResponse.Error, "secret identifier at index 0 must not be nil")
 		}()
 
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
@@ -890,7 +892,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			err = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err)
 			assert.Equal(t, invalidParamsRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.Equal(t, "invalid params error: failed to validate create secrets request: request batch must contain at least 1 item", secretsResponse.Error.Message, "Error message should match")
+			assert.Equal(t, "invalid params error: encrypted secrets must contain at least one identifier", secretsResponse.Error.Message, "Error message should match")
 			assert.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), secretsResponse.Error.Code, "Error code should match")
 		}()
 
@@ -911,7 +913,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 				{
 					Id: &vaultcommon.SecretIdentifier{
 						Key:   "",
-						Owner: "test_owner",
+						Owner: owner, // matches authorized owner so key-validation error fires
 					},
 					EncryptedValue: "test_value",
 				},

--- a/core/services/gateway/handlers/vault/handler_test.go
+++ b/core/services/gateway/handlers/vault/handler_test.go
@@ -445,15 +445,19 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 	})
 
 	t.Run("nil EncryptedSecrets inside CreateSecrets body", func(t *testing.T) {
-		var wg sync.WaitGroup
 		h, callback, _, _ := setupHandler(t)
 		emptyCreateSecretsRequest := &vaultcommon.CreateSecretsRequest{
 			RequestId: "test_request_id",
 			EncryptedSecrets: []*vaultcommon.EncryptedSecret{
-				nil,
 				{
-					EncryptedValue: "abc123", // should be a valid hex string
+					Id: &vaultcommon.SecretIdentifier{
+						Key:       "k",
+						Namespace: "default",
+						Owner:     owner,
+					},
+					EncryptedValue: "abc123",
 				},
+				nil,
 			},
 		}
 		emptyParams, err := json.Marshal(emptyCreateSecretsRequest)
@@ -466,30 +470,24 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: (*json.RawMessage)(&emptyParams),
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			resp, err2 := callback.Wait(t.Context())
-			assert.NoError(t, err2)
-			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
-			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
-			assert.NoError(t, err2)
-			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.ErrorContains(t, secretsResponse.Error, "encrypted secret at index 0 must include an identifier")
-		}()
-
+		// A valid secret with matching owner precedes the nil entry so authorization
+		// passes owner binding and rejects the nil element at index 1.
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
-		require.NoError(t, err)
-		wg.Wait()
+		require.ErrorContains(t, err, "encrypted secret at index 1 must include an identifier")
 	})
 
 	t.Run("no id inside CreateSecrets.EncryptedSecrets body", func(t *testing.T) {
 		var wg sync.WaitGroup
-		h, callback, _, _ := setupHandler(t)
+		h, callback, don, _ := setupHandler(t)
+		don.AssertNotCalled(t, "SendToNode")
+
+		// Id is present with the authorized owner so authorization passes owner binding;
+		// key is omitted so validation fails on the incomplete identifier, not owner mismatch.
 		emptyCreateSecretsRequest := &vaultcommon.CreateSecretsRequest{
 			RequestId: "test_request_id",
 			EncryptedSecrets: []*vaultcommon.EncryptedSecret{
 				{
+					Id:             &vaultcommon.SecretIdentifier{Owner: owner},
 					EncryptedValue: "abc123", // should be a valid hex string
 				},
 			},
@@ -513,7 +511,8 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err2)
 			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.ErrorContains(t, secretsResponse.Error, "encrypted secret at index 0 must include an identifier")
+			assert.Contains(t, secretsResponse.Error.Message, "key cannot be empty")
+			assert.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), secretsResponse.Error.Code, "Error code should match")
 		}()
 
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
@@ -586,19 +585,13 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 	})
 
 	t.Run("nil id in delete secrets", func(t *testing.T) {
-		var wg sync.WaitGroup
 		h, callback, _, _ := setupHandler(t)
 
-		id := &vaultcommon.SecretIdentifier{
-			Key:       "foo",
-			Namespace: "default",
-			Owner:     owner,
-		}
 		reqData := &vaultcommon.DeleteSecretsRequest{
 			RequestId: "id",
 			Ids: []*vaultcommon.SecretIdentifier{
+				{Key: "foo", Namespace: "default", Owner: owner},
 				nil,
-				id,
 			},
 		}
 		reqDataBytes, err := json.Marshal(reqData)
@@ -610,43 +603,10 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: (*json.RawMessage)(&reqDataBytes),
 		}
 
-		responseData := &vaultcommon.DeleteSecretsResponse{
-			Responses: []*vaultcommon.DeleteSecretResponse{
-				{
-					Id:      id,
-					Success: true,
-				},
-			},
-		}
-		resultBytes, err := json.Marshal(responseData)
-		require.NoError(t, err)
-		expectedRequestID := owner + vaulttypes.RequestIDSeparator + requestID
-		response := jsonrpc.Response[json.RawMessage]{
-			ID:     expectedRequestID,
-			Result: (*json.RawMessage)(&resultBytes),
-			Method: vaulttypes.MethodSecretsDelete,
-		}
-		resultBytes, err = json.Marshal(responseData)
-		require.NoError(t, err)
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			resp, err2 := callback.Wait(t.Context())
-			assert.NoError(t, err2)
-			var secretsResponse jsonrpc.Response[vaultcommon.DeleteSecretsResponse]
-			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
-			assert.NoError(t, err2)
-			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.ErrorContains(t, secretsResponse.Error, "secret identifier at index 0 must not be nil")
-		}()
-
+		// A valid identifier with matching owner precedes the nil entry so authorization
+		// passes owner binding and rejects the nil element at index 1.
 		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
-		require.NoError(t, err)
-
-		err = h.HandleNodeMessage(t.Context(), &response, NodeOne.Address)
-		require.NoError(t, err)
-		wg.Wait()
+		require.ErrorContains(t, err, "secret identifier at index 1 must not be nil")
 	})
 
 	t.Run("happy path - list secret identifiers", func(t *testing.T) {
@@ -841,7 +801,6 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 	})
 
 	t.Run("empty params error", func(t *testing.T) {
-		var wg sync.WaitGroup
 		h, callback, don, _ := setupHandler(t)
 		// Don't expect SendToNode to be called for parse errors
 		don.AssertNotCalled(t, "SendToNode")
@@ -852,26 +811,13 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: &json.RawMessage{},
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			resp, err := callback.Wait(t.Context())
-			assert.NoError(t, err)
-			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
-			err = json.Unmarshal(resp.RawResponse, &secretsResponse)
-			assert.NoError(t, err)
-			assert.Equal(t, emptyParamsRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.Equal(t, "user message parse error: unexpected end of JSON input", secretsResponse.Error.Message, "Error message should match")
-			assert.Equal(t, api.ToJSONRPCErrorCode(api.UserMessageParseError), secretsResponse.Error.Code, "Error code should match")
-		}()
-
+		// Owner binding is enforced during authorization, before a callback is registered.
+		// HandleJSONRPCUserMessage returns the error directly.
 		err := h.HandleJSONRPCUserMessage(t.Context(), emptyParamsRequest, callback)
-		require.NoError(t, err)
-		wg.Wait()
+		require.ErrorContains(t, err, "failed to parse create secrets request")
 	})
 
 	t.Run("no request inside the batch request", func(t *testing.T) {
-		var wg sync.WaitGroup
 		h, callback, don, _ := setupHandler(t)
 		// Don't expect SendToNode to be called for invalid params
 		don.AssertNotCalled(t, "SendToNode")
@@ -883,22 +829,10 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			Params: &invalidParams,
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			resp, err := callback.Wait(t.Context())
-			assert.NoError(t, err)
-			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
-			err = json.Unmarshal(resp.RawResponse, &secretsResponse)
-			assert.NoError(t, err)
-			assert.Equal(t, invalidParamsRequest.ID, secretsResponse.ID, "Request ID should match")
-			assert.Equal(t, "invalid params error: encrypted secrets must contain at least one identifier", secretsResponse.Error.Message, "Error message should match")
-			assert.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), secretsResponse.Error.Code, "Error code should match")
-		}()
-
+		// Owner binding is enforced during authorization, before a callback is registered.
+		// HandleJSONRPCUserMessage returns the error directly.
 		err := h.HandleJSONRPCUserMessage(t.Context(), invalidParamsRequest, callback)
-		require.NoError(t, err)
-		wg.Wait()
+		require.ErrorContains(t, err, "encrypted secrets must contain at least one identifier")
 	})
 
 	t.Run("invalid params error", func(t *testing.T) {

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -1962,17 +1962,12 @@ func (r *ReportingPlugin) stateTransitionPendingQueue(ctx context.Context, seqNr
 			keptItems = keptItems[:errBoundLimited.Limit]
 		}
 	} else {
-		limit, err := r.cfg.MaxPendingQueueWriteSize.Limit(ctx)
-		if err != nil {
-			return fmt.Errorf("could not fetch pending queue write size limit: %w", err)
-		}
-		if len(keptItems) > limit {
-			r.lggr.Warnw("pending queue write size limit reached, truncating",
-				"seqNr", seqNr,
-				"keptItemCount", len(keptItems),
-				"limit", limit,
-			)
-			keptItems = keptItems[:limit]
+		if err := r.cfg.MaxPendingQueueWriteSize.Check(ctx, len(keptItems)); err != nil {
+			var errBoundLimited limits.ErrorBoundLimited[int]
+			if !errors.As(err, &errBoundLimited) {
+				return fmt.Errorf("failed to check pending queue write size limit: %w", err)
+			}
+			keptItems = keptItems[:errBoundLimited.Limit]
 		}
 	}
 

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -62,6 +62,7 @@ type ReportingPluginConfig struct {
 	MaxShareLengthBytes               limits.BoundLimiter[pkgconfig.Size]
 	MaxRequestBatchSize               limits.BoundLimiter[int]
 	MaxBatchSize                      limits.BoundLimiter[int]
+	MaxPendingQueueWriteSize          limits.BoundLimiter[int]
 	MaxBlobPayloadBytes               limits.BoundLimiter[pkgconfig.Size]
 	VaultForceEmptyOCRRounds          limits.GateLimiter
 	VaultOptimizationsEnabled         limits.GateLimiter
@@ -219,6 +220,11 @@ func newReportingPluginConfigLimiters(factory limits.Factory) (*ReportingPluginC
 		return nil, fmt.Errorf("VaultMaxBlobPayloadSizeLimit: %w", err)
 	}
 
+	maxPendingQueueWriteSizeLimiter, err := limits.MakeUpperBoundLimiter(factory, cresettings.Default.VaultPendingQueueWriteSizeLimit)
+	if err != nil {
+		return nil, fmt.Errorf("VaultPendingQueueWriteSizeLimit: %w", err)
+	}
+
 	return &ReportingPluginConfig{
 		MaxShareLengthBytes:               maxShareLengthBytesLimiter,
 		MaxRequestBatchSize:               maxRequestBatchSizeLimiter,
@@ -227,6 +233,7 @@ func newReportingPluginConfigLimiters(factory limits.Factory) (*ReportingPluginC
 		MaxIdentifierOwnerLengthBytes:     maxIdentifierOwnerLengthBytesLimiter,
 		MaxIdentifierNamespaceLengthBytes: maxIdentifierNamespaceLengthBytesLimiter,
 		MaxBlobPayloadBytes:               maxBlobPayloadBytesLimiter,
+		MaxPendingQueueWriteSize:          maxPendingQueueWriteSizeLimiter,
 		VaultForceEmptyOCRRounds:          vaultForceEmptyOCRRounds,
 		VaultOptimizationsEnabled:         vaultOptimizationsEnabled,
 	}, nil
@@ -301,6 +308,7 @@ func (r *ReportingPluginFactory) NewReportingPlugin(ctx context.Context, config 
 		"maxRequestBatchSize", logLimit(ctx, r.lggr, cfg.MaxRequestBatchSize),
 		"maxShareLengthBytes", logLimit(ctx, r.lggr, cfg.MaxShareLengthBytes),
 		"batchSize", logLimit(ctx, r.lggr, cfg.MaxBatchSize),
+		"maxPendingQueueWriteSize", logLimit(ctx, r.lggr, cfg.MaxPendingQueueWriteSize),
 		"maxBlobPayloadBytes", logLimit(ctx, r.lggr, cfg.MaxBlobPayloadBytes),
 		"maxQueryBytes", pluginLimits.MaxQueryBytes,
 		"maxObservationBytes", pluginLimits.MaxObservationBytes,
@@ -1703,7 +1711,6 @@ func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq 
 			r.lggr.Errorw("failed to unmarshal observations", "error", err, "observation", ao.Observation)
 			continue
 		}
-
 		marshalledObs[uint8(ao.Observer)] = obs
 	}
 
@@ -1953,6 +1960,19 @@ func (r *ReportingPlugin) stateTransitionPendingQueue(ctx context.Context, seqNr
 				return fmt.Errorf("failed to check batch size limit: %w", err)
 			}
 			keptItems = keptItems[:errBoundLimited.Limit]
+		}
+	} else {
+		limit, err := r.cfg.MaxPendingQueueWriteSize.Limit(ctx)
+		if err != nil {
+			return fmt.Errorf("could not fetch pending queue write size limit: %w", err)
+		}
+		if len(keptItems) > limit {
+			r.lggr.Warnw("pending queue write size limit reached, truncating",
+				"seqNr", seqNr,
+				"keptItemCount", len(keptItems),
+				"limit", limit,
+			)
+			keptItems = keptItems[:limit]
 		}
 	}
 
@@ -2561,6 +2581,7 @@ func (r *ReportingPlugin) Close() error {
 		r.cfg.MaxShareLengthBytes.Close(),
 		r.cfg.MaxRequestBatchSize.Close(),
 		r.cfg.MaxBatchSize.Close(),
+		r.cfg.MaxPendingQueueWriteSize.Close(),
 		r.cfg.VaultForceEmptyOCRRounds.Close(),
 	)
 }

--- a/core/services/ocr2/plugins/vault/plugin_helpers_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_helpers_test.go
@@ -220,8 +220,8 @@ func makeReportingPluginConfig(
 	require.NoError(t, err)
 
 	return &ReportingPluginConfig{
-		MaxBatchSize:                      bsl,
-		MaxPendingQueueWriteSize:          maxPendingQueueWriteSizeLimiter,
+		MaxBatchSize:             bsl,
+		MaxPendingQueueWriteSize: maxPendingQueueWriteSizeLimiter,
 
 		PublicKey:                         publicKey,
 		PrivateKeyShare:                   privateKeyShare,

--- a/core/services/ocr2/plugins/vault/plugin_helpers_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_helpers_test.go
@@ -208,6 +208,9 @@ func makeReportingPluginConfig(
 	requestBatchSizeLimiter, err := limits.MakeUpperBoundLimiter(limits.Factory{Settings: cresettings.DefaultGetter}, settings.Int(maxRequestBatchSize))
 	require.NoError(t, err)
 
+	maxPendingQueueWriteSizeLimiter, err := limits.MakeUpperBoundLimiter(limits.Factory{Settings: cresettings.DefaultGetter}, cresettings.Default.VaultPendingQueueWriteSizeLimit)
+	require.NoError(t, err)
+
 	var maxBlobPayloadLimiter limits.BoundLimiter[pkgconfig.Size]
 	if maxBlobPayloadBytes > 0 {
 		maxBlobPayloadLimiter, err = limits.MakeUpperBoundLimiter(limits.Factory{Settings: cresettings.DefaultGetter}, settings.Size(pkgconfig.Size(maxBlobPayloadBytes)*pkgconfig.Byte))
@@ -217,7 +220,8 @@ func makeReportingPluginConfig(
 	require.NoError(t, err)
 
 	return &ReportingPluginConfig{
-		MaxBatchSize: bsl,
+		MaxBatchSize:                      bsl,
+		MaxPendingQueueWriteSize:          maxPendingQueueWriteSizeLimiter,
 
 		PublicKey:                         publicKey,
 		PrivateKeyShare:                   privateKeyShare,

--- a/core/services/ocr2/plugins/vault/plugin_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_test.go
@@ -108,6 +108,7 @@ func TestPlugin_ReportingPluginFactory_UsesDefaultsIfNotProvidedInOffchainConfig
 
 	typedRP := rp.(*ReportingPlugin)
 	assertLimit(t, cresettings.Default.VaultPluginBatchSizeLimit.DefaultValue, typedRP.cfg.MaxBatchSize)
+	assertLimit(t, cresettings.Default.VaultPendingQueueWriteSizeLimit.DefaultValue, typedRP.cfg.MaxPendingQueueWriteSize)
 	assert.NotNil(t, typedRP.cfg.PublicKey)
 	assert.NotNil(t, typedRP.cfg.PrivateKeyShare)
 	assertLimit(t, 100, typedRP.cfg.MaxSecretsPerOwner)
@@ -156,6 +157,7 @@ func TestPlugin_ReportingPluginFactory_UsesDefaultsIfNotProvidedInOffchainConfig
 
 	typedRP = rp.(*ReportingPlugin)
 	assertLimit(t, cresettings.Default.VaultPluginBatchSizeLimit.DefaultValue, typedRP.cfg.MaxBatchSize)
+	assertLimit(t, cresettings.Default.VaultPendingQueueWriteSizeLimit.DefaultValue, typedRP.cfg.MaxPendingQueueWriteSize)
 	assertLimit(t, 2, typedRP.cfg.MaxSecretsPerOwner)
 	assertLimit(t, 2000, typedRP.cfg.MaxCiphertextLengthBytes)
 	assertLimit(t, 64, typedRP.cfg.MaxIdentifierOwnerLengthBytes)
@@ -234,6 +236,7 @@ func TestPlugin_ReportingPluginFactory_UseDKGResult(t *testing.T) {
 
 	typedRP := rp.(*ReportingPlugin)
 	assertLimit(t, cresettings.Default.VaultPluginBatchSizeLimit.DefaultValue, typedRP.cfg.MaxBatchSize)
+	assertLimit(t, cresettings.Default.VaultPendingQueueWriteSizeLimit.DefaultValue, typedRP.cfg.MaxPendingQueueWriteSize)
 
 	pkBytes, err := typedRP.cfg.PublicKey.Marshal()
 	require.NoError(t, err)

--- a/core/services/ocr2/plugins/vault/plugin_throughput_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_throughput_test.go
@@ -29,27 +29,27 @@ func TestPlugin_ThroughputAnalysis(t *testing.T) {
 	const (
 		donN           = 10
 		donF           = 3
-		byzQuorumSize  = 2*donF + 1 // 7 — chosen observations for GetSecrets
-		fPlusOne       = donF + 1   // 4 — chosen observations for all other types
-		maxBatchSize   = 200        // VaultPluginBatchSizeLimit
-		maxPendingBlob = 20         // max blob *handles* per Observation(); each handle may cover many requests via PendingQueueBlobItems
+		byzQuorumSize  = 2*donF + 1       // 7 — chosen observations for GetSecrets
+		fPlusOne       = donF + 1         // 4 — chosen observations for all other types
+		maxBatchSize   = 12               // VaultPluginBatchSizeLimit
+		maxPendingBlob = 2 * maxBatchSize // max blob *handles* per Observation(); each handle may cover many requests via PendingQueueBlobItems
 	)
 
 	// --- Per-secret limits (from cresettings defaults and plugin config) ---
 	const (
-		maxSecretsPerRequest = 1          // VaultRequestBatchSizeLimit (GetSecrets cap)
+		maxSecretsPerRequest = 5          // VaultRequestBatchSizeLimit (GetSecrets cap)
 		maxEncryptionKeysWC  = 2*donF + 1 // max encryption keys per secret request
-		maxCiphertextBytes   = 0          // MaxCiphertextLengthBytes
+		maxCiphertextBytes   = 2000       // MaxCiphertextLengthBytes
 		// Shares are base64 strings.
 		// Current base64 string limit = 600 bytes → raw binary = 600 * 3/4 = 450 bytes.
-		maxShareBytes      = 300
+		maxShareBytes      = 600
 		maxIdentifierBytes = 64 // key / namespace / owner each
 	)
 
 	// --- Size limits under test ---
 	const (
 		maxObservationBytes     = 512 * 1024      // 512 KB
-		maxStateTransitionBytes = 2 * 1024 * 1024 // 5 MB
+		maxStateTransitionBytes = 5 * 1024 * 1024 // 5 MB
 	)
 
 	// --- BlobHandle wire size for this DON (n=10, f=3, byzQuorumSize=7) ---

--- a/core/services/ocr2/plugins/vault/plugin_throughput_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_throughput_test.go
@@ -29,27 +29,27 @@ func TestPlugin_ThroughputAnalysis(t *testing.T) {
 	const (
 		donN           = 10
 		donF           = 3
-		byzQuorumSize  = 2*donF + 1       // 7 — chosen observations for GetSecrets
-		fPlusOne       = donF + 1         // 4 — chosen observations for all other types
-		maxBatchSize   = 12               // VaultPluginBatchSizeLimit
-		maxPendingBlob = 2 * maxBatchSize // max blob *handles* per Observation(); each handle may cover many requests via PendingQueueBlobItems
+		byzQuorumSize  = 2*donF + 1 // 7 — chosen observations for GetSecrets
+		fPlusOne       = donF + 1   // 4 — chosen observations for all other types
+		maxBatchSize   = 200        // VaultPluginBatchSizeLimit
+		maxPendingBlob = 20         // max blob *handles* per Observation(); each handle may cover many requests via PendingQueueBlobItems
 	)
 
 	// --- Per-secret limits (from cresettings defaults and plugin config) ---
 	const (
-		maxSecretsPerRequest = 5          // VaultRequestBatchSizeLimit (GetSecrets cap)
+		maxSecretsPerRequest = 1          // VaultRequestBatchSizeLimit (GetSecrets cap)
 		maxEncryptionKeysWC  = 2*donF + 1 // max encryption keys per secret request
-		maxCiphertextBytes   = 2000       // MaxCiphertextLengthBytes
+		maxCiphertextBytes   = 0          // MaxCiphertextLengthBytes
 		// Shares are base64 strings.
 		// Current base64 string limit = 600 bytes → raw binary = 600 * 3/4 = 450 bytes.
-		maxShareBytes      = 600
+		maxShareBytes      = 300
 		maxIdentifierBytes = 64 // key / namespace / owner each
 	)
 
 	// --- Size limits under test ---
 	const (
 		maxObservationBytes     = 512 * 1024      // 512 KB
-		maxStateTransitionBytes = 5 * 1024 * 1024 // 5 MB
+		maxStateTransitionBytes = 2 * 1024 * 1024 // 5 MB
 	)
 
 	// --- BlobHandle wire size for this DON (n=10, f=3, byzQuorumSize=7) ---

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -42,14 +42,14 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260504204047-af9826978b72
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260522094612-5f9f748bd87a
 	github.com/smartcontractkit/chainlink-deployments-framework v0.105.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260609161557-8ceae53b8ab1
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20260521215851-3fdbb363496f
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.10.1-0.20260528221400-84746b70eeeb
 	github.com/smartcontractkit/chainlink-solana v1.3.1-0.20260605202330-b5a89c32fdc1

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1382,8 +1382,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd/go.mod h1:SBN8Urnh5sQvrQRbSo1Nr8coWatHg8LZoPw3R/42sho=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23 h1:1Rt4HLpwbRN1YtBFcbsxSJYIiUP2wJ11qizevOEeCrs=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23/go.mod h1:V+wrhuNve+JiFwoBr25d6y0lL1rYSCSJhTFyloL3ueo=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443 h1:uclvPWuit298UwfANmUUFWZdYX/pcQZLUosZVjwqs40=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443/go.mod h1:fP9RqD25/gTx3XqRstN8o4lAI3jp42vwJBLRZwRoOOM=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e h1:uTuCrOqBZeYfIl2QG70KuCG7xpubUETFJpHiip5+7FU=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e/go.mod h1:GlEVw7ziizXoMfzl1onNSwansrVBLHhj5gUJlGQpb4I=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0 h1:NExKM/D0HneOq/N5LGTbkV4VOa0UHCvfTNEb4GqYpto=
@@ -1418,8 +1418,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f h1:t+OoYaXLdH0WHK2pbWKjTSnSQa5JBQD1+gf0yISYfQk=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a h1:alnfvQgCKPFqsfijZQnr6Sbus2GT5YZ9BT/KzVrbszE=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 h1:SG+wAsNyAcA6Kk19ljuxi3HK9Ll2lpHik8OKoY4x7A0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0 h1:q+VDPcxWrj5k9QizSYfUOSMnDH3Sd5HvbPguZOgfXTY=

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260522094612-5f9f748bd87a
@@ -97,7 +97,7 @@ require (
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260423135514-5b1a7565a99c
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20260521164805-26d78d5e1243
 	github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a
 	github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305
 	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305

--- a/go.sum
+++ b/go.sum
@@ -1181,8 +1181,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd h1:IMopuENFVS63AerRELdfWo6o60UNUidcldJOxJLmk24=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd/go.mod h1:SBN8Urnh5sQvrQRbSo1Nr8coWatHg8LZoPw3R/42sho=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443 h1:uclvPWuit298UwfANmUUFWZdYX/pcQZLUosZVjwqs40=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443/go.mod h1:fP9RqD25/gTx3XqRstN8o4lAI3jp42vwJBLRZwRoOOM=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e h1:uTuCrOqBZeYfIl2QG70KuCG7xpubUETFJpHiip5+7FU=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e/go.mod h1:GlEVw7ziizXoMfzl1onNSwansrVBLHhj5gUJlGQpb4I=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0 h1:NExKM/D0HneOq/N5LGTbkV4VOa0UHCvfTNEb4GqYpto=
@@ -1215,8 +1215,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f h1:t+OoYaXLdH0WHK2pbWKjTSnSQa5JBQD1+gf0yISYfQk=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a h1:alnfvQgCKPFqsfijZQnr6Sbus2GT5YZ9BT/KzVrbszE=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 h1:SG+wAsNyAcA6Kk19ljuxi3HK9Ll2lpHik8OKoY4x7A0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 h1:NJdGFhzT6zMaTod4QkBqVD2sg0I25iw1boOYtTpEwRo=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260506144252-c100eabfda74
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260506144252-c100eabfda74
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.105.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260609161557-8ceae53b8ab1
@@ -408,7 +408,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/heartbeat v0.0.0-20260115142640-f6b99095c12e // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d // indirect
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f // indirect
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a // indirect
 	github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 // indirect
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 // indirect
 	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1367,8 +1367,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd/go.mod h1:SBN8Urnh5sQvrQRbSo1Nr8coWatHg8LZoPw3R/42sho=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23 h1:1Rt4HLpwbRN1YtBFcbsxSJYIiUP2wJ11qizevOEeCrs=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23/go.mod h1:V+wrhuNve+JiFwoBr25d6y0lL1rYSCSJhTFyloL3ueo=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443 h1:uclvPWuit298UwfANmUUFWZdYX/pcQZLUosZVjwqs40=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443/go.mod h1:fP9RqD25/gTx3XqRstN8o4lAI3jp42vwJBLRZwRoOOM=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e h1:uTuCrOqBZeYfIl2QG70KuCG7xpubUETFJpHiip5+7FU=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e/go.mod h1:GlEVw7ziizXoMfzl1onNSwansrVBLHhj5gUJlGQpb4I=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0 h1:NExKM/D0HneOq/N5LGTbkV4VOa0UHCvfTNEb4GqYpto=
@@ -1403,8 +1403,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f h1:t+OoYaXLdH0WHK2pbWKjTSnSQa5JBQD1+gf0yISYfQk=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a h1:alnfvQgCKPFqsfijZQnr6Sbus2GT5YZ9BT/KzVrbszE=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 h1:SG+wAsNyAcA6Kk19ljuxi3HK9Ll2lpHik8OKoY4x7A0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0 h1:q+VDPcxWrj5k9QizSYfUOSMnDH3Sd5HvbPguZOgfXTY=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260506144252-c100eabfda74
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260506144252-c100eabfda74
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e
 	github.com/smartcontractkit/chainlink-deployments-framework v0.105.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260609161557-8ceae53b8ab1
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.16.1
@@ -490,7 +490,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/heartbeat v0.0.0-20260115142640-f6b99095c12e // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d // indirect
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f // indirect
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a // indirect
 	github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 // indirect
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1633,8 +1633,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd/go.mod h1:SBN8Urnh5sQvrQRbSo1Nr8coWatHg8LZoPw3R/42sho=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23 h1:1Rt4HLpwbRN1YtBFcbsxSJYIiUP2wJ11qizevOEeCrs=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23/go.mod h1:V+wrhuNve+JiFwoBr25d6y0lL1rYSCSJhTFyloL3ueo=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443 h1:uclvPWuit298UwfANmUUFWZdYX/pcQZLUosZVjwqs40=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443/go.mod h1:fP9RqD25/gTx3XqRstN8o4lAI3jp42vwJBLRZwRoOOM=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e h1:uTuCrOqBZeYfIl2QG70KuCG7xpubUETFJpHiip5+7FU=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e/go.mod h1:GlEVw7ziizXoMfzl1onNSwansrVBLHhj5gUJlGQpb4I=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0 h1:NExKM/D0HneOq/N5LGTbkV4VOa0UHCvfTNEb4GqYpto=
@@ -1669,8 +1669,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f h1:t+OoYaXLdH0WHK2pbWKjTSnSQa5JBQD1+gf0yISYfQk=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a h1:alnfvQgCKPFqsfijZQnr6Sbus2GT5YZ9BT/KzVrbszE=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 h1:SG+wAsNyAcA6Kk19ljuxi3HK9Ll2lpHik8OKoY4x7A0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0 h1:q+VDPcxWrj5k9QizSYfUOSMnDH3Sd5HvbPguZOgfXTY=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -33,12 +33,12 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.101
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20260507123701-77fc93b573bb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.105.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260609161557-8ceae53b8ab1
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20260521215851-3fdbb363496f
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260528221400-84746b70eeeb

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1540,8 +1540,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd h1:IMopuENFVS63AerRELdfWo6o60UNUidcldJOxJLmk24=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd/go.mod h1:SBN8Urnh5sQvrQRbSo1Nr8coWatHg8LZoPw3R/42sho=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443 h1:uclvPWuit298UwfANmUUFWZdYX/pcQZLUosZVjwqs40=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443/go.mod h1:fP9RqD25/gTx3XqRstN8o4lAI3jp42vwJBLRZwRoOOM=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e h1:uTuCrOqBZeYfIl2QG70KuCG7xpubUETFJpHiip5+7FU=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e/go.mod h1:GlEVw7ziizXoMfzl1onNSwansrVBLHhj5gUJlGQpb4I=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0 h1:NExKM/D0HneOq/N5LGTbkV4VOa0UHCvfTNEb4GqYpto=
@@ -1576,8 +1576,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f h1:t+OoYaXLdH0WHK2pbWKjTSnSQa5JBQD1+gf0yISYfQk=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a h1:alnfvQgCKPFqsfijZQnr6Sbus2GT5YZ9BT/KzVrbszE=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 h1:SG+wAsNyAcA6Kk19ljuxi3HK9Ll2lpHik8OKoY4x7A0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0 h1:q+VDPcxWrj5k9QizSYfUOSMnDH3Sd5HvbPguZOgfXTY=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -60,12 +60,12 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/smartcontractkit/chain-selectors v1.0.101
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.105.0
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20260521215851-3fdbb363496f
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260331131315-f08a616d8dcd
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260528221400-84746b70eeeb
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.16.2

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1554,8 +1554,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd h1:IMopuENFVS63AerRELdfWo6o60UNUidcldJOxJLmk24=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260428133800-3b1484e8b1fd/go.mod h1:SBN8Urnh5sQvrQRbSo1Nr8coWatHg8LZoPw3R/42sho=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443 h1:uclvPWuit298UwfANmUUFWZdYX/pcQZLUosZVjwqs40=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260605180138-9678dea7f443/go.mod h1:fP9RqD25/gTx3XqRstN8o4lAI3jp42vwJBLRZwRoOOM=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e h1:uTuCrOqBZeYfIl2QG70KuCG7xpubUETFJpHiip5+7FU=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260609183712-678afb1edd2e/go.mod h1:GlEVw7ziizXoMfzl1onNSwansrVBLHhj5gUJlGQpb4I=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0 h1:NExKM/D0HneOq/N5LGTbkV4VOa0UHCvfTNEb4GqYpto=
@@ -1590,8 +1590,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:ATjAPIVJibHRcIfiG47rEQkUIOoYa6KDvWj3zwCAw6g=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f h1:t+OoYaXLdH0WHK2pbWKjTSnSQa5JBQD1+gf0yISYfQk=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260604171908-6734db2d444f/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a h1:alnfvQgCKPFqsfijZQnr6Sbus2GT5YZ9BT/KzVrbszE=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 h1:SG+wAsNyAcA6Kk19ljuxi3HK9Ll2lpHik8OKoY4x7A0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0 h1:q+VDPcxWrj5k9QizSYfUOSMnDH3Sd5HvbPguZOgfXTY=

--- a/system-tests/tests/smoke/cre/vault_don_test.go
+++ b/system-tests/tests/smoke/cre/vault_don_test.go
@@ -923,8 +923,7 @@ func executeVaultSecretsIdentifierValidationTest(t *testing.T, encryptedSecret s
 
 	const (
 		validKey         = "validkey"
-		invalidKey       = "invalid-key-with-hyphens"   // hyphen not in [a-zA-Z0-9_]
-		invalidOwner     = "invalid-owner-with-hyphens" // hyphen not in [a-zA-Z0-9_]
+		invalidKey       = "invalid-key-with-hyphens" // hyphen not in [a-zA-Z0-9_]
 		validNamespace   = "main"
 		invalidNamespace = "invalid-namespace-hyphens" // hyphen not in [a-zA-Z0-9_]
 	)
@@ -960,7 +959,6 @@ func executeVaultSecretsIdentifierValidationTest(t *testing.T, encryptedSecret s
 	writeCases := []writeCase{
 		{"invalid key", invalidKey, owner, validNamespace},
 		{"invalid namespace", validKey, owner, invalidNamespace},
-		{"invalid owner", validKey, invalidOwner, validNamespace},
 	}
 
 	for _, op := range []string{vaulttypes.MethodSecretsCreate, vaulttypes.MethodSecretsUpdate, vaulttypes.MethodSecretsDelete} {

--- a/system-tests/tests/smoke/cre/vault_don_test.go
+++ b/system-tests/tests/smoke/cre/vault_don_test.go
@@ -60,6 +60,22 @@ func ExecuteVaultAllowListBasedTests(t *testing.T, fixture *vaultScenarioFixture
 	gwURL := fixture.GatewayURL.String()
 	vaultPublicKey := fixture.VaultPublicKey
 
+	t.Run("allowlist_rejects_create_when_identifier_owner_mismatch", func(t *testing.T) {
+		sc := testEnv.CreEnvironment.Blockchains[0].(*evm.Blockchain).SethClient
+		authorizedOwner := sc.MustGetRootKeyAddress().Hex()
+		mismatchedOwner := common.HexToAddress("0x000000000000000000000000000000000000dEaD").Hex()
+		wfRegAddr := crecontracts.MustGetAddressFromDataStore(testEnv.CreEnvironment.CldfEnvironment.DataStore, testEnv.CreEnvironment.Blockchains[0].ChainSelector(), keystone_changeset.WorkflowRegistry.String(), testEnv.CreEnvironment.ContractVersions[keystone_changeset.WorkflowRegistry.String()], "")
+		wfReg, err := workflow_registry_v2_wrapper.NewWorkflowRegistry(common.HexToAddress(wfRegAddr), sc.Client)
+		require.NoError(t, err)
+		requireVaultLinkOwner(t, sc, common.HexToAddress(wfRegAddr), testEnv.CreEnvironment.ContractVersions[keystone_changeset.WorkflowRegistry.String()])
+		vaultParsedPublicKey := mustVaultPublicKey(t, vaultPublicKey)
+		secretID := uniqueVaultSecretID("allowlistownermismatch")
+		encryptedSecret, err := vaultutils.EncryptSecretWithWorkflowOwner("secret-allowlist-owner-mismatch", vaultParsedPublicKey, sc.MustGetRootKeyAddress())
+		require.NoError(t, err)
+		auth := newAllowlistVaultRequestAuth(authorizedOwner, sc, wfReg)
+		executeVaultSecretsCreateOwnerMismatchRejectedTest(t, auth, authorizedOwner, mismatchedOwner, encryptedSecret, secretID, gwURL)
+	})
+
 	t.Run("allowlist_crud_with_workflow_owner_identity", func(t *testing.T) {
 		sc := testEnv.CreEnvironment.Blockchains[0].(*evm.Blockchain).SethClient
 		workflowOwnerAddress := sc.MustGetRootKeyAddress()
@@ -210,6 +226,13 @@ func ExecuteVaultMixedAuthTest(t *testing.T, fixture *vaultScenarioFixture, test
 		executeVaultJWTSecretsDeleteTest(t, issuer, secretID, orgID, derivedJWTWorkflowOwner, gwURL, []string{"main", "alt"})
 		executeVaultJWTSecretsListAbsentFromNamespace(t, issuer, secretID, orgID, derivedJWTWorkflowOwner, gwURL, "main")
 		executeVaultJWTSecretsListAbsentFromNamespace(t, issuer, secretID, orgID, derivedJWTWorkflowOwner, gwURL, "alt")
+	})
+
+	t.Run("jwt_rejected_when_identifier_owner_does_not_match_authorized_owner", func(t *testing.T) {
+		secretID := uniqueVaultSecretID("jwtownermismatch")
+		encryptedSecret, err := vaultutils.EncryptSecretWithWorkflowOwner("secret-jwt-owner-mismatch", vaultParsedPublicKey, derivedJWTWorkflowOwnerAddr)
+		require.NoError(t, err)
+		executeVaultSecretsCreateOwnerMismatchRejectedTest(t, jwtAuth, derivedJWTWorkflowOwner, workflowOwner, encryptedSecret, secretID, gwURL)
 	})
 
 	t.Run("jwt_rejected_when_ciphertext_label_is_linked_workflow_owner_but_identifier_owner_is_jwt_derived", func(t *testing.T) {

--- a/system-tests/tests/smoke/cre/vault_don_test_helpers.go
+++ b/system-tests/tests/smoke/cre/vault_don_test_helpers.go
@@ -772,6 +772,33 @@ func mustMintVaultJWTForRequestWithExtraClaims(t *testing.T, issuer *stvault.Tes
 	return token
 }
 
+// executeVaultSecretsCreateOwnerMismatchRejectedTest sends a create request whose
+// SecretIdentifier.Owner does not match the authenticated workflow owner and expects
+// gateway authorization rejection (owner binding in the composite Authorizer).
+func executeVaultSecretsCreateOwnerMismatchRejectedTest(
+	t *testing.T,
+	auth vaultRequestAuth,
+	authorizedOwner, mismatchedIdentifierOwner, encryptedSecret, secretID, gatewayURL string,
+) {
+	t.Helper()
+
+	uniqueRequestID := uuid.New().String()
+	secretsCreateRequest := vault_helpers.CreateSecretsRequest{
+		RequestId:        uniqueRequestID,
+		EncryptedSecrets: buildEncryptedSecrets(secretID, mismatchedIdentifierOwner, encryptedSecret, []string{"main"}),
+	}
+	jsonRequest := newVaultJSONRequest(t, uniqueRequestID, vaulttypes.MethodSecretsCreate, &secretsCreateRequest)
+	auth.apply(t, &jsonRequest)
+
+	jsonResponse := sendVaultJWTRequestToGatewayExpectError(t, gatewayURL, jsonRequest, http.StatusBadRequest)
+	require.Equal(t, uniqueRequestID, jsonResponse.ID)
+	require.NotNil(t, jsonResponse.Error)
+	require.Contains(t, jsonResponse.Error.Error(), "request not authorized")
+	require.Contains(t, jsonResponse.Error.Error(), "does not match authorized workflow owner")
+	require.Contains(t, jsonResponse.Error.Error(), mismatchedIdentifierOwner)
+	require.Contains(t, jsonResponse.Error.Error(), authorizedOwner)
+}
+
 func sendVaultJWTRequestToGatewayExpectError(t *testing.T, gatewayURL string, jsonRequest jsonrpc.Request[json.RawMessage], wantStatus int) jsonrpc.Response[json.RawMessage] {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Cherry-picks two merged develop PRs onto `release/2.51.1`:

- **#22732** — Cap vault pending queue writes per OCR round
- **#22748** — Check secret owner calls matches all inner secret owners

Also bumps `chainlink-common` to `v0.11.2-0.20260609183712-678afb1edd2e` (includes `VaultPendingQueueWriteSizeLimit` from chainlink-common #2119), which is required for the pending queue cap to compile on this release branch.

## Test plan

- [ ] CI passes on this PR
- [ ] Vault plugin and gateway handler unit tests pass
- [ ] Vault DON smoke tests pass (`vault_don_test.go` auth mismatch coverage included)