### PR TITLE
fix(vault): align JWT replay guard expiry with validation leeway

### DIFF
--- a/core/capabilities/vault/jwt_based_auth.go
+++ b/core/capabilities/vault/jwt_based_auth.go
@@ -48,6 +48,9 @@ const (
 	defaultJWTAuthJobSpecTenantID uint64 = 1
 	defaultJWKSRefreshInterval           = 15 * time.Minute
 	defaultHTTPTimeout                   = 5 * time.Second
+	// jwtValidationLeeway must match jwt.WithLeeway in validateToken. Replay
+	// protection must retain digests for the full JWT validation window.
+	jwtValidationLeeway = time.Minute
 )
 
 // Auth0Config captures the Vault JWT issuer settings shared by gateway and node handlers.
@@ -263,12 +266,13 @@ func (v *jwtBasedAuth) AuthorizeRequest(ctx context.Context, req jsonrpc.Request
 		return nil, fmt.Errorf("invalid JWT auth token: %w", err)
 	}
 
-	v.lggr.Debugw("JWTBasedAuth authorization succeeded", "method", req.Method, "requestID", req.ID, "orgID", claims.OrgID, "workflowOwner", derivedWorkflowOwner, "digest", requestDigest, "expiresAt", claims.ExpiresAt.UTC().Unix())
+	authExpiresAt := claims.ExpiresAt.UTC().Add(jwtValidationLeeway).Unix()
+	v.lggr.Debugw("JWTBasedAuth authorization succeeded", "method", req.Method, "requestID", req.ID, "orgID", claims.OrgID, "workflowOwner", derivedWorkflowOwner, "digest", requestDigest, "expiresAt", authExpiresAt)
 	return &AuthResult{
 		orgID:         claims.OrgID,
 		workflowOwner: derivedWorkflowOwner,
 		digest:        requestDigest,
-		expiresAt:     claims.ExpiresAt.UTC().Unix(),
+		expiresAt:     authExpiresAt,
 	}, nil
 }
 
@@ -305,7 +309,7 @@ func (v *jwtBasedAuth) validateToken(ctx context.Context, tokenString string) (*
 		jwt.WithAudience(v.audience),
 		jwt.WithExpirationRequired(),
 		jwt.WithIssuedAt(),
-		jwt.WithLeeway(time.Minute),
+		jwt.WithLeeway(jwtValidationLeeway),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w. Expected Issuer: %s, Actual Issuer: %s", ErrInvalidToken, err, v.issuerURL, unverified.Claims.(jwt.MapClaims)["iss"])

--- a/core/capabilities/vault/jwt_based_auth_test.go
+++ b/core/capabilities/vault/jwt_based_auth_test.go
@@ -217,6 +217,98 @@ func TestJWTBasedAuth_ValidTokenWithoutWorkflowOwner(t *testing.T) {
 	require.Equal(t, "digest456", result.RequestDigest)
 }
 
+func TestJWTBasedAuth_AuthResultExpiryIncludesValidationLeeway(t *testing.T) {
+	rsaKey := generateTestRSAKey(t, "key-1")
+	jwksServer := newTestJWKSServer(t, rsaKey)
+
+	issuer := jwksServer.URL() + "/"
+	audience := "https://vault.test.chain.link"
+	v := newTestValidator(t, issuer, audience)
+
+	derivedOrg123Owner := testJWTExpectedWorkflowOwner(t, 1, "org-123")
+	rawRequest := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":"req-1","method":"vault.secrets.list","params":{"request_id":"req-1","owner":"%s","namespace":"main"}}`, derivedOrg123Owner))
+	req, err := jsonrpc.DecodeRequest[json.RawMessage](rawRequest, "")
+	require.NoError(t, err)
+
+	digest, err := req.Digest()
+	require.NoError(t, err)
+
+	tokenExp := time.Now().Add(2 * time.Minute).Truncate(time.Second)
+	token := createTestJWT(t, rsaKey, jwt.MapClaims{
+		"iss":                             issuer,
+		"aud":                             audience,
+		"exp":                             jwt.NewNumericDate(tokenExp),
+		"iat":                             jwt.NewNumericDate(time.Now()),
+		"org_id":                          "org-123",
+		ClaimVaultSecretManagementEnabled: "true",
+		ClaimChainlinkTenantID:            "1",
+		"scope":                           OAuthScopeVaultSecretsList,
+		"authorization_details": []interface{}{
+			map[string]interface{}{
+				"type":  "request_digest",
+				"value": digest,
+			},
+		},
+	})
+
+	req, err = jsonrpc.DecodeRequest[json.RawMessage](rawRequest, token)
+	require.NoError(t, err)
+
+	authResult, err := v.AuthorizeRequest(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, tokenExp.UTC().Add(time.Minute).Unix(), authResult.ExpiresAt())
+}
+
+func TestAuthorizer_RejectsJWTReplayDuringValidationLeewayWindow(t *testing.T) {
+	rsaKey := generateTestRSAKey(t, "key-1")
+	jwksServer := newTestJWKSServer(t, rsaKey)
+
+	issuer := jwksServer.URL() + "/"
+	audience := "https://vault.test.chain.link"
+	v := newTestValidator(t, issuer, audience)
+
+	derivedOrg123Owner := testJWTExpectedWorkflowOwner(t, 1, "org-123")
+	rawRequest := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":"req-1","method":"vault.secrets.list","params":{"request_id":"req-1","owner":"%s","namespace":"main"}}`, derivedOrg123Owner))
+	req, err := jsonrpc.DecodeRequest[json.RawMessage](rawRequest, "")
+	require.NoError(t, err)
+
+	digest, err := req.Digest()
+	require.NoError(t, err)
+
+	// Raw exp is in the past but still within the JWT validation leeway window.
+	tokenExp := time.Now().Add(-30 * time.Second)
+	token := createTestJWT(t, rsaKey, jwt.MapClaims{
+		"iss":                             issuer,
+		"aud":                             audience,
+		"exp":                             jwt.NewNumericDate(tokenExp),
+		"iat":                             jwt.NewNumericDate(time.Now().Add(-2 * time.Minute)),
+		"org_id":                          "org-123",
+		ClaimVaultSecretManagementEnabled: "true",
+		ClaimChainlinkTenantID:            "1",
+		"scope":                           OAuthScopeVaultSecretsList,
+		"authorization_details": []interface{}{
+			map[string]interface{}{
+				"type":  "request_digest",
+				"value": digest,
+			},
+		},
+	})
+
+	req, err = jsonrpc.DecodeRequest[json.RawMessage](rawRequest, token)
+	require.NoError(t, err)
+
+	a := NewAuthorizer(nil, v, logger.TestLogger(t))
+
+	authResult, err := a.AuthorizeRequest(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, digest, authResult.Digest())
+	require.Equal(t, tokenExp.UTC().Add(time.Minute).Unix(), authResult.ExpiresAt())
+
+	authResult, err = a.AuthorizeRequest(t.Context(), req)
+	require.Nil(t, authResult)
+	require.ErrorIs(t, err, ErrRequestAlreadySeen)
+}
+
 func TestJWTBasedAuth_ExpiredToken(t *testing.T) {
 	rsaKey := generateTestRSAKey(t, "key-1")
 	jwksServer := newTestJWKSServer(t, rsaKey)

--- a/core/capabilities/vault/jwt_based_auth_test.go
+++ b/core/capabilities/vault/jwt_based_auth_test.go
@@ -226,7 +226,7 @@ func TestJWTBasedAuth_AuthResultExpiryIncludesValidationLeeway(t *testing.T) {
 	v := newTestValidator(t, issuer, audience)
 
 	derivedOrg123Owner := testJWTExpectedWorkflowOwner(t, 1, "org-123")
-	rawRequest := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":"req-1","method":"vault.secrets.list","params":{"request_id":"req-1","owner":"%s","namespace":"main"}}`, derivedOrg123Owner))
+	rawRequest := fmt.Appendf(nil, `{"jsonrpc":"2.0","id":"req-1","method":"vault.secrets.list","params":{"request_id":"req-1","owner":"%s","namespace":"main"}}`, derivedOrg123Owner)
 	req, err := jsonrpc.DecodeRequest[json.RawMessage](rawRequest, "")
 	require.NoError(t, err)
 
@@ -243,8 +243,8 @@ func TestJWTBasedAuth_AuthResultExpiryIncludesValidationLeeway(t *testing.T) {
 		ClaimVaultSecretManagementEnabled: "true",
 		ClaimChainlinkTenantID:            "1",
 		"scope":                           OAuthScopeVaultSecretsList,
-		"authorization_details": []interface{}{
-			map[string]interface{}{
+		"authorization_details": []any{
+			map[string]any{
 				"type":  "request_digest",
 				"value": digest,
 			},
@@ -268,7 +268,7 @@ func TestAuthorizer_RejectsJWTReplayDuringValidationLeewayWindow(t *testing.T) {
 	v := newTestValidator(t, issuer, audience)
 
 	derivedOrg123Owner := testJWTExpectedWorkflowOwner(t, 1, "org-123")
-	rawRequest := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":"req-1","method":"vault.secrets.list","params":{"request_id":"req-1","owner":"%s","namespace":"main"}}`, derivedOrg123Owner))
+	rawRequest := fmt.Appendf(nil, `{"jsonrpc":"2.0","id":"req-1","method":"vault.secrets.list","params":{"request_id":"req-1","owner":"%s","namespace":"main"}}`, derivedOrg123Owner)
 	req, err := jsonrpc.DecodeRequest[json.RawMessage](rawRequest, "")
 	require.NoError(t, err)
 
@@ -286,8 +286,8 @@ func TestAuthorizer_RejectsJWTReplayDuringValidationLeewayWindow(t *testing.T) {
 		ClaimVaultSecretManagementEnabled: "true",
 		ClaimChainlinkTenantID:            "1",
 		"scope":                           OAuthScopeVaultSecretsList,
-		"authorization_details": []interface{}{
-			map[string]interface{}{
+		"authorization_details": []any{
+			map[string]any{
 				"type":  "request_digest",
 				"value": digest,
 			},


### PR DESCRIPTION
## Summary
- Extend JWT `AuthResult` replay-guard expiry to `exp + jwtValidationLeeway` so it matches the JWT validation window.
- Centralize the one-minute leeway in a shared `jwtValidationLeeway` constant used by both validation and replay protection.
- Add regression tests covering leeway-aligned expiry and duplicate-request rejection after raw `exp`.
