### PR TITLE
DF-25025: Remove forwarder EOA fallback

### DIFF
--- a/core/services/ocr/delegate.go
+++ b/core/services/ocr/delegate.go
@@ -226,11 +226,10 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, jb job.Job) (services []
 		effectiveTransmitterAddress := concreteSpec.TransmitterAddress.Address()
 		if jb.ForwardingAllowed {
 			fwdrAddress, fwderr := chain.TxManager().GetForwarderForEOA(ctx, effectiveTransmitterAddress)
-			if fwderr == nil {
-				effectiveTransmitterAddress = fwdrAddress
-			} else {
-				lggr.Warnw("Skipping forwarding for job, will fallback to default behavior", "job", jb.Name, "err", fwderr)
+			if fwderr != nil {
+				return nil, errors.Wrap(fwderr, "failed to get forwarder address")
 			}
+			effectiveTransmitterAddress = fwdrAddress
 		}
 
 		cid := chain.ID()

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -643,12 +643,10 @@ func GetEVMEffectiveTransmitterID(ctx context.Context, jb *job.Job, evm types.EV
 		var effectiveTransmitterID common.Address
 		// Median forwarders need special handling because of OCR2Aggregator transmitters whitelist.
 		effectiveTransmitterID, err = evm.GetForwarderForEOA(ctx, common.HexToAddress(spec.TransmitterID.String), common.HexToAddress(spec.ContractID), string(spec.PluginType))
-		if err == nil {
-			return effectiveTransmitterID.String(), nil
-		} else if !spec.TransmitterID.Valid {
-			return "", errors.New("failed to get forwarder address and transmitterID is not set")
+		if err != nil {
+			return "", fmt.Errorf("failed to get forwarder address: %w", err)
 		}
-		lggr.Warnw("Skipping forwarding for job, will fallback to default behavior", "job", jb.Name, "err", err)
+		return effectiveTransmitterID.String(), nil
 	}
 
 	return spec.TransmitterID.String, nil

--- a/core/services/ocr2/delegate_test.go
+++ b/core/services/ocr2/delegate_test.go
@@ -124,12 +124,13 @@ func TestGetEVMEffectiveTransmitterID(t *testing.T) {
 			expectedTransmitterID: "0x7e58000000000000000000000000000000000000",
 		},
 		{
-			name:                  "when forwarders are enabled but forwarder address fails to be retrieved and when transmitterID is defined, it should default to using spec transmitterID",
+			name:                  "when forwarders are enabled but forwarder address fails to be retrieved, it should return an error (no EOA fallback)",
 			forwardingEnabled:     true,
 			transmitterID:         null.StringFrom("0x7e57000000000000000000000000000000000003"),
 			getForwarderForEOAErr: true,
 			getForwarderForEOAArg: common.HexToAddress("0x7e57000000000000000000000000000000000003"),
-			expectedTransmitterID: "0x7e57000000000000000000000000000000000003",
+			expectedError:         true,
+			expectedTransmitterID: "",
 		},
 	}
 
@@ -185,7 +186,8 @@ func TestGetEVMEffectiveTransmitterID(t *testing.T) {
 			}
 
 			require.Equal(t, tc.expectedTransmitterID, effectiveTransmitterID)
-			// when forwarding is enabled effectiveTransmitter differs unless it failed to fetch forwarder address
+			// when forwarding is disabled, the effective transmitter is always the spec transmitterID.
+			// when forwarding is enabled it resolves to the forwarder, or errors if the forwarder cannot be retrieved (no EOA fallback).
 			if !jb.ForwardingAllowed {
 				require.Equal(t, jb.OCR2OracleSpec.TransmitterID.String, effectiveTransmitterID)
 			}


### PR DESCRIPTION
## Motivation

When forwarding is enabled, the node determines the OCR transmitter by resolving the forwarder contract for the configured EOA via an RPC call at job startup. If that RPC call fails — most commonly because the EVM `MultiNode` has not selected a live RPC yet during node boot (`no live nodes available`) — the previous code logged a warning and **silently fell back to the EOA**.

That fallback is sticky and harmful:

- The EOA gets baked into the effective transmitter for the lifetime of the process.
- For Median (`ocr2FeedsTransmitter`), the tx-time forwarder lookup is gated on `slices.Contains(fromAddresses, effectiveTransmitterAddress)`, so once the EOA is the effective address, forwarding is permanently disabled.
- The job appears healthy but cannot transmit through the forwarder, and does not recover without a node restart.

This is the [DF-25025](https://smartcontract-it.atlassian.net/browse/DF-25025) reliability issue: an RPC blip at boot leaves forwarding jobs running on the wrong transmitter until they are manually restarted.

## Change

Remove the forwarder→EOA fallback so a forwarding-enabled job either uses its forwarder or fails honestly. On forwarder-resolution failure the service now returns the error, which the job spawner records (`TryRecordError`) and re-attempts on the next boot — when the RPC is warm and the correct forwarder can be resolved.

- **OCR2** — `core/services/ocr2/delegate.go` (`GetEVMEffectiveTransmitterID`): return the `GetForwarderForEOA` error instead of `Warnw` + returning the EOA.
- **OCR1** — `core/services/ocr/delegate.go` (`ServicesForSpec`): same treatment for the OCR1 forwarding path.

## Behavior change / risk

Forwarding-enabled jobs will now **fail to start** when the forwarder cannot be resolved at boot (e.g. cold RPC), where they previously started on the EOA. This is intended: an explicit, recorded failure that self-heals on the next boot is preferable to a silent, unrecoverable misconfiguration. This matches the existing "recovers on restart" behavior operators already rely on.

Scope is limited to the boot-time transmitter determination. The tx-time EOA fallbacks in the Median transmitter and broader boot-time RPC resilience (e.g. spawner retry, log-poller `RegisterFilter`/`CodeAt` tolerance) are intentionally out of scope.

> Note: this does **not** address the separate `failed to check if address ... is a contract: no live nodes available` startup log, which originates from log-poller filter registration (`RegisterFilter` → `CodeAt`) on the OCR aggregator — a different eager-RPC path that warrants its own follow-up.

## Testing

- `go build ./core/services/ocr2/ ./core/services/ocr/`
- `go test ./core/services/ocr2/` (incl. `TestGetEVMEffectiveTransmitterID`, updated to assert an error rather than the EOA fallback)
- `go test ./core/services/ocr/`

[DF-25025]: https://smartcontract-it.atlassian.net/browse/DF-25025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ