### PR TITLE
Optimize CI runner sizing for cost savings

### DIFF
--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -118,7 +118,7 @@ jobs:
     # see: https://runs-on.com/guides/troubleshoot/#runner-stealing-and-matrix-jobs
     runs-on: runs-on=${{ github.run_id }}-${{ matrix.tests.test_id }}-${{
       github.run_attempt
-      }}/cpu=16/ram=64/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+      }}/cpu=16/ram=64/family=m6i+m5.*/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     environment:
       # http://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments
       name: integration

--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -118,7 +118,7 @@ jobs:
     # see: https://runs-on.com/guides/troubleshoot/#runner-stealing-and-matrix-jobs
     runs-on: runs-on=${{ github.run_id }}-${{ matrix.tests.test_id }}-${{
       github.run_attempt
-      }}/cpu=16/ram=64/family=m6i+m5.*/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+      }}/cpu=8/ram=32/family=m6i+m5.*/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     environment:
       # http://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments
       name: integration

--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -118,7 +118,7 @@ jobs:
     # see: https://runs-on.com/guides/troubleshoot/#runner-stealing-and-matrix-jobs
     runs-on: runs-on=${{ github.run_id }}-${{ matrix.tests.test_id }}-${{
       github.run_attempt
-      }}/cpu=8/ram=32/family=m6i+m5.*/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+      }}/cpu=8/ram=32/family=m6i+m7i/spot=co/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     environment:
       # http://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments
       name: integration

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -180,7 +180,7 @@ jobs:
     # see: https://runs-on.com/guides/troubleshoot/#runner-stealing-and-matrix-jobs
     runs-on: runs-on=${{ github.run_id }}-${{ matrix.tests.test_id }}-${{
       github.run_attempt
-      }}/cpu=16/ram=64/family=m6i+m5.*/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+      }}/cpu=8/ram=32/family=m6i+m5.*/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     environment:
       # http://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments
       name: integration

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -180,7 +180,7 @@ jobs:
     # see: https://runs-on.com/guides/troubleshoot/#runner-stealing-and-matrix-jobs
     runs-on: runs-on=${{ github.run_id }}-${{ matrix.tests.test_id }}-${{
       github.run_attempt
-      }}/cpu=8/ram=32/family=m6i+m5.*/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+      }}/cpu=8/ram=32/family=m6i+m7i/spot=co/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     environment:
       # http://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments
       name: integration

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -180,7 +180,7 @@ jobs:
     # see: https://runs-on.com/guides/troubleshoot/#runner-stealing-and-matrix-jobs
     runs-on: runs-on=${{ github.run_id }}-${{ matrix.tests.test_id }}-${{
       github.run_attempt
-      }}/cpu=16/ram=64/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+      }}/cpu=16/ram=64/family=m6i+m5.*/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     environment:
       # http://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments
       name: integration

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -231,8 +231,8 @@ jobs:
           OPT_OUT: ${{ steps.label-runs-on-opt-out.outputs.check-label-found || 'false' }}
           GH_BUILDER_RUNNER: ubuntu22.04-8cores-32GB
           # include unique label (core/plugins) to ensure jobs are not competing for the same runner
-          SH_BUILDER_RUNNER_CORE: runs-on=${{ github.run_id }}-core/cpu=32+36/memory=64+72/family=c6i+c7i+c5.*/extras=s3-cache+tmpfs
-          SH_BUILDER_RUNNER_PLUGINS: runs-on=${{ github.run_id }}-plugins/cpu=32+36/memory=64+72/family=c6i+c7i+c5.*/extras=s3-cache+tmpfs
+          SH_BUILDER_RUNNER_CORE: runs-on=${{ github.run_id }}-core/cpu=16/memory=32/family=c6i+c7i+c5.*/extras=s3-cache+tmpfs
+          SH_BUILDER_RUNNER_PLUGINS: runs-on=${{ github.run_id }}-plugins/cpu=16/memory=32/family=c6i+c7i+c5.*/extras=s3-cache+tmpfs
         run: |
           if [[ "${OPT_OUT}" == "true" ]]; then
             echo "builder-runner-label=${GH_BUILDER_RUNNER}" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Right-size GitHub Actions runners to reduce costs while maintaining performance and stability.

## Changes

### CRE Test Runners (cre-system-tests.yaml, cre-regression-system-tests.yaml)
- **CPU/RAM**: 16 CPU / 64GB → 8 CPU / 32GB (50% reduction)
- **Spot**: on-demand → spot=co (capacity-optimized spot with on-demand fallback)
- **Instance families**: m6i+m5.* → m6i+m7i (latest 2 generations, flex allowed)

**Estimated savings**: ~75% cost reduction

### Build Chainlink (integration-tests.yml)
- **CPU/RAM**: 32+36 CPU / 64+72GB → 16 CPU / 32GB (50% reduction)

**Estimated savings**: ~50% cost reduction

## Testing

All trials passed successfully:
- CRE tests completed in similar time with reduced resources
- Build jobs completed successfully with reduced resources
- Spot interruptions handled gracefully (auto-fallback to on-demand)
- Flex instances (m7i-flex) provide good performance for spiky CPU workloads

## Notes

- spot=co prioritizes capacity over lowest price, reducing interruption risk
- Flex instances allowed for better availability and cost optimization
- Build jobs require minimum 16GB RAM (8GB caused OOM)