### PR TITLE
cre-5294: one capability set up on multiple DON shards (single-routing)

### DIFF
--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -412,6 +412,7 @@ func (w *launcher) onNewRegistry(ctx context.Context, localRegistry *registrysyn
 		w.lggr.Debug("Notifying DON set...")
 		w.workflowDonNotifier.NotifyDonSet(myDON.DON)
 
+		w.warnOnDuplicateInFamilyCapabilities(remoteCapabilityDONs)
 		for _, rcd := range remoteCapabilityDONs {
 			w.addRemoteCapabilities(ctx, myDON, rcd, localRegistry)
 		}
@@ -453,6 +454,22 @@ func filterDONsByFamilies(donList []registrysyncer.DON, myDONFamilies []string) 
 		}
 	}
 	return filteredDONs
+}
+
+func (w *launcher) warnOnDuplicateInFamilyCapabilities(remoteCapabilityDONs []registrysyncer.DON) {
+	donIDsByCapability := map[string][]uint32{}
+	for _, d := range remoteCapabilityDONs {
+		for capID := range d.CapabilityConfigurations {
+			donIDsByCapability[capID] = append(donIDsByCapability[capID], d.ID)
+		}
+	}
+	for capID, donIDs := range donIDsByCapability {
+		if len(donIDs) > 1 {
+			slices.Sort(donIDs)
+			w.lggr.Warnw("multiple in-family capability DONs host the same capability; only the lowest DON ID will be routed to, check DON family configuration",
+				"capabilityID", capID, "donIDs", donIDs)
+		}
+	}
 }
 
 func donFamiliesOverlap(donA []string, donB []string) bool {

--- a/core/capabilities/launcher_test.go
+++ b/core/capabilities/launcher_test.go
@@ -837,6 +837,7 @@ func TestLauncher_DonPairsToUpdate_SkipsDifferentFamilies(t *testing.T) {
 }
 
 func TestLauncher_ShardedCapabilityRoutingByFamily(t *testing.T) {
+	t.Parallel()
 	lggr := logger.Test(t)
 	registry := NewRegistry(lggr)
 	dispatcher := remoteMocks.NewDispatcher(t)
@@ -909,6 +910,7 @@ func TestLauncher_ShardedCapabilityRoutingByFamily(t *testing.T) {
 }
 
 func TestLauncher_DonPairsToUpdate_ShardedFamilies(t *testing.T) {
+	t.Parallel()
 	registry := NewRegistry(logger.Test(t))
 	dispatcher := remoteMocks.NewDispatcher(t)
 
@@ -948,6 +950,7 @@ func TestLauncher_DonPairsToUpdate_ShardedFamilies(t *testing.T) {
 }
 
 func TestLauncher_ShardedCapability_PhaseA_AllCapsInCommonFamily(t *testing.T) {
+	t.Parallel()
 	lggr := logger.Test(t)
 	registry := NewRegistry(lggr)
 	dispatcher := remoteMocks.NewDispatcher(t)
@@ -992,6 +995,7 @@ func TestLauncher_ShardedCapability_PhaseA_AllCapsInCommonFamily(t *testing.T) {
 }
 
 func TestLauncher_DonPairsToUpdate_CapShardPairsOnlyWithWorkflowShard(t *testing.T) {
+	t.Parallel()
 	registry := NewRegistry(logger.Test(t))
 	dispatcher := remoteMocks.NewDispatcher(t)
 

--- a/core/capabilities/launcher_test.go
+++ b/core/capabilities/launcher_test.go
@@ -1032,6 +1032,7 @@ func TestLauncher_DonPairsToUpdate_CapShardPairsOnlyWithWorkflowShard(t *testing
 // cap shard: the self-pair lets the shard discover its own members and the cross-pair connects
 // it to its paired workflow shard. Bootstrap family membership is irrelevant.
 func TestLauncher_DonPairsToUpdate_BootstrapConnectsIsolatedCapShard(t *testing.T) {
+	t.Parallel()
 	registry := NewRegistry(logger.Test(t))
 	dispatcher := remoteMocks.NewDispatcher(t)
 

--- a/core/capabilities/launcher_test.go
+++ b/core/capabilities/launcher_test.go
@@ -836,6 +836,194 @@ func TestLauncher_DonPairsToUpdate_SkipsDifferentFamilies(t *testing.T) {
 	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[registrysyncer.DonID(capDONZoneBID)].DON, localRegistry.IDsToDONs[registrysyncer.DonID(capDONZoneBID)].DON}, res[3])
 }
 
+func TestLauncher_ShardedCapabilityRoutingByFamily(t *testing.T) {
+	lggr := logger.Test(t)
+	registry := NewRegistry(lggr)
+	dispatcher := remoteMocks.NewDispatcher(t)
+
+	workflowDonNodes := newNodes(4)
+	capShard0Nodes, capShard1Nodes, capShard2Nodes, sharedCapNodes := newNodes(4), newNodes(4), newNodes(4), newNodes(4)
+	peer := mocks.NewPeer(t)
+	peer.On("UpdateConnections", mock.Anything).Return(nil)
+	peer.On("ID").Return(workflowDonNodes[0])
+	peer.On("IsBootstrap").Return(false)
+	wrapper := mocks.NewPeerWrapper(t)
+	wrapper.On("GetPeer").Return(peer)
+
+	fullShardedTargetID := "write-chain_evm_1@1.0.0"
+	fullSharedTargetID := "read-chain_evm_1@1.0.0"
+	shardedCapIDHash := RandomUTF8BytesWord()
+	sharedCapIDHash := RandomUTF8BytesWord()
+
+	wfDONID := uint32(1)
+	capShard0ID := uint32(2)
+	capShard1ID := uint32(3)
+	capShard2ID := uint32(4)
+	sharedCapDONID := uint32(5)
+
+	cfg, err := proto.Marshal(&capabilitiespb.CapabilityConfig{})
+	require.NoError(t, err)
+
+	localRegistry := buildLocalRegistry()
+	addDON(localRegistry, wfDONID, uint32(0), uint8(1), true, true, workflowDonNodes, []string{"zone-a", "zone-a_shard-0"}, 1, nil)
+	addDON(localRegistry, capShard0ID, uint32(0), uint8(1), true, false, capShard0Nodes, []string{"zone-a_shard-0"}, 1, [][32]byte{shardedCapIDHash})
+	addCapabilityToDON(localRegistry, capShard0ID, fullShardedTargetID, capabilities.CapabilityTypeTarget, cfg)
+	addDON(localRegistry, capShard1ID, uint32(0), uint8(1), true, false, capShard1Nodes, []string{"zone-a_shard-1"}, 1, [][32]byte{shardedCapIDHash})
+	addCapabilityToDON(localRegistry, capShard1ID, fullShardedTargetID, capabilities.CapabilityTypeTarget, cfg)
+	addDON(localRegistry, capShard2ID, uint32(0), uint8(1), true, false, capShard2Nodes, []string{"zone-a_shard-2"}, 1, [][32]byte{shardedCapIDHash})
+	addCapabilityToDON(localRegistry, capShard2ID, fullShardedTargetID, capabilities.CapabilityTypeTarget, cfg)
+	addDON(localRegistry, sharedCapDONID, uint32(0), uint8(1), true, false, sharedCapNodes, []string{"zone-a"}, 1, [][32]byte{sharedCapIDHash})
+	addCapabilityToDON(localRegistry, sharedCapDONID, fullSharedTargetID, capabilities.CapabilityTypeTarget, cfg)
+
+	launcher, err := NewLauncher(
+		lggr,
+		wrapper,
+		nil,
+		nil,
+		dispatcher,
+		registry,
+		&mockDonNotifier{},
+	)
+	require.NoError(t, err)
+	require.NoError(t, launcher.Start(t.Context()))
+	defer launcher.Close()
+
+	dispatcher.On("SetReceiver", fullShardedTargetID, capShard0ID, mock.AnythingOfType("*executable.client")).Return(nil)
+	dispatcher.On("SetReceiver", fullSharedTargetID, sharedCapDONID, mock.AnythingOfType("*executable.client")).Return(nil)
+
+	require.NoError(t, launcher.OnNewRegistry(t.Context(), localRegistry))
+
+	shardedCap, err := registry.Get(t.Context(), fullShardedTargetID)
+	require.NoError(t, err)
+	shardedInfo, err := shardedCap.Info(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, shardedInfo.DON)
+	require.Equal(t, capShard0ID, shardedInfo.DON.ID)
+
+	sharedCap, err := registry.Get(t.Context(), fullSharedTargetID)
+	require.NoError(t, err)
+	sharedInfo, err := sharedCap.Info(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, sharedInfo.DON)
+	require.Equal(t, sharedCapDONID, sharedInfo.DON.ID)
+}
+
+func TestLauncher_DonPairsToUpdate_ShardedFamilies(t *testing.T) {
+	registry := NewRegistry(logger.Test(t))
+	dispatcher := remoteMocks.NewDispatcher(t)
+
+	var pid ragetypes.PeerID
+	require.NoError(t, pid.UnmarshalText([]byte(utils.MustNewPeerID())))
+	sharedPeer := mocks.NewSharedPeer(t)
+
+	fullTargetID := "write-chain_evm_1@1.0.0"
+	capIDHash := RandomUTF8BytesWord()
+
+	workflowDonNodes := newNodes(4)
+	capShard0Nodes, capShard1Nodes, sharedCapNodes := newNodes(4), newNodes(4), newNodes(4)
+	workflowDonNodes[0] = pid // node belongs to the workflow shard
+
+	wfDONID := uint32(1)
+	capShard0ID := uint32(2)
+	capShard1ID := uint32(3)
+	sharedCapDONID := uint32(4)
+
+	localRegistry := buildLocalRegistry()
+	addDON(localRegistry, wfDONID, uint32(0), uint8(1), true, true, workflowDonNodes, []string{"zone-a", "zone-a_shard-0"}, 1, nil)
+	addDON(localRegistry, capShard0ID, uint32(0), uint8(1), true, false, capShard0Nodes, []string{"zone-a_shard-0"}, 1, [][32]byte{capIDHash})
+	addCapabilityToDON(localRegistry, capShard0ID, fullTargetID, capabilities.CapabilityTypeTarget, nil)
+	addDON(localRegistry, capShard1ID, uint32(0), uint8(1), true, false, capShard1Nodes, []string{"zone-a_shard-1"}, 1, [][32]byte{capIDHash})
+	addCapabilityToDON(localRegistry, capShard1ID, fullTargetID, capabilities.CapabilityTypeTarget, nil)
+	addDON(localRegistry, sharedCapDONID, uint32(0), uint8(1), true, false, sharedCapNodes, []string{"zone-a"}, 1, [][32]byte{capIDHash})
+	addCapabilityToDON(localRegistry, sharedCapDONID, fullTargetID, capabilities.CapabilityTypeTarget, nil)
+
+	launcher, err := NewLauncher(logger.Test(t), nil, sharedPeer, nil, dispatcher, registry, &mockDonNotifier{})
+	require.NoError(t, err)
+
+	sharedPeer.On("IsBootstrap").Return(false).Once()
+	res := launcher.donPairsToUpdate(pid, localRegistry)
+	require.Len(t, res, 2, "workflow shard connects only to its shard-family capability DON and the shared-family capability DON")
+	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[registrysyncer.DonID(wfDONID)].DON, localRegistry.IDsToDONs[registrysyncer.DonID(capShard0ID)].DON}, res[0])
+	require.Equal(t, p2ptypes.DonPair{localRegistry.IDsToDONs[registrysyncer.DonID(wfDONID)].DON, localRegistry.IDsToDONs[registrysyncer.DonID(sharedCapDONID)].DON}, res[1])
+}
+
+func TestLauncher_ShardedCapability_PhaseA_AllCapsInCommonFamily(t *testing.T) {
+	lggr := logger.Test(t)
+	registry := NewRegistry(lggr)
+	dispatcher := remoteMocks.NewDispatcher(t)
+
+	workflowDonNodes, capShard0Nodes, capShard1Nodes := newNodes(4), newNodes(4), newNodes(4)
+	peer := mocks.NewPeer(t)
+	peer.On("UpdateConnections", mock.Anything).Return(nil)
+	peer.On("ID").Return(workflowDonNodes[0])
+	peer.On("IsBootstrap").Return(false)
+	wrapper := mocks.NewPeerWrapper(t)
+	wrapper.On("GetPeer").Return(peer)
+
+	fullTargetID := "write-chain_evm_1@1.0.0"
+	cfg, err := proto.Marshal(&capabilitiespb.CapabilityConfig{})
+	require.NoError(t, err)
+
+	wfDONID := uint32(1)
+	capShard0ID := uint32(2)
+	capShard1ID := uint32(3)
+
+	localRegistry := buildLocalRegistry()
+	addDON(localRegistry, wfDONID, uint32(0), uint8(1), true, true, workflowDonNodes, []string{"zone-a", "zone-a_shard-0"}, 1, nil)
+	addDON(localRegistry, capShard0ID, uint32(0), uint8(1), true, false, capShard0Nodes, []string{"zone-a"}, 1, [][32]byte{RandomUTF8BytesWord()})
+	addCapabilityToDON(localRegistry, capShard0ID, fullTargetID, capabilities.CapabilityTypeTarget, cfg)
+	addDON(localRegistry, capShard1ID, uint32(0), uint8(1), true, false, capShard1Nodes, []string{"zone-a"}, 1, [][32]byte{RandomUTF8BytesWord()})
+	addCapabilityToDON(localRegistry, capShard1ID, fullTargetID, capabilities.CapabilityTypeTarget, cfg)
+
+	launcher, err := NewLauncher(lggr, wrapper, nil, nil, dispatcher, registry, &mockDonNotifier{})
+	require.NoError(t, err)
+	require.NoError(t, launcher.Start(t.Context()))
+	defer launcher.Close()
+
+	dispatcher.On("SetReceiver", fullTargetID, capShard0ID, mock.AnythingOfType("*executable.client")).Return(nil)
+
+	require.NoError(t, launcher.OnNewRegistry(t.Context(), localRegistry))
+
+	targetCap, err := registry.Get(t.Context(), fullTargetID)
+	require.NoError(t, err)
+	info, err := targetCap.Info(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, capShard0ID, info.DON.ID)
+}
+
+func TestLauncher_DonPairsToUpdate_CapShardPairsOnlyWithWorkflowShard(t *testing.T) {
+	registry := NewRegistry(logger.Test(t))
+	dispatcher := remoteMocks.NewDispatcher(t)
+
+	var capNodePID ragetypes.PeerID
+	require.NoError(t, capNodePID.UnmarshalText([]byte(utils.MustNewPeerID())))
+	sharedPeer := mocks.NewSharedPeer(t)
+
+	wfShard0Nodes, wfShard1Nodes, capShard0Nodes := newNodes(4), newNodes(4), newNodes(4)
+	capShard0Nodes[0] = capNodePID
+
+	wfShard0ID := uint32(1)
+	wfShard1ID := uint32(2)
+	capShard0ID := uint32(3)
+
+	localRegistry := buildLocalRegistry()
+	addDON(localRegistry, wfShard0ID, uint32(0), uint8(1), true, true, wfShard0Nodes, []string{"zone-a", "zone-a_shard-0"}, 1, nil)
+	addDON(localRegistry, wfShard1ID, uint32(0), uint8(1), true, true, wfShard1Nodes, []string{"zone-a", "zone-a_shard-1"}, 1, nil)
+	addDON(localRegistry, capShard0ID, uint32(0), uint8(1), true, false, capShard0Nodes, []string{"zone-a_shard-0"}, 1, [][32]byte{RandomUTF8BytesWord()})
+	addCapabilityToDON(localRegistry, capShard0ID, "write-chain_evm_1@1.0.0", capabilities.CapabilityTypeTarget, nil)
+
+	launcher, err := NewLauncher(logger.Test(t), nil, sharedPeer, nil, dispatcher, registry, &mockDonNotifier{})
+	require.NoError(t, err)
+
+	sharedPeer.On("IsBootstrap").Return(false).Once()
+	res := launcher.donPairsToUpdate(capNodePID, localRegistry)
+	require.Len(t, res, 1)
+	require.Equal(t, p2ptypes.DonPair{
+		localRegistry.IDsToDONs[registrysyncer.DonID(wfShard0ID)].DON,
+		localRegistry.IDsToDONs[registrysyncer.DonID(capShard0ID)].DON,
+	}, res[0])
+}
+
 func TestLauncher_V2CapabilitiesAddViaCombinedClient(t *testing.T) {
 	lggr := logger.Test(t)
 	registry := NewRegistry(lggr)

--- a/core/capabilities/launcher_test.go
+++ b/core/capabilities/launcher_test.go
@@ -1028,6 +1028,60 @@ func TestLauncher_DonPairsToUpdate_CapShardPairsOnlyWithWorkflowShard(t *testing
 	}, res[0])
 }
 
+// A bootstrap node that belongs to no shard family still wires connectivity for an isolated
+// cap shard: the self-pair lets the shard discover its own members and the cross-pair connects
+// it to its paired workflow shard. Bootstrap family membership is irrelevant.
+func TestLauncher_DonPairsToUpdate_BootstrapConnectsIsolatedCapShard(t *testing.T) {
+	registry := NewRegistry(logger.Test(t))
+	dispatcher := remoteMocks.NewDispatcher(t)
+
+	var bootstrapPID ragetypes.PeerID
+	require.NoError(t, bootstrapPID.UnmarshalText([]byte(utils.MustNewPeerID())))
+	sharedPeer := mocks.NewSharedPeer(t)
+
+	wfShard0Nodes, wfShard1Nodes, capShard0Nodes, capShard1Nodes := newNodes(4), newNodes(4), newNodes(4), newNodes(4)
+
+	wfShard0ID := uint32(1)
+	wfShard1ID := uint32(2)
+	capShard0ID := uint32(3)
+	capShard1ID := uint32(4)
+
+	localRegistry := buildLocalRegistry()
+	addDON(localRegistry, wfShard0ID, uint32(0), uint8(1), true, true, wfShard0Nodes, []string{"zone-a", "zone-a_shard-0"}, 1, nil)
+	addDON(localRegistry, wfShard1ID, uint32(0), uint8(1), true, true, wfShard1Nodes, []string{"zone-a", "zone-a_shard-1"}, 1, nil)
+	addDON(localRegistry, capShard0ID, uint32(0), uint8(1), true, false, capShard0Nodes, []string{"zone-a_shard-0"}, 1, [][32]byte{RandomUTF8BytesWord()})
+	addCapabilityToDON(localRegistry, capShard0ID, "write-chain_evm_1@1.0.0", capabilities.CapabilityTypeTarget, nil)
+	addDON(localRegistry, capShard1ID, uint32(0), uint8(1), true, false, capShard1Nodes, []string{"zone-a_shard-1"}, 1, [][32]byte{RandomUTF8BytesWord()})
+	addCapabilityToDON(localRegistry, capShard1ID, "write-chain_evm_1@1.0.0", capabilities.CapabilityTypeTarget, nil)
+
+	launcher, err := NewLauncher(logger.Test(t), nil, sharedPeer, nil, dispatcher, registry, &mockDonNotifier{})
+	require.NoError(t, err)
+
+	// bootstrapPID is a member of no DON and therefore of no shard family.
+	sharedPeer.On("IsBootstrap").Return(true).Once()
+	res := launcher.donPairsToUpdate(bootstrapPID, localRegistry)
+
+	capShard0Self := p2ptypes.DonPair{
+		localRegistry.IDsToDONs[registrysyncer.DonID(capShard0ID)].DON,
+		localRegistry.IDsToDONs[registrysyncer.DonID(capShard0ID)].DON,
+	}
+	shard0Cross := p2ptypes.DonPair{
+		localRegistry.IDsToDONs[registrysyncer.DonID(wfShard0ID)].DON,
+		localRegistry.IDsToDONs[registrysyncer.DonID(capShard0ID)].DON,
+	}
+	crossShard := p2ptypes.DonPair{
+		localRegistry.IDsToDONs[registrysyncer.DonID(wfShard1ID)].DON,
+		localRegistry.IDsToDONs[registrysyncer.DonID(capShard0ID)].DON,
+	}
+
+	require.Contains(t, res, capShard0Self, "isolated cap shard must get a self-pair for member discovery via bootstrap")
+	require.Contains(t, res, shard0Cross, "cap shard must connect to its paired workflow shard")
+	require.NotContains(t, res, crossShard, "cap shard must not connect to a workflow shard in a different shard family")
+
+	// 2 cross-pairs (shard-0, shard-1) + 4 self-pairs (one per DON).
+	require.Len(t, res, 6)
+}
+
 func TestLauncher_V2CapabilitiesAddViaCombinedClient(t *testing.T) {
 	lggr := logger.Test(t)
 	registry := NewRegistry(lggr)

--- a/core/scripts/cre/environment/configs/workflow-sharded-capabilities-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-sharded-capabilities-don.toml
@@ -1,0 +1,234 @@
+# Sharded capability routing via DON families.
+#
+# The same capability (evm-2337 write target) is hosted on multiple capability DON shards.
+# Each workflow shard is routed to exactly one capability shard by sharing a per-shard DON
+# family, while a common family ("zone-a") keeps every workflow shard connected to the
+# gateway and to shared (non-sharded) capability DONs.
+#
+# Family layout (see additional_don_families):
+#   workflow-shard-0 : don_family="zone-a" + additional=["zone-a_shard-0"]
+#   workflow-shard-1 : don_family="zone-a" + additional=["zone-a_shard-1"]
+#   cap-shard-0      : don_family="zone-a_shard-0"
+#   cap-shard-1      : don_family="zone-a_shard-1"
+#   shared-cap       : don_family="zone-a"                    (hosts vault; reachable by all shards)
+#   bootstrap-gateway: don_family="zone-a"
+#
+# The launcher's family-overlap filter therefore routes workflow-shard-0 -> cap-shard-0 and
+# workflow-shard-1 -> cap-shard-1 for evm-2337, while both shards reach shared-cap via "zone-a".
+# Gateway pairing uses the primary don_family ("zone-a") only.
+
+[chip_router]
+  image = "local-cre-chip-router:v1.0.1"
+
+[[blockchains]]
+  type = "anvil"
+  chain_id = "1337"
+  container_name = "anvil-1337"
+  docker_cmd_params = ["-b", "0.5", "--mixed-mining"]
+
+[[blockchains]]
+  type = "anvil"
+  chain_id = "2337"
+  container_name = "anvil-2337"
+  port = "8546"
+  docker_cmd_params = ["-b", "0.5", "--mixed-mining"]
+
+[jd]
+  csa_encryption_key = "d1093c0060d50a3c89c189b2e485da5a3ce57f3dcb38ab7e2c0d5f0bb2314a44" # any random 32 byte hex string
+  image = "job-distributor:0.22.1"
+
+[fake]
+  port = 8171
+
+[fake_http]
+  port = 8666
+
+[infra]
+  type = "docker"
+
+# --- Workflow shard 0 -------------------------------------------------------
+[[nodesets]]
+  nodes = 4
+  name = "workflow-shard-0"
+  don_family = "zone-a"
+  additional_don_families = ["zone-a_shard-0"]
+  don_types = ["workflow", "shard"]
+  shard_index = 0
+  override_mode = "each"
+  http_port_range_start = 10100
+  supported_evm_chains = [1337, 2337]
+
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
+  capabilities = ["cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+
+  [nodesets.db]
+    image = "postgres:12.0"
+    port = 13000
+
+  [[nodesets.node_specs]]
+    roles = ["plugin"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      custom_ports = ["60051:50051", "19876:9876"]
+      user_config_overrides = ""
+
+  [[nodesets.node_specs]]
+    roles = ["plugin"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      custom_ports = ["19877:9876"]
+      user_config_overrides = ""
+
+  [[nodesets.node_specs]]
+    roles = ["plugin"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      custom_ports = ["19878:9876"]
+      user_config_overrides = ""
+
+  [[nodesets.node_specs]]
+    roles = ["plugin"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      custom_ports = ["19879:9876"]
+      user_config_overrides = ""
+
+# --- Workflow shard 1 -------------------------------------------------------
+[[nodesets]]
+  nodes = 4
+  name = "workflow-shard-1"
+  don_family = "zone-a"
+  additional_don_families = ["zone-a_shard-1"]
+  don_types = ["workflow", "shard"]
+  shard_index = 1
+  override_mode = "all"
+  http_port_range_start = 10400
+  supported_evm_chains = [1337, 2337]
+
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
+  capabilities = ["cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+
+  [nodesets.db]
+    image = "postgres:12.0"
+    port = 13400
+
+  [[nodesets.node_specs]]
+    roles = ["plugin"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      user_config_overrides = ""
+
+# --- Capability shard 0 (hosts the sharded capability) ----------------------
+[[nodesets]]
+  nodes = 4
+  name = "cap-shard-0"
+  don_family = "zone-a_shard-0"
+  don_types = ["capabilities"]
+  exposes_remote_capabilities = true
+  override_mode = "all"
+  http_port_range_start = 10200
+  supported_evm_chains = [1337, 2337]
+
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
+  capabilities = ["evm-2337"]
+
+  [nodesets.db]
+    image = "postgres:12.0"
+    port = 13100
+
+  [[nodesets.node_specs]]
+    roles = ["plugin"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      user_config_overrides = ""
+
+# --- Capability shard 1 (hosts the same sharded capability) -----------------
+[[nodesets]]
+  nodes = 4
+  name = "cap-shard-1"
+  don_family = "zone-a_shard-1"
+  don_types = ["capabilities"]
+  exposes_remote_capabilities = true
+  override_mode = "all"
+  http_port_range_start = 10500
+  supported_evm_chains = [1337, 2337]
+
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
+  capabilities = ["evm-2337"]
+
+  [nodesets.db]
+    image = "postgres:12.0"
+    port = 13500
+
+  [[nodesets.node_specs]]
+    roles = ["plugin"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      user_config_overrides = ""
+
+# --- Shared (non-sharded) capability DON, reachable by every workflow shard --
+[[nodesets]]
+  nodes = 4
+  name = "shared-cap"
+  don_family = "zone-a"
+  don_types = ["capabilities"]
+  exposes_remote_capabilities = true
+  override_mode = "all"
+  http_port_range_start = 10600
+  supported_evm_chains = [1337, 2337]
+
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
+  capabilities = ["vault"]
+
+  [nodesets.db]
+    image = "postgres:12.0"
+    port = 13600
+
+  [[nodesets.node_specs]]
+    roles = ["plugin"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      user_config_overrides = ""
+
+# --- Bootstrap + gateway ----------------------------------------------------
+[[nodesets]]
+  nodes = 1
+  name = "bootstrap-gateway"
+  don_family = "zone-a"
+  don_types = ["bootstrap", "gateway"]
+  override_mode = "each"
+  http_port_range_start = 10300
+  supported_evm_chains = [1337, 2337]
+
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
+
+  [nodesets.db]
+    image = "postgres:12.0"
+    port = 13200
+
+  [[nodesets.node_specs]]
+    roles = ["bootstrap", "gateway"]
+    [nodesets.node_specs.node]
+      docker_ctx = "../../../.."
+      docker_file = "core/chainlink.Dockerfile"
+      docker_build_args = { "CL_IS_PROD_BUILD" = "false" }
+      custom_ports = ["5002:5002","15002:15002"]
+      user_config_overrides = ""

--- a/system-tests/lib/cre/contracts/keystone.go
+++ b/system-tests/lib/cre/contracts/keystone.go
@@ -94,8 +94,8 @@ func DeployKeystoneContracts(
 }
 
 type donConfig struct {
-	id        uint32 // Capabilities Registry DON ID
-	donFamily string // nodesets.don_family → CapabilitiesRegistryNewDONParams.DonFamilies
+	id          uint32   // Capabilities Registry DON ID
+	donFamilies []string // nodesets.don_family + additional_don_families → CapabilitiesRegistryNewDONParams.DonFamilies
 	keystone_changeset.DonCapabilities
 	flags []cre.CapabilityFlag
 }
@@ -286,7 +286,7 @@ func (d *dons) mustToV2ConfigureInput(chainSelector uint64, contractAddress stri
 
 		donParams[i] = capabilities_registry_v2.CapabilitiesRegistryNewDONParams{
 			Name:                     don.Name,
-			DonFamilies:              []string{don.donFamily},
+			DonFamilies:              don.donFamilies,
 			Config:                   []byte("{}"),
 			CapabilityConfigurations: capConfigs,
 			Nodes:                    donNodes,
@@ -433,7 +433,7 @@ func toDons(input cre.ConfigureCapabilityRegistryInput) (*dons, error) {
 
 		dons.c[donName] = donConfig{
 			id:              uint32(donMetadata.ID), //nolint:gosec // G115
-			donFamily:       donMetadata.DonFamily,
+			donFamilies:     donMetadata.DonFamilies(),
 			DonCapabilities: c,
 			flags:           donMetadata.Flags,
 		}

--- a/system-tests/lib/cre/sharded_capability_family_test.go
+++ b/system-tests/lib/cre/sharded_capability_family_test.go
@@ -1,0 +1,95 @@
+package cre
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDonMetadata_DonFamilies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		don      DonMetadata
+		expected []string
+	}{
+		{name: "primary only", don: DonMetadata{DonFamily: "zone-a"}, expected: []string{"zone-a"}},
+		{
+			name:     "primary plus shard family",
+			don:      DonMetadata{DonFamily: "zone-a", AdditionalDonFamilies: []string{"zone-a_shard-0"}},
+			expected: []string{"zone-a", "zone-a_shard-0"},
+		},
+		{
+			name:     "dedups repeated families",
+			don:      DonMetadata{DonFamily: "zone-a", AdditionalDonFamilies: []string{"zone-a", "zone-a_shard-1", "zone-a_shard-1"}},
+			expected: []string{"zone-a", "zone-a_shard-1"},
+		},
+		{
+			name:     "trims whitespace and drops empties",
+			don:      DonMetadata{DonFamily: " zone-a ", AdditionalDonFamilies: []string{"  ", " zone-a_shard-2 "}},
+			expected: []string{"zone-a", "zone-a_shard-2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, tt.don.DonFamilies())
+		})
+	}
+}
+
+func TestShardedCapabilityTopology_FamilyLayout(t *testing.T) {
+	t.Parallel()
+
+	topology := shardedCapabilityTestTopology(t)
+
+	byName := map[string]*DonMetadata{}
+	for _, d := range topology.DonsMetadata.List() {
+		byName[d.Name] = d
+	}
+
+	require.Equal(t, []string{"zone-a", "zone-a_shard-0"}, byName["workflow-shard-0"].DonFamilies())
+	require.Equal(t, []string{"zone-a", "zone-a_shard-1"}, byName["workflow-shard-1"].DonFamilies())
+	require.Equal(t, []string{"zone-a_shard-0"}, byName["cap-shard-0"].DonFamilies())
+	require.Equal(t, []string{"zone-a_shard-1"}, byName["cap-shard-1"].DonFamilies())
+	require.Equal(t, []string{"zone-a"}, byName["shared-cap"].DonFamilies())
+
+	require.Equal(t, []string{"zone-a"}, topology.WorkflowDONFamilies())
+	require.ElementsMatch(t, []DonFamilyGatewayPair{
+		{DonFamily: "zone-a", WorkflowDONName: "workflow-shard-0", GatewayDONName: "bootstrap-gateway"},
+		{DonFamily: "zone-a", WorkflowDONName: "workflow-shard-1", GatewayDONName: "bootstrap-gateway"},
+	}, topology.DonFamilyGatewayPairings())
+
+	require.Len(t, topology.GatewayConnectorsForDonFamily("zone-a").Configurations, 1)
+	require.Empty(t, topology.GatewayConnectorsForDonFamily("zone-a_shard-0").Configurations)
+	require.Empty(t, topology.GatewayConnectorsForDonFamily("zone-a_shard-1").Configurations)
+}
+
+func shardedCapabilityTestTopology(t *testing.T) *Topology {
+	t.Helper()
+
+	conn := testGatewayConnector("gateway-node-0", "bootstrap-gateway.local", 5002)
+
+	topology := &Topology{
+		DonsMetadata: &DonsMetadata{
+			dons: []*DonMetadata{
+				{Name: "workflow-shard-0", ID: 1, DonFamily: "zone-a", AdditionalDonFamilies: []string{"zone-a_shard-0"}, Flags: []string{WorkflowDON, HTTPActionCapability}},
+				{Name: "workflow-shard-1", ID: 2, DonFamily: "zone-a", AdditionalDonFamilies: []string{"zone-a_shard-1"}, Flags: []string{WorkflowDON, HTTPActionCapability}},
+				{Name: "cap-shard-0", ID: 3, DonFamily: "zone-a_shard-0", Flags: []string{CapabilitiesDON}},
+				{Name: "cap-shard-1", ID: 4, DonFamily: "zone-a_shard-1", Flags: []string{CapabilitiesDON}},
+				{Name: "shared-cap", ID: 5, DonFamily: "zone-a", Flags: []string{CapabilitiesDON}},
+				{Name: "bootstrap-gateway", DonFamily: "zone-a", NodesMetadata: []*NodeMetadata{{Roles: []string{GatewayNode}}}},
+			},
+		},
+		GatewayConnectors: &GatewayConnectors{
+			Configurations: []*DonGatewayConfiguration{conn},
+		},
+		gatewayConnectorsByDon: map[string]*DonGatewayConfiguration{
+			"bootstrap-gateway": conn,
+		},
+	}
+	require.NoError(t, topology.initDonFamilyGatewayPairing())
+	return topology
+}

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -529,6 +529,7 @@ type DonMetadata struct {
 	ID                           uint64                              `toml:"id" json:"id"`
 	Name                         string                              `toml:"name" json:"name"`
 	DonFamily                    string                              `toml:"don_family" json:"don_family"` // nodesets.don_family; gateway pairing, cap-registration, and workflow deploy family
+	AdditionalDonFamilies        []string                            `toml:"additional_don_families" json:"additional_don_families"`
 	ExposesRemoteCapabilities    bool                                `toml:"exposes_remote_capabilities" json:"exposes_remote_capabilities"`
 	ShardIndex                   uint                                `toml:"shard_index" json:"shard_index"`
 	CapabilityConfigs            map[CapabilityFlag]CapabilityConfig `toml:"capability_configs" json:"capability_configs"`
@@ -588,6 +589,7 @@ func NewDonMetadata(c *NodeSet, id uint64, provider infra.Provider, capabilityCo
 		NodesMetadata:                nodes,
 		Name:                         c.Name,
 		DonFamily:                    strings.TrimSpace(c.DonFamily),
+		AdditionalDonFamilies:        trimmedNonEmpty(c.AdditionalDonFamilies),
 		ns:                           c,
 		ExposesRemoteCapabilities:    c.ExposesRemoteCapabilities,
 		ShardIndex:                   c.ShardIndex,
@@ -596,6 +598,41 @@ func NewDonMetadata(c *NodeSet, id uint64, provider infra.Provider, capabilityCo
 	}
 
 	return out, nil
+}
+
+// trimmedNonEmpty trims whitespace from each string and drops empty results, preserving order.
+func trimmedNonEmpty(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if t := strings.TrimSpace(s); t != "" {
+			out = append(out, t)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// DonFamilies returns primary DonFamily plus AdditionalDonFamilies, de-duplicated in order.
+func (m *DonMetadata) DonFamilies() []string {
+	families := make([]string, 0, 1+len(m.AdditionalDonFamilies))
+	seen := make(map[string]struct{}, 1+len(m.AdditionalDonFamilies))
+	for _, f := range append([]string{m.DonFamily}, m.AdditionalDonFamilies...) {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		if _, ok := seen[f]; ok {
+			continue
+		}
+		seen[f] = struct{}{}
+		families = append(families, f)
+	}
+	return families
 }
 
 func processCapabilityConfigs(c *NodeSet, defaults CapabilityConfigs) (CapabilityConfigs, error) {
@@ -1217,6 +1254,8 @@ type NodeSet struct {
 	// DonFamily groups workflow and gateway nodesets for per-family gateway pairing in local CRE.
 	// Required on every nodeset; env start fails if missing or unmatched (see topology_don_family.go).
 	DonFamily string `toml:"don_family" validate:"required"`
+	// AdditionalDonFamilies are extra CapReg families for sharded capability routing.
+	AdditionalDonFamilies []string `toml:"additional_don_families"`
 	// SupportedEVMChains is filter. Use EVMChains() to get the actual list of chains supported by the nodeset.
 	SupportedEVMChains []uint64          `toml:"supported_evm_chains"` // chain IDs that the DON supports, empty means all chains
 	EnvVars            map[string]string `toml:"env_vars"`             // additional environment variables to be set on each node


### PR DESCRIPTION
multiple DON families support in order to achieve multi-DON capability routing

[cre-5294](https://smartcontract-it.atlassian.net/browse/CRE-5294)