### PR TITLE
core/utils: accept json.Number in ToDecimal

### DIFF
--- a/.changeset/accept-json-number-todecimal.md
+++ b/.changeset/accept-json-number-todecimal.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix ETHABIEncode now accepts `json.Number` when converting integer ABI values, so `uint256[]` (and other integer types) from JSON no longer fail with "type json.Number cannot be converted to decimal.Decimal".

--- a/core/services/pipeline/task.eth_abi_encode_test.go
+++ b/core/services/pipeline/task.eth_abi_encode_test.go
@@ -1,6 +1,7 @@
 package pipeline_test
 
 import (
+	"encoding/json"
 	"math"
 	"math/big"
 	"testing"
@@ -237,6 +238,40 @@ func TestETHABIEncodeTask(t *testing.T) {
 			}
 		})
 	}
+}
+
+// json.Number is what JSON unmarshalling produces for numeric tokens. ETHABIEncode
+// used to fail with "type json.Number cannot be converted to decimal.Decimal"
+// when encoding integer arrays such as uint256[] (issue #8504).
+func TestETHABIEncode_JSONNumberArray(t *testing.T) {
+	t.Parallel()
+
+	runEncode := func(t *testing.T, values any) pipeline.Result {
+		t.Helper()
+		task := pipeline.ETHABIEncodeTask{
+			BaseTask: pipeline.NewBaseTask(0, "encode", nil, nil, 0),
+			ABI:      "fulfill(uint256[] _data)",
+			Data:     `{ "_data": $(foo) }`,
+		}
+		vars := pipeline.NewVarsFrom(map[string]any{"foo": values})
+		result, runInfo := task.Run(t.Context(), logger.TestLogger(t), vars, nil)
+		assert.False(t, runInfo.IsPending)
+		assert.False(t, runInfo.IsRetryable)
+		return result
+	}
+
+	fromJSONNumbers := runEncode(t, []any{json.Number("100"), json.Number("200")})
+	require.NoError(t, fromJSONNumbers.Error)
+
+	fromInts := runEncode(t, []any{int64(100), int64(200)})
+	require.NoError(t, fromInts.Error)
+	require.Equal(t, fromInts.Value, fromJSONNumbers.Value)
+
+	fromJSONScalar := runEncode(t, []any{json.Number("115792089237316195423570985008687907853269984665640564039457584007913129639935")})
+	require.NoError(t, fromJSONScalar.Error)
+
+	fromStringInts := runEncode(t, []any{"1", "2", "3"})
+	require.NoError(t, fromStringInts.Error)
 }
 
 func TestETHABIEncode_EncodeIntegers(t *testing.T) {

--- a/core/utils/decimal.go
+++ b/core/utils/decimal.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"math"
 	"math/big"
 
@@ -54,6 +55,8 @@ func ToDecimal(input any) (decimal.Decimal, error) {
 		return v, nil
 	case *decimal.Decimal:
 		return *v, nil
+	case json.Number:
+		return decimal.NewFromString(v.String())
 	default:
 		return decimal.Decimal{}, errors.Errorf("type %T cannot be converted to decimal.Decimal (%v)", input, input)
 	}

--- a/core/utils/decimal_test.go
+++ b/core/utils/decimal_test.go
@@ -1,12 +1,14 @@
 package utils
 
 import (
+	"encoding/json"
 	"math"
 	"math/big"
 	"testing"
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDecimal(t *testing.T) {
@@ -46,6 +48,12 @@ func TestDecimal(t *testing.T) {
 		{math.NaN(), true},
 		{float32(math.NaN()), true},
 		{true, true},
+		{json.Number("1"), false},
+		{json.Number("1.1"), false},
+		{json.Number("-42"), false},
+		{json.Number("115792089237316195423570985008687907853269984665640564039457584007913129639935"), false},
+		{json.Number(""), true},
+		{json.Number("not-a-number"), true},
 	}
 	for _, tc := range tt {
 		_, err := ToDecimal(tc.v)
@@ -55,4 +63,29 @@ func TestDecimal(t *testing.T) {
 			assert.NoError(t, err)
 		}
 	}
+}
+
+func TestToDecimal_JSONNumber(t *testing.T) {
+	t.Parallel()
+
+	got, err := ToDecimal(json.Number("1024"))
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromInt(1024).Equal(got))
+
+	got, err = ToDecimal(json.Number("3.50"))
+	require.NoError(t, err)
+	assert.True(t, decimal.RequireFromString("3.50").Equal(got))
+
+	got, err = ToDecimal(json.Number("-7"))
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromInt(-7).Equal(got))
+
+	_, err = ToDecimal(json.Number("1e2"))
+	require.NoError(t, err)
+
+	_, err = ToDecimal(json.Number(""))
+	require.Error(t, err)
+
+	_, err = ToDecimal(json.Number("xyz"))
+	require.Error(t, err)
 }


### PR DESCRIPTION
Fixes #8504

### Description

`ETHABIEncode` converts integer ABI values (including each element of `uint256[]`) through `convertToETHABIInteger` → `utils.ToDecimal`. JSON unmarshalling produces `json.Number` for numeric tokens, and `ToDecimal` previously rejected that type with:

```
type json.Number cannot be converted to decimal.Decimal
```

This matches the job-run failure in #8504 (`ETHABIEncode` of a `uint256[]` from JSON numbers).

### Changes

- Accept `json.Number` in `utils.ToDecimal` (same conversion as a numeric string).
- Add unit tests for valid/invalid `json.Number` inputs.
- Add a pipeline regression test: encoding `uint256[]` from `[]json.Number` succeeds and matches the `int64` encoding.

### Requires

None.

### Supports

None.

### Test plan

- [x] `go test ./core/utils -count=1`
- [x] `go test ./core/services/pipeline -count=1 -run 'TestETHABIEncode'`