### PR TITLE
fix: wrapp user errors on vaultSecretError to avoid misclassification

### DIFF
--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -32,7 +32,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/teeattestation/nitro"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 )
 
 var _ core.GatewayConnectorHandler = (*Handler)(nil)
@@ -345,7 +344,7 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 	result, err := translateVaultResponse(vaultResp, params.EnclavePublicKey)
 	if err != nil {
 		code := jsonrpc.ErrInternal
-		if vaulttypes.IsUserError(err) {
+		if IsUserError(err) {
 			code = jsonrpc.ErrInvalidParams
 		}
 		return h.errorResponse(ctx, gatewayID, req, code, err)
@@ -387,11 +386,7 @@ func translateVaultResponse(vaultResp []*vault.SecretResponse, enclaveKey string
 
 	for _, sr := range vaultResp {
 		if sr.GetError() != "" {
-			return nil, &vaultSecretError{
-				namespace: sr.Id.GetNamespace(),
-				key:       sr.Id.GetKey(),
-				msg:       sr.GetError(),
-			}
+			return nil, newVaultSecretError(sr.Id.GetNamespace(), sr.Id.GetKey(), sr.GetError())
 		}
 
 		data := sr.GetData()

--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/teeattestation/nitro"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 )
 
 var _ core.GatewayConnectorHandler = (*Handler)(nil)
@@ -343,7 +344,11 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 
 	result, err := translateVaultResponse(vaultResp, params.EnclavePublicKey)
 	if err != nil {
-		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
+		code := jsonrpc.ErrInternal
+		if vaulttypes.IsUserError(err) {
+			code = jsonrpc.ErrInvalidParams
+		}
+		return h.errorResponse(ctx, gatewayID, req, code, err)
 	}
 
 	signedResult, err := h.signSecretsResponse(params, result)
@@ -382,7 +387,11 @@ func translateVaultResponse(vaultResp []*vault.SecretResponse, enclaveKey string
 
 	for _, sr := range vaultResp {
 		if sr.GetError() != "" {
-			return nil, fmt.Errorf("vault error for secret %s/%s: %s", sr.Id.GetNamespace(), sr.Id.GetKey(), sr.GetError())
+			return nil, &vaultSecretError{
+				namespace: sr.Id.GetNamespace(),
+				key:       sr.Id.GetKey(),
+				msg:       sr.GetError(),
+			}
 		}
 
 		data := sr.GetData()

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -952,7 +952,7 @@ func TestTranslateVaultResponse_VaultError(t *testing.T) {
 		result, err := translateVaultResponse(vaultResp, "aabbcc")
 		require.Nil(t, result)
 		require.Error(t, err)
-		assert.True(t, vaulttypes.IsUserError(err), "vault per-secret error should be classified as user error")
+		assert.True(t, IsUserError(err), "vault per-secret error should be classified as user error")
 		assert.Contains(t, err.Error(), "key does not exist")
 		assert.Contains(t, err.Error(), "main/API_TOKEN")
 	})
@@ -971,7 +971,7 @@ func TestTranslateVaultResponse_VaultError(t *testing.T) {
 		result, err := translateVaultResponse(vaultResp, "aabbcc")
 		require.Nil(t, result)
 		require.Error(t, err)
-		assert.False(t, vaulttypes.IsUserError(err), "vault system fallback must not be classified as a user error")
+		assert.False(t, IsUserError(err), "vault system fallback must not be classified as a user error")
 		assert.Contains(t, err.Error(), vaulttypes.SecretGetSystemErrorFallback)
 	})
 }
@@ -979,33 +979,27 @@ func TestTranslateVaultResponse_VaultError(t *testing.T) {
 func TestIsUserError(t *testing.T) {
 	t.Parallel()
 
-	t.Run("vaultSecretError wrapping a user error message is detected", func(t *testing.T) {
+	t.Run("vaultSecretError with user error is detected", func(t *testing.T) {
 		t.Parallel()
-		err := &vaultSecretError{namespace: "main", key: "API_TOKEN", msg: "key does not exist"}
-		assert.True(t, vaulttypes.IsUserError(err))
+		err := newVaultSecretError("main", "API_TOKEN", "key does not exist")
+		assert.True(t, IsUserError(err))
 	})
 
-	t.Run("vaultSecretError wrapping the system fallback is not detected", func(t *testing.T) {
+	t.Run("vaultSecretError with system fallback is not detected", func(t *testing.T) {
 		t.Parallel()
-		err := &vaultSecretError{namespace: "main", key: "API_TOKEN", msg: vaulttypes.SecretGetSystemErrorFallback}
-		assert.False(t, vaulttypes.IsUserError(err))
+		err := newVaultSecretError("main", "API_TOKEN", vaulttypes.SecretGetSystemErrorFallback)
+		assert.False(t, IsUserError(err))
 	})
 
 	t.Run("plain error is not a user error", func(t *testing.T) {
 		t.Parallel()
 		err := errors.New("failed to read secret from key-value store: connection refused")
-		assert.False(t, vaulttypes.IsUserError(err))
+		assert.False(t, IsUserError(err))
 	})
 
 	t.Run("nil is not a user error", func(t *testing.T) {
 		t.Parallel()
-		assert.False(t, vaulttypes.IsUserError(nil))
-	})
-
-	t.Run("direct vaulttypes.UserError is detected", func(t *testing.T) {
-		t.Parallel()
-		err := vaulttypes.NewUserError("key does not exist")
-		assert.True(t, vaulttypes.IsUserError(err))
+		assert.False(t, IsUserError(nil))
 	})
 }
 

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -588,6 +588,36 @@ func TestHandler_HandleGatewayMessage(t *testing.T) {
 			},
 		},
 		{
+			name:        "secrets get vault user error classified as invalid params",
+			registry:    secretsGetTestRegistry,
+			req:         secretsGetTestRequest,
+			workflowID:  "wf-secrets-1",
+			executionID: "0000000000000000000000000000000000000000000000000000000000000001",
+			helper: func(_ *testing.T) *mockExecutionHelper {
+				return &mockExecutionHelper{
+					rawSecrets: []*vault.SecretResponse{
+						{
+							Id: &vault.SecretIdentifier{
+								Key:       "API_TOKEN",
+								Namespace: "main",
+							},
+							Result: &vault.SecretResponse_Error{
+								Error: "key does not exist",
+							},
+						},
+					},
+				}
+			},
+			checkResp: func(t *testing.T, resp *jsonrpc.Response[json.RawMessage]) {
+				require.NotNil(t, resp.Error)
+				// Vault per-secret errors are user errors → ErrInvalidParams, not ErrInternal.
+				assert.Equal(t, jsonrpc.ErrInvalidParams, resp.Error.Code)
+				// The actual vault error message must reach the enclave (not "internal error").
+				assert.Contains(t, resp.Error.Message, "key does not exist")
+				assert.Contains(t, resp.Error.Message, "main/API_TOKEN")
+			},
+		},
+		{
 			name: "unsupported method",
 			registry: func(_ *testing.T) *mockCapRegistry {
 				return withEnclaveConfig(&mockCapRegistry{})
@@ -876,6 +906,49 @@ func TestTranslateVaultResponse_HexShares(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Secrets, 1)
 	require.Equal(t, base64.StdEncoding.EncodeToString(shareBytes), result.Secrets[0].EncryptedShares[0])
+}
+
+func TestTranslateVaultResponse_VaultError(t *testing.T) {
+	vaultResp := []*vault.SecretResponse{
+		{
+			Id: &vault.SecretIdentifier{Key: "API_TOKEN", Namespace: "main"},
+			Result: &vault.SecretResponse_Error{
+				Error: "key does not exist",
+			},
+		},
+	}
+
+	result, err := translateVaultResponse(vaultResp, "aabbcc")
+	require.Nil(t, result)
+	require.Error(t, err)
+	assert.True(t, vaulttypes.IsUserError(err), "vault per-secret error should be classified as user error")
+	assert.Contains(t, err.Error(), "key does not exist")
+	assert.Contains(t, err.Error(), "main/API_TOKEN")
+}
+
+func TestIsUserError(t *testing.T) {
+	t.Run("vaultSecretError wrapping a user error message is detected", func(t *testing.T) {
+		t.Parallel()
+		err := &vaultSecretError{namespace: "main", key: "API_TOKEN", msg: "key does not exist"}
+		assert.True(t, vaulttypes.IsUserError(err))
+	})
+
+	t.Run("plain error is not a user error", func(t *testing.T) {
+		t.Parallel()
+		err := fmt.Errorf("failed to read secret from key-value store: connection refused")
+		assert.False(t, vaulttypes.IsUserError(err))
+	})
+
+	t.Run("nil is not a user error", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, vaulttypes.IsUserError(nil))
+	})
+
+	t.Run("direct vaulttypes.UserError is detected", func(t *testing.T) {
+		t.Parallel()
+		err := vaulttypes.NewUserError("key does not exist")
+		assert.True(t, vaulttypes.IsUserError(err))
+	})
 }
 
 func TestVerifyWorkflowAuthorization(t *testing.T) {

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -993,7 +993,7 @@ func TestIsUserError(t *testing.T) {
 
 	t.Run("plain error is not a user error", func(t *testing.T) {
 		t.Parallel()
-		err := fmt.Errorf("failed to read secret from key-value store: connection refused")
+		err := errors.New("failed to read secret from key-value store: connection refused")
 		assert.False(t, vaulttypes.IsUserError(err))
 	})
 

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -618,6 +618,33 @@ func TestHandler_HandleGatewayMessage(t *testing.T) {
 			},
 		},
 		{
+			name:        "secrets get vault system error classified as internal",
+			registry:    secretsGetTestRegistry,
+			req:         secretsGetTestRequest,
+			workflowID:  "wf-secrets-1",
+			executionID: "0000000000000000000000000000000000000000000000000000000000000001",
+			helper: func(_ *testing.T) *mockExecutionHelper {
+				return &mockExecutionHelper{
+					rawSecrets: []*vault.SecretResponse{
+						{
+							Id: &vault.SecretIdentifier{
+								Key:       "API_TOKEN",
+								Namespace: "main",
+							},
+							Result: &vault.SecretResponse_Error{
+								Error: vaulttypes.SecretGetSystemErrorFallback,
+							},
+						},
+					},
+				}
+			},
+			checkResp: func(t *testing.T, resp *jsonrpc.Response[json.RawMessage]) {
+				require.NotNil(t, resp.Error)
+				// Vault system failures are internal errors → ErrInternal, not a user error.
+				assert.Equal(t, jsonrpc.ErrInternal, resp.Error.Code)
+			},
+		},
+		{
 			name: "unsupported method",
 			registry: func(_ *testing.T) *mockCapRegistry {
 				return withEnclaveConfig(&mockCapRegistry{})
@@ -909,28 +936,59 @@ func TestTranslateVaultResponse_HexShares(t *testing.T) {
 }
 
 func TestTranslateVaultResponse_VaultError(t *testing.T) {
-	vaultResp := []*vault.SecretResponse{
-		{
-			Id: &vault.SecretIdentifier{Key: "API_TOKEN", Namespace: "main"},
-			Result: &vault.SecretResponse_Error{
-				Error: "key does not exist",
-			},
-		},
-	}
+	t.Parallel()
 
-	result, err := translateVaultResponse(vaultResp, "aabbcc")
-	require.Nil(t, result)
-	require.Error(t, err)
-	assert.True(t, vaulttypes.IsUserError(err), "vault per-secret error should be classified as user error")
-	assert.Contains(t, err.Error(), "key does not exist")
-	assert.Contains(t, err.Error(), "main/API_TOKEN")
+	t.Run("user error is classified as a user error", func(t *testing.T) {
+		t.Parallel()
+		vaultResp := []*vault.SecretResponse{
+			{
+				Id: &vault.SecretIdentifier{Key: "API_TOKEN", Namespace: "main"},
+				Result: &vault.SecretResponse_Error{
+					Error: "key does not exist",
+				},
+			},
+		}
+
+		result, err := translateVaultResponse(vaultResp, "aabbcc")
+		require.Nil(t, result)
+		require.Error(t, err)
+		assert.True(t, vaulttypes.IsUserError(err), "vault per-secret error should be classified as user error")
+		assert.Contains(t, err.Error(), "key does not exist")
+		assert.Contains(t, err.Error(), "main/API_TOKEN")
+	})
+
+	t.Run("system fallback is not classified as a user error", func(t *testing.T) {
+		t.Parallel()
+		vaultResp := []*vault.SecretResponse{
+			{
+				Id: &vault.SecretIdentifier{Key: "API_TOKEN", Namespace: "main"},
+				Result: &vault.SecretResponse_Error{
+					Error: vaulttypes.SecretGetSystemErrorFallback,
+				},
+			},
+		}
+
+		result, err := translateVaultResponse(vaultResp, "aabbcc")
+		require.Nil(t, result)
+		require.Error(t, err)
+		assert.False(t, vaulttypes.IsUserError(err), "vault system fallback must not be classified as a user error")
+		assert.Contains(t, err.Error(), vaulttypes.SecretGetSystemErrorFallback)
+	})
 }
 
 func TestIsUserError(t *testing.T) {
+	t.Parallel()
+
 	t.Run("vaultSecretError wrapping a user error message is detected", func(t *testing.T) {
 		t.Parallel()
 		err := &vaultSecretError{namespace: "main", key: "API_TOKEN", msg: "key does not exist"}
 		assert.True(t, vaulttypes.IsUserError(err))
+	})
+
+	t.Run("vaultSecretError wrapping the system fallback is not detected", func(t *testing.T) {
+		t.Parallel()
+		err := &vaultSecretError{namespace: "main", key: "API_TOKEN", msg: vaulttypes.SecretGetSystemErrorFallback}
+		assert.False(t, vaulttypes.IsUserError(err))
 	})
 
 	t.Run("plain error is not a user error", func(t *testing.T) {

--- a/core/capabilities/confidentialrelay/vault_error.go
+++ b/core/capabilities/confidentialrelay/vault_error.go
@@ -10,15 +10,17 @@ import (
 // SecretResponse.Error field. The vault OCR plugin classifies user-caused
 // failures (e.g. "key does not exist", "key already exists", invalid public
 // key) as *vaulttypes.UserError and surfaces the raw message through
-// userFacingError. By the time the relay handler sees the string the Go type
-// is gone (protobuf boundary), so translateVaultResponse re-wraps it in this
-// type to carry the vault plugin's classification across.
+// userFacingError. System failures are replaced with a generic fallback
+// (vaulttypes.SecretGetSystemErrorFallback) so their details do not leak.
 //
-// Unwrap returns a *vaulttypes.UserError so vaulttypes.IsUserError (errors.As)
-// can detect it through this wrapper. The handler then maps it to
-// jsonrpc.ErrInvalidParams (a client error) instead of ErrInternal, so the
-// enclave receives the actual cause and the metrics/logs reflect a user error
-// rather than an internal failure.
+// By the time the relay handler sees the string the Go type is gone (protobuf
+// boundary), so translateVaultResponse re-wraps it here. Unwrap returns a
+// *vaulttypes.UserError only for user-caused messages; for the system fallback
+// it returns nil, so vaulttypes.IsUserError (errors.As) reports false and the
+// handler keeps the failure classified as jsonrpc.ErrInternal. The handler then
+// maps user errors to jsonrpc.ErrInvalidParams so the enclave receives the
+// actual cause and the metrics/logs reflect a user error rather than an
+// internal failure.
 type vaultSecretError struct {
 	namespace string
 	key       string
@@ -30,5 +32,8 @@ func (e *vaultSecretError) Error() string {
 }
 
 func (e *vaultSecretError) Unwrap() error {
+	if vaulttypes.IsSecretGetSystemError(e.msg) {
+		return nil
+	}
 	return vaulttypes.NewUserError(e.msg)
 }

--- a/core/capabilities/confidentialrelay/vault_error.go
+++ b/core/capabilities/confidentialrelay/vault_error.go
@@ -1,0 +1,34 @@
+package confidentialrelay
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
+)
+
+// vaultSecretError wraps a per-secret error returned by the vault DON in a
+// SecretResponse.Error field. The vault OCR plugin classifies user-caused
+// failures (e.g. "key does not exist", "key already exists", invalid public
+// key) as *vaulttypes.UserError and surfaces the raw message through
+// userFacingError. By the time the relay handler sees the string the Go type
+// is gone (protobuf boundary), so translateVaultResponse re-wraps it in this
+// type to carry the vault plugin's classification across.
+//
+// Unwrap returns a *vaulttypes.UserError so vaulttypes.IsUserError (errors.As)
+// can detect it through this wrapper. The handler then maps it to
+// jsonrpc.ErrInvalidParams (a client error) instead of ErrInternal, so the
+// enclave receives the actual cause and the metrics/logs reflect a user error
+// rather than an internal failure.
+type vaultSecretError struct {
+	namespace string
+	key       string
+	msg       string
+}
+
+func (e *vaultSecretError) Error() string {
+	return fmt.Sprintf("vault error for secret %s/%s: %s", e.namespace, e.key, e.msg)
+}
+
+func (e *vaultSecretError) Unwrap() error {
+	return vaulttypes.NewUserError(e.msg)
+}

--- a/core/capabilities/confidentialrelay/vault_error.go
+++ b/core/capabilities/confidentialrelay/vault_error.go
@@ -1,6 +1,7 @@
 package confidentialrelay
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
@@ -8,32 +9,44 @@ import (
 
 // vaultSecretError wraps a per-secret error returned by the vault DON in a
 // SecretResponse.Error field. The vault OCR plugin classifies user-caused
-// failures (e.g. "key does not exist", "key already exists", invalid public
-// key) as *vaulttypes.UserError and surfaces the raw message through
-// userFacingError. System failures are replaced with a generic fallback
-// (vaulttypes.SecretGetSystemErrorFallback) so their details do not leak.
+// failures (e.g. "key does not exist") as userError and surfaces the raw
+// message through userFacingError. System failures are replaced with a generic
+// fallback (vaulttypes.SecretGetSystemErrorFallback) so their details do not
+// leak.
 //
 // By the time the relay handler sees the string the Go type is gone (protobuf
-// boundary), so translateVaultResponse re-wraps it here. Unwrap returns a
-// *vaulttypes.UserError only for user-caused messages; for the system fallback
-// it returns nil, so vaulttypes.IsUserError (errors.As) reports false and the
-// handler keeps the failure classified as jsonrpc.ErrInternal. The handler then
-// maps user errors to jsonrpc.ErrInvalidParams so the enclave receives the
-// actual cause and the metrics/logs reflect a user error rather than an
-// internal failure.
+// boundary), so translateVaultResponse re-wraps it here with an explicit isUser
+// flag set at construction time. The handler checks the flag via IsUserError to
+// map user errors to jsonrpc.ErrInvalidParams and system errors to
+// jsonrpc.ErrInternal.
 type vaultSecretError struct {
 	namespace string
 	key       string
 	msg       string
+	isUser    bool
 }
 
 func (e *vaultSecretError) Error() string {
 	return fmt.Sprintf("vault error for secret %s/%s: %s", e.namespace, e.key, e.msg)
 }
 
-func (e *vaultSecretError) Unwrap() error {
-	if vaulttypes.IsSecretGetSystemError(e.msg) {
-		return nil
+// IsUserError reports whether err is a vaultSecretError marked as a user error.
+func IsUserError(err error) bool {
+	var vse *vaultSecretError
+	if !errors.As(err, &vse) {
+		return false
 	}
-	return vaulttypes.NewUserError(e.msg)
+	return vse.isUser
+}
+
+// newVaultSecretError creates a vaultSecretError, classifying the message as
+// user or system based on whether it matches the vault plugin's system-error
+// fallback.
+func newVaultSecretError(namespace, key, msg string) *vaultSecretError {
+	return &vaultSecretError{
+		namespace: namespace,
+		key:       key,
+		msg:       msg,
+		isUser:    !vaulttypes.IsSecretGetSystemError(msg),
+	}
 }

--- a/core/capabilities/vault/vaulttypes/types.go
+++ b/core/capabilities/vault/vaulttypes/types.go
@@ -247,3 +247,17 @@ func IsUserError(err error) bool {
 	var ue *UserError
 	return errors.As(err, &ue)
 }
+
+// SecretGetSystemErrorFallback is the generic message the vault OCR plugin
+// substitutes for a non-user (system) failure on a get-secrets request item
+// (see userFacingError). The Go error type is lost at the protobuf
+// SecretResponse.error string boundary, so downstream consumers cannot recover
+// it; this constant is the shared marker they match against to keep system
+// failures classified as internal rather than user errors.
+const SecretGetSystemErrorFallback = "failed to handle get secret request"
+
+// IsSecretGetSystemError reports whether msg is the get-secrets system-error
+// fallback, i.e. a failure that must not be classified as a user error.
+func IsSecretGetSystemError(msg string) bool {
+	return msg == SecretGetSystemErrorFallback
+}

--- a/core/capabilities/vault/vaulttypes/types.go
+++ b/core/capabilities/vault/vaulttypes/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -216,4 +217,33 @@ func ValidateSignatures(resp *SignedOCRResponse, allowedSigners []common.Address
 	}
 
 	return fmt.Errorf("only %d valid signatures, need at least %d", len(validSigners), minRequired)
+}
+
+// UserError is a vault error caused by the caller (e.g. requesting a secret
+// that does not exist, providing an invalid public key, exceeding the per-owner
+// secret limit). It lives in the shared vaulttypes package so both the vault
+// OCR plugin and downstream consumers (e.g. the confidential relay handler) can
+// use errors.As to distinguish user errors from internal failures.
+type UserError struct {
+	msg string
+}
+
+// NewUserError creates a *UserError with the given message.
+func NewUserError(msg string) *UserError {
+	return &UserError{msg: msg}
+}
+
+func (u *UserError) Error() string {
+	return u.msg
+}
+
+func (u *UserError) Is(target error) bool {
+	_, ok := target.(*UserError)
+	return ok
+}
+
+// IsUserError reports whether err is a vault UserError.
+func IsUserError(err error) bool {
+	var ue *UserError
+	return errors.As(err, &ue)
 }

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -339,27 +339,27 @@ func (r *ReportingPluginFactory) NewReportingPlugin(ctx context.Context, config 
 	r.lifecycle.SetConfigDigest(config.ConfigDigest.String())
 
 	return &ReportingPlugin{
-		lggr:                         r.lggr.Named("VaultReportingPlugin"),
-		store:                        r.store,
-		cfg:                          cfg,
-		metrics:                      metrics,
-		onchainCfg:                   config,
-		validator:                    validator,
-		lifecycle:                    r.lifecycle,
-		maxObservationBytes:          pluginLimits.MaxObservationBytes,
-		maxReportsPlusPrecursorBytes: pluginLimits.MaxReportsPlusPrecursorBytes,
-		unmarshalBlob: func(data []byte) (ocr3_1types.BlobHandle, error) {
-			handle := ocr3_1types.BlobHandle{}
-			err := handle.UnmarshalBinary(data)
-			return handle, err
-		},
-		marshalBlob: func(handle ocr3_1types.BlobHandle) ([]byte, error) {
-			return handle.MarshalBinary()
-		},
-	}, ocr3_1types.ReportingPluginInfo1{
-		Name:   "VaultReportingPlugin",
-		Limits: pluginLimits,
-	}, nil
+			lggr:                         r.lggr.Named("VaultReportingPlugin"),
+			store:                        r.store,
+			cfg:                          cfg,
+			metrics:                      metrics,
+			onchainCfg:                   config,
+			validator:                    validator,
+			lifecycle:                    r.lifecycle,
+			maxObservationBytes:          pluginLimits.MaxObservationBytes,
+			maxReportsPlusPrecursorBytes: pluginLimits.MaxReportsPlusPrecursorBytes,
+			unmarshalBlob: func(data []byte) (ocr3_1types.BlobHandle, error) {
+				handle := ocr3_1types.BlobHandle{}
+				err := handle.UnmarshalBinary(data)
+				return handle, err
+			},
+			marshalBlob: func(handle ocr3_1types.BlobHandle) ([]byte, error) {
+				return handle.MarshalBinary()
+			},
+		}, ocr3_1types.ReportingPluginInfo1{
+			Name:   "VaultReportingPlugin",
+			Limits: pluginLimits,
+		}, nil
 }
 
 type ReportingPlugin struct {
@@ -1428,25 +1428,12 @@ func (r *ReportingPlugin) observeDeleteSecretRequest(ctx context.Context, reader
 	return id, nil
 }
 
-func newUserError(msg string) *userError {
-	return &userError{msg: msg}
-}
-
-type userError struct {
-	msg string
-}
-
-func (u *userError) Error() string {
-	return u.msg
-}
-
-func (u *userError) Is(target error) bool {
-	_, ok := target.(*userError)
-	return ok
+func newUserError(msg string) *vaulttypes.UserError {
+	return vaulttypes.NewUserError(msg)
 }
 
 func userFacingError(err error, fallback string) string {
-	if errors.Is(err, &userError{}) {
+	if vaulttypes.IsUserError(err) {
 		return err.Error()
 	}
 
@@ -1456,7 +1443,7 @@ func userFacingError(err error, fallback string) string {
 func logUserErrorAware(l logger.Logger, msg string, err error, keysAndValues ...any) {
 	keysAndValues = append(keysAndValues, "error", err)
 	lggr := l.Helper(1)
-	if errors.Is(err, &userError{}) {
+	if vaulttypes.IsUserError(err) {
 		lggr.Debugw(msg, keysAndValues...)
 		return
 	}

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -1128,11 +1128,11 @@ type share struct {
 func (s *share) encryptWithKeyBinary(pk string) ([]byte, error) {
 	publicKey, err := hex.DecodeString(pk)
 	if err != nil {
-		return nil, newUserError("failed to convert public key to bytes: " + err.Error())
+		return nil, vaulttypes.NewUserError("failed to convert public key to bytes: " + err.Error())
 	}
 
 	if len(publicKey) != curve25519.PointSize {
-		return nil, newUserError(fmt.Sprintf("invalid public key size: expected %d bytes, got %d bytes", curve25519.PointSize, len(publicKey)))
+		return nil, vaulttypes.NewUserError(fmt.Sprintf("invalid public key size: expected %d bytes, got %d bytes", curve25519.PointSize, len(publicKey)))
 	}
 
 	publicKeyLength := [curve25519.PointSize]byte(publicKey)
@@ -1181,7 +1181,7 @@ func (r *ReportingPlugin) observeGetSecretsRequest(ctx context.Context, reader R
 		return nil, fmt.Errorf("failed to read secret from key-value store: %w", err)
 	}
 	if secret == nil {
-		return nil, newUserError("key does not exist")
+		return nil, vaulttypes.NewUserError("key does not exist")
 	}
 
 	sh, err := generatePlaintextShare(r.cfg.PublicKey, r.cfg.PrivateKeyShare, secret.EncryptedSecret, id.Owner)
@@ -1422,14 +1422,10 @@ func (r *ReportingPlugin) observeDeleteSecretRequest(ctx context.Context, reader
 	}
 
 	if ss == nil {
-		return id, newUserError("key does not exist")
+		return id, vaulttypes.NewUserError("key does not exist")
 	}
 
 	return id, nil
-}
-
-func newUserError(msg string) *vaulttypes.UserError {
-	return vaulttypes.NewUserError(msg)
 }
 
 func userFacingError(err error, fallback string) string {
@@ -2518,7 +2514,7 @@ func (r *ReportingPlugin) stateTransitionCreateSecrets(ctx context.Context, stor
 
 func (r *ReportingPlugin) stateTransitionCreateSecretsRequest(ctx context.Context, store WriteKVStore, req *vaultcommon.EncryptedSecret, resp *vaultcommon.CreateSecretResponse) (*vaultcommon.CreateSecretResponse, error) {
 	if resp.GetError() != "" {
-		return resp, newUserError(resp.GetError())
+		return resp, vaulttypes.NewUserError(resp.GetError())
 	}
 
 	encryptedSecret, err := decodeEncryptedSecretHex(req.EncryptedValue)
@@ -2532,7 +2528,7 @@ func (r *ReportingPlugin) stateTransitionCreateSecretsRequest(ctx context.Contex
 	}
 
 	if secret != nil {
-		return nil, newUserError("could not write to key value store: key already exists")
+		return nil, vaulttypes.NewUserError("could not write to key value store: key already exists")
 	}
 
 	count, err := store.GetSecretIdentifiersCountForOwner(ctx, req.Id.Owner)
@@ -2544,7 +2540,7 @@ func (r *ReportingPlugin) stateTransitionCreateSecretsRequest(ctx context.Contex
 	ctx = contexts.WithCRE(ctx, contexts.CRE{Owner: req.Id.Owner})
 	if ierr := r.cfg.MaxSecretsPerOwner.Check(ctx, count+1); ierr != nil {
 		if errBoundLimited, ok := errors.AsType[limits.ErrorBoundLimited[int]](ierr); ok {
-			return nil, newUserError(fmt.Sprintf("could not write to key value store: owner %s has reached maximum number of secrets (limit=%d)", req.Id.Owner, errBoundLimited.Limit))
+			return nil, vaulttypes.NewUserError(fmt.Sprintf("could not write to key value store: owner %s has reached maximum number of secrets (limit=%d)", req.Id.Owner, errBoundLimited.Limit))
 		}
 		return nil, fmt.Errorf("failed to check max secrets per owner limit: %w", ierr)
 	}
@@ -2636,7 +2632,7 @@ func (r *ReportingPlugin) stateTransitionUpdateSecrets(ctx context.Context, stor
 
 func (r *ReportingPlugin) stateTransitionUpdateSecretsRequest(ctx context.Context, store WriteKVStore, req *vaultcommon.EncryptedSecret, resp *vaultcommon.UpdateSecretResponse) (*vaultcommon.UpdateSecretResponse, error) {
 	if resp.GetError() != "" {
-		return resp, newUserError(resp.GetError())
+		return resp, vaulttypes.NewUserError(resp.GetError())
 	}
 
 	encryptedSecret, err := decodeEncryptedSecretHex(req.EncryptedValue)
@@ -2650,7 +2646,7 @@ func (r *ReportingPlugin) stateTransitionUpdateSecretsRequest(ctx context.Contex
 	}
 
 	if secret == nil {
-		return nil, newUserError("could not write update to key value store: key does not exist")
+		return nil, vaulttypes.NewUserError("could not write update to key value store: key does not exist")
 	}
 
 	err = store.WriteSecret(ctx, req.Id, &vaultcommon.StoredSecret{
@@ -2740,7 +2736,7 @@ func (r *ReportingPlugin) stateTransitionDeleteSecrets(ctx context.Context, stor
 
 func (r *ReportingPlugin) stateTransitionDeleteSecretsRequest(ctx context.Context, store WriteKVStore, id *vaultcommon.SecretIdentifier, resp *vaultcommon.DeleteSecretResponse) (*vaultcommon.DeleteSecretResponse, error) {
 	if resp.GetError() != "" {
-		return resp, newUserError(resp.GetError())
+		return resp, vaulttypes.NewUserError(resp.GetError())
 	}
 
 	err := store.DeleteSecret(ctx, id)

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -339,27 +339,27 @@ func (r *ReportingPluginFactory) NewReportingPlugin(ctx context.Context, config 
 	r.lifecycle.SetConfigDigest(config.ConfigDigest.String())
 
 	return &ReportingPlugin{
-			lggr:                         r.lggr.Named("VaultReportingPlugin"),
-			store:                        r.store,
-			cfg:                          cfg,
-			metrics:                      metrics,
-			onchainCfg:                   config,
-			validator:                    validator,
-			lifecycle:                    r.lifecycle,
-			maxObservationBytes:          pluginLimits.MaxObservationBytes,
-			maxReportsPlusPrecursorBytes: pluginLimits.MaxReportsPlusPrecursorBytes,
-			unmarshalBlob: func(data []byte) (ocr3_1types.BlobHandle, error) {
-				handle := ocr3_1types.BlobHandle{}
-				err := handle.UnmarshalBinary(data)
-				return handle, err
-			},
-			marshalBlob: func(handle ocr3_1types.BlobHandle) ([]byte, error) {
-				return handle.MarshalBinary()
-			},
-		}, ocr3_1types.ReportingPluginInfo1{
-			Name:   "VaultReportingPlugin",
-			Limits: pluginLimits,
-		}, nil
+		lggr:                         r.lggr.Named("VaultReportingPlugin"),
+		store:                        r.store,
+		cfg:                          cfg,
+		metrics:                      metrics,
+		onchainCfg:                   config,
+		validator:                    validator,
+		lifecycle:                    r.lifecycle,
+		maxObservationBytes:          pluginLimits.MaxObservationBytes,
+		maxReportsPlusPrecursorBytes: pluginLimits.MaxReportsPlusPrecursorBytes,
+		unmarshalBlob: func(data []byte) (ocr3_1types.BlobHandle, error) {
+			handle := ocr3_1types.BlobHandle{}
+			err := handle.UnmarshalBinary(data)
+			return handle, err
+		},
+		marshalBlob: func(handle ocr3_1types.BlobHandle) ([]byte, error) {
+			return handle.MarshalBinary()
+		},
+	}, ocr3_1types.ReportingPluginInfo1{
+		Name:   "VaultReportingPlugin",
+		Limits: pluginLimits,
+	}, nil
 }
 
 type ReportingPlugin struct {

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -1101,7 +1101,7 @@ func (r *ReportingPlugin) observeGetSecrets(ctx context.Context, seqNr uint64, r
 		resp, ierr := r.observeGetSecretsRequest(ctx, reader, secretRequest, requestsCountForID)
 		if ierr != nil {
 			logUserErrorAware(l, "failed to observe get secret request item", ierr, "id", secretRequest.Id)
-			errorMsg := userFacingError(ierr, "failed to handle get secret request")
+			errorMsg := userFacingError(ierr, vaulttypes.SecretGetSystemErrorFallback)
 			resps = append(resps, &vaultcommon.SecretResponse{
 				Id: secretRequest.Id,
 				Result: &vaultcommon.SecretResponse_Error{

--- a/core/services/ocr2/plugins/vault/plugin_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_test.go
@@ -8434,17 +8434,21 @@ func TestPlugin_ValidateObservation_ListSecretIdentifiersExceedsMaxSecretsPerOwn
 }
 
 func TestUserFacingError(t *testing.T) {
+	t.Parallel()
 	t.Run("returns error message for userError", func(t *testing.T) {
+		t.Parallel()
 		err := vaulttypes.NewUserError("key does not exist")
 		assert.Equal(t, "key does not exist", userFacingError(err, "fallback"))
 	})
 
 	t.Run("returns fallback for non-userError", func(t *testing.T) {
+		t.Parallel()
 		err := errors.New("internal failure")
 		assert.Equal(t, "fallback msg", userFacingError(err, "fallback msg"))
 	})
 
 	t.Run("returns wrapped error message for wrapped userError", func(t *testing.T) {
+		t.Parallel()
 		err := fmt.Errorf("context: %w", vaulttypes.NewUserError("bad key"))
 		assert.Equal(t, "context: bad key", userFacingError(err, "fallback"))
 	})

--- a/core/services/ocr2/plugins/vault/plugin_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_test.go
@@ -8435,7 +8435,7 @@ func TestPlugin_ValidateObservation_ListSecretIdentifiersExceedsMaxSecretsPerOwn
 
 func TestUserFacingError(t *testing.T) {
 	t.Run("returns error message for userError", func(t *testing.T) {
-		err := newUserError("key does not exist")
+		err := vaulttypes.NewUserError("key does not exist")
 		assert.Equal(t, "key does not exist", userFacingError(err, "fallback"))
 	})
 
@@ -8445,7 +8445,7 @@ func TestUserFacingError(t *testing.T) {
 	})
 
 	t.Run("returns wrapped error message for wrapped userError", func(t *testing.T) {
-		err := fmt.Errorf("context: %w", newUserError("bad key"))
+		err := fmt.Errorf("context: %w", vaulttypes.NewUserError("bad key"))
 		assert.Equal(t, "context: bad key", userFacingError(err, "fallback"))
 	})
 }
@@ -8453,7 +8453,7 @@ func TestUserFacingError(t *testing.T) {
 func TestLogUserErrorAware(t *testing.T) {
 	t.Run("logs at debug level for userError", func(t *testing.T) {
 		lggr, observed := logger.TestLoggerObserved(t, zapcore.DebugLevel)
-		err := newUserError("key does not exist")
+		err := vaulttypes.NewUserError("key does not exist")
 
 		logUserErrorAware(lggr, "failed to observe request", err, "id", "req-1")
 
@@ -8489,7 +8489,7 @@ func TestLogUserErrorAware(t *testing.T) {
 
 	t.Run("logs at debug level for wrapped userError", func(t *testing.T) {
 		lggr, observed := logger.TestLoggerObserved(t, zapcore.DebugLevel)
-		err := fmt.Errorf("validation: %w", newUserError("bad input"))
+		err := fmt.Errorf("validation: %w", vaulttypes.NewUserError("bad input"))
 
 		logUserErrorAware(lggr, "request failed", err, "op", "create")
 

--- a/core/services/ocr2/plugins/vault/request_validation.go
+++ b/core/services/ocr2/plugins/vault/request_validation.go
@@ -60,7 +60,7 @@ func validateRequestResponseItemCount(requestCount, responseCount int, method st
 
 func (r *ReportingPlugin) validateSecretIdentifier(ctx context.Context, id *vaultcommon.SecretIdentifier) (*vaultcommon.SecretIdentifier, error) {
 	if id == nil {
-		return nil, newUserError("secret identifier cannot be nil")
+		return nil, vaulttypes.NewUserError("secret identifier cannot be nil")
 	}
 
 	namespace := id.Namespace
@@ -69,7 +69,7 @@ func (r *ReportingPlugin) validateSecretIdentifier(ctx context.Context, id *vaul
 	}
 
 	if err := r.validator.ValidateSecretIdentifier(ctx, id.Key, id.Owner, namespace); err != nil {
-		return nil, newUserError(err.Error())
+		return nil, vaulttypes.NewUserError(err.Error())
 	}
 
 	return &vaultcommon.SecretIdentifier{
@@ -82,21 +82,21 @@ func (r *ReportingPlugin) validateSecretIdentifier(ctx context.Context, id *vaul
 func (r *ReportingPlugin) validateDuplicateSecretIdentifierUserError(id *vaultcommon.SecretIdentifier, counts map[string]int) error {
 	key := secretIdentifierKey(id)
 	if counts[key] > 1 {
-		return newUserError("duplicate request for secret identifier " + vaulttypes.KeyFor(id))
+		return vaulttypes.NewUserError("duplicate request for secret identifier " + vaulttypes.KeyFor(id))
 	}
 	return nil
 }
 
 func (r *ReportingPlugin) validateEncryptedSecretCiphertextSize(ctx context.Context, owner string, encryptedValue string) error {
 	if ierr := r.validator.ValidateCiphertextSize(ctx, owner, encryptedValue); ierr != nil {
-		return newUserError(ierr.Error())
+		return vaulttypes.NewUserError(ierr.Error())
 	}
 	return nil
 }
 
 func (r *ReportingPlugin) validateEncryptedSecretLabel(owner string, encryptedValue string) error {
 	if err := vaultcap.EnsureRightLabelOnSecret(r.cfg.PublicKey, encryptedValue, owner); err != nil {
-		return newUserError("failed to verify ciphertext: " + err.Error())
+		return vaulttypes.NewUserError("failed to verify ciphertext: " + err.Error())
 	}
 	return nil
 }
@@ -274,7 +274,7 @@ func (r *ReportingPlugin) validateListSecretIdentifiersResponseSize(ctx context.
 func decodeEncryptedSecretHex(encryptedValue string) ([]byte, error) {
 	encryptedSecret, err := hex.DecodeString(encryptedValue)
 	if err != nil {
-		return nil, newUserError("could not decode secret value: invalid hex: " + err.Error())
+		return nil, vaulttypes.NewUserError("could not decode secret value: invalid hex: " + err.Error())
 	}
 	return encryptedSecret, nil
 }


### PR DESCRIPTION
### Description

This pr creates a wrapper around user errors to prevent misclassification of it as an internal system error.

Currently, when an enclave running a confidential workflow tries to fetch secrets from the Vault DON, any error is returned back as a 32603 JSON RPC internal error. This causes us to get paged, even if a user is misuing the vault DON (such as in this incident, where the user had forgotten to upload their secret). This change checks for user error responses from the Vault DON, and if detected returns a 32602 JSON RPC user error that the enclave can detect and then _not_ alert on.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
