### PR TITLE
Add Stellar DF cache write e2e scenario

### DIFF
--- a/system-tests/lib/cre/features/stellar/stellar_cache.go
+++ b/system-tests/lib/cre/features/stellar/stellar_cache.go
@@ -1,0 +1,130 @@
+package stellar
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	cache "github.com/smartcontractkit/chainlink-stellar/bindings/contracts/data_feeds_cache"
+	"github.com/smartcontractkit/chainlink-stellar/bindings/scval"
+	stellardeployment "github.com/smartcontractkit/chainlink-stellar/deployment"
+	datafeeds "github.com/smartcontractkit/chainlink-stellar/deployment/data-feeds"
+
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
+	stellchain "github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/blockchains/stellar"
+)
+
+func StellarForwarderAddress(creEnv *cre.Environment, chainSelector uint64) string {
+	return mustForwarderAddress(creEnv.CldfEnvironment.DataStore, chainSelector)
+}
+
+type DFReportEntry struct {
+	DataID    [32]byte
+	Answer    *big.Int
+	Timestamp uint64
+}
+
+func DeployAndConfigureStellarDFCache(
+	ctx context.Context,
+	chain *stellchain.Blockchain,
+	dataID [16]byte,
+	description string,
+	forwarderAddress string,
+	workflowOwner [20]byte,
+	workflowName [10]byte,
+) (string, error) {
+	stellarChain, err := stellarCldfChain(chain)
+	if err != nil {
+		return "", err
+	}
+	owner := stellarChain.Signer.Address()
+	if fundErr := chain.Fund(ctx, owner, 0); fundErr != nil {
+		return "", fmt.Errorf("failed to fund stellar deployer %s via friendbot: %w", owner, fundErr)
+	}
+	deployer, err := stellardeployment.NewDeployerFromChain(stellarChain)
+	if err != nil {
+		return "", fmt.Errorf("failed to build stellar deployer: %w", err)
+	}
+
+	wasm, err := datafeeds.Artifact(datafeeds.DataFeedsCacheWasm)
+	if err != nil {
+		return "", fmt.Errorf("failed to source data feeds cache WASM: %w", err)
+	}
+
+	var salt [32]byte
+	cacheID, err := deployer.DeployContractBytesWithArgs(ctx, wasm, salt, []xdr.ScVal{scval.AddressToScVal(owner)})
+	if err != nil {
+		return "", fmt.Errorf("failed to deploy data feeds cache: %w", err)
+	}
+
+	c := cache.NewDataFeedsCacheClient(deployer, cacheID)
+	if err := c.AddFeedAdmin(ctx, owner); err != nil {
+		return "", fmt.Errorf("failed to register feed admin on %s: %w", cacheID, err)
+	}
+	entries := []cache.FeedConfigEntry{{
+		DataId: dataID,
+		Config: cache.FeedConfig{
+			Description: description,
+			WorkflowPermissions: []cache.WorkflowPermission{{
+				AllowedSender:        forwarderAddress,
+				AllowedWorkflowOwner: workflowOwner,
+				AllowedWorkflowName:  workflowName,
+			}},
+		},
+	}}
+	if err := c.SetFeedConfigs(ctx, owner, entries); err != nil {
+		return "", fmt.Errorf("failed to configure DF cache feed on %s: %w", cacheID, err)
+	}
+	return cacheID, nil
+}
+
+func DFCacheLatestRound(ctx context.Context, chain *stellchain.Blockchain, contractID string, dataID [16]byte) (*cache.RoundData, error) {
+	stellarChain, err := stellarCldfChain(chain)
+	if err != nil {
+		return nil, err
+	}
+	deployer, err := stellardeployment.NewDeployerFromChain(stellarChain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build stellar deployer: %w", err)
+	}
+	return cache.NewDataFeedsCacheClient(deployer, contractID).LatestRound(ctx, dataID)
+}
+
+func BuildDFReportPayload(entries []DFReportEntry) ([]byte, error) {
+	vec := make(xdr.ScVec, 0, len(entries))
+	for _, e := range entries {
+		answer, err := scval.I256ToScVal(e.Answer)
+		if err != nil {
+			return nil, fmt.Errorf("encode answer for feed %x: %w", e.DataID, err)
+		}
+		dataID := e.DataID
+		m := &xdr.ScMap{
+			structEntry("answer", answer),
+			structEntry("data_id", xdr.ScVal{Type: xdr.ScValTypeScvBytes, Bytes: bytesPtr(dataID[:])}),
+			structEntry("timestamp", xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: u64Ptr(xdr.Uint64(e.Timestamp))}),
+		}
+		vec = append(vec, xdr.ScVal{Type: xdr.ScValTypeScvMap, Map: &m})
+	}
+	vecPtr := &vec
+	val := xdr.ScVal{Type: xdr.ScValTypeScvVec, Vec: &vecPtr}
+	return val.MarshalBinary()
+}
+
+func structEntry(key string, val xdr.ScVal) xdr.ScMapEntry {
+	sym := xdr.ScSymbol(key)
+	return xdr.ScMapEntry{
+		Key: xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &sym},
+		Val: val,
+	}
+}
+
+func bytesPtr(b []byte) *xdr.ScBytes {
+	sb := xdr.ScBytes(b)
+	return &sb
+}
+
+func u64Ptr(v xdr.Uint64) *xdr.Uint64 {
+	return &v
+}

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.107
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20260708114855-e953eeb028a7
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260810171459-6fa01d7aaf11
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260810185617-74b886ae36a1
 	github.com/smartcontractkit/chainlink-common/keystore v1.3.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260810110946-8174b6bb7fc9
@@ -46,6 +46,8 @@ require (
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.20.1-0.20260701185448-696c075849ea
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260716141634-c0cc05ed05d8
+	github.com/smartcontractkit/chainlink-stellar v0.0.4-0.20260810203623-e5463b883e9e
+	github.com/smartcontractkit/chainlink-stellar/bindings v0.0.0-20260810203623-e5463b883e9e
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.16.6-0.20260708113039-95f97b2d25e9
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/chiprouter v1.0.4
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.23
@@ -57,6 +59,7 @@ require (
 	github.com/smartcontractkit/libocr v0.0.0-20260529134643-c101335a64cd
 	github.com/smartcontractkit/smdkg v0.0.0-20251029093710-c38905e58aeb
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20251120172354-e8ec0386b06c
+	github.com/stellar/go-stellar-sdk v0.6.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/ratelimit v0.3.1
 	go.uber.org/zap v1.28.0
@@ -481,8 +484,6 @@ require (
 	github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.3.0 // indirect
 	github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260513123719-d347eaf314e1 // indirect
-	github.com/smartcontractkit/chainlink-stellar v0.0.3 // indirect
-	github.com/smartcontractkit/chainlink-stellar/bindings v0.0.0-20260727172856-734bee1b2489 // indirect
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260728151254-66dc095d5ccf // indirect
 	github.com/smartcontractkit/chainlink-sui/codec v0.0.0-20260720132736-e99278bfdc96 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.9 // indirect
@@ -498,7 +499,6 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/stellar/go-stellar-sdk v0.6.0 // indirect
 	github.com/stellar/go-xdr v0.0.0-20260529210834-0bf8f4956364 // indirect
 	github.com/stephenlacy/go-ethereum-hdwallet v0.0.0-20230913225845-a4fa94429863 // indirect
 	github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1551,8 +1551,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260716164331-d938b371c5d6 h1:t5VUHVFEdcqa0/faJiHWusuW+egKpqK3YwWZO4/yJto=
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260716164331-d938b371c5d6/go.mod h1:0v6RGdYa9NezVnBPIAVyxB3A9furKWwaSkLha+URYGk=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260810171459-6fa01d7aaf11 h1:bQPSpuvhW+N9XFRADiOtP4wo/Hh642Pw6kMTus1RUpo=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260810171459-6fa01d7aaf11/go.mod h1:P9kQKuadFvQJbZcracSvMzgnLt3IXda2FLl5NiPTbVM=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260810185617-74b886ae36a1 h1:8SIXI9j1BU9gLhY78pgaUzYszTo1Ay57WeDXNY7WLtU=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260810185617-74b886ae36a1/go.mod h1:P9kQKuadFvQJbZcracSvMzgnLt3IXda2FLl5NiPTbVM=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0 h1:V05Rp9/dTc4Wyipsk1EYnW3riZyjDVKmhz3769JpnHU=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0/go.mod h1:vHV8BGm6TN7jBbMsWxq1Hqm3HbCtYFwzvKS0CCczxG8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260724142814-45996a1bcb72 h1:uWEwl7i2ryuRVoV4DmIKm6mqYevf1lH/8cQYhw/JXko=
@@ -1617,10 +1617,10 @@ github.com/smartcontractkit/chainlink-solana v1.3.1-0.20260605202330-b5a89c32fdc
 github.com/smartcontractkit/chainlink-solana v1.3.1-0.20260605202330-b5a89c32fdc1/go.mod h1:wi1QdXqhSJnADt9YRaRtEWomqknLcrdkTS0JotupuOQ=
 github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260513123719-d347eaf314e1 h1:/xvuNFI7DwOoTQnmAdYPDdY+sConn3RgZ2rMy/8AXlo=
 github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260513123719-d347eaf314e1/go.mod h1:lQK+YvR9Ox0ft72k0se7DlA+kujVWyjFQXG3DLbEZ/4=
-github.com/smartcontractkit/chainlink-stellar v0.0.3 h1:4kCD4aznUip14U058v0nMzk0Fw+Wc3skjahd8JoKRXQ=
-github.com/smartcontractkit/chainlink-stellar v0.0.3/go.mod h1:3/LaXFXZH64X1ohaawxJKIPo/KA4qOVDEmPpN0ChEZ8=
-github.com/smartcontractkit/chainlink-stellar/bindings v0.0.0-20260727172856-734bee1b2489 h1:z6inZEs6BcVKARjvnUNJQ4+7N4905L/Y1eDBFtkkRDI=
-github.com/smartcontractkit/chainlink-stellar/bindings v0.0.0-20260727172856-734bee1b2489/go.mod h1:uZEMU0BN48tmRP/Hu+RdnM70g17pgAv4s/Nux7asr2U=
+github.com/smartcontractkit/chainlink-stellar v0.0.4-0.20260810203623-e5463b883e9e h1:jhdI6WBTxfaXxYp8EBe7jBlHSXYo3m90e6XzaDwvDlM=
+github.com/smartcontractkit/chainlink-stellar v0.0.4-0.20260810203623-e5463b883e9e/go.mod h1:SdCOV3QfqbpZMd8c60DekRw3jatmsaIjQaR98WY20XQ=
+github.com/smartcontractkit/chainlink-stellar/bindings v0.0.0-20260810203623-e5463b883e9e h1:F9DVBEJFC6XzUC7lkN0jZXW7EzwyOSQ2zONdAQeqqxc=
+github.com/smartcontractkit/chainlink-stellar/bindings v0.0.0-20260810203623-e5463b883e9e/go.mod h1:IYBZArxwOQRlcx0Udx/VfFjqJpAs4NrjKsBoNITKAMg=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260728151254-66dc095d5ccf h1:iCF2MVDW/wcM/ZwuLm6x0ye5C+hTARZAmroYKGsvlZI=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260728151254-66dc095d5ccf/go.mod h1:ayMAswIoOUfKXjnPml593ODmVTgUO4FBTFpG1zjdr/I=
 github.com/smartcontractkit/chainlink-sui/codec v0.0.0-20260720132736-e99278bfdc96 h1:3R9f6pguDIjei+nKx5dUT9j6fX8urGmlZA7Ad3x9UBs=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/smartcontractkit/chain-selectors v1.0.107
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260810171459-6fa01d7aaf11
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260810185617-74b886ae36a1
 	github.com/smartcontractkit/chainlink-common/keystore v1.3.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
 	github.com/smartcontractkit/chainlink-evm/contracts/cre/gobindings v0.0.0-20260403151002-2c91155b5501
@@ -648,8 +648,8 @@ require (
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.11.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.3.0 // indirect
-	github.com/smartcontractkit/chainlink-stellar v0.0.3 // indirect
-	github.com/smartcontractkit/chainlink-stellar/bindings v0.0.0-20260727172856-734bee1b2489 // indirect
+	github.com/smartcontractkit/chainlink-stellar v0.0.4-0.20260810203623-e5463b883e9e // indirect
+	github.com/smartcontractkit/chainlink-stellar/bindings v0.0.0-20260810203623-e5463b883e9e // indirect
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20260728151254-66dc095d5ccf // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.23 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1756,8 +1756,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260716164331-d938b371c5d6 h1:t5VUHVFEdcqa0/faJiHWusuW+egKpqK3YwWZO4/yJto=
 github.com/smartcontractkit/chainlink-ccv v0.1.1-0.20260716164331-d938b371c5d6/go.mod h1:0v6RGdYa9NezVnBPIAVyxB3A9furKWwaSkLha+URYGk=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260810171459-6fa01d7aaf11 h1:bQPSpuvhW+N9XFRADiOtP4wo/Hh642Pw6kMTus1RUpo=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260810171459-6fa01d7aaf11/go.mod h1:P9kQKuadFvQJbZcracSvMzgnLt3IXda2FLl5NiPTbVM=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260810185617-74b886ae36a1 h1:8SIXI9j1BU9gLhY78pgaUzYszTo1Ay57WeDXNY7WLtU=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260810185617-74b886ae36a1/go.mod h1:P9kQKuadFvQJbZcracSvMzgnLt3IXda2FLl5NiPTbVM=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0 h1:V05Rp9/dTc4Wyipsk1EYnW3riZyjDVKmhz3769JpnHU=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0/go.mod h1:vHV8BGm6TN7jBbMsWxq1Hqm3HbCtYFwzvKS0CCczxG8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260724142814-45996a1bcb72 h1:uWEwl7i2ryuRVoV4DmIKm6mqYevf1lH/8cQYhw/JXko=
@@ -1822,10 +1822,10 @@ github.com/smartcontractkit/chainlink-solana v1.3.1-0.20260605202330-b5a89c32fdc
 github.com/smartcontractkit/chainlink-solana v1.3.1-0.20260605202330-b5a89c32fdc1/go.mod h1:wi1QdXqhSJnADt9YRaRtEWomqknLcrdkTS0JotupuOQ=
 github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260513123719-d347eaf314e1 h1:/xvuNFI7DwOoTQnmAdYPDdY+sConn3RgZ2rMy/8AXlo=
 github.com/smartcontractkit/chainlink-solana/contracts v0.0.0-20260513123719-d347eaf314e1/go.mod h1:lQK+YvR9Ox0ft72k0se7DlA+kujVWyjFQXG3DLbEZ/4=
-github.com/smartcontractkit/chainlink-stellar v0.0.3 h1:4kCD4aznUip14U058v0nMzk0Fw+Wc3skjahd8JoKRXQ=
-github.com/smartcontractkit/chainlink-stellar v0.0.3/go.mod h1:3/LaXFXZH64X1ohaawxJKIPo/KA4qOVDEmPpN0ChEZ8=
-github.com/smartcontractkit/chainlink-stellar/bindings v0.0.0-20260727172856-734bee1b2489 h1:z6inZEs6BcVKARjvnUNJQ4+7N4905L/Y1eDBFtkkRDI=
-github.com/smartcontractkit/chainlink-stellar/bindings v0.0.0-20260727172856-734bee1b2489/go.mod h1:uZEMU0BN48tmRP/Hu+RdnM70g17pgAv4s/Nux7asr2U=
+github.com/smartcontractkit/chainlink-stellar v0.0.4-0.20260810203623-e5463b883e9e h1:jhdI6WBTxfaXxYp8EBe7jBlHSXYo3m90e6XzaDwvDlM=
+github.com/smartcontractkit/chainlink-stellar v0.0.4-0.20260810203623-e5463b883e9e/go.mod h1:SdCOV3QfqbpZMd8c60DekRw3jatmsaIjQaR98WY20XQ=
+github.com/smartcontractkit/chainlink-stellar/bindings v0.0.0-20260810203623-e5463b883e9e h1:F9DVBEJFC6XzUC7lkN0jZXW7EzwyOSQ2zONdAQeqqxc=
+github.com/smartcontractkit/chainlink-stellar/bindings v0.0.0-20260810203623-e5463b883e9e/go.mod h1:IYBZArxwOQRlcx0Udx/VfFjqJpAs4NrjKsBoNITKAMg=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260728151254-66dc095d5ccf h1:iCF2MVDW/wcM/ZwuLm6x0ye5C+hTARZAmroYKGsvlZI=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260728151254-66dc095d5ccf/go.mod h1:ayMAswIoOUfKXjnPml593ODmVTgUO4FBTFpG1zjdr/I=
 github.com/smartcontractkit/chainlink-sui/codec v0.0.0-20260720132736-e99278bfdc96 h1:3R9f6pguDIjei+nKx5dUT9j6fX8urGmlZA7Ad3x9UBs=

--- a/system-tests/tests/smoke/cre/cre_suite_test.go
+++ b/system-tests/tests/smoke/cre/cre_suite_test.go
@@ -309,6 +309,12 @@ func Test_CRE_V2_Stellar_Suite(t *testing.T) {
 		env, chain, userLogsCh, baseMessageCh := setupStellarScenario(t, testEnv)
 		executeStellarWriteTest(t, env, chain, userLogsCh, baseMessageCh)
 	})
+
+	t.Run("StellarDFCacheWrite", func(t *testing.T) {
+		t.Parallel()
+		env, chain, userLogsCh, baseMessageCh := setupStellarScenario(t, testEnv)
+		executeStellarDFCacheWriteTest(t, env, chain, userLogsCh, baseMessageCh)
+	})
 }
 
 func Test_CRE_V2_Module_Cache(t *testing.T) {

--- a/system-tests/tests/smoke/cre/stellar/stellarwrite/config/config.go
+++ b/system-tests/tests/smoke/cre/stellar/stellarwrite/config/config.go
@@ -18,7 +18,8 @@ type Config struct {
 	ReportPayloadHex string `yaml:"reportPayloadHex"`
 	// RequiredSignatures is the number of OCR signatures to include in the
 	// submitted report; the Soroban forwarder expects exactly f+1.
-	RequiredSignatures int `yaml:"requiredSignatures"`
+	RequiredSignatures int    `yaml:"requiredSignatures"`
+	CronSchedule       string `yaml:"cronSchedule"`
 	// ExpectFailure, when true, treats a non-success tx status as the success
 	// condition (negative test).
 	ExpectFailure bool `yaml:"expectFailure"`

--- a/system-tests/tests/smoke/cre/stellar/stellarwrite/main.go
+++ b/system-tests/tests/smoke/cre/stellar/stellarwrite/main.go
@@ -36,9 +36,13 @@ func main() {
 }
 
 func RunStellarWriteWorkflow(cfg config.Config, logger *slog.Logger, secretsProvider sdk.SecretsProvider) (sdk.Workflow[config.Config], error) {
+	schedule := cfg.CronSchedule
+	if schedule == "" {
+		schedule = "*/30 * * * * *"
+	}
 	return sdk.Workflow[config.Config]{
 		sdk.Handler(
-			cron.Trigger(&cron.Config{Schedule: "*/30 * * * * *"}),
+			cron.Trigger(&cron.Config{Schedule: schedule}),
 			onStellarWriteTrigger,
 		),
 	}, nil

--- a/system-tests/tests/smoke/cre/stellar_capability_test.go
+++ b/system-tests/tests/smoke/cre/stellar_capability_test.go
@@ -3,6 +3,7 @@ package cre
 import (
 	"context"
 	"encoding/hex"
+	"math/big"
 	"testing"
 	"time"
 
@@ -15,7 +16,10 @@ import (
 
 	"github.com/stellar/go-stellar-sdk/xdr"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows"
+
 	crelib "github.com/smartcontractkit/chainlink/system-tests/lib/cre"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/blockchains/evm"
 	stellchain "github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/blockchains/stellar"
 	stellarfeature "github.com/smartcontractkit/chainlink/system-tests/lib/cre/features/stellar"
 	thelpers "github.com/smartcontractkit/chainlink/system-tests/tests/test-helpers"
@@ -180,6 +184,7 @@ func executeStellarWriteTest(
 		ReceiverContractID: receiverID,
 		ReportPayloadHex:   reportPayloadHex,
 		RequiredSignatures: requiredSignatures,
+		CronSchedule:       thelpers.StellarTestCronSchedule(),
 	}
 
 	const workflowFileLocation = "./stellar/stellarwrite/main.go"
@@ -208,6 +213,83 @@ func executeStellarWriteTest(
 	}, 2*time.Minute, 5*time.Second, "Stellar receiver did not record the expected payload value %d", expectedValue)
 
 	lggr.Info().Str("expected_log", expectedLog).Uint64("payload_value", expectedValue).Msg("Stellar write capability test passed")
+}
+
+func executeStellarDFCacheWriteTest(
+	t *testing.T,
+	tenv *configuration.TestEnvironment,
+	stellarChain *stellchain.Blockchain,
+	userLogsCh <-chan *workflowevents.UserLogs,
+	baseMessageCh <-chan *commonevents.BaseMessage,
+) {
+	lggr := framework.L
+	ctx := context.Background()
+
+	writeDon := stellarWriteDon(t, tenv)
+	workers, err := writeDon.Workers()
+	require.NoError(t, err, "failed to list Stellar DON workers")
+	require.NotEmpty(t, workers, "Stellar DON has no worker nodes")
+	requiredSignatures := (len(workers)-1)/3 + 1
+
+	workflowName := thelpers.UniqueStellarWorkflowName("stellar-df-cache-write")
+	forwarderAddr := stellarfeature.StellarForwarderAddress(tenv.CreEnvironment, stellarChain.ChainSelector())
+	registryChainBC, err := tenv.CreEnvironment.RegistryChain()
+	require.NoError(t, err, "failed to resolve registry chain")
+	registryChain, ok := registryChainBC.(*evm.Blockchain)
+	require.True(t, ok, "registry chain must be EVM, got %T", registryChainBC)
+	var workflowOwner [20]byte
+	copy(workflowOwner[:], registryChain.SethClient.MustGetRootKeyAddress().Bytes())
+	var workflowNameB [10]byte
+	copy(workflowNameB[:], workflows.HashTruncateName(workflowName))
+
+	var feedID [32]byte
+	copy(feedID[:], []byte("DF-25510-TEST-FEED"))
+	var dataID [16]byte
+	copy(dataID[:], feedID[:16])
+	answer := big.NewInt(123_456_789)
+	reportTS := uint64(time.Now().Unix())
+
+	cacheID, err := stellarfeature.DeployAndConfigureStellarDFCache(
+		ctx, stellarChain, dataID, "DF-25510 test feed",
+		forwarderAddr, workflowOwner, workflowNameB,
+	)
+	require.NoError(t, err, "failed to deploy and configure Stellar DF cache")
+	lggr.Info().Str("cache", cacheID).Msg("Deployed and configured Stellar DF cache")
+
+	payload, err := stellarfeature.BuildDFReportPayload([]stellarfeature.DFReportEntry{{
+		DataID:    feedID,
+		Answer:    answer,
+		Timestamp: reportTS,
+	}})
+	require.NoError(t, err, "failed to build DF report payload")
+
+	workflowConfig := thelpers.StellarWriteWorkflowConfig{
+		ChainSelector:      stellarChain.ChainSelector(),
+		WorkflowName:       workflowName,
+		ReceiverContractID: cacheID,
+		RequiredSignatures: requiredSignatures,
+		ReportPayloadHex:   hex.EncodeToString(payload),
+		CronSchedule:       thelpers.StellarTestCronSchedule(),
+	}
+
+	const workflowFileLocation = "./stellar/stellarwrite/main.go"
+	workflowID := thelpers.CompileAndDeployWorkflow(t, tenv, lggr, workflowName, &workflowConfig, workflowFileLocation)
+
+	expectedLog := "Stellar write consensus succeeded"
+	thelpers.WatchWorkflowLogs(t, lggr, userLogsCh, baseMessageCh, thelpers.WorkflowEngineInitErrorLog, expectedLog, thelpers.StellarWorkflowTimeout, thelpers.WithUserLogWorkflowID(workflowID))
+
+	require.Eventually(t, func() bool {
+		round, rErr := stellarfeature.DFCacheLatestRound(ctx, stellarChain, cacheID, dataID)
+		if rErr != nil {
+			lggr.Warn().Err(rErr).Msg("DF cache latest_round query failed; retrying")
+			return false
+		}
+		if round == nil {
+			return false
+		}
+		return round.Answer.Cmp(answer) == 0 && round.Timestamp == reportTS
+	}, 2*time.Minute, 5*time.Second, "DF cache did not record the expected round")
+	lggr.Info().Str("cache", cacheID).Msg("Stellar DF cache write test passed")
 }
 
 // setupStellarScenario provisions an isolated per-test context for a Stellar read scenario:

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -408,6 +408,7 @@ type StellarWriteWorkflowConfig struct {
 	ReportPayloadHex   string `yaml:"reportPayloadHex"`
 	RequiredSignatures int    `yaml:"requiredSignatures"`
 	ExpectFailure      bool   `yaml:"expectFailure"`
+	CronSchedule       string `yaml:"cronSchedule"`
 }
 
 // WorkflowRegistrationConfig holds configuration for workflow registration


### PR DESCRIPTION
## Summary
- Adds a smoke scenario proving the full Stellar Data Feeds write path end to end: a CRE workflow generates an OCR report, the Soroban forwarder verifies it, and the real Data Feeds cache contract records the round, which the test reads back and checks value by value.
- All changes live in the system-tests tree; no deployment packages are touched.

## Context
The existing Stellar write test proves delivery to a stub receiver. This scenario is the Aptos-parity version for Data Feeds: the receiver is the production cache contract, so it exercises the cache's permission model (allowed sender, workflow owner, workflow name) and its report decoding, not just the forwarder.

The test deploys and configures the cache through the chainlink-stellar generated bindings client. The production deploy path is the Data Feeds changeset suite in chainlink-data-feeds, which this repo cannot import; the helper mirrors its operations for the local environment.

## Changes
- **Cache helper**: new `system-tests/lib/cre/features/stellar/stellar_cache.go` deploys the cache with the deployer's constructor-args call, registers the feed admin, sets the feed config permitting the forwarder plus workflow identity, builds the XDR report payload, and reads `latest_round` back.
- **Scenario**: `executeStellarDFCacheWriteTest` drives the stock stellarwrite workflow with the host-built payload (deterministic, so consensus nodes agree byte for byte) and asserts the decoded answer and timestamp on-chain. Registered in the Stellar suite alongside the existing read and write cases.
- **Cron**: the write workflow's trigger schedule becomes configurable so local runs can use a faster tick; the default stays at thirty seconds.
- **Pins**: the two system-tests modules pin chainlink-stellar to an integration branch that carries the Data Feeds cache bindings and the embedded cache WASM. To be re-pinned to main once the upstream Data Feeds PRs land.

## Testing
- Suite package vets and builds against the pin; the scenario's earlier revision passed the full local run with the on-chain round byte-verified (decoded answer 123456789 and timestamp via latest_round). Re-running the suite on this revision is pending the upstream pin settling.

## Notes
- The chainlink-stellar pin points at integration branch `feature/stellar-df-cache-e2e-v2` (main plus cache/proxy bindings, scval and deployer additions, and embedded Data Feeds artifacts). It must be re-pinned when that work merges upstream properly.