### PR TITLE
Attach required type label to all custmsg emitters

### DIFF
--- a/core/capabilities/compute/compute.go
+++ b/core/capabilities/compute/compute.go
@@ -30,6 +30,7 @@ import (
 	wasmpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/pb"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/validation"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/webapi"
+	"github.com/smartcontractkit/chainlink/v2/core/custmsgtypes"
 	"github.com/smartcontractkit/chainlink/v2/core/platform"
 	ghcapabilities "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities"
 )
@@ -453,7 +454,7 @@ func NewAction(
 
 	var (
 		lggr    = logger.Named(log, "CustomCompute")
-		labeler = custmsg.NewLabeler()
+		labeler = custmsg.NewLabeler().WithType(custmsgtypes.TypeCompute)
 		compute = &Compute{
 			stopCh:               make(services.StopChan),
 			log:                  lggr,

--- a/core/capabilities/compute/transformer_test.go
+++ b/core/capabilities/compute/transformer_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
+	"github.com/smartcontractkit/chainlink/v2/core/custmsgtypes"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
@@ -89,7 +90,7 @@ func Test_transformer(t *testing.T) {
 	t.Parallel()
 	var (
 		lgger   = logger.Test(t)
-		emitter = custmsg.NewLabeler()
+		emitter = custmsg.NewLabeler().WithType(custmsgtypes.TypeCompute)
 	)
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()

--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -47,6 +47,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	"github.com/smartcontractkit/chainlink/v2/core/sessions"
 	"github.com/smartcontractkit/chainlink/v2/core/shutdown"
+	"github.com/smartcontractkit/chainlink/v2/core/custmsgtypes"
 	"github.com/smartcontractkit/chainlink/v2/core/static"
 	"github.com/smartcontractkit/chainlink/v2/core/store"
 	"github.com/smartcontractkit/chainlink/v2/core/store/migrate"
@@ -335,13 +336,12 @@ const ownerPermsMask = os.FileMode(0o700)
 
 // EmitNodeConfig emits the node configuration through beholder as a pb.BaseMessage
 func (s *Shell) EmitNodeConfig(ctx context.Context) {
-	cme := custmsg.NewLabeler()
 	labels := map[string]string{
 		"system":  "Application",
 		"version": static.Version,
 		"commit":  static.Sha,
 	}
-	emitter := cme.WithMapLabels(labels)
+	emitter := custmsg.NewLabeler().WithLabelsAndType(labels, custmsgtypes.TypeNodeConfig)
 
 	// Get the effective TOML configuration (with defaults applied)
 	_, effectiveTOML := s.Config.ConfigTOML()

--- a/core/cmd/shell_test.go
+++ b/core/cmd/shell_test.go
@@ -622,4 +622,5 @@ func TestShell_emitNodeConfig(t *testing.T) {
 	require.Equal(t, "Application", baseMsg.Labels["system"])
 	require.Equal(t, static.Version, baseMsg.Labels["version"])
 	require.Equal(t, static.Sha, baseMsg.Labels["commit"])
+	require.Equal(t, "NodeConfig", baseMsg.Labels["type"])
 }

--- a/core/custmsgtypes/types.go
+++ b/core/custmsgtypes/types.go
@@ -1,0 +1,11 @@
+// Package custmsgtypes defines stable type label values for custmsg BaseMessage emissions.
+package custmsgtypes
+
+const (
+	TypeNodeConfig         = "NodeConfig"
+	TypeHeartbeat          = "Heartbeat"
+	TypeWorkflowEngine     = "WorkflowEngine"
+	TypeWorkflowSyncer     = "WorkflowSyncer"
+	TypeWorkflowArtifact   = "WorkflowArtifact"
+	TypeCompute            = "Compute"
+)

--- a/core/services/chainlink/heartbeat.go
+++ b/core/services/chainlink/heartbeat.go
@@ -10,6 +10,7 @@ import (
 	commonservices "github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/timeutil"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/custmsgtypes"
 	"github.com/smartcontractkit/chainlink/v2/core/static"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
@@ -59,7 +60,6 @@ func NewHeartbeatConfig(cfg ApplicationOpts) HeartbeatConfig {
 // Update the constructor to accept optional emitter and meter
 func NewHeartbeat(cfg HeartbeatConfig, opts ...HeartbeatOpt) Heartbeat {
 	// setup default emitter and meter
-	cme := custmsg.NewLabeler()
 	labels := map[string]string{"system": "Application", "version": static.Version, "commit": static.Sha}
 	if cfg.P2P != "" {
 		labels["peer_id"] = cfg.P2P
@@ -71,11 +71,10 @@ func NewHeartbeat(cfg HeartbeatConfig, opts ...HeartbeatOpt) Heartbeat {
 		labels["csa_key"] = cfg.CSAPublicKey
 	}
 
-	cme.WithMapLabels(labels)
 	h := Heartbeat{
 		beat:    cfg.Beat,
 		opts:    cfg,
-		emitter: cme.WithMapLabels(labels),
+		emitter: custmsg.NewLabeler().WithLabelsAndType(labels, custmsgtypes.TypeHeartbeat),
 		meter:   beholder.GetMeter(),
 	}
 

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -35,6 +35,7 @@ import (
 	linkingclient "github.com/smartcontractkit/chainlink-protos/linking-service/go/v1"
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
+	"github.com/smartcontractkit/chainlink/v2/core/custmsgtypes"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/compute"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/confidentialrelay"
 	gatewayconnector "github.com/smartcontractkit/chainlink/v2/core/capabilities/gateway_connector"
@@ -804,7 +805,7 @@ func newWorkflowRegistrySyncerV1(
 		fetcherFunc,
 		clockwork.NewRealClock(),
 		key,
-		custmsg.NewLabeler(),
+		custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact),
 		artifactsV1.WithMaxArtifactSize(
 			artifactsV1.ArtifactConfig{
 				MaxBinarySize:  uint64(capCfg.WorkflowRegistry().MaxBinarySize()),
@@ -838,7 +839,7 @@ func newWorkflowRegistrySyncerV1(
 		dontimeStore,
 		opts.UseLocalTimeProvider,
 		engineRegistry,
-		custmsg.NewLabeler(),
+		custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer),
 		engineLimiters,
 		featureFlags,
 		workflowRateLimiter,
@@ -950,7 +951,7 @@ func newWorkflowRegistrySyncerV2(
 		retrieverFunc,
 		clockwork.NewRealClock(),
 		key,
-		custmsg.NewLabeler(),
+		custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact),
 		lf,
 		artifactsV2.WithConfig(artifactsV2.StoreConfig{
 			ArtifactStorageHost: wfReg.WorkflowStorage().ArtifactStorageHost(),
@@ -1083,7 +1084,7 @@ func newWorkflowRegistrySyncerV2(
 		opts.CapabilitiesRegistry,
 		opts.ExecutionHandlers,
 		engineRegistry,
-		custmsg.NewLabeler(),
+		custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer),
 		engineLimiters,
 		featureFlags,
 		workflowRateLimiter,

--- a/core/services/workflows/artifacts/store_test.go
+++ b/core/services/workflows/artifacts/store_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/workflowkey"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
+	"github.com/smartcontractkit/chainlink/v2/core/custmsgtypes"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/secrets"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	ghcapabilities "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities"
@@ -72,7 +73,7 @@ func Test_Handler_SecretsFor(t *testing.T) {
 		fetcher.Fetch,
 		clockwork.NewFakeClock(),
 		encryptionKey,
-		custmsg.NewLabeler(),
+		custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact),
 	)
 	expectedSecrets := map[string]string{
 		"Foo": "Bar",
@@ -136,7 +137,7 @@ func Test_Handler_SecretsFor_RefreshesSecrets(t *testing.T) {
 		fetcher.Fetch,
 		clockwork.NewFakeClock(),
 		encryptionKey,
-		custmsg.NewLabeler(),
+		custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact),
 	)
 
 	expectedSecrets := map[string]string{
@@ -203,7 +204,7 @@ func Test_Handler_SecretsFor_RefreshLogic(t *testing.T) {
 		fetcher.Fetch,
 		clock,
 		encryptionKey,
-		custmsg.NewLabeler(),
+		custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact),
 	)
 
 	expectedSecrets := map[string]string{

--- a/core/services/workflows/artifacts/v2/store_test.go
+++ b/core/services/workflows/artifacts/v2/store_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/workflowkey"
 	"github.com/smartcontractkit/chainlink-common/pkg/contexts"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
+	"github.com/smartcontractkit/chainlink/v2/core/custmsgtypes"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	storage_service "github.com/smartcontractkit/chainlink-protos/storage-service/go"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -78,7 +79,7 @@ func Test_Store_DeleteWorkflowArtifacts(t *testing.T) {
 		fetcher.RetrieveURL,
 		clockwork.NewFakeClock(),
 		encryptionKey,
-		custmsg.NewLabeler(),
+		custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact),
 		limits.Factory{Logger: lggr},
 		WithConfig(StoreConfig{
 			ArtifactStorageHost: "example.com",
@@ -127,7 +128,7 @@ func Test_Store_DeleteWorkflowArtifactsBatch(t *testing.T) {
 	fetcher := &mockFetcher{}
 	h, err := NewStore(
 		lggr, orm, fetcher.Fetch, fetcher.RetrieveURL,
-		clockwork.NewFakeClock(), encryptionKey, custmsg.NewLabeler(),
+		clockwork.NewFakeClock(), encryptionKey, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact),
 		limits.Factory{Logger: lggr},
 		WithConfig(StoreConfig{ArtifactStorageHost: "example.com"}),
 	)
@@ -178,7 +179,7 @@ func Test_Store_FetchWorkflowArtifacts_WithStorage(t *testing.T) {
 		fetcher.RetrieveURL,
 		clockwork.NewFakeClock(),
 		encryptionKey,
-		custmsg.NewLabeler(),
+		custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact),
 		limits.Factory{Logger: lggr},
 		WithConfig(StoreConfig{
 			ArtifactStorageHost: "storage.chain.link",
@@ -222,7 +223,7 @@ func Test_Store_FetchWorkflowArtifacts_WithoutStorage(t *testing.T) {
 		fetcher.RetrieveURL,
 		clockwork.NewFakeClock(),
 		encryptionKey,
-		custmsg.NewLabeler(),
+		custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact),
 		limits.Factory{Logger: lggr},
 		WithConfig(StoreConfig{
 			ArtifactStorageHost: "storage.chain.link",
@@ -266,7 +267,7 @@ func Test_Store_FetchWorkflowArtifacts_SkipsRetrieving(t *testing.T) {
 		nil, // No retrieval function provided, so it should skip retrieving
 		clockwork.NewFakeClock(),
 		encryptionKey,
-		custmsg.NewLabeler(),
+		custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact),
 		limits.Factory{Logger: lggr},
 		WithConfig(StoreConfig{
 			ArtifactStorageHost: "example.com",

--- a/core/services/workflows/cmd/cre/utils/standalone_engine.go
+++ b/core/services/workflows/cmd/cre/utils/standalone_engine.go
@@ -66,7 +66,7 @@ func NewStandaloneEngine(
 	workflowSettingsCfgFn func(*cresettings.Workflows),
 ) (services.Service, []*sdkpb.TriggerSubscription, error) {
 	ctx = contexts.WithCRE(ctx, contexts.CRE{Owner: defaultOwner, Workflow: defaultWorkflowID})
-	labeler := custmsg.NewLabeler()
+	labeler := custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowEngine)
 	moduleConfig := &host.ModuleConfig{
 		Logger:                  lggr,
 		Labeler:                 labeler,
@@ -198,7 +198,7 @@ func NewStandaloneEngine(
 		FeatureFlags:        featureFlags,
 		GlobalWorkflowLimit: workflowLimits,
 
-		BeholderEmitter: custmsg.NewLabeler(),
+		BeholderEmitter: custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowEngine),
 
 		BillingClient: billingClient,
 		Hooks:         lifecycleHooks,

--- a/core/services/workflows/delegate.go
+++ b/core/services/workflows/delegate.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/platform"
+	"github.com/smartcontractkit/chainlink/v2/core/custmsgtypes"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/metering"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/store"
@@ -65,7 +66,7 @@ func (d *Delegate) OnDeleteJob(context.Context, job.Job) error { return nil }
 
 // ServicesForSpec satisfies the job.Delegate interface.
 func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.ServiceCtx, error) {
-	cma := custmsg.NewLabeler().With(platform.KeyWorkflowID, spec.WorkflowSpec.WorkflowID, platform.KeyWorkflowOwner, spec.WorkflowSpec.WorkflowOwner, platform.KeyWorkflowName, spec.WorkflowSpec.WorkflowName)
+	cma := custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowEngine).With(platform.KeyWorkflowID, spec.WorkflowSpec.WorkflowID, platform.KeyWorkflowOwner, spec.WorkflowSpec.WorkflowOwner, platform.KeyWorkflowName, spec.WorkflowSpec.WorkflowName)
 	sdkSpec, err := spec.WorkflowSpec.SDKSpec(ctx)
 	if err != nil {
 		logCustMsg(ctx, cma, fmt.Sprintf("failed to start workflow engine: failed to get workflow sdk spec: %v", err), d.logger)

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -30,6 +30,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/ratelimiter"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/shardownership"
 
+	"github.com/smartcontractkit/chainlink/v2/core/custmsgtypes"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/transmission"
 	"github.com/smartcontractkit/chainlink/v2/core/platform"
 	"github.com/smartcontractkit/chainlink/v2/core/services/shardorchestrator"
@@ -1489,7 +1490,7 @@ func NewEngine(ctx context.Context, cfg Config) (engine *Engine, err error) {
 		cfg.WorkflowRegistryAddress = "0xv1EngineDefault"
 	}
 
-	cma := custmsg.NewLabeler().With(platform.KeyWorkflowID, cfg.WorkflowID,
+	cma := custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowEngine).With(platform.KeyWorkflowID, cfg.WorkflowID,
 		platform.KeyWorkflowOwner, cfg.WorkflowOwner,
 		platform.KeyWorkflowName, cfg.WorkflowName.String(),
 		platform.KeyWorkflowVersion, platform.ValueWorkflowVersion,

--- a/core/services/workflows/syncer/handler_test.go
+++ b/core/services/workflows/syncer/handler_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/workflowkey"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
+	"github.com/smartcontractkit/chainlink/v2/core/custmsgtypes"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
@@ -120,7 +121,7 @@ func newMockDecrypter() *mockDecrypter {
 func Test_Handler(t *testing.T) {
 	t.Parallel()
 	lggr := logger.TestLogger(t)
-	emitter := custmsg.NewLabeler()
+	emitter := custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 	wfStore := store.NewInMemoryStore(lggr, clockwork.NewFakeClock())
 	registry := capabilities.NewRegistry(lggr)
 	registry.SetLocalRegistry(&capabilities.TestMetadataRegistry{})
@@ -157,7 +158,7 @@ func Test_Handler(t *testing.T) {
 		mockORM.EXPECT().Update(matches.AnyContext, giveHash, "contents").Return(int64(1), nil)
 
 		decrypter := newMockDecrypter()
-		store := artifacts.NewStoreWithDecryptSecretsFn(lggr, mockORM, fetcher, clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), decrypter.decryptSecrets)
+		store := artifacts.NewStoreWithDecryptSecretsFn(lggr, mockORM, fetcher, clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), decrypter.decryptSecrets)
 
 		donTime := dontime.NewStore(dontime.DefaultRequestTimeout)
 
@@ -186,7 +187,7 @@ func Test_Handler(t *testing.T) {
 		}
 
 		decrypter := newMockDecrypter()
-		store := artifacts.NewStoreWithDecryptSecretsFn(lggr, mockORM, fetcher, clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), decrypter.decryptSecrets)
+		store := artifacts.NewStoreWithDecryptSecretsFn(lggr, mockORM, fetcher, clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), decrypter.decryptSecrets)
 		donTime := dontime.NewStore(dontime.DefaultRequestTimeout)
 
 		h, err := NewEventHandler(lggr, wfStore, registry, donTime, true, NewEngineRegistry(), emitter, limiters, featureFlags, rl, workflowLimits, store, workflowEncryptionKey, &testDonNotifier{})
@@ -210,7 +211,7 @@ func Test_Handler(t *testing.T) {
 		require.NoError(t, err)
 
 		decrypter := newMockDecrypter()
-		store := artifacts.NewStoreWithDecryptSecretsFn(lggr, mockORM, nil, clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), decrypter.decryptSecrets)
+		store := artifacts.NewStoreWithDecryptSecretsFn(lggr, mockORM, nil, clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), decrypter.decryptSecrets)
 		donTime := dontime.NewStore(dontime.DefaultRequestTimeout)
 
 		h, err := NewEventHandler(lggr, wfStore, registry, donTime, true, NewEngineRegistry(), emitter, limiters, featureFlags, rl, workflowLimits, store, workflowEncryptionKey, &testDonNotifier{})
@@ -265,7 +266,7 @@ func Test_Handler(t *testing.T) {
 		mockORM.EXPECT().GetSecretsURLByHash(matches.AnyContext, giveHash).Return(giveURL, nil)
 
 		decrypter := newMockDecrypter()
-		store := artifacts.NewStoreWithDecryptSecretsFn(lggr, mockORM, fetcher, clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), decrypter.decryptSecrets)
+		store := artifacts.NewStoreWithDecryptSecretsFn(lggr, mockORM, fetcher, clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), decrypter.decryptSecrets)
 		donTime := dontime.NewStore(dontime.DefaultRequestTimeout)
 
 		h, err := NewEventHandler(lggr, wfStore, registry, donTime, true, NewEngineRegistry(), emitter, limiters, featureFlags, rl, workflowLimits, store, workflowEncryptionKey, &testDonNotifier{})
@@ -306,7 +307,7 @@ func Test_Handler(t *testing.T) {
 		mockORM.EXPECT().Update(matches.AnyContext, giveHash, "contents").Return(0, assert.AnError)
 
 		decrypter := newMockDecrypter()
-		store := artifacts.NewStoreWithDecryptSecretsFn(lggr, mockORM, fetcher, clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), decrypter.decryptSecrets)
+		store := artifacts.NewStoreWithDecryptSecretsFn(lggr, mockORM, fetcher, clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), decrypter.decryptSecrets)
 		donTime := dontime.NewStore(dontime.DefaultRequestTimeout)
 
 		h, err := NewEventHandler(lggr, wfStore, registry, donTime, true, NewEngineRegistry(), emitter, limiters, featureFlags, rl, workflowLimits, store, workflowEncryptionKey, &testDonNotifier{})
@@ -773,7 +774,7 @@ func testRunningWorkflow(t *testing.T, tc testCase, workflowEncryptionKey workfl
 			lggr    = logger.TestLogger(t)
 			db      = pgtest.NewSqlxDB(t)
 			orm     = artifacts.NewWorkflowRegistryDS(db, lggr)
-			emitter = custmsg.NewLabeler()
+			emitter = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 
 			binary     = tc.GiveBinary
 			config     = tc.GiveConfig
@@ -817,7 +818,7 @@ func testRunningWorkflow(t *testing.T, tc testCase, workflowEncryptionKey workfl
 		require.NoError(t, err)
 
 		decrypter := newMockDecrypter()
-		artifactStore := artifacts.NewStoreWithDecryptSecretsFn(lggr, orm, tc.fetcher.FetcherFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), decrypter.decryptSecrets)
+		artifactStore := artifacts.NewStoreWithDecryptSecretsFn(lggr, orm, tc.fetcher.FetcherFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), decrypter.decryptSecrets)
 		donTime := dontime.NewStore(dontime.DefaultRequestTimeout)
 
 		h, err := NewEventHandler(lggr, store, registry, donTime, true, NewEngineRegistry(), emitter, limiters, featureFlags, rl, workflowLimits, artifactStore, workflowEncryptionKey, &testDonNotifier{}, opts...)
@@ -897,7 +898,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 			lggr         = logger.TestLogger(t)
 			db           = pgtest.NewSqlxDB(t)
 			orm          = artifacts.NewWorkflowRegistryDS(db, lggr)
-			emitter      = custmsg.NewLabeler()
+			emitter      = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 			workflowName = testutils.RandomizeName(t.Name())
 
 			binary        = wasmtest.GetTestBinary(t, binaryCmd, true)
@@ -943,7 +944,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		decrypter := newMockDecrypter()
-		artifactStore := artifacts.NewStoreWithDecryptSecretsFn(lggr, orm, fetcher.FetcherFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), decrypter.decryptSecrets)
+		artifactStore := artifacts.NewStoreWithDecryptSecretsFn(lggr, orm, fetcher.FetcherFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), decrypter.decryptSecrets)
 		donTime := dontime.NewStore(dontime.DefaultRequestTimeout)
 
 		// Mock engine factory: this test verifies delete behavior, not WASM compilation.
@@ -993,7 +994,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 			lggr         = logger.TestLogger(t)
 			db           = pgtest.NewSqlxDB(t)
 			orm          = artifacts.NewWorkflowRegistryDS(db, lggr)
-			emitter      = custmsg.NewLabeler()
+			emitter      = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 			workflowName = testutils.RandomizeName(t.Name())
 
 			binary        = wasmtest.GetTestBinary(t, binaryCmd, true)
@@ -1027,7 +1028,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 		workflowLimits, err := syncerlimiter.NewWorkflowLimits(lggr, syncerlimiter.Config{Global: 200, PerOwner: 200}, limits.Factory{})
 		require.NoError(t, err)
 		decrypter := newMockDecrypter()
-		artifactStore := artifacts.NewStoreWithDecryptSecretsFn(lggr, orm, fetcher.FetcherFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), decrypter.decryptSecrets)
+		artifactStore := artifacts.NewStoreWithDecryptSecretsFn(lggr, orm, fetcher.FetcherFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), decrypter.decryptSecrets)
 		donTime := dontime.NewStore(dontime.DefaultRequestTimeout)
 
 		h, err := NewEventHandler(lggr, store, registry, donTime, true, NewEngineRegistry(), emitter, limiters, featureFlags, rl, workflowLimits, artifactStore, workflowEncryptionKey, &testDonNotifier{}, WithEngineRegistry(er))
@@ -1053,7 +1054,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 			lggr         = logger.TestLogger(t)
 			db           = pgtest.NewSqlxDB(t)
 			orm          = artifacts.NewWorkflowRegistryDS(db, lggr)
-			emitter      = custmsg.NewLabeler()
+			emitter      = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 			workflowName = testutils.RandomizeName(t.Name())
 
 			binary        = wasmtest.GetTestBinary(t, binaryCmd, true)
@@ -1101,7 +1102,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		decrypter := newMockDecrypter()
-		artifactStore := artifacts.NewStoreWithDecryptSecretsFn(lggr, orm, fetcher.FetcherFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), decrypter.decryptSecrets)
+		artifactStore := artifacts.NewStoreWithDecryptSecretsFn(lggr, orm, fetcher.FetcherFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), decrypter.decryptSecrets)
 		mockAS := newMockArtifactStore(artifactStore, errors.New(failWith))
 		donTime := dontime.NewStore(dontime.DefaultRequestTimeout)
 
@@ -1155,7 +1156,7 @@ func Test_workflowPausedActivatedUpdatedHandler(t *testing.T) {
 			lggr         = logger.TestLogger(t)
 			db           = pgtest.NewSqlxDB(t)
 			orm          = artifacts.NewWorkflowRegistryDS(db, lggr)
-			emitter      = custmsg.NewLabeler()
+			emitter      = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 			workflowName = testutils.RandomizeName(t.Name())
 
 			binary        = wasmtest.GetTestBinary(t, binaryCmd, true)
@@ -1206,7 +1207,7 @@ func Test_workflowPausedActivatedUpdatedHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		decrypter := newMockDecrypter()
-		artifactStore := artifacts.NewStoreWithDecryptSecretsFn(lggr, orm, fetcher.FetcherFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), decrypter.decryptSecrets)
+		artifactStore := artifacts.NewStoreWithDecryptSecretsFn(lggr, orm, fetcher.FetcherFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), decrypter.decryptSecrets)
 		donTime := dontime.NewStore(dontime.DefaultRequestTimeout)
 
 		workflowEncryptionKey := workflowkey.MustNewXXXTestingOnly(big.NewInt(1))
@@ -1318,11 +1319,11 @@ func TestEngineFactoryFn_SuccessfulCreation(t *testing.T) {
 	workflowLimits, err := syncerlimiter.NewWorkflowLimits(lggr, syncerlimiter.Config{Global: 200, PerOwner: 200}, limits.Factory{})
 	require.NoError(t, err)
 
-	emitter := custmsg.NewLabeler()
+	emitter := custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 	decrypter := newMockDecrypter()
 	fetcher := newMockFetcher(map[string]mockFetchResp{})
 	orm := mocks.NewORM(t)
-	artifactStore := artifacts.NewStoreWithDecryptSecretsFn(lggr, orm, fetcher.FetcherFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), decrypter.decryptSecrets)
+	artifactStore := artifacts.NewStoreWithDecryptSecretsFn(lggr, orm, fetcher.FetcherFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), decrypter.decryptSecrets)
 	workflowEncryptionKey := workflowkey.MustNewXXXTestingOnly(big.NewInt(1))
 
 	eventHandler, err := NewEventHandler(

--- a/core/services/workflows/syncer/v2/handler_test.go
+++ b/core/services/workflows/syncer/v2/handler_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder/beholdertest"
 	"github.com/smartcontractkit/chainlink-common/pkg/contexts"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
+	"github.com/smartcontractkit/chainlink/v2/core/custmsgtypes"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
@@ -177,7 +178,7 @@ func Test_Handler(t *testing.T) {
 		t.Parallel()
 		lggr := logger.TestLogger(t)
 		lf := limits.Factory{Logger: lggr}
-		emitter := custmsg.NewLabeler()
+		emitter := custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 		wfStore := store.NewInMemoryStore(lggr, clockwork.NewFakeClock())
 		registry := capabilities.NewRegistry(lggr)
 		registry.SetLocalRegistry(&capabilities.TestMetadataRegistry{})
@@ -206,7 +207,7 @@ func Test_Handler(t *testing.T) {
 			return []byte("contents"), nil
 		}
 
-		store, err := artifacts.NewStore(lggr, mockORM, fetcher, retriever, clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), lf, artifacts.WithConfig(artifacts.StoreConfig{
+		store, err := artifacts.NewStore(lggr, mockORM, fetcher, retriever, clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), lf, artifacts.WithConfig(artifacts.StoreConfig{
 			ArtifactStorageHost: "example.com",
 		}))
 		require.NoError(t, err)
@@ -699,7 +700,7 @@ func Test_workflowRegisteredHandler_confidentialRouting(t *testing.T) {
 			lf                    = limits.Factory{Logger: lggr}
 			db                    = pgtest.NewSqlxDB(t)
 			orm                   = artifacts.NewWorkflowRegistryDS(db, lggr)
-			emitter               = custmsg.NewLabeler()
+			emitter               = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 			binary                = wasmtest.GetTestBinary(t, withTeeV2Cmd, true)
 			encodedBinary         = []byte(base64.StdEncoding.EncodeToString(binary))
 			config                = []byte("")
@@ -724,7 +725,7 @@ func Test_workflowRegisteredHandler_confidentialRouting(t *testing.T) {
 			signedBinaryURL:                      {Body: encodedBinary, Err: nil},
 			signedConfigURL:                      {Body: config, Err: nil},
 		})
-		artifactStore, err := artifacts.NewStore(lggr, orm, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), lf, artifacts.WithConfig(artifacts.StoreConfig{
+		artifactStore, err := artifacts.NewStore(lggr, orm, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), lf, artifacts.WithConfig(artifacts.StoreConfig{
 			ArtifactStorageHost: "example.com",
 		}))
 		require.NoError(t, err)
@@ -812,7 +813,7 @@ func Test_workflowRegisteredHandler_confidentialRouting(t *testing.T) {
 			lf      = limits.Factory{Logger: lggr}
 			db      = pgtest.NewSqlxDB(t)
 			orm     = artifacts.NewWorkflowRegistryDS(db, lggr)
-			emitter = custmsg.NewLabeler()
+			emitter = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 
 			binary                = wasmtest.GetTestBinary(t, noTeeV2Cmd, true)
 			encodedBinary         = []byte(base64.StdEncoding.EncodeToString(binary))
@@ -838,7 +839,7 @@ func Test_workflowRegisteredHandler_confidentialRouting(t *testing.T) {
 			signedBinaryURL:                      {Body: encodedBinary, Err: nil},
 			signedConfigURL:                      {Body: config, Err: nil},
 		})
-		artifactStore, err := artifacts.NewStore(lggr, orm, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), lf, artifacts.WithConfig(artifacts.StoreConfig{
+		artifactStore, err := artifacts.NewStore(lggr, orm, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), lf, artifacts.WithConfig(artifacts.StoreConfig{
 			ArtifactStorageHost: "example.com",
 		}))
 		require.NoError(t, err)
@@ -913,7 +914,7 @@ func testRunningWorkflow(t *testing.T, tc testCase) {
 			lf      = limits.Factory{Logger: lggr}
 			db      = pgtest.NewSqlxDB(t)
 			orm     = artifacts.NewWorkflowRegistryDS(db, lggr)
-			emitter = custmsg.NewLabeler()
+			emitter = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 
 			binary                = tc.GiveBinary
 			config                = tc.GiveConfig
@@ -948,7 +949,7 @@ func testRunningWorkflow(t *testing.T, tc testCase) {
 		require.NoError(t, err)
 
 		fetcher := fetcherFactory(giveWFID[:])
-		artifactStore, err := artifacts.NewStore(lggr, orm, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), lf, artifacts.WithConfig(artifacts.StoreConfig{
+		artifactStore, err := artifacts.NewStore(lggr, orm, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), lf, artifacts.WithConfig(artifacts.StoreConfig{
 			ArtifactStorageHost: "example.com",
 		}))
 		require.NoError(t, err)
@@ -1046,7 +1047,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 			lf      = limits.Factory{Logger: lggr}
 			db      = pgtest.NewSqlxDB(t)
 			orm     = artifacts.NewWorkflowRegistryDS(db, lggr)
-			emitter = custmsg.NewLabeler()
+			emitter = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 
 			binary        = wasmtest.GetTestBinary(t, binaryCmd, true)
 			encodedBinary = []byte(base64.StdEncoding.EncodeToString(binary))
@@ -1098,7 +1099,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 		workflowLimits, err := syncerlimiter.NewWorkflowLimits(lggr, syncerlimiter.Config{Global: 200, PerOwner: 200}, lf)
 		require.NoError(t, err)
 
-		artifactStore, err := artifacts.NewStore(lggr, orm, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), lf, artifacts.WithConfig(artifacts.StoreConfig{
+		artifactStore, err := artifacts.NewStore(lggr, orm, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), lf, artifacts.WithConfig(artifacts.StoreConfig{
 			ArtifactStorageHost: "example.com",
 		}))
 		require.NoError(t, err)
@@ -1148,7 +1149,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 			lf      = limits.Factory{Logger: lggr}
 			db      = pgtest.NewSqlxDB(t)
 			orm     = artifacts.NewWorkflowRegistryDS(db, lggr)
-			emitter = custmsg.NewLabeler()
+			emitter = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 
 			binary                = wasmtest.GetTestBinary(t, binaryCmd, true)
 			config                = []byte("")
@@ -1172,7 +1173,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 		require.NoError(t, err)
 		workflowLimits, err := syncerlimiter.NewWorkflowLimits(lggr, syncerlimiter.Config{Global: 200, PerOwner: 200}, lf)
 		require.NoError(t, err)
-		artifactStore, err := artifacts.NewStore(lggr, orm, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), lf, artifacts.WithConfig(artifacts.StoreConfig{
+		artifactStore, err := artifacts.NewStore(lggr, orm, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), lf, artifacts.WithConfig(artifacts.StoreConfig{
 			ArtifactStorageHost: "example.com",
 		}))
 		require.NoError(t, err)
@@ -1199,7 +1200,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 			lf      = limits.Factory{Logger: lggr}
 			db      = pgtest.NewSqlxDB(t)
 			orm     = artifacts.NewWorkflowRegistryDS(db, lggr)
-			emitter = custmsg.NewLabeler()
+			emitter = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 
 			binary                = wasmtest.GetTestBinary(t, binaryCmd, true)
 			encodedBinary         = []byte(base64.StdEncoding.EncodeToString(binary))
@@ -1251,7 +1252,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 		workflowLimits, err := syncerlimiter.NewWorkflowLimits(lggr, syncerlimiter.Config{Global: 200, PerOwner: 200}, lf)
 		require.NoError(t, err)
 
-		artifactStore, err := artifacts.NewStore(lggr, orm, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), lf, artifacts.WithConfig(artifacts.StoreConfig{
+		artifactStore, err := artifacts.NewStore(lggr, orm, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), lf, artifacts.WithConfig(artifacts.StoreConfig{
 			ArtifactStorageHost: "example.com",
 		}))
 		require.NoError(t, err)
@@ -1426,7 +1427,7 @@ func (m *mockLinkingService) GetOrganizationFromWorkflowOwner(ctx context.Contex
 
 func Test_Handler_OrganizationID(t *testing.T) { //nolint:paralleltest // beholdertest.NewObserver uses t.Setenv
 	observer := beholdertest.NewObserver(t)
-	emitter := custmsg.NewLabeler()
+	emitter := custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 	ctx := t.Context()
 
 	// Set up mock gRPC server for linking service
@@ -1486,7 +1487,7 @@ func Test_Handler_OrganizationID(t *testing.T) { //nolint:paralleltest // behold
 	workflowLimits, err := syncerlimiter.NewWorkflowLimits(lggr, syncerlimiter.Config{Global: 200, PerOwner: 200}, lf)
 	require.NoError(t, err)
 
-	artifactStore, err := artifacts.NewStore(lggr, mockORM, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), lf, artifacts.WithConfig(artifacts.StoreConfig{
+	artifactStore, err := artifacts.NewStore(lggr, mockORM, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), lf, artifacts.WithConfig(artifacts.StoreConfig{
 		ArtifactStorageHost: "example.com",
 	}))
 	require.NoError(t, err)
@@ -1557,7 +1558,7 @@ func Test_Handler_OrganizationID(t *testing.T) { //nolint:paralleltest // behold
 	// Test deletion event
 	t.Run("WorkflowDeleted event includes org ID in labels", func(t *testing.T) {
 		deleteObserver := beholdertest.NewObserver(t)
-		deleteEmitter := custmsg.NewLabeler()
+		deleteEmitter := custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 
 		mockDeleteORM := mocks.NewORM(t)
 		spec := &job.WorkflowSpec{
@@ -1569,7 +1570,7 @@ func Test_Handler_OrganizationID(t *testing.T) { //nolint:paralleltest // behold
 		mockDeleteORM.EXPECT().GetWorkflowSpec(mock.Anything, types.WorkflowID(giveWFID).Hex()).Return(spec, nil)
 		mockDeleteORM.EXPECT().DeleteWorkflowSpec(mock.Anything, types.WorkflowID(giveWFID).Hex()).Return(nil)
 
-		deleteArtifactStore, err := artifacts.NewStore(lggr, mockDeleteORM, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), lf, artifacts.WithConfig(artifacts.StoreConfig{
+		deleteArtifactStore, err := artifacts.NewStore(lggr, mockDeleteORM, fetcher.FetcherFunc(), fetcher.RetrieverFunc(), clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowArtifact), lf, artifacts.WithConfig(artifacts.StoreConfig{
 			ArtifactStorageHost: "example.com",
 		}))
 		require.NoError(t, err)

--- a/core/services/workflows/syncer/v2/workflow_syncer_v2_test.go
+++ b/core/services/workflows/syncer/v2/workflow_syncer_v2_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
+	"github.com/smartcontractkit/chainlink/v2/core/custmsgtypes"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
@@ -246,7 +247,7 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyPausedV2(t *testing.T) {
 	var (
 		ctx       = t.Context()
 		lggr      = logger.TestLogger(t)
-		emitter   = custmsg.NewLabeler()
+		emitter   = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 		backendTH = testutils.NewEVMBackendTH(t)
 		db        = pgtest.NewSqlxDB(t)
 		orm       = artifacts.NewWorkflowRegistryDS(db, lggr)
@@ -351,7 +352,7 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyActivatedV2(t *testing.T) {
 	var (
 		ctx       = t.Context()
 		lggr      = logger.TestLogger(t)
-		emitter   = custmsg.NewLabeler()
+		emitter   = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 		backendTH = testutils.NewEVMBackendTH(t)
 		db        = pgtest.NewSqlxDB(t)
 		orm       = artifacts.NewWorkflowRegistryDS(db, lggr)

--- a/core/services/workflows/syncer/workflow_syncer_test.go
+++ b/core/services/workflows/syncer/workflow_syncer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/workflowkey"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
+	"github.com/smartcontractkit/chainlink/v2/core/custmsgtypes"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
@@ -326,7 +327,7 @@ func Test_SecretsWorker(t *testing.T) {
 			var (
 				ctx       = t.Context()
 				lggr      = logger.TestLogger(t)
-				emitter   = custmsg.NewLabeler()
+				emitter   = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 				backendTH = testutils.NewEVMBackendTH(t)
 				db        = pgtest.NewSqlxDB(t)
 				orm       = artifacts.NewWorkflowRegistryDS(db, lggr)
@@ -546,7 +547,7 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyPaused(t *testing.T) {
 	var (
 		ctx       = t.Context()
 		lggr      = logger.TestLogger(t)
-		emitter   = custmsg.NewLabeler()
+		emitter   = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 		backendTH = testutils.NewEVMBackendTH(t)
 		db        = pgtest.NewSqlxDB(t)
 		orm       = artifacts.NewWorkflowRegistryDS(db, lggr)
@@ -647,7 +648,7 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyActivated(t *testing.T) {
 	var (
 		ctx       = t.Context()
 		lggr      = logger.TestLogger(t)
-		emitter   = custmsg.NewLabeler()
+		emitter   = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowSyncer)
 		backendTH = testutils.NewEVMBackendTH(t)
 		db        = pgtest.NewSqlxDB(t)
 		orm       = artifacts.NewWorkflowRegistryDS(db, lggr)

--- a/core/services/workflows/v2/config_test.go
+++ b/core/services/workflows/v2/config_test.go
@@ -110,6 +110,8 @@ func (m *noopBeholderEmitter) Emit(_ context.Context, _ string) error {
 	return nil
 }
 
+func (m *noopBeholderEmitter) WithType(string) custmsg.MessageEmitter { return m }
+func (m *noopBeholderEmitter) WithLabelsAndType(map[string]string, string) custmsg.MessageEmitter { return m }
 func (m *noopBeholderEmitter) WithMapLabels(labels map[string]string) custmsg.MessageEmitter {
 	return m
 }

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -35,6 +35,7 @@ import (
 	vaultMock "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault/mock"
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
+	"github.com/smartcontractkit/chainlink/v2/core/custmsgtypes"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings"
@@ -820,7 +821,7 @@ func TestEngine_Execution(t *testing.T) {
 		},
 	}
 	beholderObserver := beholdertest.NewObserver(t)
-	cfg.BeholderEmitter = custmsg.NewLabeler()
+	cfg.BeholderEmitter = custmsg.NewLabeler().WithType(custmsgtypes.TypeWorkflowEngine)
 
 	t.Run("successful execution with no capability calls", func(t *testing.T) {
 		t.Parallel()
@@ -2881,6 +2882,8 @@ func (t *trackingBeholderEmitter) With(keyValues ...string) custmsg.MessageEmitt
 	return t
 }
 
+func (t *trackingBeholderEmitter) WithType(string) custmsg.MessageEmitter { return t }
+func (t *trackingBeholderEmitter) WithLabelsAndType(map[string]string, string) custmsg.MessageEmitter { return t }
 func (t *trackingBeholderEmitter) WithMapLabels(labels map[string]string) custmsg.MessageEmitter {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260703215130-fb7f626f085c
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260522094612-5f9f748bd87a
@@ -426,8 +426,6 @@ require (
 	pgregory.net/rapid v1.2.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-replace github.com/smartcontractkit/chainlink-common => /Users/pk/TASKS/260703-custmsg-type-label-for-basemessage-emissions/.worktrees/chainlink-common/custmsg-type-label-for-basemessage-emissions
 
 replace github.com/fbsobreira/gotron-sdk => github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b
 

--- a/go.mod
+++ b/go.mod
@@ -427,6 +427,8 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
+replace github.com/smartcontractkit/chainlink-common => /Users/pk/TASKS/260703-custmsg-type-label-for-basemessage-emissions/.worktrees/chainlink-common/custmsg-type-label-for-basemessage-emissions
+
 replace github.com/fbsobreira/gotron-sdk => github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20260218133534-cbd44da2856b
 
 tool github.com/smartcontractkit/chainlink-common/pkg/loop/cmd/loopinstall

--- a/go.sum
+++ b/go.sum
@@ -1162,8 +1162,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033 h1:WjZwKtUA/0TPvzgCt8bcdq+BHMIL65S0oU79mxgZn/Y=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260622154332-695181f87033/go.mod h1:15M0qBycFN5jkNjaYFkutYkGAmhuT401IfaJvz32lcg=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0 h1:ywWOEZYL4DhVwf/TQ5jXsGlx6CzERsYbqd6ov3OS1sc=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260701091216-9264d4444ce0/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260703215130-fb7f626f085c h1:Ap8NjOxrDrQWKZwxtpS0LxH6XKWahhqjDYI2myv1Dz8=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260703215130-fb7f626f085c/go.mod h1:ncZiIgraMh4F9lWDoJwB1TX395qZFR5bvnZcHbD0A1Q=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=


### PR DESCRIPTION
## Summary

- Add `core/custmsgtypes` with stable type constants (NodeConfig, Heartbeat, WorkflowEngine, WorkflowSyncer, WorkflowArtifact, Compute)
- Update all `custmsg.NewLabeler()` call sites to chain `.WithType(...)` before emit
- Bump `chainlink-common` to branch pseudo-version `v0.11.2-0.20260703215130-fb7f626f085c`

Depends on https://github.com/smartcontractkit/chainlink-common/pull/2222 — merge common first, then re-bump to released pseudo-version before merging this PR.

## Test plan

- [x] `go test ./core/cmd/ -run TestShell_emitNodeConfig`
- [x] `go test ./core/services/workflows/syncer/...`
- [x] `go test ./core/services/workflows/artifacts/...`
- [x] `go test ./core/capabilities/compute/`
- [x] `go test ./core/services/workflows/v2/...`