### PR TITLE
[CCIP-12413] fix(ccip): bound per-chain reader/writer creation (#23105)

### DIFF
--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -56,6 +56,13 @@ var _ cctypes.OracleCreator = &pluginOracleCreator{}
 const (
 	defaultCommitGasLimit = 500_000
 	defaultExecGasLimit   = 6_500_000
+
+	// readerWriterCreationTimeout bounds the per-chain contract reader/writer creation,
+	// binding, and startup during oracle creation.
+	// Applied per chain, so it must stay small: a DON can span many chains and the timeout
+	// is spent serially in the worst case. 10s matches the other blockchain-facing timeouts
+	// in defaultLocalConfig and rpctimeout.Default.
+	readerWriterCreationTimeout = 10 * time.Second
 )
 
 // pluginOracleCreator creates oracles that reference plugins running
@@ -684,76 +691,87 @@ func (i *pluginOracleCreator) createReadersAndWriters(
 	extendedReaders := make(map[cciptypes.ChainSelector]contractreader.Extended)
 	chainWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 	for relayID, relayer := range i.relayers {
-		chainID := relayID.ChainID
-		relayChainFamily := relayID.Network
-		chainDetails, err1 := chainsel.GetChainDetailsByChainIDAndFamily(chainID, relayChainFamily)
-		chainSelector := cciptypes.ChainSelector(chainDetails.ChainSelector)
-		if err1 != nil {
-			return nil, nil, nil, fmt.Errorf("failed to get chain selector from chain ID %s: %w", chainID, err1)
-		}
+		if err := func() error {
+			// Bound each chain's reader/writer creation with its own deadline so an unavailable
+			// chain LOOPP fails fast instead of blocking the launcher context
+			// forever.
+			chainCtx, cancel := context.WithTimeout(ctx, readerWriterCreationTimeout)
+			defer cancel()
 
-		cr, err1 := crcw.GetChainReader(ctx, ccipcommon.ChainReaderProviderOpts{
-			Lggr:            i.lggr,
-			Relayer:         relayer,
-			ChainID:         chainID,
-			DestChainID:     destChainID,
-			HomeChainID:     homeChainID,
-			Ofc:             ofc,
-			ChainSelector:   chainSelector,
-			ChainFamily:     relayChainFamily,
-			DestChainFamily: destChainFamily,
-			Transmitters:    i.transmitters,
-		})
-		if err1 != nil {
-			// Some Chain family might not need crcw to be created, and if createChainAccessorsAndContractTransmitters will catch error if it does
-			i.lggr.Debugf("skipping creating reader and writers for chain %s, reader creation: %v", chainID, err1)
-			continue
-		}
-
-		if chainID == destChainID && destChainFamily == relayChainFamily {
-			offrampAddress := destAddrStr
-			err2 := cr.Bind(ctx, []types.BoundContract{
-				{
-					Address: offrampAddress,
-					Name:    consts.ContractNameOffRamp,
-				},
-			})
-			if err2 != nil {
-				return nil, nil, nil, fmt.Errorf("failed to bind chain reader for dest chain %s's offramp at %s: %w", chainID, offrampAddress, err2)
+			chainID := relayID.ChainID
+			relayChainFamily := relayID.Network
+			chainDetails, err1 := chainsel.GetChainDetailsByChainIDAndFamily(chainID, relayChainFamily)
+			chainSelector := cciptypes.ChainSelector(chainDetails.ChainSelector)
+			if err1 != nil {
+				return fmt.Errorf("failed to get chain selector from chain ID %s: %w", chainID, err1)
 			}
-		}
 
-		if err2 := cr.Start(ctx); err2 != nil {
-			return nil, nil, nil, fmt.Errorf("failed to start contract reader for chain %s: %w", chainID, err2)
-		}
+			cr, err1 := crcw.GetChainReader(chainCtx, ccipcommon.ChainReaderProviderOpts{
+				Lggr:            i.lggr,
+				Relayer:         relayer,
+				ChainID:         chainID,
+				DestChainID:     destChainID,
+				HomeChainID:     homeChainID,
+				Ofc:             ofc,
+				ChainSelector:   chainSelector,
+				ChainFamily:     relayChainFamily,
+				DestChainFamily: destChainFamily,
+				Transmitters:    i.transmitters,
+			})
+			if err1 != nil {
+				// Some Chain family might not need crcw to be created, and if createChainAccessorsAndContractTransmitters will catch error if it does
+				i.lggr.Debugf("skipping creating reader and writers for chain %s, reader creation: %v", chainID, err1)
+				return nil
+			}
 
-		cw, err1 := crcw.GetChainWriter(ctx, ccipcommon.ChainWriterProviderOpts{
-			ChainID:                chainID,
-			Relayer:                relayer,
-			Transmitters:           i.transmitters,
-			ExecBatchGasLimit:      execBatchGasLimit,
-			CommitEvmBatchGasLimit: commitEvmGasLimit,
-			ChainFamily:            relayChainFamily,
-			OfframpProgramAddress:  config.Config.OfframpAddress,
-		})
-		if err1 != nil {
-			// Some Chain family might not need crcw to be created, and if createChainAccessorsAndContractTransmitters will catch error if it does
-			i.lggr.Debugf("skipping creating chain writer for chain %s, writer creation: %v", chainID, err1)
-			continue
-		}
+			if chainID == destChainID && destChainFamily == relayChainFamily {
+				offrampAddress := destAddrStr
+				err2 := cr.Bind(chainCtx, []types.BoundContract{
+					{
+						Address: offrampAddress,
+						Name:    consts.ContractNameOffRamp,
+					},
+				})
+				if err2 != nil {
+					return fmt.Errorf("failed to bind chain reader for dest chain %s's offramp at %s: %w", chainID, offrampAddress, err2)
+				}
+			}
 
-		if err4 := cw.Start(ctx); err4 != nil {
-			return nil, nil, nil, fmt.Errorf("failed to start chain writer for chain %s: %w", chainID, err4)
-		}
+			if err2 := cr.Start(chainCtx); err2 != nil {
+				return fmt.Errorf("failed to start contract reader for chain %s: %w", chainID, err2)
+			}
 
-		extendedCr, err := wrapContractReaderInObservedExtended(i.lggr, cr, chainSelector)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to wrap contract reader for chain %s: %w", chainID, err)
-		}
+			cw, err1 := crcw.GetChainWriter(chainCtx, ccipcommon.ChainWriterProviderOpts{
+				ChainID:                chainID,
+				Relayer:                relayer,
+				Transmitters:           i.transmitters,
+				ExecBatchGasLimit:      execBatchGasLimit,
+				CommitEvmBatchGasLimit: commitEvmGasLimit,
+				ChainFamily:            relayChainFamily,
+				OfframpProgramAddress:  config.Config.OfframpAddress,
+			})
+			if err1 != nil {
+				// Some Chain family might not need crcw to be created, and if createChainAccessorsAndContractTransmitters will catch error if it does
+				i.lggr.Debugf("skipping creating chain writer for chain %s, writer creation: %v", chainID, err1)
+				return nil
+			}
 
-		contractReaders[chainSelector] = cr
-		extendedReaders[chainSelector] = extendedCr
-		chainWriters[chainSelector] = cw
+			if err4 := cw.Start(chainCtx); err4 != nil {
+				return fmt.Errorf("failed to start chain writer for chain %s: %w", chainID, err4)
+			}
+
+			extendedCr, err := wrapContractReaderInObservedExtended(i.lggr, cr, chainSelector)
+			if err != nil {
+				return fmt.Errorf("failed to wrap contract reader for chain %s: %w", chainID, err)
+			}
+
+			contractReaders[chainSelector] = cr
+			extendedReaders[chainSelector] = extendedCr
+			chainWriters[chainSelector] = cw
+			return nil
+		}(); err != nil {
+			return nil, nil, nil, err
+		}
 	}
 	return contractReaders, extendedReaders, chainWriters, nil
 }


### PR DESCRIPTION
fix(ccip): bound per-chain reader/writer creation

- Wrap each chain's reader/writer create, bind, and start in a 10s context during oracle creation
- The launcher context has no deadline, so a down chain LOOPP would block the gRPC refresh loop forever, freezing the launcher and pinning the shared relayer connection
- A dead chain now fails fast and the launcher retries next tick

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
