### PR TITLE
chore: bump confidential http gitref

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -47,5 +47,5 @@ plugins:
       installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "24ffd2435ed7d6bca45525c2189d720b7a4ef6bc"
+      gitRef: "4ac24e5f31cf5c936e31c6d3ef2509d6ad7a5791"
       installPath: "./cmd/confidential-http"


### PR DESCRIPTION
## Summary

Bumps the confidential http gitref in `plugins/plugins.private.yaml`.
