### PR TITLE
Fix semaphore usage in don2don server req

### DIFF
--- a/core/capabilities/remote/executable/request/server_request.go
+++ b/core/capabilities/remote/executable/request/server_request.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
-
-	"slices"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -133,13 +132,19 @@ type ServerRequest struct {
 	mux  sync.Mutex
 	lggr logger.Logger
 
-	metrics *srMetrics
+	metrics          *srMetrics
+	parallelExecutor ParallelExecutor
+}
+
+type ParallelExecutor interface {
+	ExecuteTask(ctx context.Context, fn func(ctx context.Context)) error
 }
 
 func NewServerRequest(capability capabilities.ExecutableCapability, method string, capabilityID string, capabilityDonID uint32,
 	capabilityPeerID p2ptypes.PeerID,
 	callingDon capabilities.DON, requestID string,
-	dispatcher types.Dispatcher, requestTimeout time.Duration, capMethodName string, lggr logger.Logger) (*ServerRequest, error) {
+	dispatcher types.Dispatcher, requestTimeout time.Duration, capMethodName string, lggr logger.Logger,
+	parallelExecutor ParallelExecutor) (*ServerRequest, error) {
 	lggr = logger.With(logger.Named(lggr, "ServerRequest"), "requestID", requestID) // cap ID and method name included in the parent logger
 
 	m, err := newSrMetrics(capabilityID, callingDon.ID)
@@ -163,6 +168,7 @@ func NewServerRequest(capability capabilities.ExecutableCapability, method strin
 		capMethodName:           capMethodName,
 		lggr:                    lggr,
 		metrics:                 m,
+		parallelExecutor:        parallelExecutor,
 	}, nil
 }
 
@@ -191,7 +197,10 @@ func (e *ServerRequest) OnMessage(ctx context.Context, msg *types.MessageBody) e
 	if e.minimumRequiredRequestsReceived() && !e.hasResponse() {
 		switch e.method {
 		case types.MethodExecute:
-			e.executeRequest(ctx, msg, executeCapabilityRequest)
+			err = e.parallelExecutor.ExecuteTask(ctx, func(ctx context.Context) {
+				e.executeRequest(ctx, msg, executeCapabilityRequest)
+			})
+			return fmt.Errorf("failed to execute capability request: %w", err)
 		default:
 			e.setError(types.Error_INTERNAL_ERROR, "unknown method %s"+e.method)
 		}

--- a/core/capabilities/remote/executable/server.go
+++ b/core/capabilities/remote/executable/server.go
@@ -293,7 +293,7 @@ func (r *server) Receive(ctx context.Context, msg *types.MessageBody) {
 		}
 
 		sr, ierr := request.NewServerRequest(cfg.underlying, msg.Method, cfg.capInfo.ID, cfg.localDonInfo.ID, r.peerID,
-			callingDon, messageID, r.dispatcher, cfg.remoteExecutableConfig.RequestTimeout, r.capMethodName, r.lggr)
+			callingDon, messageID, r.dispatcher, cfg.remoteExecutableConfig.RequestTimeout, r.capMethodName, r.lggr, r.parallelExecutor)
 		if ierr != nil {
 			r.lggr.Errorw("failed to instantiate server request", "err", ierr)
 			return
@@ -306,14 +306,9 @@ func (r *server) Receive(ctx context.Context, msg *types.MessageBody) {
 	}
 
 	reqAndMsgID := r.requestIDToRequest[requestID]
-	if executeTaskErr := r.parallelExecutor.ExecuteTask(ctx,
-		func(ctx context.Context) {
-			err = reqAndMsgID.request.OnMessage(ctx, msg)
-			if err != nil {
-				r.lggr.Errorw("failed to execute on message", "messageID", reqAndMsgID.messageID, "err", err)
-			}
-		}); executeTaskErr != nil {
-		r.lggr.Errorw("failed to execute on message task", "messageID", messageID, "err", executeTaskErr)
+	err = reqAndMsgID.request.OnMessage(ctx, msg)
+	if err != nil {
+		r.lggr.Errorw("failed to execute on message", "messageID", reqAndMsgID.messageID, "err", err)
 	}
 }
 


### PR DESCRIPTION
Ensure that we lock the semaphore only once the capability execution is ready to occur. 

Previously, multiple goroutines could acquire the semaphore lock and then wait for the same request to execute.
Thus, a single request occupied multiple semaphore slots for an extended period.