### PR TITLE
fix testdb setup to ensure you can createrole

### DIFF
--- a/.changeset/small-hills-earn.md
+++ b/.changeset/small-hills-earn.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix Fixed permissions in test db setup script (grant CREATEROLE and repair leftover NOLOGIN pgtdbuser for pgtestdb)

--- a/core/scripts/setup_testdb.sh
+++ b/core/scripts/setup_testdb.sh
@@ -28,6 +28,18 @@ WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$database')\gexec
 ALTER DATABASE $database OWNER TO $username;
 GRANT ALL PRIVILEGES ON DATABASE "$database" TO "$username";
 ALTER USER $username CREATEDB;
+-- CREATEROLE is required by pgtestdb, which provisions an isolated role (pgtdbuser) per test run.
+ALTER USER $username CREATEROLE;
+
+-- Repair a leftover pgtdbuser from an earlier run that lacks LOGIN. pgtestdb only sets
+-- LOGIN when it first creates the role, so a pre-existing NOLOGIN role stays broken and
+-- tests fail with: role "pgtdbuser" is not permitted to log in (SQLSTATE 28000).
+DO \$\$
+BEGIN
+    IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgtdbuser' AND NOT rolcanlogin) THEN
+        ALTER ROLE pgtdbuser WITH LOGIN PASSWORD 'pgtdbpass';
+    END IF;
+END \$\$;
 
 EOF
 


### PR DESCRIPTION
Ran into this issue when running through the test setup instructions in the readme. I believe all it takes to recreate the issue was to run `make testdb-force` and then `go test ./core/store/migrate/`.
