### PR TITLE
tools/bin/modgraph: remove artifical groupings

### DIFF
--- a/go.md
+++ b/go.md
@@ -2,25 +2,6 @@
 ## Main module
 ```mermaid
 flowchart LR
-  subgraph chains
-    chainlink-aptos
-    chainlink-cosmos
-    chainlink-evm
-    chainlink-solana
-    chainlink-starknet/relayer
-    chainlink-tron/relayer
-  end
-
-  subgraph products
-    chainlink-automation
-    chainlink-data-streams
-    chainlink-feeds
-    chainlink-functions
-    chainlink-vrf
-  end
-
-  classDef group stroke-dasharray:6,fill:none;
-  class chains,products group
 
 	ccip-contract-examples/chains/evm
 	click ccip-contract-examples/chains/evm href "https://github.com/smartcontractkit/ccip-contract-examples"
@@ -313,25 +294,6 @@ flowchart LR
 ## All modules
 ```mermaid
 flowchart LR
-  subgraph chains
-    chainlink-aptos
-    chainlink-cosmos
-    chainlink-evm
-    chainlink-solana
-    chainlink-starknet/relayer
-    chainlink-tron/relayer
-  end
-
-  subgraph products
-    chainlink-automation
-    chainlink-data-streams
-    chainlink-feeds
-    chainlink-functions
-    chainlink-vrf
-  end
-
-  classDef group stroke-dasharray:6,fill:none;
-  class chains,products group
 
 	ccip-contract-examples/chains/evm --> chainlink-ccip
 	click ccip-contract-examples/chains/evm href "https://github.com/smartcontractkit/ccip-contract-examples"

--- a/tools/bin/modgraph
+++ b/tools/bin/modgraph
@@ -8,25 +8,6 @@ echo "# smartcontractkit Go modules
 ## Main module
 \`\`\`mermaid
 flowchart LR
-  subgraph chains
-    chainlink-aptos
-    chainlink-cosmos
-    chainlink-evm
-    chainlink-solana
-    chainlink-starknet/relayer
-    chainlink-tron/relayer
-  end
-
-  subgraph products
-    chainlink-automation
-    chainlink-data-streams
-    chainlink-feeds
-    chainlink-functions
-    chainlink-vrf
-  end
-
-  classDef group stroke-dasharray:6,fill:none;
-  class chains,products group
 "
 go mod graph | modgraph -prefix github.com/smartcontractkit/
 echo "\`\`\`"
@@ -34,25 +15,6 @@ echo "\`\`\`"
 echo "## All modules
 \`\`\`mermaid
 flowchart LR
-  subgraph chains
-    chainlink-aptos
-    chainlink-cosmos
-    chainlink-evm
-    chainlink-solana
-    chainlink-starknet/relayer
-    chainlink-tron/relayer
-  end
-
-  subgraph products
-    chainlink-automation
-    chainlink-data-streams
-    chainlink-feeds
-    chainlink-functions
-    chainlink-vrf
-  end
-
-  classDef group stroke-dasharray:6,fill:none;
-  class chains,products group
 "
 
 # temp-repo directories are gitignored local artifacts (see .gitignore) and are not


### PR DESCRIPTION
These artificial chain and product subgraphs don't add value anymore.