### PR TITLE
[DX-4553] Correctly Size CCIP Integration Test Runners

### DIFF
--- a/.github/.agents/skills/right-size-runners/SKILL.md
+++ b/.github/.agents/skills/right-size-runners/SKILL.md
@@ -26,6 +26,9 @@ Setup:
 - Validate runner config via available runners API before use.
 - Use `gh` CLI for workflow execution and PRs.
 - Only change one variable per trial to accurately assess its impact.
+- Always compare Apples to Apples
+   - If looking to optimize speed when caching isn't a factor, ensure that cache hits on one trial do not unfairly advantage it over another trial.
+   - Always document the exact runner configuration used for each trial to maintain reproducibility.
 </constraints>
 
 <resources>

--- a/.github/.agents/skills/right-size-runners/SKILL.md
+++ b/.github/.agents/skills/right-size-runners/SKILL.md
@@ -53,11 +53,9 @@ Setup:
 7. Analyze results. Update trial log. Present summary and propose next steps.
 
 <trial-template>
-
-| Runner   | Experiment    | Expectation     | Branch   | Run ID   | Commit | Stability       | Runtime | Cost | Notes    |
-|----------|---------------|-----------------|----------|----------|--------|-----------------|---------|------|----------|
-| `config` | What's tested | Expected result | `branch` | `run-id` | `sha`  | Pass/Fail/Flaky | mm:ss   | $    | Findings |
-
+| Runner | Experiment | Expectation | Branch | Run ID | Commit | Stability | Runtime | Cost | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| `config` | What's tested | Expected result | `branch` | `run-id` | `sha` | Pass/Fail/Flaky | mm:ss | $ | Findings |
 </trial-template>
 </loop>
 
@@ -68,11 +66,10 @@ When the user says stop, or all possible experiments have been exhausted:
 * Summarize all findings (cost + speed + stability changes) per workflow/job as table(s) for PR description.
 
 ## [Workflow/Job Name] Runner Changes
-
-| Runner | Stability | Runtime | Runtime Delta (Abs/%) | Cost | Cost Delta (Abs/%) |
-|--------|-----------|---------|---------------|------|------------|
-| [original runner before trials] | Pass/Fail/Flaky | mm:ss | +0:00 (+0%) | $ | +$ (+0%) |
-| [new runner] | Pass/Fail/Flaky | mm:ss | +0:00 (+0%) | $ | +$ (+0%) |
+| Approach | Runner | Stability | Runtime | Runtime Delta (Abs/%) | Cost | Cost Delta (Abs/%) |
+|---|---|---|---|---|---|---|
+| Old | [original runner before trials] | Pass/Fail/Flaky | mm:ss | +0:00 (+0%) | $ | +$ (+0%) |
+| New | [new runner] | Pass/Fail/Flaky | mm:ss | +0:00 (+0%) | $ | +$ (+0%) |
 
 * Remove all debugs, and make final edits on a new branch after approval, and ask user to commit.
 * Cleanup all trial branches, logs, and PRs.

--- a/.github/.agents/skills/right-size-runners/SKILL.md
+++ b/.github/.agents/skills/right-size-runners/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: right-size-runners
+description: Properly size CI runners for price, performance, and stability.
+disable-model-invocation: true
+---
+
+<initialization>
+Missing info? Ask user:
+1. Workflow to optimize.
+2. Priorities (default: stability > speed > cost).
+3. "Speed" definition (e.g., cache hits vs raw execution).
+4. "Stability" definition (e.g., are flaky tests acceptable?).
+5. Determine "spot" setting. Don't ask user directly about what spot setting to use, ask questions to lead you to correct setting. [runs-on spot reference](https://runs-on.com/docs/costs/spot-pricing/)
+
+Setup:
+1. Read workflow. Identify jobs, runners, critical path, and bottlenecks.
+2. Ask to optimize specific job or whole workflow.
+3. Modify workflow for testing (bypass gates, use mock inputs, add `workflow_dispatch`).
+4. Init or resume trial log at `.github/.agents/skills/right-size-runners/trials/<workflow>.md`.
+5. Run a baseline trial with the current runner configuration to establish a performance and stability benchmark.
+</initialization>
+
+<constraints>
+- OOM/Out of Disk Space failures are NEVER acceptable.
+- Prefer default `ubuntu-latest`. Use `runs-on` for more resources.
+- Validate runner config via available runners API before use.
+- Use `gh` CLI for workflow execution and PRs.
+- Only change one variable per trial to accurately assess its impact.
+</constraints>
+
+<resources>
+- [runs-on docs](https://runs-on.com/docs/)
+- [available runners](https://go.runs-on.com/api)
+- [GitHub Action docs](https://docs.github.com/en/actions)
+</resources>
+
+<loop>
+1. Define trials. Update `<workflow>.md` log.
+2. Ask user to approve trials. Check if they want to run them in parallel or sequentially.
+3. New (disposable) branch + commit + push. Message: `cpu=X/ram=Y`. PR title: `[DO NOT MERGE] Trial: <workflow-name>` description: details of trial
+4. Trigger workflow. Wait in background without polluting context:
+   ```sh
+   gh run watch <run_id> -i 60 --exit-status > /dev/null 2>&1
+   ```
+5. Once background task completes, check final status and get job IDs:
+   ```sh
+   gh run view <run_id> --json conclusion,url,jobs
+   ```
+6. Extract runner telemetry (CPU/RAM). DO NOT fetch full logs! Extract only the "Complete runner" step:
+   ```sh
+   gh run view <run_id> --job <job_id> --log | awk -F'\t' '$2=="Complete runner"{print substr($0, index($0, $3))}'
+   ```
+7. Analyze results. Update trial log. Present summary and propose next steps.
+
+<trial-template>
+
+| Runner   | Experiment    | Expectation     | Branch   | Run ID   | Commit | Stability       | Runtime | Cost | Notes    |
+|----------|---------------|-----------------|----------|----------|--------|-----------------|---------|------|----------|
+| `config` | What's tested | Expected result | `branch` | `run-id` | `sha`  | Pass/Fail/Flaky | mm:ss   | $    | Findings |
+
+</trial-template>
+</loop>
+
+<complete>
+When the user says stop, or all possible experiments have been exhausted:
+
+* Suggest final recommendations.
+* Summarize all findings (cost + speed + stability changes) per workflow/job as table(s) for PR description.
+
+## [Workflow/Job Name] Runner Changes
+
+| Runner | Stability | Runtime | Runtime Delta (Abs/%) | Cost | Cost Delta (Abs/%) |
+|--------|-----------|---------|---------------|------|------------|
+| [original runner before trials] | Pass/Fail/Flaky | mm:ss | +0:00 (+0%) | $ | +$ (+0%) |
+| [new runner] | Pass/Fail/Flaky | mm:ss | +0:00 (+0%) | $ | +$ (+0%) |
+
+* Remove all debugs, and make final edits on a new branch after approval, and ask user to commit.
+* Cleanup all trial branches, logs, and PRs.
+</complete>

--- a/.github/.agents/skills/right-size-runners/SKILL.md
+++ b/.github/.agents/skills/right-size-runners/SKILL.md
@@ -63,13 +63,16 @@ Setup:
 When the user says stop, or all possible experiments have been exhausted:
 
 * Suggest final recommendations.
-* Summarize all findings (cost + speed + stability changes) per workflow/job as table(s) for PR description.
+* Summarize all findings (cost + speed + stability changes) per workflow/job as table(s) for PR description as below format in raw markdown.
 
+```md
 ## [Workflow/Job Name] Runner Changes
+
 | Approach | Runner | Stability | Runtime | Runtime Delta (Abs/%) | Cost | Cost Delta (Abs/%) |
 |---|---|---|---|---|---|---|
 | Old | [original runner before trials] | Pass/Fail/Flaky | mm:ss | +0:00 (+0%) | $ | +$ (+0%) |
 | New | [new runner] | Pass/Fail/Flaky | mm:ss | +0:00 (+0%) | $ | +$ (+0%) |
+```
 
 * Remove all debugs, and make final edits on a new branch after approval, and ask user to commit.
 * Cleanup all trial branches, logs, and PRs.

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -12,6 +12,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_reorg_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m7i+m8i/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP v1.6 Tests
@@ -33,6 +34,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_reorg_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m7i+m8i/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP v1.6 Tests
@@ -54,6 +56,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_token_price_updates_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m7i+m8i/extras=s3-cache+tmpfs
     triggers:
       - PR E2E CCIP v1.6 Tests
       - Merge Queue E2E CCIP v1.6 Tests
@@ -79,6 +82,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_gas_price_updates_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m7i+m8i/extras=s3-cache+tmpfs
     triggers:
       - PR E2E CCIP v1.6 Tests
       - Merge Queue E2E CCIP v1.6 Tests
@@ -103,6 +107,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_gas_price_updates_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m7i+m8i/extras=s3-cache+tmpfs
     triggers:
       - PR E2E CCIP v1.6 Tests
       - Merge Queue E2E CCIP v1.6 Tests
@@ -127,10 +132,9 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m7i+m8i/extras=s3-cache+tmpfs
     triggers:
       # Push/Nightly triggers removed: test consistently times out after 30m (RMN curse-revocation flake). Re-add once fixed.
-      - Workflow Dispatch E2E CCIP v1.6 Tests
     test_cmd: |
       cd smoke/ccip && \
       gotestsum \
@@ -151,7 +155,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m7i+m8i/extras=s3-cache+tmpfs
     triggers:
       - PR E2E CCIP v1.6 Tests
       - Nightly E2E Tests
@@ -177,6 +181,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_jobspec_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m7i+m8i/extras=s3-cache+tmpfs
     triggers:
       - PR E2E CCIP v1.6 Tests
       - Merge Queue E2E CCIP v1.6 Tests
@@ -202,6 +207,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_jobspec_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m7i+m8i/extras=s3-cache+tmpfs
     triggers:
       - PR E2E CCIP v1.6 Tests
       - Merge Queue E2E CCIP v1.6 Tests

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tools/clroot/db.sqlite3-wal
 .env*
 .dbenv
 !.github/actions/setup-postgres/.env
+/.github/.agents/skills/right-size-runners/trials/
 .direnv
 .idea
 .vscode/


### PR DESCRIPTION
* Adds an AI skill to generate hypotheses and run experiments to pick CI runners based on different priorities, generally optimizing for stability, speed, and cost
* Correctly sizes runners for CCIP Integration tests using the above skill for optimal speed and cost.

| Approach | Runner | Stability | Runtime | Runtime Delta | Cost* | Cost Delta |
|---|--------|-----------|---------|---------------|-------|------------|
| Old | non-RMN `ubuntu-latest`, RMN `32/128 non-spot` (RMN timeout test removed) | Flaky | 19m45s | — | ~$0.20 | — |
| New | all `16/64 spot` | Pass | 12m45s | -7m00s (-35%) | ~$0.30 | +$0.10 (+50%) |
