### PR TITLE
[CCIP-11146] Fix flaky Test_CCIPGasPriceUpdatesWriteFrequency

### DIFF
--- a/integration-tests/smoke/ccip/ccip_gas_price_updates_test.go
+++ b/integration-tests/smoke/ccip/ccip_gas_price_updates_test.go
@@ -67,11 +67,19 @@ func Test_CCIPGasPriceUpdatesWriteFrequency(t *testing.T) {
 	// Already because initial fee we set in the test is different from the fee that will be calculated
 	// based on weth price, both chains will have their fees updated to new prices after gasPriceExpiry time.
 	assert.Eventually(t, func() bool {
-		// offRamps should have updated the sequence number
+		// This condition runs in a separate goroutine spawned by assert.Eventually,
+		// so it must not call require/FailNow (which would runtime.Goexit the goroutine
+		// and hang the loop until timeout). Transient RPC errors are treated as a retry.
 		priceUpdatesSeqNumChain1Now, err := offRampChain1.GetLatestPriceSequenceNumber(callOpts)
-		require.NoError(t, err)
+		if err != nil {
+			t.Logf("failed to get latest price sequence number for chain1: %v", err)
+			return false
+		}
 		priceUpdatesSeqNumChain2Now, err := offRampChain2.GetLatestPriceSequenceNumber(callOpts)
-		require.NoError(t, err)
+		if err != nil {
+			t.Logf("failed to get latest price sequence number for chain2: %v", err)
+			return false
+		}
 		t.Logf("priceUpdatesSeqNumChain1: %v", priceUpdatesSeqNumChain1Now)
 		t.Logf("priceUpdatesSeqNumChain2: %v", priceUpdatesSeqNumChain2Now)
 		if priceUpdatesSeqNumChain1Now <= priceUpdatesSeqNumChain1 {
@@ -82,9 +90,15 @@ func Test_CCIPGasPriceUpdatesWriteFrequency(t *testing.T) {
 		}
 
 		chain2FeeNow, err := feeQuoter1.GetDestinationChainGasPrice(callOpts, sourceChain2)
-		require.NoError(t, err)
+		if err != nil {
+			t.Logf("failed to get destination chain gas price for chain2: %v", err)
+			return false
+		}
 		chain1FeeNow, err := feeQuoter2.GetDestinationChainGasPrice(callOpts, sourceChain1)
-		require.NoError(t, err)
+		if err != nil {
+			t.Logf("failed to get destination chain gas price for chain1: %v", err)
+			return false
+		}
 		t.Logf("chainFee1 (stored in chain2): %v", chain1FeeNow)
 		t.Logf("chainFee2 (stored in chain1): %v", chain2FeeNow)
 


### PR DESCRIPTION
## Motivation

`Test_CCIPGasPriceUpdatesWriteFrequency` (integration-tests/smoke/ccip) is flaky — tracked in [CCIP-11146](https://smartcontract-it.atlassian.net/browse/CCIP-11146).

## Root cause

The `assert.Eventually` condition called `require.NoError(t, err)`. testify runs the condition in a **separate goroutine** (`go checkCond()`), so `require`/`FailNow` there calls `runtime.Goexit()` on that goroutine *without* delivering a result on the result channel. A single transient simulated-RPC error therefore hangs the `Eventually` loop until its `waitFor` timeout (`tests.WaitTimeout(t)` ≈ the remaining shared-binary deadline) — or the package `-timeout` panic — surfacing as an intermittent flake rather than a clean failure.

## Change

Replace the four `require.NoError` calls inside the callback with `if err != nil { return false }` so transient errors retry on the next tick. The test's goal is unchanged.

## Validation

Local validation isn't feasible (separate Go module not reachable from the root-based diagnose harness); relying on CI to confirm the flake rate drops.

[CCIP-11146]: https://smartcontract-it.atlassian.net/browse/CCIP-11146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ