### PR TITLE
delete zksync from ccip deploy

### DIFF
--- a/deployment/ccip/changeset/cs_prerequisites.go
+++ b/deployment/ccip/changeset/cs_prerequisites.go
@@ -33,7 +33,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc677"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/multicall3"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/weth9"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/weth9_zksync"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -246,21 +245,12 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 					err2       error
 				)
 
-				if chain.IsZkSyncVM {
-					rmnAddress, _, rmnC, err2 = rmn_contract.DeployRMNContractZk(
-						nil,
-						chain.ClientZkSyncVM,
-						chain.DeployerKeyZkSyncVM,
-						chain.Client,
-						*deployOpts.LegacyDeploymentCfg.RMNConfig,
-					)
-				} else {
-					rmnAddress, tx2, rmnC, err2 = rmn_contract.DeployRMNContract(
-						chain.DeployerKey,
-						chain.Client,
-						*deployOpts.LegacyDeploymentCfg.RMNConfig,
-					)
-				}
+				rmnAddress, tx2, rmnC, err2 = rmn_contract.DeployRMNContract(
+					chain.DeployerKey,
+					chain.Client,
+					*deployOpts.LegacyDeploymentCfg.RMNConfig,
+				)
+
 				return cldf.ContractDeploy[*rmn_contract.RMNContract]{
 					Address: rmnAddress, Contract: rmnC, Tx: tx2, Tv: cldf.NewTypeAndVersion(shared.RMN, deployment.Version1_5_0), Err: err2,
 				}
@@ -281,19 +271,11 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 						rmnC       *mock_rmn_contract.MockRMNContract
 						err2       error
 					)
-					if chain.IsZkSyncVM {
-						rmnAddress, _, rmnC, err2 = mock_rmn_contract.DeployMockRMNContractZk(
-							nil,
-							chain.ClientZkSyncVM,
-							chain.DeployerKeyZkSyncVM,
-							chain.Client,
-						)
-					} else {
-						rmnAddress, tx2, rmnC, err2 = mock_rmn_contract.DeployMockRMNContract(
-							chain.DeployerKey,
-							chain.Client,
-						)
-					}
+					rmnAddress, tx2, rmnC, err2 = mock_rmn_contract.DeployMockRMNContract(
+						chain.DeployerKey,
+						chain.Client,
+					)
+
 					return cldf.ContractDeploy[*mock_rmn_contract.MockRMNContract]{
 						Address: rmnAddress, Contract: rmnC, Tx: tx2, Tv: cldf.NewTypeAndVersion(shared.MockRMN, deployment.Version1_0_0), Err: err2,
 					}
@@ -317,21 +299,12 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 					rmnProxy2    *rmn_proxy_contract.RMNProxy
 					err2         error
 				)
-				if chain.IsZkSyncVM {
-					rmnProxyAddr, _, rmnProxy2, err2 = rmn_proxy_contract.DeployRMNProxyZk(
-						nil,
-						chain.ClientZkSyncVM,
-						chain.DeployerKeyZkSyncVM,
-						chain.Client,
-						rmnAddr,
-					)
-				} else {
-					rmnProxyAddr, tx2, rmnProxy2, err2 = rmn_proxy_contract.DeployRMNProxy(
-						chain.DeployerKey,
-						chain.Client,
-						rmnAddr,
-					)
-				}
+				rmnProxyAddr, tx2, rmnProxy2, err2 = rmn_proxy_contract.DeployRMNProxy(
+					chain.DeployerKey,
+					chain.Client,
+					rmnAddr,
+				)
+
 				return cldf.ContractDeploy[*rmn_proxy_contract.RMNProxy]{
 					Address: rmnProxyAddr, Contract: rmnProxy2, Tx: tx2, Tv: cldf.NewTypeAndVersion(shared.ARMProxy, deployment.Version1_0_0), Err: err2,
 				}
@@ -384,18 +357,10 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 					tokenAdminRegistry     *token_admin_registry.TokenAdminRegistry
 					err2                   error
 				)
-				if chain.IsZkSyncVM {
-					tokenAdminRegistryAddr, _, tokenAdminRegistry, err2 = token_admin_registry.DeployTokenAdminRegistryZk(
-						nil,
-						chain.ClientZkSyncVM,
-						chain.DeployerKeyZkSyncVM,
-						chain.Client,
-					)
-				} else {
-					tokenAdminRegistryAddr, tx2, tokenAdminRegistry, err2 = token_admin_registry.DeployTokenAdminRegistry(
-						chain.DeployerKey,
-						chain.Client)
-				}
+				tokenAdminRegistryAddr, tx2, tokenAdminRegistry, err2 = token_admin_registry.DeployTokenAdminRegistry(
+					chain.DeployerKey,
+					chain.Client)
+
 				return cldf.ContractDeploy[*token_admin_registry.TokenAdminRegistry]{
 					Address: tokenAdminRegistryAddr, Contract: tokenAdminRegistry, Tx: tx2, Tv: cldf.NewTypeAndVersion(shared.TokenAdminRegistry, deployment.Version1_5_0), Err: err2,
 				}
@@ -425,20 +390,11 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 					regMod     *registry_module_owner_custom.RegistryModuleOwnerCustom
 					err2       error
 				)
-				if chain.IsZkSyncVM {
-					regModAddr, _, regMod, err2 = registry_module_owner_custom.DeployRegistryModuleOwnerCustomZk(
-						nil,
-						chain.ClientZkSyncVM,
-						chain.DeployerKeyZkSyncVM,
-						chain.Client,
-						tokenAdminReg.Address(),
-					)
-				} else {
-					regModAddr, tx2, regMod, err2 = registry_module_owner_custom.DeployRegistryModuleOwnerCustom(
-						chain.DeployerKey,
-						chain.Client,
-						tokenAdminReg.Address())
-				}
+				regModAddr, tx2, regMod, err2 = registry_module_owner_custom.DeployRegistryModuleOwnerCustom(
+					chain.DeployerKey,
+					chain.Client,
+					tokenAdminReg.Address())
+
 				return cldf.ContractDeploy[*registry_module_owner_custom.RegistryModuleOwnerCustom]{
 					Address: regModAddr, Contract: regMod, Tx: tx2, Tv: cldf.NewTypeAndVersion(shared.RegistryModule, deployment.Version1_6_0), Err: err2,
 				}
@@ -484,24 +440,6 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 	}
 
 	if weth9Contract == nil {
-		deployWeth9ZkAndPort := func(chain cldf_evm.Chain) (*weth9.WETH9, common.Address, error) {
-			weth9AddrZk, _, weth9zk, err := weth9_zksync.DeployWETH9ZKSyncZk(
-				nil,
-				chain.ClientZkSyncVM,
-				chain.DeployerKeyZkSyncVM,
-				chain.Client,
-			)
-			if err != nil {
-				return nil, common.Address{}, err
-			}
-			weth9ZkPorted, err := weth9.NewWETH9(weth9zk.Address(), chain.Client)
-			if err != nil {
-				return nil, common.Address{}, err
-			}
-
-			return weth9ZkPorted, weth9AddrZk, nil
-		}
-
 		weth, err := cldf.DeployContract(lggr, chain, ab,
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*weth9.WETH9] {
 				var (
@@ -510,14 +448,11 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 					weth9c    *weth9.WETH9
 					err2      error
 				)
-				if chain.IsZkSyncVM {
-					weth9c, weth9Addr, err2 = deployWeth9ZkAndPort(chain)
-				} else {
-					weth9Addr, tx2, weth9c, err2 = weth9.DeployWETH9(
-						chain.DeployerKey,
-						chain.Client,
-					)
-				}
+				weth9Addr, tx2, weth9c, err2 = weth9.DeployWETH9(
+					chain.DeployerKey,
+					chain.Client,
+				)
+
 				return cldf.ContractDeploy[*weth9.WETH9]{
 					Address: weth9Addr, Contract: weth9c, Tx: tx2, Tv: cldf.NewTypeAndVersion(shared.WETH9, deployment.Version1_0_0), Err: err2,
 				}
@@ -542,23 +477,13 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 					routerC    *router.Router
 					err2       error
 				)
-				if chain.IsZkSyncVM {
-					routerAddr, _, routerC, err2 = router.DeployRouterZk(
-						nil,
-						chain.ClientZkSyncVM,
-						chain.DeployerKeyZkSyncVM,
-						chain.Client,
-						weth9Contract.Address(),
-						rmnProxy.Address(),
-					)
-				} else {
-					routerAddr, tx2, routerC, err2 = router.DeployRouter(
-						chain.DeployerKey,
-						chain.Client,
-						weth9Contract.Address(),
-						rmnProxy.Address(),
-					)
-				}
+				routerAddr, tx2, routerC, err2 = router.DeployRouter(
+					chain.DeployerKey,
+					chain.Client,
+					weth9Contract.Address(),
+					rmnProxy.Address(),
+				)
+
 				return cldf.ContractDeploy[*router.Router]{
 					Address: routerAddr, Contract: routerC, Tx: tx2, Tv: cldf.NewTypeAndVersion(shared.Router, deployment.Version1_2_0), Err: err2,
 				}
@@ -624,19 +549,11 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 					multicall3Wrapper *multicall3.Multicall3
 					err2              error
 				)
-				if chain.IsZkSyncVM {
-					multicall3Addr, _, multicall3Wrapper, err2 = multicall3.DeployMulticall3Zk(
-						nil,
-						chain.ClientZkSyncVM,
-						chain.DeployerKeyZkSyncVM,
-						chain.Client,
-					)
-				} else {
-					multicall3Addr, tx2, multicall3Wrapper, err2 = multicall3.DeployMulticall3(
-						chain.DeployerKey,
-						chain.Client,
-					)
-				}
+				multicall3Addr, tx2, multicall3Wrapper, err2 = multicall3.DeployMulticall3(
+					chain.DeployerKey,
+					chain.Client,
+				)
+
 				return cldf.ContractDeploy[*multicall3.Multicall3]{
 					Address: multicall3Addr, Contract: multicall3Wrapper, Tx: tx2, Tv: cldf.NewTypeAndVersion(shared.Multicall3, deployment.Version1_0_0), Err: err2,
 				}
@@ -681,21 +598,12 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 					receiver     *maybe_revert_message_receiver.MaybeRevertMessageReceiver
 					err2         error
 				)
-				if chain.IsZkSyncVM {
-					receiverAddr, _, receiver, err2 = maybe_revert_message_receiver.DeployMaybeRevertMessageReceiverZk(
-						nil,
-						chain.ClientZkSyncVM,
-						chain.DeployerKeyZkSyncVM,
-						chain.Client,
-						false,
-					)
-				} else {
-					receiverAddr, tx, receiver, err2 = maybe_revert_message_receiver.DeployMaybeRevertMessageReceiver(
-						chain.DeployerKey,
-						chain.Client,
-						false,
-					)
-				}
+				receiverAddr, tx, receiver, err2 = maybe_revert_message_receiver.DeployMaybeRevertMessageReceiver(
+					chain.DeployerKey,
+					chain.Client,
+					false,
+				)
+
 				return cldf.ContractDeploy[*maybe_revert_message_receiver.MaybeRevertMessageReceiver]{
 					Address: receiverAddr, Contract: receiver, Tx: tx, Tv: cldf.NewTypeAndVersion(shared.CCIPReceiver, deployment.Version1_0_0), Err: err2,
 				}
@@ -722,25 +630,14 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 						priceRegAddrC *price_registry_1_2_0.PriceRegistry
 						err2          error
 					)
-					if chain.IsZkSyncVM {
-						priceRegAddr, _, priceRegAddrC, err2 = price_registry_1_2_0.DeployPriceRegistryZk(
-							nil,
-							chain.ClientZkSyncVM,
-							chain.DeployerKeyZkSyncVM,
-							chain.Client,
-							nil,
-							[]common.Address{weth9Contract.Address(), linkAddr},
-							deployOpts.LegacyDeploymentCfg.PriceRegStalenessThreshold,
-						)
-					} else {
-						priceRegAddr, tx2, priceRegAddrC, err2 = price_registry_1_2_0.DeployPriceRegistry(
-							chain.DeployerKey,
-							chain.Client,
-							nil,
-							[]common.Address{weth9Contract.Address(), linkAddr},
-							deployOpts.LegacyDeploymentCfg.PriceRegStalenessThreshold,
-						)
-					}
+					priceRegAddr, tx2, priceRegAddrC, err2 = price_registry_1_2_0.DeployPriceRegistry(
+						chain.DeployerKey,
+						chain.Client,
+						nil,
+						[]common.Address{weth9Contract.Address(), linkAddr},
+						deployOpts.LegacyDeploymentCfg.PriceRegStalenessThreshold,
+					)
+
 					return cldf.ContractDeploy[*price_registry_1_2_0.PriceRegistry]{
 						Address: priceRegAddr, Contract: priceRegAddrC, Tx: tx2,
 						Tv: cldf.NewTypeAndVersion(shared.PriceRegistry, deployment.Version1_2_0), Err: err2,
@@ -791,31 +688,17 @@ func deployTokenPools(
 					contract                 *factory_burn_mint_erc20.FactoryBurnMintERC20
 					err2                     error
 				)
-				if chain.IsZkSyncVM {
-					factoryBurnMintERC20Addr, _, contract, err2 = factory_burn_mint_erc20.DeployFactoryBurnMintERC20Zk(
-						nil,
-						chain.ClientZkSyncVM,
-						chain.DeployerKeyZkSyncVM,
-						chain.Client,
-						string(shared.FactoryBurnMintERC20Symbol),
-						string(shared.FactoryBurnMintERC20Symbol),
-						18,
-						big.NewInt(0),
-						big.NewInt(0),
-						chain.DeployerKey.From,
-					)
-				} else {
-					factoryBurnMintERC20Addr, tx2, contract, err2 = factory_burn_mint_erc20.DeployFactoryBurnMintERC20(
-						chain.DeployerKey,
-						chain.Client,
-						string(shared.FactoryBurnMintERC20Symbol),
-						string(shared.FactoryBurnMintERC20Symbol),
-						18,
-						big.NewInt(0),
-						big.NewInt(0),
-						chain.DeployerKey.From,
-					)
-				}
+				factoryBurnMintERC20Addr, tx2, contract, err2 = factory_burn_mint_erc20.DeployFactoryBurnMintERC20(
+					chain.DeployerKey,
+					chain.Client,
+					string(shared.FactoryBurnMintERC20Symbol),
+					string(shared.FactoryBurnMintERC20Symbol),
+					18,
+					big.NewInt(0),
+					big.NewInt(0),
+					chain.DeployerKey.From,
+				)
+
 				return cldf.ContractDeploy[*factory_burn_mint_erc20.FactoryBurnMintERC20]{
 					Address: factoryBurnMintERC20Addr, Contract: contract, Tx: tx2, Tv: cldf.NewTypeAndVersion(shared.FactoryBurnMintERC20Token, deployment.Version1_6_2), Err: err2,
 				}
@@ -839,29 +722,16 @@ func deployTokenPools(
 					contract              *burn_mint_token_pool.BurnMintTokenPool
 					err2                  error
 				)
-				if chain.IsZkSyncVM {
-					burnMintTokenPoolAddr, _, contract, err2 = burn_mint_token_pool.DeployBurnMintTokenPoolZk(
-						nil,
-						chain.ClientZkSyncVM,
-						chain.DeployerKeyZkSyncVM,
-						chain.Client,
-						factoryBurnMintERC20.Address(),
-						18,
-						[]common.Address{}, // empty allow list
-						rmnProxy,
-						router,
-					)
-				} else {
-					burnMintTokenPoolAddr, tx2, contract, err2 = burn_mint_token_pool.DeployBurnMintTokenPool(
-						chain.DeployerKey,
-						chain.Client,
-						factoryBurnMintERC20.Address(),
-						18,
-						[]common.Address{}, // empty allow list
-						rmnProxy,
-						router,
-					)
-				}
+				burnMintTokenPoolAddr, tx2, contract, err2 = burn_mint_token_pool.DeployBurnMintTokenPool(
+					chain.DeployerKey,
+					chain.Client,
+					factoryBurnMintERC20.Address(),
+					18,
+					[]common.Address{}, // empty allow list
+					rmnProxy,
+					router,
+				)
+
 				return cldf.ContractDeploy[*burn_mint_token_pool.BurnMintTokenPool]{
 					Address: burnMintTokenPoolAddr, Contract: contract, Tx: tx2, Tv: cldf.NewTypeAndVersion(shared.BurnMintTokenPool, deployment.Version1_5_1), Err: err2,
 				}
@@ -885,29 +755,16 @@ func deployTokenPools(
 					contract                  *burn_from_mint_token_pool.BurnFromMintTokenPool
 					err2                      error
 				)
-				if chain.IsZkSyncVM {
-					burnFromMintTokenPoolAddr, _, contract, err2 = burn_from_mint_token_pool.DeployBurnFromMintTokenPoolZk(
-						nil,
-						chain.ClientZkSyncVM,
-						chain.DeployerKeyZkSyncVM,
-						chain.Client,
-						factoryBurnMintERC20.Address(),
-						18,
-						[]common.Address{}, // empty allow list
-						rmnProxy,
-						router,
-					)
-				} else {
-					burnFromMintTokenPoolAddr, tx2, contract, err2 = burn_from_mint_token_pool.DeployBurnFromMintTokenPool(
-						chain.DeployerKey,
-						chain.Client,
-						factoryBurnMintERC20.Address(),
-						18,
-						[]common.Address{}, // empty allow list
-						rmnProxy,
-						router,
-					)
-				}
+				burnFromMintTokenPoolAddr, tx2, contract, err2 = burn_from_mint_token_pool.DeployBurnFromMintTokenPool(
+					chain.DeployerKey,
+					chain.Client,
+					factoryBurnMintERC20.Address(),
+					18,
+					[]common.Address{}, // empty allow list
+					rmnProxy,
+					router,
+				)
+
 				return cldf.ContractDeploy[*burn_from_mint_token_pool.BurnFromMintTokenPool]{
 					Address: burnFromMintTokenPoolAddr, Contract: contract, Tx: tx2, Tv: cldf.NewTypeAndVersion(shared.BurnFromMintTokenPool, deployment.Version1_5_1), Err: err2,
 				}
@@ -930,29 +787,16 @@ func deployTokenPools(
 					contract                      *burn_with_from_mint_token_pool.BurnWithFromMintTokenPool
 					err2                          error
 				)
-				if chain.IsZkSyncVM {
-					burnWithFromMintTokenPoolAddr, _, contract, err2 = burn_with_from_mint_token_pool.DeployBurnWithFromMintTokenPoolZk(
-						nil,
-						chain.ClientZkSyncVM,
-						chain.DeployerKeyZkSyncVM,
-						chain.Client,
-						factoryBurnMintERC20.Address(),
-						18,
-						[]common.Address{}, // empty allow list
-						rmnProxy,
-						router,
-					)
-				} else {
-					burnWithFromMintTokenPoolAddr, tx2, contract, err2 = burn_with_from_mint_token_pool.DeployBurnWithFromMintTokenPool(
-						chain.DeployerKey,
-						chain.Client,
-						factoryBurnMintERC20.Address(),
-						18,
-						[]common.Address{}, // empty allow list
-						rmnProxy,
-						router,
-					)
-				}
+				burnWithFromMintTokenPoolAddr, tx2, contract, err2 = burn_with_from_mint_token_pool.DeployBurnWithFromMintTokenPool(
+					chain.DeployerKey,
+					chain.Client,
+					factoryBurnMintERC20.Address(),
+					18,
+					[]common.Address{}, // empty allow list
+					rmnProxy,
+					router,
+				)
+
 				return cldf.ContractDeploy[*burn_with_from_mint_token_pool.BurnWithFromMintTokenPool]{
 					Address: burnWithFromMintTokenPoolAddr, Contract: contract, Tx: tx2, Tv: cldf.NewTypeAndVersion(shared.BurnWithFromMintTokenPool, deployment.Version1_5_1), Err: err2,
 				}
@@ -976,31 +820,17 @@ func deployTokenPools(
 					contract                 *lock_release_token_pool.LockReleaseTokenPool
 					err2                     error
 				)
-				if chain.IsZkSyncVM {
-					lockReleaseTokenPoolAddr, _, contract, err2 = lock_release_token_pool.DeployLockReleaseTokenPoolZk(
-						nil,
-						chain.ClientZkSyncVM,
-						chain.DeployerKeyZkSyncVM,
-						chain.Client,
-						factoryBurnMintERC20.Address(),
-						18,
-						[]common.Address{}, // empty allow list
-						rmnProxy,
-						false,
-						router,
-					)
-				} else {
-					lockReleaseTokenPoolAddr, tx2, contract, err2 = lock_release_token_pool.DeployLockReleaseTokenPool(
-						chain.DeployerKey,
-						chain.Client,
-						factoryBurnMintERC20.Address(),
-						18,
-						[]common.Address{}, // empty allow list
-						rmnProxy,
-						false,
-						router,
-					)
-				}
+				lockReleaseTokenPoolAddr, tx2, contract, err2 = lock_release_token_pool.DeployLockReleaseTokenPool(
+					chain.DeployerKey,
+					chain.Client,
+					factoryBurnMintERC20.Address(),
+					18,
+					[]common.Address{}, // empty allow list
+					rmnProxy,
+					false,
+					router,
+				)
+
 				return cldf.ContractDeploy[*lock_release_token_pool.LockReleaseTokenPool]{
 					Address: lockReleaseTokenPoolAddr, Contract: contract, Tx: tx2, Tv: cldf.NewTypeAndVersion(shared.LockReleaseTokenPool, deployment.Version1_5_1), Err: err2,
 				}
@@ -1040,27 +870,15 @@ func deployUSDC(
 				tokenContract *burn_mint_erc677.BurnMintERC677
 				err2          error
 			)
-			if chain.IsZkSyncVM {
-				tokenAddress, _, tokenContract, err2 = burn_mint_erc677.DeployBurnMintERC677Zk(
-					nil,
-					chain.ClientZkSyncVM,
-					chain.DeployerKeyZkSyncVM,
-					chain.Client,
-					shared.USDCName,
-					string(shared.USDCSymbol),
-					shared.UsdcDecimals,
-					big.NewInt(0),
-				)
-			} else {
-				tokenAddress, tx, tokenContract, err2 = burn_mint_erc677.DeployBurnMintERC677(
-					chain.DeployerKey,
-					chain.Client,
-					shared.USDCName,
-					string(shared.USDCSymbol),
-					shared.UsdcDecimals,
-					big.NewInt(0),
-				)
-			}
+			tokenAddress, tx, tokenContract, err2 = burn_mint_erc677.DeployBurnMintERC677(
+				chain.DeployerKey,
+				chain.Client,
+				shared.USDCName,
+				string(shared.USDCSymbol),
+				shared.UsdcDecimals,
+				big.NewInt(0),
+			)
+
 			return cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
 				Address:  tokenAddress,
 				Contract: tokenContract,
@@ -1092,25 +910,14 @@ func deployUSDC(
 				transmitterContract *mock_usdc_token_transmitter.MockE2EUSDCTransmitter
 				err2                error
 			)
-			if chain.IsZkSyncVM {
-				transmitterAddress, _, transmitterContract, err2 = mock_usdc_token_transmitter.DeployMockE2EUSDCTransmitterZk(
-					nil,
-					chain.ClientZkSyncVM,
-					chain.DeployerKeyZkSyncVM,
-					chain.Client,
-					0,
-					reader.AllAvailableDomains()[chain.Selector],
-					token.Address,
-				)
-			} else {
-				transmitterAddress, tx, transmitterContract, err2 = mock_usdc_token_transmitter.DeployMockE2EUSDCTransmitter(
-					chain.DeployerKey,
-					chain.Client,
-					0,
-					reader.AllAvailableDomains()[chain.Selector],
-					token.Address,
-				)
-			}
+			transmitterAddress, tx, transmitterContract, err2 = mock_usdc_token_transmitter.DeployMockE2EUSDCTransmitter(
+				chain.DeployerKey,
+				chain.Client,
+				0,
+				reader.AllAvailableDomains()[chain.Selector],
+				token.Address,
+			)
+
 			return cldf.ContractDeploy[*mock_usdc_token_transmitter.MockE2EUSDCTransmitter]{
 				Address:  transmitterAddress,
 				Contract: transmitterContract,
@@ -1132,23 +939,13 @@ func deployUSDC(
 				messengerContract *mock_usdc_token_messenger.MockE2EUSDCTokenMessenger
 				err2              error
 			)
-			if chain.IsZkSyncVM {
-				messengerAddress, _, messengerContract, err2 = mock_usdc_token_messenger.DeployMockE2EUSDCTokenMessengerZk(
-					nil,
-					chain.ClientZkSyncVM,
-					chain.DeployerKeyZkSyncVM,
-					chain.Client,
-					0,
-					transmitter.Address,
-				)
-			} else {
-				messengerAddress, tx, messengerContract, err2 = mock_usdc_token_messenger.DeployMockE2EUSDCTokenMessenger(
-					chain.DeployerKey,
-					chain.Client,
-					0,
-					transmitter.Address,
-				)
-			}
+			messengerAddress, tx, messengerContract, err2 = mock_usdc_token_messenger.DeployMockE2EUSDCTokenMessenger(
+				chain.DeployerKey,
+				chain.Client,
+				0,
+				transmitter.Address,
+			)
+
 			return cldf.ContractDeploy[*mock_usdc_token_messenger.MockE2EUSDCTokenMessenger]{
 				Address:  messengerAddress,
 				Contract: messengerContract,
@@ -1170,29 +967,16 @@ func deployUSDC(
 				tokenPoolContract *usdc_token_pool.USDCTokenPool
 				err2              error
 			)
-			if chain.IsZkSyncVM {
-				tokenPoolAddress, _, tokenPoolContract, err2 = usdc_token_pool.DeployUSDCTokenPoolZk(
-					nil,
-					chain.ClientZkSyncVM,
-					chain.DeployerKeyZkSyncVM,
-					chain.Client,
-					messenger.Address,
-					token.Address,
-					[]common.Address{},
-					rmnProxy,
-					router,
-				)
-			} else {
-				tokenPoolAddress, tx, tokenPoolContract, err2 = usdc_token_pool.DeployUSDCTokenPool(
-					chain.DeployerKey,
-					chain.Client,
-					messenger.Address,
-					token.Address,
-					[]common.Address{},
-					rmnProxy,
-					router,
-				)
-			}
+			tokenPoolAddress, tx, tokenPoolContract, err2 = usdc_token_pool.DeployUSDCTokenPool(
+				chain.DeployerKey,
+				chain.Client,
+				messenger.Address,
+				token.Address,
+				[]common.Address{},
+				rmnProxy,
+				router,
+			)
+
 			return cldf.ContractDeploy[*usdc_token_pool.USDCTokenPool]{
 				Address:  tokenPoolAddress,
 				Contract: tokenPoolContract,
@@ -1228,27 +1012,15 @@ func deployLBTC(
 				tokenContract *burn_mint_erc677.BurnMintERC677
 				err2          error
 			)
-			if chain.IsZkSyncVM {
-				tokenAddress, _, tokenContract, err2 = burn_mint_erc677.DeployBurnMintERC677Zk(
-					nil,
-					chain.ClientZkSyncVM,
-					chain.DeployerKeyZkSyncVM,
-					chain.Client,
-					shared.LBTCSymbol,
-					string(shared.LBTCSymbol),
-					shared.LBTCDecimals,
-					big.NewInt(0),
-				)
-			} else {
-				tokenAddress, tx, tokenContract, err2 = burn_mint_erc677.DeployBurnMintERC677(
-					chain.DeployerKey,
-					chain.Client,
-					string(shared.LBTCSymbol),
-					string(shared.LBTCSymbol),
-					shared.LBTCDecimals,
-					big.NewInt(0),
-				)
-			}
+			tokenAddress, tx, tokenContract, err2 = burn_mint_erc677.DeployBurnMintERC677(
+				chain.DeployerKey,
+				chain.Client,
+				string(shared.LBTCSymbol),
+				string(shared.LBTCSymbol),
+				shared.LBTCDecimals,
+				big.NewInt(0),
+			)
+
 			return cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
 				Address:  tokenAddress,
 				Contract: tokenContract,
@@ -1282,30 +1054,16 @@ func deployLBTC(
 			)
 			// valid 32 bytes staging Lombard message hash
 			destPoolData := hexutil.MustDecode("0xdee9d5a70c34ab6ad3d3be55cc81b8f3dbd7aaf4070d7f1046b239e4995df489")
-			if chain.IsZkSyncVM {
-				tokenPoolAddress, _, tokenPoolContract, err2 = mock_lbtc_token_pool.DeployMockE2ELBTCTokenPoolZk(
-					nil,
-					chain.ClientZkSyncVM,
-					chain.DeployerKeyZkSyncVM,
-					chain.Client,
-					chain.DeployerKeyZkSyncVM,
-					token.Address,
-					[]common.Address{},
-					rmnProxy,
-					router,
-					destPoolData,
-				)
-			} else {
-				tokenPoolAddress, tx, tokenPoolContract, err2 = mock_lbtc_token_pool.DeployMockE2ELBTCTokenPool(
-					chain.DeployerKey,
-					chain.Client,
-					token.Address,
-					[]common.Address{},
-					rmnProxy,
-					router,
-					destPoolData,
-				)
-			}
+			tokenPoolAddress, tx, tokenPoolContract, err2 = mock_lbtc_token_pool.DeployMockE2ELBTCTokenPool(
+				chain.DeployerKey,
+				chain.Client,
+				token.Address,
+				[]common.Address{},
+				rmnProxy,
+				router,
+				destPoolData,
+			)
+
 			return cldf.ContractDeploy[*mock_lbtc_token_pool.MockE2ELBTCTokenPool]{
 				Address:  tokenPoolAddress,
 				Contract: tokenPoolContract,

--- a/deployment/ccip/changeset/cs_prerequisites_test.go
+++ b/deployment/ccip/changeset/cs_prerequisites_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -23,21 +22,6 @@ func TestDeployPrerequisites(t *testing.T) {
 
 	e, err := environment.New(t.Context(),
 		environment.WithEVMSimulatedN(t, 2),
-		environment.WithLogger(logger.Test(t)),
-	)
-	require.NoError(t, err)
-
-	testDeployPrerequisitesWithEnv(t, *e)
-}
-
-func TestDeployPrerequisitesZk(t *testing.T) {
-	// Timeouts in CI
-	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/CCIP-6427")
-
-	t.Parallel()
-
-	e, err := environment.New(t.Context(),
-		environment.WithZKSyncContainerN(t, 2),
 		environment.WithLogger(logger.Test(t)),
 	)
 	require.NoError(t, err)

--- a/deployment/ccip/changeset/v1_6/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_deploy_chain_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_3/fee_quoter"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -39,26 +38,6 @@ func TestDeployChainContractsChangeset(t *testing.T) {
 	homeChainSel := chain_selectors.TEST_90000001.Selector
 	env, err := environment.New(t.Context(),
 		environment.WithEVMSimulated(t, []uint64{homeChainSel}),
-		environment.WithLogger(logger.Test(t)),
-	)
-	require.NoError(t, err)
-
-	testhelpers.RegisterNodes(t, env, 4, homeChainSel)
-
-	testDeployChainContractsChangesetWithEnv(t, *env, homeChainSel)
-}
-
-func TestDeployChainContractsChangesetZk(t *testing.T) {
-	// Timeouts in CI
-	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/CCIP-6427")
-
-	t.Parallel()
-
-	homeChainSel := chain_selectors.TEST_90000001.Selector
-	zkChainSel := chain_selectors.TEST_90000050.Selector
-	env, err := environment.New(t.Context(),
-		environment.WithEVMSimulated(t, []uint64{homeChainSel}),
-		environment.WithZKSyncContainer(t, []uint64{zkChainSel}),
 		environment.WithLogger(logger.Test(t)),
 	)
 	require.NoError(t, err)

--- a/deployment/ccip/changeset/v1_6/cs_deploy_registry_module.go
+++ b/deployment/ccip/changeset/v1_6/cs_deploy_registry_module.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -86,29 +84,11 @@ func DeployRegistryModuleChangeset(e cldf.Environment, cfg DeployRegistryModuleC
 
 		registryModule, err := cldf.DeployContract(e.Logger, chain, addressBook,
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*registry_module_owner_custom.RegistryModuleOwnerCustom] {
-				var (
-					regModAddr common.Address
-					tx         *types.Transaction
-					regMod     *registry_module_owner_custom.RegistryModuleOwnerCustom
-					err2       error
+				regModAddr, tx, regMod, err2 := registry_module_owner_custom.DeployRegistryModuleOwnerCustom(
+					chain.DeployerKey,
+					chain.Client,
+					chainState.TokenAdminRegistry.Address(),
 				)
-
-				if chain.IsZkSyncVM {
-					regModAddr, _, regMod, err2 = registry_module_owner_custom.DeployRegistryModuleOwnerCustomZk(
-						nil,
-						chain.ClientZkSyncVM,
-						chain.DeployerKeyZkSyncVM,
-						chain.Client,
-						chainState.TokenAdminRegistry.Address(),
-					)
-					// ZkSync deployment doesn't return a transaction, so tx remains nil
-				} else {
-					regModAddr, tx, regMod, err2 = registry_module_owner_custom.DeployRegistryModuleOwnerCustom(
-						chain.DeployerKey,
-						chain.Client,
-						chainState.TokenAdminRegistry.Address(),
-					)
-				}
 
 				return cldf.ContractDeploy[*registry_module_owner_custom.RegistryModuleOwnerCustom]{
 					Address:  regModAddr,

--- a/deployment/ccip/internal/opsutils/evm.go
+++ b/deployment/ccip/internal/opsutils/evm.go
@@ -1,22 +1,17 @@
 package opsutils
 
 import (
-	"context"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"math/big"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	proposeutils "github.com/smartcontractkit/cld-changesets/legacy/mcms/proposeutils"
 	evmstate "github.com/smartcontractkit/cld-changesets/legacy/pkg/family/evm"
-	"github.com/zksync-sdk/zksync2-go/accounts"
-	"github.com/zksync-sdk/zksync2-go/clients"
 
 	mcmslib "github.com/smartcontractkit/mcms"
 	mcmssdk "github.com/smartcontractkit/mcms/sdk"
@@ -245,19 +240,15 @@ type EVMDeployOutput struct {
 // Deployment operations must define defaults for these options in case users do not provide them.
 // These options allow operators to deploy new bytecodes for the same ABI.
 type ContractOpts struct {
-	Version          *semver.Version
-	EVMBytecode      []byte
-	ZkSyncVMBytecode []byte
+	Version     *semver.Version
+	EVMBytecode []byte
 }
 
-func (c *ContractOpts) Validate(isZkSyncVM bool) error {
+func (c *ContractOpts) Validate() error {
 	if c.Version == nil {
 		return errors.New("version must be defined")
 	}
-	if isZkSyncVM && len(c.ZkSyncVMBytecode) == 0 {
-		return errors.New("zkSyncVM bytecode must be defined")
-	}
-	if !isZkSyncVM && len(c.EVMBytecode) == 0 {
+	if len(c.EVMBytecode) == 0 {
 		return errors.New("evm bytecode must be defined")
 	}
 	return nil
@@ -292,7 +283,7 @@ func NewEVMDeployOperation[IN any](
 			if contractOpts == nil {
 				return EVMDeployOutput{}, errors.New("must define ContractOpts for deployment, no defaults provided")
 			}
-			if err := contractOpts.Validate(chain.IsZkSyncVM); err != nil {
+			if err := contractOpts.Validate(); err != nil {
 				return EVMDeployOutput{}, fmt.Errorf("invalid ContractOpts: %w", err)
 			}
 			typeAndVersion := cldf.NewTypeAndVersion(contractType, *contractOpts.Version)
@@ -304,39 +295,21 @@ func NewEVMDeployOperation[IN any](
 				return EVMDeployOutput{}, fmt.Errorf("ABI is nil for %s", typeAndVersion)
 			}
 
-			var (
-				addr common.Address
-				tx   *types.Transaction
+			addr, tx, _, err := bind.DeployContract(
+				CloneTransactOptsWithGas(chain.DeployerKey, input.GasLimit, input.GasPrice),
+				*parsedABI,
+				contractOpts.EVMBytecode,
+				chain.Client,
+				makeArgs(input.DeployInput)...,
 			)
-			if chain.IsZkSyncVM {
-				addr, err = deployZkContract(
-					nil,
-					contractOpts.ZkSyncVMBytecode,
-					chain.ClientZkSyncVM,
-					chain.DeployerKeyZkSyncVM,
-					parsedABI,
-					makeArgs(input.DeployInput)...,
-				)
-			} else {
-				addr, tx, _, err = bind.DeployContract(
-					CloneTransactOptsWithGas(chain.DeployerKey, input.GasLimit, input.GasPrice),
-					*parsedABI,
-					contractOpts.EVMBytecode,
-					chain.Client,
-					makeArgs(input.DeployInput)...,
-				)
-			}
 			if err != nil {
 				b.Logger.Errorw("Failed to deploy contract", "typeAndVersion", typeAndVersion, "chain", chain.String(), "err", err.Error())
 				return EVMDeployOutput{}, fmt.Errorf("failed to deploy %s on %s: %w", typeAndVersion, chain, err)
 			}
-			// ZkSync transactions are confirmed in deployZkContract
-			if !chain.IsZkSyncVM {
-				_, err := chain.Confirm(tx)
-				if err != nil {
-					b.Logger.Errorw("Failed to confirm deployment", "typeAndVersion", typeAndVersion, "chain", chain.String(), "err", err.Error())
-					return EVMDeployOutput{}, fmt.Errorf("failed to confirm deployment of %s on %s: %w", typeAndVersion, chain, err)
-				}
+			_, err = chain.Confirm(tx)
+			if err != nil {
+				b.Logger.Errorw("Failed to confirm deployment", "typeAndVersion", typeAndVersion, "chain", chain.String(), "err", err.Error())
+				return EVMDeployOutput{}, fmt.Errorf("failed to confirm deployment of %s on %s: %w", typeAndVersion, chain, err)
 			}
 			return EVMDeployOutput{
 				Address:        addr,
@@ -452,47 +425,4 @@ func GetBoostedGasForAttempt(cfg cldfproposalutils.GasBoostConfig, attempt uint)
 	gasPrice = initialGasPrice + uint64(attempt)*gasPriceIncrement
 
 	return
-}
-
-func deployZkContract(
-	deployOpts *accounts.TransactOpts,
-	bytecode []byte,
-	client *clients.Client,
-	wallet *accounts.Wallet,
-	parsedABI *abi.ABI,
-	args ...any,
-) (common.Address, error) {
-	var calldata []byte
-	var err error
-	if len(args) > 0 {
-		calldata, err = parsedABI.Pack("", args...)
-		if err != nil {
-			return common.Address{}, fmt.Errorf("failed to pack constructor args: %w", err)
-		}
-	}
-
-	salt := make([]byte, 32)
-	n, err := rand.Read(salt)
-	if err != nil {
-		return common.Address{}, fmt.Errorf("failed to read random bytes: %w", err)
-	}
-	if n != len(salt) {
-		return common.Address{}, fmt.Errorf("failed to read random bytes: expected %d, got %d", len(salt), n)
-	}
-
-	txHash, err := wallet.Deploy(deployOpts, accounts.Create2Transaction{
-		Bytecode: bytecode,
-		Calldata: calldata,
-		Salt:     salt,
-	})
-	if err != nil {
-		return common.Address{}, fmt.Errorf("failed to deploy zk contract: %w", err)
-	}
-
-	receipt, err := client.WaitMined(context.Background(), txHash)
-	if err != nil {
-		return common.Address{}, fmt.Errorf("failed to confirm zk contract deployment: %w", err)
-	}
-
-	return receipt.ContractAddress, nil
 }

--- a/deployment/ccip/internal/opsutils/evm_test.go
+++ b/deployment/ccip/internal/opsutils/evm_test.go
@@ -438,10 +438,9 @@ func TestNewEVMCallOperation(t *testing.T) {
 
 func TestContractOpts_Validate(t *testing.T) {
 	tests := []struct {
-		desc       string
-		opts       *ContractOpts
-		isZkSyncVM bool
-		err        string
+		desc string
+		opts *ContractOpts
+		err  string
 	}{
 		{
 			desc: "valid evm opts",
@@ -449,15 +448,6 @@ func TestContractOpts_Validate(t *testing.T) {
 				Version:     semver.MustParse("1.0.0"),
 				EVMBytecode: []byte{0x01, 0x02, 0x03},
 			},
-			isZkSyncVM: false,
-		},
-		{
-			desc: "valid zksyncvm opts",
-			opts: &ContractOpts{
-				Version:          semver.MustParse("1.0.0"),
-				ZkSyncVMBytecode: []byte{0x05, 0x06, 0x07, 0x08},
-			},
-			isZkSyncVM: true,
 		},
 		{
 			desc: "nil version",
@@ -469,22 +459,13 @@ func TestContractOpts_Validate(t *testing.T) {
 			opts: &ContractOpts{
 				Version: semver.MustParse("1.0.0"),
 			},
-			isZkSyncVM: false,
-			err:        "evm bytecode must be defined",
-		},
-		{
-			desc: "missing zkSyncVM bytecode",
-			opts: &ContractOpts{
-				Version: semver.MustParse("1.0.0"),
-			},
-			isZkSyncVM: true,
-			err:        "zkSyncVM bytecode must be defined",
+			err: "evm bytecode must be defined",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			err := test.opts.Validate(test.isZkSyncVM)
+			err := test.opts.Validate()
 			if test.err == "" {
 				require.NoError(t, err)
 			} else {
@@ -573,9 +554,8 @@ func TestNewEVMDeployOperation(t *testing.T) {
 			contractType,
 			&bind.MetaData{},
 			&ContractOpts{
-				Version:          semver.MustParse("0.1.0"),
-				EVMBytecode:      nil,
-				ZkSyncVMBytecode: []byte{0x05, 0x06, 0x07, 0x08},
+				Version:     semver.MustParse("0.1.0"),
+				EVMBytecode: nil,
 			},
 			func(string) []any { return nil },
 		)
@@ -605,9 +585,8 @@ func TestNewEVMDeployOperation(t *testing.T) {
 		input := EVMDeployInput[string]{
 			ChainSelector: 123,
 			ContractOpts: &ContractOpts{
-				Version:          semver.MustParse("0.1.0"),
-				EVMBytecode:      nil,
-				ZkSyncVMBytecode: []byte{0x05, 0x06, 0x07, 0x08},
+				Version:     semver.MustParse("0.1.0"),
+				EVMBytecode: nil,
 			},
 			DeployInput: "test",
 		}
@@ -632,9 +611,8 @@ func TestNewEVMDeployOperation(t *testing.T) {
 		input := EVMDeployInput[string]{
 			ChainSelector: 123,
 			ContractOpts: &ContractOpts{
-				Version:          semver.MustParse("0.1.0"),
-				EVMBytecode:      []byte{0x01, 0x02, 0x03, 0x04},
-				ZkSyncVMBytecode: []byte{0x05, 0x06, 0x07, 0x08},
+				Version:     semver.MustParse("0.1.0"),
+				EVMBytecode: []byte{0x01, 0x02, 0x03, 0x04},
 			},
 			DeployInput: "test",
 		}
@@ -671,9 +649,8 @@ func TestNewEVMDeployOperation(t *testing.T) {
 		input := EVMDeployInput[string]{
 			ChainSelector: 5009297550715157269,
 			ContractOpts: &ContractOpts{
-				Version:          semver.MustParse("0.1.0"),
-				EVMBytecode:      []byte{0x01, 0x02, 0x03, 0x04},
-				ZkSyncVMBytecode: []byte{0x05, 0x06, 0x07, 0x08},
+				Version:     semver.MustParse("0.1.0"),
+				EVMBytecode: []byte{0x01, 0x02, 0x03, 0x04},
 			},
 			DeployInput: "test",
 		}
@@ -712,9 +689,8 @@ func TestNewEVMDeployOperation(t *testing.T) {
 		input := EVMDeployInput[string]{
 			ChainSelector: 5009297550715157269,
 			ContractOpts: &ContractOpts{
-				Version:          semver.MustParse("0.1.0"),
-				EVMBytecode:      []byte{0x00},
-				ZkSyncVMBytecode: []byte{0x00},
+				Version:     semver.MustParse("0.1.0"),
+				EVMBytecode: []byte{0x00},
 			},
 			DeployInput: "test",
 		}
@@ -750,9 +726,8 @@ func TestNewEVMDeployOperation(t *testing.T) {
 		input := EVMDeployInput[string]{
 			ChainSelector: 5009297550715157269,
 			ContractOpts: &ContractOpts{
-				Version:          semver.MustParse("0.1.0"),
-				EVMBytecode:      []byte{0x00},
-				ZkSyncVMBytecode: []byte{0x00},
+				Version:     semver.MustParse("0.1.0"),
+				EVMBytecode: []byte{0x00},
 			},
 			DeployInput: "test",
 		}

--- a/deployment/ccip/operation/evm/v1_2/ops_router.go
+++ b/deployment/ccip/operation/evm/v1_2/ops_router.go
@@ -33,9 +33,8 @@ var (
 		shared.Router,
 		router.RouterMetaData,
 		&opsutils.ContractOpts{
-			Version:          &deployment.Version1_2_0,
-			EVMBytecode:      common.FromHex(router.RouterBin),
-			ZkSyncVMBytecode: router.RouterZkBytecode,
+			Version:     &deployment.Version1_2_0,
+			EVMBytecode: common.FromHex(router.RouterBin),
 		},
 		func(input DeployRouterInput) []any {
 			return []any{input.WethAddress, input.RMNProxy}
@@ -49,9 +48,8 @@ var (
 		shared.TestRouter,
 		router.RouterMetaData,
 		&opsutils.ContractOpts{
-			Version:          &deployment.Version1_2_0,
-			EVMBytecode:      common.FromHex(router.RouterBin),
-			ZkSyncVMBytecode: router.RouterZkBytecode,
+			Version:     &deployment.Version1_2_0,
+			EVMBytecode: common.FromHex(router.RouterBin),
 		},
 		func(input DeployRouterInput) []any {
 			return []any{input.WethAddress, input.RMNProxy}

--- a/deployment/ccip/operation/evm/v1_5_1/ops_token_pool_factory.go
+++ b/deployment/ccip/operation/evm/v1_5_1/ops_token_pool_factory.go
@@ -28,9 +28,8 @@ var (
 		shared.TokenPoolFactory,
 		token_pool_factory.TokenPoolFactoryMetaData,
 		&opsutil.ContractOpts{
-			Version:          &deployment.Version1_5_1,
-			EVMBytecode:      common.FromHex(token_pool_factory.TokenPoolFactoryBin),
-			ZkSyncVMBytecode: token_pool_factory.ZkBytecode,
+			Version:     &deployment.Version1_5_1,
+			EVMBytecode: common.FromHex(token_pool_factory.TokenPoolFactoryBin),
 		},
 		func(input DeployTokenPoolFactoryInput) []any {
 			return []any{

--- a/deployment/ccip/operation/evm/v1_6/ops_fee_quoter.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_fee_quoter.go
@@ -46,9 +46,8 @@ var (
 		shared.FeeQuoter,
 		fee_quoter.FeeQuoterMetaData,
 		&opsutils.ContractOpts{
-			Version:          &deployment.Version1_6_3, // defaults to v1_6_3, but can be overwritten by input params.FeeQuoterOpts
-			EVMBytecode:      common.FromHex(fee_quoter.FeeQuoterBin),
-			ZkSyncVMBytecode: fee_quoter.ZkBytecode,
+			Version:     &deployment.Version1_6_3, // defaults to v1_6_3, but can be overwritten by input params.FeeQuoterOpts
+			EVMBytecode: common.FromHex(fee_quoter.FeeQuoterBin),
 		},
 		func(input DeployFeeQInput) []any {
 			return []any{

--- a/deployment/ccip/operation/evm/v1_6/ops_nonce_manager.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_nonce_manager.go
@@ -21,9 +21,8 @@ var (
 		shared.NonceManager,
 		nonce_manager.NonceManagerMetaData,
 		&opsutils.ContractOpts{
-			Version:          &deployment.Version1_6_0,
-			EVMBytecode:      common.FromHex(nonce_manager.NonceManagerBin),
-			ZkSyncVMBytecode: nonce_manager.ZkBytecode,
+			Version:     &deployment.Version1_6_0,
+			EVMBytecode: common.FromHex(nonce_manager.NonceManagerBin),
 		},
 		func(input []common.Address) []any {
 			return []any{input}

--- a/deployment/ccip/operation/evm/v1_6/ops_offramp.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_offramp.go
@@ -24,9 +24,8 @@ var (
 		shared.OffRamp,
 		offramp.OffRampMetaData,
 		&opsutils.ContractOpts{
-			Version:          &deployment.Version1_6_0,
-			EVMBytecode:      common.FromHex(offramp.OffRampBin),
-			ZkSyncVMBytecode: offramp.ZkBytecode,
+			Version:     &deployment.Version1_6_0,
+			EVMBytecode: common.FromHex(offramp.OffRampBin),
 		},
 		func(input DeployOffRampInput) []any {
 			return []any{

--- a/deployment/ccip/operation/evm/v1_6/ops_onramp.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_onramp.go
@@ -21,9 +21,8 @@ var (
 		shared.OnRamp,
 		onramp.OnRampMetaData,
 		&opsutils.ContractOpts{
-			Version:          &deployment.Version1_6_0,
-			EVMBytecode:      common.FromHex(onramp.OnRampBin),
-			ZkSyncVMBytecode: onramp.ZkBytecode,
+			Version:     &deployment.Version1_6_0,
+			EVMBytecode: common.FromHex(onramp.OnRampBin),
 		},
 		func(input DeployOnRampInput) []any {
 			return []any{

--- a/deployment/ccip/operation/evm/v1_6/ops_rmnremote.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_rmnremote.go
@@ -40,9 +40,8 @@ var (
 		shared.RMNRemote,
 		rmn_remote.RMNRemoteMetaData,
 		&opsutils.ContractOpts{
-			Version:          &deployment.Version1_6_0,
-			EVMBytecode:      common.FromHex(rmn_remote.RMNRemoteBin),
-			ZkSyncVMBytecode: rmn_remote.ZkBytecode,
+			Version:     &deployment.Version1_6_0,
+			EVMBytecode: common.FromHex(rmn_remote.RMNRemoteBin),
 		},
 		func(input DeployRMNRemoteInput) []any {
 			return []any{

--- a/deployment/ccip/view/v1_0/link_token_test.go
+++ b/deployment/ccip/view/v1_0/link_token_test.go
@@ -9,7 +9,6 @@ import (
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/link_token"
@@ -28,24 +27,6 @@ func TestLinkTokenView(t *testing.T) {
 	_, tx, lt, err := link_token.DeployLinkToken(chain.DeployerKey, chain.Client)
 	require.NoError(t, err)
 	_, err = chain.Confirm(tx)
-	require.NoError(t, err)
-
-	testLinkTokenViewWithChain(t, chain, lt)
-}
-
-func TestLinkTokenViewZk(t *testing.T) {
-	// Timeouts in CI
-	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/CCIP-6427")
-	t.Parallel()
-
-	selector := chainselectors.TEST_90000050.Selector
-	env, err := environment.New(t.Context(),
-		environment.WithZKSyncContainer(t, []uint64{selector}),
-	)
-	require.NoError(t, err)
-
-	chain := env.BlockChains.EVMChains()[selector]
-	_, _, lt, err := link_token.DeployLinkTokenZk(nil, chain.ClientZkSyncVM, chain.DeployerKeyZkSyncVM, chain.Client)
 	require.NoError(t, err)
 
 	testLinkTokenViewWithChain(t, chain, lt)


### PR DESCRIPTION
All CCIP ZKSync-based chains support EVM bytecode, the custom compiling and deploying of code is no longer needed.