### PR TITLE
Check secrets restrictions in relay DON

### DIFF
--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -641,7 +642,55 @@ func (h *Handler) verifyWorkflowAuthorization(don capabilities.DON, params confi
 	if execution.GetWorkflowId() != params.WorkflowID {
 		return fmt.Errorf("workflow_id not authorized: request %q vs signed %q", params.WorkflowID, execution.GetWorkflowId())
 	}
+
+	// The signed WorkflowExecution also carries the secret restrictions the workflow declared.
+	// The enclave enforces them, but the relay is the security boundary and re-checks so a
+	// breached enclave cannot fetch secrets the workflow never authorized.
+	if err := verifySecretsWithinRestrictions(execution.GetRestrictions(), params.Secrets); err != nil {
+		return err
+	}
 	return nil
+}
+
+// verifySecretsWithinRestrictions enforces that every requested secret is permitted by the
+// workflow's declared secret restrictions. A secret is permitted when it matches an exact
+// restriction (id and namespace) or a prefixed restriction (namespace and key prefix). When
+// no secret restrictions are set the workflow declared no limit, so all secrets are allowed.
+func verifySecretsWithinRestrictions(restrictions *sdkpb.Restrictions, secrets []confidentialrelaytypes.SecretIdentifier) error {
+	secretRestrictions := restrictions.GetSecrets()
+	if secretRestrictions == nil {
+		return nil
+	}
+
+	exact := make(map[confidentialrelaytypes.SecretIdentifier]struct{})
+	var prefixes []*sdkpb.SecretPrefixRestriction
+	for _, sr := range secretRestrictions.GetRestrictions() {
+		switch v := sr.GetRestriction().(type) {
+		case *sdkpb.SecretRestriction_ExactSecret:
+			exact[confidentialrelaytypes.SecretIdentifier{Key: v.ExactSecret.GetId(), Namespace: v.ExactSecret.GetNamespace()}] = struct{}{}
+		case *sdkpb.SecretRestriction_PrefixedSecret:
+			prefixes = append(prefixes, v.PrefixedSecret)
+		}
+	}
+
+	for _, s := range secrets {
+		if !secretAllowedByRestrictions(s, exact, prefixes) {
+			return fmt.Errorf("secret %q in namespace %q not permitted by workflow restrictions", s.Key, s.Namespace)
+		}
+	}
+	return nil
+}
+
+func secretAllowedByRestrictions(s confidentialrelaytypes.SecretIdentifier, exact map[confidentialrelaytypes.SecretIdentifier]struct{}, prefixes []*sdkpb.SecretPrefixRestriction) bool {
+	if _, ok := exact[s]; ok {
+		return true
+	}
+	for _, p := range prefixes {
+		if p.GetNamespace() == s.Namespace && strings.HasPrefix(s.Key, p.GetPrefix()) {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *Handler) jsonResponse(req *jsonrpc.Request[json.RawMessage], result any) *jsonrpc.Response[json.RawMessage] {

--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -646,10 +646,7 @@ func (h *Handler) verifyWorkflowAuthorization(don capabilities.DON, params confi
 	// The signed WorkflowExecution also carries the secret restrictions the workflow declared.
 	// The enclave enforces them, but the relay is the security boundary and re-checks so a
 	// breached enclave cannot fetch secrets the workflow never authorized.
-	if err := verifySecretsWithinRestrictions(execution.GetRestrictions(), params.Secrets); err != nil {
-		return err
-	}
-	return nil
+	return verifySecretsWithinRestrictions(execution.GetRestrictions(), params.Secrets)
 }
 
 // verifySecretsWithinRestrictions enforces that every requested secret is permitted by the

--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -651,12 +651,17 @@ func (h *Handler) verifyWorkflowAuthorization(don capabilities.DON, params confi
 
 // verifySecretsWithinRestrictions enforces that every requested secret is permitted by the
 // workflow's declared secret restrictions. A secret is permitted when it matches an exact
-// restriction (id and namespace) or a prefixed restriction (namespace and key prefix). When
-// no secret restrictions are set the workflow declared no limit, so all secrets are allowed.
+// restriction (id and namespace) or a prefixed restriction (namespace and key prefix), and the
+// number of requested secrets does not exceed MaxSecrets. When no secret restrictions are set
+// the workflow declared no limit, so all secrets are allowed.
 func verifySecretsWithinRestrictions(restrictions *sdkpb.Restrictions, secrets []confidentialrelaytypes.SecretIdentifier) error {
 	secretRestrictions := restrictions.GetSecrets()
 	if secretRestrictions == nil {
 		return nil
+	}
+
+	if len(secrets) > int(secretRestrictions.GetMaxSecrets()) {
+		return fmt.Errorf("requested %d secrets, exceeds the workflow's limit of %d", len(secrets), secretRestrictions.GetMaxSecrets())
 	}
 
 	exact := make(map[confidentialrelaytypes.SecretIdentifier]struct{})

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -917,3 +917,104 @@ func TestVerifyWorkflowAuthorization(t *testing.T) {
 		require.ErrorContains(t, h.verifyWorkflowAuthorization(don, params), "do not share one compute request")
 	})
 }
+
+func TestVerifySecretsWithinRestrictions(t *testing.T) {
+	t.Parallel()
+
+	exact := func(id, ns string) *sdkpb.SecretRestriction {
+		return &sdkpb.SecretRestriction{Restriction: &sdkpb.SecretRestriction_ExactSecret{
+			ExactSecret: &sdkpb.Secret{Id: id, Namespace: ns},
+		}}
+	}
+	prefixed := func(prefix, ns string) *sdkpb.SecretRestriction {
+		return &sdkpb.SecretRestriction{Restriction: &sdkpb.SecretRestriction_PrefixedSecret{
+			PrefixedSecret: &sdkpb.SecretPrefixRestriction{Prefix: prefix, Namespace: ns},
+		}}
+	}
+	secretsRestrictions := func(rs ...*sdkpb.SecretRestriction) *sdkpb.Restrictions {
+		return &sdkpb.Restrictions{Secrets: &sdkpb.SecretsRestritions{Restrictions: rs}}
+	}
+	id := func(key, ns string) confidentialrelaytypes.SecretIdentifier {
+		return confidentialrelaytypes.SecretIdentifier{Key: key, Namespace: ns}
+	}
+
+	tests := []struct {
+		name         string
+		restrictions *sdkpb.Restrictions
+		secrets      []confidentialrelaytypes.SecretIdentifier
+		wantErr      string
+	}{
+		{
+			name:         "nil restrictions allow all",
+			restrictions: nil,
+			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "prod")},
+		},
+		{
+			name:         "nil secrets restrictions allow all",
+			restrictions: &sdkpb.Restrictions{},
+			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "prod")},
+		},
+		{
+			name:         "exact match all present",
+			restrictions: secretsRestrictions(exact("api-key", "prod"), exact("db-pass", "prod")),
+			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "prod"), id("db-pass", "prod")},
+		},
+		{
+			name:         "exact match missing secret rejected",
+			restrictions: secretsRestrictions(exact("api-key", "prod")),
+			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "prod"), id("db-pass", "prod")},
+			wantErr:      `secret "db-pass" in namespace "prod" not permitted`,
+		},
+		{
+			name:         "exact match wrong namespace rejected",
+			restrictions: secretsRestrictions(exact("api-key", "prod")),
+			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "staging")},
+			wantErr:      `secret "api-key" in namespace "staging" not permitted`,
+		},
+		{
+			name:         "prefix match allowed",
+			restrictions: secretsRestrictions(prefixed("svc-", "prod")),
+			secrets:      []confidentialrelaytypes.SecretIdentifier{id("svc-a", "prod"), id("svc-b", "prod")},
+		},
+		{
+			name:         "prefix match wrong namespace rejected",
+			restrictions: secretsRestrictions(prefixed("svc-", "prod")),
+			secrets:      []confidentialrelaytypes.SecretIdentifier{id("svc-a", "staging")},
+			wantErr:      `secret "svc-a" in namespace "staging" not permitted`,
+		},
+		{
+			name:         "prefix non-match rejected",
+			restrictions: secretsRestrictions(prefixed("svc-", "prod")),
+			secrets:      []confidentialrelaytypes.SecretIdentifier{id("other-a", "prod")},
+			wantErr:      `secret "other-a" in namespace "prod" not permitted`,
+		},
+		{
+			name:         "mixed exact and prefix",
+			restrictions: secretsRestrictions(exact("api-key", "prod"), prefixed("svc-", "prod")),
+			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "prod"), id("svc-x", "prod")},
+		},
+		{
+			name:         "empty restriction list rejects requested secret",
+			restrictions: secretsRestrictions(),
+			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "prod")},
+			wantErr:      `secret "api-key" in namespace "prod" not permitted`,
+		},
+		{
+			name:         "empty restriction list allows no secrets",
+			restrictions: secretsRestrictions(),
+			secrets:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := verifySecretsWithinRestrictions(tt.restrictions, tt.secrets)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -931,12 +931,15 @@ func TestVerifySecretsWithinRestrictions(t *testing.T) {
 			PrefixedSecret: &sdkpb.SecretPrefixRestriction{Prefix: prefix, Namespace: ns},
 		}}
 	}
-	secretsRestrictions := func(rs ...*sdkpb.SecretRestriction) *sdkpb.Restrictions {
-		return &sdkpb.Restrictions{Secrets: &sdkpb.SecretsRestritions{Restrictions: rs}}
+	secretsRestrictions := func(maxSecrets int32, rs ...*sdkpb.SecretRestriction) *sdkpb.Restrictions {
+		return &sdkpb.Restrictions{Secrets: &sdkpb.SecretsRestritions{MaxSecrets: maxSecrets, Restrictions: rs}}
 	}
 	id := func(key, ns string) confidentialrelaytypes.SecretIdentifier {
 		return confidentialrelaytypes.SecretIdentifier{Key: key, Namespace: ns}
 	}
+	// unlimited is a MaxSecrets large enough that the count check never fires, so these cases
+	// exercise only the exact/prefix membership logic.
+	const unlimited int32 = 100
 
 	tests := []struct {
 		name         string
@@ -956,53 +959,70 @@ func TestVerifySecretsWithinRestrictions(t *testing.T) {
 		},
 		{
 			name:         "exact match all present",
-			restrictions: secretsRestrictions(exact("api-key", "prod"), exact("db-pass", "prod")),
+			restrictions: secretsRestrictions(unlimited, exact("api-key", "prod"), exact("db-pass", "prod")),
 			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "prod"), id("db-pass", "prod")},
 		},
 		{
 			name:         "exact match missing secret rejected",
-			restrictions: secretsRestrictions(exact("api-key", "prod")),
+			restrictions: secretsRestrictions(unlimited, exact("api-key", "prod")),
 			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "prod"), id("db-pass", "prod")},
 			wantErr:      `secret "db-pass" in namespace "prod" not permitted`,
 		},
 		{
 			name:         "exact match wrong namespace rejected",
-			restrictions: secretsRestrictions(exact("api-key", "prod")),
+			restrictions: secretsRestrictions(unlimited, exact("api-key", "prod")),
 			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "staging")},
 			wantErr:      `secret "api-key" in namespace "staging" not permitted`,
 		},
 		{
 			name:         "prefix match allowed",
-			restrictions: secretsRestrictions(prefixed("svc-", "prod")),
+			restrictions: secretsRestrictions(unlimited, prefixed("svc-", "prod")),
 			secrets:      []confidentialrelaytypes.SecretIdentifier{id("svc-a", "prod"), id("svc-b", "prod")},
 		},
 		{
 			name:         "prefix match wrong namespace rejected",
-			restrictions: secretsRestrictions(prefixed("svc-", "prod")),
+			restrictions: secretsRestrictions(unlimited, prefixed("svc-", "prod")),
 			secrets:      []confidentialrelaytypes.SecretIdentifier{id("svc-a", "staging")},
 			wantErr:      `secret "svc-a" in namespace "staging" not permitted`,
 		},
 		{
 			name:         "prefix non-match rejected",
-			restrictions: secretsRestrictions(prefixed("svc-", "prod")),
+			restrictions: secretsRestrictions(unlimited, prefixed("svc-", "prod")),
 			secrets:      []confidentialrelaytypes.SecretIdentifier{id("other-a", "prod")},
 			wantErr:      `secret "other-a" in namespace "prod" not permitted`,
 		},
 		{
 			name:         "mixed exact and prefix",
-			restrictions: secretsRestrictions(exact("api-key", "prod"), prefixed("svc-", "prod")),
+			restrictions: secretsRestrictions(unlimited, exact("api-key", "prod"), prefixed("svc-", "prod")),
 			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "prod"), id("svc-x", "prod")},
 		},
 		{
 			name:         "empty restriction list rejects requested secret",
-			restrictions: secretsRestrictions(),
+			restrictions: secretsRestrictions(unlimited),
 			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "prod")},
 			wantErr:      `secret "api-key" in namespace "prod" not permitted`,
 		},
 		{
 			name:         "empty restriction list allows no secrets",
-			restrictions: secretsRestrictions(),
+			restrictions: secretsRestrictions(unlimited),
 			secrets:      nil,
+		},
+		{
+			name:         "total limit zero denies all",
+			restrictions: secretsRestrictions(0, exact("api-key", "prod")),
+			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "prod")},
+			wantErr:      `requested 1 secrets, exceeds the workflow's limit of 0`,
+		},
+		{
+			name:         "total limit exceeded",
+			restrictions: secretsRestrictions(1, exact("api-key", "prod"), exact("db-pass", "prod")),
+			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "prod"), id("db-pass", "prod")},
+			wantErr:      `requested 2 secrets, exceeds the workflow's limit of 1`,
+		},
+		{
+			name:         "total limit exactly met",
+			restrictions: secretsRestrictions(2, exact("api-key", "prod"), exact("db-pass", "prod")),
+			secrets:      []confidentialrelaytypes.SecretIdentifier{id("api-key", "prod"), id("db-pass", "prod")},
 		},
 	}
 


### PR DESCRIPTION
Ensures that secrets sent in a relay DON request match against the `Restrictions` object contained within the signed `ComputeRequest` object.

Possible secret types include exact match and prefix.