### PR TITLE
chore: bump confidential capabilities gitref

### DIFF
--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -123,10 +123,10 @@ plugins:
 
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "358ac8100efe55cea33a180f9c306eb5a166a4b3"
+      gitRef: "96f4d477083f4e7c81e7297b18dd614d5fc6faf9"
       installPath: "./cmd/confidential-http"
 
   confidential-workflows:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-workflows/capability"
-      gitRef: "358ac8100efe55cea33a180f9c306eb5a166a4b3"
+      gitRef: "96f4d477083f4e7c81e7297b18dd614d5fc6faf9"
       installPath: "./cmd/confidential-workflows"


### PR DESCRIPTION
bumps to release 1.2.0: https://github.com/smartcontractkit/chainlink-confidential-compute/releases/tag/1.2.0