### PR TITLE
[DX-4045] Loopinstall Caching

### DIFF
--- a/.github/actions/setup-aptos/action.yml
+++ b/.github/actions/setup-aptos/action.yml
@@ -1,0 +1,27 @@
+name: Setup Aptos CLI
+description: Install and cache Aptos CLI
+inputs:
+  version:
+    description: Aptos CLI version
+    required: false
+    default: "8.1.0"
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Aptos CLI
+      id: cache
+      uses: actions/cache@v6
+      with:
+        path: ~/.aptos/bin
+        key: ${{ runner.os }}-${{ runner.arch }}-aptos-${{ inputs.version }}
+
+    - name: Install Aptos CLI
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      uses: aptos-labs/actions/install-aptos-cli@fdd3a3a628c840d5c35086a87e9cc3141b635505
+      with:
+        CLI_VERSION: ${{ inputs.version }}
+
+    - name: Export Aptos CLI to PATH
+      shell: bash
+      run: echo "$HOME/.aptos/bin" >> "$GITHUB_PATH"

--- a/.github/actions/setup-aptos/action.yml
+++ b/.github/actions/setup-aptos/action.yml
@@ -13,8 +13,11 @@ runs:
       id: cache
       uses: actions/cache@v6
       with:
-        path: ~/.aptos/bin
+        path: |
+          ~/.local/bin/aptos
         key: ${{ runner.os }}-${{ runner.arch }}-aptos-${{ inputs.version }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-aptos-
 
     - name: Install Aptos CLI
       if: ${{ steps.cache.outputs.cache-hit != 'true' }}
@@ -24,4 +27,4 @@ runs:
 
     - name: Export Aptos CLI to PATH
       shell: bash
-      run: echo "$HOME/.aptos/bin" >> "$GITHUB_PATH"
+      run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/.github/actions/setup-aptos/action.yml
+++ b/.github/actions/setup-aptos/action.yml
@@ -21,7 +21,7 @@ runs:
 
     - name: Install Aptos CLI
       if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-      uses: aptos-labs/actions/install-aptos-cli@fdd3a3a628c840d5c35086a87e9cc3141b635505
+      uses: aptos-labs/actions/install-aptos-cli@70f94109f7392b0ca0ae156fdee567b4bb6a52f6 # 2026-04-07
       with:
         CLI_VERSION: ${{ inputs.version }}
 

--- a/.github/actions/setup-loop-plugins/action.yml
+++ b/.github/actions/setup-loop-plugins/action.yml
@@ -1,0 +1,74 @@
+name: Setup LOOP Plugins
+description: Setup and cache LOOP plugins
+inputs:
+  plugin-file:
+    description: Path to public plugins file
+    required: false
+    default: plugins/plugins.public.yaml
+  install-local:
+    description: Whether to install local plugins
+    required: false
+    default: "true"
+  cache-version:
+    description: Cache version bust knob
+    required: false
+    default: "v1"
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve Cache Keys and Directories
+      id: keys
+      shell: bash
+      run: |
+        echo "bin=$HOME/.cache/cl-loop-plugins/bin" >> "$GITHUB_OUTPUT"
+        echo "gocache=$HOME/.cache/cl-loop-plugins/gocache" >> "$GITHUB_OUTPUT"
+        echo "goversion=$(go env GOVERSION)" >> "$GITHUB_OUTPUT"
+
+    - name: Restore Binaries Cache (Tier 1)
+      id: bin-cache
+      uses: actions/cache/restore@v6
+      with:
+        path: ${{ steps.keys.outputs.bin }}
+        key: ${{ runner.os }}-${{ runner.arch }}-loopbin-${{ inputs.cache-version }}-${{ steps.keys.outputs.goversion }}-${{ hashFiles(inputs.plugin-file) }}
+
+    - name: Restore Go Build Cache (Tier 2)
+      id: gocache-cache
+      if: ${{ steps.bin-cache.outputs.cache-hit != 'true' }}
+      uses: actions/cache/restore@v6
+      with:
+        path: ${{ steps.keys.outputs.gocache }}
+        key: ${{ runner.os }}-${{ runner.arch }}-loopgocache-${{ inputs.cache-version }}-${{ steps.keys.outputs.goversion }}-${{ hashFiles(inputs.plugin-file) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-loopgocache-${{ inputs.cache-version }}-${{ steps.keys.outputs.goversion }}-
+
+    - name: Build public plugins
+      if: ${{ steps.bin-cache.outputs.cache-hit != 'true' }}
+      shell: bash
+      env:
+        GOBIN: ${{ steps.keys.outputs.bin }}
+        GOCACHE: ${{ steps.keys.outputs.gocache }}
+      run: make install-plugins-public
+
+    - name: Save Binaries Cache (Tier 1)
+      if: ${{ steps.bin-cache.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v6
+      with:
+        path: ${{ steps.keys.outputs.bin }}
+        key: ${{ runner.os }}-${{ runner.arch }}-loopbin-${{ inputs.cache-version }}-${{ steps.keys.outputs.goversion }}-${{ hashFiles(inputs.plugin-file) }}
+
+    - name: Save Go Build Cache (Tier 2)
+      if: ${{ steps.bin-cache.outputs.cache-hit != 'true' && steps.gocache-cache.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v6
+      with:
+        path: ${{ steps.keys.outputs.gocache }}
+        key: ${{ runner.os }}-${{ runner.arch }}-loopgocache-${{ inputs.cache-version }}-${{ steps.keys.outputs.goversion }}-${{ hashFiles(inputs.plugin-file) }}
+
+    - name: Export plugin bin to PATH
+      shell: bash
+      run: echo "${{ steps.keys.outputs.bin }}" >> "$GITHUB_PATH"
+
+    - name: Install local plugins
+      if: ${{ inputs.install-local == 'true' }}
+      shell: bash
+      run: make install-plugins-local

--- a/.github/actions/setup-loop-plugins/action.yml
+++ b/.github/actions/setup-loop-plugins/action.yml
@@ -1,10 +1,18 @@
 name: Setup LOOP Plugins
 description: Setup and cache LOOP plugins
 inputs:
-  plugin-file:
-    description: Path to public plugins file
+  install-public:
+    description: Whether to install public plugins
     required: false
-    default: plugins/plugins.public.yaml
+    default: "true"
+  install-private:
+    description: Whether to install private plugins
+    required: false
+    default: "false"
+  install-testing:
+    description: Whether to install testing plugins
+    required: false
+    default: "false"
   install-local:
     description: Whether to install local plugins
     required: false
@@ -25,12 +33,23 @@ runs:
         echo "gocache=$HOME/.cache/cl-loop-plugins/gocache" | tee -a "$GITHUB_OUTPUT"
         echo "goversion=$(go env GOVERSION)" | tee -a "$GITHUB_OUTPUT"
 
+        FILES=""
+        [ "${{ inputs.install-public }}" = "true" ] && FILES="$FILES plugins/plugins.public.yaml"
+        [ "${{ inputs.install-private }}" = "true" ] && FILES="$FILES plugins/plugins.private.yaml"
+        [ "${{ inputs.install-testing }}" = "true" ] && FILES="$FILES plugins/plugins.testing.yaml"
+
+        MANIFEST_HASH=""
+        if [ -n "$FILES" ]; then
+          MANIFEST_HASH=$(cat $FILES 2>/dev/null | shasum -a 256 | awk '{print $1}')
+        fi
+        echo "manifesthash=$MANIFEST_HASH" | tee -a "$GITHUB_OUTPUT"
+
     - name: Restore Binaries Cache (Tier 1)
       id: bin-cache
       uses: actions/cache/restore@v6
       with:
         path: ${{ steps.keys.outputs.bin }}
-        key: ${{ runner.os }}-${{ runner.arch }}-loopbin-${{ inputs.cache-version }}-${{ steps.keys.outputs.goversion }}-${{ hashFiles(inputs.plugin-file) }}
+        key: ${{ runner.os }}-${{ runner.arch }}-loopbin-${{ inputs.cache-version }}-${{ steps.keys.outputs.goversion }}-${{ steps.keys.outputs.manifesthash }}
 
     - name: Restore Go Build Cache (Tier 2)
       id: gocache-cache
@@ -38,31 +57,47 @@ runs:
       uses: actions/cache/restore@v6
       with:
         path: ${{ steps.keys.outputs.gocache }}
-        key: ${{ runner.os }}-${{ runner.arch }}-loopgocache-${{ inputs.cache-version }}-${{ steps.keys.outputs.goversion }}-${{ hashFiles(inputs.plugin-file) }}
+        key: ${{ runner.os }}-${{ runner.arch }}-loopgocache-${{ inputs.cache-version }}-${{ steps.keys.outputs.goversion }}-${{ steps.keys.outputs.manifesthash }}
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-loopgocache-${{ inputs.cache-version }}-${{ steps.keys.outputs.goversion }}-
 
     - name: Build public plugins
-      if: ${{ steps.bin-cache.outputs.cache-hit != 'true' }}
+      if: ${{ steps.bin-cache.outputs.cache-hit != 'true' && inputs.install-public == 'true' }}
       shell: bash
       env:
         GOBIN: ${{ steps.keys.outputs.bin }}
         GOCACHE: ${{ steps.keys.outputs.gocache }}
       run: make install-plugins-public
 
+    - name: Build private plugins
+      if: ${{ steps.bin-cache.outputs.cache-hit != 'true' && inputs.install-private == 'true' }}
+      shell: bash
+      env:
+        GOBIN: ${{ steps.keys.outputs.bin }}
+        GOCACHE: ${{ steps.keys.outputs.gocache }}
+      run: make install-plugins-private
+
+    - name: Build testing plugins
+      if: ${{ steps.bin-cache.outputs.cache-hit != 'true' && inputs.install-testing == 'true' }}
+      shell: bash
+      env:
+        GOBIN: ${{ steps.keys.outputs.bin }}
+        GOCACHE: ${{ steps.keys.outputs.gocache }}
+      run: make install-plugins-testing
+
     - name: Save Binaries Cache (Tier 1)
       if: ${{ steps.bin-cache.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v6
       with:
         path: ${{ steps.keys.outputs.bin }}
-        key: ${{ runner.os }}-${{ runner.arch }}-loopbin-${{ inputs.cache-version }}-${{ steps.keys.outputs.goversion }}-${{ hashFiles(inputs.plugin-file) }}
+        key: ${{ runner.os }}-${{ runner.arch }}-loopbin-${{ inputs.cache-version }}-${{ steps.keys.outputs.goversion }}-${{ steps.keys.outputs.manifesthash }}
 
     - name: Save Go Build Cache (Tier 2)
       if: ${{ steps.bin-cache.outputs.cache-hit != 'true' && steps.gocache-cache.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v6
       with:
         path: ${{ steps.keys.outputs.gocache }}
-        key: ${{ runner.os }}-${{ runner.arch }}-loopgocache-${{ inputs.cache-version }}-${{ steps.keys.outputs.goversion }}-${{ hashFiles(inputs.plugin-file) }}
+        key: ${{ runner.os }}-${{ runner.arch }}-loopgocache-${{ inputs.cache-version }}-${{ steps.keys.outputs.goversion }}-${{ steps.keys.outputs.manifesthash }}
 
     - name: Export plugin bin to PATH
       shell: bash

--- a/.github/actions/setup-loop-plugins/action.yml
+++ b/.github/actions/setup-loop-plugins/action.yml
@@ -21,9 +21,9 @@ runs:
       id: keys
       shell: bash
       run: |
-        echo "bin=$HOME/.cache/cl-loop-plugins/bin" >> "$GITHUB_OUTPUT"
-        echo "gocache=$HOME/.cache/cl-loop-plugins/gocache" >> "$GITHUB_OUTPUT"
-        echo "goversion=$(go env GOVERSION)" >> "$GITHUB_OUTPUT"
+        echo "bin=$HOME/.cache/cl-loop-plugins/bin" | tee -a "$GITHUB_OUTPUT"
+        echo "gocache=$HOME/.cache/cl-loop-plugins/gocache" | tee -a "$GITHUB_OUTPUT"
+        echo "goversion=$(go env GOVERSION)" | tee -a "$GITHUB_OUTPUT"
 
     - name: Restore Binaries Cache (Tier 1)
       id: bin-cache

--- a/.github/actions/setup-solana/action.yml
+++ b/.github/actions/setup-solana/action.yml
@@ -1,6 +1,10 @@
 name: Setup Solana CLI
 description: Setup solana CLI
 inputs:
+  version:
+    description: Solana CLI version
+    required: false
+    default: v1.18.26
   base-path:
     description: Path to the base of the repo
     required: false
@@ -13,8 +17,10 @@ runs:
       name: Cache solana CLI
       with:
         path: |
-          ~/.local/share/solana/install/active_release/bin
-        key: ${{ runner.os }}-${{ runner.arch }}-solana-cli-${{ hashFiles(format('{0}/tools/ci/install_solana', inputs.base-path)) }}
+          ~/.local/share/solana
+        key: ${{ runner.os }}-${{ runner.arch }}-solana-cli-${{ inputs.version }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-solana-cli-
 
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: Install solana cli

--- a/.github/actions/setup-solana/action.yml
+++ b/.github/actions/setup-solana/action.yml
@@ -1,10 +1,6 @@
 name: Setup Solana CLI
 description: Setup solana CLI
 inputs:
-  version:
-    description: Solana CLI version
-    required: false
-    default: v1.18.26
   base-path:
     description: Path to the base of the repo
     required: false
@@ -18,7 +14,7 @@ runs:
       with:
         path: |
           ~/.local/share/solana
-        key: ${{ runner.os }}-${{ runner.arch }}-solana-cli-${{ inputs.version }}
+        key: ${{ runner.os }}-${{ runner.arch }}-solana-cli-${{ hashFiles(format('{0}/tools/ci/install_solana', inputs.base-path)) }}
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-solana-cli-
 

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -367,9 +367,7 @@ jobs:
 
       - name: Setup Aptos
         if: ${{ matrix.type.should-run == 'true' && matrix.type.setup-aptos == 'true' }}
-        uses: aptos-labs/actions/install-aptos-cli@fdd3a3a628c840d5c35086a87e9cc3141b635505 # 2026-05-20
-        with:
-          CLI_VERSION: 8.1.0
+        uses: ./.github/actions/setup-aptos
 
       - name: Setup Sui CLI v1.72.2
         if: ${{ matrix.type.should-run == 'true' && matrix.type.setup-sui == 'true' }}

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -404,7 +404,7 @@ jobs:
         if:
           ${{ matrix.type.should-run == 'true' && matrix.type.install-loopps == 'true'
           }}
-        run: make install-plugins
+        uses: ./.github/actions/setup-loop-plugins
 
       - name: Increase Timeouts for Fuzz/Race
         # Increase timeouts for scheduled runs only

--- a/.github/workflows/ci-deployments.yml
+++ b/.github/workflows/ci-deployments.yml
@@ -156,12 +156,12 @@ jobs:
           build-cache-write: ${{ matrix.shard-id == 1 && 'default-branch-only' || 'never' }}
           go-version-file: deployment/go.mod
           go-module-file: deployment/go.sum
+      - name: Download Go vendor packages
+        run: go mod download
       - name: Setup Solana
         uses: ./.github/actions/setup-solana
       - name: Setup Aptos
-        uses: aptos-labs/actions/install-aptos-cli@fdd3a3a628c840d5c35086a87e9cc3141b635505 # 2026-05-20
-        with:
-          CLI_VERSION: 8.1.0
+        uses: ./.github/actions/setup-aptos
       - name: Setup Sui CLI v1.72.2
         uses: ./.github/actions/setup-sui
         with:
@@ -173,10 +173,10 @@ jobs:
           tmpfs: "true"
           image-tag: "16-alpine"
           postgres-options: "-c max_connections=1000 -c shared_buffers=2GB -c fsync=off -c synchronous_commit=off -c full_page_writes=off -c client_min_messages=warning" # Turn off some prod-protections to make postgres go brrr. https://github.com/peterldowns/pgtestdb#how-do-i-make-it-go-faster
-      - name: Download Go vendor packages
-        run: go mod download
       - name: Setup DB
-        run: go run ./core/store/cmd/preparetest
+        run: |
+          go install ./core/store/cmd/preparetest
+          preparetest
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}
       - name: Install LOOP Plugins

--- a/.github/workflows/ci-deployments.yml
+++ b/.github/workflows/ci-deployments.yml
@@ -157,6 +157,7 @@ jobs:
           go-version-file: deployment/go.mod
           go-module-file: deployment/go.sum
       - name: Download Go vendor packages
+        working-directory: deployment
         run: go mod download
       - name: Setup Solana
         uses: ./.github/actions/setup-solana

--- a/.github/workflows/ci-deployments.yml
+++ b/.github/workflows/ci-deployments.yml
@@ -180,7 +180,7 @@ jobs:
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}
       - name: Install LOOP Plugins
-        run: make install-plugins
+        uses: ./.github/actions/setup-loop-plugins
       - name: Run tests
         timeout-minutes: 25
         continue-on-error: true

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -232,11 +232,11 @@ jobs:
             echo "::endgroup::"
           fi
 
-      - name: Install Aptos CLI
+      - name: Setup Aptos CLI
         if: ${{ matrix.tests.test_name == 'Test_CRE_V2_Aptos_Suite' }}
-        uses: aptos-labs/actions/install-aptos-cli@fdd3a3a628c840d5c35086a87e9cc3141b635505 # 2026-05-20
+        uses: ./.github/actions/setup-aptos
         with:
-          CLI_VERSION: 7.8.0
+          version: "7.8.0"
 
       - name: Setup Stellar CRE contracts
         if: ${{ contains(matrix.tests.test_name, 'Stellar') }}


### PR DESCRIPTION
Running `loopinstall` takes ~5 minutes in CI, and there's no proper caching for it. This PR [adds it in two tiers](https://github.com/smartcontractkit/chainlink/compare/loopinstallCaching?expand=1#diff-bf24a49405b71a06abeb9ec0d7eb1e23eeb6b72fa34b9b2c86e1ce6c85ee25aeR28-R35).

* Tier 1 caches the binaries. Handy when plugins file doesn't change.
* Tier 2 handles the build cache for the binaries, for when plugin versions do change.