### PR TITLE
Move capabilities plugin from private to public manifests.

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -7,44 +7,6 @@ defaults:
   goflags: "-ldflags=-s"
 
 plugins:
-  cron:
-    - moduleURI: "github.com/smartcontractkit/capabilities/cron"
-      gitRef: "69e882e0f24cf9ae897366c4dcbbd3c7e035ae33"
-      installPath: "."
-      flags: "-tags timetzdata"
-  readcontract:
-    - moduleURI: "github.com/smartcontractkit/capabilities/readcontract"
-      gitRef: "3fad562d65996bf447372023b5123c0c6e8850c7"
-      installPath: "."
-  consensus:
-    - moduleURI: "github.com/smartcontractkit/capabilities/consensus"
-      gitRef: "69e882e0f24cf9ae897366c4dcbbd3c7e035ae33"
-      installPath: "."
-  workflowevent:
-    - enabled: false
-      moduleURI: "github.com/smartcontractkit/capabilities/workflowevent"
-      gitRef: "69e882e0f24cf9ae897366c4dcbbd3c7e035ae33"
-      installPath: "."
-  httpaction:
-    - moduleURI: "github.com/smartcontractkit/capabilities/http_action"
-      gitRef: "78f22db50d700d9b369578aebafd7d239daee8d1"
-      installPath: "."
-  httptrigger:
-    - moduleURI: "github.com/smartcontractkit/capabilities/http_trigger"
-      gitRef: "602b8fb7d379afb0a245dd6b4f67cc4557c40541"
-      installPath: "."
-  evm:
-    - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
-      gitRef: "9d0d4e43abcab3e2144890fa71bc696724638ec5"
-      installPath: "."
-  solana:
-    - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/solana"
-      gitRef: "baffa8733456bf8409cfbc006fd3a79b2e114997"
-      installPath: "."
-  aptos:
-    - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "5424665d88fc5c239a2af353abcf0f0e0e4cb710"
-      installPath: "."
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
       gitRef: "4ac24e5f31cf5c936e31c6d3ef2509d6ad7a5791"

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -68,3 +68,50 @@ plugins:
     - moduleURI: "github.com/smartcontractkit/chainlink-evm"
       gitRef: "v0.3.4-0.20260623170329-4577ef4ba0ae"
       installPath: "./pkg/cmd/chainlink-evm"
+
+  cron:
+    - moduleURI: "github.com/smartcontractkit/capabilities/cron"
+      gitRef: "69e882e0f24cf9ae897366c4dcbbd3c7e035ae33"
+      installPath: "."
+      flags: "-tags timetzdata"
+
+  capability-readcontract:
+    - moduleURI: "github.com/smartcontractkit/capabilities/readcontract"
+      gitRef: "3fad562d65996bf447372023b5123c0c6e8850c7"
+      installPath: "."
+
+  consensus:
+    - moduleURI: "github.com/smartcontractkit/capabilities/consensus"
+      gitRef: "69e882e0f24cf9ae897366c4dcbbd3c7e035ae33"
+      installPath: "."
+
+  capability-workflowevent:
+    - enabled: false
+      moduleURI: "github.com/smartcontractkit/capabilities/workflowevent"
+      gitRef: "69e882e0f24cf9ae897366c4dcbbd3c7e035ae33"
+      installPath: "."
+
+  capability-httpaction:
+    - moduleURI: "github.com/smartcontractkit/capabilities/http_action"
+      gitRef: "78f22db50d700d9b369578aebafd7d239daee8d1"
+      installPath: "."
+
+  capability-httptrigger:
+    - moduleURI: "github.com/smartcontractkit/capabilities/http_trigger"
+      gitRef: "602b8fb7d379afb0a245dd6b4f67cc4557c40541"
+      installPath: "."
+
+  capability-evm:
+    - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
+      gitRef: "9d0d4e43abcab3e2144890fa71bc696724638ec5"
+      installPath: "."
+
+  capability-solana:
+    - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/solana"
+      gitRef: "baffa8733456bf8409cfbc006fd3a79b2e114997"
+      installPath: "."
+
+  capability-aptos:
+    - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
+      gitRef: "5424665d88fc5c239a2af353abcf0f0e0e4cb710"
+      installPath: "."

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -69,7 +69,7 @@ plugins:
       gitRef: "v0.3.4-0.20260623170329-4577ef4ba0ae"
       installPath: "./pkg/cmd/chainlink-evm"
 
-  cron:
+  capability-cron:
     - moduleURI: "github.com/smartcontractkit/capabilities/cron"
       gitRef: "69e882e0f24cf9ae897366c4dcbbd3c7e035ae33"
       installPath: "."
@@ -80,7 +80,7 @@ plugins:
       gitRef: "3fad562d65996bf447372023b5123c0c6e8850c7"
       installPath: "."
 
-  consensus:
+  capability-consensus:
     - moduleURI: "github.com/smartcontractkit/capabilities/consensus"
       gitRef: "69e882e0f24cf9ae897366c4dcbbd3c7e035ae33"
       installPath: "."


### PR DESCRIPTION
Since the repo (https://github.com/smartcontractkit/capabilities) is now public.

Tested by running `make docker-plugins` locally.