### PR TITLE
[CCIP-11722] Fix TestCCIPReader_Nonces flake: mine each SetInboundNonce tx

### DIFF
--- a/integration-tests/smoke/ccip/ccip_reader_test.go
+++ b/integration-tests/smoke/ccip/ccip_reader_test.go
@@ -756,14 +756,17 @@ func TestCCIPReader_Nonces(t *testing.T) {
 		Auth:               auth,
 	})
 
-	// Add some nonces.
+	// Add some nonces. Commit after each tx so the next iteration's PendingNonceAt
+	// observes the bumped nonce instead of racing the simulated txpool's async nonce
+	// accounting ("replacement transaction underpriced" under load). Mirrors
+	// commitSqNrs / emitCommitReports.
 	for chain, addrs := range nonces {
 		for addr, nonce := range addrs {
 			_, err := s.contract.SetInboundNonce(s.auth, uint64(chain), nonce, common.LeftPadBytes(addr.Bytes(), 32))
 			require.NoError(t, err)
+			s.sb.Commit()
 		}
 	}
-	s.sb.Commit()
 
 	request := make(map[cciptypes.ChainSelector][]string)
 	for chain, addresses := range nonces {


### PR DESCRIPTION
## What

Fixes the flaky `TestCCIPReader_Nonces` in `integration-tests/smoke/ccip` (CCIP-11722, ~30% failure rate in CI per Trunk).

## Root cause

The setup loop sends 6 `SetInboundNonce` txs from a single EOA (`auth.Nonce == nil`) with **no `Commit()` between them**, then a single `Commit()`. Each send resolves its nonce via `PendingNonceAt` on the `ethclient/simulated` backend, whose pending nonce is updated by an **asynchronous** txpool loop. Under CPU contention (the full `smoke/ccip` package running in parallel in CI), that loop lags — two consecutive sends resolve the same nonce, and go-ethereum rejects the duplicate with **"replacement transaction underpriced"**, failing `require.NoError`.

This is the same async-txpool nonce race fixed for `commitSqNrs` in #22031; `emitCommitReports` already follows the safe pattern.

## Fix

`Commit()` after each `SetInboundNonce` so the next iteration's `PendingNonceAt` reads the **committed** nonce instead of racing the async pending pool. The trailing redundant `Commit()` is removed.

## Verification

- `make test ARGS="diagnose --iterations 30 --parallel-iterations 2 -- --run TestCCIPReader_Nonces ./integration-tests/smoke/ccip"` post-fix: **30/30 pass**, no regression (p50 ~28s).
- The flake is CPU-contention-dependent and does not reproduce locally in isolation (30/30 also pass pre-fix in isolation) — confidence rests on the deterministic mechanism + the #22031 precedent.