### PR TITLE
fix solana write system test flake

### DIFF
--- a/system-tests/lib/cre/environment/blockchains/solana/solana.go
+++ b/system-tests/lib/cre/environment/blockchains/solana/solana.go
@@ -222,7 +222,7 @@ func initSolanaInput(bi *blockchain.Input) error {
 			}
 
 			// TODO PLEX-1718 use latest contracts sha for now. Derive commit sha from go.mod once contracts are in a separate go module
-			err2 = solutils.DownloadChainlinkSolanaProgramArtifacts(context.Background(), bi.ContractsDir, "ea62f88cbdb4", logger.Nop())
+			err2 = solutils.DownloadChainlinkSolanaProgramArtifacts(context.Background(), bi.ContractsDir, "90043607d911", logger.Nop())
 		})
 		if err2 != nil {
 			return fmt.Errorf("failed to download solana artifacts: %w", err2)

--- a/system-tests/tests/smoke/cre/cre_suite_test.go
+++ b/system-tests/tests/smoke/cre/cre_suite_test.go
@@ -238,8 +238,6 @@ const solanaConfigPath = "/configs/workflow-don-solana.toml"
 
 //nolint:paralleltest // isolate local cre env run
 func Test_CRE_V2_Solana_Write(t *testing.T) {
-	t.Skip("Skipping flaky test")
-
 	testEnv := t_helpers.SetupTestEnvironmentWithConfig(t, t_helpers.GetTestConfig(t, solanaConfigPath))
 	t.Run("Solana Write", func(t *testing.T) {
 		ExecuteSolanaWriteTest(t, testEnv)


### PR DESCRIPTION
```Program log: AnchorError caused by account: oracles_config. Error Code: ConstraintMut. Error Number: 2000. Error Message: A mut constraint was violated.```
- contract change from this [chainlink-solana PR](https://github.com/smartcontractkit/chainlink-solana/pull/1508) from 5/12
- we were using 4/20 chainlink-solana in [capabilities](https://github.com/smartcontractkit/capabilities/pull/682/changes#diff-e044a49a600d949723ec6880634a87ed013fc7e74d92baeff88b1d8ca58de4cfL15) until yesterday
- but didn't bump artifact (Fix: this PR bumps it)

Didn't catch this on-chain because: it's safe to pass a writeable account to a read-only function but it errors when you pass a read-only account to a mut function. So currently:
- onchain: New Forwarder, old client. read-only function, writable account passed from client, fine (next image bump will be new,new)
- system tests: Old forwarder, new client: mutable function, read-only account, breaks (after this PR it's new,new)

PR was able to get through because system tests [cache artifacts](https://github.com/smartcontractkit/chainlink/blob/43968566be6e84f5011ae66a356d2268b00de3d2/system-tests/lib/cre/environment/blockchains/solana/solana.go#L234-L250)

Re-ran successfully 5 times in a row



