### PR TITLE
Removing RMN test triggers on specific PRs

### DIFF
--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -129,8 +129,7 @@ runner-test-matrix:
     runs_on: ubuntu24.04-16cores-64GB
     runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
-      - Nightly E2E Tests
-      - Push E2E CCIP v1.6 Tests
+      # Push/Nightly triggers removed: test consistently times out after 30m (RMN curse-revocation flake). Re-add once fixed.
       - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \


### PR DESCRIPTION
This is a flaky test that's blocking the core node release process; removing triggers for `TestRMN_TwoMessagesOneSourceChainCursed` test.
