### PR TITLE
Improves UX of Linting in CI

### DIFF
--- a/.github/actions/golangci-lint/action.yml
+++ b/.github/actions/golangci-lint/action.yml
@@ -94,7 +94,7 @@ runs:
         REPORT_PATH: ${{ github.workspace }}/${{ steps.set-working-directory.outputs.golangci-lint-working-directory }}golangci-lint-report.xml
         REPORT_PATH_JSON: ${{ github.workspace }}/${{ steps.set-working-directory.outputs.golangci-lint-working-directory }}golangci-lint-report.json
       with:
-        version: v2.13.0
+        version: v2.13.1
         only-new-issues: true
         skip-cache: true
         args: --output.text.path=stdout --output.checkstyle.path=${{ env.REPORT_PATH }} --output.json.path=${{ env.REPORT_PATH_JSON }} --max-same-issues=0 --max-issues-per-linter=0

--- a/.github/actions/golangci-lint/action.yml
+++ b/.github/actions/golangci-lint/action.yml
@@ -97,7 +97,7 @@ runs:
         version: v2.12.2
         only-new-issues: true
         skip-cache: true
-        args: --output.checkstyle.path=${{ env.REPORT_PATH }} --output.json.path=${{ env.REPORT_PATH_JSON }} --max-same-issues=0 --max-issues-per-linter=0
+        args: --output.text.path=stdout --output.checkstyle.path=${{ env.REPORT_PATH }} --output.json.path=${{ env.REPORT_PATH_JSON }} --max-same-issues=0 --max-issues-per-linter=0
         working-directory: ${{ steps.set-working-directory.outputs.golangci-lint-working-directory }}
 
     - name: Print Golangci-lint report results
@@ -105,25 +105,10 @@ runs:
       if: failure()
       shell: bash
       env:
-        REPORT_PATH: ./${{ steps.set-working-directory.outputs.golangci-lint-working-directory }}golangci-lint-report.xml
         REPORT_PATH_JSON: ./${{ steps.set-working-directory.outputs.golangci-lint-working-directory }}golangci-lint-report.json
+        MODULE_NAME: ${{ inputs.go-directory }}
       run: |
-        cat ${REPORT_PATH}
-        echo "file-count=$(jq '[.Issues[].Pos.Filename] | unique | length' ${REPORT_PATH_JSON})" | tee -a $GITHUB_OUTPUT
-        echo "issue-count=$(jq '.Issues | length' ./${REPORT_PATH_JSON})" | tee -a $GITHUB_OUTPUT
-        echo "critical-issue-count=$(jq '[.Issues[].Severity | select(. | IN("high", "medium"))] | length' ${REPORT_PATH_JSON})" | tee -a $GITHUB_OUTPUT
-        echo 'per-source-count<<EOF' | tee -a $GITHUB_OUTPUT
-        echo "$(jq -r '.Issues[].FromLinter' ${REPORT_PATH_JSON} | sort | uniq -c | sort -nr)" | tee -a $GITHUB_OUTPUT
-        echo 'EOF' | tee -a $GITHUB_OUTPUT
-        echo 'per-severity-count<<EOF' | tee -a $GITHUB_OUTPUT
-        echo "$(jq -r '.Issues[].Severity | select(. != "") // "none"' ${REPORT_PATH_JSON} | sort | uniq -c | awk '
-          /high/   {print "1 "$0}
-          /medium/ {print "2 "$0}
-          /low/    {print "3 "$0}
-          /warn/   {print "4 "$0}
-          /none/   {print "5 "$0}
-          ' | sort -n | sed 's/^[1-5] //')" | tee -a $GITHUB_OUTPUT
-        echo 'EOF' | tee -a $GITHUB_OUTPUT
+        python3 "${{ github.action_path }}/process_report.py"
 
       # Get a valid name for the upload-artifact step.
       # Avoid error: `The artifact name is not valid: <path>/<to>/<artifact>/` caused by `/`.

--- a/.github/actions/golangci-lint/action.yml
+++ b/.github/actions/golangci-lint/action.yml
@@ -102,7 +102,7 @@ runs:
 
     - name: Print Golangci-lint report results
       id: print
-      if: failure()
+      if: always()
       shell: bash
       env:
         REPORT_PATH_JSON: ./${{ steps.set-working-directory.outputs.golangci-lint-working-directory }}golangci-lint-report.json
@@ -110,38 +110,13 @@ runs:
       run: |
         python3 "${{ github.action_path }}/process_report.py"
 
-      # Get a valid name for the upload-artifact step.
-      # Avoid error: `The artifact name is not valid: <path>/<to>/<artifact>/` caused by `/`.
-      # Remove trailing `/` from the directory name: `core/scripts/` -> `core/scripts`.
-      # Replace remaining `/` with `-`: `core/scripts` -> `core-scripts`.
-      # Assign `root` if the directory name is empty (ref: step.id: set-working-directory).
-    - name: Get valid suffix for artifact name
-      if: always()
-      id: suffix
-      shell: bash
-      run: |
-        go_directory=${{ steps.set-working-directory.outputs.golangci-lint-working-directory }}
-        echo "Validating if directory name '$go_directory' is empty or has slashes"
-
-        if [[ $go_directory == *\/* ]]; then
-            suffix=$(echo "$go_directory" | sed 's:\/$::' | tr '/' '-')
-            echo "Directory name with slashes '$go_directory' updated to a valid artifact suffix '$suffix'"
-        elif [[ $go_directory == "" ]]; then
-          suffix="root"
-          echo "Root directory (empty string) updated to a valid artifact suffix '$suffix'"
-        else
-          suffix="$go_directory"
-          echo "Directory name is valid for the artifact suffix: '$suffix'"
-        fi
-
-        echo "suffix=${suffix}" >> "${GITHUB_OUTPUT}"
-
     - name: Store Golangci-lint report artifact
       if: always()
       id: upload-artifact
       uses: actions/upload-artifact@v7
       with:
         # Use a unique suffix for each lint report artifact to avoid duplication errors
-        name: golangci-lint-report-${{ steps.suffix.outputs.suffix }}
+        name: golangci-lint-report-${{ steps.print.outputs.suffix }}
         # N/B: value may be empty (no slash) OR `<path>/<to>/<module>/` (with slash tat the end)
         path: ./${{ steps.set-working-directory.outputs.golangci-lint-working-directory }}golangci-lint-report.*
+

--- a/.github/actions/golangci-lint/action.yml
+++ b/.github/actions/golangci-lint/action.yml
@@ -94,7 +94,7 @@ runs:
         REPORT_PATH: ${{ github.workspace }}/${{ steps.set-working-directory.outputs.golangci-lint-working-directory }}golangci-lint-report.xml
         REPORT_PATH_JSON: ${{ github.workspace }}/${{ steps.set-working-directory.outputs.golangci-lint-working-directory }}golangci-lint-report.json
       with:
-        version: v2.12.2
+        version: v2.13.0
         only-new-issues: true
         skip-cache: true
         args: --output.text.path=stdout --output.checkstyle.path=${{ env.REPORT_PATH }} --output.json.path=${{ env.REPORT_PATH_JSON }} --max-same-issues=0 --max-issues-per-linter=0
@@ -119,4 +119,3 @@ runs:
         name: golangci-lint-report-${{ steps.print.outputs.suffix }}
         # N/B: value may be empty (no slash) OR `<path>/<to>/<module>/` (with slash tat the end)
         path: ./${{ steps.set-working-directory.outputs.golangci-lint-working-directory }}golangci-lint-report.*
-

--- a/.github/actions/golangci-lint/process_report.py
+++ b/.github/actions/golangci-lint/process_report.py
@@ -4,7 +4,14 @@ import collections
 import json
 import os
 import sys
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+
+def get_artifact_suffix(module_name: str) -> str:
+    clean = module_name.strip().rstrip("/")
+    if clean.startswith("./"):
+        clean = clean[2:]
+    return clean.replace("/", "-") if clean and clean != "." else "root"
 
 
 def process(
@@ -12,7 +19,10 @@ def process(
     module_name: str = "",
     summary_path: Optional[str] = None,
     output_path: Optional[str] = None,
+    critical_severities: Sequence[str] = ("high", "medium"),
 ) -> Tuple[List[str], str, Dict[str, Any]]:
+    suffix = get_artifact_suffix(module_name)
+
     if not os.path.isfile(report_path):
         raise FileNotFoundError(f"Report file not found: {report_path}")
 
@@ -41,10 +51,11 @@ def process(
     file_count = len(filenames)
     issue_count = len(issues)
 
+    critical_set = {s.lower() for s in critical_severities}
     critical_issue_count = sum(
         1
         for issue in issues
-        if (issue.get("Severity") or "").lower() in ("high", "medium")
+        if (issue.get("Severity") or "").lower() in critical_set
     )
 
     linter_counts = collections.Counter(
@@ -72,6 +83,7 @@ def process(
         "critical-issue-count": critical_issue_count,
         "per-source-count": per_source_str,
         "per-severity-count": per_severity_str,
+        "suffix": suffix,
     }
 
     # 3. Markdown Step Summary
@@ -129,6 +141,7 @@ def process(
             f.write(f"file-count={file_count}\n")
             f.write(f"issue-count={issue_count}\n")
             f.write(f"critical-issue-count={critical_issue_count}\n")
+            f.write(f"suffix={suffix}\n")
             f.write("per-source-count<<EOF\n")
             f.write(per_source_str + "\n")
             f.write("EOF\n")
@@ -161,6 +174,17 @@ def main() -> None:
         default=os.environ.get("GITHUB_OUTPUT"),
         help="Path to GitHub Output file",
     )
+    critical_default = (
+        os.environ["CRITICAL_SEVERITIES"].split(",")
+        if "CRITICAL_SEVERITIES" in os.environ
+        else ["high", "medium"]
+    )
+    parser.add_argument(
+        "--critical-severities",
+        nargs="+",
+        default=critical_default,
+        help="List of severities to treat as critical",
+    )
     args = parser.parse_args()
 
     if not args.report_path:
@@ -173,6 +197,7 @@ def main() -> None:
             module_name=args.module_name,
             summary_path=args.summary_path,
             output_path=args.output_path,
+            critical_severities=args.critical_severities,
         )
         for annotation in annotations:
             print(annotation)
@@ -183,3 +208,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/.github/actions/golangci-lint/process_report.py
+++ b/.github/actions/golangci-lint/process_report.py
@@ -23,11 +23,15 @@ def process(
 ) -> Tuple[str, Dict[str, Any]]:
     suffix = get_artifact_suffix(module_name)
 
-    if not os.path.isfile(report_path):
-        raise FileNotFoundError(f"Report file not found: {report_path}")
-
-    with open(report_path, "r", encoding="utf-8") as f:
-        data = json.load(f)
+    if report_path and os.path.isfile(report_path):
+        with open(report_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    else:
+        print(
+            f"::warning::Lint report not found at {report_path!r}; treating as empty report",
+            file=sys.stderr,
+        )
+        data = {"Issues": []}
 
     issues: List[Dict[str, Any]] = data.get("Issues") or []
 
@@ -76,8 +80,11 @@ def process(
     }
 
     # 2. Markdown Step Summary
+    display_module_name = module_name.strip()
+    if display_module_name in ("", ".", "./"):
+        display_module_name = "root"
     summary_lines = [
-        f"### 🔍 GolangCI Lint Results: `{module_name}`",
+        f"### 🔍 GolangCI Lint Results: `{display_module_name}`",
         "",
         "| Metric | Count |",
         "| :--- | :--- |",

--- a/.github/actions/golangci-lint/process_report.py
+++ b/.github/actions/golangci-lint/process_report.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+import argparse
+import collections
+import json
+import os
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def process(
+    report_path: str,
+    module_name: str = "",
+    summary_path: Optional[str] = None,
+    output_path: Optional[str] = None,
+) -> Tuple[List[str], str, Dict[str, Any]]:
+    if not os.path.isfile(report_path):
+        raise FileNotFoundError(f"Report file not found: {report_path}")
+
+    with open(report_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    issues: List[Dict[str, Any]] = data.get("Issues") or []
+
+    # 1. Annotations
+    annotations: List[str] = []
+    for issue in issues:
+        pos = issue.get("Pos") or {}
+        filename = pos.get("Filename", "")
+        line = pos.get("Line", 1)
+        col = pos.get("Column", 1)
+        linter = issue.get("FromLinter", "golangci-lint")
+        text = issue.get("Text", "").strip().replace("\r", "").replace("\n", " ")
+        annotations.append(f"::error file={filename},line={line},col={col},title={linter}::{text}")
+
+    # 2. Metrics & Counts
+    filenames = {
+        issue.get("Pos", {}).get("Filename")
+        for issue in issues
+        if issue.get("Pos", {}).get("Filename")
+    }
+    file_count = len(filenames)
+    issue_count = len(issues)
+
+    critical_issue_count = sum(
+        1
+        for issue in issues
+        if (issue.get("Severity") or "").lower() in ("high", "medium")
+    )
+
+    linter_counts = collections.Counter(
+        issue.get("FromLinter") or "unknown" for issue in issues
+    )
+    # Sort by count desc, then linter name asc
+    sorted_linters = sorted(linter_counts.items(), key=lambda x: (-x[1], x[0]))
+    per_source_lines = [f"{count:>4} {linter}" for linter, count in sorted_linters]
+    per_source_str = "\n".join(per_source_lines)
+
+    severity_order = {"high": 1, "medium": 2, "low": 3, "warn": 4, "none": 5}
+    severity_counts = collections.Counter(
+        (issue.get("Severity") or "none").lower() for issue in issues
+    )
+    sorted_severities = sorted(
+        severity_counts.items(),
+        key=lambda x: (severity_order.get(x[0], 99), -x[1]),
+    )
+    per_severity_lines = [f"{count:>4} {sev}" for sev, count in sorted_severities]
+    per_severity_str = "\n".join(per_severity_lines)
+
+    outputs = {
+        "file-count": file_count,
+        "issue-count": issue_count,
+        "critical-issue-count": critical_issue_count,
+        "per-source-count": per_source_str,
+        "per-severity-count": per_severity_str,
+    }
+
+    # 3. Markdown Step Summary
+    summary_lines = [
+        f"### 🔍 GolangCI Lint Results: `{module_name}`",
+        "",
+        "| Metric | Count |",
+        "| :--- | :--- |",
+        f"| **Total Issues** | {issue_count} |",
+        f"| **Files Affected** | {file_count} |",
+        f"| **Critical Issues** | {critical_issue_count} |",
+        "",
+    ]
+
+    if issues:
+        summary_lines.extend(
+            [
+                "<details><summary><b>Detailed Issues List</b></summary>",
+                "",
+                "| File | Line | Linter | Message |",
+                "| :--- | :--- | :--- | :--- |",
+            ]
+        )
+        for issue in issues[:100]:
+            pos = issue.get("Pos") or {}
+            filename = pos.get("Filename", "")
+            line = pos.get("Line", "")
+            linter = issue.get("FromLinter", "")
+            msg = (
+                issue.get("Text", "")
+                .strip()
+                .replace("\r", "")
+                .replace("\n", " ")
+                .replace("|", "&#124;")
+            )
+            summary_lines.append(f"| `{filename}` | {line} | `{linter}` | {msg} |")
+
+        summary_lines.append("")
+        if len(issues) > 100:
+            summary_lines.append(
+                "*...showing first 100 issues only (see full report artifact for complete list)*\n"
+            )
+        summary_lines.append("</details>\n")
+
+    summary_content = "\n".join(summary_lines)
+
+    # Write summary if path provided
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as f:
+            f.write(summary_content + "\n")
+
+    # Write GITHUB_OUTPUT if path provided
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as f:
+            f.write(f"file-count={file_count}\n")
+            f.write(f"issue-count={issue_count}\n")
+            f.write(f"critical-issue-count={critical_issue_count}\n")
+            f.write("per-source-count<<EOF\n")
+            f.write(per_source_str + "\n")
+            f.write("EOF\n")
+            f.write("per-severity-count<<EOF\n")
+            f.write(per_severity_str + "\n")
+            f.write("EOF\n")
+
+    return annotations, summary_content, outputs
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Process GolangCI-Lint JSON report.")
+    parser.add_argument(
+        "--report-path",
+        default=os.environ.get("REPORT_PATH_JSON"),
+        help="Path to JSON report file",
+    )
+    parser.add_argument(
+        "--module-name",
+        default=os.environ.get("MODULE_NAME", ""),
+        help="Module name",
+    )
+    parser.add_argument(
+        "--summary-path",
+        default=os.environ.get("GITHUB_STEP_SUMMARY"),
+        help="Path to GitHub Step Summary file",
+    )
+    parser.add_argument(
+        "--output-path",
+        default=os.environ.get("GITHUB_OUTPUT"),
+        help="Path to GitHub Output file",
+    )
+    args = parser.parse_args()
+
+    if not args.report_path:
+        print("::error::Report path not specified via --report-path or REPORT_PATH_JSON", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        annotations, _, _ = process(
+            report_path=args.report_path,
+            module_name=args.module_name,
+            summary_path=args.summary_path,
+            output_path=args.output_path,
+        )
+        for annotation in annotations:
+            print(annotation)
+    except Exception as e:
+        print(f"::error::Failed to process lint report: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/golangci-lint/process_report.py
+++ b/.github/actions/golangci-lint/process_report.py
@@ -20,7 +20,7 @@ def process(
     summary_path: Optional[str] = None,
     output_path: Optional[str] = None,
     critical_severities: Sequence[str] = ("high", "medium"),
-) -> Tuple[List[str], str, Dict[str, Any]]:
+) -> Tuple[str, Dict[str, Any]]:
     suffix = get_artifact_suffix(module_name)
 
     if not os.path.isfile(report_path):
@@ -31,18 +31,7 @@ def process(
 
     issues: List[Dict[str, Any]] = data.get("Issues") or []
 
-    # 1. Annotations
-    annotations: List[str] = []
-    for issue in issues:
-        pos = issue.get("Pos") or {}
-        filename = pos.get("Filename", "")
-        line = pos.get("Line", 1)
-        col = pos.get("Column", 1)
-        linter = issue.get("FromLinter", "golangci-lint")
-        text = issue.get("Text", "").strip().replace("\r", "").replace("\n", " ")
-        annotations.append(f"::error file={filename},line={line},col={col},title={linter}::{text}")
-
-    # 2. Metrics & Counts
+    # 1. Metrics & Counts
     filenames = {
         issue.get("Pos", {}).get("Filename")
         for issue in issues
@@ -86,7 +75,7 @@ def process(
         "suffix": suffix,
     }
 
-    # 3. Markdown Step Summary
+    # 2. Markdown Step Summary
     summary_lines = [
         f"### 🔍 GolangCI Lint Results: `{module_name}`",
         "",
@@ -149,7 +138,7 @@ def process(
             f.write(per_severity_str + "\n")
             f.write("EOF\n")
 
-    return annotations, summary_content, outputs
+    return summary_content, outputs
 
 
 def main() -> None:
@@ -192,15 +181,13 @@ def main() -> None:
         sys.exit(1)
 
     try:
-        annotations, _, _ = process(
+        process(
             report_path=args.report_path,
             module_name=args.module_name,
             summary_path=args.summary_path,
             output_path=args.output_path,
             critical_severities=args.critical_severities,
         )
-        for annotation in annotations:
-            print(annotation)
     except Exception as e:
         print(f"::error::Failed to process lint report: {e}", file=sys.stderr)
         sys.exit(1)

--- a/.github/actions/golangci-lint/test_process_report.py
+++ b/.github/actions/golangci-lint/test_process_report.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import process_report
+
+
+class TestProcessReport(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.report_file = Path(self.temp_dir.name) / "report.json"
+        self.output_file = Path(self.temp_dir.name) / "output.txt"
+        self.summary_file = Path(self.temp_dir.name) / "summary.md"
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_process_report_with_issues(self):
+        data = {
+            "Issues": [
+                {
+                    "FromLinter": "paralleltest",
+                    "Text": "Function TestFoo missing parallel\n",
+                    "Severity": "high",
+                    "Pos": {
+                        "Filename": "core/foo_test.go",
+                        "Line": 10,
+                        "Column": 2,
+                    },
+                },
+                {
+                    "FromLinter": "revive",
+                    "Text": "exported method Bar should have comment | doc",
+                    "Severity": "low",
+                    "Pos": {
+                        "Filename": "core/foo_test.go",
+                        "Line": 25,
+                        "Column": 1,
+                    },
+                },
+                {
+                    "FromLinter": "revive",
+                    "Text": "unused param x",
+                    "Severity": "medium",
+                    "Pos": {
+                        "Filename": "core/bar.go",
+                        "Line": 5,
+                        "Column": 8,
+                    },
+                },
+            ]
+        }
+        with open(self.report_file, "w") as f:
+            json.dump(data, f)
+
+        annotations, summary, outputs = process_report.process(
+            report_path=str(self.report_file),
+            module_name="core",
+            summary_path=str(self.summary_file),
+            output_path=str(self.output_file),
+        )
+
+        # Check annotations
+        self.assertEqual(len(annotations), 3)
+        self.assertEqual(
+            annotations[0],
+            "::error file=core/foo_test.go,line=10,col=2,title=paralleltest::Function TestFoo missing parallel",
+        )
+
+        # Check outputs
+        self.assertEqual(outputs["file-count"], 2)
+        self.assertEqual(outputs["issue-count"], 3)
+        self.assertEqual(outputs["critical-issue-count"], 2)  # high (1) + medium (1)
+        self.assertIn("2 revive", outputs["per-source-count"])
+        self.assertIn("1 paralleltest", outputs["per-source-count"])
+        self.assertIn("1 high", outputs["per-severity-count"])
+        self.assertIn("1 medium", outputs["per-severity-count"])
+        self.assertIn("1 low", outputs["per-severity-count"])
+
+        # Check summary file content
+        with open(self.summary_file, "r") as f:
+            summary_content = f.read()
+        self.assertIn("### 🔍 GolangCI Lint Results: `core`", summary_content)
+        self.assertIn("| **Total Issues** | 3 |", summary_content)
+        self.assertIn("| **Files Affected** | 2 |", summary_content)
+        self.assertIn("| **Critical Issues** | 2 |", summary_content)
+        self.assertIn("`core/foo_test.go`", summary_content)
+        self.assertIn("exported method Bar should have comment &#124; doc", summary_content)
+
+    def test_process_report_empty_issues(self):
+        data = {"Issues": []}
+        with open(self.report_file, "w") as f:
+            json.dump(data, f)
+
+        annotations, summary, outputs = process_report.process(
+            report_path=str(self.report_file),
+            module_name="plugins",
+            summary_path=str(self.summary_file),
+            output_path=str(self.output_file),
+        )
+
+        self.assertEqual(len(annotations), 0)
+        self.assertEqual(outputs["file-count"], 0)
+        self.assertEqual(outputs["issue-count"], 0)
+        self.assertEqual(outputs["critical-issue-count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/actions/golangci-lint/test_process_report.py
+++ b/.github/actions/golangci-lint/test_process_report.py
@@ -56,18 +56,11 @@ class TestProcessReport(unittest.TestCase):
         with open(self.report_file, "w") as f:
             json.dump(data, f)
 
-        annotations, summary, outputs = process_report.process(
+        summary, outputs = process_report.process(
             report_path=str(self.report_file),
             module_name="core",
             summary_path=str(self.summary_file),
             output_path=str(self.output_file),
-        )
-
-        # Check annotations
-        self.assertEqual(len(annotations), 3)
-        self.assertEqual(
-            annotations[0],
-            "::error file=core/foo_test.go,line=10,col=2,title=paralleltest::Function TestFoo missing parallel",
         )
 
         # Check outputs
@@ -95,14 +88,13 @@ class TestProcessReport(unittest.TestCase):
         with open(self.report_file, "w") as f:
             json.dump(data, f)
 
-        annotations, summary, outputs = process_report.process(
+        summary, outputs = process_report.process(
             report_path=str(self.report_file),
             module_name="plugins",
             summary_path=str(self.summary_file),
             output_path=str(self.output_file),
         )
 
-        self.assertEqual(len(annotations), 0)
         self.assertEqual(outputs["file-count"], 0)
         self.assertEqual(outputs["issue-count"], 0)
         self.assertEqual(outputs["critical-issue-count"], 0)
@@ -134,7 +126,7 @@ class TestProcessReport(unittest.TestCase):
             json.dump(data, f)
 
         # When only 'high' is critical
-        _, _, outputs = process_report.process(
+        _, outputs = process_report.process(
             report_path=str(self.report_file),
             module_name="core",
             summary_path=str(self.summary_file),
@@ -144,7 +136,7 @@ class TestProcessReport(unittest.TestCase):
         self.assertEqual(outputs["critical-issue-count"], 1)
 
         # When none are critical
-        _, _, outputs = process_report.process(
+        _, outputs = process_report.process(
             report_path=str(self.report_file),
             module_name="core",
             summary_path=str(self.summary_file),

--- a/.github/actions/golangci-lint/test_process_report.py
+++ b/.github/actions/golangci-lint/test_process_report.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import json
-import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -98,6 +97,24 @@ class TestProcessReport(unittest.TestCase):
         self.assertEqual(outputs["file-count"], 0)
         self.assertEqual(outputs["issue-count"], 0)
         self.assertEqual(outputs["critical-issue-count"], 0)
+
+    def test_process_report_missing_file_treated_as_empty(self):
+        missing = Path(self.temp_dir.name) / "does-not-exist.json"
+
+        summary, outputs = process_report.process(
+            report_path=str(missing),
+            module_name="core/scripts",
+            summary_path=str(self.summary_file),
+            output_path=str(self.output_file),
+        )
+
+        self.assertEqual(outputs["file-count"], 0)
+        self.assertEqual(outputs["issue-count"], 0)
+        self.assertEqual(outputs["critical-issue-count"], 0)
+        self.assertEqual(outputs["suffix"], "core-scripts")
+
+        with open(self.output_file, "r") as f:
+            self.assertIn("suffix=core-scripts", f.read())
 
     def test_process_report_custom_critical_severities(self):
         data = {

--- a/.github/actions/golangci-lint/test_process_report.py
+++ b/.github/actions/golangci-lint/test_process_report.py
@@ -107,6 +107,62 @@ class TestProcessReport(unittest.TestCase):
         self.assertEqual(outputs["issue-count"], 0)
         self.assertEqual(outputs["critical-issue-count"], 0)
 
+    def test_process_report_custom_critical_severities(self):
+        data = {
+            "Issues": [
+                {
+                    "FromLinter": "paralleltest",
+                    "Text": "Function TestFoo missing parallel\n",
+                    "Severity": "high",
+                    "Pos": {"Filename": "core/foo_test.go", "Line": 10, "Column": 2},
+                },
+                {
+                    "FromLinter": "revive",
+                    "Text": "exported method Bar should have comment | doc",
+                    "Severity": "low",
+                    "Pos": {"Filename": "core/foo_test.go", "Line": 25, "Column": 1},
+                },
+                {
+                    "FromLinter": "revive",
+                    "Text": "unused param x",
+                    "Severity": "medium",
+                    "Pos": {"Filename": "core/bar.go", "Line": 5, "Column": 8},
+                },
+            ]
+        }
+        with open(self.report_file, "w") as f:
+            json.dump(data, f)
+
+        # When only 'high' is critical
+        _, _, outputs = process_report.process(
+            report_path=str(self.report_file),
+            module_name="core",
+            summary_path=str(self.summary_file),
+            output_path=str(self.output_file),
+            critical_severities=("high",),
+        )
+        self.assertEqual(outputs["critical-issue-count"], 1)
+
+        # When none are critical
+        _, _, outputs = process_report.process(
+            report_path=str(self.report_file),
+            module_name="core",
+            summary_path=str(self.summary_file),
+            output_path=str(self.output_file),
+            critical_severities=(),
+        )
+        self.assertEqual(outputs["critical-issue-count"], 0)
+        self.assertEqual(outputs["suffix"], "core")
+
+    def test_get_artifact_suffix(self):
+        self.assertEqual(process_report.get_artifact_suffix(""), "root")
+        self.assertEqual(process_report.get_artifact_suffix("."), "root")
+        self.assertEqual(process_report.get_artifact_suffix("./"), "root")
+        self.assertEqual(process_report.get_artifact_suffix("core/scripts"), "core-scripts")
+        self.assertEqual(process_report.get_artifact_suffix("core/scripts/"), "core-scripts")
+        self.assertEqual(process_report.get_artifact_suffix("plugins"), "plugins")
+
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -205,7 +205,7 @@ jobs:
           token: ${{ secrets.QA_SLACK_API_KEY }}
           payload: |
             channel: ${{ secrets.SLACK_TEAM_CORE_CHANNEL_ID}}
-            text: ":red-warn: golangci-lint: module `${{ matrix.modules }}` has ${{ steps.golang-lint.outputs.golang-report-issue-count }} issues across ${{ steps.golang-lint.outputs.golang-report-file-count }} files\n<${{ format('https://github.com/{0}/actions/runs/{1}/jobs/{2}', github.repository, github.run_id, github.job_id) }}|View Run> - <${{ steps.golang-lint.outputs.golang-report-artifact-url }}|Download Report>\n*By severity*: ${{ steps.golang-lint.outputs.golang-report-per-severity-count }}\n*By linter*: ${{ steps.golang-lint.outputs.golang-report-per-source-count }}"
+            text: ":red-warn: golangci-lint: module `${{ matrix.modules }}` has ${{ steps.golang-lint.outputs.golang-report-issue-count }} issues across ${{ steps.golang-lint.outputs.golang-report-file-count }} files\n<${{ format('https://github.com/{0}/actions/runs/{1}', github.repository, github.run_id) }}|View Run> - <${{ steps.golang-lint.outputs.golang-report-artifact-url }}|Download Report>\n*By severity*: ${{ steps.golang-lint.outputs.golang-report-per-severity-count }}\n*By linter*: ${{ steps.golang-lint.outputs.golang-report-per-source-count }}"
 
   # Fails if any golangci-lint matrix jobs fails and silently succeeds otherwise
   # Consolidates golangci-lint matrix job results under one required `lint` check

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -197,6 +197,15 @@ jobs:
           # so restrict checkpoint writes to push events where the matrix is the push diff.
           build-cache-write: ${{ github.event_name == 'push' && 'default-branch-only' || 'never' }}
 
+      - name: Debug Slack message
+        if: always()
+        env:
+          SLACK_TEXT: ":red-warn: golangci-lint: module `${{ matrix.modules }}` has ${{ steps.golang-lint.outputs.golang-report-issue-count }} issues across ${{ steps.golang-lint.outputs.golang-report-file-count }} files\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}|View Run> - <${{ steps.golang-lint.outputs.golang-report-artifact-url }}|Download Report>\n*By severity*: ${{ steps.golang-lint.outputs.golang-report-per-severity-count }}\n*By linter*: ${{ steps.golang-lint.outputs.golang-report-per-source-count }}"
+        run: |
+          echo "Would send Slack message (send-if = failure && critical>0 && weekday):"
+          echo "channel=${{ secrets.SLACK_TEAM_CORE_CHANNEL_ID}}"
+          echo "text=${SLACK_TEXT}"
+
       - name: Notify Slack
         if: ${{ failure() && steps.golang-lint.outputs.golang-report-critical-issue-count > 0 && needs.run-frequency.outputs.one-per-weekday-frequency == 'true' }}
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -172,7 +172,7 @@ jobs:
       # For golangci-lint-action's `only-new-issues` option.
       pull-requests: read
     runs-on: runs-on=${{ github.run_id }}-${{ strategy.job-index
-      }}/cpu=16/ram=32/family=c6gd/spot=false/image=ubuntu24-full-arm64/extras=s3-cache
+      }}/cpu=16/ram=32/family=c8g+c9g/spot=co/image=ubuntu24-full-arm64/extras=s3-cache
     strategy:
       fail-fast: false
       matrix:
@@ -592,9 +592,9 @@ jobs:
             # Not a scheduled event - no frequencies to set. They default to false.
             exit 0
           fi
-          
-          curent_day=$(date +%u)
-          if [ "$curent_day" -ge 6 ]; then
+
+          current_day=$(date +%u)
+          if [ "$current_day" -ge 6 ]; then
             # Weekend
             exit 0
           fi

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -199,13 +199,13 @@ jobs:
 
       - name: Notify Slack
         if: ${{ failure() && steps.golang-lint.outputs.golang-report-critical-issue-count > 0 && needs.run-frequency.outputs.one-per-weekday-frequency == 'true' }}
-        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # 3.0.2
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           method: chat.postMessage
           token: ${{ secrets.QA_SLACK_API_KEY }}
           payload: |
             channel: ${{ secrets.SLACK_TEAM_CORE_CHANNEL_ID}}
-            text: ":red-warn: golangci-lint: module `${{ matrix.modules }}` has ${{ steps.golang-lint.outputs.golang-report-issue-count }} issues across ${{ steps.golang-lint.outputs.golang-report-file-count }} files\n<${{ format('https://github.com/{0}/actions/runs/{1}', github.repository, github.run_id) }}|View Run> - <${{ steps.golang-lint.outputs.golang-report-artifact-url }}|Download Report>\n*By severity*: ${{ steps.golang-lint.outputs.golang-report-per-severity-count }}\n*By linter*: ${{ steps.golang-lint.outputs.golang-report-per-source-count }}"
+            text: ":red-warn: golangci-lint: module `${{ matrix.modules }}` has ${{ steps.golang-lint.outputs.golang-report-issue-count }} issues across ${{ steps.golang-lint.outputs.golang-report-file-count }} files\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}|View Run> - <${{ steps.golang-lint.outputs.golang-report-artifact-url }}|Download Report>\n*By severity*: ${{ steps.golang-lint.outputs.golang-report-per-severity-count }}\n*By linter*: ${{ steps.golang-lint.outputs.golang-report-per-source-count }}"
 
   # Fails if any golangci-lint matrix jobs fails and silently succeeds otherwise
   # Consolidates golangci-lint matrix job results under one required `lint` check

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,7 +4,7 @@ nodejs        20.13.1
 pnpm          10.6.5
 postgres      16.14
 helm          3.18.4
-golangci-lint 2.12.2
+golangci-lint 2.13.0
 protoc        29.3
 python        3.10.5
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,7 +4,7 @@ nodejs        20.13.1
 pnpm          10.6.5
 postgres      16.14
 helm          3.18.4
-golangci-lint 2.13.0
+golangci-lint 2.13.1
 protoc        29.3
 python        3.10.5
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,7 +16,7 @@ CL_LOOPINSTALL_OUTPUT_DIR ?=
 LOOPINSTALL_PUBLIC_ARGS  := $(if $(strip $(CL_LOOPINSTALL_OUTPUT_DIR)),--output-installation-artifacts $(CL_LOOPINSTALL_OUTPUT_DIR)/public.json)
 LOOPINSTALL_PRIVATE_ARGS := $(if $(strip $(CL_LOOPINSTALL_OUTPUT_DIR)),--output-installation-artifacts $(CL_LOOPINSTALL_OUTPUT_DIR)/private.json)
 LOOPINSTALL_TESTING_ARGS := $(if $(strip $(CL_LOOPINSTALL_OUTPUT_DIR)),--output-installation-artifacts $(CL_LOOPINSTALL_OUTPUT_DIR)/testing.json)
-GOLANGCI_LINT_VERSION = "v2.13.0"
+GOLANGCI_LINT_VERSION = "v2.13.1"
 # Pin path so `make generate` does not pick up a different mockery (e.g. v3) from PATH.
 MOCKERY_BIN ?= $(shell command -v mockery 2>/dev/null || (GOBIN="$$(go env GOBIN)"; if [ -n "$$GOBIN" -a -f "$$GOBIN/mockery" ]; then echo "$$GOBIN/mockery"; else echo "$$(go env GOPATH)/bin/mockery"; fi))
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,7 +16,7 @@ CL_LOOPINSTALL_OUTPUT_DIR ?=
 LOOPINSTALL_PUBLIC_ARGS  := $(if $(strip $(CL_LOOPINSTALL_OUTPUT_DIR)),--output-installation-artifacts $(CL_LOOPINSTALL_OUTPUT_DIR)/public.json)
 LOOPINSTALL_PRIVATE_ARGS := $(if $(strip $(CL_LOOPINSTALL_OUTPUT_DIR)),--output-installation-artifacts $(CL_LOOPINSTALL_OUTPUT_DIR)/private.json)
 LOOPINSTALL_TESTING_ARGS := $(if $(strip $(CL_LOOPINSTALL_OUTPUT_DIR)),--output-installation-artifacts $(CL_LOOPINSTALL_OUTPUT_DIR)/testing.json)
-GOLANGCI_LINT_VERSION = "v2.12.2"
+GOLANGCI_LINT_VERSION = "v2.13.0"
 # Pin path so `make generate` does not pick up a different mockery (e.g. v3) from PATH.
 MOCKERY_BIN ?= $(shell command -v mockery 2>/dev/null || (GOBIN="$$(go env GOBIN)"; if [ -n "$$GOBIN" -a -f "$$GOBIN/mockery" ]; then echo "$$GOBIN/mockery"; else echo "$$(go env GOPATH)/bin/mockery"; fi))
 

--- a/core/main.go
+++ b/core/main.go
@@ -47,9 +47,12 @@ func newProductionClient() *cmd.Shell {
 		Runner:                         cmd.ChainlinkRunner{},
 		PromptingSessionRequestBuilder: cmd.NewPromptingSessionRequestBuilder(prompter),
 		ChangePasswordPrompter:         cmd.NewChangePasswordPrompter(),
+		PasswordPrompter:               cmd.NewPasswordPrompter(),
+	}
+}
+
 // IntentionalMisspeldFunction demonstrates lint annotations and summary tables in CI.
 func IntentionalMisspeldFunction() string {
 	val := fmt.Sprintf("%s", "test")
 	return val
 }
-

--- a/core/main.go
+++ b/core/main.go
@@ -50,4 +50,3 @@ func newProductionClient() *cmd.Shell {
 		PasswordPrompter:               cmd.NewPasswordPrompter(),
 	}
 }
-

--- a/core/main.go
+++ b/core/main.go
@@ -47,6 +47,9 @@ func newProductionClient() *cmd.Shell {
 		Runner:                         cmd.ChainlinkRunner{},
 		PromptingSessionRequestBuilder: cmd.NewPromptingSessionRequestBuilder(prompter),
 		ChangePasswordPrompter:         cmd.NewChangePasswordPrompter(),
-		PasswordPrompter:               cmd.NewPasswordPrompter(),
-	}
+// IntentionalMisspeldFunction demonstrates lint annotations and summary tables in CI.
+func IntentionalMisspeldFunction() string {
+	val := fmt.Sprintf("%s", "test")
+	return val
 }
+

--- a/core/main.go
+++ b/core/main.go
@@ -51,8 +51,3 @@ func newProductionClient() *cmd.Shell {
 	}
 }
 
-// IntentionalMisspeldFunction demonstrates lint annotations and summary tables in CI.
-func IntentionalMisspeldFunction() string {
-	val := fmt.Sprintf("%s", "test")
-	return val
-}

--- a/integration-tests/.tool-versions
+++ b/integration-tests/.tool-versions
@@ -2,5 +2,5 @@ golang 1.26.5
 k3d 5.4.6
 kubectl 1.25.5
 nodejs 20.13.1
-golangci-lint 2.13.0
+golangci-lint 2.13.1
 task 3.35.1

--- a/integration-tests/.tool-versions
+++ b/integration-tests/.tool-versions
@@ -2,5 +2,5 @@ golang 1.26.5
 k3d 5.4.6
 kubectl 1.25.5
 nodejs 20.13.1
-golangci-lint 2.12.2
+golangci-lint 2.13.0
 task 3.35.1


### PR DESCRIPTION
## Intent

Fix the UX of golangci-lint failures in CI. The previous style only [prints out a raw XML file](https://github.com/smartcontractkit/chainlink/actions/runs/32334530439/job/96321433855#step:5:1037), which is annoying for agents and humans to parse.

## Changes

* Print human and agent parsable linting errors.
  * [Summary table in workflow summary](https://github.com/smartcontractkit/chainlink/actions/runs/32374714895/attempts/1#summary-96443359468)
  * [Print plain errors in action](https://github.com/smartcontractkit/chainlink/actions/runs/32374714895/job/96443359468?pr=23463#step:5:977)
  * Show error annotations in GitHub diff
     <img width="498" height="251" alt="image" src="https://github.com/user-attachments/assets/c8a09fb9-4169-41a5-8acf-e51bc61a25c2" />

* Swap fragile, in-workflow bash logic to a more understandable and tested Python script.
* [Fix the Slack link to use the proper job ID](https://github.com/smartcontractkit/chainlink/pull/23463/changes#diff-31bd198ce2c6956ed10bdfe25a233b755f3a201ad094a67c449115ef76d9ff43R208)