### PR TITLE
Fix develop sync: restore push credentials

### DIFF
--- a/.github/workflows/sync-develop-from-smartcontractkit-chainlink.yml
+++ b/.github/workflows/sync-develop-from-smartcontractkit-chainlink.yml
@@ -9,12 +9,13 @@ jobs:
   sync:
     name: Sync
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
-          persist-credentials: false
           ref: develop
-        if: env.GITHUB_REPOSITORY != 'smartcontractkit/chainlink'
+        if: github.repository != 'smartcontractkit/chainlink'
       - name: Sync
         run: |
           git remote add upstream "https://github.com/smartcontractkit/chainlink.git"
@@ -27,4 +28,4 @@ jobs:
             git fetch upstream
             git push origin upstream/develop:develop
           fi
-        if: env.GITHUB_REPOSITORY != 'smartcontractkit/chainlink'
+        if: github.repository != 'smartcontractkit/chainlink'


### PR DESCRIPTION
Draft. `sync-develop-from-smartcontractkit-chainlink.yml` has failed on **every** scheduled run in `smartcontractkit/chainlink-internal`:

```
fatal: could not read Username for 'https://github.com': No such device or address
Process completed with exit code 128
```

`persist-credentials: false` strips the token from the checkout, so `git fetch upstream` succeeds against public chainlink and `git push origin` has no credentials. Every 30 minutes it fetches the full history, then fails at the push. No alerting, so it went unnoticed — `chainlink-internal` has not synced since **2023-11-23** and is roughly **7,100 commits behind**.

That repo is the documented test target for `chainlink-releases` workflow changes, so the staleness has been silently degrading release-tooling verification.

## The change

| Line | Why |
| --- | --- |
| drop `persist-credentials: false` | the actual bug — the push needs the checkout token |
| add `permissions: contents: write` | a persisted but read-only token would still fail; this is the only scope the push needs |
| `env.GITHUB_REPOSITORY` → `github.repository` (x2) | the guard read a context that is never set, so it was always true |

**The guard fix is required, not incidental.** Granting `contents: write` to a job whose guard never fires would mean this running every 30 minutes against `smartcontractkit/chainlink` itself with write permission. It no-ops there via the SHA comparison, but the permission would be real. Reading `github.repository` makes the workflow genuinely inert upstream — which is what the condition was written to express.

## Verified

| Repository | Guard before | Guard after |
| --- | --- | --- |
| `smartcontractkit/chainlink` | true (ran) | **false (inert)** |
| `smartcontractkit/chainlink-internal` | true | true |
| `smartcontractkit/chainlink-canary` | true | true |

## Not addressed

Branch protection on the target. A direct fast-forward push to `chainlink-internal`'s `develop` is currently rejected with `protected branch hook declined`, and I cannot see what enforces it — `/branches/develop/protection` 404s and the rules API returns nothing for that branch. If that also applies to `GITHUB_TOKEN`, the sync will need a token that satisfies it. Raised with DevEx separately.

Context: RANE-5108.