### PR TITLE
extract solana SHA from plugins.public.yaml instead of go.mod

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -709,7 +709,7 @@ jobs:
 
   get-solana-sha:
     if: needs.solana-smoke-tests-setup.outputs.should-run-solana-tests == 'true'
-    name: Get Solana Sha From Go Mod
+    name: Get Solana Sha From Plugins
     environment:
       # http://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments
       name: integration
@@ -728,20 +728,20 @@ jobs:
           repository: smartcontractkit/chainlink
           ref: ${{ env.CHAINLINK_REF }}
 
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-        with:
-          only-modules: "true"
-
-      - name: Get the sha from go mod
+      - name: Get the sha from plugins
         id: getshortsha
         run: |
-          sol_ver=$(go list -m -json github.com/smartcontractkit/chainlink-solana  | jq -r .Version)
-          if [ -z "${sol_ver}" ]; then
-              echo "Error: could not get the solana version from the go.mod file, look above for error(s)"
+          sol_git_ref=$(grep -A2 'moduleURI: "github.com/smartcontractkit/chainlink-solana"' plugins/plugins.public.yaml | grep 'gitRef:' | sed -E 's/.*gitRef:[[:space:]]*"?([^"#[:space:]]+)"?.*/\1/')
+          if [ -z "${sol_git_ref}" ]; then
+              echo "Error: could not get the solana gitRef from plugins/plugins.public.yaml"
               exit 1
           fi
-          short_sha="${sol_ver##*-}"
+          short_sha="${sol_git_ref##*-}"
+          if [ -z "${short_sha}" ]; then
+              echo "Error: extracted solana short sha is empty from gitRef: ${sol_git_ref}"
+              exit 1
+          fi
+          echo "solana gitRef is: ${sol_git_ref}"
           echo "short sha is: ${short_sha}"
           echo "short_sha=${short_sha}" | tee -a "$GITHUB_OUTPUT"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -728,22 +728,21 @@ jobs:
           repository: smartcontractkit/chainlink
           ref: ${{ env.CHAINLINK_REF }}
 
-      - name: Get the sha from plugins
-        id: getshortsha
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+        with:
+          only-modules: "true"
+
+      - name: Get solana commit ref
+        id: getref
         run: |
-          sol_git_ref=$(grep -A2 'moduleURI: "github.com/smartcontractkit/chainlink-solana"' plugins/plugins.public.yaml | grep 'gitRef:' | sed -E 's/.*gitRef:[[:space:]]*"?([^"#[:space:]]+)"?.*/\1/')
-          if [ -z "${sol_git_ref}" ]; then
-              echo "Error: could not get the solana gitRef from plugins/plugins.public.yaml"
+          commit_ref=$(go run ./tools/pluginref/ --plugin-file ./plugins/plugins.public.yaml --plugin solana)
+          if [ -z "${commit_ref}" ]; then
+              echo "Error: could not resolve solana commit ref from plugins/plugins.public.yaml"
               exit 1
           fi
-          short_sha="${sol_git_ref##*-}"
-          if [ -z "${short_sha}" ]; then
-              echo "Error: extracted solana short sha is empty from gitRef: ${sol_git_ref}"
-              exit 1
-          fi
-          echo "solana gitRef is: ${sol_git_ref}"
-          echo "short sha is: ${short_sha}"
-          echo "short_sha=${short_sha}" | tee -a "$GITHUB_OUTPUT"
+          echo "commit_ref is: ${commit_ref}"
+          echo "commit_ref=${commit_ref}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Checkout solana
         uses: actions/checkout@v6
@@ -758,9 +757,9 @@ jobs:
         id: getsha
         run: |
           cd solanapath
-          full_sha=$(git rev-parse ${{steps.getshortsha.outputs.short_sha}}^{}) # additional suffix allows handling tagged versions as well
+          full_sha=$(git rev-parse "${{steps.getref.outputs.commit_ref}}^{}")
           if [ -z "${full_sha}" ]; then
-              echo "Error: could not get the full sha from the short sha using git, look above for error(s)"
+              echo "Error: could not resolve commit ref to a commit sha using git, look above for error(s)"
               exit 1
           fi
           echo "sha is: ${full_sha}"

--- a/tools/pluginref/README.md
+++ b/tools/pluginref/README.md
@@ -1,0 +1,39 @@
+# Pluginref: Resolve Plugin gitRef
+
+Looks up a plugin's `gitRef` in a plugins YAML file and prints a ref suitable for `git rev-parse`.
+
+## Usage
+
+```bash
+go run ./tools/pluginref/ \
+  --plugin-file ./plugins/plugins.public.yaml \
+  --plugin solana
+```
+
+Example output for the current Solana entry: `b5a89c32fdc1`
+
+Resolve to a full commit SHA in a checked-out repo:
+
+```bash
+commit_ref=$(go run ./tools/pluginref/ --plugin-file ./plugins/plugins.public.yaml --plugin solana)
+git -C ./chainlink-solana rev-parse "${commit_ref}^{}"
+```
+
+## Options
+
+- `--plugin-file <path>`: Path to a plugins YAML file (required)
+- `--plugin <name>`: Plugin key under `plugins:` (required), e.g. `solana`, `starknet`
+
+## Supported gitRef formats
+
+| gitRef example | Output |
+|---|---|
+| `v1.3.1-0.20260605202330-b5a89c32fdc1` | `b5a89c32fdc1` (pseudo-version commit hash) |
+| `v0.0.0-20260609211101-71d38bd6a0a9` | `71d38bd6a0a9` |
+| `73cd3d46ad0ce2871160369cb6447aeb9b48513f` | full SHA unchanged |
+| `v1.2.3` | `v1.2.3` (tag) |
+| `sub/v1.2.3` | `sub/v1.2.3` (prefixed tag) |
+
+## CI
+
+Used by the Solana smoke test workflow in `.github/workflows/integration-tests.yml` to read the plugin version from `plugins.public.yaml` instead of `go.mod`.

--- a/tools/pluginref/main.go
+++ b/tools/pluginref/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -18,10 +19,10 @@ func main() {
 		Short: "Resolve a plugin gitRef from YAML to a git rev-parse ref",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if pluginFile == "" {
-				return fmt.Errorf("--plugin-file is required")
+				return errors.New("--plugin-file is required")
 			}
 			if pluginName == "" {
-				return fmt.Errorf("--plugin is required")
+				return errors.New("--plugin is required")
 			}
 
 			gitRef, err := gitRefForPlugin(pluginFile, pluginName)

--- a/tools/pluginref/main.go
+++ b/tools/pluginref/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	var (
+		pluginFile string
+		pluginName string
+	)
+
+	rootCmd := &cobra.Command{
+		Use:   "pluginref",
+		Short: "Resolve a plugin gitRef from YAML to a git rev-parse ref",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if pluginFile == "" {
+				return fmt.Errorf("--plugin-file is required")
+			}
+			if pluginName == "" {
+				return fmt.Errorf("--plugin is required")
+			}
+
+			gitRef, err := gitRefForPlugin(pluginFile, pluginName)
+			if err != nil {
+				return err
+			}
+
+			commitRef, err := commitRefForGitRef(gitRef)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(commitRef)
+			return nil
+		},
+	}
+
+	rootCmd.Flags().StringVar(&pluginFile, "plugin-file", "", "Path to plugins YAML file")
+	rootCmd.Flags().StringVar(&pluginName, "plugin", "", "Plugin name (YAML key under plugins:)")
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/tools/pluginref/ref.go
+++ b/tools/pluginref/ref.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type pluginsFile struct {
+	Plugins map[string][]pluginEntry `yaml:"plugins"`
+}
+
+type pluginEntry struct {
+	ModuleURI string `yaml:"moduleURI"`
+	GitRef    string `yaml:"gitRef"`
+}
+
+var (
+	pseudoWithSHARe = regexp.MustCompile(
+		`^v\d+\.\d+\.\d+(?:-\d{14}|-(?:0|[0-9A-Za-z-]+\.0)\.\d{14})-([0-9a-f]{7,40})$`,
+	)
+	plainTagRe    = regexp.MustCompile(`^v\d+\.\d+\.\d+([.-].*)?$`)
+	prefixedTagRe = regexp.MustCompile(`^(.+?)/+(v\d+\.\d+\.\d+(?:[.-].*)?)$`)
+	shaOnlyRe     = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
+	pseudoMiddleRe = regexp.MustCompile(`^(?:\d{14}|(?:0|[0-9A-Za-z-]+\.0)\.\d{14})$`)
+)
+
+type moduleVersion struct {
+	Raw       string
+	SHA       string
+	Tag       string
+	TagPrefix string
+}
+
+func normalizeVersion(raw string) moduleVersion {
+	mv := moduleVersion{Raw: raw}
+	low := strings.ToLower(strings.TrimSpace(raw))
+
+	if m := pseudoWithSHARe.FindStringSubmatch(low); m != nil {
+		mv.SHA = m[1]
+		return mv
+	}
+
+	if strings.HasPrefix(low, "v") && strings.Count(low, "-") == 2 {
+		parts := strings.Split(low, "-")
+		middle := parts[1]
+		last := strings.TrimPrefix(parts[2], "g")
+		if pseudoMiddleRe.MatchString(middle) && shaOnlyRe.MatchString(last) {
+			mv.SHA = last
+			return mv
+		}
+	}
+
+	if shaOnlyRe.MatchString(low) {
+		mv.SHA = low
+		return mv
+	}
+
+	if m := prefixedTagRe.FindStringSubmatch(low); len(m) == 3 && plainTagRe.MatchString(m[2]) {
+		orig := strings.TrimSpace(raw)
+		if pos := strings.LastIndex(orig, "/"); pos >= 0 && pos+1 < len(orig) {
+			return moduleVersion{
+				Raw:       raw,
+				Tag:       orig[pos+1:],
+				TagPrefix: strings.TrimSuffix(orig[:pos], "/"),
+			}
+		}
+	}
+
+	if plainTagRe.MatchString(low) {
+		mv.Tag = raw
+		return mv
+	}
+
+	return mv
+}
+
+// gitRefForPlugin returns the gitRef for a named plugin in a plugins YAML file.
+func gitRefForPlugin(path, name string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read plugin file %s: %w", path, err)
+	}
+
+	var pf pluginsFile
+	if err := yaml.Unmarshal(data, &pf); err != nil {
+		return "", fmt.Errorf("parse plugin file %s: %w", path, err)
+	}
+
+	entries, ok := pf.Plugins[name]
+	if !ok || len(entries) == 0 {
+		return "", fmt.Errorf("plugin %q not found in %s", name, path)
+	}
+
+	for _, entry := range entries {
+		if entry.GitRef != "" {
+			return entry.GitRef, nil
+		}
+	}
+
+	return "", fmt.Errorf("plugin %q has no gitRef in %s", name, path)
+}
+
+// commitRefForGitRef returns a git object name suitable for rev-parse.
+func commitRefForGitRef(gitRef string) (string, error) {
+	gitRef = strings.TrimSpace(gitRef)
+	if gitRef == "" {
+		return "", fmt.Errorf("gitRef is empty")
+	}
+
+	mv := normalizeVersion(gitRef)
+	if mv.SHA != "" {
+		return mv.SHA, nil
+	}
+	if mv.Tag != "" {
+		if mv.TagPrefix != "" {
+			return mv.Raw, nil
+		}
+		return mv.Tag, nil
+	}
+	if mv.Raw != "" {
+		return mv.Raw, nil
+	}
+
+	return "", fmt.Errorf("unrecognized gitRef: %s", gitRef)
+}

--- a/tools/pluginref/ref.go
+++ b/tools/pluginref/ref.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -22,9 +23,9 @@ var (
 	pseudoWithSHARe = regexp.MustCompile(
 		`^v\d+\.\d+\.\d+(?:-\d{14}|-(?:0|[0-9A-Za-z-]+\.0)\.\d{14})-([0-9a-f]{7,40})$`,
 	)
-	plainTagRe    = regexp.MustCompile(`^v\d+\.\d+\.\d+([.-].*)?$`)
-	prefixedTagRe = regexp.MustCompile(`^(.+?)/+(v\d+\.\d+\.\d+(?:[.-].*)?)$`)
-	shaOnlyRe     = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
+	plainTagRe     = regexp.MustCompile(`^v\d+\.\d+\.\d+([.-].*)?$`)
+	prefixedTagRe  = regexp.MustCompile(`^(.+?)/+(v\d+\.\d+\.\d+(?:[.-].*)?)$`)
+	shaOnlyRe      = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
 	pseudoMiddleRe = regexp.MustCompile(`^(?:\d{14}|(?:0|[0-9A-Za-z-]+\.0)\.\d{14})$`)
 )
 
@@ -108,7 +109,7 @@ func gitRefForPlugin(path, name string) (string, error) {
 func commitRefForGitRef(gitRef string) (string, error) {
 	gitRef = strings.TrimSpace(gitRef)
 	if gitRef == "" {
-		return "", fmt.Errorf("gitRef is empty")
+		return "", errors.New("gitRef is empty")
 	}
 
 	mv := normalizeVersion(gitRef)

--- a/tools/pluginref/ref.go
+++ b/tools/pluginref/ref.go
@@ -121,9 +121,7 @@ func commitRefForGitRef(gitRef string) (string, error) {
 		}
 		return mv.Tag, nil
 	}
-	if mv.Raw != "" {
-		return mv.Raw, nil
-	}
 
-	return "", fmt.Errorf("unrecognized gitRef: %s", gitRef)
+	// Unrecognized formats (e.g. branch names) pass through for git rev-parse.
+	return mv.Raw, nil
 }

--- a/tools/pluginref/ref_test.go
+++ b/tools/pluginref/ref_test.go
@@ -39,7 +39,10 @@ func samplePluginsYAML() string {
 }
 
 func TestNormalizeVersion(t *testing.T) {
+	t.Parallel()
+
 	t.Run("plain tag", func(t *testing.T) {
+		t.Parallel()
 		mv := normalizeVersion("v1.2.3")
 		if mv.Tag != "v1.2.3" || mv.SHA != "" || mv.TagPrefix != "" {
 			t.Fatalf("unexpected mv: %+v", mv)
@@ -47,6 +50,7 @@ func TestNormalizeVersion(t *testing.T) {
 	})
 
 	t.Run("prefixed tag", func(t *testing.T) {
+		t.Parallel()
 		mv := normalizeVersion("sub/dir/v1.2.3")
 		if mv.Tag != "v1.2.3" || mv.TagPrefix != "sub/dir" || mv.SHA != "" {
 			t.Fatalf("unexpected mv: %+v", mv)
@@ -54,6 +58,7 @@ func TestNormalizeVersion(t *testing.T) {
 	})
 
 	t.Run("pseudo with sha", func(t *testing.T) {
+		t.Parallel()
 		valids := []struct {
 			in   string
 			want string
@@ -63,14 +68,18 @@ func TestNormalizeVersion(t *testing.T) {
 			{"v1.2.3-0.20250102030405-abcdef123456", "abcdef123456"},
 		}
 		for _, tc := range valids {
-			mv := normalizeVersion(tc.in)
-			if mv.SHA != tc.want {
-				t.Fatalf("normalizeVersion(%q).SHA = %q, want %q", tc.in, mv.SHA, tc.want)
-			}
+			t.Run(tc.in, func(t *testing.T) {
+				t.Parallel()
+				mv := normalizeVersion(tc.in)
+				if mv.SHA != tc.want {
+					t.Fatalf("normalizeVersion(%q).SHA = %q, want %q", tc.in, mv.SHA, tc.want)
+				}
+			})
 		}
 	})
 
 	t.Run("raw sha", func(t *testing.T) {
+		t.Parallel()
 		const sha = "73cd3d46ad0ce2871160369cb6447aeb9b48513f"
 		mv := normalizeVersion(sha)
 		if mv.SHA != sha {
@@ -80,6 +89,8 @@ func TestNormalizeVersion(t *testing.T) {
 }
 
 func TestCommitRefForGitRef(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		gitRef string
 		want   string
@@ -92,23 +103,30 @@ func TestCommitRefForGitRef(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		got, err := commitRefForGitRef(tc.gitRef)
-		if err != nil {
-			t.Fatalf("commitRefForGitRef(%q): %v", tc.gitRef, err)
-		}
-		if got != tc.want {
-			t.Fatalf("commitRefForGitRef(%q) = %q, want %q", tc.gitRef, got, tc.want)
-		}
+		t.Run(tc.gitRef, func(t *testing.T) {
+			t.Parallel()
+			got, err := commitRefForGitRef(tc.gitRef)
+			if err != nil {
+				t.Fatalf("commitRefForGitRef(%q): %v", tc.gitRef, err)
+			}
+			if got != tc.want {
+				t.Fatalf("commitRefForGitRef(%q) = %q, want %q", tc.gitRef, got, tc.want)
+			}
+		})
 	}
 }
 
 func TestCommitRefForGitRefErrors(t *testing.T) {
+	t.Parallel()
+
 	if _, err := commitRefForGitRef(""); err == nil {
 		t.Fatal("expected error for empty gitRef")
 	}
 }
 
 func TestGitRefForPlugin(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	path := writeFile(t, dir, "plugins.yaml", samplePluginsYAML())
 
@@ -121,34 +139,48 @@ func TestGitRefForPlugin(t *testing.T) {
 	}
 
 	for name, want := range cases {
-		got, err := gitRefForPlugin(path, name)
-		if err != nil {
-			t.Fatalf("gitRefForPlugin(%q): %v", name, err)
-		}
-		if got != want {
-			t.Fatalf("gitRefForPlugin(%q) = %q, want %q", name, got, want)
-		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, err := gitRefForPlugin(path, name)
+			if err != nil {
+				t.Fatalf("gitRefForPlugin(%q): %v", name, err)
+			}
+			if got != want {
+				t.Fatalf("gitRefForPlugin(%q) = %q, want %q", name, got, want)
+			}
+		})
 	}
 }
 
 func TestGitRefForPluginErrors(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	path := writeFile(t, dir, "plugins.yaml", samplePluginsYAML())
 
-	if _, err := gitRefForPlugin(path, "missing"); err == nil {
-		t.Fatal("expected error for missing plugin")
-	}
+	t.Run("missing plugin", func(t *testing.T) {
+		t.Parallel()
+		if _, err := gitRefForPlugin(path, "missing"); err == nil {
+			t.Fatal("expected error for missing plugin")
+		}
+	})
 
-	emptyPath := writeFile(t, dir, "empty.yaml", `plugins: {}`)
-	if _, err := gitRefForPlugin(emptyPath, "solana"); err == nil {
-		t.Fatal("expected error for unknown plugin in empty file")
-	}
+	t.Run("unknown plugin in empty file", func(t *testing.T) {
+		t.Parallel()
+		emptyPath := writeFile(t, dir, "empty.yaml", `plugins: {}`)
+		if _, err := gitRefForPlugin(emptyPath, "solana"); err == nil {
+			t.Fatal("expected error for unknown plugin in empty file")
+		}
+	})
 
-	noRefPath := writeFile(t, dir, "noref.yaml", `plugins:
+	t.Run("plugin without gitRef", func(t *testing.T) {
+		t.Parallel()
+		noRefPath := writeFile(t, dir, "noref.yaml", `plugins:
   solana:
     - moduleURI: "github.com/smartcontractkit/chainlink-solana"
 `)
-	if _, err := gitRefForPlugin(noRefPath, "solana"); err == nil {
-		t.Fatal("expected error for plugin without gitRef")
-	}
+		if _, err := gitRefForPlugin(noRefPath, "solana"); err == nil {
+			t.Fatal("expected error for plugin without gitRef")
+		}
+	})
 }

--- a/tools/pluginref/ref_test.go
+++ b/tools/pluginref/ref_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func samplePluginsYAML() string {
+	return `plugins:
+  solana:
+    - moduleURI: "github.com/smartcontractkit/chainlink-solana"
+      gitRef: "v1.3.1-0.20260605202330-b5a89c32fdc1"
+      installPath: "./pkg/solana/cmd/chainlink-solana"
+  starknet:
+    - moduleURI: "github.com/smartcontractkit/chainlink-starknet/relayer"
+      gitRef: "73cd3d46ad0ce2871160369cb6447aeb9b48513f" # 2026-04-08
+      installPath: "./pkg/chainlink/cmd/chainlink-starknet"
+  aptos:
+    - moduleURI: "github.com/smartcontractkit/chainlink-aptos"
+      gitRef: "v0.0.0-20260609211101-71d38bd6a0a9"
+      installPath: "./cmd/chainlink-aptos"
+  tagged:
+    - moduleURI: "github.com/example/repo"
+      gitRef: "v1.2.3"
+  prefixed:
+    - moduleURI: "github.com/example/repo/sub"
+      gitRef: "sub/v1.2.3"
+`
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	t.Run("plain tag", func(t *testing.T) {
+		mv := normalizeVersion("v1.2.3")
+		if mv.Tag != "v1.2.3" || mv.SHA != "" || mv.TagPrefix != "" {
+			t.Fatalf("unexpected mv: %+v", mv)
+		}
+	})
+
+	t.Run("prefixed tag", func(t *testing.T) {
+		mv := normalizeVersion("sub/dir/v1.2.3")
+		if mv.Tag != "v1.2.3" || mv.TagPrefix != "sub/dir" || mv.SHA != "" {
+			t.Fatalf("unexpected mv: %+v", mv)
+		}
+	})
+
+	t.Run("pseudo with sha", func(t *testing.T) {
+		valids := []struct {
+			in   string
+			want string
+		}{
+			{"v0.0.0-20260609211101-71d38bd6a0a9", "71d38bd6a0a9"},
+			{"v1.3.1-0.20260605202330-b5a89c32fdc1", "b5a89c32fdc1"},
+			{"v1.2.3-0.20250102030405-abcdef123456", "abcdef123456"},
+		}
+		for _, tc := range valids {
+			mv := normalizeVersion(tc.in)
+			if mv.SHA != tc.want {
+				t.Fatalf("normalizeVersion(%q).SHA = %q, want %q", tc.in, mv.SHA, tc.want)
+			}
+		}
+	})
+
+	t.Run("raw sha", func(t *testing.T) {
+		const sha = "73cd3d46ad0ce2871160369cb6447aeb9b48513f"
+		mv := normalizeVersion(sha)
+		if mv.SHA != sha {
+			t.Fatalf("unexpected mv: %+v", mv)
+		}
+	})
+}
+
+func TestCommitRefForGitRef(t *testing.T) {
+	cases := []struct {
+		gitRef string
+		want   string
+	}{
+		{"v1.3.1-0.20260605202330-b5a89c32fdc1", "b5a89c32fdc1"},
+		{"v0.0.0-20260609211101-71d38bd6a0a9", "71d38bd6a0a9"},
+		{"73cd3d46ad0ce2871160369cb6447aeb9b48513f", "73cd3d46ad0ce2871160369cb6447aeb9b48513f"},
+		{"v1.2.3", "v1.2.3"},
+		{"sub/v1.2.3", "sub/v1.2.3"},
+	}
+
+	for _, tc := range cases {
+		got, err := commitRefForGitRef(tc.gitRef)
+		if err != nil {
+			t.Fatalf("commitRefForGitRef(%q): %v", tc.gitRef, err)
+		}
+		if got != tc.want {
+			t.Fatalf("commitRefForGitRef(%q) = %q, want %q", tc.gitRef, got, tc.want)
+		}
+	}
+}
+
+func TestCommitRefForGitRefErrors(t *testing.T) {
+	if _, err := commitRefForGitRef(""); err == nil {
+		t.Fatal("expected error for empty gitRef")
+	}
+}
+
+func TestGitRefForPlugin(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "plugins.yaml", samplePluginsYAML())
+
+	cases := map[string]string{
+		"solana":   "v1.3.1-0.20260605202330-b5a89c32fdc1",
+		"starknet": "73cd3d46ad0ce2871160369cb6447aeb9b48513f",
+		"aptos":    "v0.0.0-20260609211101-71d38bd6a0a9",
+		"tagged":   "v1.2.3",
+		"prefixed": "sub/v1.2.3",
+	}
+
+	for name, want := range cases {
+		got, err := gitRefForPlugin(path, name)
+		if err != nil {
+			t.Fatalf("gitRefForPlugin(%q): %v", name, err)
+		}
+		if got != want {
+			t.Fatalf("gitRefForPlugin(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestGitRefForPluginErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "plugins.yaml", samplePluginsYAML())
+
+	if _, err := gitRefForPlugin(path, "missing"); err == nil {
+		t.Fatal("expected error for missing plugin")
+	}
+
+	emptyPath := writeFile(t, dir, "empty.yaml", `plugins: {}`)
+	if _, err := gitRefForPlugin(emptyPath, "solana"); err == nil {
+		t.Fatal("expected error for unknown plugin in empty file")
+	}
+
+	noRefPath := writeFile(t, dir, "noref.yaml", `plugins:
+  solana:
+    - moduleURI: "github.com/smartcontractkit/chainlink-solana"
+`)
+	if _, err := gitRefForPlugin(noRefPath, "solana"); err == nil {
+		t.Fatal("expected error for plugin without gitRef")
+	}
+}


### PR DESCRIPTION
Given following content of 
[plugins/plugins.public.yaml](https://github.com/smartcontractkit/chainlink/blob/develop/plugins/plugins.public.yaml#L36-L39):
```
  solana:
    - moduleURI: "github.com/smartcontractkit/chainlink-solana"
      gitRef: "v1.3.1-0.20260605202330-b5a89c32fdc1"
      installPath: "./pkg/solana/cmd/chainlink-solana"
```

When tested on local manually:
```
➜  chainlink git:(extract-solana-sha-from-plugins-unblock-mq) go run ./tools/pluginref/ --plugin-file ./plugins/plugins.public.yaml --plugin solana
b5a89c32fdc1
```