### PR TITLE
chore: bump confidential http gitref

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -48,5 +48,5 @@ plugins:
   confidential-http:
     - moduleURI:
         "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "490ea72d7b66ea0b650528a0ca5e4c60cb04d423"
+      gitRef: "cfea304ecfe68a8056cc8b6d7d42b0eff9a608fa"
       installPath: "./cmd/confidential-http"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -48,5 +48,5 @@ plugins:
   confidential-http:
     - moduleURI:
         "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "cfea304ecfe68a8056cc8b6d7d42b0eff9a608fa"
+      gitRef: "24ffd2435ed7d6bca45525c2189d720b7a4ef6bc"
       installPath: "./cmd/confidential-http"


### PR DESCRIPTION
## Summary

Bumps the confidential http gitref in `plugins/plugins.private.yaml`.
