### PR TITLE
fix(sui): OCR3 changeset support to MCMS

### DIFF
--- a/deployment/ccip/changeset/sui/cs_set_ocr3_offramp.go
+++ b/deployment/ccip/changeset/sui/cs_set_ocr3_offramp.go
@@ -67,6 +67,11 @@ func (s SetOCR3Offramp) Apply(e cldf.Environment, config v1_6.SetOCR3OffRampConf
 			CCIPOnChainState: state,
 		}
 
+		// If timelock proposal is to be generated, disable signer in deps
+		if config.MCMS != nil {
+			deps.SuiChain.Signer = nil
+		}
+
 		// DonIds for the chain
 		donID, err := internal.DonIDForChain(deps.CCIPOnChainState.Chains[config.HomeChainSel].CapabilityRegistry,
 			deps.CCIPOnChainState.Chains[config.HomeChainSel].CCIPHome,

--- a/deployment/ccip/changeset/sui/cs_set_ocr3_offramp.go
+++ b/deployment/ccip/changeset/sui/cs_set_ocr3_offramp.go
@@ -9,7 +9,6 @@ import (
 	"golang.org/x/crypto/blake2b"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
@@ -160,7 +159,7 @@ func (s SetOCR3Offramp) Apply(e cldf.Environment, config v1_6.SetOCR3OffRampConf
 			addr := "0x" + hex.EncodeToString(hash[:])
 			execTransmitters = append(execTransmitters, addr)
 		}
-		_, err = operations.ExecuteOperation(e.OperationsBundle, offrampops.SetOCR3ConfigOp, deps.SuiChain, setOCR3ConfigCommitInput)
+		_, err = cld_ops.ExecuteOperation(e.OperationsBundle, offrampops.SetOCR3ConfigOp, deps.SuiChain, setOCR3ConfigCommitInput)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -179,7 +178,7 @@ func (s SetOCR3Offramp) Apply(e cldf.Environment, config v1_6.SetOCR3OffRampConf
 			Transmitters:                   execTransmitters,
 		}
 
-		report, err := operations.ExecuteOperation(e.OperationsBundle, offrampops.SetOCR3ConfigOp, deps.SuiChain, setOCR3ConfigExecInput)
+		report, err := cld_ops.ExecuteOperation(e.OperationsBundle, offrampops.SetOCR3ConfigOp, deps.SuiChain, setOCR3ConfigExecInput)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}

--- a/deployment/ccip/changeset/sui/cs_set_ocr3_offramp.go
+++ b/deployment/ccip/changeset/sui/cs_set_ocr3_offramp.go
@@ -5,22 +5,25 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/smartcontractkit/mcms"
 	"golang.org/x/crypto/blake2b"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
 	sui_deployment "github.com/smartcontractkit/chainlink-sui/deployment"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 	offrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_offramp"
+	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
+	suiutils "github.com/smartcontractkit/chainlink-sui/deployment/utils"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/internal"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 )
 
@@ -45,6 +48,8 @@ func (s SetOCR3Offramp) Apply(e cldf.Environment, config v1_6.SetOCR3OffRampConf
 	}
 
 	ab := cldf.NewMemoryAddressBook()
+
+	mcmsProposals := []mcms.TimelockProposal{}
 
 	for _, remoteSelector := range config.RemoteChainSels {
 		suiChains := e.BlockChains.SuiChains()
@@ -174,9 +179,41 @@ func (s SetOCR3Offramp) Apply(e cldf.Environment, config v1_6.SetOCR3OffRampConf
 			Transmitters:                   execTransmitters,
 		}
 
-		_, err = operations.ExecuteOperation(e.OperationsBundle, offrampops.SetOCR3ConfigOp, deps.SuiChain, setOCR3ConfigExecInput)
+		report, err := operations.ExecuteOperation(e.OperationsBundle, offrampops.SetOCR3ConfigOp, deps.SuiChain, setOCR3ConfigExecInput)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
+		}
+
+		genericReport := report.ToGenericReport()
+		if config.MCMS != nil {
+			defs := []cld_ops.Definition{genericReport.Def}
+			inputs := []any{genericReport.Input}
+
+			suiTimelockConfig := suiutils.TimelockConfig{
+				MCMSAction:   config.MCMS.MCMSAction,
+				MinDelay:     config.MCMS.MinDelay,
+				OverrideRoot: config.MCMS.OverrideRoot,
+			}
+			mcmsState := suiState[remoteSelector].MCMSState(false)
+			mcmsConfig := mcmsops.ProposalGenerateInput{
+				ChainSelector:      remoteSelector,
+				Defs:               defs,
+				Inputs:             inputs,
+				MmcsPackageID:      mcmsState.PackageID,
+				McmsStateObjID:     mcmsState.StateObjectID,
+				TimelockObjID:      mcmsState.TimelockObjectID,
+				AccountObjID:       mcmsState.AccountStateObjectID,
+				RegistryObjID:      mcmsState.RegistryObjectID,
+				DeployerStateObjID: mcmsState.DeployerStateObjectID,
+				TimelockConfig:     suiTimelockConfig,
+			}
+
+			result, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.MCMSDynamicProposalGenerateSeq, deps.SuiChain, mcmsConfig)
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate MCMS proposal: %w", err)
+			}
+
+			mcmsProposals = append(mcmsProposals, result.Output)
 		}
 	}
 
@@ -186,8 +223,9 @@ func (s SetOCR3Offramp) Apply(e cldf.Environment, config v1_6.SetOCR3OffRampConf
 	}
 
 	return cldf.ChangesetOutput{
-		AddressBook: ab,
-		DataStore:   ds,
+		AddressBook:           ab,
+		DataStore:             ds,
+		MCMSTimelockProposals: mcmsProposals,
 	}, nil
 }
 


### PR DESCRIPTION
# Summary

The SUI `SetOCR3Offramp` changeset didn't have support for MCMS. For SUI, a signer is present in the deps will make operation try to execute the call, by simply removing the signer from deps will trigger the operation to encode the call and return an MCMS proposal.