### PR TITLE
cre-5718: one-shot readiness effect with a regression test

### DIFF
--- a/core/capabilities/remote/messagecache/message_cache.go
+++ b/core/capabilities/remote/messagecache/message_cache.go
@@ -42,7 +42,9 @@ func (c *MessageCache[EventID, PeerID]) Insert(eventID EventID, peerID PeerID, t
 // Return true if there are messages from at least <minCount> peers,
 // received more recently than <minTimestamp>.
 // Return all messages that satisfy the above condition.
-// Ready() will return true at most once per event if <once> is true.
+// If <once> is true, Ready() returns false once MarkDelivered has been called
+// for the event. Call MarkDelivered only after the caller has successfully
+// consumed the aggregated result (e.g. after aggregation succeeds).
 func (c *MessageCache[EventID, PeerID]) Ready(eventID EventID, minCount uint32, minTimestamp int64, once bool) (bool, [][]byte) {
 	ev, ok := c.events[eventID]
 	if !ok {
@@ -64,9 +66,6 @@ func (c *MessageCache[EventID, PeerID]) Ready(eventID EventID, minCount uint32, 
 		}
 	}
 	if countAboveMinTimestamp >= minCount {
-		if once {
-			ev.wasReady = true
-		}
 		return true, accPayloads
 	}
 	return false, nil

--- a/core/capabilities/remote/messagecache/message_cache.go
+++ b/core/capabilities/remote/messagecache/message_cache.go
@@ -64,10 +64,18 @@ func (c *MessageCache[EventID, PeerID]) Ready(eventID EventID, minCount uint32, 
 		}
 	}
 	if countAboveMinTimestamp >= minCount {
-		ev.wasReady = true
+		if once {
+			ev.wasReady = true
+		}
 		return true, accPayloads
 	}
 	return false, nil
+}
+
+func (c *MessageCache[EventID, PeerID]) MarkDelivered(eventID EventID) {
+	if ev, ok := c.events[eventID]; ok {
+		ev.wasReady = true
+	}
 }
 
 // WasReady reports whether Ready has already returned true for eventID (once=true path).

--- a/core/capabilities/remote/messagecache/message_cache_test.go
+++ b/core/capabilities/remote/messagecache/message_cache_test.go
@@ -33,13 +33,20 @@ func TestMessageCache_InsertReady(t *testing.T) {
 	ready, _ = cache.Ready(eventID1, 2, 150, true)
 	require.False(t, ready)
 
-	// ready with two messages (once only)
+	// ready with two messages — Ready does not commit delivery state;
+	// it returns true every time the threshold is met until MarkDelivered.
 	ready, messages := cache.Ready(eventID1, 2, 100, true)
 	require.True(t, ready)
 	require.Equal(t, []byte(payloadA), messages[0])
 	require.Equal(t, []byte(payloadA), messages[1])
 
-	// not ready again for the same event ID
+	// still ready before MarkDelivered (failed aggregation can retry)
+	ready, _ = cache.Ready(eventID1, 2, 100, true)
+	require.True(t, ready)
+	require.False(t, cache.WasReady(eventID1))
+
+	// after MarkDelivered, once=true returns false and WasReady reports true
+	cache.MarkDelivered(eventID1)
 	ready, _ = cache.Ready(eventID1, 2, 100, true)
 	require.False(t, ready)
 	require.True(t, cache.WasReady(eventID1))

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -375,6 +375,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 			p.lggr.Errorw("failed to unmarshal request", "err", unmarshalErr)
 			return
 		}
+		p.messageCache.MarkDelivered(key)
 		p.mu.Unlock()
 
 		capAttrs := metric.WithAttributes(
@@ -486,6 +487,7 @@ func (p *triggerPublisher) Receive(ctx context.Context, msg *types.MessageBody) 
 		p.lggr.Debugw("unregister trigger", "workflowID", key.workflowID, "triggerID", key.triggerID,
 			"callerDonId", msg.CallerDonId, "minRequired", minRequired, "sender", sender)
 		delete(p.registrations, key)
+		p.unregisterCache.MarkDelivered(key)
 		p.unregisterCache.Delete(key)
 		p.messageCache.Delete(key)
 		p.mu.Unlock()

--- a/core/capabilities/remote/trigger_subscriber.go
+++ b/core/capabilities/remote/trigger_subscriber.go
@@ -371,18 +371,30 @@ func (s *triggerSubscriber) Receive(_ context.Context, msg *types.MessageBody) {
 
 			nowMs := time.Now().UnixMilli()
 			creationTs := s.messageCache.Insert(key, sender, nowMs, msg.Payload)
-			ready, payloads := s.messageCache.Ready(key, cfg.remoteConfig.MinResponsesToAggregate, nowMs-cfg.remoteConfig.MessageExpiry.Milliseconds(), true)
+
+			ready := false
+			var payloads [][]byte
+			if !s.messageCache.WasReady(key) {
+				ready, payloads = s.messageCache.Ready(key, cfg.remoteConfig.MinResponsesToAggregate, nowMs-cfg.remoteConfig.MessageExpiry.Milliseconds(), false)
+			}
+			if !ready {
+				s.mu.Unlock()
+				s.lggr.Debugw("trigger event received", "triggerEventId", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID, "sender", sender, "ready", ready, "nowTs", nowMs, "creationTs", creationTs, "minResponsesToAggregate", cfg.remoteConfig.MinResponsesToAggregate)
+				continue
+			}
+
+			aggregatedResponse, err := cfg.aggregator.Aggregate(meta.TriggerEventId, payloads)
+			if err != nil {
+				s.mu.Unlock()
+				s.lggr.Debugw("trigger event received", "triggerEventId", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID, "sender", sender, "ready", ready, "nowTs", nowMs, "creationTs", creationTs, "minResponsesToAggregate", cfg.remoteConfig.MinResponsesToAggregate)
+				s.lggr.Errorw("failed to aggregate responses", "triggerEventID", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID, "err", err)
+				continue
+			}
+			s.messageCache.MarkDelivered(key)
 			s.mu.Unlock()
 			s.lggr.Debugw("trigger event received", "triggerEventId", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID, "sender", sender, "ready", ready, "nowTs", nowMs, "creationTs", creationTs, "minResponsesToAggregate", cfg.remoteConfig.MinResponsesToAggregate)
-			if ready {
-				aggregatedResponse, err := cfg.aggregator.Aggregate(meta.TriggerEventId, payloads)
-				if err != nil {
-					s.lggr.Errorw("failed to aggregate responses", "triggerEventID", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID, "err", err)
-					continue
-				}
-				s.lggr.Infow("remote trigger event aggregated", "triggerEventID", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID)
-				registration.callback <- aggregatedResponse
-			}
+			s.lggr.Infow("remote trigger event aggregated", "triggerEventID", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID)
+			registration.callback <- aggregatedResponse
 		}
 	case types.MethodTriggerRegistrationCheck:
 		meta := msg.GetTriggerEventMetadata()

--- a/core/capabilities/remote/trigger_subscriber.go
+++ b/core/capabilities/remote/trigger_subscriber.go
@@ -371,12 +371,7 @@ func (s *triggerSubscriber) Receive(_ context.Context, msg *types.MessageBody) {
 
 			nowMs := time.Now().UnixMilli()
 			creationTs := s.messageCache.Insert(key, sender, nowMs, msg.Payload)
-
-			ready := false
-			var payloads [][]byte
-			if !s.messageCache.WasReady(key) {
-				ready, payloads = s.messageCache.Ready(key, cfg.remoteConfig.MinResponsesToAggregate, nowMs-cfg.remoteConfig.MessageExpiry.Milliseconds(), false)
-			}
+			ready, payloads := s.messageCache.Ready(key, cfg.remoteConfig.MinResponsesToAggregate, nowMs-cfg.remoteConfig.MessageExpiry.Milliseconds(), true)
 			if !ready {
 				s.mu.Unlock()
 				s.lggr.Debugw("trigger event received", "triggerEventId", meta.TriggerEventId, "workflowId", workflowID, "triggerID", triggerID, "sender", sender, "ready", ready, "nowTs", nowMs, "creationTs", creationTs, "minResponsesToAggregate", cfg.remoteConfig.MinResponsesToAggregate)

--- a/core/capabilities/remote/trigger_subscriber_byzantine_first_quorum_test.go
+++ b/core/capabilities/remote/trigger_subscriber_byzantine_first_quorum_test.go
@@ -1,0 +1,178 @@
+package remote_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
+	remotetypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	remoteMocks "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types/mocks"
+)
+
+// reproduces the one-shot readiness defect
+func TestTriggerSubscriber_ByzantineFirstQuorumSuppressesLaterHonestAggregation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		numMembers   = 4
+		minResponses = 3
+		eventID      = "byz-first-quorum-event"
+		triggerID    = "trigger-byz-first-quorum"
+	)
+
+	// ── Setup: subscriber with 4 cap-DON members and MinResponsesToAggregate=3 ──
+
+	lggr := logger.Test(t)
+	capInfo, capDon, workflowDon := buildTwoTestDONs(t, numMembers, 1)
+	dispatcher := remoteMocks.NewDispatcher(t)
+	dispatcher.On("Send", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	config := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     time.Hour,
+		RegistrationExpiry:      100 * time.Second,
+		MinResponsesToAggregate: minResponses,
+		MessageExpiry:           100 * time.Second,
+	}
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
+	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
+	require.NoError(t, subscriber.Start(t.Context()))
+
+	regReq := commoncap.TriggerRegistrationRequest{
+		TriggerID: triggerID,
+		Metadata:  commoncap.RequestMetadata{WorkflowID: workflowID1},
+	}
+	callbackCh, err := subscriber.RegisterTrigger(t.Context(), regReq)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), regReq))
+		require.NoError(t, subscriber.Close())
+	})
+
+	// Two byte-distinct payloads.  Both are valid TriggerResponses but they
+	// differ in Outputs, so the default-mode aggregator (which requires
+	// minResponses byte-identical payloads) cannot find a quorum among a
+	// 1-byzantine / 2-honest split.
+	honestPayload := marshalTriggerResponseOutputs(t, eventID, map[string]any{"price": "8300"})
+	byzantinePayload := marshalTriggerResponseOutputs(t, eventID, map[string]any{"price": "8300-tampered"})
+	require.NotEqual(t, honestPayload, byzantinePayload,
+		"honest and byzantine payloads must be byte-distinct for the aggregator to split")
+
+	// Helper: build a MethodTriggerEvent message from a specific DON member
+	// with a pre-marshaled payload.  All messages share the same eventID so
+	// they land in the same MessageCache entry.
+	msgFrom := func(memberIdx int, payload []byte) *remotetypes.MessageBody {
+		return &remotetypes.MessageBody{
+			Sender: capDon.Members[memberIdx][:],
+			Method: remotetypes.MethodTriggerEvent,
+			Metadata: &remotetypes.MessageBody_TriggerEventMetadata{
+				TriggerEventMetadata: &remotetypes.TriggerEventMetadata{
+					TriggerEventId: eventID,
+					WorkflowIds:    []string{workflowID1},
+					TriggerIds:     []string{triggerID},
+				},
+			},
+			Payload: payload,
+		}
+	}
+
+	// ── Phase 1: Deliver the mixed first quorum [byzantine, honest, honest] ──
+	//
+	//   distinct senders = 3 >= MinResponsesToAggregate
+	//     => Ready(..., once=true) returns true and commits wasReady=true
+	//   payloads = [byzantine, honest, honest]
+	//     => only 2 identical => Aggregate() fails
+	//   wasReady stays true (the defect)
+	subscriber.Receive(t.Context(), msgFrom(0, byzantinePayload))
+	subscriber.Receive(t.Context(), msgFrom(1, honestPayload))
+	subscriber.Receive(t.Context(), msgFrom(2, honestPayload))
+
+	// Aggregation failed on the mixed quorum — no callback expected.
+	select {
+	case <-callbackCh:
+		t.Fatal("unexpected callback from mixed first quorum [byzantine, honest, honest]")
+	default:
+	}
+
+	// ── Phase 2: Deliver the fourth (honest) response ──
+	//
+	//   The cache now holds [byzantine, honest, honest, honest].
+	//   3 identical honest payloads >= MinResponsesToAggregate => aggregation
+	//   WOULD succeed if Ready() were called again.  But wasReady=true makes
+	//   Ready(..., once=true) return false immediately, so aggregation is
+	//   never retried.
+	subscriber.Receive(t.Context(), msgFrom(3, honestPayload))
+
+	// Before the fix: the callback never fires (wasReady blocks the retry).
+	// After the fix:  the callback fires with the honest aggregated response.
+	select {
+	case resp := <-callbackCh:
+		require.NotNil(t, resp.Event.Outputs,
+			"aggregated response must carry outputs after the fix")
+	case <-time.After(2 * time.Second):
+		t.Fatal(
+			"DEFECT [report 85306]: 3 matching honest responses are in the cache " +
+				"after the mixed first quorum, but MessageCache.wasReady=true " +
+				"prevents aggregation retry. Fix: only commit wasReady after " +
+				"Aggregate() succeeds — call Ready(..., once=false) and mark " +
+				"delivered post-aggregation, or reset wasReady=false on " +
+				"aggregation error so the next response can re-attempt.",
+		)
+	}
+
+	// ── Phase 3: Prove the subscriber is still functional with a fresh event ──
+	//
+	//   A new all-honest event should aggregate normally, confirming the
+	//   subscriber/cache/aggregator pipeline is not permanently broken —
+	//   only the attacked event was suppressed.
+	const recoveryEventID = "recovery-event"
+	recoveryPayload := marshalTriggerResponseOutputs(t, recoveryEventID, map[string]any{"price": "8400"})
+	recoveryMsg := func(memberIdx int) *remotetypes.MessageBody {
+		return &remotetypes.MessageBody{
+			Sender: capDon.Members[memberIdx][:],
+			Method: remotetypes.MethodTriggerEvent,
+			Metadata: &remotetypes.MessageBody_TriggerEventMetadata{
+				TriggerEventMetadata: &remotetypes.TriggerEventMetadata{
+					TriggerEventId: recoveryEventID,
+					WorkflowIds:    []string{workflowID1},
+					TriggerIds:     []string{triggerID},
+				},
+			},
+			Payload: recoveryPayload,
+		}
+	}
+	subscriber.Receive(t.Context(), recoveryMsg(0))
+	subscriber.Receive(t.Context(), recoveryMsg(1))
+	subscriber.Receive(t.Context(), recoveryMsg(2))
+
+	select {
+	case resp := <-callbackCh:
+		require.NotNil(t, resp.Event.Outputs,
+			"recovery event must aggregate and deliver to callback")
+	case <-time.After(2 * time.Second):
+		t.Fatal("recovery event unexpectedly failed to aggregate — subscriber is not functional")
+	}
+}
+
+// marshalTriggerResponseOutputs creates a marshaled TriggerResponse with the
+// given event ID and outputs map.  Two calls with different outputs produce
+// byte-distinct payloads that the default-mode aggregator treats as different.
+func marshalTriggerResponseOutputs(t *testing.T, eventID string, outputs map[string]any) []byte {
+	t.Helper()
+	val, err := values.NewMap(outputs)
+	require.NoError(t, err)
+	resp := commoncap.TriggerResponse{
+		Event: commoncap.TriggerEvent{ID: eventID, Outputs: val},
+	}
+	marshaled, err := pb.MarshalTriggerResponse(resp)
+	require.NoError(t, err)
+	return marshaled
+}

--- a/core/capabilities/remote/trigger_subscriber_byzantine_first_quorum_test.go
+++ b/core/capabilities/remote/trigger_subscriber_byzantine_first_quorum_test.go
@@ -15,151 +15,159 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
 	remotetypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	remoteMocks "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types/mocks"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/synctest"
 )
 
 // reproduces the one-shot readiness defect
 func TestTriggerSubscriber_ByzantineFirstQuorumSuppressesLaterHonestAggregation(t *testing.T) {
 	t.Parallel()
 
-	const (
-		numMembers   = 4
-		minResponses = 3
-		eventID      = "byz-first-quorum-event"
-		triggerID    = "trigger-byz-first-quorum"
-	)
-
-	// ── Setup: subscriber with 4 cap-DON members and MinResponsesToAggregate=3 ──
-
-	lggr := logger.Test(t)
-	capInfo, capDon, workflowDon := buildTwoTestDONs(t, numMembers, 1)
-	dispatcher := remoteMocks.NewDispatcher(t)
-	dispatcher.On("Send", mock.Anything, mock.Anything).Return(nil).Maybe()
-
-	config := &commoncap.RemoteTriggerConfig{
-		RegistrationRefresh:     time.Hour,
-		RegistrationExpiry:      100 * time.Second,
-		MinResponsesToAggregate: minResponses,
-		MessageExpiry:           100 * time.Second,
-	}
-	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
-	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
-	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
-	require.NoError(t, subscriber.Start(t.Context()))
-
-	regReq := commoncap.TriggerRegistrationRequest{
-		TriggerID: triggerID,
-		Metadata:  commoncap.RequestMetadata{WorkflowID: workflowID1},
-	}
-	callbackCh, err := subscriber.RegisterTrigger(t.Context(), regReq)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, subscriber.UnregisterTrigger(t.Context(), regReq))
-		require.NoError(t, subscriber.Close())
-	})
-
-	// Two byte-distinct payloads.  Both are valid TriggerResponses but they
-	// differ in Outputs, so the default-mode aggregator (which requires
-	// minResponses byte-identical payloads) cannot find a quorum among a
-	// 1-byzantine / 2-honest split.
-	honestPayload := marshalTriggerResponseOutputs(t, eventID, map[string]any{"price": "8300"})
-	byzantinePayload := marshalTriggerResponseOutputs(t, eventID, map[string]any{"price": "8300-tampered"})
-	require.NotEqual(t, honestPayload, byzantinePayload,
-		"honest and byzantine payloads must be byte-distinct for the aggregator to split")
-
-	// Helper: build a MethodTriggerEvent message from a specific DON member
-	// with a pre-marshaled payload.  All messages share the same eventID so
-	// they land in the same MessageCache entry.
-	msgFrom := func(memberIdx int, payload []byte) *remotetypes.MessageBody {
-		return &remotetypes.MessageBody{
-			Sender: capDon.Members[memberIdx][:],
-			Method: remotetypes.MethodTriggerEvent,
-			Metadata: &remotetypes.MessageBody_TriggerEventMetadata{
-				TriggerEventMetadata: &remotetypes.TriggerEventMetadata{
-					TriggerEventId: eventID,
-					WorkflowIds:    []string{workflowID1},
-					TriggerIds:     []string{triggerID},
-				},
-			},
-			Payload: payload,
-		}
-	}
-
-	// ── Phase 1: Deliver the mixed first quorum [byzantine, honest, honest] ──
-	//
-	//   distinct senders = 3 >= MinResponsesToAggregate
-	//     => Ready(..., once=true) returns true and commits wasReady=true
-	//   payloads = [byzantine, honest, honest]
-	//     => only 2 identical => Aggregate() fails
-	//   wasReady stays true (the defect)
-	subscriber.Receive(t.Context(), msgFrom(0, byzantinePayload))
-	subscriber.Receive(t.Context(), msgFrom(1, honestPayload))
-	subscriber.Receive(t.Context(), msgFrom(2, honestPayload))
-
-	// Aggregation failed on the mixed quorum — no callback expected.
-	select {
-	case <-callbackCh:
-		t.Fatal("unexpected callback from mixed first quorum [byzantine, honest, honest]")
-	default:
-	}
-
-	// ── Phase 2: Deliver the fourth (honest) response ──
-	//
-	//   The cache now holds [byzantine, honest, honest, honest].
-	//   3 identical honest payloads >= MinResponsesToAggregate => aggregation
-	//   WOULD succeed if Ready() were called again.  But wasReady=true makes
-	//   Ready(..., once=true) return false immediately, so aggregation is
-	//   never retried.
-	subscriber.Receive(t.Context(), msgFrom(3, honestPayload))
-
-	// Before the fix: the callback never fires (wasReady blocks the retry).
-	// After the fix:  the callback fires with the honest aggregated response.
-	select {
-	case resp := <-callbackCh:
-		require.NotNil(t, resp.Event.Outputs,
-			"aggregated response must carry outputs after the fix")
-	case <-time.After(2 * time.Second):
-		t.Fatal(
-			"DEFECT [report 85306]: 3 matching honest responses are in the cache " +
-				"after the mixed first quorum, but MessageCache.wasReady=true " +
-				"prevents aggregation retry. Fix: only commit wasReady after " +
-				"Aggregate() succeeds — call Ready(..., once=false) and mark " +
-				"delivered post-aggregation, or reset wasReady=false on " +
-				"aggregation error so the next response can re-attempt.",
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			numMembers   = 4
+			minResponses = 3
+			eventID      = "byz-first-quorum-event"
+			triggerID    = "trigger-byz-first-quorum"
 		)
-	}
 
-	// ── Phase 3: Prove the subscriber is still functional with a fresh event ──
-	//
-	//   A new all-honest event should aggregate normally, confirming the
-	//   subscriber/cache/aggregator pipeline is not permanently broken —
-	//   only the attacked event was suppressed.
-	const recoveryEventID = "recovery-event"
-	recoveryPayload := marshalTriggerResponseOutputs(t, recoveryEventID, map[string]any{"price": "8400"})
-	recoveryMsg := func(memberIdx int) *remotetypes.MessageBody {
-		return &remotetypes.MessageBody{
-			Sender: capDon.Members[memberIdx][:],
-			Method: remotetypes.MethodTriggerEvent,
-			Metadata: &remotetypes.MessageBody_TriggerEventMetadata{
-				TriggerEventMetadata: &remotetypes.TriggerEventMetadata{
-					TriggerEventId: recoveryEventID,
-					WorkflowIds:    []string{workflowID1},
-					TriggerIds:     []string{triggerID},
-				},
-			},
-			Payload: recoveryPayload,
+		// ── Setup: subscriber with 4 cap-DON members and MinResponsesToAggregate=3 ──
+
+		lggr := logger.Test(t)
+		capInfo, capDon, workflowDon := buildTwoTestDONs(t, numMembers, 1)
+		dispatcher := remoteMocks.NewDispatcher(t)
+		dispatcher.On("Send", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+		config := &commoncap.RemoteTriggerConfig{
+			RegistrationRefresh:     time.Hour,
+			RegistrationExpiry:      100 * time.Second,
+			MinResponsesToAggregate: minResponses,
+			MessageExpiry:           100 * time.Second,
 		}
-	}
-	subscriber.Receive(t.Context(), recoveryMsg(0))
-	subscriber.Receive(t.Context(), recoveryMsg(1))
-	subscriber.Receive(t.Context(), recoveryMsg(2))
+		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+		agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
+		require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
+		require.NoError(t, subscriber.Start(t.Context()))
 
-	select {
-	case resp := <-callbackCh:
-		require.NotNil(t, resp.Event.Outputs,
-			"recovery event must aggregate and deliver to callback")
-	case <-time.After(2 * time.Second):
-		t.Fatal("recovery event unexpectedly failed to aggregate — subscriber is not functional")
-	}
+		regReq := commoncap.TriggerRegistrationRequest{
+			TriggerID: triggerID,
+			Metadata:  commoncap.RequestMetadata{WorkflowID: workflowID1},
+		}
+		callbackCh, err := subscriber.RegisterTrigger(t.Context(), regReq)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, subscriber.UnregisterTrigger(t.Context(), regReq))
+			require.NoError(t, subscriber.Close())
+		})
+
+		// Two byte-distinct payloads.  Both are valid TriggerResponses but they
+		// differ in Outputs, so the default-mode aggregator (which requires
+		// minResponses byte-identical payloads) cannot find a quorum among a
+		// 1-byzantine / 2-honest split.
+		honestPayload := marshalTriggerResponseOutputs(t, eventID, map[string]any{"price": "8300"})
+		byzantinePayload := marshalTriggerResponseOutputs(t, eventID, map[string]any{"price": "8300-tampered"})
+		require.NotEqual(t, honestPayload, byzantinePayload,
+			"honest and byzantine payloads must be byte-distinct for the aggregator to split")
+
+		// Helper: build a MethodTriggerEvent message from a specific DON member
+		// with a pre-marshaled payload.  All messages share the same eventID so
+		// they land in the same MessageCache entry.
+		msgFrom := func(memberIdx int, payload []byte) *remotetypes.MessageBody {
+			return &remotetypes.MessageBody{
+				Sender: capDon.Members[memberIdx][:],
+				Method: remotetypes.MethodTriggerEvent,
+				Metadata: &remotetypes.MessageBody_TriggerEventMetadata{
+					TriggerEventMetadata: &remotetypes.TriggerEventMetadata{
+						TriggerEventId: eventID,
+						WorkflowIds:    []string{workflowID1},
+						TriggerIds:     []string{triggerID},
+					},
+				},
+				Payload: payload,
+			}
+		}
+
+		// ── Phase 1: Deliver the mixed first quorum [byzantine, honest, honest] ──
+		//
+		//   distinct senders = 3 >= MinResponsesToAggregate
+		//     => Ready(..., once=true) returns true and commits wasReady=true
+		//   payloads = [byzantine, honest, honest]
+		//     => only 2 identical => Aggregate() fails
+		//   wasReady stays true (the defect)
+		subscriber.Receive(t.Context(), msgFrom(0, byzantinePayload))
+		subscriber.Receive(t.Context(), msgFrom(1, honestPayload))
+		subscriber.Receive(t.Context(), msgFrom(2, honestPayload))
+
+		// Aggregation failed on the mixed quorum — no callback expected.
+		// Receive is synchronous, so the callback channel is deterministically
+		// empty at this point; the non-blocking probe is stable under synctest.
+		select {
+		case <-callbackCh:
+			t.Fatal("unexpected callback from mixed first quorum [byzantine, honest, honest]")
+		default:
+		}
+
+		// ── Phase 2: Deliver the fourth (honest) response ──
+		//
+		//   The cache now holds [byzantine, honest, honest, honest].
+		//   3 identical honest payloads >= MinResponsesToAggregate => aggregation
+		//   WOULD succeed if Ready() were called again.  But wasReady=true makes
+		//   Ready(..., once=true) return false immediately, so aggregation is
+		//   never retried.
+		subscriber.Receive(t.Context(), msgFrom(3, honestPayload))
+
+		// Before the fix: the callback never fires (wasReady blocks the retry).
+		// After the fix:  the callback fires with the honest aggregated response.
+		// Under synctest the time.After fires deterministically (fake clock
+		// advances instantly once all goroutines block) instead of waiting real
+		// seconds.
+		select {
+		case resp := <-callbackCh:
+			require.NotNil(t, resp.Event.Outputs,
+				"aggregated response must carry outputs after the fix")
+		case <-time.After(2 * time.Second):
+			t.Fatal(
+				"DEFECT [report 85306]: 3 matching honest responses are in the cache " +
+					"after the mixed first quorum, but MessageCache.wasReady=true " +
+					"prevents aggregation retry. Fix: only commit wasReady after " +
+					"Aggregate() succeeds — call Ready(..., once=false) and mark " +
+					"delivered post-aggregation, or reset wasReady=false on " +
+					"aggregation error so the next response can re-attempt.",
+			)
+		}
+
+		// ── Phase 3: Prove the subscriber is still functional with a fresh event ──
+		//
+		//   A new all-honest event should aggregate normally, confirming the
+		//   subscriber/cache/aggregator pipeline is not permanently broken —
+		//   only the attacked event was suppressed.
+		const recoveryEventID = "recovery-event"
+		recoveryPayload := marshalTriggerResponseOutputs(t, recoveryEventID, map[string]any{"price": "8400"})
+		recoveryMsg := func(memberIdx int) *remotetypes.MessageBody {
+			return &remotetypes.MessageBody{
+				Sender: capDon.Members[memberIdx][:],
+				Method: remotetypes.MethodTriggerEvent,
+				Metadata: &remotetypes.MessageBody_TriggerEventMetadata{
+					TriggerEventMetadata: &remotetypes.TriggerEventMetadata{
+						TriggerEventId: recoveryEventID,
+						WorkflowIds:    []string{workflowID1},
+						TriggerIds:     []string{triggerID},
+					},
+				},
+				Payload: recoveryPayload,
+			}
+		}
+		subscriber.Receive(t.Context(), recoveryMsg(0))
+		subscriber.Receive(t.Context(), recoveryMsg(1))
+		subscriber.Receive(t.Context(), recoveryMsg(2))
+
+		select {
+		case resp := <-callbackCh:
+			require.NotNil(t, resp.Event.Outputs,
+				"recovery event must aggregate and deliver to callback")
+		case <-time.After(2 * time.Second):
+			t.Fatal("recovery event unexpectedly failed to aggregate — subscriber is not functional")
+		}
+	})
 }
 
 // marshalTriggerResponseOutputs creates a marshaled TriggerResponse with the


### PR DESCRIPTION
one-shot readiness effect with a regression test

all details in the JIRA issue linked below

[cre-5718](https://smartcontract-it.atlassian.net/browse/cre-5718)

---

A note for the reviewer:

The fix extends the s.mu critical section to include Aggregate().

Before (original):
```
s.mu.Lock()
  Insert + Ready(once=true)    // fast: map ops + timestamp scan
s.mu.Unlock()                  // ← lock released here
Aggregate(...)                 // CPU-bound: byte compare or SHA256 hashing
callback <- response           // channel send
```

After (fix):
```
s.mu.Lock()
  Insert + Ready(once=false)   // fast: map ops + timestamp scan
  Aggregate(...)               // CPU-bound — NOW UNDER LOCK
  MarkDelivered                // trivial
s.mu.Unlock()                  // ← lock released here
callback <- response           // channel send (still outside lock)
```

As far as I checked the latency it's marginally worse, but pls think about cases where this could go south. There is an option to make it non-blocking, but it would make this code even less readable.