### PR TITLE
fix(go.mod): resolve phantom starknet-p2pspecs module for tooling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -432,3 +432,5 @@ tool github.com/smartcontractkit/chainlink-common/pkg/loop/cmd/loopinstall
 tool github.com/smartcontractkit/chainlink-common/script/cmd/dependabot
 
 replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.5
+
+replace github.com/starknet-io/starknet-p2pspecs => github.com/NethermindEth/juno v0.15.11


### PR DESCRIPTION
## Problem

GoLand (and any command that resolves the full module graph, e.g. `go list -m all`) fails on the repo with:

```
go: github.com/starknet-io/starknet-p2pspecs@v0.0.0-00010101000000-000000000000: invalid version:
    git ls-remote ... exit status 128:
    remote: Repository not found.
    fatal: repository 'https://github.com/starknet-io/starknet-p2pspecs/' not found
```

## Root cause

The dependency chain is:

```
chainlink/v2 → NethermindEth/juno@v0.15.11 → starknet-io/starknet-p2pspecs@v0.0.0-00010101…
```

`juno@v0.15.11`'s own `go.mod` requires `starknet-p2pspecs` at the empty sentinel version and satisfies it with a **local-path replace to a git submodule**:

```
replace github.com/starknet-io/starknet-p2pspecs => ./starknet-p2pspecs
```

`replace` directives in a dependency are ignored by downstream modules, and the submodule is not included in juno's module zip. So consumers see a bare `require` at the sentinel version and try to fetch a GitHub repo that returns 404.

`go build`/`go test` succeed because juno is an **indirect** dependency and none of its packages are imported — but full-graph tooling (IDE indexing) breaks.

## Fix

Redirect the never-compiled module to a resolvable stand-in — juno itself, already required at the same version:

```
replace github.com/starknet-io/starknet-p2pspecs => github.com/NethermindEth/juno v0.15.11
```

- The module is never imported/compiled, so the target's contents are irrelevant.
- `go.sum` is **unchanged** (juno@v0.15.11 is already present).
- `go list -m all` resolves cleanly (verified offline, exit 0).

## Long-term

The real fix belongs upstream in juno (publish `starknet-p2pspecs` as a proper module or vendor it), since the local-path replace can never work for downstream consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)