### PR TITLE
Fix: bump pinned curl to match current Ubuntu 24.04 archive

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -117,7 +117,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates=20260601~24.04.1 \
     gnupg=2.4.4-2ubuntu17.4 \
     lsb-release=12.0-2 \
-    curl=8.5.0-2ubuntu10.11 \
+    curl=8.5.0-2ubuntu10.12 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Postgres for CLI tools, needed specifically for DB backups

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -116,7 +116,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates=20260601~24.04.1 \
     gnupg=2.4.4-2ubuntu17.4 \
     lsb-release=12.0-2 \
-    curl=8.5.0-2ubuntu10.11 \
+    curl=8.5.0-2ubuntu10.12 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Postgres for CLI tools, needed specifically for DB backups


### PR DESCRIPTION
## What

Bumps `curl=8.5.0-2ubuntu10.11` → `8.5.0-2ubuntu10.12` in `core/chainlink.Dockerfile` and `plugins/chainlink.Dockerfile`.

## Why

Every docker build job (core, ccip, both plugin variants) is failing right now with:

```
curl : Depends: libcurl4t64 (= 8.5.0-2ubuntu10.11) but 8.5.0-2ubuntu10.12 is to be installed
E: Unable to correct problems, you have held broken packages.
```

The Ubuntu 24.04 archive has moved to `libcurl4t64 8.5.0-2ubuntu10.12`; the pinned `curl` version no longer resolves. This is base-image drift, not code — confirmed on #23460, which only touches `server.go` and fails at the identical Dockerfile line.

## Verification

CI log for the failing build explicitly states `8.5.0-2ubuntu10.12 is to be installed`, which is what this PR pins to.