### PR TITLE
fix(cre): reverts http capability references in plugins.public.yaml

### DIFF
--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -93,12 +93,12 @@ plugins:
 
   capability-httpaction:
     - moduleURI: "github.com/smartcontractkit/capabilities/http_action"
-      gitRef: "8a87578a3aac306d9b154e8d674c43b4a740971c"
+      gitRef: "792fd475a9c294b61fa90b9dd23388da2827f093"
       installPath: "."
 
   capability-httptrigger:
     - moduleURI: "github.com/smartcontractkit/capabilities/http_trigger"
-      gitRef: "8a87578a3aac306d9b154e8d674c43b4a740971c"
+      gitRef: "792fd475a9c294b61fa90b9dd23388da2827f093"
       installPath: "."
 
   capability-evm:


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

reverts to a version of the capability that has a necessary feature flag

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
