### PR TITLE
[DX-4449] Add Retries to Deal with LLO Flakes

### DIFF
--- a/core/services/ocr2/plugins/llo/helpers_test.go
+++ b/core/services/ocr2/plugins/llo/helpers_test.go
@@ -62,12 +62,10 @@ func startMercuryServer(t *testing.T, srv *mercuryServer, pubKeys []ed25519.Publ
 	// Set up the grpc server
 	var lc net.ListenConfig
 	lis, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("[MAIN] failed to listen: %v", err)
-	}
+	require.NoError(t, err, "[MAIN] failed to listen")
 	serverURL = lis.Addr().String()
 	sMtls, err := mtls.NewTransportSigner(srv.csaSigner, pubKeys)
-	require.NoError(t, err)
+	require.NoError(t, err, "[MAIN] failed to create transport signer")
 	s := grpc.NewServer(grpc.Creds(sMtls),
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             time.Second,
@@ -79,7 +77,7 @@ func startMercuryServer(t *testing.T, srv *mercuryServer, pubKeys []ed25519.Publ
 
 	// Start serving
 	go func() {
-		s.Serve(lis) //nolint:errcheck // don't care about errors in tests
+		s.Serve(lis) //nolint:errcheck // don't care about this error in tests
 	}()
 
 	t.Cleanup(s.Stop)
@@ -193,7 +191,7 @@ func setupNode(
 		c.P2P.V2.AnnounceAddresses = &p2paddresses
 		c.P2P.V2.ListenAddresses = &p2paddresses
 		c.P2P.V2.DeltaDial = commonconfig.MustNewDuration(500 * time.Millisecond)
-		c.P2P.V2.DeltaReconcile = commonconfig.MustNewDuration(5 * time.Second)
+		c.P2P.V2.DeltaReconcile = commonconfig.MustNewDuration(2 * time.Second)
 
 		// [Mercury]
 		c.Mercury.VerboseLogging = new(true)

--- a/core/services/ocr2/plugins/llo/helpers_test.go
+++ b/core/services/ocr2/plugins/llo/helpers_test.go
@@ -191,7 +191,7 @@ func setupNode(
 		c.P2P.V2.AnnounceAddresses = &p2paddresses
 		c.P2P.V2.ListenAddresses = &p2paddresses
 		c.P2P.V2.DeltaDial = commonconfig.MustNewDuration(500 * time.Millisecond)
-		c.P2P.V2.DeltaReconcile = commonconfig.MustNewDuration(2 * time.Second)
+		c.P2P.V2.DeltaReconcile = commonconfig.MustNewDuration(5 * time.Second)
 
 		// [Mercury]
 		c.Mercury.VerboseLogging = new(true)

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -235,10 +235,9 @@ func makeDefaultOCRConfig() *OCRConfig {
 	if err != nil {
 		panic(err)
 	}
-	maxDurationInit := 1 * time.Second
 	return &OCRConfig{
-		DeltaProgress:                           1 * time.Second,
-		DeltaResend:                             2 * time.Second,
+		DeltaProgress:                           2 * time.Second,
+		DeltaResend:                             20 * time.Second,
 		DeltaInitial:                            400 * time.Millisecond,
 		DeltaRound:                              500 * time.Millisecond,
 		DeltaGrace:                              250 * time.Millisecond,
@@ -246,7 +245,7 @@ func makeDefaultOCRConfig() *OCRConfig {
 		DeltaStage:                              1 * time.Minute,
 		RMax:                                    100,
 		ReportingPluginConfig:                   []byte{},
-		MaxDurationInitialization:               &maxDurationInit,
+		MaxDurationInitialization:               nil,
 		MaxDurationQuery:                        0,
 		MaxDurationObservation:                  250 * time.Millisecond,
 		MaxDurationShouldAcceptAttestedReport:   0,
@@ -1224,13 +1223,9 @@ dp -> deribit_funding_interval_hours_parse -> deribit_funding_interval_hours_dec
 				err = mercury.PayloadTypes.UnpackIntoMap(v, req.Payload)
 				require.NoError(t, err)
 				report, exists := v["report"]
-				if !exists {
-					t.Fatalf("expected payload %#v to contain 'report'", v)
-				}
+				require.True(t, exists, "expected payload %#v to contain 'report'", v)
 				reportCtx, exists := v["reportContext"]
-				if !exists {
-					t.Fatalf("expected payload %#v to contain 'reportContext'", v)
-				}
+				require.True(t, exists, "expected payload %#v to contain 'reportContext'", v)
 
 				// Check the report context
 				assert.Equal(t, [32]byte(digest), reportCtx.([3][32]uint8)[0])                                                                      // config digest
@@ -2844,7 +2839,7 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 	backend.Commit()
 
 	tombstonedChannel := map[uint32]bool{2: true}
-	checkNoReportsWindow := 3 * time.Second
+	checkNoReportsWindow := 5 * time.Second
 	require.Eventually(t, func() bool {
 		start := time.Now()
 		sawTombstoned := false
@@ -2878,7 +2873,7 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 			stableSince = time.Now()
 			return false
 		}
-		return time.Since(stableSince) > 1*time.Second
+		return time.Since(stableSince) > 2*time.Second
 	}, 15*time.Second, 100*time.Millisecond, "tombstoned channel's stream should eventually stop being observed")
 
 	bCallsStable := streamBCalls.Load()

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -235,9 +235,10 @@ func makeDefaultOCRConfig() *OCRConfig {
 	if err != nil {
 		panic(err)
 	}
+	maxDurationInit := 1 * time.Second
 	return &OCRConfig{
-		DeltaProgress:                           2 * time.Second,
-		DeltaResend:                             20 * time.Second,
+		DeltaProgress:                           1 * time.Second,
+		DeltaResend:                             2 * time.Second,
 		DeltaInitial:                            400 * time.Millisecond,
 		DeltaRound:                              500 * time.Millisecond,
 		DeltaGrace:                              250 * time.Millisecond,
@@ -245,7 +246,7 @@ func makeDefaultOCRConfig() *OCRConfig {
 		DeltaStage:                              1 * time.Minute,
 		RMax:                                    100,
 		ReportingPluginConfig:                   []byte{},
-		MaxDurationInitialization:               nil,
+		MaxDurationInitialization:               &maxDurationInit,
 		MaxDurationQuery:                        0,
 		MaxDurationObservation:                  250 * time.Millisecond,
 		MaxDurationShouldAcceptAttestedReport:   0,
@@ -1041,7 +1042,7 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 }`
 
 		pricePipeline := fmt.Sprintf(`
-dp          [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}"];
+dp          [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}" retries=3];
 eth_parse    					[type=jsonparse path="result,ethPrice"];
 eth_decimal 					[type=multiply times=1 streamID=%d];
 link_parse    				[type=jsonparse path="result,linkPrice"];
@@ -1051,7 +1052,7 @@ dp -> link_parse -> link_decimal;
 `, bridgeName, ethStreamID, linkStreamID)
 
 		dexBasedAssetPipeline := fmt.Sprintf(`
-dp          [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}"];
+dp          [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}" retries=3];
 
 bp_parse    				[type=jsonparse path="result,benchmarkPrice"];
 base_market_depth_parse   	[type=jsonparse path="result,baseMarketDepth"];
@@ -1068,7 +1069,7 @@ dp -> quote_market_depth_parse -> quote_market_depth_decimal;
 
 		// Don't use a multiply task so that the task result has int64 type.
 		rwaPipeline := fmt.Sprintf(`
-dp [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}"];
+dp [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}" retries=3];
 
 market_status_parse [type=jsonparse path="data,marketStatus" streamID=%d];
 stonk_price_parse [type=jsonparse path="data,benchmarkPrice"];
@@ -1107,7 +1108,7 @@ dp -> stonk_price_parse -> stonk_price_timestamped_missing_indicated_time;
 		)
 
 		benchmarkPricePipeline := fmt.Sprintf(`
-dp          [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}"];
+dp          [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}" retries=3];
 
 bp_parse    				[type=jsonparse path="result,benchmarkPrice"];
 bp_decimal 					[type=multiply times=1 streamID=%d];
@@ -1116,21 +1117,21 @@ dp -> bp_parse -> bp_decimal;
 `, bridgeName, benchmarkPriceStreamID)
 
 		timestampedStreamValuePipeline := fmt.Sprintf(`
-ds1_payload [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}"];
-ds1_benchmark [type=jsonparse path="result,benchmarkPrice"];
-ds1_payload -> ds1_benchmark -> benchmark_price;
-ds1_provider_indicated_time [type=jsonparse lax=true path="timestamps,providerIndicatedTimeUnixMs"];
-ds1_payload -> ds1_provider_indicated_time -> provider_indicated_time;
-ds1_data_received_time [type=jsonparse lax=true path="timestamps,providerDataReceivedUnixMs"];
-ds1_payload -> ds1_data_received_time -> data_received_time;
+payload [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}" retries=3];
 
-ds2_payload [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}"];
+ds1_benchmark [type=jsonparse path="result,benchmarkPrice"];
+payload -> ds1_benchmark -> benchmark_price;
+ds1_provider_indicated_time [type=jsonparse lax=true path="timestamps,providerIndicatedTimeUnixMs"];
+payload -> ds1_provider_indicated_time -> provider_indicated_time;
+ds1_data_received_time [type=jsonparse lax=true path="timestamps,providerDataReceivedUnixMs"];
+payload -> ds1_data_received_time -> data_received_time;
+
 ds2_benchmark [type=jsonparse path="result,benchmarkPrice2"];
-ds2_payload -> ds2_benchmark -> benchmark_price;
+payload -> ds2_benchmark -> benchmark_price;
 ds2_provider_indicated_time [type=jsonparse lax=true path="timestamps,providerIndicatedTimeUnixMs2"];
-ds2_payload -> ds2_provider_indicated_time -> provider_indicated_time;
+payload -> ds2_provider_indicated_time -> provider_indicated_time;
 ds2_data_received_time [type=jsonparse lax=true path="timestamps,providerDataReceivedUnixMs"];
-ds2_payload -> ds2_data_received_time -> data_received_time;
+payload -> ds2_data_received_time -> data_received_time;
 
 benchmark_price [type=median streamID=%d index=0];
 provider_indicated_time [type=median lax=true];
@@ -1139,10 +1140,10 @@ provider_indicated_time -> benchmark_price_timestamp;
 data_received_time -> benchmark_price_timestamp;
 
 benchmark_price_timestamp [type=coalesce streamID=%d index=1];
-`, bridgeName, bridgeName, timestampedStreamValueValueStreamID, timestampedStreamValueTimestampStreamID)
+`, bridgeName, timestampedStreamValueValueStreamID, timestampedStreamValueTimestampStreamID)
 
 		fundingRatePipeline := fmt.Sprintf(`
-dp          [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}"];
+dp          [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}" retries=3];
 
 binance_funding_rate_parse   [type=jsonparse path="result,binanceFundingRate"];
 binance_funding_rate_decimal [type=multiply times=1 streamID=%d];
@@ -2544,7 +2545,7 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 			// Verify that channels 2 and 21 stop producing reports after tombstoning
 			// We wait for a period where we don't see reports from these channels
 			tombstonedChannels := map[uint32]bool{2: true, 21: true}
-			checkPeriod := 5 * time.Second
+			checkPeriod := 3 * time.Second
 
 			require.Eventually(t, func() bool {
 				// Collect reports for a period and verify tombstoned channels don't appear
@@ -2843,7 +2844,7 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 	backend.Commit()
 
 	tombstonedChannel := map[uint32]bool{2: true}
-	checkNoReportsWindow := 5 * time.Second
+	checkNoReportsWindow := 3 * time.Second
 	require.Eventually(t, func() bool {
 		start := time.Now()
 		sawTombstoned := false
@@ -2877,7 +2878,7 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 			stableSince = time.Now()
 			return false
 		}
-		return time.Since(stableSince) > 2*time.Second
+		return time.Since(stableSince) > 1*time.Second
 	}, 15*time.Second, 100*time.Millisecond, "tombstoned channel's stream should eventually stop being observed")
 
 	bCallsStable := streamBCalls.Load()


### PR DESCRIPTION
[llo](https://smartcontract-it.atlassian.net/jira/dashboards/11464?maximized=52303) is currently our flakiest package, with a bunch of rare flakes causing issues. Each individual test's flake rate is rare (1%-2%), but combined, they add up.

The flakes happen when, in rare circumstances, the `httptest` servers are under too much load and are too slow to respond or error out. Adding `retries=3` to the job specs prevents this case from happening. Confirmed with 2,150 iterations locally:

```sh
❯ make test ARGS="diagnose --iterations 2150 --parallel-iterations 5 -- ./core/services/ocr2/plugins/llo..."
```
