### PR TITLE
workflows/v2: defer confidential workflows when the TEE runner is unavailable

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.106
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260707105132-2da5d31f22fc
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1580,8 +1580,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100 h1:sH546tdm3VaYGaRLnZ6ZYBZiE25vEkMap76Xq/vQWx0=
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100/go.mod h1:0v6RGdYa9NezVnBPIAVyxB3A9furKWwaSkLha+URYGk=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4 h1:LzDSHQ5bM4pp8Wrr0mFjg60A4J47+IFPIuC/rHNF1qA=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26 h1:Ibqau2kZgzJVzcKcwHsdrGlqoyNv/onuEV6GgKT9AKo=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6 h1:DvfhsiIxB4JMuR+r1UciKV8jKiwhI/OZI/QhKawC4pM=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6/go.mod h1:6NefaCIMH4zFBN3T+cvsFGYoy3oTSPKDaxPAyBzlYTU=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/core/services/workflows/v2/confidential_module.go
+++ b/core/services/workflows/v2/confidential_module.go
@@ -66,7 +66,7 @@ type ConfidentialModule struct {
 	lggr              logger.Logger
 	requirements      sync.Map
 	restritions       sync.Map
-	infoOnce          sync.Once
+	providerMu        sync.Mutex
 	provider          func(tee *sdkpb.Tee) bool
 	executionHandlers *confidentialrelay.ExecutionHandlers
 	enabledGate       limits.GateLimiter
@@ -168,11 +168,34 @@ func (m *ConfidentialModule) providedTees(ctx context.Context) []*sdkpb.TeeTypeA
 }
 
 func (m *ConfidentialModule) Tee(ctx context.Context, tee *sdkpb.Tee) bool {
-	m.infoOnce.Do(func() {
-		m.provider = host.NewProviderFromSelection(m.providedTees(ctx))
-	})
+	// If confidential-workflows is disabled by settings, this runner cannot satisfy
+	// the requirement. Returning false surfaces host.ErrRunnerUnavailable upstream so
+	// the engine holds the workflow (and retries) instead of failing initialization.
+	if err := m.enabledGate.AllowErr(ctx); err != nil {
+		return false
+	}
+	return m.teeProvider(ctx)(tee)
+}
 
-	return m.provider(tee)
+// teeProvider returns a selection function over the confidential-workflows
+// capability's supported TEEs. It caches the selection only once the capability
+// reports at least one supported region; while it reports none (e.g. the capability
+// is not yet available on this node) it re-queries on each call so the module
+// self-heals when the capability comes up. The previous sync.Once cached an empty
+// selection permanently, leaving the workflow broken even after the capability
+// recovered.
+func (m *ConfidentialModule) teeProvider(ctx context.Context) func(*sdkpb.Tee) bool {
+	m.providerMu.Lock()
+	defer m.providerMu.Unlock()
+	if m.provider != nil {
+		return m.provider
+	}
+	tees := m.providedTees(ctx)
+	provider := host.NewProviderFromSelection(tees)
+	if len(tees) > 0 {
+		m.provider = provider
+	}
+	return provider
 }
 
 func loadAndDelete[T any](m *sync.Map, key string) T {

--- a/core/services/workflows/v2/confidential_module.go
+++ b/core/services/workflows/v2/confidential_module.go
@@ -168,22 +168,17 @@ func (m *ConfidentialModule) providedTees(ctx context.Context) []*sdkpb.TeeTypeA
 }
 
 func (m *ConfidentialModule) Tee(ctx context.Context, tee *sdkpb.Tee) bool {
-	// If confidential-workflows is disabled by settings, this runner cannot satisfy
-	// the requirement. Returning false surfaces host.ErrRunnerUnavailable upstream so
-	// the engine holds the workflow (and retries) instead of failing initialization.
+	// Disabled by settings: report unsatisfiable (engine defers via
+	// host.ErrRunnerUnavailable) rather than failing init.
 	if err := m.enabledGate.AllowErr(ctx); err != nil {
 		return false
 	}
 	return m.teeProvider(ctx)(tee)
 }
 
-// teeProvider returns a selection function over the confidential-workflows
-// capability's supported TEEs. It caches the selection only once the capability
-// reports at least one supported region; while it reports none (e.g. the capability
-// is not yet available on this node) it re-queries on each call so the module
-// self-heals when the capability comes up. The previous sync.Once cached an empty
-// selection permanently, leaving the workflow broken even after the capability
-// recovered.
+// teeProvider caches only a non-empty TEE selection and otherwise re-queries, so the
+// module self-heals when the capability appears (the old sync.Once cached an empty
+// selection permanently).
 func (m *ConfidentialModule) teeProvider(ctx context.Context) func(*sdkpb.Tee) bool {
 	m.providerMu.Lock()
 	defer m.providerMu.Unlock()

--- a/core/services/workflows/v2/confidential_module_test.go
+++ b/core/services/workflows/v2/confidential_module_test.go
@@ -345,8 +345,7 @@ func TestConfidentialModule_Tee(t *testing.T) {
 
 	t.Run("disabled gate returns false without querying the capability", func(t *testing.T) {
 		t.Parallel()
-		// No GetExecutable expectation: a disabled gate must short-circuit before the
-		// module ever queries the confidential-workflows capability.
+		// No GetExecutable expectation: a disabled gate must short-circuit before querying.
 		capReg := regmocks.NewCapabilitiesRegistry(t)
 
 		mod := mustNewConfidentialModule(t, capReg, &confidentialrelay.ExecutionHandlers{}, "", nil, "wf", "owner", "name", "tag", limits.NewGateLimiter(false), lggr)
@@ -358,10 +357,8 @@ func TestConfidentialModule_Tee(t *testing.T) {
 		capReg := regmocks.NewCapabilitiesRegistry(t)
 		execCap := capmocks.NewExecutableCapability(t)
 
-		// First lookup: the capability reports no regions (e.g. not yet available on
-		// this node). Second lookup: it now reports a matching region. The module must
-		// re-query rather than permanently caching the first empty result, so it
-		// self-heals once the capability comes up.
+		// First lookup empty, second returns a region: the module must re-query, not
+		// cache the empty result.
 		capReg.EXPECT().GetExecutable(matches.AnyContext, confidentialWorkflowsCapabilityID).
 			Return(execCap, nil).Twice()
 		execCap.EXPECT().Execute(matches.AnyContext, mock.Anything).

--- a/core/services/workflows/v2/confidential_module_test.go
+++ b/core/services/workflows/v2/confidential_module_test.go
@@ -343,6 +343,39 @@ func TestConfidentialModule_Tee(t *testing.T) {
 		assert.False(t, mod.Tee(ctx, anyRegionsTee("us-east-1")))
 	})
 
+	t.Run("disabled gate returns false without querying the capability", func(t *testing.T) {
+		t.Parallel()
+		// No GetExecutable expectation: a disabled gate must short-circuit before the
+		// module ever queries the confidential-workflows capability.
+		capReg := regmocks.NewCapabilitiesRegistry(t)
+
+		mod := mustNewConfidentialModule(t, capReg, &confidentialrelay.ExecutionHandlers{}, "", nil, "wf", "owner", "name", "tag", limits.NewGateLimiter(false), lggr)
+		assert.False(t, mod.Tee(ctx, anyRegionsTee("us-east-1")))
+	})
+
+	t.Run("empty response is not cached and re-queries until regions appear", func(t *testing.T) {
+		t.Parallel()
+		capReg := regmocks.NewCapabilitiesRegistry(t)
+		execCap := capmocks.NewExecutableCapability(t)
+
+		// First lookup: the capability reports no regions (e.g. not yet available on
+		// this node). Second lookup: it now reports a matching region. The module must
+		// re-query rather than permanently caching the first empty result, so it
+		// self-heals once the capability comes up.
+		capReg.EXPECT().GetExecutable(matches.AnyContext, confidentialWorkflowsCapabilityID).
+			Return(execCap, nil).Twice()
+		execCap.EXPECT().Execute(matches.AnyContext, mock.Anything).
+			Return(capabilities.CapabilityResponse{Payload: buildRespPayload(t, nil)}, nil).Once()
+		execCap.EXPECT().Execute(matches.AnyContext, mock.Anything).
+			Return(capabilities.CapabilityResponse{Payload: buildRespPayload(t, []*sdkpb.TeeTypeAndRegions{
+				{Type: sdkpb.TeeType_TEE_TYPE_AWS_NITRO, Regions: []string{"us-east-1"}},
+			})}, nil).Once()
+
+		mod := mustNewConfidentialModule(t, capReg, &confidentialrelay.ExecutionHandlers{}, "", nil, "wf", "owner", "name", "tag", limits.NewGateLimiter(true), lggr)
+		assert.False(t, mod.Tee(ctx, anyRegionsTee("us-east-1")))
+		assert.True(t, mod.Tee(ctx, anyRegionsTee("us-east-1")))
+	})
+
 	t.Run("capability Execute error returns false", func(t *testing.T) {
 		t.Parallel()
 		capReg := regmocks.NewCapabilitiesRegistry(t)

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -33,6 +33,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows"
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/host"
 	billing "github.com/smartcontractkit/chainlink-protos/billing/go"
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 	protoevents "github.com/smartcontractkit/chainlink-protos/workflows/go/events"
@@ -348,6 +349,15 @@ func (e *Engine) init(ctx context.Context) {
 
 	err = e.runTriggerSubscriptionPhase(ctx)
 	if err != nil {
+		if errors.Is(err, host.ErrRunnerUnavailable) {
+			// A required runner (e.g. the confidential-workflows TEE runner) is not
+			// yet available on this node, typically a capability still rolling out
+			// across the DON. Hold the workflow and retry on the next sync rather than
+			// treating this as a fatal init failure and error-storming.
+			e.logger().Warnw("Workflow initialization deferred: required runner not yet available", "err", err)
+			e.cfg.Hooks.OnInitialized(err)
+			return
+		}
 		e.logger().Errorw("Workflow Engine initialization failed", "err", err)
 		e.cfg.Hooks.OnInitialized(err)
 		return

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -350,10 +350,8 @@ func (e *Engine) init(ctx context.Context) {
 	err = e.runTriggerSubscriptionPhase(ctx)
 	if err != nil {
 		if errors.Is(err, host.ErrRunnerUnavailable) {
-			// A required runner (e.g. the confidential-workflows TEE runner) is not
-			// yet available on this node, typically a capability still rolling out
-			// across the DON. Hold the workflow and retry on the next sync rather than
-			// treating this as a fatal init failure and error-storming.
+			// Required runner not on this node yet (capability still rolling out):
+			// defer and retry on the next sync instead of a fatal init failure.
 			e.logger().Warnw("Workflow initialization deferred: required runner not yet available", "err", err)
 			e.cfg.Hooks.OnInitialized(err)
 			return

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260707105132-2da5d31f22fc
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1390,8 +1390,8 @@ github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100 h
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100/go.mod h1:0v6RGdYa9NezVnBPIAVyxB3A9furKWwaSkLha+URYGk=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4 h1:LzDSHQ5bM4pp8Wrr0mFjg60A4J47+IFPIuC/rHNF1qA=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26 h1:Ibqau2kZgzJVzcKcwHsdrGlqoyNv/onuEV6GgKT9AKo=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6 h1:DvfhsiIxB4JMuR+r1UciKV8jKiwhI/OZI/QhKawC4pM=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6/go.mod h1:6NefaCIMH4zFBN3T+cvsFGYoy3oTSPKDaxPAyBzlYTU=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62
 	github.com/smartcontractkit/chainlink-data-streams v0.1.15-0.20260707105132-2da5d31f22fc

--- a/go.sum
+++ b/go.sum
@@ -1161,6 +1161,8 @@ github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100 h
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100/go.mod h1:0v6RGdYa9NezVnBPIAVyxB3A9furKWwaSkLha+URYGk=
 github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4 h1:LzDSHQ5bM4pp8Wrr0mFjg60A4J47+IFPIuC/rHNF1qA=
 github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26 h1:Ibqau2kZgzJVzcKcwHsdrGlqoyNv/onuEV6GgKT9AKo=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6 h1:DvfhsiIxB4JMuR+r1UciKV8jKiwhI/OZI/QhKawC4pM=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6/go.mod h1:6NefaCIMH4zFBN3T+cvsFGYoy3oTSPKDaxPAyBzlYTU=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/go.sum
+++ b/go.sum
@@ -1159,8 +1159,6 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100 h1:sH546tdm3VaYGaRLnZ6ZYBZiE25vEkMap76Xq/vQWx0=
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100/go.mod h1:0v6RGdYa9NezVnBPIAVyxB3A9furKWwaSkLha+URYGk=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4 h1:LzDSHQ5bM4pp8Wrr0mFjg60A4J47+IFPIuC/rHNF1qA=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26 h1:Ibqau2kZgzJVzcKcwHsdrGlqoyNv/onuEV6GgKT9AKo=
 github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6 h1:DvfhsiIxB4JMuR+r1UciKV8jKiwhI/OZI/QhKawC4pM=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260715161014-611d8ac32364

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1377,8 +1377,8 @@ github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100 h
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100/go.mod h1:0v6RGdYa9NezVnBPIAVyxB3A9furKWwaSkLha+URYGk=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4 h1:LzDSHQ5bM4pp8Wrr0mFjg60A4J47+IFPIuC/rHNF1qA=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26 h1:Ibqau2kZgzJVzcKcwHsdrGlqoyNv/onuEV6GgKT9AKo=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6 h1:DvfhsiIxB4JMuR+r1UciKV8jKiwhI/OZI/QhKawC4pM=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6/go.mod h1:6NefaCIMH4zFBN3T+cvsFGYoy3oTSPKDaxPAyBzlYTU=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260715161014-611d8ac32364
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.16.6-0.20260708113039-95f97b2d25e9

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1637,8 +1637,8 @@ github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100 h
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100/go.mod h1:0v6RGdYa9NezVnBPIAVyxB3A9furKWwaSkLha+URYGk=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194 h1:QxZkbKtQyPtVLYP4eMwc+VbXY7M5ve1deSiLZ2pOA+Y=
 github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260616151800-9a3a31c4e194/go.mod h1:bNMFRxwWdgVFdSsFZRmsUUPoBUncU3RM765K99svIKM=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4 h1:LzDSHQ5bM4pp8Wrr0mFjg60A4J47+IFPIuC/rHNF1qA=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26 h1:Ibqau2kZgzJVzcKcwHsdrGlqoyNv/onuEV6GgKT9AKo=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6 h1:DvfhsiIxB4JMuR+r1UciKV8jKiwhI/OZI/QhKawC4pM=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6/go.mod h1:6NefaCIMH4zFBN3T+cvsFGYoy3oTSPKDaxPAyBzlYTU=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.106
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20260708114855-e953eeb028a7
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260715161014-611d8ac32364

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1551,8 +1551,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100 h1:sH546tdm3VaYGaRLnZ6ZYBZiE25vEkMap76Xq/vQWx0=
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100/go.mod h1:0v6RGdYa9NezVnBPIAVyxB3A9furKWwaSkLha+URYGk=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4 h1:LzDSHQ5bM4pp8Wrr0mFjg60A4J47+IFPIuC/rHNF1qA=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26 h1:Ibqau2kZgzJVzcKcwHsdrGlqoyNv/onuEV6GgKT9AKo=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6 h1:DvfhsiIxB4JMuR+r1UciKV8jKiwhI/OZI/QhKawC4pM=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6/go.mod h1:6NefaCIMH4zFBN3T+cvsFGYoy3oTSPKDaxPAyBzlYTU=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/smartcontractkit/chain-selectors v1.0.106
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26
 	github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1756,8 +1756,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100 h1:sH546tdm3VaYGaRLnZ6ZYBZiE25vEkMap76Xq/vQWx0=
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260715132147-59df1b138100/go.mod h1:0v6RGdYa9NezVnBPIAVyxB3A9furKWwaSkLha+URYGk=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4 h1:LzDSHQ5bM4pp8Wrr0mFjg60A4J47+IFPIuC/rHNF1qA=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260715145851-8219609496a4/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26 h1:Ibqau2kZgzJVzcKcwHsdrGlqoyNv/onuEV6GgKT9AKo=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260716125729-0858a6e0ec26/go.mod h1:snfVBRRQTpC2x5O3bQHZe9SvJX5yv/SbG8oHkJTKLtE=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6 h1:DvfhsiIxB4JMuR+r1UciKV8jKiwhI/OZI/QhKawC4pM=
 github.com/smartcontractkit/chainlink-common/keystore v1.2.1-0.20260623104656-f39eba3e2bc6/go.mod h1:6NefaCIMH4zFBN3T+cvsFGYoy3oTSPKDaxPAyBzlYTU=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=


### PR DESCRIPTION
## What

When a confidential (`HandlerInTee`) workflow subscribes on a node where the `confidential-workflows@1.0.0-alpha` capability is not available yet (e.g. still rolling out across the DON), the engine hard-failed init with "cannot find a runner" and error-stormed `Workflow Engine initialization failed` on every sync tick. This defers the workflow and retries instead.

- `ConfidentialModule.Tee` now honors the `enabledGate` in the **subscribe** path (not just `Execute`), so a settings-disabled feature is inert rather than fatal.
- `teeProvider` no longer caches an empty region set permanently (the old `sync.Once`): it re-queries until the capability reports regions, so the module **self-heals** once the capability comes up.
- Engine init treats `host.ErrRunnerUnavailable` (from chainlink-common) as a **deferred** (warn + retry) condition rather than a fatal `Workflow Engine initialization failed`.

## Why

On a mixed/rolling DON, the confidential-workflows capability is not on every node yet; `ConfidentialModule.providedTees` reports zero regions on those nodes, so subscribe fails and every confidential workflow error-storms init until the capability arrives. Worse, the old `sync.Once` kept the module stuck on the cached-empty result even after the capability recovered. This makes confidential workflows degrade gracefully and self-heal.

## Dependency

Depends on **chainlink-common #2259** (adds `host.ErrRunnerUnavailable` + the runner-type-vs-unavailable distinction in `requirement_selecting_module`). The `chainlink-common` bump here points at that PR branch commit and will be re-pointed to its merged commit before merge.

## Tests

`core/services/workflows/v2` suite green. Added `Tee` cases: disabled-gate short-circuits without querying the capability; empty region set is not cached and re-queries until regions appear (self-heal).