### PR TITLE
chore: ccip changesets exclusively use internal opsutils

### DIFF
--- a/deployment/ccip/changeset/cs_grant_and_mint_link_token.go
+++ b/deployment/ccip/changeset/cs_grant_and_mint_link_token.go
@@ -8,14 +8,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
-	opsutil "github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
-
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm"
 	ccipseqs "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -104,7 +102,7 @@ func GrantMintRoleAndMintLogic(e cldf.Environment, cfg GrantMintRoleAndMintConfi
 	}
 	if owner == chain.DeployerKey.From {
 		//  Grant deployer address mint/burn access on the LINK_TOKEN
-		_, err := operations.ExecuteOperation(e.OperationsBundle, ccipops.GrantMintAndBurnRolesERC677Op, chain, opsevm.EVMCallInput[common.Address]{
+		_, err := operations.ExecuteOperation(e.OperationsBundle, ccipops.GrantMintAndBurnRolesERC677Op, chain, opsutils.EVMCallInput[common.Address]{
 			Address:       linkState.LinkToken.Address(),
 			ChainSelector: chain.ChainSelector(),
 			CallInput:     chain.DeployerKey.From,
@@ -116,7 +114,7 @@ func GrantMintRoleAndMintLogic(e cldf.Environment, cfg GrantMintRoleAndMintConfi
 
 	// Mint tokens to the given faucet address and verify the balance
 	e.Logger.Infow("Minting tokens", "chain", cfg.Selector, "to", cfg.ToAddress, "amount", cfg.Amount.String())
-	_, err = operations.ExecuteOperation(e.OperationsBundle, ccipops.MintERC677Op, chain, opsutil.EVMCallInput[ccipops.MintERC677Config]{
+	_, err = operations.ExecuteOperation(e.OperationsBundle, ccipops.MintERC677Op, chain, opsutils.EVMCallInput[ccipops.MintERC677Config]{
 		Address:       linkState.LinkToken.Address(),
 		ChainSelector: chain.ChainSelector(),
 		CallInput: ccipops.MintERC677Config{
@@ -151,7 +149,7 @@ func GrantMintRoleAndMintLogic(e cldf.Environment, cfg GrantMintRoleAndMintConfi
 
 	if isMinter {
 		// Revoke Mint Role
-		_, err = operations.ExecuteOperation(e.OperationsBundle, ccipops.RevokeMintRoleERC677Op, chain, opsutil.EVMCallInput[common.Address]{
+		_, err = operations.ExecuteOperation(e.OperationsBundle, ccipops.RevokeMintRoleERC677Op, chain, opsutils.EVMCallInput[common.Address]{
 			Address:       linkState.LinkToken.Address(),
 			ChainSelector: chain.ChainSelector(),
 			CallInput:     chain.DeployerKey.From,
@@ -163,7 +161,7 @@ func GrantMintRoleAndMintLogic(e cldf.Environment, cfg GrantMintRoleAndMintConfi
 
 	if isBurner {
 		// Revoke Burn Role
-		_, err = operations.ExecuteOperation(e.OperationsBundle, ccipops.RevokeBurnRoleERC677Op, chain, opsutil.EVMCallInput[common.Address]{
+		_, err = operations.ExecuteOperation(e.OperationsBundle, ccipops.RevokeBurnRoleERC677Op, chain, opsutils.EVMCallInput[common.Address]{
 			Address:       linkState.LinkToken.Address(),
 			ChainSelector: chain.ChainSelector(),
 			CallInput:     chain.DeployerKey.From,
@@ -225,7 +223,7 @@ func GrantMintRoleLogic(e cldf.Environment, input GrantMintRoleInput) (cldf.Chan
 		input.ToSequenceInput(state),
 	)
 
-	return opsutil.AddEVMCallSequenceToCSOutput(
+	return opsutils.AddEVMCallSequenceToCSOutput(
 		e,
 		cldf.ChangesetOutput{},
 		seqReport,
@@ -237,9 +235,9 @@ func GrantMintRoleLogic(e cldf.Environment, input GrantMintRoleInput) (cldf.Chan
 }
 
 func (input GrantMintRoleInput) ToSequenceInput(state stateview.CCIPOnChainState) ccipseqs.GrantMintRoleSeqInp {
-	updates := make(map[uint64]opsevm.EVMCallInput[common.Address], len(input.GrantMintRoleByChain))
+	updates := make(map[uint64]opsutils.EVMCallInput[common.Address], len(input.GrantMintRoleByChain))
 	for chainSel, cfg := range input.GrantMintRoleByChain {
-		updates[chainSel] = opsevm.EVMCallInput[common.Address]{
+		updates[chainSel] = opsutils.EVMCallInput[common.Address]{
 			ChainSelector: chainSel,
 			Address:       state.Chains[chainSel].LinkToken.Address(),
 			CallInput:     cfg.ToAddress,

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -8,27 +8,26 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
-	"github.com/smartcontractkit/mcms"
 	"golang.org/x/exp/maps"
 
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/1_5_0/burn_mint_erc20_with_drip"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
+	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
+	proposeutils "github.com/smartcontractkit/cld-changesets/legacy/mcms/proposeutils"
+	"github.com/smartcontractkit/mcms"
 
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/1_5_0/burn_mint_erc20_with_drip"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc677"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/erc677"
+	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
-	proposeutils "github.com/smartcontractkit/cld-changesets/legacy/mcms/proposeutils"
-
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -817,7 +816,7 @@ func grantDefaultAdminRoleForBurnMintERC20Token(env cldf.Environment, selector u
 }
 
 func addMinterForERC677Token(env cldf.Environment, chain cldf_evm.Chain, tokenAddress common.Address, poolAddress common.Address) error {
-	_, err := operations.ExecuteOperation(env.OperationsBundle, ccipops.GrantMintAndBurnRolesERC677Op, chain, opsevm.EVMCallInput[common.Address]{
+	_, err := operations.ExecuteOperation(env.OperationsBundle, ccipops.GrantMintAndBurnRolesERC677Op, chain, opsutils.EVMCallInput[common.Address]{
 		Address:       tokenAddress,
 		ChainSelector: chain.Selector,
 		CallInput:     poolAddress,

--- a/deployment/ccip/changeset/v1_5_1/cs_fast_transfer_token_pools.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_fast_transfer_token_pools.go
@@ -8,13 +8,12 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
-	opsutil "github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_5_1"
 	ccipseq "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm/v1_5_1"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
@@ -355,7 +354,7 @@ func fastTransferUpdateLaneConfigLogic(env cldf.Environment, c FastTransferUpdat
 	}
 
 	// Build the sequence input for multi-chain updates
-	updatesByChain := make(map[uint64]opsevm.EVMCallInput[ccipops.UpdateDestChainConfigInput])
+	updatesByChain := make(map[uint64]opsutils.EVMCallInput[ccipops.UpdateDestChainConfigInput])
 
 	for sourceChainSelector, updates := range c.Updates {
 		pool, err := bindings.GetFastTransferTokenPoolContract(env, c.TokenSymbol, c.ContractType, c.ContractVersion, sourceChainSelector)
@@ -403,7 +402,7 @@ func fastTransferUpdateLaneConfigLogic(env cldf.Environment, c FastTransferUpdat
 			})
 		}
 
-		updatesByChain[sourceChainSelector] = opsevm.EVMCallInput[ccipops.UpdateDestChainConfigInput]{
+		updatesByChain[sourceChainSelector] = opsutils.EVMCallInput[ccipops.UpdateDestChainConfigInput]{
 			Address:       pool.Address(),
 			ChainSelector: sourceChainSelector,
 			CallInput: ccipops.UpdateDestChainConfigInput{
@@ -420,7 +419,7 @@ func fastTransferUpdateLaneConfigLogic(env cldf.Environment, c FastTransferUpdat
 	}
 
 	seqReport, err := operations.ExecuteSequence(env.OperationsBundle, ccipseq.FastTransferTokenPoolUpdateDestChainConfigSequence, env.BlockChains.EVMChains(), seqInput)
-	return opsutil.AddEVMCallSequenceToCSOutput(
+	return opsutils.AddEVMCallSequenceToCSOutput(
 		env,
 		cldf.ChangesetOutput{},
 		seqReport,
@@ -446,7 +445,7 @@ func fastTransferUpdateFillerAllowlistLogic(env cldf.Environment, c FastTransfer
 	}
 
 	// Build the sequence input for multi-chain updates
-	updatesByChain := make(map[uint64]opsevm.EVMCallInput[ccipops.UpdateFillerAllowlistInput])
+	updatesByChain := make(map[uint64]opsutils.EVMCallInput[ccipops.UpdateFillerAllowlistInput])
 
 	for sourceChainSelector, update := range c.Updates {
 		pool, err := bindings.GetFastTransferTokenPoolContract(env, c.TokenSymbol, c.ContractType, c.ContractVersion, sourceChainSelector)
@@ -454,7 +453,7 @@ func fastTransferUpdateFillerAllowlistLogic(env cldf.Environment, c FastTransfer
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get fast transfer token pool contract for %s token on chain %d: %w", c.TokenSymbol, sourceChainSelector, err)
 		}
 
-		updatesByChain[sourceChainSelector] = opsevm.EVMCallInput[ccipops.UpdateFillerAllowlistInput]{
+		updatesByChain[sourceChainSelector] = opsutils.EVMCallInput[ccipops.UpdateFillerAllowlistInput]{
 			Address:       pool.Address(),
 			ChainSelector: sourceChainSelector,
 			CallInput: ccipops.UpdateFillerAllowlistInput{
@@ -472,7 +471,7 @@ func fastTransferUpdateFillerAllowlistLogic(env cldf.Environment, c FastTransfer
 	}
 
 	seqReport, err := operations.ExecuteSequence(env.OperationsBundle, ccipseq.FastTransferTokenPoolUpdateFillerAllowlistSequence, env.BlockChains.EVMChains(), seqInput)
-	return opsutil.AddEVMCallSequenceToCSOutput(
+	return opsutils.AddEVMCallSequenceToCSOutput(
 		env,
 		cldf.ChangesetOutput{},
 		seqReport,
@@ -498,7 +497,7 @@ func fastTransferWithdrawPoolFeesLogic(env cldf.Environment, c FastTransferWithd
 	}
 
 	// Build the sequence input for multi-chain withdrawals
-	withdrawalsByChain := make(map[uint64]opsevm.EVMCallInput[ccipops.WithdrawPoolFeesInput])
+	withdrawalsByChain := make(map[uint64]opsutils.EVMCallInput[ccipops.WithdrawPoolFeesInput])
 
 	for chainSelector, recipient := range c.Withdrawals {
 		pool, err := bindings.GetFastTransferTokenPoolContract(env, c.TokenSymbol, c.ContractType, c.ContractVersion, chainSelector)
@@ -506,7 +505,7 @@ func fastTransferWithdrawPoolFeesLogic(env cldf.Environment, c FastTransferWithd
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get fast transfer token pool contract for %s token on chain %d: %w", c.TokenSymbol, chainSelector, err)
 		}
 
-		withdrawalsByChain[chainSelector] = opsevm.EVMCallInput[ccipops.WithdrawPoolFeesInput]{
+		withdrawalsByChain[chainSelector] = opsutils.EVMCallInput[ccipops.WithdrawPoolFeesInput]{
 			Address:       pool.Address(),
 			ChainSelector: chainSelector,
 			CallInput: ccipops.WithdrawPoolFeesInput{
@@ -527,7 +526,7 @@ func fastTransferWithdrawPoolFeesLogic(env cldf.Environment, c FastTransferWithd
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute fast transfer token pool withdraw pool fees sequence: %w", err)
 	}
 
-	return opsutil.AddEVMCallSequenceToCSOutput(
+	return opsutils.AddEVMCallSequenceToCSOutput(
 		env,
 		cldf.ChangesetOutput{},
 		seqReport,

--- a/deployment/ccip/changeset/v1_5_1/cs_hybrid_token_pool_groups.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_hybrid_token_pool_groups.go
@@ -6,13 +6,12 @@ import (
 	"math/big"
 
 	"github.com/Masterminds/semver/v3"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
-	opsutil "github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_5_1"
 	ccipseq "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm/v1_5_1"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
@@ -203,7 +202,7 @@ func hybridTokenPoolUpdateGroupsLogic(env cldf.Environment, c HybridTokenPoolUpd
 	}
 
 	// Build the sequence input for multi-chain updates
-	updatesByChain := make(map[uint64]opsevm.EVMCallInput[ccipops.UpdateGroupsInput])
+	updatesByChain := make(map[uint64]opsutils.EVMCallInput[ccipops.UpdateGroupsInput])
 
 	for chainSelector, groupUpdates := range c.Updates {
 		pool, err := getHybridTokenPoolContract(env, c.TokenSymbol, c.ContractType, c.ContractVersion, chainSelector)
@@ -225,7 +224,7 @@ func hybridTokenPoolUpdateGroupsLogic(env cldf.Environment, c HybridTokenPoolUpd
 			})
 		}
 
-		updatesByChain[chainSelector] = opsevm.EVMCallInput[ccipops.UpdateGroupsInput]{
+		updatesByChain[chainSelector] = opsutils.EVMCallInput[ccipops.UpdateGroupsInput]{
 			Address:       pool.Address(),
 			ChainSelector: chainSelector,
 			CallInput: ccipops.UpdateGroupsInput{
@@ -246,7 +245,7 @@ func hybridTokenPoolUpdateGroupsLogic(env cldf.Environment, c HybridTokenPoolUpd
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute hybrid token pool update groups sequence: %w", err)
 	}
 
-	return opsutil.AddEVMCallSequenceToCSOutput(
+	return opsutils.AddEVMCallSequenceToCSOutput(
 		env,
 		cldf.ChangesetOutput{},
 		seqReport,

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -9,21 +9,19 @@ import (
 	"math/big"
 	"slices"
 
-	"github.com/smartcontractkit/cld-changesets/legacy/pkg/family/evm"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
-	"golang.org/x/sync/errgroup"
-
-	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
-
-	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"golang.org/x/sync/errgroup"
+
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
+	proposeutils "github.com/smartcontractkit/cld-changesets/legacy/mcms/proposeutils"
+	"github.com/smartcontractkit/cld-changesets/legacy/pkg/family/evm"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-
-	proposeutils "github.com/smartcontractkit/cld-changesets/legacy/mcms/proposeutils"
+	mcmslib "github.com/smartcontractkit/mcms"
+	mcmssdk "github.com/smartcontractkit/mcms/sdk"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/nonce_manager"
@@ -31,31 +29,25 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/onramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_3/fee_quoter"
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
+	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-
-	mcmslib "github.com/smartcontractkit/mcms"
-	mcmssdk "github.com/smartcontractkit/mcms/sdk"
-	mcmstypes "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/internal"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/pointer"
 	ccipops1_2 "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_2"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_6"
 	ccipseqs "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm/v1_6"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-
-	opsutil "github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/pointer"
-
-	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 )
 
 const (
@@ -180,13 +172,13 @@ func (cfg UpdateNonceManagerConfig) ToSequenceInput(state stateview.CCIPOnChainS
 	updatesByChain := make(map[uint64]ccipseqs.NonceManagerUpdateInput, len(cfg.UpdatesByChain))
 
 	for chainSel, update := range cfg.UpdatesByChain {
-		var callerOpInput *opsevm.EVMCallInput[nonce_manager.AuthorizedCallersAuthorizedCallerArgs]
+		var callerOpInput *opsutils.EVMCallInput[nonce_manager.AuthorizedCallersAuthorizedCallerArgs]
 		if len(update.AddedAuthCallers) > 0 || len(update.RemovedAuthCallers) > 0 {
 			callerOpInputArgs := nonce_manager.AuthorizedCallersAuthorizedCallerArgs{
 				AddedCallers:   update.AddedAuthCallers,
 				RemovedCallers: update.RemovedAuthCallers,
 			}
-			callerOpInput = &(opsevm.EVMCallInput[nonce_manager.AuthorizedCallersAuthorizedCallerArgs]{
+			callerOpInput = &(opsutils.EVMCallInput[nonce_manager.AuthorizedCallersAuthorizedCallerArgs]{
 				Address:       state.Chains[chainSel].NonceManager.Address(),
 				ChainSelector: chainSel,
 				CallInput:     callerOpInputArgs,
@@ -195,7 +187,7 @@ func (cfg UpdateNonceManagerConfig) ToSequenceInput(state stateview.CCIPOnChainS
 		}
 
 		// construct this input
-		var rampUpdatesOpInput *opsevm.EVMCallInput[[]nonce_manager.NonceManagerPreviousRampsArgs]
+		var rampUpdatesOpInput *opsutils.EVMCallInput[[]nonce_manager.NonceManagerPreviousRampsArgs]
 		if len(update.PreviousRampsArgs) > 0 {
 			rampUpdatesOpInputArgs := make([]nonce_manager.NonceManagerPreviousRampsArgs, 0)
 			for _, prevRamp := range update.PreviousRampsArgs {
@@ -215,7 +207,7 @@ func (cfg UpdateNonceManagerConfig) ToSequenceInput(state stateview.CCIPOnChainS
 					},
 				})
 			}
-			rampUpdatesOpInput = &(opsevm.EVMCallInput[[]nonce_manager.NonceManagerPreviousRampsArgs]{
+			rampUpdatesOpInput = &(opsutils.EVMCallInput[[]nonce_manager.NonceManagerPreviousRampsArgs]{
 				Address:       state.Chains[chainSel].NonceManager.Address(),
 				ChainSelector: chainSel,
 				CallInput:     rampUpdatesOpInputArgs,
@@ -252,7 +244,7 @@ func UpdateNonceManagersChangeset(e cldf.Environment, cfg UpdateNonceManagerConf
 		e.BlockChains.EVMChains(),
 		cfg.ToSequenceInput(s),
 	)
-	return opsutil.AddEVMCallSequenceToCSOutput(e, output, report, err, s.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyAuthorizedCallerUpdates and ApplyPreviousRampsUpdates on NonceManagers")
+	return opsutils.AddEVMCallSequenceToCSOutput(e, output, report, err, s.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyAuthorizedCallerUpdates and ApplyPreviousRampsUpdates on NonceManagers")
 }
 
 type OnRampDestinationUpdate struct {
@@ -320,7 +312,7 @@ func (cfg UpdateOnRampDestsConfig) Validate(e cldf.Environment) error {
 }
 
 func (cfg UpdateOnRampDestsConfig) ToSequenceInput(state stateview.CCIPOnChainState) ccipseqs.OnRampApplyDestChainConfigUpdatesSequenceInput {
-	updatesByChain := make(map[uint64]opsevm.EVMCallInput[[]onramp.OnRampDestChainConfigArgs], len(cfg.UpdatesByChain))
+	updatesByChain := make(map[uint64]opsutils.EVMCallInput[[]onramp.OnRampDestChainConfigArgs], len(cfg.UpdatesByChain))
 	for chainSel, updates := range cfg.UpdatesByChain {
 		var args []onramp.OnRampDestChainConfigArgs
 		for destination, update := range updates {
@@ -339,7 +331,7 @@ func (cfg UpdateOnRampDestsConfig) ToSequenceInput(state stateview.CCIPOnChainSt
 				AllowlistEnabled:  update.AllowListEnabled,
 			})
 		}
-		updatesByChain[chainSel] = opsevm.EVMCallInput[[]onramp.OnRampDestChainConfigArgs]{
+		updatesByChain[chainSel] = opsutils.EVMCallInput[[]onramp.OnRampDestChainConfigArgs]{
 			Address:       state.Chains[chainSel].OnRamp.Address(),
 			ChainSelector: chainSel,
 			CallInput:     args,
@@ -370,7 +362,7 @@ func UpdateOnRampsDestsChangeset(e cldf.Environment, cfg UpdateOnRampDestsConfig
 		e.BlockChains.EVMChains(),
 		cfg.ToSequenceInput(s),
 	)
-	return opsutil.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, s.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyDestChainConfigUpdates on OnRamps")
+	return opsutils.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, s.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyDestChainConfigUpdates on OnRamps")
 }
 
 type OnRampDynamicConfigUpdate struct {
@@ -829,7 +821,7 @@ func (cfg UpdateFeeQuoterPricesConfig) Validate(e cldf.Environment) error {
 }
 
 func (cfg UpdateFeeQuoterPricesConfig) ToSequenceInput(state stateview.CCIPOnChainState) ccipseqs.FeeQuoterUpdatePricesSequenceInput {
-	updates := make(map[uint64]opsevm.EVMCallInput[fee_quoter.InternalPriceUpdates], len(cfg.PricesByChain))
+	updates := make(map[uint64]opsutils.EVMCallInput[fee_quoter.InternalPriceUpdates], len(cfg.PricesByChain))
 	for chainSel, prices := range cfg.PricesByChain {
 		tokenPriceUpdates := make([]fee_quoter.InternalTokenPriceUpdate, len(prices.TokenPrices))
 		i := 0
@@ -849,7 +841,7 @@ func (cfg UpdateFeeQuoterPricesConfig) ToSequenceInput(state stateview.CCIPOnCha
 			}
 			i++
 		}
-		updates[chainSel] = opsevm.EVMCallInput[fee_quoter.InternalPriceUpdates]{
+		updates[chainSel] = opsutils.EVMCallInput[fee_quoter.InternalPriceUpdates]{
 			ChainSelector: chainSel,
 			Address:       state.Chains[chainSel].FeeQuoter.Address(),
 			CallInput: fee_quoter.InternalPriceUpdates{
@@ -880,7 +872,7 @@ func UpdateFeeQuoterPricesChangeset(e cldf.Environment, cfg UpdateFeeQuoterPrice
 		e.BlockChains.EVMChains(),
 		cfg.ToSequenceInput(s),
 	)
-	return opsutil.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, s.EVMMCMSStateByChain(), cfg.MCMS, "Call UpdatePrices on FeeQuoters")
+	return opsutils.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, s.EVMMCMSStateByChain(), cfg.MCMS, "Call UpdatePrices on FeeQuoters")
 }
 
 type UpdateFeeQuoterDestsConfig struct {
@@ -950,7 +942,7 @@ func (cfg UpdateFeeQuoterDestsConfig) Validate(e cldf.Environment) error {
 }
 
 func (cfg UpdateFeeQuoterDestsConfig) ToSequenceInput(state stateview.CCIPOnChainState) ccipseqs.FeeQuoterApplyDestChainConfigUpdatesSequenceInput {
-	updates := make(map[uint64]opsevm.EVMCallInput[[]fee_quoter.FeeQuoterDestChainConfigArgs], len(cfg.UpdatesByChain))
+	updates := make(map[uint64]opsutils.EVMCallInput[[]fee_quoter.FeeQuoterDestChainConfigArgs], len(cfg.UpdatesByChain))
 	for chainSel, destChainUpdates := range cfg.UpdatesByChain {
 		args := make([]fee_quoter.FeeQuoterDestChainConfigArgs, len(destChainUpdates))
 		i := 0
@@ -961,7 +953,7 @@ func (cfg UpdateFeeQuoterDestsConfig) ToSequenceInput(state stateview.CCIPOnChai
 			}
 			i++
 		}
-		updates[chainSel] = opsevm.EVMCallInput[[]fee_quoter.FeeQuoterDestChainConfigArgs]{
+		updates[chainSel] = opsutils.EVMCallInput[[]fee_quoter.FeeQuoterDestChainConfigArgs]{
 			Address:       state.Chains[chainSel].FeeQuoter.Address(),
 			ChainSelector: chainSel,
 			CallInput:     args,
@@ -991,7 +983,7 @@ func UpdateFeeQuoterDestsChangeset(e cldf.Environment, cfg UpdateFeeQuoterDestsC
 		e.BlockChains.EVMChains(),
 		cfg.ToSequenceInput(s),
 	)
-	return opsutil.AddEVMCallSequenceToCSOutput(e, output, report, err, s.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyDestChainConfigUpdates on FeeQuoters")
+	return opsutils.AddEVMCallSequenceToCSOutput(e, output, report, err, s.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyDestChainConfigUpdates on FeeQuoters")
 }
 
 func GetAllActiveExecConfigs(e cldf.Environment, homeChainSelector uint64, destChainSelector uint64) ([]*pluginconfig.ExecuteOffchainConfig, error) {
@@ -1132,7 +1124,7 @@ func (cfg UpdateOffRampSourcesConfig) Validate(e cldf.Environment, state statevi
 }
 
 func (cfg UpdateOffRampSourcesConfig) ToSequenceInput(state stateview.CCIPOnChainState) ccipseqs.OffRampApplySourceChainConfigUpdatesSequenceInput {
-	updatesByChain := make(map[uint64]opsevm.EVMCallInput[[]offramp.OffRampSourceChainConfigArgs], len(cfg.UpdatesByChain))
+	updatesByChain := make(map[uint64]opsutils.EVMCallInput[[]offramp.OffRampSourceChainConfigArgs], len(cfg.UpdatesByChain))
 	for chainSel, updates := range cfg.UpdatesByChain {
 		var args []offramp.OffRampSourceChainConfigArgs
 		for source, update := range updates {
@@ -1154,7 +1146,7 @@ func (cfg UpdateOffRampSourcesConfig) ToSequenceInput(state stateview.CCIPOnChai
 				IsRMNVerificationDisabled: update.IsRMNVerificationDisabled,
 			})
 		}
-		updatesByChain[chainSel] = opsevm.EVMCallInput[[]offramp.OffRampSourceChainConfigArgs]{
+		updatesByChain[chainSel] = opsutils.EVMCallInput[[]offramp.OffRampSourceChainConfigArgs]{
 			ChainSelector: chainSel,
 			Address:       state.Chains[chainSel].OffRamp.Address(),
 			CallInput:     args,
@@ -1184,7 +1176,7 @@ func UpdateOffRampSourcesChangeset(e cldf.Environment, cfg UpdateOffRampSourcesC
 		cfg.ToSequenceInput(state),
 	)
 
-	return opsutil.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplySourceChainConfigUpdates on OffRamps")
+	return opsutils.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplySourceChainConfigUpdates on OffRamps")
 }
 
 type RouterUpdates struct {
@@ -1297,7 +1289,7 @@ func (cfg UpdateRouterRampsConfig) Validate(e cldf.Environment, state stateview.
 }
 
 func (cfg UpdateRouterRampsConfig) ToSequenceInput(state stateview.CCIPOnChainState) ccipseqs.RouterApplyRampUpdatesSequenceInput {
-	input := make(map[uint64]opsevm.EVMCallInput[ccipops1_2.RouterApplyRampUpdatesOpInput], len(cfg.UpdatesByChain))
+	input := make(map[uint64]opsutils.EVMCallInput[ccipops1_2.RouterApplyRampUpdatesOpInput], len(cfg.UpdatesByChain))
 	for chainSel, update := range cfg.UpdatesByChain {
 		routerC := state.Chains[chainSel].Router
 		if cfg.TestRouter {
@@ -1337,7 +1329,7 @@ func (cfg UpdateRouterRampsConfig) ToSequenceInput(state stateview.CCIPOnChainSt
 				})
 			}
 		}
-		input[chainSel] = opsevm.EVMCallInput[ccipops1_2.RouterApplyRampUpdatesOpInput]{
+		input[chainSel] = opsutils.EVMCallInput[ccipops1_2.RouterApplyRampUpdatesOpInput]{
 			ChainSelector: chainSel,
 			Address:       routerC.Address(),
 			CallInput: ccipops1_2.RouterApplyRampUpdatesOpInput{
@@ -1375,7 +1367,7 @@ func UpdateRouterRampsChangeset(e cldf.Environment, cfg UpdateRouterRampsConfig)
 		e.BlockChains.EVMChains(),
 		cfg.ToSequenceInput(state),
 	)
-	return opsutil.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyRampUpdates on Routers")
+	return opsutils.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyRampUpdates on Routers")
 }
 
 type SetOCR3OffRampConfig struct {
@@ -1820,11 +1812,11 @@ func ApplyFeeTokensUpdatesFeeQuoterChangeset(e cldf.Environment, cfg ApplyFeeTok
 		e.BlockChains.EVMChains(),
 		cfg.ToSequenceInput(state),
 	)
-	return opsutil.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, state.EVMMCMSStateByChain(), cfg.MCMSConfig, "Call ApplyFeeTokensUpdatesConfig on FeeQuoter")
+	return opsutils.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, state.EVMMCMSStateByChain(), cfg.MCMSConfig, "Call ApplyFeeTokensUpdatesConfig on FeeQuoter")
 }
 
 func (cfg ApplyFeeTokensUpdatesConfig) ToSequenceInput(state stateview.CCIPOnChainState) ccipseqs.FeeQuoterUpdateFeeTokensConfig {
-	input := make(map[uint64]opsevm.EVMCallInput[ccipops.ApplyFeeTokensUpdatesInput], len(cfg.UpdatesByChain))
+	input := make(map[uint64]opsutils.EVMCallInput[ccipops.ApplyFeeTokensUpdatesInput], len(cfg.UpdatesByChain))
 
 	for chainSel, updates := range cfg.UpdatesByChain {
 		tokenAddresses, _ := state.Chains[chainSel].TokenAddressBySymbol()
@@ -1835,7 +1827,7 @@ func (cfg ApplyFeeTokensUpdatesConfig) ToSequenceInput(state stateview.CCIPOnCha
 		for _, token := range updates.TokensToAdd {
 			tokensToAdd = append(tokensToAdd, tokenAddresses[token])
 		}
-		input[chainSel] = opsevm.EVMCallInput[ccipops.ApplyFeeTokensUpdatesInput]{
+		input[chainSel] = opsutils.EVMCallInput[ccipops.ApplyFeeTokensUpdatesInput]{
 			ChainSelector: chainSel,
 			Address:       state.Chains[chainSel].FeeQuoter.Address(),
 			CallInput: ccipops.ApplyFeeTokensUpdatesInput{
@@ -2070,11 +2062,11 @@ func ApplyPremiumMultiplierWeiPerEthUpdatesFeeQuoterChangeset(e cldf.Environment
 		e.BlockChains.EVMChains(),
 		cfg.ToSequenceInput(state),
 	)
-	return opsutil.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyPremiumMultiplierWeiPerEthUpdates on FeeQuoter")
+	return opsutils.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyPremiumMultiplierWeiPerEthUpdates on FeeQuoter")
 }
 
 func (cfg PremiumMultiplierWeiPerEthUpdatesConfig) ToSequenceInput(state stateview.CCIPOnChainState) ccipseqs.FeeQuoterUpdatePremiumMultiplierWeiPerEthConfig {
-	input := make(map[uint64]opsevm.EVMCallInput[[]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs], len(cfg.Updates))
+	input := make(map[uint64]opsutils.EVMCallInput[[]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs], len(cfg.Updates))
 
 	for chainSel, updates := range cfg.Updates {
 		tokenAddresses, _ := state.Chains[chainSel].TokenAddressBySymbol()
@@ -2085,7 +2077,7 @@ func (cfg PremiumMultiplierWeiPerEthUpdatesConfig) ToSequenceInput(state statevi
 				PremiumMultiplierWeiPerEth: update.PremiumMultiplierWeiPerEth,
 			})
 		}
-		input[chainSel] = opsevm.EVMCallInput[[]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs]{
+		input[chainSel] = opsutils.EVMCallInput[[]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs]{
 			ChainSelector: chainSel,
 			Address:       state.Chains[chainSel].FeeQuoter.Address(),
 			CallInput:     premiumMultiplierUpdates,
@@ -2205,11 +2197,11 @@ func ApplyTokenTransferFeeConfigUpdatesFeeQuoterChangeset(e cldf.Environment, cf
 		e.BlockChains.EVMChains(),
 		cfg.ToSequenceInput(state),
 	)
-	return opsutil.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyTokenTransferFeeConfigUpdates on FeeQuoter")
+	return opsutils.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyTokenTransferFeeConfigUpdates on FeeQuoter")
 }
 
 func (cfg ApplyTokenTransferFeeConfigUpdatesConfig) ToSequenceInput(state stateview.CCIPOnChainState) ccipseqs.FeeQuoterUpdateTokenTransferConfig {
-	input := make(map[uint64]opsevm.EVMCallInput[ccipops.ApplyTokenTransferFeeConfigUpdatesConfigPerChain], len(cfg.UpdatesByChain))
+	input := make(map[uint64]opsutils.EVMCallInput[ccipops.ApplyTokenTransferFeeConfigUpdatesConfigPerChain], len(cfg.UpdatesByChain))
 	for chainSel, updates := range cfg.UpdatesByChain {
 		tokenAddresses, _ := state.Chains[chainSel].TokenAddressBySymbol()
 		var tokenTransferFeeConfigs []fee_quoter.FeeQuoterTokenTransferFeeConfigArgs
@@ -2234,7 +2226,7 @@ func (cfg ApplyTokenTransferFeeConfigUpdatesConfig) ToSequenceInput(state statev
 				Token:             tokenAddresses[remove.Token],
 			})
 		}
-		input[chainSel] = opsevm.EVMCallInput[ccipops.ApplyTokenTransferFeeConfigUpdatesConfigPerChain]{
+		input[chainSel] = opsutils.EVMCallInput[ccipops.ApplyTokenTransferFeeConfigUpdatesConfigPerChain]{
 			ChainSelector: chainSel,
 			Address:       state.Chains[chainSel].FeeQuoter.Address(),
 			CallInput: ccipops.ApplyTokenTransferFeeConfigUpdatesConfigPerChain{
@@ -2312,14 +2304,14 @@ func UpdateWrappedNativeOnRouterChangeset(e cldf.Environment, cfg UpdateWrappedN
 		cfg.ToSequenceInput(state),
 	)
 
-	return opsutil.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call UpdateWrappedNativeAddressOnRouterOp on Router")
+	return opsutils.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, report, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call UpdateWrappedNativeAddressOnRouterOp on Router")
 }
 
 func (cfg UpdateWrappedNativeOnRouterConfig) ToSequenceInput(state stateview.CCIPOnChainState) ccipseqs.RouterUpdateWrappedNativeSequenceInput {
-	input := make(map[uint64]opsevm.EVMCallInput[common.Address], len(cfg.UpdatesByChain))
+	input := make(map[uint64]opsutils.EVMCallInput[common.Address], len(cfg.UpdatesByChain))
 
 	for chainSel, newWrappedAddress := range cfg.UpdatesByChain {
-		input[chainSel] = opsevm.EVMCallInput[common.Address]{
+		input[chainSel] = opsutils.EVMCallInput[common.Address]{
 			ChainSelector: chainSel,
 			Address:       state.Chains[chainSel].Router.Address(),
 			CallInput:     newWrappedAddress,

--- a/deployment/ccip/changeset/v1_6/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_deploy_chain_test.go
@@ -5,35 +5,31 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
-	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 	"github.com/stretchr/testify/require"
 
-	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
-	cldftesthelpers "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils/testhelpers"
-
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
+	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_3/fee_quoter"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
-	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
-
-	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
+	cldftesthelpers "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils/testhelpers"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_6"
 	ccipseq "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm/v1_6"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 )
 
@@ -153,7 +149,7 @@ func testDeployChainContractsChangesetWithEnv(t *testing.T, e cldf.Environment, 
 	// deploy feequoter with higher version
 	newFqVersion := semver.MustParse("1.6.4")
 	for sel, params := range contractParams {
-		params.FeeQuoterOpts = &opsevm.ContractOpts{
+		params.FeeQuoterOpts = &opsutils.ContractOpts{
 			Version:     newFqVersion,
 			EVMBytecode: common.FromHex(fee_quoter.FeeQuoterBin), // TODO: Can we replace this with actual 1.6.2 bytecode?
 		}

--- a/deployment/ccip/changeset/v1_6/cs_translate_onramp_to_feequoter.go
+++ b/deployment/ccip/changeset/v1_6/cs_translate_onramp_to_feequoter.go
@@ -4,19 +4,17 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_3/fee_quoter"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
-	opsutil "github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_6"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-
 	migrate_seq "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm/migration"
 	ccipseqs "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm/v1_6"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 )
 
 var (
@@ -107,7 +105,7 @@ func TranslateEVM2EVMOnRampsToFeeQuoterChangeset(e cldf.Environment, cfg Transla
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute FeeQuoterApplyDestChainConfigUpdatesSequence: %w", err)
 	}
-	csOutput, err = opsutil.AddEVMCallSequenceToCSOutput(e, csOutput, report, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyDestChainConfigUpdates on FeeQuoter")
+	csOutput, err = opsutils.AddEVMCallSequenceToCSOutput(e, csOutput, report, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyDestChainConfigUpdates on FeeQuoter")
 	if err != nil {
 		return csOutput, fmt.Errorf("failed to apply FeeQuoter dest chain config updates: %w", err)
 	}
@@ -122,7 +120,7 @@ func TranslateEVM2EVMOnRampsToFeeQuoterChangeset(e cldf.Environment, cfg Transla
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute FeeQuoterApplyFeeTokensUpdatesSeq: %w", err)
 	}
-	csOutput, err = opsutil.AddEVMCallSequenceToCSOutput(e, csOutput, feeTokensReport, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyFeeTokensUpdatesConfig on FeeQuoter")
+	csOutput, err = opsutils.AddEVMCallSequenceToCSOutput(e, csOutput, feeTokensReport, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyFeeTokensUpdatesConfig on FeeQuoter")
 	if err != nil {
 		return csOutput, fmt.Errorf("failed to apply FeeQuoter fee tokens updates: %w", err)
 	}
@@ -137,7 +135,7 @@ func TranslateEVM2EVMOnRampsToFeeQuoterChangeset(e cldf.Environment, cfg Transla
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute FeeQApplyPremiumMultiplierWeiPerEthUpdatesSeq: %w", err)
 	}
-	csOutput, err = opsutil.AddEVMCallSequenceToCSOutput(e, csOutput, premiumMultiplierSqReport, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyPremiumMultiplierWeiPerEthUpdates on FeeQuoter")
+	csOutput, err = opsutils.AddEVMCallSequenceToCSOutput(e, csOutput, premiumMultiplierSqReport, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyPremiumMultiplierWeiPerEthUpdates on FeeQuoter")
 	if err != nil {
 		return csOutput, fmt.Errorf("failed to apply FeeQuoter premium Multiplier config updates: %w", err)
 	}
@@ -145,7 +143,7 @@ func TranslateEVM2EVMOnRampsToFeeQuoterChangeset(e cldf.Environment, cfg Transla
 }
 
 func (cfg TranslateEVM2EVMOnRampsToFeeQuoterConfig) toSequenceInput(e cldf.Environment, state stateview.CCIPOnChainState) migrate_seq.FeeQuoterUpdateTokenTransferConfig {
-	input := make(map[uint64]opsutil.EVMCallInput[migrate_seq.OnRampToFeeQuoterDestChainConfigInput])
+	input := make(map[uint64]opsutils.EVMCallInput[migrate_seq.OnRampToFeeQuoterDestChainConfigInput])
 	for sel := range e.BlockChains.EVMChains() {
 		onRamps := make(map[uint64]common.Address)
 		newFeeQuoterParams := make(map[uint64]migrate_seq.NewFeeQuoterDestChainConfigParams)
@@ -159,7 +157,7 @@ func (cfg TranslateEVM2EVMOnRampsToFeeQuoterConfig) toSequenceInput(e cldf.Envir
 		if len(onRamps) == 0 {
 			continue
 		}
-		input[sel] = opsutil.EVMCallInput[migrate_seq.OnRampToFeeQuoterDestChainConfigInput]{
+		input[sel] = opsutils.EVMCallInput[migrate_seq.OnRampToFeeQuoterDestChainConfigInput]{
 			ChainSelector: sel,
 			Address:       state.Chains[sel].FeeQuoter.Address(),
 			CallInput: migrate_seq.OnRampToFeeQuoterDestChainConfigInput{
@@ -176,12 +174,12 @@ func (cfg TranslateEVM2EVMOnRampsToFeeQuoterConfig) toSequenceInput(e cldf.Envir
 }
 
 func (cfg TranslateEVM2EVMOnRampsToFeeQuoterConfig) toFeeTokenApplySeqInput(state stateview.CCIPOnChainState, tokens map[uint64][]common.Address) ccipseqs.FeeQuoterUpdateFeeTokensConfig {
-	input := make(map[uint64]opsevm.EVMCallInput[ccipops.ApplyFeeTokensUpdatesInput], len(tokens))
+	input := make(map[uint64]opsutils.EVMCallInput[ccipops.ApplyFeeTokensUpdatesInput], len(tokens))
 
 	for chainSel, tokens := range tokens {
 		var tokensToRemove, tokensToAdd []common.Address
 		tokensToAdd = append(tokensToAdd, tokens...)
-		input[chainSel] = opsevm.EVMCallInput[ccipops.ApplyFeeTokensUpdatesInput]{
+		input[chainSel] = opsutils.EVMCallInput[ccipops.ApplyFeeTokensUpdatesInput]{
 			ChainSelector: chainSel,
 			Address:       state.Chains[chainSel].FeeQuoter.Address(),
 			CallInput: ccipops.ApplyFeeTokensUpdatesInput{
@@ -197,7 +195,7 @@ func (cfg TranslateEVM2EVMOnRampsToFeeQuoterConfig) toFeeTokenApplySeqInput(stat
 }
 
 func (cfg TranslateEVM2EVMOnRampsToFeeQuoterConfig) toPremiumMultiplierCfgSeqInput(state stateview.CCIPOnChainState, tokenPremiumCfgs map[uint64][]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs) ccipseqs.FeeQuoterUpdatePremiumMultiplierWeiPerEthConfig {
-	input := make(map[uint64]opsevm.EVMCallInput[[]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs], len(tokenPremiumCfgs))
+	input := make(map[uint64]opsutils.EVMCallInput[[]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs], len(tokenPremiumCfgs))
 
 	for chainSel, updates := range tokenPremiumCfgs {
 		var premiumMultiplierUpdates []fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs
@@ -207,7 +205,7 @@ func (cfg TranslateEVM2EVMOnRampsToFeeQuoterConfig) toPremiumMultiplierCfgSeqInp
 				PremiumMultiplierWeiPerEth: update.PremiumMultiplierWeiPerEth,
 			})
 		}
-		input[chainSel] = opsevm.EVMCallInput[[]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs]{
+		input[chainSel] = opsutils.EVMCallInput[[]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs]{
 			ChainSelector: chainSel,
 			Address:       state.Chains[chainSel].FeeQuoter.Address(),
 			CallInput:     premiumMultiplierUpdates,
@@ -248,7 +246,7 @@ func TranslateEVM2EVMOnRampsToFeeQTokenTransferFeeConfigChangeset(e cldf.Environ
 	}
 
 	// TODO: check the output: its empty
-	csOutput, err = opsutil.AddEVMCallSequenceToCSOutput(e, csOutput, report, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyTokenTransferFeeConfigUpdates on FeeQuoter")
+	csOutput, err = opsutils.AddEVMCallSequenceToCSOutput(e, csOutput, report, err, state.EVMMCMSStateByChain(), cfg.MCMS, "Call ApplyTokenTransferFeeConfigUpdates on FeeQuoter")
 	if err != nil {
 		return csOutput, fmt.Errorf("failed to apply FeeQuoter fee tokens updates: %w", err)
 	}
@@ -256,9 +254,9 @@ func TranslateEVM2EVMOnRampsToFeeQTokenTransferFeeConfigChangeset(e cldf.Environ
 }
 
 func (cfg TranslateEVM2EVMOnRampsToFeeQuoterConfig) tokenTransferFeeConfigArgsToSeqInput(state stateview.CCIPOnChainState, tokenTransferFeeCfgArgs map[uint64][]fee_quoter.FeeQuoterTokenTransferFeeConfigArgs) ccipseqs.FeeQuoterUpdateTokenTransferConfig {
-	input := make(map[uint64]opsevm.EVMCallInput[ccipops.ApplyTokenTransferFeeConfigUpdatesConfigPerChain])
+	input := make(map[uint64]opsutils.EVMCallInput[ccipops.ApplyTokenTransferFeeConfigUpdatesConfigPerChain])
 	for chainSel, tokensFeeCfgArgs := range tokenTransferFeeCfgArgs {
-		input[chainSel] = opsevm.EVMCallInput[ccipops.ApplyTokenTransferFeeConfigUpdatesConfigPerChain]{
+		input[chainSel] = opsutils.EVMCallInput[ccipops.ApplyTokenTransferFeeConfigUpdatesConfigPerChain]{
 			ChainSelector: chainSel,
 			Address:       state.Chains[chainSel].FeeQuoter.Address(),
 			CallInput: ccipops.ApplyTokenTransferFeeConfigUpdatesConfigPerChain{

--- a/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes.go
+++ b/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 
 	"github.com/Masterminds/semver/v3"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -29,7 +28,7 @@ import (
 	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
 	proposeutils "github.com/smartcontractkit/cld-changesets/legacy/mcms/proposeutils"
 
-	opsutil "github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 )
@@ -258,8 +257,8 @@ func UpdateLanesLogic(e cldf.Environment, mcmsConfig *cldfproposalutils.Timelock
 	}
 
 	v2FeeQuoterChains := make(map[uint64]struct{})
-	v1FeeQuoterDestsUpdates := make(map[uint64]opsevm.EVMCallInput[[]fee_quoter.FeeQuoterDestChainConfigArgs])
-	v1FeeQuoterPriceUpdates := make(map[uint64]opsevm.EVMCallInput[fee_quoter.InternalPriceUpdates])
+	v1FeeQuoterDestsUpdates := make(map[uint64]opsutils.EVMCallInput[[]fee_quoter.FeeQuoterDestChainConfigArgs])
+	v1FeeQuoterPriceUpdates := make(map[uint64]opsutils.EVMCallInput[fee_quoter.InternalPriceUpdates])
 
 	for chainSel, update := range feeQuoterDestsInput.UpdatesByChain {
 		version, ok := feeQuoterVersionsByChain[chainSel]
@@ -310,7 +309,7 @@ func UpdateLanesLogic(e cldf.Environment, mcmsConfig *cldfproposalutils.Timelock
 		RouterApplyRampUpdatesSequenceInput:               configs.UpdateRouterRampsConfig.ToSequenceInput(state),
 		NonceManagerUpdatesSequenceInput:                  nonceManagerInput,
 	})
-	output, err := opsutil.AddEVMCallSequenceToCSOutput(
+	output, err := opsutils.AddEVMCallSequenceToCSOutput(
 		e,
 		cldf.ChangesetOutput{},
 		report,
@@ -694,7 +693,7 @@ func maybeAddPreviousRampUpdate(
 
 	update := updates[sourceChain]
 	if update.PreviousRampsArgs == nil {
-		update.PreviousRampsArgs = &opsevm.EVMCallInput[[]nonce_manager.NonceManagerPreviousRampsArgs]{
+		update.PreviousRampsArgs = &opsutils.EVMCallInput[[]nonce_manager.NonceManagerPreviousRampsArgs]{
 			Address:       chainState.NonceManager.Address(),
 			ChainSelector: sourceChain,
 			CallInput:     make([]nonce_manager.NonceManagerPreviousRampsArgs, 0),

--- a/deployment/ccip/changeset/v1_6/cs_update_rmn_config.go
+++ b/deployment/ccip/changeset/v1_6/cs_update_rmn_config.go
@@ -8,28 +8,21 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
-	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
-
-	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-
+	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
 	proposeutils "github.com/smartcontractkit/cld-changesets/legacy/mcms/proposeutils"
-
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
 	mcmslib "github.com/smartcontractkit/mcms"
 	mcmssdk "github.com/smartcontractkit/mcms/sdk"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_home"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
-
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/p2pkey"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
-	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
-
-	opsutil "github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipseq "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm/v1_6"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
@@ -76,10 +69,10 @@ func (c SetRMNRemoteOnRMNProxyConfig) Validate(e cldf.Environment, state statevi
 }
 
 func (c SetRMNRemoteOnRMNProxyConfig) ToSequenceInput(state stateview.CCIPOnChainState) ccipseq.SetRMNRemoteOnRMNProxySequenceInput {
-	updatesByChain := make(map[uint64]opsevm.EVMCallInput[common.Address], len(c.ChainSelectors))
+	updatesByChain := make(map[uint64]opsutils.EVMCallInput[common.Address], len(c.ChainSelectors))
 
 	for _, chainSel := range c.ChainSelectors {
-		updatesByChain[chainSel] = opsevm.EVMCallInput[common.Address]{
+		updatesByChain[chainSel] = opsutils.EVMCallInput[common.Address]{
 			Address:       state.Chains[chainSel].RMNProxy.Address(),
 			ChainSelector: chainSel,
 			CallInput:     state.Chains[chainSel].RMNRemote.Address(),
@@ -108,7 +101,7 @@ func SetRMNRemoteOnRMNProxyChangeset(e cldf.Environment, cfg SetRMNRemoteOnRMNPr
 		e.BlockChains.EVMChains(),
 		cfg.ToSequenceInput(state),
 	)
-	return opsutil.AddEVMCallSequenceToCSOutput(e, output, report, err, state.EVMMCMSStateByChain(), cfg.MCMSConfig, "Call SetARM on RMNProxies")
+	return opsutils.AddEVMCallSequenceToCSOutput(e, output, report, err, state.EVMMCMSStateByChain(), cfg.MCMSConfig, "Call SetARM on RMNProxies")
 }
 
 type RMNNopConfig struct {
@@ -629,9 +622,9 @@ func SetRMNRemoteConfigChangeset(e cldf.Environment, config ccipseq.SetRMNRemote
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get active digest from RMNHome contract with address %s: %w", rmnHome.Address(), err)
 	}
 
-	input := make(map[uint64]opsevm.EVMCallInput[rmn_remote.RMNRemoteConfig])
+	input := make(map[uint64]opsutils.EVMCallInput[rmn_remote.RMNRemoteConfig])
 	for chainSel, cfg := range config.RMNRemoteConfigs {
-		input[chainSel] = opsevm.EVMCallInput[rmn_remote.RMNRemoteConfig]{
+		input[chainSel] = opsutils.EVMCallInput[rmn_remote.RMNRemoteConfig]{
 			ChainSelector: chainSel,
 			NoSend:        config.MCMSConfig != nil,
 			Address:       state.Chains[chainSel].RMNRemote.Address(),
@@ -649,5 +642,5 @@ func SetRMNRemoteConfigChangeset(e cldf.Environment, config ccipseq.SetRMNRemote
 		e.BlockChains.EVMChains(),
 		input,
 	)
-	return opsutil.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, seqReport, err, state.EVMMCMSStateByChain(), config.MCMSConfig, "Set RMNRemote configs")
+	return opsutils.AddEVMCallSequenceToCSOutput(e, cldf.ChangesetOutput{}, seqReport, err, state.EVMMCMSStateByChain(), config.MCMSConfig, "Set RMNRemote configs")
 }

--- a/deployment/ccip/changeset/v1_6_2/cs_configure_cctp_message_transmitter_proxy.go
+++ b/deployment/ccip/changeset/v1_6_2/cs_configure_cctp_message_transmitter_proxy.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	cmtp "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_2/cctp_message_transmitter_proxy"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
@@ -18,7 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/evm"
@@ -27,7 +26,7 @@ import (
 var (
 	ConfigureCCTPMessageTransmitterProxy = cldf.CreateChangeSet(configureCCTPMessageTransmitterProxyContractLogic, configureCCTPMessageTransmitterProxyContractPrecondition)
 
-	CCTPMessageTransmitterProxyConfigOp = opsevm.NewEVMCallOperation(
+	CCTPMessageTransmitterProxyConfigOp = opsutils.NewEVMCallOperation(
 		"CCTPMessageTransmitterProxyConfigOp",
 		semver.MustParse("1.6.2"),
 		"Setting CCTP message transmitter proxy config",
@@ -42,8 +41,8 @@ var (
 		"CCTPMessageTransmitterProxyConfigSequence",
 		semver.MustParse("1.6.2"),
 		"Setting CCTP message transmitter proxy config across multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, inputs map[uint64]opsevm.EVMCallInput[[]cmtp.CCTPMessageTransmitterProxyAllowedCallerConfigArgs]) (map[uint64][]opsevm.EVMCallOutput, error) {
-			out := make(map[uint64][]opsevm.EVMCallOutput, len(inputs))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, inputs map[uint64]opsutils.EVMCallInput[[]cmtp.CCTPMessageTransmitterProxyAllowedCallerConfigArgs]) (map[uint64][]opsutils.EVMCallOutput, error) {
+			out := make(map[uint64][]opsutils.EVMCallOutput, len(inputs))
 
 			for chainSelector, input := range inputs {
 				if _, ok := chains[chainSelector]; !ok {
@@ -52,9 +51,9 @@ var (
 
 				report, err := operations.ExecuteOperation(b, CCTPMessageTransmitterProxyConfigOp, chains[chainSelector], input)
 				if err != nil {
-					return map[uint64][]opsevm.EVMCallOutput{}, fmt.Errorf("failed to set CCTP message transmitt proxy config for chain %d: %w", chainSelector, err)
+					return map[uint64][]opsutils.EVMCallOutput{}, fmt.Errorf("failed to set CCTP message transmitt proxy config for chain %d: %w", chainSelector, err)
 				}
-				out[chainSelector] = []opsevm.EVMCallOutput{report.Output}
+				out[chainSelector] = []opsutils.EVMCallOutput{report.Output}
 			}
 
 			return out, nil
@@ -137,7 +136,7 @@ func configureCCTPMessageTransmitterProxyContractLogic(env cldf.Environment, c C
 	}
 
 	// Convert CLD/migrations inputs to onchain inputs.
-	input := make(map[uint64]opsevm.EVMCallInput[[]cmtp.CCTPMessageTransmitterProxyAllowedCallerConfigArgs], len(c.CCTPProxies))
+	input := make(map[uint64]opsutils.EVMCallInput[[]cmtp.CCTPMessageTransmitterProxyAllowedCallerConfigArgs], len(c.CCTPProxies))
 	for chainSelector, proxyConfig := range c.CCTPProxies {
 		_, chainState, err := state.GetEVMChainState(env, chainSelector)
 		if err != nil {
@@ -153,7 +152,7 @@ func configureCCTPMessageTransmitterProxyContractLogic(env cldf.Environment, c C
 			})
 		}
 
-		input[chainSelector] = opsevm.EVMCallInput[[]cmtp.CCTPMessageTransmitterProxyAllowedCallerConfigArgs]{
+		input[chainSelector] = opsutils.EVMCallInput[[]cmtp.CCTPMessageTransmitterProxyAllowedCallerConfigArgs]{
 			ChainSelector: chainSelector,
 			NoSend:        c.MCMS != nil,
 			Address:       chainState.CCTPMessageTransmitterProxies[deployment.Version1_6_2].Address(),
@@ -168,7 +167,7 @@ func configureCCTPMessageTransmitterProxyContractLogic(env cldf.Environment, c C
 		env.BlockChains.EVMChains(),
 		input,
 	)
-	return opsevm.AddEVMCallSequenceToCSOutput(
+	return opsutils.AddEVMCallSequenceToCSOutput(
 		env,
 		cldf.ChangesetOutput{},
 		seqReport,

--- a/deployment/ccip/changeset/v1_6_2/cs_configure_usdc_token_pool.go
+++ b/deployment/ccip/changeset/v1_6_2/cs_configure_usdc_token_pool.go
@@ -9,19 +9,18 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/gagliardetto/solana-go"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
 	utp "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_2/usdc_token_pool"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/evm"
@@ -30,7 +29,7 @@ import (
 var (
 	ConfigUSDCTokenPoolChangeSet = cldf.CreateChangeSet(configUSDCTokenPoolLogic, configUSDCTokenPoolPrecondition)
 
-	USDCTokenPoolConfigOp = opsevm.NewEVMCallOperation(
+	USDCTokenPoolConfigOp = opsutils.NewEVMCallOperation(
 		"USDCTokenPoolConfigOp",
 		semver.MustParse("1.6.2"),
 		"Setting USDC Token Pool config",
@@ -45,8 +44,8 @@ var (
 		"USDCTokenPoolConfigSequence",
 		semver.MustParse("1.6.2"),
 		"Setting USDC Token Pool config across multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, inputs map[uint64]opsevm.EVMCallInput[[]utp.USDCTokenPoolDomainUpdate]) (map[uint64][]opsevm.EVMCallOutput, error) {
-			out := make(map[uint64][]opsevm.EVMCallOutput, len(inputs))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, inputs map[uint64]opsutils.EVMCallInput[[]utp.USDCTokenPoolDomainUpdate]) (map[uint64][]opsutils.EVMCallOutput, error) {
+			out := make(map[uint64][]opsutils.EVMCallOutput, len(inputs))
 
 			for chainSelector, input := range inputs {
 				if _, ok := chains[chainSelector]; !ok {
@@ -55,9 +54,9 @@ var (
 
 				report, err := operations.ExecuteOperation(b, USDCTokenPoolConfigOp, chains[chainSelector], input)
 				if err != nil {
-					return map[uint64][]opsevm.EVMCallOutput{}, fmt.Errorf("failed to set USDC token pool config for chain %d: %w", chainSelector, err)
+					return map[uint64][]opsutils.EVMCallOutput{}, fmt.Errorf("failed to set USDC token pool config for chain %d: %w", chainSelector, err)
 				}
-				out[chainSelector] = []opsevm.EVMCallOutput{report.Output}
+				out[chainSelector] = []opsutils.EVMCallOutput{report.Output}
 			}
 
 			return out, nil
@@ -155,7 +154,7 @@ func configUSDCTokenPoolLogic(env cldf.Environment, c ConfigUSDCTokenPoolConfig)
 	}
 
 	// Convert CLD/migrations inputs to onchain inputs.
-	input := make(map[uint64]opsevm.EVMCallInput[[]utp.USDCTokenPoolDomainUpdate], len(c.USDCPools))
+	input := make(map[uint64]opsutils.EVMCallInput[[]utp.USDCTokenPoolDomainUpdate], len(c.USDCPools))
 	for sourceChainSelector, poolConfig := range c.USDCPools {
 		_, chainState, err := state.GetEVMChainState(env, sourceChainSelector)
 		if err != nil {
@@ -198,7 +197,7 @@ func configUSDCTokenPoolLogic(env cldf.Environment, c ConfigUSDCTokenPoolConfig)
 			})
 		}
 
-		input[sourceChainSelector] = opsevm.EVMCallInput[[]utp.USDCTokenPoolDomainUpdate]{
+		input[sourceChainSelector] = opsutils.EVMCallInput[[]utp.USDCTokenPoolDomainUpdate]{
 			ChainSelector: sourceChainSelector,
 			NoSend:        c.MCMS != nil,
 			Address:       chainState.USDCTokenPoolsV1_6[deployment.Version1_6_2].Address(),
@@ -213,7 +212,7 @@ func configUSDCTokenPoolLogic(env cldf.Environment, c ConfigUSDCTokenPoolConfig)
 		env.BlockChains.EVMChains(),
 		input,
 	)
-	return opsevm.AddEVMCallSequenceToCSOutput(
+	return opsutils.AddEVMCallSequenceToCSOutput(
 		env,
 		cldf.ChangesetOutput{},
 		seqReport,

--- a/deployment/ccip/internal/opsutils/evm.go
+++ b/deployment/ccip/internal/opsutils/evm.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	proposeutils "github.com/smartcontractkit/cld-changesets/legacy/mcms/proposeutils"
 	evmstate "github.com/smartcontractkit/cld-changesets/legacy/pkg/family/evm"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 	"github.com/zksync-sdk/zksync2-go/accounts"
 	"github.com/zksync-sdk/zksync2-go/clients"
 
@@ -117,7 +116,7 @@ func NewEVMCallOperation[IN any, C any](
 func AddEVMCallSequenceToCSOutput[IN any](
 	e cldf.Environment,
 	csOutput cldf.ChangesetOutput,
-	seqReport operations.SequenceReport[IN, map[uint64][]opsevm.EVMCallOutput],
+	seqReport operations.SequenceReport[IN, map[uint64][]EVMCallOutput],
 	seqErr error,
 	mcmsStateByChain map[uint64]evmstate.MCMSWithTimelockState,
 	mcmsCfg *cldfproposalutils.TimelockConfig,

--- a/deployment/ccip/internal/opsutils/evm_test.go
+++ b/deployment/ccip/internal/opsutils/evm_test.go
@@ -17,7 +17,6 @@ import (
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
 	evmstate "github.com/smartcontractkit/cld-changesets/legacy/pkg/family/evm"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 	mcmslib "github.com/smartcontractkit/mcms"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
@@ -112,7 +111,7 @@ func TestAddEVMCallSequenceToCSOutput_SequenceError(t *testing.T) {
 	require.NoError(t, err)
 
 	csOutput := cldf.ChangesetOutput{}
-	seqReport := operations.SequenceReport[string, map[uint64][]opsevm.EVMCallOutput]{}
+	seqReport := operations.SequenceReport[string, map[uint64][]EVMCallOutput]{}
 	seqErr := errors.New("sequence failed")
 
 	result, err := AddEVMCallSequenceToCSOutput(
@@ -140,7 +139,7 @@ func TestAddEVMCallSequenceToCSOutput_NoMCMS(t *testing.T) {
 	require.NoError(t, err)
 
 	csOutput := cldf.ChangesetOutput{}
-	seqReport := operations.SequenceReport[string, map[uint64][]opsevm.EVMCallOutput]{}
+	seqReport := operations.SequenceReport[string, map[uint64][]EVMCallOutput]{}
 
 	result, err := AddEVMCallSequenceToCSOutput(
 		*env,
@@ -165,7 +164,7 @@ func TestAddEVMCallSequenceToCSOutput_AllConfirmed(t *testing.T) {
 	require.NoError(t, err)
 
 	csOutput := cldf.ChangesetOutput{}
-	seqReport := operations.SequenceReport[string, map[uint64][]opsevm.EVMCallOutput]{}
+	seqReport := operations.SequenceReport[string, map[uint64][]EVMCallOutput]{}
 	mcmsCfg := &cldfproposalutils.TimelockConfig{}
 
 	result, err := AddEVMCallSequenceToCSOutput(
@@ -241,9 +240,9 @@ func TestAddEVMCallSequenceToCSOutput_ProposalCombination(t *testing.T) {
 	}
 
 	// Create sequence report with unconfirmed calls to generate a new proposal
-	seqReport := operations.SequenceReport[string, map[uint64][]opsevm.EVMCallOutput]{
-		Report: operations.Report[string, map[uint64][]opsevm.EVMCallOutput]{
-			Output: map[uint64][]opsevm.EVMCallOutput{
+	seqReport := operations.SequenceReport[string, map[uint64][]EVMCallOutput]{
+		Report: operations.Report[string, map[uint64][]EVMCallOutput]{
+			Output: map[uint64][]EVMCallOutput{
 				selector2: {
 					{
 						To:           common.HexToAddress("0x3333333333333333333333333333333333333333"),

--- a/deployment/ccip/operation/evm/ops_erc677_token.go
+++ b/deployment/ccip/operation/evm/ops_erc677_token.go
@@ -6,12 +6,11 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc677"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-	opsutil "github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	cciptypes "github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 )
 
@@ -20,7 +19,7 @@ type MintERC677Config struct {
 	Amount *big.Int
 }
 
-var MintERC677Op = opsutil.NewEVMCallOperation(
+var MintERC677Op = opsutils.NewEVMCallOperation(
 	"MintERC677Op",
 	&deployment.Version1_0_0,
 	"Mint ERC677 tokens on the specified evm chain",
@@ -32,7 +31,7 @@ var MintERC677Op = opsutil.NewEVMCallOperation(
 	},
 )
 
-var GrantMintAndBurnRolesERC677Op = opsevm.NewEVMCallOperation(
+var GrantMintAndBurnRolesERC677Op = opsutils.NewEVMCallOperation(
 	"GrantMintAndBurnRolesERC677Op",
 	&deployment.Version1_0_0,
 	"Grant MINTER_ROLE and BURNER_ROLE to the specified ERC677 token address",
@@ -44,7 +43,7 @@ var GrantMintAndBurnRolesERC677Op = opsevm.NewEVMCallOperation(
 	},
 )
 
-var RevokeMintRoleERC677Op = opsutil.NewEVMCallOperation(
+var RevokeMintRoleERC677Op = opsutils.NewEVMCallOperation(
 	"RevokeMintRoleERC677Op",
 	&deployment.Version1_0_0,
 	"Revoke MINTER_ROLE from the specified ERC677 token address",
@@ -56,7 +55,7 @@ var RevokeMintRoleERC677Op = opsutil.NewEVMCallOperation(
 	},
 )
 
-var RevokeBurnRoleERC677Op = opsutil.NewEVMCallOperation(
+var RevokeBurnRoleERC677Op = opsutils.NewEVMCallOperation(
 	"RevokeBurnRoleERC677Op",
 	&deployment.Version1_0_0,
 	"Revoke BURNER_ROLE from the specified ERC677 token address",

--- a/deployment/ccip/operation/evm/v1_2/ops_router.go
+++ b/deployment/ccip/operation/evm/v1_2/ops_router.go
@@ -5,12 +5,11 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-	opsutil "github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 )
 
@@ -27,13 +26,13 @@ type RouterApplyRampUpdatesOpInput struct {
 }
 
 var (
-	DeployRouter = opsutil.NewEVMDeployOperation(
+	DeployRouter = opsutils.NewEVMDeployOperation(
 		"DeployRouter",
 		semver.MustParse("1.0.0"),
 		"Deploys Router 1.2 contract on the specified evm chain",
 		shared.Router,
 		router.RouterMetaData,
-		&opsutil.ContractOpts{
+		&opsutils.ContractOpts{
 			Version:          &deployment.Version1_2_0,
 			EVMBytecode:      common.FromHex(router.RouterBin),
 			ZkSyncVMBytecode: router.RouterZkBytecode,
@@ -43,13 +42,13 @@ var (
 		},
 	)
 
-	DeployTestRouter = opsevm.NewEVMDeployOperation(
+	DeployTestRouter = opsutils.NewEVMDeployOperation(
 		"DeployTestRouter",
 		semver.MustParse("1.0.0"),
 		"Deploys TestRouter 1.2 contract on the specified evm chain",
 		shared.TestRouter,
 		router.RouterMetaData,
-		&opsevm.ContractOpts{
+		&opsutils.ContractOpts{
 			Version:          &deployment.Version1_2_0,
 			EVMBytecode:      common.FromHex(router.RouterBin),
 			ZkSyncVMBytecode: router.RouterZkBytecode,
@@ -59,7 +58,7 @@ var (
 		},
 	)
 
-	RouterApplyRampUpdatesOp = opsevm.NewEVMCallOperation(
+	RouterApplyRampUpdatesOp = opsutils.NewEVMCallOperation(
 		"RouterApplyRampUpdatesOp",
 		semver.MustParse("1.0.0"),
 		"Updates OnRamps and OffRamps on the Router contract",
@@ -71,7 +70,7 @@ var (
 		},
 	)
 
-	UpdateWrappedNativeAddressOnRouterOp = opsevm.NewEVMCallOperation(
+	UpdateWrappedNativeAddressOnRouterOp = opsutils.NewEVMCallOperation(
 		"UpdateWrappedNativeAddressOnRouterOp",
 		semver.MustParse("1.0.0"),
 		"Updates Wrapped Native token address on Router contract for a chain",

--- a/deployment/ccip/operation/evm/v1_5_1/ops_fast_transfer_token_pool.go
+++ b/deployment/ccip/operation/evm/v1_5_1/ops_fast_transfer_token_pool.go
@@ -5,13 +5,12 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/bindings"
 	burn_mint_external "github.com/smartcontractkit/chainlink/deployment/ccip/shared/bindings/burn_mint_with_external_minter_fast_transfer_token_pool"
 	hybrid_external "github.com/smartcontractkit/chainlink/deployment/ccip/shared/bindings/hybrid_with_external_minter_fast_transfer_token_pool"
-
-	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 )
 
 // UpdateDestChainConfigInput defines the input for updating destination chain configuration
@@ -32,7 +31,7 @@ type WithdrawPoolFeesInput struct {
 
 var (
 	// BurnMint Fast Transfer Token Pool Operations
-	BurnMintFastTransferTokenPoolUpdateDestChainConfigOp = opsevm.NewEVMCallOperation(
+	BurnMintFastTransferTokenPoolUpdateDestChainConfigOp = opsutils.NewEVMCallOperation(
 		"BurnMintFastTransferTokenPoolUpdateDestChainConfigOp",
 		semver.MustParse("1.0.0"),
 		"Update destination chain configurations on BurnMint fast transfer token pool contract",
@@ -47,7 +46,7 @@ var (
 		},
 	)
 
-	BurnMintFastTransferTokenPoolUpdateFillerAllowlistOp = opsevm.NewEVMCallOperation(
+	BurnMintFastTransferTokenPoolUpdateFillerAllowlistOp = opsutils.NewEVMCallOperation(
 		"BurnMintFastTransferTokenPoolUpdateFillerAllowlistOp",
 		semver.MustParse("1.0.0"),
 		"Update filler allowlist on BurnMint fast transfer token pool contract",
@@ -63,7 +62,7 @@ var (
 	)
 
 	// BurnMintWithExternalMinter Fast Transfer Token Pool Operations
-	BurnMintWithExternalMinterFastTransferTokenPoolUpdateDestChainConfigOp = opsevm.NewEVMCallOperation(
+	BurnMintWithExternalMinterFastTransferTokenPoolUpdateDestChainConfigOp = opsutils.NewEVMCallOperation(
 		"BurnMintWithExternalMinterFastTransferTokenPoolUpdateDestChainConfigOp",
 		semver.MustParse("1.0.0"),
 		"Update destination chain configurations on BurnMintWithExternalMinter fast transfer token pool contract",
@@ -78,7 +77,7 @@ var (
 		},
 	)
 
-	BurnMintWithExternalMinterFastTransferTokenPoolUpdateFillerAllowlistOp = opsevm.NewEVMCallOperation(
+	BurnMintWithExternalMinterFastTransferTokenPoolUpdateFillerAllowlistOp = opsutils.NewEVMCallOperation(
 		"BurnMintWithExternalMinterFastTransferTokenPoolUpdateFillerAllowlistOp",
 		semver.MustParse("1.0.0"),
 		"Update filler allowlist on BurnMintWithExternalMinter fast transfer token pool contract",
@@ -94,7 +93,7 @@ var (
 	)
 
 	// BurnMint Fast Transfer Token Pool Withdraw Operations
-	BurnMintFastTransferTokenPoolWithdrawPoolFeesOp = opsevm.NewEVMCallOperation(
+	BurnMintFastTransferTokenPoolWithdrawPoolFeesOp = opsutils.NewEVMCallOperation(
 		"BurnMintFastTransferTokenPoolWithdrawPoolFeesOp",
 		semver.MustParse("1.0.0"),
 		"Withdraw pool fees from BurnMint fast transfer token pool contract",
@@ -110,7 +109,7 @@ var (
 	)
 
 	// BurnMintWithExternalMinter Fast Transfer Token Pool Withdraw Operations
-	BurnMintWithExternalMinterFastTransferTokenPoolWithdrawPoolFeesOp = opsevm.NewEVMCallOperation(
+	BurnMintWithExternalMinterFastTransferTokenPoolWithdrawPoolFeesOp = opsutils.NewEVMCallOperation(
 		"BurnMintWithExternalMinterFastTransferTokenPoolWithdrawPoolFeesOp",
 		semver.MustParse("1.0.0"),
 		"Withdraw pool fees from BurnMintWithExternalMinter fast transfer token pool contract",
@@ -126,7 +125,7 @@ var (
 	)
 
 	// HybridWithExternalMinter Fast Transfer Token Pool Operations
-	HybridWithExternalMinterFastTransferTokenPoolUpdateDestChainConfigOp = opsevm.NewEVMCallOperation(
+	HybridWithExternalMinterFastTransferTokenPoolUpdateDestChainConfigOp = opsutils.NewEVMCallOperation(
 		"HybridWithExternalMinterFastTransferTokenPoolUpdateDestChainConfigOp",
 		semver.MustParse("1.0.0"),
 		"Update destination chain configurations on HybridWithExternalMinter fast transfer token pool contract",
@@ -141,7 +140,7 @@ var (
 		},
 	)
 
-	HybridWithExternalMinterFastTransferTokenPoolUpdateFillerAllowlistOp = opsevm.NewEVMCallOperation(
+	HybridWithExternalMinterFastTransferTokenPoolUpdateFillerAllowlistOp = opsutils.NewEVMCallOperation(
 		"HybridWithExternalMinterFastTransferTokenPoolUpdateFillerAllowlistOp",
 		semver.MustParse("1.0.0"),
 		"Update filler allowlist on HybridWithExternalMinter fast transfer token pool contract",
@@ -156,7 +155,7 @@ var (
 		},
 	)
 
-	HybridWithExternalMinterFastTransferTokenPoolWithdrawPoolFeesOp = opsevm.NewEVMCallOperation(
+	HybridWithExternalMinterFastTransferTokenPoolWithdrawPoolFeesOp = opsutils.NewEVMCallOperation(
 		"HybridWithExternalMinterFastTransferTokenPoolWithdrawPoolFeesOp",
 		semver.MustParse("1.0.0"),
 		"Withdraw pool fees from HybridWithExternalMinter fast transfer token pool contract",

--- a/deployment/ccip/operation/evm/v1_5_1/ops_hybrid_token_pool.go
+++ b/deployment/ccip/operation/evm/v1_5_1/ops_hybrid_token_pool.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	hybrid_external "github.com/smartcontractkit/chainlink/deployment/ccip/shared/bindings/hybrid_with_external_minter_fast_transfer_token_pool"
 )
@@ -27,7 +27,7 @@ type UpdateGroupsInput struct {
 
 var (
 	// HybridWithExternalMinterTokenPoolUpdateGroupsOp updates groups on hybrid token pool contracts
-	HybridWithExternalMinterTokenPoolUpdateGroupsOp = opsevm.NewEVMCallOperation(
+	HybridWithExternalMinterTokenPoolUpdateGroupsOp = opsutils.NewEVMCallOperation(
 		"HybridWithExternalMinterTokenPoolUpdateGroupsOp",
 		semver.MustParse("1.0.0"),
 		"Update groups on HybridWithExternalMinter token pool contract",

--- a/deployment/ccip/operation/evm/v1_6/ops_ccip_home.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_ccip_home.go
@@ -3,13 +3,12 @@ package v1_6
 import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
-
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/ccip_home"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 )
 
@@ -21,7 +20,7 @@ type AddDONOpInput struct {
 	F                        uint8
 }
 
-var AddDONOp = opsevm.NewEVMCallOperation(
+var AddDONOp = opsutils.NewEVMCallOperation(
 	"AddDONOp",
 	semver.MustParse("1.0.0"),
 	"Adds DONs via the CapabilitiesRegistry",
@@ -41,7 +40,7 @@ type UpdateDONOpInput struct {
 	F                        uint8
 }
 
-var UpdateDONOp = opsevm.NewEVMCallOperation(
+var UpdateDONOp = opsutils.NewEVMCallOperation(
 	"UpdateDONOp",
 	semver.MustParse("1.0.0"),
 	"Updates DONs via the CapabilitiesRegistry",
@@ -58,7 +57,7 @@ type ApplyChainConfigUpdatesOpInput struct {
 	RemoteChainAdds    []ccip_home.CCIPHomeChainConfigArgs
 }
 
-var ApplyChainConfigUpdatesOp = opsevm.NewEVMCallOperation(
+var ApplyChainConfigUpdatesOp = opsutils.NewEVMCallOperation(
 	"ApplyChainConfigUpdatesOp",
 	semver.MustParse("1.0.0"),
 	"Updates chain configurations on CCIPHome",

--- a/deployment/ccip/operation/evm/v1_6/ops_fee_quoter.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_fee_quoter.go
@@ -11,12 +11,11 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_3/fee_quoter"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-	opsutil "github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
 )
@@ -40,13 +39,13 @@ type ApplyFeeTokensUpdatesInput struct {
 }
 
 var (
-	DeployFeeQuoterOp = opsevm.NewEVMDeployOperation(
+	DeployFeeQuoterOp = opsutils.NewEVMDeployOperation(
 		"DeployFeeQuoter",
 		semver.MustParse("1.0.0"),
 		"Deploys FeeQuoter 1.6.x contract on the specified evm chain",
 		shared.FeeQuoter,
 		fee_quoter.FeeQuoterMetaData,
-		&opsevm.ContractOpts{
+		&opsutils.ContractOpts{
 			Version:          &deployment.Version1_6_3, // defaults to v1_6_3, but can be overwritten by input params.FeeQuoterOpts
 			EVMBytecode:      common.FromHex(fee_quoter.FeeQuoterBin),
 			ZkSyncVMBytecode: fee_quoter.ZkBytecode,
@@ -77,7 +76,7 @@ var (
 		},
 	)
 
-	FeeQApplyAuthorizedCallerOp = opsutil.NewEVMCallOperation(
+	FeeQApplyAuthorizedCallerOp = opsutils.NewEVMCallOperation(
 		"FeeQApplyAuthorizedCallerOp",
 		semver.MustParse("1.0.0"),
 		"Apply authorized caller to FeeQuoter 1.6 contract on the specified evm chain",
@@ -89,7 +88,7 @@ var (
 		},
 	)
 
-	FeeQuoterApplyDestChainConfigUpdatesOp = opsevm.NewEVMCallOperation(
+	FeeQuoterApplyDestChainConfigUpdatesOp = opsutils.NewEVMCallOperation(
 		"FeeQuoterApplyDestChainConfigUpdatesOp",
 		semver.MustParse("1.0.0"),
 		"Apply updates to destination chain configs on the FeeQuoter 1.6.0 contract",
@@ -101,7 +100,7 @@ var (
 		},
 	)
 
-	FeeQuoterUpdatePricesOp = opsevm.NewEVMCallOperation(
+	FeeQuoterUpdatePricesOp = opsutils.NewEVMCallOperation(
 		"FeeQuoterUpdatePricesOp",
 		semver.MustParse("1.0.0"),
 		"Update token and gas prices on the FeeQuoter 1.6.0 contract",
@@ -112,7 +111,7 @@ var (
 			return feeQuoter.UpdatePrices(opts, input)
 		},
 	)
-	FeeQuoterApplyTokenTransferFeeCfgOp = opsevm.NewEVMCallOperation(
+	FeeQuoterApplyTokenTransferFeeCfgOp = opsutils.NewEVMCallOperation(
 		"FeeQuoterApplyTokenTransferFeeCfgOp",
 		semver.MustParse("1.0.0"),
 		"Update or Remove token transfer Fee Configs on the FeeQuoter 1.6.0 contract",
@@ -124,7 +123,7 @@ var (
 		},
 	)
 
-	FeeQuoterApplyFeeTokensUpdatesOp = opsevm.NewEVMCallOperation(
+	FeeQuoterApplyFeeTokensUpdatesOp = opsutils.NewEVMCallOperation(
 		"FeeQuoterApplyFeeTokensUpdatesOp",
 		semver.MustParse("1.0.0"),
 		"Add or Remove supported fee tokens FeeQuoter 1.6.0 contract",
@@ -136,7 +135,7 @@ var (
 		},
 	)
 
-	FeeQApplyPremiumMultiplierWeiPerEthUpdateOp = opsevm.NewEVMCallOperation(
+	FeeQApplyPremiumMultiplierWeiPerEthUpdateOp = opsutils.NewEVMCallOperation(
 		"FeeQApplyPremiumMultiplierWeiPerEthUpdateOp",
 		semver.MustParse("1.0.0"),
 		"Applies premiumMultiplierWeiPerEth for tokens in FeeQuoter 1.6.0 contract",

--- a/deployment/ccip/operation/evm/v1_6/ops_nonce_manager.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_nonce_manager.go
@@ -5,22 +5,22 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/nonce_manager"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 )
 
 var (
-	DeployNonceManagerOp = opsevm.NewEVMDeployOperation(
+	DeployNonceManagerOp = opsutils.NewEVMDeployOperation(
 		"DeployNonceManager",
 		semver.MustParse("1.0.0"),
 		"Deploys NonceManager 1.6 contract on the specified evm chain",
 		shared.NonceManager,
 		nonce_manager.NonceManagerMetaData,
-		&opsevm.ContractOpts{
+		&opsutils.ContractOpts{
 			Version:          &deployment.Version1_6_0,
 			EVMBytecode:      common.FromHex(nonce_manager.NonceManagerBin),
 			ZkSyncVMBytecode: nonce_manager.ZkBytecode,
@@ -30,7 +30,7 @@ var (
 		},
 	)
 
-	NonceManagerUpdateAuthorizedCallerOp = opsevm.NewEVMCallOperation(
+	NonceManagerUpdateAuthorizedCallerOp = opsutils.NewEVMCallOperation(
 		"NonceManagerUpdateAuthorizedCallerOp",
 		semver.MustParse("1.0.0"),
 		"Updates authorized callers in NonceManager 1.6 contract on the specified evm chain",
@@ -42,7 +42,7 @@ var (
 		},
 	)
 
-	NonceManagerPreviousRampsUpdatesOp = opsevm.NewEVMCallOperation(
+	NonceManagerPreviousRampsUpdatesOp = opsutils.NewEVMCallOperation(
 		"NonceManagerPreviousRampsUpdatesOp",
 		semver.MustParse("1.0.0"),
 		"Applies previous ramps updates in NonceManager 1.6 contract on the specified evm chain",

--- a/deployment/ccip/operation/evm/v1_6/ops_offramp.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_offramp.go
@@ -7,23 +7,23 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 )
 
 var (
-	DeployOffRampOp = opsevm.NewEVMDeployOperation(
+	DeployOffRampOp = opsutils.NewEVMDeployOperation(
 		"DeployOffRamp",
 		semver.MustParse("1.0.0"),
 		"Deploys OffRamp 1.6 contract on the specified evm chain",
 		shared.OffRamp,
 		offramp.OffRampMetaData,
-		&opsevm.ContractOpts{
+		&opsutils.ContractOpts{
 			Version:          &deployment.Version1_6_0,
 			EVMBytecode:      common.FromHex(offramp.OffRampBin),
 			ZkSyncVMBytecode: offramp.ZkBytecode,
@@ -47,7 +47,7 @@ var (
 		},
 	)
 
-	OffRampApplySourceChainConfigUpdatesOp = opsevm.NewEVMCallOperation(
+	OffRampApplySourceChainConfigUpdatesOp = opsutils.NewEVMCallOperation(
 		"OffRampApplySourceChainConfigUpdatesOp",
 		semver.MustParse("1.0.0"),
 		"Applies updates to source chain configurations stored on the OffRamp contract",

--- a/deployment/ccip/operation/evm/v1_6/ops_onramp.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_onramp.go
@@ -5,22 +5,22 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/onramp"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 )
 
 var (
-	DeployOnRampOp = opsevm.NewEVMDeployOperation(
+	DeployOnRampOp = opsutils.NewEVMDeployOperation(
 		"DeployOnRamp",
 		semver.MustParse("1.0.0"),
 		"Deploys OnRamp 1.6 contract on the specified evm chain",
 		shared.OnRamp,
 		onramp.OnRampMetaData,
-		&opsevm.ContractOpts{
+		&opsutils.ContractOpts{
 			Version:          &deployment.Version1_6_0,
 			EVMBytecode:      common.FromHex(onramp.OnRampBin),
 			ZkSyncVMBytecode: onramp.ZkBytecode,
@@ -42,7 +42,7 @@ var (
 		},
 	)
 
-	OnRampApplyDestChainConfigUpdatesOp = opsevm.NewEVMCallOperation(
+	OnRampApplyDestChainConfigUpdatesOp = opsutils.NewEVMCallOperation(
 		"OnRampApplyDestChainConfigUpdatesOp",
 		semver.MustParse("1.0.0"),
 		"Applies updates to destination chain configurations stored on the OnRamp contract",

--- a/deployment/ccip/operation/evm/v1_6/ops_rmnremote.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_rmnremote.go
@@ -5,7 +5,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_0_0/rmn_proxy_contract"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
@@ -13,6 +12,7 @@ import (
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 )
 
@@ -33,13 +33,13 @@ type DeployRMNRemoteInput struct {
 }
 
 var (
-	DeployRMNRemoteOp = opsevm.NewEVMDeployOperation(
+	DeployRMNRemoteOp = opsutils.NewEVMDeployOperation(
 		"DeployRMNRemote",
 		semver.MustParse("1.0.0"),
 		"Deploys RMNRemote 1.6 contract on the specified evm chain",
 		shared.RMNRemote,
 		rmn_remote.RMNRemoteMetaData,
-		&opsevm.ContractOpts{
+		&opsutils.ContractOpts{
 			Version:          &deployment.Version1_6_0,
 			EVMBytecode:      common.FromHex(rmn_remote.RMNRemoteBin),
 			ZkSyncVMBytecode: rmn_remote.ZkBytecode,
@@ -52,7 +52,7 @@ var (
 		},
 	)
 
-	SetRMNRemoteConfigOp = opsevm.NewEVMCallOperation(
+	SetRMNRemoteConfigOp = opsutils.NewEVMCallOperation(
 		"SetRMNRemoteConfigOp",
 		semver.MustParse("1.0.0"),
 		"Setting RMNRemoteConfig based on ActiveDigest from RMNHome",
@@ -63,7 +63,7 @@ var (
 			return rmnRemote.SetConfig(opts, input)
 		})
 
-	SetRMNRemoteOnRMNProxyOp = opsevm.NewEVMCallOperation(
+	SetRMNRemoteOnRMNProxyOp = opsutils.NewEVMCallOperation(
 		"SetRMNRemoteOnRMNProxyOp",
 		semver.MustParse("1.0.0"),
 		"Sets SetRMNRemote on RMNProxy contract on the specified evm chain",

--- a/deployment/ccip/sequence/evm/seq_erc677_token.go
+++ b/deployment/ccip/sequence/evm/seq_erc677_token.go
@@ -5,18 +5,18 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm"
 )
 
 // GrantMintRoleSeqInp defines inputs for granting mint role across multiple chains
 type GrantMintRoleSeqInp struct {
 	// UpdatesByChain maps chain selector to the EVM call input for that chain
-	UpdatesByChain map[uint64]opsevm.EVMCallInput[common.Address]
+	UpdatesByChain map[uint64]opsutils.EVMCallInput[common.Address]
 }
 
 var (
@@ -25,8 +25,8 @@ var (
 		"GrantMintAndBurnRoleSequence",
 		semver.MustParse("1.0.0"),
 		"Grant mint & Burn role on ERC677 token contracts across multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, inputs GrantMintRoleSeqInp) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(inputs.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, inputs GrantMintRoleSeqInp) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(inputs.UpdatesByChain))
 			for chainSel, input := range inputs.UpdatesByChain {
 				chain, ok := chains[chainSel]
 				if !ok {
@@ -36,7 +36,7 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute GrantMintAndBurnRolesERC677Op on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})

--- a/deployment/ccip/sequence/evm/v1_5_1/seq_fast_transfer_token_pool.go
+++ b/deployment/ccip/sequence/evm/v1_5_1/seq_fast_transfer_token_pool.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_5_1"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 )
@@ -19,7 +19,7 @@ type FastTransferTokenPoolUpdateDestChainConfigSequenceInput struct {
 	// ContractType specifies which type of fast transfer token pool to update
 	ContractType cldf.ContractType
 	// UpdatesByChain maps chain selector to the EVM call input for that chain
-	UpdatesByChain map[uint64]opsevm.EVMCallInput[ccipops.UpdateDestChainConfigInput]
+	UpdatesByChain map[uint64]opsutils.EVMCallInput[ccipops.UpdateDestChainConfigInput]
 }
 
 // FastTransferTokenPoolUpdateFillerAllowlistSequenceInput defines inputs for updating filler allowlists across multiple chains
@@ -27,7 +27,7 @@ type FastTransferTokenPoolUpdateFillerAllowlistSequenceInput struct {
 	// ContractType specifies which type of fast transfer token pool to update
 	ContractType cldf.ContractType
 	// UpdatesByChain maps chain selector to the EVM call input for that chain
-	UpdatesByChain map[uint64]opsevm.EVMCallInput[ccipops.UpdateFillerAllowlistInput]
+	UpdatesByChain map[uint64]opsutils.EVMCallInput[ccipops.UpdateFillerAllowlistInput]
 }
 
 // FastTransferTokenPoolWithdrawPoolFeesSequenceInput defines inputs for withdrawing pool fees across multiple chains
@@ -35,7 +35,7 @@ type FastTransferTokenPoolWithdrawPoolFeesSequenceInput struct {
 	// ContractType specifies which type of fast transfer token pool to withdraw from
 	ContractType cldf.ContractType
 	// WithdrawalsByChain maps chain selector to the EVM call input for that chain
-	WithdrawalsByChain map[uint64]opsevm.EVMCallInput[ccipops.WithdrawPoolFeesInput]
+	WithdrawalsByChain map[uint64]opsutils.EVMCallInput[ccipops.WithdrawPoolFeesInput]
 }
 
 var (
@@ -45,8 +45,8 @@ var (
 		"FastTransferTokenPoolUpdateDestChainConfigSequence",
 		semver.MustParse("1.0.0"),
 		"Update destination chain configurations on fast transfer token pool contracts across multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FastTransferTokenPoolUpdateDestChainConfigSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FastTransferTokenPoolUpdateDestChainConfigSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.UpdatesByChain))
 
 			for chainSel, update := range input.UpdatesByChain {
 				chain, ok := chains[chainSel]
@@ -55,7 +55,7 @@ var (
 				}
 
 				// Select the appropriate operation based on contract type
-				var operation *operations.Operation[opsevm.EVMCallInput[ccipops.UpdateDestChainConfigInput], opsevm.EVMCallOutput, cldf_evm.Chain]
+				var operation *operations.Operation[opsutils.EVMCallInput[ccipops.UpdateDestChainConfigInput], opsutils.EVMCallOutput, cldf_evm.Chain]
 				switch input.ContractType {
 				case shared.BurnMintFastTransferTokenPool:
 					operation = ccipops.BurnMintFastTransferTokenPoolUpdateDestChainConfigOp
@@ -71,7 +71,7 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute fast transfer token pool update dest chain config op on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})
@@ -82,8 +82,8 @@ var (
 		"FastTransferTokenPoolUpdateFillerAllowlistSequence",
 		semver.MustParse("1.0.0"),
 		"Update filler allowlists on fast transfer token pool contracts across multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FastTransferTokenPoolUpdateFillerAllowlistSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FastTransferTokenPoolUpdateFillerAllowlistSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.UpdatesByChain))
 
 			for chainSel, update := range input.UpdatesByChain {
 				chain, ok := chains[chainSel]
@@ -92,7 +92,7 @@ var (
 				}
 
 				// Select the appropriate operation based on contract type
-				var operation *operations.Operation[opsevm.EVMCallInput[ccipops.UpdateFillerAllowlistInput], opsevm.EVMCallOutput, cldf_evm.Chain]
+				var operation *operations.Operation[opsutils.EVMCallInput[ccipops.UpdateFillerAllowlistInput], opsutils.EVMCallOutput, cldf_evm.Chain]
 				switch input.ContractType {
 				case shared.BurnMintFastTransferTokenPool:
 					operation = ccipops.BurnMintFastTransferTokenPoolUpdateFillerAllowlistOp
@@ -108,7 +108,7 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute fast transfer token pool update filler allowlist op on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})
@@ -119,8 +119,8 @@ var (
 		"FastTransferTokenPoolWithdrawPoolFeesSequence",
 		semver.MustParse("1.0.0"),
 		"Withdraw pool fees from fast transfer token pool contracts across multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FastTransferTokenPoolWithdrawPoolFeesSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.WithdrawalsByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FastTransferTokenPoolWithdrawPoolFeesSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.WithdrawalsByChain))
 
 			for chainSel, withdrawal := range input.WithdrawalsByChain {
 				chain, ok := chains[chainSel]
@@ -129,7 +129,7 @@ var (
 				}
 
 				// Select the appropriate operation based on contract type
-				var operation *operations.Operation[opsevm.EVMCallInput[ccipops.WithdrawPoolFeesInput], opsevm.EVMCallOutput, cldf_evm.Chain]
+				var operation *operations.Operation[opsutils.EVMCallInput[ccipops.WithdrawPoolFeesInput], opsutils.EVMCallOutput, cldf_evm.Chain]
 				switch input.ContractType {
 				case shared.BurnMintFastTransferTokenPool:
 					operation = ccipops.BurnMintFastTransferTokenPoolWithdrawPoolFeesOp
@@ -145,7 +145,7 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute fast transfer token pool withdraw pool fees op on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})

--- a/deployment/ccip/sequence/evm/v1_5_1/seq_hybrid_token_pool.go
+++ b/deployment/ccip/sequence/evm/v1_5_1/seq_hybrid_token_pool.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_5_1"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 )
@@ -19,7 +19,7 @@ type HybridTokenPoolUpdateGroupsSequenceInput struct {
 	// ContractType specifies which type of hybrid token pool to update
 	ContractType cldf.ContractType
 	// UpdatesByChain maps chain selector to the EVM call input for that chain
-	UpdatesByChain map[uint64]opsevm.EVMCallInput[ccipops.UpdateGroupsInput]
+	UpdatesByChain map[uint64]opsutils.EVMCallInput[ccipops.UpdateGroupsInput]
 }
 
 var (
@@ -28,8 +28,8 @@ var (
 		"HybridTokenPoolUpdateGroupsSequence",
 		semver.MustParse("1.0.0"),
 		"Update groups on hybrid token pool contracts across multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input HybridTokenPoolUpdateGroupsSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input HybridTokenPoolUpdateGroupsSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.UpdatesByChain))
 
 			for chainSel, update := range input.UpdatesByChain {
 				chain, ok := chains[chainSel]
@@ -38,7 +38,7 @@ var (
 				}
 
 				// Select the appropriate operation based on contract type
-				var operation *operations.Operation[opsevm.EVMCallInput[ccipops.UpdateGroupsInput], opsevm.EVMCallOutput, cldf_evm.Chain]
+				var operation *operations.Operation[opsutils.EVMCallInput[ccipops.UpdateGroupsInput], opsutils.EVMCallOutput, cldf_evm.Chain]
 				switch input.ContractType {
 				case shared.HybridWithExternalMinterFastTransferTokenPool:
 					operation = ccipops.HybridWithExternalMinterTokenPoolUpdateGroupsOp
@@ -50,7 +50,7 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute hybrid token pool update groups op on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})

--- a/deployment/ccip/sequence/evm/v1_6/seq_ccip_home.go
+++ b/deployment/ccip/sequence/evm/v1_6/seq_ccip_home.go
@@ -6,13 +6,13 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/ccip_home"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_6"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
@@ -51,9 +51,9 @@ var AddDONAndSetCandidateSequence = operations.NewSequence(
 	"AddDONAndSetCandidateSequence",
 	semver.MustParse("1.0.0"),
 	"Adds commit / exec DONs for chains and sets their candidates on CCIPHome",
-	func(b operations.Bundle, deps DONSequenceDeps, input AddDONAndSetCandidateSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-		opOutputs := make(map[uint64][]opsevm.EVMCallOutput, 1) // Only calls against the home chain will be made
-		opOutputs[deps.HomeChain.Selector] = make([]opsevm.EVMCallOutput, len(input.DONs))
+	func(b operations.Bundle, deps DONSequenceDeps, input AddDONAndSetCandidateSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+		opOutputs := make(map[uint64][]opsutils.EVMCallOutput, 1) // Only calls against the home chain will be made
+		opOutputs[deps.HomeChain.Selector] = make([]opsutils.EVMCallOutput, len(input.DONs))
 
 		for i, don := range input.DONs {
 			encodedSetCandidateCall, err := CCIPHomeABI.Pack(
@@ -64,13 +64,13 @@ var AddDONAndSetCandidateSequence = operations.NewSequence(
 				[32]byte{},
 			)
 			if err != nil {
-				return map[uint64][]opsevm.EVMCallOutput{}, fmt.Errorf("failed to pack set candidate call: %w", err)
+				return map[uint64][]opsutils.EVMCallOutput{}, fmt.Errorf("failed to pack set candidate call: %w", err)
 			}
 			report, err := operations.ExecuteOperation(
 				b,
 				ccipops.AddDONOp,
 				deps.HomeChain,
-				opsevm.EVMCallInput[ccipops.AddDONOpInput]{
+				opsutils.EVMCallInput[ccipops.AddDONOpInput]{
 					Address:       input.CapabilitiesRegistry,
 					ChainSelector: deps.HomeChain.Selector,
 					CallInput: ccipops.AddDONOpInput{
@@ -116,9 +116,9 @@ var SetCandidateSequence = operations.NewSequence(
 	"SetCandidateSequence",
 	semver.MustParse("1.0.0"),
 	"Updates candidates for existing commit / exec DONs across multiple chains",
-	func(b operations.Bundle, deps DONSequenceDeps, input SetCandidateSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-		opOutputs := make(map[uint64][]opsevm.EVMCallOutput, 1) // Only calls against the home chain will be made
-		opOutputs[deps.HomeChain.Selector] = make([]opsevm.EVMCallOutput, len(input.DONs))
+	func(b operations.Bundle, deps DONSequenceDeps, input SetCandidateSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+		opOutputs := make(map[uint64][]opsutils.EVMCallOutput, 1) // Only calls against the home chain will be made
+		opOutputs[deps.HomeChain.Selector] = make([]opsutils.EVMCallOutput, len(input.DONs))
 
 		for i, don := range input.DONs {
 			encodedSetCandidateCall, err := CCIPHomeABI.Pack(
@@ -129,13 +129,13 @@ var SetCandidateSequence = operations.NewSequence(
 				don.ExistingDigest,
 			)
 			if err != nil {
-				return map[uint64][]opsevm.EVMCallOutput{}, fmt.Errorf("failed to pack set candidate call: %w", err)
+				return map[uint64][]opsutils.EVMCallOutput{}, fmt.Errorf("failed to pack set candidate call: %w", err)
 			}
 			report, err := operations.ExecuteOperation(
 				b,
 				ccipops.UpdateDONOp,
 				deps.HomeChain,
-				opsevm.EVMCallInput[ccipops.UpdateDONOpInput]{
+				opsutils.EVMCallInput[ccipops.UpdateDONOpInput]{
 					Address:       input.CapabilitiesRegistry,
 					ChainSelector: deps.HomeChain.Selector,
 					CallInput: ccipops.UpdateDONOpInput{
@@ -183,9 +183,9 @@ var PromoteCandidateSequence = operations.NewSequence(
 	"PromoteCandidateSequence",
 	semver.MustParse("1.0.0"),
 	"Promote candidates for existing commit / exec DONs across multiple chains",
-	func(b operations.Bundle, deps DONSequenceDeps, input PromoteCandidateSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-		opOutputs := make(map[uint64][]opsevm.EVMCallOutput, 1) // Only calls against the home chain will be made
-		opOutputs[deps.HomeChain.Selector] = make([]opsevm.EVMCallOutput, len(input.DONs))
+	func(b operations.Bundle, deps DONSequenceDeps, input PromoteCandidateSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+		opOutputs := make(map[uint64][]opsutils.EVMCallOutput, 1) // Only calls against the home chain will be made
+		opOutputs[deps.HomeChain.Selector] = make([]opsutils.EVMCallOutput, len(input.DONs))
 
 		for i, don := range input.DONs {
 			encodedPromoteCandidateCall, err := CCIPHomeABI.Pack(
@@ -196,13 +196,13 @@ var PromoteCandidateSequence = operations.NewSequence(
 				don.ActiveDigest,
 			)
 			if err != nil {
-				return map[uint64][]opsevm.EVMCallOutput{}, fmt.Errorf("failed to pack promote candidate call: %w", err)
+				return map[uint64][]opsutils.EVMCallOutput{}, fmt.Errorf("failed to pack promote candidate call: %w", err)
 			}
 			report, err := operations.ExecuteOperation(
 				b,
 				ccipops.UpdateDONOp,
 				deps.HomeChain,
-				opsevm.EVMCallInput[ccipops.UpdateDONOpInput]{
+				opsutils.EVMCallInput[ccipops.UpdateDONOpInput]{
 					Address:       input.CapabilitiesRegistry,
 					ChainSelector: deps.HomeChain.Selector,
 					CallInput: ccipops.UpdateDONOpInput{
@@ -241,9 +241,9 @@ var ApplyChainConfigUpdatesSequence = operations.NewSequence(
 	"ApplyChainConfigUpdatesSequence",
 	semver.MustParse("1.0.0"),
 	"Updates chain configurations on CCIPHome, using multiple ApplyChainConfigUpdates according to a batch size",
-	func(b operations.Bundle, deps DONSequenceDeps, input ApplyChainConfigUpdatesSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-		opOutputs := make(map[uint64][]opsevm.EVMCallOutput, 1) // Only calls against the home chain will be made
-		opOutputs[deps.HomeChain.Selector] = make([]opsevm.EVMCallOutput, 0)
+	func(b operations.Bundle, deps DONSequenceDeps, input ApplyChainConfigUpdatesSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+		opOutputs := make(map[uint64][]opsutils.EVMCallOutput, 1) // Only calls against the home chain will be made
+		opOutputs[deps.HomeChain.Selector] = make([]opsutils.EVMCallOutput, 0)
 
 		batches := make([]ccipops.ApplyChainConfigUpdatesOpInput, 0)
 		currentBatch := ccipops.ApplyChainConfigUpdatesOpInput{
@@ -289,7 +289,7 @@ var ApplyChainConfigUpdatesSequence = operations.NewSequence(
 				b,
 				ccipops.ApplyChainConfigUpdatesOp,
 				deps.HomeChain,
-				opsevm.EVMCallInput[ccipops.ApplyChainConfigUpdatesOpInput]{
+				opsutils.EVMCallInput[ccipops.ApplyChainConfigUpdatesOpInput]{
 					Address:       input.CCIPHome,
 					ChainSelector: deps.HomeChain.Selector,
 					CallInput:     batch,

--- a/deployment/ccip/sequence/evm/v1_6/seq_deploy_chain.go
+++ b/deployment/ccip/sequence/evm/v1_6/seq_deploy_chain.go
@@ -7,9 +7,6 @@ import (
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
-	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/sync/errgroup"
@@ -22,14 +19,15 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 
-	opsutil "github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipopsv1_2 "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_2"
 	ccipopsv1_6 "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_6"
 )
 
 type ChainContractParams struct {
-	FeeQuoterOpts   *opsevm.ContractOpts
+	FeeQuoterOpts   *opsutils.ContractOpts
 	FeeQuoterParams ccipopsv1_6.FeeQuoterParams
 	OffRampParams   ccipopsv1_6.OffRampParams
 }
@@ -145,7 +143,7 @@ var (
 			if err != nil {
 				return nil, fmt.Errorf("invalid DeployChainContractsSeqConfig: %w", err)
 			}
-			gasBoostConfigs := opsutil.GasBoostConfigsForChainMap(input.ContractParamsPerChain, input.GasBoostConfigPerChain)
+			gasBoostConfigs := opsutils.GasBoostConfigsForChainMap(input.ContractParamsPerChain, input.GasBoostConfigPerChain)
 			out := make(map[uint64]map[string]string)
 			grp := errgroup.Group{}
 			homeChain, ok := deps[input.HomeChainSelector]
@@ -175,13 +173,13 @@ var (
 						if chainAddresses.LegacyRMNAddress == (common.Address{}) {
 							b.Logger.Warnf("No legacy RMN contract found for %s, will not setRMN in RMNRemote", chain.String())
 						}
-						report, err := operations.ExecuteOperation(b, ccipopsv1_6.DeployRMNRemoteOp, chain, opsevm.EVMDeployInput[ccipopsv1_6.DeployRMNRemoteInput]{
+						report, err := operations.ExecuteOperation(b, ccipopsv1_6.DeployRMNRemoteOp, chain, opsutils.EVMDeployInput[ccipopsv1_6.DeployRMNRemoteInput]{
 							ChainSelector: chainSelector,
 							DeployInput: ccipopsv1_6.DeployRMNRemoteInput{
 								ChainSelector: chainSelector,
 								RMNLegacyAddr: chainAddresses.LegacyRMNAddress,
 							},
-						}, opsevm.RetryDeploymentWithGasBoost[ccipopsv1_6.DeployRMNRemoteInput](gasBoostConfigs[chainSelector]))
+						}, opsutils.RetryDeploymentWithGasBoost[ccipopsv1_6.DeployRMNRemoteInput](gasBoostConfigs[chainSelector]))
 						if err != nil {
 							return fmt.Errorf("failed to deploy RMNRemote for %s: %w", chain, err)
 						}
@@ -197,7 +195,7 @@ var (
 						return fmt.Errorf("failed to check if RMNRemote config is set for %s: %w", chain, err)
 					}
 					if !set {
-						_, err = operations.ExecuteOperation(b, ccipopsv1_6.SetRMNRemoteConfigOp, chain, opsevm.EVMCallInput[rmn_remote.RMNRemoteConfig]{
+						_, err = operations.ExecuteOperation(b, ccipopsv1_6.SetRMNRemoteConfigOp, chain, opsutils.EVMCallInput[rmn_remote.RMNRemoteConfig]{
 							Address:       rmnRemoteAddress,
 							NoSend:        false,
 							ChainSelector: chainSelector,
@@ -208,7 +206,7 @@ var (
 								},
 								FSign: 0,
 							},
-						}, opsevm.RetryCallWithGasBoost[rmn_remote.RMNRemoteConfig](gasBoostConfigs[chainSelector]))
+						}, opsutils.RetryCallWithGasBoost[rmn_remote.RMNRemoteConfig](gasBoostConfigs[chainSelector]))
 						if err != nil {
 							return fmt.Errorf("failed to set RMNRemote config for chain %d: %w", chainSelector, err)
 						}
@@ -217,14 +215,14 @@ var (
 					}
 					// Deploy Test Router if not already deployed
 					if chainAddresses.TestRouterAddress == (common.Address{}) {
-						report, err := operations.ExecuteOperation(b, ccipopsv1_2.DeployTestRouter, chain, opsevm.EVMDeployInput[ccipopsv1_2.DeployRouterInput]{
+						report, err := operations.ExecuteOperation(b, ccipopsv1_2.DeployTestRouter, chain, opsutils.EVMDeployInput[ccipopsv1_2.DeployRouterInput]{
 							ChainSelector: chainSelector,
 							DeployInput: ccipopsv1_2.DeployRouterInput{
 								ChainSelector: chainSelector,
 								RMNProxy:      chainAddresses.RMNProxyAddress,
 								WethAddress:   chainAddresses.WrappedNativeAddress,
 							},
-						}, opsevm.RetryDeploymentWithGasBoost[ccipopsv1_2.DeployRouterInput](gasBoostConfigs[chainSelector]))
+						}, opsutils.RetryDeploymentWithGasBoost[ccipopsv1_2.DeployRouterInput](gasBoostConfigs[chainSelector]))
 						if err != nil {
 							return fmt.Errorf("failed to deploy test router for %s: %w", chain, err)
 						}
@@ -233,10 +231,10 @@ var (
 					}
 					// Deploy NonceManager if not already deployed
 					if chainAddresses.NonceManagerAddress == (common.Address{}) {
-						report, err := operations.ExecuteOperation(b, ccipopsv1_6.DeployNonceManagerOp, chain, opsevm.EVMDeployInput[[]common.Address]{
+						report, err := operations.ExecuteOperation(b, ccipopsv1_6.DeployNonceManagerOp, chain, opsutils.EVMDeployInput[[]common.Address]{
 							ChainSelector: chainSelector,
 							DeployInput:   []common.Address{},
-						}, opsevm.RetryDeploymentWithGasBoost[[]common.Address](gasBoostConfigs[chainSelector]))
+						}, opsutils.RetryDeploymentWithGasBoost[[]common.Address](gasBoostConfigs[chainSelector]))
 						if err != nil {
 							return fmt.Errorf("failed to deploy nonce manager for %s: %w", chain, err)
 						}
@@ -248,7 +246,7 @@ var (
 					}
 					// Deploy FeeQuoter if not already deployed
 					if chainAddresses.FeeQuoterAddress == (common.Address{}) {
-						report, err := operations.ExecuteOperation(b, ccipopsv1_6.DeployFeeQuoterOp, chain, opsevm.EVMDeployInput[ccipopsv1_6.DeployFeeQInput]{
+						report, err := operations.ExecuteOperation(b, ccipopsv1_6.DeployFeeQuoterOp, chain, opsutils.EVMDeployInput[ccipopsv1_6.DeployFeeQInput]{
 							ChainSelector: chainSelector,
 							ContractOpts:  contractParams.FeeQuoterOpts,
 							DeployInput: ccipopsv1_6.DeployFeeQInput{
@@ -260,7 +258,7 @@ var (
 								// Deployer key should be removed sometime after initial deployment
 								PriceUpdaters: []common.Address{chainAddresses.TimelockAddress, chain.DeployerKey.From},
 							},
-						}, opsevm.RetryDeploymentWithGasBoost[ccipopsv1_6.DeployFeeQInput](gasBoostConfigs[chainSelector]))
+						}, opsutils.RetryDeploymentWithGasBoost[ccipopsv1_6.DeployFeeQInput](gasBoostConfigs[chainSelector]))
 						if err != nil {
 							return fmt.Errorf("failed to deploy fee quoter for %s: %w", chain, err)
 						}
@@ -279,7 +277,7 @@ var (
 						if feeAggregator == (common.Address{}) {
 							feeAggregator = chain.DeployerKey.From
 						}
-						report, err := operations.ExecuteOperation(b, ccipopsv1_6.DeployOnRampOp, chain, opsevm.EVMDeployInput[ccipopsv1_6.DeployOnRampInput]{
+						report, err := operations.ExecuteOperation(b, ccipopsv1_6.DeployOnRampOp, chain, opsutils.EVMDeployInput[ccipopsv1_6.DeployOnRampInput]{
 							ChainSelector: chainSelector,
 							DeployInput: ccipopsv1_6.DeployOnRampInput{
 								ChainSelector:      chainSelector,
@@ -289,7 +287,7 @@ var (
 								FeeQuoter:          feeQuoterAddress,
 								FeeAggregator:      feeAggregator,
 							},
-						}, opsevm.RetryDeploymentWithGasBoost[ccipopsv1_6.DeployOnRampInput](gasBoostConfigs[chainSelector]))
+						}, opsutils.RetryDeploymentWithGasBoost[ccipopsv1_6.DeployOnRampInput](gasBoostConfigs[chainSelector]))
 						if err != nil {
 							return fmt.Errorf("failed to deploy on ramp for %s: %w", chain, err)
 						}
@@ -300,7 +298,7 @@ var (
 					}
 					// Deploy OffRamp if not already deployed
 					if chainAddresses.OffRampAddress == (common.Address{}) {
-						report, err := operations.ExecuteOperation(b, ccipopsv1_6.DeployOffRampOp, chain, opsevm.EVMDeployInput[ccipopsv1_6.DeployOffRampInput]{
+						report, err := operations.ExecuteOperation(b, ccipopsv1_6.DeployOffRampOp, chain, opsutils.EVMDeployInput[ccipopsv1_6.DeployOffRampInput]{
 							ChainSelector: chainSelector,
 							DeployInput: ccipopsv1_6.DeployOffRampInput{
 								Chain:              chainSelector,
@@ -310,7 +308,7 @@ var (
 								TokenAdminRegistry: chainAddresses.TokenAdminRegistryAddress,
 								FeeQuoter:          feeQuoterAddress,
 							},
-						}, opsevm.RetryDeploymentWithGasBoost[ccipopsv1_6.DeployOffRampInput](gasBoostConfigs[chainSelector]))
+						}, opsutils.RetryDeploymentWithGasBoost[ccipopsv1_6.DeployOffRampInput](gasBoostConfigs[chainSelector]))
 						if err != nil {
 							return fmt.Errorf("failed to deploy off ramp for %s: %w", chain, err)
 						}
@@ -322,14 +320,14 @@ var (
 
 					// Add offRamp as an authorized caller on the FeeQuoter
 					if newFeeQuoter {
-						_, err = operations.ExecuteOperation(b, ccipopsv1_6.FeeQApplyAuthorizedCallerOp, chain, opsutil.EVMCallInput[fee_quoter.AuthorizedCallersAuthorizedCallerArgs]{
+						_, err = operations.ExecuteOperation(b, ccipopsv1_6.FeeQApplyAuthorizedCallerOp, chain, opsutils.EVMCallInput[fee_quoter.AuthorizedCallersAuthorizedCallerArgs]{
 							ChainSelector: chainSelector,
 							NoSend:        false,
 							Address:       feeQuoterAddress,
 							CallInput: fee_quoter.AuthorizedCallersAuthorizedCallerArgs{
 								AddedCallers: []common.Address{offRampAddress},
 							},
-						}, opsutil.RetryCallWithGasBoost[fee_quoter.AuthorizedCallersAuthorizedCallerArgs](gasBoostConfigs[chainSelector]))
+						}, opsutils.RetryCallWithGasBoost[fee_quoter.AuthorizedCallersAuthorizedCallerArgs](gasBoostConfigs[chainSelector]))
 						if err != nil {
 							return fmt.Errorf("failed to set off ramp as authorized caller of FeeQuoter on chain %s: %w", chain, err)
 						}
@@ -337,7 +335,7 @@ var (
 					// Add offRamp and onRamp as authorized callers on the NonceManager
 					if newNonceManager {
 						_, err = operations.ExecuteOperation(b, ccipopsv1_6.NonceManagerUpdateAuthorizedCallerOp, chain,
-							opsevm.EVMCallInput[nonce_manager.AuthorizedCallersAuthorizedCallerArgs]{
+							opsutils.EVMCallInput[nonce_manager.AuthorizedCallersAuthorizedCallerArgs]{
 								ChainSelector: chainSelector,
 								NoSend:        false,
 								Address:       nonceManagerAddress,
@@ -347,7 +345,7 @@ var (
 										onRampAddress,
 									},
 								},
-							}, opsevm.RetryCallWithGasBoost[nonce_manager.AuthorizedCallersAuthorizedCallerArgs](gasBoostConfigs[chainSelector]))
+							}, opsutils.RetryCallWithGasBoost[nonce_manager.AuthorizedCallersAuthorizedCallerArgs](gasBoostConfigs[chainSelector]))
 						if err != nil {
 							return fmt.Errorf("failed to set off ramp and on ramp as authorized callers of NonceManager on chain %s: %w", chain, err)
 						}

--- a/deployment/ccip/sequence/evm/v1_6/seq_fee_quoter.go
+++ b/deployment/ccip/sequence/evm/v1_6/seq_fee_quoter.go
@@ -4,33 +4,33 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_3/fee_quoter"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_6"
 )
 
 type FeeQuoterApplyDestChainConfigUpdatesSequenceInput struct {
-	UpdatesByChain map[uint64]opsevm.EVMCallInput[[]fee_quoter.FeeQuoterDestChainConfigArgs]
+	UpdatesByChain map[uint64]opsutils.EVMCallInput[[]fee_quoter.FeeQuoterDestChainConfigArgs]
 }
 
 type FeeQuoterUpdatePricesSequenceInput struct {
-	UpdatesByChain map[uint64]opsevm.EVMCallInput[fee_quoter.InternalPriceUpdates]
+	UpdatesByChain map[uint64]opsutils.EVMCallInput[fee_quoter.InternalPriceUpdates]
 }
 
 type FeeQuoterUpdateTokenTransferConfig struct {
-	UpdatesByChain map[uint64]opsevm.EVMCallInput[ccipops.ApplyTokenTransferFeeConfigUpdatesConfigPerChain]
+	UpdatesByChain map[uint64]opsutils.EVMCallInput[ccipops.ApplyTokenTransferFeeConfigUpdatesConfigPerChain]
 }
 
 type FeeQuoterUpdateFeeTokensConfig struct {
-	UpdatesByChain map[uint64]opsevm.EVMCallInput[ccipops.ApplyFeeTokensUpdatesInput]
+	UpdatesByChain map[uint64]opsutils.EVMCallInput[ccipops.ApplyFeeTokensUpdatesInput]
 }
 
 type FeeQuoterUpdatePremiumMultiplierWeiPerEthConfig struct {
-	UpdatesByChain map[uint64]opsevm.EVMCallInput[[]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs]
+	UpdatesByChain map[uint64]opsutils.EVMCallInput[[]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs]
 }
 
 var (
@@ -38,8 +38,8 @@ var (
 		"FeeQuoterApplyDestChainConfigUpdatesSequence",
 		semver.MustParse("1.0.0"),
 		"Apply updates to destination chain configs on the FeeQuoter 1.6.0 contract across multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FeeQuoterApplyDestChainConfigUpdatesSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FeeQuoterApplyDestChainConfigUpdatesSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.UpdatesByChain))
 			for chainSel, update := range input.UpdatesByChain {
 				chain, ok := chains[chainSel]
 				if !ok {
@@ -49,7 +49,7 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute FeeQuoterApplyDestChainConfigUpdatesOp on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})
@@ -58,8 +58,8 @@ var (
 		"FeeQuoterUpdatePricesSequence",
 		semver.MustParse("1.0.0"),
 		"Update token and gas prices on FeeQuoter 1.6.0 contracts on multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FeeQuoterUpdatePricesSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FeeQuoterUpdatePricesSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.UpdatesByChain))
 			for chainSel, update := range input.UpdatesByChain {
 				chain, ok := chains[chainSel]
 				if !ok {
@@ -69,7 +69,7 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute FeeQuoterUpdatePricesOp on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})
@@ -78,8 +78,8 @@ var (
 		"FeeQuoterUpdateTransferTokenFeeConfigSequence",
 		semver.MustParse("1.0.0"),
 		"Update token and gas prices on FeeQuoter 1.6.0 contracts on multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FeeQuoterUpdateTokenTransferConfig) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FeeQuoterUpdateTokenTransferConfig) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.UpdatesByChain))
 			for chainSel, update := range input.UpdatesByChain {
 				chain, ok := chains[chainSel]
 				if !ok {
@@ -89,7 +89,7 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute FeeQuoterApplyTokenTransferFeeCfgOp on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})
@@ -98,8 +98,8 @@ var (
 		"FeeQuoterApplyFeeTokensUpdatesSeq",
 		semver.MustParse("1.0.0"),
 		"Add or Remove supported tokens on FeeQuoter 1.6.0 contracts on multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FeeQuoterUpdateFeeTokensConfig) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FeeQuoterUpdateFeeTokensConfig) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.UpdatesByChain))
 			for chainSel, input := range input.UpdatesByChain {
 				chain, ok := chains[chainSel]
 				if !ok {
@@ -109,7 +109,7 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute FeeQuoterApplyFeeTokensUpdatesOp on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})
@@ -118,8 +118,8 @@ var (
 		"FeeQApplyPremiumMultiplierWeiPerEthUpdatesSeq",
 		semver.MustParse("1.0.0"),
 		"Applies premiumMultiplierWeiPerEth for tokens in FeeQuoter 1.6.0 contract on multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FeeQuoterUpdatePremiumMultiplierWeiPerEthConfig) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input FeeQuoterUpdatePremiumMultiplierWeiPerEthConfig) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.UpdatesByChain))
 			for chainSel, input := range input.UpdatesByChain {
 				chain, ok := chains[chainSel]
 				if !ok {
@@ -129,7 +129,7 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute ApplyPremiumMultiplierWeiPerEthUpdates on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})

--- a/deployment/ccip/sequence/evm/v1_6/seq_nonce_manager.go
+++ b/deployment/ccip/sequence/evm/v1_6/seq_nonce_manager.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/nonce_manager"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_6"
 )
 
@@ -18,8 +18,8 @@ type NonceManagerUpdatesSequenceInput struct {
 }
 
 type NonceManagerUpdateInput struct {
-	AuthorizedCallerArgs *opsevm.EVMCallInput[nonce_manager.AuthorizedCallersAuthorizedCallerArgs]
-	PreviousRampsArgs    *opsevm.EVMCallInput[[]nonce_manager.NonceManagerPreviousRampsArgs]
+	AuthorizedCallerArgs *opsutils.EVMCallInput[nonce_manager.AuthorizedCallersAuthorizedCallerArgs]
+	PreviousRampsArgs    *opsutils.EVMCallInput[[]nonce_manager.NonceManagerPreviousRampsArgs]
 }
 
 var (
@@ -27,11 +27,11 @@ var (
 		"UpdateNonceManagerSequence",
 		semver.MustParse("1.0.0"),
 		"Apply updates to the Nonce Manager contract across multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input NonceManagerUpdatesSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input NonceManagerUpdatesSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.UpdatesByChain))
 
 			for chainSel, update := range input.UpdatesByChain {
-				chainOutputs := []opsevm.EVMCallOutput{}
+				chainOutputs := []opsutils.EVMCallOutput{}
 				chain, ok := chains[chainSel]
 				if !ok {
 					return nil, fmt.Errorf("chain with selector %d not defined", chainSel)

--- a/deployment/ccip/sequence/evm/v1_6/seq_offramp.go
+++ b/deployment/ccip/sequence/evm/v1_6/seq_offramp.go
@@ -4,17 +4,17 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_6"
 )
 
 type OffRampApplySourceChainConfigUpdatesSequenceInput struct {
-	UpdatesByChain map[uint64]opsevm.EVMCallInput[[]offramp.OffRampSourceChainConfigArgs]
+	UpdatesByChain map[uint64]opsutils.EVMCallInput[[]offramp.OffRampSourceChainConfigArgs]
 }
 
 var (
@@ -22,8 +22,8 @@ var (
 		"OffRampApplySourceChainConfigUpdatesSequence",
 		semver.MustParse("1.0.0"),
 		"Applies updates to source chain configurations stored on OffRamp contracts on multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input OffRampApplySourceChainConfigUpdatesSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input OffRampApplySourceChainConfigUpdatesSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.UpdatesByChain))
 			for chainSel, update := range input.UpdatesByChain {
 				chain, ok := chains[chainSel]
 				if !ok {
@@ -34,7 +34,7 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute OffRampApplySourceChainConfigUpdatesOp on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})

--- a/deployment/ccip/sequence/evm/v1_6/seq_onramp.go
+++ b/deployment/ccip/sequence/evm/v1_6/seq_onramp.go
@@ -4,17 +4,17 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/onramp"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_6"
 )
 
 type OnRampApplyDestChainConfigUpdatesSequenceInput struct {
-	UpdatesByChain map[uint64]opsevm.EVMCallInput[[]onramp.OnRampDestChainConfigArgs]
+	UpdatesByChain map[uint64]opsutils.EVMCallInput[[]onramp.OnRampDestChainConfigArgs]
 }
 
 var (
@@ -22,8 +22,8 @@ var (
 		"OnRampApplyDestChainConfigUpdatesSequence",
 		semver.MustParse("1.0.0"),
 		"Applies updates to destination chain configurations stored on OnRamp contracts on multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input OnRampApplyDestChainConfigUpdatesSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input OnRampApplyDestChainConfigUpdatesSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.UpdatesByChain))
 			for chainSel, update := range input.UpdatesByChain {
 				chain, ok := chains[chainSel]
 				if !ok {
@@ -33,7 +33,7 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute OnRampApplyDestChainConfigUpdatesOp on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})

--- a/deployment/ccip/sequence/evm/v1_6/seq_rmn.go
+++ b/deployment/ccip/sequence/evm/v1_6/seq_rmn.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
@@ -15,6 +14,7 @@ import (
 
 	mcmschangesets "github.com/smartcontractkit/cld-changesets/legacy/mcms/changesets"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_6"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 )
@@ -24,8 +24,8 @@ var (
 		"SetRMNRemoteConfigSequence",
 		semver.MustParse("1.0.0"),
 		"Set RMNRemoteConfig based on ActiveDigest from RMNHome for evm chain(s)",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, inputs map[uint64]opsevm.EVMCallInput[rmn_remote.RMNRemoteConfig]) (map[uint64][]opsevm.EVMCallOutput, error) {
-			out := make(map[uint64][]opsevm.EVMCallOutput, len(inputs))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, inputs map[uint64]opsutils.EVMCallInput[rmn_remote.RMNRemoteConfig]) (map[uint64][]opsutils.EVMCallOutput, error) {
+			out := make(map[uint64][]opsutils.EVMCallOutput, len(inputs))
 
 			for chainSelector, input := range inputs {
 				if _, ok := chains[chainSelector]; !ok {
@@ -34,9 +34,9 @@ var (
 
 				report, err := operations.ExecuteOperation(b, ccipops.SetRMNRemoteConfigOp, chains[chainSelector], input)
 				if err != nil {
-					return map[uint64][]opsevm.EVMCallOutput{}, fmt.Errorf("failed to set RMNRemoteConfig for chain %d: %w", chainSelector, err)
+					return map[uint64][]opsutils.EVMCallOutput{}, fmt.Errorf("failed to set RMNRemoteConfig for chain %d: %w", chainSelector, err)
 				}
-				out[chainSelector] = []opsevm.EVMCallOutput{report.Output}
+				out[chainSelector] = []opsutils.EVMCallOutput{report.Output}
 			}
 
 			return out, nil
@@ -46,8 +46,8 @@ var (
 		"SetRMNRemoteOnRMNProxySequece",
 		semver.MustParse("1.0.0"),
 		"Setting SetRMNRemote on RMNProxy across multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input SetRMNRemoteOnRMNProxySequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input SetRMNRemoteOnRMNProxySequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.UpdatesByChain))
 
 			for chainSel, update := range input.UpdatesByChain {
 				chain, ok := chains[chainSel]
@@ -58,14 +58,14 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute SetRMNRemoteOnRMNProxyOp on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})
 )
 
 type SetRMNRemoteOnRMNProxySequenceInput struct {
-	UpdatesByChain map[uint64]opsevm.EVMCallInput[common.Address] `json:"updatesByChain"`
+	UpdatesByChain map[uint64]opsutils.EVMCallInput[common.Address] `json:"updatesByChain"`
 }
 
 type SetRMNRemoteConfig struct {

--- a/deployment/ccip/sequence/evm/v1_6/seq_router.go
+++ b/deployment/ccip/sequence/evm/v1_6/seq_router.go
@@ -5,20 +5,20 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_2"
 )
 
 type RouterApplyRampUpdatesSequenceInput struct {
-	UpdatesByChain map[uint64]opsevm.EVMCallInput[ccipops.RouterApplyRampUpdatesOpInput]
+	UpdatesByChain map[uint64]opsutils.EVMCallInput[ccipops.RouterApplyRampUpdatesOpInput]
 }
 
 type RouterUpdateWrappedNativeSequenceInput struct {
-	UpdatesByChain map[uint64]opsevm.EVMCallInput[common.Address]
+	UpdatesByChain map[uint64]opsutils.EVMCallInput[common.Address]
 }
 
 var (
@@ -26,8 +26,8 @@ var (
 		"RouterApplyRampUpdatesSequence",
 		semver.MustParse("1.0.0"),
 		"Updates OnRamps and OffRamps on Router contracts across multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input RouterApplyRampUpdatesSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input RouterApplyRampUpdatesSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.UpdatesByChain))
 			for chainSel, update := range input.UpdatesByChain {
 				chain, ok := chains[chainSel]
 				if !ok {
@@ -37,7 +37,7 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute RouterApplyRampUpdatesOp on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})
@@ -46,8 +46,8 @@ var (
 		"RouterUpdateWrappedNativeSequence",
 		semver.MustParse("1.0.0"),
 		"Updates Wrapped Native token on Router contracts across multiple EVM chains",
-		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input RouterUpdateWrappedNativeSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-			opOutputs := make(map[uint64][]opsevm.EVMCallOutput, len(input.UpdatesByChain))
+		func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input RouterUpdateWrappedNativeSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+			opOutputs := make(map[uint64][]opsutils.EVMCallOutput, len(input.UpdatesByChain))
 			for chainSel, newWrappedAddress := range input.UpdatesByChain {
 				chain, ok := chains[chainSel]
 				if !ok {
@@ -57,7 +57,7 @@ var (
 				if err != nil {
 					return nil, fmt.Errorf("failed to execute UpdateWrappedNativeAddressOnRouterOp on %s: %w", chain, err)
 				}
-				opOutputs[chainSel] = []opsevm.EVMCallOutput{report.Output}
+				opOutputs[chainSel] = []opsutils.EVMCallOutput{report.Output}
 			}
 			return opOutputs, nil
 		})

--- a/deployment/ccip/sequence/evm/v1_6/seq_update_lanes.go
+++ b/deployment/ccip/sequence/evm/v1_6/seq_update_lanes.go
@@ -5,10 +5,11 @@ import (
 
 	"dario.cat/mergo"
 	"github.com/Masterminds/semver/v3"
-	opsevm "github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 )
 
 type UpdateLanesSequenceInput struct {
@@ -24,8 +25,8 @@ var UpdateLanesSequence = operations.NewSequence(
 	"UpdateLanesSequence",
 	semver.MustParse("1.0.0"),
 	"Updates lanes on CCIP 1.6.0",
-	func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input UpdateLanesSequenceInput) (map[uint64][]opsevm.EVMCallOutput, error) {
-		result := make(map[uint64][]opsevm.EVMCallOutput)
+	func(b operations.Bundle, chains map[uint64]cldf_evm.Chain, input UpdateLanesSequenceInput) (map[uint64][]opsutils.EVMCallOutput, error) {
+		result := make(map[uint64][]opsutils.EVMCallOutput)
 
 		result, err := runAndMergeSequence(b, chains, FeeQuoterApplyDestChainConfigUpdatesSequence, input.FeeQuoterApplyDestChainConfigUpdatesSequenceInput, result)
 		if err != nil {
@@ -72,12 +73,12 @@ var UpdateLanesSequence = operations.NewSequence(
 func runAndMergeSequence[IN any](
 	b operations.Bundle,
 	chains map[uint64]cldf_evm.Chain,
-	seq *operations.Sequence[IN, map[uint64][]opsevm.EVMCallOutput, map[uint64]cldf_evm.Chain],
+	seq *operations.Sequence[IN, map[uint64][]opsutils.EVMCallOutput, map[uint64]cldf_evm.Chain],
 	input IN,
-	agg map[uint64][]opsevm.EVMCallOutput,
-) (map[uint64][]opsevm.EVMCallOutput, error) {
+	agg map[uint64][]opsutils.EVMCallOutput,
+) (map[uint64][]opsutils.EVMCallOutput, error) {
 	if agg == nil {
-		agg = make(map[uint64][]opsevm.EVMCallOutput)
+		agg = make(map[uint64][]opsutils.EVMCallOutput)
 	}
 	report, err := operations.ExecuteSequence(b, seq, chains, input)
 	if err != nil {


### PR DESCRIPTION
This change removes the dependency on the
`github.com/smartcontractkit/cld-changesets/pkg/family/evm/operations` package for evm operation utils, instead preferring the internal `opsutils` package.
