### PR TITLE
Bump version in package.json to 2.52.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.51.3",
+  "version": "2.52.0",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump `package.json` version from `2.51.3` to `2.52.0` only.
- Branch cut from `v2.51.3-rc.0` (same code as RC; metadata version bump for DON version lock / roll-forward).

## Context
- Follows [#22867](https://github.com/smartcontractkit/chainlink/pull/22867) pattern on `release/2.51.3`.
- DF1 Starknet v0.14.3 rollout — new node version required when DON cannot roll back image.
- Prerequisite for `release-pre` beta/RC (`is-hotfix=false`).

## Test plan
- [ ] Merge when checks acceptable (same bar as [#22867](https://github.com/smartcontractkit/chainlink/pull/22867))
- [ ] Run `release-pre` from `release/2.51.3` after merge