### PR TITLE
CRE-3260: fix flaky TestWSServer_WSClient_DefaultConfig_Failure

### DIFF
--- a/core/services/gateway/network/wsserver_test.go
+++ b/core/services/gateway/network/wsserver_test.go
@@ -149,7 +149,7 @@ func TestWSServer_WSClient_DefaultConfig_Failure(t *testing.T) {
 	// whether the client finishes flushing the message before the server closes
 	// the socket. Both outcomes are valid: the behavior under test is that the
 	// server aborts the handshake, which we assert below via waitCh.
-	_, _ = client.Connect(testutils.Context(t), parsedURL)
+	_, _ = client.Connect(t.Context(), parsedURL)
 
 	select {
 	case <-waitCh:

--- a/core/services/gateway/network/wsserver_test.go
+++ b/core/services/gateway/network/wsserver_test.go
@@ -9,12 +9,11 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/smartcontractkit/quarantine"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
@@ -123,7 +122,6 @@ func TestWSServer_WSClient_DefaultConfig_Success(t *testing.T) {
 }
 
 func TestWSServer_WSClient_DefaultConfig_Failure(t *testing.T) {
-	quarantine.Flaky(t, "DX-1752")
 	t.Parallel()
 	_, acceptor, urlStr := startNewWSServer(t, 10_000)
 
@@ -143,9 +141,20 @@ func TestWSServer_WSClient_DefaultConfig_Failure(t *testing.T) {
 	urlStr = strings.Replace(urlStr, "http", "ws", 1)
 	parsedURL, err := url.Parse(urlStr)
 	require.NoError(t, err)
-	conn, err := client.Connect(testutils.Context(t), parsedURL)
-	require.NoError(t, err)
-	require.NotNil(t, conn)
 
-	<-waitCh
+	// The challenge response (20000 bytes) exceeds the server's MaxRequestBytes
+	// (10000), so the server aborts the handshake and closes the connection.
+	// Connect may either return successfully or fail while writing the oversized
+	// response (e.g. "broken pipe" / "connection reset by peer"), depending on
+	// whether the client finishes flushing the message before the server closes
+	// the socket. Both outcomes are valid: the behavior under test is that the
+	// server aborts the handshake, which we assert below via waitCh.
+	_, _ = client.Connect(testutils.Context(t), parsedURL)
+
+	select {
+	case <-waitCh:
+		// Server aborted the handshake as expected.
+	case <-time.After(testutils.WaitTimeout(t)):
+		t.Fatal("timed out waiting for the server to abort the handshake")
+	}
 }


### PR DESCRIPTION
## JIRA
https://smartcontract-it.atlassian.net/browse/CRE-3260

## Problem
`TestWSServer_WSClient_DefaultConfig_Failure` (`core/services/gateway/network/wsserver_test.go`) was intermittently failing (~1% on `develop`), flapping flaky↔healthy for months.

This is a **test bug, not a production bug**. The test sends a 20,000-byte challenge response that deliberately exceeds the server's `MaxRequestBytes` (10,000). The server behaves correctly: it detects `websocket: read limit exceeded`, calls `AbortHandshake`, and closes the connection.

The flake is on the **client side**. Depending on goroutine scheduling, the server can close the socket before the client finishes flushing the oversized response, so `conn.WriteMessage` returns `write: broken pipe` / `connection reset by peer`. `client.Connect` then returns that error and the old `require.NoError(t, err)` failed. Whether the client's write wins the race against the server's close is non-deterministic and irrelevant to the behavior under test.

Reproduced locally under CPU contention:
```
WebSocketClient: couldn't send challenge response  err="write tcp ...: write: broken pipe"
wsserver_test.go: Received unexpected error: ...broken pipe
```

## Fix (test-only)
- Tolerate either `Connect` outcome (write may succeed, or fail because the server already closed) — both are valid.
- Assert the actual behavior under test: the server calls `AbortHandshake`, observed via `waitCh`, now wrapped in a `select` with `testutils.WaitTimeout(t)` so a genuine regression fails fast instead of hanging.
- Removed the `quarantine.Flaky(t, "DX-1752")` marker (and the now-unused import) so the test runs in CI again now that the root cause is fixed.

No production code changed.

## Verification
- Reproduced the original flake first: 2/60, then 1/120 failures under heavy contention, with the `broken pipe` / `connection reset` error confirming the mechanism.
- After the fix: **0 failures of the target test across 600 contended `-race` runs**, plus **50/50 consecutive verbose passes** under contention with `-race`. Full package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)