### PR TITLE
fix(cre): install owner-verification gate before building workflow sources

### DIFF
--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -1110,8 +1110,14 @@ func newWorkflowRegistrySyncerV2(
 	}
 
 	registryOpts := []syncerV2.Option{
-		syncerV2.WithAdditionalSources(addSourceConfigs),
+		// WithCentralizedOwnerVerification MUST be applied before WithAdditionalSources:
+		// WithAdditionalSources builds GRPC workflow sources eagerly and requires the
+		// owner-verification gate (and settings getter) to already be set on the registry.
+		// If it runs first, the gate is still nil and NewGRPCWorkflowSource fails with
+		// "CentralizedOwnerVerificationEnabled gate is required", silently dropping the
+		// centralized source and every workflow it serves.
 		syncerV2.WithCentralizedOwnerVerification(engineLimiters.CentralizedWorkflowOwnerVerificationEnabled, lf.Settings),
+		syncerV2.WithAdditionalSources(addSourceConfigs),
 		syncerV2.WithShardOrchestratorClient(shardOrchestratorClient),
 		syncerV2.WithMaxConcurrency(wfReg.MaxConcurrency()),
 		syncerV2.WithMaxActivationRetries(wfReg.MaxActivationRetries()),


### PR DESCRIPTION
## Summary

`newWorkflowRegistrySyncerV2` builds its syncer options as an ordered slice and applies them in order (`for _, opt := range opts { opt(wr) }`). `WithAdditionalSources` constructs GRPC workflow sources **eagerly** inside the option closure and reads the registry's owner-verification gate — but that gate is only installed by `WithCentralizedOwnerVerification`.

The two options were ordered so that sources were built **before** the gate was set, leaving the gate `nil` when the source was constructed, so `NewGRPCWorkflowSource` failed with:

    CentralizedOwnerVerificationEnabled gate is required

That error is caught and logged as `Failed to create GRPC workflow source`, and the source is dropped. With the centralized (GRPC) workflow source absent, every workflow it serves falls out of the syncer's desired-state set. After a node restart (e.g. a rolling deploy) those engines are never recreated, the node stops reporting them to the gateway, the gateway reaps them, and callers get:

    Workflow not found. 'workflowID' 0x... is not a valid workflow ID   (HTTP 400)

## Fix

Apply `WithCentralizedOwnerVerification` before `WithAdditionalSources` so the gate (and settings getter) are set before any GRPC source is constructed. A comment documents the dependency so the order isn't reverted.

## Impact

Any node running a build with the `CentralizedOwnerVerificationEnabled` guard drops its centralized workflow source at startup, taking down all centrally-sourced workflows on that node. Observed in staging as a wave of gateway "workflow not found" errors following a rolling restart.
