### PR TITLE
fix(pipeline): allow literal ethtx from addresses

### DIFF
--- a/.changeset/literal-ethtx-addresses.md
+++ b/.changeset/literal-ethtx-addresses.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix Allow literal Ethereum addresses in `ethtx` task `from` fields.

--- a/core/services/pipeline/getters.go
+++ b/core/services/pipeline/getters.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -132,6 +133,9 @@ func JSONWithVarExprs(jsExpr string, vars Vars, allowErrors bool) GetterFunc {
 		jd.UseNumber()
 		if err := jd.Decode(&val); err != nil {
 			return nil, errors.Wrapf(ErrBadInput, "while unmarshalling JSON: %v; js: %s", err, string(replaced))
+		}
+		if err := jd.Decode(&struct{}{}); err != io.EOF {
+			return nil, errors.Wrapf(ErrBadInput, "while unmarshalling JSON: unexpected trailing data; js: %s", string(replaced))
 		}
 		reinterpreted, err := jsonserializable.ReinterpretJSONNumbers(val)
 		if err != nil {

--- a/core/services/pipeline/getters_test.go
+++ b/core/services/pipeline/getters_test.go
@@ -95,6 +95,8 @@ func TestGetters_JSONWithVarExprs(t *testing.T) {
 		{`{ "$(foo.bar)": $(zet) }`, "value", 123, pipeline.ErrBadInput, false},
 		{`{ "x": { "__chainlink_key_path__": 0 } }`, "", nil, pipeline.ErrBadInput, false},
 		{`{ "e": $(err)`, "e", nil, pipeline.ErrBadInput, false},
+		{`0x882969652440ccf14a5dbb9bd53eb21cb1e11e5c`, "", nil, pipeline.ErrBadInput, false},
+		{`{} {}`, "", nil, pipeline.ErrBadInput, false},
 	}
 
 	for _, test := range tests {

--- a/core/services/pipeline/task.eth_tx.go
+++ b/core/services/pipeline/task.eth_tx.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-viper/mapstructure/v2"
@@ -51,6 +52,28 @@ type ETHKeyStore interface {
 }
 
 var _ Task = (*ETHTxTask)(nil)
+
+func literalEVMAddress(value string) GetterFunc {
+	return func() (any, error) {
+		trimmed := strings.TrimSpace(value)
+		if len(trimmed) != 2+2*common.AddressLength ||
+			!strings.HasPrefix(trimmed, "0x") ||
+			!common.IsHexAddress(trimmed) {
+			return nil, ErrParameterEmpty
+		}
+		return []common.Address{common.HexToAddress(trimmed)}, nil
+	}
+}
+
+func ethTxFromGetters(value string, vars Vars) []GetterFunc {
+	return From(
+		VarExpr(value, vars),
+		literalEVMAddress(value),
+		JSONWithVarExprs(value, vars, false),
+		NonemptyString(value),
+		nil,
+	)
+}
 
 func (t *ETHTxTask) Type() TaskType {
 	return TaskTypeETHTx
@@ -100,7 +123,7 @@ func (t *ETHTxTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, inpu
 		failOnRevert          BoolParam
 	)
 	err = stderrors.Join(
-		errors.Wrap(ResolveParam(&fromAddrs, From(VarExpr(t.From, vars), JSONWithVarExprs(t.From, vars, false), NonemptyString(t.From), nil)), "from"),
+		errors.Wrap(ResolveParam(&fromAddrs, ethTxFromGetters(t.From, vars)), "from"),
 		errors.Wrap(ResolveParam(&toAddr, From(VarExpr(t.To, vars), NonemptyString(t.To))), "to"),
 		errors.Wrap(ResolveParam(&data, From(VarExpr(t.Data, vars), NonemptyString(t.Data))), "data"),
 		errors.Wrap(ResolveParam(&gasLimit, From(VarExpr(t.GasLimit, vars), NonemptyString(t.GasLimit), maximumGasLimit)), "gasLimit"),

--- a/core/services/pipeline/task.eth_tx_internal_test.go
+++ b/core/services/pipeline/task.eth_tx_internal_test.go
@@ -1,0 +1,23 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestETHTxFromGetters_LiteralAddress(t *testing.T) {
+	t.Parallel()
+
+	const address = "0x882969652440ccf14a5dbb9bd53eb21cb1e11e5c"
+	var fromAddrs AddressSliceParam
+
+	err := ResolveParam(
+		&fromAddrs,
+		ethTxFromGetters(address, NewVarsFrom(nil)),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, AddressSliceParam{common.HexToAddress(address)}, fromAddrs)
+}

--- a/core/services/pipeline/task.eth_tx_test.go
+++ b/core/services/pipeline/task.eth_tx_test.go
@@ -100,6 +100,48 @@ func TestETHTxTask(t *testing.T) {
 			nil, nil, "", pipeline.RunInfo{},
 		},
 		{
+			"happy (literal from address)",
+			"0x882969652440ccf14a5dbb9bd53eb21cb1e11e5c",
+			"0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF",
+			"foobar",
+			"12345",
+			`{ "jobID": 321, "requestID": "0x5198616554d738d9485d1a7cf53b2f33e09c3bbc8fe9ac0020bd672cd2bc15d2", "requestTxHash": "0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8" }`,
+			`0`,
+			testutils.FixtureChainID.String(),
+			`{"CheckerType": "vrf_v2", "VRFCoordinatorAddress": "0x2E396ecbc8223Ebc16EC45136228AE5EDB649943"}`,
+			nil,
+			false,
+			pipeline.NewVarsFrom(nil),
+			nil,
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.MockEvmTxManager) {
+				data := []byte("foobar")
+				gasLimit := uint64(12345)
+				jobID := int32(321)
+				addr := common.HexToAddress("0x2E396ecbc8223Ebc16EC45136228AE5EDB649943")
+				txMeta := &txmgr.TxMeta{
+					JobID:         &jobID,
+					RequestID:     &reqID,
+					RequestTxHash: &reqTxHash,
+					FailOnRevert:  null.BoolFrom(false),
+				}
+				keyStore.On("GetRoundRobinAddress", mock.Anything, testutils.FixtureChainID, from).Return(from, nil)
+				txManager.On("CreateTransaction", mock.Anything, txmgr.TxRequest{
+					FromAddress:    from,
+					ToAddress:      to,
+					EncodedPayload: data,
+					FeeLimit:       gasLimit,
+					Meta:           txMeta,
+					Strategy:       txmgrcommon.NewSendEveryStrategy(),
+					Checker: txmgr.TransmitCheckerSpec{
+						CheckerType:           txmgr.TransmitCheckerTypeVRFV2,
+						VRFCoordinatorAddress: &addr,
+					},
+					SignalCallback: true,
+				}).Return(txmgr.Tx{}, nil)
+			},
+			nil, nil, "", pipeline.RunInfo{},
+		},
+		{
 			"happy (with vars)",
 			`[ $(fromAddr) ]`,
 			"$(toAddr)",


### PR DESCRIPTION
## Summary

- allow `ethtx` task `from` fields to use a single literal Ethereum address
- preserve variable-expression, JSON-array, and existing fallback handling
- reject trailing JSON data instead of silently accepting the first value
- add focused parser, getter, and task regression coverage

## Root cause

The `from` resolver tried variable and JSON parsing before its string fallback. A bare `0x...` address is not valid JSON and therefore could not be resolved as an address slice.

## Impact

Pipeline specs can pin an `ethtx` task to one literal address without wrapping it in a JSON array. Existing variable and array forms remain supported.

## Validation

- `gofmt -d` on all changed Go files
- `go test ./core/services/pipeline -run '^(TestGetters_JSONWithVarExprs|TestETHTxFromGetters_LiteralAddress)$' -count=1`
- `git diff --check`

The broader `TestETHTxTask` table requires `CL_DATABASE_URL`; it was not runnable in the local environment and is left to CI.
