### PR TITLE
Async AckEvent and RegisterTrigger in LogTrigger Receiver

### DIFF
--- a/core/capabilities/remote/executable/server.go
+++ b/core/capabilities/remote/executable/server.go
@@ -166,7 +166,7 @@ func (r *server) Start(ctx context.Context) error {
 		}
 
 		// Initialize parallel executor with the configured max parallel requests
-		r.parallelExecutor = remote.NewParallelExecutor(int(cfg.remoteExecutableConfig.ServerMaxParallelRequests))
+		r.parallelExecutor = remote.NewParallelExecutor(int(cfg.remoteExecutableConfig.ServerMaxParallelRequests), "executable_server")
 
 		r.wg.Go(func() {
 			ticker := time.NewTicker(getServerTickerInterval(cfg))

--- a/core/capabilities/remote/executable/server.go
+++ b/core/capabilities/remote/executable/server.go
@@ -44,7 +44,7 @@ type server struct {
 	stopCh      services.StopChan
 	wg          sync.WaitGroup
 
-	parallelExecutor *parallelExecutor
+	parallelExecutor *remote.ParallelExecutor
 }
 
 type dynamicServerConfig struct {
@@ -166,7 +166,7 @@ func (r *server) Start(ctx context.Context) error {
 		}
 
 		// Initialize parallel executor with the configured max parallel requests
-		r.parallelExecutor = newParallelExecutor(int(cfg.remoteExecutableConfig.ServerMaxParallelRequests))
+		r.parallelExecutor = remote.NewParallelExecutor(int(cfg.remoteExecutableConfig.ServerMaxParallelRequests))
 
 		r.wg.Go(func() {
 			ticker := time.NewTicker(getServerTickerInterval(cfg))

--- a/core/capabilities/remote/messagecache/message_cache.go
+++ b/core/capabilities/remote/messagecache/message_cache.go
@@ -70,6 +70,15 @@ func (c *MessageCache[EventID, PeerID]) Ready(eventID EventID, minCount uint32, 
 	return false, nil
 }
 
+// WasReady reports whether Ready has already returned true for eventID (once=true path).
+func (c *MessageCache[EventID, PeerID]) WasReady(eventID EventID) bool {
+	ev, ok := c.events[eventID]
+	if !ok {
+		return false
+	}
+	return ev.wasReady
+}
+
 func (c *MessageCache[EventID, PeerID]) Delete(eventID EventID) {
 	delete(c.events, eventID)
 }

--- a/core/capabilities/remote/messagecache/message_cache_test.go
+++ b/core/capabilities/remote/messagecache/message_cache_test.go
@@ -42,6 +42,7 @@ func TestMessageCache_InsertReady(t *testing.T) {
 	// not ready again for the same event ID
 	ready, _ = cache.Ready(eventID1, 2, 100, true)
 	require.False(t, ready)
+	require.True(t, cache.WasReady(eventID1))
 }
 
 func TestMessageCache_DeleteOlderThan(t *testing.T) {

--- a/core/capabilities/remote/parallel_executor.go
+++ b/core/capabilities/remote/parallel_executor.go
@@ -1,4 +1,4 @@
-package executable
+package remote
 
 import (
 	"context"
@@ -8,7 +8,8 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 )
 
-type parallelExecutor struct {
+// ParallelExecutor runs tasks concurrently up to a configured limit.
+type ParallelExecutor struct {
 	services.StateMachine
 	wg       sync.WaitGroup
 	stopChan services.StopChan
@@ -16,19 +17,19 @@ type parallelExecutor struct {
 	taskSemaphore chan struct{}
 }
 
-func newParallelExecutor(maxParallelTasks int) *parallelExecutor {
-	executor := &parallelExecutor{
+// NewParallelExecutor creates an executor that allows at most maxParallelTasks in-flight tasks.
+func NewParallelExecutor(maxParallelTasks int) *ParallelExecutor {
+	return &ParallelExecutor{
 		stopChan:      make(services.StopChan),
 		wg:            sync.WaitGroup{},
 		taskSemaphore: make(chan struct{}, maxParallelTasks),
 	}
-
-	return executor
 }
 
-// ExecuteTask executes a task in parallel up to the maximum allowed parallel executions.  If the maximum execute limit
-// is reached, the function will block until a slot is available or the context is cancelled.
-func (t *parallelExecutor) ExecuteTask(ctx context.Context, fn func(ctx context.Context)) error {
+// ExecuteTask executes a task in parallel up to the maximum allowed parallel executions. If the
+// maximum execute limit is reached, the function will block until a slot is available or the
+// context is cancelled.
+func (t *ParallelExecutor) ExecuteTask(ctx context.Context, fn func(ctx context.Context)) error {
 	select {
 	case t.taskSemaphore <- struct{}{}:
 		stopped := !t.IfNotStopped(func() {
@@ -52,13 +53,15 @@ func (t *parallelExecutor) ExecuteTask(ctx context.Context, fn func(ctx context.
 	return nil
 }
 
-func (t *parallelExecutor) Start(ctx context.Context) error {
+// Start starts the executor.
+func (t *ParallelExecutor) Start(ctx context.Context) error {
 	return t.StartOnce(t.Name(), func() error {
 		return nil
 	})
 }
 
-func (t *parallelExecutor) Close() error {
+// Close stops the executor and waits for in-flight tasks to finish.
+func (t *ParallelExecutor) Close() error {
 	return t.StopOnce(t.Name(), func() error {
 		close(t.stopChan)
 		t.wg.Wait()
@@ -66,6 +69,7 @@ func (t *parallelExecutor) Close() error {
 	})
 }
 
-func (t *parallelExecutor) Name() string {
+// Name returns the service name.
+func (t *ParallelExecutor) Name() string {
 	return "ParallelExecutor"
 }

--- a/core/capabilities/remote/parallel_executor.go
+++ b/core/capabilities/remote/parallel_executor.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"sync"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 )
 
@@ -14,16 +17,59 @@ type ParallelExecutor struct {
 	wg       sync.WaitGroup
 	stopChan services.StopChan
 
-	taskSemaphore chan struct{}
+	taskSemaphore  chan struct{}
+	name           string
+	slotUsageGauge metric.Float64Gauge
+	slotUsageAttrs []attribute.KeyValue
+}
+
+// ParallelExecutorOption configures a ParallelExecutor.
+type ParallelExecutorOption func(*ParallelExecutor)
+
+// WithExecutorName sets the service name returned by Name().
+func WithExecutorName(name string) ParallelExecutorOption {
+	return func(e *ParallelExecutor) {
+		e.name = name
+	}
+}
+
+// WithSlotUsageMetric records occupied/max slot ratio on the gauge when tasks start and finish.
+func WithSlotUsageMetric(gauge metric.Float64Gauge, attrs ...attribute.KeyValue) ParallelExecutorOption {
+	return func(e *ParallelExecutor) {
+		e.slotUsageGauge = gauge
+		e.slotUsageAttrs = attrs
+	}
 }
 
 // NewParallelExecutor creates an executor that allows at most maxParallelTasks in-flight tasks.
-func NewParallelExecutor(maxParallelTasks int) *ParallelExecutor {
-	return &ParallelExecutor{
+func NewParallelExecutor(maxParallelTasks int, opts ...ParallelExecutorOption) *ParallelExecutor {
+	e := &ParallelExecutor{
 		stopChan:      make(services.StopChan),
 		wg:            sync.WaitGroup{},
 		taskSemaphore: make(chan struct{}, maxParallelTasks),
 	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// SetSlotUsageGauge binds the gauge used by RecordSlotUsage. Attributes are set via WithSlotUsageMetric.
+func (t *ParallelExecutor) SetSlotUsageGauge(gauge metric.Float64Gauge) {
+	t.slotUsageGauge = gauge
+}
+
+// RecordSlotUsage publishes current slot utilization to the configured gauge, if any.
+func (t *ParallelExecutor) RecordSlotUsage(ctx context.Context) {
+	if t.slotUsageGauge == nil {
+		return
+	}
+	maxSlots := t.MaxSlots()
+	if maxSlots == 0 {
+		return
+	}
+	usage := float64(t.OccupiedSlots()) / float64(maxSlots)
+	t.slotUsageGauge.Record(ctx, usage, metric.WithAttributes(t.slotUsageAttrs...))
 }
 
 // OccupiedSlots returns the number of in-flight tasks holding executor slots.
@@ -42,12 +88,16 @@ func (t *ParallelExecutor) MaxSlots() int {
 func (t *ParallelExecutor) ExecuteTask(ctx context.Context, fn func(ctx context.Context)) error {
 	select {
 	case t.taskSemaphore <- struct{}{}:
+		t.RecordSlotUsage(ctx)
 		stopped := !t.IfNotStopped(func() {
 			t.wg.Go(func() {
 				ctxWithStop, cancel := t.stopChan.Ctx(ctx)
+				defer func() {
+					cancel()
+					<-t.taskSemaphore
+					t.RecordSlotUsage(ctxWithStop)
+				}()
 				fn(ctxWithStop)
-				cancel()
-				<-t.taskSemaphore
 			})
 		})
 
@@ -81,5 +131,8 @@ func (t *ParallelExecutor) Close() error {
 
 // Name returns the service name.
 func (t *ParallelExecutor) Name() string {
+	if t.name != "" {
+		return t.name
+	}
 	return "ParallelExecutor"
 }

--- a/core/capabilities/remote/parallel_executor.go
+++ b/core/capabilities/remote/parallel_executor.go
@@ -3,11 +3,13 @@ package remote
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 )
 
@@ -23,62 +25,39 @@ type ParallelExecutor struct {
 	slotUsageAttrs []attribute.KeyValue
 }
 
-// ParallelExecutorOption configures a ParallelExecutor.
-type ParallelExecutorOption func(*ParallelExecutor)
-
-// WithExecutorName sets the service name returned by Name().
-func WithExecutorName(name string) ParallelExecutorOption {
-	return func(e *ParallelExecutor) {
-		e.name = name
-	}
-}
-
-// WithSlotUsageMetric records occupied/max slot ratio on the gauge when tasks start and finish.
-func WithSlotUsageMetric(gauge metric.Float64Gauge, attrs ...attribute.KeyValue) ParallelExecutorOption {
-	return func(e *ParallelExecutor) {
-		e.slotUsageGauge = gauge
-		e.slotUsageAttrs = attrs
-	}
-}
-
 // NewParallelExecutor creates an executor that allows at most maxParallelTasks in-flight tasks.
-func NewParallelExecutor(maxParallelTasks int, opts ...ParallelExecutorOption) *ParallelExecutor {
+func NewParallelExecutor(maxParallelTasks int, name string, attrs ...attribute.KeyValue) *ParallelExecutor {
+	attrs = append(attrs, attribute.String("parallel_executor_name", name))
 	e := &ParallelExecutor{
-		stopChan:      make(services.StopChan),
-		wg:            sync.WaitGroup{},
-		taskSemaphore: make(chan struct{}, maxParallelTasks),
-	}
-	for _, opt := range opts {
-		opt(e)
+		stopChan:       make(services.StopChan),
+		wg:             sync.WaitGroup{},
+		taskSemaphore:  make(chan struct{}, maxParallelTasks),
+		name:           name,
+		slotUsageAttrs: attrs,
 	}
 	return e
 }
 
-// SetSlotUsageGauge binds the gauge used by RecordSlotUsage. Attributes are set via WithSlotUsageMetric.
-func (t *ParallelExecutor) SetSlotUsageGauge(gauge metric.Float64Gauge) {
-	t.slotUsageGauge = gauge
-}
-
-// RecordSlotUsage publishes current slot utilization to the configured gauge, if any.
-func (t *ParallelExecutor) RecordSlotUsage(ctx context.Context) {
+// recordSlotUsage publishes current slot utilization to the configured gauge, if any.
+func (t *ParallelExecutor) recordSlotUsage(ctx context.Context) {
 	if t.slotUsageGauge == nil {
 		return
 	}
-	maxSlots := t.MaxSlots()
+	maxSlots := t.maxSlots()
 	if maxSlots == 0 {
 		return
 	}
-	usage := float64(t.OccupiedSlots()) / float64(maxSlots)
+	usage := float64(t.occupiedSlots()) / float64(maxSlots)
 	t.slotUsageGauge.Record(ctx, usage, metric.WithAttributes(t.slotUsageAttrs...))
 }
 
-// OccupiedSlots returns the number of in-flight tasks holding executor slots.
-func (t *ParallelExecutor) OccupiedSlots() int {
+// occupiedSlots returns the number of in-flight tasks holding executor slots.
+func (t *ParallelExecutor) occupiedSlots() int {
 	return len(t.taskSemaphore)
 }
 
-// MaxSlots returns the maximum number of concurrent tasks allowed.
-func (t *ParallelExecutor) MaxSlots() int {
+// maxSlots returns the maximum number of concurrent tasks allowed.
+func (t *ParallelExecutor) maxSlots() int {
 	return cap(t.taskSemaphore)
 }
 
@@ -88,14 +67,14 @@ func (t *ParallelExecutor) MaxSlots() int {
 func (t *ParallelExecutor) ExecuteTask(ctx context.Context, fn func(ctx context.Context)) error {
 	select {
 	case t.taskSemaphore <- struct{}{}:
-		t.RecordSlotUsage(ctx)
+		t.recordSlotUsage(ctx)
 		stopped := !t.IfNotStopped(func() {
 			t.wg.Go(func() {
 				ctxWithStop, cancel := t.stopChan.Ctx(ctx)
 				defer func() {
 					cancel()
 					<-t.taskSemaphore
-					t.RecordSlotUsage(ctxWithStop)
+					t.recordSlotUsage(ctxWithStop)
 				}()
 				fn(ctxWithStop)
 			})
@@ -115,6 +94,11 @@ func (t *ParallelExecutor) ExecuteTask(ctx context.Context, fn func(ctx context.
 
 // Start starts the executor.
 func (t *ParallelExecutor) Start(ctx context.Context) error {
+	var err error
+	t.slotUsageGauge, err = beholder.GetMeter().Float64Gauge("platform_parallel_executor_slot_usage")
+	if err != nil {
+		return fmt.Errorf("failed to register platform_parallel_executor_slot_usage: %w", err)
+	}
 	return t.StartOnce(t.Name(), func() error {
 		return nil
 	})

--- a/core/capabilities/remote/parallel_executor.go
+++ b/core/capabilities/remote/parallel_executor.go
@@ -70,10 +70,11 @@ func (t *ParallelExecutor) ExecuteTask(ctx context.Context, fn func(ctx context.
 		t.recordSlotUsage(ctx)
 		stopped := !t.IfNotStopped(func() {
 			t.wg.Go(func() {
-				ctxWithStop, _ := t.stopChan.Ctx(ctx)
+				ctxWithStop, cancel := t.stopChan.Ctx(ctx)
 				defer func() {
 					<-t.taskSemaphore
 					t.recordSlotUsage(ctxWithStop)
+					cancel()
 				}()
 				fn(ctxWithStop)
 			})

--- a/core/capabilities/remote/parallel_executor.go
+++ b/core/capabilities/remote/parallel_executor.go
@@ -26,6 +26,16 @@ func NewParallelExecutor(maxParallelTasks int) *ParallelExecutor {
 	}
 }
 
+// OccupiedSlots returns the number of in-flight tasks holding executor slots.
+func (t *ParallelExecutor) OccupiedSlots() int {
+	return len(t.taskSemaphore)
+}
+
+// MaxSlots returns the maximum number of concurrent tasks allowed.
+func (t *ParallelExecutor) MaxSlots() int {
+	return cap(t.taskSemaphore)
+}
+
 // ExecuteTask executes a task in parallel up to the maximum allowed parallel executions. If the
 // maximum execute limit is reached, the function will block until a slot is available or the
 // context is cancelled.

--- a/core/capabilities/remote/parallel_executor.go
+++ b/core/capabilities/remote/parallel_executor.go
@@ -70,9 +70,8 @@ func (t *ParallelExecutor) ExecuteTask(ctx context.Context, fn func(ctx context.
 		t.recordSlotUsage(ctx)
 		stopped := !t.IfNotStopped(func() {
 			t.wg.Go(func() {
-				ctxWithStop, cancel := t.stopChan.Ctx(ctx)
+				ctxWithStop, _ := t.stopChan.Ctx(ctx)
 				defer func() {
-					cancel()
 					<-t.taskSemaphore
 					t.recordSlotUsage(ctxWithStop)
 				}()

--- a/core/capabilities/remote/parallel_executor_test.go
+++ b/core/capabilities/remote/parallel_executor_test.go
@@ -79,6 +79,8 @@ func Test_ExecutingMultipleTasksInParallel(t *testing.T) {
 	}
 
 	assert.Eventually(t, func() bool { return counter.Load() == 10 }, 5*time.Second, 10*time.Millisecond)
+	assert.Equal(t, 10, tp.OccupiedSlots())
+	assert.Equal(t, 10, tp.MaxSlots())
 }
 
 func Test_StopsExecutingMultipleParallelTasksWhenClosed(t *testing.T) {

--- a/core/capabilities/remote/parallel_executor_test.go
+++ b/core/capabilities/remote/parallel_executor_test.go
@@ -1,4 +1,4 @@
-package executable
+package remote_test
 
 import (
 	"context"
@@ -10,11 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
 )
 
 func Test_CancellingContext_StopsTask(t *testing.T) {
 	t.Parallel()
-	tp := newParallelExecutor(10)
+	tp := remote.NewParallelExecutor(10)
 	servicetest.Run(t, tp)
 
 	cancelFns := make([]context.CancelFunc, 0, 10)
@@ -44,7 +45,7 @@ func Test_CancellingContext_StopsTask(t *testing.T) {
 
 func Test_ExecuteRequestTimesOutWhenParallelExecutionLimitReached(t *testing.T) {
 	t.Parallel()
-	tp := newParallelExecutor(3)
+	tp := remote.NewParallelExecutor(3)
 	servicetest.Run(t, tp)
 
 	for range 3 {
@@ -64,7 +65,7 @@ func Test_ExecuteRequestTimesOutWhenParallelExecutionLimitReached(t *testing.T) 
 
 func Test_ExecutingMultipleTasksInParallel(t *testing.T) {
 	t.Parallel()
-	tp := newParallelExecutor(10)
+	tp := remote.NewParallelExecutor(10)
 	servicetest.Run(t, tp)
 
 	var counter atomic.Int32
@@ -82,7 +83,7 @@ func Test_ExecutingMultipleTasksInParallel(t *testing.T) {
 
 func Test_StopsExecutingMultipleParallelTasksWhenClosed(t *testing.T) {
 	t.Parallel()
-	tp := newParallelExecutor(10)
+	tp := remote.NewParallelExecutor(10)
 	var counter atomic.Int32
 	t.Cleanup(func() {
 		assert.Eventually(t, func() bool { return counter.Load() == 0 }, 5*time.Second, 10*time.Millisecond)

--- a/core/capabilities/remote/parallel_executor_test.go
+++ b/core/capabilities/remote/parallel_executor_test.go
@@ -15,7 +15,7 @@ import (
 
 func Test_CancellingContext_StopsTask(t *testing.T) {
 	t.Parallel()
-	tp := remote.NewParallelExecutor(10)
+	tp := remote.NewParallelExecutor(10, "test_parallel_executor")
 	servicetest.Run(t, tp)
 
 	cancelFns := make([]context.CancelFunc, 0, 10)
@@ -45,7 +45,7 @@ func Test_CancellingContext_StopsTask(t *testing.T) {
 
 func Test_ExecuteRequestTimesOutWhenParallelExecutionLimitReached(t *testing.T) {
 	t.Parallel()
-	tp := remote.NewParallelExecutor(3)
+	tp := remote.NewParallelExecutor(3, "test_parallel_executor")
 	servicetest.Run(t, tp)
 
 	for range 3 {
@@ -65,7 +65,7 @@ func Test_ExecuteRequestTimesOutWhenParallelExecutionLimitReached(t *testing.T) 
 
 func Test_ExecutingMultipleTasksInParallel(t *testing.T) {
 	t.Parallel()
-	tp := remote.NewParallelExecutor(10)
+	tp := remote.NewParallelExecutor(10, "test_parallel_executor")
 	servicetest.Run(t, tp)
 
 	var counter atomic.Int32
@@ -79,13 +79,11 @@ func Test_ExecutingMultipleTasksInParallel(t *testing.T) {
 	}
 
 	assert.Eventually(t, func() bool { return counter.Load() == 10 }, 5*time.Second, 10*time.Millisecond)
-	assert.Equal(t, 10, tp.OccupiedSlots())
-	assert.Equal(t, 10, tp.MaxSlots())
 }
 
 func Test_StopsExecutingMultipleParallelTasksWhenClosed(t *testing.T) {
 	t.Parallel()
-	tp := remote.NewParallelExecutor(10)
+	tp := remote.NewParallelExecutor(10, "test_parallel_executor")
 	var counter atomic.Int32
 	t.Cleanup(func() {
 		assert.Eventually(t, func() bool { return counter.Load() == 0 }, 5*time.Second, 10*time.Millisecond)

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -415,12 +415,10 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			p.mu.Lock()
 			defer p.mu.Unlock()
 			if registerErr == nil {
-				_, cancel := p.stopCh.NewCtx()
 				p.metrics.registerTriggerCounter.Add(taskCtx, 1, capAttrs, metric.WithAttributes(attribute.String("outcome", "success")))
 				p.registrations[key] = &pubRegState{
 					callback: callbackCh,
 					request:  unmarshaled,
-					cancel:   cancel,
 				}
 				p.wg.Add(1)
 				go p.triggerEventLoop(callbackCh, key)
@@ -523,8 +521,6 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		p.unregisterCache.Delete(key)
 		p.messageCache.Delete(key)
 		p.mu.Unlock()
-
-		reg.cancel()
 
 		ctx, cancel := p.stopCh.NewCtx()
 		err = p.cfg.Load().underlying.UnregisterTrigger(ctx, reg.request)

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -382,99 +382,95 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		p.lggr.Errorw("trigger request failed with error",
 			"method", SanitizeLogString(msg.Method), "sender", sender, "errorMsg", SanitizeLogString(msg.ErrorMsg))
 	case types.MethodTriggerEventAck:
-		p.handleTriggerEventAck(ctx, cfg, msg, sender)
+		triggerMetadata := msg.GetTriggerEventMetadata()
+		if triggerMetadata == nil {
+			p.lggr.Errorw("received empty trigger event ack metadata", "sender", sender)
+			break
+		}
+		triggerEventID := triggerMetadata.TriggerEventId
+		p.lggr.Debugw("received trigger event ACK", "sender", sender, "trigger event ID", triggerEventID)
+
+		p.mu.Lock()
+		callerDon, ok := cfg.workflowDONs[msg.CallerDonId]
+		if !ok {
+			p.mu.Unlock()
+			p.lggr.Errorw("received a message from unsupported workflow DON", "callerDonId", msg.CallerDonId)
+			return
+		}
+		if !cfg.membersCache[msg.CallerDonId][sender] {
+			p.mu.Unlock()
+			p.lggr.Errorw("sender not a member of its workflow DON", "callerDonId", msg.CallerDonId, "sender", sender)
+			return
+		}
+		if len(triggerMetadata.TriggerIds) != 1 {
+			p.mu.Unlock()
+			p.lggr.Errorw("did not receive single triggerID in ACK request", "callerDonId", msg.CallerDonId, "sender", sender, "triggerIDs", triggerMetadata.TriggerIds)
+			return
+		}
+		triggerID := triggerMetadata.TriggerIds[0]
+
+		key := ackKey{msg.CallerDonId, triggerEventID, triggerID}
+		nowMs := time.Now().UnixMilli()
+		p.ackCache.Insert(key, sender, nowMs, msg.Payload)
+		minRequired := uint32(2*callerDon.F + 1)
+		ready, _ := p.ackCache.Ready(key, minRequired, 0, false)
+		ackCount := len(p.ackCache.Peers(key))
+		if !ready {
+			p.mu.Unlock()
+			p.lggr.Debugw("not ready to ACK trigger event yet",
+				"triggerEventId", triggerEventID,
+				"triggerID", triggerID,
+				"acksReceived", ackCount,
+				"minRequired", minRequired)
+			return
+		}
+
+		p.mu.Unlock()
+
+		if p.ackExecutor == nil {
+			p.lggr.Errorw("ack executor not started; cannot forward AckEvent",
+				"triggerEventId", triggerEventID, "triggerID", triggerID)
+			return
+		}
+
+		callerDonID := msg.CallerDonId
+		ackAttrs := metric.WithAttributes(
+			attribute.String("capabilityID", p.capabilityID),
+			attribute.String("callerDonID", strconv.FormatUint(uint64(callerDonID), 10)),
+		)
+
+		p.lggr.Infow("ACK quorum reached, forwarding to underlying trigger",
+			"triggerEventId", triggerEventID,
+			"triggerID", triggerID,
+			"minRequired", minRequired)
+
+		scheduleErr := p.ackExecutor.ExecuteTask(ctx, func(taskCtx context.Context) {
+			p.lggr.Infow("executing AckEvent task",
+				"triggerEventId", triggerEventID,
+				"triggerID", triggerID,
+				"callerDonId", callerDonID,
+				"minRequired", minRequired)
+			ackErr := cfg.underlying.AckEvent(taskCtx, triggerID, triggerEventID, p.capMethodName)
+			if ackErr != nil {
+				p.metrics.ackEventCounter.Add(taskCtx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "error")))
+				p.lggr.Errorw("failed to AckEvent on underlying trigger capability",
+					"eventID", triggerEventID, "capabilityID", p.capabilityID, "err", ackErr)
+				return
+			}
+			p.lggr.Infow("AckEvent completed successfully",
+				"triggerEventId", triggerEventID,
+				"triggerID", triggerID,
+				"callerDonId", callerDonID,
+				"minRequired", minRequired)
+			p.metrics.ackEventCounter.Add(taskCtx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "success")))
+		})
+		if scheduleErr != nil {
+			p.lggr.Errorw("failed to schedule AckEvent task",
+				"triggerEventId", triggerEventID, "triggerID", triggerID, "err", scheduleErr)
+		}
 	default:
 		p.lggr.Errorw("received message with unknown method",
 			"method", SanitizeLogString(msg.Method), "sender", sender)
-	}
-}
-
-func (p *triggerPublisher) handleTriggerEventAck(ctx context.Context, cfg *dynamicPublisherConfig, msg *types.MessageBody, sender p2ptypes.PeerID) {
-	triggerMetadata := msg.GetTriggerEventMetadata()
-	if triggerMetadata == nil {
-		p.lggr.Errorw("received empty trigger event ack metadata", "sender", sender)
-		return
-	}
-	triggerEventID := triggerMetadata.TriggerEventId
-	p.lggr.Debugw("received trigger event ACK", "sender", sender, "trigger event ID", triggerEventID)
-
-	p.mu.Lock()
-	callerDon, ok := cfg.workflowDONs[msg.CallerDonId]
-	if !ok {
-		p.mu.Unlock()
-		p.lggr.Errorw("received a message from unsupported workflow DON", "callerDonId", msg.CallerDonId)
-		return
-	}
-	if !cfg.membersCache[msg.CallerDonId][sender] {
-		p.mu.Unlock()
-		p.lggr.Errorw("sender not a member of its workflow DON", "callerDonId", msg.CallerDonId, "sender", sender)
-		return
-	}
-	if len(triggerMetadata.TriggerIds) != 1 {
-		p.mu.Unlock()
-		p.lggr.Errorw("did not receive single triggerID in ACK request", "callerDonId", msg.CallerDonId, "sender", sender, "triggerIDs", triggerMetadata.TriggerIds)
-		return
-	}
-	triggerID := triggerMetadata.TriggerIds[0]
-
-	key := ackKey{msg.CallerDonId, triggerEventID, triggerID}
-	nowMs := time.Now().UnixMilli()
-	p.ackCache.Insert(key, sender, nowMs, msg.Payload)
-	minRequired := uint32(2*callerDon.F + 1)
-	ready, _ := p.ackCache.Ready(key, minRequired, 0, false)
-	ackCount := len(p.ackCache.Peers(key))
-	if !ready {
-		p.mu.Unlock()
-		p.lggr.Debugw("not ready to ACK trigger event yet",
-			"triggerEventId", triggerEventID,
-			"triggerID", triggerID,
-			"acksReceived", ackCount,
-			"minRequired", minRequired)
-		return
-	}
-
-	p.mu.Unlock()
-
-	if p.ackExecutor == nil {
-		p.lggr.Errorw("ack executor not started; cannot forward AckEvent",
-			"triggerEventId", triggerEventID, "triggerID", triggerID)
-		return
-	}
-
-	callerDonID := msg.CallerDonId
-	ackAttrs := metric.WithAttributes(
-		attribute.String("capabilityID", p.capabilityID),
-		attribute.String("callerDonID", strconv.FormatUint(uint64(callerDonID), 10)),
-	)
-
-	p.lggr.Infow("ACK quorum reached, forwarding to underlying trigger",
-		"triggerEventId", triggerEventID,
-		"triggerID", triggerID,
-		"minRequired", minRequired)
-
-	scheduleErr := p.ackExecutor.ExecuteTask(ctx, func(taskCtx context.Context) {
-		p.lggr.Infow("executing AckEvent task",
-			"triggerEventId", triggerEventID,
-			"triggerID", triggerID,
-			"callerDonId", callerDonID,
-			"minRequired", minRequired)
-		ackErr := cfg.underlying.AckEvent(taskCtx, triggerID, triggerEventID, p.capMethodName)
-		if ackErr != nil {
-			p.metrics.ackEventCounter.Add(taskCtx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "error")))
-			p.lggr.Errorw("failed to AckEvent on underlying trigger capability",
-				"eventID", triggerEventID, "capabilityID", p.capabilityID, "err", ackErr)
-			return
-		}
-		p.lggr.Infow("AckEvent completed successfully",
-			"triggerEventId", triggerEventID,
-			"triggerID", triggerID,
-			"callerDonId", callerDonID,
-			"minRequired", minRequired)
-		p.metrics.ackEventCounter.Add(taskCtx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "success")))
-	})
-	if scheduleErr != nil {
-		p.lggr.Errorw("failed to schedule AckEvent task",
-			"triggerEventId", triggerEventID, "triggerID", triggerID, "err", scheduleErr)
 	}
 }
 

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -56,12 +56,16 @@ type triggerPublisher struct {
 }
 
 type triggerPublisherMetrics struct {
-	registerTriggerCounter   metric.Int64Counter
-	unregisterTriggerCounter metric.Int64Counter
-	ackEventCounter          metric.Int64Counter
-	ackExecutorSlotUsage     metric.Float64Gauge
-	ackPreExecuteDurationMs  metric.Int64Histogram
-	ackTaskDurationMs        metric.Int64Histogram
+	registerTriggerCounter          metric.Int64Counter
+	unregisterTriggerCounter        metric.Int64Counter
+	ackEventCounter                 metric.Int64Counter
+	ackExecutorSlotUsage            metric.Float64Gauge
+	ackPreExecuteDurationMs         metric.Int64Histogram
+	ackTaskDurationMs               metric.Int64Histogram
+	registerTriggerReceiveDurationMs metric.Int64Histogram
+	registerTriggerTaskDurationMs    metric.Int64Histogram
+	unregisterTriggerReceiveDurationMs metric.Int64Histogram
+	unregisterTriggerTaskDurationMs    metric.Int64Histogram
 }
 
 type dynamicPublisherConfig struct {
@@ -195,6 +199,22 @@ func (p *triggerPublisher) initMetrics() error {
 	if err != nil {
 		return fmt.Errorf("failed to register platform_trigger_publisher_ack_task_duration_ms: %w", err)
 	}
+	p.metrics.registerTriggerReceiveDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_register_trigger_receive_duration_ms", ackDurationBuckets)
+	if err != nil {
+		return fmt.Errorf("failed to register platform_trigger_publisher_register_trigger_receive_duration_ms: %w", err)
+	}
+	p.metrics.registerTriggerTaskDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_register_trigger_task_duration_ms", ackDurationBuckets)
+	if err != nil {
+		return fmt.Errorf("failed to register platform_trigger_publisher_register_trigger_task_duration_ms: %w", err)
+	}
+	p.metrics.unregisterTriggerReceiveDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_unregister_trigger_receive_duration_ms", ackDurationBuckets)
+	if err != nil {
+		return fmt.Errorf("failed to register platform_trigger_publisher_unregister_trigger_receive_duration_ms: %w", err)
+	}
+	p.metrics.unregisterTriggerTaskDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_unregister_trigger_task_duration_ms", ackDurationBuckets)
+	if err != nil {
+		return fmt.Errorf("failed to register platform_trigger_publisher_unregister_trigger_task_duration_ms: %w", err)
+	}
 	return nil
 }
 
@@ -233,6 +253,18 @@ func (p *triggerPublisher) recordAckTaskDuration(ctx context.Context, d time.Dur
 		outcome = "success"
 	}
 	p.metrics.ackTaskDurationMs.Record(ctx, d.Milliseconds(), metric.WithAttributes(
+		attribute.String("capabilityID", p.capabilityID),
+		attribute.String("capMethodName", p.capMethodName),
+		attribute.String("callerDonID", strconv.FormatUint(uint64(callerDonID), 10)),
+		attribute.String("outcome", outcome),
+	))
+}
+
+func (p *triggerPublisher) recordReceivePathDuration(hist metric.Int64Histogram, ctx context.Context, callerDonID uint32, outcome string, d time.Duration) {
+	if hist == nil {
+		return
+	}
+	hist.Record(ctx, d.Milliseconds(), metric.WithAttributes(
 		attribute.String("capabilityID", p.capabilityID),
 		attribute.String("capMethodName", p.capMethodName),
 		attribute.String("callerDonID", strconv.FormatUint(uint64(callerDonID), 10)),
@@ -299,21 +331,32 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 
 	switch msg.Method {
 	case types.MethodRegisterTrigger:
+		registerStart := time.Now()
+		callerDonID := msg.CallerDonId
+		registerOutcome := "invalid"
+		defer func() {
+			p.recordReceivePathDuration(p.metrics.registerTriggerReceiveDurationMs, ctx, callerDonID, registerOutcome, time.Since(registerStart))
+		}()
+
 		req, unmarshalErr := pb.UnmarshalTriggerRegistrationRequest(msg.Payload)
 		if unmarshalErr != nil {
+			registerOutcome = "unmarshal_error"
 			p.lggr.Errorw("failed to unmarshal trigger registration request", "err", unmarshalErr)
 			return
 		}
 		callerDon, ok := cfg.workflowDONs[msg.CallerDonId]
 		if !ok {
+			registerOutcome = "unsupported_don"
 			p.lggr.Errorw("received a message from unsupported workflow DON", "callerDonId", msg.CallerDonId)
 			return
 		}
 		if !cfg.membersCache[msg.CallerDonId][sender] {
+			registerOutcome = "invalid_sender"
 			p.lggr.Errorw("sender not a member of its workflow DON", "callerDonId", msg.CallerDonId, "sender", sender)
 			return
 		}
 		if err = validation.ValidateWorkflowOrExecutionID(req.Metadata.WorkflowID); err != nil {
+			registerOutcome = "invalid_workflow_id"
 			p.lggr.Errorw("received trigger request with invalid workflow ID", "workflowId", SanitizeLogString(req.Metadata.WorkflowID), "err", err)
 			return
 		}
@@ -325,9 +368,11 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		p.messageCache.Insert(key, sender, nowMs, msg.Payload)
 		if existing, exists := p.registrations[key]; exists {
 			if existing.registrationErr != nil {
+				registerOutcome = "skipped_user_error"
 				p.lggr.Debugw("skipping trigger registration; previous attempt failed with user error",
 					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", existing.registrationErr)
 			} else {
+				registerOutcome = "skipped_exists"
 				p.lggr.Debugw("trigger registration already exists", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
 			}
 			return
@@ -336,26 +381,36 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		minRequired := uint32(2*callerDon.F + 1)
 		ready, payloads := p.messageCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), false)
 		if !ready {
+			registerOutcome = "not_ready"
 			p.lggr.Debugw("not ready to aggregate yet", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "minRequired", minRequired)
 			return
 		}
 		aggregated, aggregateErr := aggregation.AggregateModeRaw(payloads, uint32(callerDon.F+1))
 		if aggregateErr != nil {
+			registerOutcome = "aggregate_error"
 			p.lggr.Errorw("failed to aggregate trigger registrations", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", aggregateErr)
 			return
 		}
 		unmarshaled, unmarshalErr := pb.UnmarshalTriggerRegistrationRequest(aggregated)
 		if unmarshalErr != nil {
+			registerOutcome = "aggregate_unmarshal_error"
 			p.lggr.Errorw("failed to unmarshal request", "err", unmarshalErr)
 			return
 		}
 		ctx, cancel := p.stopCh.NewCtx()
+		taskStart := time.Now()
 		callbackCh, registerErr := cfg.underlying.RegisterTrigger(ctx, unmarshaled)
+		taskOutcome := "success"
+		if registerErr != nil {
+			taskOutcome = "error"
+		}
+		p.recordReceivePathDuration(p.metrics.registerTriggerTaskDurationMs, ctx, callerDonID, taskOutcome, time.Since(taskStart))
 		capAttrs := metric.WithAttributes(
 			attribute.String("capabilityID", p.capabilityID),
 			attribute.String("callerDonID", strconv.FormatUint(uint64(key.callerDonID), 10)),
 		)
 		if registerErr == nil {
+			registerOutcome = "success"
 			p.metrics.registerTriggerCounter.Add(ctx, 1, capAttrs, metric.WithAttributes(attribute.String("outcome", "success")))
 			p.registrations[key] = &pubRegState{
 				callback: callbackCh,
@@ -366,6 +421,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			go p.triggerEventLoop(callbackCh, key)
 			p.lggr.Debugw("updated trigger registration", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
 		} else {
+			registerOutcome = "error"
 			p.metrics.registerTriggerCounter.Add(ctx, 1, capAttrs, metric.WithAttributes(attribute.String("outcome", "error")))
 			cancel()
 			var capErr caperrors.Error
@@ -379,22 +435,33 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			}
 		}
 	case types.MethodUnregisterTrigger:
+		unregisterStart := time.Now()
+		callerDonID := msg.CallerDonId
+		unregisterOutcome := "invalid"
+		defer func() {
+			p.recordReceivePathDuration(p.metrics.unregisterTriggerReceiveDurationMs, ctx, callerDonID, unregisterOutcome, time.Since(unregisterStart))
+		}()
+
 		meta := msg.GetTriggerEventMetadata()
 		if meta == nil {
+			unregisterOutcome = "nil_metadata"
 			p.lggr.Errorw("received unregister with nil metadata", "sender", sender)
 			return
 		}
 		if len(meta.WorkflowIds) != 1 || len(meta.TriggerIds) != 1 {
+			unregisterOutcome = "invalid_metadata"
 			p.lggr.Errorw("received unregister with unexpected metadata sizes",
 				"sender", sender, "workflowIdsLen", len(meta.WorkflowIds), "triggerIdsLen", len(meta.TriggerIds))
 			return
 		}
 		callerDon, ok := cfg.workflowDONs[msg.CallerDonId]
 		if !ok {
+			unregisterOutcome = "unsupported_don"
 			p.lggr.Errorw("received unregister from unsupported workflow DON", "callerDonId", msg.CallerDonId)
 			return
 		}
 		if !cfg.membersCache[msg.CallerDonId][sender] {
+			unregisterOutcome = "invalid_sender"
 			p.lggr.Errorw("unregister sender not a member of its workflow DON", "callerDonId", msg.CallerDonId, "sender", sender)
 			return
 		}
@@ -409,6 +476,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		reg, exists := p.registrations[key]
 		if !exists {
 			p.mu.Unlock()
+			unregisterOutcome = "not_registered"
 			return
 		}
 		nowMs := time.Now().UnixMilli()
@@ -417,6 +485,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		ready, _ := p.unregisterCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), true)
 		if !ready {
 			p.mu.Unlock()
+			unregisterOutcome = "not_ready"
 			p.lggr.Debugw("unregister quorum not reached yet", "workflowID", key.workflowID, "triggerID", key.triggerID, "sender", sender, "minRequired", minRequired)
 			return
 		}
@@ -430,9 +499,18 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		reg.cancel()
 
 		ctx, cancel := p.stopCh.NewCtx()
+		taskStart := time.Now()
 		err = p.cfg.Load().underlying.UnregisterTrigger(ctx, reg.request)
+		taskOutcome := "success"
 		if err != nil {
+			taskOutcome = "error"
+		}
+		p.recordReceivePathDuration(p.metrics.unregisterTriggerTaskDurationMs, ctx, callerDonID, taskOutcome, time.Since(taskStart))
+		if err != nil {
+			unregisterOutcome = "error"
 			p.lggr.Errorw("failed to unregister trigger on underlying", "workflowID", key.workflowID, "triggerID", key.triggerID, "err", err)
+		} else {
+			unregisterOutcome = "success"
 		}
 		cancel()
 		p.lggr.Infow("unregistered trigger", "workflowID", key.workflowID, "triggerID", key.triggerID)

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -422,8 +422,8 @@ func (p *triggerPublisher) handleTriggerEventAck(ctx context.Context, cfg *dynam
 	p.ackCache.Insert(key, sender, nowMs, msg.Payload)
 	minRequired := uint32(2*callerDon.F + 1)
 	ready, _ := p.ackCache.Ready(key, minRequired, 0, false)
+	ackCount := len(p.ackCache.Peers(key))
 	if !ready {
-		ackCount := len(p.ackCache.Peers(key))
 		p.mu.Unlock()
 		p.lggr.Debugw("not ready to ACK trigger event yet",
 			"triggerEventId", triggerEventID,
@@ -432,7 +432,7 @@ func (p *triggerPublisher) handleTriggerEventAck(ctx context.Context, cfg *dynam
 			"minRequired", minRequired)
 		return
 	}
-	ackCount := len(p.ackCache.Peers(key))
+
 	p.mu.Unlock()
 
 	if p.ackExecutor == nil {
@@ -447,19 +447,12 @@ func (p *triggerPublisher) handleTriggerEventAck(ctx context.Context, cfg *dynam
 		attribute.String("callerDonID", strconv.FormatUint(uint64(callerDonID), 10)),
 	)
 
-	p.lggr.Infow("starting AckEvent task",
+	p.lggr.Infow("ACK quorum reached, forwarding to underlying trigger",
 		"triggerEventId", triggerEventID,
 		"triggerID", triggerID,
-		"callerDonId", callerDonID,
-		"sender", sender,
-		"acksReceived", ackCount,
 		"minRequired", minRequired)
 
 	scheduleErr := p.ackExecutor.ExecuteTask(ctx, func(taskCtx context.Context) {
-		p.lggr.Infow("ACK quorum reached, forwarding to underlying trigger",
-			"triggerEventId", triggerEventID,
-			"triggerID", triggerID,
-			"minRequired", minRequired)
 		p.lggr.Infow("executing AckEvent task",
 			"triggerEventId", triggerEventID,
 			"triggerID", triggerID,
@@ -472,6 +465,11 @@ func (p *triggerPublisher) handleTriggerEventAck(ctx context.Context, cfg *dynam
 				"eventID", triggerEventID, "capabilityID", p.capabilityID, "err", ackErr)
 			return
 		}
+		p.lggr.Infow("AckEvent completed successfully",
+			"triggerEventId", triggerEventID,
+			"triggerID", triggerID,
+			"callerDonId", callerDonID,
+			"minRequired", minRequired)
 		p.metrics.ackEventCounter.Add(taskCtx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "success")))
 	})
 	if scheduleErr != nil {

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -112,8 +112,8 @@ var _ types.ReceiverService = &triggerPublisher{}
 
 const (
 	minAllowedBatchCollectionPeriod = 10 * time.Millisecond
-	defaultMaxParallelAcks          = 100 // TODO: pass through config from remoteConfig
-	defaultMaxParallelRegisters     = 100 // TODO: pass through config from remoteConfig
+	defaultMaxParallelAcks          = 100
+	defaultMaxParallelRegisters     = 100
 )
 
 func NewTriggerPublisher(capabilityID string, capMethodName string, dispatcher types.Dispatcher, lggr logger.Logger) *triggerPublisher {
@@ -294,6 +294,7 @@ func (p *triggerPublisher) Start(ctx context.Context) error {
 	return nil
 }
 
+// TODO: Reduce complexity -> https://smartcontract-it.atlassian.net/browse/PLEX-3258
 func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) {
 	cfg := p.cfg.Load()
 	if cfg == nil {
@@ -449,7 +450,6 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			p.metrics.registerTriggerCounter.Add(taskCtx, 1, capAttrs, metric.WithAttributes(attribute.String("outcome", "error")))
 			var capErr caperrors.Error
 			if errors.As(registerErr, &capErr) && capErr.Origin() == caperrors.OriginUser {
-
 				p.registrations[key] = &pubRegState{registrationErr: registerErr}
 				p.lggr.Errorw("trigger registration failed with user error; will not retry",
 					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", registerErr)

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -56,9 +56,12 @@ type triggerPublisher struct {
 }
 
 type triggerPublisherMetrics struct {
-	registerTriggerCounter   metric.Int64Counter
-	unregisterTriggerCounter metric.Int64Counter
-	ackEventCounter          metric.Int64Counter
+	registerTriggerCounter      metric.Int64Counter
+	unregisterTriggerCounter    metric.Int64Counter
+	ackEventCounter             metric.Int64Counter
+	ackExecutorSlotUsage        metric.Float64Gauge
+	ackPreExecuteDurationMs     metric.Int64Histogram
+	ackTaskDurationMs           metric.Int64Histogram
 }
 
 type dynamicPublisherConfig struct {
@@ -179,7 +182,62 @@ func (p *triggerPublisher) initMetrics() error {
 	if err != nil {
 		return fmt.Errorf("failed to register platform_trigger_publisher_ack_event_total: %w", err)
 	}
+	p.metrics.ackExecutorSlotUsage, err = beholder.GetMeter().Float64Gauge("platform_trigger_publisher_ack_executor_slot_usage")
+	if err != nil {
+		return fmt.Errorf("failed to register platform_trigger_publisher_ack_executor_slot_usage: %w", err)
+	}
+	ackDurationBuckets := metric.WithExplicitBucketBoundaries(1, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000)
+	p.metrics.ackPreExecuteDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_ack_pre_execute_duration_ms", ackDurationBuckets)
+	if err != nil {
+		return fmt.Errorf("failed to register platform_trigger_publisher_ack_pre_execute_duration_ms: %w", err)
+	}
+	p.metrics.ackTaskDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_ack_task_duration_ms", ackDurationBuckets)
+	if err != nil {
+		return fmt.Errorf("failed to register platform_trigger_publisher_ack_task_duration_ms: %w", err)
+	}
 	return nil
+}
+
+func (p *triggerPublisher) recordAckExecutorSlotUsage(ctx context.Context) {
+	if p.ackExecutor == nil || p.metrics.ackExecutorSlotUsage == nil {
+		return
+	}
+	maxSlots := p.ackExecutor.MaxSlots()
+	if maxSlots == 0 {
+		return
+	}
+	usage := float64(p.ackExecutor.OccupiedSlots()) / float64(maxSlots)
+	p.metrics.ackExecutorSlotUsage.Record(ctx, usage, metric.WithAttributes(
+		attribute.String("capabilityID", p.capabilityID),
+		attribute.String("capMethodName", p.capMethodName),
+	))
+}
+
+func (p *triggerPublisher) recordAckPreExecuteDuration(ctx context.Context, d time.Duration, callerDonID uint32) {
+	if p.metrics.ackPreExecuteDurationMs == nil {
+		return
+	}
+	p.metrics.ackPreExecuteDurationMs.Record(ctx, d.Milliseconds(), metric.WithAttributes(
+		attribute.String("capabilityID", p.capabilityID),
+		attribute.String("capMethodName", p.capMethodName),
+		attribute.String("callerDonID", strconv.FormatUint(uint64(callerDonID), 10)),
+	))
+}
+
+func (p *triggerPublisher) recordAckTaskDuration(ctx context.Context, d time.Duration, callerDonID uint32, success bool) {
+	if p.metrics.ackTaskDurationMs == nil {
+		return
+	}
+	outcome := "error"
+	if success {
+		outcome = "success"
+	}
+	p.metrics.ackTaskDurationMs.Record(ctx, d.Milliseconds(), metric.WithAttributes(
+		attribute.String("capabilityID", p.capabilityID),
+		attribute.String("capMethodName", p.capMethodName),
+		attribute.String("callerDonID", strconv.FormatUint(uint64(callerDonID), 10)),
+		attribute.String("outcome", outcome),
+	))
 }
 
 func (p *triggerPublisher) Start(ctx context.Context) error {
@@ -382,6 +440,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		p.lggr.Errorw("trigger request failed with error",
 			"method", SanitizeLogString(msg.Method), "sender", sender, "errorMsg", SanitizeLogString(msg.ErrorMsg))
 	case types.MethodTriggerEventAck:
+		ackHandlerStart := time.Now()
 		triggerMetadata := msg.GetTriggerEventMetadata()
 		if triggerMetadata == nil {
 			p.lggr.Errorw("received empty trigger event ack metadata", "sender", sender)
@@ -413,7 +472,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		nowMs := time.Now().UnixMilli()
 		p.ackCache.Insert(key, sender, nowMs, msg.Payload)
 		minRequired := uint32(2*callerDon.F + 1)
-		ready, _ := p.ackCache.Ready(key, minRequired, 0, false)
+		ready, _ := p.ackCache.Ready(key, minRequired, 0, true)
 		ackCount := len(p.ackCache.Peers(key))
 		if !ready {
 			p.mu.Unlock()
@@ -445,12 +504,16 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			"minRequired", minRequired)
 
 		scheduleErr := p.ackExecutor.ExecuteTask(ctx, func(taskCtx context.Context) {
+			defer p.recordAckExecutorSlotUsage(taskCtx)
+			p.recordAckPreExecuteDuration(taskCtx, time.Since(ackHandlerStart), callerDonID)
+			taskStart := time.Now()
 			p.lggr.Infow("executing AckEvent task",
 				"triggerEventId", triggerEventID,
 				"triggerID", triggerID,
 				"callerDonId", callerDonID,
 				"minRequired", minRequired)
 			ackErr := cfg.underlying.AckEvent(taskCtx, triggerID, triggerEventID, p.capMethodName)
+			p.recordAckTaskDuration(taskCtx, time.Since(taskStart), callerDonID, ackErr == nil)
 			if ackErr != nil {
 				p.metrics.ackEventCounter.Add(taskCtx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "error")))
 				p.lggr.Errorw("failed to AckEvent on underlying trigger capability",
@@ -467,6 +530,8 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		if scheduleErr != nil {
 			p.lggr.Errorw("failed to schedule AckEvent task",
 				"triggerEventId", triggerEventID, "triggerID", triggerID, "err", scheduleErr)
+		} else {
+			p.recordAckExecutorSlotUsage(ctx)
 		}
 	default:
 		p.lggr.Errorw("received message with unknown method",

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -352,6 +352,15 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		}
 		// NOTE: require 2F+1 by default, introduce different strategies later (KS-76)
 		minRequired := uint32(2*callerDon.F + 1)
+		// once=true: only one register attempt per registration cycle. Whichever workflow
+		// node message satisfies quorum schedules RegisterTrigger; the following messages
+		// from other nodes do not (Ready returns false, WasReady returns true). If that attempt fails, registration
+		// must wait for the next cycle (e.g. re-quorum after messageCache.Delete on system
+		// error, or a fresh registration flow).
+		//
+		// This did not matter when registration was synchronous—the "already exists" check
+		// above returned early without causing unncessary RegisterTrigger calls. With async registration,
+		// that check may pass in time, so once=true prevents duplicate RegisterTrigger calls for the same trigger.
 		ready, payloads := p.messageCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), true)
 		if !ready {
 			peersReceived := len(p.messageCache.Peers(key))

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -56,16 +56,14 @@ type triggerPublisher struct {
 }
 
 type triggerPublisherMetrics struct {
-	registerTriggerCounter             metric.Int64Counter
-	unregisterTriggerCounter           metric.Int64Counter
-	ackEventCounter                    metric.Int64Counter
-	ackExecutorSlotUsage               metric.Float64Gauge
-	ackPreExecuteDurationMs            metric.Int64Histogram
-	ackTaskDurationMs                  metric.Int64Histogram
-	registerTriggerReceiveDurationMs   metric.Int64Histogram
-	registerTriggerTaskDurationMs      metric.Int64Histogram
-	unregisterTriggerReceiveDurationMs metric.Int64Histogram
-	unregisterTriggerTaskDurationMs    metric.Int64Histogram
+	registerTriggerCounter      metric.Int64Counter
+	unregisterTriggerCounter    metric.Int64Counter
+	ackEventCounter             metric.Int64Counter
+	ackExecutorSlotUsage        metric.Float64Gauge
+	registerExecutorSlotUsage   metric.Float64Gauge
+	registerTriggerDurationMs   metric.Int64Histogram
+	unregisterTriggerDurationMs metric.Int64Histogram
+	ackEventDurationMs          metric.Int64Histogram
 }
 
 type dynamicPublisherConfig struct {
@@ -191,30 +189,22 @@ func (p *triggerPublisher) initMetrics() error {
 	if err != nil {
 		return fmt.Errorf("failed to register platform_trigger_publisher_ack_executor_slot_usage: %w", err)
 	}
-	ackDurationBuckets := metric.WithExplicitBucketBoundaries(1, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000)
-	p.metrics.ackPreExecuteDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_ack_pre_execute_duration_ms", ackDurationBuckets)
+	p.metrics.registerExecutorSlotUsage, err = beholder.GetMeter().Float64Gauge("platform_trigger_publisher_register_executor_slot_usage")
 	if err != nil {
-		return fmt.Errorf("failed to register platform_trigger_publisher_ack_pre_execute_duration_ms: %w", err)
+		return fmt.Errorf("failed to register platform_trigger_publisher_register_executor_slot_usage: %w", err)
 	}
-	p.metrics.ackTaskDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_ack_task_duration_ms", ackDurationBuckets)
+	durationBuckets := metric.WithExplicitBucketBoundaries(1, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000)
+	p.metrics.registerTriggerDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_register_trigger_duration_ms", durationBuckets)
 	if err != nil {
-		return fmt.Errorf("failed to register platform_trigger_publisher_ack_task_duration_ms: %w", err)
+		return fmt.Errorf("failed to register platform_trigger_publisher_register_trigger_duration_ms: %w", err)
 	}
-	p.metrics.registerTriggerReceiveDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_register_trigger_receive_duration_ms", ackDurationBuckets)
+	p.metrics.unregisterTriggerDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_unregister_trigger_duration_ms", durationBuckets)
 	if err != nil {
-		return fmt.Errorf("failed to register platform_trigger_publisher_register_trigger_receive_duration_ms: %w", err)
+		return fmt.Errorf("failed to register platform_trigger_publisher_unregister_trigger_duration_ms: %w", err)
 	}
-	p.metrics.registerTriggerTaskDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_register_trigger_task_duration_ms", ackDurationBuckets)
+	p.metrics.ackEventDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_ack_event_duration_ms", durationBuckets)
 	if err != nil {
-		return fmt.Errorf("failed to register platform_trigger_publisher_register_trigger_task_duration_ms: %w", err)
-	}
-	p.metrics.unregisterTriggerReceiveDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_unregister_trigger_receive_duration_ms", ackDurationBuckets)
-	if err != nil {
-		return fmt.Errorf("failed to register platform_trigger_publisher_unregister_trigger_receive_duration_ms: %w", err)
-	}
-	p.metrics.unregisterTriggerTaskDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_unregister_trigger_task_duration_ms", ackDurationBuckets)
-	if err != nil {
-		return fmt.Errorf("failed to register platform_trigger_publisher_unregister_trigger_task_duration_ms: %w", err)
+		return fmt.Errorf("failed to register platform_trigger_publisher_ack_event_duration_ms: %w", err)
 	}
 	return nil
 }
@@ -234,41 +224,28 @@ func (p *triggerPublisher) recordAckExecutorSlotUsage(ctx context.Context) {
 	))
 }
 
-func (p *triggerPublisher) recordAckPreExecuteDuration(ctx context.Context, d time.Duration, callerDonID uint32) {
-	if p.metrics.ackPreExecuteDurationMs == nil {
+func (p *triggerPublisher) recordRegisterExecutorSlotUsage(ctx context.Context) {
+	if p.registerExecutor == nil || p.metrics.registerExecutorSlotUsage == nil {
 		return
 	}
-	p.metrics.ackPreExecuteDurationMs.Record(ctx, d.Milliseconds(), metric.WithAttributes(
+	maxSlots := p.registerExecutor.MaxSlots()
+	if maxSlots == 0 {
+		return
+	}
+	usage := float64(p.registerExecutor.OccupiedSlots()) / float64(maxSlots)
+	p.metrics.registerExecutorSlotUsage.Record(ctx, usage, metric.WithAttributes(
 		attribute.String("capabilityID", p.capabilityID),
 		attribute.String("capMethodName", p.capMethodName),
-		attribute.String("callerDonID", strconv.FormatUint(uint64(callerDonID), 10)),
 	))
 }
 
-func (p *triggerPublisher) recordAckTaskDuration(ctx context.Context, d time.Duration, callerDonID uint32, success bool) {
-	if p.metrics.ackTaskDurationMs == nil {
-		return
-	}
-	outcome := "error"
-	if success {
-		outcome = "success"
-	}
-	p.metrics.ackTaskDurationMs.Record(ctx, d.Milliseconds(), metric.WithAttributes(
-		attribute.String("capabilityID", p.capabilityID),
-		attribute.String("capMethodName", p.capMethodName),
-		attribute.String("callerDonID", strconv.FormatUint(uint64(callerDonID), 10)),
-		attribute.String("outcome", outcome),
-	))
-}
-
-func (p *triggerPublisher) recordReceivePathDuration(hist metric.Int64Histogram, ctx context.Context, callerDonID uint32, outcome string, d time.Duration) {
+func (p *triggerPublisher) recordMethodDuration(ctx context.Context, hist metric.Int64Histogram, outcome string, d time.Duration) {
 	if hist == nil {
 		return
 	}
 	hist.Record(ctx, d.Milliseconds(), metric.WithAttributes(
 		attribute.String("capabilityID", p.capabilityID),
 		attribute.String("capMethodName", p.capMethodName),
-		attribute.String("callerDonID", strconv.FormatUint(uint64(callerDonID), 10)),
 		attribute.String("outcome", outcome),
 	))
 }
@@ -338,10 +315,23 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 	switch msg.Method {
 	case types.MethodRegisterTrigger:
 		registerStart := time.Now()
-		callerDonID := msg.CallerDonId
 		registerOutcome := "invalid"
+		// Duration is recorded either by this defer (synchronous Receive exits) or by the
+		// register executor goroutine (success/error). recordRegisterDuration=false on
+		// successful schedule prevents double-counting.
+		//
+		// Interpreting outcomes:
+		//   - success/error: quorum reached, RegisterTrigger ran (includes executor queue
+		//     wait + underlying work such as DB). Use for end-to-end register latency.
+		//   - anything else (not_ready, skipped_exists, schedule_failed, ...): Receive
+		//     returned without calling RegisterTrigger. These did early-exit as intended.
+		//     High p99 here means Receive itself was slow—typically p.mu wait and/or
+		//     time blocked acquiring an executor slot (schedule_failed), not DB writes.
+		recordRegisterDuration := true
 		defer func() {
-			p.recordReceivePathDuration(p.metrics.registerTriggerReceiveDurationMs, ctx, callerDonID, registerOutcome, time.Since(registerStart))
+			if recordRegisterDuration {
+				p.recordMethodDuration(ctx, p.metrics.registerTriggerDurationMs, registerOutcome, time.Since(registerStart))
+			}
 		}()
 
 		req, unmarshalErr := pb.UnmarshalTriggerRegistrationRequest(msg.Payload)
@@ -421,13 +411,13 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		)
 
 		scheduleErr := p.registerExecutor.ExecuteTask(ctx, func(taskCtx context.Context) {
-			taskStart := time.Now()
+			defer p.recordRegisterExecutorSlotUsage(taskCtx)
 			callbackCh, registerErr := cfg.underlying.RegisterTrigger(taskCtx, unmarshaled)
 			taskOutcome := "success"
 			if registerErr != nil {
 				taskOutcome = "error"
 			}
-			p.recordReceivePathDuration(p.metrics.registerTriggerTaskDurationMs, taskCtx, callerDonID, taskOutcome, time.Since(taskStart))
+			p.recordMethodDuration(taskCtx, p.metrics.registerTriggerDurationMs, taskOutcome, time.Since(registerStart))
 
 			p.mu.Lock()
 			defer p.mu.Unlock()
@@ -448,13 +438,18 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			p.metrics.registerTriggerCounter.Add(taskCtx, 1, capAttrs, metric.WithAttributes(attribute.String("outcome", "error")))
 			var capErr caperrors.Error
 			if errors.As(registerErr, &capErr) && capErr.Origin() == caperrors.OriginUser {
+
 				p.registrations[key] = &pubRegState{registrationErr: registerErr}
 				p.lggr.Errorw("trigger registration failed with user error; will not retry",
 					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", registerErr)
 				return
 			}
+			// System errors should retry. Ready(..., once=true) sets wasReady on quorum and never
+			// resets it; without Delete, later messages keep getting not_ready even though we
+			// never registered. Delete clears wasReady so a fresh quorum can schedule again.
 			p.lggr.Errorw("trigger registration failed with system error; will retry",
 				"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", registerErr)
+			p.messageCache.Delete(key)
 		})
 		if scheduleErr != nil {
 			registerOutcome = "schedule_failed"
@@ -462,13 +457,15 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 				"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", scheduleErr)
 			return
 		}
+		// Hand off to executor; disable defer recording—goroutine records success/error.
+		recordRegisterDuration = false
+		p.recordRegisterExecutorSlotUsage(ctx)
 		registerOutcome = "scheduled"
 	case types.MethodUnregisterTrigger:
 		unregisterStart := time.Now()
-		callerDonID := msg.CallerDonId
 		unregisterOutcome := "invalid"
 		defer func() {
-			p.recordReceivePathDuration(p.metrics.unregisterTriggerReceiveDurationMs, ctx, callerDonID, unregisterOutcome, time.Since(unregisterStart))
+			p.recordMethodDuration(ctx, p.metrics.unregisterTriggerDurationMs, unregisterOutcome, time.Since(unregisterStart))
 		}()
 
 		meta := msg.GetTriggerEventMetadata()
@@ -528,13 +525,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		reg.cancel()
 
 		ctx, cancel := p.stopCh.NewCtx()
-		taskStart := time.Now()
 		err = p.cfg.Load().underlying.UnregisterTrigger(ctx, reg.request)
-		taskOutcome := "success"
-		if err != nil {
-			taskOutcome = "error"
-		}
-		p.recordReceivePathDuration(p.metrics.unregisterTriggerTaskDurationMs, ctx, callerDonID, taskOutcome, time.Since(taskStart))
 		if err != nil {
 			unregisterOutcome = "error"
 			p.lggr.Errorw("failed to unregister trigger on underlying", "workflowID", key.workflowID, "triggerID", key.triggerID, "err", err)
@@ -548,10 +539,21 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			"method", SanitizeLogString(msg.Method), "sender", sender, "errorMsg", SanitizeLogString(msg.ErrorMsg))
 	case types.MethodTriggerEventAck:
 		ackHandlerStart := time.Now()
+		ackOutcome := "invalid"
+		// Same two-path duration model as register: defer for synchronous Receive exits,
+		// executor goroutine for success/error after quorum. See register case comment.
+		recordAckDuration := true
+		defer func() {
+			if recordAckDuration {
+				p.recordMethodDuration(ctx, p.metrics.ackEventDurationMs, ackOutcome, time.Since(ackHandlerStart))
+			}
+		}()
+
 		triggerMetadata := msg.GetTriggerEventMetadata()
 		if triggerMetadata == nil {
+			ackOutcome = "nil_metadata"
 			p.lggr.Errorw("received empty trigger event ack metadata", "sender", sender)
-			break
+			return
 		}
 		triggerEventID := triggerMetadata.TriggerEventId
 		p.lggr.Debugw("received trigger event ACK", "sender", sender, "trigger event ID", triggerEventID)
@@ -560,16 +562,19 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		callerDon, ok := cfg.workflowDONs[msg.CallerDonId]
 		if !ok {
 			p.mu.Unlock()
+			ackOutcome = "unsupported_don"
 			p.lggr.Errorw("received a message from unsupported workflow DON", "callerDonId", msg.CallerDonId)
 			return
 		}
 		if !cfg.membersCache[msg.CallerDonId][sender] {
 			p.mu.Unlock()
+			ackOutcome = "invalid_sender"
 			p.lggr.Errorw("sender not a member of its workflow DON", "callerDonId", msg.CallerDonId, "sender", sender)
 			return
 		}
 		if len(triggerMetadata.TriggerIds) != 1 {
 			p.mu.Unlock()
+			ackOutcome = "invalid_trigger_ids"
 			p.lggr.Errorw("did not receive single triggerID in ACK request", "callerDonId", msg.CallerDonId, "sender", sender, "triggerIDs", triggerMetadata.TriggerIds)
 			return
 		}
@@ -583,6 +588,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		ackCount := len(p.ackCache.Peers(key))
 		if !ready {
 			p.mu.Unlock()
+			ackOutcome = "not_ready"
 			p.lggr.Debugw("not ready to ACK trigger event yet",
 				"triggerEventId", triggerEventID,
 				"triggerID", triggerID,
@@ -594,6 +600,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		p.mu.Unlock()
 
 		if p.ackExecutor == nil {
+			ackOutcome = "executor_not_started"
 			p.lggr.Errorw("ack executor not started; cannot forward AckEvent",
 				"triggerEventId", triggerEventID, "triggerID", triggerID)
 			return
@@ -612,15 +619,17 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 
 		scheduleErr := p.ackExecutor.ExecuteTask(ctx, func(taskCtx context.Context) {
 			defer p.recordAckExecutorSlotUsage(taskCtx)
-			p.recordAckPreExecuteDuration(taskCtx, time.Since(ackHandlerStart), callerDonID)
-			taskStart := time.Now()
 			p.lggr.Infow("executing AckEvent task",
 				"triggerEventId", triggerEventID,
 				"triggerID", triggerID,
 				"callerDonId", callerDonID,
 				"minRequired", minRequired)
 			ackErr := cfg.underlying.AckEvent(taskCtx, triggerID, triggerEventID, p.capMethodName)
-			p.recordAckTaskDuration(taskCtx, time.Since(taskStart), callerDonID, ackErr == nil)
+			taskOutcome := "success"
+			if ackErr != nil {
+				taskOutcome = "error"
+			}
+			p.recordMethodDuration(taskCtx, p.metrics.ackEventDurationMs, taskOutcome, time.Since(ackHandlerStart))
 			if ackErr != nil {
 				p.metrics.ackEventCounter.Add(taskCtx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "error")))
 				p.lggr.Errorw("failed to AckEvent on underlying trigger capability",
@@ -635,11 +644,13 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			p.metrics.ackEventCounter.Add(taskCtx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "success")))
 		})
 		if scheduleErr != nil {
+			ackOutcome = "schedule_failed"
 			p.lggr.Errorw("failed to schedule AckEvent task",
 				"triggerEventId", triggerEventID, "triggerID", triggerID, "err", scheduleErr)
-		} else {
-			p.recordAckExecutorSlotUsage(ctx)
+			return
 		}
+		recordAckDuration = false
+		p.recordAckExecutorSlotUsage(ctx)
 	default:
 		p.lggr.Errorw("received message with unknown method",
 			"method", SanitizeLogString(msg.Method), "sender", sender)

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -323,7 +323,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		// Interpreting outcomes:
 		//   - success/error: quorum reached, RegisterTrigger ran (includes executor queue
 		//     wait + underlying work such as DB). Use for end-to-end register latency.
-		//   - anything else (not_ready, skipped_exists, schedule_failed, ...): Receive
+		//   - anything else (not_ready, quorum_already_met, skipped_exists, schedule_failed, ...):
 		//     returned without calling RegisterTrigger. These did early-exit as intended.
 		//     High p99 here means Receive itself was slow—typically p.mu wait and/or
 		//     time blocked acquiring an executor slot (schedule_failed), not DB writes.
@@ -377,9 +377,20 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		minRequired := uint32(2*callerDon.F + 1)
 		ready, payloads := p.messageCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), true)
 		if !ready {
-			registerOutcome = "not_ready"
-			p.mu.Unlock()
-			p.lggr.Debugw("not ready to aggregate yet", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "minRequired", minRequired)
+			peersReceived := len(p.messageCache.Peers(key))
+			if p.messageCache.WasReady(key) {
+				registerOutcome = "quorum_already_met"
+				p.mu.Unlock()
+				p.lggr.Debugw("quorum already met; ignoring duplicate registration message",
+					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID,
+					"peersReceived", peersReceived, "minRequired", minRequired)
+			} else {
+				registerOutcome = "not_ready"
+				p.mu.Unlock()
+				p.lggr.Debugw("quorum not reached yet",
+					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID,
+					"peersReceived", peersReceived, "minRequired", minRequired)
+			}
 			return
 		}
 		aggregated, aggregateErr := aggregation.AggregateModeRaw(payloads, uint32(callerDon.F+1))
@@ -510,9 +521,20 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		p.unregisterCache.Insert(key, sender, nowMs, nil)
 		ready, _ := p.unregisterCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), true)
 		if !ready {
-			p.mu.Unlock()
-			unregisterOutcome = "not_ready"
-			p.lggr.Debugw("unregister quorum not reached yet", "workflowID", key.workflowID, "triggerID", key.triggerID, "sender", sender, "minRequired", minRequired)
+			peersReceived := len(p.unregisterCache.Peers(key))
+			if p.unregisterCache.WasReady(key) {
+				unregisterOutcome = "quorum_already_met"
+				p.mu.Unlock()
+				p.lggr.Debugw("unregister quorum already met; ignoring duplicate message",
+					"workflowID", key.workflowID, "triggerID", key.triggerID, "sender", sender,
+					"peersReceived", peersReceived, "minRequired", minRequired)
+			} else {
+				unregisterOutcome = "not_ready"
+				p.mu.Unlock()
+				p.lggr.Debugw("unregister quorum not reached yet",
+					"workflowID", key.workflowID, "triggerID", key.triggerID, "sender", sender,
+					"peersReceived", peersReceived, "minRequired", minRequired)
+			}
 			return
 		}
 		p.lggr.Debugw("unregister trigger", "workflowID", key.workflowID, "triggerID", key.triggerID,
@@ -588,12 +610,21 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		ackCount := len(p.ackCache.Peers(key))
 		if !ready {
 			p.mu.Unlock()
-			ackOutcome = "not_ready"
-			p.lggr.Debugw("not ready to ACK trigger event yet",
-				"triggerEventId", triggerEventID,
-				"triggerID", triggerID,
-				"acksReceived", ackCount,
-				"minRequired", minRequired)
+			if p.ackCache.WasReady(key) {
+				ackOutcome = "quorum_already_met"
+				p.lggr.Debugw("ACK quorum already met; ignoring duplicate message",
+					"triggerEventId", triggerEventID,
+					"triggerID", triggerID,
+					"acksReceived", ackCount,
+					"minRequired", minRequired)
+			} else {
+				ackOutcome = "not_ready"
+				p.lggr.Debugw("ACK quorum not reached yet",
+					"triggerEventId", triggerEventID,
+					"triggerID", triggerID,
+					"acksReceived", ackCount,
+					"minRequired", minRequired)
+			}
 			return
 		}
 

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -50,6 +50,7 @@ type triggerPublisher struct {
 	bqMu          sync.Mutex // protects batchingQueue
 	stopCh        services.StopChan
 	wg            sync.WaitGroup
+	ackExecutor   *ParallelExecutor
 	lggr          logger.Logger
 	metrics       triggerPublisherMetrics
 }
@@ -104,7 +105,10 @@ type TriggerPublisher interface {
 var _ TriggerPublisher = &triggerPublisher{}
 var _ types.ReceiverService = &triggerPublisher{}
 
-const minAllowedBatchCollectionPeriod = 10 * time.Millisecond
+const (
+	minAllowedBatchCollectionPeriod = 10 * time.Millisecond
+	defaultMaxParallelAcks          = 100 // TODO: pass through config from remoteConfig
+)
 
 func NewTriggerPublisher(capabilityID string, capMethodName string, dispatcher types.Dispatcher, lggr logger.Logger) *triggerPublisher {
 	return &triggerPublisher{
@@ -207,11 +211,17 @@ func (p *triggerPublisher) Start(ctx context.Context) error {
 	go p.registrationCheckLoop()
 	p.wg.Add(1)
 	go p.batchingLoop()
+
+	p.ackExecutor = NewParallelExecutor(defaultMaxParallelAcks)
+	if err := p.ackExecutor.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start ack executor: %w", err)
+	}
+
 	p.lggr.Info("TriggerPublisher started")
 	return nil
 }
 
-func (p *triggerPublisher) Receive(_ context.Context, msg *types.MessageBody) {
+func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) {
 	cfg := p.cfg.Load()
 	if cfg == nil {
 		p.lggr.Errorw("received message but config is not set")
@@ -372,68 +382,101 @@ func (p *triggerPublisher) Receive(_ context.Context, msg *types.MessageBody) {
 		p.lggr.Errorw("trigger request failed with error",
 			"method", SanitizeLogString(msg.Method), "sender", sender, "errorMsg", SanitizeLogString(msg.ErrorMsg))
 	case types.MethodTriggerEventAck:
-		triggerMetadata := msg.GetTriggerEventMetadata()
-		if triggerMetadata == nil {
-			p.lggr.Errorw("received empty trigger event ack metadata", "sender", sender)
-			break
-		}
-		triggerEventID := triggerMetadata.TriggerEventId
-		p.lggr.Debugw("received trigger event ACK", "sender", sender, "trigger event ID", triggerEventID)
+		p.handleTriggerEventAck(ctx, cfg, msg, sender)
+	default:
+		p.lggr.Errorw("received message with unknown method",
+			"method", SanitizeLogString(msg.Method), "sender", sender)
+	}
+}
 
-		p.mu.Lock()
-		defer p.mu.Unlock()
-		callerDon, ok := cfg.workflowDONs[msg.CallerDonId]
-		if !ok {
-			p.lggr.Errorw("received a message from unsupported workflow DON", "callerDonId", msg.CallerDonId)
-			return
-		}
-		if !cfg.membersCache[msg.CallerDonId][sender] {
-			p.lggr.Errorw("sender not a member of its workflow DON", "callerDonId", msg.CallerDonId, "sender", sender)
-			return
-		}
+func (p *triggerPublisher) handleTriggerEventAck(ctx context.Context, cfg *dynamicPublisherConfig, msg *types.MessageBody, sender p2ptypes.PeerID) {
+	triggerMetadata := msg.GetTriggerEventMetadata()
+	if triggerMetadata == nil {
+		p.lggr.Errorw("received empty trigger event ack metadata", "sender", sender)
+		return
+	}
+	triggerEventID := triggerMetadata.TriggerEventId
+	p.lggr.Debugw("received trigger event ACK", "sender", sender, "trigger event ID", triggerEventID)
 
-		if len(triggerMetadata.TriggerIds) != 1 {
-			p.lggr.Errorw("did not receive single triggerID in ACK request", "callerDonId", msg.CallerDonId, "sender", sender, "triggerIDs", triggerMetadata.TriggerIds)
-			return
-		}
-		triggerID := triggerMetadata.TriggerIds[0]
+	p.mu.Lock()
+	callerDon, ok := cfg.workflowDONs[msg.CallerDonId]
+	if !ok {
+		p.mu.Unlock()
+		p.lggr.Errorw("received a message from unsupported workflow DON", "callerDonId", msg.CallerDonId)
+		return
+	}
+	if !cfg.membersCache[msg.CallerDonId][sender] {
+		p.mu.Unlock()
+		p.lggr.Errorw("sender not a member of its workflow DON", "callerDonId", msg.CallerDonId, "sender", sender)
+		return
+	}
+	if len(triggerMetadata.TriggerIds) != 1 {
+		p.mu.Unlock()
+		p.lggr.Errorw("did not receive single triggerID in ACK request", "callerDonId", msg.CallerDonId, "sender", sender, "triggerIDs", triggerMetadata.TriggerIds)
+		return
+	}
+	triggerID := triggerMetadata.TriggerIds[0]
 
-		key := ackKey{msg.CallerDonId, triggerEventID, triggerID}
-		nowMs := time.Now().UnixMilli()
-		p.ackCache.Insert(key, sender, nowMs, msg.Payload)
-		minRequired := uint32(2*callerDon.F + 1)
-		ready, _ := p.ackCache.Ready(key, minRequired, 0, false)
-		if !ready {
-			ackCount := len(p.ackCache.Peers(key))
-			p.lggr.Debugw("not ready to ACK trigger event yet",
-				"triggerEventId", triggerEventID,
-				"triggerID", triggerID,
-				"acksReceived", ackCount,
-				"minRequired", minRequired)
-			return
-		}
+	key := ackKey{msg.CallerDonId, triggerEventID, triggerID}
+	nowMs := time.Now().UnixMilli()
+	p.ackCache.Insert(key, sender, nowMs, msg.Payload)
+	minRequired := uint32(2*callerDon.F + 1)
+	ready, _ := p.ackCache.Ready(key, minRequired, 0, false)
+	if !ready {
+		ackCount := len(p.ackCache.Peers(key))
+		p.mu.Unlock()
+		p.lggr.Debugw("not ready to ACK trigger event yet",
+			"triggerEventId", triggerEventID,
+			"triggerID", triggerID,
+			"acksReceived", ackCount,
+			"minRequired", minRequired)
+		return
+	}
+	ackCount := len(p.ackCache.Peers(key))
+	p.mu.Unlock()
 
-		ctx, cancel := p.stopCh.NewCtx()
-		defer cancel()
+	if p.ackExecutor == nil {
+		p.lggr.Errorw("ack executor not started; cannot forward AckEvent",
+			"triggerEventId", triggerEventID, "triggerID", triggerID)
+		return
+	}
+
+	callerDonID := msg.CallerDonId
+	ackAttrs := metric.WithAttributes(
+		attribute.String("capabilityID", p.capabilityID),
+		attribute.String("callerDonID", strconv.FormatUint(uint64(callerDonID), 10)),
+	)
+
+	p.lggr.Infow("starting AckEvent task",
+		"triggerEventId", triggerEventID,
+		"triggerID", triggerID,
+		"callerDonId", callerDonID,
+		"sender", sender,
+		"acksReceived", ackCount,
+		"minRequired", minRequired)
+
+	scheduleErr := p.ackExecutor.ExecuteTask(ctx, func(taskCtx context.Context) {
 		p.lggr.Infow("ACK quorum reached, forwarding to underlying trigger",
 			"triggerEventId", triggerEventID,
 			"triggerID", triggerID,
 			"minRequired", minRequired)
-		err = cfg.underlying.AckEvent(ctx, triggerID, triggerEventID, p.capMethodName)
-		ackAttrs := metric.WithAttributes(
-			attribute.String("capabilityID", p.capabilityID),
-			attribute.String("callerDonID", strconv.FormatUint(uint64(msg.CallerDonId), 10)),
-		)
-		if err != nil {
-			p.metrics.ackEventCounter.Add(ctx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "error")))
+		p.lggr.Infow("executing AckEvent task",
+			"triggerEventId", triggerEventID,
+			"triggerID", triggerID,
+			"callerDonId", callerDonID,
+			"minRequired", minRequired)
+		ackErr := cfg.underlying.AckEvent(taskCtx, triggerID, triggerEventID, p.capMethodName)
+		if ackErr != nil {
+			p.metrics.ackEventCounter.Add(taskCtx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "error")))
 			p.lggr.Errorw("failed to AckEvent on underlying trigger capability",
-				"eventID", triggerEventID, "capabilityID", p.capabilityID, "err", err)
-		} else {
-			p.metrics.ackEventCounter.Add(ctx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "success")))
+				"eventID", triggerEventID, "capabilityID", p.capabilityID, "err", ackErr)
+			return
 		}
-	default:
-		p.lggr.Errorw("received message with unknown method",
-			"method", SanitizeLogString(msg.Method), "sender", sender)
+		p.metrics.ackEventCounter.Add(taskCtx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "success")))
+	})
+	if scheduleErr != nil {
+		p.lggr.Errorw("failed to schedule AckEvent task",
+			"triggerEventId", triggerEventID, "triggerID", triggerID, "err", scheduleErr)
 	}
 }
 
@@ -746,6 +789,11 @@ func (p *triggerPublisher) batchingLoop() {
 func (p *triggerPublisher) Close() error {
 	close(p.stopCh)
 	p.wg.Wait()
+	if p.ackExecutor != nil {
+		if err := p.ackExecutor.Close(); err != nil {
+			return fmt.Errorf("failed to close ack executor: %w", err)
+		}
+	}
 	p.lggr.Info("TriggerPublisher closed")
 	return nil
 }

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -213,9 +213,6 @@ func (p *triggerPublisher) initMetrics() error {
 }
 
 func (p *triggerPublisher) recordMethodDuration(ctx context.Context, hist metric.Int64Histogram, outcome string, d time.Duration) {
-	if hist == nil {
-		return
-	}
 	hist.Record(ctx, d.Milliseconds(), metric.WithAttributes(
 		attribute.String("capabilityID", p.capabilityID),
 		attribute.String("capMethodName", p.capMethodName),
@@ -351,6 +348,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		// that check may pass in time, so once=true prevents duplicate RegisterTrigger calls for the same trigger.
 		ready, payloads := p.messageCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), true)
 		if !ready {
+			p.mu.Unlock()
 			peersReceived := len(p.messageCache.Peers(key))
 			if p.messageCache.WasReady(key) {
 				p.lggr.Debugw("quorum already met; ignoring duplicate registration message",
@@ -361,7 +359,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID,
 					"peersReceived", peersReceived, "minRequired", minRequired)
 			}
-			p.mu.Unlock()
+
 			return
 		}
 		aggregated, aggregateErr := aggregation.AggregateModeRaw(payloads, uint32(callerDon.F+1))
@@ -376,19 +374,12 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			p.lggr.Errorw("failed to unmarshal request", "err", unmarshalErr)
 			return
 		}
-		if err = p.registerExecutor.Ready(); err != nil {
-			p.mu.Unlock()
-			p.lggr.Errorw("register executor not started; cannot register trigger",
-				"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
-			return
-		}
 		p.mu.Unlock()
 
 		capAttrs := metric.WithAttributes(
 			attribute.String("capabilityID", p.capabilityID),
 			attribute.String("callerDonID", strconv.FormatUint(uint64(key.callerDonID), 10)),
 		)
-
 		scheduleErr := p.registerExecutor.ExecuteTask(ctx, func(taskCtx context.Context) {
 			callbackCh, registerErr := cfg.underlying.RegisterTrigger(taskCtx, unmarshaled)
 			taskOutcome := "success"
@@ -575,12 +566,6 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		}
 
 		p.mu.Unlock()
-
-		if err = p.ackExecutor.Ready(); err != nil {
-			p.lggr.Errorw("ack executor not started; cannot forward AckEvent",
-				"triggerEventId", triggerEventID, "triggerID", triggerID)
-			return
-		}
 
 		callerDonID := msg.CallerDonId
 		ackAttrs := metric.WithAttributes(

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -319,23 +319,19 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 
 		req, unmarshalErr := pb.UnmarshalTriggerRegistrationRequest(msg.Payload)
 		if unmarshalErr != nil {
-			registerOutcome = "unmarshal_error"
 			p.lggr.Errorw("failed to unmarshal trigger registration request", "err", unmarshalErr)
 			return
 		}
 		callerDon, ok := cfg.workflowDONs[msg.CallerDonId]
 		if !ok {
-			registerOutcome = "unsupported_don"
 			p.lggr.Errorw("received a message from unsupported workflow DON", "callerDonId", msg.CallerDonId)
 			return
 		}
 		if !cfg.membersCache[msg.CallerDonId][sender] {
-			registerOutcome = "invalid_sender"
 			p.lggr.Errorw("sender not a member of its workflow DON", "callerDonId", msg.CallerDonId, "sender", sender)
 			return
 		}
 		if err = validation.ValidateWorkflowOrExecutionID(req.Metadata.WorkflowID); err != nil {
-			registerOutcome = "invalid_workflow_id"
 			p.lggr.Errorw("received trigger request with invalid workflow ID", "workflowId", SanitizeLogString(req.Metadata.WorkflowID), "err", err)
 			return
 		}
@@ -347,11 +343,9 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		if existing, exists := p.registrations[key]; exists {
 			p.mu.Unlock()
 			if existing.registrationErr != nil {
-				registerOutcome = "skipped_user_error"
 				p.lggr.Debugw("skipping trigger registration; previous attempt failed with user error",
 					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", existing.registrationErr)
 			} else {
-				registerOutcome = "skipped_exists"
 				p.lggr.Debugw("trigger registration already exists", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
 			}
 			return
@@ -362,13 +356,11 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		if !ready {
 			peersReceived := len(p.messageCache.Peers(key))
 			if p.messageCache.WasReady(key) {
-				registerOutcome = "quorum_already_met"
 				p.mu.Unlock()
 				p.lggr.Debugw("quorum already met; ignoring duplicate registration message",
 					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID,
 					"peersReceived", peersReceived, "minRequired", minRequired)
 			} else {
-				registerOutcome = "not_ready"
 				p.mu.Unlock()
 				p.lggr.Debugw("quorum not reached yet",
 					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID,
@@ -378,20 +370,17 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		}
 		aggregated, aggregateErr := aggregation.AggregateModeRaw(payloads, uint32(callerDon.F+1))
 		if aggregateErr != nil {
-			registerOutcome = "aggregate_error"
 			p.mu.Unlock()
 			p.lggr.Errorw("failed to aggregate trigger registrations", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", aggregateErr)
 			return
 		}
 		unmarshaled, unmarshalErr := pb.UnmarshalTriggerRegistrationRequest(aggregated)
 		if unmarshalErr != nil {
-			registerOutcome = "aggregate_unmarshal_error"
 			p.mu.Unlock()
 			p.lggr.Errorw("failed to unmarshal request", "err", unmarshalErr)
 			return
 		}
 		if err := p.registerExecutor.Ready(); err != nil {
-			registerOutcome = "executor_not_started"
 			p.mu.Unlock()
 			p.lggr.Errorw("register executor not started; cannot register trigger",
 				"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
@@ -442,14 +431,12 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			p.messageCache.Delete(key)
 		})
 		if scheduleErr != nil {
-			registerOutcome = "schedule_failed"
 			p.lggr.Errorw("failed to schedule RegisterTrigger task",
 				"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", scheduleErr)
 			return
 		}
 		// Hand off to executor; disable defer recording—goroutine records success/error.
 		recordRegisterDuration = false
-		registerOutcome = "scheduled"
 	case types.MethodUnregisterTrigger:
 		unregisterStart := time.Now()
 		unregisterOutcome := "invalid"
@@ -459,24 +446,20 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 
 		meta := msg.GetTriggerEventMetadata()
 		if meta == nil {
-			unregisterOutcome = "nil_metadata"
 			p.lggr.Errorw("received unregister with nil metadata", "sender", sender)
 			return
 		}
 		if len(meta.WorkflowIds) != 1 || len(meta.TriggerIds) != 1 {
-			unregisterOutcome = "invalid_metadata"
 			p.lggr.Errorw("received unregister with unexpected metadata sizes",
 				"sender", sender, "workflowIdsLen", len(meta.WorkflowIds), "triggerIdsLen", len(meta.TriggerIds))
 			return
 		}
 		callerDon, ok := cfg.workflowDONs[msg.CallerDonId]
 		if !ok {
-			unregisterOutcome = "unsupported_don"
 			p.lggr.Errorw("received unregister from unsupported workflow DON", "callerDonId", msg.CallerDonId)
 			return
 		}
 		if !cfg.membersCache[msg.CallerDonId][sender] {
-			unregisterOutcome = "invalid_sender"
 			p.lggr.Errorw("unregister sender not a member of its workflow DON", "callerDonId", msg.CallerDonId, "sender", sender)
 			return
 		}
@@ -491,7 +474,6 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		reg, exists := p.registrations[key]
 		if !exists {
 			p.mu.Unlock()
-			unregisterOutcome = "not_registered"
 			return
 		}
 		nowMs := time.Now().UnixMilli()
@@ -501,13 +483,11 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		if !ready {
 			peersReceived := len(p.unregisterCache.Peers(key))
 			if p.unregisterCache.WasReady(key) {
-				unregisterOutcome = "quorum_already_met"
 				p.mu.Unlock()
 				p.lggr.Debugw("unregister quorum already met; ignoring duplicate message",
 					"workflowID", key.workflowID, "triggerID", key.triggerID, "sender", sender,
 					"peersReceived", peersReceived, "minRequired", minRequired)
 			} else {
-				unregisterOutcome = "not_ready"
 				p.mu.Unlock()
 				p.lggr.Debugw("unregister quorum not reached yet",
 					"workflowID", key.workflowID, "triggerID", key.triggerID, "sender", sender,
@@ -549,7 +529,6 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 
 		triggerMetadata := msg.GetTriggerEventMetadata()
 		if triggerMetadata == nil {
-			ackOutcome = "nil_metadata"
 			p.lggr.Errorw("received empty trigger event ack metadata", "sender", sender)
 			return
 		}
@@ -560,19 +539,16 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		callerDon, ok := cfg.workflowDONs[msg.CallerDonId]
 		if !ok {
 			p.mu.Unlock()
-			ackOutcome = "unsupported_don"
 			p.lggr.Errorw("received a message from unsupported workflow DON", "callerDonId", msg.CallerDonId)
 			return
 		}
 		if !cfg.membersCache[msg.CallerDonId][sender] {
 			p.mu.Unlock()
-			ackOutcome = "invalid_sender"
 			p.lggr.Errorw("sender not a member of its workflow DON", "callerDonId", msg.CallerDonId, "sender", sender)
 			return
 		}
 		if len(triggerMetadata.TriggerIds) != 1 {
 			p.mu.Unlock()
-			ackOutcome = "invalid_trigger_ids"
 			p.lggr.Errorw("did not receive single triggerID in ACK request", "callerDonId", msg.CallerDonId, "sender", sender, "triggerIDs", triggerMetadata.TriggerIds)
 			return
 		}
@@ -587,14 +563,12 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		if !ready {
 			p.mu.Unlock()
 			if p.ackCache.WasReady(key) {
-				ackOutcome = "quorum_already_met"
 				p.lggr.Debugw("ACK quorum already met; ignoring duplicate message",
 					"triggerEventId", triggerEventID,
 					"triggerID", triggerID,
 					"acksReceived", ackCount,
 					"minRequired", minRequired)
 			} else {
-				ackOutcome = "not_ready"
 				p.lggr.Debugw("ACK quorum not reached yet",
 					"triggerEventId", triggerEventID,
 					"triggerID", triggerID,
@@ -607,7 +581,6 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		p.mu.Unlock()
 
 		if err := p.ackExecutor.Ready(); err != nil {
-			ackOutcome = "executor_not_started"
 			p.lggr.Errorw("ack executor not started; cannot forward AckEvent",
 				"triggerEventId", triggerEventID, "triggerID", triggerID)
 			return
@@ -650,7 +623,6 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			p.metrics.ackEventCounter.Add(taskCtx, 1, ackAttrs, metric.WithAttributes(attribute.String("outcome", "success")))
 		})
 		if scheduleErr != nil {
-			ackOutcome = "schedule_failed"
 			p.lggr.Errorw("failed to schedule AckEvent task",
 				"triggerEventId", triggerEventID, "triggerID", triggerID, "err", scheduleErr)
 			return

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -917,7 +917,7 @@ func (p *triggerPublisher) batchingLoop() {
 
 func (p *triggerPublisher) Close() error {
 	close(p.stopCh)
-	p.wg.Wait()
+
 	if p.ackExecutor != nil {
 		if err := p.ackExecutor.Close(); err != nil {
 			return fmt.Errorf("failed to close ack executor: %w", err)
@@ -928,6 +928,8 @@ func (p *triggerPublisher) Close() error {
 			return fmt.Errorf("failed to close register executor: %w", err)
 		}
 	}
+
+	p.wg.Wait()
 	p.lggr.Info("TriggerPublisher closed")
 	return nil
 }

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -56,12 +56,12 @@ type triggerPublisher struct {
 }
 
 type triggerPublisherMetrics struct {
-	registerTriggerCounter      metric.Int64Counter
-	unregisterTriggerCounter    metric.Int64Counter
-	ackEventCounter             metric.Int64Counter
-	ackExecutorSlotUsage        metric.Float64Gauge
-	ackPreExecuteDurationMs     metric.Int64Histogram
-	ackTaskDurationMs           metric.Int64Histogram
+	registerTriggerCounter   metric.Int64Counter
+	unregisterTriggerCounter metric.Int64Counter
+	ackEventCounter          metric.Int64Counter
+	ackExecutorSlotUsage     metric.Float64Gauge
+	ackPreExecuteDurationMs  metric.Int64Histogram
+	ackTaskDurationMs        metric.Int64Histogram
 }
 
 type dynamicPublisherConfig struct {

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -389,7 +389,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			p.lggr.Errorw("failed to unmarshal request", "err", unmarshalErr)
 			return
 		}
-		if err := p.registerExecutor.Ready(); err != nil {
+		if err = p.registerExecutor.Ready(); err != nil {
 			p.mu.Unlock()
 			p.lggr.Errorw("register executor not started; cannot register trigger",
 				"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
@@ -589,7 +589,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 
 		p.mu.Unlock()
 
-		if err := p.ackExecutor.Ready(); err != nil {
+		if err = p.ackExecutor.Ready(); err != nil {
 			p.lggr.Errorw("ack executor not started; cannot forward AckEvent",
 				"triggerEventId", triggerEventID, "triggerID", triggerID)
 			return

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -117,6 +117,11 @@ const (
 )
 
 func NewTriggerPublisher(capabilityID string, capMethodName string, dispatcher types.Dispatcher, lggr logger.Logger) *triggerPublisher {
+	slotUsageAttrs := []attribute.KeyValue{
+		attribute.String("capabilityID", capabilityID),
+		attribute.String("capMethodName", capMethodName),
+	}
+
 	return &triggerPublisher{
 		capabilityID:    capabilityID,
 		capMethodName:   capMethodName,
@@ -128,6 +133,14 @@ func NewTriggerPublisher(capabilityID string, capMethodName string, dispatcher t
 		batchingQueue:   make(map[[32]byte]*batchedResponse),
 		stopCh:          make(services.StopChan),
 		lggr:            logger.With(logger.Named(lggr, "TriggerPublisher"), "capabilityID", capabilityID, "capMethodName", capMethodName),
+		ackExecutor: NewParallelExecutor(defaultMaxParallelAcks,
+			WithExecutorName("trigger_publisher_ack_executor"),
+			WithSlotUsageMetric(nil, slotUsageAttrs...),
+		),
+		registerExecutor: NewParallelExecutor(defaultMaxParallelRegisters,
+			WithExecutorName("trigger_publisher_register_executor"),
+			WithSlotUsageMetric(nil, slotUsageAttrs...),
+		),
 	}
 }
 
@@ -193,6 +206,8 @@ func (p *triggerPublisher) initMetrics() error {
 	if err != nil {
 		return fmt.Errorf("failed to register platform_trigger_publisher_register_executor_slot_usage: %w", err)
 	}
+	p.ackExecutor.SetSlotUsageGauge(p.metrics.ackExecutorSlotUsage)
+	p.registerExecutor.SetSlotUsageGauge(p.metrics.registerExecutorSlotUsage)
 	durationBuckets := metric.WithExplicitBucketBoundaries(1, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000)
 	p.metrics.registerTriggerDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_register_trigger_duration_ms", durationBuckets)
 	if err != nil {
@@ -207,36 +222,6 @@ func (p *triggerPublisher) initMetrics() error {
 		return fmt.Errorf("failed to register platform_trigger_publisher_ack_event_duration_ms: %w", err)
 	}
 	return nil
-}
-
-func (p *triggerPublisher) recordAckExecutorSlotUsage(ctx context.Context) {
-	if p.ackExecutor == nil || p.metrics.ackExecutorSlotUsage == nil {
-		return
-	}
-	maxSlots := p.ackExecutor.MaxSlots()
-	if maxSlots == 0 {
-		return
-	}
-	usage := float64(p.ackExecutor.OccupiedSlots()) / float64(maxSlots)
-	p.metrics.ackExecutorSlotUsage.Record(ctx, usage, metric.WithAttributes(
-		attribute.String("capabilityID", p.capabilityID),
-		attribute.String("capMethodName", p.capMethodName),
-	))
-}
-
-func (p *triggerPublisher) recordRegisterExecutorSlotUsage(ctx context.Context) {
-	if p.registerExecutor == nil || p.metrics.registerExecutorSlotUsage == nil {
-		return
-	}
-	maxSlots := p.registerExecutor.MaxSlots()
-	if maxSlots == 0 {
-		return
-	}
-	usage := float64(p.registerExecutor.OccupiedSlots()) / float64(maxSlots)
-	p.metrics.registerExecutorSlotUsage.Record(ctx, usage, metric.WithAttributes(
-		attribute.String("capabilityID", p.capabilityID),
-		attribute.String("capMethodName", p.capMethodName),
-	))
 }
 
 func (p *triggerPublisher) recordMethodDuration(ctx context.Context, hist metric.Int64Histogram, outcome string, d time.Duration) {
@@ -280,12 +265,9 @@ func (p *triggerPublisher) Start(ctx context.Context) error {
 	p.wg.Add(1)
 	go p.batchingLoop()
 
-	p.ackExecutor = NewParallelExecutor(defaultMaxParallelAcks)
 	if err := p.ackExecutor.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start ack executor: %w", err)
 	}
-
-	p.registerExecutor = NewParallelExecutor(defaultMaxParallelRegisters)
 	if err := p.registerExecutor.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start register executor: %w", err)
 	}
@@ -408,7 +390,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			p.lggr.Errorw("failed to unmarshal request", "err", unmarshalErr)
 			return
 		}
-		if p.registerExecutor == nil {
+		if err := p.registerExecutor.Ready(); err != nil {
 			registerOutcome = "executor_not_started"
 			p.mu.Unlock()
 			p.lggr.Errorw("register executor not started; cannot register trigger",
@@ -423,7 +405,6 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		)
 
 		scheduleErr := p.registerExecutor.ExecuteTask(ctx, func(taskCtx context.Context) {
-			defer p.recordRegisterExecutorSlotUsage(taskCtx)
 			callbackCh, registerErr := cfg.underlying.RegisterTrigger(taskCtx, unmarshaled)
 			taskOutcome := "success"
 			if registerErr != nil {
@@ -470,7 +451,6 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		}
 		// Hand off to executor; disable defer recording—goroutine records success/error.
 		recordRegisterDuration = false
-		p.recordRegisterExecutorSlotUsage(ctx)
 		registerOutcome = "scheduled"
 	case types.MethodUnregisterTrigger:
 		unregisterStart := time.Now()
@@ -630,7 +610,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 
 		p.mu.Unlock()
 
-		if p.ackExecutor == nil {
+		if err := p.ackExecutor.Ready(); err != nil {
 			ackOutcome = "executor_not_started"
 			p.lggr.Errorw("ack executor not started; cannot forward AckEvent",
 				"triggerEventId", triggerEventID, "triggerID", triggerID)
@@ -649,7 +629,6 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			"minRequired", minRequired)
 
 		scheduleErr := p.ackExecutor.ExecuteTask(ctx, func(taskCtx context.Context) {
-			defer p.recordAckExecutorSlotUsage(taskCtx)
 			p.lggr.Infow("executing AckEvent task",
 				"triggerEventId", triggerEventID,
 				"triggerID", triggerID,
@@ -681,7 +660,6 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			return
 		}
 		recordAckDuration = false
-		p.recordAckExecutorSlotUsage(ctx)
 	default:
 		p.lggr.Errorw("received message with unknown method",
 			"method", SanitizeLogString(msg.Method), "sender", sender)

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -208,7 +208,7 @@ func (p *triggerPublisher) initMetrics() error {
 	}
 	p.ackExecutor.SetSlotUsageGauge(p.metrics.ackExecutorSlotUsage)
 	p.registerExecutor.SetSlotUsageGauge(p.metrics.registerExecutorSlotUsage)
-	durationBuckets := metric.WithExplicitBucketBoundaries(1, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000)
+	durationBuckets := metric.WithExplicitBucketBoundaries(1, 10, 50, 250, 1_000, 5_000)
 	p.metrics.registerTriggerDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_register_trigger_duration_ms", durationBuckets)
 	if err != nil {
 		return fmt.Errorf("failed to register platform_trigger_publisher_register_trigger_duration_ms: %w", err)
@@ -365,16 +365,15 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		if !ready {
 			peersReceived := len(p.messageCache.Peers(key))
 			if p.messageCache.WasReady(key) {
-				p.mu.Unlock()
 				p.lggr.Debugw("quorum already met; ignoring duplicate registration message",
 					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID,
 					"peersReceived", peersReceived, "minRequired", minRequired)
 			} else {
-				p.mu.Unlock()
 				p.lggr.Debugw("quorum not reached yet",
 					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID,
 					"peersReceived", peersReceived, "minRequired", minRequired)
 			}
+			p.mu.Unlock()
 			return
 		}
 		aggregated, aggregateErr := aggregation.AggregateModeRaw(payloads, uint32(callerDon.F+1))

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -40,30 +40,30 @@ type triggerPublisher struct {
 	dispatcher    types.Dispatcher
 	cfg           atomic.Pointer[dynamicPublisherConfig]
 
-	messageCache    *messagecache.MessageCache[registrationKey, p2ptypes.PeerID]
-	registrations   map[registrationKey]*pubRegState
-	unregisterCache *messagecache.MessageCache[registrationKey, p2ptypes.PeerID]
-	ackCache        *messagecache.MessageCache[ackKey, p2ptypes.PeerID]
-	mu              sync.RWMutex // protects messageCache, ackCache, unregisterCache, and registrations
-
-	batchingQueue map[[32]byte]*batchedResponse
-	bqMu          sync.Mutex // protects batchingQueue
-	stopCh        services.StopChan
-	wg            sync.WaitGroup
-	ackExecutor   *ParallelExecutor
-	lggr          logger.Logger
-	metrics       triggerPublisherMetrics
+	messageCache     *messagecache.MessageCache[registrationKey, p2ptypes.PeerID]
+	registrations    map[registrationKey]*pubRegState
+	unregisterCache  *messagecache.MessageCache[registrationKey, p2ptypes.PeerID]
+	ackCache         *messagecache.MessageCache[ackKey, p2ptypes.PeerID]
+	mu               sync.RWMutex // protects messageCache, ackCache, unregisterCache, and registrations
+	batchingQueue    map[[32]byte]*batchedResponse
+	bqMu             sync.Mutex // protects batchingQueue
+	stopCh           services.StopChan
+	wg               sync.WaitGroup
+	ackExecutor      *ParallelExecutor
+	registerExecutor *ParallelExecutor
+	lggr             logger.Logger
+	metrics          triggerPublisherMetrics
 }
 
 type triggerPublisherMetrics struct {
-	registerTriggerCounter          metric.Int64Counter
-	unregisterTriggerCounter        metric.Int64Counter
-	ackEventCounter                 metric.Int64Counter
-	ackExecutorSlotUsage            metric.Float64Gauge
-	ackPreExecuteDurationMs         metric.Int64Histogram
-	ackTaskDurationMs               metric.Int64Histogram
-	registerTriggerReceiveDurationMs metric.Int64Histogram
-	registerTriggerTaskDurationMs    metric.Int64Histogram
+	registerTriggerCounter             metric.Int64Counter
+	unregisterTriggerCounter           metric.Int64Counter
+	ackEventCounter                    metric.Int64Counter
+	ackExecutorSlotUsage               metric.Float64Gauge
+	ackPreExecuteDurationMs            metric.Int64Histogram
+	ackTaskDurationMs                  metric.Int64Histogram
+	registerTriggerReceiveDurationMs   metric.Int64Histogram
+	registerTriggerTaskDurationMs      metric.Int64Histogram
 	unregisterTriggerReceiveDurationMs metric.Int64Histogram
 	unregisterTriggerTaskDurationMs    metric.Int64Histogram
 }
@@ -115,6 +115,7 @@ var _ types.ReceiverService = &triggerPublisher{}
 const (
 	minAllowedBatchCollectionPeriod = 10 * time.Millisecond
 	defaultMaxParallelAcks          = 100 // TODO: pass through config from remoteConfig
+	defaultMaxParallelRegisters     = 100 // TODO: pass through config from remoteConfig
 )
 
 func NewTriggerPublisher(capabilityID string, capMethodName string, dispatcher types.Dispatcher, lggr logger.Logger) *triggerPublisher {
@@ -307,6 +308,11 @@ func (p *triggerPublisher) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to start ack executor: %w", err)
 	}
 
+	p.registerExecutor = NewParallelExecutor(defaultMaxParallelRegisters)
+	if err := p.registerExecutor.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start register executor: %w", err)
+	}
+
 	p.lggr.Info("TriggerPublisher started")
 	return nil
 }
@@ -364,9 +370,9 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		key := registrationKey{msg.CallerDonId, req.Metadata.WorkflowID, req.TriggerID}
 		nowMs := time.Now().UnixMilli()
 		p.mu.Lock()
-		defer p.mu.Unlock()
 		p.messageCache.Insert(key, sender, nowMs, msg.Payload)
 		if existing, exists := p.registrations[key]; exists {
+			p.mu.Unlock()
 			if existing.registrationErr != nil {
 				registerOutcome = "skipped_user_error"
 				p.lggr.Debugw("skipping trigger registration; previous attempt failed with user error",
@@ -379,61 +385,84 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		}
 		// NOTE: require 2F+1 by default, introduce different strategies later (KS-76)
 		minRequired := uint32(2*callerDon.F + 1)
-		ready, payloads := p.messageCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), false)
+		ready, payloads := p.messageCache.Ready(key, minRequired, nowMs-cfg.remoteConfig.RegistrationExpiry.Milliseconds(), true)
 		if !ready {
 			registerOutcome = "not_ready"
+			p.mu.Unlock()
 			p.lggr.Debugw("not ready to aggregate yet", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "minRequired", minRequired)
 			return
 		}
 		aggregated, aggregateErr := aggregation.AggregateModeRaw(payloads, uint32(callerDon.F+1))
 		if aggregateErr != nil {
 			registerOutcome = "aggregate_error"
+			p.mu.Unlock()
 			p.lggr.Errorw("failed to aggregate trigger registrations", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", aggregateErr)
 			return
 		}
 		unmarshaled, unmarshalErr := pb.UnmarshalTriggerRegistrationRequest(aggregated)
 		if unmarshalErr != nil {
 			registerOutcome = "aggregate_unmarshal_error"
+			p.mu.Unlock()
 			p.lggr.Errorw("failed to unmarshal request", "err", unmarshalErr)
 			return
 		}
-		ctx, cancel := p.stopCh.NewCtx()
-		taskStart := time.Now()
-		callbackCh, registerErr := cfg.underlying.RegisterTrigger(ctx, unmarshaled)
-		taskOutcome := "success"
-		if registerErr != nil {
-			taskOutcome = "error"
+		if p.registerExecutor == nil {
+			registerOutcome = "executor_not_started"
+			p.mu.Unlock()
+			p.lggr.Errorw("register executor not started; cannot register trigger",
+				"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
+			return
 		}
-		p.recordReceivePathDuration(p.metrics.registerTriggerTaskDurationMs, ctx, callerDonID, taskOutcome, time.Since(taskStart))
+		p.mu.Unlock()
+
 		capAttrs := metric.WithAttributes(
 			attribute.String("capabilityID", p.capabilityID),
 			attribute.String("callerDonID", strconv.FormatUint(uint64(key.callerDonID), 10)),
 		)
-		if registerErr == nil {
-			registerOutcome = "success"
-			p.metrics.registerTriggerCounter.Add(ctx, 1, capAttrs, metric.WithAttributes(attribute.String("outcome", "success")))
-			p.registrations[key] = &pubRegState{
-				callback: callbackCh,
-				request:  unmarshaled,
-				cancel:   cancel,
+
+		scheduleErr := p.registerExecutor.ExecuteTask(ctx, func(taskCtx context.Context) {
+			taskStart := time.Now()
+			callbackCh, registerErr := cfg.underlying.RegisterTrigger(taskCtx, unmarshaled)
+			taskOutcome := "success"
+			if registerErr != nil {
+				taskOutcome = "error"
 			}
-			p.wg.Add(1)
-			go p.triggerEventLoop(callbackCh, key)
-			p.lggr.Debugw("updated trigger registration", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
-		} else {
-			registerOutcome = "error"
-			p.metrics.registerTriggerCounter.Add(ctx, 1, capAttrs, metric.WithAttributes(attribute.String("outcome", "error")))
-			cancel()
+			p.recordReceivePathDuration(p.metrics.registerTriggerTaskDurationMs, taskCtx, callerDonID, taskOutcome, time.Since(taskStart))
+
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			if registerErr == nil {
+				_, cancel := p.stopCh.NewCtx()
+				p.metrics.registerTriggerCounter.Add(taskCtx, 1, capAttrs, metric.WithAttributes(attribute.String("outcome", "success")))
+				p.registrations[key] = &pubRegState{
+					callback: callbackCh,
+					request:  unmarshaled,
+					cancel:   cancel,
+				}
+				p.wg.Add(1)
+				go p.triggerEventLoop(callbackCh, key)
+				p.lggr.Debugw("updated trigger registration", "workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID)
+				return
+			}
+
+			p.metrics.registerTriggerCounter.Add(taskCtx, 1, capAttrs, metric.WithAttributes(attribute.String("outcome", "error")))
 			var capErr caperrors.Error
 			if errors.As(registerErr, &capErr) && capErr.Origin() == caperrors.OriginUser {
 				p.registrations[key] = &pubRegState{registrationErr: registerErr}
 				p.lggr.Errorw("trigger registration failed with user error; will not retry",
 					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", registerErr)
-			} else {
-				p.lggr.Errorw("trigger registration failed with system error; will retry",
-					"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", registerErr)
+				return
 			}
+			p.lggr.Errorw("trigger registration failed with system error; will retry",
+				"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", registerErr)
+		})
+		if scheduleErr != nil {
+			registerOutcome = "schedule_failed"
+			p.lggr.Errorw("failed to schedule RegisterTrigger task",
+				"workflowId", req.Metadata.WorkflowID, "triggerID", req.TriggerID, "err", scheduleErr)
+			return
 		}
+		registerOutcome = "scheduled"
 	case types.MethodUnregisterTrigger:
 		unregisterStart := time.Now()
 		callerDonID := msg.CallerDonId
@@ -929,6 +958,11 @@ func (p *triggerPublisher) Close() error {
 	if p.ackExecutor != nil {
 		if err := p.ackExecutor.Close(); err != nil {
 			return fmt.Errorf("failed to close ack executor: %w", err)
+		}
+	}
+	if p.registerExecutor != nil {
+		if err := p.registerExecutor.Close(); err != nil {
+			return fmt.Errorf("failed to close register executor: %w", err)
 		}
 	}
 	p.lggr.Info("TriggerPublisher closed")

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -59,8 +59,6 @@ type triggerPublisherMetrics struct {
 	registerTriggerCounter      metric.Int64Counter
 	unregisterTriggerCounter    metric.Int64Counter
 	ackEventCounter             metric.Int64Counter
-	ackExecutorSlotUsage        metric.Float64Gauge
-	registerExecutorSlotUsage   metric.Float64Gauge
 	registerTriggerDurationMs   metric.Int64Histogram
 	unregisterTriggerDurationMs metric.Int64Histogram
 	ackEventDurationMs          metric.Int64Histogram
@@ -134,12 +132,12 @@ func NewTriggerPublisher(capabilityID string, capMethodName string, dispatcher t
 		stopCh:          make(services.StopChan),
 		lggr:            logger.With(logger.Named(lggr, "TriggerPublisher"), "capabilityID", capabilityID, "capMethodName", capMethodName),
 		ackExecutor: NewParallelExecutor(defaultMaxParallelAcks,
-			WithExecutorName("trigger_publisher_ack_executor"),
-			WithSlotUsageMetric(nil, slotUsageAttrs...),
+			"trigger_publisher_ack_executor",
+			slotUsageAttrs...,
 		),
 		registerExecutor: NewParallelExecutor(defaultMaxParallelRegisters,
-			WithExecutorName("trigger_publisher_register_executor"),
-			WithSlotUsageMetric(nil, slotUsageAttrs...),
+			"trigger_publisher_register_executor",
+			slotUsageAttrs...,
 		),
 	}
 }
@@ -198,17 +196,7 @@ func (p *triggerPublisher) initMetrics() error {
 	if err != nil {
 		return fmt.Errorf("failed to register platform_trigger_publisher_ack_event_total: %w", err)
 	}
-	p.metrics.ackExecutorSlotUsage, err = beholder.GetMeter().Float64Gauge("platform_trigger_publisher_ack_executor_slot_usage")
-	if err != nil {
-		return fmt.Errorf("failed to register platform_trigger_publisher_ack_executor_slot_usage: %w", err)
-	}
-	p.metrics.registerExecutorSlotUsage, err = beholder.GetMeter().Float64Gauge("platform_trigger_publisher_register_executor_slot_usage")
-	if err != nil {
-		return fmt.Errorf("failed to register platform_trigger_publisher_register_executor_slot_usage: %w", err)
-	}
-	p.ackExecutor.SetSlotUsageGauge(p.metrics.ackExecutorSlotUsage)
-	p.registerExecutor.SetSlotUsageGauge(p.metrics.registerExecutorSlotUsage)
-	durationBuckets := metric.WithExplicitBucketBoundaries(1, 10, 50, 250, 1_000, 5_000)
+	durationBuckets := metric.WithExplicitBucketBoundaries(1, 50, 250, 1_000, 5_000, 30_000)
 	p.metrics.registerTriggerDurationMs, err = beholder.GetMeter().Int64Histogram("platform_trigger_publisher_register_trigger_duration_ms", durationBuckets)
 	if err != nil {
 		return fmt.Errorf("failed to register platform_trigger_publisher_register_trigger_duration_ms: %w", err)

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -110,8 +110,8 @@ var _ types.ReceiverService = &triggerPublisher{}
 
 const (
 	minAllowedBatchCollectionPeriod = 10 * time.Millisecond
-	defaultMaxParallelAcks          = 100
-	defaultMaxParallelRegisters     = 100
+	defaultMaxParallelAcks          = 100 // TODO: make this configurable https://smartcontract-it.atlassian.net/browse/PLEX-3266
+	defaultMaxParallelRegisters     = 100 // TODO: make this configurable https://smartcontract-it.atlassian.net/browse/PLEX-3266
 )
 
 func NewTriggerPublisher(capabilityID string, capMethodName string, dispatcher types.Dispatcher, lggr logger.Logger) *triggerPublisher {
@@ -545,23 +545,17 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		nowMs := time.Now().UnixMilli()
 		p.ackCache.Insert(key, sender, nowMs, msg.Payload)
 		minRequired := uint32(2*callerDon.F + 1)
-		ready, _ := p.ackCache.Ready(key, minRequired, 0, true)
+		// false is set to <once> to return ready even after quorum
+		// to add redundancy in case AckEvent fails below.
+		ready, _ := p.ackCache.Ready(key, minRequired, 0, false)
 		ackCount := len(p.ackCache.Peers(key))
 		if !ready {
 			p.mu.Unlock()
-			if p.ackCache.WasReady(key) {
-				p.lggr.Debugw("ACK quorum already met; ignoring duplicate message",
-					"triggerEventId", triggerEventID,
-					"triggerID", triggerID,
-					"acksReceived", ackCount,
-					"minRequired", minRequired)
-			} else {
-				p.lggr.Debugw("ACK quorum not reached yet",
-					"triggerEventId", triggerEventID,
-					"triggerID", triggerID,
-					"acksReceived", ackCount,
-					"minRequired", minRequired)
-			}
+			p.lggr.Debugw("ACK quorum not reached yet",
+				"triggerEventId", triggerEventID,
+				"triggerID", triggerID,
+				"acksReceived", ackCount,
+				"minRequired", minRequired)
 			return
 		}
 

--- a/core/capabilities/remote/trigger_publisher_test.go
+++ b/core/capabilities/remote/trigger_publisher_test.go
@@ -1244,11 +1244,21 @@ func TestTriggerPublisher_RegisterTrigger_FailureShortCircuit(t *testing.T) {
 		publisher.Receive(ctx, regMsg)
 		require.Eventually(t, func() bool { return underlying.callCount == 1 }, 2*time.Second, 10*time.Millisecond)
 
-		// publisher.Receive(ctx, regMsg)
-		// require.Eventually(t, func() bool { return underlying.callCount == 2 }, 2*time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool {
+			if underlying.callCount >= 2 {
+				return true
+			}
+			publisher.Receive(ctx, regMsg)
+			return underlying.callCount >= 2
+		}, 2*time.Second, 10*time.Millisecond)
 
-		// publisher.Receive(ctx, regMsg)
-		// require.Eventually(t, func() bool { return underlying.callCount == 3 }, 2*time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool {
+			if underlying.callCount >= 3 {
+				return true
+			}
+			publisher.Receive(ctx, regMsg)
+			return underlying.callCount >= 3
+		}, 2*time.Second, 10*time.Millisecond)
 
 		require.NoError(t, publisher.Close())
 	})

--- a/core/capabilities/remote/trigger_publisher_test.go
+++ b/core/capabilities/remote/trigger_publisher_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -125,7 +126,7 @@ func TestTriggerPublisher_ReceiveTriggerEventAcks(t *testing.T) {
 	regEvent := newAckEventMessage(t, eventID, triggerID, workflowDONID, peers[1])
 	publisher.Receive(ctx, regEvent)
 
-	require.True(t, underlyingTriggerCap.eventAckd)
+	require.Eventually(t, func() bool { return underlyingTriggerCap.ackCount.Load() == 1 }, 2*time.Second, 10*time.Millisecond)
 	require.NoError(t, publisher.Close())
 }
 
@@ -331,6 +332,8 @@ type testTrigger struct {
 	registrationsCh chan commoncap.TriggerRegistrationRequest
 	eventCh         chan commoncap.TriggerResponse
 	eventAckd       bool
+	ackCount        atomic.Int32
+	ackBlock        chan struct{}
 }
 
 func (tr *testTrigger) Info(_ context.Context) (commoncap.CapabilityInfo, error) {
@@ -348,7 +351,92 @@ func (tr *testTrigger) UnregisterTrigger(_ context.Context, request commoncap.Tr
 
 func (tr *testTrigger) AckEvent(_ context.Context, triggerID string, eventID string, method string) error {
 	tr.eventAckd = true
+	tr.ackCount.Add(1)
+	if tr.ackBlock != nil {
+		<-tr.ackBlock
+	}
 	return nil
+}
+
+func TestTriggerPublisher_AckEvent_DoesNotBlockReceive(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	capabilityDONID, workflowDONID := uint32(1), uint32(2)
+	underlying, publisher, _, peers := newServices(t, capabilityDONID, workflowDONID, 1, time.Second)
+	underlying.ackBlock = make(chan struct{})
+
+	eventID := "evt-block-test"
+	triggerID := "trigA"
+	publisher.Receive(ctx, newAckEventMessage(t, eventID, triggerID, workflowDONID, peers[1]))
+
+	regDone := make(chan struct{})
+	go func() {
+		publisher.Receive(ctx, newRegisterTriggerMessage(t, workflowDONID, peers[1]))
+		close(regDone)
+	}()
+
+	select {
+	case <-regDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("RegisterTrigger Receive blocked while AckEvent in flight")
+	}
+
+	close(underlying.ackBlock)
+	require.Eventually(t, func() bool { return underlying.ackCount.Load() == 1 }, 2*time.Second, 10*time.Millisecond)
+	require.NoError(t, publisher.Close())
+}
+
+func TestTriggerPublisher_AckEvent_RedundantAfterQuorum(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	lggr := logger.Test(t)
+	capabilityDONID, workflowDONID := uint32(1), uint32(2)
+
+	capInfo := commoncap.CapabilityInfo{
+		ID:             capID,
+		CapabilityType: commoncap.CapabilityTypeTrigger,
+		Description:    "Remote Trigger",
+	}
+	peers := make([]p2ptypes.PeerID, 4)
+	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
+	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
+	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
+	require.NoError(t, peers[3].UnmarshalText([]byte("12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw")))
+
+	capDonInfo := commoncap.DON{ID: capabilityDONID, Members: []p2ptypes.PeerID{peers[0]}, F: 0}
+	workflowDonInfo := commoncap.DON{ID: workflowDONID, Members: peers, F: 1}
+	workflowDONs := map[uint32]commoncap.DON{workflowDONID: workflowDonInfo}
+
+	underlying := &testTrigger{
+		info:            capInfo,
+		registrationsCh: make(chan commoncap.TriggerRegistrationRequest, 1),
+		eventCh:         make(chan commoncap.TriggerResponse, 1),
+	}
+	dispatcher := mocks.NewDispatcher(t)
+	allowRegistrationChecks(dispatcher)
+	config := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Millisecond,
+		RegistrationExpiry:      100 * time.Second,
+		MinResponsesToAggregate: 1,
+		MessageExpiry:           100 * time.Second,
+		MaxBatchSize:            1,
+		BatchCollectionPeriod:   time.Second,
+	}
+	publisher := remote.NewTriggerPublisher(capInfo.ID, "", dispatcher, lggr)
+	require.NoError(t, publisher.SetConfig(config, underlying, capDonInfo, workflowDONs))
+	require.NoError(t, publisher.Start(ctx))
+
+	eventID := "evt-redundant"
+	triggerID := "trigA"
+	for _, peer := range peers {
+		publisher.Receive(ctx, newAckEventMessage(t, eventID, triggerID, workflowDONID, peer))
+	}
+
+	// F=1 needs 3 ACKs; 4th peer ACK re-fires Ready(once=false) for implicit retry.
+	require.Eventually(t, func() bool { return underlying.ackCount.Load() == 2 }, 2*time.Second, 10*time.Millisecond)
+	require.NoError(t, publisher.Close())
 }
 
 func TestTriggerPublisher_MultipleTriggersSameWorkflow(t *testing.T) {
@@ -1080,6 +1168,8 @@ func TestTriggerPublisher_SecondDeliveryAfterFullAck_ReachesAllPeers(t *testing.
 
 	publisher.Receive(ctx, newAckEventMessage(t, eventID, "triggerA", workflowDONID, peers[0]))
 	publisher.Receive(ctx, newAckEventMessage(t, eventID, "triggerA", workflowDONID, peers[1]))
+
+	time.Sleep(100 * time.Millisecond)
 
 	underlying.SendEvent("triggerA", commoncap.TriggerResponse{
 		Event: commoncap.TriggerEvent{ID: eventID},

--- a/core/capabilities/remote/trigger_publisher_test.go
+++ b/core/capabilities/remote/trigger_publisher_test.go
@@ -340,6 +340,20 @@ func (tr *testTrigger) Info(_ context.Context) (commoncap.CapabilityInfo, error)
 	return tr.info, nil
 }
 
+// waitForRegistration blocks until async RegisterTrigger delivers to the underlying mock.
+func waitForRegistration(t *testing.T, ch <-chan commoncap.TriggerRegistrationRequest) commoncap.TriggerRegistrationRequest {
+	t.Helper()
+	require.Eventually(t, func() bool { return len(ch) > 0 }, 2*time.Second, 10*time.Millisecond)
+	return <-ch
+}
+
+// waitForUnregister blocks until UnregisterTrigger runs on the underlying mock.
+func waitForUnregister(t *testing.T, ch <-chan string) string {
+	t.Helper()
+	require.Eventually(t, func() bool { return len(ch) > 0 }, 2*time.Second, 10*time.Millisecond)
+	return <-ch
+}
+
 func (tr *testTrigger) RegisterTrigger(_ context.Context, request commoncap.TriggerRegistrationRequest) (<-chan commoncap.TriggerResponse, error) {
 	tr.registrationsCh <- request
 	return tr.eventCh, nil
@@ -438,14 +452,14 @@ func TestTriggerPublisher_MultipleTriggersSameWorkflow(t *testing.T) {
 	// Register trigger1
 	regEvent1 := newRegisterTriggerMessageWithTriggerID(t, workflowDONID, peers[1], "trigger1")
 	publisher.Receive(ctx, regEvent1)
-	reg1 := <-underlying.registrationsCh
+	reg1 := waitForRegistration(t, underlying.registrationsCh)
 	require.Equal(t, "trigger1", reg1.TriggerID)
 	require.Equal(t, workflowID1, reg1.Metadata.WorkflowID)
 
 	// Register trigger2 for the same workflow
 	regEvent2 := newRegisterTriggerMessageWithTriggerID(t, workflowDONID, peers[1], "trigger2")
 	publisher.Receive(ctx, regEvent2)
-	reg2 := <-underlying.registrationsCh
+	reg2 := waitForRegistration(t, underlying.registrationsCh)
 	require.Equal(t, "trigger2", reg2.TriggerID)
 	require.Equal(t, workflowID1, reg2.Metadata.WorkflowID) // same workflowID
 
@@ -538,7 +552,7 @@ func TestTriggerPublisher_ExplicitUnregister(t *testing.T) {
 	regEvent := newRegisterTriggerMessageWithTriggerID(t, workflowDONID, peers[1], "triggerA")
 	publisher.Receive(ctx, regEvent)
 
-	<-underlying.registrationsCh
+	waitForRegistration(t, underlying.registrationsCh)
 
 	// Send unregister
 	unregMsg := &remotetypes.MessageBody{
@@ -553,7 +567,7 @@ func TestTriggerPublisher_ExplicitUnregister(t *testing.T) {
 		},
 	}
 	publisher.Receive(ctx, unregMsg)
-	require.Equal(t, "triggerA", <-underlying.unregisterCalled)
+	require.Equal(t, "triggerA", waitForUnregister(t, underlying.unregisterCalled))
 	require.NoError(t, publisher.Close())
 }
 
@@ -616,7 +630,7 @@ func TestTriggerPublisher_SendsRegistrationChecks(t *testing.T) {
 
 	regEvent := newRegisterTriggerMessageWithTriggerID(t, workflowDONID, peers[1], "triggerA")
 	publisher.Receive(ctx, regEvent)
-	<-underlying.registrationsCh
+	waitForRegistration(t, underlying.registrationsCh)
 
 	select {
 	case msg := <-checkReceived:
@@ -685,7 +699,7 @@ func TestTriggerPublisher_RegistrationChecksChunkByMaxBatchSize(t *testing.T) {
 
 	for i := range nRegs {
 		publisher.Receive(ctx, newRegisterTriggerMessageWithTriggerID(t, workflowDONID, peers[1], fmt.Sprintf("trigger_%d", i)))
-		<-underlying.registrationsCh
+		waitForRegistration(t, underlying.registrationsCh)
 	}
 
 	// 250 registrations at MaxBatchSize=100 → chunk lengths 100, 100, 50 per tick per peer.
@@ -763,7 +777,7 @@ func TestTriggerPublisher_UnregisterValidatesSenderMembership(t *testing.T) {
 	// Register a trigger from the valid workflow DON member
 	regEvent := newRegisterTriggerMessageWithTriggerID(t, workflowDONID, peers[1], "triggerA")
 	publisher.Receive(ctx, regEvent)
-	<-underlying.registrationsCh
+	waitForRegistration(t, underlying.registrationsCh)
 
 	// Send unregister from a peer NOT in the workflow DON — should be ignored
 	unregMsg := &remotetypes.MessageBody{
@@ -790,7 +804,7 @@ func TestTriggerPublisher_UnregisterValidatesSenderMembership(t *testing.T) {
 	// Now send from the valid member — should succeed
 	unregMsg.Sender = peers[1][:]
 	publisher.Receive(ctx, unregMsg)
-	require.Equal(t, "triggerA", <-underlying.unregisterCalled)
+	require.Equal(t, "triggerA", waitForUnregister(t, underlying.unregisterCalled))
 
 	require.NoError(t, publisher.Close())
 }
@@ -849,7 +863,7 @@ func TestTriggerPublisher_UnregisterRequiresQuorum(t *testing.T) {
 	for _, p := range []p2ptypes.PeerID{peers[1], peers[2], peers[3]} {
 		publisher.Receive(ctx, newRegisterTriggerMessageWithTriggerID(t, workflowDONID, p, "triggerA"))
 	}
-	require.Equal(t, "triggerA", (<-underlying.registrationsCh).TriggerID)
+	require.Equal(t, "triggerA", waitForRegistration(t, underlying.registrationsCh).TriggerID)
 
 	unregMeta := &remotetypes.MessageBody_TriggerEventMetadata{
 		TriggerEventMetadata: &remotetypes.TriggerEventMetadata{
@@ -875,7 +889,7 @@ func TestTriggerPublisher_UnregisterRequiresQuorum(t *testing.T) {
 	}
 
 	recvUnreg(peers[3])
-	require.Equal(t, "triggerA", <-underlying.unregisterCalled)
+	require.Equal(t, "triggerA", waitForUnregister(t, underlying.unregisterCalled))
 
 	require.NoError(t, publisher.Close())
 }
@@ -1004,7 +1018,7 @@ func TestTriggerPublisher_AckCacheCleanup(t *testing.T) {
 
 	regEvent := newRegisterTriggerMessageWithTriggerID(t, workflowDONID, peers[0], "triggerA")
 	publisher.Receive(ctx, regEvent)
-	<-underlying.registrationsCh
+	waitForRegistration(t, underlying.registrationsCh)
 
 	ackMsg := newAckEventMessage(t, "event1", "triggerA", workflowDONID, peers[0])
 	publisher.Receive(ctx, ackMsg)
@@ -1097,7 +1111,7 @@ func TestTriggerPublisher_SecondDeliveryAfterFullAck_ReachesAllPeers(t *testing.
 
 	regEvent := newRegisterTriggerMessageWithTriggerID(t, workflowDONID, peers[0], "triggerA")
 	publisher.Receive(ctx, regEvent)
-	<-underlying.registrationsCh
+	waitForRegistration(t, underlying.registrationsCh)
 
 	eventID := "shared-event-second-delivery-regression"
 	underlying.SendEvent("triggerA", commoncap.TriggerResponse{
@@ -1187,11 +1201,11 @@ func TestTriggerPublisher_RegisterTrigger_FailureShortCircuit(t *testing.T) {
 
 		regMsg := newRegisterTriggerMessage(t, workflowDONID, peers[1])
 		publisher.Receive(ctx, regMsg)
-		require.Eventually(t, func() bool { return underlying.callCount == 1 }, 2*time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool { return underlying.callCount.Load() == 1 }, 2*time.Second, 10*time.Millisecond)
 
 		publisher.Receive(ctx, regMsg)
 		publisher.Receive(ctx, regMsg)
-		require.Eventually(t, func() bool { return underlying.callCount == 1 }, 2*time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool { return underlying.callCount.Load() == 1 }, 2*time.Second, 10*time.Millisecond)
 
 		require.NoError(t, publisher.Close())
 	})
@@ -1242,22 +1256,22 @@ func TestTriggerPublisher_RegisterTrigger_FailureShortCircuit(t *testing.T) {
 
 		regMsg := newRegisterTriggerMessage(t, workflowDONID, peers[1])
 		publisher.Receive(ctx, regMsg)
-		require.Eventually(t, func() bool { return underlying.callCount == 1 }, 2*time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool { return underlying.callCount.Load() == 1 }, 2*time.Second, 10*time.Millisecond)
 
 		require.Eventually(t, func() bool {
-			if underlying.callCount >= 2 {
+			if underlying.callCount.Load() >= 2 {
 				return true
 			}
 			publisher.Receive(ctx, regMsg)
-			return underlying.callCount >= 2
+			return underlying.callCount.Load() >= 2
 		}, 2*time.Second, 10*time.Millisecond)
 
 		require.Eventually(t, func() bool {
-			if underlying.callCount >= 3 {
+			if underlying.callCount.Load() >= 3 {
 				return true
 			}
 			publisher.Receive(ctx, regMsg)
-			return underlying.callCount >= 3
+			return underlying.callCount.Load() >= 3
 		}, 2*time.Second, 10*time.Millisecond)
 
 		require.NoError(t, publisher.Close())
@@ -1268,7 +1282,7 @@ func TestTriggerPublisher_RegisterTrigger_FailureShortCircuit(t *testing.T) {
 type errTrigger struct {
 	info      commoncap.CapabilityInfo
 	err       error
-	callCount int
+	callCount atomic.Int32
 }
 
 func (tr *errTrigger) Info(_ context.Context) (commoncap.CapabilityInfo, error) {
@@ -1276,7 +1290,7 @@ func (tr *errTrigger) Info(_ context.Context) (commoncap.CapabilityInfo, error) 
 }
 
 func (tr *errTrigger) RegisterTrigger(_ context.Context, _ commoncap.TriggerRegistrationRequest) (<-chan commoncap.TriggerResponse, error) {
-	tr.callCount++
+	tr.callCount.Add(1)
 	return nil, tr.err
 }
 

--- a/core/capabilities/remote/trigger_publisher_test.go
+++ b/core/capabilities/remote/trigger_publisher_test.go
@@ -387,58 +387,6 @@ func TestTriggerPublisher_AckEvent_DoesNotBlockReceive(t *testing.T) {
 	require.NoError(t, publisher.Close())
 }
 
-func TestTriggerPublisher_AckEvent_RedundantAfterQuorum(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-	lggr := logger.Test(t)
-	capabilityDONID, workflowDONID := uint32(1), uint32(2)
-
-	capInfo := commoncap.CapabilityInfo{
-		ID:             capID,
-		CapabilityType: commoncap.CapabilityTypeTrigger,
-		Description:    "Remote Trigger",
-	}
-	peers := make([]p2ptypes.PeerID, 4)
-	require.NoError(t, peers[0].UnmarshalText([]byte(peerID1)))
-	require.NoError(t, peers[1].UnmarshalText([]byte(peerID2)))
-	require.NoError(t, peers[2].UnmarshalText([]byte(peerID3)))
-	require.NoError(t, peers[3].UnmarshalText([]byte("12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw")))
-
-	capDonInfo := commoncap.DON{ID: capabilityDONID, Members: []p2ptypes.PeerID{peers[0]}, F: 0}
-	workflowDonInfo := commoncap.DON{ID: workflowDONID, Members: peers, F: 1}
-	workflowDONs := map[uint32]commoncap.DON{workflowDONID: workflowDonInfo}
-
-	underlying := &testTrigger{
-		info:            capInfo,
-		registrationsCh: make(chan commoncap.TriggerRegistrationRequest, 1),
-		eventCh:         make(chan commoncap.TriggerResponse, 1),
-	}
-	dispatcher := mocks.NewDispatcher(t)
-	allowRegistrationChecks(dispatcher)
-	config := &commoncap.RemoteTriggerConfig{
-		RegistrationRefresh:     100 * time.Millisecond,
-		RegistrationExpiry:      100 * time.Second,
-		MinResponsesToAggregate: 1,
-		MessageExpiry:           100 * time.Second,
-		MaxBatchSize:            1,
-		BatchCollectionPeriod:   time.Second,
-	}
-	publisher := remote.NewTriggerPublisher(capInfo.ID, "", dispatcher, lggr)
-	require.NoError(t, publisher.SetConfig(config, underlying, capDonInfo, workflowDONs))
-	require.NoError(t, publisher.Start(ctx))
-
-	eventID := "evt-redundant"
-	triggerID := "trigA"
-	for _, peer := range peers {
-		publisher.Receive(ctx, newAckEventMessage(t, eventID, triggerID, workflowDONID, peer))
-	}
-
-	// F=1 needs 3 ACKs; 4th peer ACK re-fires Ready(once=false) for implicit retry.
-	require.Eventually(t, func() bool { return underlying.ackCount.Load() == 2 }, 2*time.Second, 10*time.Millisecond)
-	require.NoError(t, publisher.Close())
-}
-
 func TestTriggerPublisher_MultipleTriggersSameWorkflow(t *testing.T) {
 	t.Parallel()
 

--- a/core/capabilities/remote/trigger_publisher_test.go
+++ b/core/capabilities/remote/trigger_publisher_test.go
@@ -41,7 +41,7 @@ func TestTriggerPublisher_Register(t *testing.T) {
 	// valid registration
 	regEvent = newRegisterTriggerMessage(t, workflowDONID, peers[1])
 	publisher.Receive(ctx, regEvent)
-	require.NotEmpty(t, underlyingTriggerCap.registrationsCh)
+	require.Eventually(t, func() bool { return len(underlyingTriggerCap.registrationsCh) > 0 }, 2*time.Second, 10*time.Millisecond)
 	forwarded := <-underlyingTriggerCap.registrationsCh
 	require.Equal(t, workflowID1, forwarded.Metadata.WorkflowID)
 
@@ -57,7 +57,7 @@ func TestTriggerPublisher_ReceiveTriggerEvents_NoBatching(t *testing.T) {
 	underlyingTriggerCap, publisher, dispatcher, peers := newServices(t, capabilityDONID, workflowDONID, 1, time.Second)
 	regEvent := newRegisterTriggerMessage(t, workflowDONID, peers[1])
 	publisher.Receive(ctx, regEvent)
-	require.NotEmpty(t, underlyingTriggerCap.registrationsCh)
+	require.Eventually(t, func() bool { return len(underlyingTriggerCap.registrationsCh) > 0 }, 2*time.Second, 10*time.Millisecond)
 
 	// send a trigger event and expect that it gets delivered right away
 	awaitOutgoingMessageCh := make(chan struct{})
@@ -80,7 +80,7 @@ func TestTriggerPublisher_ReceiveTriggerEvents_BatchingEnabled(t *testing.T) {
 		underlyingTriggerCap, publisher, dispatcher, peers := newServices(t, capabilityDONID, workflowDONID, 2, batchPeriod)
 		regEvent := newRegisterTriggerMessage(t, workflowDONID, peers[1])
 		publisher.Receive(ctx, regEvent)
-		require.NotEmpty(t, underlyingTriggerCap.registrationsCh)
+		require.Eventually(t, func() bool { return len(underlyingTriggerCap.registrationsCh) > 0 }, 2*time.Second, 10*time.Millisecond)
 
 		awaitOutgoingMessageCh := make(chan struct{}, 1)
 
@@ -1187,11 +1187,11 @@ func TestTriggerPublisher_RegisterTrigger_FailureShortCircuit(t *testing.T) {
 
 		regMsg := newRegisterTriggerMessage(t, workflowDONID, peers[1])
 		publisher.Receive(ctx, regMsg)
-		require.Equal(t, 1, underlying.callCount, "RegisterTrigger should be called once on first quorum")
+		require.Eventually(t, func() bool { return underlying.callCount == 1 }, 2*time.Second, 10*time.Millisecond)
 
 		publisher.Receive(ctx, regMsg)
 		publisher.Receive(ctx, regMsg)
-		require.Equal(t, 1, underlying.callCount, "RegisterTrigger must not be retried after a user error")
+		require.Eventually(t, func() bool { return underlying.callCount == 1 }, 2*time.Second, 10*time.Millisecond)
 
 		require.NoError(t, publisher.Close())
 	})
@@ -1242,13 +1242,13 @@ func TestTriggerPublisher_RegisterTrigger_FailureShortCircuit(t *testing.T) {
 
 		regMsg := newRegisterTriggerMessage(t, workflowDONID, peers[1])
 		publisher.Receive(ctx, regMsg)
-		require.Equal(t, 1, underlying.callCount, "RegisterTrigger should be called once on first quorum")
+		require.Eventually(t, func() bool { return underlying.callCount == 1 }, 2*time.Second, 10*time.Millisecond)
 
-		publisher.Receive(ctx, regMsg)
-		require.Equal(t, 2, underlying.callCount, "RegisterTrigger should be retried after a system error")
+		// publisher.Receive(ctx, regMsg)
+		// require.Eventually(t, func() bool { return underlying.callCount == 2 }, 2*time.Second, 10*time.Millisecond)
 
-		publisher.Receive(ctx, regMsg)
-		require.Equal(t, 3, underlying.callCount, "RegisterTrigger should keep retrying on system errors")
+		// publisher.Receive(ctx, regMsg)
+		// require.Eventually(t, func() bool { return underlying.callCount == 3 }, 2*time.Second, 10*time.Millisecond)
 
 		require.NoError(t, publisher.Close())
 	})

--- a/core/capabilities/remote/trigger_publisher_test.go
+++ b/core/capabilities/remote/trigger_publisher_test.go
@@ -1118,8 +1118,6 @@ func TestTriggerPublisher_SecondDeliveryAfterFullAck_ReachesAllPeers(t *testing.
 	publisher.Receive(ctx, newAckEventMessage(t, eventID, "triggerA", workflowDONID, peers[0]))
 	publisher.Receive(ctx, newAckEventMessage(t, eventID, "triggerA", workflowDONID, peers[1]))
 
-	time.Sleep(100 * time.Millisecond)
-
 	underlying.SendEvent("triggerA", commoncap.TriggerResponse{
 		Event: commoncap.TriggerEvent{ID: eventID},
 	})

--- a/core/capabilities/remote/trigger_publisher_test.go
+++ b/core/capabilities/remote/trigger_publisher_test.go
@@ -370,9 +370,10 @@ func TestTriggerPublisher_AckEvent_DoesNotBlockReceive(t *testing.T) {
 	triggerID := "trigA"
 	publisher.Receive(ctx, newAckEventMessage(t, eventID, triggerID, workflowDONID, peers[1]))
 
+	regMsg := newRegisterTriggerMessage(t, workflowDONID, peers[1])
 	regDone := make(chan struct{})
 	go func() {
-		publisher.Receive(ctx, newRegisterTriggerMessage(t, workflowDONID, peers[1]))
+		publisher.Receive(ctx, regMsg)
 		close(regDone)
 	}()
 

--- a/core/services/workflows/monitoring/monitoring.go
+++ b/core/services/workflows/monitoring/monitoring.go
@@ -51,6 +51,10 @@ type EngineMetrics struct {
 	workflowExecutionFailedCounter    metric.Int64Counter
 	workflowExecutionStartedCounter   metric.Int64Counter
 	workflowExecutionSucceededCounter metric.Int64Counter
+	// workflowExecutionFinishedCounter counts every terminal execution outcome
+	// (completed, error, timeout). Use with a status attribute so a single series
+	// family can serve as both numerator and denominator without vector(0) joins.
+	workflowExecutionFinishedCounter metric.Int64Counter
 
 	getSecretsDuration metric.Int64Histogram
 
@@ -184,6 +188,14 @@ func InitMonitoringResources() (em *EngineMetrics, err error) {
 	em.workflowExecutionSucceededCounter, err = beholder.GetMeter().Int64Counter("platform_engine_workflow_execution_succeeded_count")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register workflow execution succeeded counter: %w", err)
+	}
+
+	em.workflowExecutionFinishedCounter, err = beholder.GetMeter().Int64Counter(
+		"platform_engine_workflow_execution_finished_count",
+		metric.WithDescription("Count of workflow executions that reached a terminal status (completed, error, or timeout)"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register workflow execution finished counter: %w", err)
 	}
 
 	// Deprecated: use the gauge below
@@ -667,6 +679,13 @@ func (c WorkflowsMetricLabeler) IncrementWorkflowExecutionSucceededCounter(ctx c
 func (c WorkflowsMetricLabeler) IncrementWorkflowExecutionStartedCounter(ctx context.Context) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
 	c.em.workflowExecutionStartedCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
+}
+
+// IncrementWorkflowExecutionFinishedCounter increments the terminal-outcome counter.
+// status should be one of "completed", "errored", or "timeout".
+func (c WorkflowsMetricLabeler) IncrementWorkflowExecutionFinishedCounter(ctx context.Context, status string) {
+	otelLabels := append(beholder.OtelAttributes(c.Labels).AsStringAttributes(), attribute.String("status", status))
+	c.em.workflowExecutionFinishedCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
 }
 
 func (c WorkflowsMetricLabeler) IncrementExecutionTimestampAssignedCounter(ctx context.Context) {

--- a/core/services/workflows/monitoring/monitoring.go
+++ b/core/services/workflows/monitoring/monitoring.go
@@ -51,10 +51,6 @@ type EngineMetrics struct {
 	workflowExecutionFailedCounter    metric.Int64Counter
 	workflowExecutionStartedCounter   metric.Int64Counter
 	workflowExecutionSucceededCounter metric.Int64Counter
-	// workflowExecutionFinishedCounter counts every terminal execution outcome
-	// (completed, error, timeout). Use with a status attribute so a single series
-	// family can serve as both numerator and denominator without vector(0) joins.
-	workflowExecutionFinishedCounter metric.Int64Counter
 
 	getSecretsDuration metric.Int64Histogram
 
@@ -188,14 +184,6 @@ func InitMonitoringResources() (em *EngineMetrics, err error) {
 	em.workflowExecutionSucceededCounter, err = beholder.GetMeter().Int64Counter("platform_engine_workflow_execution_succeeded_count")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register workflow execution succeeded counter: %w", err)
-	}
-
-	em.workflowExecutionFinishedCounter, err = beholder.GetMeter().Int64Counter(
-		"platform_engine_workflow_execution_finished_count",
-		metric.WithDescription("Count of workflow executions that reached a terminal status (completed, error, or timeout)"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to register workflow execution finished counter: %w", err)
 	}
 
 	// Deprecated: use the gauge below
@@ -679,13 +667,6 @@ func (c WorkflowsMetricLabeler) IncrementWorkflowExecutionSucceededCounter(ctx c
 func (c WorkflowsMetricLabeler) IncrementWorkflowExecutionStartedCounter(ctx context.Context) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
 	c.em.workflowExecutionStartedCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
-}
-
-// IncrementWorkflowExecutionFinishedCounter increments the terminal-outcome counter.
-// status should be one of "completed", "errored", or "timeout".
-func (c WorkflowsMetricLabeler) IncrementWorkflowExecutionFinishedCounter(ctx context.Context, status string) {
-	otelLabels := append(beholder.OtelAttributes(c.Labels).AsStringAttributes(), attribute.String("status", status))
-	c.em.workflowExecutionFinishedCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
 }
 
 func (c WorkflowsMetricLabeler) IncrementExecutionTimestampAssignedCounter(ctx context.Context) {

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -1016,7 +1016,6 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		} else {
 			e.metrics.UpdateWorkflowErrorDurationHistogram(ctx, int64(executionDuration.Seconds()))
 		}
-		e.metrics.IncrementWorkflowExecutionFinishedCounter(ctx, executionStatus)
 		executionLogger.Errorw("Workflow execution failed with module execution error", "status", executionStatus, "durationMs", executionDuration.Milliseconds(), "err", execErr)
 		return
 	}
@@ -1030,7 +1029,6 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		execErr = errors.New(result.GetError())
 		e.metrics.UpdateWorkflowErrorDurationHistogram(ctx, int64(executionDuration.Seconds()))
 		e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String()).IncrementWorkflowExecutionFailedCounter(ctx)
-		e.metrics.IncrementWorkflowExecutionFinishedCounter(ctx, executionStatus)
 		executionLogger.Errorw("Workflow execution failed", "status", executionStatus, "durationMs", executionDuration.Milliseconds(), "error", result.GetError())
 		return
 	}
@@ -1039,7 +1037,6 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	executionLogger.Infow("Workflow execution finished successfully", "durationMs", executionDuration.Milliseconds())
 	e.metrics.UpdateWorkflowCompletedDurationHistogram(ctx, int64(executionDuration.Seconds()))
 	e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String()).IncrementWorkflowExecutionSucceededCounter(ctx)
-	e.metrics.IncrementWorkflowExecutionFinishedCounter(ctx, executionStatus)
 	e.cfg.Hooks.OnResultReceived(result)
 }
 

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -1016,6 +1016,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		} else {
 			e.metrics.UpdateWorkflowErrorDurationHistogram(ctx, int64(executionDuration.Seconds()))
 		}
+		e.metrics.IncrementWorkflowExecutionFinishedCounter(ctx, executionStatus)
 		executionLogger.Errorw("Workflow execution failed with module execution error", "status", executionStatus, "durationMs", executionDuration.Milliseconds(), "err", execErr)
 		return
 	}
@@ -1029,6 +1030,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		execErr = errors.New(result.GetError())
 		e.metrics.UpdateWorkflowErrorDurationHistogram(ctx, int64(executionDuration.Seconds()))
 		e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String()).IncrementWorkflowExecutionFailedCounter(ctx)
+		e.metrics.IncrementWorkflowExecutionFinishedCounter(ctx, executionStatus)
 		executionLogger.Errorw("Workflow execution failed", "status", executionStatus, "durationMs", executionDuration.Milliseconds(), "error", result.GetError())
 		return
 	}
@@ -1037,6 +1039,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	executionLogger.Infow("Workflow execution finished successfully", "durationMs", executionDuration.Milliseconds())
 	e.metrics.UpdateWorkflowCompletedDurationHistogram(ctx, int64(executionDuration.Seconds()))
 	e.metrics.With("workflowID", e.cfg.WorkflowID, "workflowName", e.cfg.WorkflowName.String()).IncrementWorkflowExecutionSucceededCounter(ctx)
+	e.metrics.IncrementWorkflowExecutionFinishedCounter(ctx, executionStatus)
 	e.cfg.Hooks.OnResultReceived(result)
 }
 


### PR DESCRIPTION
**Ticket**: https://smartcontract-it.atlassian.net/browse/PLEX-3250

**Reason**:
A surge in dropped messages (saturated channel usage) of trigger_publisher Receiver was caused by invalid registrations incorrectly being classified as system errors (instead of user errors) and continuously taking time in a synchronous process. The correct classification itself would probably solve the entire issue, but during investigation, we realised making the process async is also important.
There is a ticket for correctly classifying the errors as well. https://smartcontract-it.atlassian.net/browse/PLEX-3248


We make multiple optimisations in this PR:

- We set `p.ackCache.Ready` and `p.messageCache.Ready` to return true only once (on the 2F+1 call). It returns false for the subsequent F calls, saving us unnecessary DB operations.
  - Because we do that, we are adding a `WasReady()` method to the message cache to distinguish between `not ready due to lack of quorum` and `not ready due to replied with ready already`
- We make RegisterTrigger and AckEvent code paths **async**
   - Both do DB operations underneath which are slow and block channel consumption
- Specifically, the surge in dropped messages (saturated channel usage) was caused by invalid registrations incorrectly being classified as system errors (instead of user errors) and continuously taking time in a synchronous process. The correct classification itself would probably solve the entire issue, but while we were at it, we solved for the future.
- We added duration metrics and slot usage metrics for future monitoring as well.

No more channel usage more than 0.1 (https://grafana.ops.prod.cldev.sh/goto/dfronhjb4pgjkf?orgId=default)

New metrics added: https://grafana.ops.prod.cldev.sh/goto/bfrlrqnah4934e?orgId=default