### PR TITLE
fix(cre): org resolution on update

### DIFF
--- a/core/services/workflows/v2/capability_executor.go
+++ b/core/services/workflows/v2/capability_executor.go
@@ -217,7 +217,7 @@ func (c *ExecutionHelper) callCapability(ctx context.Context, request *sdkpb.Cap
 
 	execLogger.Debug("Executing capability ...")
 	c.metrics.With(platform.KeyCapabilityID, request.Id).IncrementCapabilityInvocationCounter(ctx)
-	loggerLabels := *c.loggerLabels.Load()
+	loggerLabels := c.eventLabels()
 	_ = events.EmitCapabilityStartedEvent(ctx, loggerLabels, c.WorkflowExecutionID, request.Id, meteringRef, request.Method)
 
 	execCtx, execCancel, err := c.cfg.LocalLimiters.CapabilityCallTime.WithTimeout(ctx)
@@ -311,8 +311,7 @@ func (c *ExecutionHelper) EmitUserMetric(ctx context.Context, metric *eventsv2.W
 		return err
 	}
 	metric.Name = userMetricPrefix + metric.Name + suffix
-	loggerLabels := *c.loggerLabels.Load()
-	return events.EmitUserMetric(ctx, loggerLabels, metric)
+	return events.EmitUserMetric(ctx, c.eventLabels(), metric)
 }
 
 // systemCapabilities lists capability IDs that are internal plumbing and must

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -139,6 +139,20 @@ func (e *Engine) buildLabels(localNode *capabilities.Node) []any {
 	}
 }
 
+// eventLabels returns a copy of the current label map with org ID applied.
+func (e *Engine) eventLabels() map[string]string {
+	return maps.Clone(*e.loggerLabels.Load())
+}
+
+// storeLoggerLabels persists base labels and always merges in the resolved org ID.
+func (e *Engine) storeLoggerLabels(base map[string]string) {
+	labels := maps.Clone(base)
+	if e.orgID != "" {
+		labels[platform.KeyOrganizationID] = e.orgID
+	}
+	e.loggerLabels.Store(&labels)
+}
+
 // logger returns the current logger in a thread-safe manner.
 // This method should be used instead of accessing e.lggr directly to avoid race conditions
 // when the logger is dynamically updated (e.g., when DON configuration changes).
@@ -262,9 +276,7 @@ func (e *Engine) start(ctx context.Context) error {
 			e.orgID = orgID
 		}
 	}
-	loggerLabels := maps.Clone(*e.loggerLabels.Load())
-	loggerLabels[platform.KeyOrganizationID] = e.orgID
-	e.loggerLabels.Store(&loggerLabels)
+	e.storeLoggerLabels(e.eventLabels())
 
 	e.metrics = e.metrics.With(platform.KeyOrganizationID, e.orgID)
 
@@ -370,7 +382,11 @@ func (e *Engine) localNodeSync(ctx context.Context) {
 		"Workflow DON Config Version (pinned)", pinnedWorkflowDonConfigVersion,
 	)
 
-	// Recreate the beholder logger with updated labels to reflect the new DON version
+	// Publish the new node before updating logger state so concurrent executions
+	// observe the synced DON while labels are rebuilt.
+	e.localNode.Store(&localNode)
+
+	// Recreate the beholder logger with updated labels to reflect the new DON version.
 	labels := e.buildLabels(&localNode)
 	newLogger := logger.Sugared(
 		custmsg.NewBeholderLogger(e.cfg.Lggr, e.cfg.BeholderEmitter).
@@ -379,15 +395,13 @@ func (e *Engine) localNodeSync(ctx context.Context) {
 	)
 	e.setLogger(newLogger)
 
-	// Update loggerLabels map for metrics
 	labelsMap := make(map[string]string, len(labels)/2)
 	for i := 0; i < len(labels); i += 2 {
 		labelsMap[labels[i].(string)] = labels[i+1].(string)
 	}
-	e.loggerLabels.Store(&labelsMap)
+	e.storeLoggerLabels(labelsMap)
 
 	e.cfg.Hooks.OnNodeSynced(localNode, nil)
-	e.localNode.Store(&localNode)
 }
 
 func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
@@ -405,7 +419,7 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 	userLogChan := make(chan *protoevents.LogLine, maxUserLogEventsPerExecution)
 	defer close(userLogChan)
 	e.srvcEng.Go(func(_ context.Context) {
-		e.emitUserLogs(subCtx, userLogChan, e.cfg.WorkflowID, *e.loggerLabels.Load())
+		e.emitUserLogs(subCtx, userLogChan, e.cfg.WorkflowID, e.eventLabels())
 	})
 
 	var timeProvider TimeProvider = &types.LocalTimeProvider{}
@@ -703,11 +717,8 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		return
 	}
 
-	// Use the org resolved at engine startup for all executions in this engine instance.
-	executionOrgID := contexts.CREValue(ctx).Org
-	loggerLabels := maps.Clone(*e.loggerLabels.Load())
-	loggerLabels[platform.KeyOrganizationID] = executionOrgID
-	lggr := e.logger().With(platform.KeyOrganizationID, executionOrgID)
+	loggerLabels := e.eventLabels()
+	lggr := e.logger().With(platform.KeyOrganizationID, e.orgID)
 
 	var executionTimestamp time.Time
 	if tsErr := e.cfg.LocalLimiters.ExecutionTimestampsEnabled.AllowErr(ctx); tsErr == nil {

--- a/core/services/workflows/v2/engine_labels_test.go
+++ b/core/services/workflows/v2/engine_labels_test.go
@@ -1,0 +1,35 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/platform"
+)
+
+func TestEngine_EventLabelsPreservedAfterLabelRebuild(t *testing.T) {
+	t.Parallel()
+
+	cfg := &EngineConfig{
+		WorkflowID:    "wf-1",
+		WorkflowOwner: "owner-1",
+	}
+	engine := &Engine{cfg: cfg, orgID: "test-org"}
+	base := map[string]string{platform.KeyWorkflowID: "wf-1"}
+	engine.storeLoggerLabels(base)
+
+	labels := engine.eventLabels()
+	require.Equal(t, "test-org", labels[platform.KeyOrganizationID])
+
+	// Simulate localNodeSync rebuilding labels from buildLabels without org.
+	engine.storeLoggerLabels(map[string]string{
+		platform.KeyWorkflowID: "wf-1",
+		platform.KeyDonID:      "11",
+		platform.DonVersion:    "1",
+	})
+
+	labels = engine.eventLabels()
+	require.Equal(t, "test-org", labels[platform.KeyOrganizationID])
+	require.Equal(t, "11", labels[platform.KeyDonID])
+}

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -614,6 +614,143 @@ func TestEngine_OrganizationIdLogger_OrgResolverFailure(t *testing.T) {
 	require.NoError(t, engine.Close())
 }
 
+// TestEngine_OrganizationIdPreservedAfterLocalNodeSync verifies that the org ID
+// resolved at engine startup survives a localNodeSync label rebuild.
+//
+// localNodeSync rebuilds logger labels from DON state without re-resolving the org.
+// The org ID must still propagate into capability request metadata on subsequent executions.
+//
+// Test flow:
+// 1. Start the engine and resolve org ID from the workflow owner
+// 2. Trigger localNodeSync via a DON update (ConfigVersion 1 -> 2)
+// 3. Run a workflow execution that calls a capability
+// 4. Assert the capability receives Metadata.OrgID matching the resolved org
+func TestEngine_OrganizationIdPreservedAfterLocalNodeSync(t *testing.T) {
+	t.Parallel()
+
+	const (
+		wantOrgID    = "test-org-123"
+		capabilityID = "org-test-cap@1.0.0"
+	)
+
+	module := modulemocks.NewModuleV2(t)
+	module.EXPECT().Start()
+	module.EXPECT().Close()
+	capreg := regmocks.NewCapabilitiesRegistry(t)
+	billingClient := setupMockBillingClient(t)
+
+	initialNode := newNode(t, func(n *capabilities.Node) {
+		n.WorkflowDON.ConfigVersion = 1
+	})
+	updatedNode := newNode(t, func(n *capabilities.Node) {
+		n.WorkflowDON.ConfigVersion = 2
+	})
+	capreg.EXPECT().LocalNode(matches.AnyContext).Return(initialNode, nil).Once()
+	capreg.EXPECT().LocalNode(matches.AnyContext).Return(updatedNode, nil).Once()
+
+	mockOrgResolver := &mockOrgResolver{orgID: wantOrgID}
+
+	initDoneCh := make(chan error)
+	subscribedToTriggersCh := make(chan []string, 1)
+	executionFinishedCh := make(chan string)
+	donCh := make(chan capabilities.DON)
+	nodeSyncedCh := make(chan capabilities.Node, 1)
+
+	subscriberMock := capmocks.NewDonSubscriber(t)
+	subscriberMock.EXPECT().Subscribe(matches.AnyContext).Return(donCh, func() {}, nil)
+
+	cfg := defaultTestConfig(t, nil)
+	propagateOrgIDGetter, err := settings.NewJSONGetter([]byte(`{"global":{"PropagateOrgIDInRequestMetadata":"true"}}`))
+	require.NoError(t, err)
+	cfg.LocalLimiters.Settings = propagateOrgIDGetter
+	cfg.DonSubscriber = subscriberMock
+	cfg.Module = module
+	cfg.CapRegistry = capreg
+	cfg.BillingClient = billingClient
+	cfg.OrgResolver = mockOrgResolver
+	cfg.Hooks = v2.LifecycleHooks{
+		OnInitialized: func(err error) {
+			initDoneCh <- err
+		},
+		OnSubscribedToTriggers: func(triggerIDs []string) {
+			subscribedToTriggersCh <- triggerIDs
+		},
+		OnExecutionFinished: func(executionID string, _ string) {
+			executionFinishedCh <- executionID
+		},
+		OnNodeSynced: func(node capabilities.Node, err error) {
+			require.NoError(t, err)
+			nodeSyncedCh <- node
+		},
+	}
+
+	engine, err := v2.NewEngine(cfg)
+	require.NoError(t, err)
+
+	module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(1), nil).Once()
+	trigger := capmocks.NewTriggerCapability(t)
+	capreg.EXPECT().GetTrigger(matches.AnyContext, "id_0").Return(trigger, nil).Once()
+	eventCh := make(chan capabilities.TriggerResponse)
+	trigger.EXPECT().RegisterTrigger(matches.AnyContext, mock.Anything).Return(eventCh, nil).Once()
+	trigger.EXPECT().UnregisterTrigger(matches.AnyContext, mock.Anything).Return(nil).Once()
+	trigger.EXPECT().AckEvent(matches.AnyContext, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	require.NoError(t, engine.Start(t.Context()))
+	require.NoError(t, <-initDoneCh)
+	require.Equal(t, []string{"id_0"}, <-subscribedToTriggersCh)
+	require.True(t, mockOrgResolver.getCalled, "expected org resolver to be called during engine start")
+
+	donCh <- capabilities.DON{}
+	syncedNode := <-nodeSyncedCh
+	require.Equal(t, uint32(2), syncedNode.WorkflowDON.ConfigVersion)
+
+	capabilityOrgIDCh := make(chan string, 1)
+	capability := capmocks.NewExecutableCapability(t)
+	capreg.EXPECT().GetExecutable(matches.AnyContext, capabilityID).Return(capability, nil).Once()
+	capreg.EXPECT().ConfigForCapability(mock.Anything, mock.Anything, mock.Anything).
+		Return(capabilities.CapabilityConfiguration{}, nil).
+		Once()
+	capability.EXPECT().
+		Info(matches.AnyContext).
+		Return(capabilities.CapabilityInfo{IsLocal: true}, nil).
+		Once()
+	capability.EXPECT().
+		Execute(matches.AnyContext, mock.Anything).
+		Run(func(_ context.Context, req capabilities.CapabilityRequest) {
+			capabilityOrgIDCh <- req.Metadata.OrgID
+		}).
+		Return(capabilities.CapabilityResponse{}, nil).
+		Once()
+
+	module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).
+		Run(func(ctx context.Context, _ *sdkpb.ExecuteRequest, executor host.ExecutionHelper) {
+			_, errCap := executor.CallCapability(ctx, &sdkpb.CapabilityRequest{
+				Id:         capabilityID,
+				Method:     "execute",
+				CallbackId: 1,
+			})
+			require.NoError(t, errCap)
+		}).
+		Return(nil, nil).
+		Once()
+
+	mockTriggerEvent := capabilities.TriggerEvent{
+		TriggerType: "basic-trigger@1.0.0",
+		ID:          "post_local_node_sync_event",
+	}
+	eventCh <- capabilities.TriggerResponse{Event: mockTriggerEvent}
+
+	executionID := <-executionFinishedCh
+	wantExecID, err := workflowEvents.GenerateExecutionID(cfg.WorkflowID, mockTriggerEvent.ID)
+	require.NoError(t, err)
+	require.Equal(t, wantExecID, executionID)
+
+	// The capability call after localNodeSync must carry the org ID resolved at startup.
+	require.Equal(t, wantOrgID, <-capabilityOrgIDCh, "capability request metadata must include org ID after local node sync")
+
+	require.NoError(t, engine.Close())
+}
+
 // mockOrgResolver is a test implementation of orgresolver.OrgResolver
 type mockOrgResolver struct {
 	orgID           string


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

* updating the cap registry forces new labels on the engine loggers, but the org ID was left off due to inconsistent application of writing labels
* centralizes the reading and writing of labels on the logger to two new methods
* adds unit tests to verify that a synced node keeps the org id after resolution

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
