### PR TITLE
Initialize gin mode only once.

### DIFF
--- a/core/web/evm_transfer_controller_test.go
+++ b/core/web/evm_transfer_controller_test.go
@@ -123,7 +123,6 @@ func TestTransfersController_CreateSuccess_From_WithRelayer(t *testing.T) {
 	require.NoError(t, err)
 	app.EXPECT().GetAuditLogger().Return(auditLogger).Once()
 
-	gin.SetMode(gin.TestMode)
 	ctrl := &web.EVMTransfersController{App: app}
 
 	r := gin.New()
@@ -172,7 +171,6 @@ func TestTransfersController_CreateFail_NoLegacyNoRelayer(t *testing.T) {
 
 	request := models.SendEtherRequest{EVMChainID: sqlutil.New(chainC)}
 
-	gin.SetMode(gin.TestMode)
 	ctrl := &web.EVMTransfersController{App: app}
 
 	r := gin.New()


### PR DESCRIPTION
The gin mode is already set up here https://github.com/smartcontractkit/chainlink/blob/d0b454afcfd090292b5a23b158cd45b58b052248/core/internal/cltest/cltest.go#L151. Setting it up in parallel tests leads to a race.