### PR TITLE
chore: bump confidential capabilities gitref

### DIFF
--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -123,10 +123,10 @@ plugins:
 
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "96f4d477083f4e7c81e7297b18dd614d5fc6faf9"
+      gitRef: "83ddf6bc7d41c59c700d482133d3a2786c045e0c"
       installPath: "./cmd/confidential-http"
 
   confidential-workflows:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-workflows/capability"
-      gitRef: "96f4d477083f4e7c81e7297b18dd614d5fc6faf9"
+      gitRef: "83ddf6bc7d41c59c700d482133d3a2786c045e0c"
       installPath: "./cmd/confidential-workflows"

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -123,10 +123,10 @@ plugins:
 
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "83ddf6bc7d41c59c700d482133d3a2786c045e0c"
+      gitRef: "b9926f01321595b1db0fa169fdafb3dbd24dd161"
       installPath: "./cmd/confidential-http"
 
   confidential-workflows:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-workflows/capability"
-      gitRef: "83ddf6bc7d41c59c700d482133d3a2786c045e0c"
+      gitRef: "b9926f01321595b1db0fa169fdafb3dbd24dd161"
       installPath: "./cmd/confidential-workflows"


### PR DESCRIPTION
Bumps to release 1.3.0: https://github.com/smartcontractkit/chainlink-confidential-compute/releases/tag/v1.3.0