### PR TITLE
Fix vault public key fetch retrying with duplicate JSON-RPC request IDs

### DIFF
--- a/system-tests/tests/smoke/cre/vault_don_test_helpers.go
+++ b/system-tests/tests/smoke/cre/vault_don_test_helpers.go
@@ -72,27 +72,36 @@ func mustDeriveJWTVaultWorkflowOwner(t *testing.T, orgID string) string {
 func FetchVaultPublicKey(t *testing.T, gatewayURL string) (publicKey string) {
 	framework.L.Info().Msg("Fetching Vault Public Key...")
 
-	uniqueRequestID := uuid.New().String()
+	var (
+		httpResponseBody []byte
+		uniqueRequestID  string
+	)
 
-	getPublicKeyRequest := jsonrpc.Request[vault_helpers.GetPublicKeyRequest]{
-		Version: jsonrpc.JsonRpcVersion,
-		ID:      uniqueRequestID,
-		Method:  vaulttypes.MethodPublicKeyGet,
-		Params:  &vault_helpers.GetPublicKeyRequest{},
-	}
-	requestBody, err := json.Marshal(getPublicKeyRequest)
-	require.NoError(t, err, "failed to marshal public key request")
-
+	// Each retry must use a fresh JSON-RPC request ID. The gateway deduplicates by ID and
+	// returns "request ID already exists" when Eventually reuses the same body, so a single
+	// non-200 first attempt would fail every subsequent poll until timeout.
 	require.Eventually(t, func() bool {
-		statusCode, _ := sendVaultRequestToGateway(t, gatewayURL, requestBody)
-		return statusCode == http.StatusOK
+		uniqueRequestID = uuid.New().String()
+		getPublicKeyRequest := jsonrpc.Request[vault_helpers.GetPublicKeyRequest]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      uniqueRequestID,
+			Method:  vaulttypes.MethodPublicKeyGet,
+			Params:  &vault_helpers.GetPublicKeyRequest{},
+		}
+		requestBody, err := json.Marshal(getPublicKeyRequest)
+		require.NoError(t, err, "failed to marshal public key request")
+		statusCode, body := sendVaultRequestToGateway(t, gatewayURL, requestBody)
+		if statusCode != http.StatusOK {
+			return false
+		}
+		httpResponseBody = body
+		return true
 	}, time.Second*120, time.Second*5)
-	statusCode, httpResponseBody := sendVaultRequestToGateway(t, gatewayURL, requestBody)
-	require.Equal(t, http.StatusOK, statusCode, "Gateway endpoint should respond with 200 OK")
+	require.NotEmpty(t, httpResponseBody, "expected a successful public key response")
 
 	framework.L.Info().Msg("Checking jsonResponse structure...")
 	var jsonResponse jsonrpc.Response[vault_helpers.GetPublicKeyResponse]
-	err = json.Unmarshal(httpResponseBody, &jsonResponse)
+	err := json.Unmarshal(httpResponseBody, &jsonResponse)
 	require.NoError(t, err, "failed to unmarshal GetPublicKeyResponse")
 	framework.L.Info().Msgf("JSON Body: %v", jsonResponse)
 	if jsonResponse.Error != nil {


### PR DESCRIPTION
## Summary
- Fix `FetchVaultPublicKey` so each `require.Eventually` retry builds a fresh JSON-RPC request ID and reuses the successful response body.
- Comment documents CI evidence: reusing the same body in `require.Eventually` produced repeated `-32600 request ID already exists` responses and the poll never reached 200 OK.

## Test plan
- [ ] Re-run vault DON CRE E2E smoke tests (`workflow-gateway-capabilities*` vault variants)