### PR TITLE
[CRE-4955] Use `WorkflowTag` instead of `Tag` consistently 

### DIFF
--- a/core/scripts/cre/environment/environment/workflow.go
+++ b/core/scripts/cre/environment/environment/workflow.go
@@ -484,7 +484,7 @@ func deployWorkflow(
 
 	fmt.Printf("\n⚙️ Registering workflow '%s' with the workflow registry\n\n", workflowNameFlag)
 
-	workflowID, registerErr := creworkflow.RegisterWithContract(ctx, sethClient, common.HexToAddress(workflowRegistryAddress), workflowRegistryVersion, uint64(donIDFlag), donFamily, workflowNameFlag, "file://"+wasmWorkflowFilePathFlag, configPath, nil, nil, &containerTargetDirFlag)
+	workflowID, registerErr := creworkflow.RegisterWithContract(ctx, sethClient, common.HexToAddress(workflowRegistryAddress), workflowRegistryVersion, uint64(donIDFlag), donFamily, workflowNameFlag, creworkflow.DefaultWorkflowTag, "file://"+wasmWorkflowFilePathFlag, configPath, nil, nil, &containerTargetDirFlag)
 	if registerErr != nil {
 		return errors.Wrapf(registerErr, "❌ failed to register workflow %s", workflowNameFlag)
 	}

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -434,7 +434,7 @@ func (h *eventHandler) Handle(ctx context.Context, event Event) error {
 			platform.KeyWorkflowID, wfID,
 			platform.KeyWorkflowName, payload.WorkflowName,
 			platform.KeyWorkflowOwner, hex.EncodeToString(payload.WorkflowOwner),
-			platform.KeyWorkflowTag, payload.Tag,
+			platform.KeyWorkflowTag, payload.WorkflowTag,
 			platform.KeyOrganizationID, orgID,
 			platform.WorkflowRegistryAddress, h.workflowRegistryAddress,
 			platform.WorkflowRegistryChainSelector, h.workflowRegistryChainSelector,
@@ -459,7 +459,7 @@ func (h *eventHandler) Handle(ctx context.Context, event Event) error {
 		}
 
 		h.lggr.Debugw("handled event (WorkflowPaused)", "workflowID", wfID, "workflowName", payload.WorkflowName, "workflowOwner", hex.EncodeToString(payload.WorkflowOwner),
-			"workflowTag", payload.Tag, "type", event.Name)
+			"workflowTag", payload.WorkflowTag, "type", event.Name)
 		return nil
 	case WorkflowDeleted:
 		payload, ok := event.Data.(WorkflowDeletedEvent)

--- a/core/services/workflows/syncer/v2/types.go
+++ b/core/services/workflows/syncer/v2/types.go
@@ -141,7 +141,6 @@ type WorkflowRegisteredEvent struct {
 	WorkflowTag   string
 	BinaryURL     string
 	ConfigURL     string
-	Tag           string
 	Attributes    []byte
 	Source        string // source that provided this workflow metadata
 }
@@ -155,7 +154,6 @@ type WorkflowActivatedEvent struct {
 	WorkflowTag   string
 	BinaryURL     string
 	ConfigURL     string
-	Tag           string
 	Attributes    []byte
 	Source        string // source that provided this workflow metadata
 }
@@ -169,7 +167,6 @@ type WorkflowPausedEvent struct {
 	WorkflowTag   string
 	BinaryURL     string
 	ConfigURL     string
-	Tag           string
 	Attributes    []byte
 	Source        string
 }

--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -565,9 +565,9 @@ func (w *workflowRegistry) generateReconciliationEvents(
 					CreatedAt:     wfMeta.CreatedAt,
 					Status:        wfMeta.Status,
 					WorkflowName:  wfMeta.WorkflowName,
+					WorkflowTag:   wfMeta.Tag,
 					BinaryURL:     wfMeta.BinaryURL,
 					ConfigURL:     wfMeta.ConfigURL,
-					Tag:           wfMeta.Tag,
 					Attributes:    wfMeta.Attributes,
 					Source:        wfMeta.Source,
 				}
@@ -638,6 +638,7 @@ func (w *workflowRegistry) generateReconciliationEvents(
 					CreatedAt:     wfMeta.CreatedAt,
 					Status:        wfMeta.Status,
 					WorkflowName:  wfMeta.WorkflowName,
+					WorkflowTag:   wfMeta.Tag,
 					Source:        wfMeta.Source,
 				}
 				events = append(

--- a/core/services/workflows/syncer/v2/workflow_registry_test.go
+++ b/core/services/workflows/syncer/v2/workflow_registry_test.go
@@ -96,7 +96,7 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 			WorkflowName:  wfName,
 			BinaryURL:     binaryURL,
 			ConfigURL:     configURL,
-			Tag:           tag,
+			WorkflowTag:   tag,
 			Attributes:    attributes,
 		}
 		require.Equal(t, expectedActivatedEvent, events[0].Data)
@@ -175,7 +175,7 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 			WorkflowName:  wfName,
 			BinaryURL:     binaryURL2,
 			ConfigURL:     configURL,
-			Tag:           tag,
+			WorkflowTag:   tag,
 			Attributes:    attributes,
 		}
 		require.Equal(t, expectedActivatedEvent, events[1].Data)
@@ -489,7 +489,7 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 			WorkflowName:  wfName,
 			BinaryURL:     binaryURL,
 			ConfigURL:     configURL,
-			Tag:           tag,
+			WorkflowTag:   tag,
 			Attributes:    attributes,
 		}
 		require.Equal(t, expectedActivatedEvent, events[0].Data)
@@ -684,7 +684,7 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 			WorkflowName:  wfName,
 			BinaryURL:     binaryURL,
 			ConfigURL:     configURL,
-			Tag:           tag,
+			WorkflowTag:   tag,
 			Attributes:    attributes,
 		}
 		signature := fmt.Sprintf("%s-%s-%s", WorkflowActivated, event.WorkflowID.Hex(), toSpecStatus(WorkflowStatusActive))
@@ -819,7 +819,7 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 			WorkflowName:  wfName,
 			BinaryURL:     binaryURL,
 			ConfigURL:     configURL,
-			Tag:           tag,
+			WorkflowTag:   tag,
 			Attributes:    attributes,
 		}
 		signature := fmt.Sprintf("%s-%s-%s", WorkflowRegistered, event.WorkflowID.Hex(), toSpecStatus(WorkflowStatusActive))
@@ -1118,7 +1118,7 @@ func Test_generateReconciliationEventsV2(t *testing.T) {
 			WorkflowName:  wfName,
 			BinaryURL:     binaryURL,
 			ConfigURL:     configURL,
-			Tag:           tag,
+			WorkflowTag:   tag,
 			Attributes:    attributes,
 		}
 		pendingEvents := map[string]*reconciliationEvent{

--- a/system-tests/lib/cre/workflow/workflow.go
+++ b/system-tests/lib/cre/workflow/workflow.go
@@ -30,7 +30,7 @@ import (
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	pkgworkflows "github.com/smartcontractkit/chainlink-common/pkg/workflows"
 	capabilities_registry_v2 "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/capabilities_registry_wrapper_v2"
-	workflow_registry_wrapper_v2 "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper_v2"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper_v2"
 	chainlinkvalues "github.com/smartcontractkit/chainlink-protos/cre/go/values"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/postgres"
 	"github.com/smartcontractkit/chainlink-testing-framework/seth"
@@ -46,7 +46,7 @@ const (
 	fileURLTemplate = "file://%s/%s"
 
 	// Default values for workflow registration
-	defaultWorkflowTag    = "some-tag"
+	DefaultWorkflowTag    = "some-tag"
 	defaultWorkflowStatus = uint8(0)
 
 	// Common error message templates
@@ -84,7 +84,7 @@ func RegisterWithContract(
 	sc *seth.Client,
 	workflowRegistryAddr common.Address,
 	version *semver.Version,
-	donID uint64, donFamily, workflowName, binaryURL string,
+	donID uint64, donFamily, workflowName, worfklowTag, binaryURL string,
 	configURL, secretsURL *string,
 	attributes []byte,
 	artifactsDirInContainer *string,
@@ -125,7 +125,7 @@ func RegisterWithContract(
 		return "", fmt.Errorf("only workflow registry contract major version 2 is supported (got %v)", version)
 	}
 
-	if err := registerWorkflow(sc, workflowRegistryAddr, version, donFamily, workflowName, workflowID, binaryURLToUse, configURLToUse, attributes); err != nil {
+	if err := registerWorkflow(sc, workflowRegistryAddr, version, donFamily, workflowName, workflowID, worfklowTag, binaryURLToUse, configURLToUse, attributes); err != nil {
 		return "", err
 	}
 
@@ -240,7 +240,7 @@ func registerWorkflow(
 	sc *seth.Client,
 	workflowRegistryAddr common.Address,
 	version *semver.Version,
-	donFamily, workflowName, workflowID, binaryURL, configURL string,
+	donFamily, workflowName, workflowID, workflowTag, binaryURL, configURL string,
 	attributes []byte,
 ) error {
 	registry, err := getRegistryInstance(sc, workflowRegistryAddr, version)
@@ -264,7 +264,7 @@ func registerWorkflow(
 	_, err = sc.Decode(registry.UpsertWorkflow(
 		sc.NewTXOpts(),
 		workflowName,
-		defaultWorkflowTag,
+		workflowTag,
 		[32]byte(common.Hex2Bytes(workflowID)),
 		defaultWorkflowStatus,
 		donFamily,

--- a/system-tests/lib/cre/workflow/workflow.go
+++ b/system-tests/lib/cre/workflow/workflow.go
@@ -84,7 +84,7 @@ func RegisterWithContract(
 	sc *seth.Client,
 	workflowRegistryAddr common.Address,
 	version *semver.Version,
-	donID uint64, donFamily, workflowName, worfklowTag, binaryURL string,
+	donID uint64, donFamily, workflowName, workflowTag, binaryURL string,
 	configURL, secretsURL *string,
 	attributes []byte,
 	artifactsDirInContainer *string,
@@ -125,7 +125,7 @@ func RegisterWithContract(
 		return "", fmt.Errorf("only workflow registry contract major version 2 is supported (got %v)", version)
 	}
 
-	if err := registerWorkflow(sc, workflowRegistryAddr, version, donFamily, workflowName, workflowID, worfklowTag, binaryURLToUse, configURLToUse, attributes); err != nil {
+	if err := registerWorkflow(sc, workflowRegistryAddr, version, donFamily, workflowName, workflowID, workflowTag, binaryURLToUse, configURLToUse, attributes); err != nil {
 		return "", err
 	}
 

--- a/system-tests/tests/regression/cre/http_trigger_regression_test.go
+++ b/system-tests/tests/regression/cre/http_trigger_regression_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/dkgrecipientkey"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	gateway_common "github.com/smartcontractkit/chainlink-common/pkg/types/gateway"
 	commonevents "github.com/smartcontractkit/chainlink-protos/workflows/go/common"
@@ -25,14 +26,13 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake"
 
-	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/dkgrecipientkey"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
-
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/blockchains/evm"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/workflow"
 	libcrypto "github.com/smartcontractkit/chainlink/system-tests/lib/crypto"
 	http_config "github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/http/config"
 	t_helpers "github.com/smartcontractkit/chainlink/system-tests/tests/test-helpers"
 	ttypes "github.com/smartcontractkit/chainlink/system-tests/tests/test-helpers/configuration"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 // regression - HTTP trigger negative test cases
@@ -259,7 +259,7 @@ func createHTTPTriggerRequestWithKey(t *testing.T, workflowName, workflowOwner s
 		Workflow: gateway_common.WorkflowSelector{
 			WorkflowOwner: workflowOwner,
 			WorkflowName:  workflowName,
-			WorkflowTag:   "TEMP_TAG",
+			WorkflowTag:   workflow.DefaultWorkflowTag,
 		},
 		Input: []byte(`{
 			"customer": "test-customer-unauthorized",

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -61,7 +61,6 @@ import (
 	stellchain "github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/blockchains/stellar"
 	stellarfeature "github.com/smartcontractkit/chainlink/system-tests/lib/cre/features/stellar"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/flags"
-	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/workflow"
 	creworkflow "github.com/smartcontractkit/chainlink/system-tests/lib/cre/workflow"
 	crecrypto "github.com/smartcontractkit/chainlink/system-tests/lib/crypto"
 	consensus_negative_config "github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/consensus/config"
@@ -815,7 +814,7 @@ func CompileAndDeployWorkflow[T WorkflowConfig](t *testing.T,
 	workflowRegConfig := &WorkflowRegistrationConfig{
 		WorkflowName:            workflowName,
 		WorkflowLocation:        workflowFileLocation,
-		WorkflowTag:             workflow.DefaultWorkflowTag,
+		WorkflowTag:             creworkflow.DefaultWorkflowTag,
 		ConfigFilePath:          workflowConfigPath,
 		CompressedWasmPath:      compressedWorkflowWasmPath,
 		WorkflowRegistryAddr:    common.HexToAddress(workflowRegistryAddress.Address),

--- a/system-tests/tests/test-helpers/t_helpers.go
+++ b/system-tests/tests/test-helpers/t_helpers.go
@@ -61,6 +61,7 @@ import (
 	stellchain "github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/blockchains/stellar"
 	stellarfeature "github.com/smartcontractkit/chainlink/system-tests/lib/cre/features/stellar"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/flags"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/workflow"
 	creworkflow "github.com/smartcontractkit/chainlink/system-tests/lib/cre/workflow"
 	crecrypto "github.com/smartcontractkit/chainlink/system-tests/lib/crypto"
 	consensus_negative_config "github.com/smartcontractkit/chainlink/system-tests/tests/regression/cre/consensus/config"
@@ -414,6 +415,7 @@ type StellarWriteWorkflowConfig struct {
 type WorkflowRegistrationConfig struct {
 	WorkflowName            string
 	WorkflowLocation        string
+	WorkflowTag             string
 	ConfigFilePath          string
 	CompressedWasmPath      string
 	SecretsURL              string
@@ -715,6 +717,7 @@ func registerWorkflowErr(ctx context.Context, wfRegCfg *WorkflowRegistrationConf
 		wfRegCfg.DonID,
 		wfRegCfg.DonFamily,
 		wfRegCfg.WorkflowName,
+		wfRegCfg.WorkflowTag,
 		binaryURL,
 		configURL,
 		nil, // no secrets yet
@@ -812,6 +815,7 @@ func CompileAndDeployWorkflow[T WorkflowConfig](t *testing.T,
 	workflowRegConfig := &WorkflowRegistrationConfig{
 		WorkflowName:            workflowName,
 		WorkflowLocation:        workflowFileLocation,
+		WorkflowTag:             workflow.DefaultWorkflowTag,
 		ConfigFilePath:          workflowConfigPath,
 		CompressedWasmPath:      compressedWorkflowWasmPath,
 		WorkflowRegistryAddr:    common.HexToAddress(workflowRegistryAddress.Address),


### PR DESCRIPTION
Currently WorkflowActivatedEvent would not carry `WorkflowTag ` but `Tag`. Note that the latter is never read and hence is not useful. After this PR we start populating `WorkflowTag` consistently and remove `Tag`.

Ideally, the `WorkflowTag` should also be propagated in all the tests using `CompileAndDeployWorkflow`. However, instead of passing it everywhere, we hardcoded `DefaultWorkflowTag` for now (if it is needed one can always update `CompileAndDeployWorkflow`)