### PR TITLE
cre-5198: cache metrics via metrics endpoint

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.104
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260618155522-3600f66e26cd
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260522094612-5f9f748bd87a
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.104
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260618155522-3600f66e26cd
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260522094612-5f9f748bd87a
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1580,8 +1580,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h1:WjZwKtUA/0TPvzgCt8bcdq+BHMIL65S0oU79mxgZn/Y=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4 h1:UZWRrW2b8vE+HtfK9c5fJ6oSamgHr0ZeX7NJQ0BdArc=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa h1:9/2oQIZOPq15/f5jSx6VHuFEllhHJYNZYLQMzXAFR7I=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1580,8 +1580,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h1:WjZwKtUA/0TPvzgCt8bcdq+BHMIL65S0oU79mxgZn/Y=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa h1:9/2oQIZOPq15/f5jSx6VHuFEllhHJYNZYLQMzXAFR7I=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0 h1:ywWOEZYL4DhVwf/TQ5jXsGlx6CzERsYbqd6ov3OS1sc=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -20,7 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/workflowkey"
 	"github.com/smartcontractkit/chainlink-common/pkg/billing"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
-	"github.com/smartcontractkit/chainlink-common/pkg/diskmonitor"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	nodeauthjwt "github.com/smartcontractkit/chainlink-common/pkg/nodeauth/jwt"
@@ -1031,10 +1030,9 @@ func newWorkflowRegistrySyncerV2(
 		}
 
 		if diskMonitorEnabled {
-			dm, dmErr := diskmonitor.NewDiskMonitor(
+			dm, dmErr := syncerV2.NewWorkflowModuleCacheDiskMonitor(
 				lggr,
 				fileStore.CacheDir(),
-				syncerV2.GaugeWorkflowModuleCacheDiskUsageBytes,
 				syncerV2.WorkflowModuleCacheDiskMonitorTickInterval,
 			)
 			if dmErr != nil {

--- a/core/services/workflows/syncer/v2/disk_monitor.go
+++ b/core/services/workflows/syncer/v2/disk_monitor.go
@@ -1,0 +1,24 @@
+package v2
+
+import (
+	"time"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/diskmonitor"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+// NewWorkflowModuleCacheDiskMonitor measures cacheDir on tickInterval and exports disk usage
+// to both Beholder telemetry and the node /metrics endpoint.
+func NewWorkflowModuleCacheDiskMonitor(
+	lggr logger.Logger,
+	cacheDir string,
+	tickInterval time.Duration,
+) (*diskmonitor.DiskMonitor, error) {
+	return diskmonitor.NewDiskMonitor(
+		lggr,
+		cacheDir,
+		GaugeWorkflowModuleCacheDiskUsageBytes,
+		tickInterval,
+		diskmonitor.WithPrometheusGauge(promModuleCacheDiskUsageBytes),
+	)
+}

--- a/core/services/workflows/syncer/v2/metrics.go
+++ b/core/services/workflows/syncer/v2/metrics.go
@@ -141,6 +141,7 @@ func (cm *CacheMetrics) recordReload(ctx context.Context, source string) {
 		return
 	}
 	cm.reloadSource.Add(ctx, 1, metric.WithAttributes(attribute.String("source", source)))
+	promModuleCacheReloadTotal.WithLabelValues(source).Inc()
 }
 
 func (cm *CacheMetrics) recordEviction(ctx context.Context, count int) {
@@ -148,6 +149,7 @@ func (cm *CacheMetrics) recordEviction(ctx context.Context, count int) {
 		return
 	}
 	cm.evictionTotal.Add(ctx, int64(count))
+	promModuleCacheEvictionTotal.Add(float64(count))
 }
 
 func (cm *CacheMetrics) recordLoaded(ctx context.Context, count int) {
@@ -155,6 +157,7 @@ func (cm *CacheMetrics) recordLoaded(ctx context.Context, count int) {
 		return
 	}
 	cm.loadedGauge.Record(ctx, int64(count))
+	promModuleCacheLoaded.Set(float64(count))
 }
 
 func (cm *CacheMetrics) recordMemorySaved(ctx context.Context, bytes int64) {
@@ -162,6 +165,7 @@ func (cm *CacheMetrics) recordMemorySaved(ctx context.Context, bytes int64) {
 		return
 	}
 	cm.memorySaved.Record(ctx, bytes)
+	promModuleCacheMemorySavedBytes.Set(float64(bytes))
 }
 
 func (cm *CacheMetrics) recordVersionMismatch(ctx context.Context) {
@@ -169,6 +173,7 @@ func (cm *CacheMetrics) recordVersionMismatch(ctx context.Context) {
 		return
 	}
 	cm.versionMismatch.Add(ctx, 1)
+	promModuleCacheVersionMismatchTotal.Inc()
 }
 
 func (cm *CacheMetrics) recordPinExhausted(ctx context.Context) {
@@ -176,6 +181,7 @@ func (cm *CacheMetrics) recordPinExhausted(ctx context.Context) {
 		return
 	}
 	cm.pinExhausted.Add(ctx, 1)
+	promModuleCachePinExhaustedTotal.Inc()
 	if cachePinExhaustedHook != nil {
 		cachePinExhaustedHook()
 	}
@@ -186,6 +192,7 @@ func (cm *CacheMetrics) recordTryAcquireExhausted(ctx context.Context) {
 		return
 	}
 	cm.tryAcquireExhausted.Add(ctx, 1)
+	promModuleCacheTryAcquireExhaustedTotal.Inc()
 	if cacheTryAcquireExhaustedHook != nil {
 		cacheTryAcquireExhaustedHook()
 	}

--- a/core/services/workflows/syncer/v2/prom_metrics.go
+++ b/core/services/workflows/syncer/v2/prom_metrics.go
@@ -1,0 +1,41 @@
+package v2
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	promModuleCacheReloadTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "platform_workflow_module_cache_reload_total",
+		Help: "Module cache reloads by source (weak_ref or disk)",
+	}, []string{"source"})
+	promModuleCacheEvictionTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "platform_workflow_module_cache_eviction_total",
+		Help: "Total module cache evictions",
+	})
+	promModuleCacheLoaded = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "platform_workflow_module_cache_loaded",
+		Help: "Currently loaded modules in the LRU cache",
+	})
+	promModuleCacheMemorySavedBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "platform_workflow_module_cache_memory_saved_bytes",
+		Help: "Bytes of memory saved by evicting idle modules",
+	})
+	promModuleCacheVersionMismatchTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "platform_workflow_module_cache_version_mismatch_total",
+		Help: "Cached binaries rejected due to engine version mismatch",
+	})
+	promModuleCachePinExhaustedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "platform_workflow_module_cache_pin_exhausted_total",
+		Help: "Execute retries exhausted before a pin succeeds",
+	})
+	promModuleCacheTryAcquireExhaustedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "platform_workflow_module_cache_try_acquire_exhausted_total",
+		Help: "moduleEntry CAS attempts exhausted while pinning",
+	})
+	promModuleCacheDiskUsageBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "platform_workflow_module_cache_disk_usage_bytes",
+		Help: "Total on-disk bytes under the module cache directory",
+	})
+)

--- a/core/services/workflows/syncer/v2/prom_metrics_test.go
+++ b/core/services/workflows/syncer/v2/prom_metrics_test.go
@@ -1,0 +1,49 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func counterValue(t *testing.T, c prometheus.Counter) float64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, c.Write(&m))
+	return m.GetCounter().GetValue()
+}
+
+func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, g.Write(&m))
+	return m.GetGauge().GetValue()
+}
+
+func TestCacheMetricsPrometheusExport(t *testing.T) {
+	t.Parallel()
+
+	cm, err := NewCacheMetrics()
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	cm.recordReload(ctx, "disk")
+	cm.recordReload(ctx, "weak_ref")
+	cm.recordEviction(ctx, 2)
+	cm.recordLoaded(ctx, 3)
+	cm.recordMemorySaved(ctx, 4096)
+	cm.recordVersionMismatch(ctx)
+	cm.recordPinExhausted(ctx)
+	cm.recordTryAcquireExhausted(ctx)
+
+	require.InDelta(t, 1, counterValue(t, promModuleCacheReloadTotal.WithLabelValues("disk")), 0)
+	require.InDelta(t, 1, counterValue(t, promModuleCacheReloadTotal.WithLabelValues("weak_ref")), 0)
+	require.InDelta(t, 2, counterValue(t, promModuleCacheEvictionTotal), 0)
+	require.InDelta(t, 3, gaugeValue(t, promModuleCacheLoaded), 0)
+	require.InDelta(t, 4096, gaugeValue(t, promModuleCacheMemorySavedBytes), 0)
+	require.InDelta(t, 1, counterValue(t, promModuleCacheVersionMismatchTotal), 0)
+	require.InDelta(t, 1, counterValue(t, promModuleCachePinExhaustedTotal), 0)
+	require.InDelta(t, 1, counterValue(t, promModuleCacheTryAcquireExhaustedTotal), 0)
+}

--- a/core/services/workflows/syncer/v2/prom_metrics_test.go
+++ b/core/services/workflows/syncer/v2/prom_metrics_test.go
@@ -22,11 +22,16 @@ func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
 	return m.GetGauge().GetValue()
 }
 
-func TestCacheMetricsPrometheusExport(t *testing.T) {
-	t.Parallel()
-
+func TestCacheMetricsPrometheusExport(t *testing.T) { //nolint:paralleltest // package-global promauto metrics
 	cm, err := NewCacheMetrics()
 	require.NoError(t, err)
+
+	reloadDiskBefore := counterValue(t, promModuleCacheReloadTotal.WithLabelValues("disk"))
+	reloadWeakRefBefore := counterValue(t, promModuleCacheReloadTotal.WithLabelValues("weak_ref"))
+	evictionBefore := counterValue(t, promModuleCacheEvictionTotal)
+	versionMismatchBefore := counterValue(t, promModuleCacheVersionMismatchTotal)
+	pinExhaustedBefore := counterValue(t, promModuleCachePinExhaustedTotal)
+	tryAcquireExhaustedBefore := counterValue(t, promModuleCacheTryAcquireExhaustedTotal)
 
 	ctx := t.Context()
 	cm.recordReload(ctx, "disk")
@@ -38,12 +43,12 @@ func TestCacheMetricsPrometheusExport(t *testing.T) {
 	cm.recordPinExhausted(ctx)
 	cm.recordTryAcquireExhausted(ctx)
 
-	require.InDelta(t, 1, counterValue(t, promModuleCacheReloadTotal.WithLabelValues("disk")), 0)
-	require.InDelta(t, 1, counterValue(t, promModuleCacheReloadTotal.WithLabelValues("weak_ref")), 0)
-	require.InDelta(t, 2, counterValue(t, promModuleCacheEvictionTotal), 0)
+	require.InDelta(t, reloadDiskBefore+1, counterValue(t, promModuleCacheReloadTotal.WithLabelValues("disk")), 0)
+	require.InDelta(t, reloadWeakRefBefore+1, counterValue(t, promModuleCacheReloadTotal.WithLabelValues("weak_ref")), 0)
+	require.InDelta(t, evictionBefore+2, counterValue(t, promModuleCacheEvictionTotal), 0)
 	require.InDelta(t, 3, gaugeValue(t, promModuleCacheLoaded), 0)
 	require.InDelta(t, 4096, gaugeValue(t, promModuleCacheMemorySavedBytes), 0)
-	require.InDelta(t, 1, counterValue(t, promModuleCacheVersionMismatchTotal), 0)
-	require.InDelta(t, 1, counterValue(t, promModuleCachePinExhaustedTotal), 0)
-	require.InDelta(t, 1, counterValue(t, promModuleCacheTryAcquireExhaustedTotal), 0)
+	require.InDelta(t, versionMismatchBefore+1, counterValue(t, promModuleCacheVersionMismatchTotal), 0)
+	require.InDelta(t, pinExhaustedBefore+1, counterValue(t, promModuleCachePinExhaustedTotal), 0)
+	require.InDelta(t, tryAcquireExhaustedBefore+1, counterValue(t, promModuleCacheTryAcquireExhaustedTotal), 0)
 }

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260618155522-3600f66e26cd
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260522094612-5f9f748bd87a
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260618155522-3600f66e26cd
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260522094612-5f9f748bd87a
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1383,8 +1383,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa h1:9/2oQIZOPq15/f5jSx6VHuFEllhHJYNZYLQMzXAFR7I=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0 h1:ywWOEZYL4DhVwf/TQ5jXsGlx6CzERsYbqd6ov3OS1sc=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1383,8 +1383,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4 h1:UZWRrW2b8vE+HtfK9c5fJ6oSamgHr0ZeX7NJQ0BdArc=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa h1:9/2oQIZOPq15/f5jSx6VHuFEllhHJYNZYLQMzXAFR7I=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260522094612-5f9f748bd87a

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260522094612-5f9f748bd87a

--- a/go.sum
+++ b/go.sum
@@ -1162,8 +1162,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h1:WjZwKtUA/0TPvzgCt8bcdq+BHMIL65S0oU79mxgZn/Y=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa h1:9/2oQIZOPq15/f5jSx6VHuFEllhHJYNZYLQMzXAFR7I=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0 h1:ywWOEZYL4DhVwf/TQ5jXsGlx6CzERsYbqd6ov3OS1sc=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/go.sum
+++ b/go.sum
@@ -1162,8 +1162,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h1:WjZwKtUA/0TPvzgCt8bcdq+BHMIL65S0oU79mxgZn/Y=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4 h1:UZWRrW2b8vE+HtfK9c5fJ6oSamgHr0ZeX7NJQ0BdArc=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa h1:9/2oQIZOPq15/f5jSx6VHuFEllhHJYNZYLQMzXAFR7I=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260618155522-3600f66e26cd
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260506144252-c100eabfda74
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260623170329-4577ef4ba0ae

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260618155522-3600f66e26cd
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260506144252-c100eabfda74
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260623170329-4577ef4ba0ae

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1370,8 +1370,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa h1:9/2oQIZOPq15/f5jSx6VHuFEllhHJYNZYLQMzXAFR7I=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0 h1:ywWOEZYL4DhVwf/TQ5jXsGlx6CzERsYbqd6ov3OS1sc=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1370,8 +1370,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4 h1:UZWRrW2b8vE+HtfK9c5fJ6oSamgHr0ZeX7NJQ0BdArc=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa h1:9/2oQIZOPq15/f5jSx6VHuFEllhHJYNZYLQMzXAFR7I=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260618155522-3600f66e26cd
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260506144252-c100eabfda74
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260623170329-4577ef4ba0ae
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.16.5

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260618155522-3600f66e26cd
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260506144252-c100eabfda74
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260623170329-4577ef4ba0ae
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.16.5

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1632,8 +1632,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4 h1:UZWRrW2b8vE+HtfK9c5fJ6oSamgHr0ZeX7NJQ0BdArc=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa h1:9/2oQIZOPq15/f5jSx6VHuFEllhHJYNZYLQMzXAFR7I=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1632,8 +1632,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa h1:9/2oQIZOPq15/f5jSx6VHuFEllhHJYNZYLQMzXAFR7I=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0 h1:ywWOEZYL4DhVwf/TQ5jXsGlx6CzERsYbqd6ov3OS1sc=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.104
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20260609211101-71d38bd6a0a9
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260623170329-4577ef4ba0ae

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.104
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20260609211101-71d38bd6a0a9
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260623170329-4577ef4ba0ae

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1545,8 +1545,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h1:WjZwKtUA/0TPvzgCt8bcdq+BHMIL65S0oU79mxgZn/Y=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4 h1:UZWRrW2b8vE+HtfK9c5fJ6oSamgHr0ZeX7NJQ0BdArc=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa h1:9/2oQIZOPq15/f5jSx6VHuFEllhHJYNZYLQMzXAFR7I=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1545,8 +1545,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h1:WjZwKtUA/0TPvzgCt8bcdq+BHMIL65S0oU79mxgZn/Y=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa h1:9/2oQIZOPq15/f5jSx6VHuFEllhHJYNZYLQMzXAFR7I=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0 h1:ywWOEZYL4DhVwf/TQ5jXsGlx6CzERsYbqd6ov3OS1sc=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/smartcontractkit/chain-selectors v1.0.104
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/smartcontractkit/chain-selectors v1.0.104
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1559,8 +1559,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h1:WjZwKtUA/0TPvzgCt8bcdq+BHMIL65S0oU79mxgZn/Y=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4 h1:UZWRrW2b8vE+HtfK9c5fJ6oSamgHr0ZeX7NJQ0BdArc=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260630121500-1f04da8d69d4/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa h1:9/2oQIZOPq15/f5jSx6VHuFEllhHJYNZYLQMzXAFR7I=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1559,8 +1559,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260511195239-0f6e1b177fc7/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h1:WjZwKtUA/0TPvzgCt8bcdq+BHMIL65S0oU79mxgZn/Y=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa h1:9/2oQIZOPq15/f5jSx6VHuFEllhHJYNZYLQMzXAFR7I=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701072730-1ee0b85caafa/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0 h1:ywWOEZYL4DhVwf/TQ5jXsGlx6CzERsYbqd6ov3OS1sc=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=


### PR DESCRIPTION
[cre-5198](https://smartcontract-it.atlassian.net/browse/cre-5198)

Related:
- https://github.com/smartcontractkit/chainlink-common/pull/2212