### PR TITLE
save docker logs only if a devenv test failed

### DIFF
--- a/devenv/config.go
+++ b/devenv/config.go
@@ -39,8 +39,8 @@ var L = log.Output(zerolog.ConsoleWriter{Out: os.Stderr}).Level(zerolog.InfoLeve
 // and unmarshalls the files from left to right overriding keys.
 func Load[T any]() (*T, error) {
 	var config T
-	paths := strings.Split(os.Getenv(EnvVarTestConfigs), ",")
-	for _, path := range paths {
+	paths := strings.SplitSeq(os.Getenv(EnvVarTestConfigs), ",")
+	for path := range paths {
 		L.Info().Str("Path", path).Msg("Loading configuration input")
 		data, err := os.ReadFile(filepath.Join(DefaultConfigDir, path))
 		if err != nil {

--- a/devenv/products/automation/automation_ocr_helpers.go
+++ b/devenv/products/automation/automation_ocr_helpers.go
@@ -209,10 +209,7 @@ func SendLinkFundsToDeploymentAddresses(
 	boundContract := bind.NewBoundContract(multicallAddress, multiCallABI, chainClient.Client, chainClient.Client, chainClient.Client)
 	var lastReceipt *gethtypes.Receipt
 	for start := 0; start < len(call); start += maxBatchSize {
-		end := start + maxBatchSize
-		if end > len(call) {
-			end = len(call)
-		}
+		end := min(start+maxBatchSize, len(call))
 		chunk := make([]contracts.Call, end-start)
 		copy(chunk, call[start:end])
 		// call aggregate3 to group a safe number of transfers per transaction

--- a/devenv/products/automation/concurrency/executor.go
+++ b/devenv/products/automation/concurrency/executor.go
@@ -77,7 +77,7 @@ func (e *ConcurrentExecutor[ResultType, ResultChannelType, TaskType]) GetErrors(
 // Executor will attempt to distribute the tasks evenly among the executors.
 func (e *ConcurrentExecutor[ResultType, ResultChannelType, TaskType]) ExecuteSimple(concurrency int, repeatTimes int, simpleProcessorFn SimpleTaskProcessorFn[ResultChannelType]) ([]ResultType, error) {
 	dummy := make([]TaskType, repeatTimes)
-	for i := 0; i < repeatTimes; i++ {
+	for i := range repeatTimes {
 		dummy[i] = *new(TaskType)
 	}
 

--- a/devenv/products/automation/concurrency/executor_test.go
+++ b/devenv/products/automation/concurrency/executor_test.go
@@ -172,7 +172,7 @@ func TestExecuteFailFast(t *testing.T) {
 			expectedExecutions := 1000
 
 			configs := []config{}
-			for i := 0; i < expectedExecutions; i++ {
+			for range expectedExecutions {
 				configs = append(configs, struct{}{})
 			}
 
@@ -278,7 +278,7 @@ func TestParentContext(t *testing.T) {
 	taskCount := 1000
 
 	configs := []config{}
-	for i := 0; i < taskCount; i++ {
+	for range taskCount {
 		configs = append(configs, struct{}{})
 	}
 

--- a/devenv/products/automation/concurrency/slice.go
+++ b/devenv/products/automation/concurrency/slice.go
@@ -12,7 +12,7 @@ func DivideSlice[T any](slice []T, parts int) [][]T {
 	remainder := sliceLength % parts
 
 	start := 0
-	for i := 0; i < parts; i++ {
+	for i := range parts {
 		end := start + baseSize
 		if i < remainder { // Distribute the remainder among the first slices
 			end++

--- a/devenv/products/config.go
+++ b/devenv/products/config.go
@@ -19,8 +19,8 @@ var L = log.Output(zerolog.ConsoleWriter{Out: os.Stderr}).Level(zerolog.DebugLev
 
 func Load[T any]() (*T, error) {
 	var config T
-	paths := strings.Split(os.Getenv(EnvVarTestConfigs), ",")
-	for _, path := range paths {
+	paths := strings.SplitSeq(os.Getenv(EnvVarTestConfigs), ",")
+	for path := range paths {
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read product config file path %s: %w", path, err)

--- a/devenv/products/logs.go
+++ b/devenv/products/logs.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"testing"
 	"time"
 
 	mobyclient "github.com/moby/moby/client"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
 
@@ -247,29 +249,34 @@ func DefaultSettings(extraAllowedMessages ...AllowedLogMessage) ChainlinkNodeLog
 	}
 }
 
-func CleanupContainerLogs(settings ChainlinkNodeLogScannerSettings) error {
+func CleanupContainerLogs(t *testing.T, settings ChainlinkNodeLogScannerSettings) {
 	logDir := fmt.Sprintf("%s-%d", framework.DefaultCTFLogsDir, time.Now().UnixNano())
 
-	return framework.StreamCTFContainerLogsFanout(
-		framework.LogStreamConsumer{
+	consumers := []framework.LogStreamConsumer{
+		{
 			Name: "scan-logs",
 			Consume: func(logStreams map[string]io.ReadCloser) error {
 				return ScanLogsFromStreams(framework.L, settings, logStreams)
 			},
 		},
-		framework.LogStreamConsumer{
-			Name: "save-container-logs",
-			Consume: func(logStreams map[string]io.ReadCloser) error {
-				_, saveErr := framework.SaveContainerLogsFromStreams(logDir, logStreams)
-				return saveErr
-			},
-		},
-		framework.LogStreamConsumer{
+		{
 			Name: "print-panic-logs",
 			Consume: func(logStreams map[string]io.ReadCloser) error {
 				_ = framework.CheckContainersForPanicsFromStreams(logStreams, 100)
 				return nil
 			},
 		},
-	)
+	}
+
+	if t.Failed() {
+		consumers = append(consumers, framework.LogStreamConsumer{
+			Name: "save-container-logs",
+			Consume: func(logStreams map[string]io.ReadCloser) error {
+				_, saveErr := framework.SaveContainerLogsFromStreams(logDir, logStreams)
+				return saveErr
+			},
+		})
+	}
+
+	require.NoError(t, framework.StreamCTFContainerLogsFanout(consumers...), "Docker logs processing failed")
 }

--- a/devenv/tests/automation/smoke_test.go
+++ b/devenv/tests/automation/smoke_test.go
@@ -94,8 +94,7 @@ func basicAutomationTest(t *testing.T, testcase Testcase) {
 	l.Info().Msg("Running test " + testcase.Name + " with registry version " + testcase.RegistryVersion.String())
 
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings())
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	outputFile := "../../env-out.toml"

--- a/devenv/tests/cron/smoke_test.go
+++ b/devenv/tests/cron/smoke_test.go
@@ -20,8 +20,7 @@ func TestSmoke(t *testing.T) {
 	pdConfig, err := products.LoadOutput[cron.Configurator](outputFile)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings())
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	cls, err := clclient.New(in.NodeSets[0].Out.CLNodes)
@@ -32,7 +31,7 @@ func TestSmoke(t *testing.T) {
 		require.NoError(c, err)
 		require.GreaterOrEqual(c, len(runs.Data), 10)
 		for _, j := range runs.Data {
-			require.Equal(c, []interface{}{interface{}(nil)}, j.Attributes.Errors)
+			require.Equal(c, []any{any(nil)}, j.Attributes.Errors)
 		}
 	}, 2*time.Minute, 2*time.Second)
 }

--- a/devenv/tests/features/jd_test.go
+++ b/devenv/tests/features/jd_test.go
@@ -17,8 +17,7 @@ func TestMultipleJobDistributors(t *testing.T) {
 	node := in.NodeSets[0].Out.CLNodes[0].Node
 
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings())
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	c, err := client.NewWithContext(t.Context(), node.ExternalURL, client.Credentials{

--- a/devenv/tests/features/reorg_finality_violation_test.go
+++ b/devenv/tests/features/reorg_finality_violation_test.go
@@ -30,8 +30,7 @@ func TestReorgHeadTrackerFinalityViolation(t *testing.T) {
 			zapcore.DPanicLevel,
 			products.WarnAboutAllowedMsgs_No,
 		)
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings(reorgMessage))
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings(reorgMessage))
 	})
 
 	rpcClient := rpc.New(in.Blockchains[0].Out.Nodes[0].ExternalHTTPUrl, nil)

--- a/devenv/tests/logpoller/logpoller_test.go
+++ b/devenv/tests/logpoller/logpoller_test.go
@@ -162,8 +162,7 @@ func executePollerTest(t *testing.T, cfg *Config, allowedLogMessages ...products
 	ctx := t.Context()
 
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings(allowedLogMessages...))
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	outputFile := "../../env-out.toml"
@@ -328,8 +327,7 @@ func executeLogPollerReplay(t *testing.T, cfg *Config, consistencyTimeout string
 	l := framework.L
 	ctx := t.Context()
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings(allowedLogMessages...))
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings(allowedLogMessages...))
 	})
 
 	eventsToEmit := []abi.Event{}

--- a/devenv/tests/ocr2/chaos_test.go
+++ b/devenv/tests/ocr2/chaos_test.go
@@ -26,13 +26,12 @@ func TestOCR2Chaos(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings(products.NewAllowedLogMessage(
+		products.CleanupContainerLogs(t, products.DefaultSettings(products.NewAllowedLogMessage(
 			"SLOW SQL QUERY",
 			"It is expected, because we are messing with the containers during the test",
 			zapcore.DPanicLevel,
 			products.WarnAboutAllowedMsgs_No,
 		)))
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
 	})
 	c, _, _, err := products.ETHClient(t.Context(), in.Blockchains[0].Out.Nodes[0].ExternalWSUrl, pdConfig.Config[0].GasSettings.FeeCapMultiplier, pdConfig.Config[0].GasSettings.TipCapMultiplier)
 	require.NoError(t, err)

--- a/devenv/tests/ocr2/smoke_test.go
+++ b/devenv/tests/ocr2/smoke_test.go
@@ -32,8 +32,7 @@ func TestSmoke(t *testing.T) {
 			zapcore.DPanicLevel,
 			products.WarnAboutAllowedMsgs_No,
 		)
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings(forwarderMessage))
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings(forwarderMessage))
 	})
 	c, _, _, err := products.ETHClient(t.Context(), in.Blockchains[0].Out.Nodes[0].ExternalWSUrl, pdConfig.Config[0].GasSettings.FeeCapMultiplier, pdConfig.Config[0].GasSettings.TipCapMultiplier)
 	require.NoError(t, err)

--- a/devenv/tests/vrfv2/batch_test.go
+++ b/devenv/tests/vrfv2/batch_test.go
@@ -23,8 +23,7 @@ import (
 
 func TestVRFv2BatchFulfillmentEnabledDisabled(t *testing.T) {
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings())
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	outputFile := "../../env-vrfv2-out.toml"

--- a/devenv/tests/vrfv2/bhs_test.go
+++ b/devenv/tests/vrfv2/bhs_test.go
@@ -26,8 +26,7 @@ import (
 
 func TestVRFV2WithBHS(t *testing.T) {
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings())
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	outputFile := "../../env-vrfv2-bhs-out.toml"

--- a/devenv/tests/vrfv2/multiple_keys_test.go
+++ b/devenv/tests/vrfv2/multiple_keys_test.go
@@ -21,8 +21,7 @@ import (
 
 func TestVRFv2MultipleSendingKeys(t *testing.T) {
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings())
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	outputFile := "../../env-vrfv2-out.toml"

--- a/devenv/tests/vrfv2/smoke_test.go
+++ b/devenv/tests/vrfv2/smoke_test.go
@@ -24,8 +24,7 @@ import (
 
 func TestVRFv2Basic(t *testing.T) {
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings())
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	outputFile := "../../env-vrfv2-out.toml"

--- a/devenv/tests/vrfv2plus/batch_test.go
+++ b/devenv/tests/vrfv2plus/batch_test.go
@@ -27,8 +27,7 @@ import (
 
 func TestVRFv2PlusBatchFulfillment(t *testing.T) {
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings())
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	outputFile := "../../env-vrf2plus-out.toml"

--- a/devenv/tests/vrfv2plus/bhf_test.go
+++ b/devenv/tests/vrfv2plus/bhf_test.go
@@ -30,8 +30,7 @@ func TestVRFV2PlusWithBHF(t *testing.T) {
 			zapcore.DPanicLevel,
 			products.WarnAboutAllowedMsgs_No,
 		)
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings(bhfMessage))
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings(bhfMessage))
 	})
 
 	outputFile := "../../env-vrf2plus-bhX-out.toml"

--- a/devenv/tests/vrfv2plus/bhs_test.go
+++ b/devenv/tests/vrfv2plus/bhs_test.go
@@ -21,8 +21,7 @@ import (
 
 func TestVRFV2PlusWithBHS(t *testing.T) {
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings())
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	outputFile := "../../env-vrf2plus-bhX-out.toml"

--- a/devenv/tests/vrfv2plus/migration_test.go
+++ b/devenv/tests/vrfv2plus/migration_test.go
@@ -32,8 +32,7 @@ const (
 
 func TestVRFv2PlusMigration(t *testing.T) {
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings())
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	outputFile := "../../env-vrf2plus-out.toml"

--- a/devenv/tests/vrfv2plus/multiple_keys_test.go
+++ b/devenv/tests/vrfv2plus/multiple_keys_test.go
@@ -22,8 +22,7 @@ import (
 
 func TestVRFv2PlusMultipleSendingKeys(t *testing.T) {
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings())
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	outputFile := "../../env-vrf2plus-out.toml"

--- a/devenv/tests/vrfv2plus/pending_block_test.go
+++ b/devenv/tests/vrfv2plus/pending_block_test.go
@@ -21,8 +21,7 @@ import (
 
 func TestVRFv2PlusPendingBlockSimulationAndZeroConfirmationDelays(t *testing.T) {
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings())
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	outputFile := "../../env-vrf2plus-out.toml"

--- a/devenv/tests/vrfv2plus/replay_test.go
+++ b/devenv/tests/vrfv2plus/replay_test.go
@@ -24,8 +24,7 @@ import (
 
 func TestVRFv2PlusReplayAfterTimeout(t *testing.T) {
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings())
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	outputFile := "../../env-vrf2plus-out.toml"

--- a/devenv/tests/vrfv2plus/smoke_test.go
+++ b/devenv/tests/vrfv2plus/smoke_test.go
@@ -24,8 +24,7 @@ import (
 
 func TestVRFv2PlusSmoke(t *testing.T) {
 	t.Cleanup(func() {
-		cleanupErr := products.CleanupContainerLogs(products.DefaultSettings())
-		require.NoError(t, cleanupErr, "failed to process cleanup container logs")
+		products.CleanupContainerLogs(t, products.DefaultSettings())
 	})
 
 	outputFile := "../../env-vrf2plus-out.toml"


### PR DESCRIPTION
To avoid problems like this one: 
```
Unhandled exception. System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/2.335.1/_diag/Worker_20260611-172018-utc.log' System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/2.335.1/_diag/Worker_20260611-172018-utc.log' at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset) at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder) at System.Diagnostics.TextWriterTraceListener.Flush() at System.Diagnostics.TraceSource.Flush() at GitHub.Runner.Common.Tracing.Dispose(Boolean disposing) at GitHub.Runner.Common.Tracing.Dispose() at GitHub.Runner.Common.TraceManager.Dispose(Boolean disposing) at GitHub.Runner.Common.TraceManager.Dispose() at GitHub.Runner.Common.HostContext.Dispose(Boolean disposing) at GitHub.Runner.Common.HostContext.Dispose() at GitHub.Runner.Worker.Program.Main(String[] args) at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset) at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder) at System.Diagnostics.TextWriterTraceListener.Flush() at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id) at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message) at GitHub.Runner.Worker.Worker.RunAsync(String pipeIn, String pipeOut) at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args) System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/2.335.1/_diag/Worker_20260611-172018-utc.log' at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset) at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder) at System.Diagnostics.TextWriterTraceListener.Flush() at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id) at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message) at GitHub.Runner.Common.Tracing.Error(Exception exception) at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args)
```

CI run: https://github.com/smartcontractkit/chainlink/actions/runs/27433126566 ✅ 