### PR TITLE
cre-5533: reconciliation match for engine (pt. 2)

### DIFF
--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -566,7 +566,9 @@ func (h *eventHandler) workflowRegisteredEvent(
 		}
 
 		spec = newSpec
-	case spec.WorkflowID != payload.WorkflowID.Hex():
+	case spec.WorkflowID != payload.WorkflowID.Hex() ||
+		spec.WorkflowOwner != hex.EncodeToString(payload.WorkflowOwner) ||
+		spec.WorkflowName != payload.WorkflowName:
 		newSpec, innerErr := h.createWorkflowSpec(ctx, payload)
 		if innerErr != nil {
 			return innerErr

--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -568,12 +568,14 @@ func (w *workflowRegistry) generateReconciliationEvents(
 			// id (e.g. a WorkflowDeleted deferred via ErrDrainInProgress that was superseded by the workflow being
 			// re-activated before drain completed) so the end-of-loop invariant check does not fire.
 			case true:
-				wantKey, keyErr := ReconcileKey(wfMeta.Owner, wfMeta.WorkflowName)
-				if keyErr != nil {
-					return nil, fmt.Errorf("failed to compute reconcile key: %w", keyErr)
-				}
-				if runningEngine.ReconcileKey != "" && runningEngine.ReconcileKey != wantKey {
-					break
+				if runningEngine.Source == sourceName && runningEngine.ReconcileKey != "" {
+					wantKey, keyErr := ReconcileKey(wfMeta.Owner, wfMeta.WorkflowName)
+					if keyErr != nil {
+						return nil, fmt.Errorf("failed to compute reconcile key: %w", keyErr)
+					}
+					if runningEngine.ReconcileKey != wantKey {
+						break
+					}
 				}
 				workflowsSeen[id] = true
 				delete(pendingEvents, id)
@@ -592,6 +594,13 @@ func (w *workflowRegistry) generateReconciliationEvents(
 					delete(pendingEvents, id)
 				}
 			case true:
+				// A paused record from another source must not stop this source's engine (a colliding/reused ID)
+				if runningEngine.Source != sourceName {
+					if _, ok := pendingEvents[id]; ok && pendingEvents[id].signature != signature {
+						delete(pendingEvents, id)
+					}
+					break
+				}
 				// Will be handled in the event handler as a deleted event and will clear the DB workflow spec.
 				workflowsSeen[id] = true
 

--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -517,6 +517,10 @@ func (w *workflowRegistry) generateReconciliationEvents(
 	for _, wfMeta := range workflowMetadata {
 		id := wfMeta.WorkflowID.Hex()
 		runningEngine, engineFound := w.engineRegistry.Get(wfMeta.WorkflowID)
+		// Reconciliation for a source may only take destructive action (evict/stop) on engines that source
+		// owns. An engine matching only by a reused/colliding WorkflowID belongs to another source and is
+		// reconciled there, so it must not be torn down from here.
+		ownedByThisSource := engineFound && runningEngine.Source == sourceName
 
 		switch wfMeta.Status {
 		case WorkflowStatusActive:
@@ -568,7 +572,7 @@ func (w *workflowRegistry) generateReconciliationEvents(
 			// id (e.g. a WorkflowDeleted deferred via ErrDrainInProgress that was superseded by the workflow being
 			// re-activated before drain completed) so the end-of-loop invariant check does not fire.
 			case true:
-				if runningEngine.Source == sourceName && runningEngine.ReconcileKey != "" {
+				if ownedByThisSource && runningEngine.ReconcileKey != "" {
 					wantKey, keyErr := ReconcileKey(wfMeta.Owner, wfMeta.WorkflowName)
 					if keyErr != nil {
 						return nil, fmt.Errorf("failed to compute reconcile key: %w", keyErr)
@@ -594,8 +598,9 @@ func (w *workflowRegistry) generateReconciliationEvents(
 					delete(pendingEvents, id)
 				}
 			case true:
-				// A paused record from another source must not stop this source's engine (a colliding/reused ID)
-				if runningEngine.Source != sourceName {
+				// A paused record from another source must not stop this source's engine (a colliding/reused ID);
+				// mirror the not-found path's pending cleanup and skip.
+				if !ownedByThisSource {
 					if _, ok := pendingEvents[id]; ok && pendingEvents[id].signature != signature {
 						delete(pendingEvents, id)
 					}

--- a/core/services/workflows/syncer/v2/workflow_registry_test.go
+++ b/core/services/workflows/syncer/v2/workflow_registry_test.go
@@ -279,6 +279,66 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 		require.Empty(t, events)
 	})
 
+	t.Run("ActiveCollisionFromOtherSource_DoesNotEvictOtherSourceEngine", func(t *testing.T) {
+		t.Parallel()
+		lggr := logger.TestLogger(t)
+		ctx := t.Context()
+		wfID := wfTypes.WorkflowID([32]byte{1})
+		privateSource := "grpc:private:v1"
+		publicSource := "contract:1:0xpublic"
+
+		er := NewEngineRegistry()
+		key, err := ReconcileKey([]byte("private-owner"), "private-workflow")
+		require.NoError(t, err)
+		require.NoError(t, er.AddWithReconcileKey(wfID, privateSource, key, &mockService{}))
+		wr, err := NewWorkflowRegistry(
+			lggr,
+			func(context.Context, []byte) (types.ContractReader, error) { return nil, nil },
+			"", "test-chain-selector",
+			Config{QueryCount: 20, SyncStrategy: SyncStrategyReconciliation},
+			&eventHandler{}, capabilities.NewDonNotifier(), er,
+		)
+		require.NoError(t, err)
+
+		metadata := []WorkflowMetadataView{{
+			WorkflowID: wfID, Owner: []byte("attacker"), Status: WorkflowStatusActive,
+			WorkflowName: "attacker-workflow", Tag: "attacker-tag", Source: publicSource,
+		}}
+		events, err := wr.generateReconciliationEvents(ctx, map[string]*reconciliationEvent{}, metadata, &types.Head{Height: "123"}, publicSource)
+		require.NoError(t, err)
+		require.Empty(t, events, "the other source's engine must not be torn down")
+	})
+
+	t.Run("PausedCollisionFromOtherSource_DoesNotStopOtherSourceEngine", func(t *testing.T) {
+		t.Parallel()
+		lggr := logger.TestLogger(t)
+		ctx := t.Context()
+		wfID := wfTypes.WorkflowID([32]byte{9})
+		privateSource := "grpc:private-policy:v1"
+		publicSource := "contract:1:0xpublic"
+
+		er := NewEngineRegistry()
+		key, err := ReconcileKey([]byte("private-owner"), "private-policy-workflow")
+		require.NoError(t, err)
+		require.NoError(t, er.AddWithReconcileKey(wfID, privateSource, key, &mockService{}))
+		wr, err := NewWorkflowRegistry(
+			lggr,
+			func(context.Context, []byte) (types.ContractReader, error) { return nil, nil },
+			"", "test-chain-selector",
+			Config{QueryCount: 20, SyncStrategy: SyncStrategyReconciliation},
+			&eventHandler{}, capabilities.NewDonNotifier(), er,
+		)
+		require.NoError(t, err)
+
+		metadata := []WorkflowMetadataView{{
+			WorkflowID: wfID, Owner: []byte("attacker"), Status: WorkflowStatusPaused,
+			WorkflowName: "public-paused-collision", Source: publicSource,
+		}}
+		events, err := wr.generateReconciliationEvents(ctx, map[string]*reconciliationEvent{}, metadata, &types.Head{Height: "500"}, publicSource)
+		require.NoError(t, err)
+		require.Empty(t, events, "no WorkflowPaused must be emitted for the other source's engine")
+	})
+
 	t.Run("WorkflowDeletedEvent", func(t *testing.T) {
 		t.Parallel()
 		lggr := logger.TestLogger(t)
@@ -510,7 +570,7 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 		wfID := [32]byte{1}
 		owner := []byte{}
 		wfName := "wf name 1"
-		err := er.Add(wfID, ContractWorkflowSourceName, &mockService{})
+		err := er.Add(wfID, "TestSource", &mockService{})
 		require.NoError(t, err)
 		wr, err := NewWorkflowRegistry(
 			lggr,


### PR DESCRIPTION
more extensive identity validation on restart, delete, activate and pause

ref. #23157

[cre-5533](https://smartcontract-it.atlassian.net/browse/cre-5533)