### PR TITLE
fix(capabilities/remote): reap stale registration staging entries in Trigger Publisher

### DIFF
--- a/core/capabilities/remote/messagecache/message_cache.go
+++ b/core/capabilities/remote/messagecache/message_cache.go
@@ -74,6 +74,11 @@ func (c *MessageCache[EventID, PeerID]) Delete(eventID EventID) {
 	delete(c.events, eventID)
 }
 
+// Len returns the number of distinct event keys currently held in the cache.
+func (c *MessageCache[EventID, PeerID]) Len() int {
+	return len(c.events)
+}
+
 // Peers returns a snapshot of peer IDs that have inserted a message for eventID.
 func (c *MessageCache[EventID, PeerID]) Peers(eventID EventID) map[PeerID]bool {
 	ev, ok := c.events[eventID]

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -461,15 +461,24 @@ func (p *triggerPublisher) cacheCleanupLoop() {
 			}
 			now := time.Now().UnixMilli()
 
-			// Registrations are no longer expired by timeout. Subscribers that
+			// Active registrations are no longer expired by timeout. Subscribers that
 			// no longer want a registration respond to MethodTriggerRegistrationCheck
 			// with MethodUnregisterTrigger, which is handled in Receive.
+			//
+			// Pre-quorum entries in messageCache, however, never become active
+			// registrations, so the unregister path cannot remove them. Reap stale
+			// staging entries here so a sender of distinct-key registrations that never
+			// reach quorum cannot grow the cache without bound.
 			p.mu.Lock()
 			deleted := p.ackCache.DeleteOlderThan(now - cfg.remoteConfig.MessageExpiry.Milliseconds())
+			deletedStaging := p.messageCache.DeleteOlderThan(now - cfg.remoteConfig.RegistrationExpiry.Milliseconds())
 			p.mu.Unlock()
 
 			if deleted > 0 {
 				p.lggr.Debugw("cleaned expired AckCache entries", "deleted", deleted)
+			}
+			if deletedStaging > 0 {
+				p.lggr.Debugw("cleaned stale registration staging entries", "deleted", deletedStaging)
 			}
 		}
 	}

--- a/core/capabilities/remote/trigger_publisher_registration_cache_test.go
+++ b/core/capabilities/remote/trigger_publisher_registration_cache_test.go
@@ -1,0 +1,103 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	remotetypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types/mocks"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
+	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
+)
+
+type stubTrigger struct{}
+
+func (stubTrigger) Info(context.Context) (commoncap.CapabilityInfo, error) {
+	return commoncap.CapabilityInfo{ID: "stub@1", CapabilityType: commoncap.CapabilityTypeTrigger, Description: "stub"}, nil
+}
+
+func (stubTrigger) RegisterTrigger(context.Context, commoncap.TriggerRegistrationRequest) (<-chan commoncap.TriggerResponse, error) {
+	return make(chan commoncap.TriggerResponse), nil
+}
+
+func (stubTrigger) UnregisterTrigger(context.Context, commoncap.TriggerRegistrationRequest) error {
+	return nil
+}
+
+func (stubTrigger) AckEvent(context.Context, string, string, string) error {
+	return nil
+}
+
+func regCachePeer(i int) p2ptypes.PeerID {
+	var p p2ptypes.PeerID
+	p[30] = byte(i >> 8)
+	p[31] = byte(i)
+	return p
+}
+
+// A workflow-DON member that can never reach the 2F+1 registration quorum must not be
+// able to grow the registration staging cache without bound. Pre-quorum registrations
+// never become active registrations, so the unregister path cannot remove them;
+// cacheCleanupLoop must reap stale staging entries (older than RegistrationExpiry).
+func TestTriggerPublisher_RegistrationStagingCacheIsBounded(t *testing.T) {
+	ctx := testutils.Context(t)
+	lggr := logger.Test(t)
+
+	const capabilityDONID = uint32(1)
+	const workflowDONID = uint32(2)
+
+	capDON := commoncap.DON{ID: capabilityDONID, Members: []p2ptypes.PeerID{regCachePeer(1000)}, F: 0}
+	wfMembers := []p2ptypes.PeerID{regCachePeer(1), regCachePeer(2), regCachePeer(3)}
+	workflowDON := commoncap.DON{ID: workflowDONID, Members: wfMembers, F: 1} // quorum 2F+1 = 3
+	attacker := wfMembers[0]
+
+	dispatcher := mocks.NewDispatcher(t)
+	dispatcher.On("Send", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	cfg := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Millisecond,
+		RegistrationExpiry:      500 * time.Millisecond,
+		MinResponsesToAggregate: 3,
+		MessageExpiry:           200 * time.Millisecond, // cacheCleanupLoop tick interval
+		MaxBatchSize:            1,
+		BatchCollectionPeriod:   time.Second,
+	}
+
+	publisher := NewTriggerPublisher("cap_id@1", "", dispatcher, lggr)
+	require.NoError(t, publisher.SetConfig(cfg, stubTrigger{}, capDON, map[uint32]commoncap.DON{workflowDON.ID: workflowDON}))
+	require.NoError(t, publisher.Start(ctx))
+	t.Cleanup(func() { _ = publisher.Close() })
+
+	const n = 1000
+	for i := 0; i < n; i++ {
+		wfID := fmt.Sprintf("%064x", i) // distinct, valid 32-byte-hex workflow id => distinct staging key
+		req := commoncap.TriggerRegistrationRequest{Metadata: commoncap.RequestMetadata{WorkflowID: wfID}}
+		marshaled, err := pb.MarshalTriggerRegistrationRequest(req)
+		require.NoError(t, err)
+		publisher.Receive(ctx, &remotetypes.MessageBody{
+			Sender:      attacker[:],
+			Method:      remotetypes.MethodRegisterTrigger,
+			CallerDonId: workflowDONID,
+			Payload:     marshaled,
+		})
+	}
+
+	cacheLen := func() int {
+		publisher.mu.Lock()
+		defer publisher.mu.Unlock()
+		return publisher.messageCache.Len()
+	}
+
+	require.GreaterOrEqual(t, cacheLen(), n*9/10, "below-quorum registrations should be staged in messageCache")
+
+	require.Eventually(t, func() bool { return cacheLen() == 0 }, 4*time.Second, 100*time.Millisecond,
+		"stale below-quorum registration staging entries must be reaped by cacheCleanupLoop")
+}


### PR DESCRIPTION
# Description

The remote Trigger Publisher stages incoming `RegisterTrigger` messages in `messageCache`, keyed by `(CallerDonId, WorkflowID, TriggerID)`, until `2F+1` matching registrations aggregate. This staging cache is never reaped:

- `(*triggerPublisher).Receive` inserts into `messageCache` unconditionally (before the quorum check), and `WorkflowID`/`TriggerID` are caller-controlled (`WorkflowID` is format-validated only; `TriggerID` is unvalidated), so the key space is unbounded.
- The periodic cleanup reaps the sibling caches but not this one: `ackCache.DeleteOlderThan` is in `cacheCleanupLoop`, `unregisterCache.DeleteOlderThan` is in `sendRegistrationChecks`, and `messageCache.DeleteOlderThan` is called in neither. (`MessageCache` ships `DeleteOlderThan`, and the sibling Trigger Subscriber reaps its own cache in `eventCleanupLoop`.)
- The only `messageCache.Delete` is on the unregister path, which early-returns for keys that are not active registrations. Pre-quorum entries never become active registrations, so they are never removed.

Net effect: a single workflow-DON member sending distinct-key registrations that never reach quorum grows the staging cache without bound, exhausting node memory. This is a resource-exhaustion / liveness hardening fix (no confidentiality or integrity impact); the attacker must be an authenticated workflow-DON member, but the unbounded growth defeats the `2F+1` aggregation defense from a single below-quorum member.

# Fix

Reap stale staging entries in `cacheCleanupLoop`, mirroring `ackCache`. Entries older than `RegistrationExpiry` are already past the aggregation window used by `Ready` (which counts only entries newer than `now - RegistrationExpiry`), so removing them is safe and does not affect active registrations or in-window aggregation:

```go
deletedStaging := p.messageCache.DeleteOlderThan(now - cfg.remoteConfig.RegistrationExpiry.Milliseconds())
```

Also adds a small `MessageCache.Len()` accessor used by the regression test.

# Tests

- New regression test `TestTriggerPublisher_RegistrationStagingCacheIsBounded`: a single below-quorum workflow-DON member floods distinct-key registrations; the test asserts the staging cache is non-empty after the flood and is reaped to zero by `cacheCleanupLoop`. It fails on the current code (the cache is never reclaimed) and passes with this change.
- The existing `TestTriggerPublisher*` suite still passes, confirming the change does not affect legitimate registration aggregation or the unregister flow.

# Notes

The diff is +118/-1 across three files (`message_cache.go`, `trigger_publisher.go`, the new test). A defense-in-depth per-sender or total size cap on the staging cache would bound it independently of the time-based reaper; this PR keeps the change minimal and consistent with the existing sibling-cache cleanup.
