### PR TITLE
fix(workflows): cap get-secrets histogram buckets in MetricViews

### DIFF
--- a/core/services/workflows/monitoring/metric_views_test.go
+++ b/core/services/workflows/monitoring/metric_views_test.go
@@ -42,6 +42,6 @@ func TestMetricViews_getSecretsDurationBuckets(t *testing.T) {
 	data, ok := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[int64])
 	require.True(t, ok)
 	require.Len(t, data.DataPoints, 1)
+	// 7 boundaries produce 8 Prometheus buckets (including the implicit +Inf).
 	assert.Equal(t, wantBoundaries, data.DataPoints[0].Bounds)
-	assert.Len(t, data.DataPoints[0].Bounds, 7, "expected 7 boundaries (8 Prometheus buckets including +Inf)")
 }

--- a/core/services/workflows/monitoring/metric_views_test.go
+++ b/core/services/workflows/monitoring/metric_views_test.go
@@ -1,0 +1,47 @@
+package monitoring_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/monitoring"
+)
+
+func TestMetricViews_getSecretsDurationBuckets(t *testing.T) {
+	t.Parallel()
+
+	wantBoundaries := []float64{0, 10, 50, 100, 250, 500, 1000}
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithView(monitoring.MetricViews()...),
+	)
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	hist, err := mp.Meter("test").Int64Histogram(
+		"platform_engine_get_secrets_duration_ms",
+		metric.WithUnit("ms"),
+	)
+	require.NoError(t, err)
+	hist.Record(context.Background(), 75)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	require.Len(t, rm.ScopeMetrics, 1)
+	require.Len(t, rm.ScopeMetrics[0].Metrics, 1)
+	require.Equal(t, "platform_engine_get_secrets_duration_ms", rm.ScopeMetrics[0].Metrics[0].Name)
+
+	data, ok := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[int64])
+	require.True(t, ok)
+	require.Len(t, data.DataPoints, 1)
+	assert.Equal(t, wantBoundaries, data.DataPoints[0].Bounds)
+	assert.Len(t, data.DataPoints[0].Bounds, 7, "expected 7 boundaries (8 Prometheus buckets including +Inf)")
+}

--- a/core/services/workflows/monitoring/monitoring.go
+++ b/core/services/workflows/monitoring/monitoring.go
@@ -490,6 +490,13 @@ func MetricViews() []sdkmetric.View {
 				Boundaries: []float64{0, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60},
 			}},
 		),
+		// Default OTel buckets (16) for this instrument; Capabilities dashboards use p50/p90.
+		sdkmetric.NewView(
+			sdkmetric.Instrument{Name: "platform_engine_get_secrets_duration_ms"},
+			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+				Boundaries: []float64{0, 10, 50, 100, 250, 500, 1000},
+			}},
+		),
 	}
 }
 

--- a/core/services/workflows/monitoring/monitoring.go
+++ b/core/services/workflows/monitoring/monitoring.go
@@ -490,7 +490,8 @@ func MetricViews() []sdkmetric.View {
 				Boundaries: []float64{0, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60},
 			}},
 		),
-		// Default OTel buckets (16) for this instrument; Capabilities dashboards use p50/p90.
+		// Reduce from OTel's 16 default buckets to 8 to limit series cardinality;
+		// Capabilities dashboards only use p50/p90, so coarse buckets are fine.
 		sdkmetric.NewView(
 			sdkmetric.Instrument{Name: "platform_engine_get_secrets_duration_ms"},
 			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{


### PR DESCRIPTION
## Summary

- Add an OTel SDK view in `MetricViews()` for `platform_engine_get_secrets_duration_ms` with 7 explicit boundaries (8 Prometheus buckets including `+Inf`), down from the OTel default of 16 buckets.
- Metric owner change in chainlink (option B): view lives next to the other `platform_engine_*` histogram views wired via `shell.go` → `beholder.Config.MetricViews`.
- Test asserts the view applies via `TestMetricViews_getSecretsDurationBuckets`.

## Motivation

High-cardinality CRE workflow nodes accumulate series from histogram `le` labels × workflow count. This instrument had no custom view (unlike the other platform_engine histograms in `monitoring.go`).

## Dashboard impact (Medium)

**Capabilities** dashboard (`Capabilities.json`, 13 zones) uses:
- `histogram_quantile(0.50, …platform_engine_get_secrets_duration_ms_milliseconds_bucket…)`
- `histogram_quantile(0.90, …)`

Fewer buckets may shift p50/p90 slightly vs default boundaries. Validate on staging after deploy.

## Test plan

- [x] `go test ./core/services/workflows/monitoring/ -run TestMetricViews_getSecretsDurationBuckets`
- [ ] Staging: spot-check Capabilities get-secrets p50/p90 panels vs pre-change baseline

## Related

- chainlink-common #2225 / #2226 (beholder cardinality + PerWorkflow buckets) — independent; do **not** add a duplicate DefaultViews override for this metric (option C rejected).
