### PR TITLE
[CRE] Confidential workflows: stop setting deprecated outside-envelope binary_url

### DIFF
--- a/.changeset/confworkflow-binary-url-1781183798.md
+++ b/.changeset/confworkflow-binary-url-1781183798.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal Confidential workflows: stop setting the deprecated outside-envelope `ConfidentialWorkflowRequest.binary_url`. `binary_url` stays in the hashed `WorkflowExecution` (PublicData); the enclave reads it there.

--- a/core/services/workflows/syncer/v2/handler_test.go
+++ b/core/services/workflows/syncer/v2/handler_test.go
@@ -751,7 +751,6 @@ func Test_workflowRegisteredHandler_confidentialRouting(t *testing.T) {
 					BinaryUrl:         binaryURL,
 					Requirements:      &sdk.Requirements{Tee: &sdk.Tee{Item: &sdk.Tee_AnyRegions{}}},
 				},
-				BinaryUrl: binaryURL,
 			},
 		}
 

--- a/core/services/workflows/v2/confidential_module.go
+++ b/core/services/workflows/v2/confidential_module.go
@@ -107,7 +107,6 @@ func (m *ConfidentialModule) Execute(
 			Requirements:      requirements,
 			BinaryUrl:         m.binaryURL,
 		},
-		BinaryUrl: m.binaryURL,
 	}
 
 	capOutput := &confworkflowtypes.ConfidentialWorkflowResponse{}


### PR DESCRIPTION
binary_url moves back into the hash. Keep `WorkflowExecution.binary_url` (inside
`PublicData`, the canonical locator covered by the consensus hash) and stop also
setting the now-deprecated request-level `ConfidentialWorkflowRequest.binary_url`,
which the enclave never reads.

No behavior change: the enclave reads `execution.BinaryUrl`. This just removes the
redundant copy that chainlink-common #2144 marks `// Deprecated:`.

### Requires
- chainlink-protos #387 (merged) restores in-hash binary_url and deprecates the
  outside-envelope field.

### Supports
- The confidential binary-fetch pivot: CC #352 (host-agent sidecar) and #353
  (enclave fetches via sidecar). binary_url now rides only in the hash and the
  enclave hands it to the sidecar as the storage locator.

Jira: https://smartcontract-it.atlassian.net/browse/PRIV-389
