### PR TITLE
Don't Run Tests >= 200ms Runtime on `-short` Flag

### DIFF
--- a/core/bridges/cache_test.go
+++ b/core/bridges/cache_test.go
@@ -128,6 +128,10 @@ func TestBridgeCache_Type(t *testing.T) {
 }
 
 func TestBridgeCache_Response(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	t.Run("loads response from data source", func(t *testing.T) {

--- a/core/capabilities/ccip/oraclecreator/observation_metrics_collector_test.go
+++ b/core/capabilities/ccip/oraclecreator/observation_metrics_collector_test.go
@@ -394,6 +394,10 @@ func TestObservationMetricsCollector_NonTargetMetrics(t *testing.T) {
 // TestObservationMetricsCollector_BackgroundPolling verifies that Start publishes metrics
 // on a timer without any explicit Collect call from the outside (i.e. without a Prometheus scrape).
 func TestObservationMetricsCollector_BackgroundPolling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	lggr, err := logger.New()
 	require.NoError(t, err)
 
@@ -445,6 +449,10 @@ func TestObservationMetricsCollector_BackgroundPolling(t *testing.T) {
 // TestObservationMetricsCollector_CloseStopsPolling verifies that Close stops the background
 // goroutine and no further publishes occur even if the counter keeps incrementing.
 func TestObservationMetricsCollector_CloseStopsPolling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	lggr, err := logger.New()
 	require.NoError(t, err)
 

--- a/core/capabilities/remote/executable/server_test.go
+++ b/core/capabilities/remote/executable/server_test.go
@@ -192,6 +192,10 @@ func Test_Server_Execute_RespondsAfterSufficientRequests(t *testing.T) {
 }
 
 func Test_Server_InsufficientCallers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	ctx := t.Context()
@@ -872,6 +876,10 @@ func Test_Server_SetConfig_ShutdownRaces(t *testing.T) {
 }
 
 func Test_Server_Execute_WithConcurrentSetConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	lggr := logger.Test(t)
 	numWorkflowPeers := 4

--- a/core/capabilities/remote/trigger_publisher_test.go
+++ b/core/capabilities/remote/trigger_publisher_test.go
@@ -648,6 +648,10 @@ func TestTriggerPublisher_SendsRegistrationChecks(t *testing.T) {
 }
 
 func TestTriggerPublisher_RegistrationChecksChunkByMaxBatchSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	ctx := t.Context()
 	lggr := logger.Test(t)
@@ -959,6 +963,10 @@ func TestTriggerPublisher_UnregisterInvalidMetadata(t *testing.T) {
 }
 
 func TestTriggerPublisher_AckCacheCleanup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	ctx := t.Context()
 	lggr := logger.Test(t)

--- a/core/capabilities/remote/trigger_registration_load_test.go
+++ b/core/capabilities/remote/trigger_registration_load_test.go
@@ -163,6 +163,10 @@ func (t *noopTrigger) AckEvent(_ context.Context, _ string, _ string, _ string) 
 // --- Test: Subscriber registrationLoop traffic volume ---
 
 func TestRegistrationTrafficVolume(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	cases := []struct {
@@ -253,6 +257,10 @@ func TestRegistrationTrafficVolume(t *testing.T) {
 // --- Test: Publisher sendRegistrationChecks traffic volume ---
 
 func TestRegistrationCheckTrafficVolume(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	cases := []struct {
 		nRegistrations  int
@@ -529,6 +537,10 @@ func TestRegistrationLoopLockDuration(t *testing.T) {
 // DON peers, workflow F=2 → quorum 5). This does not simulate dispatcher drops
 // or shared-channel saturation; see test log for that limitation.
 func TestTrafficAttribution_RegisterLoopVsChecksVsEventsAndAcks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	ctx := t.Context()
 	lggr := logger.Test(t)

--- a/core/capabilities/triggers/base_trigger_event_store_test.go
+++ b/core/capabilities/triggers/base_trigger_event_store_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestBaseTrigger_CRE_MissingOrgID_DoesNotPersistOrResend(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	lggr := logger.Test(t)
 	ctx := t.Context()
 

--- a/core/capabilities/vault/jwt_based_auth_test.go
+++ b/core/capabilities/vault/jwt_based_auth_test.go
@@ -480,6 +480,10 @@ func TestJWTBasedAuth_EmptyToken(t *testing.T) {
 }
 
 func TestJWTBasedAuth_JWKSKeyRotation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	keyA := generateTestRSAKey(t, "key-A")
 	keyB := generateTestRSAKey(t, "key-B")
 

--- a/core/capabilities/vault/zone_b_restriction_test.go
+++ b/core/capabilities/vault/zone_b_restriction_test.go
@@ -117,6 +117,10 @@ func TestCapability_Execute_ZoneBRestriction_DeniesNonAllowlistedOwner(t *testin
 // request then blocks in handleRequest until the context deadline, so we assert
 // it got past the gate (no zone-b denial) and reached the handler (timeout).
 func TestCapability_Execute_ZoneBRestriction_AllowsAllowlistedOwner(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	capability := newZoneBTestCapability(t, `{"global":{"VaultZoneBWorkflowGetSecretsRestrictEnabled":"true"},"owner":{"`+allowlistedOwner+`":{"PerOwner":{"VaultZoneBGetSecretsAllowed":"true"}}}}`)
 

--- a/core/capabilities/webapi/trigger/trigger_test.go
+++ b/core/capabilities/webapi/trigger/trigger_test.go
@@ -157,6 +157,10 @@ func requireChanMsg[T capabilities.TriggerResponse](t *testing.T, ch <-chan capa
 }
 
 func TestTriggerExecute(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	th := setup(t)
 	ctx := t.Context()
 	ctx, cancelContext := context.WithDeadline(ctx, time.Now().Add(10*time.Second))

--- a/core/logger/zap_test.go
+++ b/core/logger/zap_test.go
@@ -273,6 +273,10 @@ func TestZapLogger_Name(t *testing.T) {
 }
 
 func TestLogger_Leak(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	ac := NewUpdatableCore()
 	defer ac.Close()
 	startObjectsNum := heapObjects()

--- a/core/scripts/chaincli/config/config.go
+++ b/core/scripts/chaincli/config/config.go
@@ -65,20 +65,20 @@ type Config struct {
 
 	// Upkeep Config
 	RegistryVersion                 RegistryVersion `mapstructure:"KEEPER_REGISTRY_VERSION"`
-	RegistryAddress                 string                 `mapstructure:"KEEPER_REGISTRY_ADDRESS"`
-	RegistryConfigUpdate            bool                   `mapstructure:"KEEPER_CONFIG_UPDATE"`
-	KeepersCount                    int                    `mapstructure:"KEEPERS_COUNT"`
-	UpkeepTestRange                 int64                  `mapstructure:"UPKEEP_TEST_RANGE"`
-	UpkeepAverageEligibilityCadence int64                  `mapstructure:"UPKEEP_AVERAGE_ELIGIBILITY_CADENCE"`
-	UpkeepInterval                  int64                  `mapstructure:"UPKEEP_INTERVAL"`
-	UpkeepCheckData                 string                 `mapstructure:"UPKEEP_CHECK_DATA"`
-	UpkeepGasLimit                  uint32                 `mapstructure:"UPKEEP_GAS_LIMIT"`
-	UpkeepCount                     int64                  `mapstructure:"UPKEEP_COUNT"`
-	AddFundsAmount                  string                 `mapstructure:"UPKEEP_ADD_FUNDS_AMOUNT"`
-	VerifiableLoadTest              bool                   `mapstructure:"VERIFIABLE_LOAD_TEST"`
-	UseArbBlockNumber               bool                   `mapstructure:"USE_ARB_BLOCK_NUMBER"`
-	VerifiableLoadContractAddress   string                 `mapstructure:"VERIFIABLE_LOAD_CONTRACT_ADDRESS"`
-	UpkeepType                      UpkeepType             `mapstructure:"UPKEEP_TYPE"`
+	RegistryAddress                 string          `mapstructure:"KEEPER_REGISTRY_ADDRESS"`
+	RegistryConfigUpdate            bool            `mapstructure:"KEEPER_CONFIG_UPDATE"`
+	KeepersCount                    int             `mapstructure:"KEEPERS_COUNT"`
+	UpkeepTestRange                 int64           `mapstructure:"UPKEEP_TEST_RANGE"`
+	UpkeepAverageEligibilityCadence int64           `mapstructure:"UPKEEP_AVERAGE_ELIGIBILITY_CADENCE"`
+	UpkeepInterval                  int64           `mapstructure:"UPKEEP_INTERVAL"`
+	UpkeepCheckData                 string          `mapstructure:"UPKEEP_CHECK_DATA"`
+	UpkeepGasLimit                  uint32          `mapstructure:"UPKEEP_GAS_LIMIT"`
+	UpkeepCount                     int64           `mapstructure:"UPKEEP_COUNT"`
+	AddFundsAmount                  string          `mapstructure:"UPKEEP_ADD_FUNDS_AMOUNT"`
+	VerifiableLoadTest              bool            `mapstructure:"VERIFIABLE_LOAD_TEST"`
+	UseArbBlockNumber               bool            `mapstructure:"USE_ARB_BLOCK_NUMBER"`
+	VerifiableLoadContractAddress   string          `mapstructure:"VERIFIABLE_LOAD_CONTRACT_ADDRESS"`
+	UpkeepType                      UpkeepType      `mapstructure:"UPKEEP_TYPE"`
 
 	// Node config scraping and verification
 	NodeConfigURL string `mapstructure:"NODE_CONFIG_URL"`

--- a/core/services/arbiter/shardconfig_test.go
+++ b/core/services/arbiter/shardconfig_test.go
@@ -115,6 +115,10 @@ func TestShardConfigSyncer_GetDesiredShardCount_BeforeFetch(t *testing.T) {
 }
 
 func TestShardConfigSyncer_GetDesiredShardCount_AfterFetch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	lggr := logger.TestLogger(t)
 	mockReader := &mockShardConfigContractReader{shardCount: 42}
 	factory := mockShardConfigReaderFactory(mockReader)

--- a/core/services/chainlink/heartbeat_test.go
+++ b/core/services/chainlink/heartbeat_test.go
@@ -52,6 +52,10 @@ func TestNewHeartbeat_ConfiguresHeartbeatInterval(t *testing.T) {
 }
 
 func TestHeartbeat_MeterEvents(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	lggr := logger.TestLogger(t)
 
 	// Use a thread-safe byte collector

--- a/core/services/chainlink/node_platform_test.go
+++ b/core/services/chainlink/node_platform_test.go
@@ -410,6 +410,10 @@ func TestNodePlatformJobInfo_EmitsSubmitterAddressesForCCVExecutorJobs(t *testin
 }
 
 func TestNodePlatformJobInfo_PaginatesSubmitterAddressJobs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	obs := beholdertest.NewObserver(t)
 
 	jobs := make([]job.Job, 1001)

--- a/core/services/cron/cron_test.go
+++ b/core/services/cron/cron_test.go
@@ -51,6 +51,10 @@ func TestCronV2Pipeline(t *testing.T) {
 }
 
 func TestCronV2Schedule(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	spec := job.Job{

--- a/core/services/gateway/common/aggregation/workflow_metadata_aggregator_test.go
+++ b/core/services/gateway/common/aggregation/workflow_metadata_aggregator_test.go
@@ -342,6 +342,10 @@ func TestWorkflowMetadataAggregator_Aggregate_ChronologicalOrder_SameWorkflowNam
 }
 
 func TestWorkflowMetadataAggregator_ReapObservations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	lggr := logger.Test(t)
 	cleanupInterval := 1 * time.Second
 	testMetrics := createTestMetrics(t)
@@ -377,6 +381,10 @@ func TestWorkflowMetadataAggregator_ReapObservations(t *testing.T) {
 }
 
 func TestWorkflowMetadataAggregator_ReapObservations_UnexpiredObservation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	lggr := logger.Test(t)
 	cleanupInterval := 1 * time.Second
 	testMetrics := createTestMetrics(t)

--- a/core/services/gateway/connectionmanager_test.go
+++ b/core/services/gateway/connectionmanager_test.go
@@ -481,6 +481,10 @@ func doHandshake(t *testing.T, mgr gateway.ConnectionManager, clock clockwork.Cl
 }
 
 func TestConnectionManager_ReadDeadline_ClosesIdleConnection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	cfg, nodes := newTestConfig(t, 1)
@@ -515,6 +519,10 @@ func TestConnectionManager_ReadDeadline_ClosesIdleConnection(t *testing.T) {
 }
 
 func TestConnectionManager_ReadDeadline_ConnectionAliveWithPongs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	cfg, nodes := newTestConfig(t, 1)
@@ -554,6 +562,10 @@ func TestConnectionManager_ReadDeadline_ConnectionAliveWithPongs(t *testing.T) {
 }
 
 func TestConnectionManager_ReadDeadline_DisabledWhenZero(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	cfg, nodes := newTestConfig(t, 1)

--- a/core/services/gateway/handlers/capabilities/handler_test.go
+++ b/core/services/gateway/handlers/capabilities/handler_test.go
@@ -575,6 +575,10 @@ func TestPruneCallbacks(t *testing.T) {
 }
 
 func TestHandlerStartClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	handler, _, _, _ := setupHandler(t)
 	ctx := t.Context()
 

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
@@ -686,6 +686,10 @@ func TestIsValidJSON(t *testing.T) {
 }
 
 func TestHttpTriggerHandler_HandleUserTriggerRequest_Retries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	lggr := logger.Test(t)
 	cfg := ServiceConfig{
 		MaxTriggerRequestDurationMs: 2000, // 2 seconds for test
@@ -747,6 +751,10 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_Retries(t *testing.T) {
 }
 
 func TestHttpTriggerHandler_HandleUserTriggerRequest_SendsToNodesInParallel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	lggr := logger.Test(t)

--- a/core/services/gateway/keepalive_loop_internal_test.go
+++ b/core/services/gateway/keepalive_loop_internal_test.go
@@ -56,6 +56,10 @@ func (m *mockPingConn) Write(ctx context.Context, msgType int, _ []byte) error {
 // node's Write blocked (half-open TCP), the loop stalls and no other node
 // receives pings.
 func TestKeepAliveLoop_StuckNodeBlocksAll(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	lggr := logger.Test(t)

--- a/core/services/gateway/network/httpclient_test.go
+++ b/core/services/gateway/network/httpclient_test.go
@@ -19,6 +19,10 @@ import (
 )
 
 func TestHTTPClient_Send(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	// Setup the test environment
@@ -308,6 +312,10 @@ func TestHTTPClient_Send(t *testing.T) {
 // this means that the errors returned can change depending on whether the tests are
 // run on osx or on linux.
 func TestHTTPClient_BlocksUnallowed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	// Setup the test environment

--- a/core/services/job/models_test.go
+++ b/core/services/job/models_test.go
@@ -30,7 +30,7 @@ func TestStandardCapabilitiesSpec_Deserialization(t *testing.T) {
 	forwardingAllowed = false
 	command = "consensus"
 	config = """"""
-	
+
 	[oracle_factory]
 	enabled = true
 	bootstrap_peers = ["12D3KooWBAzThfs9pD4WcsFKCi68EUz2fZgZskDBT6JcJRndPss5@cl-keystone-two-bt-0:5001"]
@@ -313,6 +313,10 @@ func TestOCR2OracleSpec(t *testing.T) {
 }
 
 func TestWorkflowSpec_Validate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	type fields struct {
 		Workflow string
 	}

--- a/core/services/job/wasm_file_spec_factory_test.go
+++ b/core/services/job/wasm_file_spec_factory_test.go
@@ -19,6 +19,10 @@ import (
 )
 
 func TestWasmFileSpecFactory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	binaryLocation := createTestBinary(t)
 	configLocation := "testdata/config.json"
 	config, err := os.ReadFile(configLocation)

--- a/core/services/llo/observation/data_source_test.go
+++ b/core/services/llo/observation/data_source_test.go
@@ -195,6 +195,10 @@ func (s *mockCache) AddMany(values map[llotypes.StreamID]lloprotocol.StreamValue
 }
 
 func Test_DataSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	lggr := logger.NullLogger
 	mainCtx := t.Context()

--- a/core/services/llo/telem/sampling_test.go
+++ b/core/services/llo/telem/sampling_test.go
@@ -141,6 +141,10 @@ func TestSample(t *testing.T) {
 
 // TestPruningLoop ensures the pruning loop works as expected.
 func TestPruningLoop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	lggr := logger.TestSugared(t)

--- a/core/services/nurse_test.go
+++ b/core/services/nurse_test.go
@@ -98,6 +98,10 @@ func (c mockConfig) GoroutineThreshold() int {
 }
 
 func TestNurse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	l := logger.TestLogger(t)
 	nrse := NewNurse(newMockConfig(t), l)
 	nrse.AddCheck("test", func() (bool, Meta) { return true, Meta{} })

--- a/core/services/ocr/config_overrider_test.go
+++ b/core/services/ocr/config_overrider_test.go
@@ -56,6 +56,10 @@ func newConfigOverriderUni(t *testing.T, pollITicker utils.TickerBase, flagsCont
 }
 
 func TestIntegration_OCRConfigOverrider_EntersHibernation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	g := gomega.NewWithT(t)
 
 	flagsContract := mocks.NewFlags(t)

--- a/core/services/ocr2/plugins/llo/bench/plugin_bench_test.go
+++ b/core/services/ocr2/plugins/llo/bench/plugin_bench_test.go
@@ -38,6 +38,10 @@ var benchWorkloads = []workload{
 // same format. This guards the benchmark: if the two drivers diverge, the
 // latency numbers are not comparing like for like.
 func TestParity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	for _, w := range benchWorkloads {
 		t.Run(w.String(), func(t *testing.T) {

--- a/core/services/ocr2/plugins/vault/plugin_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_test.go
@@ -8514,6 +8514,10 @@ func TestLogUserErrorAware(t *testing.T) {
 }
 
 func TestPlugin_broadcastBlobPayloads(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("empty payloads returns empty slice", func(t *testing.T) {
 		marshalBlobOverride := func(ocr3_1types.BlobHandle) ([]byte, error) {
 			return []byte("handle"), nil

--- a/core/services/ocrcommon/data_source_test.go
+++ b/core/services/ocrcommon/data_source_test.go
@@ -52,6 +52,10 @@ func Test_InMemoryDataSource(t *testing.T) {
 }
 
 func Test_CachedInMemoryDataSourceErrHandling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	changeResultValue := func(runner *pipelinemocks.Runner, value string, returnErr, once bool) {
 		result := pipeline.Result{
 			Value: value,

--- a/core/services/standardcapabilities/standard_capabilities_test.go
+++ b/core/services/standardcapabilities/standard_capabilities_test.go
@@ -183,6 +183,10 @@ func (c *capturingRegistrar) RegisterLOOP(cfg plugins.CmdConfig) (func() *exec.C
 func (c *capturingRegistrar) UnregisterLOOP(string) {}
 
 func TestStandardCapabilityStart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("NOK-not_found_binary_does_not_block", func(t *testing.T) {
 		ctx := t.Context()
 		lggr := logger.TestLogger(t)

--- a/core/services/synchronization/chip_ingress_batch_client_test.go
+++ b/core/services/synchronization/chip_ingress_batch_client_test.go
@@ -297,6 +297,10 @@ func TestChipIngressBatchClient_ChainSelectorInAttributes(t *testing.T) {
 }
 
 func TestChipIngressBatchClient_HealthMonitoring(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	g := gomega.NewWithT(t)
 
 	chipClient := chipingressmocks.NewClient(t)
@@ -318,6 +322,10 @@ func TestChipIngressBatchClient_HealthMonitoring(t *testing.T) {
 }
 
 func TestChipIngressBatchClient_HealthMonitoring_PingFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	g := gomega.NewWithT(t)
 
 	chipClient := chipingressmocks.NewClient(t)

--- a/core/services/workflows/cmd/cre/examples/compile_test.go
+++ b/core/services/workflows/cmd/cre/examples/compile_test.go
@@ -12,6 +12,10 @@ import (
 const pathPrefix = "core/services/workflows/cmd/cre/examples"
 
 func Test_AllExampleWorkflowsCompileToWASM(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	paths := []string{
 		"v2/http_read",

--- a/core/services/workflows/cmd/cre/utils/runner_test.go
+++ b/core/services/workflows/cmd/cre/utils/runner_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 func TestRunner(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	t.Run("happy path with an empty workflow", func(t *testing.T) {

--- a/core/services/workflows/internal/retry_test.go
+++ b/core/services/workflows/internal/retry_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestRetryableZeroMaxRetries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)

--- a/core/services/workflows/store/store_memory_test.go
+++ b/core/services/workflows/store/store_memory_test.go
@@ -114,6 +114,10 @@ func TestInMemoryStore_DeleteByWorkflowID(t *testing.T) {
 }
 
 func TestInMemoryStore_ExpiresNonCompletedExecutions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	expirationDuration := 50 * time.Millisecond
 

--- a/core/services/workflows/syncer/v2/fetcher_test.go
+++ b/core/services/workflows/syncer/v2/fetcher_test.go
@@ -49,6 +49,10 @@ func (w *wrapper) GetGatewayConnector() connector.GatewayConnector {
 }
 
 func TestNewFetcherService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	ctx := t.Context()
 	lggr := logger.TestLogger(t)
@@ -359,6 +363,10 @@ func TestNewFetcherService(t *testing.T) {
 }
 
 func TestNewFetcherFunc(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	lggr := logger.TestLogger(t)
 	ctx := t.Context()

--- a/core/services/workflows/syncer/v2/handler_test.go
+++ b/core/services/workflows/syncer/v2/handler_test.go
@@ -1617,7 +1617,7 @@ func (m *mockLinkingService) GetOrganizationFromWorkflowOwner(ctx context.Contex
 	}, nil
 }
 
-//nolint:paralleltest // beholdertest.NewObserver uses global state, can't run in parallel
+//nolint:paralleltest // beholdertest.NewObserver(t) cannot be used in parallel tests because it relies on global state
 func Test_Handler_OrganizationID(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/core/services/workflows/v2/engine_execution_concurrency_test.go
+++ b/core/services/workflows/v2/engine_execution_concurrency_test.go
@@ -159,6 +159,10 @@ func TestEngine_ExecutionConcurrencySerializesOverlappingRuns(t *testing.T) {
 // fresh events are sent and all execute. Total: 10 events, 5 expire, 5
 // execute.
 func TestEngine_StaleTriggerEventIsSkipped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	const queueTimeout = 5 * time.Second

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -1510,6 +1510,10 @@ func TestEngine_CapabilityCallTimeout(t *testing.T) {
 }
 
 func TestEngine_WASMBinary_Simple(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	cmd := "core/services/workflows/test/wasm/v2/cmd"
 	log := logger.Test(t)
@@ -1594,6 +1598,10 @@ func TestEngine_WASMBinary_Simple(t *testing.T) {
 }
 
 func TestEngine_WASMBinary_With_Config(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	cmd := "core/services/workflows/test/wasm/v2/cmd/with_config"
 	binaryB := wasmtest.GetTestBinary(t, cmd, false)
 
@@ -1690,6 +1698,10 @@ func TestEngine_WASMBinary_With_Config(t *testing.T) {
 }
 
 func TestSecretsFetcher_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	cmd := "core/services/workflows/test/wasm/v2/cmd/with_secrets"
 	binaryB := wasmtest.GetTestBinary(t, cmd, false)
@@ -1979,6 +1991,10 @@ func TestEngine_DuplicateTriggerSameConfig(t *testing.T) {
 }
 
 func TestEngine_DeduplicatesSameEventID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	module := modulemocks.NewModuleV2(t)
@@ -2289,6 +2305,10 @@ func TestEngine_HandleNewDON(t *testing.T) {
 // 3. Trigger a real DON update via NotifyDonSet() with ConfigVersion = 2
 // 4. Verify that the beholder logger labels are still pinned to ConfigVersion = 1
 func TestEngine_DonVersionLabelUpdatePinned(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)

--- a/core/sessions/user_test.go
+++ b/core/sessions/user_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestNewUser(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tests := []struct {

--- a/core/shutdown/shutdown_test.go
+++ b/core/shutdown/shutdown_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestHandleShutdown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	proc, err := os.FindProcess(os.Getpid())
 	require.NoError(t, err)
 

--- a/core/utils/backoff_ticker_test.go
+++ b/core/utils/backoff_ticker_test.go
@@ -45,6 +45,10 @@ func TestBackoffTicker_StopTwice(t *testing.T) {
 }
 
 func TestBackoffTicker_NoTicksAfterStop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	min := 100 * time.Millisecond
@@ -78,6 +82,10 @@ func TestBackoffTicker_NoTicksAfterStop(t *testing.T) {
 }
 
 func TestBackoffTicker_Ticks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	min := 100 * time.Millisecond

--- a/core/utils/finite_ticker_test.go
+++ b/core/utils/finite_ticker_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestFiniteTicker(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	var counter atomic.Int32

--- a/core/utils/utils_test.go
+++ b/core/utils/utils_test.go
@@ -381,6 +381,10 @@ func TestValidateCronSchedule(t *testing.T) {
 }
 
 func TestPausableTicker(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	var counter atomic.Int32
@@ -427,6 +431,10 @@ func TestPausableTicker(t *testing.T) {
 }
 
 func TestCronTicker(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	var counter atomic.Int32

--- a/core/web/evm_transfer_controller_test.go
+++ b/core/web/evm_transfer_controller_test.go
@@ -457,6 +457,10 @@ func TestTransfersController_CreateSuccess_eip1559(t *testing.T) {
 }
 
 func TestTransfersController_FindTxAttempt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	tx := txmgr.Tx{ID: 1}
 	attempt := txmgr.TxAttempt{ID: 2}


### PR DESCRIPTION
## Intent

Make `-short` flag actually use short test executions. Handy for git hooks and quick checks.

Implemented with:

```sh
go test -json -short ./... | gotestsum tool slowest --skip-stmt "testing.Short" --threshold 200ms
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>