### PR TITLE
feat(cre/vault): support DKG resharing in ConfigureVaultDKG

### DIFF
--- a/deployment/cre/ocr3/ocr3_1/changeset/operations/contracts/configure_vault_dkg.go
+++ b/deployment/cre/ocr3/ocr3_1/changeset/operations/contracts/configure_vault_dkg.go
@@ -37,6 +37,12 @@ type ConfigureVaultDKGInput struct {
 type DKGDon struct {
 	contracts.DonNodeSet
 	RecipientPublicKeys []string `json:"recipientPublicKeys" yaml:"recipientPublicKeys"`
+	// PreviousInstanceID, when set, makes this a resharing DKG instead of a fresh dealing.
+	// It must be the currently-live DKG instance ID (e.g.
+	// "sanmarinodkg/v1/<dkgContract>/<configDigest>"). Resharing preserves the group
+	// (master) public key while changing the participant/share set; a fresh dealing
+	// (nil) generates a NEW group key. Leave nil only for the very first DKG config.
+	PreviousInstanceID *string `json:"previousInstanceID,omitempty" yaml:"previousInstanceID,omitempty"`
 }
 
 type ConfigureVaultDKG struct{}
@@ -135,5 +141,6 @@ func dkgOffchainConfig(don DKGDon, threshold int) *ocr3_1.DKGOffchainConfig {
 		T:                   threshold,
 		DealerPublicKeys:    don.RecipientPublicKeys,
 		RecipientPublicKeys: don.RecipientPublicKeys,
+		PreviousInstanceID:  don.PreviousInstanceID,
 	}
 }


### PR DESCRIPTION
## Motivation

Vault DON node rotations currently re-key the DKG through `vault_set_dkg_config` (`ConfigureVaultDKG`). That changeset always produced a **fresh** DKG dealing — the offchain config was built with no `PreviousInstanceID` — which generates a **new group (master) public key**. For a live vault DON that means the published `VaultPublicKey` changes and every previously stored secret (encrypted to the old key) becomes undecryptable.

The underlying smdkg protocol and `ocr3_1.DKGOffchainConfig` already support **resharing** via `PreviousInstanceID` (honored by `DKGOffchainConfig.Marshal()`), but nothing wired it through the changeset.
