### PR TITLE
Bump confidential capabilities to 1.1.0

### DIFF
--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -123,10 +123,10 @@ plugins:
 
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "95807ca72dae84e8d31879db439a49748bf5c74a"
+      gitRef: "358ac8100efe55cea33a180f9c306eb5a166a4b3"
       installPath: "./cmd/confidential-http"
 
   confidential-workflows:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-workflows/capability"
-      gitRef: "95807ca72dae84e8d31879db439a49748bf5c74a"
+      gitRef: "358ac8100efe55cea33a180f9c306eb5a166a4b3"
       installPath: "./cmd/confidential-workflows"


### PR DESCRIPTION
Bumps capability binaries to the 1.1.0 release: https://github.com/smartcontractkit/chainlink-confidential-compute/releases/tag/1.1.0