### PR TITLE
Fake HTTP Trigger - disable redirects

### DIFF
--- a/core/capabilities/fakes/confidential_http_action.go
+++ b/core/capabilities/fakes/confidential_http_action.go
@@ -109,7 +109,8 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 	// Create HTTP client with timeout (default 30 seconds)
 	timeout := time.Duration(30) * time.Second
 	client := &http.Client{
-		Timeout: timeout,
+		Timeout:       timeout,
+		CheckRedirect: disableRedirects,
 	}
 
 	// Validate HTTP method

--- a/core/capabilities/fakes/confidential_http_action_test.go
+++ b/core/capabilities/fakes/confidential_http_action_test.go
@@ -90,6 +90,8 @@ secretsNames:
 }
 
 func TestDirectConfidentialHTTPAction_Redirects(t *testing.T) {
+	t.Parallel()
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/somewhere-else", http.StatusFound)
 	}))

--- a/core/capabilities/fakes/confidential_http_action_test.go
+++ b/core/capabilities/fakes/confidential_http_action_test.go
@@ -1,6 +1,9 @@
 package fakes
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	commonCap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
 	confidentialhttp "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialhttp"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -82,4 +87,27 @@ secretsNames:
 	require.True(t, ok)
 	require.Len(t, secrets, 1)
 	assert.Equal(t, "MISSING_ENV_VAR", secrets[0])
+}
+
+func TestDirectConfidentialHTTPAction_Redirects(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/somewhere-else", http.StatusFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	lggr := logger.Test(t)
+	action := NewDirectConfidentialHTTPAction(lggr, filepath.Join(t.TempDir(), "secrets.yaml"))
+
+	input := &confidentialhttp.ConfidentialHTTPRequest{
+		Request: &confidentialhttp.HTTPRequest{
+			Url:    srv.URL,
+			Method: "GET",
+		},
+	}
+
+	result, err := action.SendRequest(context.Background(), commonCap.RequestMetadata{}, input)
+	require.Error(t, err)
+	assert.Equal(t, caperrors.InvalidArgument, err.Code())
+	assert.Contains(t, err.Error(), "redirects are not allowed")
+	assert.Nil(t, result)
 }

--- a/core/capabilities/fakes/http_action.go
+++ b/core/capabilities/fakes/http_action.go
@@ -130,6 +130,9 @@ func (fh *DirectHTTPAction) SendRequest(ctx context.Context, metadata commonCap.
 			Response:         httpResponse,
 			ResponseMetadata: commonCap.ResponseMetadata{},
 		}
+		if errors.Is(err, errRedirectsDisabled) {
+			return &responseAndMetadata, caperrors.NewPublicUserError(err, caperrors.InvalidArgument)
+		}
 		return &responseAndMetadata, caperrors.NewPrivateSystemError(err, caperrors.Unknown)
 	}
 	defer resp.Body.Close()
@@ -174,12 +177,21 @@ func (fh *DirectHTTPAction) SendRequest(ctx context.Context, metadata commonCap.
 	return &responseAndMetadata, nil
 }
 
+// errRedirectsDisabled mirrors the CRE DON's HTTP action capability, which
+// does not permit following redirects (see capabilities/http_action/common/proxy.go).
+var errRedirectsDisabled = errors.New("redirects are not allowed")
+
+func disableRedirects(*http.Request, []*http.Request) error {
+	return errRedirectsDisabled
+}
+
 // newHTTPClient builds the HTTP client used to make the outbound request. When
 // the request carries mTLS auth, the client is configured to present the
 // supplied certificate and private key as a client certificate.
 func newHTTPClient(input *customhttp.Request, timeout time.Duration) (*http.Client, error) {
 	client := &http.Client{
-		Timeout: timeout,
+		Timeout:       timeout,
+		CheckRedirect: disableRedirects,
 	}
 
 	mtls := input.GetMtls()

--- a/core/capabilities/fakes/http_action_test.go
+++ b/core/capabilities/fakes/http_action_test.go
@@ -78,6 +78,34 @@ func TestDirectHTTPAction_RequestHeaders(t *testing.T) {
 	})
 }
 
+func TestDirectHTTPAction_Redirects(t *testing.T) {
+	t.Run("redirects are blocked like the DON, and surfaced as a user error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/somewhere-else", http.StatusFound)
+		}))
+		t.Cleanup(srv.Close)
+
+		lggr := logger.Test(t)
+		action := NewDirectHTTPAction(lggr)
+		require.NoError(t, action.Start(context.Background()))
+		t.Cleanup(func() { _ = action.Close() })
+
+		input := &customhttp.Request{
+			Url:    srv.URL,
+			Method: "GET",
+		}
+		metadata := commonCap.RequestMetadata{}
+
+		result, err := action.SendRequest(context.Background(), metadata, input)
+		require.Error(t, err)
+		assert.Equal(t, caperrors.InvalidArgument, err.Code())
+		assert.Contains(t, err.Error(), "redirects are not allowed")
+		require.NotNil(t, result)
+		require.NotNil(t, result.Response)
+		assert.Equal(t, uint32(0), result.Response.StatusCode)
+	})
+}
+
 // Fixed self-signed ECDSA P-256 material (valid until 2100) used by the mTLS
 // tests. The client cert (CN=test-client) doubles as its own CA so the server
 // can verify it; the server cert (CN=127.0.0.1, IP SAN 127.0.0.1) doubles as

--- a/core/capabilities/fakes/http_action_test.go
+++ b/core/capabilities/fakes/http_action_test.go
@@ -79,6 +79,8 @@ func TestDirectHTTPAction_RequestHeaders(t *testing.T) {
 }
 
 func TestDirectHTTPAction_Redirects(t *testing.T) {
+	t.Parallel()
+
 	t.Run("redirects are blocked like the DON, and surfaced as a user error", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/somewhere-else", http.StatusFound)


### PR DESCRIPTION
This pull request strengthens the HTTP action capabilities by ensuring that HTTP redirects are explicitly blocked, matching the behavior of the DON's HTTP action capability. It introduces a shared redirect-blocking mechanism, surfaces redirect attempts as user errors, and adds comprehensive tests to verify this behavior.

**Redirect handling improvements:**

* Added a `disableRedirects` function and `errRedirectsDisabled` error to block HTTP redirects, setting `CheckRedirect` in HTTP clients for both `DirectHTTPAction` and `DirectConfidentialHTTPAction`. This ensures any redirect attempt results in a user-facing error, aligning with DON's behavior.
* Updated error handling in `DirectHTTPAction.SendRequest` to return a public user error with code `InvalidArgument` when redirects are encountered.