### PR TITLE
fix: keep vault system errors classified as internal

### DIFF
--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -618,6 +618,33 @@ func TestHandler_HandleGatewayMessage(t *testing.T) {
 			},
 		},
 		{
+			name:        "secrets get vault system error classified as internal",
+			registry:    secretsGetTestRegistry,
+			req:         secretsGetTestRequest,
+			workflowID:  "wf-secrets-1",
+			executionID: "0000000000000000000000000000000000000000000000000000000000000001",
+			helper: func(_ *testing.T) *mockExecutionHelper {
+				return &mockExecutionHelper{
+					rawSecrets: []*vault.SecretResponse{
+						{
+							Id: &vault.SecretIdentifier{
+								Key:       "API_TOKEN",
+								Namespace: "main",
+							},
+							Result: &vault.SecretResponse_Error{
+								Error: vaulttypes.SecretGetSystemErrorFallback,
+							},
+						},
+					},
+				}
+			},
+			checkResp: func(t *testing.T, resp *jsonrpc.Response[json.RawMessage]) {
+				require.NotNil(t, resp.Error)
+				// Vault system failures are internal errors → ErrInternal, not a user error.
+				assert.Equal(t, jsonrpc.ErrInternal, resp.Error.Code)
+			},
+		},
+		{
 			name: "unsupported method",
 			registry: func(_ *testing.T) *mockCapRegistry {
 				return withEnclaveConfig(&mockCapRegistry{})
@@ -909,21 +936,40 @@ func TestTranslateVaultResponse_HexShares(t *testing.T) {
 }
 
 func TestTranslateVaultResponse_VaultError(t *testing.T) {
-	vaultResp := []*vault.SecretResponse{
-		{
-			Id: &vault.SecretIdentifier{Key: "API_TOKEN", Namespace: "main"},
-			Result: &vault.SecretResponse_Error{
-				Error: "key does not exist",
+	t.Run("user error is classified as a user error", func(t *testing.T) {
+		vaultResp := []*vault.SecretResponse{
+			{
+				Id: &vault.SecretIdentifier{Key: "API_TOKEN", Namespace: "main"},
+				Result: &vault.SecretResponse_Error{
+					Error: "key does not exist",
+				},
 			},
-		},
-	}
+		}
 
-	result, err := translateVaultResponse(vaultResp, "aabbcc")
-	require.Nil(t, result)
-	require.Error(t, err)
-	assert.True(t, vaulttypes.IsUserError(err), "vault per-secret error should be classified as user error")
-	assert.Contains(t, err.Error(), "key does not exist")
-	assert.Contains(t, err.Error(), "main/API_TOKEN")
+		result, err := translateVaultResponse(vaultResp, "aabbcc")
+		require.Nil(t, result)
+		require.Error(t, err)
+		assert.True(t, vaulttypes.IsUserError(err), "vault per-secret error should be classified as user error")
+		assert.Contains(t, err.Error(), "key does not exist")
+		assert.Contains(t, err.Error(), "main/API_TOKEN")
+	})
+
+	t.Run("system fallback is not classified as a user error", func(t *testing.T) {
+		vaultResp := []*vault.SecretResponse{
+			{
+				Id: &vault.SecretIdentifier{Key: "API_TOKEN", Namespace: "main"},
+				Result: &vault.SecretResponse_Error{
+					Error: vaulttypes.SecretGetSystemErrorFallback,
+				},
+			},
+		}
+
+		result, err := translateVaultResponse(vaultResp, "aabbcc")
+		require.Nil(t, result)
+		require.Error(t, err)
+		assert.False(t, vaulttypes.IsUserError(err), "vault system fallback must not be classified as a user error")
+		assert.Contains(t, err.Error(), vaulttypes.SecretGetSystemErrorFallback)
+	})
 }
 
 func TestIsUserError(t *testing.T) {
@@ -931,6 +977,12 @@ func TestIsUserError(t *testing.T) {
 		t.Parallel()
 		err := &vaultSecretError{namespace: "main", key: "API_TOKEN", msg: "key does not exist"}
 		assert.True(t, vaulttypes.IsUserError(err))
+	})
+
+	t.Run("vaultSecretError wrapping the system fallback is not detected", func(t *testing.T) {
+		t.Parallel()
+		err := &vaultSecretError{namespace: "main", key: "API_TOKEN", msg: vaulttypes.SecretGetSystemErrorFallback}
+		assert.False(t, vaulttypes.IsUserError(err))
 	})
 
 	t.Run("plain error is not a user error", func(t *testing.T) {

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -936,7 +936,10 @@ func TestTranslateVaultResponse_HexShares(t *testing.T) {
 }
 
 func TestTranslateVaultResponse_VaultError(t *testing.T) {
+	t.Parallel()
+
 	t.Run("user error is classified as a user error", func(t *testing.T) {
+		t.Parallel()
 		vaultResp := []*vault.SecretResponse{
 			{
 				Id: &vault.SecretIdentifier{Key: "API_TOKEN", Namespace: "main"},
@@ -955,6 +958,7 @@ func TestTranslateVaultResponse_VaultError(t *testing.T) {
 	})
 
 	t.Run("system fallback is not classified as a user error", func(t *testing.T) {
+		t.Parallel()
 		vaultResp := []*vault.SecretResponse{
 			{
 				Id: &vault.SecretIdentifier{Key: "API_TOKEN", Namespace: "main"},
@@ -973,6 +977,8 @@ func TestTranslateVaultResponse_VaultError(t *testing.T) {
 }
 
 func TestIsUserError(t *testing.T) {
+	t.Parallel()
+
 	t.Run("vaultSecretError wrapping a user error message is detected", func(t *testing.T) {
 		t.Parallel()
 		err := &vaultSecretError{namespace: "main", key: "API_TOKEN", msg: "key does not exist"}

--- a/core/capabilities/confidentialrelay/vault_error.go
+++ b/core/capabilities/confidentialrelay/vault_error.go
@@ -10,15 +10,17 @@ import (
 // SecretResponse.Error field. The vault OCR plugin classifies user-caused
 // failures (e.g. "key does not exist", "key already exists", invalid public
 // key) as *vaulttypes.UserError and surfaces the raw message through
-// userFacingError. By the time the relay handler sees the string the Go type
-// is gone (protobuf boundary), so translateVaultResponse re-wraps it in this
-// type to carry the vault plugin's classification across.
+// userFacingError. System failures are replaced with a generic fallback
+// (vaulttypes.SecretGetSystemErrorFallback) so their details do not leak.
 //
-// Unwrap returns a *vaulttypes.UserError so vaulttypes.IsUserError (errors.As)
-// can detect it through this wrapper. The handler then maps it to
-// jsonrpc.ErrInvalidParams (a client error) instead of ErrInternal, so the
-// enclave receives the actual cause and the metrics/logs reflect a user error
-// rather than an internal failure.
+// By the time the relay handler sees the string the Go type is gone (protobuf
+// boundary), so translateVaultResponse re-wraps it here. Unwrap returns a
+// *vaulttypes.UserError only for user-caused messages; for the system fallback
+// it returns nil, so vaulttypes.IsUserError (errors.As) reports false and the
+// handler keeps the failure classified as jsonrpc.ErrInternal. The handler then
+// maps user errors to jsonrpc.ErrInvalidParams so the enclave receives the
+// actual cause and the metrics/logs reflect a user error rather than an
+// internal failure.
 type vaultSecretError struct {
 	namespace string
 	key       string
@@ -30,5 +32,8 @@ func (e *vaultSecretError) Error() string {
 }
 
 func (e *vaultSecretError) Unwrap() error {
+	if vaulttypes.IsSecretGetSystemError(e.msg) {
+		return nil
+	}
 	return vaulttypes.NewUserError(e.msg)
 }

--- a/core/capabilities/vault/vaulttypes/types.go
+++ b/core/capabilities/vault/vaulttypes/types.go
@@ -247,3 +247,17 @@ func IsUserError(err error) bool {
 	var ue *UserError
 	return errors.As(err, &ue)
 }
+
+// SecretGetSystemErrorFallback is the generic message the vault OCR plugin
+// substitutes for a non-user (system) failure on a get-secrets request item
+// (see userFacingError). The Go error type is lost at the protobuf
+// SecretResponse.error string boundary, so downstream consumers cannot recover
+// it; this constant is the shared marker they match against to keep system
+// failures classified as internal rather than user errors.
+const SecretGetSystemErrorFallback = "failed to handle get secret request"
+
+// IsSecretGetSystemError reports whether msg is the get-secrets system-error
+// fallback, i.e. a failure that must not be classified as a user error.
+func IsSecretGetSystemError(msg string) bool {
+	return msg == SecretGetSystemErrorFallback
+}

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -1101,7 +1101,7 @@ func (r *ReportingPlugin) observeGetSecrets(ctx context.Context, seqNr uint64, r
 		resp, ierr := r.observeGetSecretsRequest(ctx, reader, secretRequest, requestsCountForID)
 		if ierr != nil {
 			logUserErrorAware(l, "failed to observe get secret request item", ierr, "id", secretRequest.Id)
-			errorMsg := userFacingError(ierr, "failed to handle get secret request")
+			errorMsg := userFacingError(ierr, vaulttypes.SecretGetSystemErrorFallback)
 			resps = append(resps, &vaultcommon.SecretResponse{
 				Id: secretRequest.Id,
 				Result: &vaultcommon.SecretResponse_Error{


### PR DESCRIPTION
## What

Corrective patch on top of #23514. The base PR classifies vault per-secret errors as user errors, but does it for *every* `SecretResponse.Error` — including genuine system failures — which would suppress system-error alerts.

## The flaw in #23514

`vaultSecretError.Unwrap()` returned a `*vaulttypes.UserError` unconditionally, so `vaulttypes.IsUserError` was `true` for any per-secret vault error. But the vault OCR plugin's `observeGetSecretsRequest` returns a mix:

- **User errors** (`newUserError`): "key does not exist", invalid public key, etc.
- **System errors** (plain `fmt.Errorf`): KV-store read failures, decryption/share-generation failures.

These flow through `userFacingError`, which keeps the raw message for user errors but replaces system errors with a generic fallback (`"failed to handle get secret request"`). The Go type is lost at the protobuf `SecretResponse.error` string boundary, so the relay handler can't recover it. #23514's unconditional `UserError` meant a KV-store outage or decryption failure would be mapped to `jsonrpc.ErrInvalidParams` (user error) instead of `ErrInternal` — the opposite of the intended fix. You'd trade false user-error alerts for missed system-error alerts.

#23514's tests didn't catch this: the `TestIsUserError` "plain error is not a user error" case used a raw `fmt.Errorf` that never passes through `translateVaultResponse`'s wrapper, so the system-fallback-string path was never exercised.

## The fix

Export the fallback as `vaulttypes.SecretGetSystemErrorFallback` so the vault plugin and relay handler share one marker (the plugin now uses the constant instead of a string literal, so it can't drift), and have `vaultSecretError.Unwrap()` return `nil` for that message so `IsUserError` reports `false`:

```go
func (e *vaultSecretError) Unwrap() error {
	if vaulttypes.IsSecretGetSystemError(e.msg) {
		return nil
	}
	return vaulttypes.NewUserError(e.msg)
}
```

User errors still unwrap to a `UserError` and map to `ErrInvalidParams` (the base PR's behavior, unchanged). System errors keep falling through to `ErrInternal`.

## Files

- `core/capabilities/vault/vaulttypes/types.go` — add `SecretGetSystemErrorFallback` + `IsSecretGetSystemError`.
- `core/services/ocr2/plugins/vault/plugin.go` — use the shared constant at the GetSecrets fallback site.
- `core/capabilities/confidentialrelay/vault_error.go` — `Unwrap` returns `nil` for the system fallback.
- `core/capabilities/confidentialrelay/handler_test.go` — add the system-fallback cases (`TestTranslateVaultResponse_VaultError`, `TestIsUserError`, `TestHandler_HandleGatewayMessage`) asserting `IsUserError == false` and `ErrInternal`.

## Verification

- `go build ./core/capabilities/vault/vaulttypes/... ./core/capabilities/confidentialrelay/... ./core/services/ocr2/plugins/vault/...` — clean.
- `go test ./core/capabilities/confidentialrelay/...` (including new + existing error tests) — pass.
- `go test ./core/services/ocr2/plugins/vault/...` non-DB tests (including `SecretDoesNotExist`, exercising the touched `newUserError`→`userFacingError` path) — pass. Only pre-existing ORM/factory tests requiring `CL_DATABASE_URL` (Postgres) fail, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
