### PR TITLE
chore: bump confidential http capability gitref

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -9,5 +9,5 @@ defaults:
 plugins:
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "4ac24e5f31cf5c936e31c6d3ef2509d6ad7a5791"
+      gitRef: "bee6cc7d7cfc8d48e04c8d42ad35187b9b70fd72"
       installPath: "./cmd/confidential-http"


### PR DESCRIPTION
## Summary

Bumps the confidential http capability gitref in `plugins/plugins.private.yaml`.
