### PR TITLE
Add support for configuring fault-tolerance (F) and node set updates

### DIFF
--- a/deployment/cre/capabilities_registry/v2/changeset/update_don.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/update_don.go
@@ -53,6 +53,14 @@ type UpdateDONInput struct {
 	// config count collisions.
 	FirstOCR3ConfigCapabilities []string `json:"firstOCR3ConfigCapabilities" yaml:"firstOCR3ConfigCapabilities"`
 
+	// F is the new fault-tolerance value for the DON. If 0, the current on-chain value is kept.
+	F uint8 `json:"f,omitempty" yaml:"f,omitempty"`
+
+	// Nodes is the new set of P2P IDs for the DON (e.g. "p2p_12D3KooW...").
+	// If empty, the current on-chain node set is kept.
+	// Safe to combine with MergeCapabilityConfigsWithOnChain=true when CapabilityConfigs is empty.
+	Nodes []string `json:"nodes,omitempty" yaml:"nodes,omitempty"`
+
 	MCMSConfig *crecontracts.MCMSConfig `json:"mcmsConfig" yaml:"mcmsConfig"`
 }
 
@@ -135,9 +143,24 @@ func (u UpdateDON) Apply(e cldf.Environment, config UpdateDONInput) (cldf.Change
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to process OCR3 configs: %w", err)
 	}
 
-	p2pIDs := make([]p2pkey.PeerID, 0)
-	for _, node := range nodes {
-		p2pIDs = append(p2pIDs, node.P2pId)
+	p2pIDs := make([]p2pkey.PeerID, 0, len(nodes))
+	if len(config.Nodes) > 0 {
+		for _, s := range config.Nodes {
+			var id p2pkey.PeerID
+			if err := id.UnmarshalText([]byte(s)); err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("invalid P2P ID %q: %w", s, err)
+			}
+			p2pIDs = append(p2pIDs, id)
+		}
+	} else {
+		for _, node := range nodes {
+			p2pIDs = append(p2pIDs, node.P2pId)
+		}
+	}
+
+	fValue := don.F
+	if config.F != 0 {
+		fValue = config.F
 	}
 
 	// Create the appropriate strategy
@@ -183,7 +206,7 @@ func (u UpdateDON) Apply(e cldf.Environment, config UpdateDONInput) (cldf.Change
 			MergeCapabilityConfigsWithOnChain: config.MergeCapabilityConfigsWithOnChain,
 			DonName:                           config.DONName,
 			NewDonName:                        config.NewDonName,
-			F:                                 don.F,
+			F:                                 fValue,
 			IsPrivate:                         !don.IsPublic,
 			Force:                             config.Force,
 			MCMSConfig:                        config.MCMSConfig,

--- a/deployment/cre/capabilities_registry/v2/changeset/update_don_test.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/update_don_test.go
@@ -588,13 +588,15 @@ func setupRegistryWith3Nodes(t *testing.T) *updFixture {
 
 func TestUpdateDONChangeset_WithF_OverridesOnChainValue(t *testing.T) {
 	t.Parallel()
-	fx := setupRegistryForUpdateDON(t, false, false)
+	// Use the 3-node fixture (F=1 initially). F=2 is valid with 3 nodes (F < N).
+	fx := setupRegistryWith3Nodes(t)
 
 	err := fx.rt.Exec(runtime.ChangesetTask(changeset.UpdateDON{}, changeset.UpdateDONInput{
 		RegistryQualifier:                 fx.qualifier,
 		RegistryChainSel:                  fx.selector,
 		DONName:                           fx.donName,
 		MergeCapabilityConfigsWithOnChain: true,
+		Nodes:                             []string{p2pID1, p2pID2, p2pID3}, // keep 3 nodes so F=2 is valid
 		F:                                 2,
 	}))
 	require.NoError(t, err)

--- a/deployment/cre/capabilities_registry/v2/changeset/update_don_test.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/update_don_test.go
@@ -38,6 +38,8 @@ const (
 	signer2             = "5240b57854dd1f21c10353ea458eecd8593624d0e0a7cca07c62a4b58df8c252"
 	p2pID1              = "p2p_12D3KooWM1111111111111111111111111111111111111111111"
 	p2pID2              = "p2p_12D3KooWM1111111111111111111111111111111111111111112"
+	p2pID3              = "p2p_12D3KooWM1111111111111111111111111111111111111111113"
+	signer3             = "5240b57854dd1f21c10353ea458eecd8593624d0e0a7cca07c62a4b58df8c253"
 	encryptionPublicKey = "7240b57854dd1f21c10353ea458eecd8593624d0e0a7cca07c62a4b58df8c254"
 )
 
@@ -477,4 +479,197 @@ func TestUpdateDON_FirstOCR3ConfigCapabilities(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "firstOCR3ConfigCapabilities")
 	})
+}
+
+// setupRegistryWith3Nodes creates a registry with 3 NOPs and 3 nodes but a DON that
+// initially contains only p2pID1 and p2pID2 (F=1). This lets tests verify that
+// UpdateDON can expand the node set to include the third node.
+func setupRegistryWith3Nodes(t *testing.T) *updFixture {
+	t.Helper()
+
+	selector := chainselectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+		environment.WithLogger(logger.Test(t)),
+	))
+	require.NoError(t, err)
+
+	qualifier := "update-don-3nodes-tests"
+
+	deployTask := runtime.ChangesetTask(changeset.DeployCapabilitiesRegistry{}, changeset.DeployCapabilitiesRegistryInput{
+		ChainSelector: selector,
+		Qualifier:     qualifier,
+	})
+	require.NoError(t, rt.Exec(deployTask))
+	deployOutput := rt.State().Outputs[deployTask.ID()]
+	require.NotNil(t, deployOutput)
+
+	addr := deployOutput.DataStore.Addresses().Filter(datastore.AddressRefByQualifier(qualifier))[0].Address
+
+	reg, err := capabilities_registry_v2.NewCapabilitiesRegistry(common.HexToAddress(addr), rt.Environment().BlockChains.EVMChains()[selector].Client)
+	require.NoError(t, err)
+
+	writeChain := capabilities_registry_v2.CapabilitiesRegistryCapability{
+		CapabilityId: "write-chain@1.0.1",
+		Metadata:     []byte(`{"capabilityType": 3, "responseType": 1}`),
+	}
+	var writeChainMeta map[string]any
+	require.NoError(t, json.Unmarshal(writeChain.Metadata, &writeChainMeta))
+
+	nop1, nop2, nop3 := "test-nop-1", "test-nop-2", "test-nop-3"
+	donName := "upd-don-3nodes"
+
+	err = rt.Exec(
+		runtime.ChangesetTask(changeset.ConfigureCapabilitiesRegistry{}, changeset.ConfigureCapabilitiesRegistryInput{
+			ChainSelector:               selector,
+			CapabilitiesRegistryAddress: addr,
+			Nops: []changeset.CapabilitiesRegistryNodeOperator{
+				{Admin: common.HexToAddress("0x01"), Name: nop1},
+				{Admin: common.HexToAddress("0x02"), Name: nop2},
+				{Admin: common.HexToAddress("0x03"), Name: nop3},
+			},
+			Capabilities: []changeset.CapabilitiesRegistryCapability{
+				{CapabilityID: writeChain.CapabilityId, Metadata: writeChainMeta},
+			},
+			Nodes: []changeset.CapabilitiesRegistryNodeParams{
+				{
+					NOP:                 nop1,
+					Signer:              signer1,
+					P2pID:               p2pID1,
+					EncryptionPublicKey: encryptionPublicKey,
+					CsaKey:              csaKey,
+					CapabilityIDs:       []string{writeChain.CapabilityId},
+				},
+				{
+					NOP:                 nop2,
+					Signer:              signer2,
+					P2pID:               p2pID2,
+					EncryptionPublicKey: encryptionPublicKey,
+					CsaKey:              csaKey,
+					CapabilityIDs:       []string{writeChain.CapabilityId},
+				},
+				{
+					NOP:                 nop3,
+					Signer:              signer3,
+					P2pID:               p2pID3,
+					EncryptionPublicKey: encryptionPublicKey,
+					CsaKey:              csaKey,
+					CapabilityIDs:       []string{writeChain.CapabilityId},
+				},
+			},
+			DONs: []changeset.CapabilitiesRegistryNewDONParams{
+				{
+					Name: donName,
+					Config: map[string]any{
+						"defaultConfig": map[string]any{},
+					},
+					CapabilityConfigurations: []changeset.CapabilitiesRegistryCapabilityConfiguration{
+						{CapabilityID: writeChain.CapabilityId, Config: map[string]any{"defaultConfig": map[string]any{}}},
+					},
+					Nodes:    []string{p2pID1, p2pID2},
+					F:        1,
+					IsPublic: true,
+				},
+			},
+		}),
+	)
+	require.NoError(t, err)
+
+	return &updFixture{
+		rt:        rt,
+		selector:  selector,
+		qualifier: qualifier,
+		address:   addr,
+		registry:  reg,
+		donName:   donName,
+		capIDs:    []string{writeChain.CapabilityId},
+	}
+}
+
+func TestUpdateDONChangeset_WithF_OverridesOnChainValue(t *testing.T) {
+	t.Parallel()
+	fx := setupRegistryForUpdateDON(t, false, false)
+
+	err := fx.rt.Exec(runtime.ChangesetTask(changeset.UpdateDON{}, changeset.UpdateDONInput{
+		RegistryQualifier:                 fx.qualifier,
+		RegistryChainSel:                  fx.selector,
+		DONName:                           fx.donName,
+		MergeCapabilityConfigsWithOnChain: true,
+		F:                                 2,
+	}))
+	require.NoError(t, err)
+
+	got, err := fx.registry.GetDONByName(nil, fx.donName)
+	require.NoError(t, err)
+	assert.Equal(t, uint8(2), got.F)
+}
+
+func TestUpdateDONChangeset_WithF_Zero_PreservesExistingF(t *testing.T) {
+	t.Parallel()
+	fx := setupRegistryForUpdateDON(t, false, false)
+
+	err := fx.rt.Exec(runtime.ChangesetTask(changeset.UpdateDON{}, changeset.UpdateDONInput{
+		RegistryQualifier:                 fx.qualifier,
+		RegistryChainSel:                  fx.selector,
+		DONName:                           fx.donName,
+		MergeCapabilityConfigsWithOnChain: true,
+		F:                                 0, // zero value — keep on-chain F
+	}))
+	require.NoError(t, err)
+
+	got, err := fx.registry.GetDONByName(nil, fx.donName)
+	require.NoError(t, err)
+	assert.Equal(t, uint8(1), got.F, "F must remain unchanged when input F=0")
+}
+
+func TestUpdateDONChangeset_WithNodes_OverridesOnChainNodes(t *testing.T) {
+	t.Parallel()
+	fx := setupRegistryWith3Nodes(t)
+
+	// DON currently has 2 nodes (p2pID1, p2pID2); expand to all 3.
+	err := fx.rt.Exec(runtime.ChangesetTask(changeset.UpdateDON{}, changeset.UpdateDONInput{
+		RegistryQualifier:                 fx.qualifier,
+		RegistryChainSel:                  fx.selector,
+		DONName:                           fx.donName,
+		MergeCapabilityConfigsWithOnChain: true,
+		Nodes:                             []string{p2pID1, p2pID2, p2pID3},
+	}))
+	require.NoError(t, err)
+
+	got, err := fx.registry.GetDONByName(nil, fx.donName)
+	require.NoError(t, err)
+	// The registry stores hashed P2P IDs; membership count is the authoritative assertion.
+	assert.Len(t, got.NodeP2PIds, 3, "DON must now have 3 members")
+}
+
+func TestUpdateDONChangeset_WithNodes_Empty_PreservesExistingNodes(t *testing.T) {
+	t.Parallel()
+	fx := setupRegistryForUpdateDON(t, false, false)
+
+	err := fx.rt.Exec(runtime.ChangesetTask(changeset.UpdateDON{}, changeset.UpdateDONInput{
+		RegistryQualifier:                 fx.qualifier,
+		RegistryChainSel:                  fx.selector,
+		DONName:                           fx.donName,
+		MergeCapabilityConfigsWithOnChain: true,
+		Nodes:                             nil, // empty — keep on-chain nodes
+	}))
+	require.NoError(t, err)
+
+	got, err := fx.registry.GetDONByName(nil, fx.donName)
+	require.NoError(t, err)
+	assert.Len(t, got.NodeP2PIds, 2, "node set must remain unchanged when Nodes is nil")
+}
+
+func TestUpdateDONChangeset_WithNodes_InvalidP2PID(t *testing.T) {
+	t.Parallel()
+	fx := setupRegistryForUpdateDON(t, false, false)
+
+	_, err := changeset.UpdateDON{}.Apply(fx.rt.Environment(), changeset.UpdateDONInput{
+		RegistryQualifier: fx.qualifier,
+		RegistryChainSel:  fx.selector,
+		DONName:           fx.donName,
+		Nodes:             []string{"not-a-valid-p2p-id"},
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid P2P ID")
 }


### PR DESCRIPTION
UpdateDONInput had no way to override the DON's fault-tolerance value (F) or node membership — both were always read from the current on-chain state, making it impossible to resize a DON via a durable pipeline.

  - Adds F uint8 to UpdateDONInput: when non-zero, overrides the on-chain F value; when zero, the existing value is preserved.
  - Adds Nodes []string to UpdateDONInput: when non-empty, replaces the DON's P2P ID set with the provided list (validated at Apply time); when empty, the on-chain node set is kept unchanged.
  - Both fields are backward-compatible — existing callers that set neither field get identical behaviour to before.
  - Wires fValue and the resolved p2pIDs through to the contracts.UpdateDONInput passed to the operation layer, which already accepted both fields.