### PR TITLE
bump common and fix tests

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.104
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260707105132-2da5d31f22fc
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1581,8 +1581,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094 h1:uMn1w/n95p+pSxK6hYNqji/sDaab8D0Cxuph9qUkM2g=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094/go.mod h1:3XQmy2zQHrmufebP7dM+x595+gghxzyIKxK9wv91Rh8=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b h1:tQz44wP1HL/Y+9iX+gEmuDeoBEftV0yDvhgfuiG1Xv0=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977 h1:3deFvPKyJCyPl7+L/tpAGILEAUkeq7vWnltlIJWvdMc=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/core/services/durableemitter/durable_event_store_orm_test.go
+++ b/core/services/durableemitter/durable_event_store_orm_test.go
@@ -114,13 +114,13 @@ func TestPgDurableEventStore_ObserveDurableQueue(t *testing.T) {
 	ctx := t.Context()
 	store := durableemitter.NewPgDurableEventStore(db)
 
-	st, err := store.ObserveDurableQueue(ctx, time.Hour, time.Minute)
+	st, err := store.ObserveDurableQueue(ctx, time.Hour)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), st.Depth)
 
 	_, err = store.Insert(ctx, []byte("payload-bytes"))
 	require.NoError(t, err)
-	st, err = store.ObserveDurableQueue(ctx, time.Hour, time.Minute)
+	st, err = store.ObserveDurableQueue(ctx, time.Hour)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), st.Depth)
 	assert.Equal(t, int64(len("payload-bytes")), st.PayloadBytes)

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260707105132-2da5d31f22fc
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1384,8 +1384,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094 h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094/go.mod h1:3XQmy2zQHrmufebP7dM+x595+gghxzyIKxK9wv91Rh8=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b h1:tQz44wP1HL/Y+9iX+gEmuDeoBEftV0yDvhgfuiG1Xv0=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977 h1:3deFvPKyJCyPl7+L/tpAGILEAUkeq7vWnltlIJWvdMc=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260707105132-2da5d31f22fc

--- a/go.sum
+++ b/go.sum
@@ -1159,8 +1159,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094 h1:uMn1w/n95p+pSxK6hYNqji/sDaab8D0Cxuph9qUkM2g=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094/go.mod h1:3XQmy2zQHrmufebP7dM+x595+gghxzyIKxK9wv91Rh8=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b h1:tQz44wP1HL/Y+9iX+gEmuDeoBEftV0yDvhgfuiG1Xv0=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977 h1:3deFvPKyJCyPl7+L/tpAGILEAUkeq7vWnltlIJWvdMc=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260623170329-4577ef4ba0ae

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1371,8 +1371,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094 h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094/go.mod h1:3XQmy2zQHrmufebP7dM+x595+gghxzyIKxK9wv91Rh8=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b h1:tQz44wP1HL/Y+9iX+gEmuDeoBEftV0yDvhgfuiG1Xv0=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977 h1:3deFvPKyJCyPl7+L/tpAGILEAUkeq7vWnltlIJWvdMc=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260623170329-4577ef4ba0ae
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.16.6-0.20260630120514-36abe27604df

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1631,8 +1631,8 @@ github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094 h
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094/go.mod h1:3XQmy2zQHrmufebP7dM+x595+gghxzyIKxK9wv91Rh8=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b h1:tQz44wP1HL/Y+9iX+gEmuDeoBEftV0yDvhgfuiG1Xv0=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977 h1:3deFvPKyJCyPl7+L/tpAGILEAUkeq7vWnltlIJWvdMc=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.104
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20260708114855-e953eeb028a7
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260623170329-4577ef4ba0ae

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1546,8 +1546,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094 h1:uMn1w/n95p+pSxK6hYNqji/sDaab8D0Cxuph9qUkM2g=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094/go.mod h1:3XQmy2zQHrmufebP7dM+x595+gghxzyIKxK9wv91Rh8=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b h1:tQz44wP1HL/Y+9iX+gEmuDeoBEftV0yDvhgfuiG1Xv0=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977 h1:3deFvPKyJCyPl7+L/tpAGILEAUkeq7vWnltlIJWvdMc=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/smartcontractkit/chain-selectors v1.0.104
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1751,8 +1751,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094 h1:uMn1w/n95p+pSxK6hYNqji/sDaab8D0Cxuph9qUkM2g=
 github.com/smartcontractkit/chainlink-ccv v0.0.2-0.20260706093831-dad26b360094/go.mod h1:3XQmy2zQHrmufebP7dM+x595+gghxzyIKxK9wv91Rh8=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b h1:tQz44wP1HL/Y+9iX+gEmuDeoBEftV0yDvhgfuiG1Xv0=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977 h1:3deFvPKyJCyPl7+L/tpAGILEAUkeq7vWnltlIJWvdMc=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260714160921-4033d0253977/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0 h1:1BH/b14CkGjArfzznlioQpIJiynECWVT48JUP9E277U=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.0/go.mod h1:9R/74vN+bJ5PbkOyM/pUy/AeAZaRwYb/k4XPeXcbDio=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=


### PR DESCRIPTION
This pull request primarily updates the `chainlink-common` dependency version across multiple modules and makes a small change to a test in the durable emitter service. The dependency update ensures consistency and pulls in the latest changes from `chainlink-common`, while the test update reflects a change in the `ObserveDurableQueue` method's signature.

Dependency updates:

* Updated `github.com/smartcontractkit/chainlink-common` to version `v0.11.2-0.20260714160921-4033d0253977` in the following `go.mod` files: `go.mod`, `core/scripts/go.mod`, `deployment/go.mod`, `integration-tests/go.mod`, `integration-tests/load/go.mod`, `system-tests/lib/go.mod`, and `system-tests/tests/go.mod`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L88-R88) [[2]](diffhunk://#diff-e62e9f1d5d119cfd293a9429b5ba18709855e60b4c18bf22efbf17ce97527a80L50-R50) [[3]](diffhunk://#diff-16ac5f47ba6841978858e293f48c1b9c75df1ea5aa9fd1171ee857de81510defL50-R50) [[4]](diffhunk://#diff-7c016cae50e2281d7a89e537d58b33cb9e01501820ff9301365fc006c94b712bL36-R36) [[5]](diffhunk://#diff-15f8f80fd17ebb70a1da6cbea30cb26566ff9fd8c49137f23869f110c0060b5cL27-R27) [[6]](diffhunk://#diff-1d4e7d3b1a36c04110400d7de579e1b3ec982cdf6ff6922677025b4d98db907eL40-R40) [[7]](diffhunk://#diff-85e1a39b2f2def912a409e0e944fc8f9071dde0051353ffd87c63085a48aed1cL65-R65)

Test and code compatibility:

* Updated the `TestPgDurableEventStore_ObserveDurableQueue` test in `core/services/durableemitter/durable_event_store_orm_test.go` to match a signature change in `ObserveDurableQueue`, removing the second duration argument.