### PR TITLE
feat(cre/engine): adds org id missing metric

### DIFF
--- a/core/services/workflows/monitoring/monitoring.go
+++ b/core/services/workflows/monitoring/monitoring.go
@@ -83,6 +83,8 @@ type EngineMetrics struct {
 	donTimeCallsCounter    metric.Int64Counter
 	donTimeTimeoutsCounter metric.Int64Counter
 	donTimeErrorsCounter   metric.Int64Counter
+
+	orgIDMissingCounter metric.Int64Counter
 }
 
 func InitMonitoringResources() (em *EngineMetrics, err error) {
@@ -438,6 +440,14 @@ func InitMonitoringResources() (em *EngineMetrics, err error) {
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to register don time errors counter: %w", err)
+	}
+
+	em.orgIDMissingCounter, err = beholder.GetMeter().Int64Counter(
+		"platform_engine_org_id_missing_total",
+		metric.WithDescription("Count of beholder events emitted by the engine without a resolved organization ID"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register org id missing counter: %w", err)
 	}
 
 	return em, nil
@@ -811,4 +821,14 @@ func (c WorkflowsMetricLabeler) IncrementDonTimeTimeoutsCounter(ctx context.Cont
 func (c WorkflowsMetricLabeler) IncrementDonTimeErrorsCounter(ctx context.Context) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
 	c.em.donTimeErrorsCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
+}
+
+// IncrementOrgIDMissingCounter increments the org_id_missing counter when the
+// engine emits beholder events without a resolved organization ID. The reason
+// attribute identifies why the org ID is missing (resolver_nil, resolver_error,
+// or empty_response).
+func (c WorkflowsMetricLabeler) IncrementOrgIDMissingCounter(ctx context.Context, reason string) {
+	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
+	otelLabels = append(otelLabels, attribute.String("reason", reason))
+	c.em.orgIDMissingCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
 }

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -266,23 +266,36 @@ func NewEngine(cfg *EngineConfig) (*Engine, error) {
 	return engine, nil
 }
 
+// resolvedOrg holds the result of an organization ID resolution attempt.
+type resolvedOrg struct {
+	// ID is the resolved organization ID, or empty if resolution failed.
+	ID string
+	// Err is the error returned by the OrgResolver, or nil if resolution
+	// succeeded or the resolver was not configured.
+	Err error
+	// Reason explains why ID is empty: "resolver_nil" (OrgResolver not
+	// configured), "resolver_error" (Get returned an error), or
+	// "empty_response" (Get returned an empty string). Empty on success.
+	Reason string
+}
+
 // resolveOrgID resolves the organization ID for the given workflow owner.
-// If resolution fails, the returned orgID is empty and missingReason explains
-// why: "resolver_nil" (OrgResolver not configured), "resolver_error" (Get
-// returned an error), or "empty_response" (Get returned an empty string).
-// On success, missingReason is empty.
-func resolveOrgID(ctx context.Context, resolver orgresolver.OrgResolver, workflowOwner string) (orgID, missingReason string) {
+// If resolution fails, the returned ID is empty and Reason explains why.
+// The original error from the resolver (if any) is preserved in Err and
+// logged via the provided logger.
+func resolveOrgID(ctx context.Context, resolver orgresolver.OrgResolver, workflowOwner string, lggr logger.SugaredLogger) resolvedOrg {
 	if resolver == nil {
-		return "", "resolver_nil"
+		return resolvedOrg{Reason: "resolver_nil"}
 	}
 	orgID, err := resolver.Get(ctx, workflowOwner)
 	if err != nil {
-		return "", "resolver_error"
+		lggr.Warnw("Failed to resolve organization ID, continuing without it", "workflowOwner", workflowOwner, "err", err)
+		return resolvedOrg{Err: err, Reason: "resolver_error"}
 	}
 	if orgID == "" {
-		return "", "empty_response"
+		return resolvedOrg{Reason: "empty_response"}
 	}
-	return orgID, ""
+	return resolvedOrg{ID: orgID}
 }
 
 func (e *Engine) start(ctx context.Context) error {
@@ -292,12 +305,9 @@ func (e *Engine) start(ctx context.Context) error {
 	// Resolve the workflow owner's org once at engine startup and treat it as stable
 	// for the lifetime of this engine instance. If org membership/linking changes, the
 	// workflow must be restarted to pick up the new org mapping.
-	orgID, missingReason := resolveOrgID(ctx, e.cfg.OrgResolver, e.cfg.WorkflowOwner)
-	if missingReason != "" {
-		e.logger().Warnw("Failed to resolve organization ID, continuing without it", "workflowOwner", e.cfg.WorkflowOwner, "reason", missingReason)
-	}
-	e.orgID = orgID
-	e.orgIDMissingReason = missingReason
+	resolved := resolveOrgID(ctx, e.cfg.OrgResolver, e.cfg.WorkflowOwner, e.logger())
+	e.orgID = resolved.ID
+	e.orgIDMissingReason = resolved.Reason
 	e.storeLoggerLabels(e.eventLabels())
 
 	e.metrics = e.metrics.With(platform.KeyOrganizationID, e.orgID)

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -878,6 +878,9 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 
 	startTime := e.cfg.Clock.Now()
 	executionLogger.Infow("Workflow execution starting ...")
+	if e.orgID == "" {
+		e.metrics.IncrementOrgIDMissingCounter(ctx, e.orgIDMissingReason)
+	}
 	_ = events.EmitExecutionStartedEvent(ctx, loggerLabels, triggerEvent.ID, executionID)
 
 	registrationID := TriggerRegistrationID(e.cfg.WorkflowID, wrappedTriggerEvent.triggerIndex)

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -29,6 +29,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/metrics"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/orgresolver"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
@@ -265,6 +266,25 @@ func NewEngine(cfg *EngineConfig) (*Engine, error) {
 	return engine, nil
 }
 
+// resolveOrgID resolves the organization ID for the given workflow owner.
+// If resolution fails, the returned orgID is empty and missingReason explains
+// why: "resolver_nil" (OrgResolver not configured), "resolver_error" (Get
+// returned an error), or "empty_response" (Get returned an empty string).
+// On success, missingReason is empty.
+func resolveOrgID(ctx context.Context, resolver orgresolver.OrgResolver, workflowOwner string) (orgID, missingReason string) {
+	if resolver == nil {
+		return "", "resolver_nil"
+	}
+	orgID, err := resolver.Get(ctx, workflowOwner)
+	if err != nil {
+		return "", "resolver_error"
+	}
+	if orgID == "" {
+		return "", "empty_response"
+	}
+	return orgID, ""
+}
+
 func (e *Engine) start(ctx context.Context) error {
 	e.cfg.Module.Start()
 	ctx = context.WithoutCancel(ctx)
@@ -272,21 +292,12 @@ func (e *Engine) start(ctx context.Context) error {
 	// Resolve the workflow owner's org once at engine startup and treat it as stable
 	// for the lifetime of this engine instance. If org membership/linking changes, the
 	// workflow must be restarted to pick up the new org mapping.
-	e.orgID = ""
-	e.orgIDMissingReason = ""
-	if e.cfg.OrgResolver == nil {
-		e.orgIDMissingReason = "resolver_nil"
-	} else {
-		orgID, gerr := e.cfg.OrgResolver.Get(ctx, e.cfg.WorkflowOwner)
-		if gerr != nil {
-			e.logger().Warnw("Failed to resolve organization ID, continuing without it", "workflowOwner", e.cfg.WorkflowOwner, "err", gerr)
-			e.orgIDMissingReason = "resolver_error"
-		} else if orgID == "" {
-			e.orgIDMissingReason = "empty_response"
-		} else {
-			e.orgID = orgID
-		}
+	orgID, missingReason := resolveOrgID(ctx, e.cfg.OrgResolver, e.cfg.WorkflowOwner)
+	if missingReason != "" {
+		e.logger().Warnw("Failed to resolve organization ID, continuing without it", "workflowOwner", e.cfg.WorkflowOwner, "reason", missingReason)
 	}
+	e.orgID = orgID
+	e.orgIDMissingReason = missingReason
 	e.storeLoggerLabels(e.eventLabels())
 
 	e.metrics = e.metrics.With(platform.KeyOrganizationID, e.orgID)

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -92,6 +92,11 @@ type Engine struct {
 	tracer trace.Tracer
 
 	orgID string
+	// orgIDMissingReason records why orgID is empty ("resolver_nil",
+	// "resolver_error", or "empty_response"). It is set once in start() and
+	// read by startExecution() to label the org_id_missing counter. It is only
+	// meaningful when orgID == "".
+	orgIDMissingReason string
 
 	draining         atomic.Bool
 	activeExecutions atomic.Int32
@@ -268,10 +273,16 @@ func (e *Engine) start(ctx context.Context) error {
 	// for the lifetime of this engine instance. If org membership/linking changes, the
 	// workflow must be restarted to pick up the new org mapping.
 	e.orgID = ""
-	if e.cfg.OrgResolver != nil {
+	e.orgIDMissingReason = ""
+	if e.cfg.OrgResolver == nil {
+		e.orgIDMissingReason = "resolver_nil"
+	} else {
 		orgID, gerr := e.cfg.OrgResolver.Get(ctx, e.cfg.WorkflowOwner)
 		if gerr != nil {
 			e.logger().Warnw("Failed to resolve organization ID, continuing without it", "workflowOwner", e.cfg.WorkflowOwner, "err", gerr)
+			e.orgIDMissingReason = "resolver_error"
+		} else if orgID == "" {
+			e.orgIDMissingReason = "empty_response"
 		} else {
 			e.orgID = orgID
 		}

--- a/core/services/workflows/v2/engine_org_id_missing_test.go
+++ b/core/services/workflows/v2/engine_org_id_missing_test.go
@@ -91,6 +91,8 @@ func collectCounterValue(t *testing.T, reader *sdkmetric.ManualReader, name stri
 // TestEngine_OrgIDMissingReason verifies that the engine correctly records
 // why org ID is missing during the resolution logic in start().
 func TestEngine_OrgIDMissingReason(t *testing.T) {
+	t.Parallel()
+
 	resolverErr := errors.New("linking service unavailable")
 
 	tests := []struct {
@@ -132,13 +134,15 @@ func TestEngine_OrgIDMissingReason(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			resolved := resolveOrgID(context.Background(), tt.orgResolver, "owner-1", logger.Sugared(logger.Test(t)))
 			require.Equal(t, tt.wantOrgID, resolved.ID)
 			require.Equal(t, tt.wantReason, resolved.Reason)
 			if tt.wantErr != nil {
-				require.Equal(t, tt.wantErr, resolved.Err)
+				require.EqualError(t, resolved.Err, tt.wantErr.Error())
 			} else {
-				require.Nil(t, resolved.Err)
+				require.NoError(t, resolved.Err)
 			}
 		})
 	}
@@ -148,6 +152,8 @@ func TestEngine_OrgIDMissingReason(t *testing.T) {
 // incremented with the correct reason label when orgID is empty, and not
 // incremented when orgID is set.
 func TestEngine_OrgIDMissingCounter(t *testing.T) {
+	t.Parallel()
+
 	const counterName = "platform_engine_org_id_missing_total"
 
 	tests := []struct {
@@ -187,6 +193,7 @@ func TestEngine_OrgIDMissingCounter(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		//nolint:paralleltest // subtests mutate the global beholder client via setupTestMeter
 		t.Run(tt.name, func(t *testing.T) {
 			reader := setupTestMeter(t)
 

--- a/core/services/workflows/v2/engine_org_id_missing_test.go
+++ b/core/services/workflows/v2/engine_org_id_missing_test.go
@@ -10,10 +10,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/metrics"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/orgresolver"
-	modulemocks "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host/mocks"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/monitoring"
 )
@@ -126,38 +124,9 @@ func TestEngine_OrgIDMissingReason(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &EngineConfig{
-				Lggr:          logger.Test(t),
-				Module:        modulemocks.NewModuleV2(t),
-				WorkflowID:    "wf-1",
-				WorkflowOwner: "owner-1",
-			}
-			if tt.orgResolver != nil {
-				cfg.OrgResolver = tt.orgResolver
-			}
-
-			engine := &Engine{cfg: cfg}
-
-			// Replicate the org ID resolution logic from start() without
-			// starting goroutines (which would require module mocks, cap
-			// registry, etc.).
-			engine.orgID = ""
-			engine.orgIDMissingReason = ""
-			if cfg.OrgResolver == nil {
-				engine.orgIDMissingReason = "resolver_nil"
-			} else {
-				orgID, gerr := cfg.OrgResolver.Get(context.Background(), cfg.WorkflowOwner)
-				if gerr != nil {
-					engine.orgIDMissingReason = "resolver_error"
-				} else if orgID == "" {
-					engine.orgIDMissingReason = "empty_response"
-				} else {
-					engine.orgID = orgID
-				}
-			}
-
-			require.Equal(t, tt.wantOrgID, engine.orgID)
-			require.Equal(t, tt.wantReason, engine.orgIDMissingReason)
+			orgID, missingReason := resolveOrgID(context.Background(), tt.orgResolver, "owner-1")
+			require.Equal(t, tt.wantOrgID, orgID)
+			require.Equal(t, tt.wantReason, missingReason)
 		})
 	}
 }

--- a/core/services/workflows/v2/engine_org_id_missing_test.go
+++ b/core/services/workflows/v2/engine_org_id_missing_test.go
@@ -1,0 +1,234 @@
+package v2
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/metrics"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/orgresolver"
+	modulemocks "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host/mocks"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/monitoring"
+)
+
+// testOrgResolver is a test implementation of orgresolver.OrgResolver.
+type testOrgResolver struct {
+	orgID string
+	err   error
+}
+
+func (m *testOrgResolver) Get(_ context.Context, _ string) (string, error) {
+	return m.orgID, m.err
+}
+
+func (m *testOrgResolver) Start(_ context.Context) error { return nil }
+func (m *testOrgResolver) Close() error                  { return nil }
+func (m *testOrgResolver) HealthReport() map[string]error {
+	return map[string]error{m.Name(): nil}
+}
+func (m *testOrgResolver) Name() string { return "TestOrgResolver" }
+func (m *testOrgResolver) Ready() error { return nil }
+
+var _ orgresolver.OrgResolver = (*testOrgResolver)(nil)
+
+// setupTestMeter creates a beholder client backed by a manual meter reader
+// so tests can collect and inspect metric increments. Returns the reader and
+// registers a cleanup that restores the previous global beholder client.
+func setupTestMeter(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	prevClient := beholder.GetClient()
+	t.Cleanup(func() { beholder.SetClient(prevClient) })
+
+	client := &beholder.Client{
+		Meter:         mp.Meter("beholder"),
+		MeterProvider: mp,
+	}
+	beholder.SetClient(client)
+
+	return reader
+}
+
+// collectCounterValue reads metrics from the manual reader and returns the
+// total sum of the named counter across all data points, plus the set of
+// reason attribute values seen.
+func collectCounterValue(t *testing.T, reader *sdkmetric.ManualReader, name string) (int64, []string) {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	var total int64
+	var reasons []string
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			data, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "expected Sum[int64] for %s, got %T", name, m.Data)
+			for _, dp := range data.DataPoints {
+				total += dp.Value
+				if r, ok := dp.Attributes.Value("reason"); ok {
+					reasons = append(reasons, r.AsString())
+				}
+			}
+		}
+	}
+	return total, reasons
+}
+
+// TestEngine_OrgIDMissingReason verifies that the engine correctly records
+// why org ID is missing during the resolution logic in start().
+func TestEngine_OrgIDMissingReason(t *testing.T) {
+	tests := []struct {
+		name        string
+		orgResolver orgresolver.OrgResolver
+		wantReason  string
+		wantOrgID   string
+	}{
+		{
+			name:        "resolver_nil",
+			orgResolver: nil,
+			wantReason:  "resolver_nil",
+			wantOrgID:   "",
+		},
+		{
+			name:        "resolver_error",
+			orgResolver: &testOrgResolver{orgID: "", err: errors.New("linking service unavailable")},
+			wantReason:  "resolver_error",
+			wantOrgID:   "",
+		},
+		{
+			name:        "empty_response",
+			orgResolver: &testOrgResolver{orgID: "", err: nil},
+			wantReason:  "empty_response",
+			wantOrgID:   "",
+		},
+		{
+			name:        "valid_org_id",
+			orgResolver: &testOrgResolver{orgID: "org-123", err: nil},
+			wantReason:  "",
+			wantOrgID:   "org-123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &EngineConfig{
+				Lggr:          logger.Test(t),
+				Module:        modulemocks.NewModuleV2(t),
+				WorkflowID:    "wf-1",
+				WorkflowOwner: "owner-1",
+			}
+			if tt.orgResolver != nil {
+				cfg.OrgResolver = tt.orgResolver
+			}
+
+			engine := &Engine{cfg: cfg}
+
+			// Replicate the org ID resolution logic from start() without
+			// starting goroutines (which would require module mocks, cap
+			// registry, etc.).
+			engine.orgID = ""
+			engine.orgIDMissingReason = ""
+			if cfg.OrgResolver == nil {
+				engine.orgIDMissingReason = "resolver_nil"
+			} else {
+				orgID, gerr := cfg.OrgResolver.Get(context.Background(), cfg.WorkflowOwner)
+				if gerr != nil {
+					engine.orgIDMissingReason = "resolver_error"
+				} else if orgID == "" {
+					engine.orgIDMissingReason = "empty_response"
+				} else {
+					engine.orgID = orgID
+				}
+			}
+
+			require.Equal(t, tt.wantOrgID, engine.orgID)
+			require.Equal(t, tt.wantReason, engine.orgIDMissingReason)
+		})
+	}
+}
+
+// TestEngine_OrgIDMissingCounter verifies that the org_id_missing counter is
+// incremented with the correct reason label when orgID is empty, and not
+// incremented when orgID is set.
+func TestEngine_OrgIDMissingCounter(t *testing.T) {
+	const counterName = "platform_engine_org_id_missing_total"
+
+	tests := []struct {
+		name       string
+		orgID      string
+		reason     string
+		wantCount  int64
+		wantReason string
+	}{
+		{
+			name:       "increments with resolver_nil reason",
+			orgID:      "",
+			reason:     "resolver_nil",
+			wantCount:  1,
+			wantReason: "resolver_nil",
+		},
+		{
+			name:       "increments with resolver_error reason",
+			orgID:      "",
+			reason:     "resolver_error",
+			wantCount:  1,
+			wantReason: "resolver_error",
+		},
+		{
+			name:       "increments with empty_response reason",
+			orgID:      "",
+			reason:     "empty_response",
+			wantCount:  1,
+			wantReason: "empty_response",
+		},
+		{
+			name:      "does not increment when orgID is set",
+			orgID:     "org-123",
+			reason:    "",
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := setupTestMeter(t)
+
+			em, err := monitoring.InitMonitoringResources()
+			require.NoError(t, err)
+
+			labeler := monitoring.NewWorkflowsMetricLabeler(metrics.NewLabeler(), em)
+			engine := &Engine{
+				cfg:                &EngineConfig{WorkflowID: "wf-1", WorkflowOwner: "owner-1"},
+				orgID:              tt.orgID,
+				orgIDMissingReason: tt.reason,
+				metrics:            labeler,
+			}
+
+			// Simulate the counter increment from startExecution()
+			if engine.orgID == "" {
+				engine.metrics.IncrementOrgIDMissingCounter(context.Background(), engine.orgIDMissingReason)
+			}
+
+			gotCount, gotReasons := collectCounterValue(t, reader, counterName)
+			require.Equal(t, tt.wantCount, gotCount)
+			if tt.wantCount > 0 {
+				require.Contains(t, gotReasons, tt.wantReason)
+			}
+		})
+	}
+}

--- a/core/services/workflows/v2/engine_org_id_missing_test.go
+++ b/core/services/workflows/v2/engine_org_id_missing_test.go
@@ -40,6 +40,11 @@ var _ orgresolver.OrgResolver = (*testOrgResolver)(nil)
 // setupTestMeter creates a beholder client backed by a manual meter reader
 // so tests can collect and inspect metric increments. Returns the reader and
 // registers a cleanup that restores the previous global beholder client.
+//
+// The client is built from a fully-initialized noop client so that the
+// Emitter, Tracer, and Logger fields are always non-nil — this prevents nil
+// pointer panics if a parallel test calls beholder.GetEmitter() while our
+// client is briefly the global one.
 func setupTestMeter(t *testing.T) *sdkmetric.ManualReader {
 	t.Helper()
 
@@ -50,10 +55,11 @@ func setupTestMeter(t *testing.T) *sdkmetric.ManualReader {
 	prevClient := beholder.GetClient()
 	t.Cleanup(func() { beholder.SetClient(prevClient) })
 
-	client := &beholder.Client{
-		Meter:         mp.Meter("beholder"),
-		MeterProvider: mp,
-	}
+	// Start from a noop client so Emitter/Tracer/Logger are valid, then swap
+	// only the meter for our manual reader.
+	client := beholder.NoopClientConfig{Lggr: logger.Test(t)}.New()
+	client.Meter = mp.Meter("beholder")
+	client.MeterProvider = mp
 	beholder.SetClient(client)
 
 	return reader
@@ -151,9 +157,9 @@ func TestEngine_OrgIDMissingReason(t *testing.T) {
 // TestEngine_OrgIDMissingCounter verifies that the org_id_missing counter is
 // incremented with the correct reason label when orgID is empty, and not
 // incremented when orgID is set.
+//
+//nolint:paralleltest // subtests mutate the global beholder client via setupTestMeter
 func TestEngine_OrgIDMissingCounter(t *testing.T) {
-	t.Parallel()
-
 	const counterName = "platform_engine_org_id_missing_total"
 
 	tests := []struct {

--- a/core/services/workflows/v2/engine_org_id_missing_test.go
+++ b/core/services/workflows/v2/engine_org_id_missing_test.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/metrics"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/orgresolver"
 
@@ -90,43 +91,55 @@ func collectCounterValue(t *testing.T, reader *sdkmetric.ManualReader, name stri
 // TestEngine_OrgIDMissingReason verifies that the engine correctly records
 // why org ID is missing during the resolution logic in start().
 func TestEngine_OrgIDMissingReason(t *testing.T) {
+	resolverErr := errors.New("linking service unavailable")
+
 	tests := []struct {
 		name        string
 		orgResolver orgresolver.OrgResolver
 		wantReason  string
 		wantOrgID   string
+		wantErr     error
 	}{
 		{
 			name:        "resolver_nil",
 			orgResolver: nil,
 			wantReason:  "resolver_nil",
 			wantOrgID:   "",
+			wantErr:     nil,
 		},
 		{
 			name:        "resolver_error",
-			orgResolver: &testOrgResolver{orgID: "", err: errors.New("linking service unavailable")},
+			orgResolver: &testOrgResolver{orgID: "", err: resolverErr},
 			wantReason:  "resolver_error",
 			wantOrgID:   "",
+			wantErr:     resolverErr,
 		},
 		{
 			name:        "empty_response",
 			orgResolver: &testOrgResolver{orgID: "", err: nil},
 			wantReason:  "empty_response",
 			wantOrgID:   "",
+			wantErr:     nil,
 		},
 		{
 			name:        "valid_org_id",
 			orgResolver: &testOrgResolver{orgID: "org-123", err: nil},
 			wantReason:  "",
 			wantOrgID:   "org-123",
+			wantErr:     nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			orgID, missingReason := resolveOrgID(context.Background(), tt.orgResolver, "owner-1")
-			require.Equal(t, tt.wantOrgID, orgID)
-			require.Equal(t, tt.wantReason, missingReason)
+			resolved := resolveOrgID(context.Background(), tt.orgResolver, "owner-1", logger.Sugared(logger.Test(t)))
+			require.Equal(t, tt.wantOrgID, resolved.ID)
+			require.Equal(t, tt.wantReason, resolved.Reason)
+			if tt.wantErr != nil {
+				require.Equal(t, tt.wantErr, resolved.Err)
+			} else {
+				require.Nil(t, resolved.Err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

adds metric to track each time a workflow execution starts without a resolved organization ID

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
