### PR TITLE
fix(cre): wire ChainWrite.TargetsLimit to non-EVM WriteReport capabilities

### DIFF
--- a/core/scripts/cre/environment/configs/workflow-gateway-don-stellar.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-don-stellar.toml
@@ -35,7 +35,7 @@
   # Stellar chains this DON supports (string network ids), used for key generation and node relayer config.
   supported_stellar_chains = ["baefd734b8d3e48472cff83912375fedbc7573701912fe308af730180f97d74a"]
   # Workflow runtime limits need both the EVM registry chain (1337) and the Stellar chain selector.
-  env_vars = { CL_CRE_SETTINGS_DEFAULT = '{"PerWorkflow":{"CapabilityCallTimeout":"5m0s","ChainAllowed":{"Default":"false","Values":{"1337":"true","17301180955411967724":"true"}},"ExecutionTimestampsEnabled":"true"}}', CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
+  env_vars = { CL_CRE_SETTINGS_DEFAULT = '{"PerWorkflow":{"CapabilityCallTimeout":"5m0s","ChainAllowed":{"Default":"false","Values":{"1337":"true","17301180955411967724":"true"}},"ExecutionTimestampsEnabled":"true","ChainRead":{"CallLimit":"32"}}}', CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
   capabilities = ["cron", "consensus", "don-time"]
   registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
 

--- a/core/services/workflows/v2/capability_executor.go
+++ b/core/services/workflows/v2/capability_executor.go
@@ -64,7 +64,24 @@ func (c *ExecutionHelper) initLimiters(limiters *EngineLimiters) {
 		{"evm", "GetTransactionReceipt"}: limiters.ChainReadCalls,
 		{"evm", "HeaderByNumber"}:        limiters.ChainReadCalls,
 
-		{"evm", "WriteReport"}: limiters.ChainWriteTargets,
+		{"aptos", "View"}: limiters.ChainReadCalls,
+
+		{"solana", "GetAccountInfoWithOpts"}:      limiters.ChainReadCalls,
+		{"solana", "GetBalance"}:                  limiters.ChainReadCalls,
+		{"solana", "GetBlock"}:                    limiters.ChainReadCalls,
+		{"solana", "GetFeeForMessage"}:            limiters.ChainReadCalls,
+		{"solana", "GetMultipleAccountsWithOpts"}: limiters.ChainReadCalls,
+		{"solana", "GetSignatureStatuses"}:        limiters.ChainReadCalls,
+		{"solana", "GetSlotHeight"}:               limiters.ChainReadCalls,
+		{"solana", "GetTransaction"}:              limiters.ChainReadCalls,
+
+		{"stellar", "GetLatestLedger"}: limiters.ChainReadCalls,
+		{"stellar", "ReadContract"}:    limiters.ChainReadCalls,
+
+		{"evm", "WriteReport"}:     limiters.ChainWriteTargets,
+		{"aptos", "WriteReport"}:   limiters.ChainWriteTargets,
+		{"solana", "WriteReport"}:  limiters.ChainWriteTargets,
+		{"stellar", "WriteReport"}: limiters.ChainWriteTargets,
 
 		{"http-actions", "SendRequest"}:      limiters.HTTPActionCalls,
 		{"confidential-http", "SendRequest"}: limiters.ConfidentialHTTPCalls,


### PR DESCRIPTION
## Summary

`ChainWrite.TargetsLimit` in CRE settings was silently unthrottled for non-EVM chains. The `callLimiters` map in `capability_executor.go` only wired `ChainWriteTargets` to `{"evm", "WriteReport"}` — Aptos, Solana, and Stellar `WriteReport` calls bypassed the limiter entirely.

## The gap

The lookup at `capability_executor.go:101`:
```go
limiter, ok := c.callLimiters[capCall{name: capName, method: request.Method}]
if ok { /* apply limit */ }
// if !ok → limiter silently skipped
```

For an Aptos write, `ParseID("aptos:ChainSelector:4457093679053095497@1.0.0")` returns `name="aptos"`. The map only had `{"evm", "WriteReport"}` — so `ok=false` and the call proceeded unchecked.

| family | `WriteReport` exists? | In `callLimiters` (before) | In `callLimiters` (after) |
|---|---|---|---|
| `evm` | ✅ | ✅ | ✅ |
| `aptos` | ✅ | ❌ | ✅ |
| `solana` | ✅ | ❌ | ✅ |
| `stellar` | ✅ | ❌ | ✅ |

## The fix

Add new map entries — the limiter object (`limiters.ChainWriteTargets`) and settings schema (`cresettings.chainWrite.TargetsLimit`) already exist and are chain-family-agnostic:

```go
		{"aptos", "View"}: limiters.ChainReadCalls,

		{"solana", "GetAccountInfoWithOpts"}:      limiters.ChainReadCalls,
		{"solana", "GetBalance"}:                  limiters.ChainReadCalls,
		{"solana", "GetBlock"}:                    limiters.ChainReadCalls,
		{"solana", "GetFeeForMessage"}:            limiters.ChainReadCalls,
		{"solana", "GetMultipleAccountsWithOpts"}: limiters.ChainReadCalls,
		{"solana", "GetSignatureStatuses"}:        limiters.ChainReadCalls,
		{"solana", "GetSlotHeight"}:               limiters.ChainReadCalls,
		{"solana", "GetTransaction"}:              limiters.ChainReadCalls,

		{"stellar", "GetLatestLedger"}: limiters.ChainReadCalls,
		{"stellar", "ReadContract"}:    limiters.ChainReadCalls,

		{"evm", "WriteReport"}:     limiters.ChainWriteTargets,
		{"aptos", "WriteReport"}:   limiters.ChainWriteTargets,
		{"solana", "WriteReport"}:  limiters.ChainWriteTargets,
		{"stellar", "WriteReport"}: limiters.ChainWriteTargets,
```

## Production impact

Any production workflow writing to Aptos/Solana/Stellar has **unlimited write targets** today, regardless of `ChainWrite.TargetsLimit` in the org-level CRE settings. With this fix, `TargetsLimit=0` correctly blocks all chain writes, not just EVM.

## How discovered

While debugging fire-drill `transmit_fault` scenarios in `chainlink-data-feeds`. We investigated whether `ChainWrite.TargetsLimit=0` could replace the bad-contract-address fault (hot-reloadable, no re-register), but found Aptos writes bypassed the limiter — leading to this fix.

## Test plan

- [ ] `go test ./core/services/workflows/v2/...` passes (verified locally)
- [ ] Existing EVM write-limit tests still pass (no behavioral change for EVM)
- [ ] Manual: set `ChainWrite.TargetsLimit = 0` on an Aptos-targeted workflow, verify writes are now blocked (previously: writes succeeded)