### PR TITLE
Update CHANGELOG for v2.54.3

### DIFF
--- a/.changeset/minor-bump-1783450192.md
+++ b/.changeset/minor-bump-1783450192.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-Minor bump to start next version

--- a/.changeset/small-hills-earn.md
+++ b/.changeset/small-hills-earn.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix Fixed permissions in test db setup script (grant CREATEROLE and repair leftover NOLOGIN pgtdbuser for pgtestdb)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Minor Changes
 
+- [#23043](https://github.com/smartcontractkit/chainlink/pull/23043) [`fe901c7`](https://github.com/smartcontractkit/chainlink/commit/fe901c73df31613b5f3789a672365daf1e64ec30) - Minor bump to start next version
+
+### Patch Changes
+
+- [#22973](https://github.com/smartcontractkit/chainlink/pull/22973) [`389792a`](https://github.com/smartcontractkit/chainlink/commit/389792a9ed6586dea7e04bafd7fe41479a94b30f) - #bugfix Fixed permissions in test db setup script (grant CREATEROLE and repair leftover NOLOGIN pgtdbuser for pgtestdb)
+
+## 2.55.0
+
+### Minor Changes
+
 - [#22876](https://github.com/smartcontractkit/chainlink/pull/22876) [`c0c329e`](https://github.com/smartcontractkit/chainlink/commit/c0c329e1739cda8f5857877eefb0724e28916675) - Add the ConfidentialWorkflows.Enabled feature gate to the v2 workflow engine. Confidential workflow execution can now be toggled per workflow/owner/org/global via the settings registry; when disabled, ConfidentialModule.Execute rejects the request.
 
 - [#22996](https://github.com/smartcontractkit/chainlink/pull/22996) [`d3685b2`](https://github.com/smartcontractkit/chainlink/commit/d3685b2fc93879be0de861895395a86845d20ae3) - Minor bump to start next version


### PR DESCRIPTION
Consumes the v2.54.3 changesets and updates CHANGELOG.md. This PR replaces the release workflow's blocked direct push to the protected release branch.