### PR TITLE
fix(utils): avoid int64 overflow for uint and uint64 in ToDecimal

### DIFF
--- a/core/utils/decimal.go
+++ b/core/utils/decimal.go
@@ -27,7 +27,7 @@ func ToDecimal(input any) (decimal.Decimal, error) {
 	case int64:
 		return decimal.New(v, 0), nil
 	case uint:
-		return decimal.New(int64(v), 0), nil
+		return decimal.NewFromUint64(uint64(v)), nil
 	case uint8:
 		return decimal.New(int64(v), 0), nil
 	case uint16:
@@ -35,7 +35,7 @@ func ToDecimal(input any) (decimal.Decimal, error) {
 	case uint32:
 		return decimal.New(int64(v), 0), nil
 	case uint64:
-		return decimal.New(int64(v), 0), nil
+		return decimal.NewFromUint64(v), nil
 	case float64:
 		if !validFloat(v) {
 			return decimal.Decimal{}, errors.Errorf("invalid float %v, cannot convert to decimal", v)

--- a/core/utils/decimal_test.go
+++ b/core/utils/decimal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDecimal(t *testing.T) {
@@ -55,4 +56,18 @@ func TestDecimal(t *testing.T) {
 			assert.NoError(t, err)
 		}
 	}
+}
+
+func TestDecimalUint64NoOverflow(t *testing.T) {
+	t.Parallel()
+
+	// Values above math.MaxInt64 were silently corrupted: int64(math.MaxUint64) == -1.
+	want, _ := decimal.NewFromString("18446744073709551615") // math.MaxUint64
+	got, err := ToDecimal(uint64(math.MaxUint64))
+	require.NoError(t, err)
+	assert.True(t, got.Equal(want), "uint64(MaxUint64): got %s, want %s", got, want)
+
+	got, err = ToDecimal(uint(math.MaxUint64))
+	require.NoError(t, err)
+	assert.True(t, got.Equal(want), "uint(MaxUint64): got %s, want %s", got, want)
 }


### PR DESCRIPTION
## Summary

`ToDecimal` converts `uint` and `uint64` inputs via `decimal.New(int64(v), 0)`.
On 64-bit systems, values above `math.MaxInt64` (9.2×10¹⁸) overflow silently:

```go
int64(math.MaxUint64) == -1   // wraps to negative
```

Any pipeline or OCR job that feeds a large unsigned integer through `ToDecimal`
will receive a wrong negative decimal without any error.

## Fix

Switch `uint` and `uint64` to `decimal.NewFromUint64`, available since
`shopspring/decimal` v1.3.1 (chainlink already uses v1.4.0).
`uint8`, `uint16`, `uint32` are unaffected — their maximums fit in int64.

## Test

Added `TestDecimalUint64NoOverflow` which asserts the exact decimal value of
`uint64(math.MaxUint64)` and `uint(math.MaxUint64)` rather than just checking
that no error is returned.