### PR TITLE
core/services/gateway/handlers/confidentialrelay/: bound per-node sends in confidential relay fan-out

### DIFF
--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -30,6 +30,9 @@ import (
 const (
 	defaultCleanUpPeriod = 5 * time.Second
 
+	defaultRequestTimeoutSec  = 30
+	defaultNodeSendTimeoutSec = 10
+
 	// Re-exported from chainlink-common for local use and test convenience.
 	MethodSecretsGet     = relaytypes.MethodSecretsGet
 	MethodCapabilityExec = relaytypes.MethodCapabilityExec
@@ -116,6 +119,11 @@ type relayBundler interface {
 
 type Config struct {
 	RequestTimeoutSec int `json:"requestTimeoutSec"`
+
+	// NodeSendTimeoutSec bounds each individual fan-out send to a single relay node, and is
+	// clamped to RequestTimeoutSec. It must stay below it so that one node whose connection
+	// accepts no writes cannot delay delivery to the rest of the DON.
+	NodeSendTimeoutSec int `json:"nodeSendTimeoutSec"`
 }
 
 type handler struct {
@@ -130,6 +138,7 @@ type handler struct {
 	globalNodeRateLimiter limits.RateLimiter
 	perNodeRateLimiters   map[string]limits.RateLimiter
 	requestTimeout        time.Duration
+	nodeSendTimeout       time.Duration
 
 	activeRequests map[string]*activeRequest
 	metrics        *metrics
@@ -154,7 +163,14 @@ func NewHandler(methodConfig json.RawMessage, donConfig *config.DONConfig, don g
 	}
 
 	if cfg.RequestTimeoutSec == 0 {
-		cfg.RequestTimeoutSec = 30
+		cfg.RequestTimeoutSec = defaultRequestTimeoutSec
+	}
+
+	if cfg.NodeSendTimeoutSec == 0 {
+		cfg.NodeSendTimeoutSec = defaultNodeSendTimeoutSec
+	}
+	if cfg.NodeSendTimeoutSec > cfg.RequestTimeoutSec {
+		cfg.NodeSendTimeoutSec = cfg.RequestTimeoutSec
 	}
 
 	globalNodeRateLimiter, err := limitsFactory.MakeRateLimiter(cresettings.Default.GatewayConfidentialRelayGlobalRate)
@@ -181,6 +197,7 @@ func NewHandler(methodConfig json.RawMessage, donConfig *config.DONConfig, don g
 		don:                   don,
 		lggr:                  logger.Named(lggr, "ConfidentialRelayHandler:"+donConfig.DonId),
 		requestTimeout:        time.Duration(cfg.RequestTimeoutSec) * time.Second,
+		nodeSendTimeout:       time.Duration(cfg.NodeSendTimeoutSec) * time.Second,
 		globalNodeRateLimiter: globalNodeRateLimiter,
 		perNodeRateLimiters:   perNodeRateLimiters,
 		activeRequests:        make(map[string]*activeRequest),
@@ -460,9 +477,16 @@ func (h *handler) fanOutToNodes(ctx context.Context, l logger.Logger, ar *active
 		nodeErrors atomic.Uint32
 	)
 
+	// Each send is bounded independently. A node whose websocket accepts no writes blocks
+	// until its context is cancelled, and because the caller only reads the response callback
+	// after this function returns, an unbounded send would hold the request open until the
+	// client gives up, discarding a bundle that already reached quorum.
+	sendCtx, cancel := context.WithTimeout(ctx, h.nodeSendTimeout)
+	defer cancel()
+
 	for _, node := range h.donConfig.Members {
 		group.Go(func() error {
-			err := h.don.SendToNode(ctx, node.Address, &ar.req)
+			err := h.don.SendToNode(sendCtx, node.Address, &ar.req)
 			if err != nil {
 				nodeErrors.Add(1)
 				l.Errorw("error sending request to node", "node", node.Address, "error", err)

--- a/core/services/gateway/handlers/confidentialrelay/handler_test.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler_test.go
@@ -60,6 +60,31 @@ func (d *barrierDON) SendToNode(ctx context.Context, _ string, _ *jsonrpc.Reques
 	}
 }
 
+// blockedDON models a node whose websocket accepts no writes: the send to blockedAddr blocks
+// until its context is cancelled, while every other node returns immediately.
+type blockedDON struct {
+	blockedAddr string
+	mu          sync.Mutex
+	delivered   []string
+}
+
+func (d *blockedDON) SendToNode(ctx context.Context, addr string, _ *jsonrpc.Request[json.RawMessage]) error {
+	if addr == d.blockedAddr {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	d.mu.Lock()
+	d.delivered = append(d.delivered, addr)
+	d.mu.Unlock()
+	return nil
+}
+
+func (d *blockedDON) deliveredCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.delivered)
+}
+
 var nodeOne = config.NodeConfig{
 	Name:    "node1",
 	Address: "0x1234",
@@ -863,6 +888,87 @@ func TestConfidentialRelayHandler_FanOutToNodes_IsConcurrent(t *testing.T) {
 	started := don.started
 	don.mu.Unlock()
 	assert.Equal(t, 2, started)
+}
+
+func TestConfidentialRelayHandler_NodeSendTimeoutConfig(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		cfg        Config
+		wantSendMs int64
+	}{
+		{"defaults when unset", Config{}, defaultNodeSendTimeoutSec * 1000},
+		{"honours explicit value", Config{RequestTimeoutSec: 30, NodeSendTimeoutSec: 5}, 5000},
+		{"clamped to request timeout", Config{RequestTimeoutSec: 3, NodeSendTimeoutSec: 45}, 3000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			lggr := logger.Test(t)
+			methodConfig, err := json.Marshal(tc.cfg)
+			require.NoError(t, err)
+			donConfig := &config.DONConfig{DonId: "test_relay_don", F: 1, Members: []config.NodeConfig{nodeOne}}
+			limitsFactory := limits.Factory{Settings: cresettings.DefaultGetter, Logger: lggr}
+
+			h, err := NewHandler(methodConfig, donConfig, mocks.NewDON(t), lggr, clockwork.NewFakeClock(), limitsFactory)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantSendMs, h.nodeSendTimeout.Milliseconds())
+			assert.LessOrEqual(t, h.nodeSendTimeout, h.requestTimeout)
+		})
+	}
+}
+
+// A node that never drains its socket must not hold the request open. Before the per-send
+// bound, group.Wait blocked until the caller's context expired, and because the gateway only
+// reads the response callback after the handler returns, a bundle that had already reached
+// quorum was discarded in favour of a client timeout.
+func TestConfidentialRelayHandler_BlockedNodeDoesNotStallFanOut(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+	don := &blockedDON{blockedAddr: "0x0002"}
+	donConfig := &config.DONConfig{
+		DonId: "test_relay_don",
+		F:     1,
+		Members: []config.NodeConfig{
+			{Name: "node0", Address: "0x0000"},
+			{Name: "node1", Address: "0x0001"},
+			{Name: "node2", Address: "0x0002"},
+			{Name: "node3", Address: "0x0003"},
+		},
+	}
+
+	methodConfig, err := json.Marshal(Config{RequestTimeoutSec: 30})
+	require.NoError(t, err)
+	limitsFactory := limits.Factory{Settings: cresettings.DefaultGetter, Logger: lggr}
+	h, err := NewHandler(methodConfig, donConfig, don, lggr, clockwork.NewFakeClock(), limitsFactory)
+	require.NoError(t, err)
+	// Shortened so the test exercises the bound without waiting the production default.
+	h.nodeSendTimeout = 50 * time.Millisecond
+
+	params := json.RawMessage(`{"workflow_id":"wf1"}`)
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-blocked-node",
+		Method: MethodCapabilityExec,
+		Params: &params,
+	}
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- h.HandleJSONRPCUserMessage(t.Context(), req, common.NewCallback())
+	}()
+
+	select {
+	case fanOutErr := <-done:
+		// Three of four nodes still received the request, so quorum remains possible and the
+		// blocked node is reported as a node error rather than a request failure.
+		require.NoError(t, fanOutErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("fan-out stalled on the blocked node instead of bounding the send")
+	}
+
+	assert.Less(t, time.Since(start), h.requestTimeout, "fan-out must return well inside the request timeout")
+	assert.Equal(t, 3, don.deliveredCount(), "healthy nodes should all receive the request")
 }
 
 func capExecSignedRespPtr(t *testing.T, id string, result relaytypes.CapabilityResponseResult, signer []byte) *jsonrpc.Response[json.RawMessage] {


### PR DESCRIPTION
The fan-out is already parallel but we end up blocked in a waitgroup:

- [`fanOutToNodes`](https://github.com/smartcontractkit/chainlink/blob/72d15e00c6/core/services/gateway/handlers/confidentialrelay/handler.go#L457-L483) spawns one goroutine per member, then waits on [`group.Wait()`](https://github.com/smartcontractkit/chainlink/blob/72d15e00c6/core/services/gateway/handlers/confidentialrelay/handler.go#L474)
- [`gateway.go`](https://github.com/smartcontractkit/chainlink/blob/72d15e00c6/core/services/gateway/gateway.go#L274-L280) only reads the response callback after the handler returns.
- [`SendToNode`](https://github.com/smartcontractkit/chainlink/blob/72d15e00c6/core/services/gateway/handlers/confidentialrelay/handler.go#L465) ends in [`wsConnectionWrapper.Write`](https://github.com/smartcontractkit/chainlink/blob/72d15e00c6/core/services/gateway/network/wsconnection.go#L122) which has no write deadline; its only escape is ctx cancellation, and the raw request ctx is passed straight through.

```
20:28:04.946  handling confidential relay request
20:28:08.999  forwarding relay response bundle to enclave  signed=7   <- quorum, +4.05s
20:28:08.999  response sent to user                                   <- payload buffered
20:29:04.944  error sending request to node  0x914d7e13...  context canceled   <- +60.0s
20:29:04.944  successfully forwarded request to relay nodes           <- fanOutToNodes returns
```

`fanOutToNodes` finished 50+ seconds after its own answer was ready and execution failed after ~60 seconds. This fix bound each send with `NodeSendTimeoutSec`, default 10s, clamped to `RequestTimeoutSec`.
