### PR TITLE
bump confidential release gitref

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -9,5 +9,9 @@ defaults:
 plugins:
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "8812c6483a6e6cded22b3fe9615cf1d18b054fd5"
+      gitRef: "4cac911b36d589a67689e3ab1ca26ea263eea440"
       installPath: "./cmd/confidential-http"
+  confidential-workflows:
+    - moduleURI: "github.com/smartcontractkit/confidential-compute/enclave/apps/confidential-workflows/capability"
+      gitRef: "4cac911b36d589a67689e3ab1ca26ea263eea440"
+      installPath: "./cmd/confidential-workflows"


### PR DESCRIPTION
Bumps to release v1.3.0: https://github.com/smartcontractkit/confidential-compute/releases/tag/v1.3.0.

Also adds confidential-workflows as a new binary.