### PR TITLE
Fake Http Trigger - Add trigger index for in local gateway

### DIFF
--- a/core/capabilities/fakes/gateway/local.go
+++ b/core/capabilities/fakes/gateway/local.go
@@ -10,8 +10,6 @@ import (
 	"net/http"
 	"strconv"
 	"time"
-
-	httptypedapi "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/triggers/http"
 )
 
 const (
@@ -21,7 +19,8 @@ const (
 	shutdownTimeout   = time.Second
 )
 
-type triggerRequest struct {
+type TriggerRequest struct {
+	Index int             `json:"index"`
 	Input json.RawMessage `json:"input"`
 }
 
@@ -43,23 +42,23 @@ func NewLocalGateway(config Config) *LocalGateway {
 
 // ListenForTriggerPayload starts an HTTP server on the configured port and
 // blocks until a POST /trigger request arrives or ctx is cancelled.
-func (g *LocalGateway) ListenForTriggerPayload(ctx context.Context) (*httptypedapi.Payload, error) {
+func (g *LocalGateway) ListenForTriggerPayload(ctx context.Context) (*TriggerRequest, error) {
 	type result struct {
-		payload *httptypedapi.Payload
+		payload *TriggerRequest
 		err     error
 	}
 	resultCh := make(chan result, 1)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc(triggerPath, func(w http.ResponseWriter, r *http.Request) {
-		input, err := parseRequest(r)
+		payload, err := parseRequest(r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
 		select {
-		case resultCh <- result{payload: &httptypedapi.Payload{Input: input}}:
+		case resultCh <- result{payload: payload}:
 			w.WriteHeader(http.StatusOK)
 		case <-r.Context().Done():
 			http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
@@ -97,7 +96,7 @@ func (g *LocalGateway) ListenForTriggerPayload(ctx context.Context) (*httptypeda
 	}
 }
 
-func parseRequest(req *http.Request) ([]byte, error) {
+func parseRequest(req *http.Request) (*TriggerRequest, error) {
 	if req.Method != http.MethodPost {
 		return nil, errors.New("gateway expects POST request")
 	}
@@ -108,10 +107,10 @@ func parseRequest(req *http.Request) ([]byte, error) {
 		return nil, fmt.Errorf("read request body: %w", err)
 	}
 
-	var request triggerRequest
+	var request TriggerRequest
 	if err := json.Unmarshal(body, &request); err != nil {
 		return nil, fmt.Errorf("parse request body: %w", err)
 	}
 
-	return request.Input, nil
+	return &request, nil
 }

--- a/core/capabilities/fakes/gateway/local_test.go
+++ b/core/capabilities/fakes/gateway/local_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/smartcontractkit/freeport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	httptypedapi "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/triggers/http"
 )
 
 // waitForPort polls until the TCP port is reachable or timeout passes.
@@ -46,7 +44,7 @@ func TestListenForTriggerPayload_HappyPath(t *testing.T) {
 	defer cancel()
 
 	type result struct {
-		payload *httptypedapi.Payload
+		payload *TriggerRequest
 		err     error
 	}
 	resultCh := make(chan result, 1)
@@ -64,7 +62,9 @@ func TestListenForTriggerPayload_HappyPath(t *testing.T) {
 	// directly, the []byte field would be base64-encoded by json.Marshal,
 	// which is not what a real HTTP client sends.
 	inputJSON := json.RawMessage(`{"order":"pizza","size":"large"}`)
+	triggerIndex := 2
 	rawBody := map[string]any{
+		"index": triggerIndex,
 		"input": inputJSON,
 	}
 	body, err := json.Marshal(rawBody)
@@ -86,6 +86,8 @@ func TestListenForTriggerPayload_HappyPath(t *testing.T) {
 	require.NoError(t, res.err)
 	require.NotNil(t, res.payload)
 
+	// The payload trigger index must match
+	assert.Equal(t, triggerIndex, res.payload.Index)
 	// The payload input must match what was sent in Params.Input.
-	assert.Equal(t, []byte(inputJSON), res.payload.Input)
+	assert.Equal(t, []byte(inputJSON), []byte(res.payload.Input))
 }


### PR DESCRIPTION
**API and Type Changes:**
- Introduced a new exported `TriggerRequest` struct with `Index` and `Input` fields, replacing the previous unexported `triggerRequest` type.
- Updated the `ListenForTriggerPayload` method to return a `*TriggerRequest` instead of a generic payload type, and adjusted the handler logic accordingly.