### PR TITLE
chore(cre): adds gateway don metric by bumping http cap

### DIFF
--- a/.changeset/legal-pears-cheat.md
+++ b/.changeset/legal-pears-cheat.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#added adds new gateway don metric for tracking when no gateways are available

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -93,7 +93,7 @@ plugins:
 
   capability-httpaction:
     - moduleURI: "github.com/smartcontractkit/capabilities/http_action"
-      gitRef: "324e84d8aafef0fff4c1fd6b78a90dcd43a2b6e9"
+      gitRef: "cd4b91ceffa1e7ee24b57fa4461cd57a2b79d0b9"
       installPath: "."
 
   capability-httptrigger:


### PR DESCRIPTION
## Summary

- Bumps `http-actions` capability version in `plugins/plugins.public.yaml` to include the new `http_action_no_gateways_available_count` metric

## Context

When the HTTP action capability runs in gateway proxy mode, it selects a gateway from the configured DON to route outbound requests. If no gateways match the configured `GatewayProxyDonID`, the capability previously failed silently — the failure was only visible as a generic `gateway_send_error_count` with an empty `node_address`, making it indistinguishable from other gateway errors.

The new metric `http_action_no_gateways_available_count` is emitted at two failure paths:
1. `gatewayIDsForDon` returns an empty list (no gateways configured for DON)
2. Ring exhaustion after all gateways are evicted (no available gateways)

The metric includes a `gateway_proxy_don_id` attribute for identifying which DON is misconfigured.

**Capability PR:** https://github.com/smartcontractkit/capabilities/pull/717


[CRE-5903]: https://smartcontract-it.atlassian.net/browse/CRE-5903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ