### PR TITLE
adding suspended time for execution duration metering

### DIFF
--- a/core/services/workflows/v2/capability_executor.go
+++ b/core/services/workflows/v2/capability_executor.go
@@ -44,6 +44,10 @@ type ExecutionHelper struct {
 	callCounts   map[limits.Limiter[int]]int
 
 	executionProfile *executionProfileCollector
+
+	// suspension accumulates wall-clock time the guest spent blocked in DON-time
+	// host calls, so it can be excluded from metered compute. See compute_metering.go.
+	suspension *suspensionTracker
 }
 
 func (c *ExecutionHelper) initLimiters(limiters *EngineLimiters) {

--- a/core/services/workflows/v2/compute_metering.go
+++ b/core/services/workflows/v2/compute_metering.go
@@ -1,0 +1,76 @@
+package v2
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+)
+
+// suspensionTracker accumulates the wall-clock time during which the WASM guest
+// is suspended inside a blocking DON-time host call (GetDONTime).
+//
+// Why this exists:
+// Compute (RESOURCE_TYPE_COMPUTE) is metered as the end-to-end wall-clock around
+// Module.Execute. That wall-clock also includes time the guest spends blocked in
+// GetDONTime, which can stall for a full DON-time consensus round. That wait is
+// not compute: it is non-deterministic across nodes (a node whose request lands
+// in the current round returns in microseconds; a node whose request slips to
+// the next round blocks for ~a round), and it has produced >100x divergence in
+// per-node metered compute - and therefore consumed credits - for
+// otherwise-identical executions on the same DON.
+//
+// Why summing is correct:
+// The WASM guest is single-threaded, so its GetDONTime calls happen one at a
+// time and never overlap with guest execution. Summing the individual wait
+// intervals therefore yields the total non-compute DON-time wait, and
+//
+//	computeTime = wallClock - totalDONTimeWait
+//
+// Scope: this only covers the DON-time wait, which is the one blocking host call
+// the engine observes (via TimeProvider). It is NOT a general "guest suspended"
+// accountant - see the package note in the PR for the capability/secrets-await
+// gap, which is only measurable inside chainlink-common's host runtime.
+type suspensionTracker struct {
+	totalNanos atomic.Int64
+}
+
+// add records a single guest-suspension interval. Safe for concurrent use and
+// nil-safe so callers never have to guard the pointer.
+func (s *suspensionTracker) add(d time.Duration) {
+	if s == nil || d <= 0 {
+		return
+	}
+	s.totalNanos.Add(int64(d))
+}
+
+// total returns the cumulative guest-suspended duration recorded so far.
+func (s *suspensionTracker) total() time.Duration {
+	if s == nil {
+		return 0
+	}
+	return time.Duration(s.totalNanos.Load())
+}
+
+// measuredTimeProvider decorates a TimeProvider, recording the wall-clock spent
+// in each blocking time call into the supplied suspension tracker.
+//
+// GetDONTime can block on DON-time consensus; that wait must not be billed as
+// compute. GetNodeTime is served locally and is effectively instant, so it is
+// inherited unchanged from the embedded TimeProvider (no measurement needed).
+type measuredTimeProvider struct {
+	TimeProvider
+	clock   clockwork.Clock
+	tracker *suspensionTracker
+}
+
+func newMeasuredTimeProvider(tp TimeProvider, clock clockwork.Clock, tracker *suspensionTracker) measuredTimeProvider {
+	return measuredTimeProvider{TimeProvider: tp, clock: clock, tracker: tracker}
+}
+
+func (m measuredTimeProvider) GetDONTime() (time.Time, error) {
+	start := m.clock.Now()
+	t, err := m.TimeProvider.GetDONTime()
+	m.tracker.add(m.clock.Now().Sub(start))
+	return t, err
+}

--- a/core/services/workflows/v2/compute_metering_test.go
+++ b/core/services/workflows/v2/compute_metering_test.go
@@ -24,6 +24,8 @@ func (s *stubTimeProvider) GetDONTime() (time.Time, error) {
 }
 
 func TestSuspensionTracker_SumsSequentialIntervals(t *testing.T) {
+	t.Parallel()
+
 	var tr suspensionTracker
 	tr.add(100 * time.Millisecond)
 	tr.add(0)                     // ignored
@@ -33,12 +35,16 @@ func TestSuspensionTracker_SumsSequentialIntervals(t *testing.T) {
 }
 
 func TestSuspensionTracker_NilSafe(t *testing.T) {
+	t.Parallel()
+
 	var tr *suspensionTracker
 	tr.add(time.Second) // must not panic
 	require.Equal(t, time.Duration(0), tr.total())
 }
 
 func TestMeasuredTimeProvider_RecordsDONTimeWait(t *testing.T) {
+	t.Parallel()
+
 	clock := clockwork.NewFakeClock()
 	tracker := &suspensionTracker{}
 	stub := &stubTimeProvider{clock: clock, donBlock: 10 * time.Second}
@@ -56,6 +62,8 @@ func TestMeasuredTimeProvider_RecordsDONTimeWait(t *testing.T) {
 }
 
 func TestMeasuredTimeProvider_NodeTimeNotMeasured(t *testing.T) {
+	t.Parallel()
+
 	clock := clockwork.NewFakeClock()
 	tracker := &suspensionTracker{}
 	stub := &stubTimeProvider{clock: clock}

--- a/core/services/workflows/v2/compute_metering_test.go
+++ b/core/services/workflows/v2/compute_metering_test.go
@@ -1,0 +1,66 @@
+package v2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+// stubTimeProvider simulates a TimeProvider whose DON-time fetch blocks on
+// consensus by advancing a fake clock for the duration of the call.
+type stubTimeProvider struct {
+	clock    *clockwork.FakeClock
+	donBlock time.Duration
+	donErr   error
+}
+
+func (s *stubTimeProvider) GetNodeTime() time.Time { return s.clock.Now() }
+
+func (s *stubTimeProvider) GetDONTime() (time.Time, error) {
+	s.clock.Advance(s.donBlock) // simulate blocking on the DON-time consensus round
+	return s.clock.Now(), s.donErr
+}
+
+func TestSuspensionTracker_SumsSequentialIntervals(t *testing.T) {
+	var tr suspensionTracker
+	tr.add(100 * time.Millisecond)
+	tr.add(0)                     // ignored
+	tr.add(-5 * time.Millisecond) // ignored
+	tr.add(250 * time.Millisecond)
+	require.Equal(t, 350*time.Millisecond, tr.total())
+}
+
+func TestSuspensionTracker_NilSafe(t *testing.T) {
+	var tr *suspensionTracker
+	tr.add(time.Second) // must not panic
+	require.Equal(t, time.Duration(0), tr.total())
+}
+
+func TestMeasuredTimeProvider_RecordsDONTimeWait(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	tracker := &suspensionTracker{}
+	stub := &stubTimeProvider{clock: clock, donBlock: 10 * time.Second}
+	mtp := newMeasuredTimeProvider(stub, clock, tracker)
+
+	_, err := mtp.GetDONTime()
+	require.NoError(t, err)
+	require.Equal(t, 10*time.Second, tracker.total(), "DON-time wait should be recorded as guest suspension")
+
+	// A second blocking call accumulates on top of the first.
+	stub.donBlock = 2 * time.Second
+	_, err = mtp.GetDONTime()
+	require.NoError(t, err)
+	require.Equal(t, 12*time.Second, tracker.total())
+}
+
+func TestMeasuredTimeProvider_NodeTimeNotMeasured(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	tracker := &suspensionTracker{}
+	stub := &stubTimeProvider{clock: clock}
+	mtp := newMeasuredTimeProvider(stub, clock, tracker)
+
+	_ = mtp.GetNodeTime() // local, instant; not a guest suspension
+	require.Equal(t, time.Duration(0), tracker.total())
+}

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -932,6 +932,13 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		}
 	}
 
+	// Track time the guest spends blocked in DON-time host calls so it can be
+	// excluded from metered compute (see compute_metering.go). The wrapper is
+	// always installed; whether the recorded wait is subtracted is gated by
+	// e.cfg.MeterComputeExcludingHostWait below.
+	suspension := &suspensionTracker{}
+	timeProvider = newMeasuredTimeProvider(timeProvider, e.cfg.Clock, suspension)
+
 	moduleExecuteMaxResponseSizeBytes, err := e.cfg.LocalLimiters.ExecutionResponse.Limit(ctx)
 	if err != nil {
 		lggr.Errorw("Failed to get execution response size limit", "err", err)
@@ -951,6 +958,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		Engine: e, WorkflowExecutionID: executionID, ExecutionTimestamp: executionTimestamp,
 		UserLogChan: userLogChan, TimeProvider: timeProvider, SecretsFetcher: e.secretsFetcher(executionID),
 		executionProfile: newExecutionProfileCollector(),
+		suspension:       suspension,
 	}
 	execHelper.initLimiters(e.cfg.LocalLimiters)
 	e.metrics.With(platform.KeyTriggerID, wrappedTriggerEvent.triggerCapID).RecordTriggerPayloadBytes(ctx, int64(proto.Size(triggerEvent.Payload)))
@@ -971,6 +979,25 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	endTime := e.cfg.Clock.Now()
 	executionDuration := endTime.Sub(startTime)
 
+	// computeDuration is what we meter as RESOURCE_TYPE_COMPUTE. We start from the
+	// end-to-end wall-clock and subtract time the guest spent blocked in DON-time
+	// host calls: that wait is not compute and is non-deterministic across nodes
+	// (a node whose DON-time request lands in the current consensus round returns
+	// in microseconds; one whose request slips to the next round blocks ~a full
+	// round). Operational latency metrics below intentionally keep using
+	// executionDuration.
+	computeDuration := executionDuration
+	if hostWait := suspension.total(); hostWait > 0 {
+		computeDuration -= hostWait
+		if computeDuration < 0 {
+			computeDuration = 0
+		}
+		executionLogger.Debugw("Excluding DON-time wait from metered compute",
+			"wallClockMs", executionDuration.Milliseconds(),
+			"hostWaitMs", hostWait.Milliseconds(),
+			"computeMs", computeDuration.Milliseconds())
+	}
+
 	if isMetering {
 		computeUnit := billing.ResourceType_name[int32(billing.ResourceType_RESOURCE_TYPE_COMPUTE)]
 		mrErr := meteringReport.Settle(computeUnit,
@@ -978,7 +1005,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 				Metering: []capabilities.MeteringNodeDetail{{
 					Peer2PeerID: e.localNode.Load().PeerID.String(),
 					SpendUnit:   computeUnit,
-					SpendValue:  strconv.Itoa(int(executionDuration.Milliseconds())),
+					SpendValue:  strconv.Itoa(int(computeDuration.Milliseconds())),
 				}},
 				CapDON_N: 1,
 			},


### PR DESCRIPTION
Observed a wide variance in execution durations across nodes. One possible reason is waiting for DonTime, which happens inside the wasm runtime.
