### PR TITLE
Add health check info to NodeBuildInfo, rename to NodeInfo

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -507,7 +507,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 // indirect
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 // indirect
-	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 // indirect
+	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b // indirect
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.11.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260331131315-f08a616d8dcd // indirect
 	github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1626,8 +1626,8 @@ github.com/smartcontractkit/chainlink-protos/job-distributor v0.19.0 h1:FC+WdJ8Y
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.19.0/go.mod h1:2ahgl5bI9+fMCD+dBC785Lak38Tb7ApdTe5I8a09Qp0=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 h1:NJdGFhzT6zMaTod4QkBqVD2sg0I25iw1boOYtTpEwRo=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305/go.mod h1:qSTSwX3cBP3FKQwQacdjArqv0g6QnukjV4XuzO6UyoY=
-github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 h1:bnSl5p3mFekSJ6QcbZ1TmHn2ffYiX8xk6hNzVmyhstQ=
-github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
+github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b h1:A2+kmPy4wNQf6LoG8d9LjzrHHiykT2C74p9DNQJpTw8=
+github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
 github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0 h1:hGEJFD2X3oNIPXQbtIPxCJyg5CcKglRCYBmESS+gmeQ=
 github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0/go.mod h1:PjZD54vr6rIKEKQj6HNA4hllvYI/QpT+Zefj3tqkFAs=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.11.0 h1:NXKTdIESAiCkVnPS6dyZP+NXVek3GzXa6P4uFAs0o8Y=

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -217,8 +217,7 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 	var srvcs []services.ServiceCtx
 
 	heartbeat := NewHeartbeat(NewHeartbeatConfig(opts))
-	nodePlatformBuildInfo := NewNodePlatformBuildInfoService(NewNodePlatformBuildInfoConfig(opts))
-	srvcs = append(srvcs, &heartbeat, &nodePlatformBuildInfo)
+	srvcs = append(srvcs, &heartbeat)
 
 	auditLogger := opts.AuditLogger
 	cfg := opts.Config
@@ -786,6 +785,9 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 		return nil, fmt.Errorf("failed to configure health checker otel hooks: %w", err)
 	}
 	healthChecker := healthCfg.New()
+
+	nodePlatformInfo := NewNodePlatformInfoService(healthChecker, NewNodePlatformInfoConfig(opts))
+	srvcs = append(srvcs, &nodePlatformInfo)
 
 	var lbs []utils.DependentAwaiter
 	for _, c := range legacyEVMChains.Slice() {

--- a/core/services/chainlink/node_platform_info.go
+++ b/core/services/chainlink/node_platform_info.go
@@ -1,0 +1,154 @@
+package chainlink
+
+import (
+	"cmp"
+	"context"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+	commonservices "github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/timeutil"
+	commonv1 "github.com/smartcontractkit/chainlink-protos/node-platform/common/v1"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/static"
+)
+
+const (
+	nodePlatformDomain          = "node-platform"
+	nodePlatformBuildInfoEntity = "common.v1.NodeInfo"
+
+	nodePlatformDataSchema = "/node-platform/common/v1"
+	nodePlatformBeat       = 3 * time.Minute
+)
+
+// HealthChecker is an interface for github.com/smartcontractkit/chainlink-common@/pkg/services/health.go
+// it registers all services in chainlink/core/services/chainlink/application.go
+// and then we call IsHealthy to receive system-wide health-check and errors for each service
+type HealthChecker interface {
+	IsHealthy() (bool, map[string]error)
+}
+
+// NodePlatformInfoService is a basic info service for node
+// provides node build info and a health-check/errors
+type NodePlatformInfoService struct {
+	commonservices.Service
+	eng     *commonservices.Engine
+	beat    time.Duration
+	emitter beholder.Emitter
+	hc      HealthChecker
+
+	opts NodePlatformInfoConfig
+}
+
+type NodePlatformInfoConfig struct {
+	Beat time.Duration
+	Lggr logger.Logger
+	// Key info
+	CSAKeyStore  keystore.CSA
+	CSAPublicKey string
+	// Build info
+	CommitSHA  string
+	DockerTag  string
+	VersionTag string
+	Version    string
+}
+
+func NewNodePlatformInfoConfig(opts ApplicationOpts) NodePlatformInfoConfig {
+	return NodePlatformInfoConfig{
+		Beat:        nodePlatformBeat,
+		Lggr:        opts.Logger,
+		CSAKeyStore: opts.KeyStore.CSA(),
+		CommitSHA:   static.Sha,
+		DockerTag:   cmp.Or(opts.DockerTag, string(static.Unset)),
+		VersionTag:  cmp.Or(opts.VersionTag, static.VersionTag),
+		Version:     cmp.Or(opts.Version, static.Version),
+	}
+}
+
+func NewNodePlatformInfoService(hc HealthChecker, cfg NodePlatformInfoConfig) NodePlatformInfoService {
+	s := NodePlatformInfoService{
+		opts:    cfg,
+		beat:    cfg.Beat,
+		emitter: beholder.GetEmitter(),
+		hc:      hc,
+	}
+
+	s.Service, s.eng = commonservices.Config{
+		Name:  "NodePlatformInfo",
+		Start: s.start,
+	}.NewServiceEngine(cfg.Lggr)
+
+	return s
+}
+
+func (s *NodePlatformInfoService) start(ctx context.Context) error {
+	s.resolveCSAPublicKey(ctx)
+	s.eng.GoTick(timeutil.NewTicker(s.GetBeat), s.emit)
+	return nil
+}
+
+func (s *NodePlatformInfoService) resolveCSAPublicKey(ctx context.Context) {
+	if s.opts.CSAKeyStore == nil {
+		return
+	}
+
+	csaKey, err := keystore.GetDefault(ctx, s.opts.CSAKeyStore)
+	if err != nil {
+		s.eng.Errorw("failed to resolve CSA key for node-platform build info", "err", err)
+		return
+	}
+
+	s.opts.CSAPublicKey = csaKey.PublicKeyString()
+}
+
+func (s *NodePlatformInfoService) emit(ctx context.Context) {
+	// report current health check state and errors
+	var (
+		allServicesHealthy    bool
+		healthCheckErrs       map[string]error
+		healthCheckErrStrings = make(map[string]string)
+	)
+	if s.hc != nil {
+		allServicesHealthy, healthCheckErrs = s.hc.IsHealthy()
+		if len(healthCheckErrs) > 0 {
+			for k, v := range healthCheckErrs {
+				healthCheckErrStrings[k] = v.Error()
+			}
+		}
+	}
+
+	payloadBytes, err := proto.Marshal(&commonv1.NodeInfo{
+		CsaPublicKey: s.opts.CSAPublicKey,
+		CommitSha:    s.opts.CommitSHA,
+		DockerTag:    s.opts.DockerTag,
+		VersionTag:   s.opts.VersionTag,
+		Version:      s.opts.Version,
+		Healthy:      allServicesHealthy,
+		HealthErrors: healthCheckErrStrings,
+	})
+	if err != nil {
+		s.eng.Errorw("failed to marshal node-platform build info", "err", err)
+		return
+	}
+
+	emitter := s.emitter
+	if emitter == nil {
+		emitter = beholder.GetEmitter()
+	}
+
+	err = emitter.Emit(ctx, payloadBytes,
+		beholder.AttrKeyDomain, nodePlatformDomain,
+		beholder.AttrKeyEntity, nodePlatformBuildInfoEntity,
+		beholder.AttrKeyDataSchema, nodePlatformDataSchema,
+	)
+	if err != nil {
+		s.eng.Errorw("failed to emit node-platform build info", "err", err)
+	}
+}
+
+func (s *NodePlatformInfoService) GetBeat() time.Duration {
+	return s.beat
+}

--- a/core/services/chainlink/node_platform_info_test.go
+++ b/core/services/chainlink/node_platform_info_test.go
@@ -1,0 +1,118 @@
+package chainlink_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/csakey"
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder/beholdertest"
+	commoncfg "github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	commonv1 "github.com/smartcontractkit/chainlink-protos/node-platform/common/v1"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
+	keystoremocks "github.com/smartcontractkit/chainlink/v2/core/services/keystore/mocks"
+)
+
+var (
+	testHealthSvcKey   = "test_service"
+	errTestHealthCheck = errors.New("error loading some component")
+)
+
+type MockHealthChecker struct{}
+
+func (mhc *MockHealthChecker) IsHealthy() (bool, map[string]error) {
+	return false, map[string]error{
+		testHealthSvcKey: errTestHealthCheck,
+	}
+}
+
+func TestNewNodePlatformInfoConfig_UsesThreeMinuteBeat(t *testing.T) {
+	t.Parallel()
+	csaStore := &keystoremocks.CSA{}
+	keyStore := &keystoremocks.Master{}
+	keyStore.EXPECT().CSA().Return(csaStore).Once()
+
+	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, _ *chainlink.Secrets) {
+		c.Telemetry.HeartbeatInterval = commoncfg.MustNewDuration(5 * time.Second)
+	})
+
+	buildInfoCfg := chainlink.NewNodePlatformInfoConfig(chainlink.ApplicationOpts{
+		Config:   cfg,
+		Logger:   logger.TestLogger(t),
+		KeyStore: keyStore,
+	})
+
+	require.Equal(t, 3*time.Minute, buildInfoCfg.Beat)
+	require.Same(t, csaStore, buildInfoCfg.CSAKeyStore)
+}
+
+func TestNodePlatformInfo_EmitsNodeInfo(t *testing.T) { //nolint:paralleltest // can't be run in parallel
+	obs := beholdertest.NewObserver(t)
+
+	servicetest.Run(t, chainlink.NewNodePlatformInfoService(&MockHealthChecker{}, chainlink.NodePlatformInfoConfig{
+		Beat:         10 * time.Millisecond,
+		Lggr:         logger.TestLogger(t),
+		CSAPublicKey: "csa-public-key",
+		CommitSHA:    "commit-sha",
+		DockerTag:    "docker-tag",
+		VersionTag:   "version-tag",
+		Version:      "1.2.3",
+	}))
+
+	require.Eventually(t, func() bool {
+		return obs.Len(t, beholder.AttrKeyEntity, "common.v1.NodeInfo") > 0
+	}, time.Second, 10*time.Millisecond)
+
+	msgs := obs.Messages(t, beholder.AttrKeyEntity, "common.v1.NodeInfo")
+	require.NotEmpty(t, msgs)
+
+	msg := msgs[0]
+	require.Equal(t, "node-platform", msg.Attrs[beholder.AttrKeyDomain])
+	require.Equal(t, "/node-platform/common/v1", msg.Attrs[beholder.AttrKeyDataSchema])
+
+	var payload commonv1.NodeInfo
+	require.NoError(t, proto.Unmarshal(msg.Body, &payload))
+	require.Equal(t, "csa-public-key", payload.CsaPublicKey)
+	require.Equal(t, "commit-sha", payload.CommitSha)
+	require.Equal(t, "docker-tag", payload.DockerTag)
+	require.Equal(t, "version-tag", payload.VersionTag)
+	require.Equal(t, "1.2.3", payload.Version)
+	require.False(t, payload.Healthy)
+	require.Equal(t, map[string]string{testHealthSvcKey: errTestHealthCheck.Error()}, payload.HealthErrors)
+}
+
+func TestNodePlatformInfo_ResolvesCSAKeyOnStart(t *testing.T) { //nolint:paralleltest // can't be run in parallel
+	obs := beholdertest.NewObserver(t)
+	csaStore := &keystoremocks.CSA{}
+
+	csaStore.EXPECT().EnsureKey(mock.Anything).Return(nil).Once()
+	csaStore.EXPECT().GetAll().Return([]csakey.KeyV2{cltest.DefaultCSAKey}, nil).Once()
+
+	servicetest.Run(t, chainlink.NewNodePlatformInfoService(&MockHealthChecker{}, chainlink.NodePlatformInfoConfig{
+		Beat:        10 * time.Millisecond,
+		Lggr:        logger.TestLogger(t),
+		CSAKeyStore: csaStore,
+		CommitSHA:   "commit-sha",
+		DockerTag:   "docker-tag",
+		VersionTag:  "version-tag",
+		Version:     "1.2.3",
+	}))
+
+	require.Eventually(t, func() bool {
+		return obs.Len(t, beholder.AttrKeyEntity, "common.v1.NodeInfo") > 0
+	}, time.Second, 10*time.Millisecond)
+
+	msg := obs.Messages(t, beholder.AttrKeyEntity, "common.v1.NodeInfo")[0]
+	var payload commonv1.NodeInfo
+	require.NoError(t, proto.Unmarshal(msg.Body, &payload))
+	require.Equal(t, cltest.DefaultCSAKey.PublicKeyString(), payload.CsaPublicKey)
+}

--- a/core/services/chainlink/node_platform_job_info.go
+++ b/core/services/chainlink/node_platform_job_info.go
@@ -26,15 +26,10 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
-	"github.com/smartcontractkit/chainlink/v2/core/static"
 )
 
 const (
-	nodePlatformDomain          = "node-platform"
-	nodePlatformBuildInfoEntity = "common.v1.NodeBuildInfo"
 	nodePlatformJobInfoEntity   = "common.v1.NodeJobInfo"
-	nodePlatformDataSchema      = "/node-platform/common/v1"
-	nodePlatformBeat            = 3 * time.Minute
 	nodePlatformJobInfoPageSize = 1000
 
 	nodeSubmitterFieldTransmitterAddress                 = "transmitterAddress"
@@ -46,120 +41,6 @@ const (
 	nodeSubmitterFieldObservationSourceETHTxFrom         = "observationSource.ethtx.from"
 	nodeSubmitterFieldTransmitterKeys                    = "transmitterKeys"
 )
-
-type NodePlatformBuildInfoService struct {
-	commonservices.Service
-	eng *commonservices.Engine
-
-	opts    NodePlatformBuildInfoConfig
-	beat    time.Duration
-	emitter beholder.Emitter
-}
-
-type NodePlatformBuildInfoConfig struct {
-	Beat         time.Duration
-	Lggr         logger.Logger
-	CSAKeyStore  keystore.CSA
-	CSAPublicKey string
-	CommitSHA    string
-	DockerTag    string
-	VersionTag   string
-	Version      string
-}
-
-func NewNodePlatformBuildInfoConfig(opts ApplicationOpts) NodePlatformBuildInfoConfig {
-	version := opts.Version
-	if version == "" {
-		version = static.Version
-	}
-
-	versionTag := opts.VersionTag
-	if versionTag == "" {
-		versionTag = static.VersionTag
-	}
-
-	dockerTag := opts.DockerTag
-	if dockerTag == "" {
-		dockerTag = static.Unset
-	}
-
-	return NodePlatformBuildInfoConfig{
-		Beat:        nodePlatformBeat,
-		Lggr:        opts.Logger,
-		CSAKeyStore: opts.KeyStore.CSA(),
-		CommitSHA:   static.Sha,
-		DockerTag:   dockerTag,
-		VersionTag:  versionTag,
-		Version:     version,
-	}
-}
-
-func NewNodePlatformBuildInfoService(cfg NodePlatformBuildInfoConfig) NodePlatformBuildInfoService {
-	s := NodePlatformBuildInfoService{
-		opts:    cfg,
-		beat:    cfg.Beat,
-		emitter: beholder.GetEmitter(),
-	}
-
-	s.Service, s.eng = commonservices.Config{
-		Name:  "NodePlatformBuildInfo",
-		Start: s.start,
-	}.NewServiceEngine(cfg.Lggr)
-
-	return s
-}
-
-func (s *NodePlatformBuildInfoService) start(ctx context.Context) error {
-	s.resolveCSAPublicKey(ctx)
-	s.eng.GoTick(timeutil.NewTicker(s.GetBeat), s.emit)
-	return nil
-}
-
-func (s *NodePlatformBuildInfoService) resolveCSAPublicKey(ctx context.Context) {
-	if s.opts.CSAKeyStore == nil {
-		return
-	}
-
-	csaKey, err := keystore.GetDefault(ctx, s.opts.CSAKeyStore)
-	if err != nil {
-		s.eng.Errorw("failed to resolve CSA key for node-platform build info", "err", err)
-		return
-	}
-
-	s.opts.CSAPublicKey = csaKey.PublicKeyString()
-}
-
-func (s *NodePlatformBuildInfoService) emit(ctx context.Context) {
-	payloadBytes, err := proto.Marshal(&commonv1.NodeBuildInfo{
-		CsaPublicKey: s.opts.CSAPublicKey,
-		CommitSha:    s.opts.CommitSHA,
-		DockerTag:    s.opts.DockerTag,
-		VersionTag:   s.opts.VersionTag,
-		Version:      s.opts.Version,
-	})
-	if err != nil {
-		s.eng.Errorw("failed to marshal node-platform build info", "err", err)
-		return
-	}
-
-	emitter := s.emitter
-	if emitter == nil {
-		emitter = beholder.GetEmitter()
-	}
-
-	err = emitter.Emit(ctx, payloadBytes,
-		beholder.AttrKeyDomain, nodePlatformDomain,
-		beholder.AttrKeyEntity, nodePlatformBuildInfoEntity,
-		beholder.AttrKeyDataSchema, nodePlatformDataSchema,
-	)
-	if err != nil {
-		s.eng.Errorw("failed to emit node-platform build info", "err", err)
-	}
-}
-
-func (s *NodePlatformBuildInfoService) GetBeat() time.Duration {
-	return s.beat
-}
 
 type NodePlatformJobInfoService struct {
 	commonservices.Service

--- a/core/services/chainlink/node_platform_job_info_test.go
+++ b/core/services/chainlink/node_platform_job_info_test.go
@@ -5,27 +5,21 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/guregu/null.v4"
 
-	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/csakey"
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder/beholdertest"
-	commoncfg "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	commonv1 "github.com/smartcontractkit/chainlink-protos/node-platform/common/v1"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
-	keystoremocks "github.com/smartcontractkit/chainlink/v2/core/services/keystore/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 )
 
@@ -69,58 +63,6 @@ func eip55Address(raw string) evmtypes.EIP55Address {
 func eip55AddressPtr(raw string) *evmtypes.EIP55Address {
 	address := eip55Address(raw)
 	return &address
-}
-
-func TestNewNodePlatformBuildInfoConfig_UsesThreeMinuteBeat(t *testing.T) {
-	csaStore := &keystoremocks.CSA{}
-	keyStore := &keystoremocks.Master{}
-	keyStore.EXPECT().CSA().Return(csaStore).Once()
-
-	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, _ *chainlink.Secrets) {
-		c.Telemetry.HeartbeatInterval = commoncfg.MustNewDuration(5 * time.Second)
-	})
-
-	buildInfoCfg := chainlink.NewNodePlatformBuildInfoConfig(chainlink.ApplicationOpts{
-		Config:   cfg,
-		Logger:   logger.TestLogger(t),
-		KeyStore: keyStore,
-	})
-
-	require.Equal(t, 3*time.Minute, buildInfoCfg.Beat)
-	require.Same(t, csaStore, buildInfoCfg.CSAKeyStore)
-}
-
-func TestNodePlatformBuildInfo_EmitsNodeBuildInfo(t *testing.T) {
-	obs := beholdertest.NewObserver(t)
-
-	servicetest.Run(t, chainlink.NewNodePlatformBuildInfoService(chainlink.NodePlatformBuildInfoConfig{
-		Beat:         10 * time.Millisecond,
-		Lggr:         logger.TestLogger(t),
-		CSAPublicKey: "csa-public-key",
-		CommitSHA:    "commit-sha",
-		DockerTag:    "docker-tag",
-		VersionTag:   "version-tag",
-		Version:      "1.2.3",
-	}))
-
-	require.Eventually(t, func() bool {
-		return obs.Len(t, beholder.AttrKeyEntity, "common.v1.NodeBuildInfo") > 0
-	}, time.Second, 10*time.Millisecond)
-
-	msgs := obs.Messages(t, beholder.AttrKeyEntity, "common.v1.NodeBuildInfo")
-	require.NotEmpty(t, msgs)
-
-	msg := msgs[0]
-	require.Equal(t, "node-platform", msg.Attrs[beholder.AttrKeyDomain])
-	require.Equal(t, "/node-platform/common/v1", msg.Attrs[beholder.AttrKeyDataSchema])
-
-	var payload commonv1.NodeBuildInfo
-	require.NoError(t, proto.Unmarshal(msg.Body, &payload))
-	require.Equal(t, "csa-public-key", payload.CsaPublicKey)
-	require.Equal(t, "commit-sha", payload.CommitSha)
-	require.Equal(t, "docker-tag", payload.DockerTag)
-	require.Equal(t, "version-tag", payload.VersionTag)
-	require.Equal(t, "1.2.3", payload.Version)
 }
 
 func TestNodePlatformJobInfo_EmitsSubmitterAddressesFromJobFields(t *testing.T) {
@@ -457,31 +399,4 @@ func TestNodePlatformJobInfo_PaginatesSubmitterAddressJobs(t *testing.T) {
 		}
 		return false
 	}, time.Second, 100*time.Millisecond)
-}
-
-func TestNodePlatformBuildInfo_ResolvesCSAKeyOnStart(t *testing.T) {
-	obs := beholdertest.NewObserver(t)
-	csaStore := &keystoremocks.CSA{}
-
-	csaStore.EXPECT().EnsureKey(mock.Anything).Return(nil).Once()
-	csaStore.EXPECT().GetAll().Return([]csakey.KeyV2{cltest.DefaultCSAKey}, nil).Once()
-
-	servicetest.Run(t, chainlink.NewNodePlatformBuildInfoService(chainlink.NodePlatformBuildInfoConfig{
-		Beat:        10 * time.Millisecond,
-		Lggr:        logger.TestLogger(t),
-		CSAKeyStore: csaStore,
-		CommitSHA:   "commit-sha",
-		DockerTag:   "docker-tag",
-		VersionTag:  "version-tag",
-		Version:     "1.2.3",
-	}))
-
-	require.Eventually(t, func() bool {
-		return obs.Len(t, beholder.AttrKeyEntity, "common.v1.NodeBuildInfo") > 0
-	}, time.Second, 10*time.Millisecond)
-
-	msg := obs.Messages(t, beholder.AttrKeyEntity, "common.v1.NodeBuildInfo")[0]
-	var payload commonv1.NodeBuildInfo
-	require.NoError(t, proto.Unmarshal(msg.Body, &payload))
-	require.Equal(t, cltest.DefaultCSAKey.PublicKeyString(), payload.CsaPublicKey)
 }

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -440,7 +440,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 // indirect
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 // indirect
-	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 // indirect
+	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b // indirect
 	github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260331131315-f08a616d8dcd // indirect
 	github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6 // indirect

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1431,8 +1431,8 @@ github.com/smartcontractkit/chainlink-protos/job-distributor v0.19.0 h1:FC+WdJ8Y
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.19.0/go.mod h1:2ahgl5bI9+fMCD+dBC785Lak38Tb7ApdTe5I8a09Qp0=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 h1:NJdGFhzT6zMaTod4QkBqVD2sg0I25iw1boOYtTpEwRo=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305/go.mod h1:qSTSwX3cBP3FKQwQacdjArqv0g6QnukjV4XuzO6UyoY=
-github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 h1:bnSl5p3mFekSJ6QcbZ1TmHn2ffYiX8xk6hNzVmyhstQ=
-github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
+github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b h1:A2+kmPy4wNQf6LoG8d9LjzrHHiykT2C74p9DNQJpTw8=
+github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
 github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0 h1:hGEJFD2X3oNIPXQbtIPxCJyg5CcKglRCYBmESS+gmeQ=
 github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0/go.mod h1:PjZD54vr6rIKEKQj6HNA4hllvYI/QpT+Zefj3tqkFAs=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.11.0 h1:NXKTdIESAiCkVnPS6dyZP+NXVek3GzXa6P4uFAs0o8Y=

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260623200841-e0322b819f62
 	github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305
-	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305
+	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.11.0
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260331131315-f08a616d8dcd
 	github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1204,8 +1204,8 @@ github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-
 github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36/go.mod h1:vL1bDgPSJjV0EqHYs4dDlR+EEE0cJchgvGLYXhwIjXY=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 h1:NJdGFhzT6zMaTod4QkBqVD2sg0I25iw1boOYtTpEwRo=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305/go.mod h1:qSTSwX3cBP3FKQwQacdjArqv0g6QnukjV4XuzO6UyoY=
-github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 h1:bnSl5p3mFekSJ6QcbZ1TmHn2ffYiX8xk6hNzVmyhstQ=
-github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
+github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b h1:A2+kmPy4wNQf6LoG8d9LjzrHHiykT2C74p9DNQJpTw8=
+github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.11.0 h1:NXKTdIESAiCkVnPS6dyZP+NXVek3GzXa6P4uFAs0o8Y=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.11.0/go.mod h1:m/A3lqD7ms/RsQ9BT5P2uceYY0QX5mIt4KQxT2G6qEo=
 github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260331131315-f08a616d8dcd h1:7DURXB3+Qf9REr3XA+q0FNyZO3CSAeSgJvNaek/GiZI=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -422,7 +422,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260623200841-e0322b819f62 // indirect
 	github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 // indirect
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 // indirect
-	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 // indirect
+	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b // indirect
 	github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.11.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260331131315-f08a616d8dcd // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1418,8 +1418,8 @@ github.com/smartcontractkit/chainlink-protos/job-distributor v0.19.0 h1:FC+WdJ8Y
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.19.0/go.mod h1:2ahgl5bI9+fMCD+dBC785Lak38Tb7ApdTe5I8a09Qp0=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 h1:NJdGFhzT6zMaTod4QkBqVD2sg0I25iw1boOYtTpEwRo=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305/go.mod h1:qSTSwX3cBP3FKQwQacdjArqv0g6QnukjV4XuzO6UyoY=
-github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 h1:bnSl5p3mFekSJ6QcbZ1TmHn2ffYiX8xk6hNzVmyhstQ=
-github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
+github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b h1:A2+kmPy4wNQf6LoG8d9LjzrHHiykT2C74p9DNQJpTw8=
+github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
 github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0 h1:hGEJFD2X3oNIPXQbtIPxCJyg5CcKglRCYBmESS+gmeQ=
 github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0/go.mod h1:PjZD54vr6rIKEKQj6HNA4hllvYI/QpT+Zefj3tqkFAs=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.11.0 h1:NXKTdIESAiCkVnPS6dyZP+NXVek3GzXa6P4uFAs0o8Y=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -502,7 +502,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 // indirect
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.19.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 // indirect
-	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 // indirect
+	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b // indirect
 	github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.11.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260331131315-f08a616d8dcd // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1680,8 +1680,8 @@ github.com/smartcontractkit/chainlink-protos/job-distributor v0.19.0 h1:FC+WdJ8Y
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.19.0/go.mod h1:2ahgl5bI9+fMCD+dBC785Lak38Tb7ApdTe5I8a09Qp0=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 h1:NJdGFhzT6zMaTod4QkBqVD2sg0I25iw1boOYtTpEwRo=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305/go.mod h1:qSTSwX3cBP3FKQwQacdjArqv0g6QnukjV4XuzO6UyoY=
-github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 h1:bnSl5p3mFekSJ6QcbZ1TmHn2ffYiX8xk6hNzVmyhstQ=
-github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
+github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b h1:A2+kmPy4wNQf6LoG8d9LjzrHHiykT2C74p9DNQJpTw8=
+github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
 github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0 h1:hGEJFD2X3oNIPXQbtIPxCJyg5CcKglRCYBmESS+gmeQ=
 github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0/go.mod h1:PjZD54vr6rIKEKQj6HNA4hllvYI/QpT+Zefj3tqkFAs=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.11.0 h1:NXKTdIESAiCkVnPS6dyZP+NXVek3GzXa6P4uFAs0o8Y=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -473,7 +473,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-rules v0.0.0-20260505131349-78e491b80735 // indirect
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 // indirect
-	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 // indirect
+	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b // indirect
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.11.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/ring/go v0.0.0-20260331131315-f08a616d8dcd // indirect
 	github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1591,8 +1591,8 @@ github.com/smartcontractkit/chainlink-protos/job-distributor v0.19.0 h1:FC+WdJ8Y
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.19.0/go.mod h1:2ahgl5bI9+fMCD+dBC785Lak38Tb7ApdTe5I8a09Qp0=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 h1:NJdGFhzT6zMaTod4QkBqVD2sg0I25iw1boOYtTpEwRo=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305/go.mod h1:qSTSwX3cBP3FKQwQacdjArqv0g6QnukjV4XuzO6UyoY=
-github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 h1:bnSl5p3mFekSJ6QcbZ1TmHn2ffYiX8xk6hNzVmyhstQ=
-github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
+github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b h1:A2+kmPy4wNQf6LoG8d9LjzrHHiykT2C74p9DNQJpTw8=
+github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
 github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0 h1:hGEJFD2X3oNIPXQbtIPxCJyg5CcKglRCYBmESS+gmeQ=
 github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0/go.mod h1:PjZD54vr6rIKEKQj6HNA4hllvYI/QpT+Zefj3tqkFAs=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.11.0 h1:NXKTdIESAiCkVnPS6dyZP+NXVek3GzXa6P4uFAs0o8Y=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -165,7 +165,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d // indirect
 	github.com/smartcontractkit/chainlink-protos/data-feeds v0.1.1-0.20260501174546-2e8846986b36 // indirect
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.19.0 // indirect
-	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 // indirect
+	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b // indirect
 	github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260513123719-d347eaf314e1 // indirect
 	github.com/smartcontractkit/chainlink-sui/codec v0.0.0-20260706170510-94f3a0409ea5 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.9 // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1605,8 +1605,8 @@ github.com/smartcontractkit/chainlink-protos/job-distributor v0.19.0 h1:FC+WdJ8Y
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.19.0/go.mod h1:2ahgl5bI9+fMCD+dBC785Lak38Tb7ApdTe5I8a09Qp0=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305 h1:NJdGFhzT6zMaTod4QkBqVD2sg0I25iw1boOYtTpEwRo=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305/go.mod h1:qSTSwX3cBP3FKQwQacdjArqv0g6QnukjV4XuzO6UyoY=
-github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305 h1:bnSl5p3mFekSJ6QcbZ1TmHn2ffYiX8xk6hNzVmyhstQ=
-github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260512230622-65f10f4cd305/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
+github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b h1:A2+kmPy4wNQf6LoG8d9LjzrHHiykT2C74p9DNQJpTw8=
+github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260708090335-8281df6a874b/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
 github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0 h1:hGEJFD2X3oNIPXQbtIPxCJyg5CcKglRCYBmESS+gmeQ=
 github.com/smartcontractkit/chainlink-protos/op-catalog v0.1.0/go.mod h1:PjZD54vr6rIKEKQj6HNA4hllvYI/QpT+Zefj3tqkFAs=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.11.0 h1:NXKTdIESAiCkVnPS6dyZP+NXVek3GzXa6P4uFAs0o8Y=


### PR DESCRIPTION
This adds basic health-checking info to the Beholder metrics node platform service emits.
[Ticket](https://smartcontract-it.atlassian.net/browse/RANE-4647)

This [PR](https://github.com/smartcontractkit/chainlink-protos/pull/423/changes) changes `Protobuf` format, so it should be reviewed and merged first.
