### PR TITLE
feat(cre/vault): require explicit dealer+recipient keys for DKG resharing

### DIFF
--- a/deployment/cre/ocr3/ocr3_1/changeset/operations/contracts/configure_vault_dkg.go
+++ b/deployment/cre/ocr3/ocr3_1/changeset/operations/contracts/configure_vault_dkg.go
@@ -36,6 +36,19 @@ type ConfigureVaultDKGInput struct {
 
 type DKGDon struct {
 	contracts.DonNodeSet
+	// DealerPublicKeys are the DKG public keys of the dealers (the nodes that contribute
+	// shares in this run). Both DealerPublicKeys and RecipientPublicKeys must always be set
+	// explicitly so the intent of the run is unambiguous:
+	//   - Fresh DKG (PreviousInstanceID nil): DealerPublicKeys must equal RecipientPublicKeys
+	//     (every participant both deals and receives).
+	//   - Resharing (PreviousInstanceID set): DealerPublicKeys must exactly equal the previous
+	//     instance's RecipientPublicKeys (same values, same order) — the old holders reshare to
+	//     the new set. RecipientPublicKeys is the new participant set. The smdkg plugin rejects
+	//     the config if dealers do not match the prior recipients.
+	DealerPublicKeys []string `json:"dealerPublicKeys" yaml:"dealerPublicKeys"`
+	// RecipientPublicKeys are the DKG public keys of the recipients (the resulting participant
+	// set that will hold shares of the master secret). NodeIDs correspond positionally to
+	// RecipientPublicKeys.
 	RecipientPublicKeys []string `json:"recipientPublicKeys" yaml:"recipientPublicKeys"`
 	// PreviousInstanceID, when set, makes this a resharing DKG instead of a fresh dealing.
 	// It must be the currently-live DKG instance ID (e.g.
@@ -63,8 +76,17 @@ func (l ConfigureVaultDKG) VerifyPreconditions(_ cldf.Environment, input Configu
 	if len(input.DON.RecipientPublicKeys) == 0 {
 		return errors.New("at least one recipient public key is required")
 	}
+	if len(input.DON.DealerPublicKeys) == 0 {
+		return errors.New("at least one dealer public key is required (set dealerPublicKeys explicitly: equal to recipientPublicKeys for a fresh DKG, or equal to the previous instance's recipientPublicKeys for a reshare)")
+	}
 	if len(input.DON.NodeIDs) != len(input.DON.RecipientPublicKeys) {
 		return errors.New("the number of don node IDs must match the number of recipient public keys")
+	}
+	// For a fresh DKG every participant both deals and receives, so the sets must be identical.
+	// For a reshare they legitimately differ (dealers = previous recipients), so only enforce
+	// equality when this is not a reshare.
+	if input.DON.PreviousInstanceID == nil && !equalStringSlices(input.DON.DealerPublicKeys, input.DON.RecipientPublicKeys) {
+		return errors.New("for a fresh DKG (no previousInstanceID) dealerPublicKeys must equal recipientPublicKeys")
 	}
 	if input.OracleConfig == nil {
 		return errors.New("oracle config is required")
@@ -139,8 +161,20 @@ func (l ConfigureVaultDKG) Apply(e cldf.Environment, input ConfigureVaultDKGInpu
 func dkgOffchainConfig(don DKGDon, threshold int) *ocr3_1.DKGOffchainConfig {
 	return &ocr3_1.DKGOffchainConfig{
 		T:                   threshold,
-		DealerPublicKeys:    don.RecipientPublicKeys,
+		DealerPublicKeys:    don.DealerPublicKeys,
 		RecipientPublicKeys: don.RecipientPublicKeys,
 		PreviousInstanceID:  don.PreviousInstanceID,
 	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Motivation

Follow-up to #23390. That PR added `PreviousInstanceID` to enable resharing, but it was **insufficient**: `dkgOffchainConfig` still built the config with `DealerPublicKeys = RecipientPublicKeys = the new participant set`.

The smdkg plugin (`internal/ocr/plugin/plugin.go`, `initializeCryptoProvider`) requires, for a reshare, that `DealerPublicKeys` **exactly match the previous instance's `RecipientPublicKeys`** (same values, same order):

```
mismatch in number of dealers and prior recipients: %d vs %d
dealer public key at index %d does not match prior recipient public key
```

Because the changeset forced dealers = the new set, every membership change failed that check:
- **add** (7→8): dealers 8 vs prior recipients 7 → count mismatch
- **delete** (7→6): 6 vs 7 → count mismatch
- **swap** (7→7): count ok, but the swapped index's dealer ≠ prior recipient → key mismatch

So resharing only worked for an identical-membership re-key — not an actual node rotation.

## Change

- Add an explicit `DealerPublicKeys` field to `DKGDon`.
- **Always require both** `dealerPublicKeys` and `recipientPublicKeys` in the input, so the pipeline YAML is unambiguous about intent.
- Validate: for a fresh DKG (`previousInstanceID` nil) `dealerPublicKeys` must equal `recipientPublicKeys`; for a reshare they legitimately differ.
- `dkgOffchainConfig` now threads `DealerPublicKeys` through instead of reusing the recipient set.

### Usage

- **Fresh DKG:** `dealerPublicKeys == recipientPublicKeys` (all participants deal and receive).
- **Reshare (node rotation):** `dealerPublicKeys` = the previous instance's `recipientPublicKeys` (old holders), `recipientPublicKeys` = the new set, `previousInstanceID` = the live instance. Old holders reshare to the new set, preserving the group public key.

## Testing

- `go build` / `go vet` pass on `develop`.
- Additive field; combined with the fresh-DKG equality check, existing fresh-DKG configs that set both lists equal are unaffected.

## Note

This changes the input contract (both key lists now required). Callers/pipelines that previously supplied only `recipientPublicKeys` must now also set `dealerPublicKeys`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)