### PR TITLE
[CRE] Releases: turn off draft PRs and add manual action

### DIFF
--- a/.github/actions/deploy-cre-products/action.yml
+++ b/.github/actions/deploy-cre-products/action.yml
@@ -1,0 +1,61 @@
+name: deploy-cre-products
+description: "Deploy a chainlink image to every CRE product target"
+
+inputs:
+  aws-role-arn:
+    description: "AWS role ARN for GATI"
+    required: true
+  aws-lambda-url:
+    description: "AWS Lambda URL for GATI"
+    required: true
+  aws-region:
+    description: "AWS region"
+    required: true
+  repo-destination:
+    description: "Destination repository for deployment"
+    required: true
+  oci-image-tag:
+    description: "OCI image tag to deploy"
+    required: true
+  pr-close-enabled:
+    description: "Optionally close previous PRs."
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Deploy CRE
+      uses: ./.github/actions/deploy-image
+      with:
+        aws-role-arn: ${{ inputs.aws-role-arn }}
+        aws-lambda-url: ${{ inputs.aws-lambda-url }}
+        aws-region: ${{ inputs.aws-region }}
+        repo-destination: ${{ inputs.repo-destination }}
+        oci-image-tag: ${{ inputs.oci-image-tag }}
+        oci-repository-url: public.ecr.aws/chainlink/chainlink
+        pr-close-enabled: ${{ inputs.pr-close-enabled }}
+        pr-draft: false
+        pr-labels: ""
+        products: |
+          cre-mainline-staging_zone-a
+          cre-mainline-staging_zone-b
+          cre-mainline-prod_zone-a
+          cre-mainline-prod_zone-b
+          cre-mainline-prod_zone-global
+          cre-mainline-prod_testnet-group-1
+          cre-mainline-prod_testnet-group-2
+          cre-mainline-prod_testnet-group-3
+          cre-mainline-prod_testnet-group-4
+          cre-df-staging_zone-a
+          cre-df-staging_zone-b
+          cre-df-prod_zone-a
+          cre-df-prod_zone-b
+          cre-bcm-prod_zone-a-group-1
+          cre-bcm-prod_zone-a-group-2
+          cre-bcm-prod_zone-a-group-3
+          cre-bcm-prod_zone-a-group-4
+          cre-bcm-prod_zone-b-group-1
+          cre-bcm-prod_zone-b-group-2
+          cre-bcm-prod_zone-b-group-3
+          cre-reliability

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -220,38 +220,13 @@ jobs:
 
       - name: Deploy CRE RC
         if: needs.checks.outputs.prerelease-phase == 'rc'
-        uses: ./.github/actions/deploy-image
+        uses: ./.github/actions/deploy-cre-products
         with:
           aws-role-arn: ${{ secrets.AWS_RELENG_PROD_GATI_WORKFLOW_INVOKE_ARN }}
           aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
           aws-region: ${{ secrets.AWS_REGION }}
           repo-destination: ${{ secrets.REPO_K8S_DEPLOY }}
           oci-image-tag: ${{ needs.docker-core.outputs.docker-manifest-tag }}
-          oci-repository-url: public.ecr.aws/chainlink/chainlink
-          pr-close-enabled: false
-          pr-labels: ""
-          products: |
-            cre-mainline-staging_zone-a
-            cre-mainline-staging_zone-b
-            cre-mainline-prod_zone-a
-            cre-mainline-prod_zone-b
-            cre-mainline-prod_zone-global
-            cre-mainline-prod_testnet-group-1
-            cre-mainline-prod_testnet-group-2
-            cre-mainline-prod_testnet-group-3
-            cre-mainline-prod_testnet-group-4
-            cre-df-staging_zone-a
-            cre-df-staging_zone-b
-            cre-df-prod_zone-a
-            cre-df-prod_zone-b
-            cre-bcm-prod_zone-a-group-1
-            cre-bcm-prod_zone-a-group-2
-            cre-bcm-prod_zone-a-group-3
-            cre-bcm-prod_zone-a-group-4
-            cre-bcm-prod_zone-b-group-1
-            cre-bcm-prod_zone-b-group-2
-            cre-bcm-prod_zone-b-group-3
-            cre-reliability
 
   # Notify Slack channel for new git tags associated with pre-releases.
   # Final release notifications originate from the release coordinator repo.

--- a/.github/workflows/deploy-cre-manual.yml
+++ b/.github/workflows/deploy-cre-manual.yml
@@ -1,0 +1,62 @@
+name: "Deploy CRE (Manual)"
+
+# Manually bump CRE to a chainlink image that's already been published, e.g. a
+# hotfix RC that build-publish.yml skipped deploying automatically.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Chainlink release tag already built and pushed (e.g. "v2.38.1-rc.0")'
+        required: true
+      pr-close-enabled:
+        description: "Close previously opened deploy PRs before opening a new one"
+        required: false
+        default: true
+        type: boolean
+
+permissions: {}
+
+jobs:
+  validate:
+    name: "Validate"
+    if: github.repository == 'smartcontractkit/chainlink'
+    runs-on: ubuntu-24.04
+    permissions: {}
+    outputs:
+      oci-image-tag: ${{ steps.parse.outputs.oci-image-tag }}
+    steps:
+      - name: Parse and validate version input
+        id: parse
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+            echo "::error::version must be an RC tag like v2.38.1-rc.0 (CRE is only ever deployed at rc phase), got: $VERSION"
+            exit 1
+          fi
+          echo "oci-image-tag=${VERSION#v}" | tee -a "$GITHUB_OUTPUT"
+
+  deploy:
+    name: "Deploy CRE"
+    needs: [validate]
+    if: github.repository == 'smartcontractkit/chainlink'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Deploy CRE
+        uses: ./.github/actions/deploy-cre-products
+        with:
+          aws-role-arn: ${{ secrets.AWS_RELENG_PROD_GATI_WORKFLOW_INVOKE_ARN }}
+          aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          repo-destination: ${{ secrets.REPO_K8S_DEPLOY }}
+          oci-image-tag: ${{ needs.validate.outputs.oci-image-tag }}
+          pr-close-enabled: ${{ inputs.pr-close-enabled }}


### PR DESCRIPTION
1. bump PRs don't open as a draft PR (saves 1 click per PR)
2. a manual triggered workflow to be used for hotfixes, otherwise hotfix bumps would still be by hand
    input:
    - version (version has to already be cut)
    - whether to clobber old already open PRs