### PR TITLE
fix(cre): wire ChainWrite.TargetsLimit to non-EVM WriteReport capabilities

### DIFF
--- a/.changeset/beholder-telemetry-metric-cardinality-limit.md
+++ b/.changeset/beholder-telemetry-metric-cardinality-limit.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#added Add `Telemetry.MetricCardinalityLimit` config to support limiting Beholder OTel SDK metric cardinality.

--- a/.changeset/classified-execution-status.md
+++ b/.changeset/classified-execution-status.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#added The v2 workflow engine now emits `ClassifiedExecutionStatus` on `WorkflowExecutionFinished` events, distinguishing failures caused by the user's workflow (`USER_ERROR`) from platform/infrastructure failures (`SYSTEM_ERROR`). The v1 engine is unaffected.

--- a/.changeset/fix-workflow-store-mem-leak.md
+++ b/.changeset/fix-workflow-store-mem-leak.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix Rebuild the in-memory workflow execution store's map when pruning so old bucket storage becomes eligible for GC. Go maps never shrink after deletes, which stranded memory as the store churned through millions of executions.

--- a/.changeset/minor-bump-1784128294.md
+++ b/.changeset/minor-bump-1784128294.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-Minor bump to start next version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog Chainlink Core
 
+## 2.57.0
+
+### Minor Changes
+
+- [#23084](https://github.com/smartcontractkit/chainlink/pull/23084) [`3007515`](https://github.com/smartcontractkit/chainlink/commit/3007515ee09add2c991511c61ce36ededaff8f64) - #added Add `Telemetry.MetricCardinalityLimit` config to support limiting Beholder OTel SDK metric cardinality.
+
+- [#23136](https://github.com/smartcontractkit/chainlink/pull/23136) [`aa67b6b`](https://github.com/smartcontractkit/chainlink/commit/aa67b6b6bb599eeeea06ed5baa12b8b95b03e50e) - #added The v2 workflow engine now emits `ClassifiedExecutionStatus` on `WorkflowExecutionFinished` events, distinguishing failures caused by the user's workflow (`USER_ERROR`) from platform/infrastructure failures (`SYSTEM_ERROR`). The v1 engine is unaffected.
+
+- [#23134](https://github.com/smartcontractkit/chainlink/pull/23134) [`46a0f6e`](https://github.com/smartcontractkit/chainlink/commit/46a0f6e77b5f06eebdfe9143b2d30ac6dfb6262a) - Minor bump to start next version
+
+### Patch Changes
+
+- [#22708](https://github.com/smartcontractkit/chainlink/pull/22708) [`db2daaa`](https://github.com/smartcontractkit/chainlink/commit/db2daaa270901330ead425a8206a27422f0e239d) - #bugfix Rebuild the in-memory workflow execution store's map when pruning so old bucket storage becomes eligible for GC. Go maps never shrink after deletes, which stranded memory as the store churned through millions of executions.
+
 ## 2.56.0
 
 ### Minor Changes

--- a/core/services/workflows/v2/capability_executor.go
+++ b/core/services/workflows/v2/capability_executor.go
@@ -64,7 +64,10 @@ func (c *ExecutionHelper) initLimiters(limiters *EngineLimiters) {
 		{"evm", "GetTransactionReceipt"}: limiters.ChainReadCalls,
 		{"evm", "HeaderByNumber"}:        limiters.ChainReadCalls,
 
-		{"evm", "WriteReport"}: limiters.ChainWriteTargets,
+		{"evm", "WriteReport"}:     limiters.ChainWriteTargets,
+		{"aptos", "WriteReport"}:   limiters.ChainWriteTargets,
+		{"solana", "WriteReport"}:  limiters.ChainWriteTargets,
+		{"stellar", "WriteReport"}: limiters.ChainWriteTargets,
 
 		{"http-actions", "SendRequest"}:      limiters.HTTPActionCalls,
 		{"confidential-http", "SendRequest"}: limiters.ConfidentialHTTPCalls,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.56.0",
+  "version": "2.57.0",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

`ChainWrite.TargetsLimit` in CRE settings was silently unthrottled for non-EVM chains. The `callLimiters` map in `capability_executor.go` only wired `ChainWriteTargets` to `{"evm", "WriteReport"}` — Aptos, Solana, and Stellar `WriteReport` calls bypassed the limiter entirely.

## The gap

The lookup at `capability_executor.go:101`:
```go
limiter, ok := c.callLimiters[capCall{name: capName, method: request.Method}]
if ok { /* apply limit */ }
// if !ok → limiter silently skipped
```

For an Aptos write, `ParseID("aptos:ChainSelector:4457093679053095497@1.0.0")` returns `name="aptos"`. The map only had `{"evm", "WriteReport"}` — so `ok=false` and the call proceeded unchecked.

| family | `WriteReport` exists? | In `callLimiters` (before) | In `callLimiters` (after) |
|---|---|---|---|
| `evm` | ✅ | ✅ | ✅ |
| `aptos` | ✅ | ❌ | ✅ |
| `solana` | ✅ | ❌ | ✅ |
| `stellar` | ✅ | ❌ | ✅ |

## The fix

Add 3 map entries — the limiter object (`limiters.ChainWriteTargets`) and settings schema (`cresettings.chainWrite.TargetsLimit`) already exist and are chain-family-agnostic:

```go
{"evm", "WriteReport"}:     limiters.ChainWriteTargets,
{"aptos", "WriteReport"}:   limiters.ChainWriteTargets,  // new
{"solana", "WriteReport"}:  limiters.ChainWriteTargets,  // new
{"stellar", "WriteReport"}: limiters.ChainWriteTargets,  // new
```

## Production impact

Any production workflow writing to Aptos/Solana/Stellar has **unlimited write targets** today, regardless of `ChainWrite.TargetsLimit` in the org-level CRE settings. With this fix, `TargetsLimit=0` correctly blocks all chain writes, not just EVM.

## How discovered

While debugging fire-drill `transmit_fault` scenarios in `chainlink-data-feeds`. We investigated whether `ChainWrite.TargetsLimit=0` could replace the bad-contract-address fault (hot-reloadable, no re-register), but found Aptos writes bypassed the limiter — leading to this fix.

## Test plan

- [ ] `go test ./core/services/workflows/v2/...` passes (verified locally)
- [ ] Existing EVM write-limit tests still pass (no behavioral change for EVM)
- [ ] Manual: set `ChainWrite.TargetsLimit = 0` on an Aptos-targeted workflow, verify writes are now blocked (previously: writes succeeded)