### PR TITLE
fix(confidentialrelay): deterministic proto serialization for capability responses [CL112-05]

### DIFF
--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -464,7 +464,10 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 		if err != nil {
 			return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, fmt.Errorf("converting capability response: %w", err))
 		}
-		respBytes, err := proto.Marshal(sdkResp)
+		// Deterministic marshal so every relay node emits byte-identical
+		// response payloads; relay aggregation requires identical bytes to
+		// reach quorum. [CL112-05]
+		respBytes, err := proto.MarshalOptions{Deterministic: true}.Marshal(sdkResp)
 		if err != nil {
 			return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, fmt.Errorf("marshalling capability response: %w", err))
 		}
@@ -630,8 +633,13 @@ func toSDKCapabilityResponse(capResp capabilities.CapabilityResponse) (*sdkpb.Ca
 
 	if capResp.Value != nil {
 		valProto := values.Proto(capResp.Value)
-		wrapped, err := anypb.New(valProto)
-		if err != nil {
+		// Serialize the wrapped value deterministically. anypb stores the
+		// inner message as opaque bytes, so a non-deterministic marshal here
+		// (e.g. map-valued content in arbitrary key order) would produce
+		// different Any payloads across relay nodes and break quorum, even
+		// when nodes return the same logical value. [CL112-05]
+		wrapped := &anypb.Any{}
+		if err := anypb.MarshalFrom(wrapped, valProto, proto.MarshalOptions{Deterministic: true}); err != nil {
 			return nil, fmt.Errorf("wrapping value map in Any: %w", err)
 		}
 		return &sdkpb.CapabilityResponse{

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -946,6 +946,45 @@ func TestTranslateVaultResponse_BinaryShares(t *testing.T) {
 	require.Equal(t, base64.StdEncoding.EncodeToString(shareBytes), result.Secrets[0].EncryptedShares[0])
 }
 
+// Relay aggregation requires byte-identical responses from every node to reach
+// quorum. A map-valued response is the worst case: protobuf map fields marshal
+// in nondeterministic key order by default, so the same logical value would
+// serialize to different bytes across nodes (and across calls) unless we force
+// deterministic serialization. This guards both the Any payload construction in
+// toSDKCapabilityResponse and the outer marshal. [CL112-05]
+func TestToSDKCapabilityResponse_DeterministicSerialization(t *testing.T) {
+	val, err := values.Wrap(map[string]any{
+		"alpha":   1,
+		"bravo":   "two",
+		"charlie": true,
+		"delta":   []any{1, 2, 3},
+		"echo":    map[string]any{"nested1": "x", "nested2": "y", "nested3": "z"},
+		"foxtrot": "value-foxtrot",
+		"golf":    "value-golf",
+		"hotel":   "value-hotel",
+	})
+	require.NoError(t, err)
+	valMap, ok := val.(*values.Map)
+	require.True(t, ok)
+
+	capResp := capabilities.CapabilityResponse{Value: valMap}
+
+	var want []byte
+	for i := 0; i < 50; i++ {
+		sdkResp, err := toSDKCapabilityResponse(capResp)
+		require.NoError(t, err)
+		got, err := proto.MarshalOptions{Deterministic: true}.Marshal(sdkResp)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		if i == 0 {
+			want = got
+			continue
+		}
+		require.Equal(t, want, got,
+			"serialized capability response must be byte-identical across calls (iteration %d)", i)
+	}
+}
+
 func TestTranslateVaultResponse_HexShares(t *testing.T) {
 	enclaveKey := "aabbcc"
 	shareBytes := []byte("share-1")

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -953,6 +953,7 @@ func TestTranslateVaultResponse_BinaryShares(t *testing.T) {
 // deterministic serialization. This guards both the Any payload construction in
 // toSDKCapabilityResponse and the outer marshal. [CL112-05]
 func TestToSDKCapabilityResponse_DeterministicSerialization(t *testing.T) {
+	t.Parallel()
 	val, err := values.Wrap(map[string]any{
 		"alpha":   1,
 		"bravo":   "two",
@@ -970,7 +971,7 @@ func TestToSDKCapabilityResponse_DeterministicSerialization(t *testing.T) {
 	capResp := capabilities.CapabilityResponse{Value: valMap}
 
 	var want []byte
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		sdkResp, err := toSDKCapabilityResponse(capResp)
 		require.NoError(t, err)
 		got, err := proto.MarshalOptions{Deterministic: true}.Marshal(sdkResp)


### PR DESCRIPTION
Relay aggregation requires byte-identical responses from every node to reach quorum. `handleCapabilityExecute` marshaled responses with the default (non-deterministic) options, and `toSDKCapabilityResponse` wrapped map-valued results via `anypb.New`, which stores the inner message as opaque bytes serialized in arbitrary key order. The same logical response could therefore serialize to different bytes across nodes and block quorum.

This marshals the response and the wrapped `Any` payload with `Deterministic: true`, so map-valued content serializes in stable key order. Adds a regression test asserting byte-identical output across repeated serializations (fails without the fix).

Audit finding CL112-05 / PRIV-459.