### PR TITLE
[CRE-2556] Improve connection between node and gateway

### DIFF
--- a/core/services/gateway/connectionmanager.go
+++ b/core/services/gateway/connectionmanager.go
@@ -167,8 +167,10 @@ func (m *connectionManager) Start(ctx context.Context) error {
 				}
 				go donConnMgr.readLoop(nodeAddress, nodeState)
 			}
-			donConnMgr.closeWait.Add(1)
-			go donConnMgr.keepaliveLoop(m.config.HeartbeatIntervalSec)
+			donConnMgr.closeWait.Add(len(donConnMgr.nodes))
+			for nodeAddress, nodeState := range donConnMgr.nodes {
+				go donConnMgr.nodeKeepalive(nodeAddress, nodeState, m.config.HeartbeatIntervalSec)
+			}
 		}
 		return m.wsServer.Start(ctx)
 	})
@@ -367,7 +369,7 @@ func (m *donConnectionManager) readLoop(nodeAddress string, nodeState *nodeState
 	}
 }
 
-func (m *donConnectionManager) keepaliveLoop(intervalSec uint32) {
+func (m *donConnectionManager) nodeKeepalive(addr string, ns *nodeState, intervalSec uint32) {
 	defer m.closeWait.Done()
 	ctx, cancel := m.shutdownCh.NewCtx()
 	defer cancel()
@@ -376,27 +378,25 @@ func (m *donConnectionManager) keepaliveLoop(intervalSec uint32) {
 		m.lggr.Errorw("keepalive interval is 0, keepalive disabled", "donID", m.donConfig.DonId)
 		return
 	}
-	m.lggr.Infow("starting keepalive loop", "donID", m.donConfig.DonId)
+	m.lggr.Infow("starting keepalive loop", "donID", m.donConfig.DonId, "nodeName", ns.name)
 
-	keepaliveTicker := time.NewTicker(time.Duration(intervalSec) * time.Second)
-	defer keepaliveTicker.Stop()
+	ticker := time.NewTicker(time.Duration(intervalSec) * time.Second)
+	defer ticker.Stop()
 
 	for {
 		select {
 		case <-m.shutdownCh:
 			return
-		case <-keepaliveTicker.C:
-			errorCount := 0
-			for nodeAddress, nodeState := range m.nodes {
-				err := nodeState.conn.Write(ctx, websocket.PingMessage, []byte{})
-				m.gMetrics.RecordKeepalivePingsSent(ctx, nodeAddress, nodeState.name, err == nil)
-				if err != nil {
-					m.lggr.Debugw("unable to send keepalive ping to node", "nodeAddress", nodeAddress, "name", nodeState.name, "donID", m.donConfig.DonId, "err", err)
-					errorCount++
-				}
+		case <-ticker.C:
+			// Per-node write with a timeout context
+			pingCtx, pingCancel := context.WithTimeout(ctx, 5*time.Second)
+			err := ns.conn.Write(pingCtx, websocket.PingMessage, []byte{})
+			pingCancel()
+			m.gMetrics.RecordKeepalivePingsSent(ctx, addr, ns.name, err == nil)
+			if err != nil {
+				m.lggr.Debugw("unable to send keepalive ping to node",
+					"nodeAddress", addr, "name", ns.name, "err", err)
 			}
-			promKeepalivesSent.WithLabelValues(m.donConfig.DonId).Set(float64(len(m.nodes) - errorCount))
-			m.lggr.Infow("sent keepalive pings to nodes", "donID", m.donConfig.DonId, "errCount", errorCount)
 		}
 	}
 }

--- a/core/services/gateway/connector/config.go
+++ b/core/services/gateway/connector/config.go
@@ -29,6 +29,14 @@ func (ConnectorConfig) From(c config.GatewayConnector) ConnectorConfig {
 		AuthTimestampToleranceSec: c.AuthTimestampToleranceSec(),
 	}
 
+	// AuthTimestampToleranceSec should be at least 5 seconds
+	// Under network instability nodes may lose connection to the gateway
+	// having a smaller tolerance range would reduce the chances of success on retries.
+	// this is what happened on https://smartcontract-it.atlassian.net/browse/INCIDENT-2556
+	if r.AuthTimestampToleranceSec < 5 {
+		r.AuthTimestampToleranceSec = 5
+	}
+
 	if len(c.Gateways()) != 0 {
 		r.Gateways = make([]ConnectorGatewayConfig, len(c.Gateways()))
 		for i, gateway := range c.Gateways() {

--- a/core/services/gateway/connector/config.go
+++ b/core/services/gateway/connector/config.go
@@ -5,6 +5,8 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/network"
 )
 
+const defaultAuthTimestampToleranceSec = 5
+
 type ConnectorConfig struct {
 	NodeAddress               string
 	DonId                     string
@@ -29,12 +31,12 @@ func (ConnectorConfig) From(c config.GatewayConnector) ConnectorConfig {
 		AuthTimestampToleranceSec: c.AuthTimestampToleranceSec(),
 	}
 
-	// AuthTimestampToleranceSec should be at least 5 seconds
+	// AuthTimestampToleranceSec defaults to 5 seconds
 	// Under network instability nodes may lose connection to the gateway
 	// having a smaller tolerance range would reduce the chances of success on retries.
 	// this is what happened on https://smartcontract-it.atlassian.net/browse/INCIDENT-2556
-	if r.AuthTimestampToleranceSec < 5 {
-		r.AuthTimestampToleranceSec = 5
+	if r.AuthTimestampToleranceSec == 0 {
+		r.AuthTimestampToleranceSec = defaultAuthTimestampToleranceSec
 	}
 
 	if len(c.Gateways()) != 0 {

--- a/core/services/gateway/keepalive_loop_internal_test.go
+++ b/core/services/gateway/keepalive_loop_internal_test.go
@@ -1,0 +1,126 @@
+package gateway
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/monitoring"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/network"
+)
+
+// mockPingConn is a minimal WSConnectionWrapper for keepalive testing.
+// It counts ping writes and optionally blocks on Write to simulate a
+// half-open TCP connection.
+type mockPingConn struct {
+	pingCount atomic.Int64
+	unblock   chan struct{} // if non-nil, Write blocks until closed
+}
+
+func (m *mockPingConn) Start(context.Context) error          { return nil }
+func (m *mockPingConn) HealthReport() map[string]error       { return nil }
+func (m *mockPingConn) Name() string                         { return "mockPingConn" }
+func (m *mockPingConn) Ready() error                         { return nil }
+func (m *mockPingConn) Reset(*websocket.Conn) <-chan error   { return nil }
+func (m *mockPingConn) ReadChannel() <-chan network.ReadItem { return nil }
+func (m *mockPingConn) Close() error                         { return nil }
+
+func (m *mockPingConn) Write(ctx context.Context, msgType int, _ []byte) error {
+	if msgType == websocket.PingMessage {
+		m.pingCount.Add(1)
+	}
+	if m.unblock != nil {
+		select {
+		case <-m.unblock:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+// TestKeepAliveLoop_StuckNodeDoesBlocksAll
+// this reproduces a bug in which one stall node blocks pings to all nodes.
+// This leads to a wrong representation of the communication between nodes and gateway, making it harder to diagnose an incident.
+//
+// Before the keepaliveLoop used to ping nodes sequentially with no per-node timeout. If one
+// node's Write blocked (half-open TCP), the loop stalls and no other node
+// receives pings.
+func TestKeepAliveLoop_StuckNodeBlocksAll(t *testing.T) {
+	t.Parallel()
+
+	lggr := logger.Test(t)
+	gMetrics, err := monitoring.NewGatewayMetrics()
+	require.NoError(t, err)
+
+	unblock := make(chan struct{})
+	t.Cleanup(func() { close(unblock) })
+
+	stuckConn := &mockPingConn{unblock: unblock}
+	healthyConns := make([]*mockPingConn, 3)
+	mockNodes := make(map[string]*nodeState, 4)
+	mockNodes["0xstuck"] = &nodeState{name: "stuck", conn: stuckConn}
+	for i := range healthyConns {
+		healthyConns[i] = &mockPingConn{}
+		mockNodes["0xhealthy"+string(rune('0'+i))] = &nodeState{
+			name: "healthy_" + string(rune('0'+i)),
+			conn: healthyConns[i],
+		}
+	}
+
+	donMgr := &donConnectionManager{
+		donConfig:  &config.DONConfig{DonId: "test_don"},
+		nodes:      mockNodes,
+		handlers:   nil,
+		closeWait:  sync.WaitGroup{},
+		shutdownCh: make(services.StopChan),
+		gMetrics:   gMetrics,
+		lggr:       lggr,
+	}
+
+	// Start the keepalive loop directly with a 1-second interval.
+	const heartbeatSec = 1
+	donMgr.closeWait.Add(len(donMgr.nodes))
+	for nodeAddress, nodeState := range donMgr.nodes {
+		go donMgr.nodeKeepalive(nodeAddress, nodeState, heartbeatSec)
+	}
+
+	// Let at least 2 ticks fire. With the bug, the loop is stuck on the
+	// first node and never reaches the healthy nodes. With the fix,
+	// healthy nodes get pinged each tick.
+	time.Sleep(3 * time.Second)
+
+	// --- Check ping counts BEFORE stopping the loop ---
+	//
+	// BEFORE the fix (sequential, no per-node timeout):
+	//   The loop calls Write on "0xstuck" first. It blocks on unblock.
+	//   The loop never reaches the healthy nodes.
+	//   → all healthyConns have pingCount == 0 → test FAILS.
+	//
+	// AFTER the fix (per-node timeout or concurrent sends):
+	//   Each node is pinged independently. The stuck node blocks/times out
+	//   but healthy nodes still receive pings.
+	//   → all healthyConns have pingCount >= 1 → test PASSES.
+	for i, hc := range healthyConns {
+		pings := hc.pingCount.Load()
+		t.Logf("healthy_%d: %d pings", i, pings)
+		require.Greater(t, pings, int64(0),
+			"healthy node %d received 0 pings — keepaliveLoop is stuck on the blocked node", i)
+	}
+
+	stuckPings := stuckConn.pingCount.Load()
+	t.Logf("stuck node: %d ping attempts", stuckPings)
+
+	// Stop the loop (after assertions so the stuck Write doesn't unblock early).
+	close(donMgr.shutdownCh)
+	donMgr.closeWait.Wait()
+}

--- a/core/services/gateway/keepalive_loop_internal_test.go
+++ b/core/services/gateway/keepalive_loop_internal_test.go
@@ -113,8 +113,7 @@ func TestKeepAliveLoop_StuckNodeBlocksAll(t *testing.T) {
 	for i, hc := range healthyConns {
 		pings := hc.pingCount.Load()
 		t.Logf("healthy_%d: %d pings", i, pings)
-		require.Greater(t, pings, int64(0),
-			"healthy node %d received 0 pings — keepaliveLoop is stuck on the blocked node", i)
+		require.Positive(t, pings, "healthy node %d received 0 pings — keepaliveLoop is stuck on the blocked node", i)
 	}
 
 	stuckPings := stuckConn.pingCount.Load()


### PR DESCRIPTION
### Description

This pr contains two improvements:
- The keepalive loop was a single routine for every node, in case of one node down, the loop would get stuck. This translates to seeing the `platform_gateway_keepalive_pings_sent_total` metric drop for all nodes when in reality only one may be down. This change will help diagnose quicker these kind of issues
- `AuthTimestampToleranceSec` default to 5. Under network instability scenarios, the handshake between node and gateway might take more than 1 second. Having 0 as default means this has to happen on the same second. This config change gives the node a bit more time to re-connect and can decrease a 1hr incident to seconds by allowing the reconnection to succeed.

[CRE-2556](https://smartcontract-it.atlassian.net/browse/INCIDENT-2556)

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-2556]: https://smartcontract-it.atlassian.net/browse/CRE-2556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ