### PR TITLE
fix: cherry-pick #23441 — pin stellar image for E2E tests

### DIFF
--- a/core/scripts/cre/environment/configs/workflow-gateway-don-stellar.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-don-stellar.toml
@@ -9,6 +9,7 @@
 
 [[blockchains]]
   type = "stellar"
+  image = "stellar/quickstart:pr968-v653-b1315.2-latest"
   chain_id = "baefd734b8d3e48472cff83912375fedbc7573701912fe308af730180f97d74a"
   # Pin the standalone network to mainnet's live protocol (26) so local/CI matches
   docker_cmd_params = ["--protocol-version", "26"]


### PR DESCRIPTION
Cherry-picks `74f8cb0c65` (#23441, by @adam-hamrick) onto `release/2.60.0`.

## Why

`workflow-gateway-don-stellar.toml` pinned the Stellar *protocol* (`--protocol-version 26`) but not the *image*, so the node resolved to `stellar/quickstart:latest`. Upstream rebuilt that tag on 2026-08-18, and the WASM embedded in the pinned `chainlink-stellar v0.0.3` module stopped passing simulation:

```
deploy forwarder wasm: failed to upload WASM:
simulation error: HostError: Error(Context, InternalError)
```

This broke `develop` and every release branch simultaneously — `develop`'s Stellar suite was green at 11:24 UTC and red at 14:16, with no Stellar-related commits in between. #23441 pins the image and both Stellar jobs pass.

## Why the release branch needs it separately

PRs into `develop` pick the fix up via the merge ref, but **tag pushes** cut from `release/2.60.0` read this config from the branch itself. Without this, the Stellar suites fail on every tag cut off 2.60.0.

Follows the same pattern as #23432.

## Notes

- Applies cleanly, no conflicts. One line added.
- Original authorship preserved (Adam Hamrick).