### PR TITLE
fix(ci): require both docker manifests before Slack notify

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -223,8 +223,8 @@ jobs:
   slack-notify:
     permissions:
       contents: read
-    if: always() && (needs.docker-core.result == 'success' ||
-      needs.docker-ccip.result == 'success')
+    if: always() && needs.docker-core.result == 'success' &&
+      needs.docker-ccip.result == 'success'
     needs: [checks, docker-core, docker-ccip]
     uses: ./.github/workflows/release-notifications.yml
     secrets: inherit


### PR DESCRIPTION
## Summary
- Tighten `slack-notify` in `build-publish.yml` so it runs only when **both** `docker-core` and `docker-ccip` manifest jobs succeed
- Prevents incomplete Slack announcements when one manifest flakes and the other succeeds (seen on canary `v2.990.5-beta.0` and public chainlink runs)

**Jira:** [RANE-4695](https://smartcontract-it.atlassian.net/browse/RANE-4695) (private release improvements). Complements [RANE-4683](https://smartcontract-it.atlassian.net/browse/RANE-4683) manifest hardening but is intentionally a separate, chainlink-only change.

## Context
Manifest jobs can fail intermittently on `cosign verify` ("no signatures found") while the other image publishes successfully. The previous `if` used OR logic, so Slack still posted with only one image line.

## Test plan
- [ ] Merge and verify next tag build posts both chainlink + ccip image lines, or no Slack post if either manifest fails
- [ ] Confirm `trigger-post-build-publish` still gates on `docker-core` only (unchanged)

Related: smartcontractkit/.github#1577 (cosign verify retry — addresses root flake in shared action)

[RANE-4695]: https://smartcontract-it.atlassian.net/browse/RANE-4695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RANE-4683]: https://smartcontract-it.atlassian.net/browse/RANE-4683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ