### PR TITLE
feat: add per-DON gateway count metric to gateway connector

### DIFF
--- a/core/capabilities/gateway_connector/service_wrapper.go
+++ b/core/capabilities/gateway_connector/service_wrapper.go
@@ -117,9 +117,9 @@ func (e *ServiceWrapper) Start(ctx context.Context) error {
 		// stays empty and the connector skips metric recording.
 		csaKeyID := ""
 		if e.csa != nil {
-			csaKey, err := keystore.GetDefault(ctx, e.csa)
-			if err != nil {
-				return fmt.Errorf("failed to resolve CSA key for gateway connector: %w", err)
+			csaKey, csaErr := keystore.GetDefault(ctx, e.csa)
+			if csaErr != nil {
+				return fmt.Errorf("failed to resolve CSA key for gateway connector: %w", csaErr)
 			}
 			csaKeyID = csaKey.ID()
 		}

--- a/core/capabilities/gateway_connector/service_wrapper.go
+++ b/core/capabilities/gateway_connector/service_wrapper.go
@@ -41,12 +41,16 @@ type ServiceWrapper struct {
 	connector             connector.GatewayConnector
 	lggr                  logger.Logger
 	clock                 clockwork.Clock
+	csa                   keystore.CSA
 	discoveredNodeAddress string // Stores auto-discovered node address if not configured
 }
 
 // NOTE: this wrapper is needed to make sure that our services are started after Keystore.
 // keystore is used for signing operations.
 // chainID is the chain ID for which keys should be discovered.
+// csa is the CSA keystore used to resolve the node's CSA key ID for metrics
+// labeling. May be nil for callers that do not have a CSA keystore available;
+// in that case the per-DON gateway count metric is not recorded.
 func NewGatewayConnectorServiceWrapper(
 	config config.GatewayConnector,
 	keystore Keystore,
@@ -54,6 +58,7 @@ func NewGatewayConnectorServiceWrapper(
 	chainID *big.Int,
 	clock clockwork.Clock,
 	lggr logger.Logger,
+	csa keystore.CSA,
 ) *ServiceWrapper {
 	return &ServiceWrapper{
 		stopCh:   make(services.StopChan),
@@ -63,6 +68,7 @@ func NewGatewayConnectorServiceWrapper(
 		chainID:  chainID,
 		clock:    clock,
 		lggr:     logger.Named(lggr, "GatewayConnectorServiceWrapper"),
+		csa:      csa,
 	}
 }
 
@@ -105,7 +111,20 @@ func (e *ServiceWrapper) Start(ctx context.Context) error {
 			translated.NodeAddress = nodeAddress
 		}
 
-		e.connector, err = connector.NewGatewayConnector(&translated, e, e.clock, e.lggr)
+		// Resolve the node's CSA key ID for metrics labeling. EnsureKey is
+		// called defensively via keystore.GetDefault so a missing key is
+		// created before lookup. When no CSA keystore is wired in, csaKeyID
+		// stays empty and the connector skips metric recording.
+		csaKeyID := ""
+		if e.csa != nil {
+			csaKey, err := keystore.GetDefault(ctx, e.csa)
+			if err != nil {
+				return fmt.Errorf("failed to resolve CSA key for gateway connector: %w", err)
+			}
+			csaKeyID = csaKey.ID()
+		}
+
+		e.connector, err = connector.NewGatewayConnector(&translated, e, e.clock, e.lggr, csaKeyID)
 		if err != nil {
 			return err
 		}

--- a/core/capabilities/gateway_connector/service_wrapper_test.go
+++ b/core/capabilities/gateway_connector/service_wrapper_test.go
@@ -123,7 +123,7 @@ func generateWrapper(t *testing.T, privateKey *ecdsa.PrivateKey, keystoreKey *ec
 
 	ethKeystore := &keystest.FakeChainStore{Addresses: keystest.Addresses{keystoreKeyV2.Address}}
 	gc := config.Capabilities().GatewayConnector()
-	wrapper := gatewayconnector.NewGatewayConnectorServiceWrapper(gc, ethKeystore, nil, big.NewInt(1), clockwork.NewFakeClock(), lggr)
+	wrapper := gatewayconnector.NewGatewayConnectorServiceWrapper(gc, ethKeystore, nil, big.NewInt(1), clockwork.NewFakeClock(), lggr, nil)
 	return wrapper, nil
 }
 
@@ -173,6 +173,7 @@ func setupAutoDiscoverTest(
 		big.NewInt(1),
 		clockwork.NewFakeClock(),
 		lggr,
+		nil,
 	), nil
 }
 

--- a/core/scripts/gateway/connector/run_connector.go
+++ b/core/scripts/gateway/connector/run_connector.go
@@ -89,7 +89,7 @@ func main() {
 	}
 	client := &client{privateKey: sampleKey, lggr: lggr}
 	// client acts as a signer here
-	connector, _ := connector.NewGatewayConnector(&cfg, client, clockwork.NewRealClock(), lggr)
+	connector, _ := connector.NewGatewayConnector(&cfg, client, clockwork.NewRealClock(), lggr, "")
 	err = connector.AddHandler(context.Background(), []string{"test_method"}, client)
 	if err != nil {
 		fmt.Println("error adding handler:", err)

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -362,7 +362,8 @@ func newGatewayConnectorWrapper(
 		keyStore.Eth(),
 		chainID,
 		clockwork.NewRealClock(),
-		lggr)
+		lggr,
+		keyStore.CSA())
 
 	return wrapper, nil
 }

--- a/core/services/gateway/connector/connector.go
+++ b/core/services/gateway/connector/connector.go
@@ -116,10 +116,7 @@ func NewGatewayConnector(config *ConnectorConfig, signer Signer, clock clockwork
 	}
 	metrics, err := newConnectorMetrics()
 	if err != nil {
-		// Metrics are non-essential; log and continue without them rather than
-		// failing connector construction.
-		lggr.Warnw("failed to initialize gateway connector metrics", "err", err)
-		metrics = nil
+		return nil, fmt.Errorf("failed to create gateway connector metrics: %w", err)
 	}
 	connector := &gatewayConnector{
 		config:      config,

--- a/core/services/gateway/connector/connector.go
+++ b/core/services/gateway/connector/connector.go
@@ -56,6 +56,7 @@ type gatewayConnector struct {
 	config      *ConnectorConfig
 	clock       clockwork.Clock
 	nodeAddress []byte
+	csaKey      string
 	signer      Signer
 	handlersMu  sync.RWMutex
 	handlers    map[string]core.GatewayConnectorHandler
@@ -64,6 +65,7 @@ type gatewayConnector struct {
 	closeWait   sync.WaitGroup
 	shutdownCh  services.StopChan
 	lggr        logger.Logger
+	metrics     *connectorMetrics
 }
 
 func (c *gatewayConnector) HealthReport() map[string]error {
@@ -101,7 +103,7 @@ func (gs *gatewayState) awaitConn(ctx context.Context) error {
 	}
 }
 
-func NewGatewayConnector(config *ConnectorConfig, signer Signer, clock clockwork.Clock, lggr logger.Logger) (*gatewayConnector, error) {
+func NewGatewayConnector(config *ConnectorConfig, signer Signer, clock clockwork.Clock, lggr logger.Logger, csaKey string) (*gatewayConnector, error) {
 	if config == nil || signer == nil || clock == nil || lggr == nil {
 		return nil, errors.New("nil dependency")
 	}
@@ -112,14 +114,23 @@ func NewGatewayConnector(config *ConnectorConfig, signer Signer, clock clockwork
 	if err != nil {
 		return nil, err
 	}
+	metrics, err := newConnectorMetrics()
+	if err != nil {
+		// Metrics are non-essential; log and continue without them rather than
+		// failing connector construction.
+		lggr.Warnw("failed to initialize gateway connector metrics", "err", err)
+		metrics = nil
+	}
 	connector := &gatewayConnector{
 		config:      config,
 		clock:       clock,
 		nodeAddress: addressBytes,
+		csaKey:      csaKey,
 		signer:      signer,
 		handlers:    make(map[string]core.GatewayConnectorHandler),
 		shutdownCh:  make(chan struct{}),
 		lggr:        logger.Named(lggr, "GatewayConnector"),
+		metrics:     metrics,
 	}
 	gateways := make(map[string]*gatewayState)
 	urlToId := make(map[string]string)
@@ -328,6 +339,7 @@ func (c *gatewayConnector) reconnectLoop(gatewayState *gatewayState) {
 func (c *gatewayConnector) Start(ctx context.Context) error {
 	return c.StartOnce("GatewayConnector", func() error {
 		c.lggr.Info("starting gateway connector")
+		c.recordGatewaysPerDon(ctx)
 		for _, gatewayState := range c.gateways {
 			if err := gatewayState.conn.Start(ctx); err != nil {
 				return err
@@ -338,6 +350,27 @@ func (c *gatewayConnector) Start(ctx context.Context) error {
 		}
 		return nil
 	})
+}
+
+// recordGatewaysPerDon emits one gauge sample per DON ID configured on this
+// connector, labeled with the node's CSA key. In multi-DON mode each gateway's
+// DonID is used; in single-DON mode the top-level DonId is used. Recording is
+// skipped when the CSA key is empty or metrics are unavailable.
+func (c *gatewayConnector) recordGatewaysPerDon(ctx context.Context) {
+	if c.metrics == nil || c.csaKey == "" {
+		return
+	}
+	counts := make(map[string]int)
+	for _, gw := range c.config.Gateways {
+		donID := gw.DonID
+		if donID == "" {
+			donID = c.config.DonId
+		}
+		counts[donID]++
+	}
+	for donID, count := range counts {
+		c.metrics.recordGatewaysPerDon(ctx, c.csaKey, donID, count)
+	}
 }
 
 func (c *gatewayConnector) Close() error {

--- a/core/services/gateway/connector/connector_test.go
+++ b/core/services/gateway/connector/connector_test.go
@@ -48,7 +48,7 @@ func newTestConnector(t *testing.T, config *ConnectorConfig) (*gatewayConnector,
 	signer := gatewaymocks.NewSigner(t)
 	handler := gatewaymocks.NewGatewayConnectorHandler(t)
 	clock := clockwork.NewFakeClock()
-	connector, err := NewGatewayConnector(config, signer, clock, logger.Test(t))
+	connector, err := NewGatewayConnector(config, signer, clock, logger.Test(t), "")
 	require.NoError(t, err)
 	require.NoError(t, connector.AddHandler(t.Context(), []string{testMethod1}, handler))
 	return connector, signer, handler
@@ -129,7 +129,7 @@ URL = "ws://localhost:8081/node"
 	for name, config := range invalidCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			_, err := NewGatewayConnector(parseTOMLConfig(t, config), signer, clock, logger.Test(t))
+			_, err := NewGatewayConnector(parseTOMLConfig(t, config), signer, clock, logger.Test(t), "")
 			require.Error(t, err)
 		})
 	}

--- a/core/services/gateway/connector/metrics.go
+++ b/core/services/gateway/connector/metrics.go
@@ -1,0 +1,40 @@
+package connector
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+)
+
+// connectorMetrics holds Beholder-backed metrics for the gateway connector.
+type connectorMetrics struct {
+	gatewaysPerDon metric.Int64Gauge
+}
+
+// newConnectorMetrics constructs the connector metrics. Returns nil and a
+// non-nil error if the Beholder meter is unavailable; callers should treat a
+// nil *connectorMetrics as "metrics disabled" and skip recording.
+func newConnectorMetrics() (*connectorMetrics, error) {
+	gatewaysPerDon, err := beholder.GetMeter().Int64Gauge("platform_gateway_connector_gateways_per_don")
+	if err != nil {
+		return nil, err
+	}
+	return &connectorMetrics{gatewaysPerDon: gatewaysPerDon}, nil
+}
+
+// recordGatewaysPerDon records the number of gateways configured on this node's
+// gateway connector for a given DON ID. csaKey is the node's CSA key ID (hex)
+// and is used as the per-node label. When csaKey is empty the call is a no-op
+// so that unlabeled series are never emitted.
+func (m *connectorMetrics) recordGatewaysPerDon(ctx context.Context, csaKey, donID string, count int) {
+	if m == nil || csaKey == "" {
+		return
+	}
+	m.gatewaysPerDon.Record(ctx, int64(count), metric.WithAttributes(
+		attribute.String("csa_key", csaKey),
+		attribute.String("gateway_don_id", donID),
+	))
+}

--- a/core/services/gateway/connector/validate_config_test.go
+++ b/core/services/gateway/connector/validate_config_test.go
@@ -138,7 +138,7 @@ func TestNewGatewayConnector_ConfigValidation(t *testing.T) {
 	t.Run("legacy config passes", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewGatewayConnector(validConnectorConfig(), signer, clock, lggr)
+		_, err := NewGatewayConnector(validConnectorConfig(), signer, clock, lggr, "")
 		require.NoError(t, err)
 	})
 
@@ -151,7 +151,7 @@ func TestNewGatewayConnector_ConfigValidation(t *testing.T) {
 			{ID: "gateway_eu_1", DonID: "gateway_don_eu", URL: "ws://localhost:8081/eu-1"},
 		}
 
-		_, err := NewGatewayConnector(cfg, signer, clock, lggr)
+		_, err := NewGatewayConnector(cfg, signer, clock, lggr, "")
 		require.NoError(t, err)
 	})
 
@@ -164,7 +164,7 @@ func TestNewGatewayConnector_ConfigValidation(t *testing.T) {
 			{ID: "gateway_eu", URL: "ws://localhost:8081/eu"},
 		}
 
-		_, err := NewGatewayConnector(cfg, signer, clock, lggr)
+		_, err := NewGatewayConnector(cfg, signer, clock, lggr, "")
 		require.EqualError(t, err, "all gateways must set DonID when multi-DON mode is enabled")
 	})
 }

--- a/core/services/gateway/integration_tests/gateway_integration_test.go
+++ b/core/services/gateway/integration_tests/gateway_integration_test.go
@@ -202,7 +202,7 @@ func TestIntegration_Gateway_NoFullNodes_BasicConnectionAndMessage(t *testing.T)
 	// Launch Connector
 	client := &client{privateKey: nodeKeys.PrivateKey}
 	// client acts as a signer here
-	connector, err := connector.NewGatewayConnector(parseConnectorConfig(t, nodeConfigTemplate, nodeKeys.Address, nodeURL), client, clockwork.NewRealClock(), lggr)
+	connector, err := connector.NewGatewayConnector(parseConnectorConfig(t, nodeConfigTemplate, nodeKeys.Address, nodeURL), client, clockwork.NewRealClock(), lggr, "")
 	require.NoError(t, err)
 	require.NoError(t, connector.AddHandler(t.Context(), []string{"test"}, client))
 	client.connector = connector

--- a/core/services/ocr2/plugins/functions/plugin.go
+++ b/core/services/ocr2/plugins/functions/plugin.go
@@ -217,7 +217,7 @@ func NewConnector(ctx context.Context, pluginConfig *config.PluginConfig, ethKey
 		return nil, nil, err
 	}
 	// handler acts as a signer here
-	connector, err := connector.NewGatewayConnector(pluginConfig.GatewayConnectorConfig, handler, clockwork.NewRealClock(), lggr)
+	connector, err := connector.NewGatewayConnector(pluginConfig.GatewayConnectorConfig, handler, clockwork.NewRealClock(), lggr, "")
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Summary

Adds a Beholder gauge metric `platform_gateway_connector_gateways_per_don` that records, per node CSA key, the number of gateways configured for each DON ID on the gateway connector. This enables an o11y dashboard tracking which labeled DONs external NOPs route through a given node and how many gateways back each one.

## Metric

| Field | Value |
|-------|-------|
| Name | `platform_gateway_connector_gateways_per_don` |
| Type | Gauge (Beholder / OpenTelemetry) |
| Labels | `csa_key`, `gateway_don_id` |
| Value | count of gateways configured for that DON ID on this node's connector |
