### PR TITLE
cre gateway: log errors returned to user in http trigger handler

### DIFF
--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -532,6 +532,12 @@ func isValidJSON(data []byte) bool {
 }
 
 func (h *httpTriggerHandler) handleUserError(ctx context.Context, requestID string, code int64, message string, callback handlers.Callback) {
+	switch code {
+	case jsonrpc.ErrInternal, jsonrpc.ErrServerOverloaded, jsonrpc.ErrUnknown, jsonrpc.ErrLimitExceeded, jsonrpc.ErrConflict:
+		h.lggr.Errorw("returning error to user", "code", code, "message", message, "requestID", requestID)
+	default:
+		h.lggr.Warnw("returning error to user", "code", code, "message", message, "requestID", requestID)
+	}
 	resp := &jsonrpc.Response[json.RawMessage]{
 		Version: "2.0",
 		ID:      requestID,


### PR DESCRIPTION


handleUserError in the HTTP trigger handler returns errors to the user but does not log them, making it hard to observe what errors are being surfaced.

