### PR TITLE
[CRE] Sharding support in HTTP gateway handler

### DIFF
--- a/core/services/gateway/common/aggregation/workflow_metadata_aggregator.go
+++ b/core/services/gateway/common/aggregation/workflow_metadata_aggregator.go
@@ -142,7 +142,7 @@ func (agg *WorkflowMetadataAggregator) Collect(obs *gateway_common.WorkflowMetad
 
 // Aggregate returns the aggregated workflow metadata for workflows that have reached the threshold.
 // Results are sorted chronologically by sequence number (newest first, oldest last).
-func (agg *WorkflowMetadataAggregator) Aggregate() ([]gateway_common.WorkflowMetadata, error) {
+func (agg *WorkflowMetadataAggregator) Aggregate() []gateway_common.WorkflowMetadata {
 	agg.mu.RLock()
 	defer agg.mu.RUnlock()
 
@@ -173,7 +173,7 @@ func (agg *WorkflowMetadataAggregator) Aggregate() ([]gateway_common.WorkflowMet
 		aggregated[i] = obs.metadata
 	}
 
-	return aggregated, nil
+	return aggregated
 }
 
 type NodeObservations struct {

--- a/core/services/gateway/common/aggregation/workflow_metadata_aggregator_test.go
+++ b/core/services/gateway/common/aggregation/workflow_metadata_aggregator_test.go
@@ -194,20 +194,18 @@ func TestWorkflowMetadataAggregator_Aggregate(t *testing.T) {
 	observation3 := createTestWorkflowMetadata("workflowID2", "workflowName2", "workflowOwner2", "workflowTag2", []gateway_common.AuthorizedKey{authorizedKey3})
 
 	// Test aggregation with no observations
-	result, err := agg.Aggregate()
-	require.NoError(t, err)
+	result := agg.Aggregate()
 	require.Empty(t, result)
 
 	// Add observations below threshold
-	err = agg.Collect(observation1, "node1")
+	err := agg.Collect(observation1, "node1")
 	require.NoError(t, err)
 	err = agg.Collect(observation2, "node1")
 	require.NoError(t, err)
 	err = agg.Collect(observation3, "node1")
 	require.NoError(t, err)
 
-	result, err = agg.Aggregate()
-	require.NoError(t, err)
+	result = agg.Aggregate()
 	require.Empty(t, result)
 
 	// Add observations to reach threshold for workflowID1
@@ -216,16 +214,14 @@ func TestWorkflowMetadataAggregator_Aggregate(t *testing.T) {
 	err = agg.Collect(observation2, "node2")
 	require.NoError(t, err)
 
-	result, err = agg.Aggregate()
-	require.NoError(t, err)
+	result = agg.Aggregate()
 	require.Len(t, result, 2) // observation1 and observation2 reach threshold
 
 	// Add observation to reach threshold for workflowID2
 	err = agg.Collect(observation3, "node2")
 	require.NoError(t, err)
 
-	result, err = agg.Aggregate()
-	require.NoError(t, err)
+	result = agg.Aggregate()
 	require.Len(t, result, 3) // observation3 reaches threshold
 }
 
@@ -266,8 +262,7 @@ func TestWorkflowMetadataAggregator_Aggregate_ChronologicalOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	// All observations should reach threshold
-	result, err := agg.Aggregate()
-	require.NoError(t, err)
+	result := agg.Aggregate()
 	require.Len(t, result, 3)
 
 	// Verify chronological order
@@ -325,8 +320,7 @@ func TestWorkflowMetadataAggregator_Aggregate_ChronologicalOrder_SameWorkflowNam
 	require.NoError(t, err)
 
 	// Only observations that reached threshold should be returned
-	result, err := agg.Aggregate()
-	require.NoError(t, err)
+	result := agg.Aggregate()
 	require.Len(t, result, 2)
 
 	// Verify order: observation3 (newer) before observation1 (older)
@@ -338,8 +332,7 @@ func TestWorkflowMetadataAggregator_Aggregate_ChronologicalOrder_SameWorkflowNam
 	err = agg.Collect(observation2, "node2")
 	require.NoError(t, err)
 
-	result, err = agg.Aggregate()
-	require.NoError(t, err)
+	result = agg.Aggregate()
 	require.Len(t, result, 3)
 
 	// Verify order: observation3 (newest), observation2 (middle), observation1 (oldest)

--- a/core/services/gateway/handler_factory.go
+++ b/core/services/gateway/handler_factory.go
@@ -81,7 +81,7 @@ func (hf *handlerFactory) NewHandler(
 	case WebAPICapabilitiesType:
 		return capabilities.NewHandler(handlerConfig, donConfig, don, hf.httpClient, hf.lggr)
 	case HTTPCapabilityType:
-		return v2.NewGatewayHandler(handlerConfig, donConfig, don, hf.httpClient, hf.lggr, hf.lf, hf.httpClientFactory)
+		return v2.NewGatewayHandler(handlerConfig, shardedDONs, shardsConnMgrs, hf.httpClient, hf.lggr, hf.lf, hf.httpClientFactory)
 	case VaultHandlerType:
 		return vault.NewHandler(handlerConfig, donConfig, don, hf.capabilitiesRegistry, hf.workflowRegistrySyncer, hf.lggr, clockwork.NewRealClock(), hf.lf)
 	case ConfidentialRelayHandlerType:

--- a/core/services/gateway/handlers/capabilities/v2/http_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_handler.go
@@ -45,7 +45,8 @@ const (
 type gatewayHandler struct {
 	services.StateMachine
 	config                 ServiceConfig
-	don                    handlers.DON
+	shards                 []*shardEndpoint          // all DON shards served by this handler, across the full DON×shard matrix
+	nodeAddrToShard        map[string]*shardEndpoint // node address -> owning shard, for routing responses back to the correct shard conn manager
 	lggr                   logger.Logger
 	httpClient             network.HTTPClient
 	globalNodeRateLimiter  limits.RateLimiter            // Global rate limiter shared across all incoming node requests from workflow DON
@@ -116,7 +117,7 @@ type RetryConfig struct {
 	Multiplier float64 `json:"multiplier"`
 }
 
-func NewGatewayHandler(handlerConfig json.RawMessage, donConfig *config.DONConfig, don handlers.DON, httpClient network.HTTPClient, lggr logger.Logger, lf limits.Factory, httpClientFactory network.HTTPClientFactory) (*gatewayHandler, error) {
+func NewGatewayHandler(handlerConfig json.RawMessage, shardedDONs []config.ShardedDONConfig, shardsConnMgrs [][]handlers.DON, httpClient network.HTTPClient, lggr logger.Logger, lf limits.Factory, httpClientFactory network.HTTPClientFactory) (*gatewayHandler, error) {
 	var cfg ServiceConfig
 	err := json.Unmarshal(handlerConfig, &cfg)
 	if err != nil {
@@ -124,12 +125,18 @@ func NewGatewayHandler(handlerConfig json.RawMessage, donConfig *config.DONConfi
 	}
 	cfg = WithDefaults(cfg)
 
+	shards, nodeAddrToShard, err := buildShardEndpoints(shardedDONs, shardsConnMgrs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build shard endpoints: %w", err)
+	}
+	members := allMembers(shards)
+
 	globalNodeRateLimiter, err := lf.MakeRateLimiter(cresettings.Default.GatewayHTTPGlobalRate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create global node rate limiter: %w", err)
 	}
-	perNodeRateLimiters := make(map[string]limits.RateLimiter, len(donConfig.Members))
-	for _, member := range donConfig.Members {
+	perNodeRateLimiters := make(map[string]limits.RateLimiter, len(members))
+	for _, member := range members {
 		var rl limits.RateLimiter
 		rl, err = lf.MakeRateLimiter(cresettings.Default.GatewayHTTPPerNodeRate)
 		if err != nil {
@@ -153,17 +160,18 @@ func NewGatewayHandler(handlerConfig json.RawMessage, donConfig *config.DONConfi
 		return nil, fmt.Errorf("failed to create mtls concurrency limiter: %w", err)
 	}
 
-	metrics, err := metrics.NewMetrics(donConfig)
+	metrics, err := metrics.NewMetrics(members)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize metrics: %w", err)
 	}
 
-	metadataHandler := NewWorkflowMetadataHandler(lggr, cfg, don, donConfig, metrics)
-	triggerHandler := NewHTTPTriggerHandler(lggr, cfg, donConfig, don, metadataHandler, userRateLimiter, metrics)
+	metadataHandler := NewWorkflowMetadataHandler(lggr, cfg, shards, nodeAddrToShard, metrics)
+	triggerHandler := NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, metrics)
 	return &gatewayHandler{
 		config:                 cfg,
-		don:                    don,
-		lggr:                   logger.With(logger.Named(lggr, handlerName), "donId", donConfig.DonId),
+		shards:                 shards,
+		nodeAddrToShard:        nodeAddrToShard,
+		lggr:                   logger.Named(lggr, handlerName),
 		httpClient:             httpClient,
 		globalNodeRateLimiter:  globalNodeRateLimiter,
 		perNodeRateLimiters:    perNodeRateLimiters,
@@ -524,11 +532,15 @@ func (h *gatewayHandler) sendResponseToNode(ctx context.Context, requestID strin
 		Params:  &rawParams,
 	}
 
-	err = h.don.SendToNode(ctx, nodeAddr, req)
+	shard, ok := h.nodeAddrToShard[nodeAddr]
+	if !ok {
+		return fmt.Errorf("cannot route response to unknown node %s (no owning shard)", nodeAddr)
+	}
+	err = shard.connMgr.SendToNode(ctx, nodeAddr, req)
 	if err != nil {
 		return err
 	}
 
-	h.lggr.Debugw("sent response to node", "to", nodeAddr)
+	h.lggr.Debugw("sent response to node", "to", nodeAddr, "shard", shard.donID)
 	return nil
 }

--- a/core/services/gateway/handlers/capabilities/v2/http_handler_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_handler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	gateway_common "github.com/smartcontractkit/chainlink-common/pkg/types/gateway"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
 	triggermocks "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities/v2/mocks"
 	handlermocks "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/network"
@@ -37,7 +38,8 @@ func TestNewGatewayHandler(t *testing.T) {
 		mockHTTPClient := httpmocks.NewHTTPClient(t)
 		lggr := logger.Test(t)
 
-		handler, err := NewGatewayHandler(configBytes, donConfig, mockDon, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
+		shardedDONs, connMgrs := shardedArgs(donConfig, mockDon)
+		handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
 		require.NoError(t, err)
 		require.NotNil(t, handler)
 		require.NotNil(t, handler.responseCache)
@@ -52,7 +54,8 @@ func TestNewGatewayHandler(t *testing.T) {
 		mockHTTPClient := httpmocks.NewHTTPClient(t)
 		lggr := logger.Test(t)
 
-		handler, err := NewGatewayHandler(invalidConfig, donConfig, mockDon, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
+		shardedDONs, connMgrs := shardedArgs(donConfig, mockDon)
+		handler, err := NewGatewayHandler(invalidConfig, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
 		require.Error(t, err)
 		require.Nil(t, handler)
 	})
@@ -69,7 +72,8 @@ func TestNewGatewayHandler(t *testing.T) {
 		mockHTTPClient := httpmocks.NewHTTPClient(t)
 		lggr := logger.Test(t)
 
-		handler, err := NewGatewayHandler(configBytes, donConfig, mockDon, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
+		shardedDONs, connMgrs := shardedArgs(donConfig, mockDon)
+		handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
 		require.NoError(t, err)
 		require.NotNil(t, handler)
 		require.Equal(t, defaultCleanUpPeriodMs, handler.config.CleanUpPeriodMs) // Default value
@@ -80,7 +84,7 @@ func TestHandleNodeMessage(t *testing.T) {
 	handler := createTestHandler(t)
 
 	t.Run("successful node message handling", func(t *testing.T) {
-		mockDon := handler.don.(*handlermocks.DON)
+		mockDon := handler.shards[0].connMgr.(*handlermocks.DON)
 		mockHTTPClient := handler.httpClient.(*httpmocks.HTTPClient)
 
 		// Prepare outbound request
@@ -121,7 +125,7 @@ func TestHandleNodeMessage(t *testing.T) {
 	})
 
 	t.Run("successful node message handling with MultiHeaders", func(t *testing.T) {
-		mockDon := handler.don.(*handlermocks.DON)
+		mockDon := handler.shards[0].connMgr.(*handlermocks.DON)
 		mockHTTPClient := handler.httpClient.(*httpmocks.HTTPClient)
 
 		// Prepare outbound request
@@ -219,7 +223,7 @@ func TestHandleNodeMessage(t *testing.T) {
 			Result: &rawRequest,
 		}
 
-		mockDon := handler.don.(*handlermocks.DON)
+		mockDon := handler.shards[0].connMgr.(*handlermocks.DON)
 		// First call: should fetch from HTTP client and cache the response
 		httpResp := &network.HTTPResponse{
 			StatusCode: 200,
@@ -265,7 +269,7 @@ func TestHandleNodeMessage(t *testing.T) {
 			Result: &rawRequest,
 		}
 
-		mockDon := handler.don.(*handlermocks.DON)
+		mockDon := handler.shards[0].connMgr.(*handlermocks.DON)
 		mockHTTPClient := handler.httpClient.(*httpmocks.HTTPClient)
 		httpResp := &network.HTTPResponse{
 			StatusCode: 500,
@@ -430,7 +434,8 @@ func TestGatewayHandler_Start_CallsDeleteExpired(t *testing.T) {
 	mockHTTPClient := httpmocks.NewHTTPClient(t)
 	lggr := logger.Test(t)
 
-	handler, err := NewGatewayHandler(configBytes, donConfig, mockDon, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
+	shardedDONs, connMgrs := shardedArgs(donConfig, mockDon)
+	handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
 	mockCache := newMockResponseCache()
@@ -453,6 +458,15 @@ func TestGatewayHandler_Start_CallsDeleteExpired(t *testing.T) {
 
 func serviceCfg() ServiceConfig {
 	return WithDefaults(ServiceConfig{})
+}
+
+// shardedArgs builds the multi-shard arguments for NewGatewayHandler from a
+// legacy single-shard DONConfig and its connection manager, producing a
+// one-DON one-shard matrix.
+func shardedArgs(donConfig *config.DONConfig, mockDon *handlermocks.DON) ([]config.ShardedDONConfig, [][]handlers.DON) {
+	return []config.ShardedDONConfig{
+		{DonName: donConfig.DonId, F: donConfig.F, Shards: []config.Shard{{Nodes: donConfig.Members}}},
+	}, [][]handlers.DON{{mockDon}}
 }
 
 func createTestHandler(t *testing.T) *gatewayHandler {
@@ -483,7 +497,8 @@ func createTestHandlerWithConfig(t *testing.T, cfg ServiceConfig) *gatewayHandle
 	mockHTTPClient := httpmocks.NewHTTPClient(t)
 	lggr := logger.Test(t)
 
-	handler, err := NewGatewayHandler(configBytes, donConfig, mockDon, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
+	shardedDONs, connMgrs := shardedArgs(donConfig, mockDon)
+	handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
 
@@ -670,7 +685,7 @@ func TestCreateHTTPRequestCallback(t *testing.T) {
 
 func TestMakeOutgoingRequest_SendResponseUsesIndependentContext(t *testing.T) {
 	handler := createTestHandler(t)
-	mockDon := handler.don.(*handlermocks.DON)
+	mockDon := handler.shards[0].connMgr.(*handlermocks.DON)
 	mockHTTPClient := handler.httpClient.(*httpmocks.HTTPClient)
 
 	outboundReq := gateway_common.OutboundHTTPRequest{
@@ -734,7 +749,7 @@ func TestMakeOutgoingRequestCachingBehavior(t *testing.T) {
 			Result: &rawRequest,
 		}
 
-		mockDon := handler.don.(*handlermocks.DON)
+		mockDon := handler.shards[0].connMgr.(*handlermocks.DON)
 		mockHTTPClient := handler.httpClient.(*httpmocks.HTTPClient)
 		httpResp := &network.HTTPResponse{
 			StatusCode: 200,
@@ -778,7 +793,7 @@ func TestMakeOutgoingRequestCachingBehavior(t *testing.T) {
 			Result: &rawRequest,
 		}
 
-		mockDon := handler.don.(*handlermocks.DON)
+		mockDon := handler.shards[0].connMgr.(*handlermocks.DON)
 		mockHTTPClient := handler.httpClient.(*httpmocks.HTTPClient)
 		httpResp := &network.HTTPResponse{
 			StatusCode: 200,
@@ -822,7 +837,7 @@ func TestMakeOutgoingRequestCachingBehavior(t *testing.T) {
 			Result: &rawRequest,
 		}
 
-		mockDon := handler.don.(*handlermocks.DON)
+		mockDon := handler.shards[0].connMgr.(*handlermocks.DON)
 		mockHTTPClient := handler.httpClient.(*httpmocks.HTTPClient)
 		httpResp := &network.HTTPResponse{
 			StatusCode: 200,
@@ -864,7 +879,7 @@ func setupRateLimitingTest(t *testing.T, cfg ServiceConfig) (*gatewayHandler, *j
 	}
 
 	mockHTTPClient := handler.httpClient.(*httpmocks.HTTPClient)
-	mockDon := handler.don.(*handlermocks.DON)
+	mockDon := handler.shards[0].connMgr.(*handlermocks.DON)
 
 	return handler, resp, mockHTTPClient, mockDon
 }

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/platform"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/api"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/common/aggregation"
-	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities/v2/metrics"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
@@ -42,17 +41,20 @@ const (
 
 type savedCallback struct {
 	handlers.Callback
-	requestStartTime   time.Time
-	createdAt          time.Time
-	responseAggregator *aggregation.IdenticalNodeResponseAggregator
-	doneCh             chan struct{} // closed when callback is responded to. signals sendWithRetries to stop retrying
+	requestStartTime time.Time
+	createdAt        time.Time
+	// responseAggregators holds one IdenticalNodeResponseAggregator per shard the
+	// workflow is assigned to, keyed by shard donID. The first shard to reach its
+	// quorum produces the user response.
+	responseAggregators map[string]*aggregation.IdenticalNodeResponseAggregator
+	doneCh              chan struct{} // closed when callback is responded to. signals sendWithRetries to stop retrying
 }
 
 type httpTriggerHandler struct {
 	services.StateMachine
 	config                  ServiceConfig
-	don                     handlers.DON
-	donConfig               *config.DONConfig
+	shards                  []*shardEndpoint
+	nodeAddrToShard         map[string]*shardEndpoint
 	lggr                    logger.Logger
 	callbacksMu             sync.Mutex
 	callbacks               map[string]savedCallback // requestID -> savedCallback
@@ -69,13 +71,13 @@ type HTTPTriggerHandler interface {
 	HandleNodeTriggerResponse(ctx context.Context, resp *jsonrpc.Response[json.RawMessage], nodeAddr string) error
 }
 
-func NewHTTPTriggerHandler(lggr logger.Logger, cfg ServiceConfig, donConfig *config.DONConfig, don handlers.DON, workflowMetadataHandler *WorkflowMetadataHandler, userRateLimiter limits.RateLimiter, metrics *metrics.Metrics) *httpTriggerHandler {
+func NewHTTPTriggerHandler(lggr logger.Logger, cfg ServiceConfig, shards []*shardEndpoint, nodeAddrToShard map[string]*shardEndpoint, workflowMetadataHandler *WorkflowMetadataHandler, userRateLimiter limits.RateLimiter, metrics *metrics.Metrics) *httpTriggerHandler {
 	return &httpTriggerHandler{
 		lggr:                    logger.Named(lggr, "RequestCallbacks"),
 		callbacks:               make(map[string]savedCallback),
 		config:                  cfg,
-		don:                     don,
-		donConfig:               donConfig,
+		shards:                  shards,
+		nodeAddrToShard:         nodeAddrToShard,
 		stopCh:                  make(services.StopChan),
 		workflowMetadataHandler: workflowMetadataHandler,
 		userRateLimiter:         userRateLimiter,
@@ -129,12 +131,12 @@ func (h *httpTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req *
 		return errors.New("error marshaling trigger request: " + err.Error())
 	}
 
-	doneCh, err := h.setupCallback(ctx, req.ID, callback, requestStartTime)
+	doneCh, err := h.setupCallback(ctx, req.ID, callback, requestStartTime, workflowID)
 	if err != nil {
 		return err
 	}
 
-	return h.sendWithRetries(ctx, legacyExecutionID, executionIDWithTriggerIndex, reqWithKey, doneCh)
+	return h.sendWithRetries(ctx, legacyExecutionID, executionIDWithTriggerIndex, reqWithKey, workflowID, doneCh)
 }
 
 func (h *httpTriggerHandler) validatedTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callback handlers.Callback) (*jsonrpc.Request[gateway_common.HTTPTriggerRequest], error) {
@@ -394,7 +396,7 @@ func (h *httpTriggerHandler) checkRateLimit(ctx context.Context, workflowID, req
 	return nil
 }
 
-func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string, callback handlers.Callback, requestStartTime time.Time) (<-chan struct{}, error) {
+func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string, callback handlers.Callback, requestStartTime time.Time, workflowID string) (<-chan struct{}, error) {
 	h.callbacksMu.Lock()
 	defer h.callbacksMu.Unlock()
 
@@ -403,20 +405,32 @@ func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string
 		return nil, fmt.Errorf("in-flight request ID: %s", requestID)
 	}
 
-	// (N+F)//2 + 1 threshold where N = number of nodes, F = number of faulty nodes
-	threshold := (len(h.donConfig.Members)+h.donConfig.F)/2 + 1
-	agg, err := aggregation.NewIdenticalNodeResponseAggregator(threshold)
-	if err != nil {
-		return nil, errors.New("failed to create response aggregator: " + err.Error())
+	// Build one response aggregator per shard the workflow is assigned to.
+	assigned := h.workflowMetadataHandler.WorkflowShards(workflowID)
+	if len(assigned) == 0 {
+		// this shouldn't happen because we checked it in authorizeRequest()
+		h.handleUserError(ctx, requestID, jsonrpc.ErrInternal, fmt.Sprintf("Workflow %s is not assigned to any DONs", workflowID), callback)
+		return nil, errors.New("workflow is not assigned to any shards")
+	}
+
+	aggregators := make(map[string]*aggregation.IdenticalNodeResponseAggregator, len(assigned))
+	for _, shard := range assigned {
+		// (N+F)//2 + 1 threshold where N = number of nodes, F = number of faulty nodes
+		threshold := (len(shard.members)+shard.f)/2 + 1
+		agg, err := aggregation.NewIdenticalNodeResponseAggregator(threshold)
+		if err != nil {
+			return nil, errors.New("failed to create response aggregator: " + err.Error())
+		}
+		aggregators[shard.donID] = agg
 	}
 
 	doneCh := make(chan struct{})
 	h.callbacks[requestID] = savedCallback{
-		Callback:           callback,
-		requestStartTime:   requestStartTime,
-		createdAt:          time.Now(),
-		responseAggregator: agg,
-		doneCh:             doneCh,
+		Callback:            callback,
+		requestStartTime:    requestStartTime,
+		createdAt:           time.Now(),
+		responseAggregators: aggregators,
+		doneCh:              doneCh,
 	}
 	return doneCh, nil
 }
@@ -440,12 +454,24 @@ func (h *httpTriggerHandler) HandleNodeTriggerResponse(ctx context.Context, resp
 	if !exists {
 		return errors.New("callback not found for request ID: " + resp.ID)
 	}
-	aggResp, err := saved.responseAggregator.CollectAndAggregate(resp, nodeAddr)
+
+	// Route the response into the aggregator for the shard that owns this node.
+	shard, ok := h.nodeAddrToShard[nodeAddr]
+	if !ok {
+		return fmt.Errorf("received trigger response from unknown node %s (no owning shard)", nodeAddr)
+	}
+	agg, ok := saved.responseAggregators[shard.donID]
+	if !ok {
+		// The node belongs to a shard this workflow isn't assigned to (or the
+		// callback was captured before the workflow was assigned there).
+		return fmt.Errorf("node %s (shard %s) is not assigned to workflow for request ID %s", nodeAddr, shard.donID, resp.ID)
+	}
+	aggResp, err := agg.CollectAndAggregate(resp, nodeAddr)
 	if err != nil {
 		return err
 	}
 	if aggResp == nil {
-		h.lggr.Debugw("Not enough responses to aggregate", "requestID", resp.ID, "nodeAddress", nodeAddr)
+		h.lggr.Debugw("Not enough responses to aggregate", "requestID", resp.ID, "nodeAddress", nodeAddr, "shard", shard.donID)
 		return nil
 	}
 	rawResp, err := json.Marshal(aggResp)
@@ -461,7 +487,8 @@ func (h *httpTriggerHandler) HandleNodeTriggerResponse(ctx context.Context, resp
 		return err
 	}
 
-	// Only after successfully sending the response, clean up the callback
+	// First shard to reach quorum wins: only after successfully sending the
+	// response, clean up the callback (closes doneCh, stopping all shard sends).
 	h.cleanupCallback(resp.ID)
 	latencyMs := time.Since(saved.requestStartTime).Milliseconds()
 	h.metrics.RecordRequestHandlerLatency(ctx, latencyMs, h.lggr)
@@ -568,14 +595,31 @@ type nodeSendResult struct {
 	err         error
 }
 
-// sendWithRetries attempts to send the request to all DON members in parallel,
-// retrying failed nodes until either all succeed or the max trigger request duration is reached.
-// Each send attempt is bounded by a per-node timeout, smaller than the overall request duration,
-// so that a single slow or unresponsive node can't delay delivery to the rest of the DON.
-// doneCh is closed when the callback has been responded to (quorum reached), allowing immediate termination.
-func (h *httpTriggerHandler) sendWithRetries(ctx context.Context, legacyExecutionID, executionIDWithTriggerIndex string, req *jsonrpc.Request[json.RawMessage], doneCh <-chan struct{}) error {
+// sendWithRetries fans the request out to every shard the workflow is assigned
+// to, running an independent per-shard retry loop in parallel. Each per-shard
+// loop sends to that shard's members via the shard's own connection manager,
+// retrying failed nodes until all succeed or the max trigger request duration
+// is reached. Each send attempt is bounded by a per-node timeout, smaller than
+// the overall request duration, so that a single slow or unresponsive node can't
+// delay delivery to the rest of the DON.
+// doneCh is closed when the callback has been responded to (first shard reaches
+// quorum), allowing immediate termination of all shard loops.
+func (h *httpTriggerHandler) sendWithRetries(ctx context.Context, legacyExecutionID, executionIDWithTriggerIndex string, req *jsonrpc.Request[json.RawMessage], workflowID string, doneCh <-chan struct{}) error {
 	if doneCh == nil {
 		return errors.New("doneCh cannot be nil")
+	}
+
+	assigned := h.workflowMetadataHandler.WorkflowShards(workflowID)
+	if len(assigned) == 0 {
+		// this shouldn't happen because we checked it in authorizeRequest()
+		h.callbacksMu.Lock()
+		saved, exists := h.callbacks[req.ID]
+		if exists {
+			h.handleUserError(ctx, req.ID, jsonrpc.ErrInternal, fmt.Sprintf("Workflow %s is not assigned to any DONs", workflowID), saved.Callback)
+			h.cleanupCallback(req.ID)
+		}
+		h.callbacksMu.Unlock()
+		return fmt.Errorf("workflow %s not assigned to any shard", workflowID)
 	}
 
 	// Create a context that will be cancelled when the max request duration is reached
@@ -583,6 +627,27 @@ func (h *httpTriggerHandler) sendWithRetries(ctx context.Context, legacyExecutio
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, maxDuration)
 	defer cancel()
 
+	// Run one send loop per assigned shard in parallel.
+	errCh := make(chan error, len(assigned))
+	for _, shard := range assigned {
+		h.wg.Go(func() {
+			errCh <- h.sendToShard(ctxWithTimeout, shard, legacyExecutionID, executionIDWithTriggerIndex, req, doneCh)
+		})
+	}
+
+	var combinedErr error
+	for range assigned {
+		if err := <-errCh; err != nil {
+			combinedErr = errors.Join(combinedErr, err)
+		}
+	}
+	return combinedErr
+}
+
+// sendToShard sends the request to all members of a single shard, retrying
+// failures until all succeed, the callback is responded to (doneCh), or ctx is
+// cancelled (overall max duration).
+func (h *httpTriggerHandler) sendToShard(ctx context.Context, shard *shardEndpoint, legacyExecutionID, executionIDWithTriggerIndex string, req *jsonrpc.Request[json.RawMessage], doneCh <-chan struct{}) error {
 	nodeTimeout := time.Duration(h.config.NodeSendTimeoutMs) * time.Millisecond
 
 	successfulNodes := make(map[string]bool)
@@ -595,7 +660,7 @@ func (h *httpTriggerHandler) sendWithRetries(ctx context.Context, legacyExecutio
 
 	for {
 		var pending []string
-		for _, member := range h.donConfig.Members {
+		for _, member := range shard.members {
 			if !successfulNodes[member.Address] {
 				pending = append(pending, member.Address)
 			}
@@ -609,12 +674,12 @@ func (h *httpTriggerHandler) sendWithRetries(ctx context.Context, legacyExecutio
 			go func(nodeAddress string) {
 				defer wg.Done()
 
-				nodeCtx, nodeCancel := context.WithTimeout(ctxWithTimeout, nodeTimeout)
+				nodeCtx, nodeCancel := context.WithTimeout(ctx, nodeTimeout)
 				defer nodeCancel()
 
 				h.metrics.IncrementTriggerCapabilityRequestCount(ctx, nodeAddress, gateway_common.MethodWorkflowExecute, h.lggr)
 				sendStart := time.Now()
-				err := h.don.SendToNode(nodeCtx, nodeAddress, req)
+				err := shard.connMgr.SendToNode(nodeCtx, nodeAddress, req)
 				h.metrics.RecordGatewayToNodeLatency(ctx, time.Since(sendStart).Milliseconds(), nodeAddress, gateway_common.MethodWorkflowExecute, h.lggr)
 				if err != nil {
 					h.metrics.IncrementTriggerCapabilityRequestFailures(ctx, nodeAddress, gateway_common.MethodWorkflowExecute, h.lggr)
@@ -632,6 +697,7 @@ func (h *httpTriggerHandler) sendWithRetries(ctx context.Context, legacyExecutio
 				combinedErr = errors.Join(combinedErr, fmt.Errorf("node %s: %w", res.nodeAddress, res.err))
 				h.lggr.Debugw("Failed to send trigger request to node, will retry",
 					"node", res.nodeAddress,
+					"shard", shard.donID,
 					"legacyExecutionID", legacyExecutionID,
 					"executionIDWithTriggerIndex", executionIDWithTriggerIndex,
 					"error", res.err)
@@ -640,35 +706,38 @@ func (h *httpTriggerHandler) sendWithRetries(ctx context.Context, legacyExecutio
 			}
 		}
 
-		if len(successfulNodes) == len(h.donConfig.Members) {
-			h.lggr.Infow("Successfully sent trigger request to all nodes",
+		if len(successfulNodes) == len(shard.members) {
+			h.lggr.Infow("Successfully sent trigger request to all nodes in shard",
+				"shard", shard.donID,
 				"legacyExecutionID", legacyExecutionID,
 				"executionIDWithTriggerIndex", executionIDWithTriggerIndex,
-				"nodeCount", len(h.donConfig.Members))
+				"nodeCount", len(shard.members))
 			return nil
 		}
 
 		// Not all nodes succeeded, wait and retry
 		h.lggr.Debugw("Retrying failed nodes for trigger request",
+			"shard", shard.donID,
 			"legacyExecutionID", legacyExecutionID,
 			"executionIDWithTriggerIndex", executionIDWithTriggerIndex,
-			"failedCount", len(h.donConfig.Members)-len(successfulNodes),
+			"failedCount", len(shard.members)-len(successfulNodes),
 			"errors", combinedErr)
 
 		select {
 		case <-doneCh:
 			h.lggr.Infow("Callback already responded to, stopping retries",
+				"shard", shard.donID,
 				"legacyExecutionID", legacyExecutionID,
 				"executionIDWithTriggerIndex", executionIDWithTriggerIndex,
 				"requestID", req.ID,
 				"successNodes", len(successfulNodes),
-				"totalNodes", len(h.donConfig.Members))
+				"totalNodes", len(shard.members))
 			return nil
 		case <-time.After(b.Duration()):
 			continue
-		case <-ctxWithTimeout.Done():
-			return fmt.Errorf("request retry time exceeded, some nodes may not have received the request: legacyExecutionID=%s, executionIDWithTriggerIndex=%s, successNodes=%d, totalNodes=%d",
-				legacyExecutionID, executionIDWithTriggerIndex, len(successfulNodes), len(h.donConfig.Members))
+		case <-ctx.Done():
+			return fmt.Errorf("shard %s: request retry time exceeded, some nodes may not have received the request: legacyExecutionID=%s, executionIDWithTriggerIndex=%s, successNodes=%d, totalNodes=%d",
+				shard.donID, legacyExecutionID, executionIDWithTriggerIndex, len(successfulNodes), len(shard.members))
 		}
 	}
 }

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
@@ -21,6 +21,7 @@ import (
 	gateway_common "github.com/smartcontractkit/chainlink-common/pkg/types/gateway"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/api"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/common/aggregation"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities/v2/metrics"
@@ -527,6 +528,37 @@ func registerWorkflow(_ *testing.T, handler *httpTriggerHandler, workflowID stri
 		workflowName:  "test-workflow",
 		workflowTag:   "v1.0",
 	}
+	// Assign the workflow to every shard the metadata handler knows about so
+	// that WorkflowShards(workflowID) returns them and the trigger handler's
+	// fan-out (setupCallback/sendWithRetries) reaches all shards. The default
+	// test harness uses a single shard, so this registers on that one shard;
+	// registerWorkflowOnShards overrides this with a specific subset.
+	assignWorkflowToAllShards(handler.workflowMetadataHandler, workflowID)
+}
+
+// assignWorkflowToAllShards writes workflowShards[workflowID] = copy(mh.shards)
+// under the metadata handler's mutex. Used by registerWorkflow and by tests
+// that populate the metadata maps directly.
+func assignWorkflowToAllShards(mh *WorkflowMetadataHandler, workflowID string) {
+	mh.mu.Lock()
+	defer mh.mu.Unlock()
+	mh.workflowShards[workflowID] = append([]*shardEndpoint(nil), mh.shards...)
+}
+
+// registerWorkflowOnShards is the sharding-aware variant of registerWorkflow.
+// It registers a workflow's authorized key and selector, and assigns the
+// workflow to the given shard endpoints so that WorkflowShards(workflowID)
+// returns them and the trigger handler fans the request out only to those
+// shards. The metadata handler's map is written directly under its mutex.
+func registerWorkflowOnShards(t *testing.T, handler *httpTriggerHandler, workflowID string, privateKey *ecdsa.PrivateKey, assignedShards ...*shardEndpoint) {
+	t.Helper()
+	registerWorkflow(t, handler, workflowID, privateKey)
+
+	handler.workflowMetadataHandler.mu.Lock()
+	defer handler.workflowMetadataHandler.mu.Unlock()
+	assigned := make([]*shardEndpoint, len(assignedShards))
+	copy(assigned, assignedShards)
+	handler.workflowMetadataHandler.workflowShards[workflowID] = assigned
 }
 
 func TestHttpTriggerHandler_ReapExpiredCallbacks(t *testing.T) {
@@ -854,6 +886,108 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_SlowNodeDoesNotBlockOthers(
 	require.NoError(t, err)
 }
 
+// TestHttpTriggerHandler_HandleUserTriggerRequest_DeliversOnlyToRegisteredShards
+// verifies the sharding fan-out behavior introduced by the sharding commit.
+//
+// Setup: a single DON with 3 shards (3 disjoint node sets, one connection
+// manager per shard). Workflow X is registered on 2 of the 3 shards. A user
+// trigger request for workflow X must be delivered to the members of those 2
+// shards only; the 3rd shard's connection manager must never be contacted, and
+// the per-request callback must carry exactly 2 response aggregators (one per
+// assigned shard).
+func TestHttpTriggerHandler_HandleUserTriggerRequest_DeliversOnlyToRegisteredShards(t *testing.T) {
+	t.Parallel()
+
+	lggr := logger.Test(t)
+	cfg := WithDefaults(ServiceConfig{
+		MaxTriggerRequestDurationMs: 5000,
+		NodeSendTimeoutMs:           5000,
+	})
+
+	// Three shards, each with 3 disjoint nodes. donIDs: "don", "don_1", "don_2".
+	shardedDONs := []config.ShardedDONConfig{
+		{
+			DonName: "don",
+			F:       1, // (N+F)//2+1 = (3+1)//2+1 = 3 for quorum
+			Shards: []config.Shard{
+				{Nodes: []config.NodeConfig{{Address: "n1"}, {Address: "n2"}, {Address: "n3"}}},
+				{Nodes: []config.NodeConfig{{Address: "n4"}, {Address: "n5"}, {Address: "n6"}}},
+				{Nodes: []config.NodeConfig{{Address: "n7"}, {Address: "n8"}, {Address: "n9"}}},
+			},
+		},
+	}
+	shard0Don := handlermocks.NewDON(t)
+	shard1Don := handlermocks.NewDON(t)
+	shard2Don := handlermocks.NewDON(t)
+	connMgrs := [][]handlers.DON{{shard0Don, shard1Don, shard2Don}}
+
+	shards, nodeAddrToShard, err := buildShardEndpoints(shardedDONs, connMgrs)
+	require.NoError(t, err)
+	require.Len(t, shards, 3)
+	// Sanity-check donID derivation used by the metadata/trigger handlers.
+	require.Equal(t, "don", shards[0].donID)
+	require.Equal(t, "don_1", shards[1].donID)
+	require.Equal(t, "don_2", shards[2].donID)
+
+	allMembersSlice := allMembers(shards)
+	testMetrics, err := metrics.NewMetrics(allMembersSlice)
+	require.NoError(t, err)
+	metadataHandler := NewWorkflowMetadataHandler(lggr, cfg, shards, nodeAddrToShard, testMetrics)
+	userRateLimiter := createTestUserRateLimiter()
+	handler := NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, testMetrics)
+
+	privateKey := createTestPrivateKey(t)
+	// Register workflow X on exactly 2 of the 3 shards (shard0 and shard1).
+	registerWorkflowOnShards(t, handler, workflowID, privateKey, shards[0], shards[1])
+
+	// Build and sign the user trigger request for workflow X.
+	triggerReq := createTestTriggerRequest(workflowID)
+	reqBytes, err := json.Marshal(triggerReq)
+	require.NoError(t, err)
+	rawParams := json.RawMessage(reqBytes)
+	req := &jsonrpc.Request[json.RawMessage]{
+		Version: "2.0",
+		ID:      "test-request-sharded",
+		Method:  gateway_common.MethodWorkflowExecute,
+		Params:  &rawParams,
+	}
+	req.Auth = createTestJWTToken(t, req, privateKey)
+	callback := hc.NewCallback()
+
+	// The two registered shards' connection managers must each be hit once per
+	// member (sends succeed on the first attempt, so no retries).
+	for _, addr := range []string{"n1", "n2", "n3"} {
+		shard0Don.EXPECT().SendToNode(mock.Anything, addr, mock.Anything).Return(nil).Once()
+	}
+	for _, addr := range []string{"n4", "n5", "n6"} {
+		shard1Don.EXPECT().SendToNode(mock.Anything, addr, mock.Anything).Return(nil).Once()
+	}
+	// shard2Don gets NO expectations: any call to it would be a routing bug.
+
+	require.NoError(t, handler.Start(t.Context()))
+	t.Cleanup(func() { _ = handler.Close() })
+
+	err = handler.HandleUserTriggerRequest(t.Context(), req, callback, time.Now())
+	require.NoError(t, err)
+
+	// Assert the callback was set up with one aggregator per *registered* shard.
+	handler.callbacksMu.Lock()
+	saved, exists := handler.callbacks[req.ID]
+	handler.callbacksMu.Unlock()
+	require.True(t, exists, "callback should be registered for the request ID")
+	require.Len(t, saved.responseAggregators, 2, "exactly 2 shards are registered for this workflow")
+	require.Contains(t, saved.responseAggregators, "don")
+	require.Contains(t, saved.responseAggregators, "don_1")
+	require.NotContains(t, saved.responseAggregators, "don_2")
+
+	// Assert the mock connection managers saw exactly the expected sends. The
+	// cleanup registered by NewDON will call AssertExpectations on test teardown,
+	// which would fail if shard2Don had been contacted.
+	shard0Don.AssertExpectations(t)
+	shard1Don.AssertExpectations(t)
+	shard2Don.AssertExpectations(t)
+}
+
 func TestHttpTriggerHandler_HandleUserTriggerRequest_JWTAuthorization(t *testing.T) {
 	handler, mockDon := createTestTriggerHandler(t)
 	ctx := t.Context()
@@ -878,6 +1012,10 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_JWTAuthorization(t *testing
 		workflowName:  "test-workflow",
 		workflowTag:   "v1.0",
 	}
+	// Assign the workflow to all shards so setupCallback/sendWithRetries can
+	// fan the request out (these tests populate the metadata maps directly
+	// instead of calling registerWorkflow).
+	assignWorkflowToAllShards(handler.workflowMetadataHandler, workflowID)
 
 	t.Run("successful JWT authorization", func(t *testing.T) {
 		callback := hc.NewCallback()
@@ -1026,6 +1164,10 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_WorkflowLookup(t *testing.T
 	}
 	handler.workflowMetadataHandler.workflowIDToRef[workflowID] = workflowRef
 	handler.workflowMetadataHandler.workflowRefToID[workflowRef] = workflowID
+	// Assign the workflow to all shards so setupCallback/sendWithRetries can
+	// fan the request out (this test populates the metadata maps directly
+	// instead of calling registerWorkflow).
+	assignWorkflowToAllShards(handler.workflowMetadataHandler, workflowID)
 
 	t.Run("successful workflow lookup by name", func(t *testing.T) {
 		callback := hc.NewCallback()
@@ -1699,6 +1841,19 @@ func newTestTriggerHandler(t *testing.T, lggr logger.Logger, cfg ServiceConfig, 
 	}
 	shards, nodeAddrToShard, err := buildShardEndpoints(shardedDONs, [][]handlers.DON{{mockDon}})
 	require.NoError(t, err)
+	// Repoint the metadata handler at THIS handler's shard set so that the
+	// workflowShards populated by registerWorkflow route sends to mockDon. The
+	// metadata handler may have been built with its own shard set (and donIDs) by
+	// createTestMetadataHandler, so rebuild its per-shard aggregators keyed by the
+	// shared shards' donIDs. (donIDs differ when createTestMetadataHandler's
+	// donConfig has an empty DonId.)
+	metadataHandler.shards = shards
+	metadataHandler.nodeAddrToShard = nodeAddrToShard
+	metadataHandler.aggs = make(map[string]*aggregation.WorkflowMetadataAggregator, len(shards))
+	for _, shard := range shards {
+		threshold := shard.f + 1
+		metadataHandler.aggs[shard.donID] = aggregation.NewWorkflowMetadataAggregator(metadataHandler.lggr, threshold, time.Duration(cfg.CleanUpPeriodMs)*time.Millisecond, testMetrics)
+	}
 	return NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, testMetrics)
 }
 
@@ -1722,11 +1877,22 @@ func createTestTriggerHandlerWithConfig(t *testing.T, cfg ServiceConfig) (*httpT
 	}
 	mockDon := handlermocks.NewDON(t)
 	lggr := logger.Test(t)
-	metadataHandler := createTestMetadataHandler(t)
-	userRateLimiter := createTestUserRateLimiter()
 	testMetrics := createTestMetrics(t, donConfig)
 
-	handler := newTestTriggerHandler(t, lggr, cfg, donConfig, mockDon, metadataHandler, userRateLimiter, testMetrics)
+	// Build ONE shared shard set so the metadata handler and the trigger handler
+	// reference the SAME shardEndpoint instances (and the same mockDon). This is
+	// required because registerWorkflow writes workflowShards to the metadata
+	// handler's .shards, and sendWithRetries reads them back and sends via
+	// shard.connMgr — both must hit mockDon, which the test sets expectations on.
+	shardedDONs := []config.ShardedDONConfig{
+		{DonName: donConfig.DonId, F: donConfig.F, Shards: []config.Shard{{Nodes: donConfig.Members}}},
+	}
+	shards, nodeAddrToShard, err := buildShardEndpoints(shardedDONs, [][]handlers.DON{{mockDon}})
+	require.NoError(t, err)
+
+	metadataHandler := NewWorkflowMetadataHandler(lggr, WithDefaults(cfg), shards, nodeAddrToShard, testMetrics)
+	userRateLimiter := createTestUserRateLimiter()
+	handler := NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, testMetrics)
 	return handler, mockDon
 }
 

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
@@ -36,7 +36,7 @@ const (
 )
 
 func createTestMetrics(t *testing.T, donConfig *config.DONConfig) *metrics.Metrics {
-	m, err := metrics.NewMetrics(donConfig)
+	m, err := metrics.NewMetrics(donConfig.Members)
 	require.NoError(t, err)
 	return m
 }
@@ -80,7 +80,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 
 		require.True(t, exists)
 		require.Equal(t, callback, saved.Callback)
-		require.NotNil(t, saved.responseAggregator)
+		require.NotNil(t, saved.responseAggregators)
 	})
 
 	t.Run("successful trigger request with missing 0x prefix", func(t *testing.T) {
@@ -115,7 +115,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 
 		require.True(t, exists)
 		require.Equal(t, callback, saved.Callback)
-		require.NotNil(t, saved.responseAggregator)
+		require.NotNil(t, saved.responseAggregators)
 	})
 
 	t.Run("successful trigger request with padded workflow ID", func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 
 		require.True(t, exists)
 		require.Equal(t, callback, saved.Callback)
-		require.NotNil(t, saved.responseAggregator)
+		require.NotNil(t, saved.responseAggregators)
 	})
 
 	t.Run("successful trigger request with padded workflow ID and missing 0x prefix", func(t *testing.T) {
@@ -187,7 +187,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 
 		require.True(t, exists)
 		require.Equal(t, callback, saved.Callback)
-		require.NotNil(t, saved.responseAggregator)
+		require.NotNil(t, saved.responseAggregators)
 	})
 
 	t.Run("invalid JSON params", func(t *testing.T) {
@@ -674,7 +674,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_Retries(t *testing.T) {
 	metadataHandler := createTestMetadataHandler(t)
 	userRateLimiter := createTestUserRateLimiter()
 	testMetrics := createTestMetrics(t, donConfig)
-	handler := NewHTTPTriggerHandler(lggr, cfg, donConfig, mockDon, metadataHandler, userRateLimiter, testMetrics)
+	handler := newTestTriggerHandler(t, lggr, cfg, donConfig, mockDon, metadataHandler, userRateLimiter, testMetrics)
 	privateKey := createTestPrivateKey(t)
 	registerWorkflow(t, handler, workflowID, privateKey)
 
@@ -738,7 +738,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_SendsToNodesInParallel(t *t
 	metadataHandler := createTestMetadataHandler(t)
 	userRateLimiter := createTestUserRateLimiter()
 	testMetrics := createTestMetrics(t, donConfig)
-	handler := NewHTTPTriggerHandler(lggr, cfg, donConfig, mockDon, metadataHandler, userRateLimiter, testMetrics)
+	handler := newTestTriggerHandler(t, lggr, cfg, donConfig, mockDon, metadataHandler, userRateLimiter, testMetrics)
 	privateKey := createTestPrivateKey(t)
 	registerWorkflow(t, handler, workflowID, privateKey)
 
@@ -804,7 +804,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_SlowNodeDoesNotBlockOthers(
 	metadataHandler := createTestMetadataHandler(t)
 	userRateLimiter := createTestUserRateLimiter()
 	testMetrics := createTestMetrics(t, donConfig)
-	handler := NewHTTPTriggerHandler(lggr, cfg, donConfig, mockDon, metadataHandler, userRateLimiter, testMetrics)
+	handler := newTestTriggerHandler(t, lggr, cfg, donConfig, mockDon, metadataHandler, userRateLimiter, testMetrics)
 	privateKey := createTestPrivateKey(t)
 	registerWorkflow(t, handler, workflowID, privateKey)
 
@@ -859,9 +859,9 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_JWTAuthorization(t *testing
 	ctx := t.Context()
 
 	// Setup metadata handler with test data
-	err := handler.workflowMetadataHandler.agg.Start(ctx)
+	err := handler.workflowMetadataHandler.aggs[handler.workflowMetadataHandler.shards[0].donID].Start(ctx)
 	require.NoError(t, err)
-	defer handler.workflowMetadataHandler.agg.Close()
+	defer handler.workflowMetadataHandler.aggs[handler.workflowMetadataHandler.shards[0].donID].Close()
 
 	// Create test keys
 	privateKey := createTestPrivateKey(t)
@@ -1003,9 +1003,9 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_WorkflowLookup(t *testing.T
 	handler, mockDon := createTestTriggerHandler(t)
 	ctx := t.Context()
 
-	err := handler.workflowMetadataHandler.agg.Start(ctx)
+	err := handler.workflowMetadataHandler.aggs[handler.workflowMetadataHandler.shards[0].donID].Start(ctx)
 	require.NoError(t, err)
-	defer handler.workflowMetadataHandler.agg.Close()
+	defer handler.workflowMetadataHandler.aggs[handler.workflowMetadataHandler.shards[0].donID].Close()
 
 	privateKey := createTestPrivateKey(t)
 	signerAddr := crypto.PubkeyToAddress(privateKey.PublicKey)
@@ -1681,11 +1681,25 @@ func createTestMetadataHandler(t *testing.T) *WorkflowMetadataHandler {
 	}
 	cfg := WithDefaults(ServiceConfig{})
 	testMetrics := createTestMetrics(t, donConfig)
-	return NewWorkflowMetadataHandler(lggr, cfg, mockDon, donConfig, testMetrics)
+	shardedDONs := []config.ShardedDONConfig{
+		{DonName: donConfig.DonId, F: donConfig.F, Shards: []config.Shard{{Nodes: donConfig.Members}}},
+	}
+	shards, nodeAddrToShard, err := buildShardEndpoints(shardedDONs, [][]handlers.DON{{mockDon}})
+	require.NoError(t, err)
+	return NewWorkflowMetadataHandler(lggr, cfg, shards, nodeAddrToShard, testMetrics)
 }
 
 func createTestUserRateLimiter() limits.RateLimiter {
 	return limits.UnlimitedRateLimiter()
+}
+
+func newTestTriggerHandler(t *testing.T, lggr logger.Logger, cfg ServiceConfig, donConfig *config.DONConfig, mockDon *handlermocks.DON, metadataHandler *WorkflowMetadataHandler, userRateLimiter limits.RateLimiter, testMetrics *metrics.Metrics) *httpTriggerHandler {
+	shardedDONs := []config.ShardedDONConfig{
+		{DonName: donConfig.DonId, F: donConfig.F, Shards: []config.Shard{{Nodes: donConfig.Members}}},
+	}
+	shards, nodeAddrToShard, err := buildShardEndpoints(shardedDONs, [][]handlers.DON{{mockDon}})
+	require.NoError(t, err)
+	return NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, testMetrics)
 }
 
 func createTestTriggerHandler(t *testing.T) (*httpTriggerHandler, *handlermocks.DON) {
@@ -1712,7 +1726,7 @@ func createTestTriggerHandlerWithConfig(t *testing.T, cfg ServiceConfig) (*httpT
 	userRateLimiter := createTestUserRateLimiter()
 	testMetrics := createTestMetrics(t, donConfig)
 
-	handler := NewHTTPTriggerHandler(lggr, cfg, donConfig, mockDon, metadataHandler, userRateLimiter, testMetrics)
+	handler := newTestTriggerHandler(t, lggr, cfg, donConfig, mockDon, metadataHandler, userRateLimiter, testMetrics)
 	return handler, mockDon
 }
 
@@ -1739,7 +1753,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_RateLimiting(t *testing.T) 
 
 	t.Run("successful rate limit check with CRE context", func(t *testing.T) {
 		userRateLimiter := createTestUserRateLimiter() // Unlimited
-		handler := NewHTTPTriggerHandler(lggr, cfg, donConfig, mockDon, metadataHandler, userRateLimiter, testMetrics)
+		handler := newTestTriggerHandler(t, lggr, cfg, donConfig, mockDon, metadataHandler, userRateLimiter, testMetrics)
 
 		privateKey := createTestPrivateKey(t)
 		workflowID := "0x1234567890abcdef1234567890abcdef12345678901234567890abcdef123456"
@@ -1785,7 +1799,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_RateLimiting(t *testing.T) 
 	t.Run("rate limit exceeded returns proper error", func(t *testing.T) {
 		// Create a rate limiter with very restrictive limits
 		restrictiveRateLimiter := limits.WorkflowRateLimiter(1, 0)
-		handler := NewHTTPTriggerHandler(lggr, cfg, donConfig, mockDon, metadataHandler, restrictiveRateLimiter, testMetrics)
+		handler := newTestTriggerHandler(t, lggr, cfg, donConfig, mockDon, metadataHandler, restrictiveRateLimiter, testMetrics)
 
 		privateKey := createTestPrivateKey(t)
 		workflowID := "0x1234567890abcdef1234567890abcdef12345678901234567890abcdef123456"
@@ -1849,7 +1863,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_StopsRetriesOnQuorum(t *tes
 	metadataHandler := createTestMetadataHandler(t)
 	userRateLimiter := createTestUserRateLimiter()
 	testMetrics := createTestMetrics(t, donConfig)
-	handler := NewHTTPTriggerHandler(lggr, cfg, donConfig, mockDon, metadataHandler, userRateLimiter, testMetrics)
+	handler := newTestTriggerHandler(t, lggr, cfg, donConfig, mockDon, metadataHandler, userRateLimiter, testMetrics)
 	privateKey := createTestPrivateKey(t)
 	registerWorkflow(t, handler, workflowID, privateKey)
 

--- a/core/services/gateway/handlers/capabilities/v2/metrics/metrics.go
+++ b/core/services/gateway/handlers/capabilities/v2/metrics/metrics.go
@@ -79,8 +79,9 @@ type Metrics struct {
 	nodeAddressToNodeName map[string]string
 }
 
-// NewMetrics creates a new instance of Metrics with all metrics initialized
-func NewMetrics(donConfig *config.DONConfig) (*Metrics, error) {
+// NewMetrics creates a new instance of Metrics with all metrics initialized.
+// members is the union of node configs across all DON shards.
+func NewMetrics(members []config.NodeConfig) (*Metrics, error) {
 	meter := beholder.GetMeter()
 
 	common, err := newCommonMetrics(meter)
@@ -99,10 +100,8 @@ func NewMetrics(donConfig *config.DONConfig) (*Metrics, error) {
 	}
 
 	nodeAddressToNodeName := make(map[string]string)
-	if donConfig != nil {
-		for _, member := range donConfig.Members {
-			nodeAddressToNodeName[member.Address] = member.Name
-		}
+	for _, member := range members {
+		nodeAddressToNodeName[member.Address] = member.Name
 	}
 
 	return &Metrics{

--- a/core/services/gateway/handlers/capabilities/v2/metrics/metrics_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/metrics/metrics_test.go
@@ -11,13 +11,11 @@ import (
 func TestNewMetrics(t *testing.T) {
 	t.Parallel()
 
-	donConfig := &config.DONConfig{
-		Members: []config.NodeConfig{
-			{Address: "0xnode1", Name: "node1"},
-			{Address: "0xnode2", Name: "node2"},
-		},
+	members := []config.NodeConfig{
+		{Address: "0xnode1", Name: "node1"},
+		{Address: "0xnode2", Name: "node2"},
 	}
-	metrics, err := NewMetrics(donConfig)
+	metrics, err := NewMetrics(members)
 	require.NoError(t, err)
 	require.NotNil(t, metrics)
 	require.NotNil(t, metrics.action)

--- a/core/services/gateway/handlers/capabilities/v2/shard_endpoints.go
+++ b/core/services/gateway/handlers/capabilities/v2/shard_endpoints.go
@@ -1,0 +1,77 @@
+package v2
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
+)
+
+type shardEndpoint struct {
+	// donID is the shard-specific DON identifier, derived via config.ShardDONID.
+	// Shard 0 uses the bare DON name; shard N>0 uses "donName_N".
+	donID    string
+	donName  string
+	shardIdx int
+	// connMgr is the connection manager for this shard. It only knows how to reach
+	// nodes that are members of this shard.
+	connMgr handlers.DON
+	members []config.NodeConfig
+	f       int
+}
+
+// buildShardEndpoints expands the full DON×shard matrix into a flat list of
+// shardEndpoints, and builds a nodeAddr -> shardEndpoint lookup. The outer
+// dimension of shardsConnMgrs indexes DONs (parallel to shardedDONs); the inner
+// dimension indexes shards within that DON (parallel to shardedDONs[i].Shards).
+// Memberships must be disjoint.
+func buildShardEndpoints(shardedDONs []config.ShardedDONConfig, shardsConnMgrs [][]handlers.DON) ([]*shardEndpoint, map[string]*shardEndpoint, error) {
+	if len(shardedDONs) == 0 || len(shardsConnMgrs) == 0 {
+		return nil, nil, errors.New("at least one DON and connection manager required")
+	}
+	if len(shardedDONs) != len(shardsConnMgrs) {
+		return nil, nil, fmt.Errorf("shardedDONs length %d does not match shardsConnMgrs length %d", len(shardedDONs), len(shardsConnMgrs))
+	}
+
+	var endpoints []*shardEndpoint
+	addrToShard := make(map[string]*shardEndpoint)
+
+	for i, sd := range shardedDONs {
+		connMgrs := shardsConnMgrs[i]
+		if len(sd.Shards) != len(connMgrs) {
+			return nil, nil, fmt.Errorf("DON %s: shards length %d does not match connection managers length %d", sd.DonName, len(sd.Shards), len(connMgrs))
+		}
+		for shardIdx, shard := range sd.Shards {
+			if connMgrs[shardIdx] == nil {
+				return nil, nil, fmt.Errorf("DON %s shard %d: nil connection manager", sd.DonName, shardIdx)
+			}
+			ep := &shardEndpoint{
+				donID:    config.ShardDONID(sd.DonName, shardIdx),
+				donName:  sd.DonName,
+				shardIdx: shardIdx,
+				connMgr:  connMgrs[shardIdx],
+				members:  shard.Nodes,
+				f:        sd.F,
+			}
+			endpoints = append(endpoints, ep)
+			for _, member := range shard.Nodes {
+				if existing, ok := addrToShard[member.Address]; ok {
+					return nil, nil, fmt.Errorf("node address %s appears in both %s and %s; shard memberships must be disjoint", member.Address, existing.donID, ep.donID)
+				}
+				addrToShard[member.Address] = ep
+			}
+		}
+	}
+
+	return endpoints, addrToShard, nil
+}
+
+// allMembers returns the union of all shard members across the matrix.
+func allMembers(endpoints []*shardEndpoint) []config.NodeConfig {
+	var out []config.NodeConfig
+	for _, ep := range endpoints {
+		out = append(out, ep.members...)
+	}
+	return out
+}

--- a/core/services/gateway/handlers/capabilities/v2/shard_endpoints_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/shard_endpoints_test.go
@@ -1,0 +1,141 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
+	handlermocks "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/mocks"
+)
+
+// handlersDON is a local alias to keep the test matrix literals readable.
+type handlersDON = handlers.DON
+
+func TestBuildShardEndpoints(t *testing.T) {
+	t.Parallel()
+
+	node := func(addr string) config.NodeConfig {
+		return config.NodeConfig{Name: addr, Address: addr}
+	}
+
+	t.Run("single DON single shard (backward compatible)", func(t *testing.T) {
+		t.Parallel()
+
+		don := handlermocks.NewDON(t)
+		shardedDONs := []config.ShardedDONConfig{
+			{DonName: "donA", F: 1, Shards: []config.Shard{{Nodes: []config.NodeConfig{node("n1"), node("n2")}}}},
+		}
+		connMgrs := [][]handlersDON{{don}}
+
+		eps, addrMap, err := buildShardEndpoints(shardedDONs, connMgrs)
+		require.NoError(t, err)
+		require.Len(t, eps, 1)
+		require.Equal(t, "donA", eps[0].donID) // shard 0 => bare name
+		require.Equal(t, 0, eps[0].shardIdx)
+		require.Equal(t, 1, eps[0].f)
+		require.Len(t, addrMap, 2)
+		require.Same(t, eps[0], addrMap["n1"])
+	})
+
+	t.Run("full matrix: two DONs each with two shards", func(t *testing.T) {
+		t.Parallel()
+
+		dons := [][]handlersDON{
+			{handlermocks.NewDON(t), handlermocks.NewDON(t)},
+			{handlermocks.NewDON(t), handlermocks.NewDON(t)},
+		}
+		shardedDONs := []config.ShardedDONConfig{
+			{DonName: "donA", F: 1, Shards: []config.Shard{
+				{Nodes: []config.NodeConfig{node("a0"), node("a1")}},
+				{Nodes: []config.NodeConfig{node("a2"), node("a3")}},
+			}},
+			{DonName: "donB", F: 2, Shards: []config.Shard{
+				{Nodes: []config.NodeConfig{node("b0")}},
+				{Nodes: []config.NodeConfig{node("b1")}},
+			}},
+		}
+
+		eps, addrMap, err := buildShardEndpoints(shardedDONs, dons)
+		require.NoError(t, err)
+		require.Len(t, eps, 4)
+		// donIDs: shard 0 bare, shard 1 suffixed
+		require.Equal(t, "donA", eps[0].donID)
+		require.Equal(t, "donA_1", eps[1].donID)
+		require.Equal(t, "donB", eps[2].donID)
+		require.Equal(t, "donB_1", eps[3].donID)
+		require.Len(t, addrMap, 6)
+		require.Same(t, eps[1], addrMap["a2"])
+		require.Same(t, eps[3], addrMap["b1"])
+		require.Equal(t, 2, addrMap["b1"].f)
+	})
+
+	t.Run("rejects empty matrix", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := buildShardEndpoints(nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects ragged outer dimension", func(t *testing.T) {
+		t.Parallel()
+
+		shardedDONs := []config.ShardedDONConfig{
+			{DonName: "donA", Shards: []config.Shard{{Nodes: []config.NodeConfig{node("n1")}}}},
+		}
+		_, _, err := buildShardEndpoints(shardedDONs, [][]handlersDON{})
+		require.Error(t, err)
+	})
+
+	t.Run("rejects ragged inner dimension", func(t *testing.T) {
+		t.Parallel()
+
+		shardedDONs := []config.ShardedDONConfig{
+			{DonName: "donA", Shards: []config.Shard{
+				{Nodes: []config.NodeConfig{node("n1")}},
+				{Nodes: []config.NodeConfig{node("n2")}},
+			}},
+		}
+		connMgrs := [][]handlersDON{{handlermocks.NewDON(t)}} // only 1 conn mgr for 2 shards
+		_, _, err := buildShardEndpoints(shardedDONs, connMgrs)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects nil connection manager", func(t *testing.T) {
+		t.Parallel()
+
+		shardedDONs := []config.ShardedDONConfig{
+			{DonName: "donA", Shards: []config.Shard{{Nodes: []config.NodeConfig{node("n1")}}}},
+		}
+		connMgrs := [][]handlersDON{{nil}}
+		_, _, err := buildShardEndpoints(shardedDONs, connMgrs)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects duplicate node address across shards", func(t *testing.T) {
+		t.Parallel()
+
+		shardedDONs := []config.ShardedDONConfig{
+			{DonName: "donA", Shards: []config.Shard{
+				{Nodes: []config.NodeConfig{node("n1")}},
+				{Nodes: []config.NodeConfig{node("n1")}}, // duplicate
+			}},
+		}
+		connMgrs := [][]handlersDON{{handlermocks.NewDON(t), handlermocks.NewDON(t)}}
+		_, _, err := buildShardEndpoints(shardedDONs, connMgrs)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "disjoint")
+	})
+
+	t.Run("allMembers unions all shards", func(t *testing.T) {
+		t.Parallel()
+
+		eps := []*shardEndpoint{
+			{members: []config.NodeConfig{node("n1"), node("n2")}},
+			{members: []config.NodeConfig{node("n3")}},
+		}
+		members := allMembers(eps)
+		require.Len(t, members, 3)
+	})
+}

--- a/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
@@ -127,6 +127,30 @@ func (h *WorkflowMetadataHandler) syncMetadata(ctx context.Context) {
 				workflowName:  data.WorkflowSelector.WorkflowName,
 				workflowTag:   data.WorkflowSelector.WorkflowTag,
 			}
+
+			// Case 1: this workflow ID was already registered. If the reference
+			// matches, this is the same workflow reported by another shard —
+			// append the shard to its fan-out list. If the reference differs,
+			// it's a conflicting observation; drop it.
+			if existingRef, idExists := workflowIDToRef[workflowID]; idExists {
+				if existingRef == workflowRef {
+					workflowShards[workflowID] = append(workflowShards[workflowID], shard)
+				} else {
+					h.lggr.Debugw("Duplicate workflow ID with conflicting reference, dropping",
+						"workflowID", workflowID, "existingRef", existingRef, "conflictingRef", workflowRef)
+				}
+				continue
+			}
+
+			// Case 2: this workflow reference was already registered under a
+			// different workflow ID. First-wins by reference; drop the duplicate.
+			if _, refExists := workflowRefToID[workflowRef]; refExists {
+				h.lggr.Debugw("Duplicate workflow reference found, dropping",
+					"workflowRef", workflowRef, "workflowID", workflowID)
+				continue
+			}
+
+			// Case 3: new workflow ID and reference — register it.
 			workflowIDToRef[workflowID] = workflowRef
 			workflowRefToID[workflowRef] = workflowID
 			authorizedKeys[workflowID] = make(map[gateway.AuthorizedKey]struct{})

--- a/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler.go
@@ -14,8 +14,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/gateway"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/common/aggregation"
-	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
-	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities/v2/metrics"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
@@ -42,10 +40,12 @@ type WorkflowMetadataHandler struct {
 	authorizedKeys  map[string]map[gateway.AuthorizedKey]struct{} // map of workflow ID to authorized keys
 	workflowRefToID map[workflowReference]string                  // map of workflow reference to workflow ID
 	workflowIDToRef map[string]workflowReference                  // map of workflow ID to workflow reference
-	agg             *aggregation.WorkflowMetadataAggregator
+	workflowShards  map[string][]*shardEndpoint                   // map of workflow ID to the shards it is assigned to (quorum reached)
+	// aggs holds one WorkflowMetadataAggregator per shard, keyed by shard donID.
+	aggs            map[string]*aggregation.WorkflowMetadataAggregator
+	shards          []*shardEndpoint
+	nodeAddrToShard map[string]*shardEndpoint
 	config          ServiceConfig
-	don             handlers.DON
-	donConfig       *config.DONConfig
 	stopCh          services.StopChan
 	metrics         *metrics.Metrics
 	jwtCache        *jwtReplayCache // JWT replay protection cache
@@ -53,18 +53,23 @@ type WorkflowMetadataHandler struct {
 	startTime       time.Time // time when Start() was called
 }
 
-// NewWorkflowMetadataHandler creates a new WorkflowMetadataHandler.
-func NewWorkflowMetadataHandler(lggr logger.Logger, cfg ServiceConfig, don handlers.DON, donConfig *config.DONConfig, metrics *metrics.Metrics) *WorkflowMetadataHandler {
-	// f+1 identical responses from workflow are needed for workflow metadata to be registered
-	threshold := donConfig.F + 1
+// NewWorkflowMetadataHandler creates a new WorkflowMetadataHandler spanning the
+// full DON×shard matrix. Each shard gets its own aggregator with threshold F+1.
+func NewWorkflowMetadataHandler(lggr logger.Logger, cfg ServiceConfig, shards []*shardEndpoint, nodeAddrToShard map[string]*shardEndpoint, metrics *metrics.Metrics) *WorkflowMetadataHandler {
+	aggs := make(map[string]*aggregation.WorkflowMetadataAggregator, len(shards))
+	for _, shard := range shards {
+		threshold := shard.f + 1
+		aggs[shard.donID] = aggregation.NewWorkflowMetadataAggregator(lggr, threshold, time.Duration(cfg.CleanUpPeriodMs)*time.Millisecond, metrics)
+	}
 	return &WorkflowMetadataHandler{
 		lggr:            logger.Named(lggr, "HTTPTriggerWorkflowMetadataHandler"),
 		authorizedKeys:  make(map[string]map[gateway.AuthorizedKey]struct{}),
 		workflowRefToID: make(map[workflowReference]string),
 		workflowIDToRef: make(map[string]workflowReference),
-		agg:             aggregation.NewWorkflowMetadataAggregator(lggr, threshold, time.Duration(cfg.CleanUpPeriodMs)*time.Millisecond, metrics),
-		don:             don,
-		donConfig:       donConfig,
+		workflowShards:  make(map[string][]*shardEndpoint),
+		aggs:            aggs,
+		shards:          shards,
+		nodeAddrToShard: nodeAddrToShard,
 		config:          cfg,
 		stopCh:          make(services.StopChan),
 		metrics:         metrics,
@@ -102,42 +107,36 @@ func (h *WorkflowMetadataHandler) Authorize(workflowID string, token string, req
 	return &key, nil
 }
 
-// syncMetadata aggregates the authorized keys and workflow selectors from the WorkflowMetadataAggregator and updates the local cache.
-// Should be called periodically to keep the authorized keys up to date.
+// syncMetadata aggregates the authorized keys and workflow selectors from each
+// shard's WorkflowMetadataAggregator and updates the local cache. A workflow is
+// considered assigned to a shard once that shard's aggregator reports it (i.e.
+// F+1 of the shard's nodes observed it).
 func (h *WorkflowMetadataHandler) syncMetadata(ctx context.Context) {
-	metadata, err := h.agg.Aggregate()
-	if err != nil {
-		h.lggr.Errorw("Failed to aggregate auth data", "error", err)
-		return
-	}
 	authorizedKeys := make(map[string]map[gateway.AuthorizedKey]struct{})
 	workflowRefToID := make(map[workflowReference]string)
 	workflowIDToRef := make(map[string]workflowReference)
-	for _, data := range metadata {
-		workflowRef := workflowReference{
-			workflowOwner: data.WorkflowSelector.WorkflowOwner,
-			workflowName:  data.WorkflowSelector.WorkflowName,
-			workflowTag:   data.WorkflowSelector.WorkflowTag,
-		}
-		// Only the first aggregated workflow reference is used because
-		// workflow reference is unique (enforced by workflow registry)
-		// workflow reference and workflow ID mapping in the gateway eventually becomes consistent
-		// with the mapping on-chain
-		if _, exists := workflowIDToRef[data.WorkflowSelector.WorkflowID]; exists {
-			h.lggr.Debug("Duplicate workflow ID found", "workflowID", data.WorkflowSelector.WorkflowID)
-			continue
-		}
-		if _, exists := workflowRefToID[workflowRef]; exists {
-			h.lggr.Debugw("Duplicate workflow reference found", "workflowRef", workflowRef, "workflowID", data.WorkflowSelector.WorkflowID)
-			continue
-		}
-		workflowIDToRef[data.WorkflowSelector.WorkflowID] = workflowRef
-		workflowRefToID[workflowRef] = data.WorkflowSelector.WorkflowID
-		authorizedKeys[data.WorkflowSelector.WorkflowID] = make(map[gateway.AuthorizedKey]struct{})
-		for _, key := range data.AuthorizedKeys {
-			authorizedKeys[data.WorkflowSelector.WorkflowID][key] = struct{}{}
+	workflowShards := make(map[string][]*shardEndpoint)
+
+	for _, shard := range h.shards {
+		agg := h.aggs[shard.donID]
+		metadata := agg.Aggregate()
+		for _, data := range metadata {
+			workflowID := data.WorkflowSelector.WorkflowID
+			workflowRef := workflowReference{
+				workflowOwner: data.WorkflowSelector.WorkflowOwner,
+				workflowName:  data.WorkflowSelector.WorkflowName,
+				workflowTag:   data.WorkflowSelector.WorkflowTag,
+			}
+			workflowIDToRef[workflowID] = workflowRef
+			workflowRefToID[workflowRef] = workflowID
+			authorizedKeys[workflowID] = make(map[gateway.AuthorizedKey]struct{})
+			for _, key := range data.AuthorizedKeys {
+				authorizedKeys[workflowID][key] = struct{}{}
+			}
+			workflowShards[workflowID] = append(workflowShards[workflowID], shard)
 		}
 	}
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -155,11 +154,13 @@ func (h *WorkflowMetadataHandler) syncMetadata(ctx context.Context) {
 	h.authorizedKeys = authorizedKeys
 	h.workflowRefToID = workflowRefToID
 	h.workflowIDToRef = workflowIDToRef
+	h.workflowShards = workflowShards
 	h.metrics.RecordLoadedMetadataSize(ctx, int64(len(h.workflowIDToRef)), h.lggr)
 }
 
-// sendMetadataPullRequest sends a request to all nodes in the DON to pull the latest metadata.
-// no retries are performed, as the caller is expected to poll periodically.
+// sendMetadataPullRequest sends a request to all nodes in every shard to pull
+// the latest metadata. no retries are performed, as the caller is expected to
+// poll periodically.
 func (h *WorkflowMetadataHandler) sendMetadataPullRequest() error {
 	timeout := time.Duration(h.config.MetadataPullRequestTimeoutMs) * time.Millisecond
 	ctx, cancel := h.stopCh.CtxWithTimeout(timeout)
@@ -171,12 +172,14 @@ func (h *WorkflowMetadataHandler) sendMetadataPullRequest() error {
 		Method:  gateway.MethodPullWorkflowMetadata,
 	}
 	var combinedErr error
-	for _, member := range h.donConfig.Members {
-		h.metrics.IncrementTriggerCapabilityRequestCount(ctx, member.Address, gateway.MethodPullWorkflowMetadata, h.lggr)
-		err := h.don.SendToNode(ctx, member.Address, req)
-		if err != nil {
-			h.metrics.IncrementTriggerCapabilityRequestFailures(ctx, member.Address, gateway.MethodPullWorkflowMetadata, h.lggr)
-			combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to send pull request to node %s: %w", member.Address, err))
+	for _, shard := range h.shards {
+		for _, member := range shard.members {
+			h.metrics.IncrementTriggerCapabilityRequestCount(ctx, member.Address, gateway.MethodPullWorkflowMetadata, h.lggr)
+			err := shard.connMgr.SendToNode(ctx, member.Address, req)
+			if err != nil {
+				h.metrics.IncrementTriggerCapabilityRequestFailures(ctx, member.Address, gateway.MethodPullWorkflowMetadata, h.lggr)
+				combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to send pull request to node %s (shard %s): %w", member.Address, shard.donID, err))
+			}
 		}
 	}
 	return combinedErr
@@ -193,8 +196,12 @@ func (h *WorkflowMetadataHandler) OnMetadataPush(ctx context.Context, resp *json
 	if err != nil {
 		return err
 	}
+	agg, err := h.aggForNode(nodeAddr)
+	if err != nil {
+		return err
+	}
 	var combinedErr error
-	err = h.agg.Collect(&metadata, nodeAddr)
+	err = agg.Collect(&metadata, nodeAddr)
 	if err != nil {
 		combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to collect observation: %w", err))
 	}
@@ -214,12 +221,36 @@ func (h *WorkflowMetadataHandler) OnMetadataPullResponse(ctx context.Context, re
 			return err
 		}
 	}
+	agg, err := h.aggForNode(nodeAddr)
+	if err != nil {
+		return err
+	}
 	var combinedErr error
 	for _, data := range metadata {
-		err := h.agg.Collect(&data, nodeAddr)
+		err := agg.Collect(&data, nodeAddr)
 		combinedErr = errors.Join(combinedErr, err)
 	}
 	return combinedErr
+}
+
+// aggForNode returns the per-shard aggregator that owns the given node address.
+func (h *WorkflowMetadataHandler) aggForNode(nodeAddr string) (*aggregation.WorkflowMetadataAggregator, error) {
+	shard, ok := h.nodeAddrToShard[nodeAddr]
+	if !ok {
+		return nil, fmt.Errorf("received metadata from unknown node %s (no owning shard)", nodeAddr)
+	}
+	return h.aggs[shard.donID], nil
+}
+
+// WorkflowShards returns the shards a workflow is currently assigned to (those
+// whose quorum reported the workflow's metadata). The returned slice is a copy.
+func (h *WorkflowMetadataHandler) WorkflowShards(workflowID string) []*shardEndpoint {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	shards := h.workflowShards[workflowID]
+	out := make([]*shardEndpoint, len(shards))
+	copy(out, shards)
+	return out
 }
 
 // Start begins the periodic pull loop.
@@ -227,9 +258,10 @@ func (h *WorkflowMetadataHandler) Start(ctx context.Context) error {
 	return h.StartOnce("WorkflowMetadataHandler", func() error {
 		h.lggr.Info("Starting HTTP Trigger Metadata Handler")
 		h.startTime = time.Now()
-		err := h.agg.Start(ctx)
-		if err != nil {
-			return err
+		for _, shard := range h.shards {
+			if err := h.aggs[shard.donID].Start(ctx); err != nil {
+				return fmt.Errorf("failed to start aggregator for shard %s: %w", shard.donID, err)
+			}
 		}
 		h.runTicker(time.Duration(h.config.MetadataPullIntervalMs)*time.Millisecond, func(ctx context.Context) {
 			err2 := h.sendMetadataPullRequest()
@@ -322,8 +354,10 @@ func (h *WorkflowMetadataHandler) GetWorkflowReference(workflowID string) (workf
 func (h *WorkflowMetadataHandler) Close() error {
 	return h.StopOnce("WorkflowMetadataHandler", func() error {
 		h.lggr.Info("Stopping HTTP Trigger Metadata Handler")
-		if err := h.agg.Close(); err != nil {
-			h.lggr.Errorw("Failed to close WorkflowMetadataAggregator", "error", err)
+		for _, shard := range h.shards {
+			if err := h.aggs[shard.donID].Close(); err != nil {
+				h.lggr.Errorw("Failed to close WorkflowMetadataAggregator", "shard", shard.donID, "error", err)
+			}
 		}
 		close(h.stopCh)
 		h.wg.Wait()

--- a/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler_test.go
@@ -162,15 +162,26 @@ func TestSyncMetadataMultipleWorkflows(t *testing.T) {
 		workflowOwner: testWorkflowOwner1,
 		workflowTag:   testWorkflowTag1,
 	}
+	// Both "workflow1" and "workflow2" share the same workflow reference. The
+	// workflow reference is unique (enforced by the on-chain registry), so
+	// syncMetadata deduplicates by reference: only the first observed workflow ID
+	// wins. Aggregate() returns observations newest-first, so "workflow2" (the
+	// last collected, highest sequence number) is processed first and wins the
+	// reference; "workflow1" is dropped as a duplicate reference.
 	require.Len(t, handler.authorizedKeys, 1)
-	for workflowID, workflowKeys := range handler.authorizedKeys {
-		ref, exists := handler.workflowIDToRef[workflowID]
-		require.True(t, exists)
-		require.Equal(t, expectedRef, ref)
-		_, exists = handler.workflowRefToID[expectedRef]
-		require.True(t, exists)
-		require.Len(t, workflowKeys, 1)
-	}
+	require.Contains(t, handler.authorizedKeys, "workflow2")
+	workflowKeys := handler.authorizedKeys["workflow2"]
+	require.Len(t, workflowKeys, 1)
+
+	ref, exists := handler.workflowIDToRef["workflow2"]
+	require.True(t, exists)
+	require.Equal(t, expectedRef, ref)
+	winningWorkflowID, exists := handler.workflowRefToID[expectedRef]
+	require.True(t, exists)
+	require.Equal(t, "workflow2", winningWorkflowID)
+	// "workflow1" must have been dropped by the reference dedup.
+	_, exists = handler.workflowIDToRef["workflow1"]
+	require.False(t, exists)
 }
 
 func TestSendMetadataPullRequest(t *testing.T) {

--- a/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/workflow_metadata_handler_test.go
@@ -16,6 +16,7 @@ import (
 	gateway_common "github.com/smartcontractkit/chainlink-common/pkg/types/gateway"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities/v2/metrics"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
@@ -49,10 +50,22 @@ func createTestWorkflowMetadataHandler(t *testing.T) (*WorkflowMetadataHandler, 
 	}
 
 	cfg := WithDefaults(ServiceConfig{})
-	testMetrics, err := metrics.NewMetrics(donConfig)
+	testMetrics, err := metrics.NewMetrics(donConfig.Members)
 	require.NoError(t, err)
-	handler := NewWorkflowMetadataHandler(lggr, cfg, mockDon, donConfig, testMetrics)
+	shards, nodeAddrToShard := singleShardEndpoints(t, donConfig, mockDon)
+	handler := NewWorkflowMetadataHandler(lggr, cfg, shards, nodeAddrToShard, testMetrics)
 	return handler, mockDon, donConfig
+}
+
+// singleShardEndpoints builds a one-DON one-shard endpoint matrix from a legacy
+// DONConfig for tests.
+func singleShardEndpoints(t *testing.T, donConfig *config.DONConfig, mockDon *mocks.DON) ([]*shardEndpoint, map[string]*shardEndpoint) {
+	shardedDONs := []config.ShardedDONConfig{
+		{DonName: donConfig.DonId, F: donConfig.F, Shards: []config.Shard{{Nodes: donConfig.Members}}},
+	}
+	shards, nodeAddrToShard, err := buildShardEndpoints(shardedDONs, [][]handlers.DON{{mockDon}})
+	require.NoError(t, err)
+	return shards, nodeAddrToShard
 }
 
 func TestSyncMetadata(t *testing.T) {
@@ -64,9 +77,9 @@ func TestSyncMetadata(t *testing.T) {
 
 	// Start the aggregator to enable data collection
 	ctx := t.Context()
-	err := handler.agg.Start(ctx)
+	err := handler.aggs[handler.shards[0].donID].Start(ctx)
 	require.NoError(t, err)
-	defer handler.agg.Close()
+	defer handler.aggs[handler.shards[0].donID].Close()
 
 	// Add some test data to aggregator
 	key := gateway_common.AuthorizedKey{
@@ -84,9 +97,9 @@ func TestSyncMetadata(t *testing.T) {
 	}
 
 	// Collect enough observations to meet threshold (F+1 = 2)
-	err = handler.agg.Collect(&observation, "node1")
+	err = handler.aggs[handler.shards[0].donID].Collect(&observation, "node1")
 	require.NoError(t, err)
-	err = handler.agg.Collect(&observation, "node2")
+	err = handler.aggs[handler.shards[0].donID].Collect(&observation, "node2")
 	require.NoError(t, err)
 	handler.syncMetadata(t.Context())
 
@@ -112,9 +125,9 @@ func TestSyncMetadataMultipleWorkflows(t *testing.T) {
 	handler, _, _ := createTestWorkflowMetadataHandler(t)
 
 	ctx := t.Context()
-	err := handler.agg.Start(ctx)
+	err := handler.aggs[handler.shards[0].donID].Start(ctx)
 	require.NoError(t, err)
-	defer handler.agg.Close()
+	defer handler.aggs[handler.shards[0].donID].Close()
 
 	// Add observations for multiple workflows
 	workflows := []string{"workflow1", "workflow2"}
@@ -136,9 +149,9 @@ func TestSyncMetadataMultipleWorkflows(t *testing.T) {
 					},
 				},
 			}
-			err = handler.agg.Collect(&observation, "node1")
+			err = handler.aggs[handler.shards[0].donID].Collect(&observation, "node1")
 			require.NoError(t, err)
-			err = handler.agg.Collect(&observation, "node2")
+			err = handler.aggs[handler.shards[0].donID].Collect(&observation, "node2")
 			require.NoError(t, err)
 		}
 	}
@@ -212,13 +225,89 @@ func TestSendMetadataPullRequestVerifyPayload(t *testing.T) {
 	mockDon.AssertNumberOfCalls(t, "SendToNode", len(donConfig.Members))
 }
 
+// createMultiShardMetadataHandler builds a metadata handler over two shards of
+// one DON: shard 0 = {node1,node2}, shard 1 = {node3,node4}, F=0 so threshold=1.
+func createMultiShardMetadataHandler(t *testing.T) (*WorkflowMetadataHandler, *mocks.DON, *mocks.DON) {
+	lggr := logger.Test(t)
+	mockDon0 := mocks.NewDON(t)
+	mockDon1 := mocks.NewDON(t)
+	shardedDONs := []config.ShardedDONConfig{
+		{DonName: "don", F: 0, Shards: []config.Shard{
+			{Nodes: []config.NodeConfig{{Address: "node1"}, {Address: "node2"}}},
+			{Nodes: []config.NodeConfig{{Address: "node3"}, {Address: "node4"}}},
+		}},
+	}
+	shards, nodeAddrToShard, err := buildShardEndpoints(shardedDONs, [][]handlers.DON{{mockDon0, mockDon1}})
+	require.NoError(t, err)
+	testMetrics, err := metrics.NewMetrics(allMembers(shards))
+	require.NoError(t, err)
+	cfg := WithDefaults(ServiceConfig{})
+	return NewWorkflowMetadataHandler(lggr, cfg, shards, nodeAddrToShard, testMetrics), mockDon0, mockDon1
+}
+
+func TestMultiShardAssignment(t *testing.T) {
+	t.Parallel()
+
+	handler, _, _ := createMultiShardMetadataHandler(t)
+	ctx := t.Context()
+	for _, shard := range handler.shards {
+		require.NoError(t, handler.aggs[shard.donID].Start(ctx))
+		t.Cleanup(func() { _ = handler.aggs[shard.donID].Close() })
+	}
+
+	obs := gateway_common.WorkflowMetadata{
+		WorkflowSelector: gateway_common.WorkflowSelector{
+			WorkflowID:    testWorkflowID1,
+			WorkflowName:  testWorkflowNameHex1,
+			WorkflowOwner: testWorkflowOwner1,
+			WorkflowTag:   testWorkflowTag1,
+		},
+		AuthorizedKeys: []gateway_common.AuthorizedKey{{KeyType: gateway_common.KeyTypeECDSAEVM, PublicKey: testPublicKey1}},
+	}
+
+	// Initially unassigned.
+	require.Empty(t, handler.WorkflowShards(testWorkflowID1))
+
+	// Quorum (F+1=1) reached only in shard 1 (node3).
+	require.NoError(t, handler.aggs[handler.shards[1].donID].Collect(&obs, "node3"))
+	handler.syncMetadata(ctx)
+	assigned := handler.WorkflowShards(testWorkflowID1)
+	require.Len(t, assigned, 1)
+	require.Equal(t, handler.shards[1].donID, assigned[0].donID)
+
+	// Later quorum reached in shard 0 too (node1) => assigned to both shards.
+	require.NoError(t, handler.aggs[handler.shards[0].donID].Collect(&obs, "node1"))
+	handler.syncMetadata(ctx)
+	assigned = handler.WorkflowShards(testWorkflowID1)
+	require.Len(t, assigned, 2)
+
+	// An observation from an unknown node is rejected.
+	_, err := handler.aggForNode("unknown-node")
+	require.Error(t, err)
+}
+
+func TestSendMetadataPullRequestMultiShard(t *testing.T) {
+	t.Parallel()
+
+	handler, mockDon0, mockDon1 := createMultiShardMetadataHandler(t)
+	for _, addr := range []string{"node1", "node2"} {
+		mockDon0.EXPECT().SendToNode(mock.Anything, addr, mock.Anything).Return(nil).Once()
+	}
+	for _, addr := range []string{"node3", "node4"} {
+		mockDon1.EXPECT().SendToNode(mock.Anything, addr, mock.Anything).Return(nil).Once()
+	}
+	require.NoError(t, handler.sendMetadataPullRequest())
+	mockDon0.AssertExpectations(t)
+	mockDon1.AssertExpectations(t)
+}
+
 func TestOnMetadataPush(t *testing.T) {
 	handler, _, _ := createTestWorkflowMetadataHandler(t)
 	ctx := t.Context()
 
-	err := handler.agg.Start(ctx)
+	err := handler.aggs[handler.shards[0].donID].Start(ctx)
 	require.NoError(t, err)
-	defer handler.agg.Close()
+	defer handler.aggs[handler.shards[0].donID].Close()
 
 	metadata := gateway_common.WorkflowMetadata{
 		WorkflowSelector: gateway_common.WorkflowSelector{
@@ -274,9 +363,9 @@ func TestOnMetadataPullResponse(t *testing.T) {
 	handler, _, _ := createTestWorkflowMetadataHandler(t)
 	ctx := t.Context()
 
-	err := handler.agg.Start(ctx)
+	err := handler.aggs[handler.shards[0].donID].Start(ctx)
 	require.NoError(t, err)
-	defer handler.agg.Close()
+	defer handler.aggs[handler.shards[0].donID].Close()
 
 	key1 := gateway_common.AuthorizedKey{
 		KeyType:   gateway_common.KeyTypeECDSAEVM,
@@ -803,9 +892,9 @@ func TestOnMetadataPushWithValidation(t *testing.T) {
 	handler, _, _ := createTestWorkflowMetadataHandler(t)
 	ctx := t.Context()
 
-	err := handler.agg.Start(ctx)
+	err := handler.aggs[handler.shards[0].donID].Start(ctx)
 	require.NoError(t, err)
-	defer handler.agg.Close()
+	defer handler.aggs[handler.shards[0].donID].Close()
 
 	t.Run("valid metadata passes validation", func(t *testing.T) {
 		metadata := gateway_common.WorkflowMetadata{
@@ -869,9 +958,9 @@ func TestOnMetadataPullResponseWithValidation(t *testing.T) {
 	handler, _, _ := createTestWorkflowMetadataHandler(t)
 	ctx := t.Context()
 
-	err := handler.agg.Start(ctx)
+	err := handler.aggs[handler.shards[0].donID].Start(ctx)
 	require.NoError(t, err)
-	defer handler.agg.Close()
+	defer handler.aggs[handler.shards[0].donID].Close()
 
 	t.Run("valid metadata array passes validation", func(t *testing.T) {
 		metadata := []gateway_common.WorkflowMetadata{


### PR DESCRIPTION
HTTP Trigger now understands workflows assigned to multiple shards (e.g. primary + backup). Workflow registration is handled per-shard. Incoming trigger requests are routed to all shards the workflow is assigned to.

HTTP action doesn't need any shard-related changes.

Two main files changed by the PR:
1. http_trigger_handler.go: support per-shard fan-out and response aggregation.
2. workflow_metadata_handler.go: support per-shard workflow/sender allowlisting