### PR TITLE
chore: implement local NewContractMetadata state view helper

### DIFF
--- a/deployment/ccip/view/v1_0/link_token.go
+++ b/deployment/ccip/view/v1_0/link_token.go
@@ -7,15 +7,15 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	linkcontracts "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/contracts/link"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/link_token"
+
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type LinkTokenView struct {
-	cldfutil.ContractMetaData
+	view.ContractMetaData
 	Decimals uint8            `json:"decimals"`
 	Supply   *big.Int         `json:"supply"`
 	Minters  []common.Address `json:"minters"`
@@ -45,7 +45,7 @@ func GenerateLinkTokenView(lt *link_token.LinkToken) (LinkTokenView, error) {
 	}
 
 	return LinkTokenView{
-		ContractMetaData: cldfutil.ContractMetaData{
+		ContractMetaData: view.ContractMetaData{
 			TypeAndVersion: cldf.TypeAndVersion{
 				Type:    linkcontracts.LinkToken,
 				Version: *semver.MustParse("1.0.0"),

--- a/deployment/ccip/view/v1_0/mcms.go
+++ b/deployment/ccip/view/v1_0/mcms.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
-	"github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type Role struct {
@@ -56,7 +56,7 @@ var (
 // --- evm ---
 
 type MCMSView struct {
-	cldfutil.ContractMetaData
+	view.ContractMetaData
 	// Note config is json marshallable.
 	Config mcmstypes.Config `json:"config"`
 }
@@ -91,7 +91,7 @@ func GenerateMCMSView(mcms owner_helpers.ManyChainMultiSig) (MCMSView, error) {
 
 	return MCMSView{
 		// Has no type and version on the contract
-		ContractMetaData: cldfutil.ContractMetaData{
+		ContractMetaData: view.ContractMetaData{
 			Owner:   owner,
 			Address: mcms.Address(),
 		},
@@ -100,7 +100,7 @@ func GenerateMCMSView(mcms owner_helpers.ManyChainMultiSig) (MCMSView, error) {
 }
 
 type TimelockView struct {
-	cldfutil.ContractMetaData
+	view.ContractMetaData
 	MembersByRole map[string][]common.Address `json:"membersByRole"`
 }
 
@@ -123,7 +123,7 @@ func GenerateTimelockView(tl owner_helpers.RBACTimelock) (TimelockView, error) {
 
 	return TimelockView{
 		// Has no type and version or owner.
-		ContractMetaData: cldfutil.ContractMetaData{
+		ContractMetaData: view.ContractMetaData{
 			Address: tl.Address(),
 		},
 		MembersByRole: membersByRole,
@@ -131,12 +131,12 @@ func GenerateTimelockView(tl owner_helpers.RBACTimelock) (TimelockView, error) {
 }
 
 type CallProxyView struct {
-	cldfutil.ContractMetaData
+	view.ContractMetaData
 }
 
 func GenerateCallProxyView(cp owner_helpers.CallProxy) (CallProxyView, error) {
 	return CallProxyView{
-		ContractMetaData: cldfutil.ContractMetaData{
+		ContractMetaData: view.ContractMetaData{
 			Address: cp.Address(),
 		},
 	}, nil

--- a/deployment/ccip/view/v1_0/rmn_proxy_contract.go
+++ b/deployment/ccip/view/v1_0/rmn_proxy_contract.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_0_0/rmn_proxy_contract"
+
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type RMNProxyView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	RMN common.Address `json:"rmn"`
 }
 
@@ -20,7 +20,7 @@ func GenerateRMNProxyView(r *rmn_proxy_contract.RMNProxy) (RMNProxyView, error) 
 	if r == nil {
 		return RMNProxyView{}, errors.New("cannot generate view for nil RMNProxy")
 	}
-	meta, err := commoncldchangesets.NewContractMetaData(r, r.Address())
+	meta, err := view.NewContractMetaData(r, r.Address())
 	if err != nil {
 		return RMNProxyView{}, fmt.Errorf("failed to generate contract metadata for RMNProxy: %w", err)
 	}

--- a/deployment/ccip/view/v1_0/static_link_token.go
+++ b/deployment/ccip/view/v1_0/static_link_token.go
@@ -6,15 +6,15 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 
-	"github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	linkcontracts "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/contracts/link"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/link_token_interface"
+
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type StaticLinkTokenView struct {
-	cldfutil.ContractMetaData
+	view.ContractMetaData
 	Decimals uint8    `json:"decimals"`
 	Supply   *big.Int `json:"supply"`
 }
@@ -30,7 +30,7 @@ func GenerateStaticLinkTokenView(lt *link_token_interface.LinkToken) (StaticLink
 	}
 
 	return StaticLinkTokenView{
-		ContractMetaData: cldfutil.ContractMetaData{
+		ContractMetaData: view.ContractMetaData{
 			TypeAndVersion: cldf.TypeAndVersion{
 				Type:    linkcontracts.StaticLinkToken,
 				Version: *semver.MustParse("1.0.0"),

--- a/deployment/ccip/view/v1_2/price_registry.go
+++ b/deployment/ccip/view/v1_2/price_registry.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 
 	price_registry_1_2_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/price_registry"
 )
 
 type PriceRegistryView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	FeeTokens          []common.Address `json:"feeTokens"`
 	StalenessThreshold string           `json:"stalenessThreshold"`
 	Updaters           []common.Address `json:"updaters"`
@@ -22,7 +22,7 @@ func GeneratePriceRegistryView(pr *price_registry_1_2_0.PriceRegistry) (PriceReg
 	if pr == nil {
 		return PriceRegistryView{}, errors.New("cannot generate view for nil PriceRegistry")
 	}
-	meta, err := commoncldchangesets.NewContractMetaData(pr, pr.Address())
+	meta, err := view.NewContractMetaData(pr, pr.Address())
 	if err != nil {
 		return PriceRegistryView{}, fmt.Errorf("failed to generate contract metadata for PriceRegistry %s: %w", pr.Address(), err)
 	}

--- a/deployment/ccip/view/v1_2/router.go
+++ b/deployment/ccip/view/v1_2/router.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 )
 
 type RouterView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	IsTestRouter  bool                        `json:"isTestRouter"`
 	WrappedNative common.Address              `json:"wrappedNative,omitempty"`
 	ARMProxy      common.Address              `json:"armProxy,omitempty"`
@@ -20,7 +20,7 @@ type RouterView struct {
 }
 
 func GenerateRouterView(r *router.Router, isTestRouter bool) (RouterView, error) {
-	meta, err := commoncldchangesets.NewContractMetaData(r, r.Address())
+	meta, err := view.NewContractMetaData(r, r.Address())
 	if err != nil {
 		return RouterView{}, fmt.Errorf("view error to get router metadata: %w", err)
 	}

--- a/deployment/ccip/view/v1_5/commit_store.go
+++ b/deployment/ccip/view/v1_5/commit_store.go
@@ -3,13 +3,13 @@ package v1_5
 import (
 	"github.com/ethereum/go-ethereum/common"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/commit_store"
 )
 
 type CommitStoreView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	DynamicConfig              commit_store.CommitStoreDynamicConfig   `json:"dynamicConfig"`
 	ExpectedNextSequenceNumber uint64                                  `json:"expectedNextSequenceNumber"`
 	LatestPriceEpochAndRound   uint64                                  `json:"latestPriceEpochAndRound"`

--- a/deployment/ccip/view/v1_5/offramp.go
+++ b/deployment/ccip/view/v1_5/offramp.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"fmt"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_offramp"
 )
 
 type OffRampView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	StaticConfig  evm_2_evm_offramp.EVM2EVMOffRampStaticConfig  `json:"staticConfig"`
 	DynamicConfig evm_2_evm_offramp.EVM2EVMOffRampDynamicConfig `json:"dynamicConfig"`
 }
@@ -19,7 +19,7 @@ func GenerateOffRampView(r *evm_2_evm_offramp.EVM2EVMOffRamp) (OffRampView, erro
 	if r == nil {
 		return OffRampView{}, errors.New("cannot generate view for nil OffRamp")
 	}
-	meta, err := commoncldchangesets.NewContractMetaData(r, r.Address())
+	meta, err := view.NewContractMetaData(r, r.Address())
 	if err != nil {
 		return OffRampView{}, fmt.Errorf("failed to generate contract metadata for OffRamp %s: %w", r.Address(), err)
 	}

--- a/deployment/ccip/view/v1_5/onramp.go
+++ b/deployment/ccip/view/v1_5/onramp.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"fmt"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_onramp"
 )
 
 type OnRampView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	StaticConfig  evm_2_evm_onramp.EVM2EVMOnRampStaticConfig  `json:"staticConfig"`
 	DynamicConfig evm_2_evm_onramp.EVM2EVMOnRampDynamicConfig `json:"dynamicConfig"`
 }
@@ -19,7 +19,7 @@ func GenerateOnRampView(r *evm_2_evm_onramp.EVM2EVMOnRamp) (OnRampView, error) {
 	if r == nil {
 		return OnRampView{}, errors.New("cannot generate view for nil OnRamp")
 	}
-	meta, err := commoncldchangesets.NewContractMetaData(r, r.Address())
+	meta, err := view.NewContractMetaData(r, r.Address())
 	if err != nil {
 		return OnRampView{}, fmt.Errorf("failed to generate contract metadata for OnRamp %s: %w", r.Address(), err)
 	}

--- a/deployment/ccip/view/v1_5/rmn.go
+++ b/deployment/ccip/view/v1_5/rmn.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/rmn_contract"
+
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type RMNView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	ConfigDetails            rmn_contract.GetConfigDetails `json:"configDetails"`
 	PermaBlessedCommitStores []common.Address              `json:"permaBlessedCommitStores"`
 }
@@ -20,7 +21,7 @@ func GenerateRMNView(r *rmn_contract.RMNContract) (RMNView, error) {
 	if r == nil {
 		return RMNView{}, errors.New("cannot generate view for nil RMN")
 	}
-	meta, err := commoncldchangesets.NewContractMetaData(r, r.Address())
+	meta, err := view.NewContractMetaData(r, r.Address())
 	if err != nil {
 		return RMNView{}, fmt.Errorf("failed to generate contract metadata for RMN: %w", err)
 	}

--- a/deployment/ccip/view/v1_5/token_pool.go
+++ b/deployment/ccip/view/v1_5/token_pool.go
@@ -6,13 +6,12 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/burn_mint_token_pool_and_proxy"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view/shared"
 	v1_5_1 "github.com/smartcontractkit/chainlink/deployment/ccip/view/v1_5_1"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type TokenPoolContract interface {
@@ -109,7 +108,7 @@ func GenerateTokenPoolView(pool TokenPoolContract, priceFeed common.Address) (v1
 	}
 
 	return v1_5_1.TokenPoolView{
-		ContractMetaData: commoncldchangesets.ContractMetaData{
+		ContractMetaData: view.ContractMetaData{
 			TypeAndVersion: typeAndVersion,
 			Address:        pool.Address(),
 			Owner:          owner,

--- a/deployment/ccip/view/v1_5/tokenadminregistry.go
+++ b/deployment/ccip/view/v1_5/tokenadminregistry.go
@@ -8,15 +8,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/sync/errgroup"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view/shared"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type TokenAdminRegistryView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	Tokens map[common.Address]TokenDetails `json:"tokens"`
 }
 
@@ -34,7 +33,7 @@ func GenerateTokenAdminRegistryView(taContract *token_admin_registry.TokenAdminR
 	if err != nil {
 		return TokenAdminRegistryView{}, fmt.Errorf("view error for token admin registry: %w", err)
 	}
-	tvMeta, err := commoncldchangesets.NewContractMetaData(taContract, taContract.Address())
+	tvMeta, err := view.NewContractMetaData(taContract, taContract.Address())
 	if err != nil {
 		return TokenAdminRegistryView{}, fmt.Errorf("metadata error for token admin registry: %w", err)
 	}

--- a/deployment/ccip/view/v1_5_1/token_pool.go
+++ b/deployment/ccip/view/v1_5_1/token_pool.go
@@ -7,8 +7,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/exp/maps"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/burn_from_mint_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/burn_mint_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/burn_with_from_mint_token_pool"
@@ -19,6 +17,7 @@ import (
 	lock_release_token_pool_v1_6_1 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_1/lock_release_token_pool"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view/shared"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type TokenPoolContract interface {
@@ -107,7 +106,7 @@ type PoolView struct {
 }
 
 type TokenPoolView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	Token              common.Address               `json:"token"`
 	TokenPriceFeed     common.Address               `json:"tokenPriceFeed"`
 	RemoteChainConfigs map[uint64]RemoteChainConfig `json:"remoteChainConfigs"`
@@ -191,7 +190,7 @@ func GenerateTokenPoolView(pool TokenPoolContract, priceFeed common.Address) (To
 	}
 
 	return TokenPoolView{
-		ContractMetaData: commoncldchangesets.ContractMetaData{
+		ContractMetaData: view.ContractMetaData{
 			TypeAndVersion: typeAndVersion,
 			Address:        pool.Address(),
 			Owner:          owner,

--- a/deployment/ccip/view/v1_6/ccip_home.go
+++ b/deployment/ccip/view/v1_6/ccip_home.go
@@ -13,14 +13,13 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/ccip_home"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/p2pkey"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 	cciptypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 )
 
@@ -83,7 +82,7 @@ type CCIPHomeVersionedConfig struct {
 }
 
 type CCIPHomeView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	ChainConfigs       []CCIPHomeChainConfigArgView `json:"chainConfigs"`
 	CapabilityRegistry common.Address               `json:"capabilityRegistry"`
 	Dons               []DonView                    `json:"dons"`
@@ -104,7 +103,7 @@ func GenerateCCIPHomeView(cr *capabilities_registry.CapabilitiesRegistry, ch *cc
 	if ch == nil {
 		return CCIPHomeView{}, errors.New("cannot generate view for nil CCIPHome")
 	}
-	meta, err := commoncldchangesets.NewContractMetaData(ch, ch.Address())
+	meta, err := view.NewContractMetaData(ch, ch.Address())
 	if err != nil {
 		return CCIPHomeView{}, fmt.Errorf("failed to generate contract metadata for CCIPHome %s: %w", ch.Address(), err)
 	}

--- a/deployment/ccip/view/v1_6/feequoter.go
+++ b/deployment/ccip/view/v1_6/feequoter.go
@@ -5,16 +5,15 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	router1_2 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_3/fee_quoter"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view/v1_2"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type FeeQuoterView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	AuthorizedCallers                       []string                                 `json:"authorizedCallers,omitempty"`
 	FeeTokensConfig                         []FeeTokenConfig                         `json:"feeTokensConfig,omitempty"`
 	StaticConfig                            FeeQuoterStaticConfig                    `json:"staticConfig"`
@@ -70,7 +69,7 @@ func GenerateFeeQuoterView(fqContract *fee_quoter.FeeQuoter, router, testRouter 
 	for _, ac := range authorizedCallers {
 		fq.AuthorizedCallers = append(fq.AuthorizedCallers, ac.Hex())
 	}
-	fq.ContractMetaData, err = commoncldchangesets.NewContractMetaData(fqContract, fqContract.Address())
+	fq.ContractMetaData, err = view.NewContractMetaData(fqContract, fqContract.Address())
 	if err != nil {
 		return FeeQuoterView{}, fmt.Errorf("metadata error for FeeQuoter: %w", err)
 	}

--- a/deployment/ccip/view/v1_6/noncemanager.go
+++ b/deployment/ccip/view/v1_6/noncemanager.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/nonce_manager"
 )
 
 type NonceManagerView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	AuthorizedCallers []common.Address `json:"authorizedCallers,omitempty"`
 }
 
@@ -20,7 +20,7 @@ func GenerateNonceManagerView(nm *nonce_manager.NonceManager) (NonceManagerView,
 	if err != nil {
 		return NonceManagerView{}, fmt.Errorf("view error for nonce manager: %w", err)
 	}
-	nmMeta, err := commoncldchangesets.NewContractMetaData(nm, nm.Address())
+	nmMeta, err := view.NewContractMetaData(nm, nm.Address())
 	if err != nil {
 		return NonceManagerView{}, fmt.Errorf("metadata error for nonce manager: %w", err)
 	}

--- a/deployment/ccip/view/v1_6/offramp.go
+++ b/deployment/ccip/view/v1_6/offramp.go
@@ -8,14 +8,13 @@ import (
 	router1_2 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view/v1_2"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type OffRampView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	DynamicConfig                       offramp.OffRampDynamicConfig        `json:"dynamicConfig"`
 	SourceChainConfigs                  map[uint64]OffRampSourceChainConfig `json:"sourceChainConfigs"`
 	SourceChainConfigsBasedOnTestRouter map[uint64]OffRampSourceChainConfig `json:"sourceChainConfigsBasedOnTestRouter"`
@@ -33,7 +32,7 @@ func GenerateOffRampView(
 	offRampContract offramp.OffRampInterface,
 	routerContract, testRouterContract *router1_2.Router,
 ) (OffRampView, error) {
-	tv, err := commoncldchangesets.NewContractMetaData(offRampContract, offRampContract.Address())
+	tv, err := view.NewContractMetaData(offRampContract, offRampContract.Address())
 	if err != nil {
 		return OffRampView{}, err
 	}

--- a/deployment/ccip/view/v1_6/onramp.go
+++ b/deployment/ccip/view/v1_6/onramp.go
@@ -10,13 +10,12 @@ import (
 	router1_2 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/onramp"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view/v1_2"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type OnRampView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	DynamicConfig                          onramp.OnRampDynamicConfig       `json:"dynamicConfig"`
 	StaticConfig                           onramp.OnRampStaticConfig        `json:"staticConfig"`
 	DestChainSpecificData                  map[uint64]DestChainSpecificData `json:"destChainSpecificData"`
@@ -33,7 +32,7 @@ func GenerateOnRampView(
 	routerContract, testRouterContract *router1_2.Router,
 	taContract *token_admin_registry.TokenAdminRegistry,
 ) (OnRampView, error) {
-	tv, err := commoncldchangesets.NewContractMetaData(onRampContract, onRampContract.Address())
+	tv, err := view.NewContractMetaData(onRampContract, onRampContract.Address())
 	if err != nil {
 		return OnRampView{}, fmt.Errorf("failed to get contract metadata: %w", err)
 	}

--- a/deployment/ccip/view/v1_6/rmnhome.go
+++ b/deployment/ccip/view/v1_6/rmnhome.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_home"
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/p2pkey"
 )
 
 type RMNHomeView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	CandidateConfig *RMNHomeVersionedConfig `json:"candidateConfig,omitempty"`
 	ActiveConfig    *RMNHomeVersionedConfig `json:"activeConfig,omitempty"`
 }
@@ -164,7 +164,7 @@ func GenerateRMNHomeView(rmnReader *rmn_home.RMNHome) (RMNHomeView, error) {
 		return RMNHomeView{}, fmt.Errorf("failed to generate candidate config for contract %s: %w", address, err)
 	}
 
-	contractMetaData, err := commoncldchangesets.NewContractMetaData(rmnReader, rmnReader.Address())
+	contractMetaData, err := view.NewContractMetaData(rmnReader, rmnReader.Address())
 	if err != nil {
 		return RMNHomeView{}, fmt.Errorf("failed to create contract metadata for contract %s: %w", address, err)
 	}

--- a/deployment/ccip/view/v1_6/rmnremote.go
+++ b/deployment/ccip/view/v1_6/rmnremote.go
@@ -5,11 +5,10 @@ import (
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type RMNRemoteCurseEntry struct {
@@ -18,7 +17,7 @@ type RMNRemoteCurseEntry struct {
 }
 
 type RMNRemoteView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	IsCursed             bool                     `json:"isCursed"`
 	Config               RMNRemoteVersionedConfig `json:"config"`
 	CursedSubjectEntries []RMNRemoteCurseEntry    `json:"cursedSubjectEntries,omitempty"`
@@ -47,7 +46,7 @@ func mapCurseSubjects(subjects [][16]byte, family string) []RMNRemoteCurseEntry 
 }
 
 func GenerateRMNRemoteView(rmnReader *rmn_remote.RMNRemote) (RMNRemoteView, error) {
-	tv, err := commoncldchangesets.NewContractMetaData(rmnReader, rmnReader.Address())
+	tv, err := view.NewContractMetaData(rmnReader, rmnReader.Address())
 	if err != nil {
 		return RMNRemoteView{}, err
 	}

--- a/deployment/common/view/v1_0/capreg.go
+++ b/deployment/common/view/v1_0/capreg.go
@@ -10,15 +10,15 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/p2pkey"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
+
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 // CapabilityRegistryView is a high-fidelity view of the capabilities registry contract.
 type CapabilityRegistryView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	Capabilities []CapabilityView `json:"capabilities,omitempty"`
 	Nodes        []NodeView       `json:"nodes,omitempty"`
 	Nops         []NopView        `json:"nops,omitempty"`
@@ -30,7 +30,7 @@ type CapabilityRegistryView struct {
 func (v *CapabilityRegistryView) MarshalJSON() ([]byte, error) {
 	// Alias to avoid recursive calls
 	type Alias struct {
-		commoncldchangesets.ContractMetaData
+		view.ContractMetaData
 		Capabilities    []CapabilityView      `json:"capabilities,omitempty"`
 		Nodes           []NodeView            `json:"nodes,omitempty"`
 		Nops            []NopView             `json:"nops,omitempty"`
@@ -57,7 +57,7 @@ func (v *CapabilityRegistryView) MarshalJSON() ([]byte, error) {
 func (v *CapabilityRegistryView) UnmarshalJSON(data []byte) error {
 	// Alias to avoid recursive calls
 	type Alias struct {
-		commoncldchangesets.ContractMetaData
+		view.ContractMetaData
 		Capabilities    []CapabilityView      `json:"capabilities,omitempty"`
 		Nodes           []NodeView            `json:"nodes,omitempty"`
 		Nops            []NopView             `json:"nops,omitempty"`
@@ -84,7 +84,7 @@ func (v *CapabilityRegistryView) UnmarshalJSON(data []byte) error {
 
 // GenerateCapabilityRegistryView generates a CapRegView from a CapabilitiesRegistry contract.
 func GenerateCapabilityRegistryView(capReg *capabilities_registry.CapabilitiesRegistry) (CapabilityRegistryView, error) {
-	tv, err := commoncldchangesets.NewContractMetaData(capReg, capReg.Address())
+	tv, err := view.NewContractMetaData(capReg, capReg.Address())
 	if err != nil {
 		return CapabilityRegistryView{}, err
 	}

--- a/deployment/common/view/v1_0/capreg_test.go
+++ b/deployment/common/view/v1_0/capreg_test.go
@@ -6,14 +6,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	cr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 func TestCapRegView_Denormalize(t *testing.T) {
 	type fields struct {
-		ContractMetaData commoncldchangesets.ContractMetaData
+		ContractMetaData view.ContractMetaData
 		Capabilities     []CapabilityView
 		Nodes            []NodeView
 		Dons             []DonView

--- a/deployment/common/view/v1_0/workflowreg.go
+++ b/deployment/common/view/v1_0/workflowreg.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 
 	workflow_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper_v1"
 )
@@ -23,7 +23,7 @@ const (
 
 // WorkflowRegistryView is a high-fidelity view of the workflow registry contract.
 type WorkflowRegistryView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	Workflows           []WorkflowView   `json:"workflows,omitempty"`
 	AuthorizedAddresses []common.Address `json:"authorized_addresses,omitempty"`
 	AllowedDONs         []uint32         `json:"allowed_dons,omitempty"`
@@ -112,7 +112,7 @@ func GenerateWorkflowRegistryView(wr workflow_registry.WorkflowRegistryInterface
 	var errs []error
 
 	// 1) Build up basic contract metadata.
-	md, err := commoncldchangesets.NewContractMetaData(wr, wr.Address())
+	md, err := view.NewContractMetaData(wr, wr.Address())
 	if err != nil {
 		errs = append(errs, &WorkflowRegistryError{
 			Operation: "failed to build WorkflowRegistry ContractMetaData",

--- a/deployment/common/view/v2_0/capreg.go
+++ b/deployment/common/view/v2_0/capreg.go
@@ -13,18 +13,16 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
+	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/p2pkey"
+	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/capabilities_registry_wrapper_v2"
 
 	"github.com/smartcontractkit/chainlink/deployment/cre/capabilities_registry/v2/changeset/pkg"
 	creocr3 "github.com/smartcontractkit/chainlink/deployment/cre/ocr3"
-
-	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/capabilities_registry_wrapper_v2"
-
-	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/p2pkey"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type CapabilityRegistryViewV2 struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	Capabilities []CapabilityView `json:"capabilities,omitempty"`
 	Nodes        []NodeView       `json:"nodes,omitempty"`
 	Nops         []NopView        `json:"nops,omitempty"`
@@ -33,7 +31,7 @@ type CapabilityRegistryViewV2 struct {
 
 // CapabilityRegistryView is a high-fidelity view of the capabilities registry contract.
 type CapabilityRegistryView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 	Capabilities []CapabilityView `json:"capabilities,omitempty"`
 	Nodes        []NodeView       `json:"nodes,omitempty"`
 	Nops         []NopView        `json:"nops,omitempty"`
@@ -45,7 +43,7 @@ type CapabilityRegistryView struct {
 func (v *CapabilityRegistryView) MarshalJSON() ([]byte, error) {
 	// Alias to avoid recursive calls
 	type Alias struct {
-		commoncldchangesets.ContractMetaData
+		view.ContractMetaData
 		Capabilities    []CapabilityView      `json:"capabilities,omitempty"`
 		Nodes           []NodeView            `json:"nodes,omitempty"`
 		Nops            []NopView             `json:"nops,omitempty"`
@@ -72,7 +70,7 @@ func (v *CapabilityRegistryView) MarshalJSON() ([]byte, error) {
 func (v *CapabilityRegistryView) UnmarshalJSON(data []byte) error {
 	// Alias to avoid recursive calls
 	type Alias struct {
-		commoncldchangesets.ContractMetaData
+		view.ContractMetaData
 		Capabilities    []CapabilityView      `json:"capabilities,omitempty"`
 		Nodes           []NodeView            `json:"nodes,omitempty"`
 		Nops            []NopView             `json:"nops,omitempty"`
@@ -139,7 +137,7 @@ func (e *ExtendedCapabilityRegistry) GetDONsSimple(opts *bind.CallOpts) ([]capab
 
 // GenerateCapabilityRegistryView generates a CapRegView from a CapabilitiesRegistry contract.
 func GenerateCapabilityRegistryView(capReg *ExtendedCapabilityRegistry) (CapabilityRegistryView, error) {
-	tv, err := commoncldchangesets.NewContractMetaData(capReg, capReg.Address())
+	tv, err := view.NewContractMetaData(capReg, capReg.Address())
 	if err != nil {
 		return CapabilityRegistryView{}, err
 	}

--- a/deployment/common/view/v2_0/capreg_test.go
+++ b/deployment/common/view/v2_0/capreg_test.go
@@ -8,16 +8,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	cr "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/capabilities_registry_wrapper_v2"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/view/v2_0"
 	"github.com/smartcontractkit/chainlink/deployment/cre/capabilities_registry/v2/changeset/pkg"
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type fields struct {
-	ContractMetaData commoncldchangesets.ContractMetaData
+	ContractMetaData view.ContractMetaData
 	Capabilities     []v2_0.CapabilityView
 	Nodes            []v2_0.NodeView
 	Dons             []v2_0.DonView

--- a/deployment/data-feeds/view/v1_0/cache_contract.go
+++ b/deployment/data-feeds/view/v1_0/cache_contract.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"fmt"
 
-	commoncldchangesets "github.com/smartcontractkit/cld-changesets/pkg/cldfutil"
-
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
+
+	"github.com/smartcontractkit/chainlink/deployment/internal/view"
 )
 
 type CacheView struct {
-	commoncldchangesets.ContractMetaData
+	view.ContractMetaData
 }
 
 // GenerateDataFeedsCacheView generates a CacheView from a DataFeedsCache contract.
@@ -18,7 +18,7 @@ func GenerateDataFeedsCacheView(cache *cache.DataFeedsCache) (CacheView, error) 
 	if cache == nil {
 		return CacheView{}, errors.New("cannot generate view for nil DataFeedsCache")
 	}
-	meta, err := commoncldchangesets.NewContractMetaData(cache, cache.Address())
+	meta, err := view.NewContractMetaData(cache, cache.Address())
 	if err != nil {
 		return CacheView{}, fmt.Errorf("failed to generate contract metadata for DataFeedsCache: %w", err)
 	}

--- a/deployment/internal/view/contract.go
+++ b/deployment/internal/view/contract.go
@@ -1,0 +1,36 @@
+package view
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type ContractMetaData struct {
+	TypeAndVersion string         `json:"typeAndVersion,omitempty"`
+	Address        common.Address `json:"address,omitempty"`
+	Owner          common.Address `json:"owner,omitempty"`
+}
+
+func NewContractMetaData(tv Meta, addr common.Address) (ContractMetaData, error) {
+	tvStr, err := tv.TypeAndVersion(nil)
+	if err != nil {
+		return ContractMetaData{}, fmt.Errorf("failed to get type and version addr %s: %w", addr.String(), err)
+	}
+	owner, err := tv.Owner(nil)
+	if err != nil {
+		return ContractMetaData{}, fmt.Errorf("failed to get owner addr %s: %w", addr.String(), err)
+	}
+
+	return ContractMetaData{
+		TypeAndVersion: tvStr,
+		Address:        addr,
+		Owner:          owner,
+	}, nil
+}
+
+type Meta interface {
+	TypeAndVersion(opts *bind.CallOpts) (string, error)
+	Owner(opts *bind.CallOpts) (common.Address, error)
+}


### PR DESCRIPTION
This helper replaces the imported NewContractMetadata from `cld-changesets`. These are only used for state views within this repo, so we should implement this locally.

