### PR TITLE
fix(ci): CTF binary install fallback for pseudo-versions (2.55.0)

### DIFF
--- a/.github/workflows/devenv-compat.yml
+++ b/.github/workflows/devenv-compat.yml
@@ -166,9 +166,19 @@ jobs:
       - name: Get CTF version from go.mod
         shell: bash
         working-directory: ${{ env.WORKING_DIR }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          CTF_VERSION=$(go list -m -json "github.com/smartcontractkit/chainlink-testing-framework/framework" | jq -r .Version)
-          echo "CTF_TAG=framework/$CTF_VERSION" >> "$GITHUB_ENV"
+          CTF_VERSION=$(go list -m -json "github.com/smartcontractkit/chainlink-testing-framework/framework" | jq -r 'if .Replace then .Replace.Version else .Version end')
+          # Pseudo-versions (and unreleased semver tags) have no GitHub release assets.
+          if [[ "$CTF_VERSION" == *"-"* ]]; then
+            CTF_VERSION="v${CTF_VERSION#v}"
+            CTF_VERSION="v${CTF_VERSION%%-*}"
+          fi
+          if ! gh release view "framework/${CTF_VERSION}" --repo smartcontractkit/chainlink-testing-framework >/dev/null 2>&1; then
+            CTF_VERSION=$(gh release list --repo smartcontractkit/chainlink-testing-framework --limit 50 --json tagName -q '[.[] | select(.tagName | startswith("framework/v0.")) | .tagName | sub("^framework/"; "")][0]')
+          fi
+          echo "CTF_TAG=framework/${CTF_VERSION}" >> "$GITHUB_ENV"
 
       - name: Install CTF binary
         working-directory: ${{ env.WORKING_DIR }}


### PR DESCRIPTION
## Summary
- Fixes **CRE Upgrade Test / Install CTF binary** failure on post-build for `v2.55.0-rc.0` ([run 28892378086](https://github.com/smartcontractkit/chainlink/actions/runs/28892378086/job/85708392333))
- Root cause: `system-tests/tests/go.mod` references CTF framework pseudo-version `v0.16.6-0.20260630120514-36abe27604df`, but no matching GitHub release exists (latest published: `framework/v0.16.5`)
- Workflow now strips pseudo-versions to base semver and falls back to the latest published `framework/v0.*` release when assets are missing

## Test plan
- [ ] Merge to `release/2.55.0`
- [ ] Re-run failed **CRE Upgrade Test** job (or full post-build) from updated branch / new RC tag
- [ ] Confirm **Install CTF binary** downloads `framework/v0.16.5` successfully

## Note
Rerunning the failed job on the existing `v2.55.0-rc.0` tag alone will **not** pick up this fix (workflow is resolved from the tag ref). After merge, either cut `v2.55.0-rc.1` or dispatch post-build from `release/2.55.0` HEAD.