### PR TITLE
core/cmd: fix concurrent map write in Test_ReplayFromBlock

### DIFF
--- a/core/cmd/blocks_commands_test.go
+++ b/core/cmd/blocks_commands_test.go
@@ -22,11 +22,11 @@ func Test_ReplayFromBlock(t *testing.T) {
 
 	client, _ := app.NewShellAndRenderer()
 
-	set := flag.NewFlagSet("test", 0)
-	flagSetApplyFromAction(client.ReplayFromBlock, set, "")
-
 	t.Run("invalid args", func(t *testing.T) {
 		t.Parallel()
+		set := flag.NewFlagSet("test", 0)
+		flagSetApplyFromAction(client.ReplayFromBlock, set, "")
+
 		// Incorrect block number
 		require.NoError(t, set.Set("block-number", "0"))
 		c := cli.NewContext(nil, set, nil)
@@ -47,6 +47,9 @@ func Test_ReplayFromBlock(t *testing.T) {
 
 	t.Run("evm replay", func(t *testing.T) {
 		t.Parallel()
+		set := flag.NewFlagSet("test", 0)
+		flagSetApplyFromAction(client.ReplayFromBlock, set, "")
+
 		require.NoError(t, set.Set("block-number", "1"))
 		require.NoError(t, set.Set("chain-id", "5"))
 		require.NoError(t, set.Set("family", "evm"))


### PR DESCRIPTION
The two t.Parallel() subtests of Test_ReplayFromBlock shared a single flag.FlagSet, and flag.FlagSet.Set is not safe for concurrent use (it mutates a plain map). Running both subtests in parallel raced on that map, causing a fatal (unrecoverable) "concurrent map writes" error that crashed the whole core/cmd test binary and got dozens of unrelated in-flight tests in the package quarantined as flaky.

Give each subtest its own FlagSet instead of sharing one across goroutines.


