### PR TITLE
fix: setup-wasmd(ci), bump to v0.70.2

### DIFF
--- a/.github/actions/setup-wasmd/action.yml
+++ b/.github/actions/setup-wasmd/action.yml
@@ -15,7 +15,7 @@ runs:
         path: ~/wasmd-build
         # this caching works without cloning the repo because the install_wasmd contains
         # the commit hash.
-        key: ${{ runner.os }}-wasmd-cli-${{ hashFiles('${{ inputs.base-path }}/tools/ci/install_wasmd') }}
+        key: ${{ runner.os }}-wasmd-cli-${{ hashFiles(format('{0}/tools/ci/install_wasmd', inputs.base-path)) }}
 
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: Install wasmd

--- a/tools/ci/install_wasmd
+++ b/tools/ci/install_wasmd
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # latest release tag
-GIT_TAG="v0.61.10"
+GIT_TAG="v0.70.2"
 
 CHECKOUT_DIR="${HOME}/wasmd-checkout"
 BUILD_DIR="${HOME}/wasmd-build"


### PR DESCRIPTION

* Fixes `setup-wasmd` cache key
* Bumps wasmd to `v0.70.2`


### Notes

We are seeing errors.

https://github.com/smartcontractkit/chainlink/actions/runs/27376785058/job/80907732555?pr=22810#step:9:331
https://github.com/smartcontractkit/chainlink/actions/runs/27376785058/job/80907732546?pr=22810#step:9:328

```
go: downloading golang.org/x/time v0.12.0
go: downloading github.com/google/s2a-go v0.1.9
go: downloading go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0
# github.com/bytedance/sonic/internal/rt
Error: ../wasmd-build/pkg/mod/github.com/bytedance/sonic@v1.14.2/internal/rt/stubs.go:33:22: undefined: GoMapIterator
Error: ../wasmd-build/pkg/mod/github.com/bytedance/sonic@v1.14.2/internal/rt/stubs.go:36:54: undefined: GoMapIterator
make: *** [Makefile:91: install] Error 1
Error: Process completed with exit code 2.
```

#### Root cause

1. The wasmd cache key was never working properly, so it was always resolving to: `Linux-wasmd-cli-`
    * So the contents of the file was never actually considered (because the path didn't resolve)
2. When we upgraded to go 1.26 it should have broken, but it didn't,  because the cache was never evicted
3. The cache is now evicted, and it is now failing to build wasmd

The build failure is related to bytedance/sonic 1.14.2: https://github.com/bytedance/sonic/issues/895

Updating to wasmd 0.70.2 fixes this as it's bumped the dep to 1.15+



### Testing

This PR.

Notes that the cache key problem is fixed:
* https://github.com/smartcontractkit/chainlink/actions/runs/27379466986/job/80912213890?pr=22827#step:9:72

```
Cache not found for input keys: Linux-wasmd-cli-62737e41dff348df0cd8793dd972fe1a21fe0f4432a27901c5feb235002349bd
```
