### PR TITLE
chore: bump confidential capabilities gitref (#23469)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -265,7 +265,13 @@ jobs:
       name: integration
       deployment: false
     runs-on: ${{ matrix.image.runner }}
-    needs: [labels, enforce-ctf-version, changes]
+    needs:
+      [
+        labels,
+        enforce-ctf-version,
+        run-core-cre-e2e-tests-setup,
+        run-ccip-v1-6-e2e-tests-setup,
+      ]
     permissions:
       id-token: write
       contents: read
@@ -279,12 +285,8 @@ jobs:
             cache-scope: core
             any-should-run: >-
               ${{
-                github.event_name == 'workflow_dispatch' ||
-                needs.changes.outputs.general-changes == 'true' ||
-                needs.changes.outputs.core-changes == 'true' ||
-                needs.changes.outputs.cre-changes == 'true' ||
-                needs.changes.outputs.ccip-changes == 'true' ||
-                needs.labels.outputs.run-e2e-tests-label-found == 'true'
+                needs.run-ccip-v1-6-e2e-tests-setup.outputs.should-run == 'true' ||
+                needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'
               }}
 
           - name: (plugins)
@@ -294,11 +296,7 @@ jobs:
             cache-scope: plugins
             any-should-run: >-
               ${{
-                github.event_name == 'workflow_dispatch' ||
-                needs.changes.outputs.general-changes == 'true' ||
-                needs.changes.outputs.core-changes == 'true' ||
-                needs.changes.outputs.cre-changes == 'true' ||
-                needs.labels.outputs.run-e2e-tests-label-found == 'true'
+                needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'
               }}
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners

--- a/core/scripts/cre/environment/configs/workflow-gateway-don-stellar.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-don-stellar.toml
@@ -9,6 +9,7 @@
 
 [[blockchains]]
   type = "stellar"
+  image = "stellar/quickstart:pr968-v653-b1315.2-latest"
   chain_id = "baefd734b8d3e48472cff83912375fedbc7573701912fe308af730180f97d74a"
   # Pin the standalone network to mainnet's live protocol (26) so local/CI matches
   docker_cmd_params = ["--protocol-version", "26"]

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -118,10 +118,10 @@ plugins:
 
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "b9926f01321595b1db0fa169fdafb3dbd24dd161"
+      gitRef: "54a8289c30de50809a1c414ffecee4a81efeb2e9"
       installPath: "./cmd/confidential-http"
 
   confidential-workflows:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-workflows/capability"
-      gitRef: "b9926f01321595b1db0fa169fdafb3dbd24dd161"
+      gitRef: "54a8289c30de50809a1c414ffecee4a81efeb2e9"
       installPath: "./cmd/confidential-workflows"


### PR DESCRIPTION
## Summary

Cherry-pick of #23469 to `release/2.60.3`: bumps the confidential capabilities gitref in `plugins/plugins.public.yaml` and the Dockerfiles. (Closed — superseded by #23474/#23475.)
