### PR TITLE
chore: bump confidential capabilities gitref

### DIFF
--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -118,10 +118,10 @@ plugins:
 
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "54a8289c30de50809a1c414ffecee4a81efeb2e9"
+      gitRef: "9c9bdd52bec2622bf034f1020678d8bc30a3ced7"
       installPath: "./cmd/confidential-http"
 
   confidential-workflows:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-workflows/capability"
-      gitRef: "54a8289c30de50809a1c414ffecee4a81efeb2e9"
+      gitRef: "9c9bdd52bec2622bf034f1020678d8bc30a3ced7"
       installPath: "./cmd/confidential-workflows"


### PR DESCRIPTION
Bumps to the tip of release/1.3.0: https://github.com/smartcontractkit/chainlink-confidential-compute/commits/release/1.3.0/