### PR TITLE
[DX-5064] fix: pin stellar image for E2E tests

### DIFF
--- a/core/scripts/cre/environment/configs/workflow-gateway-don-stellar.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-don-stellar.toml
@@ -9,7 +9,7 @@
 
 [[blockchains]]
   type = "stellar"
-  image = "stellar/quickstart:v655-b1325.1-latest"
+  image = "stellar/quickstart:pr968-v653-b1315.2-latest"
   chain_id = "baefd734b8d3e48472cff83912375fedbc7573701912fe308af730180f97d74a"
   # Pin the standalone network to mainnet's live protocol (26) so local/CI matches
   docker_cmd_params = ["--protocol-version", "26"]

--- a/core/scripts/cre/environment/configs/workflow-gateway-don-stellar.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-don-stellar.toml
@@ -9,6 +9,7 @@
 
 [[blockchains]]
   type = "stellar"
+  image = "stellar/quickstart:v655-b1325.1-latest"
   chain_id = "baefd734b8d3e48472cff83912375fedbc7573701912fe308af730180f97d74a"
   # Pin the standalone network to mainnet's live protocol (26) so local/CI matches
   docker_cmd_params = ["--protocol-version", "26"]


### PR DESCRIPTION
Pins stellar/quickstart image to last-working version for E2E tests.