### PR TITLE
Require attested EnclaveConfig at confidentialrelay handler (PRIV-458)

### DIFF
--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -502,8 +502,11 @@ func (h *Handler) verifyEnclaveConfigMatchesDON(localNode capabilities.Node, cfg
 		return errors.New("enclave config is required")
 	}
 	expectedF := uint32(localNode.WorkflowDON.F)
-	if cfg.F != expectedF {
-		return fmt.Errorf("enclave config F mismatch: enclave reports %d, expected %d", cfg.F, expectedF)
+	// F is a floor, matching the CC-side check (validateEnclaveSigners): the
+	// enclave's reported F must meet or exceed the DON's fault tolerance. A
+	// higher F is a stricter quorum and is acceptable; a lower one is not.
+	if cfg.F < expectedF {
+		return fmt.Errorf("enclave config F %d does not meet the minimum required DON F %d", cfg.F, expectedF)
 	}
 	if len(cfg.Signers) != len(localNode.WorkflowDON.Members) {
 		return fmt.Errorf("enclave config signers count mismatch: enclave reports %d, expected %d",

--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -493,12 +493,13 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 // metadata too); the caller's lookup is an O(1) in-memory read populated by
 // the registry syncer, so this stays off the RPC hot path.
 //
-// cfg is optional: a nil EnclaveConfig (sender on an older protocol that does
-// not include it) is accepted and skips the check. The config is verified
-// only when present.
+// cfg is required: a nil EnclaveConfig is rejected. The wire field stays
+// optional in chainlink-common so older senders compile, but the relay is the
+// security boundary and will not service a request that omits the config, since
+// an absent config cannot be checked against onchain DON state.
 func (h *Handler) verifyEnclaveConfigMatchesDON(localNode capabilities.Node, cfg *confidentialrelaytypes.EnclaveConfig) error {
 	if cfg == nil {
-		return nil
+		return errors.New("enclave config is required")
 	}
 	expectedF := uint32(localNode.WorkflowDON.F)
 	if cfg.F != expectedF {

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -739,7 +739,7 @@ func TestHandler_VerifyEnclaveConfig(t *testing.T) {
 		require.Nil(t, resp.Error)
 	})
 
-	t.Run("nil config accepted on capability execute (optional)", func(t *testing.T) {
+	t.Run("nil config rejected on capability execute (required)", func(t *testing.T) {
 		reg := withEnclaveConfig(&mockCapRegistry{
 			executables: map[string]*mockExecutable{
 				"my-cap@1.0.0": {execResult: capabilities.CapabilityResponse{Payload: &anypb.Any{}}},
@@ -754,13 +754,13 @@ func TestHandler_VerifyEnclaveConfig(t *testing.T) {
 			ReferenceID:   "1",
 			CapabilityID:  "my-cap@1.0.0",
 			Payload:       makeCapabilityPayload(t, map[string]any{"key": "val"}),
-			EnclaveConfig: nil, // sender on older protocol; check is skipped
+			EnclaveConfig: nil, // missing config cannot be checked against DON state
 			Attestation:   testAttestationB64,
 		})
 		err := h.HandleGatewayMessage(context.Background(), "gw-1", req)
 		require.NoError(t, err)
 		resp := gwConn.lastResp
-		require.Nil(t, resp.Error)
+		require.NotNil(t, resp.Error)
 	})
 
 	t.Run("F mismatch rejected on capability execute", func(t *testing.T) {

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -763,7 +763,7 @@ func TestHandler_VerifyEnclaveConfig(t *testing.T) {
 		require.NotNil(t, resp.Error)
 	})
 
-	t.Run("F mismatch rejected on capability execute", func(t *testing.T) {
+	t.Run("F below DON minimum rejected on capability execute", func(t *testing.T) {
 		reg := withEnclaveConfig(&mockCapRegistry{
 			executables: map[string]*mockExecutable{
 				"my-cap@1.0.0": {execResult: capabilities.CapabilityResponse{Payload: &anypb.Any{}}},
@@ -772,7 +772,7 @@ func TestHandler_VerifyEnclaveConfig(t *testing.T) {
 		gwConn := &mockGatewayConnector{}
 		h := newTestHandler(t, reg, gwConn)
 		badCfg := testEnclaveConfig()
-		badCfg.F += 5 // any non-matching value
+		badCfg.F = testEnclaveF - 1 // below the DON's minimum F
 		req := makeRequest(t, confidentialrelaytypes.MethodCapabilityExec, confidentialrelaytypes.CapabilityRequestParams{
 			WorkflowID:    "wf-1",
 			Owner:         testOwner,
@@ -787,6 +787,32 @@ func TestHandler_VerifyEnclaveConfig(t *testing.T) {
 		require.NoError(t, err)
 		resp := gwConn.lastResp
 		require.NotNil(t, resp.Error)
+	})
+
+	t.Run("F above DON minimum accepted on capability execute", func(t *testing.T) {
+		reg := withEnclaveConfig(&mockCapRegistry{
+			executables: map[string]*mockExecutable{
+				"my-cap@1.0.0": {execResult: capabilities.CapabilityResponse{Payload: &anypb.Any{}}},
+			},
+		})
+		gwConn := &mockGatewayConnector{}
+		h := newTestHandler(t, reg, gwConn)
+		cfg := testEnclaveConfig()
+		cfg.F = testEnclaveF + 1 // a higher F is a stricter quorum; floor check accepts it
+		req := makeRequest(t, confidentialrelaytypes.MethodCapabilityExec, confidentialrelaytypes.CapabilityRequestParams{
+			WorkflowID:    "wf-1",
+			Owner:         testOwner,
+			ExecutionID:   "32c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce1",
+			ReferenceID:   "1",
+			CapabilityID:  "my-cap@1.0.0",
+			Payload:       makeCapabilityPayload(t, map[string]any{"key": "val"}),
+			EnclaveConfig: &cfg,
+			Attestation:   testAttestationB64,
+		})
+		err := h.HandleGatewayMessage(context.Background(), "gw-1", req)
+		require.NoError(t, err)
+		resp := gwConn.lastResp
+		require.Nil(t, resp.Error)
 	})
 
 	t.Run("signers count mismatch rejected on capability execute", func(t *testing.T) {
@@ -878,12 +904,12 @@ func TestHandler_VerifyEnclaveConfig(t *testing.T) {
 		require.Nil(t, resp.Error)
 	})
 
-	t.Run("F mismatch rejected on secrets get", func(t *testing.T) {
+	t.Run("F below DON minimum rejected on secrets get", func(t *testing.T) {
 		reg := secretsGetTestRegistry(t)
 		gwConn := &mockGatewayConnector{}
 		h := newTestHandler(t, reg, gwConn)
 		params := secretsGetTestParams()
-		params.EnclaveConfig.F += 5
+		params.EnclaveConfig.F = testEnclaveF - 1 // below the DON's minimum F
 		req := makeRequest(t, confidentialrelaytypes.MethodSecretsGet, params)
 		err := h.HandleGatewayMessage(context.Background(), "gw-1", req)
 		require.NoError(t, err)


### PR DESCRIPTION
Follow-up to #22516, which added relay-side verification of the attested
EnclaveConfig against onchain DON state but accepted a nil config
(verify-if-present) while senders rolled forward. The CC sender now always
populates the field (CC #330 merged), so the relay can require it.

Two changes:

1. Require EnclaveConfig. A request that omits it is rejected, since an absent
   config cannot be checked against DON state. The wire field stays optional in
   chainlink-common (#2111), so this is not a compile break for any downstream
   consumer. Enforcement lives only at the relay, the security boundary.

2. Match the CC-side F semantics. The relay checked enclave F for exact
   equality; CC's validateEnclaveSigners treats DON F as a floor (enclave F must
   meet or exceed it). Align the relay with CC so both sides agree on what a
   valid config is. Signer-set matching was already identical.

Runtime-only; acceptable since confidential workflows is unreleased.