### PR TITLE
synchronization: log per-event partial delivery errors from PublishBatch

### DIFF
--- a/core/services/synchronization/chip_ingress_batch_worker.go
+++ b/core/services/synchronization/chip_ingress_batch_worker.go
@@ -30,7 +30,6 @@ type chipIngressBatchWorker struct {
 	logging          bool
 	lggr             logger.Logger
 	dropMessageCount atomic.Uint32
-	partialDropCount atomic.Uint32
 }
 
 // NewChipIngressBatchWorker returns a worker for a given contractID that can send
@@ -80,35 +79,17 @@ func (cw *chipIngressBatchWorker) Send(ctx context.Context) {
 
 	// Inspect per-event results for partial delivery errors. When transaction_enabled=false
 	// (the default), the server can accept some events while rejecting others.
-	// Group by error code so a large batch with many failures produces one log line.
-	var partialDrops int
-	byCode := map[string]int{}
+	//
+	// This is intentionally not logged: it's a per-event, often persistent server-side
+	// condition (e.g. missing schema) that would otherwise WARN on every send interval
+	// (as low as 500ms) for as long as it lasts. ChipIngressPartialDeliveryDropped
+	// (telemetry_type, error_code) is the intended signal for alerting/investigation.
 	for _, result := range resp.GetResults() {
 		if e := result.GetError(); e != nil {
 			code := e.GetErrorCode().String()
-			byCode[code]++
-			partialDrops++
 			TelemetryClientMessagesDropped.WithLabelValues(chipIngress, string(cw.telemType)).Inc()
 			ChipIngressPartialDeliveryDropped.WithLabelValues(string(cw.telemType), code).Inc()
 		}
-	}
-	if partialDrops > 0 {
-		// Partial delivery is often caused by a persistent condition (missing/misconfigured
-		// schema), which would otherwise re-trigger this WARN on every send interval
-		// (as low as 500ms) for as long as the condition lasts. Throttle with the same
-		// exponential-then-linear backoff used by logBufferFullWithExpBackoff.
-		count := cw.partialDropCount.Add(uint32(partialDrops))
-		if count > 0 && (count%100 == 0 || count&(count-1) == 0) {
-			cw.lggr.Warnw("chip ingress partial delivery errors",
-				"dropped", partialDrops,
-				"totalDropped", count,
-				"by_code", byCode,
-				"telemType", cw.telemType,
-				"contractID", cw.contractID,
-			)
-		}
-	} else {
-		cw.partialDropCount.Store(0)
 	}
 
 	TelemetryClientMessagesSent.WithLabelValues(chipIngress, string(cw.telemType)).Inc()

--- a/core/services/synchronization/chip_ingress_batch_worker.go
+++ b/core/services/synchronization/chip_ingress_batch_worker.go
@@ -30,6 +30,7 @@ type chipIngressBatchWorker struct {
 	logging          bool
 	lggr             logger.Logger
 	dropMessageCount atomic.Uint32
+	partialDropCount atomic.Uint32
 }
 
 // NewChipIngressBatchWorker returns a worker for a given contractID that can send
@@ -70,11 +71,44 @@ func (cw *chipIngressBatchWorker) Send(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, cw.sendTimeout)
 	defer cancel()
 
-	_, err := cw.chipClient.PublishBatch(ctx, batch)
+	resp, err := cw.chipClient.PublishBatch(ctx, batch)
 	if err != nil {
 		cw.lggr.Warnf("Could not send telemetry via ChIP ingress: %v", err)
 		TelemetryClientMessagesSendErrors.WithLabelValues(chipIngress, string(cw.telemType)).Inc()
 		return
+	}
+
+	// Inspect per-event results for partial delivery errors. When transaction_enabled=false
+	// (the default), the server can accept some events while rejecting others.
+	// Group by error code so a large batch with many failures produces one log line.
+	var partialDrops int
+	byCode := map[string]int{}
+	for _, result := range resp.GetResults() {
+		if e := result.GetError(); e != nil {
+			code := e.GetErrorCode().String()
+			byCode[code]++
+			partialDrops++
+			TelemetryClientMessagesDropped.WithLabelValues(chipIngress, string(cw.telemType)).Inc()
+			ChipIngressPartialDeliveryDropped.WithLabelValues(string(cw.telemType), code).Inc()
+		}
+	}
+	if partialDrops > 0 {
+		// Partial delivery is often caused by a persistent condition (missing/misconfigured
+		// schema), which would otherwise re-trigger this WARN on every send interval
+		// (as low as 500ms) for as long as the condition lasts. Throttle with the same
+		// exponential-then-linear backoff used by logBufferFullWithExpBackoff.
+		count := cw.partialDropCount.Add(uint32(partialDrops))
+		if count > 0 && (count%100 == 0 || count&(count-1) == 0) {
+			cw.lggr.Warnw("chip ingress partial delivery errors",
+				"dropped", partialDrops,
+				"totalDropped", count,
+				"by_code", byCode,
+				"telemType", cw.telemType,
+				"contractID", cw.contractID,
+			)
+		}
+	} else {
+		cw.partialDropCount.Store(0)
 	}
 
 	TelemetryClientMessagesSent.WithLabelValues(chipIngress, string(cw.telemType)).Inc()

--- a/core/services/synchronization/chip_ingress_batch_worker_test.go
+++ b/core/services/synchronization/chip_ingress_batch_worker_test.go
@@ -8,6 +8,7 @@ import (
 	cepb "github.com/cloudevents/sdk-go/binding/format/protobuf/v2/pb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/chipingress"
@@ -23,6 +24,38 @@ func (noopChipIngressPublisher) Publish(ctx context.Context, event *cepb.CloudEv
 
 func (noopChipIngressPublisher) PublishBatch(ctx context.Context, batch *pb.CloudEventBatch, opts ...grpc.CallOption) (*pb.PublishResponse, error) {
 	return &pb.PublishResponse{}, nil
+}
+
+type partialChipIngressPublisher struct {
+	resp *pb.PublishResponse
+}
+
+func (p partialChipIngressPublisher) Publish(ctx context.Context, event *cepb.CloudEvent, opts ...grpc.CallOption) (*pb.PublishResponse, error) {
+	return &pb.PublishResponse{}, nil
+}
+
+func (p partialChipIngressPublisher) PublishBatch(ctx context.Context, batch *pb.CloudEventBatch, opts ...grpc.CallOption) (*pb.PublishResponse, error) {
+	return p.resp, nil
+}
+
+func (p partialChipIngressPublisher) Ping(ctx context.Context, req *pb.EmptyRequest, opts ...grpc.CallOption) (*pb.PingResponse, error) {
+	return &pb.PingResponse{}, nil
+}
+
+func (p partialChipIngressPublisher) StreamEvents(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[pb.StreamEventsRequest, pb.StreamEventsResponse], error) {
+	return nil, nil
+}
+
+func (p partialChipIngressPublisher) RegisterSchema(ctx context.Context, req *pb.RegisterSchemaRequest, opts ...grpc.CallOption) (*pb.RegisterSchemaResponse, error) {
+	return &pb.RegisterSchemaResponse{}, nil
+}
+
+func (p partialChipIngressPublisher) Close() error {
+	return nil
+}
+
+func (p partialChipIngressPublisher) RegisterSchemas(ctx context.Context, schemas ...*pb.Schema) (map[string]int, error) {
+	return nil, nil
 }
 
 func (noopChipIngressPublisher) Ping(ctx context.Context, req *pb.EmptyRequest, opts ...grpc.CallOption) (*pb.PingResponse, error) {
@@ -43,6 +76,124 @@ func (noopChipIngressPublisher) Close() error {
 
 func (noopChipIngressPublisher) RegisterSchemas(ctx context.Context, schemas ...*pb.Schema) (map[string]int, error) {
 	return nil, nil
+}
+
+func TestChipIngressBatchWorker_Send_PartialDelivery(t *testing.T) {
+	t.Parallel()
+	// Verify that Send groups per-event errors into a single WARN log line
+	// (partial delivery, transactionEnabled=false).
+	partialResp := &pb.PublishResponse{
+		Results: []*pb.PublishResult{
+			{
+				EventId: "evt-1",
+				Error: &pb.PublishError{
+					ErrorCode: pb.PublishErrorCode_PUBLISH_ERROR_CODE_VALIDATION_FAILED,
+					Reason:    "schema not found",
+				},
+			},
+			{
+				EventId: "evt-2",
+				Error: &pb.PublishError{
+					ErrorCode: pb.PublishErrorCode_PUBLISH_ERROR_CODE_VALIDATION_FAILED,
+					Reason:    "schema not found",
+				},
+			},
+		},
+	}
+	publisher := partialChipIngressPublisher{resp: partialResp}
+
+	lggr, observed := logger.TestLoggerObserved(t, zap.WarnLevel)
+	chTelemetry := make(chan TelemPayload, 5)
+	worker := NewChipIngressBatchWorker(
+		2,
+		time.Second,
+		publisher,
+		chTelemetry,
+		"0xabc",
+		OCR,
+		lggr,
+		true,
+	)
+
+	chTelemetry <- TelemPayload{
+		Telemetry:     []byte("payload1"),
+		TelemType:     OCR,
+		ContractID:    "0xabc",
+		Domain:        "data-feeds",
+		Entity:        "ocr.v1.telemetry",
+		ChainSelector: 7700,
+		Network:       "EVM",
+		ChainID:       "1",
+	}
+	chTelemetry <- TelemPayload{
+		Telemetry:     []byte("payload2"),
+		TelemType:     OCR,
+		ContractID:    "0xabc",
+		Domain:        "data-feeds",
+		Entity:        "ocr.v1.telemetry",
+		ChainSelector: 7700,
+		Network:       "EVM",
+		ChainID:       "1",
+	}
+
+	require.NotPanics(t, func() { worker.Send(t.Context()) })
+	assert.Empty(t, chTelemetry)
+
+	// Two failed events must produce exactly one grouped WARN log line.
+	logs := observed.FilterMessage("chip ingress partial delivery errors")
+	require.Equal(t, 1, logs.Len(), "expected exactly one grouped log line for 2 failed events")
+	assert.Equal(t, zap.WarnLevel, logs.All()[0].Level)
+}
+
+func TestChipIngressBatchWorker_Send_PartialDeliveryThrottled(t *testing.T) {
+	t.Parallel()
+	// A persistent partial-delivery condition (e.g. missing schema) must not log on every
+	// Send call - it should follow the same backoff cadence as logBufferFullWithExpBackoff.
+	singleFailureResp := &pb.PublishResponse{
+		Results: []*pb.PublishResult{
+			{
+				EventId: "evt-1",
+				Error: &pb.PublishError{
+					ErrorCode: pb.PublishErrorCode_PUBLISH_ERROR_CODE_SCHEMA_MISSING,
+					Reason:    "schema not found",
+				},
+			},
+		},
+	}
+	publisher := partialChipIngressPublisher{resp: singleFailureResp}
+
+	lggr, observed := logger.TestLoggerObserved(t, zap.WarnLevel)
+	chTelemetry := make(chan TelemPayload, 1)
+	worker := NewChipIngressBatchWorker(
+		1,
+		time.Second,
+		publisher,
+		chTelemetry,
+		"0xabc",
+		OCR,
+		lggr,
+		true,
+	)
+
+	payload := TelemPayload{
+		Telemetry:     []byte("payload"),
+		TelemType:     OCR,
+		ContractID:    "0xabc",
+		Domain:        "data-feeds",
+		Entity:        "ocr.v1.telemetry",
+		ChainSelector: 7700,
+		Network:       "EVM",
+		ChainID:       "1",
+	}
+
+	// Drop counts after each send: 1, 2, 3. Backoff logs at 1 and 2 (powers of two), not at 3.
+	for range 3 {
+		chTelemetry <- payload
+		require.NotPanics(t, func() { worker.Send(t.Context()) })
+	}
+
+	logs := observed.FilterMessage("chip ingress partial delivery errors")
+	assert.Equal(t, 2, logs.Len(), "expected the third consecutive failure to be throttled")
 }
 
 func TestChipIngressBatchWorker_BuildCloudEventBatch(t *testing.T) {

--- a/core/services/synchronization/chip_ingress_batch_worker_test.go
+++ b/core/services/synchronization/chip_ingress_batch_worker_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	cepb "github.com/cloudevents/sdk-go/binding/format/protobuf/v2/pb"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -80,8 +81,11 @@ func (noopChipIngressPublisher) RegisterSchemas(ctx context.Context, schemas ...
 
 func TestChipIngressBatchWorker_Send_PartialDelivery(t *testing.T) {
 	t.Parallel()
-	// Verify that Send groups per-event errors into a single WARN log line
-	// (partial delivery, transactionEnabled=false).
+	// Verify that Send records per-event partial-delivery errors as metrics without
+	// logging: partial delivery is a per-event, often persistent condition (e.g. missing
+	// schema), so logging it would spam at fleet-wide volume. The
+	// ChipIngressPartialDeliveryDropped metric (telemetry_type, error_code) is the
+	// intended signal.
 	partialResp := &pb.PublishResponse{
 		Results: []*pb.PublishResult{
 			{
@@ -136,64 +140,17 @@ func TestChipIngressBatchWorker_Send_PartialDelivery(t *testing.T) {
 		ChainID:       "1",
 	}
 
+	code := pb.PublishErrorCode_PUBLISH_ERROR_CODE_VALIDATION_FAILED.String()
+	before := testutil.ToFloat64(ChipIngressPartialDeliveryDropped.WithLabelValues(string(OCR), code))
+
 	require.NotPanics(t, func() { worker.Send(t.Context()) })
 	assert.Empty(t, chTelemetry)
 
-	// Two failed events must produce exactly one grouped WARN log line.
-	logs := observed.FilterMessage("chip ingress partial delivery errors")
-	require.Equal(t, 1, logs.Len(), "expected exactly one grouped log line for 2 failed events")
-	assert.Equal(t, zap.WarnLevel, logs.All()[0].Level)
-}
-
-func TestChipIngressBatchWorker_Send_PartialDeliveryThrottled(t *testing.T) {
-	t.Parallel()
-	// A persistent partial-delivery condition (e.g. missing schema) must not log on every
-	// Send call - it should follow the same backoff cadence as logBufferFullWithExpBackoff.
-	singleFailureResp := &pb.PublishResponse{
-		Results: []*pb.PublishResult{
-			{
-				EventId: "evt-1",
-				Error: &pb.PublishError{
-					ErrorCode: pb.PublishErrorCode_PUBLISH_ERROR_CODE_SCHEMA_MISSING,
-					Reason:    "schema not found",
-				},
-			},
-		},
-	}
-	publisher := partialChipIngressPublisher{resp: singleFailureResp}
-
-	lggr, observed := logger.TestLoggerObserved(t, zap.WarnLevel)
-	chTelemetry := make(chan TelemPayload, 1)
-	worker := NewChipIngressBatchWorker(
-		1,
-		time.Second,
-		publisher,
-		chTelemetry,
-		"0xabc",
-		OCR,
-		lggr,
-		true,
-	)
-
-	payload := TelemPayload{
-		Telemetry:     []byte("payload"),
-		TelemType:     OCR,
-		ContractID:    "0xabc",
-		Domain:        "data-feeds",
-		Entity:        "ocr.v1.telemetry",
-		ChainSelector: 7700,
-		Network:       "EVM",
-		ChainID:       "1",
-	}
-
-	// Drop counts after each send: 1, 2, 3. Backoff logs at 1 and 2 (powers of two), not at 3.
-	for range 3 {
-		chTelemetry <- payload
-		require.NotPanics(t, func() { worker.Send(t.Context()) })
-	}
+	after := testutil.ToFloat64(ChipIngressPartialDeliveryDropped.WithLabelValues(string(OCR), code))
+	assert.Equal(t, float64(2), after-before, "expected both failed events to increment the metric")
 
 	logs := observed.FilterMessage("chip ingress partial delivery errors")
-	assert.Equal(t, 2, logs.Len(), "expected the third consecutive failure to be throttled")
+	assert.Zero(t, logs.Len(), "partial delivery drops must not be logged")
 }
 
 func TestChipIngressBatchWorker_BuildCloudEventBatch(t *testing.T) {

--- a/core/services/synchronization/metrics.go
+++ b/core/services/synchronization/metrics.go
@@ -30,4 +30,9 @@ var (
 		Name: "telemetry_client_workers",
 		Help: "Number of telemetry workers",
 	}, []string{"endpoint", "telemetry_type"})
+
+	ChipIngressPartialDeliveryDropped = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "chip_ingress_partial_delivery_dropped",
+		Help: "Number of chip ingress events dropped due to per-event server rejection (partial delivery)",
+	}, []string{"telemetry_type", "error_code"})
 )


### PR DESCRIPTION
## Summary

- \`chip_ingress_batch_worker.Send\` was discarding the \`PublishBatch\` response (\`_, err := ...\`).
- Now captures \`resp\` and inspects \`resp.GetResults()\`: per-event errors are grouped by error code and emitted as **one WARN log per batch** (\`dropped\`, \`by_code\`) so a batch with many failures does not flood logs.
- Adds a new \`chip_ingress_partial_delivery_dropped{telemetry_type, error_code}\` Prometheus counter so dashboards and alerts can track rejection types by error code without relying on logs.
- Existing \`telemetry_client_messages_dropped\` counter still increments per dropped event (backward-compatible).
- Implements AC #4 from [INFOPLAT-13901](https://smartcontract-it.atlassian.net/browse/INFOPLAT-13901): inspect other \`PublishBatch\` call sites and surface partial-delivery errors.

Jira: [INFOPLAT-13901](https://smartcontract-it.atlassian.net/browse/INFOPLAT-13901) | Epic: [INFOPLAT-7177](https://smartcontract-it.atlassian.net/browse/INFOPLAT-7177)

**Depends on** chainlink-common PR [#2210](https://github.com/smartcontractkit/chainlink-common/pull/2210) merging first, then a \`go.mod\` bump before this PR is ready to merge.

## Changes

- \`core/services/synchronization/metrics.go\`: new \`chip_ingress_partial_delivery_dropped\` counter with \`["telemetry_type", "error_code"]\` labels
- \`core/services/synchronization/chip_ingress_batch_worker.go\`: capture \`resp\`, group results by \`error_code\`, single WARN log per batch, increment both counters per dropped event
- \`core/services/synchronization/chip_ingress_batch_worker_test.go\`: \`TestChipIngressBatchWorker_Send_PartialDelivery\` — two failed events produce exactly one grouped WARN log line

## Test plan

- [ ] \`go test ./core/services/synchronization/... -count=1\` passes
- [ ] \`TestChipIngressBatchWorker_Send_PartialDelivery\` passes — single WARN log for 2 failed events
- [ ] After go.mod bump: re-run to confirm no regressions from chainlink-common dep update
- [ ] \`chip_ingress_partial_delivery_dropped{telemetry_type="ocr", error_code="PUBLISH_ERROR_CODE_VALIDATION_FAILED"}\` increments per dropped event

[INFOPLAT-13901]: https://smartcontract-it.atlassian.net/browse/INFOPLAT-13901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INFOPLAT-7177]: https://smartcontract-it.atlassian.net/browse/INFOPLAT-7177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ