### PR TITLE
Fix vault blob batching test replay-guard tolerance ordering

### DIFF
--- a/system-tests/tests/smoke/cre/vault_don_test.go
+++ b/system-tests/tests/smoke/cre/vault_don_test.go
@@ -500,14 +500,15 @@ func sendConcurrentVaultCreate(t *testing.T, gwURL, requestID string, jsonReques
 		framework.L.Info().Str("requestID", requestID).Msg("vault create gateway-to-DON timeout; treating as success for batching load test")
 		return
 	}
+	// Replay guard can arrive on a non-200 HTTP status after a retried gateway call; check before StatusOK.
+	if bytes.Contains(body, []byte("request was already authorized previously")) {
+		framework.L.Info().Str("requestID", requestID).Msg("vault create returned replay-guard error after retry; DON processed the original request — treating as success")
+		return
+	}
 	require.Equal(t, http.StatusOK, statusCode, "Gateway endpoint should respond with 200 OK; body=%s", string(body))
 
 	var parsed jsonrpc.Response[vaulttypes.SignedOCRResponse]
 	require.NoError(t, json.Unmarshal(body, &parsed), "failed to unmarshal gateway response")
-	if parsed.Error != nil && strings.Contains(parsed.Error.Message, "request was already authorized previously") {
-		framework.L.Info().Str("requestID", requestID).Msg("vault create returned replay-guard error after retry; DON processed the original request — treating as success")
-		return
-	}
 	require.Nil(t, parsed.Error, "gateway returned error: %v", parsed.Error)
 	require.Equal(t, requestID, parsed.ID)
 	require.Equal(t, vaulttypes.MethodSecretsCreate, parsed.Method)


### PR DESCRIPTION
## Summary

- Fix flaky `pending_queue_blob_batching_many_concurrent_creates` failures in vault CRE E2E (`secret_6`, `secret_20` in merge queue run [28111583502](https://github.com/smartcontractkit/chainlink/actions/runs/28111583502)).
- `sendConcurrentVaultCreate` already documents that replay-guard responses (`request was already authorized previously`) mean the DON processed the original request, but the check ran **after** `require.Equal(..., http.StatusOK)`. Under burst load, gateway retries can return replay guard on a non-200 status, failing before the tolerance branch ran.

## Fix

Check the response body for replay guard **before** asserting HTTP 200 (same pattern as the existing 503 timeout tolerance).

## Context

This blocked merge queue for #22927; unrelated to that PR's engine test race fix.

## Test plan

- [ ] `Test_CRE_V2_Suite_Bucket_B` / `pending_queue_blob_batching_many_concurrent_creates` passes in Integration Tests
- [ ] Merge queue for #22927 succeeds after this lands (or re-queue passes with flake)