### PR TITLE
[CRE-4846] surface EVM capability startup errors in system tests

### DIFF
--- a/system-tests/lib/cre/features/evm/v2/evm.go
+++ b/system-tests/lib/cre/features/evm/v2/evm.go
@@ -113,7 +113,7 @@ func (o *EVM) PreEnvStartup(
 
 		capabilities = append(capabilities, keystone_changeset.DONCapabilityWithConfig{
 			Capability: kcr.CapabilitiesRegistryCapability{
-				LabelledName: "evm" + ":ChainSelector:" + strconv.FormatUint(selector, 10),
+				LabelledName: CapabilityLabelledName(selector),
 				Version:      "1.0.0",
 			},
 			Config: &capabilitiespb.CapabilityConfig{
@@ -633,4 +633,8 @@ func chainsWithForwarders(blockchains []blockchains.Blockchain, nodeSets []cre.N
 	}
 
 	return chainsWithForwarders
+}
+
+func CapabilityLabelledName(chainSelector uint64) string {
+	return "evm:ChainSelector:" + strconv.FormatUint(chainSelector, 10)
 }

--- a/system-tests/tests/regression/cre/evm_regression_test.go
+++ b/system-tests/tests/regression/cre/evm_regression_test.go
@@ -218,6 +218,14 @@ func EVMReadFailsTest(t *testing.T, testEnv *ttypes.TestEnvironment, evmNegative
 			continue
 		}
 
+		// Wait until the EVM capability LOOP plugin has fully started on all nodes that are
+		// configured to run it before deploying the workflow. A startup race can cause
+		// nodes to fail initDON() (empty local registry) and never register the capability,
+		// resulting in all requests returning a generic Private:System:Unknown error.
+		//
+		// Remove this once https://smartcontract-it.atlassian.net/browse/PLEX-3130 is fixed.
+		t_helpers.WaitForEVMCapabilityStartup(t, testEnv.Dons, bcOutput.ChainSelector())
+
 		testLogger.Info().Msgf("Deploying additional contracts to chain %s (%d)", chainID, chainSelector)
 		readBalancesAddress, rbErr := contracts.DeployReadBalancesContract(testLogger, chainSelector, creEnvironment)
 		require.NoError(t, rbErr, "failed to deploy Read Balances contract on chain %d", chainSelector)
@@ -290,6 +298,14 @@ func EVMLogTriggerFailsTest(t *testing.T, testEnv *ttypes.TestEnvironment, evmNe
 			testLogger.Info().Msgf("Skipping chain %s as it is not enabled for EVM LogTrigger workflow test", chainID)
 			continue
 		}
+
+		// Wait until the EVM capability LOOP plugin has fully started on all nodes that are
+		// configured to run it before deploying the workflow. A startup race can cause
+		// nodes to fail initDON() (empty local registry) and never register the capability,
+		// resulting in all requests returning a generic Private:System:Unknown error.
+		//
+		// Remove this once https://smartcontract-it.atlassian.net/browse/PLEX-3130 is fixed.
+		t_helpers.WaitForEVMCapabilityStartup(t, testEnv.Dons, bcOutput.ChainSelector())
 
 		testLogger.Info().Msg("Creating EVM LogTrigger Fail workflow configuration...")
 
@@ -392,6 +408,14 @@ func EVMWriteFailsTest(t *testing.T, testEnv *ttypes.TestEnvironment, evmNegativ
 			testLogger.Info().Msgf("Skipping chain %d as it is not enabled for EVM Read workflow test", chainID)
 			continue
 		}
+
+		// Wait until the EVM capability LOOP plugin has fully started on all nodes that are
+		// configured to run it before deploying the workflow. A startup race can cause
+		// nodes to fail initDON() (empty local registry) and never register the capability,
+		// resulting in all requests returning a generic Private:System:Unknown error.
+		//
+		// Remove this once https://smartcontract-it.atlassian.net/browse/PLEX-3130 is fixed.
+		t_helpers.WaitForEVMCapabilityStartup(t, testEnv.Dons, bcOutput.ChainSelector())
 
 		forwarderAddress := contracts.MustGetAddressFromDataStore(creEnvironment.CldfEnvironment.DataStore, chainSelector, keystone_changeset.KeystoneForwarder.String(), creEnvironment.ContractVersions[keystone_changeset.KeystoneForwarder.String()], "")
 		workflowOwner := bcOutput.(*evm.Blockchain).SethClient.MustGetRootKeyAddress()

--- a/system-tests/tests/test-helpers/container_logs.go
+++ b/system-tests/tests/test-helpers/container_logs.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/assert"
@@ -38,6 +40,94 @@ func clNodeContainerNames(t *testing.T, testEnv *ttypes.TestEnvironment) []strin
 	}
 	slices.Sort(out)
 	return out
+}
+
+// waitForStandardCapabilityStartup polls the given container logs until every container has
+// emitted "Started standard capabilities" with capabilityLabelledName in the same log line. Container logs are
+// read in parallel for speed. The caller is responsible for selecting which containers to check —
+// different capabilities run on different node sets (e.g. evm-worker-1337 on workflow nodes,
+// evm-worker-2337 on capabilities nodes), so the caller must resolve the correct set beforehand.
+//
+// "Started standard capabilities" is logged by standardcapabilities/standard_capabilities.go after
+// Initialise() and Infos() both succeed. It is not specific to any capability type.
+//
+// Background: on startup a race between CRE.RegistrySyncerORM persisting the local DON registry
+// and the LOOP plugin calling GetLocalNode() can leave 3 of 4 nodes with a permanently unregistered
+// capability. Waiting for this log on every expected container ensures the capability is serving
+// before any dependent workflow is deployed.
+func waitForStandardCapabilityStartup(t *testing.T, containerNames []string, capabilityLabelledName string, timeout time.Duration) {
+	t.Helper()
+	if len(containerNames) == 0 {
+		framework.L.Warn().Msgf("WaitForStandardCapabilityStartup: no containers to check for capability %s, skipping", capabilityLabelledName)
+		return
+	}
+
+	expected := make(map[string]struct{}, len(containerNames))
+	for _, name := range containerNames {
+		expected[name] = struct{}{}
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		logStreams, err := framework.StreamContainerLogs(
+			client.ContainerListOptions{All: true},
+			client.ContainerLogsOptions{ShowStdout: true, ShowStderr: true},
+		)
+		if err != nil {
+			framework.L.Warn().Err(err).Msg("WaitForStandardCapabilityStartup: error streaming container logs, retrying")
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		// Read all relevant container logs in parallel.
+		var mu sync.Mutex
+		ready := make(map[string]struct{})
+		var wg sync.WaitGroup
+		for containerName, reader := range logStreams {
+			if _, ok := expected[containerName]; !ok {
+				_ = reader.Close()
+				continue
+			}
+			wg.Add(1)
+			go func(name string, r io.ReadCloser) {
+				defer wg.Done()
+				content, readErr := readContainerLogs(r)
+				if readErr != nil {
+					framework.L.Warn().Str("container", name).Err(readErr).Msg("WaitForStandardCapabilityStartup: could not read logs")
+					return
+				}
+
+				for line := range strings.SplitSeq(content, "\n") {
+					if strings.Contains(line, "Started standard capabilities") && strings.Contains(line, capabilityLabelledName) {
+						mu.Lock()
+						ready[name] = struct{}{}
+						mu.Unlock()
+						return
+					}
+				}
+			}(containerName, reader)
+		}
+		wg.Wait()
+
+		if len(ready) >= len(expected) {
+			framework.L.Info().Msgf("WaitForStandardCapabilityStartup: %s ready on all %d expected containers", capabilityLabelledName, len(expected))
+			return
+		}
+
+		framework.L.Info().Msgf("WaitForStandardCapabilityStartup: %s ready on %d/%d containers", capabilityLabelledName, len(ready), len(expected))
+
+		if time.Now().After(deadline) {
+			missing := make([]string, 0, len(expected)-len(ready))
+			for name := range expected {
+				if _, ok := ready[name]; !ok {
+					missing = append(missing, name)
+				}
+			}
+			require.FailNowf(t, "capability startup timeout",
+				"standard capability %s did not start within %s on containers: %v", capabilityLabelledName, timeout, missing)
+		}
+		time.Sleep(5 * time.Second)
+	}
 }
 
 func AssertNodeLogs(t *testing.T, testEnv *ttypes.TestEnvironment, needle string) {

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -42,10 +42,13 @@ import (
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/solkey"
 	commonevents "github.com/smartcontractkit/chainlink-protos/workflows/go/common"
 	workflowevents "github.com/smartcontractkit/chainlink-protos/workflows/go/events"
 
+	evm_v2 "github.com/smartcontractkit/chainlink/system-tests/lib/cre/features/evm/v2"
 	consensus_negative_config "github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/consensus/config"
 	evmread_negative_config "github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/evm/evmread-negative/config"
 	evmwrite_negative_config "github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/evm/evmwrite-negative/config"
@@ -844,4 +847,31 @@ func truncateWorkflowName(name, uniquenessSeed string) string {
 func ParallelEnabled() bool {
 	v := strings.TrimSpace(strings.ToLower(os.Getenv("CRE_TEST_PARALLEL_ENABLED")))
 	return v == "1" || v == "true" || v == "yes"
+}
+
+func WaitForEVMCapabilityStartup(t *testing.T, dons *cre.Dons, chainSelector uint64) {
+	// Wait until the EVM capability LOOP plugin has fully started on all nodes that are
+	// configured to run it before deploying the workflow. A startup race can cause
+	// nodes to fail initDON() (empty local registry) and never register the capability,
+	// resulting in all requests returning a generic Private:System:Unknown error.
+	//
+	// Remove this once https://smartcontract-it.atlassian.net/browse/PLEX-3130 is fixed.
+	var capContainers []string
+
+	for _, don := range dons.List() {
+		enabledChainIDs, eErr := don.GetEnabledChainIDsForCapability(cre.EVMCapability)
+		require.NoError(t, eErr, "failed to get enabled chain IDs for EVM capability on DON %s", don.Name)
+
+		chainID, err := chain_selectors.ChainIdFromSelector(chainSelector)
+		require.NoError(t, err, "failed to get chain ID from chain selector %d", chainSelector)
+
+		if !slices.Contains(enabledChainIDs, chainID) {
+			continue
+		}
+
+		for _, node := range don.Nodes {
+			capContainers = append(capContainers, node.Name)
+		}
+	}
+	waitForStandardCapabilityStartup(t, capContainers, evm_v2.CapabilityLabelledName(chainSelector), 2*time.Minute)
 }


### PR DESCRIPTION
Check whether capability has been initialized or whether a race condition prevented it. This will not fix the test, but will fail it without executing test logic, which would fail anyway. Once the underlaying issue has been fixed we can remove this check.

Race condition in question is captured in this ticket: https://smartcontract-it.atlassian.net/browse/PLEX-3130

No other capability seems to suffer from this issue.