### PR TITLE
[DO NOT MERGE] canary: force DON2DON non-determinism to validate mixed-env

### DIFF
--- a/core/scripts/cre/environment/configs/mixed-env-don.toml.tmpl
+++ b/core/scripts/cre/environment/configs/mixed-env-don.toml.tmpl
@@ -60,7 +60,9 @@
   # because bootstrap job for capability DON will be created on the boostrap node from this DON
   supported_evm_chains = [1337, 2337]
 
-  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
+  # CRE_CANARY_NONDETERMINISM activates the DO-NOT-MERGE canary in capability_executor.go
+  # (PR-built nodes only; develop nodes lack the code) to validate the mixed-env check.
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}', CRE_CANARY_NONDETERMINISM = "1" }
   capabilities = ["cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337"]
   registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
 

--- a/core/scripts/cre/environment/configs/mixed-env-don.toml.tmpl
+++ b/core/scripts/cre/environment/configs/mixed-env-don.toml.tmpl
@@ -111,7 +111,9 @@
   # to identify nodes in the gateway configuration (required by vault and gateway-based HTTP capabilities)
   supported_evm_chains = [1337, 2337]
 
-  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
+  # CRE_CANARY_NONDETERMINISM activates the DO-NOT-MERGE vault OCR3 report canary in
+  # core/services/ocr2/plugins/vault/plugin.go (PR-built nodes only) to validate the check.
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}', CRE_CANARY_NONDETERMINISM = "1" }
   capabilities = ["vault", "evm-2337"]
 
   [nodesets.db]

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"os"
 	"slices"
 	"sort"
 	"sync"
@@ -2922,6 +2923,16 @@ func (r *ReportingPlugin) generateJSONReport(id string, requestType vaultcommon.
 }
 
 func wrapReportWithKeyBundleInfo(report []byte, reportInfo []byte) (ocr3types.ReportWithInfo[[]byte], error) {
+	// TEMPORARY CANARY — DO NOT MERGE. On PR-built nodes (mixed-env only, gated by
+	// CRE_CANARY_NONDETERMINISM) perturb the SIGNED report bytes (.Report) so vault OCR3
+	// nodes disagree during report attestation — the state/outcome has already been
+	// committed by this point, so this is a clean report-phase divergence. libocr then
+	// logs "This is commonly caused by non-determinism in the ReportingPlugin". (Changing
+	// ReportInfo instead only affects the unsigned .Info and breaks routing, not attestation.)
+	if os.Getenv("CRE_CANARY_NONDETERMINISM") != "" {
+		report = append(append([]byte{}, report...), 0x00)
+	}
+
 	infos, err := structpb.NewStruct(map[string]any{
 		// Use the EVM key bundle to sign the report.
 		"keyBundleName": "evm",

--- a/core/services/workflows/v2/capability_executor.go
+++ b/core/services/workflows/v2/capability_executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -234,6 +235,15 @@ func (c *ExecutionHelper) callCapability(ctx context.Context, request *sdkpb.Cap
 	propagateOrgIDMeta, _ := cresettings.Default.PropagateOrgIDInRequestMetadata.GetOrDefault(ctx, creGetter)
 	if propagateOrgIDMeta && c.orgID != "" {
 		capReq.Metadata.OrgID = c.orgID
+	}
+	// TEMPORARY CANARY — DO NOT MERGE. Validates the mixed-env non-determinism check.
+	// Active only when CRE_CANARY_NONDETERMINISM is set (the mixed-env topology sets it),
+	// so unit tests and normal runs are unaffected. On PR-built nodes it stamps a constant
+	// OrgID, so the executable-capability request payload differs from develop-built nodes;
+	// the capability DON logs "received messages with the same id and different payloads",
+	// which the mixed-env TestMain log scan turns into "Non-Determinism introduced".
+	if os.Getenv("CRE_CANARY_NONDETERMINISM") != "" {
+		capReq.Metadata.OrgID = "canary-nondeterminism"
 	}
 
 	execLogger.Debug("Executing capability ...")


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — canary test

Temporary canary stacked on top of #23290 (mixed-env topology) to prove the mixed-env non-determinism check actually fires in CI.

**What it does:** `capability_executor.go` unconditionally stamps `Metadata.OrgID = "canary-nondeterminism"` on executable-capability requests (ignoring `PropagateOrgIDInRequestMetadata`). PR-built nodes then emit a different request payload than develop-built nodes.

**Expected result:**
- The capability DON logs `received messages with the same id and different payloads`.
- The mixed-env `TestMain` scan fails the `mixed-env` matrix entries (`Test_CRE_V2_Suite_Bucket_A` / `_B`) with `Non-Determinism introduced`.
- The non-mixed-env matrix entries are unaffected.

Base is the feature branch, so the diff is just the 6-line canary. **Close and delete this branch once CI has demonstrated the catch.**
