### PR TITLE
update confidential workflows gitref

### DIFF
--- a/core/services/gateway/handlers/confidentialrelay/bundler.go
+++ b/core/services/gateway/handlers/confidentialrelay/bundler.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 
 	relaytypes "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialrelay"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
@@ -11,6 +13,14 @@ import (
 )
 
 var errUnknownMethod = errors.New("unknown relay method")
+
+// maxLoggedNodeErrors caps how many distinct node error samples we surface in
+// structured logs.
+const maxLoggedNodeErrors = 5
+
+// maxNodeErrorMessageLen is the max length of node error messages; longer
+// messages are truncated.
+const maxNodeErrorMessageLen = 200
 
 // bundler assembles the gateway's response to the enclave. The gateway is a dumb
 // fan-in: it forwards every per-node signed response it collected, in one bundle,
@@ -27,22 +37,95 @@ var errUnknownMethod = errors.New("unknown relay method")
 // and could commit to a forged response, starving the enclave of the real one.
 type bundler struct{}
 
+// BundleSummary is the fan-in accounting for one Bundle call. Signed is the only
+// count that can contribute to enclave quorum; the rest is diagnostic.
+type BundleSummary struct {
+	response    *jsonrpc.Response[json.RawMessage]
+	signed      int
+	errorCount  int
+	undecodable int
+	total       int
+	nodeErrors  map[string]string
+}
+
+func (s *BundleSummary) Response() *jsonrpc.Response[json.RawMessage] { return s.response }
+func (s *BundleSummary) Signed() int                                  { return s.signed }
+func (s *BundleSummary) Error() int                                   { return s.errorCount }
+func (s *BundleSummary) Undecodable() int                             { return s.undecodable }
+func (s *BundleSummary) Total() int                                   { return s.total }
+
+// NodeErrorsFormatted returns a stable, compact sample of node error messages
+// for structured logs.
+func (s *BundleSummary) NodeErrorsFormatted() string {
+	if s == nil || len(s.nodeErrors) == 0 {
+		return ""
+	}
+	addrs := make([]string, 0, len(s.nodeErrors))
+	for addr := range s.nodeErrors {
+		addrs = append(addrs, addr)
+	}
+	sort.Strings(addrs)
+	parts := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		parts = append(parts, addr+"="+s.nodeErrors[addr])
+	}
+	return strings.Join(parts, "; ")
+}
+
+func (s *BundleSummary) addError(nodeAddr string, wireErr *jsonrpc.WireError) {
+	s.errorCount++
+	if s.nodeErrors == nil {
+		s.nodeErrors = make(map[string]string)
+	}
+	if len(s.nodeErrors) >= maxLoggedNodeErrors {
+		return
+	}
+	if _, exists := s.nodeErrors[nodeAddr]; exists {
+		return
+	}
+	msg := "nil result"
+	if wireErr != nil {
+		msg = sanitizeNodeErrorMessage(wireErr.Message)
+		if msg == "" {
+			msg = fmt.Sprintf("jsonrpc error code %d", wireErr.Code)
+		}
+	}
+	s.nodeErrors[nodeAddr] = msg
+}
+
+func (s *BundleSummary) addUndecodable() { s.undecodable++ }
+
+func (s *BundleSummary) setSignedResponse(resp *jsonrpc.Response[json.RawMessage], signed int) {
+	s.response = resp
+	s.signed = signed
+}
+
+func newBundleSummary(total int) *BundleSummary {
+	return &BundleSummary{
+		total:      total,
+		nodeErrors: make(map[string]string),
+	}
+}
+
 // Bundle builds the SignedXResponseBundle envelope from the per-node responses
 // collected so far. Transport-level JSON-RPC errors, nil results, and responses
 // that do not decode as a signed relay response are skipped (they carry no usable
 // signature). Order is not significant: the enclave groups the bundle by response
-// hash and verifies each signature independently. Returns the encoded bundle
-// response and the count of signed responses it contains.
-func (b *bundler) Bundle(req jsonrpc.Request[json.RawMessage], resps map[string]jsonrpc.Response[json.RawMessage], l logger.Logger) (*jsonrpc.Response[json.RawMessage], int, error) {
+// hash and verifies each signature independently.
+func (b *bundler) Bundle(req jsonrpc.Request[json.RawMessage], resps map[string]jsonrpc.Response[json.RawMessage], l logger.Logger) (*BundleSummary, error) {
+	summary := newBundleSummary(len(resps))
+
 	switch req.Method {
 	case relaytypes.MethodSecretsGet:
 		out := make([]relaytypes.SignedSecretsResponseResult, 0, len(resps))
 		for nodeAddr, r := range resps {
 			if r.Error != nil || r.Result == nil {
+				summary.addError(nodeAddr, r.Error)
 				continue
 			}
 			var signed relaytypes.SignedSecretsResponseResult
 			if err := json.Unmarshal(*r.Result, &signed); err != nil {
+				summary.addUndecodable()
 				l.Warnw("skipping undecodable secrets response from node", "nodeAddr", nodeAddr, "error", err)
 				continue
 			}
@@ -50,17 +133,20 @@ func (b *bundler) Bundle(req jsonrpc.Request[json.RawMessage], resps map[string]
 		}
 		encoded, err := json.Marshal(relaytypes.SignedSecretsResponseBundle{Responses: out})
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to encode secrets response bundle: %w", err)
+			return nil, fmt.Errorf("failed to encode secrets response bundle: %w", err)
 		}
-		return wrapBundle(req, encoded), len(out), nil
+		summary.setSignedResponse(wrapBundle(req, encoded), len(out))
+		return summary, nil
 	case relaytypes.MethodCapabilityExec:
 		out := make([]relaytypes.SignedCapabilityResponseResult, 0, len(resps))
 		for nodeAddr, r := range resps {
 			if r.Error != nil || r.Result == nil {
+				summary.addError(nodeAddr, r.Error)
 				continue
 			}
 			var signed relaytypes.SignedCapabilityResponseResult
 			if err := json.Unmarshal(*r.Result, &signed); err != nil {
+				summary.addUndecodable()
 				l.Warnw("skipping undecodable capability response from node", "nodeAddr", nodeAddr, "error", err)
 				continue
 			}
@@ -68,11 +154,12 @@ func (b *bundler) Bundle(req jsonrpc.Request[json.RawMessage], resps map[string]
 		}
 		encoded, err := json.Marshal(relaytypes.SignedCapabilityResponseBundle{Responses: out})
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to encode capability response bundle: %w", err)
+			return nil, fmt.Errorf("failed to encode capability response bundle: %w", err)
 		}
-		return wrapBundle(req, encoded), len(out), nil
+		summary.setSignedResponse(wrapBundle(req, encoded), len(out))
+		return summary, nil
 	default:
-		return nil, 0, fmt.Errorf("%w: %q", errUnknownMethod, req.Method)
+		return nil, fmt.Errorf("%w: %q", errUnknownMethod, req.Method)
 	}
 }
 
@@ -83,4 +170,12 @@ func wrapBundle(req jsonrpc.Request[json.RawMessage], encoded json.RawMessage) *
 		Method:  req.Method,
 		Result:  &encoded,
 	}
+}
+
+func sanitizeNodeErrorMessage(msg string) string {
+	msg = strings.TrimSpace(msg)
+	if len(msg) <= maxNodeErrorMessageLen {
+		return msg
+	}
+	return msg[:maxNodeErrorMessageLen-1] + ".."
 }

--- a/core/services/gateway/handlers/confidentialrelay/bundler_test.go
+++ b/core/services/gateway/handlers/confidentialrelay/bundler_test.go
@@ -2,6 +2,7 @@ package confidentialrelay
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -102,10 +103,12 @@ func TestBundler_capabilityExec_forwardsAllResponses(t *testing.T) {
 		"n2": capExecSignedResponse(t, "req-1", resultB, []byte("signer-1")),
 	}
 
-	out, count, err := b.Bundle(req, resps, lggr)
+	summary, err := b.Bundle(req, resps, lggr)
 	require.NoError(t, err)
-	require.Equal(t, 3, count)
-	bundle := decodeCapabilityBundle(t, out)
+	require.Equal(t, 3, summary.Signed())
+	require.Equal(t, 3, summary.Total())
+	require.Equal(t, 0, summary.Error())
+	bundle := decodeCapabilityBundle(t, summary.Response())
 	require.Len(t, bundle.Responses, 3, "every collected response is forwarded; order is not significant")
 }
 
@@ -122,10 +125,10 @@ func TestBundler_capabilityExec_singleResponseIsOneEntry(t *testing.T) {
 		"n0": capExecSignedResponse(t, "req-solo", relaytypes.CapabilityResponseResult{Payload: "x"}, []byte("signer-0")),
 	}
 
-	out, count, err := b.Bundle(req, resps, lggr)
+	summary, err := b.Bundle(req, resps, lggr)
 	require.NoError(t, err)
-	require.Equal(t, 1, count)
-	bundle := decodeCapabilityBundle(t, out)
+	require.Equal(t, 1, summary.Signed())
+	bundle := decodeCapabilityBundle(t, summary.Response())
 	require.Len(t, bundle.Responses, 1)
 }
 
@@ -158,10 +161,14 @@ func TestBundler_skipsTransportErrorsAndUndecodable(t *testing.T) {
 		"n3": capExecSignedResponse(t, "req-err", result, []byte("signer-3")),
 	}
 
-	out, count, err := b.Bundle(req, resps, lggr)
+	summary, err := b.Bundle(req, resps, lggr)
 	require.NoError(t, err)
-	require.Equal(t, 2, count, "transport errors and undecodable results are dropped from the bundle")
-	bundle := decodeCapabilityBundle(t, out)
+	require.Equal(t, 2, summary.Signed(), "transport errors and undecodable results are dropped from the bundle")
+	require.Equal(t, 1, summary.Error())
+	require.Equal(t, 1, summary.Undecodable())
+	require.Equal(t, 4, summary.Total())
+	require.Contains(t, summary.NodeErrorsFormatted(), "n0=node failure")
+	bundle := decodeCapabilityBundle(t, summary.Response())
 	require.Len(t, bundle.Responses, 2)
 }
 
@@ -171,10 +178,11 @@ func TestBundler_emptyResponses(t *testing.T) {
 	b := &bundler{}
 
 	req := capExecRequest(t, "req-empty", validCapParams("wf-1"))
-	out, count, err := b.Bundle(req, map[string]jsonrpc.Response[json.RawMessage]{}, lggr)
+	summary, err := b.Bundle(req, map[string]jsonrpc.Response[json.RawMessage]{}, lggr)
 	require.NoError(t, err)
-	require.Equal(t, 0, count)
-	bundle := decodeCapabilityBundle(t, out)
+	require.Equal(t, 0, summary.Signed())
+	require.Equal(t, 0, summary.Total())
+	bundle := decodeCapabilityBundle(t, summary.Response())
 	require.Empty(t, bundle.Responses)
 }
 
@@ -225,12 +233,12 @@ func TestBundler_secretsGet_forwardsAllResponses(t *testing.T) {
 		"n2": signed([]byte("signer-2")),
 	}
 
-	out, count, err := b.Bundle(req, resps, lggr)
+	summary, err := b.Bundle(req, resps, lggr)
 	require.NoError(t, err)
-	require.Equal(t, 3, count)
+	require.Equal(t, 3, summary.Signed())
 
 	var bundle relaytypes.SignedSecretsResponseBundle
-	require.NoError(t, json.Unmarshal(*out.Result, &bundle))
+	require.NoError(t, json.Unmarshal(*summary.Response().Result, &bundle))
 	require.Len(t, bundle.Responses, 3)
 	require.Equal(t, result, bundle.Responses[0].Result)
 }
@@ -245,7 +253,24 @@ func TestBundler_unknownMethod(t *testing.T) {
 		ID:      "req-x",
 		Method:  "confidential.unknown",
 	}
-	out, _, err := b.Bundle(req, map[string]jsonrpc.Response[json.RawMessage]{}, lggr)
-	require.Nil(t, out)
+	summary, err := b.Bundle(req, map[string]jsonrpc.Response[json.RawMessage]{}, lggr)
+	require.Nil(t, summary)
 	require.ErrorIs(t, err, errUnknownMethod)
+}
+
+func TestSanitizeNodeErrorMessage_Truncates(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("a", maxNodeErrorMessageLen+50)
+	got := sanitizeNodeErrorMessage(long)
+	require.Equal(t, maxNodeErrorMessageLen-1+len(".."), len(got))
+	require.True(t, strings.HasSuffix(got, ".."))
+}
+
+func TestBundleSummary_NodeErrorsFormatted_StableOrder(t *testing.T) {
+	t.Parallel()
+	s := &BundleSummary{nodeErrors: map[string]string{
+		"0x0002": "b",
+		"0x0001": "a",
+	}}
+	require.Equal(t, "0x0001=a; 0x0002=b", s.NodeErrorsFormatted())
 }

--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -341,41 +341,81 @@ func (h *handler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Response[
 
 	copiedResponses := ar.copiedResponses()
 	// The gateway is a dumb fan-in: it does not verify signatures, check signer
-	// membership, or decide quorum. It forwards the bundle of collected signed
-	// responses to the enclave, which is the sole trust anchor.
+	// membership, or decide enclave quorum. It forwards collected signed responses
+	// to the enclave, which is the sole trust anchor.
 	//
-	// Forwarding is driven by signed response count only. JSON-RPC errors and
-	// undecodable replies cannot contribute to enclave quorum, so counting them
-	// toward 2F+1 would let a burst of fast failures (e.g. execution-handler-not-
-	// found on lagging nodes) close the request with a signed bundle below F+1.
-	// Under the <=F-faulty threat model, 2F+1 signed replies guarantee at least
-	// F+1 honest signed results are present for the enclave. A node that already
-	// returned an error will not replace it; waiting only helps for nodes that
-	// have not yet replied. If 2F+1 signed never arrive, the cleanup timer
-	// forwards what was collected only when it still carries at least F+1 signed
-	// responses, the minimum the enclave needs.
+	// Completion rules:
+	//   1. signed >= 2F+1: forward early (under <=F faulty, F+1 honest are guaranteed).
+	//   2. remaining == 0 && signed >= F+1: all members replied with enough signed
+	//      responses; forward the partial bundle without waiting for cleanup.
+	//   3. remaining == 0 && signed < F+1, or signed+remaining < F+1: more waiting
+	//      cannot produce enclave quorum, so fail immediately (do not forward a
+	//      doomed bundle or sleep until the cleanup timer).
+	// JSON-RPC errors and undecodable replies cannot contribute to enclave quorum.
+	// A node that already returned an error will not replace it.
 	summary, err := h.bundler.Bundle(ar.req, copiedResponses, l)
 	if err != nil {
 		l.Errorw("failed to build relay response bundle", "error", err)
 		return h.sendResponseAndCleanup(ctx, ar, h.constructErrorResponse(ar.req, api.FatalError, err))
 	}
-	requiredSigned := 2*h.donConfig.F + 1
+	earlyNeed := 2*h.donConfig.F + 1
+	minQuorum := h.donConfig.F + 1
 	nodes := len(h.donConfig.Members)
-	if summary.Signed() < requiredSigned {
-		l.Debugw("waiting for more signed relay responses before forwarding bundle",
+	remaining := nodes - summary.Total()
+	maxPossibleSigned := summary.Signed() + remaining
+	if summary.Signed() >= earlyNeed {
+		// minSigned=0: signed count already meets 2F+1.
+		return h.forwardBundle(ctx, l, ar, summary, 0)
+	}
+	if remaining == 0 && summary.Signed() >= minQuorum {
+		// Every node has replied; no more signed successes can arrive. Forward the
+		// partial signed bundle so the enclave can attempt F+1 quorum without waiting
+		// for the cleanup timer (which races the enclave's gateway HTTP timeout).
+		l.Infow("all nodes responded; forwarding partial signed bundle",
 			"signed", summary.Signed(),
-			"need", requiredSigned,
+			"minQuorum", minQuorum,
+			"earlyNeed", earlyNeed,
 			"collected", summary.Total(),
 			"nodes", nodes,
-			"remaining", nodes-summary.Total(),
 			"errors", summary.Error(),
 			"undecodable", summary.Undecodable(),
 			"nodeErrors", summary.NodeErrorsFormatted(),
 		)
-		return nil
+		return h.forwardBundle(ctx, l, ar, summary, 0)
 	}
-	// minSigned=0: signed count already meets 2F+1.
-	return h.forwardBundle(ctx, l, ar, summary, 0)
+	if maxPossibleSigned < minQuorum {
+		// Even if every outstanding node returns a signed success, enclave quorum is
+		// impossible. Fail now rather than waiting for silence/timeout or forwarding
+		// a doomed bundle.
+		l.Warnw("relay quorum unreachable; returning error without waiting",
+			"signed", summary.Signed(),
+			"minQuorum", minQuorum,
+			"earlyNeed", earlyNeed,
+			"collected", summary.Total(),
+			"nodes", nodes,
+			"remaining", remaining,
+			"maxPossibleSigned", maxPossibleSigned,
+			"errors", summary.Error(),
+			"undecodable", summary.Undecodable(),
+			"nodeErrors", summary.NodeErrorsFormatted(),
+		)
+		return h.sendResponseAndCleanup(ctx, ar, h.constructErrorResponse(ar.req, api.FatalError,
+			fmt.Errorf("relay quorum unreachable: %d signed responses, at most %d possible, need %d (collected=%d nodes=%d remaining=%d errors=%d undecodable=%d)",
+				summary.Signed(), maxPossibleSigned, minQuorum, summary.Total(), nodes, remaining, summary.Error(), summary.Undecodable())))
+	}
+	l.Debugw("waiting for more signed relay responses before forwarding bundle",
+		"signed", summary.Signed(),
+		"earlyNeed", earlyNeed,
+		"minQuorum", minQuorum,
+		"collected", summary.Total(),
+		"nodes", nodes,
+		"remaining", remaining,
+		"maxPossibleSigned", maxPossibleSigned,
+		"errors", summary.Error(),
+		"undecodable", summary.Undecodable(),
+		"nodeErrors", summary.NodeErrorsFormatted(),
+	)
+	return nil
 }
 
 // forwardBundle sends a previously-built bundle to the enclave. The gateway makes

--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -246,9 +246,15 @@ func (h *handler) removeExpiredRequests(ctx context.Context) {
 		// guaranteed to reject, so forwardBundle returns a timeout error instead of
 		// a futile round trip. The gateway still verifies nothing: this is only a
 		// count floor, not a trust decision.
-		h.lggr.Debugw("request expired, forwarding collected responses to enclave", "requestID", er.req.ID, "responseCount", len(responses))
-		if err := h.bundleAndForward(ctx, h.lggr, er, responses, h.donConfig.F+1); err != nil {
-			h.lggr.Errorw("error forwarding bundle on expiry", "requestID", er.req.ID, "error", err)
+		l := logger.With(h.lggr, "method", er.req.Method, "requestID", er.req.ID)
+		l.Debugw("request expired, forwarding collected responses to enclave",
+			"collected", len(responses),
+			"nodes", len(h.donConfig.Members),
+			"remaining", len(h.donConfig.Members)-len(responses),
+			"minSigned", h.donConfig.F+1,
+		)
+		if err := h.bundleAndForward(ctx, l, er, responses, h.donConfig.F+1); err != nil {
+			l.Errorw("error forwarding bundle on expiry", "error", err)
 		}
 	}
 }
@@ -353,11 +359,14 @@ func (h *handler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Response[
 		return h.sendResponseAndCleanup(ctx, ar, h.constructErrorResponse(ar.req, api.FatalError, err))
 	}
 	requiredSigned := 2*h.donConfig.F + 1
+	nodes := len(h.donConfig.Members)
 	if summary.Signed() < requiredSigned {
 		l.Debugw("waiting for more signed relay responses before forwarding bundle",
 			"signed", summary.Signed(),
 			"need", requiredSigned,
-			"total", summary.Total(),
+			"collected", summary.Total(),
+			"nodes", nodes,
+			"remaining", nodes-summary.Total(),
 			"errors", summary.Error(),
 			"undecodable", summary.Undecodable(),
 			"nodeErrors", summary.NodeErrorsFormatted(),
@@ -380,28 +389,36 @@ func (h *handler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Response[
 // minSigned=0 because its signed-count trigger already implies enough signed
 // responses; the gateway inspects no cryptographic signatures in either case.
 func (h *handler) forwardBundle(ctx context.Context, l logger.Logger, ar *activeRequest, summary *BundleSummary, minSigned int) error {
+	nodes := len(h.donConfig.Members)
 	if summary.Signed() < minSigned {
 		l.Warnw("too few signed responses for enclave quorum; returning timeout",
 			"signed", summary.Signed(),
 			"need", minSigned,
-			"total", summary.Total(),
+			"earlyNeed", 2*h.donConfig.F+1,
+			"collected", summary.Total(),
+			"nodes", nodes,
+			"remaining", nodes-summary.Total(),
 			"errors", summary.Error(),
 			"undecodable", summary.Undecodable(),
 			"nodeErrors", summary.NodeErrorsFormatted(),
 		)
 		return h.sendResponseAndCleanup(ctx, ar, h.constructErrorResponse(ar.req, api.RequestTimeoutError,
-			fmt.Errorf("request expired: %d signed relay responses, need at least %d to reach quorum (total=%d errors=%d undecodable=%d)",
-				summary.Signed(), minSigned, summary.Total(), summary.Error(), summary.Undecodable())))
+			fmt.Errorf("request expired: %d signed relay responses, need at least %d to reach quorum (collected=%d nodes=%d errors=%d undecodable=%d)",
+				summary.Signed(), minSigned, summary.Total(), nodes, summary.Error(), summary.Undecodable())))
 	}
 
 	rawResponse, err := jsonrpc.EncodeResponse(summary.Response())
 	if err != nil {
-		h.lggr.Errorw("failed to encode response", "requestID", ar.req.ID, "error", err)
+		l.Errorw("failed to encode response", "error", err)
 		return h.sendResponseAndCleanup(ctx, ar, h.constructErrorResponse(ar.req, api.NodeReponseEncodingError, err))
 	}
 	l.Infow("forwarding relay response bundle to enclave",
 		"signedResponses", summary.Signed(),
-		"totalResponses", summary.Total(),
+		"minSigned", minSigned,
+		"earlyNeed", 2*h.donConfig.F+1,
+		"collected", summary.Total(),
+		"nodes", nodes,
+		"remaining", nodes-summary.Total(),
 		"errorResponses", summary.Error(),
 		"undecodableResponses", summary.Undecodable(),
 		"nodeErrors", summary.NodeErrorsFormatted(),

--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -70,6 +70,7 @@ type activeRequest struct {
 	req       jsonrpc.Request[json.RawMessage]
 	responses map[string]*jsonrpc.Response[json.RawMessage]
 	mu        sync.Mutex
+	completed atomic.Bool
 
 	createdAt time.Time
 	gwhandlers.Callback
@@ -470,12 +471,17 @@ func (h *handler) fanOutToNodes(ctx context.Context, l logger.Logger, ar *active
 	return nil
 }
 
-// sendResponseAndCleanup sends payload.
-// The request is always removed from activeRequests
-// regardless of whether the send succeeds, since a failed callback cannot
-// be retried.
+// sendResponseAndCleanup claims the request, sends payload, and removes it from
+// activeRequests. Concurrent completion paths (node-message forward,
+// terminal-state forward, expiry) may all race here; only the first claimer
+// sends. Metrics are recorded only after a successful send so losers do not
+// double-count.
 func (h *handler) sendResponseAndCleanup(ctx context.Context, ar *activeRequest, payload gwhandlers.UserCallbackPayload) error {
-	h.recordMetrics(ctx, payload.ErrorCode)
+	if !ar.completed.CompareAndSwap(false, true) {
+		// Another path already answered this request.
+		return nil
+	}
+
 	sendErr := ar.SendResponse(payload)
 
 	h.mu.Lock()
@@ -487,6 +493,7 @@ func (h *handler) sendResponseAndCleanup(ctx context.Context, ar *activeRequest,
 		return sendErr
 	}
 
+	h.recordMetrics(ctx, payload.ErrorCode)
 	h.lggr.Debugw("response sent to user", "requestID", ar.req.ID, "errorCode", payload.ErrorCode)
 	return nil
 }

--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -334,20 +334,38 @@ func (h *handler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Response[
 
 	copiedResponses := ar.copiedResponses()
 	// The gateway is a dumb fan-in: it does not verify signatures, check signer
-	// membership, or decide quorum. It forwards the bundle of all collected
-	// responses to the enclave, which is the sole trust anchor. We wait for 2F+1
-	// responses so that, under the <=F-faulty threat model, at least F+1 honest
-	// matching responses are guaranteed to be in the bundle for the enclave to
-	// reach its F+1-valid-signature quorum. Once 2F+1 have arrived we forward
-	// immediately (minSigned=0: the count is already guaranteed sufficient). If
-	// 2F+1 never arrive, the cleanup timer forwards what was collected only when it
-	// still carries at least F+1 signed responses, the minimum the enclave needs.
-	requiredResponses := 2*h.donConfig.F + 1
-	if len(copiedResponses) < requiredResponses {
-		l.Debugw("waiting for more relay responses before forwarding bundle", "have", len(copiedResponses), "need", requiredResponses)
+	// membership, or decide quorum. It forwards the bundle of collected signed
+	// responses to the enclave, which is the sole trust anchor.
+	//
+	// Forwarding is driven by signed response count only. JSON-RPC errors and
+	// undecodable replies cannot contribute to enclave quorum, so counting them
+	// toward 2F+1 would let a burst of fast failures (e.g. execution-handler-not-
+	// found on lagging nodes) close the request with a signed bundle below F+1.
+	// Under the <=F-faulty threat model, 2F+1 signed replies guarantee at least
+	// F+1 honest signed results are present for the enclave. A node that already
+	// returned an error will not replace it; waiting only helps for nodes that
+	// have not yet replied. If 2F+1 signed never arrive, the cleanup timer
+	// forwards what was collected only when it still carries at least F+1 signed
+	// responses, the minimum the enclave needs.
+	summary, err := h.bundler.Bundle(ar.req, copiedResponses, l)
+	if err != nil {
+		l.Errorw("failed to build relay response bundle", "error", err)
+		return h.sendResponseAndCleanup(ctx, ar, h.constructErrorResponse(ar.req, api.FatalError, err))
+	}
+	requiredSigned := 2*h.donConfig.F + 1
+	if summary.Signed() < requiredSigned {
+		l.Debugw("waiting for more signed relay responses before forwarding bundle",
+			"signed", summary.Signed(),
+			"need", requiredSigned,
+			"total", summary.Total(),
+			"errors", summary.Error(),
+			"undecodable", summary.Undecodable(),
+			"nodeErrors", summary.NodeErrorsFormatted(),
+		)
 		return nil
 	}
-	return h.bundleAndForward(ctx, l, ar, copiedResponses, 0)
+	// minSigned=0: signed count already meets 2F+1.
+	return h.forwardBundle(ctx, l, ar, summary, 0)
 }
 
 // forwardBundle sends a previously-built bundle to the enclave. The gateway makes
@@ -358,8 +376,8 @@ func (h *handler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Response[
 // F+1 signed responses cannot possibly be accepted. On the timeout path we pass
 // minSigned=F+1 to skip that guaranteed-reject round trip and return a timeout
 // error instead. (F+1 signed is necessary, not sufficient: some signatures may be
-// invalid, so the timeout path stays optimistic.) The 2F+1 path passes
-// minSigned=0 because its raw-count trigger already implies enough signed
+// invalid, so the timeout path stays optimistic.) The 2F+1 signed path passes
+// minSigned=0 because its signed-count trigger already implies enough signed
 // responses; the gateway inspects no cryptographic signatures in either case.
 func (h *handler) forwardBundle(ctx context.Context, l logger.Logger, ar *activeRequest, summary *BundleSummary, minSigned int) error {
 	if summary.Signed() < minSigned {

--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -110,7 +110,7 @@ func (ar *activeRequest) copiedResponses() map[string]jsonrpc.Response[json.RawM
 }
 
 type relayBundler interface {
-	Bundle(req jsonrpc.Request[json.RawMessage], resps map[string]jsonrpc.Response[json.RawMessage], l logger.Logger) (*jsonrpc.Response[json.RawMessage], int, error)
+	Bundle(req jsonrpc.Request[json.RawMessage], resps map[string]jsonrpc.Response[json.RawMessage], l logger.Logger) (*BundleSummary, error)
 }
 
 type Config struct {
@@ -240,14 +240,14 @@ func (h *handler) removeExpiredRequests(ctx context.Context) {
 
 	for _, er := range expiredRequests {
 		responses := er.copiedResponses()
-		// We never reached the 2F+1 early trigger. Forward what we collected only
+		// We never reached the 2F+1 forward threshold. Forward what we collected only
 		// if the bundle can still reach the enclave's F+1 quorum (faulty nodes may
 		// have simply stayed silent). Below F+1 signed responses the enclave is
 		// guaranteed to reject, so forwardBundle returns a timeout error instead of
 		// a futile round trip. The gateway still verifies nothing: this is only a
 		// count floor, not a trust decision.
 		h.lggr.Debugw("request expired, forwarding collected responses to enclave", "requestID", er.req.ID, "responseCount", len(responses))
-		if err := h.forwardBundle(ctx, h.lggr, er, responses, h.donConfig.F+1); err != nil {
+		if err := h.bundleAndForward(ctx, h.lggr, er, responses, h.donConfig.F+1); err != nil {
 			h.lggr.Errorw("error forwarding bundle on expiry", "requestID", er.req.ID, "error", err)
 		}
 	}
@@ -347,44 +347,63 @@ func (h *handler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Response[
 		l.Debugw("waiting for more relay responses before forwarding bundle", "have", len(copiedResponses), "need", requiredResponses)
 		return nil
 	}
-	return h.forwardBundle(ctx, l, ar, copiedResponses, 0)
+	return h.bundleAndForward(ctx, l, ar, copiedResponses, 0)
 }
 
-// forwardBundle builds the relay response bundle from the collected per-node
-// responses and forwards it to the enclave. The gateway makes no trust decision;
-// the enclave verifies signatures and reaches quorum.
+// forwardBundle sends a previously-built bundle to the enclave. The gateway makes
+// no trust decision; the enclave verifies signatures and reaches quorum.
 //
 // minSigned is a futility floor, not a verification step. The enclave reaches
 // quorum only with F+1 valid distinct signatures, so a bundle carrying fewer than
 // F+1 signed responses cannot possibly be accepted. On the timeout path we pass
 // minSigned=F+1 to skip that guaranteed-reject round trip and return a timeout
 // error instead. (F+1 signed is necessary, not sufficient: some signatures may be
-// invalid, so the timeout path stays optimistic.) The 2F+1 early path passes
+// invalid, so the timeout path stays optimistic.) The 2F+1 path passes
 // minSigned=0 because its raw-count trigger already implies enough signed
-// responses; the gateway inspects no signatures in either case.
-func (h *handler) forwardBundle(ctx context.Context, l logger.Logger, ar *activeRequest, responses map[string]jsonrpc.Response[json.RawMessage], minSigned int) error {
-	bundleResp, signedCount, err := h.bundler.Bundle(ar.req, responses, l)
-	if err != nil {
-		l.Errorw("failed to build relay response bundle", "error", err)
-		return h.sendResponseAndCleanup(ctx, ar, h.constructErrorResponse(ar.req, api.FatalError, err))
-	}
-
-	if signedCount < minSigned {
-		l.Debugw("too few signed responses for enclave quorum; returning timeout", "signed", signedCount, "need", minSigned)
+// responses; the gateway inspects no cryptographic signatures in either case.
+func (h *handler) forwardBundle(ctx context.Context, l logger.Logger, ar *activeRequest, summary *BundleSummary, minSigned int) error {
+	if summary.Signed() < minSigned {
+		l.Warnw("too few signed responses for enclave quorum; returning timeout",
+			"signed", summary.Signed(),
+			"need", minSigned,
+			"total", summary.Total(),
+			"errors", summary.Error(),
+			"undecodable", summary.Undecodable(),
+			"nodeErrors", summary.NodeErrorsFormatted(),
+		)
 		return h.sendResponseAndCleanup(ctx, ar, h.constructErrorResponse(ar.req, api.RequestTimeoutError,
-			fmt.Errorf("request expired: %d signed relay responses, need at least %d to reach quorum", signedCount, minSigned)))
+			fmt.Errorf("request expired: %d signed relay responses, need at least %d to reach quorum (total=%d errors=%d undecodable=%d)",
+				summary.Signed(), minSigned, summary.Total(), summary.Error(), summary.Undecodable())))
 	}
 
-	rawResponse, err := jsonrpc.EncodeResponse(bundleResp)
+	rawResponse, err := jsonrpc.EncodeResponse(summary.Response())
 	if err != nil {
 		h.lggr.Errorw("failed to encode response", "requestID", ar.req.ID, "error", err)
 		return h.sendResponseAndCleanup(ctx, ar, h.constructErrorResponse(ar.req, api.NodeReponseEncodingError, err))
 	}
-	l.Debugw("forwarding relay response bundle to enclave", "signedResponses", signedCount, "totalResponses", len(responses))
+	l.Infow("forwarding relay response bundle to enclave",
+		"signedResponses", summary.Signed(),
+		"totalResponses", summary.Total(),
+		"errorResponses", summary.Error(),
+		"undecodableResponses", summary.Undecodable(),
+		"nodeErrors", summary.NodeErrorsFormatted(),
+	)
 	return h.sendResponseAndCleanup(ctx, ar, gwhandlers.UserCallbackPayload{
 		RawResponse: rawResponse,
 		ErrorCode:   api.NoError,
 	})
+}
+
+// bundleAndForward builds a bundle from the collected per-node responses and
+// forwards it subject to minSigned. Used by the timeout path, which has not
+// already built a BundleSummary.
+func (h *handler) bundleAndForward(ctx context.Context, l logger.Logger, ar *activeRequest, responses map[string]jsonrpc.Response[json.RawMessage], minSigned int) error {
+	summary, err := h.bundler.Bundle(ar.req, responses, l)
+	if err != nil {
+		l.Errorw("failed to build relay response bundle", "error", err)
+		return h.sendResponseAndCleanup(ctx, ar, h.constructErrorResponse(ar.req, api.FatalError, err))
+	}
+	return h.forwardBundle(ctx, l, ar, summary, minSigned)
 }
 
 func (h *handler) fanOutToNodes(ctx context.Context, l logger.Logger, ar *activeRequest) error {

--- a/core/services/gateway/handlers/confidentialrelay/handler_test.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler_test.go
@@ -169,9 +169,10 @@ func TestConfidentialRelayHandler_EmptyRequestID(t *testing.T) {
 	require.EqualError(t, err, "request ID cannot be empty")
 }
 
-// At F=1 the gateway forwards once it has collected 2F+1 = 3 responses, so that
-// (under <=F faulty) at least F+1 honest matching responses are guaranteed present
-// for the enclave to verify. The gateway itself makes no signature/quorum decision.
+// At F=1 the gateway forwards once it has collected 2F+1 = 3 signed responses, so
+// that (under <=F faulty) at least F+1 honest matching responses are guaranteed
+// present for the enclave to verify. The gateway itself makes no signature/quorum
+// decision beyond counting signed (non-error) replies.
 func TestConfidentialRelayHandler_ForwardsBundleAtQuorum(t *testing.T) {
 	t.Parallel()
 	h, cb, don, _ := setupHandler(t, 4)
@@ -197,22 +198,139 @@ func TestConfidentialRelayHandler_ForwardsBundleAtQuorum(t *testing.T) {
 		assert.NotNil(t, jsonResp.Result)
 		var bundle relaytypes.SignedCapabilityResponseBundle
 		assert.NoError(t, json.Unmarshal(*jsonResp.Result, &bundle))
-		assert.Len(t, bundle.Responses, 3, "the gateway forwards every collected response")
+		assert.Len(t, bundle.Responses, 3, "the gateway forwards every collected signed response")
 	}()
 
 	err := h.HandleJSONRPCUserMessage(t.Context(), req, cb)
 	require.NoError(t, err)
 
-	// First two responses do not reach the 2F+1 threshold: no callback yet.
+	// First two signed responses do not reach the 2F+1 threshold: no callback yet.
 	for i := range 2 {
 		err = h.HandleNodeMessage(t.Context(), capExecSignedRespPtr(t, "req-quorum", result, fmt.Appendf(nil, "signer-%d", i)), fmt.Sprintf("0x%04d", i))
 		require.NoError(t, err)
 	}
-	require.NotNil(t, h.getActiveRequest(req.ID), "request stays active below the 2F+1 threshold")
+	require.NotNil(t, h.getActiveRequest(req.ID), "request stays active below the 2F+1 signed threshold")
 
-	// Third response reaches 2F+1 and triggers the forward.
+	// Third signed response reaches 2F+1 and triggers the forward.
 	err = h.HandleNodeMessage(t.Context(), capExecSignedRespPtr(t, "req-quorum", result, []byte("signer-2")), "0x0002")
 	require.NoError(t, err)
+	wg.Wait()
+}
+
+// Staging failure mode: lagging nodes return fast JSON-RPC errors (e.g. execution
+// handler not found) while only a few nodes return signed successes. Raw response
+// count can hit 2F+1 while signed count is still below F+1; the gateway must keep
+// waiting for more signed replies (or timeout), not forward a doomed bundle.
+func TestConfidentialRelayHandler_DoesNotForwardOnErrorMajority(t *testing.T) {
+	t.Parallel()
+	// F=2, N=7 => forward threshold is 2F+1 = 5 signed responses; enclave needs F+1=3.
+	h, cb, don, clock := setupHandlerWithF(t, 7, 2)
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	params := validCapParamsJSON("wf1")
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-error-majority",
+		Method: MethodCapabilityExec,
+		Params: &params,
+	}
+	result := relaytypes.CapabilityResponseResult{Payload: "result"}
+
+	require.NoError(t, h.HandleJSONRPCUserMessage(t.Context(), req, cb))
+
+	// 3 fast node errors + 2 signed successes = 5 raw replies, but only 2 signed.
+	// Under the old raw-count trigger this would early-forward a bundle of 2 and
+	// the enclave would fail needing F+1=3. We must stay active.
+	for i := range 3 {
+		errResp := &jsonrpc.Response[json.RawMessage]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      req.ID,
+			Method:  MethodCapabilityExec,
+			Error:   &jsonrpc.WireError{Code: -32602, Message: "execution handler for workflow not found"},
+		}
+		require.NoError(t, h.HandleNodeMessage(t.Context(), errResp, fmt.Sprintf("0x%04d", i)))
+	}
+	for i := 3; i < 5; i++ {
+		require.NoError(t, h.HandleNodeMessage(t.Context(),
+			capExecSignedRespPtr(t, req.ID, result, fmt.Appendf(nil, "signer-%d", i)),
+			fmt.Sprintf("0x%04d", i),
+		))
+	}
+	require.NotNil(t, h.getActiveRequest(req.ID), "must not forward when signed count is below 2F+1")
+
+	// Two more signed successes (nodes 5,6) bring signed to 4, still below 5.
+	for i := 5; i < 7; i++ {
+		require.NoError(t, h.HandleNodeMessage(t.Context(),
+			capExecSignedRespPtr(t, req.ID, result, fmt.Appendf(nil, "signer-%d", i)),
+			fmt.Sprintf("0x%04d", i),
+		))
+	}
+	require.NotNil(t, h.getActiveRequest(req.ID), "4 signed is still below 2F+1=5; keep waiting")
+
+	// Timeout with signed=4 (>= F+1=3) should forward the partial signed bundle.
+	clock.Advance(31 * time.Second)
+	h.removeExpiredRequests(t.Context())
+
+	resp, err := cb.Wait(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, api.NoError, resp.ErrorCode)
+	var jsonResp jsonrpc.Response[json.RawMessage]
+	require.NoError(t, json.Unmarshal(resp.RawResponse, &jsonResp))
+	var bundle relaytypes.SignedCapabilityResponseBundle
+	require.NoError(t, json.Unmarshal(*jsonResp.Result, &bundle))
+	require.Len(t, bundle.Responses, 4, "errors are dropped; only signed responses are bundled")
+}
+
+// Same staging shape, but enough later signed successes arrive to hit 2F+1 signed
+// and forward without waiting for timeout. Uses F=1 so 2F+1=3 is reachable after
+// an initial error+signed mix.
+func TestConfidentialRelayHandler_ForwardsOnceEnoughSignedArrive(t *testing.T) {
+	t.Parallel()
+	h, cb, don, _ := setupHandlerWithF(t, 5, 1) // 2F+1 = 3 signed
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	params := validCapParamsJSON("wf1")
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-signed-threshold",
+		Method: MethodCapabilityExec,
+		Params: &params,
+	}
+	result := relaytypes.CapabilityResponseResult{Payload: "result"}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := cb.Wait(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, api.NoError, resp.ErrorCode)
+		var jsonResp jsonrpc.Response[json.RawMessage]
+		assert.NoError(t, json.Unmarshal(resp.RawResponse, &jsonResp))
+		var bundle relaytypes.SignedCapabilityResponseBundle
+		assert.NoError(t, json.Unmarshal(*jsonResp.Result, &bundle))
+		assert.Len(t, bundle.Responses, 3)
+	}()
+
+	require.NoError(t, h.HandleJSONRPCUserMessage(t.Context(), req, cb))
+
+	// Two errors + one signed: raw count=3 (= old 2F+1) but signed=1. Stay open.
+	for i := range 2 {
+		errResp := &jsonrpc.Response[json.RawMessage]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      req.ID,
+			Method:  MethodCapabilityExec,
+			Error:   &jsonrpc.WireError{Code: -32602, Message: "execution handler for workflow not found"},
+		}
+		require.NoError(t, h.HandleNodeMessage(t.Context(), errResp, fmt.Sprintf("0x%04d", i)))
+	}
+	require.NoError(t, h.HandleNodeMessage(t.Context(),
+		capExecSignedRespPtr(t, req.ID, result, []byte("signer-2")), "0x0002"))
+	require.NotNil(t, h.getActiveRequest(req.ID), "must not forward on raw 2F+1 when most are errors")
+
+	// Two more signed => signed=3 = 2F+1, forward.
+	require.NoError(t, h.HandleNodeMessage(t.Context(),
+		capExecSignedRespPtr(t, req.ID, result, []byte("signer-3")), "0x0003"))
+	require.NoError(t, h.HandleNodeMessage(t.Context(),
+		capExecSignedRespPtr(t, req.ID, result, []byte("signer-4")), "0x0004"))
 	wg.Wait()
 }
 

--- a/core/services/gateway/handlers/confidentialrelay/handler_test.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler_test.go
@@ -224,7 +224,7 @@ func TestConfidentialRelayHandler_ForwardsBundleAtQuorum(t *testing.T) {
 func TestConfidentialRelayHandler_DoesNotForwardOnErrorMajority(t *testing.T) {
 	t.Parallel()
 	// F=2, N=7 => forward threshold is 2F+1 = 5 signed responses; enclave needs F+1=3.
-	h, cb, don, clock := setupHandlerWithF(t, 7, 2)
+	h, cb, don, _ := setupHandlerWithF(t, 7, 2)
 	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	params := validCapParamsJSON("wf1")
@@ -257,27 +257,118 @@ func TestConfidentialRelayHandler_DoesNotForwardOnErrorMajority(t *testing.T) {
 	}
 	require.NotNil(t, h.getActiveRequest(req.ID), "must not forward when signed count is below 2F+1")
 
-	// Two more signed successes (nodes 5,6) bring signed to 4, still below 5.
+	// Two more signed successes (nodes 5,6) bring signed to 4 with all nodes replied.
+	// Terminal-state path: remaining=0 and signed >= F+1=3, so forward without timeout.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := cb.Wait(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, api.NoError, resp.ErrorCode)
+		var jsonResp jsonrpc.Response[json.RawMessage]
+		assert.NoError(t, json.Unmarshal(resp.RawResponse, &jsonResp))
+		var bundle relaytypes.SignedCapabilityResponseBundle
+		assert.NoError(t, json.Unmarshal(*jsonResp.Result, &bundle))
+		assert.Len(t, bundle.Responses, 4, "errors are dropped; only signed responses are bundled")
+	}()
 	for i := 5; i < 7; i++ {
 		require.NoError(t, h.HandleNodeMessage(t.Context(),
 			capExecSignedRespPtr(t, req.ID, result, fmt.Appendf(nil, "signer-%d", i)),
 			fmt.Sprintf("0x%04d", i),
 		))
 	}
-	require.NotNil(t, h.getActiveRequest(req.ID), "4 signed is still below 2F+1=5; keep waiting")
+	wg.Wait()
+	require.Nil(t, h.getActiveRequest(req.ID), "terminal-state forward should complete the request")
+}
 
-	// Timeout with signed=4 (>= F+1=3) should forward the partial signed bundle.
-	clock.Advance(31 * time.Second)
-	h.removeExpiredRequests(t.Context())
+// When every node has replied but signed is still below F+1, the gateway must not
+// forward a doomed bundle or wait for cleanup; it fails immediately.
+func TestConfidentialRelayHandler_TerminalStateBelowQuorumFailsImmediately(t *testing.T) {
+	t.Parallel()
+	h, cb, don, _ := setupHandlerWithF(t, 4, 1) // F+1=2, 2F+1=3
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	resp, err := cb.Wait(t.Context())
-	require.NoError(t, err)
-	require.Equal(t, api.NoError, resp.ErrorCode)
-	var jsonResp jsonrpc.Response[json.RawMessage]
-	require.NoError(t, json.Unmarshal(resp.RawResponse, &jsonResp))
-	var bundle relaytypes.SignedCapabilityResponseBundle
-	require.NoError(t, json.Unmarshal(*jsonResp.Result, &bundle))
-	require.Len(t, bundle.Responses, 4, "errors are dropped; only signed responses are bundled")
+	params := validCapParamsJSON("wf1")
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-terminal-below",
+		Method: MethodCapabilityExec,
+		Params: &params,
+	}
+	result := relaytypes.CapabilityResponseResult{Payload: "result"}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := cb.Wait(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, api.FatalError, resp.ErrorCode)
+		var jsonResp jsonrpc.Response[json.RawMessage]
+		assert.NoError(t, json.Unmarshal(resp.RawResponse, &jsonResp))
+		require.NotNil(t, jsonResp.Error)
+		assert.Contains(t, jsonResp.Error.Message, "relay quorum unreachable")
+	}()
+
+	require.NoError(t, h.HandleJSONRPCUserMessage(t.Context(), req, cb))
+
+	// 3 errors + 1 signed: all nodes replied, signed=1 < F+1=2. Fail immediately.
+	for i := range 3 {
+		errResp := &jsonrpc.Response[json.RawMessage]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      req.ID,
+			Method:  MethodCapabilityExec,
+			Error:   &jsonrpc.WireError{Code: -32602, Message: "execution handler not found"},
+		}
+		require.NoError(t, h.HandleNodeMessage(t.Context(), errResp, fmt.Sprintf("0x%04d", i)))
+	}
+	require.NoError(t, h.HandleNodeMessage(t.Context(),
+		capExecSignedRespPtr(t, req.ID, result, []byte("signer-3")), "0x0003"))
+	wg.Wait()
+	require.Nil(t, h.getActiveRequest(req.ID))
+}
+
+// If outstanding replies cannot bring signed up to F+1, fail before waiting for
+// silent nodes / timeout. Example: F=1 needs 2 signed; after 3 errors on a 4-node
+// DON only 1 slot remains, so maxPossibleSigned=1.
+func TestConfidentialRelayHandler_QuorumUnreachableFailsImmediately(t *testing.T) {
+	t.Parallel()
+	h, cb, don, _ := setupHandlerWithF(t, 4, 1) // F+1=2
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	params := validCapParamsJSON("wf1")
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-unreachable",
+		Method: MethodCapabilityExec,
+		Params: &params,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := cb.Wait(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, api.FatalError, resp.ErrorCode)
+		var jsonResp jsonrpc.Response[json.RawMessage]
+		assert.NoError(t, json.Unmarshal(resp.RawResponse, &jsonResp))
+		require.NotNil(t, jsonResp.Error)
+		assert.Contains(t, jsonResp.Error.Message, "relay quorum unreachable")
+	}()
+
+	require.NoError(t, h.HandleJSONRPCUserMessage(t.Context(), req, cb))
+
+	for i := range 3 {
+		errResp := &jsonrpc.Response[json.RawMessage]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      req.ID,
+			Method:  MethodCapabilityExec,
+			Error:   &jsonrpc.WireError{Code: -32602, Message: "execution handler not found"},
+		}
+		require.NoError(t, h.HandleNodeMessage(t.Context(), errResp, fmt.Sprintf("0x%04d", i)))
+	}
+	wg.Wait()
+	require.Nil(t, h.getActiveRequest(req.ID))
 }
 
 // Same staging shape, but enough later signed successes arrive to hit 2F+1 signed

--- a/core/services/gateway/handlers/confidentialrelay/handler_test.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler_test.go
@@ -114,13 +114,17 @@ func setupHandlerWithF(t *testing.T, numNodes, f int) (*handler, *common.Callbac
 	return h, cb, don, clock
 }
 
-// mockBundler lets a test force the bundler error path.
+// mockBundler lets a test force the bundler error path or a fixed summary.
 type mockBundler struct {
-	err error
+	err     error
+	summary *BundleSummary
 }
 
-func (m *mockBundler) Bundle(_ jsonrpc.Request[json.RawMessage], _ map[string]jsonrpc.Response[json.RawMessage], _ logger.Logger) (*jsonrpc.Response[json.RawMessage], int, error) {
-	return nil, 0, m.err
+func (m *mockBundler) Bundle(_ jsonrpc.Request[json.RawMessage], _ map[string]jsonrpc.Response[json.RawMessage], _ logger.Logger) (*BundleSummary, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.summary, nil
 }
 
 func TestConfidentialRelayHandler_Methods(t *testing.T) {

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -770,7 +770,11 @@ func (h *eventHandler) engineFactoryFn(ctx context.Context, workflowID string, o
 	binaryHash := v2.ComputeBinaryHash(binary)
 	confLggr := logger.Named(h.lggr, "WorkflowEngine.ConfidentialModule")
 	confLggr = logger.With(confLggr, "workflowID", workflowID, "workflowName", name, "workflowOwner", owner)
-	confidential, err := v2.NewConfidentialModule(h.capRegistry, h.executionHandlers, binaryURL, binaryHash, workflowID, owner, name.String(), tag, h.engineLimiters.ConfidentialWorkflowsEnabled, confLggr)
+	orgID, orgErr := h.fetchOrganizationID(ctx, owner)
+	if orgErr != nil {
+		confLggr.Warnw("failed to resolve organization ID for confidential module", "error", orgErr)
+	}
+	confidential, err := v2.NewConfidentialModule(h.capRegistry, h.executionHandlers, binaryURL, binaryHash, workflowID, owner, name.String(), tag, orgID, h.engineLimiters.ConfidentialWorkflowsEnabled, confLggr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create confidential module: %w", err)
 	}

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -770,11 +770,7 @@ func (h *eventHandler) engineFactoryFn(ctx context.Context, workflowID string, o
 	binaryHash := v2.ComputeBinaryHash(binary)
 	confLggr := logger.Named(h.lggr, "WorkflowEngine.ConfidentialModule")
 	confLggr = logger.With(confLggr, "workflowID", workflowID, "workflowName", name, "workflowOwner", owner)
-	orgID, orgErr := h.fetchOrganizationID(ctx, owner)
-	if orgErr != nil {
-		confLggr.Warnw("failed to resolve organization ID for confidential module", "error", orgErr)
-	}
-	confidential, err := v2.NewConfidentialModule(h.capRegistry, h.executionHandlers, binaryURL, binaryHash, workflowID, owner, name.String(), tag, orgID, h.engineLimiters.ConfidentialWorkflowsEnabled, confLggr)
+	confidential, err := v2.NewConfidentialModule(h.capRegistry, h.executionHandlers, binaryURL, binaryHash, workflowID, owner, name.String(), tag, h.fetchOrganizationID, h.engineLimiters.ConfidentialWorkflowsEnabled, confLggr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create confidential module: %w", err)
 	}

--- a/core/services/workflows/v2/confidential_module.go
+++ b/core/services/workflows/v2/confidential_module.go
@@ -15,7 +15,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/confidentialrelay"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
-	"github.com/smartcontractkit/chainlink-common/pkg/contexts"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
@@ -63,6 +62,7 @@ type ConfidentialModule struct {
 	workflowOwner     string
 	workflowName      string
 	workflowTag       string
+	orgID             string
 	lggr              logger.Logger
 	requirements      sync.Map
 	restritions       sync.Map
@@ -75,7 +75,7 @@ type ConfidentialModule struct {
 var _ host.RequirementEnforcingModule = (*ConfidentialModule)(nil)
 var _ host.RestrictionAwareModule = (*ConfidentialModule)(nil)
 
-func NewConfidentialModule(capRegistry core.CapabilitiesRegistry, executionHandlers *confidentialrelay.ExecutionHandlers, binaryURL string, binaryHash []byte, workflowID, workflowOwner, workflowName, workflowTag string, enabledGate limits.GateLimiter, lggr logger.Logger) (*ConfidentialModule, error) {
+func NewConfidentialModule(capRegistry core.CapabilitiesRegistry, executionHandlers *confidentialrelay.ExecutionHandlers, binaryURL string, binaryHash []byte, workflowID, workflowOwner, workflowName, workflowTag, orgID string, enabledGate limits.GateLimiter, lggr logger.Logger) (*ConfidentialModule, error) {
 	if enabledGate == nil {
 		return nil, errors.New("enabledGate must not be nil")
 	}
@@ -88,6 +88,7 @@ func NewConfidentialModule(capRegistry core.CapabilitiesRegistry, executionHandl
 		workflowOwner:     workflowOwner,
 		workflowName:      workflowName,
 		workflowTag:       workflowTag,
+		orgID:             orgID,
 		enabledGate:       enabledGate,
 		lggr:              lggr,
 	}, nil
@@ -124,7 +125,7 @@ func (m *ConfidentialModule) Execute(
 			SdkExecuteRequest: request,
 			Owner:             m.workflowOwner,
 			ExecutionId:       workflowExecutionID,
-			OrgId:             contexts.CREValue(ctx).Org,
+			OrgId:             m.orgID,
 			Requirements:      requirements,
 			BinaryUrl:         m.binaryURL,
 			Restrictions:      restrictions,
@@ -205,6 +206,7 @@ func doRequest[I, O proto.Message](
 			WorkflowName:        m.workflowName,
 			WorkflowTag:         m.workflowTag,
 			WorkflowExecutionID: execID,
+			OrgID:               m.orgID,
 		},
 	}
 

--- a/core/services/workflows/v2/confidential_module.go
+++ b/core/services/workflows/v2/confidential_module.go
@@ -62,7 +62,7 @@ type ConfidentialModule struct {
 	workflowOwner     string
 	workflowName      string
 	workflowTag       string
-	orgID             string
+	resolveOrgID      func(ctx context.Context, owner string) (string, error)
 	lggr              logger.Logger
 	requirements      sync.Map
 	restritions       sync.Map
@@ -75,9 +75,12 @@ type ConfidentialModule struct {
 var _ host.RequirementEnforcingModule = (*ConfidentialModule)(nil)
 var _ host.RestrictionAwareModule = (*ConfidentialModule)(nil)
 
-func NewConfidentialModule(capRegistry core.CapabilitiesRegistry, executionHandlers *confidentialrelay.ExecutionHandlers, binaryURL string, binaryHash []byte, workflowID, workflowOwner, workflowName, workflowTag, orgID string, enabledGate limits.GateLimiter, lggr logger.Logger) (*ConfidentialModule, error) {
+func NewConfidentialModule(capRegistry core.CapabilitiesRegistry, executionHandlers *confidentialrelay.ExecutionHandlers, binaryURL string, binaryHash []byte, workflowID, workflowOwner, workflowName, workflowTag string, resolveOrgID func(ctx context.Context, owner string) (string, error), enabledGate limits.GateLimiter, lggr logger.Logger) (*ConfidentialModule, error) {
 	if enabledGate == nil {
 		return nil, errors.New("enabledGate must not be nil")
+	}
+	if resolveOrgID == nil {
+		return nil, errors.New("resolveOrgID must not be nil")
 	}
 	return &ConfidentialModule{
 		capRegistry:       capRegistry,
@@ -88,7 +91,7 @@ func NewConfidentialModule(capRegistry core.CapabilitiesRegistry, executionHandl
 		workflowOwner:     workflowOwner,
 		workflowName:      workflowName,
 		workflowTag:       workflowTag,
-		orgID:             orgID,
+		resolveOrgID:      resolveOrgID,
 		enabledGate:       enabledGate,
 		lggr:              lggr,
 	}, nil
@@ -118,6 +121,11 @@ func (m *ConfidentialModule) Execute(
 	requirements := loadAndDelete[*sdkpb.Requirements](&m.requirements, workflowExecutionID)
 	restrictions := loadAndDelete[*sdkpb.Restrictions](&m.restritions, workflowExecutionID)
 
+	orgID, orgErr := m.resolveOrgID(ctx, m.workflowOwner)
+	if orgErr != nil {
+		m.lggr.Warnw("failed to resolve organization ID", "error", orgErr)
+	}
+
 	capInput := &confworkflowtypes.ConfidentialWorkflowRequest{
 		Execution: &confworkflowtypes.WorkflowExecution{
 			WorkflowId:        m.workflowID,
@@ -125,7 +133,7 @@ func (m *ConfidentialModule) Execute(
 			SdkExecuteRequest: request,
 			Owner:             m.workflowOwner,
 			ExecutionId:       workflowExecutionID,
-			OrgId:             m.orgID,
+			OrgId:             orgID,
 			Requirements:      requirements,
 			BinaryUrl:         m.binaryURL,
 			Restrictions:      restrictions,
@@ -133,7 +141,7 @@ func (m *ConfidentialModule) Execute(
 	}
 
 	capOutput := &confworkflowtypes.ConfidentialWorkflowResponse{}
-	if err := doRequest(ctx, m, helper.GetWorkflowExecutionID(), "Execute", capInput, capOutput); err != nil {
+	if err := doRequest(ctx, m, helper.GetWorkflowExecutionID(), "Execute", capInput, capOutput, orgID); err != nil {
 		return nil, err
 	}
 
@@ -151,7 +159,7 @@ func (m *ConfidentialModule) SetRestrictions(executionID string, restrictions *s
 func (m *ConfidentialModule) providedTees(ctx context.Context) []*sdkpb.TeeTypeAndRegions {
 	capOutput := &confworkflowtypes.ProvidedTeesResponse{}
 	// use an empty execution ID, it's not during an execution.
-	if err := doRequest(ctx, m, "", "ProvidedTees", &emptypb.Empty{}, capOutput); err != nil {
+	if err := doRequest(ctx, m, "", "ProvidedTees", &emptypb.Empty{}, capOutput, ""); err != nil {
 		m.lggr.Errorf("failed to get regions from confidential-workflows capability, assuming no supported regions: %v", err)
 		return []*sdkpb.TeeTypeAndRegions{}
 	}
@@ -182,7 +190,8 @@ func doRequest[I, O proto.Message](
 	execID string,
 	method string,
 	capInput I,
-	capOutput O) error {
+	capOutput O,
+	orgID string) error {
 	payload, err := anypb.New(capInput)
 	if err != nil {
 		return fmt.Errorf("failed to marshal capability payload: %w", err)
@@ -206,7 +215,7 @@ func doRequest[I, O proto.Message](
 			WorkflowName:        m.workflowName,
 			WorkflowTag:         m.workflowTag,
 			WorkflowExecutionID: execID,
-			OrgID:               m.orgID,
+			OrgID:               orgID,
 		},
 	}
 

--- a/core/services/workflows/v2/confidential_module_test.go
+++ b/core/services/workflows/v2/confidential_module_test.go
@@ -673,7 +673,7 @@ func TestConfidentialModule_InterfaceMethods(t *testing.T) {
 
 func mustNewConfidentialModule(t *testing.T, capRegistry *regmocks.CapabilitiesRegistry, executionHandlers *confidentialrelay.ExecutionHandlers, binaryURL string, binaryHash []byte, workflowID, workflowOwner, workflowName, workflowTag string, enabledGate limits.GateLimiter, lggr logger.Logger) *ConfidentialModule {
 	t.Helper()
-	m, err := NewConfidentialModule(capRegistry, executionHandlers, binaryURL, binaryHash, workflowID, workflowOwner, workflowName, workflowTag, "org-test", enabledGate, lggr)
+	m, err := NewConfidentialModule(capRegistry, executionHandlers, binaryURL, binaryHash, workflowID, workflowOwner, workflowName, workflowTag, func(context.Context, string) (string, error) { return "org-test", nil }, enabledGate, lggr)
 	require.NoError(t, err)
 	return m
 }
@@ -681,6 +681,6 @@ func mustNewConfidentialModule(t *testing.T, capRegistry *regmocks.CapabilitiesR
 func TestNewConfidentialModule_NilGate(t *testing.T) {
 	t.Parallel()
 	capReg := regmocks.NewCapabilitiesRegistry(t)
-	_, err := NewConfidentialModule(capReg, &confidentialrelay.ExecutionHandlers{}, "", nil, "wf", "owner", "name", "tag", "org-test", nil, logger.Test(t))
+	_, err := NewConfidentialModule(capReg, &confidentialrelay.ExecutionHandlers{}, "", nil, "wf", "owner", "name", "tag", func(context.Context, string) (string, error) { return "org-test", nil }, nil, logger.Test(t))
 	require.Error(t, err)
 }

--- a/core/services/workflows/v2/confidential_module_test.go
+++ b/core/services/workflows/v2/confidential_module_test.go
@@ -673,7 +673,7 @@ func TestConfidentialModule_InterfaceMethods(t *testing.T) {
 
 func mustNewConfidentialModule(t *testing.T, capRegistry *regmocks.CapabilitiesRegistry, executionHandlers *confidentialrelay.ExecutionHandlers, binaryURL string, binaryHash []byte, workflowID, workflowOwner, workflowName, workflowTag string, enabledGate limits.GateLimiter, lggr logger.Logger) *ConfidentialModule {
 	t.Helper()
-	m, err := NewConfidentialModule(capRegistry, executionHandlers, binaryURL, binaryHash, workflowID, workflowOwner, workflowName, workflowTag, enabledGate, lggr)
+	m, err := NewConfidentialModule(capRegistry, executionHandlers, binaryURL, binaryHash, workflowID, workflowOwner, workflowName, workflowTag, "org-test", enabledGate, lggr)
 	require.NoError(t, err)
 	return m
 }
@@ -681,6 +681,6 @@ func mustNewConfidentialModule(t *testing.T, capRegistry *regmocks.CapabilitiesR
 func TestNewConfidentialModule_NilGate(t *testing.T) {
 	t.Parallel()
 	capReg := regmocks.NewCapabilitiesRegistry(t)
-	_, err := NewConfidentialModule(capReg, &confidentialrelay.ExecutionHandlers{}, "", nil, "wf", "owner", "name", "tag", nil, logger.Test(t))
+	_, err := NewConfidentialModule(capReg, &confidentialrelay.ExecutionHandlers{}, "", nil, "wf", "owner", "name", "tag", "org-test", nil, logger.Test(t))
 	require.Error(t, err)
 }

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -11,3 +11,7 @@ plugins:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
       gitRef: "8812c6483a6e6cded22b3fe9615cf1d18b054fd5"
       installPath: "./cmd/confidential-http"
+  confidential-workflows:
+    - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-workflows/capability"
+      gitRef: "c67177319e95658f51734b528bc60dad741c075f"
+      installPath: "./cmd/confidential-workflows"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -13,5 +13,5 @@ plugins:
       installPath: "./cmd/confidential-http"
   confidential-workflows:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-workflows/capability"
-      gitRef: "c67177319e95658f51734b528bc60dad741c075f"
+      gitRef: "38ffef696e7266a40f7fa9c78e24b581261fbb96"
       installPath: "./cmd/confidential-workflows"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -13,5 +13,5 @@ plugins:
       installPath: "./cmd/confidential-http"
   confidential-workflows:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-workflows/capability"
-      gitRef: "38ffef696e7266a40f7fa9c78e24b581261fbb96"
+      gitRef: "85571dc47c1aa2a32489b649b14603e65fac943f"
       installPath: "./cmd/confidential-workflows"


### PR DESCRIPTION
## Summary

Updates the confidential-workflows gitref and wires the gateway relay handler/bundler to use the new JSON-RPC request/response shape and the new `NewConfidentialModule` constructor.

## Changes

- `core/services/gateway/handlers/confidentialrelay/bundler.go` & `handler.go`: build proper JSON-RPC request/response objects (with `jsonrpc.JsonRpcVersion`); expand handler tests.
- `core/services/workflows/v2/confidential_module.go`: `NewConfidentialModule` now takes explicit workflow metadata (workflowID, owner, name, tag, binaryURL, binaryHash) and an org-ID resolver.
- `core/services/workflows/syncer/v2/handler.go`: call the new constructor.
- `plugins/plugins.private.yaml`: bump the confidential-workflows gitref.

## Why

Aligns the gateway relay path with the async confidential relay protocol and passes the workflow context the relay needs to route and attribute requests. (Closed.)
