### PR TITLE
Update CHANGELOG and consume changesets for v2.57.1

### DIFF
--- a/.changeset/cre-confidential-relay-handler-wait.md
+++ b/.changeset/cre-confidential-relay-handler-wait.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#internal Confidential relay: on the workflow node, briefly wait (after attestation and Workflow-DON authorization pass) for a not-yet-registered execution handler before failing the enclave's relay callback. This lets a node that has not yet started its copy of the DON-shared execution register and sign in time, instead of failing the callback outright and eroding the relay quorum. The wait is bounded so a callback for an execution the node never runs still fails promptly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog Chainlink Core
 
+## 2.57.1
+
+### Patch Changes
+
+- [#23329](https://github.com/smartcontractkit/chainlink/pull/23329) [`25990b2`](https://github.com/smartcontractkit/chainlink/commit/25990b2724f8b8398f846adeb77f615112330a16) - #internal Confidential relay: on the workflow node, briefly wait (after attestation and Workflow-DON authorization pass) for a not-yet-registered execution handler before failing the enclave's relay callback. This lets a node that has not yet started its copy of the DON-shared execution register and sign in time, instead of failing the callback outright and eroding the relay quorum. The wait is bounded so a callback for an execution the node never runs still fails promptly.
+
 ## 2.57.0
 
 ### Minor Changes


### PR DESCRIPTION
Lands the changeset consumption that the `Release (Pre)` job could not push directly to `release/2.57.1` (branch protection + required-workflow rulesets reject direct pushes from the release bot; see run 30949847717).

Reproduces the bot's commit exactly: deletes `.changeset/cre-confidential-relay-handler-wait.md` and adds the corresponding CHANGELOG entry (2 files, +6/-5, matching the bot's diffstat).

Once merged, re-running `Release (Pre)` will find no changes to commit (`has-changes=false`), skip the push step entirely, and proceed to create the signed `v2.57.1-rc.1` tag.