### PR TITLE
Enforce a grace period on the relay DON bundler, once f+1 responses have landed

### DIFF
--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -33,6 +33,11 @@ const (
 	defaultRequestTimeoutSec  = 30
 	defaultNodeSendTimeoutSec = 10
 
+	// defaultQuorumGraceMillis bounds the extra wait after quorum is reached. It must
+	// stay well below the caller's own HTTP deadline, which is what actually cuts the
+	// request short when the DON never produces 2F+1 signed responses.
+	defaultQuorumGraceMillis = 10_000
+
 	// Re-exported from chainlink-common for local use and test convenience.
 	MethodSecretsGet     = relaytypes.MethodSecretsGet
 	MethodCapabilityExec = relaytypes.MethodCapabilityExec
@@ -75,6 +80,11 @@ type activeRequest struct {
 	mu        sync.Mutex
 	completed atomic.Bool
 
+	// graceStarted is set the first time the request holds F+1 signed responses, so
+	// the grace timer is armed once per request rather than on every later response.
+	graceStarted atomic.Bool
+	graceTimer   clockwork.Timer
+
 	createdAt time.Time
 	gwhandlers.Callback
 }
@@ -113,6 +123,22 @@ func (ar *activeRequest) copiedResponses() map[string]jsonrpc.Response[json.RawM
 	return copied
 }
 
+func (ar *activeRequest) setGraceTimer(t clockwork.Timer) {
+	ar.mu.Lock()
+	defer ar.mu.Unlock()
+	ar.graceTimer = t
+}
+
+func (ar *activeRequest) stopGraceTimer() {
+	ar.mu.Lock()
+	t := ar.graceTimer
+	ar.graceTimer = nil
+	ar.mu.Unlock()
+	if t != nil {
+		t.Stop()
+	}
+}
+
 type relayBundler interface {
 	Bundle(req jsonrpc.Request[json.RawMessage], resps map[string]jsonrpc.Response[json.RawMessage], l logger.Logger) (*BundleSummary, error)
 }
@@ -124,6 +150,15 @@ type Config struct {
 	// clamped to RequestTimeoutSec. It must stay below it so that one node whose connection
 	// accepts no writes cannot delay delivery to the rest of the DON.
 	NodeSendTimeoutSec int `json:"nodeSendTimeoutSec"`
+
+	// QuorumGraceMillis is how long the handler keeps collecting responses after the
+	// first F+1 signed responses arrive, before forwarding whatever it has. It bounds
+	// the wait for a DON that answers with quorum but never reaches 2F+1 signed
+	// responses, which would otherwise hold the request until RequestTimeoutSec and
+	// forward a long-viable bundle after the caller's own deadline has passed.
+	// Clamped to RequestTimeoutSec; a negative value disables the grace window and
+	// restores waiting until expiry.
+	QuorumGraceMillis int `json:"quorumGraceMillis"`
 }
 
 type handler struct {
@@ -139,6 +174,7 @@ type handler struct {
 	perNodeRateLimiters   map[string]limits.RateLimiter
 	requestTimeout        time.Duration
 	nodeSendTimeout       time.Duration
+	quorumGrace           time.Duration
 
 	activeRequests map[string]*activeRequest
 	metrics        *metrics
@@ -173,6 +209,16 @@ func NewHandler(methodConfig json.RawMessage, donConfig *config.DONConfig, don g
 		cfg.NodeSendTimeoutSec = cfg.RequestTimeoutSec
 	}
 
+	switch {
+	case cfg.QuorumGraceMillis == 0:
+		cfg.QuorumGraceMillis = defaultQuorumGraceMillis
+	case cfg.QuorumGraceMillis < 0:
+		cfg.QuorumGraceMillis = 0
+	}
+	if maxGraceMillis := cfg.RequestTimeoutSec * 1000; cfg.QuorumGraceMillis > maxGraceMillis {
+		cfg.QuorumGraceMillis = maxGraceMillis
+	}
+
 	globalNodeRateLimiter, err := limitsFactory.MakeRateLimiter(cresettings.Default.GatewayConfidentialRelayGlobalRate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create global node rate limiter: %w", err)
@@ -198,6 +244,7 @@ func NewHandler(methodConfig json.RawMessage, donConfig *config.DONConfig, don g
 		lggr:                  logger.Named(lggr, "ConfidentialRelayHandler:"+donConfig.DonId),
 		requestTimeout:        time.Duration(cfg.RequestTimeoutSec) * time.Second,
 		nodeSendTimeout:       time.Duration(cfg.NodeSendTimeoutSec) * time.Second,
+		quorumGrace:           time.Duration(cfg.QuorumGraceMillis) * time.Millisecond,
 		globalNodeRateLimiter: globalNodeRateLimiter,
 		perNodeRateLimiters:   perNodeRateLimiters,
 		activeRequests:        make(map[string]*activeRequest),
@@ -431,6 +478,9 @@ func (h *handler) forwardBundleOrTerminateIfReady(ctx context.Context, l logger.
 			fmt.Errorf("relay quorum unreachable: %d signed responses, at most %d possible, need %d (collected=%d nodes=%d remaining=%d errors=%d undecodable=%d)",
 				summary.Signed(), maxPossibleSigned, minQuorum, summary.Total(), nodes, remaining, summary.Error(), summary.Undecodable())))
 	}
+	if !expired && summary.Signed() >= minQuorum {
+		h.startQuorumGrace(l, ar, summary)
+	}
 	l.Debugw("waiting for more signed relay responses before forwarding bundle",
 		"signed", summary.Signed(),
 		"earlyNeed", earlyNeed,
@@ -444,6 +494,76 @@ func (h *handler) forwardBundleOrTerminateIfReady(ctx context.Context, l logger.
 		"nodeErrors", summary.NodeErrorsFormatted(),
 	)
 	return nil
+}
+
+// startQuorumGrace arms the grace window the first time a request holds minQuorum
+// signed responses. It bounds how long a request that will never reach earlyNeed
+// keeps waiting for the rest of the DON: without it such a request is held until
+// requestTimeout, long after the caller's own deadline has elapsed, so a bundle
+// that was viable within milliseconds is forwarded to nobody.
+func (h *handler) startQuorumGrace(l logger.Logger, ar *activeRequest, summary *BundleSummary) {
+	if h.quorumGrace <= 0 {
+		return
+	}
+	if !ar.graceStarted.CompareAndSwap(false, true) {
+		return
+	}
+	l.Infow("relay quorum reached below earlyNeed; starting grace window",
+		"signed", summary.Signed(),
+		"minQuorum", h.donConfig.F+1,
+		"earlyNeed", 2*h.donConfig.F+1,
+		"collected", summary.Total(),
+		"nodes", len(h.donConfig.Members),
+		"grace", h.quorumGrace,
+	)
+	ar.setGraceTimer(h.clock.AfterFunc(h.quorumGrace, func() { h.onQuorumGraceElapsed(ar) }))
+}
+
+// onQuorumGraceElapsed forwards the bundle collected during the grace window.
+// Collected responses are never replaced, so the signed count only grows: a request
+// that armed the timer still holds at least minQuorum signed responses here. If the
+// earlyNeed path already answered, the send is a no-op.
+func (h *handler) onQuorumGraceElapsed(ar *activeRequest) {
+	ctx, cancel := h.stopCh.NewCtx()
+	defer cancel()
+
+	l := logger.With(h.lggr, "method", ar.req.Method, "requestID", ar.req.ID)
+	summary, err := h.bundler.Bundle(ar.req, ar.copiedResponses(), l)
+	if err != nil {
+		l.Errorw("failed to build relay response bundle after quorum grace", "error", err)
+		if sendErr := h.sendResponseAndClearRequest(ctx, ar, h.constructErrorResponse(ar.req, api.FatalError, err)); sendErr != nil {
+			l.Errorw("error returning bundle failure after quorum grace", "error", sendErr)
+		}
+		return
+	}
+
+	minQuorum := h.donConfig.F + 1
+	nodes := len(h.donConfig.Members)
+	if summary.Signed() < minQuorum {
+		l.Warnw("quorum grace elapsed below quorum; leaving request to expiry",
+			"signed", summary.Signed(),
+			"minQuorum", minQuorum,
+			"collected", summary.Total(),
+			"nodes", nodes,
+		)
+		return
+	}
+
+	l.Infow("quorum grace elapsed; forwarding partial signed bundle",
+		"signed", summary.Signed(),
+		"minQuorum", minQuorum,
+		"earlyNeed", 2*h.donConfig.F+1,
+		"collected", summary.Total(),
+		"nodes", nodes,
+		"unanswered", nodes-summary.Total(),
+		"grace", h.quorumGrace,
+		"errors", summary.Error(),
+		"undecodable", summary.Undecodable(),
+		"nodeErrors", summary.NodeErrorsFormatted(),
+	)
+	if err := h.forwardBundle(ctx, l, ar, summary); err != nil {
+		l.Errorw("error forwarding bundle after quorum grace", "error", err)
+	}
 }
 
 // forwardBundle sends a previously-built bundle to the enclave. The gateway makes
@@ -509,14 +629,15 @@ func (h *handler) fanOutToNodes(ctx context.Context, l logger.Logger, ar *active
 
 // sendResponseAndClearRequest claims the request, sends payload, and removes it from
 // activeRequests. Concurrent completion paths (node-message forward,
-// terminal-state forward, expiry) may all race here; only the first claimer
-// sends. Metrics are recorded only after a successful send so losers do not
+// terminal-state forward, quorum grace, expiry) may all race here; only the first
+// claimer sends. Metrics are recorded only after a successful send so losers do not
 // double-count.
 func (h *handler) sendResponseAndClearRequest(ctx context.Context, ar *activeRequest, payload gwhandlers.UserCallbackPayload) error {
 	if !ar.completed.CompareAndSwap(false, true) {
 		// Another path already answered this request.
 		return nil
 	}
+	ar.stopGraceTimer()
 
 	sendErr := ar.SendResponse(payload)
 

--- a/core/services/gateway/handlers/confidentialrelay/handler_test.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler_test.go
@@ -108,6 +108,11 @@ func setupHandler(t *testing.T, numNodes int) (*handler, *common.Callback, *mock
 
 func setupHandlerWithF(t *testing.T, numNodes, f int) (*handler, *common.Callback, *mocks.DON, *clockwork.FakeClock) {
 	t.Helper()
+	return setupHandlerWithConfig(t, numNodes, f, Config{RequestTimeoutSec: 30})
+}
+
+func setupHandlerWithConfig(t *testing.T, numNodes, f int, handlerConfig Config) (*handler, *common.Callback, *mocks.DON, *clockwork.FakeClock) {
+	t.Helper()
 	lggr := logger.Test(t)
 	don := mocks.NewDON(t)
 
@@ -123,9 +128,6 @@ func setupHandlerWithF(t *testing.T, numNodes, f int) (*handler, *common.Callbac
 		DonId:   "test_relay_don",
 		F:       f,
 		Members: members,
-	}
-	handlerConfig := Config{
-		RequestTimeoutSec: 30,
 	}
 	methodConfig, err := json.Marshal(handlerConfig)
 	require.NoError(t, err)
@@ -517,7 +519,9 @@ func TestConfidentialRelayHandler_BundlerErrorReturnsFatal(t *testing.T) {
 // F+1 floor.
 func TestConfidentialRelayHandler_TimeoutForwardsPartialBundle(t *testing.T) {
 	t.Parallel()
-	h, cb, don, clock := setupHandler(t, 4)
+	// Grace disabled so the expiry path is the only one that can answer here; the
+	// grace window covers the same shape in TestConfidentialRelayHandler_QuorumGrace*.
+	h, cb, don, clock := setupHandlerWithConfig(t, 4, 1, Config{RequestTimeoutSec: 30, QuorumGraceMillis: -1})
 	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	params := validCapParamsJSON("wf1")
@@ -609,6 +613,150 @@ func TestConfidentialRelayHandler_TimeoutNoResponses(t *testing.T) {
 	clock.Advance(31 * time.Second)
 	h.removeExpiredRequests(t.Context())
 	wg.Wait()
+}
+
+// Production shape from the staging incident: F=3 / N=10, two nodes answer with
+// JSON-RPC errors and two never answer, so signed tops out at 6 - above minQuorum=4
+// but below earlyNeed=7. Without the grace window the request is held until
+// requestTimeout and the bundle is forwarded after the caller's HTTP deadline has
+// already returned 503.
+func TestConfidentialRelayHandler_QuorumGraceForwardsPartialBundle(t *testing.T) {
+	t.Parallel()
+	h, cb, don, clock := setupHandlerWithF(t, 10, 3)
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	params := validCapParamsJSON("wf1")
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-grace",
+		Method: MethodCapabilityExec,
+		Params: &params,
+	}
+	result := relaytypes.CapabilityResponseResult{Payload: "result"}
+
+	require.NoError(t, h.HandleJSONRPCUserMessage(t.Context(), req, cb))
+
+	for i := range 2 {
+		errResp := &jsonrpc.Response[json.RawMessage]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      req.ID,
+			Method:  MethodCapabilityExec,
+			Error:   &jsonrpc.WireError{Code: -32602, Message: "execution handler for workflow not found"},
+		}
+		require.NoError(t, h.HandleNodeMessage(t.Context(), errResp, fmt.Sprintf("0x%04d", i)))
+	}
+	for i := 2; i < 8; i++ {
+		require.NoError(t, h.HandleNodeMessage(t.Context(),
+			capExecSignedRespPtr(t, req.ID, result, fmt.Appendf(nil, "signer-%d", i)),
+			fmt.Sprintf("0x%04d", i),
+		))
+	}
+	require.NotNil(t, h.getActiveRequest(req.ID), "signed=6 is below earlyNeed=7, so the request stays open")
+
+	// The grace window was armed by the 4th signed response and has not elapsed yet.
+	clock.Advance(defaultQuorumGraceMillis*time.Millisecond - time.Second)
+	require.NotNil(t, h.getActiveRequest(req.ID), "must not forward before the grace window elapses")
+
+	clock.Advance(2 * time.Second)
+
+	resp, err := cb.Wait(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, api.NoError, resp.ErrorCode)
+	var jsonResp jsonrpc.Response[json.RawMessage]
+	require.NoError(t, json.Unmarshal(resp.RawResponse, &jsonResp))
+	var bundle relaytypes.SignedCapabilityResponseBundle
+	require.NoError(t, json.Unmarshal(*jsonResp.Result, &bundle))
+	require.Len(t, bundle.Responses, 6, "every collected signed response is forwarded")
+	require.Nil(t, h.getActiveRequest(req.ID))
+}
+
+// The grace window only bounds the wait; reaching earlyNeed still forwards
+// immediately, and the pending timer must not answer the request a second time.
+func TestConfidentialRelayHandler_QuorumGraceYieldsToEarlyForward(t *testing.T) {
+	t.Parallel()
+	h, cb, don, clock := setupHandler(t, 4) // F=1: minQuorum=2, earlyNeed=3
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	params := validCapParamsJSON("wf1")
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-grace-early",
+		Method: MethodCapabilityExec,
+		Params: &params,
+	}
+	result := relaytypes.CapabilityResponseResult{Payload: "result"}
+
+	require.NoError(t, h.HandleJSONRPCUserMessage(t.Context(), req, cb))
+	for i := range 3 {
+		require.NoError(t, h.HandleNodeMessage(t.Context(),
+			capExecSignedRespPtr(t, req.ID, result, fmt.Appendf(nil, "signer-%d", i)),
+			fmt.Sprintf("0x%04d", i),
+		))
+	}
+
+	resp, err := cb.Wait(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, api.NoError, resp.ErrorCode)
+	require.Nil(t, h.getActiveRequest(req.ID))
+
+	// The grace timer armed at the second signed response is stopped on completion;
+	// firing it must not resurrect or re-answer the request.
+	clock.Advance(2 * defaultQuorumGraceMillis * time.Millisecond)
+	require.Nil(t, h.getActiveRequest(req.ID))
+}
+
+// A request that never reaches minQuorum arms no grace timer and is left to expiry.
+func TestConfidentialRelayHandler_QuorumGraceNotArmedBelowQuorum(t *testing.T) {
+	t.Parallel()
+	h, cb, don, clock := setupHandler(t, 4) // F=1: minQuorum=2
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	params := validCapParamsJSON("wf1")
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-grace-below",
+		Method: MethodCapabilityExec,
+		Params: &params,
+	}
+	result := relaytypes.CapabilityResponseResult{Payload: "result"}
+
+	require.NoError(t, h.HandleJSONRPCUserMessage(t.Context(), req, cb))
+	require.NoError(t, h.HandleNodeMessage(t.Context(),
+		capExecSignedRespPtr(t, req.ID, result, []byte("signer-0")), "0x0000"))
+
+	ar := h.getActiveRequest(req.ID)
+	require.NotNil(t, ar)
+	require.False(t, ar.graceStarted.Load(), "one signed response is below minQuorum=2")
+
+	clock.Advance(2 * defaultQuorumGraceMillis * time.Millisecond)
+	require.NotNil(t, h.getActiveRequest(req.ID), "only expiry may complete a below-quorum request")
+}
+
+func TestConfidentialRelayHandler_QuorumGraceConfig(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name        string
+		cfg         Config
+		wantGraceMs int64
+	}{
+		{"defaults when unset", Config{}, defaultQuorumGraceMillis},
+		{"honours explicit value", Config{RequestTimeoutSec: 30, QuorumGraceMillis: 2500}, 2500},
+		{"clamped to request timeout", Config{RequestTimeoutSec: 5, QuorumGraceMillis: 20000}, 5000},
+		{"default clamped by short request timeout", Config{RequestTimeoutSec: 3}, 3000},
+		{"negative disables the grace window", Config{RequestTimeoutSec: 30, QuorumGraceMillis: -1}, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			lggr := logger.Test(t)
+			methodConfig, err := json.Marshal(tc.cfg)
+			require.NoError(t, err)
+			donConfig := &config.DONConfig{DonId: "test_relay_don", F: 1, Members: []config.NodeConfig{nodeOne}}
+			limitsFactory := limits.Factory{Settings: cresettings.DefaultGetter, Logger: lggr}
+
+			h, err := NewHandler(methodConfig, donConfig, mocks.NewDON(t), lggr, clockwork.NewFakeClock(), limitsFactory)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantGraceMs, h.quorumGrace.Milliseconds())
+			assert.LessOrEqual(t, h.quorumGrace, h.requestTimeout)
+		})
+	}
 }
 
 func TestConfidentialRelayHandler_DuplicateRequestID(t *testing.T) {


### PR DESCRIPTION
If we don't hit 2f+1, responses from the relay DON we wait a long time before return anything, even if we have >= f+1 responses already. This adds a grace period after which the bundle will come back even if only >= f+1 requests have come in.