### PR TITLE
chore: bump confidential capabilities gitref (#23469)

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -117,7 +117,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates=20260601~24.04.1 \
     gnupg=2.4.4-2ubuntu17.4 \
     lsb-release=12.0-2 \
-    curl=8.5.0-2ubuntu10.11 \
+    curl=8.5.0-2ubuntu10.12 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Postgres for CLI tools, needed specifically for DB backups

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -116,7 +116,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates=20260601~24.04.1 \
     gnupg=2.4.4-2ubuntu17.4 \
     lsb-release=12.0-2 \
-    curl=8.5.0-2ubuntu10.11 \
+    curl=8.5.0-2ubuntu10.12 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Postgres for CLI tools, needed specifically for DB backups

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -118,10 +118,10 @@ plugins:
 
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "b9926f01321595b1db0fa169fdafb3dbd24dd161"
+      gitRef: "54a8289c30de50809a1c414ffecee4a81efeb2e9"
       installPath: "./cmd/confidential-http"
 
   confidential-workflows:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-workflows/capability"
-      gitRef: "b9926f01321595b1db0fa169fdafb3dbd24dd161"
+      gitRef: "54a8289c30de50809a1c414ffecee4a81efeb2e9"
       installPath: "./cmd/confidential-workflows"


### PR DESCRIPTION
## Summary

Cherry-pick of #23469 to `release/2.60.0`: bumps the confidential capabilities gitref in `plugins/plugins.public.yaml` and the `core`/`plugins` Dockerfiles.
