### PR TITLE
fix(capabilities/fakes): sanitize HTTP response headers to valid UTF-8

### DIFF
--- a/core/capabilities/fakes/confidential_http_action.go
+++ b/core/capabilities/fakes/confidential_http_action.go
@@ -241,8 +241,13 @@ func (fh *DirectConfidentialHTTPAction) SendRequest(ctx context.Context, metadat
 	// Convert response headers to map[string]*HeaderValues
 	responseHeaders := make(map[string]*confidentialhttp.HeaderValues)
 	for name, values := range resp.Header {
-		responseHeaders[name] = &confidentialhttp.HeaderValues{
-			Values: values,
+		// Sanitize invalid UTF-8: proto string fields must be valid UTF-8 to marshal over gRPC.
+		sanitized := make([]string, len(values))
+		for i, v := range values {
+			sanitized[i] = sanitizeUTF8(v)
+		}
+		responseHeaders[sanitizeUTF8(name)] = &confidentialhttp.HeaderValues{
+			Values: sanitized,
 		}
 	}
 

--- a/core/capabilities/fakes/http_action.go
+++ b/core/capabilities/fakes/http_action.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"slices"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	commonCap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
@@ -158,8 +158,16 @@ func (fh *DirectHTTPAction) SendRequest(ctx context.Context, metadata commonCap.
 		if len(v) == 0 {
 			continue
 		}
-		headers[k] = strings.Join(v, ", ")
-		multiHeaders[k] = &customhttp.HeaderValues{Values: slices.Clone(v)}
+		// HTTP header names/values may contain arbitrary bytes, but the proto
+		// HeaderValues fields are strings and must be valid UTF-8 to marshal
+		// over gRPC. Sanitize any invalid UTF-8 to avoid marshaling failures.
+		key := sanitizeUTF8(k)
+		sanitized := make([]string, len(v))
+		for i, val := range v {
+			sanitized[i] = sanitizeUTF8(val)
+		}
+		headers[key] = strings.Join(sanitized, ", ")
+		multiHeaders[key] = &customhttp.HeaderValues{Values: sanitized}
 	}
 
 	// Create response
@@ -242,4 +250,15 @@ func (fh *DirectHTTPAction) RegisterToWorkflow(ctx context.Context, request comm
 func (fh *DirectHTTPAction) UnregisterFromWorkflow(ctx context.Context, request commonCap.UnregisterFromWorkflowRequest) error {
 	fh.eng.Infow("Unregistered from Direct Http Action", "workflowID", request.Metadata.WorkflowID)
 	return nil
+}
+
+// sanitizeUTF8 returns s unchanged if it is already valid UTF-8, otherwise it
+// replaces every invalid byte with the Unicode replacement character (U+FFFD).
+// HTTP header names/values may contain arbitrary bytes, but proto string fields
+// must be valid UTF-8 to marshal over gRPC.
+func sanitizeUTF8(s string) string {
+	if utf8.ValidString(s) {
+		return s
+	}
+	return strings.ToValidUTF8(s, "�")
 }

--- a/core/capabilities/fakes/sanitize_test.go
+++ b/core/capabilities/fakes/sanitize_test.go
@@ -1,0 +1,22 @@
+package fakes
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeUTF8(t *testing.T) {
+	t.Run("returns valid strings unchanged", func(t *testing.T) {
+		for _, s := range []string{"", "ascii", "héllo wörld", "日本語", "emoji 🚀"} {
+			require.Equal(t, s, sanitizeUTF8(s))
+		}
+	})
+
+	t.Run("replaces invalid bytes with U+FFFD", func(t *testing.T) {
+		got := sanitizeUTF8("a" + string([]byte{0xff}) + "b")
+		require.True(t, utf8.ValidString(got))
+		require.Equal(t, "a�b", got)
+	})
+}

--- a/core/capabilities/fakes/sanitize_test.go
+++ b/core/capabilities/fakes/sanitize_test.go
@@ -8,13 +8,16 @@ import (
 )
 
 func TestSanitizeUTF8(t *testing.T) {
+	t.Parallel()
 	t.Run("returns valid strings unchanged", func(t *testing.T) {
+		t.Parallel()
 		for _, s := range []string{"", "ascii", "héllo wörld", "日本語", "emoji 🚀"} {
 			require.Equal(t, s, sanitizeUTF8(s))
 		}
 	})
 
 	t.Run("replaces invalid bytes with U+FFFD", func(t *testing.T) {
+		t.Parallel()
 		got := sanitizeUTF8("a" + string([]byte{0xff}) + "b")
 		require.True(t, utf8.ValidString(got))
 		require.Equal(t, "a�b", got)


### PR DESCRIPTION
## Problem

The fake HTTP action and confidential-HTTP action capabilities (`core/capabilities/fakes`) copied upstream response header names/values — arbitrary bytes from Go's `http.Header` — directly into the proto `HeaderValues` string fields. A non-UTF-8 header caused gRPC marshaling to fail:

```
grpc: error while marshaling: string field contains invalid UTF-8
```

(Response bodies are `[]byte` and were unaffected.)

## Fix

Both fakes now sanitize header names and values via a `sanitizeUTF8` helper, replacing invalid bytes with U+FFFD while leaving already-valid strings untouched:

- `core/capabilities/fakes/http_action.go`
- `core/capabilities/fakes/confidential_http_action.go`

## Tests

- `TestSanitizeUTF8` (`core/capabilities/fakes/sanitize_test.go`) — returns valid inputs unchanged (ASCII, accented, CJK, emoji, empty); replaces invalid bytes with U+FFFD.

All pass locally.

## Context

Part of a cross-repo fix for the same pattern. Sibling PRs fix the real HTTP action capability (`smartcontractkit/capabilities`) and the confidential-http enclave capability (`chainlink-confidential-compute`). The HTTP **trigger** capability was audited and is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)