### PR TITLE
Create changeset to set workflow author and name

### DIFF
--- a/deployment/vault/changeset/automation_receiver_deploy.go
+++ b/deployment/vault/changeset/automation_receiver_deploy.go
@@ -41,6 +41,14 @@ func (d deployAutomationReceiver) VerifyPreconditions(env cldf.Environment, conf
 				return fmt.Errorf("chain %d: invalid selector %q: %w", chainSelector, chainCfg.Selector, err)
 			}
 		}
+		if (chainCfg.ExpectedAuthor != "") != (chainCfg.ExpectedWorkflowName != "") {
+			return fmt.Errorf("chain %d: expectedAuthor and expectedWorkflowName must be set together", chainSelector)
+		}
+		if chainCfg.ExpectedAuthor != "" {
+			if err := validateEthAddress("expectedAuthor", chainCfg.ExpectedAuthor); err != nil {
+				return fmt.Errorf("chain %d: %w", chainSelector, err)
+			}
+		}
 	}
 	return nil
 }
@@ -149,6 +157,20 @@ var DeployAutomationReceiverSequence = operations.NewSequence(
 			})
 			if err != nil {
 				return DeployAutomationReceiverSequenceOutput{}, fmt.Errorf("chain %d: setCallAllowed failed: %w", chainSelector, err)
+			}
+
+			// Optionally lock the receiver's inbound identity guard while the deployer still owns
+			// the contract (before ownership is transferred to the Timelock below).
+			if chainCfg.ExpectedAuthor != "" && chainCfg.ExpectedWorkflowName != "" {
+				_, err = operations.ExecuteOperation(b, SetExpectedWorkflowIdentityOperation, deps, SetExpectedWorkflowIdentityOperationInput{
+					ChainSelector:             chainSelector,
+					AutomationReceiverAddress: arAddress,
+					ExpectedAuthor:            chainCfg.ExpectedAuthor,
+					ExpectedWorkflowName:      chainCfg.ExpectedWorkflowName,
+				})
+				if err != nil {
+					return DeployAutomationReceiverSequenceOutput{}, fmt.Errorf("chain %d: setExpectedWorkflowIdentity failed: %w", chainSelector, err)
+				}
 			}
 
 			_, err = operations.ExecuteOperation(b, TransferAutomationReceiverOwnershipOperation, deps, TransferAutomationReceiverOwnershipInput{

--- a/deployment/vault/changeset/automation_receiver_deploy_test.go
+++ b/deployment/vault/changeset/automation_receiver_deploy_test.go
@@ -1,0 +1,208 @@
+package changeset
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/automation-cre/generated/latest/automation_receiver"
+
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/vault/changeset/types"
+)
+
+// readReceiverIdentity reads the on-chain expectedAuthor + expectedWorkflowName from the
+// AutomationReceiver deployed at receiverAddr on the given chain. Shared by the AR deploy
+// and combined EthBalMon+AR deploy tests to assert the inbound identity guard was configured.
+func readReceiverIdentity(t *testing.T, env cldf.Environment, selector uint64, receiverAddr string) (common.Address, [10]byte) {
+	t.Helper()
+	chain := env.BlockChains.EVMChains()[selector]
+	ar, err := automation_receiver.NewAutomationReceiver(common.HexToAddress(receiverAddr), chain.Client)
+	require.NoError(t, err)
+	author, err := ar.GetExpectedAuthor(nil)
+	require.NoError(t, err)
+	name, err := ar.GetExpectedWorkflowName(nil)
+	require.NoError(t, err)
+	return author, name
+}
+
+func TestDeployAutomationReceiver_VerifyPreconditions(t *testing.T) {
+	t.Parallel()
+
+	selector := chainselectors.TEST_90000001.Selector
+	selectorOther := chainselectors.TEST_90000002.Selector
+
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		cfg       types.DeployAutomationReceiverInput
+		wantError bool
+		errorMsg  string
+	}{
+		{
+			name:      "empty chains",
+			cfg:       types.DeployAutomationReceiverInput{Chains: map[uint64]types.AutomationReceiverChainConfig{}},
+			wantError: true,
+			errorMsg:  "chains must not be empty",
+		},
+		{
+			name: "chain not in environment",
+			cfg: types.DeployAutomationReceiverInput{Chains: map[uint64]types.AutomationReceiverChainConfig{
+				selectorOther: {ForwarderAddress: testAddr1, TargetAddress: testAddr2},
+			}},
+			wantError: true,
+			errorMsg:  "not found in environment",
+		},
+		{
+			name: "invalid forwarder address",
+			cfg: types.DeployAutomationReceiverInput{Chains: map[uint64]types.AutomationReceiverChainConfig{
+				selector: {ForwarderAddress: "not-an-address", TargetAddress: testAddr2},
+			}},
+			wantError: true,
+			errorMsg:  "forwarderAddress is not a valid hex address",
+		},
+		{
+			name: "author without name",
+			cfg: types.DeployAutomationReceiverInput{Chains: map[uint64]types.AutomationReceiverChainConfig{
+				selector: {ForwarderAddress: testAddr1, TargetAddress: testAddr2, ExpectedAuthor: testAddr2},
+			}},
+			wantError: true,
+			errorMsg:  "expectedAuthor and expectedWorkflowName must be set together",
+		},
+		{
+			name: "name without author",
+			cfg: types.DeployAutomationReceiverInput{Chains: map[uint64]types.AutomationReceiverChainConfig{
+				selector: {ForwarderAddress: testAddr1, TargetAddress: testAddr2, ExpectedWorkflowName: testWorkflowName},
+			}},
+			wantError: true,
+			errorMsg:  "expectedAuthor and expectedWorkflowName must be set together",
+		},
+		{
+			name: "invalid author address",
+			cfg: types.DeployAutomationReceiverInput{Chains: map[uint64]types.AutomationReceiverChainConfig{
+				selector: {ForwarderAddress: testAddr1, TargetAddress: testAddr2, ExpectedAuthor: "not-an-address", ExpectedWorkflowName: testWorkflowName},
+			}},
+			wantError: true,
+			errorMsg:  "expectedAuthor is not a valid hex address",
+		},
+		{
+			name: "valid without identity",
+			cfg: types.DeployAutomationReceiverInput{Chains: map[uint64]types.AutomationReceiverChainConfig{
+				selector: {ForwarderAddress: testAddr1, TargetAddress: testAddr2},
+			}},
+			wantError: false,
+		},
+		{
+			name: "valid with identity",
+			cfg: types.DeployAutomationReceiverInput{Chains: map[uint64]types.AutomationReceiverChainConfig{
+				selector: {ForwarderAddress: testAddr1, TargetAddress: testAddr2, ExpectedAuthor: testAddr2, ExpectedWorkflowName: testWorkflowName},
+			}},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := DeployAutomationReceiverChangeSet.VerifyPreconditions(*env, tt.cfg)
+			if tt.wantError {
+				require.Error(t, err)
+				if tt.errorMsg != "" {
+					require.Contains(t, err.Error(), tt.errorMsg)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestDeployAutomationReceiver_SetsIdentity exercises the SetExpectedWorkflowIdentityOperation
+// (deployer-owned direct op) through the standalone AutomationReceiver deploy flow: when
+// expectedAuthor + expectedWorkflowName are provided, they must be written on-chain before
+// ownership is transferred to the Timelock.
+func TestDeployAutomationReceiver_SetsIdentity(t *testing.T) {
+	t.Parallel()
+
+	selector := chainselectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
+
+	setupMCMSInfrastructure(t, rt, []uint64{selector})
+	fundDeployerAccounts(t, rt.Environment(), []uint64{selector})
+
+	// setCallAllowed requires the target to have deployed code (reverts with TargetHasNoCode
+	// otherwise); the timelock deployed by the MCMS setup is a convenient real contract.
+	timelockAddr, err := GetContractAddress(rt.State().DataStore, selector, commontypes.RBACTimelock)
+	require.NoError(t, err)
+
+	cfg := types.DeployAutomationReceiverInput{
+		Chains: map[uint64]types.AutomationReceiverChainConfig{
+			selector: {
+				ForwarderAddress:     testAddr1,
+				TargetAddress:        timelockAddr,
+				ExpectedAuthor:       testAddr2,
+				ExpectedWorkflowName: testWorkflowName,
+			},
+		},
+	}
+	require.NoError(t, DeployAutomationReceiverChangeSet.VerifyPreconditions(rt.Environment(), cfg))
+
+	out, err := DeployAutomationReceiverChangeSet.Apply(rt.Environment(), cfg)
+	require.NoError(t, err)
+
+	receiverAddr, err := GetContractAddress(out.DataStore, selector, cldf.ContractType(types.AutomationReceiverContractType))
+	require.NoError(t, err)
+
+	author, name := readReceiverIdentity(t, rt.Environment(), selector, receiverAddr)
+	require.Equal(t, common.HexToAddress(testAddr2), author, "expectedAuthor must be set on-chain")
+	require.NotEqual(t, [10]byte{}, name, "expectedWorkflowName must be set on-chain")
+}
+
+// TestDeployAutomationReceiver_WithoutIdentity_LeavesGuardUnset confirms the op is skipped when
+// no identity is provided (the guard stays unconfigured).
+func TestDeployAutomationReceiver_WithoutIdentity_LeavesGuardUnset(t *testing.T) {
+	t.Parallel()
+
+	selector := chainselectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
+
+	setupMCMSInfrastructure(t, rt, []uint64{selector})
+	fundDeployerAccounts(t, rt.Environment(), []uint64{selector})
+
+	timelockAddr, err := GetContractAddress(rt.State().DataStore, selector, commontypes.RBACTimelock)
+	require.NoError(t, err)
+
+	cfg := types.DeployAutomationReceiverInput{
+		Chains: map[uint64]types.AutomationReceiverChainConfig{
+			selector: {
+				ForwarderAddress: testAddr1,
+				TargetAddress:    timelockAddr,
+			},
+		},
+	}
+	out, err := DeployAutomationReceiverChangeSet.Apply(rt.Environment(), cfg)
+	require.NoError(t, err)
+
+	receiverAddr, err := GetContractAddress(out.DataStore, selector, cldf.ContractType(types.AutomationReceiverContractType))
+	require.NoError(t, err)
+
+	author, name := readReceiverIdentity(t, rt.Environment(), selector, receiverAddr)
+	require.Equal(t, common.Address{}, author, "expectedAuthor must remain unset when no identity is provided")
+	require.Equal(t, [10]byte{}, name, "expectedWorkflowName must remain unset when no identity is provided")
+}

--- a/deployment/vault/changeset/automation_receiver_set_expected_workflow_identity.go
+++ b/deployment/vault/changeset/automation_receiver_set_expected_workflow_identity.go
@@ -1,0 +1,268 @@
+package changeset
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/common"
+	proposeutils "github.com/smartcontractkit/cld-changesets/legacy/mcms/proposeutils"
+	"github.com/smartcontractkit/mcms"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	proposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/automation-cre/generated/latest/automation_receiver"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+	vaulttypes "github.com/smartcontractkit/chainlink/deployment/vault/changeset/types"
+)
+
+// SetExpectedWorkflowIdentityChangeSet builds a timelock proposal to configure the
+// AutomationReceiver's inbound identity guard (setExpectedAuthor + setExpectedWorkflowName) on
+// already-deployed receivers whose ownership is the Timelock. The AutomationReceiver reverts
+// inbound reports with WorkflowIdentityNotConfigured until the identity is configured, so this is
+// required for a deployed receiver to accept reports. Author + name are stable across workflow
+// redeploys, so this only needs to be set once (unlike pinning the workflow id).
+var SetExpectedWorkflowIdentityChangeSet cldf.ChangeSetV2[vaulttypes.SetExpectedWorkflowIdentityInput] = setExpectedWorkflowIdentity{}
+
+type setExpectedWorkflowIdentity struct{}
+
+func (s setExpectedWorkflowIdentity) VerifyPreconditions(env cldf.Environment, config vaulttypes.SetExpectedWorkflowIdentityInput) error {
+	if len(config.Chains) == 0 {
+		return errors.New("chains must not be empty")
+	}
+	if config.MCMSConfig != nil && config.MCMSConfig.MinDelay < 0 {
+		return fmt.Errorf("MCMS minimum delay cannot be negative: %d", config.MCMSConfig.MinDelay)
+	}
+	for chainSelector, chainCfg := range config.Chains {
+		if err := validateChainSelector(chainSelector, env); err != nil {
+			return fmt.Errorf("chain %d: %w", chainSelector, err)
+		}
+		if chainCfg.ExpectedAuthor == "" || chainCfg.ExpectedWorkflowName == "" {
+			return fmt.Errorf(
+				"chain %d: both expectedAuthor and expectedWorkflowName are required "+
+					"(the AutomationReceiver reverts with WorkflowIdentityNotConfigured otherwise)",
+				chainSelector,
+			)
+		}
+		if err := validateEthAddress("expectedAuthor", chainCfg.ExpectedAuthor); err != nil {
+			return fmt.Errorf("chain %d: %w", chainSelector, err)
+		}
+	}
+	return nil
+}
+
+func (s setExpectedWorkflowIdentity) Apply(e cldf.Environment, config vaulttypes.SetExpectedWorkflowIdentityInput) (cldf.ChangesetOutput, error) {
+	logger := e.Logger
+	logger.Infow("Generating setExpectedWorkflowIdentity proposal", "numChains", len(config.Chains))
+
+	evmChains := e.BlockChains.EVMChains()
+
+	var primaryChain cldf_evm.Chain
+	for chainSelector := range config.Chains {
+		primaryChain = evmChains[chainSelector]
+		break
+	}
+
+	deps := VaultDeps{
+		Auth:        primaryChain.DeployerKey,
+		Chain:       primaryChain,
+		Environment: e,
+		DataStore:   e.DataStore,
+	}
+
+	seqReport, err := operations.ExecuteSequence(
+		e.OperationsBundle,
+		SetExpectedWorkflowIdentitySequence,
+		deps,
+		SetExpectedWorkflowIdentitySequenceInput{
+			Chains:     config.Chains,
+			MCMSConfig: config.MCMSConfig,
+		},
+	)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("setExpectedWorkflowIdentity sequence failed: %w", err)
+	}
+
+	return cldf.ChangesetOutput{
+		MCMSTimelockProposals: seqReport.Output.MCMSTimelockProposals,
+	}, nil
+}
+
+// ================================================
+// ================================================
+// SetExpectedWorkflowIdentity SEQUENCE
+// ================================================
+// ================================================
+
+type SetExpectedWorkflowIdentitySequenceInput struct {
+	Chains     map[uint64]vaulttypes.SetExpectedWorkflowIdentityChainConfig `json:"chains"`
+	MCMSConfig *proposalutils.TimelockConfig                                `json:"mcms_config,omitempty"`
+}
+
+type SetExpectedWorkflowIdentitySequenceOutput struct {
+	MCMSTimelockProposals []mcms.TimelockProposal `json:"mcms_timelock_proposals"`
+}
+
+var SetExpectedWorkflowIdentitySequence = operations.NewSequence(
+	"set-expected-workflow-identity-sequence",
+	semver.MustParse("1.0.0"),
+	"Build a timelock proposal to set the expected workflow identity on AutomationReceiver for each chain",
+	func(b operations.Bundle, deps VaultDeps, input SetExpectedWorkflowIdentitySequenceInput) (SetExpectedWorkflowIdentitySequenceOutput, error) {
+		b.Logger.Infow("Starting setExpectedWorkflowIdentity sequence", "chains", len(input.Chains))
+
+		var batches []mcmstypes.BatchOperation
+		timelockAddresses := make(map[uint64]string)
+		mcmAddressByChain := make(map[uint64]string)
+
+		for chainSelector, chainCfg := range input.Chains {
+			opReport, err := operations.ExecuteOperation(b, SetExpectedWorkflowIdentityProposalOperation, deps, SetExpectedWorkflowIdentityProposalOpInput{
+				ChainSelector:        chainSelector,
+				ExpectedAuthor:       chainCfg.ExpectedAuthor,
+				ExpectedWorkflowName: chainCfg.ExpectedWorkflowName,
+				MCMSConfig:           input.MCMSConfig,
+			})
+			if err != nil {
+				return SetExpectedWorkflowIdentitySequenceOutput{}, fmt.Errorf("chain %d: failed to generate setExpectedWorkflowIdentity batch: %w", chainSelector, err)
+			}
+			opOutput := opReport.Output
+
+			batches = append(batches, opOutput.BatchOperation)
+			timelockAddresses[chainSelector] = opOutput.TimelockAddress
+			mcmAddressByChain[chainSelector] = opOutput.MCMSAddress
+		}
+
+		proposal, err := proposeutils.BuildProposalFromBatchesV2(deps.Environment, timelockAddresses, mcmAddressByChain, nil, batches, "AutomationReceiver SetExpectedWorkflowIdentity", ethBalMonProposalTimelockConfig(input.MCMSConfig))
+		if err != nil {
+			return SetExpectedWorkflowIdentitySequenceOutput{}, fmt.Errorf("failed to build timelock proposal: %w", err)
+		}
+
+		b.Logger.Infow("Generated setExpectedWorkflowIdentity proposal",
+			"chains", len(input.Chains), "operations", len(batches))
+
+		return SetExpectedWorkflowIdentitySequenceOutput{
+			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
+		}, nil
+	},
+)
+
+// ================================================
+// ================================================
+// SetExpectedWorkflowIdentity proposal OPERATION
+// ================================================
+// ================================================
+
+type SetExpectedWorkflowIdentityProposalOpInput struct {
+	ChainSelector        uint64                        `json:"chain_selector"`
+	ExpectedAuthor       string                        `json:"expected_author"`
+	ExpectedWorkflowName string                        `json:"expected_workflow_name"`
+	MCMSConfig           *proposalutils.TimelockConfig `json:"mcms_config,omitempty"`
+}
+
+type SetExpectedWorkflowIdentityProposalOpOutput struct {
+	ChainSelector   uint64                   `json:"chain_selector"`
+	BatchOperation  mcmstypes.BatchOperation `json:"batch_operation"`
+	TimelockAddress string                   `json:"timelock_address"`
+	MCMSAddress     string                   `json:"mcms_address"`
+}
+
+var SetExpectedWorkflowIdentityProposalOperation = operations.NewOperation(
+	"set-expected-workflow-identity-proposal-operation",
+	semver.MustParse("1.0.0"),
+	"Operation to create a transaction batch for AutomationReceiver setExpectedAuthor + setExpectedWorkflowName",
+	func(b operations.Bundle, deps VaultDeps, input SetExpectedWorkflowIdentityProposalOpInput) (SetExpectedWorkflowIdentityProposalOpOutput, error) {
+		b.Logger.Infow("Starting setExpectedWorkflowIdentity proposal operation",
+			"chainSelector", input.ChainSelector,
+			"expectedAuthor", input.ExpectedAuthor,
+			"expectedWorkflowName", input.ExpectedWorkflowName,
+		)
+
+		chain, ok := deps.Environment.BlockChains.EVMChains()[input.ChainSelector]
+		if !ok {
+			return SetExpectedWorkflowIdentityProposalOpOutput{}, fmt.Errorf("chain not found in environment: %d", input.ChainSelector)
+		}
+
+		automationReceiverAddr, err := getRequiredContractAddress(
+			deps.DataStore,
+			input.ChainSelector,
+			cldf.ContractType(vaulttypes.AutomationReceiverContractType),
+		)
+		if err != nil {
+			return SetExpectedWorkflowIdentityProposalOpOutput{}, fmt.Errorf("failed to get AutomationReceiver address: %w", err)
+		}
+
+		timelockAddr, err := getRequiredContractAddress(
+			deps.DataStore,
+			input.ChainSelector,
+			commontypes.RBACTimelock,
+		)
+		if err != nil {
+			return SetExpectedWorkflowIdentityProposalOpOutput{}, fmt.Errorf("failed to get timelock address: %w", err)
+		}
+		mcmsAddr, err := getRequiredContractAddress(
+			deps.DataStore,
+			input.ChainSelector,
+			ethBalMonMCMSContractTypeForProposal(input.MCMSConfig),
+		)
+		if err != nil {
+			return SetExpectedWorkflowIdentityProposalOpOutput{}, fmt.Errorf("failed to get MCMS address: %w", err)
+		}
+
+		receiver, err := automation_receiver.NewAutomationReceiver(
+			common.HexToAddress(automationReceiverAddr),
+			chain.Client,
+		)
+		if err != nil {
+			return SetExpectedWorkflowIdentityProposalOpOutput{}, fmt.Errorf("failed to instantiate AutomationReceiver at %s: %w", automationReceiverAddr, err)
+		}
+
+		// setExpectedAuthor and setExpectedWorkflowName, executed atomically in one timelock batch.
+		authorTx, err := receiver.SetExpectedAuthor(cldf.SimTransactOpts(), common.HexToAddress(input.ExpectedAuthor))
+		if err != nil {
+			return SetExpectedWorkflowIdentityProposalOpOutput{}, fmt.Errorf("failed to generate setExpectedAuthor calldata on chain %d: %w", input.ChainSelector, err)
+		}
+		nameTx, err := receiver.SetExpectedWorkflowName(cldf.SimTransactOpts(), input.ExpectedWorkflowName)
+		if err != nil {
+			return SetExpectedWorkflowIdentityProposalOpOutput{}, fmt.Errorf("failed to generate setExpectedWorkflowName calldata on chain %d: %w", input.ChainSelector, err)
+		}
+
+		batch := mcmstypes.BatchOperation{
+			ChainSelector: mcmstypes.ChainSelector(input.ChainSelector),
+			Transactions: []mcmstypes.Transaction{
+				{
+					OperationMetadata: mcmstypes.OperationMetadata{
+						ContractType: vaulttypes.AutomationReceiverContractType,
+						Tags:         []string{"setExpectedAuthor"},
+					},
+					To:               automationReceiverAddr,
+					Data:             authorTx.Data(),
+					AdditionalFields: json.RawMessage(`{"value": 0}`),
+				},
+				{
+					OperationMetadata: mcmstypes.OperationMetadata{
+						ContractType: vaulttypes.AutomationReceiverContractType,
+						Tags:         []string{"setExpectedWorkflowName"},
+					},
+					To:               automationReceiverAddr,
+					Data:             nameTx.Data(),
+					AdditionalFields: json.RawMessage(`{"value": 0}`),
+				},
+			},
+		}
+
+		b.Logger.Infow("Generated setExpectedWorkflowIdentity batch",
+			"chainSelector", input.ChainSelector,
+			"automationReceiver", automationReceiverAddr,
+		)
+
+		return SetExpectedWorkflowIdentityProposalOpOutput{
+			ChainSelector:   input.ChainSelector,
+			BatchOperation:  batch,
+			TimelockAddress: timelockAddr,
+			MCMSAddress:     mcmsAddr,
+		}, nil
+	},
+)

--- a/deployment/vault/changeset/automation_receiver_set_expected_workflow_identity.go
+++ b/deployment/vault/changeset/automation_receiver_set_expected_workflow_identity.go
@@ -11,7 +11,6 @@ import (
 	"github.com/smartcontractkit/mcms"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
-	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	proposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
@@ -61,11 +60,10 @@ func (s setExpectedWorkflowIdentity) Apply(e cldf.Environment, config vaulttypes
 
 	evmChains := e.BlockChains.EVMChains()
 
-	var primaryChain cldf_evm.Chain
-	for chainSelector := range config.Chains {
-		primaryChain = evmChains[chainSelector]
-		break
-	}
+	// deps only carries the deployer key/chain used to build the proposal (the batch itself is
+	// generated per-chain), so any chain works — pick deterministically to keep output reproducible.
+	primaryChainSelector, _ := lowestChainSelector(config.Chains)
+	primaryChain := evmChains[primaryChainSelector]
 
 	deps := VaultDeps{
 		Auth:        primaryChain.DeployerKey,

--- a/deployment/vault/changeset/automation_receiver_set_expected_workflow_identity_test.go
+++ b/deployment/vault/changeset/automation_receiver_set_expected_workflow_identity_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
@@ -12,6 +13,7 @@ import (
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/automation-cre/generated/latest/automation_receiver"
 
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/vault/changeset/types"
@@ -189,6 +191,25 @@ func TestSetExpectedWorkflowIdentityChangeSet(t *testing.T) {
 	require.Contains(t, prop.Operations[0].Transactions[1].Tags, "setExpectedWorkflowName")
 	require.Equal(t, receiverAddr, prop.Operations[0].Transactions[0].To)
 	require.Equal(t, receiverAddr, prop.Operations[0].Transactions[1].To)
+
+	// Decode the generated calldata to confirm it is exactly
+	// setExpectedAuthor(expectedAuthor) + setExpectedWorkflowName(expectedWorkflowName).
+	arABI, err := automation_receiver.AutomationReceiverMetaData.GetAbi()
+	require.NoError(t, err)
+
+	authorTx := prop.Operations[0].Transactions[0]
+	authorMethod := arABI.Methods["setExpectedAuthor"]
+	require.Equal(t, authorMethod.ID, authorTx.Data[:4])
+	authorArgs, err := authorMethod.Inputs.Unpack(authorTx.Data[4:])
+	require.NoError(t, err)
+	require.Equal(t, common.HexToAddress(testAddr2), authorArgs[0])
+
+	nameTx := prop.Operations[0].Transactions[1]
+	nameMethod := arABI.Methods["setExpectedWorkflowName"]
+	require.Equal(t, nameMethod.ID, nameTx.Data[:4])
+	nameArgs, err := nameMethod.Inputs.Unpack(nameTx.Data[4:])
+	require.NoError(t, err)
+	require.Equal(t, testWorkflowName, nameArgs[0])
 }
 
 func TestSetExpectedWorkflowIdentity_Apply_withoutReceiverInDatastore(t *testing.T) {

--- a/deployment/vault/changeset/automation_receiver_set_expected_workflow_identity_test.go
+++ b/deployment/vault/changeset/automation_receiver_set_expected_workflow_identity_test.go
@@ -1,0 +1,221 @@
+package changeset
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
+
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/vault/changeset/types"
+)
+
+const testWorkflowName = "eth-balance-monitor-test"
+
+func TestSetExpectedWorkflowIdentity_VerifyPreconditions(t *testing.T) {
+	t.Parallel()
+
+	selector := chainselectors.TEST_90000001.Selector
+	selectorOther := chainselectors.TEST_90000002.Selector
+
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	)
+	require.NoError(t, err)
+
+	validChain := func() types.SetExpectedWorkflowIdentityChainConfig {
+		return types.SetExpectedWorkflowIdentityChainConfig{
+			ExpectedAuthor:       testAddr2,
+			ExpectedWorkflowName: testWorkflowName,
+		}
+	}
+
+	tests := []struct {
+		name      string
+		cfg       types.SetExpectedWorkflowIdentityInput
+		wantError bool
+		errorMsg  string
+	}{
+		{
+			name:      "empty chains",
+			cfg:       types.SetExpectedWorkflowIdentityInput{Chains: map[uint64]types.SetExpectedWorkflowIdentityChainConfig{}},
+			wantError: true,
+			errorMsg:  "chains must not be empty",
+		},
+		{
+			name: "negative MCMS delay",
+			cfg: types.SetExpectedWorkflowIdentityInput{
+				Chains:     map[uint64]types.SetExpectedWorkflowIdentityChainConfig{selector: validChain()},
+				MCMSConfig: &cldfproposalutils.TimelockConfig{MinDelay: -1},
+			},
+			wantError: true,
+			errorMsg:  "MCMS minimum delay cannot be negative",
+		},
+		{
+			name: "unknown chain selector",
+			cfg: types.SetExpectedWorkflowIdentityInput{
+				Chains: map[uint64]types.SetExpectedWorkflowIdentityChainConfig{math.MaxUint64: validChain()},
+			},
+			wantError: true,
+			errorMsg:  "unknown chain selector",
+		},
+		{
+			name: "missing author",
+			cfg: types.SetExpectedWorkflowIdentityInput{
+				Chains: map[uint64]types.SetExpectedWorkflowIdentityChainConfig{
+					selector: {ExpectedWorkflowName: testWorkflowName},
+				},
+			},
+			wantError: true,
+			errorMsg:  "both expectedAuthor and expectedWorkflowName are required",
+		},
+		{
+			name: "missing workflow name",
+			cfg: types.SetExpectedWorkflowIdentityInput{
+				Chains: map[uint64]types.SetExpectedWorkflowIdentityChainConfig{
+					selector: {ExpectedAuthor: testAddr2},
+				},
+			},
+			wantError: true,
+			errorMsg:  "both expectedAuthor and expectedWorkflowName are required",
+		},
+		{
+			name: "invalid author address",
+			cfg: types.SetExpectedWorkflowIdentityInput{
+				Chains: map[uint64]types.SetExpectedWorkflowIdentityChainConfig{
+					selector: {
+						ExpectedAuthor:       "not-an-address",
+						ExpectedWorkflowName: testWorkflowName,
+					},
+				},
+			},
+			wantError: true,
+			errorMsg:  "expectedAuthor is not a valid hex address",
+		},
+		{
+			name: "chain not in environment",
+			cfg: types.SetExpectedWorkflowIdentityInput{
+				Chains: map[uint64]types.SetExpectedWorkflowIdentityChainConfig{selectorOther: validChain()},
+			},
+			wantError: true,
+			errorMsg:  "not found in environment",
+		},
+		{
+			name: "valid",
+			cfg: types.SetExpectedWorkflowIdentityInput{
+				Chains: map[uint64]types.SetExpectedWorkflowIdentityChainConfig{selector: validChain()},
+			},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := SetExpectedWorkflowIdentityChangeSet.VerifyPreconditions(*env, tt.cfg)
+			if tt.wantError {
+				require.Error(t, err)
+				if tt.errorMsg != "" {
+					require.Contains(t, err.Error(), tt.errorMsg)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSetExpectedWorkflowIdentityChangeSet(t *testing.T) {
+	t.Parallel()
+
+	selector := chainselectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
+
+	setupMCMSInfrastructure(t, rt, []uint64{selector})
+	fundDeployerAccounts(t, rt.Environment(), []uint64{selector})
+
+	// The AutomationReceiver's setCallAllowed requires deployed code on the target
+	// (reverts with TargetHasNoCode otherwise), so use the already-deployed timelock
+	// as the target when recording the receiver in the datastore.
+	timelockAddr, err := GetContractAddress(rt.State().DataStore, selector, commontypes.RBACTimelock)
+	require.NoError(t, err)
+
+	// Deploy the AutomationReceiver so its address is recorded in the datastore.
+	deployCfg := types.DeployAutomationReceiverInput{
+		Chains: map[uint64]types.AutomationReceiverChainConfig{
+			selector: {
+				ForwarderAddress: testAddr1,
+				TargetAddress:    timelockAddr,
+				Selector:         testSelectorHex,
+			},
+		},
+	}
+	require.NoError(t, rt.Exec(runtime.ChangesetTask(DeployAutomationReceiverChangeSet, deployCfg)))
+
+	receiverAddr, err := GetContractAddress(rt.State().DataStore, selector, cldf.ContractType(types.AutomationReceiverContractType))
+	require.NoError(t, err)
+
+	cfg := types.SetExpectedWorkflowIdentityInput{
+		Chains: map[uint64]types.SetExpectedWorkflowIdentityChainConfig{
+			selector: {
+				ExpectedAuthor:       testAddr2,
+				ExpectedWorkflowName: testWorkflowName,
+			},
+		},
+	}
+	require.NoError(t, SetExpectedWorkflowIdentityChangeSet.VerifyPreconditions(rt.Environment(), cfg))
+
+	task := runtime.ChangesetTask(SetExpectedWorkflowIdentityChangeSet, cfg)
+	require.NoError(t, rt.Exec(task))
+
+	out := rt.State().Outputs[task.ID()]
+	require.NotEmpty(t, out.MCMSTimelockProposals)
+	prop := out.MCMSTimelockProposals[0]
+	require.Contains(t, prop.Description, "AutomationReceiver SetExpectedWorkflowIdentity")
+	require.Len(t, prop.Operations, 1)
+	// Two transactions in the batch: setExpectedAuthor + setExpectedWorkflowName.
+	require.Len(t, prop.Operations[0].Transactions, 2)
+	require.Contains(t, prop.Operations[0].Transactions[0].Tags, "setExpectedAuthor")
+	require.Contains(t, prop.Operations[0].Transactions[1].Tags, "setExpectedWorkflowName")
+	require.Equal(t, receiverAddr, prop.Operations[0].Transactions[0].To)
+	require.Equal(t, receiverAddr, prop.Operations[0].Transactions[1].To)
+}
+
+func TestSetExpectedWorkflowIdentity_Apply_withoutReceiverInDatastore(t *testing.T) {
+	t.Parallel()
+
+	selector := chainselectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
+
+	// MCMS infra is present, but the AutomationReceiver was never deployed, so its
+	// address cannot be resolved from the datastore.
+	setupMCMSInfrastructure(t, rt, []uint64{selector})
+	fundDeployerAccounts(t, rt.Environment(), []uint64{selector})
+
+	cfg := types.SetExpectedWorkflowIdentityInput{
+		Chains: map[uint64]types.SetExpectedWorkflowIdentityChainConfig{
+			selector: {
+				ExpectedAuthor:       testAddr2,
+				ExpectedWorkflowName: testWorkflowName,
+			},
+		},
+	}
+	require.NoError(t, SetExpectedWorkflowIdentityChangeSet.VerifyPreconditions(rt.Environment(), cfg))
+
+	_, err = SetExpectedWorkflowIdentityChangeSet.Apply(rt.Environment(), cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "AutomationReceiver")
+}

--- a/deployment/vault/changeset/ethbalmon_automation_receiver_deploy.go
+++ b/deployment/vault/changeset/ethbalmon_automation_receiver_deploy.go
@@ -39,6 +39,14 @@ func (d deployEthBalMonWithReceiver) VerifyPreconditions(env cldf.Environment, c
 		if err := validateDeployEthBalMonMCMSInDatastore(env, chainSelector, config.MCMSConfig); err != nil {
 			return fmt.Errorf("chain %d: %w", chainSelector, err)
 		}
+		if (chainCfg.ExpectedAuthor != "") != (chainCfg.ExpectedWorkflowName != "") {
+			return fmt.Errorf("chain %d: expectedAuthor and expectedWorkflowName must be set together", chainSelector)
+		}
+		if chainCfg.ExpectedAuthor != "" {
+			if err := validateEthAddress("expectedAuthor", chainCfg.ExpectedAuthor); err != nil {
+				return fmt.Errorf("chain %d: %w", chainSelector, err)
+			}
+		}
 	}
 	return nil
 }
@@ -228,6 +236,19 @@ var DeployEthBalMonWithReceiverSequence = operations.NewSequence(
 			})
 			if err != nil {
 				return DeployEthBalMonWithReceiverSequenceOutput{}, fmt.Errorf("chain %d: setCallAllowed failed: %w", chainSelector, err)
+			}
+
+			// 3b. Optionally lock the AR's inbound identity guard (deployer still owns the AR).
+			if chainCfg.ExpectedAuthor != "" && chainCfg.ExpectedWorkflowName != "" {
+				_, err = operations.ExecuteOperation(b, SetExpectedWorkflowIdentityOperation, deps, SetExpectedWorkflowIdentityOperationInput{
+					ChainSelector:             chainSelector,
+					AutomationReceiverAddress: arAddress,
+					ExpectedAuthor:            chainCfg.ExpectedAuthor,
+					ExpectedWorkflowName:      chainCfg.ExpectedWorkflowName,
+				})
+				if err != nil {
+					return DeployEthBalMonWithReceiverSequenceOutput{}, fmt.Errorf("chain %d: setExpectedWorkflowIdentity failed: %w", chainSelector, err)
+				}
 			}
 
 			// 4. Transfer AR ownership to Timelock (OZ Ownable — single-step, immediate)

--- a/deployment/vault/changeset/ethbalmon_automation_receiver_deploy.go
+++ b/deployment/vault/changeset/ethbalmon_automation_receiver_deploy.go
@@ -36,9 +36,6 @@ func (d deployEthBalMonWithReceiver) VerifyPreconditions(env cldf.Environment, c
 		if err := validateEthAddress("forwarderAddress", chainCfg.ForwarderAddress); err != nil {
 			return fmt.Errorf("chain %d: %w", chainSelector, err)
 		}
-		if err := validateDeployEthBalMonMCMSInDatastore(env, chainSelector, config.MCMSConfig); err != nil {
-			return fmt.Errorf("chain %d: %w", chainSelector, err)
-		}
 		if (chainCfg.ExpectedAuthor != "") != (chainCfg.ExpectedWorkflowName != "") {
 			return fmt.Errorf("chain %d: expectedAuthor and expectedWorkflowName must be set together", chainSelector)
 		}
@@ -46,6 +43,9 @@ func (d deployEthBalMonWithReceiver) VerifyPreconditions(env cldf.Environment, c
 			if err := validateEthAddress("expectedAuthor", chainCfg.ExpectedAuthor); err != nil {
 				return fmt.Errorf("chain %d: %w", chainSelector, err)
 			}
+		}
+		if err := validateDeployEthBalMonMCMSInDatastore(env, chainSelector, config.MCMSConfig); err != nil {
+			return fmt.Errorf("chain %d: %w", chainSelector, err)
 		}
 	}
 	return nil

--- a/deployment/vault/changeset/ethbalmon_automation_receiver_deploy_test.go
+++ b/deployment/vault/changeset/ethbalmon_automation_receiver_deploy_test.go
@@ -1,0 +1,192 @@
+package changeset
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
+
+	"github.com/smartcontractkit/chainlink/deployment/vault/changeset/types"
+)
+
+func TestDeployEthBalMonWithReceiver_VerifyPreconditions(t *testing.T) {
+	t.Parallel()
+
+	selector := chainselectors.TEST_90000001.Selector
+	selectorOther := chainselectors.TEST_90000002.Selector
+
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	)
+	require.NoError(t, err)
+
+	// These cases all fail before the MCMS/timelock datastore check (empty chains, chain not in
+	// environment, and the input-level forwarder/identity validations), so a plain env is enough.
+	tests := []struct {
+		name      string
+		cfg       types.DeployEthBalMonWithReceiverInput
+		wantError bool
+		errorMsg  string
+	}{
+		{
+			name:      "empty chains",
+			cfg:       types.DeployEthBalMonWithReceiverInput{Chains: map[uint64]types.DeployEthBalMonWithReceiverChainConfig{}},
+			wantError: true,
+			errorMsg:  "chains must not be empty",
+		},
+		{
+			name: "chain not in environment",
+			cfg: types.DeployEthBalMonWithReceiverInput{Chains: map[uint64]types.DeployEthBalMonWithReceiverChainConfig{
+				selectorOther: {ForwarderAddress: testAddr1},
+			}},
+			wantError: true,
+			errorMsg:  "not found in environment",
+		},
+		{
+			name: "invalid forwarder address",
+			cfg: types.DeployEthBalMonWithReceiverInput{Chains: map[uint64]types.DeployEthBalMonWithReceiverChainConfig{
+				selector: {ForwarderAddress: "not-an-address"},
+			}},
+			wantError: true,
+			errorMsg:  "forwarderAddress is not a valid hex address",
+		},
+		{
+			name: "author without name",
+			cfg: types.DeployEthBalMonWithReceiverInput{Chains: map[uint64]types.DeployEthBalMonWithReceiverChainConfig{
+				selector: {ForwarderAddress: testAddr1, ExpectedAuthor: testAddr2},
+			}},
+			wantError: true,
+			errorMsg:  "expectedAuthor and expectedWorkflowName must be set together",
+		},
+		{
+			name: "name without author",
+			cfg: types.DeployEthBalMonWithReceiverInput{Chains: map[uint64]types.DeployEthBalMonWithReceiverChainConfig{
+				selector: {ForwarderAddress: testAddr1, ExpectedWorkflowName: testWorkflowName},
+			}},
+			wantError: true,
+			errorMsg:  "expectedAuthor and expectedWorkflowName must be set together",
+		},
+		{
+			name: "invalid author address",
+			cfg: types.DeployEthBalMonWithReceiverInput{Chains: map[uint64]types.DeployEthBalMonWithReceiverChainConfig{
+				selector: {ForwarderAddress: testAddr1, ExpectedAuthor: "not-an-address", ExpectedWorkflowName: testWorkflowName},
+			}},
+			wantError: true,
+			errorMsg:  "expectedAuthor is not a valid hex address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := DeployEthBalMonWithReceiverChangeSet.VerifyPreconditions(*env, tt.cfg)
+			require.Error(t, err)
+			if tt.errorMsg != "" {
+				require.Contains(t, err.Error(), tt.errorMsg)
+			}
+		})
+	}
+}
+
+func TestDeployEthBalMonWithReceiver_VerifyPreconditions_validWithMCMS(t *testing.T) {
+	t.Parallel()
+
+	selector := chainselectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
+	setupMCMSInfrastructure(t, rt, []uint64{selector})
+
+	cfg := types.DeployEthBalMonWithReceiverInput{
+		Chains: map[uint64]types.DeployEthBalMonWithReceiverChainConfig{
+			selector: {
+				ForwarderAddress:     testAddr1,
+				ExpectedAuthor:       testAddr2,
+				ExpectedWorkflowName: testWorkflowName,
+			},
+		},
+	}
+	require.NoError(t, DeployEthBalMonWithReceiverChangeSet.VerifyPreconditions(rt.Environment(), cfg))
+}
+
+// TestDeployEthBalMonWithReceiver_SetsIdentity exercises the optional identity block in the
+// combined deploy sequence: when expectedAuthor + expectedWorkflowName are provided, the
+// AutomationReceiver's inbound guard must be configured on-chain by the end of the deploy.
+func TestDeployEthBalMonWithReceiver_SetsIdentity(t *testing.T) {
+	t.Parallel()
+
+	selector := chainselectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
+
+	setupMCMSInfrastructure(t, rt, []uint64{selector})
+	fundDeployerAccounts(t, rt.Environment(), []uint64{selector})
+
+	cfg := types.DeployEthBalMonWithReceiverInput{
+		Chains: map[uint64]types.DeployEthBalMonWithReceiverChainConfig{
+			selector: {
+				ForwarderAddress:     testAddr1,
+				ExpectedAuthor:       testAddr2,
+				ExpectedWorkflowName: testWorkflowName,
+			},
+		},
+	}
+	require.NoError(t, DeployEthBalMonWithReceiverChangeSet.VerifyPreconditions(rt.Environment(), cfg))
+
+	out, err := DeployEthBalMonWithReceiverChangeSet.Apply(rt.Environment(), cfg)
+	require.NoError(t, err)
+
+	// Both contracts recorded in the datastore.
+	receiverAddr, err := GetContractAddress(out.DataStore, selector, cldf.ContractType(types.AutomationReceiverContractType))
+	require.NoError(t, err)
+	ebmAddr, err := GetContractAddress(out.DataStore, selector, cldf.ContractType(types.EthBalMonContractType))
+	require.NoError(t, err)
+	require.NotEmpty(t, ebmAddr)
+
+	// Accept-ownership proposal for EthBalMon is produced.
+	require.NotEmpty(t, out.MCMSTimelockProposals)
+
+	// Identity guard set on-chain.
+	author, name := readReceiverIdentity(t, rt.Environment(), selector, receiverAddr)
+	require.Equal(t, common.HexToAddress(testAddr2), author, "expectedAuthor must be set on-chain")
+	require.NotEqual(t, [10]byte{}, name, "expectedWorkflowName must be set on-chain")
+}
+
+// TestDeployEthBalMonWithReceiver_WithoutIdentity confirms the identity block is skipped when no
+// identity is provided; the receiver still deploys but its guard stays unconfigured.
+func TestDeployEthBalMonWithReceiver_WithoutIdentity(t *testing.T) {
+	t.Parallel()
+
+	selector := chainselectors.TEST_90000001.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithEVMSimulated(t, []uint64{selector}),
+	))
+	require.NoError(t, err)
+
+	setupMCMSInfrastructure(t, rt, []uint64{selector})
+	fundDeployerAccounts(t, rt.Environment(), []uint64{selector})
+
+	cfg := types.DeployEthBalMonWithReceiverInput{
+		Chains: map[uint64]types.DeployEthBalMonWithReceiverChainConfig{
+			selector: {ForwarderAddress: testAddr1},
+		},
+	}
+	out, err := DeployEthBalMonWithReceiverChangeSet.Apply(rt.Environment(), cfg)
+	require.NoError(t, err)
+
+	receiverAddr, err := GetContractAddress(out.DataStore, selector, cldf.ContractType(types.AutomationReceiverContractType))
+	require.NoError(t, err)
+
+	author, name := readReceiverIdentity(t, rt.Environment(), selector, receiverAddr)
+	require.Equal(t, common.Address{}, author, "expectedAuthor must remain unset when no identity is provided")
+	require.Equal(t, [10]byte{}, name, "expectedWorkflowName must remain unset when no identity is provided")
+}

--- a/deployment/vault/changeset/ethbalmon_deploy.go
+++ b/deployment/vault/changeset/ethbalmon_deploy.go
@@ -390,6 +390,80 @@ var SetCallAllowedOperation = operations.NewOperation(
 
 // ================================================
 // ================================================
+// SetExpectedWorkflowIdentity OPERATION (direct, deployer-owned)
+// ================================================
+// ================================================
+
+type SetExpectedWorkflowIdentityOperationInput struct {
+	ChainSelector             uint64 `json:"chain_selector"`
+	AutomationReceiverAddress string `json:"automation_receiver_address"`
+	ExpectedAuthor            string `json:"expected_author"`
+	ExpectedWorkflowName      string `json:"expected_workflow_name"`
+}
+
+type SetExpectedWorkflowIdentityOperationOutput struct {
+	ChainSelector uint64 `json:"chain_selector"`
+	AuthorTxHash  string `json:"author_tx_hash"`
+	NameTxHash    string `json:"name_tx_hash"`
+}
+
+// SetExpectedWorkflowIdentityOperation sets expectedAuthor + expectedWorkflowName on the
+// AutomationReceiver directly (deployer is still the owner at this point in the deploy flow,
+// before ownership is transferred to the Timelock). The receiver requires this identity to be
+// configured or it reverts inbound reports with WorkflowIdentityNotConfigured.
+var SetExpectedWorkflowIdentityOperation = operations.NewOperation(
+	"set-expected-workflow-identity",
+	semver.MustParse("1.0.0"),
+	"Set expectedAuthor and expectedWorkflowName on AutomationReceiver (deployer-owned)",
+	func(b operations.Bundle, deps VaultDeps, input SetExpectedWorkflowIdentityOperationInput) (SetExpectedWorkflowIdentityOperationOutput, error) {
+		chain, ok := deps.Environment.BlockChains.EVMChains()[input.ChainSelector]
+		if !ok {
+			return SetExpectedWorkflowIdentityOperationOutput{}, fmt.Errorf("chain not found in environment: %d", input.ChainSelector)
+		}
+
+		receiver, err := automation_receiver.NewAutomationReceiver(
+			common.HexToAddress(input.AutomationReceiverAddress),
+			chain.Client,
+		)
+		if err != nil {
+			return SetExpectedWorkflowIdentityOperationOutput{}, fmt.Errorf("failed to instantiate AutomationReceiver at %s: %w", input.AutomationReceiverAddress, err)
+		}
+
+		b.Logger.Infow("Setting expectedAuthor on AutomationReceiver",
+			"chainSelector", input.ChainSelector,
+			"automationReceiverAddress", input.AutomationReceiverAddress,
+			"expectedAuthor", input.ExpectedAuthor,
+		)
+		authorTx, err := receiver.SetExpectedAuthor(chain.DeployerKey, common.HexToAddress(input.ExpectedAuthor))
+		if err != nil {
+			return SetExpectedWorkflowIdentityOperationOutput{}, fmt.Errorf("failed to call setExpectedAuthor: %w", err)
+		}
+		if _, err := chain.Confirm(authorTx); err != nil {
+			return SetExpectedWorkflowIdentityOperationOutput{}, fmt.Errorf("failed to confirm setExpectedAuthor tx %s: %w", authorTx.Hash().Hex(), err)
+		}
+
+		b.Logger.Infow("Setting expectedWorkflowName on AutomationReceiver",
+			"chainSelector", input.ChainSelector,
+			"expectedWorkflowName", input.ExpectedWorkflowName,
+		)
+		nameTx, err := receiver.SetExpectedWorkflowName(chain.DeployerKey, input.ExpectedWorkflowName)
+		if err != nil {
+			return SetExpectedWorkflowIdentityOperationOutput{}, fmt.Errorf("failed to call setExpectedWorkflowName: %w", err)
+		}
+		if _, err := chain.Confirm(nameTx); err != nil {
+			return SetExpectedWorkflowIdentityOperationOutput{}, fmt.Errorf("failed to confirm setExpectedWorkflowName tx %s: %w", nameTx.Hash().Hex(), err)
+		}
+
+		return SetExpectedWorkflowIdentityOperationOutput{
+			ChainSelector: input.ChainSelector,
+			AuthorTxHash:  authorTx.Hash().Hex(),
+			NameTxHash:    nameTx.Hash().Hex(),
+		}, nil
+	},
+)
+
+// ================================================
+// ================================================
 // Transfer AutomationReceiver Ownership OPERATION
 // ================================================
 // ================================================

--- a/deployment/vault/changeset/types/types.go
+++ b/deployment/vault/changeset/types/types.go
@@ -118,6 +118,25 @@ const EthBalMonContractType = "EthBalMon"
 // AutomationReceiverContractType
 const AutomationReceiverContractType = "AutomationReceiver"
 
+// SetExpectedWorkflowIdentityChainConfig configures the AutomationReceiver's inbound identity
+// guard on one chain by pinning the workflow owner (author) and name. This is stable across
+// workflow redeploys (unlike the workflow id, which changes on every redeploy), so it only needs
+// to be set once. Both fields are required.
+type SetExpectedWorkflowIdentityChainConfig struct {
+	// ExpectedAuthor is the workflow owner address (hex) allowed to call the receiver.
+	ExpectedAuthor string `json:"expectedAuthor"`
+	// ExpectedWorkflowName is the raw workflow name; the receiver hashes/truncates it internally.
+	ExpectedWorkflowName string `json:"expectedWorkflowName"`
+}
+
+// SetExpectedWorkflowIdentityInput is the input to the setExpectedWorkflowIdentity changeset.
+// Keys are chain selectors; the AutomationReceiver address is resolved from the datastore.
+type SetExpectedWorkflowIdentityInput struct {
+	Chains map[uint64]SetExpectedWorkflowIdentityChainConfig `json:"chains"`
+	// MCMSConfig optionally configures the timelock proposal; when nil, schedule + proposer MCM is used.
+	MCMSConfig *cldfproposalutils.TimelockConfig `json:"mcms_config,omitempty"`
+}
+
 // SetKeeperRegistryChainConfig updates the automation executor/registry EthBalMon forwards work to.
 type SetKeeperRegistryChainConfig struct {
 	// NewKeeperRegistryAddress is the new Chainlink Automation forwarder or KMS executor address (hex).
@@ -188,6 +207,13 @@ type AutomationReceiverChainConfig struct {
 	// Selector is the 4-byte function selector as a hex string (e.g. "0x4b9f5c20").
 	// Defaults to performUpkeep(bytes) if empty.
 	Selector string `json:"selector,omitempty"`
+	// ExpectedAuthor / ExpectedWorkflowName lock the AutomationReceiver's inbound identity
+	// guard at deploy time. The receiver reverts with WorkflowIdentityNotConfigured until an
+	// identity is set, so configuring it here makes the receiver usable right after deploy.
+	// Optional: set BOTH (recommended, stable across workflow redeploys) or leave both empty
+	// to skip identity setup at deploy time.
+	ExpectedAuthor       string `json:"expectedAuthor,omitempty"`
+	ExpectedWorkflowName string `json:"expectedWorkflowName,omitempty"`
 }
 
 // DeployAutomationReceiverInput is the input to the standalone AutomationReceiver deploy changeset.
@@ -202,6 +228,11 @@ type DeployEthBalMonWithReceiverChainConfig struct {
 	// SetMinWaitPeriodSeconds configures the EthBalMon min wait period.
 	// Optional: nil or 0 defaults to 60 seconds.
 	SetMinWaitPeriodSeconds *uint64 `json:"setMinWaitPeriodSeconds,omitempty"`
+	// ExpectedAuthor / ExpectedWorkflowName lock the AutomationReceiver's inbound identity
+	// guard at deploy time (both required together to be effective). Optional: leave both empty
+	// to skip identity setup at deploy time.
+	ExpectedAuthor       string `json:"expectedAuthor,omitempty"`
+	ExpectedWorkflowName string `json:"expectedWorkflowName,omitempty"`
 }
 
 // DeployEthBalMonWithReceiverInput is the input to the combined EthBalMon + AutomationReceiver deploy changeset.

--- a/deployment/vault/changeset/utils.go
+++ b/deployment/vault/changeset/utils.go
@@ -26,6 +26,22 @@ func recipientAddressesFromERC20Transfers(transfers []types.ERC20Transfer) []str
 	return addresses
 }
 
+// lowestChainSelector returns the smallest chain-selector key in chains, and false when the map
+// is empty. Map iteration order is not deterministic in Go, so callers that only need a single
+// representative chain (e.g. to build deps / pick a deployer key) use this instead of grabbing an
+// arbitrary key, keeping changeset output reproducible for the same input.
+func lowestChainSelector[V any](chains map[uint64]V) (uint64, bool) {
+	var lowest uint64
+	found := false
+	for sel := range chains {
+		if !found || sel < lowest {
+			lowest = sel
+			found = true
+		}
+	}
+	return lowest, found
+}
+
 func GetContractAddress(ds any, chainSelector uint64, contractType cldf.ContractType) (string, error) {
 	if ds == nil {
 		return "", errors.New("datastore is nil")


### PR DESCRIPTION
# Summary

Adds a vault-domain changeset to configure the `AutomationReceiver`'s inbound identity guard (`setExpectedAuthor` + `setExpectedWorkflowName`), plus wiring to optionally set it during deployment.

# Motivation

The `AutomationReceiver` (`contracts/src/v0.8/automation-cre/AutomationReceiver.sol`) reverts every inbound report with `WorkflowIdentityNotConfigured` unless an identity is configured—either `expectedWorkflowId`, or both `expectedAuthor` and `expectedWorkflowName`:

```solidity
if (
    s_expectedWorkflowId == bytes32(0) &&
    (s_expectedAuthor == address(0) || s_expectedWorkflowName == bytes10(0))
) {
    revert WorkflowIdentityNotConfigured();
}
```

Until now, the vault domain had no changeset to configure this, so freshly deployed receivers silently rejected all reports (the write transaction succeeds at the forwarder, but the receiver call reverts and no downstream call executes).

We prefer configuring **author + workflow name** over pinning a **workflowId**, because the workflow ID changes on every workflow redeploy, whereas the author and workflow name remain stable and only need to be configured once.

# Changes

## `deployment/vault/changeset/`

### New `automation_receiver_set_expected_workflow_identity.go`

Introduces `SetExpectedWorkflowIdentityChangeSet`, which builds an MCMS Timelock proposal that calls:

- `setExpectedAuthor`
- `setExpectedWorkflowName`

on the `AutomationReceiver` for each configured chain.

The receiver address is resolved from the datastore using the same pattern as `SetCallAllowedChangeSet`.

Both setter calls are included in a single atomic batch per chain.

### New `automation_receiver_set_expected_workflow_identity_test.go`

Adds:

- Precondition table-driven tests.
- An end-to-end test that decodes the generated calldata to verify it exactly matches:
  - `setExpectedAuthor(author)`
  - `setExpectedWorkflowName(name)`
- A failure case when the receiver is missing from the datastore.

### `ethbalmon_deploy.go`

Adds a new direct operation:

- `SetExpectedWorkflowIdentityOperation`

This is a deployer-owned operation used during deployment before ownership is transferred to the Timelock.

### `automation_receiver_deploy.go` and `ethbalmon_automation_receiver_deploy.go`

Optionally configure the workflow identity during deployment (after `setCallAllowed` and before ownership transfer) whenever `expectedAuthor` and `expectedWorkflowName` are provided.

Also adds the corresponding validation.

### `types/types.go`

Adds:

- `SetExpectedWorkflowIdentityInput`
- `SetExpectedWorkflowIdentityChainConfig`

Also extends the Automation Receiver deployment configuration with the optional fields:

- `ExpectedAuthor`
- `ExpectedWorkflowName`

# Testing

- ✅ `go build ./deployment/vault/changeset/...`
- ✅ `go vet ./deployment/vault/changeset/`
- ✅ `gofmt`
- ✅ `go test ./deployment/vault/changeset/ -run TestSetExpectedWorkflowIdentity`

Tests cover:

- Preconditions
- End-to-end calldata decoding
- Missing receiver failure case

# Notes / Follow-ups

- Mirrors the existing `SetCallAllowed` changeset pattern:
  - Direct operation for deploy-time configuration.
  - MCMS proposal operation for the standalone changeset.
- The corresponding registration (YAML key → changeset) will be added to **chainlink-deployments** once this PR is merged.