### PR TITLE
Add CRE context to confidential relay

### DIFF
--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -388,6 +388,18 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInvalidParams, err)
 	}
 
+	// The enclave's capability calls arrive as fresh gateway messages rather than
+	// through the workflow engine, so ctx carries none of the CRE tenants the engine
+	// seeds.
+	//
+	// Seeded as soon as the params are parsed so every ctx use below carries the
+	// tenant.
+	ctx = contexts.WithCRE(ctx, contexts.CRE{
+		Org:      params.OrgID,
+		Owner:    params.Owner,
+		Workflow: params.WorkflowID,
+	})
+
 	handler, ok := h.executionHandlers.GetExecution(params.WorkflowID, params.ExecutionID)
 	if !ok {
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInvalidParams, fmt.Errorf("execution handler for workflow %s execution %s not found", params.WorkflowID, params.ExecutionID))
@@ -410,17 +422,6 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 	if err = h.verifyEnclaveConfigMatchesDON(localNode, params.EnclaveConfig); err != nil {
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
 	}
-
-	// The enclave's capability calls arrive as fresh gateway messages rather than
-	// through the workflow engine, so ctx carries none of the CRE tenants the
-	// engine seeds.
-	// Set after attestation verification above: these params are bound by the
-	// attested request hash, so they are only trustworthy once it has passed.
-	ctx = contexts.WithCRE(ctx, contexts.CRE{
-		Org:      params.OrgID,
-		Owner:    params.Owner,
-		Workflow: params.WorkflowID,
-	})
 
 	payloadBytes, err := base64.StdEncoding.DecodeString(params.Payload)
 	if err != nil {

--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	confidentialrelaytypes "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialrelay"
 	confidentialworkflow "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialworkflow"
+	"github.com/smartcontractkit/chainlink-common/pkg/contexts"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -409,6 +410,17 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 	if err = h.verifyEnclaveConfigMatchesDON(localNode, params.EnclaveConfig); err != nil {
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
 	}
+
+	// The enclave's capability calls arrive as fresh gateway messages rather than
+	// through the workflow engine, so ctx carries none of the CRE tenants the
+	// engine seeds.
+	// Set after attestation verification above: these params are bound by the
+	// attested request hash, so they are only trustworthy once it has passed.
+	ctx = contexts.WithCRE(ctx, contexts.CRE{
+		Org:      params.OrgID,
+		Owner:    params.Owner,
+		Workflow: params.WorkflowID,
+	})
 
 	payloadBytes, err := base64.StdEncoding.DecodeString(params.Payload)
 	if err != nil {

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	confidentialrelaytypes "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialrelay"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialworkflow"
+	"github.com/smartcontractkit/chainlink-common/pkg/contexts"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
@@ -91,10 +92,14 @@ type mockExecutionHelper struct {
 
 	lastCapabilityRequest *sdkpb.CapabilityRequest
 	lastSecretsRequest    *sdkpb.GetSecretsRequest
+	// lastCapabilityCRE records the CRE tenants on the context CallCapability was
+	// invoked with. The tenant-scoped limiters downstream fail closed without them.
+	lastCapabilityCRE contexts.CRE
 }
 
-func (m *mockExecutionHelper) CallCapability(_ context.Context, req *sdkpb.CapabilityRequest) (*sdkpb.CapabilityResponse, error) {
+func (m *mockExecutionHelper) CallCapability(ctx context.Context, req *sdkpb.CapabilityRequest) (*sdkpb.CapabilityResponse, error) {
 	m.lastCapabilityRequest = req
+	m.lastCapabilityCRE = contexts.CREValue(ctx)
 	return m.capResp, m.capErr
 }
 
@@ -388,6 +393,7 @@ func TestHandler_HandleGatewayMessage(t *testing.T) {
 					WorkflowID:    "wf-1",
 					Owner:         testOwner, // chainlink-common#2032 requires 0x-prefixed 20-byte hex
 					ExecutionID:   capExecExecutionID,
+					OrgID:         "org-1",
 					ReferenceID:   "17",
 					CapabilityID:  "my-cap@1.0.0",
 					Payload:       makeCapabilityPayload(t, map[string]any{"key": "val"}),
@@ -401,6 +407,7 @@ func TestHandler_HandleGatewayMessage(t *testing.T) {
 					WorkflowID:    "wf-1",
 					Owner:         testOwner,
 					ExecutionID:   capExecExecutionID,
+					OrgID:         "org-1",
 					ReferenceID:   "17",
 					CapabilityID:  "my-cap@1.0.0",
 					Payload:       makeCapabilityPayload(t, map[string]any{"key": "val"}),
@@ -423,6 +430,15 @@ func TestHandler_HandleGatewayMessage(t *testing.T) {
 				require.NotNil(t, helper.lastCapabilityRequest, "CallCapability should have been called")
 				assert.Equal(t, "my-cap@1.0.0", helper.lastCapabilityRequest.Id)
 				assert.Equal(t, "Execute", helper.lastCapabilityRequest.Method)
+				// Without the CRE tenants on the context, every tenant-scoped
+				// limiter downstream fails closed rather than reading a limit.
+				// Normalized(): WithCRE strips the owner's 0x prefix and lowercases
+				// it, so the tenant key matches the one the engine path produces.
+				assert.Equal(t, contexts.CRE{
+					Org:      "org-1",
+					Owner:    testOwner,
+					Workflow: "wf-1",
+				}.Normalized(), helper.lastCapabilityCRE)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Adds CRE context (workflow ID, owner, execution ID, org ID) to the confidential relay handler so relay requests carry the attribution the relay DON needs.

## Changes

- `core/capabilities/confidentialrelay/handler.go`: attach CRE context to outbound relay requests.
- `handler_test.go`: cover the new context fields.
