### PR TITLE
Fix gin concurrent test access

### DIFF
--- a/core/web/capability_controller_test.go
+++ b/core/web/capability_controller_test.go
@@ -29,7 +29,6 @@ func TestCapabilityController_ExecuteCapability_MissingBody(t *testing.T) {
 	controller := web.CapabilityController{App: mockApp}
 
 	var err error
-	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request, err = http.NewRequestWithContext(t.Context(), "POST", "/v2/capabilities/execute", nil)
@@ -50,7 +49,6 @@ func TestCapabilityController_ExecuteCapability_RegistryNotInitialized(t *testin
 
 	controller := web.CapabilityController{App: mockApp}
 
-	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	reqJSON, err := json.Marshal(requestBody)
@@ -69,7 +67,6 @@ func TestCapabilityController_ExecuteCapability_MissingRequiredFields(t *testing
 
 	controller := web.CapabilityController{App: mockApp}
 
-	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 
@@ -102,7 +99,6 @@ func TestCapabilityController_ExecuteCapability(t *testing.T) {
 
 	controller := web.CapabilityController{App: mockApp}
 
-	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 

--- a/core/web/lp_skip_controller_test.go
+++ b/core/web/lp_skip_controller_test.go
@@ -112,7 +112,6 @@ func TestLPSkipController_LPSkipToBlock_HappyPath(t *testing.T) {
 
 	controller := web.LPSkipController{App: mockApp}
 
-	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 


### PR DESCRIPTION
`gin.SetMode(gin.TestMode)` is already called in cltest's init, so there is no need to call it at all (it also creates a data race, so it makes sense to remove it).

```
==================
WARNING: DATA RACE
Write at 0x0000106ad928 by goroutine 6177:
  github.com/gin-gonic/gin.SetMode()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/mode.go:72 +0x29b
  github.com/smartcontractkit/chainlink/v2/core/web_test.TestLPSkipController_LPSkipToBlock_HappyPath()
      /home/runner/_work/chainlink/chainlink/core/web/lp_skip_controller_test.go:115 +0x28f
  testing.tRunner()
      /opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:2101 +0x38

Previous read at 0x0000106ad928 by goroutine 5729:
  github.com/gin-gonic/gin.IsDebugging()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/debug.go:20 +0x50
  github.com/gin-gonic/gin.debugPrintRoute()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/debug.go:30 +0x12
  github.com/gin-gonic/gin.(*Engine).addRoute()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/gin.go:344 +0xc7
  github.com/gin-gonic/gin.(*RouterGroup).handle()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/routergroup.go:89 +0x1d2
  github.com/gin-gonic/gin.(*RouterGroup).GET()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/routergroup.go:117 +0x2be
  github.com/smartcontractkit/chainlink/v2/core/web.guiAssetRoutes()
      /home/runner/_work/chainlink/chainlink/core/web/router.go:486 +0x251
  github.com/smartcontractkit/chainlink/v2/core/web.NewRouter()
      /home/runner/_work/chainlink/chainlink/core/web/router.go:93 +0xf04
  github.com/smartcontractkit/chainlink/v2/core/web.Router()
      /home/runner/_work/chainlink/chainlink/core/web/helpers.go:78 +0x4e
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewApplicationWithConfig()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/cltest.go:454 +0x2313
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewApplicationWithConfig()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/cltest.go:410 +0x1e77
  github.com/smartcontractkit/chainlink/v2/core/services/keystore.(*ksORM).loadKeyStates()
      <autogenerated>:1 +0x50
  github.com/smartcontractkit/chainlink/v2/core/services/keystore.(*keyManager).Unlock()
      /home/runner/_work/chainlink/chainlink/core/services/keystore/master.go:230 +0x417
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewApplicationWithConfig()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/cltest.go:396 +0x12ca
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewApplicationWithConfigAndKey()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/cltest.go:240 +0xc6
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewApplicationWithKey()
      /home/runner/_work/chainlink/chainlink/core/internal/cltest/cltest.go:233 +0x74
  github.com/smartcontractkit/chainlink/v2/core/web_test.TestTransfersController_TransferBalanceToLowError()
      /home/runner/_work/chainlink/chainlink/core/web/evm_transfer_controller_test.go:319 +0x708
  testing.tRunner()
      /opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:2101 +0x38

Goroutine 6177 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:2101 +0xb12
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:2585 +0x84
  testing.tRunner()
      /opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:2036 +0x21c
  testing.runTests()
      /opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:2583 +0x9e9
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:2443 +0xf4b
  main.main()
      _testmain.go:406 +0x164

Goroutine 5729 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:2101 +0xb12
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:2585 +0x84
  testing.tRunner()
      /opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:2036 +0x21c
  testing.runTests()
      /opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:2583 +0x9e9
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:2443 +0xf4b
  main.main()
      _testmain.go:406 +0x164
==================
```