### PR TITLE
cre-5533: reconciliation match for engine

### DIFF
--- a/core/services/workflows/syncer/v2/engine_registry.go
+++ b/core/services/workflows/syncer/v2/engine_registry.go
@@ -1,6 +1,9 @@
 package v2
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
@@ -15,13 +18,30 @@ var ErrAlreadyExists = errors.New("attempting to register duplicate engine")
 type ServiceWithMetadata struct {
 	WorkflowID types.WorkflowID
 	Source     string // Which source this workflow came from (e.g., "ContractWorkflowSource", "GRPCWorkflowSource")
+	// ReconcileKey fingerprints the on-chain record (owner/name/tag) the engine was started for.
+	// Empty when the engine was registered without identity metadata (e.g. via Add).
+	ReconcileKey string
 	services.Service
 }
 
 // engineEntry holds the engine and its associated source for internal storage
 type engineEntry struct {
-	engine services.Service
-	source string
+	engine       services.Service
+	source       string
+	reconcileKey string
+}
+
+// ReconcileKey fingerprints the workflow record identity that a WorkflowID is expected to map to.
+// Fields are length-delimited so distinct tuples cannot collide across field boundaries.
+func ReconcileKey(owner []byte, name, tag string) string {
+	h := sha256.New()
+	var lenBuf [8]byte
+	for _, part := range [][]byte{owner, []byte(name), []byte(tag)} {
+		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(part)))
+		_, _ = h.Write(lenBuf[:])
+		_, _ = h.Write(part)
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 type EngineRegistry struct {
@@ -37,14 +57,20 @@ func NewEngineRegistry() *EngineRegistry {
 
 // Add adds an engine to the registry with its source.
 func (r *EngineRegistry) Add(workflowID types.WorkflowID, source string, engine services.Service) error {
+	return r.AddWithReconcileKey(workflowID, source, "", engine)
+}
+
+// AddWithReconcileKey adds an engine to the registry with its source and identity fingerprint.
+func (r *EngineRegistry) AddWithReconcileKey(workflowID types.WorkflowID, source, reconcileKey string, engine services.Service) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, found := r.engines[workflowID]; found {
 		return ErrAlreadyExists
 	}
 	r.engines[workflowID] = engineEntry{
-		engine: engine,
-		source: source,
+		engine:       engine,
+		source:       source,
+		reconcileKey: reconcileKey,
 	}
 	return nil
 }
@@ -58,9 +84,10 @@ func (r *EngineRegistry) Get(workflowID types.WorkflowID) (ServiceWithMetadata, 
 		return ServiceWithMetadata{}, false
 	}
 	return ServiceWithMetadata{
-		WorkflowID: workflowID,
-		Source:     entry.source,
-		Service:    entry.engine,
+		WorkflowID:   workflowID,
+		Source:       entry.source,
+		ReconcileKey: entry.reconcileKey,
+		Service:      entry.engine,
 	}, true
 }
 

--- a/core/services/workflows/syncer/v2/engine_registry.go
+++ b/core/services/workflows/syncer/v2/engine_registry.go
@@ -1,13 +1,12 @@
 package v2
 
 import (
-	"crypto/sha256"
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/hashutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/types"
 )
@@ -32,16 +31,12 @@ type engineEntry struct {
 }
 
 // ReconcileKey fingerprints the workflow record identity that a WorkflowID is expected to map to.
-// Fields are length-delimited so distinct tuples cannot collide across field boundaries.
-func ReconcileKey(owner []byte, name, tag string) string {
-	h := sha256.New()
-	var lenBuf [8]byte
-	for _, part := range [][]byte{owner, []byte(name), []byte(tag)} {
-		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(part)))
-		_, _ = h.Write(lenBuf[:])
-		_, _ = h.Write(part)
+func ReconcileKey(owner []byte, name, tag string) (string, error) {
+	h, err := hashutil.BytesOfBytesKeccak([][]byte{owner, []byte(name), []byte(tag)})
+	if err != nil {
+		return "", err
 	}
-	return hex.EncodeToString(h.Sum(nil))
+	return hex.EncodeToString(h[:]), nil
 }
 
 type EngineRegistry struct {

--- a/core/services/workflows/syncer/v2/engine_registry.go
+++ b/core/services/workflows/syncer/v2/engine_registry.go
@@ -17,7 +17,7 @@ var ErrAlreadyExists = errors.New("attempting to register duplicate engine")
 type ServiceWithMetadata struct {
 	WorkflowID types.WorkflowID
 	Source     string // Which source this workflow came from (e.g., "ContractWorkflowSource", "GRPCWorkflowSource")
-	// ReconcileKey fingerprints the on-chain record (owner/name/tag) the engine was started for.
+	// ReconcileKey fingerprints the on-chain record (owner/name) the engine was started for.
 	// Empty when the engine was registered without identity metadata (e.g. via Add).
 	ReconcileKey string
 	services.Service
@@ -31,8 +31,8 @@ type engineEntry struct {
 }
 
 // ReconcileKey fingerprints the workflow record identity that a WorkflowID is expected to map to.
-func ReconcileKey(owner []byte, name, tag string) (string, error) {
-	h, err := hashutil.BytesOfBytesKeccak([][]byte{owner, []byte(name), []byte(tag)})
+func ReconcileKey(owner []byte, name string) (string, error) {
+	h, err := hashutil.BytesOfBytesKeccak([][]byte{owner, []byte(name)})
 	if err != nil {
 		return "", err
 	}

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -1015,8 +1015,9 @@ func (h *eventHandler) tryEngineCreate(ctx context.Context, spec *job.WorkflowSp
 		}
 	}
 
-	// Engine is fully initialized, add to registry with source tracking
-	if err := h.engineRegistry.Add(wid, source, engine); err != nil {
+	// Engine is fully initialized, add to registry with source tracking and identity fingerprint
+	reconcileKey := ReconcileKey(ownerBytes, spec.WorkflowName, spec.WorkflowTag)
+	if err := h.engineRegistry.AddWithReconcileKey(wid, source, reconcileKey, engine); err != nil {
 		if closeErr := engine.Close(); closeErr != nil {
 			return fmt.Errorf("failed to close workflow engine: %w during invariant violation: %w", closeErr, err)
 		}

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -1016,7 +1016,10 @@ func (h *eventHandler) tryEngineCreate(ctx context.Context, spec *job.WorkflowSp
 	}
 
 	// Engine is fully initialized, add to registry with source tracking and identity fingerprint
-	reconcileKey := ReconcileKey(ownerBytes, spec.WorkflowName, spec.WorkflowTag)
+	reconcileKey, err := ReconcileKey(ownerBytes, spec.WorkflowName, spec.WorkflowTag)
+	if err != nil {
+		return fmt.Errorf("failed to compute reconcile key: %w", err)
+	}
 	if err := h.engineRegistry.AddWithReconcileKey(wid, source, reconcileKey, engine); err != nil {
 		if closeErr := engine.Close(); closeErr != nil {
 			return fmt.Errorf("failed to close workflow engine: %w during invariant violation: %w", closeErr, err)

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -1016,7 +1016,7 @@ func (h *eventHandler) tryEngineCreate(ctx context.Context, spec *job.WorkflowSp
 	}
 
 	// Engine is fully initialized, add to registry with source tracking and identity fingerprint
-	reconcileKey, err := ReconcileKey(ownerBytes, spec.WorkflowName, spec.WorkflowTag)
+	reconcileKey, err := ReconcileKey(ownerBytes, spec.WorkflowName)
 	if err != nil {
 		return fmt.Errorf("failed to compute reconcile key: %w", err)
 	}

--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -568,8 +568,11 @@ func (w *workflowRegistry) generateReconciliationEvents(
 			// id (e.g. a WorkflowDeleted deferred via ErrDrainInProgress that was superseded by the workflow being
 			// re-activated before drain completed) so the end-of-loop invariant check does not fire.
 			case true:
-				if runningEngine.ReconcileKey != "" &&
-					runningEngine.ReconcileKey != ReconcileKey(wfMeta.Owner, wfMeta.WorkflowName, wfMeta.Tag) {
+				wantKey, keyErr := ReconcileKey(wfMeta.Owner, wfMeta.WorkflowName, wfMeta.Tag)
+				if keyErr != nil {
+					return nil, fmt.Errorf("failed to compute reconcile key: %w", keyErr)
+				}
+				if runningEngine.ReconcileKey != "" && runningEngine.ReconcileKey != wantKey {
 					break
 				}
 				workflowsSeen[id] = true

--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -516,7 +516,7 @@ func (w *workflowRegistry) generateReconciliationEvents(
 	workflowsSeen := make(map[string]bool, len(workflowMetadata))
 	for _, wfMeta := range workflowMetadata {
 		id := wfMeta.WorkflowID.Hex()
-		engineFound := w.engineRegistry.Contains(wfMeta.WorkflowID)
+		runningEngine, engineFound := w.engineRegistry.Get(wfMeta.WorkflowID)
 
 		switch wfMeta.Status {
 		case WorkflowStatusActive:
@@ -568,6 +568,10 @@ func (w *workflowRegistry) generateReconciliationEvents(
 			// id (e.g. a WorkflowDeleted deferred via ErrDrainInProgress that was superseded by the workflow being
 			// re-activated before drain completed) so the end-of-loop invariant check does not fire.
 			case true:
+				if runningEngine.ReconcileKey != "" &&
+					runningEngine.ReconcileKey != ReconcileKey(wfMeta.Owner, wfMeta.WorkflowName, wfMeta.Tag) {
+					break
+				}
 				workflowsSeen[id] = true
 				delete(pendingEvents, id)
 			}

--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -568,7 +568,7 @@ func (w *workflowRegistry) generateReconciliationEvents(
 			// id (e.g. a WorkflowDeleted deferred via ErrDrainInProgress that was superseded by the workflow being
 			// re-activated before drain completed) so the end-of-loop invariant check does not fire.
 			case true:
-				wantKey, keyErr := ReconcileKey(wfMeta.Owner, wfMeta.WorkflowName, wfMeta.Tag)
+				wantKey, keyErr := ReconcileKey(wfMeta.Owner, wfMeta.WorkflowName)
 				if keyErr != nil {
 					return nil, fmt.Errorf("failed to compute reconcile key: %w", keyErr)
 				}

--- a/core/services/workflows/syncer/v2/workflow_registry_test.go
+++ b/core/services/workflows/syncer/v2/workflow_registry_test.go
@@ -193,7 +193,7 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 		tag := "tag1"
 
 		er := NewEngineRegistry()
-		victimKey, err := ReconcileKey(victimOwner, wfName, tag)
+		victimKey, err := ReconcileKey(victimOwner, wfName)
 		require.NoError(t, err)
 		require.NoError(t, er.AddWithReconcileKey(wfID, "TestSource", victimKey, &mockService{}))
 
@@ -232,7 +232,7 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 		require.Equal(t, WorkflowDeletedEvent{WorkflowID: wfID, Source: "TestSource"}, events[0].Data)
 	})
 
-	t.Run("SameIDMatchingIdentity_NoOpDespiteBenignChanges", func(t *testing.T) {
+	t.Run("SameIDMatchingIdentity_NoOpRegardlessOfTag", func(t *testing.T) {
 		t.Parallel()
 		lggr := logger.TestLogger(t)
 		ctx := t.Context()
@@ -241,10 +241,9 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 		wfID := [32]byte{1}
 		owner := []byte{1}
 		wfName := "wf name 1"
-		tag := "tag1"
 
 		er := NewEngineRegistry()
-		key, err := ReconcileKey(owner, wfName, tag)
+		key, err := ReconcileKey(owner, wfName)
 		require.NoError(t, err)
 		require.NoError(t, er.AddWithReconcileKey(wfID, "TestSource", key, &mockService{}))
 
@@ -268,7 +267,7 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 				WorkflowName: wfName,
 				BinaryURL:    "b1",
 				ConfigURL:    "c1",
-				Tag:          tag,
+				Tag:          "tag1",
 				Attributes:   []byte{7, 7, 7},
 				DonFamily:    "A",
 			},

--- a/core/services/workflows/syncer/v2/workflow_registry_test.go
+++ b/core/services/workflows/syncer/v2/workflow_registry_test.go
@@ -181,6 +181,101 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 		require.Equal(t, expectedActivatedEvent, events[1].Data)
 	})
 
+	t.Run("RetiredIDReusedByDifferentRecord_TearsDownStaleEngine", func(t *testing.T) {
+		t.Parallel()
+		lggr := logger.TestLogger(t)
+		ctx := t.Context()
+		workflowDonNotifier := capabilities.NewDonNotifier()
+
+		wfID := [32]byte{1}
+		victimOwner := []byte{1}
+		wfName := "wf name 1"
+		tag := "tag1"
+
+		er := NewEngineRegistry()
+		require.NoError(t, er.AddWithReconcileKey(wfID, "TestSource", ReconcileKey(victimOwner, wfName, tag), &mockService{}))
+
+		wr, err := NewWorkflowRegistry(
+			lggr,
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) { return nil, nil },
+			"",
+			"test-chain-selector",
+			Config{QueryCount: 20, SyncStrategy: SyncStrategyReconciliation},
+			&eventHandler{},
+			workflowDonNotifier,
+			er,
+		)
+		require.NoError(t, err)
+
+		metadata := []WorkflowMetadataView{
+			{
+				WorkflowID:   wfID,
+				Owner:        []byte{9},
+				Status:       uint8(0),
+				WorkflowName: wfName,
+				BinaryURL:    "b1",
+				ConfigURL:    "c1",
+				Tag:          tag,
+				Attributes:   []byte{},
+				DonFamily:    "A",
+			},
+		}
+
+		pendingEvents := map[string]*reconciliationEvent{}
+		events, err := wr.generateReconciliationEvents(ctx, pendingEvents, metadata, &types.Head{Height: "123"}, "TestSource")
+		require.NoError(t, err)
+
+		require.Len(t, events, 1)
+		require.Equal(t, WorkflowDeleted, events[0].Name)
+		require.Equal(t, WorkflowDeletedEvent{WorkflowID: wfID, Source: "TestSource"}, events[0].Data)
+	})
+
+	t.Run("SameIDMatchingIdentity_NoOpDespiteBenignChanges", func(t *testing.T) {
+		t.Parallel()
+		lggr := logger.TestLogger(t)
+		ctx := t.Context()
+		workflowDonNotifier := capabilities.NewDonNotifier()
+
+		wfID := [32]byte{1}
+		owner := []byte{1}
+		wfName := "wf name 1"
+		tag := "tag1"
+
+		er := NewEngineRegistry()
+		require.NoError(t, er.AddWithReconcileKey(wfID, "TestSource", ReconcileKey(owner, wfName, tag), &mockService{}))
+
+		wr, err := NewWorkflowRegistry(
+			lggr,
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) { return nil, nil },
+			"",
+			"test-chain-selector",
+			Config{QueryCount: 20, SyncStrategy: SyncStrategyReconciliation},
+			&eventHandler{},
+			workflowDonNotifier,
+			er,
+		)
+		require.NoError(t, err)
+
+		metadata := []WorkflowMetadataView{
+			{
+				WorkflowID:   wfID,
+				Owner:        owner,
+				Status:       uint8(0),
+				WorkflowName: wfName,
+				BinaryURL:    "b1",
+				ConfigURL:    "c1",
+				Tag:          tag,
+				Attributes:   []byte{7, 7, 7},
+				DonFamily:    "A",
+			},
+		}
+
+		pendingEvents := map[string]*reconciliationEvent{}
+		events, err := wr.generateReconciliationEvents(ctx, pendingEvents, metadata, &types.Head{Height: "123"}, "TestSource")
+		require.NoError(t, err)
+		require.Empty(t, events)
+	})
+
 	t.Run("WorkflowDeletedEvent", func(t *testing.T) {
 		t.Parallel()
 		lggr := logger.TestLogger(t)

--- a/core/services/workflows/syncer/v2/workflow_registry_test.go
+++ b/core/services/workflows/syncer/v2/workflow_registry_test.go
@@ -193,7 +193,9 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 		tag := "tag1"
 
 		er := NewEngineRegistry()
-		require.NoError(t, er.AddWithReconcileKey(wfID, "TestSource", ReconcileKey(victimOwner, wfName, tag), &mockService{}))
+		victimKey, err := ReconcileKey(victimOwner, wfName, tag)
+		require.NoError(t, err)
+		require.NoError(t, er.AddWithReconcileKey(wfID, "TestSource", victimKey, &mockService{}))
 
 		wr, err := NewWorkflowRegistry(
 			lggr,
@@ -242,7 +244,9 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 		tag := "tag1"
 
 		er := NewEngineRegistry()
-		require.NoError(t, er.AddWithReconcileKey(wfID, "TestSource", ReconcileKey(owner, wfName, tag), &mockService{}))
+		key, err := ReconcileKey(owner, wfName, tag)
+		require.NoError(t, err)
+		require.NoError(t, er.AddWithReconcileKey(wfID, "TestSource", key, &mockService{}))
 
 		wr, err := NewWorkflowRegistry(
 			lggr,


### PR DESCRIPTION
this will make the workflow reconciliation match a running engine by its owner/name identity rather than WorkflowID alone

[cre-5533](https://smartcontract-it.atlassian.net/browse/cre-5533)