### PR TITLE
feat(vault): omit empty JSON report fields behind signed request ID flag

### DIFF
--- a/core/capabilities/vault/vaultutils/json.go
+++ b/core/capabilities/vault/vaultutils/json.go
@@ -12,12 +12,13 @@ import (
 
 // ToCanonicalJSON converts a protobuf message to a stable, deterministic
 // representation, including consistent sorting of keys and fields, and
-// consistent spacing.
-func ToCanonicalJSON(msg proto.Message) ([]byte, error) {
+// consistent spacing. When omitUnpopulated is true, zero-value proto fields
+// are omitted from the JSON output.
+func ToCanonicalJSON(msg proto.Message, omitUnpopulated bool) ([]byte, error) {
 	jsonb, err := protojson.MarshalOptions{
 		UseProtoNames:   false,
 		UseEnumNumbers:  false,
-		EmitUnpopulated: true,
+		EmitUnpopulated: !omitUnpopulated,
 	}.Marshal(msg)
 	if err != nil {
 		return nil, err

--- a/core/capabilities/vault/vaultutils/json_test.go
+++ b/core/capabilities/vault/vaultutils/json_test.go
@@ -3,9 +3,9 @@ package vaultutils
 import (
 	"testing"
 
+	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -89,7 +89,7 @@ func TestToCanonicalJSON_OmitsEmptyFields(t *testing.T) {
 
 		canonicalJSON, err := ToCanonicalJSON(msg, true)
 		require.NoError(t, err)
-		assert.Equal(t, `{}`, string(canonicalJSON))
+		assert.JSONEq(t, `{}`, string(canonicalJSON))
 		assert.NotEqual(t, string(withEmptyFields), string(canonicalJSON))
 	})
 

--- a/core/capabilities/vault/vaultutils/json_test.go
+++ b/core/capabilities/vault/vaultutils/json_test.go
@@ -3,10 +3,11 @@ package vaultutils
 import (
 	"testing"
 
-	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 )
 
 func TestToCanonicalJSON(t *testing.T) {

--- a/core/capabilities/vault/vaultutils/json_test.go
+++ b/core/capabilities/vault/vaultutils/json_test.go
@@ -5,17 +5,20 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestToCanonicalJSON(t *testing.T) {
+	t.Parallel()
+
 	testData, err := structpb.NewValue(map[string]any{
 		"field1": "value1",
 		"field2": 42,
 	})
 	require.NoError(t, err)
 
-	canonicalJSON, err := ToCanonicalJSON(testData)
+	canonicalJSON, err := ToCanonicalJSON(testData, false)
 	require.NoError(t, err)
 
 	expectedJSON := `{"field1":"value1","field2":42}`
@@ -28,8 +31,83 @@ func TestToCanonicalJSON(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	canonicalJSON, err = ToCanonicalJSON(testData)
+	canonicalJSON, err = ToCanonicalJSON(testData, false)
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedJSON, string(canonicalJSON)) //nolint:testifylint // testifylint requires use of assert.JSONEq which doesn't do a string match of the JSON, but does a structural match.
+}
+
+func TestToCanonicalJSON_OmitsEmptyFields(t *testing.T) {
+	t.Parallel()
+
+	id := &vaultcommon.SecretIdentifier{
+		Owner:     "owner",
+		Namespace: "main",
+		Key:       "secret1",
+	}
+
+	t.Run("nested empty string and empty repeated field", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &vaultcommon.CreateSecretsResponse{
+			RequestId: "owner::req-1",
+			Responses: []*vaultcommon.CreateSecretResponse{
+				{
+					Id:      id,
+					Success: true,
+					Error:   "",
+				},
+			},
+		}
+
+		withEmptyFields, err := ToCanonicalJSON(msg, false)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"requestId":"owner::req-1",
+			"responses":[{"id":{"owner":"owner","namespace":"main","key":"secret1"},"success":true,"error":""}]
+		}`, string(withEmptyFields))
+
+		canonicalJSON, err := ToCanonicalJSON(msg, true)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"requestId":"owner::req-1",
+			"responses":[{"id":{"owner":"owner","namespace":"main","key":"secret1"},"success":true}]
+		}`, string(canonicalJSON))
+		assert.NotEqual(t, string(withEmptyFields), string(canonicalJSON))
+	})
+
+	t.Run("empty repeated field and empty top-level string", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &vaultcommon.CreateSecretsResponse{
+			Responses: []*vaultcommon.CreateSecretResponse{},
+		}
+
+		withEmptyFields, err := ToCanonicalJSON(msg, false)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"responses":[],"requestId":""}`, string(withEmptyFields))
+
+		canonicalJSON, err := ToCanonicalJSON(msg, true)
+		require.NoError(t, err)
+		assert.Equal(t, `{}`, string(canonicalJSON))
+		assert.NotEqual(t, string(withEmptyFields), string(canonicalJSON))
+	})
+
+	t.Run("empty repeated field only", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &vaultcommon.CreateSecretsResponse{
+			RequestId: "owner::req-1",
+			Responses: []*vaultcommon.CreateSecretResponse{},
+		}
+
+		withEmptyFields, err := ToCanonicalJSON(msg, false)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"responses":[],"requestId":"owner::req-1"}`, string(withEmptyFields))
+
+		canonicalJSON, err := ToCanonicalJSON(msg, true)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"requestId":"owner::req-1"}`, string(canonicalJSON))
+		assert.NotEqual(t, string(withEmptyFields), string(canonicalJSON))
+	})
 }

--- a/core/capabilities/vault/vaultutils/signed_payload_request_id_test.go
+++ b/core/capabilities/vault/vaultutils/signed_payload_request_id_test.go
@@ -16,7 +16,7 @@ func TestSignedPayloadRequestID(t *testing.T) {
 	payload, err := ToCanonicalJSON(&vaultcommon.CreateSecretsResponse{
 		RequestId: "owner::req-1",
 		Responses: []*vaultcommon.CreateSecretResponse{},
-	})
+	}, true)
 	require.NoError(t, err)
 
 	got, err := SignedPayloadRequestID(vaulttypes.MethodSecretsCreate, json.RawMessage(payload))

--- a/core/services/gateway/handlers/vault/aggregator_test_helpers.go
+++ b/core/services/gateway/handlers/vault/aggregator_test_helpers.go
@@ -44,7 +44,7 @@ func makeSignedCreateSecretsResponse(t *testing.T, requestID string, numSigners 
 			},
 		},
 	}
-	payload, err := vaultutils.ToCanonicalJSON(createResp)
+	payload, err := vaultutils.ToCanonicalJSON(createResp, false)
 	require.NoError(t, err)
 
 	return makeSignedVaultResponse(t, vaulttypes.MethodSecretsCreate, requestID, json.RawMessage(payload), numSigners)

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -2461,7 +2461,7 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 			if r.signedResponseRequestIDEnabled(ctx) {
 				createResp.RequestId = o.Id
 			}
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, createResp)
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, createResp, r.signedResponseRequestIDEnabled(ctx))
 			if err != nil {
 				r.lggr.Errorw("failed to generate JSON report", "error", err, "id", o.Id)
 				continue
@@ -2475,7 +2475,7 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 			if r.signedResponseRequestIDEnabled(ctx) {
 				updateResp.RequestId = o.Id
 			}
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, updateResp)
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, updateResp, r.signedResponseRequestIDEnabled(ctx))
 			if err != nil {
 				r.lggr.Errorw("failed to generate JSON report", "error", err, "id", o.Id)
 				continue
@@ -2489,7 +2489,7 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 			if r.signedResponseRequestIDEnabled(ctx) {
 				deleteResp.RequestId = o.Id
 			}
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, deleteResp)
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, deleteResp, r.signedResponseRequestIDEnabled(ctx))
 			if err != nil {
 				r.lggr.Errorw("failed to generate JSON report", "error", err, "id", o.Id)
 				continue
@@ -2503,7 +2503,7 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 			if r.signedResponseRequestIDEnabled(ctx) {
 				listResp.RequestId = o.Id
 			}
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, listResp)
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, listResp, r.signedResponseRequestIDEnabled(ctx))
 			if err != nil {
 				r.lggr.Errorw("failed to generate JSON report", "error", err, "id", o.Id)
 				continue
@@ -2544,12 +2544,12 @@ func (r *ReportingPlugin) generateProtoReport(id string, requestType vaultcommon
 	return wrapReportWithKeyBundleInfo(rpb, rip)
 }
 
-func (r *ReportingPlugin) generateJSONReport(id string, requestType vaultcommon.RequestType, msg proto.Message) (ocr3types.ReportWithInfo[[]byte], error) {
+func (r *ReportingPlugin) generateJSONReport(id string, requestType vaultcommon.RequestType, msg proto.Message, omitUnpopulated bool) (ocr3types.ReportWithInfo[[]byte], error) {
 	if msg == nil {
 		return ocr3types.ReportWithInfo[[]byte]{}, errors.New("invalid report: response cannot be nil")
 	}
 
-	jsonb, err := vaultutils.ToCanonicalJSON(msg)
+	jsonb, err := vaultutils.ToCanonicalJSON(msg, omitUnpopulated)
 	if err != nil {
 		return ocr3types.ReportWithInfo[[]byte]{}, fmt.Errorf("failed to convert proto to canonical JSON: %w", err)
 	}

--- a/core/services/ocr2/plugins/vault/plugin_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_test.go
@@ -4064,7 +4064,7 @@ func TestPlugin_Reports(t *testing.T) {
 
 	signedResp := proto.Clone(resp).(*vaultcommon.CreateSecretsResponse)
 	signedResp.RequestId = vaulttypes.KeyFor(id)
-	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp)
+	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp, true)
 	require.NoError(t, err)
 	assert.Equal(t, expectedBytes, []byte(o1.ReportWithInfo.Report))
 
@@ -4081,6 +4081,70 @@ func TestPlugin_Reports(t *testing.T) {
 	err = proto.Unmarshal(o2.ReportWithInfo.Report, o2r)
 	require.NoError(t, err)
 	assert.True(t, proto.Equal(resp2, o2r))
+}
+
+func TestPlugin_Reports_JSONReportOmitUnpopulated(t *testing.T) {
+	t.Parallel()
+
+	id := &vaultcommon.SecretIdentifier{
+		Owner:     "owner",
+		Namespace: "main",
+		Key:       "secret",
+	}
+	resp := &vaultcommon.CreateSecretsResponse{
+		Responses: []*vaultcommon.CreateSecretResponse{
+			{
+				Id:      id,
+				Success: true,
+				Error:   "",
+			},
+		},
+	}
+	os := &vaultcommon.Outcomes{
+		Outcomes: []*vaultcommon.Outcome{
+			{
+				Id:          vaulttypes.KeyFor(id),
+				RequestType: vaultcommon.RequestType_CREATE_SECRETS,
+				Response: &vaultcommon.Outcome_CreateSecretsResponse{
+					CreateSecretsResponse: resp,
+				},
+			},
+		},
+	}
+	osb, err := proto.Marshal(os)
+	require.NoError(t, err)
+
+	_, pk, shares, err := tdh2easy.GenerateKeys(1, 3)
+	require.NoError(t, err)
+
+	t.Run("signed response request id enabled omits empty fields", func(t *testing.T) {
+		t.Parallel()
+
+		r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1), withVaultSignedResponseRequestIDEnabled())
+		rs, err := r.Reports(t.Context(), uint64(1), osb)
+		require.NoError(t, err)
+		require.Len(t, rs, 1)
+
+		signedResp := proto.Clone(resp).(*vaultcommon.CreateSecretsResponse)
+		signedResp.RequestId = vaulttypes.KeyFor(id)
+		expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp, true)
+		require.NoError(t, err)
+		assert.Equal(t, expectedBytes, []byte(rs[0].ReportWithInfo.Report))
+	})
+
+	t.Run("signed response request id disabled keeps empty fields", func(t *testing.T) {
+		t.Parallel()
+
+		r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1))
+		rs, err := r.Reports(t.Context(), uint64(1), osb)
+		require.NoError(t, err)
+		require.Len(t, rs, 1)
+
+		expectedBytes, err := vaultutils.ToCanonicalJSON(resp, false)
+		require.NoError(t, err)
+		assert.Equal(t, expectedBytes, []byte(rs[0].ReportWithInfo.Report))
+		assert.Contains(t, string(rs[0].ReportWithInfo.Report), `"error":""`)
+	})
 }
 
 func TestPlugin_Observation_UpdateSecretsRequest_SecretIdentifierInvalid(t *testing.T) {
@@ -4661,7 +4725,7 @@ func TestPlugin_Reports_UpdateSecretsRequest(t *testing.T) {
 
 	signedResp := proto.Clone(resp).(*vaultcommon.UpdateSecretsResponse)
 	signedResp.RequestId = vaulttypes.KeyFor(id)
-	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp)
+	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp, true)
 	require.NoError(t, err)
 	assert.Equal(t, expectedBytes, []byte(o.ReportWithInfo.Report))
 }
@@ -5057,7 +5121,7 @@ func TestPlugin_Reports_DeleteSecretsRequest(t *testing.T) {
 
 	signedResp := proto.Clone(resp).(*vaultcommon.DeleteSecretsResponse)
 	signedResp.RequestId = vaulttypes.KeyFor(id)
-	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp)
+	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp, true)
 	require.NoError(t, err)
 	assert.Equal(t, expectedBytes, []byte(o.ReportWithInfo.Report))
 }
@@ -5401,7 +5465,7 @@ func TestPlugin_Reports_ListSecretIdentifiersRequest(t *testing.T) {
 
 	signedResp := proto.Clone(resp).(*vaultcommon.ListSecretIdentifiersResponse)
 	signedResp.RequestId = vaulttypes.KeyFor(id)
-	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp)
+	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp, true)
 	require.NoError(t, err)
 	assert.Equal(t, expectedBytes, []byte(o.ReportWithInfo.Report))
 }


### PR DESCRIPTION
## Summary
- Gate omission of zero-value proto fields in vault JSON reports behind `VaultSignedResponseRequestIDEnabled`
- When the flag is enabled, `generateJSONReport` passes `omitUnpopulated=true` to `ToCanonicalJSON`, producing smaller signed payloads
- When the flag is disabled, JSON reports retain the legacy behavior and continue emitting empty fields

