### PR TITLE
Backport: bump pinned curl to match current Ubuntu 24.04 archive

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -117,7 +117,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates=20260601~24.04.1 \
     gnupg=2.4.4-2ubuntu17.4 \
     lsb-release=12.0-2 \
-    curl=8.5.0-2ubuntu10.11 \
+    curl=8.5.0-2ubuntu10.12 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Postgres for CLI tools, needed specifically for DB backups

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -116,7 +116,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates=20260601~24.04.1 \
     gnupg=2.4.4-2ubuntu17.4 \
     lsb-release=12.0-2 \
-    curl=8.5.0-2ubuntu10.11 \
+    curl=8.5.0-2ubuntu10.12 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Postgres for CLI tools, needed specifically for DB backups


### PR DESCRIPTION
## What

Backports #23461 to `release/2.61.0`: bumps `curl=8.5.0-2ubuntu10.11` → `8.5.0-2ubuntu10.12` in `core/chainlink.Dockerfile` and `plugins/chainlink.Dockerfile`.

## Why

This release branch was cut 2026-08-18, two days before #23461 merged to `develop`. It carries the same stale pin, currently blocking `Integration Tests` / `Build Chainlink Image` on #23444 with the identical apt error:

```
curl : Depends: libcurl4t64 (= 8.5.0-2ubuntu10.11) but 8.5.0-2ubuntu10.12 is to be installed
E: Unable to correct problems, you have held broken packages.
```

## Verification

Same fix already confirmed working on `develop` (#23461, three docker build jobs passed the identical apt-get line).