### PR TITLE
cre-4977: Shard Failover - sender and receiver wired

### DIFF
--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/uuid"
@@ -20,6 +21,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/workflowkey"
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/billing"
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
@@ -313,6 +315,7 @@ func (s *Services) newSubservices(
 		s.OrgResolver,
 		s.GatewayConnectorWrapper,
 		meterIdentity,
+		dispatcherWrapper.dispatcher,
 	)
 	if err != nil {
 		return nil, err
@@ -570,6 +573,18 @@ func newLocalTestMetadataRegistry(localCfg config.LocalCapabilities) *capabiliti
 	return &capabilities.TestMetadataRegistry{}
 }
 
+func newShardDonLookup(capRegistry *capabilities.Registry) func(uint32) *commoncap.DON {
+	return func(shardID uint32) *commoncap.DON {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		don, err := capRegistry.DONByID(ctx, shardID)
+		if err != nil {
+			return nil
+		}
+		return &don
+	}
+}
+
 // newDispatcherWrapper creates a new dispatcherWrapper service with peer wrappers if peering is enabled
 func newDispatcherWrapper(
 	cfg Config,
@@ -779,6 +794,7 @@ func newWorkflowRegistrySyncerV2(
 	orgResolver orgresolver.OrgResolver,
 	gatewayConnectorWrapper *gatewayconnector.ServiceWrapper,
 	meterIdentity resourcemanager.ResourceIdentity,
+	shardDispatcher remotetypes.Dispatcher,
 ) (syncerV2.WorkflowRegistrySyncer, []commonsrv.Service, error) {
 	capCfg := cfg.Capabilities()
 	wfReg := capCfg.WorkflowRegistry()
@@ -884,6 +900,12 @@ func newWorkflowRegistrySyncerV2(
 		syncerV2.WithHandlerShardFailoverEnabled(shardingFailoverEnabled),
 		syncerV2.WithShardRoutingSteady(shardRoutingSteady),
 		syncerV2.WithShardResolver(shardResolver),
+	}
+	if shardingFailoverEnabled && shardDispatcher != nil {
+		handlerOpts = append(handlerOpts,
+			syncerV2.WithShardDispatcher(shardDispatcher),
+			syncerV2.WithShardDonLookup(newShardDonLookup(opts.CapabilitiesRegistry)),
+		)
 	}
 
 	// The spec meter (and its ResourceManager) exists only when metering is
@@ -1055,6 +1077,7 @@ func newWorkflowRegistrySyncer(
 	orgResolver orgresolver.OrgResolver,
 	gatewayConnectorWrapper *gatewayconnector.ServiceWrapper,
 	meterIdentity resourcemanager.ResourceIdentity,
+	shardDispatcher remotetypes.Dispatcher,
 ) (syncerV2.WorkflowRegistrySyncer, metering.BillingClient, []commonsrv.Service, error) {
 	capCfg := cfg.Capabilities()
 
@@ -1089,6 +1112,7 @@ func newWorkflowRegistrySyncer(
 		orgResolver,
 		gatewayConnectorWrapper,
 		meterIdentity,
+		shardDispatcher,
 	)
 	return syncer, billingClient, srvcs, err
 }

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -32,9 +32,12 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/dontime"
 	generichost "github.com/smartcontractkit/chainlink-common/pkg/workflows/host"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host"
+	ringpb "github.com/smartcontractkit/chainlink-protos/ring/go"
 	eventsv2 "github.com/smartcontractkit/chainlink-protos/workflows/go/v2"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/confidentialrelay"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/sharding"
+	remotetypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/platform"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/shardorchestrator"
@@ -120,11 +123,16 @@ type eventHandler struct {
 	tracer trace.Tracer
 
 	shardOrchestratorClient shardorchestrator.ClientInterface
-	shardingEnabled         bool
-	shardingFailoverEnabled bool
-	myShardID               uint32
-	shardRoutingSteady      *shardownership.SteadySignal
-	shardResolver           shardownership.ShardResolver
+	shardingEnabled          bool
+	shardingFailoverEnabled  bool
+	myShardID                uint32
+	shardRoutingSteady       *shardownership.SteadySignal
+	shardResolver            shardownership.ShardResolver
+	shardDispatcher          remotetypes.Dispatcher
+	shardDonLookup           func(uint32) *commoncap.DON
+
+	shardFailoverServices []services.Service
+	shardFailoverMu       sync.Mutex
 
 	metrics *metrics
 }
@@ -198,6 +206,18 @@ func WithShardRoutingSteady(signal *shardownership.SteadySignal) func(*eventHand
 func WithShardResolver(resolver shardownership.ShardResolver) func(*eventHandler) {
 	return func(e *eventHandler) {
 		e.shardResolver = resolver
+	}
+}
+
+func WithShardDispatcher(dispatcher remotetypes.Dispatcher) func(*eventHandler) {
+	return func(e *eventHandler) {
+		e.shardDispatcher = dispatcher
+	}
+}
+
+func WithShardDonLookup(lookup func(uint32) *commoncap.DON) func(*eventHandler) {
+	return func(e *eventHandler) {
+		e.shardDonLookup = lookup
 	}
 }
 
@@ -376,10 +396,20 @@ func NewEventHandler(
 	return eh, nil
 }
 
-func (h *eventHandler) start(context.Context) error {
+func (h *eventHandler) start(ctx context.Context) error {
 	if h.moduleLRU != nil {
 		h.moduleLRU.Start()
 	}
+
+	h.shardFailoverMu.Lock()
+	for _, svc := range h.shardFailoverServices {
+		if err := svc.Start(ctx); err != nil {
+			h.shardFailoverMu.Unlock()
+			return fmt.Errorf("failed to start shard failover service: %w", err)
+		}
+	}
+	h.shardFailoverMu.Unlock()
+
 	return nil
 }
 
@@ -405,6 +435,12 @@ func (h *eventHandler) close() error {
 	for _, e := range es {
 		cs = append(cs, e)
 	}
+	h.shardFailoverMu.Lock()
+	for _, svc := range h.shardFailoverServices {
+		cs = append(cs, svc)
+	}
+	h.shardFailoverMu.Unlock()
+
 	return services.CloseAll(cs...)
 }
 
@@ -1180,7 +1216,7 @@ func (h *eventHandler) newV2EngineConfig(
 	name types.WorkflowName,
 	config []byte,
 ) *v2.EngineConfig {
-	return &v2.EngineConfig{
+	cfg := &v2.EngineConfig{
 		Lggr:                  h.lggr,
 		Module:                module,
 		WorkflowConfig:        config,
@@ -1216,15 +1252,151 @@ func (h *eventHandler) newV2EngineConfig(
 		SdkName:                       sdkName,
 
 		ShardOrchestratorClient: h.shardOrchestratorClient,
-		ShardingEnabled:         h.shardingEnabled,
-		ShardingFailoverEnabled: h.shardingFailoverEnabled,
-		MyShardID:               h.myShardID,
-		ShardRoutingSteady:      h.shardRoutingSteady,
-		ShardResolver:           h.shardResolver,
+		ShardingEnabled:          h.shardingEnabled,
+		ShardingFailoverEnabled:  h.shardingFailoverEnabled,
+		MyShardID:                h.myShardID,
+		ShardRoutingSteady:       h.shardRoutingSteady,
+		ShardResolver:            h.shardResolver,
+	}
+
+	if h.shardingFailoverEnabled && h.shardDispatcher != nil {
+		h.wireShardFailoverHooks(cfg)
+	}
+
+	return cfg
+}
+
+func (h *eventHandler) wireShardFailoverHooks(cfg *v2.EngineConfig) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	sub, unsub, err := h.workflowDonSubscriber.Subscribe(ctx)
+	if err != nil {
+		h.lggr.Warnw("shard failover: failed to subscribe to DON updates, skipping hook wiring", "err", err)
+		return
+	}
+	defer unsub()
+
+	var don commoncap.DON
+	select {
+	case don = <-sub:
+	case <-ctx.Done():
+		h.lggr.Warnw("shard failover: timed out waiting for DON info, skipping hook wiring")
+		return
+	}
+
+	isPrimary := h.isPrimaryShardForDon(don)
+
+	if isPrimary {
+		secondaryDon := h.resolveSecondaryDon()
+		if secondaryDon == nil {
+			h.lggr.Warnw("shard failover: no secondary DON found, primary will not send ExecutionCompleted", "primaryShardID", h.myShardID)
+			return
+		}
+
+		sender := sharding.NewExecutionCompletedSender(h.shardDispatcher, h.myShardID, *secondaryDon, h.lggr)
+		h.shardFailoverMu.Lock()
+		h.shardFailoverServices = append(h.shardFailoverServices, sender)
+		h.shardFailoverMu.Unlock()
+
+		cfg.Hooks.OnExecutionCompleted = func(workflowID string, triggerEventID string, triggerIndex int, status string, errClass events.ErrorClassification) {
+			execStatus := mapExecutionStatus(status, errClass)
+			sender.Send(context.Background(), &ringpb.ExecutionCompleted{
+				WorkflowId:      workflowID,
+				TriggerEventId:  triggerEventID,
+				TriggerIndex:    uint32(triggerIndex), //nolint:gosec // G115: triggerIndex is small
+				Status:          execStatus,
+				PrimaryShardId:  h.myShardID,
+			})
+		}
+
+		h.lggr.Infow("shard failover: wired ExecutionCompletedSender on primary", "primaryShardID", h.myShardID, "secondaryShardID", secondaryDon.ID)
+	} else {
+		primaryDon := h.resolvePrimaryDon()
+		if primaryDon == nil {
+			h.lggr.Warnw("shard failover: no primary DON found, secondary will not register receiver", "myShardID", h.myShardID)
+			return
+		}
+
+		receiver := sharding.NewExecutionCompletedReceiver(*primaryDon, func(msg *ringpb.ExecutionCompleted) {
+			h.lggr.Infow("secondary received ExecutionCompleted", "workflowID", msg.WorkflowId, "triggerEventID", msg.TriggerEventId, "status", msg.Status)
+		}, h.lggr)
+
+		if regErr := h.shardDispatcher.SetReceiverForMethod("shard-execution-completed", primaryDon.ID, remotetypes.MethodExecutionCompleted, receiver); regErr != nil {
+			h.lggr.Errorw("shard failover: failed to register ExecutionCompletedReceiver", "err", regErr)
+		} else {
+			h.shardFailoverMu.Lock()
+			h.shardFailoverServices = append(h.shardFailoverServices, receiver)
+			h.shardFailoverMu.Unlock()
+			h.lggr.Infow("shard failover: wired ExecutionCompletedReceiver on secondary", "myShardID", h.myShardID, "primaryShardID", primaryDon.ID)
+		}
 	}
 }
 
-// wireInitDoneHook wires the initDone channel to the OnInitialized lifecycle hook.
+func (h *eventHandler) isPrimaryShardForDon(_ commoncap.DON) bool {
+	if h.shardResolver == nil {
+		return h.myShardID == 0
+	}
+	allResolver, ok := h.shardResolver.(shardownership.AllShardsResolver)
+	if !ok {
+		return h.myShardID == 0
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	shards, found, err := allResolver.ResolveAllShards(ctx, "", "")
+	if err != nil || !found || len(shards) == 0 {
+		return h.myShardID == 0
+	}
+	return shards[0] == h.myShardID
+}
+
+func (h *eventHandler) resolveSecondaryDon() *commoncap.DON {
+	if h.shardDonLookup == nil {
+		return nil
+	}
+	allResolver, ok := h.shardResolver.(shardownership.AllShardsResolver)
+	if !ok {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	shards, found, err := allResolver.ResolveAllShards(ctx, "", "")
+	if err != nil || !found || len(shards) < 2 {
+		return nil
+	}
+	return h.shardDonLookup(shards[1])
+}
+
+func (h *eventHandler) resolvePrimaryDon() *commoncap.DON {
+	if h.shardDonLookup == nil {
+		return nil
+	}
+	allResolver, ok := h.shardResolver.(shardownership.AllShardsResolver)
+	if !ok {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	shards, found, err := allResolver.ResolveAllShards(ctx, "", "")
+	if err != nil || !found || len(shards) == 0 {
+		return nil
+	}
+	return h.shardDonLookup(shards[0])
+}
+
+func mapExecutionStatus(status string, errClass events.ErrorClassification) ringpb.ExecutionStatus {
+	switch status {
+	case store.StatusCompleted, store.StatusCompletedEarlyExit:
+		return ringpb.ExecutionStatus_EXECUTION_STATUS_SUCCESS
+	case store.StatusErrored, store.StatusTimeout:
+		if errClass == events.ErrorClassificationUser {
+			return ringpb.ExecutionStatus_EXECUTION_STATUS_USER_ERROR
+		}
+		return ringpb.ExecutionStatus_EXECUTION_STATUS_SYSTEM_ERROR
+	default:
+		return ringpb.ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED
+	}
+}
 // This will be called when the engine completes initialization (including trigger subscriptions).
 // We compose with any existing hook to avoid overwriting test hooks or other user-provided hooks.
 func (h *eventHandler) wireInitDoneHook(cfg *v2.EngineConfig, initDone chan<- error) {

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -123,13 +123,13 @@ type eventHandler struct {
 	tracer trace.Tracer
 
 	shardOrchestratorClient shardorchestrator.ClientInterface
-	shardingEnabled          bool
-	shardingFailoverEnabled  bool
-	myShardID                uint32
-	shardRoutingSteady       *shardownership.SteadySignal
-	shardResolver            shardownership.ShardResolver
-	shardDispatcher          remotetypes.Dispatcher
-	shardDonLookup           func(uint32) *commoncap.DON
+	shardingEnabled         bool
+	shardingFailoverEnabled bool
+	myShardID               uint32
+	shardRoutingSteady      *shardownership.SteadySignal
+	shardResolver           shardownership.ShardResolver
+	shardDispatcher         remotetypes.Dispatcher
+	shardDonLookup          func(uint32) *commoncap.DON
 
 	shardFailoverServices []services.Service
 	shardFailoverMu       sync.Mutex
@@ -1252,11 +1252,11 @@ func (h *eventHandler) newV2EngineConfig(
 		SdkName:                       sdkName,
 
 		ShardOrchestratorClient: h.shardOrchestratorClient,
-		ShardingEnabled:          h.shardingEnabled,
-		ShardingFailoverEnabled:  h.shardingFailoverEnabled,
-		MyShardID:                h.myShardID,
-		ShardRoutingSteady:       h.shardRoutingSteady,
-		ShardResolver:            h.shardResolver,
+		ShardingEnabled:         h.shardingEnabled,
+		ShardingFailoverEnabled: h.shardingFailoverEnabled,
+		MyShardID:               h.myShardID,
+		ShardRoutingSteady:      h.shardRoutingSteady,
+		ShardResolver:           h.shardResolver,
 	}
 
 	if h.shardingFailoverEnabled && h.shardDispatcher != nil {
@@ -1302,11 +1302,11 @@ func (h *eventHandler) wireShardFailoverHooks(cfg *v2.EngineConfig) {
 		cfg.Hooks.OnExecutionCompleted = func(workflowID string, triggerEventID string, triggerIndex int, status string, errClass events.ErrorClassification) {
 			execStatus := mapExecutionStatus(status, errClass)
 			sender.Send(context.Background(), &ringpb.ExecutionCompleted{
-				WorkflowId:      workflowID,
-				TriggerEventId:  triggerEventID,
-				TriggerIndex:    uint32(triggerIndex), //nolint:gosec // G115: triggerIndex is small
-				Status:          execStatus,
-				PrimaryShardId:  h.myShardID,
+				WorkflowId:     workflowID,
+				TriggerEventId: triggerEventID,
+				TriggerIndex:   uint32(triggerIndex), //nolint:gosec // G115: triggerIndex is small
+				Status:         execStatus,
+				PrimaryShardId: h.myShardID,
 			})
 		}
 
@@ -1397,6 +1397,7 @@ func mapExecutionStatus(status string, errClass events.ErrorClassification) ring
 		return ringpb.ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED
 	}
 }
+
 // This will be called when the engine completes initialization (including trigger subscriptions).
 // We compose with any existing hook to avoid overwriting test hooks or other user-provided hooks.
 func (h *eventHandler) wireInitDoneHook(cfg *v2.EngineConfig, initDone chan<- error) {


### PR DESCRIPTION
The sender and receiver are fully wired:

- Primary shard: `wireShardFailoverHooks` creates an `ExecutionCompletedSender` (targeting the secondary DON resolved via `shardDonLookup`), wires it into the engine's `OnExecutionCompleted` lifecycle hook, and registers it as a sub-service for lifecycle management.
- Secondary shard: `wireShardFailoverHooks` creates an `ExecutionCompletedReceiver` and registers it with the dispatcher via `SetReceiverForMethod(MethodExecutionCompleted)` so incoming Don2Don messages are delivered to it.
- Role detection: `isPrimaryShardForDon` uses `AllShardsResolver.ResolveAllShards` to determine if this shard is the primary (first in the assignment list).
- DON lookup: `newShardDonLookup` uses `CapabilitiesRegistry.DONByID` to resolve peer membership for the other shard.
- Dispatcher + lookup are passed from `cre.go` -> `newWorkflowRegistrySyncer` -> `newWorkflowRegistrySyncerV2` -> handler options.

It is supplementary to #23457 