### PR TITLE
[DX-4895] use 5001 as P2P.V2 port in local CRE & reconciler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 
 - [#22809](https://github.com/smartcontractkit/chainlink/pull/22809) [`af55120`](https://github.com/smartcontractkit/chainlink/commit/af5512049c60904b10489e7f1b0dc72bdefea241) - #internal Confidential workflows: stop setting the deprecated outside-envelope `ConfidentialWorkflowRequest.binary_url`. `binary_url` stays in the hashed `WorkflowExecution` (PublicData); the enclave reads it there.
 
-## 2.51.0
+## 2.56.0
 
 ### Minor Changes
 

--- a/core/scripts/cre/reconciler/internal/infra/consts.go
+++ b/core/scripts/cre/reconciler/internal/infra/consts.go
@@ -2,6 +2,6 @@ package infra
 
 const (
 	NodeAPIPort    = 6688 // chainlink node admin/REST API
-	OCRPeeringPort = 6689 // P2P V2 listen / OCR peering
+	OCRPeeringPort = 5001 // P2P V2 listen / OCR peering
 	GatewayWSPort  = 5003 // gateway node websocket endpoint
 )

--- a/core/scripts/cre/reconciler/internal/nodeconfig/nodeconfig.go
+++ b/core/scripts/cre/reconciler/internal/nodeconfig/nodeconfig.go
@@ -50,7 +50,7 @@ type ConnectorGateway struct {
 func Generate(in Inputs) (string, error) {
 	port := in.P2PPort
 	if port == 0 {
-		port = 6689
+		port = 5001
 	}
 
 	cfg := corechainlink.Config{Core: coretoml.Core{

--- a/core/scripts/cre/reconciler/internal/nodeconfig/nodeconfig_test.go
+++ b/core/scripts/cre/reconciler/internal/nodeconfig/nodeconfig_test.go
@@ -33,7 +33,7 @@ func TestGenerate_Worker(t *testing.T) {
 		Allowlist:          []string{"cron-trigger@1.0.0", "evm-1337"},
 		BootstrapPeerID:    "12D3KooWQyADpbmd1QsrxEHGNRZMDtAERy88tJNGyVowFgAPQpMu",
 		BootstrapHost:      "node-bt-0.default.svc.cluster.local",
-		P2PPort:            6689,
+		P2PPort:            5001,
 	})
 	require.NoError(t, err)
 	require.NotContains(t, got, "[[EVM]]")
@@ -48,7 +48,7 @@ func TestGenerate_Bootstrap(t *testing.T) {
 		RegistryChainID: 1337,
 		IsBootstrapNode: true,
 		BootstrapPeerID: "12D3KooWQyADpbmd1QsrxEHGNRZMDtAERy88tJNGyVowFgAPQpMu",
-		P2PPort:         6689,
+		P2PPort:         5001,
 	})
 	require.NoError(t, err)
 	require.NotContains(t, got, "WorkflowRegistry")
@@ -64,7 +64,7 @@ func TestGenerate_Gateway(t *testing.T) {
 		WorkflowRegAddress: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
 		RegistryChainID:    1337,
 		IsGatewayNode:      true,
-		P2PPort:            6689,
+		P2PPort:            5001,
 	})
 	require.NoError(t, err)
 	require.NotContains(t, got, "[[EVM]]")

--- a/core/scripts/cre/reconciler/internal/nodeconfig/testdata/bootstrap.toml
+++ b/core/scripts/cre/reconciler/internal/nodeconfig/testdata/bootstrap.toml
@@ -11,8 +11,8 @@ EnableExperimentalRageP2P = true
 
 [P2P.V2]
 Enabled = true
-DefaultBootstrappers = ['12D3KooWQyADpbmd1QsrxEHGNRZMDtAERy88tJNGyVowFgAPQpMu@localhost:6689']
-ListenAddresses = ['0.0.0.0:6689']
+DefaultBootstrappers = ['12D3KooWQyADpbmd1QsrxEHGNRZMDtAERy88tJNGyVowFgAPQpMu@localhost:5001']
+ListenAddresses = ['0.0.0.0:5001']
 
 [Capabilities]
 [Capabilities.Peering]

--- a/core/scripts/cre/reconciler/internal/nodeconfig/testdata/gateway.toml
+++ b/core/scripts/cre/reconciler/internal/nodeconfig/testdata/gateway.toml
@@ -11,7 +11,7 @@ EnableExperimentalRageP2P = true
 
 [P2P.V2]
 Enabled = true
-ListenAddresses = ['0.0.0.0:6689']
+ListenAddresses = ['0.0.0.0:5001']
 
 [Capabilities]
 [Capabilities.Peering]

--- a/core/scripts/cre/reconciler/internal/nodeconfig/testdata/worker.toml
+++ b/core/scripts/cre/reconciler/internal/nodeconfig/testdata/worker.toml
@@ -11,8 +11,8 @@ EnableExperimentalRageP2P = true
 
 [P2P.V2]
 Enabled = true
-DefaultBootstrappers = ['12D3KooWQyADpbmd1QsrxEHGNRZMDtAERy88tJNGyVowFgAPQpMu@node-bt-0.default.svc.cluster.local:6689']
-ListenAddresses = ['0.0.0.0:6689']
+DefaultBootstrappers = ['12D3KooWQyADpbmd1QsrxEHGNRZMDtAERy88tJNGyVowFgAPQpMu@node-bt-0.default.svc.cluster.local:5001']
+ListenAddresses = ['0.0.0.0:5001']
 
 [Capabilities]
 [Capabilities.Peering]

--- a/system-tests/lib/cre/topology.go
+++ b/system-tests/lib/cre/topology.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	OCRPeeringPort          = 6689
+	OCRPeeringPort          = 5001
 	CapabilitiesPeeringPort = 6690
 )
 


### PR DESCRIPTION
Due to a misunderstanding I changed it to `6689` to match how Griddle was configured. Switching it back to `5001`.