### PR TITLE
fix(ci): cherry-pick #23431 — unify should-run gates

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -265,7 +265,13 @@ jobs:
       name: integration
       deployment: false
     runs-on: ${{ matrix.image.runner }}
-    needs: [labels, enforce-ctf-version, changes]
+    needs:
+      [
+        labels,
+        enforce-ctf-version,
+        run-core-cre-e2e-tests-setup,
+        run-ccip-v1-6-e2e-tests-setup,
+      ]
     permissions:
       id-token: write
       contents: read
@@ -279,12 +285,8 @@ jobs:
             cache-scope: core
             any-should-run: >-
               ${{
-                github.event_name == 'workflow_dispatch' ||
-                needs.changes.outputs.general-changes == 'true' ||
-                needs.changes.outputs.core-changes == 'true' ||
-                needs.changes.outputs.cre-changes == 'true' ||
-                needs.changes.outputs.ccip-changes == 'true' ||
-                needs.labels.outputs.run-e2e-tests-label-found == 'true'
+                needs.run-ccip-v1-6-e2e-tests-setup.outputs.should-run == 'true' ||
+                needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'
               }}
 
           - name: (plugins)
@@ -294,11 +296,7 @@ jobs:
             cache-scope: plugins
             any-should-run: >-
               ${{
-                github.event_name == 'workflow_dispatch' ||
-                needs.changes.outputs.general-changes == 'true' ||
-                needs.changes.outputs.core-changes == 'true' ||
-                needs.changes.outputs.cre-changes == 'true' ||
-                needs.labels.outputs.run-e2e-tests-label-found == 'true'
+                needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'
               }}
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners


### PR DESCRIPTION
Cherry-picks `eaec72e14d` (#23431, by @adam-hamrick) onto `release/2.60.0` so tag pushes build their CRE test image.

## Why

Tags cut from `release/2.60.0` currently fail the same way `v2.59.0-beta.0` did — [run 30938527720](https://github.com/smartcontractkit/chainlink/actions/runs/30938527720), all 34 Core CRE E2E jobs dead in *Start local CRE* with:

```
manifest for .../chainlink-integration-tests:738ebda... not found: manifest unknown
```

`run-core-cre-e2e-tests-setup` sets `should-run=true` on a push when `ref_type == 'tag'`, but `build-chainlink`'s `any-should-run` had no tag clause — only `workflow_dispatch`, the `changes.*` path filters, and the e2e label. On a tag push the tagged commit is *"Bump version and update CHANGELOG"*, so every path filter is false, the build is skipped, and the tests run anyway against an image that was never pushed. `build-chainlink` still reports success because its steps are `if:`-skipped, so the `needs` on it is satisfied.

#23431 fixes this on `develop` by making the build gate consume the setup jobs' `should-run` outputs, so there is a single decision instead of two that can drift.

`develop` has the fix; `release/2.60.0` does not. `pull_request` runs use the merge ref and already pick it up — this cherry-pick is specifically for **tag pushes**, which read the workflow from the release branch.

## Notes

- Applies cleanly, no conflicts. Diff is byte-identical to develop's.
- Original authorship preserved (Adam Hamrick).
- Verified on this branch: no dangling `needs.changes` references remain in `build-chainlink`, YAML parses, and both setup jobs still `needs: [changes, labels]` so the ordering chain holds.