### PR TITLE
relay: enforce pre-hook secret restrictions from signed WorkflowExecution (PRIV-537)

### DIFF
--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -30,6 +31,8 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/teeattestation/nitro"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
+
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 )
 
 var _ core.GatewayConnectorHandler = (*Handler)(nil)
@@ -270,7 +273,16 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 	// forwards the Workflow-DON-signed compute requests (a 2*F+1 quorum), whose PublicData
 	// names the authorized owner. A TEE breach passes attestation but cannot forge a Workflow
 	// DON quorum over a different owner (PRIV-433).
-	if err = h.verifyWorkflowAuthorization(localNode.WorkflowDON, params); err != nil {
+	execution, err := h.verifyWorkflowAuthorization(localNode.WorkflowDON, params)
+	if err != nil {
+		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInvalidParams, err)
+	}
+
+	// Filter the requested secrets against the workflow's pre-hook restrictions carried in
+	// the same signed WorkflowExecution (PRIV-537). The enclave enforces these itself, so a
+	// violation reaching the relay implies a breached TEE: reject the whole request rather
+	// than serving a partial result.
+	if err = enforceSecretsRestrictions(execution.GetRestrictions(), params.Secrets); err != nil {
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInvalidParams, err)
 	}
 
@@ -592,9 +604,12 @@ func (h *Handler) verifyAttestationHash(ctx context.Context, attestationB64 stri
 //
 // All failures here are client errors: the request is unauthorized. The caller fetches the
 // Workflow DON (a server-side concern) and passes it in, so registry failures stay internal.
-func (h *Handler) verifyWorkflowAuthorization(don capabilities.DON, params confidentialrelaytypes.SecretsRequestParams) error {
+//
+// On success it returns the quorum-verified WorkflowExecution so the caller can enforce
+// further signed fields (the pre-hook restrictions, PRIV-537) without re-verifying.
+func (h *Handler) verifyWorkflowAuthorization(don capabilities.DON, params confidentialrelaytypes.SecretsRequestParams) (*confidentialworkflow.WorkflowExecution, error) {
 	if len(params.SignedComputeRequests) == 0 {
-		return errors.New("missing signed compute requests")
+		return nil, errors.New("missing signed compute requests")
 	}
 
 	// Match the enclave's own quorum. With requireBFTQuorum the relay demands a
@@ -613,7 +628,7 @@ func (h *Handler) verifyWorkflowAuthorization(don capabilities.DON, params confi
 	signers := make(map[string]struct{})
 	for _, scr := range params.SignedComputeRequests {
 		if scr.Hash() != hash {
-			return errors.New("forwarded signed compute requests do not share one compute request")
+			return nil, errors.New("forwarded signed compute requests do not share one compute request")
 		}
 		for _, member := range don.Members {
 			if ed25519.Verify(ed25519.PublicKey(member[:]), payload, scr.Signature) {
@@ -623,25 +638,86 @@ func (h *Handler) verifyWorkflowAuthorization(don capabilities.DON, params confi
 		}
 	}
 	if len(signers) < threshold {
-		return fmt.Errorf("insufficient Workflow DON signatures: %d unique signers, need %d", len(signers), threshold)
+		return nil, fmt.Errorf("insufficient Workflow DON signatures: %d unique signers, need %d", len(signers), threshold)
 	}
 
 	// The signed request authorizes a specific owner and workflow; the secrets request must
 	// match both, or a breached enclave could fetch another owner's secrets.
 	var execution confidentialworkflow.WorkflowExecution
 	if err := proto.Unmarshal(params.SignedComputeRequests[0].PublicData, &execution); err != nil {
-		return fmt.Errorf("failed to unmarshal workflow execution from public data: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal workflow execution from public data: %w", err)
 	}
 	if !common.IsHexAddress(params.Owner) || !common.IsHexAddress(execution.GetOwner()) {
-		return errors.New("invalid owner address")
+		return nil, errors.New("invalid owner address")
 	}
 	if common.HexToAddress(execution.GetOwner()) != common.HexToAddress(params.Owner) {
-		return fmt.Errorf("owner not authorized: request %q vs signed %q", params.Owner, execution.GetOwner())
+		return nil, fmt.Errorf("owner not authorized: request %q vs signed %q", params.Owner, execution.GetOwner())
 	}
 	if execution.GetWorkflowId() != params.WorkflowID {
-		return fmt.Errorf("workflow_id not authorized: request %q vs signed %q", params.WorkflowID, execution.GetWorkflowId())
+		return nil, fmt.Errorf("workflow_id not authorized: request %q vs signed %q", params.WorkflowID, execution.GetWorkflowId())
+	}
+	// Bind the quorum to this execution. The pre-hook restrictions are per-execution, so
+	// accepting a signed request from an older execution of the same workflow would let a
+	// breached enclave replay a looser restriction set.
+	if execution.GetExecutionId() != params.ExecutionID {
+		return nil, fmt.Errorf("execution_id not authorized: request %q vs signed %q", params.ExecutionID, execution.GetExecutionId())
+	}
+	return &execution, nil
+}
+
+// enforceSecretsRestrictions is the relay-side check of the workflow's pre-hook secret
+// restrictions (PRIV-537). The restrictions come from the quorum-verified WorkflowExecution,
+// so a breached enclave cannot loosen them. Membership semantics mirror chainlink-common's
+// in-TEE executionRestrictions wrapper; the counting budgets (max_secrets as a running
+// budget, per-prefix decrements) stay in-TEE because the relay serves each request
+// statelessly, so only the membership rules and zero-budget denials are enforceable here.
+//
+// A nil Restrictions or nil Secrets means the workflow declared no secret restrictions:
+// allowed. Namespaces are normalized ("" -> "main") on both sides before matching, so an
+// empty-namespace request cannot slip past a "main"-namespace rule or vice versa.
+func enforceSecretsRestrictions(r *sdkpb.Restrictions, secrets []confidentialrelaytypes.SecretIdentifier) error {
+	sr := r.GetSecrets()
+	if sr == nil {
+		return nil
+	}
+	for _, s := range secrets {
+		if !secretAllowed(sr, s) {
+			return fmt.Errorf("secret %q in namespace %q denied by workflow pre-hook restrictions",
+				s.Key, vaulttypes.NormalizeNamespace(s.Namespace))
+		}
 	}
 	return nil
+}
+
+// secretAllowed mirrors the in-TEE wrapper's reserveSecret membership rules: a zero
+// MaxSecrets denies everything, an exact (id, namespace) entry or a namespace+prefix rule
+// admits, and a matching prefix rule with a zero budget denies even alongside an exact
+// match (the wrapper short-circuits the same way).
+func secretAllowed(sr *sdkpb.SecretsRestritions, s confidentialrelaytypes.SecretIdentifier) bool {
+	if sr.GetMaxSecrets() == 0 {
+		return false
+	}
+	ns := vaulttypes.NormalizeNamespace(s.Namespace)
+	exact := false
+	prefixMatched := false
+	for _, rr := range sr.GetRestrictions() {
+		switch v := rr.GetRestriction().(type) {
+		case *sdkpb.SecretRestriction_ExactSecret:
+			e := v.ExactSecret
+			if e.GetId() == s.Key && vaulttypes.NormalizeNamespace(e.GetNamespace()) == ns {
+				exact = true
+			}
+		case *sdkpb.SecretRestriction_PrefixedSecret:
+			p := v.PrefixedSecret
+			if vaulttypes.NormalizeNamespace(p.GetNamespace()) == ns && strings.HasPrefix(s.Key, p.GetPrefix()) {
+				if p.GetMaxSecrets() == 0 {
+					return false
+				}
+				prefixMatched = true
+			}
+		}
+	}
+	return exact || prefixMatched
 }
 
 func (h *Handler) jsonResponse(req *jsonrpc.Request[json.RawMessage], result any) *jsonrpc.Response[json.RawMessage] {

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -258,8 +258,9 @@ func signedComputeRequestsForParams(t *testing.T, params confidentialrelaytypes.
 	t.Helper()
 	privs, _ := testWorkflowDONKeys()
 	publicData, err := proto.Marshal(&confidentialworkflow.WorkflowExecution{
-		Owner:      params.Owner,
-		WorkflowId: params.WorkflowID,
+		Owner:       params.Owner,
+		WorkflowId:  params.WorkflowID,
+		ExecutionId: params.ExecutionID,
 	})
 	require.NoError(t, err)
 	cr := confidentialrelaytypes.ComputeRequest{PublicData: publicData}
@@ -831,18 +832,19 @@ func TestTranslateVaultResponse_HexShares(t *testing.T) {
 func TestVerifyWorkflowAuthorization(t *testing.T) {
 	t.Parallel()
 	const (
-		owner      = "0xab5801a7d398351b8be11c439e05c5b3259aec9b"
-		workflowID = "wf-secrets-1"
+		owner       = "0xab5801a7d398351b8be11c439e05c5b3259aec9b"
+		workflowID  = "wf-secrets-1"
+		executionID = "0000000000000000000000000000000000000000000000000000000000000001"
 	)
 	privs, _ := testWorkflowDONKeys()
 	// The DON members are the public keys of privs; F=testEnclaveF => 2*F+1 = 3 quorum.
 	don := capabilities.DON{Members: testWorkflowDONMembers(), F: testEnclaveF}
 
-	// signedReqs builds compute requests naming o/wf, each signed by one of the given keys
-	// over the shared request hash.
-	signedReqs := func(t *testing.T, o, wf string, signers []ed25519.PrivateKey) []confidentialrelaytypes.SignedComputeRequest {
+	// signedReqs builds compute requests naming o/wf/eid, each signed by one of the given
+	// keys over the shared request hash.
+	signedReqs := func(t *testing.T, o, wf, eid string, signers []ed25519.PrivateKey) []confidentialrelaytypes.SignedComputeRequest {
 		t.Helper()
-		publicData, err := proto.Marshal(&confidentialworkflow.WorkflowExecution{Owner: o, WorkflowId: wf})
+		publicData, err := proto.Marshal(&confidentialworkflow.WorkflowExecution{Owner: o, WorkflowId: wf, ExecutionId: eid})
 		require.NoError(t, err)
 		cr := confidentialrelaytypes.ComputeRequest{PublicData: publicData}
 		payload := confidentialrelaytypes.SignedComputeRequestSignaturePayload(cr.Hash())
@@ -853,58 +855,76 @@ func TestVerifyWorkflowAuthorization(t *testing.T) {
 		return out
 	}
 
-	// validParams: 2*F+1 = 3 distinct DON signers over a compute request naming owner/workflow.
+	// validParams: 2*F+1 = 3 distinct DON signers over a compute request naming
+	// owner/workflow/execution.
 	validParams := func(t *testing.T) confidentialrelaytypes.SecretsRequestParams {
 		t.Helper()
 		return confidentialrelaytypes.SecretsRequestParams{
 			WorkflowID:            workflowID,
 			Owner:                 owner,
-			SignedComputeRequests: signedReqs(t, owner, workflowID, privs[:3]),
+			ExecutionID:           executionID,
+			SignedComputeRequests: signedReqs(t, owner, workflowID, executionID, privs[:3]),
 		}
 	}
 
 	h := newTestHandler(t, &mockCapRegistry{}, &mockGatewayConnector{})
+	verify := func(params confidentialrelaytypes.SecretsRequestParams) error {
+		_, err := h.verifyWorkflowAuthorization(don, params)
+		return err
+	}
 
 	t.Run("valid 2F+1 quorum", func(t *testing.T) {
 		t.Parallel()
-		require.NoError(t, h.verifyWorkflowAuthorization(don, validParams(t)))
+		execution, err := h.verifyWorkflowAuthorization(don, validParams(t))
+		require.NoError(t, err)
+		require.Equal(t, workflowID, execution.GetWorkflowId())
 	})
 
 	t.Run("missing signed compute requests", func(t *testing.T) {
 		t.Parallel()
 		params := validParams(t)
 		params.SignedComputeRequests = nil
-		require.ErrorContains(t, h.verifyWorkflowAuthorization(don, params), "missing signed compute requests")
+		require.ErrorContains(t, verify(params), "missing signed compute requests")
 	})
 
 	t.Run("insufficient signers for quorum", func(t *testing.T) {
 		t.Parallel()
 		params := validParams(t)
 		// Only 2 signers; F=1 requires 2*1+1 = 3.
-		params.SignedComputeRequests = signedReqs(t, owner, workflowID, privs[:2])
-		require.ErrorContains(t, h.verifyWorkflowAuthorization(don, params), "insufficient Workflow DON signatures")
+		params.SignedComputeRequests = signedReqs(t, owner, workflowID, executionID, privs[:2])
+		require.ErrorContains(t, verify(params), "insufficient Workflow DON signatures")
 	})
 
 	t.Run("signers not in Workflow DON", func(t *testing.T) {
 		t.Parallel()
 		stranger := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0xfe}, ed25519.SeedSize))
 		params := validParams(t)
-		params.SignedComputeRequests = signedReqs(t, owner, workflowID, []ed25519.PrivateKey{stranger, stranger, stranger})
-		require.ErrorContains(t, h.verifyWorkflowAuthorization(don, params), "insufficient Workflow DON signatures")
+		params.SignedComputeRequests = signedReqs(t, owner, workflowID, executionID, []ed25519.PrivateKey{stranger, stranger, stranger})
+		require.ErrorContains(t, verify(params), "insufficient Workflow DON signatures")
 	})
 
 	t.Run("owner mismatch", func(t *testing.T) {
 		t.Parallel()
 		params := validParams(t)
 		params.Owner = "0x0000000000000000000000000000000000000002"
-		require.ErrorContains(t, h.verifyWorkflowAuthorization(don, params), "owner not authorized")
+		require.ErrorContains(t, verify(params), "owner not authorized")
 	})
 
 	t.Run("workflow id mismatch", func(t *testing.T) {
 		t.Parallel()
 		params := validParams(t)
 		params.WorkflowID = "wf-other"
-		require.ErrorContains(t, h.verifyWorkflowAuthorization(don, params), "workflow_id not authorized")
+		require.ErrorContains(t, verify(params), "workflow_id not authorized")
+	})
+
+	t.Run("execution id mismatch rejects replay of another execution", func(t *testing.T) {
+		t.Parallel()
+		params := validParams(t)
+		// A quorum signed for a different execution of the same workflow/owner must not
+		// authorize this one: its pre-hook restrictions may be looser.
+		params.SignedComputeRequests = signedReqs(t, owner, workflowID,
+			"00000000000000000000000000000000000000000000000000000000000000ff", privs[:3])
+		require.ErrorContains(t, verify(params), "execution_id not authorized")
 	})
 
 	t.Run("forwarded requests disagree on compute request", func(t *testing.T) {
@@ -914,6 +934,93 @@ func TestVerifyWorkflowAuthorization(t *testing.T) {
 			ComputeRequest: confidentialrelaytypes.ComputeRequest{PublicData: []byte("different")},
 			Signature:      []byte("irrelevant"),
 		})
-		require.ErrorContains(t, h.verifyWorkflowAuthorization(don, params), "do not share one compute request")
+		require.ErrorContains(t, verify(params), "do not share one compute request")
+	})
+}
+
+func TestEnforceSecretsRestrictions(t *testing.T) {
+	t.Parallel()
+
+	exact := func(id, ns string) *sdkpb.SecretRestriction {
+		return &sdkpb.SecretRestriction{Restriction: &sdkpb.SecretRestriction_ExactSecret{
+			ExactSecret: &sdkpb.Secret{Id: id, Namespace: ns},
+		}}
+	}
+	prefixed := func(prefix, ns string, maxSecrets int32) *sdkpb.SecretRestriction {
+		return &sdkpb.SecretRestriction{Restriction: &sdkpb.SecretRestriction_PrefixedSecret{
+			PrefixedSecret: &sdkpb.SecretPrefixRestriction{Prefix: prefix, Namespace: ns, MaxSecrets: maxSecrets},
+		}}
+	}
+	restrictions := func(maxSecrets int32, rr ...*sdkpb.SecretRestriction) *sdkpb.Restrictions {
+		return &sdkpb.Restrictions{Secrets: &sdkpb.SecretsRestritions{Restrictions: rr, MaxSecrets: maxSecrets}}
+	}
+	secrets := func(ids ...confidentialrelaytypes.SecretIdentifier) []confidentialrelaytypes.SecretIdentifier {
+		return ids
+	}
+	apiKey := confidentialrelaytypes.SecretIdentifier{Key: "API_KEY", Namespace: "main"}
+
+	t.Run("nil restrictions allows everything", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, enforceSecretsRestrictions(nil, secrets(apiKey)))
+	})
+
+	t.Run("restrictions without secrets section allows everything", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, enforceSecretsRestrictions(&sdkpb.Restrictions{}, secrets(apiKey)))
+	})
+
+	t.Run("exact match allows", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, enforceSecretsRestrictions(restrictions(-1, exact("API_KEY", "main")), secrets(apiKey)))
+	})
+
+	t.Run("unlisted secret denied", func(t *testing.T) {
+		t.Parallel()
+		err := enforceSecretsRestrictions(restrictions(-1, exact("API_KEY", "main")),
+			secrets(confidentialrelaytypes.SecretIdentifier{Key: "OTHER", Namespace: "main"}))
+		require.ErrorContains(t, err, `secret "OTHER" in namespace "main" denied by workflow pre-hook restrictions`)
+	})
+
+	t.Run("one unlisted secret rejects the batch", func(t *testing.T) {
+		t.Parallel()
+		err := enforceSecretsRestrictions(restrictions(-1, exact("API_KEY", "main")),
+			secrets(apiKey, confidentialrelaytypes.SecretIdentifier{Key: "OTHER", Namespace: "main"}))
+		require.ErrorContains(t, err, "denied by workflow pre-hook restrictions")
+	})
+
+	t.Run("prefix match allows", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, enforceSecretsRestrictions(restrictions(-1, prefixed("API_", "main", -1)), secrets(apiKey)))
+	})
+
+	t.Run("prefix in other namespace denied", func(t *testing.T) {
+		t.Parallel()
+		err := enforceSecretsRestrictions(restrictions(-1, prefixed("API_", "other", -1)), secrets(apiKey))
+		require.ErrorContains(t, err, "denied by workflow pre-hook restrictions")
+	})
+
+	t.Run("zero max_secrets denies everything", func(t *testing.T) {
+		t.Parallel()
+		err := enforceSecretsRestrictions(restrictions(0, exact("API_KEY", "main")), secrets(apiKey))
+		require.ErrorContains(t, err, "denied by workflow pre-hook restrictions")
+	})
+
+	t.Run("zero-budget prefix denies even alongside an exact match", func(t *testing.T) {
+		t.Parallel()
+		// Mirrors the in-TEE wrapper: a matching prefix rule with an exhausted budget
+		// short-circuits to deny before the exact match is considered.
+		err := enforceSecretsRestrictions(restrictions(-1, exact("API_KEY", "main"), prefixed("API_", "main", 0)), secrets(apiKey))
+		require.ErrorContains(t, err, "denied by workflow pre-hook restrictions")
+	})
+
+	t.Run("empty namespace normalizes to main on the request side", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, enforceSecretsRestrictions(restrictions(-1, exact("API_KEY", "main")),
+			secrets(confidentialrelaytypes.SecretIdentifier{Key: "API_KEY", Namespace: ""})))
+	})
+
+	t.Run("empty namespace normalizes to main on the restriction side", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, enforceSecretsRestrictions(restrictions(-1, exact("API_KEY", "")), secrets(apiKey)))
 	})
 }


### PR DESCRIPTION
The Workflow-DON-signed PublicData carries the workflow's pre-hook Restrictions (chainlink-protos [#441](https://github.com/smartcontractkit/chainlink-protos/pull/411)). After the PRIV-433 quorum check, the relay now filters the requested secrets against the signed restriction membership (exact and prefix rules, vault ""->"main" namespace normalization on both sides) and binds the quorum to the request's execution_id, so a breached enclave cannot replay an older execution's looser restriction set.

Membership only: counting budgets (max_secrets, per-prefix budgets) stay enclave-side, since the relay serves each request statelessly. Semantics mirror chainlink-common's in-TEE executionRestrictions wrapper, including zero-budget denials.

Capability-path filtering is out of scope: CapabilityRequestParams has no SignedComputeRequests carrier yet.