### PR TITLE
.golangci.yaml: deny more chains

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,8 +65,8 @@ linters:
               desc: Use gopkg.in/guregu/null.v4 instead
             - pkg: github.com/go-gorm/gorm
               desc: Use github.com/jmoiron/sqlx directly instead
-            #  - pkg: github.com/smartcontractkit/chainlink-aptos
-            #   desc: Aptos only runs as a LOOPP
+            - pkg: github.com/smartcontractkit/chainlink-aptos
+              desc: Aptos only runs as a LOOPP
             - pkg: github.com/smartcontractkit/chainlink-cosmos
               desc: Cosmos only runs as a LOOPP
             - pkg: github.com/smartcontractkit/chainlink-integrations/evm
@@ -75,8 +75,14 @@ linters:
               desc: Solana only runs as a LOOPP
             - pkg: github.com/smartcontractkit/chainlink-starknet/relayer
               desc: Starknet only runs as a LOOPP
-            #  - pkg: github.com/smartcontractkit/chainlink-tron
-            #  desc: Tron only runs as a LOOPP
+            - pkg: github.com/smartcontractkit/chainlink-stellar
+              desc: Stellar only runs as a LOOPP
+            - pkg: github.com/smartcontractkit/chainlink-sui/relayer
+              desc: Sui only runs as a LOOPP
+            - pkg: github.com/smartcontractkit/chainlink-ton
+              desc: Ton only runs as a LOOPP
+            - pkg: github.com/smartcontractkit/chainlink-tron/relayer
+              desc: Tron only runs as a LOOPP
             - pkg: github.com/consul/sdk/freeport
               desc: Use github.com/smartcontractkit/freeport instead
         keystore:


### PR DESCRIPTION
Deny importing chain modules now that we have reduce dependencies to just codec modules.

Note: I wonder if we should consider swapping to gomodguard. It seems like it understands modules vs. packages better, and may even allow us to auto block the whole org while allowing only a particular list, so that we can prevent new modules from sneaking in.