### PR TITLE
Cherry-pick: Fix vault bad labels and duplicate secrets (#22931)

### DIFF
--- a/core/capabilities/vault/validator.go
+++ b/core/capabilities/vault/validator.go
@@ -161,6 +161,7 @@ func (r *RequestValidator) ValidateGetSecretsRequest(ctx context.Context, reques
 		return fmt.Errorf("request batch size exceeds maximum of %d", vaulttypes.MaxBatchSize)
 	}
 
+	uniqueIDs := map[string]bool{}
 	for idx, req := range request.Requests {
 		if req.Id == nil {
 			return errors.New("secret ID must have id set at index " + strconv.Itoa(idx))
@@ -171,6 +172,13 @@ func (r *RequestValidator) ValidateGetSecretsRequest(ctx context.Context, reques
 		if err := r.ValidateSecretIdentifier(ctx, req.Id.Key, req.Id.Owner, req.Id.Namespace); err != nil {
 			return fmt.Errorf("invalid secret identifier at index %d: %w", idx, err)
 		}
+
+		_, ok := uniqueIDs[vaulttypes.KeyFor(req.Id)]
+		if ok {
+			return errors.New("duplicate secret ID found at index " + strconv.Itoa(idx) + ": " + req.Id.String())
+		}
+
+		uniqueIDs[vaulttypes.KeyFor(req.Id)] = true
 	}
 
 	return nil

--- a/core/capabilities/vault/validator_test.go
+++ b/core/capabilities/vault/validator_test.go
@@ -712,6 +712,14 @@ func TestValidateGetSecretsRequest(t *testing.T) {
 				{Id: validID("mykey", "owner1", "")},
 			},
 		},
+		{
+			name: "duplicate secret ID in batch",
+			requests: []*vaultcommon.SecretRequest{
+				{Id: validID("key1", "owner1", "main")},
+				{Id: validID("key1", "owner1", "main")},
+			},
+			errSubstr: "duplicate secret ID found at index 1",
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -43,13 +43,13 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.103
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260618155522-3600f66e26cd
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260522094612-5f9f748bd87a
 	github.com/smartcontractkit/chainlink-deployments-framework v0.105.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260623170329-4577ef4ba0ae
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20260521215851-3fdbb363496f
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.16.2
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.23

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1571,8 +1571,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h1:WjZwKtUA/0TPvzgCt8bcdq+BHMIL65S0oU79mxgZn/Y=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e h1:i42B2D1WjvQTOQANC7vawOx3xVCbLWSueDwXWOzMqNM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e/go.mod h1:paOB/6dy57owHtOGzhgaRBWRDT5BEWfnJF5M7sgkcro=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c h1:d7vdm9wydgwV2L2AFWstYdXC+VjHG2thEK0cGblYm2U=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c/go.mod h1:wUK7w5xRrFPD2qQfdt1fLXzQzWSb4PaZaxa4nsqCWVs=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0 h1:NExKM/D0HneOq/N5LGTbkV4VOa0UHCvfTNEb4GqYpto=
@@ -1609,8 +1609,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-20260505131349-78e491b80735/go.mod h1:zAJq6Tpkx5AdFUwW67dIYnW+Bdf50drCCpMR81Qxb4E=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7 h1:iRFmfMFQtcnhGDjCuARQG4MPbcmbbJDDw7MUH3GcGy8=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b h1:VDgJWDipihV9f7M5+d21d1RzSsg5rEv+iI12oN1VQbo=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 h1:SG+wAsNyAcA6Kk19ljuxi3HK9Ll2lpHik8OKoY4x7A0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0 h1:q+VDPcxWrj5k9QizSYfUOSMnDH3Sd5HvbPguZOgfXTY=

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -66,7 +66,6 @@ type ReportingPluginConfig struct {
 	MaxBlobPayloadBytes                               limits.BoundLimiter[pkgconfig.Size]
 	VaultForceEmptyOCRRounds                          limits.GateLimiter
 	VaultOptimizationsEnabled                         limits.GateLimiter
-	VaultSignedResponseRequestIDEnabled               limits.GateLimiter
 	VaultGetSecretsShareAggregationIncludesPublicKeys limits.GateLimiter
 }
 
@@ -222,11 +221,6 @@ func newReportingPluginConfigLimiters(factory limits.Factory) (*ReportingPluginC
 		return nil, fmt.Errorf("VaultGetSecretsShareAggregationIncludesPublicKeys: %w", err)
 	}
 
-	vaultSignedResponseRequestIDEnabled, err := limits.MakeGateLimiter(factory, cresettings.Default.VaultSignedResponseRequestIDEnabled)
-	if err != nil {
-		return nil, fmt.Errorf("VaultSignedResponseRequestIDEnabled: %w", err)
-	}
-
 	maxBlobPayloadBytesLimiter, err := limits.MakeUpperBoundLimiter(factory, cresettings.Default.VaultMaxBlobPayloadSizeLimit)
 	if err != nil {
 		return nil, fmt.Errorf("VaultMaxBlobPayloadSizeLimit: %w", err)
@@ -248,7 +242,6 @@ func newReportingPluginConfigLimiters(factory limits.Factory) (*ReportingPluginC
 		MaxPendingQueueWriteSize:                          maxPendingQueueWriteSizeLimiter,
 		VaultForceEmptyOCRRounds:                          vaultForceEmptyOCRRounds,
 		VaultOptimizationsEnabled:                         vaultOptimizationsEnabled,
-		VaultSignedResponseRequestIDEnabled:               vaultSignedResponseRequestIDEnabled,
 		VaultGetSecretsShareAggregationIncludesPublicKeys: vaultGetSecretsShareAggregationIncludesPublicKeys,
 	}, nil
 }
@@ -616,10 +609,6 @@ func (r *ReportingPlugin) optimizationsEnabled(ctx context.Context) bool {
 
 func (r *ReportingPlugin) shareAggregationIncludesPublicKeys(ctx context.Context) bool {
 	return gateAllows(ctx, r.lggr, r.cfg.VaultGetSecretsShareAggregationIncludesPublicKeys, "VaultGetSecretsShareAggregationIncludesPublicKeys")
-}
-
-func (r *ReportingPlugin) signedResponseRequestIDEnabled(ctx context.Context) bool {
-	return gateAllows(ctx, r.lggr, r.cfg.VaultSignedResponseRequestIDEnabled, "VaultSignedResponseRequestIDEnabled")
 }
 
 type pendingQueueStore interface {
@@ -2510,11 +2499,7 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 				ReportWithInfo: rep,
 			})
 		case vaultcommon.RequestType_CREATE_SECRETS:
-			createResp := proto.Clone(o.GetCreateSecretsResponse()).(*vaultcommon.CreateSecretsResponse)
-			if r.signedResponseRequestIDEnabled(ctx) {
-				createResp.RequestId = o.Id
-			}
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, createResp)
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, o.GetCreateSecretsResponse())
 			if err != nil {
 				r.lggr.Errorw("failed to generate JSON report", "error", err, "id", o.Id)
 				continue
@@ -2524,11 +2509,7 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 				ReportWithInfo: rep,
 			})
 		case vaultcommon.RequestType_UPDATE_SECRETS:
-			updateResp := proto.Clone(o.GetUpdateSecretsResponse()).(*vaultcommon.UpdateSecretsResponse)
-			if r.signedResponseRequestIDEnabled(ctx) {
-				updateResp.RequestId = o.Id
-			}
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, updateResp)
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, o.GetUpdateSecretsResponse())
 			if err != nil {
 				r.lggr.Errorw("failed to generate JSON report", "error", err, "id", o.Id)
 				continue
@@ -2538,11 +2519,7 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 				ReportWithInfo: rep,
 			})
 		case vaultcommon.RequestType_DELETE_SECRETS:
-			deleteResp := proto.Clone(o.GetDeleteSecretsResponse()).(*vaultcommon.DeleteSecretsResponse)
-			if r.signedResponseRequestIDEnabled(ctx) {
-				deleteResp.RequestId = o.Id
-			}
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, deleteResp)
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, o.GetDeleteSecretsResponse())
 			if err != nil {
 				r.lggr.Errorw("failed to generate JSON report", "error", err, "id", o.Id)
 				continue
@@ -2552,11 +2529,7 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 				ReportWithInfo: rep,
 			})
 		case vaultcommon.RequestType_LIST_SECRET_IDENTIFIERS:
-			listResp := proto.Clone(o.GetListSecretIdentifiersResponse()).(*vaultcommon.ListSecretIdentifiersResponse)
-			if r.signedResponseRequestIDEnabled(ctx) {
-				listResp.RequestId = o.Id
-			}
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, listResp)
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, o.GetListSecretIdentifiersResponse())
 			if err != nil {
 				r.lggr.Errorw("failed to generate JSON report", "error", err, "id", o.Id)
 				continue

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -54,18 +54,20 @@ type ReportingPluginConfig struct {
 	PrivateKeyShare *tdh2easy.PrivateShare
 
 	// Sourced from the offchain config
-	MaxSecretsPerOwner                limits.BoundLimiter[int]
-	MaxCiphertextLengthBytes          limits.BoundLimiter[pkgconfig.Size]
-	MaxIdentifierKeyLengthBytes       limits.BoundLimiter[pkgconfig.Size]
-	MaxIdentifierOwnerLengthBytes     limits.BoundLimiter[pkgconfig.Size]
-	MaxIdentifierNamespaceLengthBytes limits.BoundLimiter[pkgconfig.Size]
-	MaxShareLengthBytes               limits.BoundLimiter[pkgconfig.Size]
-	MaxRequestBatchSize               limits.BoundLimiter[int]
-	MaxBatchSize                      limits.BoundLimiter[int]
-	MaxPendingQueueWriteSize          limits.BoundLimiter[int]
-	MaxBlobPayloadBytes               limits.BoundLimiter[pkgconfig.Size]
-	VaultForceEmptyOCRRounds          limits.GateLimiter
-	VaultOptimizationsEnabled         limits.GateLimiter
+	MaxSecretsPerOwner                                limits.BoundLimiter[int]
+	MaxCiphertextLengthBytes                          limits.BoundLimiter[pkgconfig.Size]
+	MaxIdentifierKeyLengthBytes                       limits.BoundLimiter[pkgconfig.Size]
+	MaxIdentifierOwnerLengthBytes                     limits.BoundLimiter[pkgconfig.Size]
+	MaxIdentifierNamespaceLengthBytes                 limits.BoundLimiter[pkgconfig.Size]
+	MaxShareLengthBytes                               limits.BoundLimiter[pkgconfig.Size]
+	MaxRequestBatchSize                               limits.BoundLimiter[int]
+	MaxBatchSize                                      limits.BoundLimiter[int]
+	MaxPendingQueueWriteSize                          limits.BoundLimiter[int]
+	MaxBlobPayloadBytes                               limits.BoundLimiter[pkgconfig.Size]
+	VaultForceEmptyOCRRounds                          limits.GateLimiter
+	VaultOptimizationsEnabled                         limits.GateLimiter
+	VaultSignedResponseRequestIDEnabled               limits.GateLimiter
+	VaultGetSecretsShareAggregationIncludesPublicKeys limits.GateLimiter
 }
 
 func NewReportingPluginFactory(
@@ -215,6 +217,16 @@ func newReportingPluginConfigLimiters(factory limits.Factory) (*ReportingPluginC
 		return nil, fmt.Errorf("VaultOptimizationsEnabled: %w", err)
 	}
 
+	vaultGetSecretsShareAggregationIncludesPublicKeys, err := limits.MakeGateLimiter(factory, cresettings.Default.VaultGetSecretsShareAggregationIncludesPublicKeys)
+	if err != nil {
+		return nil, fmt.Errorf("VaultGetSecretsShareAggregationIncludesPublicKeys: %w", err)
+	}
+
+	vaultSignedResponseRequestIDEnabled, err := limits.MakeGateLimiter(factory, cresettings.Default.VaultSignedResponseRequestIDEnabled)
+	if err != nil {
+		return nil, fmt.Errorf("VaultSignedResponseRequestIDEnabled: %w", err)
+	}
+
 	maxBlobPayloadBytesLimiter, err := limits.MakeUpperBoundLimiter(factory, cresettings.Default.VaultMaxBlobPayloadSizeLimit)
 	if err != nil {
 		return nil, fmt.Errorf("VaultMaxBlobPayloadSizeLimit: %w", err)
@@ -226,16 +238,18 @@ func newReportingPluginConfigLimiters(factory limits.Factory) (*ReportingPluginC
 	}
 
 	return &ReportingPluginConfig{
-		MaxShareLengthBytes:               maxShareLengthBytesLimiter,
-		MaxRequestBatchSize:               maxRequestBatchSizeLimiter,
-		MaxCiphertextLengthBytes:          maxCiphertextLengthBytesLimiter,
-		MaxIdentifierKeyLengthBytes:       maxIdentifierKeyLengthBytesLimiter,
-		MaxIdentifierOwnerLengthBytes:     maxIdentifierOwnerLengthBytesLimiter,
-		MaxIdentifierNamespaceLengthBytes: maxIdentifierNamespaceLengthBytesLimiter,
-		MaxBlobPayloadBytes:               maxBlobPayloadBytesLimiter,
-		MaxPendingQueueWriteSize:          maxPendingQueueWriteSizeLimiter,
-		VaultForceEmptyOCRRounds:          vaultForceEmptyOCRRounds,
-		VaultOptimizationsEnabled:         vaultOptimizationsEnabled,
+		MaxShareLengthBytes:                               maxShareLengthBytesLimiter,
+		MaxRequestBatchSize:                               maxRequestBatchSizeLimiter,
+		MaxCiphertextLengthBytes:                          maxCiphertextLengthBytesLimiter,
+		MaxIdentifierKeyLengthBytes:                       maxIdentifierKeyLengthBytesLimiter,
+		MaxIdentifierOwnerLengthBytes:                     maxIdentifierOwnerLengthBytesLimiter,
+		MaxIdentifierNamespaceLengthBytes:                 maxIdentifierNamespaceLengthBytesLimiter,
+		MaxBlobPayloadBytes:                               maxBlobPayloadBytesLimiter,
+		MaxPendingQueueWriteSize:                          maxPendingQueueWriteSizeLimiter,
+		VaultForceEmptyOCRRounds:                          vaultForceEmptyOCRRounds,
+		VaultOptimizationsEnabled:                         vaultOptimizationsEnabled,
+		VaultSignedResponseRequestIDEnabled:               vaultSignedResponseRequestIDEnabled,
+		VaultGetSecretsShareAggregationIncludesPublicKeys: vaultGetSecretsShareAggregationIncludesPublicKeys,
 	}, nil
 }
 
@@ -600,6 +614,14 @@ func (r *ReportingPlugin) optimizationsEnabled(ctx context.Context) bool {
 	return gateAllows(ctx, r.lggr, r.cfg.VaultOptimizationsEnabled, "VaultOptimizationsEnabled")
 }
 
+func (r *ReportingPlugin) shareAggregationIncludesPublicKeys(ctx context.Context) bool {
+	return gateAllows(ctx, r.lggr, r.cfg.VaultGetSecretsShareAggregationIncludesPublicKeys, "VaultGetSecretsShareAggregationIncludesPublicKeys")
+}
+
+func (r *ReportingPlugin) signedResponseRequestIDEnabled(ctx context.Context) bool {
+	return gateAllows(ctx, r.lggr, r.cfg.VaultSignedResponseRequestIDEnabled, "VaultSignedResponseRequestIDEnabled")
+}
+
 type pendingQueueStore interface {
 	WritePendingQueue(ctx context.Context, pending []*vaultcommon.StoredPendingQueueItem) error
 }
@@ -864,9 +886,21 @@ func (r *ReportingPlugin) observeGetSecrets(ctx context.Context, reader ReadKVSt
 			GetSecretsRequest: tp,
 		}
 	}
+
+	requestsCountForID := map[string]int{}
+	for _, sr := range tp.Requests {
+		var key string
+		if sr.Id == nil {
+			key = "<nil>"
+		} else {
+			key = vaulttypes.KeyFor(sr.Id)
+		}
+		requestsCountForID[key]++
+	}
+
 	resps := []*vaultcommon.SecretResponse{}
 	for _, secretRequest := range tp.Requests {
-		resp, ierr := r.observeGetSecretsRequest(ctx, reader, secretRequest)
+		resp, ierr := r.observeGetSecretsRequest(ctx, reader, secretRequest, requestsCountForID)
 		if ierr != nil {
 			logUserErrorAware(r.lggr, "failed to observe get secret request item", ierr, "id", secretRequest.Id)
 			errorMsg := userFacingError(ierr, "failed to handle get secret request")
@@ -938,10 +972,14 @@ func generatePlaintextShare(publicKey *tdh2easy.PublicKey, privateKeyShare *tdh2
 	return &share{data: sb}, nil
 }
 
-func (r *ReportingPlugin) observeGetSecretsRequest(ctx context.Context, reader ReadKVStore, secretRequest *vaultcommon.SecretRequest) (*vaultcommon.SecretResponse, error) {
+func (r *ReportingPlugin) observeGetSecretsRequest(ctx context.Context, reader ReadKVStore, secretRequest *vaultcommon.SecretRequest, requestsCountForID map[string]int) (*vaultcommon.SecretResponse, error) {
 	id, err := r.validateSecretIdentifier(ctx, secretRequest.Id)
 	if err != nil {
 		return nil, err
+	}
+
+	if requestsCountForID[vaulttypes.KeyFor(secretRequest.Id)] > 1 {
+		return nil, newUserError("duplicate request for secret identifier " + vaulttypes.KeyFor(id))
 	}
 
 	secret, err := reader.GetSecret(ctx, id)
@@ -1339,9 +1377,26 @@ func (r *ReportingPlugin) ValidateObservation(ctx context.Context, seqNr uint64,
 		return fmt.Errorf("invalid observation: wire size %d exceeds max observation bytes %d", len(ao.Observation), r.maxObservationBytes)
 	}
 
+	readKV := NewReadStore(keyValueReader, r.metrics)
+	var pendingQueueItems []*vaultcommon.StoredPendingQueueItem
+	if !gateAllows(ctx, r.lggr, r.cfg.VaultForceEmptyOCRRounds, "VaultForceEmptyOCRRounds") {
+		var err error
+		pendingQueueItems, err = readKV.GetPendingQueue(ctx)
+		if err != nil {
+			return fmt.Errorf("could not fetch pending queue from store: %w", err)
+		}
+	} else {
+		r.lggr.Warnw("VaultForceEmptyOCRRounds is enabled; pending queue is not read this OCR round — store-backed pending observation items are skipped")
+	}
+
+	pendingGetSecretsByID, err := buildPendingGetSecretsByID(pendingQueueItems)
+	if err != nil {
+		return fmt.Errorf("could not decode pending queue GetSecrets requests: %w", err)
+	}
+
 	idToObs := map[string]*vaultcommon.Observation{}
 	for _, o := range obs.Observations {
-		err := r.validateObservation(ctx, o)
+		err = r.validateObservation(ctx, o, pendingGetSecretsByID)
 		if err != nil {
 			return errors.New("invalid observation: " + err.Error())
 		}
@@ -1355,29 +1410,17 @@ func (r *ReportingPlugin) ValidateObservation(ctx context.Context, seqNr uint64,
 	}
 
 	// We expect
-	// - that every observation id corresponds to an item in the pending queue.
+	// - that every request id corresponds to an item in the pending queue.
 	//   This is because honest nodes may omit tail items when the full Observations proto would exceed the
 	//   max observation byte limit.
 	// - that all pending queue items can be fetched as blobs.
-	readKV := NewReadStore(keyValueReader, r.metrics)
-	var pendingQueueItems []*vaultcommon.StoredPendingQueueItem
-	if !gateAllows(ctx, r.lggr, r.cfg.VaultForceEmptyOCRRounds, "VaultForceEmptyOCRRounds") {
-		var err error
-		pendingQueueItems, err = readKV.GetPendingQueue(ctx)
-		if err != nil {
-			return fmt.Errorf("could not fetch pending queue from store: %w", err)
-		}
-	} else {
-		r.lggr.Warnw("VaultForceEmptyOCRRounds is enabled; pending queue is not read this OCR round — store-backed pending observation items are skipped")
-	}
-
 	pendingIDs := map[string]bool{}
 	for _, i := range pendingQueueItems {
 		pendingIDs[i.Id] = true
 	}
 	for id := range idToObs {
 		if !pendingIDs[id] {
-			return fmt.Errorf("invalid observation: observation id %s is not present in the pending queue", id)
+			return fmt.Errorf("invalid observation: request id %s is not present in the pending queue", id)
 		}
 	}
 
@@ -1437,14 +1480,21 @@ func shaForProto(msg proto.Message) (string, error) {
 	return fmt.Sprintf("%x", sha256.Sum256(protoBytes)), nil
 }
 
-func shaForObservation(o *vaultcommon.Observation) (string, error) {
+func (r *ReportingPlugin) shaForObservation(ctx context.Context, o *vaultcommon.Observation) (string, error) {
 	switch o.RequestType {
 	case vaultcommon.RequestType_GET_SECRETS:
 		cloned := proto.CloneOf(o)
-		for _, r := range cloned.GetGetSecretsResponse().Responses {
-			if r.GetData() != nil {
-				// Exclude the encrypted shares from the sha, as these need to be aggregated later.
-				r.GetData().EncryptedDecryptionKeyShares = nil
+		for _, rsp := range cloned.GetGetSecretsResponse().Responses {
+			if rsp.GetData() != nil {
+				if r.shareAggregationIncludesPublicKeys(ctx) {
+					for _, es := range rsp.GetData().EncryptedDecryptionKeyShares {
+						es.Shares = nil
+						es.BinaryShares = nil
+					}
+				} else {
+					// Exclude the encrypted shares from the sha, as these need to be aggregated later.
+					rsp.GetData().EncryptedDecryptionKeyShares = nil
+				}
 			}
 		}
 
@@ -1469,14 +1519,14 @@ func (r *ReportingPlugin) checkRequestBatchLimit(ctx context.Context, batchSize 
 	return nil
 }
 
-func (r *ReportingPlugin) validateObservation(ctx context.Context, o *vaultcommon.Observation) error {
+func (r *ReportingPlugin) validateObservation(ctx context.Context, o *vaultcommon.Observation, pendingGetSecretsByID map[string]*vaultcommon.GetSecretsRequest) error {
 	if o.Id == "" {
-		return errors.New("observation id cannot be empty")
+		return errors.New("request id cannot be empty")
 	}
 
 	switch o.RequestType {
 	case vaultcommon.RequestType_GET_SECRETS:
-		return r.validateGetSecretsObservation(ctx, o)
+		return r.validateGetSecretsObservation(ctx, o, pendingGetSecretsByID)
 	case vaultcommon.RequestType_CREATE_SECRETS:
 		return r.validateCreateSecretsObservation(ctx, o)
 	case vaultcommon.RequestType_UPDATE_SECRETS:
@@ -1490,14 +1540,26 @@ func (r *ReportingPlugin) validateObservation(ctx context.Context, o *vaultcommo
 	}
 }
 
-func (r *ReportingPlugin) validateGetSecretsObservation(ctx context.Context, o *vaultcommon.Observation) error {
+func (r *ReportingPlugin) validateGetSecretsObservation(ctx context.Context, o *vaultcommon.Observation, pendingGetSecretsByID map[string]*vaultcommon.GetSecretsRequest) error {
 	resp := o.GetGetSecretsResponse()
 	if resp == nil {
 		return errors.New("GetSecrets observation must have a response")
 	}
 
-	if err := r.checkRequestBatchLimit(ctx, len(resp.Responses)); err != nil {
+	pendingReq, ok := pendingGetSecretsByID[o.Id]
+	if !ok {
+		return fmt.Errorf("no GetSecrets request found in pending queue for request id %s", o.Id)
+	}
+	if embedded := o.GetGetSecretsRequest(); embedded != nil && !proto.Equal(embedded, pendingReq) {
+		return errors.New("embedded GetSecrets request does not match pending queue request")
+	}
+
+	if err := r.checkRequestBatchLimit(ctx, len(pendingReq.Requests)); err != nil {
 		return err
+	}
+
+	if len(pendingReq.Requests) != len(resp.Responses) {
+		return errors.New("GetSecrets request and response must have the same number of items")
 	}
 
 	respMap := map[string]*vaultcommon.SecretResponse{}
@@ -1521,13 +1583,17 @@ func (r *ReportingPlugin) validateGetSecretsObservation(ctx context.Context, o *
 			continue
 		}
 
+		secretReq, err := secretRequestForID(pendingReq, rsp.Id)
+		if err != nil {
+			return fmt.Errorf("GetSecrets response id not found in pending queue request: %w", err)
+		}
+		if err := validateGetSecretsShareLabels(secretReq, d); err != nil {
+			return err
+		}
+
 		// TODO orgID https://smartcontract-it.atlassian.net/browse/CRE-1707
 		innerCtx := contexts.WithCRE(ctx, contexts.CRE{Owner: rsp.Id.Owner})
 		for _, ds := range d.GetEncryptedDecryptionKeyShares() {
-			if err := validateEncryptedSharesEntry(ds); err != nil {
-				return err
-			}
-
 			shareSize, err := encryptedShareSizeForLimit(ds)
 			if err != nil {
 				return err
@@ -1718,7 +1784,7 @@ func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq 
 	// Phase 1: Process requests from the pending queue by aggregating observations.
 	// ---
 
-	// obsMap is a map from observation id -> list of observations across oracles.
+	// obsMap is a map from request id -> list of observations across oracles.
 	obsMap := map[string][]*vaultcommon.Observation{}
 	oidsToReqIDs := map[uint8][]string{} // for debugging only
 	for _, ao := range aos {
@@ -1751,7 +1817,7 @@ func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq 
 		// of the entries matching a given sha.
 		shaToObs := map[string][]*vaultcommon.Observation{}
 		for _, ob := range obs {
-			sha, err := shaForObservation(ob)
+			sha, err := r.shaForObservation(ctx, ob)
 			if err != nil {
 				r.lggr.Errorw("failed to compute sha for observation", "error", err, "observation", ob)
 				continue
@@ -2444,7 +2510,11 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 				ReportWithInfo: rep,
 			})
 		case vaultcommon.RequestType_CREATE_SECRETS:
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, o.GetCreateSecretsResponse())
+			createResp := proto.Clone(o.GetCreateSecretsResponse()).(*vaultcommon.CreateSecretsResponse)
+			if r.signedResponseRequestIDEnabled(ctx) {
+				createResp.RequestId = o.Id
+			}
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, createResp)
 			if err != nil {
 				r.lggr.Errorw("failed to generate JSON report", "error", err, "id", o.Id)
 				continue
@@ -2454,7 +2524,11 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 				ReportWithInfo: rep,
 			})
 		case vaultcommon.RequestType_UPDATE_SECRETS:
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, o.GetUpdateSecretsResponse())
+			updateResp := proto.Clone(o.GetUpdateSecretsResponse()).(*vaultcommon.UpdateSecretsResponse)
+			if r.signedResponseRequestIDEnabled(ctx) {
+				updateResp.RequestId = o.Id
+			}
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, updateResp)
 			if err != nil {
 				r.lggr.Errorw("failed to generate JSON report", "error", err, "id", o.Id)
 				continue
@@ -2464,7 +2538,11 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 				ReportWithInfo: rep,
 			})
 		case vaultcommon.RequestType_DELETE_SECRETS:
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, o.GetDeleteSecretsResponse())
+			deleteResp := proto.Clone(o.GetDeleteSecretsResponse()).(*vaultcommon.DeleteSecretsResponse)
+			if r.signedResponseRequestIDEnabled(ctx) {
+				deleteResp.RequestId = o.Id
+			}
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, deleteResp)
 			if err != nil {
 				r.lggr.Errorw("failed to generate JSON report", "error", err, "id", o.Id)
 				continue
@@ -2474,7 +2552,11 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 				ReportWithInfo: rep,
 			})
 		case vaultcommon.RequestType_LIST_SECRET_IDENTIFIERS:
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, o.GetListSecretIdentifiersResponse())
+			listResp := proto.Clone(o.GetListSecretIdentifiersResponse()).(*vaultcommon.ListSecretIdentifiersResponse)
+			if r.signedResponseRequestIDEnabled(ctx) {
+				listResp.RequestId = o.Id
+			}
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, listResp)
 			if err != nil {
 				r.lggr.Errorw("failed to generate JSON report", "error", err, "id", o.Id)
 				continue

--- a/core/services/ocr2/plugins/vault/plugin_helpers_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_helpers_test.go
@@ -36,7 +36,6 @@ type testPluginBuildOpts struct {
 	batchSize                               int
 	maxBlobPayloadBytes                     int
 	vaultOptimizationsEnabled               bool
-	vaultSignedResponseRequestIDEnabled     bool
 	vaultShareAggregationIncludesPublicKeys bool
 	marshalBlob                             func(ocr3_1types.BlobHandle) ([]byte, error)
 	unmarshalBlob                           func([]byte) (ocr3_1types.BlobHandle, error)
@@ -81,10 +80,6 @@ func withVaultOptimizationsEnabled() testPluginOption {
 
 func withVaultGetSecretsShareAggregationIncludesPublicKeys() testPluginOption {
 	return func(o *testPluginBuildOpts) { o.vaultShareAggregationIncludesPublicKeys = true }
-}
-
-func withVaultSignedResponseRequestIDEnabled() testPluginOption {
-	return func(o *testPluginBuildOpts) { o.vaultSignedResponseRequestIDEnabled = true }
 }
 
 func withOnchainCfg(n int, f int) testPluginOption {
@@ -145,9 +140,6 @@ func newTestReportingPlugin(t *testing.T, opts ...testPluginOption) *ReportingPl
 	}
 	if o.vaultShareAggregationIncludesPublicKeys {
 		cfg.VaultGetSecretsShareAggregationIncludesPublicKeys = limits.NewGateLimiter(true)
-	}
-	if o.vaultSignedResponseRequestIDEnabled {
-		cfg.VaultSignedResponseRequestIDEnabled = limits.NewGateLimiter(true)
 	}
 	ctx := context.Background()
 	pl, err := initializePluginLimits(ctx, limits.Factory{Settings: cresettings.DefaultGetter})
@@ -251,7 +243,6 @@ func makeReportingPluginConfig(
 		MaxBlobPayloadBytes:                               maxBlobPayloadLimiter,
 		VaultForceEmptyOCRRounds:                          limits.NewGateLimiter(false),
 		VaultOptimizationsEnabled:                         limits.NewGateLimiter(false),
-		VaultSignedResponseRequestIDEnabled:               limits.NewGateLimiter(false),
 		VaultGetSecretsShareAggregationIncludesPublicKeys: limits.NewGateLimiter(false),
 	}
 }

--- a/core/services/ocr2/plugins/vault/plugin_helpers_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_helpers_test.go
@@ -22,24 +22,26 @@ import (
 type testPluginOption func(*testPluginBuildOpts)
 
 type testPluginBuildOpts struct {
-	lggr                                 logger.Logger
-	store                                *requests.Store[*vaulttypes.Request]
-	publicKey                            *tdh2easy.PublicKey
-	privateKeyShare                      *tdh2easy.PrivateShare
-	onchainCfg                           ocr3types.ReportingPluginConfig
-	maxSecretsPerOwner                   int
-	maxCiphertextLengthBytes             int
-	maxIdentifierOwnerLengthBytes        int
-	maxIdentifierNamespaceLengthBytes    int
-	maxIdentifierKeyLengthBytes          int
-	maxRequestBatchSize                  int
-	batchSize                            int
-	maxBlobPayloadBytes                  int
-	vaultOptimizationsEnabled            bool
-	marshalBlob                          func(ocr3_1types.BlobHandle) ([]byte, error)
-	unmarshalBlob                        func([]byte) (ocr3_1types.BlobHandle, error)
-	maxObservationBytesOverride          int
-	maxReportsPlusPrecursorBytesOverride int
+	lggr                                    logger.Logger
+	store                                   *requests.Store[*vaulttypes.Request]
+	publicKey                               *tdh2easy.PublicKey
+	privateKeyShare                         *tdh2easy.PrivateShare
+	onchainCfg                              ocr3types.ReportingPluginConfig
+	maxSecretsPerOwner                      int
+	maxCiphertextLengthBytes                int
+	maxIdentifierOwnerLengthBytes           int
+	maxIdentifierNamespaceLengthBytes       int
+	maxIdentifierKeyLengthBytes             int
+	maxRequestBatchSize                     int
+	batchSize                               int
+	maxBlobPayloadBytes                     int
+	vaultOptimizationsEnabled               bool
+	vaultSignedResponseRequestIDEnabled     bool
+	vaultShareAggregationIncludesPublicKeys bool
+	marshalBlob                             func(ocr3_1types.BlobHandle) ([]byte, error)
+	unmarshalBlob                           func([]byte) (ocr3_1types.BlobHandle, error)
+	maxObservationBytesOverride             int
+	maxReportsPlusPrecursorBytesOverride    int
 }
 
 func withLggr(lggr logger.Logger) testPluginOption {
@@ -75,6 +77,14 @@ func withMaxSecretsPerOwner(n int) testPluginOption {
 
 func withVaultOptimizationsEnabled() testPluginOption {
 	return func(o *testPluginBuildOpts) { o.vaultOptimizationsEnabled = true }
+}
+
+func withVaultGetSecretsShareAggregationIncludesPublicKeys() testPluginOption {
+	return func(o *testPluginBuildOpts) { o.vaultShareAggregationIncludesPublicKeys = true }
+}
+
+func withVaultSignedResponseRequestIDEnabled() testPluginOption {
+	return func(o *testPluginBuildOpts) { o.vaultSignedResponseRequestIDEnabled = true }
 }
 
 func withOnchainCfg(n int, f int) testPluginOption {
@@ -132,6 +142,12 @@ func newTestReportingPlugin(t *testing.T, opts ...testPluginOption) *ReportingPl
 		o.maxIdentifierKeyLengthBytes, o.maxRequestBatchSize, o.maxBlobPayloadBytes)
 	if o.vaultOptimizationsEnabled {
 		cfg.VaultOptimizationsEnabled = limits.NewGateLimiter(true)
+	}
+	if o.vaultShareAggregationIncludesPublicKeys {
+		cfg.VaultGetSecretsShareAggregationIncludesPublicKeys = limits.NewGateLimiter(true)
+	}
+	if o.vaultSignedResponseRequestIDEnabled {
+		cfg.VaultSignedResponseRequestIDEnabled = limits.NewGateLimiter(true)
 	}
 	ctx := context.Background()
 	pl, err := initializePluginLimits(ctx, limits.Factory{Settings: cresettings.DefaultGetter})
@@ -223,18 +239,20 @@ func makeReportingPluginConfig(
 		MaxBatchSize:             bsl,
 		MaxPendingQueueWriteSize: maxPendingQueueWriteSizeLimiter,
 
-		PublicKey:                         publicKey,
-		PrivateKeyShare:                   privateKeyShare,
-		MaxSecretsPerOwner:                msl,
-		MaxShareLengthBytes:               shareLimiter,
-		MaxCiphertextLengthBytes:          cipherTextLimiter,
-		MaxIdentifierOwnerLengthBytes:     ownerLimiter,
-		MaxIdentifierNamespaceLengthBytes: namespaceOwnerLimiter,
-		MaxIdentifierKeyLengthBytes:       keyLimiter,
-		MaxRequestBatchSize:               requestBatchSizeLimiter,
-		MaxBlobPayloadBytes:               maxBlobPayloadLimiter,
-		VaultForceEmptyOCRRounds:          limits.NewGateLimiter(false),
-		VaultOptimizationsEnabled:         limits.NewGateLimiter(false),
+		PublicKey:                                         publicKey,
+		PrivateKeyShare:                                   privateKeyShare,
+		MaxSecretsPerOwner:                                msl,
+		MaxShareLengthBytes:                               shareLimiter,
+		MaxCiphertextLengthBytes:                          cipherTextLimiter,
+		MaxIdentifierOwnerLengthBytes:                     ownerLimiter,
+		MaxIdentifierNamespaceLengthBytes:                 namespaceOwnerLimiter,
+		MaxIdentifierKeyLengthBytes:                       keyLimiter,
+		MaxRequestBatchSize:                               requestBatchSizeLimiter,
+		MaxBlobPayloadBytes:                               maxBlobPayloadLimiter,
+		VaultForceEmptyOCRRounds:                          limits.NewGateLimiter(false),
+		VaultOptimizationsEnabled:                         limits.NewGateLimiter(false),
+		VaultSignedResponseRequestIDEnabled:               limits.NewGateLimiter(false),
+		VaultGetSecretsShareAggregationIncludesPublicKeys: limits.NewGateLimiter(false),
 	}
 }
 

--- a/core/services/ocr2/plugins/vault/plugin_share_label_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_share_label_test.go
@@ -1,0 +1,347 @@
+package vault
+
+import (
+	"context"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/protobuf/proto"
+
+	libocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	"github.com/smartcontractkit/tdh2/go/tdh2/tdh2easy"
+
+	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaultutils"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func TestPlugin_ValidateObservation_GetSecrets_BogusShareLabelRejected(t *testing.T) {
+	t.Parallel()
+	_, vaultPub, vaultShares, err := tdh2easy.GenerateKeys(2, 4)
+	require.NoError(t, err)
+
+	encKey := strings.Repeat("ab", 32)
+	id := &vaultcommon.SecretIdentifier{Owner: "52bc44d5378309ee2abf1539bf71de1b7d7be3b5", Namespace: "main", Key: "mysecret"}
+	req := &vaultcommon.GetSecretsRequest{
+		Requests: []*vaultcommon.SecretRequest{{Id: id, EncryptionKeys: []string{encKey}}},
+	}
+
+	esHex, err := vaultutils.EncryptSecretWithWorkflowOwner("secret", vaultPub, common.HexToAddress(id.Owner))
+	require.NoError(t, err)
+	esBytes, err := hex.DecodeString(esHex)
+	require.NoError(t, err)
+
+	honestResp := buildHonestGetSecretsResponse(t, id, esHex, vaultPub, vaultShares[0], []string{encKey}, esBytes, id.Owner)
+	byzResp := proto.Clone(honestResp).(*vaultcommon.GetSecretsResponse)
+	byzResp.Responses[0].GetData().EncryptedDecryptionKeyShares[0].EncryptionKey = strings.Repeat("ba", 32)
+
+	rdr := &kv{m: make(map[string]response)}
+	writeGetSecretsPendingQueueItem(t, rdr, vaulttypes.KeyFor(id), req)
+
+	plugin := newTestReportingPlugin(t, withKeys(vaultPub, vaultShares[0]), withOnchainCfg(4, 1))
+	byzObs := marshalObservations(t, observation{id, req, byzResp})
+
+	err = plugin.ValidateObservation(
+		context.Background(),
+		1,
+		libocrtypes.AttributedQuery{},
+		libocrtypes.AttributedObservation{Observer: 0, Observation: libocrtypes.Observation(byzObs)},
+		rdr,
+		&blobber{},
+	)
+	require.ErrorContains(t, err, "unexpected encryption key in response")
+}
+
+func TestPlugin_ValidateObservation_GetSecrets_EmbeddedRequestMismatchRejected(t *testing.T) {
+	t.Parallel()
+	_, vaultPub, vaultShares, err := tdh2easy.GenerateKeys(2, 4)
+	require.NoError(t, err)
+
+	realKey := strings.Repeat("ab", 32)
+	bogusKey := strings.Repeat("ba", 32)
+	id := &vaultcommon.SecretIdentifier{Owner: "52bc44d5378309ee2abf1539bf71de1b7d7be3b5", Namespace: "main", Key: "mysecret"}
+	pendingReq := &vaultcommon.GetSecretsRequest{
+		Requests: []*vaultcommon.SecretRequest{{Id: id, EncryptionKeys: []string{realKey}}},
+	}
+	embeddedReq := &vaultcommon.GetSecretsRequest{
+		Requests: []*vaultcommon.SecretRequest{{Id: id, EncryptionKeys: []string{bogusKey}}},
+	}
+
+	esHex, err := vaultutils.EncryptSecretWithWorkflowOwner("secret", vaultPub, common.HexToAddress(id.Owner))
+	require.NoError(t, err)
+	esBytes, err := hex.DecodeString(esHex)
+	require.NoError(t, err)
+
+	resp := buildHonestGetSecretsResponse(t, id, esHex, vaultPub, vaultShares[0], []string{bogusKey}, esBytes, id.Owner)
+	rdr := &kv{m: make(map[string]response)}
+	writeGetSecretsPendingQueueItem(t, rdr, vaulttypes.KeyFor(id), pendingReq)
+
+	plugin := newTestReportingPlugin(t, withKeys(vaultPub, vaultShares[0]), withOnchainCfg(4, 1))
+	obs := marshalObservations(t, observation{id, embeddedReq, resp})
+
+	err = plugin.ValidateObservation(
+		context.Background(),
+		1,
+		libocrtypes.AttributedQuery{},
+		libocrtypes.AttributedObservation{Observer: 0, Observation: libocrtypes.Observation(obs)},
+		rdr,
+		&blobber{},
+	)
+	require.ErrorContains(t, err, "embedded GetSecrets request does not match pending queue request")
+}
+
+func TestPlugin_ShaForObservation_ShareAggregationIncludesPublicKeysFlag(t *testing.T) {
+	t.Parallel()
+	id := &vaultcommon.SecretIdentifier{Owner: "owner", Namespace: "main", Key: "secret"}
+	realKey := strings.Repeat("ab", 32)
+	bogusKey := strings.Repeat("ba", 32)
+	req := &vaultcommon.GetSecretsRequest{
+		Requests: []*vaultcommon.SecretRequest{{Id: id, EncryptionKeys: []string{realKey}}},
+	}
+	honestResp := &vaultcommon.GetSecretsResponse{
+		Responses: []*vaultcommon.SecretResponse{{
+			Id: id,
+			Result: &vaultcommon.SecretResponse_Data{
+				Data: &vaultcommon.SecretData{
+					EncryptedValue: "encrypted-value",
+					EncryptedDecryptionKeyShares: []*vaultcommon.EncryptedShares{{
+						EncryptionKey: realKey,
+						Shares:        []string{"share"},
+					}},
+				},
+			},
+		}},
+	}
+	byzResp := proto.Clone(honestResp).(*vaultcommon.GetSecretsResponse)
+	byzResp.Responses[0].GetData().EncryptedDecryptionKeyShares[0].EncryptionKey = bogusKey
+
+	honestObs := &vaultcommon.Observation{
+		Id:          vaulttypes.KeyFor(id),
+		RequestType: vaultcommon.RequestType_GET_SECRETS,
+		Request:     &vaultcommon.Observation_GetSecretsRequest{GetSecretsRequest: req},
+		Response:    &vaultcommon.Observation_GetSecretsResponse{GetSecretsResponse: honestResp},
+	}
+	byzObs := proto.Clone(honestObs).(*vaultcommon.Observation)
+	byzObs.Response = &vaultcommon.Observation_GetSecretsResponse{GetSecretsResponse: byzResp}
+
+	ctx := context.Background()
+	pluginOff := newTestReportingPlugin(t, withOnchainCfg(4, 1))
+	shaHonestOff, err := pluginOff.shaForObservation(ctx, honestObs)
+	require.NoError(t, err)
+	shaByzOff, err := pluginOff.shaForObservation(ctx, byzObs)
+	require.NoError(t, err)
+	require.Equal(t, shaHonestOff, shaByzOff)
+
+	pluginOn := newTestReportingPlugin(t, withOnchainCfg(4, 1), withVaultGetSecretsShareAggregationIncludesPublicKeys())
+	shaHonestOn, err := pluginOn.shaForObservation(ctx, honestObs)
+	require.NoError(t, err)
+	shaByzOn, err := pluginOn.shaForObservation(ctx, byzObs)
+	require.NoError(t, err)
+	require.NotEqual(t, shaHonestOn, shaByzOn)
+}
+
+func TestPlugin_ShaForObservation_ShareAggregationIncludesPublicKeys_PermutedEntryOrder(t *testing.T) {
+	t.Parallel()
+	id := &vaultcommon.SecretIdentifier{Owner: "owner", Namespace: "main", Key: "secret"}
+	keyA := strings.Repeat("aa", 32)
+	keyB := strings.Repeat("bb", 32)
+	req := &vaultcommon.GetSecretsRequest{
+		Requests: []*vaultcommon.SecretRequest{{Id: id, EncryptionKeys: []string{keyA, keyB}}},
+	}
+
+	makeObs := func(order []string, shares []string) *vaultcommon.Observation {
+		entries := make([]*vaultcommon.EncryptedShares, len(order))
+		for i, key := range order {
+			entries[i] = &vaultcommon.EncryptedShares{EncryptionKey: key, Shares: []string{shares[i]}}
+		}
+		resp := &vaultcommon.GetSecretsResponse{
+			Responses: []*vaultcommon.SecretResponse{{
+				Id: id,
+				Result: &vaultcommon.SecretResponse_Data{
+					Data: &vaultcommon.SecretData{
+						EncryptedValue:               "encrypted-value",
+						EncryptedDecryptionKeyShares: entries,
+					},
+				},
+			}},
+		}
+		return &vaultcommon.Observation{
+			Id:          vaulttypes.KeyFor(id),
+			RequestType: vaultcommon.RequestType_GET_SECRETS,
+			Request:     &vaultcommon.Observation_GetSecretsRequest{GetSecretsRequest: req},
+			Response:    &vaultcommon.Observation_GetSecretsResponse{GetSecretsResponse: resp},
+		}
+	}
+
+	ctx := context.Background()
+	plugin := newTestReportingPlugin(t, withOnchainCfg(4, 1), withVaultGetSecretsShareAggregationIncludesPublicKeys())
+
+	shaAB, err := plugin.shaForObservation(ctx, makeObs([]string{keyA, keyB}, []string{"share-a1", "share-b1"}))
+	require.NoError(t, err)
+	shaBA, err := plugin.shaForObservation(ctx, makeObs([]string{keyB, keyA}, []string{"share-b2", "share-a2"}))
+	require.NoError(t, err)
+	require.NotEqual(t, shaAB, shaBA)
+}
+
+func TestPlugin_ShaForObservation_ShareAggregationIncludesPublicKeys_DifferentShareBytesSameLabels(t *testing.T) {
+	t.Parallel()
+	id := &vaultcommon.SecretIdentifier{Owner: "owner", Namespace: "main", Key: "secret"}
+	encKey := strings.Repeat("ab", 32)
+	req := &vaultcommon.GetSecretsRequest{
+		Requests: []*vaultcommon.SecretRequest{{Id: id, EncryptionKeys: []string{encKey}}},
+	}
+
+	makeObs := func(share string) *vaultcommon.Observation {
+		resp := &vaultcommon.GetSecretsResponse{
+			Responses: []*vaultcommon.SecretResponse{{
+				Id: id,
+				Result: &vaultcommon.SecretResponse_Data{
+					Data: &vaultcommon.SecretData{
+						EncryptedValue: "encrypted-value",
+						EncryptedDecryptionKeyShares: []*vaultcommon.EncryptedShares{{
+							EncryptionKey: encKey,
+							Shares:        []string{share},
+						}},
+					},
+				},
+			}},
+		}
+		return &vaultcommon.Observation{
+			Id:          vaulttypes.KeyFor(id),
+			RequestType: vaultcommon.RequestType_GET_SECRETS,
+			Request:     &vaultcommon.Observation_GetSecretsRequest{GetSecretsRequest: req},
+			Response:    &vaultcommon.Observation_GetSecretsResponse{GetSecretsResponse: resp},
+		}
+	}
+
+	ctx := context.Background()
+	plugin := newTestReportingPlugin(t, withOnchainCfg(4, 1), withVaultGetSecretsShareAggregationIncludesPublicKeys())
+
+	sha1, err := plugin.shaForObservation(ctx, makeObs("share-from-node-1"))
+	require.NoError(t, err)
+	sha2, err := plugin.shaForObservation(ctx, makeObs("share-from-node-2"))
+	require.NoError(t, err)
+	require.Equal(t, sha1, sha2)
+}
+
+func TestPlugin_StateTransition_GetSecretsRequest_ShareAggregationIncludesPublicKeys_CombinesShares(t *testing.T) {
+	t.Parallel()
+	lggr, observed := logger.TestLoggerObserved(t, zapcore.DebugLevel)
+	_, pk, shares, err := tdh2easy.GenerateKeys(1, 3)
+	require.NoError(t, err)
+	r := newTestReportingPlugin(t,
+		withLggr(lggr),
+		withKeys(pk, shares[0]),
+		withOnchainCfg(4, 1),
+		withVaultGetSecretsShareAggregationIncludesPublicKeys(),
+	)
+
+	id := &vaultcommon.SecretIdentifier{Owner: "owner", Namespace: "main", Key: "secret"}
+	keyA := strings.Repeat("aa", 32)
+	keyB := strings.Repeat("bb", 32)
+	req := &vaultcommon.GetSecretsRequest{
+		Requests: []*vaultcommon.SecretRequest{{Id: id, EncryptionKeys: []string{keyA, keyB}}},
+	}
+
+	makeResp := func(keyOrder []string, shareA, shareB string) *vaultcommon.GetSecretsResponse {
+		entries := map[string]*vaultcommon.EncryptedShares{
+			keyA: {EncryptionKey: keyA, Shares: []string{shareA}},
+			keyB: {EncryptionKey: keyB, Shares: []string{shareB}},
+		}
+		ordered := make([]*vaultcommon.EncryptedShares, len(keyOrder))
+		for i, key := range keyOrder {
+			ordered[i] = entries[key]
+		}
+		return &vaultcommon.GetSecretsResponse{
+			Responses: []*vaultcommon.SecretResponse{{
+				Id: id,
+				Result: &vaultcommon.SecretResponse_Data{
+					Data: &vaultcommon.SecretData{
+						EncryptedValue:               "encrypted-value",
+						EncryptedDecryptionKeyShares: ordered,
+					},
+				},
+			}},
+		}
+	}
+
+	obsb1 := marshalObservations(t, observation{id, req, makeResp([]string{keyA, keyB}, "share-a1", "share-b1")})
+	obsb2 := marshalObservations(t, observation{id, req, makeResp([]string{keyA, keyB}, "share-a2", "share-b2")})
+	obsb3 := marshalObservations(t, observation{id, req, makeResp([]string{keyA, keyB}, "share-a3", "share-b3")})
+
+	reportPrecursor, err := r.StateTransition(
+		t.Context(),
+		1,
+		libocrtypes.AttributedQuery{},
+		[]libocrtypes.AttributedObservation{
+			{Observer: 0, Observation: libocrtypes.Observation(obsb1)},
+			{Observer: 1, Observation: libocrtypes.Observation(obsb2)},
+			{Observer: 2, Observation: libocrtypes.Observation(obsb3)},
+		},
+		&kv{m: make(map[string]response)},
+		nil,
+	)
+	require.NoError(t, err)
+
+	os := &vaultcommon.Outcomes{}
+	require.NoError(t, proto.Unmarshal(reportPrecursor, os))
+	require.Len(t, os.Outcomes, 1)
+
+	expectedResp := &vaultcommon.GetSecretsResponse{
+		Responses: []*vaultcommon.SecretResponse{{
+			Id: id,
+			Result: &vaultcommon.SecretResponse_Data{
+				Data: &vaultcommon.SecretData{
+					EncryptedValue: "encrypted-value",
+					EncryptedDecryptionKeyShares: []*vaultcommon.EncryptedShares{
+						{EncryptionKey: keyA, Shares: []string{"share-a1", "share-a2", "share-a3"}},
+						{EncryptionKey: keyB, Shares: []string{"share-b1", "share-b2", "share-b3"}},
+					},
+				},
+			},
+		}},
+	}
+	assert.True(t, proto.Equal(expectedResp, os.Outcomes[0].GetGetSecretsResponse()))
+	assert.Equal(t, 1, observed.FilterMessage("sufficient observations for sha").Len())
+}
+
+func buildHonestGetSecretsResponse(
+	t *testing.T,
+	id *vaultcommon.SecretIdentifier,
+	esHex string,
+	pub *tdh2easy.PublicKey,
+	share *tdh2easy.PrivateShare,
+	encKeys []string,
+	esBytes []byte,
+	owner string,
+) *vaultcommon.GetSecretsResponse {
+	t.Helper()
+	entries := make([]*vaultcommon.EncryptedShares, len(encKeys))
+	for j, encKey := range encKeys {
+		sh, err := generatePlaintextShare(pub, share, esBytes, owner)
+		require.NoError(t, err)
+		enc, err := sh.encryptWithKeyBinary(encKey)
+		require.NoError(t, err)
+		entries[j] = &vaultcommon.EncryptedShares{
+			EncryptionKey: encKey,
+			Shares:        []string{hex.EncodeToString(enc)},
+		}
+	}
+	return &vaultcommon.GetSecretsResponse{
+		Responses: []*vaultcommon.SecretResponse{{
+			Id: id,
+			Result: &vaultcommon.SecretResponse_Data{
+				Data: &vaultcommon.SecretData{
+					EncryptedValue:               esHex,
+					EncryptedDecryptionKeyShares: entries,
+				},
+			},
+		}},
+	}
+}

--- a/core/services/ocr2/plugins/vault/plugin_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_test.go
@@ -1842,6 +1842,60 @@ func TestPlugin_Observation_CreateSecretsRequest_DisallowsDuplicateRequests(t *t
 	assert.Contains(t, resp.GetError(), "duplicate request for secret identifier")
 }
 
+func TestPlugin_Observation_GetSecretsRequest_DisallowsDuplicateRequests(t *testing.T) {
+	t.Parallel()
+	r := newTestReportingPlugin(t, withMaxIdentifierLengths(30, 30, 30), withOnchainCfg(4, 1))
+
+	seqNr := uint64(1)
+	rdr := &kv{m: make(map[string]response)}
+	id := &vaultcommon.SecretIdentifier{
+		Owner:     "owner",
+		Namespace: "main",
+		Key:       "secret",
+	}
+	p := &vaultcommon.GetSecretsRequest{
+		Requests: []*vaultcommon.SecretRequest{
+			{Id: id, EncryptionKeys: []string{"00"}},
+			{Id: id, EncryptionKeys: []string{"00"}},
+		},
+	}
+	anyp, err := anypb.New(p)
+	require.NoError(t, err)
+	require.NoError(t, newTestWriteStore(t, rdr).WritePendingQueue(t.Context(),
+		[]*vaultcommon.StoredPendingQueueItem{
+			{Id: "request-1", Item: anyp},
+		},
+	))
+
+	data, err := r.Observation(t.Context(), seqNr, types.AttributedQuery{}, rdr, &blobber{})
+	require.NoError(t, err)
+
+	obs := &vaultcommon.Observations{}
+	require.NoError(t, proto.Unmarshal(data, obs))
+	require.Len(t, obs.Observations, 1)
+	o := obs.Observations[0]
+
+	require.Equal(t, vaultcommon.RequestType_GET_SECRETS, o.RequestType)
+	require.True(t, proto.Equal(o.GetGetSecretsRequest(), p))
+
+	resp := o.GetGetSecretsResponse()
+	require.Len(t, resp.Responses, 2)
+	require.True(t, proto.Equal(id, resp.Responses[0].Id))
+	require.Contains(t, resp.Responses[0].GetError(), "duplicate request for secret identifier")
+	require.True(t, proto.Equal(id, resp.Responses[1].Id))
+	require.Contains(t, resp.Responses[1].GetError(), "duplicate request for secret identifier")
+
+	err = r.ValidateObservation(
+		t.Context(),
+		seqNr,
+		types.AttributedQuery{},
+		types.AttributedObservation{Observation: data},
+		rdr,
+		&blobber{},
+	)
+	require.ErrorContains(t, err, "duplicate response found for item owner::main::secret")
+}
+
 func TestPlugin_StateTransition_CreateSecretsRequest_CorrectlyTracksLimits(t *testing.T) {
 	_, pk, shares, err := tdh2easy.GenerateKeys(1, 3)
 	require.NoError(t, err)
@@ -2661,6 +2715,16 @@ type observation struct {
 	resp proto.Message
 }
 
+func writeGetSecretsPendingQueueItem(t *testing.T, kv *kv, obsID string, req *vaultcommon.GetSecretsRequest) {
+	t.Helper()
+	anyp, err := anypb.New(req)
+	require.NoError(t, err)
+	err = newTestWriteStore(t, kv).WritePendingQueue(t.Context(),
+		[]*vaultcommon.StoredPendingQueueItem{{Id: obsID, Item: anyp}},
+	)
+	require.NoError(t, err)
+}
+
 func marshalObservations(t *testing.T, observations ...observation) []byte {
 	obs := &vaultcommon.Observations{
 		Observations: []*vaultcommon.Observation{},
@@ -2820,6 +2884,8 @@ func TestPlugin_StateTransition_GetSecretsRequest_ResponseSizeWithinLimit(t *tes
 	require.LessOrEqual(t, len(ciphertextBytes), 2000)
 	encryptedValue := hex.EncodeToString(ciphertextBytes)
 
+	kvStore := &kv{m: make(map[string]response)}
+
 	// Create 10 observations from different observers, each with a distinct decryption share.
 	aos := make([]types.AttributedObservation, numObservers)
 	for i := range numObservers {
@@ -2829,7 +2895,6 @@ func TestPlugin_StateTransition_GetSecretsRequest_ResponseSizeWithinLimit(t *tes
 		}
 	}
 
-	kvStore := &kv{m: make(map[string]response)}
 	reportPrecursor, err := r.StateTransition(
 		t.Context(),
 		1,
@@ -2909,7 +2974,8 @@ func TestPlugin_ValidateObservations_InvalidObservations(t *testing.T) {
 
 	require.ErrorContains(t, err, "failed to unmarshal observations")
 
-	// Invalid observation -- a single observation set has observations for multiple request ids
+	// Invalid observation -- duplicate observations for the same request id
+	writeGetSecretsPendingQueueItem(t, kv, vaulttypes.KeyFor(id1), req)
 	correctResp := &vaultcommon.GetSecretsResponse{
 		Responses: []*vaultcommon.SecretResponse{
 			{
@@ -2994,7 +3060,7 @@ func TestPlugin_ValidateObservations_RequiresObservedIDsInPendingQueue(t *testin
 		kv,
 		nil,
 	)
-	require.ErrorContains(t, err, "is not present in the pending queue")
+	require.ErrorContains(t, err, "no GetSecrets request found in pending queue")
 
 	resp := &vaultcommon.GetSecretsResponse{
 		Responses: []*vaultcommon.SecretResponse{
@@ -3213,10 +3279,12 @@ func TestPlugin_StateTransition_GetSecretsRequest_CombinesShares(t *testing.T) {
 		Namespace: "main",
 		Key:       "secret",
 	}
+	encKey := "my-encryption-key"
 	req := &vaultcommon.GetSecretsRequest{
 		Requests: []*vaultcommon.SecretRequest{
 			{
-				Id: id,
+				Id:             id,
+				EncryptionKeys: []string{encKey},
 			},
 		},
 	}
@@ -3336,10 +3404,12 @@ func TestPlugin_StateTransition_GetSecretsRequest_CombinesBinaryShares(t *testin
 		Namespace: "main",
 		Key:       "secret",
 	}
+	encKey := "my-encryption-key"
 	req := &vaultcommon.GetSecretsRequest{
 		Requests: []*vaultcommon.SecretRequest{
 			{
-				Id: id,
+				Id:             id,
+				EncryptionKeys: []string{encKey},
 			},
 		},
 	}
@@ -3460,10 +3530,12 @@ func TestPlugin_StateTransition_GetSecretsRequest_CapsSharesAtTwoFPlusOne(t *tes
 		Namespace: "main",
 		Key:       "secret",
 	}
+	encKey := "my-encryption-key"
 	req := &vaultcommon.GetSecretsRequest{
 		Requests: []*vaultcommon.SecretRequest{
 			{
-				Id: id,
+				Id:             id,
+				EncryptionKeys: []string{encKey},
 			},
 		},
 	}
@@ -3548,8 +3620,10 @@ func TestPlugin_StateTransition_GetSecretsRequest_DoesNotCapSharesWhenOptimizati
 		Namespace: "main",
 		Key:       "secret",
 	}
+	encKey := "my-encryption-key"
+	kvStore := &kv{m: make(map[string]response)}
 	req := &vaultcommon.GetSecretsRequest{
-		Requests: []*vaultcommon.SecretRequest{{Id: id}},
+		Requests: []*vaultcommon.SecretRequest{{Id: id, EncryptionKeys: []string{encKey}}},
 	}
 	makeResp := func(share string) *vaultcommon.GetSecretsResponse {
 		return &vaultcommon.GetSecretsResponse{
@@ -3579,7 +3653,7 @@ func TestPlugin_StateTransition_GetSecretsRequest_DoesNotCapSharesWhenOptimizati
 			{Observer: 2, Observation: types.Observation(marshalObservations(t, observation{id, req, makeResp("share-3")}))},
 			{Observer: 3, Observation: types.Observation(marshalObservations(t, observation{id, req, makeResp("share-4")}))},
 		},
-		&kv{m: make(map[string]response)},
+		kvStore,
 		nil,
 	)
 	require.NoError(t, err)
@@ -3599,7 +3673,9 @@ func TestPlugin_StateTransition_GetSecretsRequest_OmitsOutcomeRequestWhenOptimiz
 	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1), withVaultOptimizationsEnabled())
 
 	id := &vaultcommon.SecretIdentifier{Owner: "owner", Namespace: "main", Key: "secret"}
-	req := &vaultcommon.GetSecretsRequest{Requests: []*vaultcommon.SecretRequest{{Id: id}}}
+	encKey := "my-encryption-key"
+	kvStore := &kv{m: make(map[string]response)}
+	req := &vaultcommon.GetSecretsRequest{Requests: []*vaultcommon.SecretRequest{{Id: id, EncryptionKeys: []string{encKey}}}}
 	resp := &vaultcommon.GetSecretsResponse{
 		Responses: []*vaultcommon.SecretResponse{
 			{
@@ -3626,7 +3702,7 @@ func TestPlugin_StateTransition_GetSecretsRequest_OmitsOutcomeRequestWhenOptimiz
 			{Observer: 1, Observation: types.Observation(obsb)},
 			{Observer: 2, Observation: types.Observation(obsb)},
 		},
-		&kv{m: make(map[string]response)},
+		kvStore,
 		nil,
 	)
 	require.NoError(t, err)
@@ -6055,7 +6131,7 @@ func TestPlugin_ValidateObservation_GetSecretsRequest(t *testing.T) {
 						EncryptedValue: "encrypted-value",
 						EncryptedDecryptionKeyShares: []*vaultcommon.EncryptedShares{
 							{
-								EncryptionKey: "my-encryption-key",
+								EncryptionKey: pks,
 								BinaryShares:  [][]byte{[]byte("encrypted-binary-share")},
 							},
 						},
@@ -6139,6 +6215,7 @@ func TestPlugin_ValidateObservation_GetSecretsRequest(t *testing.T) {
 						EncryptedValue: "encrypted-value",
 						EncryptedDecryptionKeyShares: []*vaultcommon.EncryptedShares{
 							{
+								EncryptionKey: pks,
 								Shares: []string{strings.Repeat("1", 1000)},
 							},
 						},
@@ -6176,8 +6253,7 @@ func TestPlugin_ValidateObservation_GetSecretsRequest(t *testing.T) {
 	)
 	require.ErrorContains(t, err, "invalid observation: share provided exceeds maximum size allowed")
 
-	// More responses than requests in the original GetSecretsRequest is now valid because
-	// request content is no longer included in the observation — validation is response-only.
+	// More responses than requests is invalid; request and response counts must match.
 	resp = &vaultcommon.GetSecretsResponse{
 		Responses: []*vaultcommon.SecretResponse{
 			{
@@ -6218,10 +6294,9 @@ func TestPlugin_ValidateObservation_GetSecretsRequest(t *testing.T) {
 		rdr,
 		bf,
 	)
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "GetSecrets request and response must have the same number of items")
 
-	// An empty EncryptedShares list is now valid because the per-key cross-check against
-	// the request's EncryptionKeys is no longer performed.
+	// Empty EncryptedShares on a data response is invalid when the pending-queue request has EncryptionKeys.
 	resp = &vaultcommon.GetSecretsResponse{
 		Responses: []*vaultcommon.SecretResponse{
 			{
@@ -6259,10 +6334,23 @@ func TestPlugin_ValidateObservation_GetSecretsRequest(t *testing.T) {
 		rdr,
 		bf,
 	)
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "expected 1 encrypted share entries")
 
-	// Batch limit is now enforced on the response count, not the request count.
 	rBatchLimited := newTestReportingPlugin(t, withMaxRequestBatchSize(1), withKeys(pk, shares[0]), withOnchainCfg(4, 1))
+
+	reqTwo := &vaultcommon.GetSecretsRequest{
+		Requests: []*vaultcommon.SecretRequest{
+			{Id: id, EncryptionKeys: []string{pks}},
+			{Id: &vaultcommon.SecretIdentifier{Owner: "owner", Namespace: "main", Key: "secret2"}, EncryptionKeys: []string{pks}},
+		},
+	}
+	anypTwo, err := anypb.New(reqTwo)
+	require.NoError(t, err)
+	require.NoError(t, newTestWriteStore(t, rdr).WritePendingQueue(t.Context(),
+		[]*vaultcommon.StoredPendingQueueItem{
+			{Id: "request-1", Item: anypTwo},
+		},
+	))
 
 	resp = &vaultcommon.GetSecretsResponse{
 		Responses: []*vaultcommon.SecretResponse{
@@ -6346,7 +6434,10 @@ func TestPlugin_ValidateObservation_GetSecrets_MismatchedResponseOwnerRejected(t
 		},
 	}
 
-	require.NoError(t, r.validateObservation(t.Context(), obs))
+	pendingGetSecretsByID := map[string]*vaultcommon.GetSecretsRequest{
+		"request-1": obs.GetGetSecretsRequest(),
+	}
+	require.NoError(t, r.validateObservation(t.Context(), obs, pendingGetSecretsByID))
 }
 
 func TestPlugin_ValidateObservation_PanicsOnEmptyShares(t *testing.T) {
@@ -6459,8 +6550,7 @@ func TestPlugin_ValidateObservation_NilSecretIdentifier(t *testing.T) {
 		expectError bool
 	}{
 		{
-			// The request is no longer included in GetSecrets observations, so a nil Id
-			// in the request field does not cause a validation error.
+			// Pending-queue request identifiers are not re-validated here; only response IDs are.
 			name: "GetSecrets request with nil Id passes",
 			obs: &vaultcommon.Observation{
 				Id:          "request-1",
@@ -6956,9 +7046,8 @@ func TestPlugin_ValidateObservation_SecretIdentifierValidation(t *testing.T) {
 		}
 	}
 
-	// makeGetSecretsObs puts the identifier only in the request; the response always uses validID.
-	// Since GetSecrets observations no longer include the request, identifier validation on the
-	// request side is not performed — all these cases pass regardless of the request ID.
+	// makeGetSecretsObs puts the identifier in the pending-queue request; the response uses validID.
+	// Request-side identifier validation is not performed in validateGetSecretsObservation.
 	makeGetSecretsObs := func(id *vaultcommon.SecretIdentifier) *vaultcommon.Observation {
 		req := &vaultcommon.GetSecretsRequest{
 			Requests: []*vaultcommon.SecretRequest{{Id: id, EncryptionKeys: []string{"key"}}},
@@ -6979,8 +7068,6 @@ func TestPlugin_ValidateObservation_SecretIdentifierValidation(t *testing.T) {
 
 	tests := []testCase{
 		// --- GetSecrets ---
-		// Request identifiers are not validated for GetSecrets (request is not included in the
-		// observation). All cases pass regardless of the identifier in the request.
 		{
 			name:      "GetSecrets valid identifier passes",
 			obs:       makeGetSecretsObs(validID),
@@ -7469,10 +7556,12 @@ func TestPlugin_ValidateObservation_RequestBatchLimit(t *testing.T) {
 			)
 			rdr := &kv{m: make(map[string]response)}
 
+			obsItem := makeObservation(t, tc.reqType, tc.batchSize)
+			if tc.reqType == vaultcommon.RequestType_GET_SECRETS {
+				writeGetSecretsPendingQueueItem(t, rdr, obsItem.Id, obsItem.GetGetSecretsRequest())
+			}
 			obs := &vaultcommon.Observations{
-				Observations: []*vaultcommon.Observation{
-					makeObservation(t, tc.reqType, tc.batchSize),
-				},
+				Observations: []*vaultcommon.Observation{obsItem},
 			}
 			ob := protoMarshal(t, obs)
 

--- a/core/services/ocr2/plugins/vault/plugin_utils.go
+++ b/core/services/ocr2/plugins/vault/plugin_utils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
@@ -73,6 +74,74 @@ func appendEncryptedShareEntry(dst, src *vaultcommon.EncryptedShares) {
 		return
 	}
 	dst.Shares = append(dst.Shares, src.Shares[0])
+}
+
+func secretRequestForID(req *vaultcommon.GetSecretsRequest, id *vaultcommon.SecretIdentifier) (*vaultcommon.SecretRequest, error) {
+	if req == nil {
+		return nil, errors.New("GetSecrets request is nil")
+	}
+	if id == nil {
+		return nil, errors.New("secret identifier is nil")
+	}
+	key := vaulttypes.KeyFor(id)
+	for _, secretReq := range req.Requests {
+		if vaulttypes.KeyFor(secretReq.Id) == key {
+			return secretReq, nil
+		}
+	}
+	return nil, fmt.Errorf("no secret request for id %s", key)
+}
+
+func validateGetSecretsShareLabels(secretReq *vaultcommon.SecretRequest, data *vaultcommon.SecretData) error {
+	if len(data.EncryptedDecryptionKeyShares) != len(secretReq.EncryptionKeys) {
+		return fmt.Errorf("expected %d encrypted share entries, got %d", len(secretReq.EncryptionKeys), len(data.EncryptedDecryptionKeyShares))
+	}
+
+	allowed := make(map[string]struct{}, len(secretReq.EncryptionKeys))
+	for _, pk := range secretReq.EncryptionKeys {
+		allowed[pk] = struct{}{}
+	}
+
+	seen := make(map[string]bool, len(secretReq.EncryptionKeys))
+	for _, es := range data.EncryptedDecryptionKeyShares {
+		if es == nil {
+			return errors.New("nil encrypted share entry")
+		}
+		if err := validateEncryptedSharesEntry(es); err != nil {
+			return err
+		}
+		if _, ok := allowed[es.EncryptionKey]; !ok {
+			return fmt.Errorf("unexpected encryption key in response: %s", es.EncryptionKey)
+		}
+		if seen[es.EncryptionKey] {
+			return fmt.Errorf("duplicate encryption key in response: %s", es.EncryptionKey)
+		}
+		seen[es.EncryptionKey] = true
+	}
+
+	for _, pk := range secretReq.EncryptionKeys {
+		if !seen[pk] {
+			return fmt.Errorf("missing encryption key in response: %s", pk)
+		}
+	}
+
+	return nil
+}
+
+func buildPendingGetSecretsByID(items []*vaultcommon.StoredPendingQueueItem) (map[string]*vaultcommon.GetSecretsRequest, error) {
+	out := make(map[string]*vaultcommon.GetSecretsRequest, len(items))
+	for _, item := range items {
+		payload, err := item.Item.UnmarshalNew()
+		if err != nil {
+			return nil, fmt.Errorf("pending queue item %s: %w", item.Id, err)
+		}
+		req, ok := payload.(*vaultcommon.GetSecretsRequest)
+		if !ok {
+			continue
+		}
+		out[item.Id] = req
+	}
+	return out, nil
 }
 
 func initializePluginLimits(ctx context.Context, limitsFactory limits.Factory) (ocr3_1types.ReportingPluginLimits, error) {

--- a/core/services/ocr2/plugins/vault/plugin_utils_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_utils_test.go
@@ -68,3 +68,60 @@ func TestAppendEncryptedShareEntry(t *testing.T) {
 		require.Empty(t, dst.Shares)
 	})
 }
+
+func TestSecretRequestForID(t *testing.T) {
+	t.Parallel()
+	id := &vaultcommon.SecretIdentifier{Owner: "owner", Namespace: "main", Key: "secret"}
+	req := &vaultcommon.GetSecretsRequest{
+		Requests: []*vaultcommon.SecretRequest{{Id: id, EncryptionKeys: []string{"k1"}}},
+	}
+	got, err := secretRequestForID(req, id)
+	require.NoError(t, err)
+	require.Equal(t, "k1", got.EncryptionKeys[0])
+
+	_, err = secretRequestForID(req, &vaultcommon.SecretIdentifier{Owner: "owner", Namespace: "main", Key: "missing"})
+	require.ErrorContains(t, err, "no secret request")
+
+	_, err = secretRequestForID(nil, id)
+	require.ErrorContains(t, err, "GetSecrets request is nil")
+}
+
+func TestValidateGetSecretsShareLabels(t *testing.T) {
+	t.Parallel()
+	secretReq := &vaultcommon.SecretRequest{
+		Id:             &vaultcommon.SecretIdentifier{Owner: "owner", Namespace: "main", Key: "secret"},
+		EncryptionKeys: []string{"key-a", "key-b"},
+	}
+
+	t.Run("valid labels", func(t *testing.T) {
+		t.Parallel()
+		err := validateGetSecretsShareLabels(secretReq, &vaultcommon.SecretData{
+			EncryptedDecryptionKeyShares: []*vaultcommon.EncryptedShares{
+				{EncryptionKey: "key-a", Shares: []string{"s1"}},
+				{EncryptionKey: "key-b", Shares: []string{"s2"}},
+			},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("bogus label", func(t *testing.T) {
+		t.Parallel()
+		err := validateGetSecretsShareLabels(secretReq, &vaultcommon.SecretData{
+			EncryptedDecryptionKeyShares: []*vaultcommon.EncryptedShares{
+				{EncryptionKey: "bogus", Shares: []string{"s1"}},
+				{EncryptionKey: "key-b", Shares: []string{"s2"}},
+			},
+		})
+		require.ErrorContains(t, err, "unexpected encryption key")
+	})
+
+	t.Run("missing label", func(t *testing.T) {
+		t.Parallel()
+		err := validateGetSecretsShareLabels(secretReq, &vaultcommon.SecretData{
+			EncryptedDecryptionKeyShares: []*vaultcommon.EncryptedShares{
+				{EncryptionKey: "key-a", Shares: []string{"s1"}},
+			},
+		})
+		require.ErrorContains(t, err, "expected 2 encrypted share entries")
+	})
+}

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -42,14 +42,14 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260618155522-3600f66e26cd
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260522094612-5f9f748bd87a
 	github.com/smartcontractkit/chainlink-deployments-framework v0.105.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260623170329-4577ef4ba0ae
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20260521215851-3fdbb363496f
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.10.1-0.20260528221400-84746b70eeeb
 	github.com/smartcontractkit/chainlink-solana v1.3.1-0.20260605202330-b5a89c32fdc1

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1380,8 +1380,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e h1:i42B2D1WjvQTOQANC7vawOx3xVCbLWSueDwXWOzMqNM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e/go.mod h1:paOB/6dy57owHtOGzhgaRBWRDT5BEWfnJF5M7sgkcro=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c h1:d7vdm9wydgwV2L2AFWstYdXC+VjHG2thEK0cGblYm2U=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c/go.mod h1:wUK7w5xRrFPD2qQfdt1fLXzQzWSb4PaZaxa4nsqCWVs=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0 h1:NExKM/D0HneOq/N5LGTbkV4VOa0UHCvfTNEb4GqYpto=
@@ -1418,8 +1418,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-20260505131349-78e491b80735/go.mod h1:zAJq6Tpkx5AdFUwW67dIYnW+Bdf50drCCpMR81Qxb4E=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7 h1:iRFmfMFQtcnhGDjCuARQG4MPbcmbbJDDw7MUH3GcGy8=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b h1:VDgJWDipihV9f7M5+d21d1RzSsg5rEv+iI12oN1VQbo=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 h1:SG+wAsNyAcA6Kk19ljuxi3HK9Ll2lpHik8OKoY4x7A0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0 h1:q+VDPcxWrj5k9QizSYfUOSMnDH3Sd5HvbPguZOgfXTY=

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260522094612-5f9f748bd87a
@@ -97,7 +97,7 @@ require (
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260423135514-5b1a7565a99c
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20260521164805-26d78d5e1243
 	github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b
 	github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305
 	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305

--- a/go.sum
+++ b/go.sum
@@ -1165,8 +1165,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h1:WjZwKtUA/0TPvzgCt8bcdq+BHMIL65S0oU79mxgZn/Y=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e h1:i42B2D1WjvQTOQANC7vawOx3xVCbLWSueDwXWOzMqNM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e/go.mod h1:paOB/6dy57owHtOGzhgaRBWRDT5BEWfnJF5M7sgkcro=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c h1:d7vdm9wydgwV2L2AFWstYdXC+VjHG2thEK0cGblYm2U=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c/go.mod h1:wUK7w5xRrFPD2qQfdt1fLXzQzWSb4PaZaxa4nsqCWVs=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0 h1:NExKM/D0HneOq/N5LGTbkV4VOa0UHCvfTNEb4GqYpto=
@@ -1201,8 +1201,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-20260505131349-78e491b80735/go.mod h1:zAJq6Tpkx5AdFUwW67dIYnW+Bdf50drCCpMR81Qxb4E=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7 h1:iRFmfMFQtcnhGDjCuARQG4MPbcmbbJDDw7MUH3GcGy8=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b h1:VDgJWDipihV9f7M5+d21d1RzSsg5rEv+iI12oN1VQbo=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 h1:SG+wAsNyAcA6Kk19ljuxi3HK9Ll2lpHik8OKoY4x7A0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 h1:NJdGFhzT6zMaTod4QkBqVD2sg0I25iw1boOYtTpEwRo=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260618155522-3600f66e26cd
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260506144252-c100eabfda74
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.105.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260623170329-4577ef4ba0ae
@@ -408,7 +408,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-20260505131349-78e491b80735 // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d // indirect
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7 // indirect
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b // indirect
 	github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 // indirect
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 // indirect
 	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1365,8 +1365,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e h1:i42B2D1WjvQTOQANC7vawOx3xVCbLWSueDwXWOzMqNM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e/go.mod h1:paOB/6dy57owHtOGzhgaRBWRDT5BEWfnJF5M7sgkcro=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c h1:d7vdm9wydgwV2L2AFWstYdXC+VjHG2thEK0cGblYm2U=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c/go.mod h1:wUK7w5xRrFPD2qQfdt1fLXzQzWSb4PaZaxa4nsqCWVs=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0 h1:NExKM/D0HneOq/N5LGTbkV4VOa0UHCvfTNEb4GqYpto=
@@ -1403,8 +1403,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-20260505131349-78e491b80735/go.mod h1:zAJq6Tpkx5AdFUwW67dIYnW+Bdf50drCCpMR81Qxb4E=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7 h1:iRFmfMFQtcnhGDjCuARQG4MPbcmbbJDDw7MUH3GcGy8=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b h1:VDgJWDipihV9f7M5+d21d1RzSsg5rEv+iI12oN1VQbo=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 h1:SG+wAsNyAcA6Kk19ljuxi3HK9Ll2lpHik8OKoY4x7A0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0 h1:q+VDPcxWrj5k9QizSYfUOSMnDH3Sd5HvbPguZOgfXTY=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260618155522-3600f66e26cd
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260506144252-c100eabfda74
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c
 	github.com/smartcontractkit/chainlink-deployments-framework v0.105.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260623170329-4577ef4ba0ae
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.16.1
@@ -490,7 +490,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-20260505131349-78e491b80735 // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d // indirect
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7 // indirect
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b // indirect
 	github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 // indirect
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1631,8 +1631,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e h1:i42B2D1WjvQTOQANC7vawOx3xVCbLWSueDwXWOzMqNM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e/go.mod h1:paOB/6dy57owHtOGzhgaRBWRDT5BEWfnJF5M7sgkcro=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c h1:d7vdm9wydgwV2L2AFWstYdXC+VjHG2thEK0cGblYm2U=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c/go.mod h1:wUK7w5xRrFPD2qQfdt1fLXzQzWSb4PaZaxa4nsqCWVs=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0 h1:NExKM/D0HneOq/N5LGTbkV4VOa0UHCvfTNEb4GqYpto=
@@ -1669,8 +1669,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-20260505131349-78e491b80735/go.mod h1:zAJq6Tpkx5AdFUwW67dIYnW+Bdf50drCCpMR81Qxb4E=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7 h1:iRFmfMFQtcnhGDjCuARQG4MPbcmbbJDDw7MUH3GcGy8=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b h1:VDgJWDipihV9f7M5+d21d1RzSsg5rEv+iI12oN1VQbo=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 h1:SG+wAsNyAcA6Kk19ljuxi3HK9Ll2lpHik8OKoY4x7A0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0 h1:q+VDPcxWrj5k9QizSYfUOSMnDH3Sd5HvbPguZOgfXTY=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -33,12 +33,12 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.103
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20260609211101-71d38bd6a0a9
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.105.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260623170329-4577ef4ba0ae
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20260521215851-3fdbb363496f
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260528221400-84746b70eeeb

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1538,8 +1538,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h1:WjZwKtUA/0TPvzgCt8bcdq+BHMIL65S0oU79mxgZn/Y=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e h1:i42B2D1WjvQTOQANC7vawOx3xVCbLWSueDwXWOzMqNM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e/go.mod h1:paOB/6dy57owHtOGzhgaRBWRDT5BEWfnJF5M7sgkcro=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c h1:d7vdm9wydgwV2L2AFWstYdXC+VjHG2thEK0cGblYm2U=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c/go.mod h1:wUK7w5xRrFPD2qQfdt1fLXzQzWSb4PaZaxa4nsqCWVs=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0 h1:NExKM/D0HneOq/N5LGTbkV4VOa0UHCvfTNEb4GqYpto=
@@ -1576,8 +1576,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-20260505131349-78e491b80735/go.mod h1:zAJq6Tpkx5AdFUwW67dIYnW+Bdf50drCCpMR81Qxb4E=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7 h1:iRFmfMFQtcnhGDjCuARQG4MPbcmbbJDDw7MUH3GcGy8=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b h1:VDgJWDipihV9f7M5+d21d1RzSsg5rEv+iI12oN1VQbo=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 h1:SG+wAsNyAcA6Kk19ljuxi3HK9Ll2lpHik8OKoY4x7A0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0 h1:q+VDPcxWrj5k9QizSYfUOSMnDH3Sd5HvbPguZOgfXTY=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -58,12 +58,12 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/smartcontractkit/chain-selectors v1.0.103
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.105.0
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20260521215851-3fdbb363496f
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260331131315-f08a616d8dcd
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260528221400-84746b70eeeb
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.16.2

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1552,8 +1552,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h1:WjZwKtUA/0TPvzgCt8bcdq+BHMIL65S0oU79mxgZn/Y=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e h1:i42B2D1WjvQTOQANC7vawOx3xVCbLWSueDwXWOzMqNM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260623132104-b6e18bcd479e/go.mod h1:paOB/6dy57owHtOGzhgaRBWRDT5BEWfnJF5M7sgkcro=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c h1:d7vdm9wydgwV2L2AFWstYdXC+VjHG2thEK0cGblYm2U=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260624151936-a3e362497a1c/go.mod h1:wUK7w5xRrFPD2qQfdt1fLXzQzWSb4PaZaxa4nsqCWVs=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260601211238-9f526774fef0 h1:NExKM/D0HneOq/N5LGTbkV4VOa0UHCvfTNEb4GqYpto=
@@ -1590,8 +1590,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-20260505131349-78e491b80735/go.mod h1:zAJq6Tpkx5AdFUwW67dIYnW+Bdf50drCCpMR81Qxb4E=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d h1:AJy55QJ/pBhXkZjc7N+ATnWfxrcjq9BI9DmdtdjwDUQ=
 github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d/go.mod h1:5JdppgngCOUS76p61zCinSCgOhPeYQ+OcDUuome5THQ=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7 h1:iRFmfMFQtcnhGDjCuARQG4MPbcmbbJDDw7MUH3GcGy8=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260618082634-432eb85805e7/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b h1:VDgJWDipihV9f7M5+d21d1RzSsg5rEv+iI12oN1VQbo=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 h1:SG+wAsNyAcA6Kk19ljuxi3HK9Ll2lpHik8OKoY4x7A0=
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0 h1:q+VDPcxWrj5k9QizSYfUOSMnDH3Sd5HvbPguZOgfXTY=


### PR DESCRIPTION
## Summary

Cherry-picks #22931 from `develop` onto `release/2.53.1`.

- Reject GetSecrets observations with invalid encryption-key labels (nil shares when public keys are present in aggregation)
- Reject duplicate secret identifiers within a single GetSecrets request
- Move share nil-ing into the OCR plugin behind `VaultGetSecretsShareAggregationIncludesPublicKeys`
- Bump `chainlink-common` for the new cresettings gate

## Cherry-pick notes

Initial conflict resolution accidentally included `VaultSignedResponseRequestIDEnabled` from #22799 (already on develop, not part of #22931). Removed in follow-up commit.

## Test plan

- [x] `go test ./core/services/ocr2/plugins/vault/... -run 'ShareLabel|PluginUtils|ValidateObservation|duplicate|label'`
- [x] `go test ./core/capabilities/vault/... -run 'Validator'`
- [ ] CI