### PR TITLE
fix(ci): should run gates for releases

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -265,7 +265,13 @@ jobs:
       name: integration
       deployment: false
     runs-on: ${{ matrix.image.runner }}
-    needs: [labels, enforce-ctf-version, changes]
+    needs:
+      [
+        labels,
+        enforce-ctf-version,
+        run-core-cre-e2e-tests-setup,
+        run-ccip-v1-6-e2e-tests-setup,
+      ]
     permissions:
       id-token: write
       contents: read
@@ -279,12 +285,8 @@ jobs:
             cache-scope: core
             any-should-run: >-
               ${{
-                github.event_name == 'workflow_dispatch' ||
-                needs.changes.outputs.general-changes == 'true' ||
-                needs.changes.outputs.core-changes == 'true' ||
-                needs.changes.outputs.cre-changes == 'true' ||
-                needs.changes.outputs.ccip-changes == 'true' ||
-                needs.labels.outputs.run-e2e-tests-label-found == 'true'
+                needs.run-ccip-v1-6-e2e-tests-setup.outputs.should-run == 'true' ||
+                needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'
               }}
 
           - name: (plugins)
@@ -294,11 +296,7 @@ jobs:
             cache-scope: plugins
             any-should-run: >-
               ${{
-                github.event_name == 'workflow_dispatch' ||
-                needs.changes.outputs.general-changes == 'true' ||
-                needs.changes.outputs.core-changes == 'true' ||
-                needs.changes.outputs.cre-changes == 'true' ||
-                needs.labels.outputs.run-e2e-tests-label-found == 'true'
+                needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'
               }}
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners


### PR DESCRIPTION
Unifies decision on when to run CI. Fixes the issue with tags not properly triggering CI, 
