### PR TITLE
(feat): Add branch override and title override to bump PR pipeline

### DIFF
--- a/.github/actions/deploy-cre-products/action.yml
+++ b/.github/actions/deploy-cre-products/action.yml
@@ -21,6 +21,12 @@ inputs:
     description: "Optionally close previous PRs."
     required: false
     default: "false"
+  pr-head-branch-override:
+    description: "Override the head branch for the PR. A literal '{product}' token is replaced with the product name. Otherwise, auto generate one."
+    required: false
+  pr-title-override:
+    description: "Override the title for the PR. A literal '{product}' token is replaced with the product name. Otherwise, auto generate one."
+    required: false
 
 runs:
   using: composite
@@ -35,6 +41,8 @@ runs:
         oci-image-tag: ${{ inputs.oci-image-tag }}
         oci-repository-url: public.ecr.aws/chainlink/chainlink
         pr-close-enabled: ${{ inputs.pr-close-enabled }}
+        pr-head-branch-override: ${{ inputs.pr-head-branch-override }}
+        pr-title-override: ${{ inputs.pr-title-override }}
         pr-draft: false
         pr-labels: ""
         products: |

--- a/.github/actions/deploy-image/action.yml
+++ b/.github/actions/deploy-image/action.yml
@@ -44,6 +44,12 @@ inputs:
     description: "Whether to create pull request as draft"
     required: false
     default: "true"
+  pr-head-branch-override:
+    description: "Override the head branch for the PR. A literal '{product}' token is replaced with the product name. Otherwise, auto generate one."
+    required: false
+  pr-title-override:
+    description: "Override the title for the PR. A literal '{product}' token is replaced with the product name. Otherwise, auto generate one."
+    required: false
   products:
     description: "Products to deploy (multiline string)"
     required: true
@@ -76,6 +82,8 @@ runs:
         PR_BASE_BRANCH: ${{ inputs.pr-base-branch }}
         PR_LABELS: ${{ inputs.pr-labels }}
         PR_DRAFT: ${{ inputs.pr-draft }}
+        PR_HEAD_BRANCH_OVERRIDE: ${{ inputs.pr-head-branch-override }}
+        PR_TITLE_OVERRIDE: ${{ inputs.pr-title-override }}
         PRODUCTS: ${{ inputs.products }}
       run: |
         gh workflow run "${WORKFLOW_FILE_NAME}" \
@@ -87,4 +95,6 @@ runs:
           --field "pr-labels=${PR_LABELS}" \
           --field "pr-draft=${PR_DRAFT}" \
           --field "pr-close-enabled=${{ inputs.pr-close-enabled }}" \
+          --field "pr-head-branch-override=${PR_HEAD_BRANCH_OVERRIDE}" \
+          --field "pr-title-override=${PR_TITLE_OVERRIDE}" \
           --field "products=${PRODUCTS}"

--- a/.github/workflows/deploy-cre-manual.yml
+++ b/.github/workflows/deploy-cre-manual.yml
@@ -2,6 +2,10 @@ name: "Deploy CRE (Manual)"
 
 # Manually bump CRE to a chainlink image that's already been published, e.g. a
 # hotfix RC that build-publish.yml skipped deploying automatically.
+#
+# Uses a version-specific branch/PR per product (instead of the standing
+# auto/deploy-<product> branch the automatic RC pipeline reuses), so a manual
+# bump never overwrites whatever the standing deploy PR currently points to.
 
 on:
   workflow_dispatch:
@@ -9,11 +13,6 @@ on:
       version:
         description: 'Chainlink release tag already built and pushed (e.g. "v2.38.1-rc.0")'
         required: true
-      pr-close-enabled:
-        description: "Close previously opened deploy PRs before opening a new one"
-        required: false
-        default: true
-        type: boolean
 
 permissions: {}
 
@@ -59,4 +58,5 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           repo-destination: ${{ secrets.REPO_K8S_DEPLOY }}
           oci-image-tag: ${{ needs.validate.outputs.oci-image-tag }}
-          pr-close-enabled: ${{ inputs.pr-close-enabled }}
+          pr-head-branch-override: auto/deploy-{product}-${{ needs.validate.outputs.oci-image-tag }}
+          pr-title-override: "{product} - Deploy ${{ needs.validate.outputs.oci-image-tag }}"


### PR DESCRIPTION
## Why this change?

Currently the version bump PRs clobbers the previously open ones. This makes hot fixes tricky, because weekly release train PRs get overwritten.

By overriding the branch we can have a unique branch per version.
By overriding the title we can have the version in the title. 