### PR TITLE
fix(workflows): reduce platform_engine histogram buckets to 8

### DIFF
--- a/core/services/workflows/monitoring/metric_views_test.go
+++ b/core/services/workflows/monitoring/metric_views_test.go
@@ -87,3 +87,36 @@ func TestMetricViews_platformEngineHistogramBuckets(t *testing.T) {
 		})
 	}
 }
+
+func TestMetricViews_getSecretsDurationBuckets(t *testing.T) {
+	t.Parallel()
+
+	wantBoundaries := []float64{0, 10, 50, 100, 250, 500, 1000}
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithView(monitoring.MetricViews()...),
+	)
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	hist, err := mp.Meter("test").Int64Histogram(
+		"platform_engine_get_secrets_duration_ms",
+		metric.WithUnit("ms"),
+	)
+	require.NoError(t, err)
+	hist.Record(context.Background(), 75)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	require.Len(t, rm.ScopeMetrics, 1)
+	require.Len(t, rm.ScopeMetrics[0].Metrics, 1)
+	require.Equal(t, "platform_engine_get_secrets_duration_ms", rm.ScopeMetrics[0].Metrics[0].Name)
+
+	data, ok := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[int64])
+	require.True(t, ok)
+	require.Len(t, data.DataPoints, 1)
+	assert.Equal(t, wantBoundaries, data.DataPoints[0].Bounds)
+	assert.Len(t, data.DataPoints[0].Bounds, 7, "expected 7 boundaries (8 Prometheus buckets including +Inf)")
+}

--- a/core/services/workflows/monitoring/metric_views_test.go
+++ b/core/services/workflows/monitoring/metric_views_test.go
@@ -1,0 +1,89 @@
+package monitoring_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/monitoring"
+)
+
+func TestMetricViews_platformEngineHistogramBuckets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		instrument string
+		unit       string
+		wantBounds []float64
+	}{
+		{
+			name:       "workflow_completed_time",
+			instrument: "platform_engine_workflow_completed_time_seconds",
+			unit:       "s",
+			wantBounds: []float64{0, 10, 40, 90, 150, 300, 900},
+		},
+		{
+			name:       "trigger_event_queue_wait",
+			instrument: "platform_engine_trigger_event_queue_wait_seconds",
+			unit:       "s",
+			wantBounds: []float64{0, 0.001, 0.01, 0.1, 1, 10, 60},
+		},
+		{
+			name:       "trigger_queue_to_execution_start",
+			instrument: "platform_engine_trigger_queue_to_execution_start_seconds",
+			unit:       "s",
+			wantBounds: []float64{0, 0.01, 0.1, 1, 10, 60, 300},
+		},
+		{
+			name:       "trigger_payload_bytes",
+			instrument: "platform_engine_trigger_payload_bytes",
+			unit:       "By",
+			wantBounds: []float64{0, 512, 4096, 32768, 262144, 1048576, 4194304},
+		},
+		{
+			name:       "execution_semaphore_wait",
+			instrument: "platform_engine_execution_semaphore_wait_seconds",
+			unit:       "s",
+			wantBounds: []float64{0, 0.001, 0.01, 0.1, 1, 10, 60},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reader := sdkmetric.NewManualReader()
+			mp := sdkmetric.NewMeterProvider(
+				sdkmetric.WithReader(reader),
+				sdkmetric.WithView(monitoring.MetricViews()...),
+			)
+			t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+			hist, err := mp.Meter("test").Float64Histogram(
+				tt.instrument,
+				metric.WithUnit(tt.unit),
+			)
+			require.NoError(t, err)
+			hist.Record(context.Background(), 1)
+
+			var rm metricdata.ResourceMetrics
+			require.NoError(t, reader.Collect(context.Background(), &rm))
+
+			require.Len(t, rm.ScopeMetrics, 1)
+			require.Len(t, rm.ScopeMetrics[0].Metrics, 1)
+			require.Equal(t, tt.instrument, rm.ScopeMetrics[0].Metrics[0].Name)
+
+			data, ok := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+			require.True(t, ok)
+			require.Len(t, data.DataPoints, 1)
+			assert.Equal(t, tt.wantBounds, data.DataPoints[0].Bounds)
+			assert.Len(t, tt.wantBounds, 7, "expected 7 boundaries (8 Prometheus buckets including +Inf)")
+		})
+	}
+}

--- a/core/services/workflows/monitoring/monitoring.go
+++ b/core/services/workflows/monitoring/monitoring.go
@@ -507,6 +507,13 @@ func MetricViews() []sdkmetric.View {
 				Boundaries: b.executionSemaphoreWait,
 			}},
 		),
+		// Default OTel buckets (16) for this instrument; Capabilities dashboards use p50/p90.
+		sdkmetric.NewView(
+			sdkmetric.Instrument{Name: "platform_engine_get_secrets_duration_ms"},
+			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+				Boundaries: []float64{0, 10, 50, 100, 250, 500, 1000},
+			}},
+		),
 	}
 }
 

--- a/core/services/workflows/monitoring/monitoring.go
+++ b/core/services/workflows/monitoring/monitoring.go
@@ -431,9 +431,27 @@ func InitMonitoringResources() (em *EngineMetrics, err error) {
 	return em, nil
 }
 
+// platformEngineHistogramBoundaries caps Prometheus le-cardinality on high-workflow-count
+// CRE nodes. Each slice has 7 explicit boundaries (8 buckets including +Inf).
+var platformEngineHistogramBoundaries = struct {
+	workflowCompletedTime              []float64
+	triggerEventQueueWait            []float64
+	triggerQueueToExecutionStart     []float64
+	triggerPayloadBytes              []float64
+	executionSemaphoreWait           []float64
+}{
+	// Workflows-Engine p95/p99; coarser than prior 16-bucket layout but keeps SLO range.
+	workflowCompletedTime:          []float64{0, 10, 40, 90, 150, 300, 900},
+	triggerEventQueueWait:          []float64{0, 0.001, 0.01, 0.1, 1, 10, 60},
+	triggerQueueToExecutionStart:   []float64{0, 0.01, 0.1, 1, 10, 60, 300},
+	triggerPayloadBytes:            []float64{0, 512, 4096, 32768, 262144, 1048576, 4194304},
+	executionSemaphoreWait:         []float64{0, 0.001, 0.01, 0.1, 1, 10, 60},
+}
+
 // Note: due to the OTEL specification, all histogram buckets
 // Must be defined when the beholder client is created
 func MetricViews() []sdkmetric.View {
+	b := platformEngineHistogramBoundaries
 	return []sdkmetric.View{
 		sdkmetric.NewView(
 			sdkmetric.Instrument{Name: "platform_engine_workflow_earlyexit_time_seconds"},
@@ -444,8 +462,7 @@ func MetricViews() []sdkmetric.View {
 		sdkmetric.NewView(
 			sdkmetric.Instrument{Name: "platform_engine_workflow_completed_time_seconds"},
 			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-				// increased granularity for the workflow execution latencies near expected values
-				Boundaries: []float64{0, 10, 20, 40, 50, 70, 90, 120, 150, 180, 210, 300, 600, 900, 1200},
+				Boundaries: b.workflowCompletedTime,
 			}},
 		),
 		sdkmetric.NewView(
@@ -469,25 +486,25 @@ func MetricViews() []sdkmetric.View {
 		sdkmetric.NewView(
 			sdkmetric.Instrument{Name: "platform_engine_trigger_event_queue_wait_seconds"},
 			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-				Boundaries: []float64{0, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60},
+				Boundaries: b.triggerEventQueueWait,
 			}},
 		),
 		sdkmetric.NewView(
 			sdkmetric.Instrument{Name: "platform_engine_trigger_queue_to_execution_start_seconds"},
 			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-				Boundaries: []float64{0, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300},
+				Boundaries: b.triggerQueueToExecutionStart,
 			}},
 		),
 		sdkmetric.NewView(
 			sdkmetric.Instrument{Name: "platform_engine_trigger_payload_bytes"},
 			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-				Boundaries: []float64{0, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304},
+				Boundaries: b.triggerPayloadBytes,
 			}},
 		),
 		sdkmetric.NewView(
 			sdkmetric.Instrument{Name: "platform_engine_execution_semaphore_wait_seconds"},
 			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-				Boundaries: []float64{0, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60},
+				Boundaries: b.executionSemaphoreWait,
 			}},
 		),
 	}

--- a/core/services/workflows/monitoring/monitoring.go
+++ b/core/services/workflows/monitoring/monitoring.go
@@ -434,18 +434,18 @@ func InitMonitoringResources() (em *EngineMetrics, err error) {
 // platformEngineHistogramBoundaries caps Prometheus le-cardinality on high-workflow-count
 // CRE nodes. Each slice has 7 explicit boundaries (8 buckets including +Inf).
 var platformEngineHistogramBoundaries = struct {
-	workflowCompletedTime              []float64
-	triggerEventQueueWait            []float64
-	triggerQueueToExecutionStart     []float64
-	triggerPayloadBytes              []float64
-	executionSemaphoreWait           []float64
+	workflowCompletedTime        []float64
+	triggerEventQueueWait        []float64
+	triggerQueueToExecutionStart []float64
+	triggerPayloadBytes          []float64
+	executionSemaphoreWait       []float64
 }{
 	// Workflows-Engine p95/p99; coarser than prior 16-bucket layout but keeps SLO range.
-	workflowCompletedTime:          []float64{0, 10, 40, 90, 150, 300, 900},
-	triggerEventQueueWait:          []float64{0, 0.001, 0.01, 0.1, 1, 10, 60},
-	triggerQueueToExecutionStart:   []float64{0, 0.01, 0.1, 1, 10, 60, 300},
-	triggerPayloadBytes:            []float64{0, 512, 4096, 32768, 262144, 1048576, 4194304},
-	executionSemaphoreWait:         []float64{0, 0.001, 0.01, 0.1, 1, 10, 60},
+	workflowCompletedTime:        []float64{0, 10, 40, 90, 150, 300, 900},
+	triggerEventQueueWait:        []float64{0, 0.001, 0.01, 0.1, 1, 10, 60},
+	triggerQueueToExecutionStart: []float64{0, 0.01, 0.1, 1, 10, 60, 300},
+	triggerPayloadBytes:          []float64{0, 512, 4096, 32768, 262144, 1048576, 4194304},
+	executionSemaphoreWait:       []float64{0, 0.001, 0.01, 0.1, 1, 10, 60},
 }
 
 // Note: due to the OTEL specification, all histogram buckets


### PR DESCRIPTION
## Summary

Reduce Prometheus `le` cardinality on five high-bucket `platform_engine_*` histograms in `MetricViews()` from 16–18 buckets to **8 buckets** (7 explicit boundaries). Instruments already at ≤8 buckets are unchanged.

| Instrument | Before | After (boundaries) |
|------------|-------:|--------------------|
| `platform_engine_workflow_completed_time_seconds` | 16 | `{0, 10, 40, 90, 150, 300, 900}` |
| `platform_engine_trigger_event_queue_wait_seconds` | 16 | `{0, 0.001, 0.01, 0.1, 1, 10, 60}` |
| `platform_engine_trigger_queue_to_execution_start_seconds` | 18 | `{0, 0.01, 0.1, 1, 10, 60, 300}` |
| `platform_engine_trigger_payload_bytes` | 17 | `{0, 512, 4096, 32768, 262144, 1048576, 4194304}` |
| `platform_engine_execution_semaphore_wait_seconds` | 16 | `{0, 0.001, 0.01, 0.1, 1, 10, 60}` |

Unchanged (already ≤8 buckets): `workflow_earlyexit_time`, `workflow_error_time`, `workflow_step_time`, `capability_execution_time`.

## Motivation

High-workflow-count CRE nodes (e.g. ~590 workflows) multiply histogram bucket series across `le` labels. These five metrics were top contributors in the cardinality incident report alongside PerWorkflow limit histograms.

Complements chainlink-common #2225 / #2226 (label filtering + PerWorkflow buckets) and chainlink #23030 (get-secrets buckets).

## Dashboard impact (Medium)

**Workflows-Engine** (13 zones): p95/p99 on `platform_engine_workflow_*_seconds_bucket` and p99 on `platform_engine_capability_execution_time_seconds_bucket`. Coarser `workflow_completed_time` buckets may shift reported quantiles; validate on staging.

**Alert impact:** None in `~/repos/alerts`.

## Test plan

- [x] `go test ./core/services/workflows/monitoring/ -run TestMetricViews_platformEngineHistogramBuckets`
- [ ] Staging: compare Workflows-Engine p95/p99 panels before/after on a high-workflow-count node
- [ ] Spot-check trigger queue / payload panels if used in ops triage

## Merge order

Independent of chainlink-common PRs; can merge in parallel with #23030 (get-secrets). Bump chainlink-common for #2225/#2226 separately when ready.

Made with [Cursor](https://cursor.com)