### PR TITLE
test: add mixed version and rolling upgrade CCIP tests

### DIFF
--- a/.github/workflows/ccip-system-tests.yaml
+++ b/.github/workflows/ccip-system-tests.yaml
@@ -31,6 +31,16 @@ on:
           "The version of Chainlink repository to use for the tests. If
           empty, defaults to github.sha."
         default: ""
+      baseline_ref:
+        required: false
+        type: string
+        default: ""
+        description: "Base-branch sha for mixed-version baseline image. Empty for non-PR events."
+      base_ref_name:
+        required: false
+        type: string
+        default: ""
+        description: "Base-branch name (e.g. 'develop'). Controls mixed-version fallback behavior."
   workflow_call:
     inputs:
       chainlink_image_repository_path:
@@ -57,6 +67,16 @@ on:
           "The version of Chainlink repository to use for the tests. If
           empty, defaults to github.sha."
         default: ""
+      baseline_ref:
+        required: false
+        type: string
+        default: ""
+        description: "Base-branch sha for mixed-version baseline image. Empty for non-PR events."
+      base_ref_name:
+        required: false
+        type: string
+        default: ""
+        description: "Base-branch name (e.g. 'develop'). Controls mixed-version fallback behavior."
 
 jobs:
   define-test-matrix:
@@ -73,7 +93,9 @@ jobs:
           TESTS_JSON='[
             {"test_name":"Test_CCIPGasPriceUpdatesWriteFrequency","timeout":"15m","selected_network":"SIMULATED_1,SIMULATED_2"},
             {"test_name":"TestRMN_GlobalCurseTwoMessagesOnTwoLanes","timeout":"15m","selected_network":"SIMULATED_1,SIMULATED_2","rmn_rageproxy_version":"master-amd6416f5d86","rmn_afn2proxy_version":"master-amd64-10b42b2"},
-            {"test_name":"TestDeleteCCIPJobs-TestRevokeJobs","timeout":"15m","selected_network":"SIMULATED_1,SIMULATED_2","job_timeout":20}
+            {"test_name":"TestDeleteCCIPJobs-TestRevokeJobs","timeout":"15m","selected_network":"SIMULATED_1,SIMULATED_2","job_timeout":20},
+            {"test_name":"Test_CCIPMixedVersionDON","timeout":"20m","selected_network":"SIMULATED_1,SIMULATED_2","mixed_version":true},
+            {"test_name":"Test_CCIPRollingUpgrade","timeout":"30m","selected_network":"SIMULATED_1,SIMULATED_2","mixed_version":true}
           ]'
 
           tests=$(echo "$TESTS_JSON" | jq -c \
@@ -168,6 +190,53 @@ jobs:
 
       - name: Setup gotestsum
         uses: ./.github/actions/setup-gotestsum
+      
+      - name: Resolve baseline image for mixed-version tests
+        id: baseline
+        shell: bash
+        env:
+          BASELINE_REF: ${{ inputs.baseline_ref }}
+          BASE_REF_NAME: ${{ inputs.base_ref_name }}
+          ECR_ACCOUNT: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
+          ECR_REGION: ${{ secrets.QA_AWS_REGION }}
+          IS_MIXED_VERSION: ${{ matrix.tests.mixed_version || false }}
+        run: |
+          if [[ "${IS_MIXED_VERSION}" != "true" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          REGISTRY="${ECR_ACCOUNT}.dkr.ecr.${ECR_REGION}.amazonaws.com"
+          skip=false
+          image=""
+          version=""
+
+          if [[ -n "${BASELINE_REF}" ]] && docker manifest inspect "${REGISTRY}/chainlink-integration-tests:${BASELINE_REF}" >/dev/null 2>&1; then
+            image="${REGISTRY}/chainlink-integration-tests"
+            version="${BASELINE_REF}"
+          elif [[ "${BASE_REF_NAME}" == release/* ]]; then
+            echo "::warning::No baseline image for release base branch '${BASE_REF_NAME}'. Skipping mixed-version test."
+            skip=true
+          else
+            DATE="$(date +'%Y%m%d')"
+            image="${REGISTRY}/chainlink"
+            version="nightly-${DATE}"
+            if ! docker manifest inspect "${image}:${version}" >/dev/null 2>&1; then
+              echo "::warning::Develop nightly image not available. Skipping mixed-version test."
+              skip=true
+            fi
+          fi
+
+          {
+            echo "skip=${skip}"
+            echo "image=${image}"
+            echo "version=${version}"
+          } >> "$GITHUB_OUTPUT"
+          if [[ "${skip}" == "true" ]]; then
+            echo "Mixed-version test skipped (no valid baseline for base branch '${BASE_REF_NAME}')."
+          else
+            echo "Baseline image: ${image}:${version}"
+          fi
 
       - name: Run CCIP smoke tests
         id: run-tests
@@ -184,7 +253,17 @@ jobs:
           E2E_RMN_AFN2PROXY_VERSION: ${{ matrix.tests.rmn_afn2proxy_version || '' }}
           E2E_TEST_CHAINLINK_VERSION: ${{ inputs.chainlink_image_tag }}
           GITHUB_TOKEN: ${{ steps.github-token.outputs.access-token || '' }}
+          CCIP_PR_IMAGE: ${{ env.E2E_TEST_CHAINLINK_IMAGE }}
+          CCIP_PR_VERSION: ${{ inputs.chainlink_image_tag }}
+          CCIP_BASELINE_IMAGE: ${{ steps.baseline.outputs.image }}
+          CCIP_BASELINE_VERSION: ${{ steps.baseline.outputs.version }}
         run: |
+          if [[ "${{ matrix.tests.mixed_version || false }}" == "true" && "${{ steps.baseline.outputs.skip }}" == "true" ]]; then
+            echo "Skipping ${TEST_NAME}: no baseline image available for mixed-version test"
+            echo "tests_result=⏭️ Skipped (no baseline)" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
           echo "Starting test: '${TEST_NAME}'"
           if [ -f "./bin/ccip-smoke.test" ]; then
             echo "Using precompiled binary"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -718,6 +718,8 @@ jobs:
       chainlink_image_repository_path: ${{ inputs.ecr_name || 'chainlink-integration-tests' }}
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       chainlink_image_tag: ${{ inputs.evm-ref && format('{0}', inputs.evm-ref) || inputs.cl_ref && format('{0}', inputs.cl_ref) || format('{0}', github.sha) }}
+      baseline_ref: ${{ github.event.pull_request.base.sha }}
+      base_ref_name: ${{ github.event.pull_request.base.ref }}
     secrets: inherit
 
   check-e2e-test-results:

--- a/integration-tests/smoke/ccip/ccip_mixed_version_test.go
+++ b/integration-tests/smoke/ccip/ccip_mixed_version_test.go
@@ -94,9 +94,6 @@ func Test_CCIPMixedVersionDON(t *testing.T) {
 		)
 	)
 
-	// Wait for filter registration for CCIPMessageSent (onramp), CommitReportAccepted (offramp), and ExecutionStateChanged (offramp)
-	testhelpers.WaitForEventFilterRegistrationOnLane(t, state, e.Env.Offchain, sourceChain, destChain)
-
 	t.Run("data message to eoa on mixed version DON", func(t *testing.T) {
 		out = mt.Run(
 			t,
@@ -197,9 +194,6 @@ func Test_CCIPRollingUpgrade(t *testing.T) {
 			false, // testRouter
 		)
 	)
-
-	// Wait for filter registration for CCIPMessageSent (onramp), CommitReportAccepted (offramp), and ExecutionStateChanged (offramp)
-	testhelpers.WaitForEventFilterRegistrationOnLane(t, state, e.Env.Offchain, sourceChain, destChain)
 
 	// Send a baseline message before any upgrades.
 	t.Run("baseline message before upgrade", func(t *testing.T) {

--- a/integration-tests/smoke/ccip/ccip_mixed_version_test.go
+++ b/integration-tests/smoke/ccip/ccip_mixed_version_test.go
@@ -243,6 +243,7 @@ func Test_CCIPRollingUpgrade(t *testing.T) {
 					MsgData:                []byte(fmt.Sprintf("message after upgrading node %d", i)),
 					ExtraArgs:              nil,
 					ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
+					Replayed:               true, // skip replay after upgrade since the node restarts and the log poller starts fresh
 				},
 			)
 		})
@@ -260,6 +261,7 @@ func Test_CCIPRollingUpgrade(t *testing.T) {
 				MsgData:                []byte("final message after rolling upgrade"),
 				ExtraArgs:              nil,
 				ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
+				Replayed:               true, // skip replay after upgrades since the nodes restart and the log poller starts fresh
 			},
 		)
 	})

--- a/integration-tests/smoke/ccip/ccip_mixed_version_test.go
+++ b/integration-tests/smoke/ccip/ccip_mixed_version_test.go
@@ -46,7 +46,7 @@ func Test_CCIPMixedVersionDON(t *testing.T) {
 
 	chains := []chainsel.Chain{
 		chainsel.GETH_TESTNET,  // source
-		chainsel.TEST_90000001, // dest
+		chainsel.GETH_DEVNET_2, // dest
 	}
 	var chainIDs = []uint64{
 		chains[0].Selector,
@@ -145,7 +145,7 @@ func Test_CCIPRollingUpgrade(t *testing.T) {
 
 	chains := []chainsel.Chain{
 		chainsel.GETH_TESTNET,  // source
-		chainsel.TEST_90000001, // dest
+		chainsel.GETH_DEVNET_2, // dest
 	}
 	var chainIDs = []uint64{
 		chains[0].Selector,

--- a/integration-tests/smoke/ccip/ccip_mixed_version_test.go
+++ b/integration-tests/smoke/ccip/ccip_mixed_version_test.go
@@ -1,0 +1,272 @@
+package ccip
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
+	mt "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/messagingtest"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
+)
+
+// mixedVersionImageSelector assigns the baseline image to bootstrap and even-indexed
+// plugin nodes, and the PR image to odd-indexed plugin nodes.
+func mixedVersionImageSelector(t *testing.T) testsetups.NodeImageSelector {
+	prImage := os.Getenv("CCIP_PR_IMAGE")
+	prVersion := os.Getenv("CCIP_PR_VERSION")
+	baselineImage := os.Getenv("CCIP_BASELINE_IMAGE")
+	baselineVersion := os.Getenv("CCIP_BASELINE_VERSION")
+
+	require.NotEmpty(t, prImage, "CCIP_PR_IMAGE must be set")
+	require.NotEmpty(t, prVersion, "CCIP_PR_VERSION must be set")
+	require.NotEmpty(t, baselineImage, "CCIP_BASELINE_IMAGE must be set")
+	require.NotEmpty(t, baselineVersion, "CCIP_BASELINE_VERSION must be set")
+
+	return func(nodeIndex int) (string, string) {
+		// nodeIndex 0 is the bootstrap node, the rest are plugin nodes.
+		if nodeIndex == 0 || nodeIndex%2 == 1 {
+			return baselineImage, baselineVersion
+		}
+		return prImage, prVersion
+	}
+}
+
+func Test_CCIPMixedVersionDON(t *testing.T) {
+	if os.Getenv(testhelpers.ENVTESTTYPE) != string(testhelpers.Docker) {
+		t.Skip("skipping mixed version test in non-docker mode, set CCIP_V16_TEST_ENV=docker")
+	}
+
+	chains := []chainsel.Chain{
+		chainsel.GETH_TESTNET,  // source
+		chainsel.TEST_90000001, // dest
+	}
+	var chainIDs = []uint64{
+		chains[0].Selector,
+		chains[1].Selector,
+	}
+
+	e, _, _ := testsetups.NewIntegrationEnvironmentWithImageSelector(
+		t,
+		mixedVersionImageSelector(t),
+		testhelpers.WithEVMChainsBySelectors(chainIDs),
+	)
+
+	state, err := stateview.LoadOnchainState(e.Env)
+	require.NoError(t, err)
+
+	allChainSelectors := maps.Keys(e.Env.BlockChains.EVMChains())
+	require.Len(t, allChainSelectors, 2)
+	sourceChain := chains[0].Selector
+	destChain := chains[1].Selector
+	require.Contains(t, allChainSelectors, sourceChain)
+	require.Contains(t, allChainSelectors, destChain)
+	t.Log("All chain selectors:", allChainSelectors,
+		", home chain selector:", e.HomeChainSel,
+		", feed chain selector:", e.FeedChainSel,
+		", source chain selector:", sourceChain,
+		", dest chain selector:", destChain,
+	)
+
+	// connect a single lane, source to dest
+	err = testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &e, state, sourceChain, destChain, false)
+	require.NoError(t, err)
+
+	var (
+		nonce  uint64
+		sender = common.LeftPadBytes(e.Env.BlockChains.EVMChains()[sourceChain].DeployerKey.From.Bytes(), 32)
+		out    mt.TestCaseOutput
+		setup  = mt.NewTestSetupWithDeployedEnv(
+			t,
+			e,
+			state,
+			sourceChain,
+			destChain,
+			sender,
+			false, // testRouter
+		)
+	)
+
+	// Wait for filter registration for CCIPMessageSent (onramp), CommitReportAccepted (offramp), and ExecutionStateChanged (offramp)
+	testhelpers.WaitForEventFilterRegistrationOnLane(t, state, e.Env.Offchain, sourceChain, destChain)
+
+	t.Run("data message to eoa on mixed version DON", func(t *testing.T) {
+		out = mt.Run(
+			t,
+			mt.TestCase{
+				ValidationType:         mt.ValidationTypeExec,
+				TestSetup:              setup,
+				Nonce:                  &nonce,
+				Receiver:               common.HexToAddress("0xdead").Bytes(),
+				MsgData:                []byte("hello from mixed version DON"),
+				ExtraArgs:              nil,                                 // default extraArgs
+				ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS, // success because offRamp won't call an EOA
+			},
+		)
+	})
+
+	t.Run("message to contract implementing CCIPReceiver on mixed version DON", func(t *testing.T) {
+		out = mt.Run(
+			t,
+			mt.TestCase{
+				ValidationType:         mt.ValidationTypeExec,
+				TestSetup:              setup,
+				Nonce:                  &out.Nonce,
+				Receiver:               state.MustGetEVMChainState(destChain).Receiver.Address().Bytes(),
+				MsgData:                []byte("hello CCIPReceiver from mixed version DON"),
+				ExtraArgs:              nil, // default extraArgs
+				ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
+			},
+		)
+	})
+}
+
+func Test_CCIPRollingUpgrade(t *testing.T) {
+	if os.Getenv(testhelpers.ENVTESTTYPE) != string(testhelpers.Docker) {
+		t.Skip("skipping rolling upgrade test in non-docker mode, set CCIP_V16_TEST_ENV=docker")
+	}
+
+	prImage := os.Getenv("CCIP_PR_IMAGE")
+	prVersion := os.Getenv("CCIP_PR_VERSION")
+	baselineImage := os.Getenv("CCIP_BASELINE_IMAGE")
+	baselineVersion := os.Getenv("CCIP_BASELINE_VERSION")
+
+	require.NotEmpty(t, prImage, "CCIP_PR_IMAGE must be set")
+	require.NotEmpty(t, prVersion, "CCIP_PR_VERSION must be set")
+	require.NotEmpty(t, baselineImage, "CCIP_BASELINE_IMAGE must be set")
+	require.NotEmpty(t, baselineVersion, "CCIP_BASELINE_VERSION must be set")
+
+	chains := []chainsel.Chain{
+		chainsel.GETH_TESTNET,  // source
+		chainsel.TEST_90000001, // dest
+	}
+	var chainIDs = []uint64{
+		chains[0].Selector,
+		chains[1].Selector,
+	}
+
+	// Start all nodes on the baseline image.
+	allBaselineImage := func(int) (string, string) {
+		return baselineImage, baselineVersion
+	}
+
+	e, _, dockerEnv := testsetups.NewIntegrationEnvironmentWithImageSelector(
+		t,
+		allBaselineImage,
+		testhelpers.WithEVMChainsBySelectors(chainIDs),
+	)
+
+	state, err := stateview.LoadOnchainState(e.Env)
+	require.NoError(t, err)
+
+	allChainSelectors := maps.Keys(e.Env.BlockChains.EVMChains())
+	require.Len(t, allChainSelectors, 2)
+	sourceChain := chains[0].Selector
+	destChain := chains[1].Selector
+	require.Contains(t, allChainSelectors, sourceChain)
+	require.Contains(t, allChainSelectors, destChain)
+	t.Log("All chain selectors:", allChainSelectors,
+		", home chain selector:", e.HomeChainSel,
+		", feed chain selector:", e.FeedChainSel,
+		", source chain selector:", sourceChain,
+		", dest chain selector:", destChain,
+	)
+
+	// connect a single lane, source to dest
+	err = testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &e, state, sourceChain, destChain, false)
+	require.NoError(t, err)
+
+	var (
+		nonce  uint64
+		sender = common.LeftPadBytes(e.Env.BlockChains.EVMChains()[sourceChain].DeployerKey.From.Bytes(), 32)
+		out    mt.TestCaseOutput
+		setup  = mt.NewTestSetupWithDeployedEnv(
+			t,
+			e,
+			state,
+			sourceChain,
+			destChain,
+			sender,
+			false, // testRouter
+		)
+	)
+
+	// Wait for filter registration for CCIPMessageSent (onramp), CommitReportAccepted (offramp), and ExecutionStateChanged (offramp)
+	testhelpers.WaitForEventFilterRegistrationOnLane(t, state, e.Env.Offchain, sourceChain, destChain)
+
+	// Send a baseline message before any upgrades.
+	t.Run("baseline message before upgrade", func(t *testing.T) {
+		out = mt.Run(
+			t,
+			mt.TestCase{
+				ValidationType:         mt.ValidationTypeExec,
+				TestSetup:              setup,
+				Nonce:                  &nonce,
+				Receiver:               common.HexToAddress("0xdead").Bytes(),
+				MsgData:                []byte("baseline before rolling upgrade"),
+				ExtraArgs:              nil,
+				ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
+			},
+		)
+	})
+
+	// Get the CL cluster nodes for upgrades.
+	localDevEnv, ok := dockerEnv.(*testsetups.DeployedLocalDevEnvironment)
+	require.True(t, ok, "expected DeployedLocalDevEnvironment in docker mode")
+	clCluster := localDevEnv.GetCLClusterTestEnv().ClCluster
+	require.NotNil(t, clCluster, "CL cluster should not be nil")
+	require.NotEmpty(t, clCluster.Nodes, "CL cluster should have nodes")
+
+	// Upgrade plugin nodes one by one, sending a message after each upgrade.
+	// Skip the bootstrap node (index 0).
+	for i, node := range clCluster.Nodes {
+		if i == 0 {
+			continue
+		}
+		t.Run(fmt.Sprintf("upgrade node %d (%s) and send message", i, node.ContainerName), func(t *testing.T) {
+			t.Logf("Upgrading node %d (%s) from %s:%s to %s:%s",
+				i, node.ContainerName,
+				node.ContainerImage, node.ContainerVersion,
+				prImage, prVersion)
+
+			err := node.UpgradeVersion(prImage, prVersion)
+			require.NoError(t, err, "failed to upgrade node %d", i)
+
+			out = mt.Run(
+				t,
+				mt.TestCase{
+					ValidationType:         mt.ValidationTypeExec,
+					TestSetup:              setup,
+					Nonce:                  &out.Nonce,
+					Receiver:               common.HexToAddress("0xdead").Bytes(),
+					MsgData:                []byte(fmt.Sprintf("message after upgrading node %d", i)),
+					ExtraArgs:              nil,
+					ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
+				},
+			)
+		})
+	}
+
+	// Send a final message after all upgrades.
+	t.Run("final message after all upgrades", func(t *testing.T) {
+		out = mt.Run(
+			t,
+			mt.TestCase{
+				ValidationType:         mt.ValidationTypeExec,
+				TestSetup:              setup,
+				Nonce:                  &out.Nonce,
+				Receiver:               state.MustGetEVMChainState(destChain).Receiver.Address().Bytes(),
+				MsgData:                []byte("final message after rolling upgrade"),
+				ExtraArgs:              nil,
+				ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
+			},
+		)
+	})
+}

--- a/integration-tests/testsetups/ccip/test_helpers.go
+++ b/integration-tests/testsetups/ccip/test_helpers.go
@@ -57,6 +57,8 @@ type DeployedLocalDevEnvironment struct {
 	GenericTCConfig *testhelpers.TestConfigs
 	devEnvTestCfg   tc.TestConfig
 	devEnvCfg       *devenv.EnvironmentConfig
+	// ImageSelector, when non-nil, determines which chainlink docker image each node runs.
+	ImageSelector NodeImageSelector
 }
 
 func (l *DeployedLocalDevEnvironment) GetCLClusterTestEnv() *test_env.CLClusterTestEnv {
@@ -115,10 +117,21 @@ func (l *DeployedLocalDevEnvironment) StartNodes(t *testing.T, crConfig deployme
 	require.NotNil(t, l.testEnv, "docker env is empty, start chains first")
 	require.NotEmpty(t, l.devEnvTestCfg, "integration test config is empty, start chains first")
 	require.NotNil(t, l.devEnvCfg, "dev environment config is empty, start chains first")
-	err := StartChainlinkNodes(t, l.devEnvCfg,
-		crConfig,
-		l.testEnv, l.devEnvTestCfg)
-	require.NoError(t, err)
+	if l.ImageSelector != nil {
+		err := StartChainlinkNodesWithImageSelector(t, l.devEnvCfg,
+			crConfig,
+			l.testEnv, l.devEnvTestCfg, l.ImageSelector)
+		require.NoError(t, err)
+	} else {
+		err := StartChainlinkNodes(t, l.devEnvCfg,
+			crConfig,
+			l.testEnv, l.devEnvTestCfg)
+		require.NoError(t, err)
+	}
+	l.setupDON(t)
+}
+
+func (l *DeployedLocalDevEnvironment) setupDON(t *testing.T) {
 	ctx := testcontext.Get(t)
 	lggr := logger.TestLogger(t)
 	e, don, err := devenv.NewEnvironment(func() context.Context { return ctx }, lggr, *l.devEnvCfg)
@@ -247,6 +260,67 @@ func NewIntegrationEnvironment(t *testing.T, opts ...testhelpers.TestOps) (testh
 		require.Failf(t, "Type %s not supported in integration tests choose between %s and %s", string(testCfg.Type), testhelpers.Memory, testhelpers.Docker)
 	}
 	return testhelpers.DeployedEnv{}, devenv.RMNCluster{}, nil
+}
+
+// NewIntegrationEnvironmentWithImageSelector is like NewIntegrationEnvironment but
+// accepts a NodeImageSelector to control which docker image each node runs.
+// Only supports Docker mode (CCIP_V16_TEST_ENV=docker).
+func NewIntegrationEnvironmentWithImageSelector(t *testing.T, imageSelector NodeImageSelector, opts ...testhelpers.TestOps) (testhelpers.DeployedEnv, devenv.RMNCluster, testhelpers.TestEnvironment) {
+	testCfg := testhelpers.DefaultTestConfigs()
+	for _, opt := range opts {
+		opt(testCfg)
+	}
+
+	// check for EnvType env var
+	testCfg.MustSetEnvTypeOrDefault(t)
+	require.NoError(t, testCfg.Validate(), "invalid test config")
+	require.Equal(t, testhelpers.Docker, testCfg.Type, "NewIntegrationEnvironmentWithImageSelector only supports docker mode, set CCIP_V16_TEST_ENV=docker")
+
+	dockerEnv := &DeployedLocalDevEnvironment{
+		GenericTCConfig: testCfg,
+		ImageSelector:   imageSelector,
+	}
+	if testCfg.PrerequisiteDeploymentOnly {
+		deployedEnv := testhelpers.NewEnvironmentWithPrerequisitesContracts(t, dockerEnv)
+		require.NotNil(t, dockerEnv.testEnv, "empty docker environment")
+		dockerEnv.UpdateDeployedEnvironment(deployedEnv)
+		return deployedEnv, devenv.RMNCluster{}, dockerEnv
+	}
+	if testCfg.RMNEnabled {
+		deployedEnv := testhelpers.NewEnvironmentWithJobsAndContracts(t, dockerEnv)
+		l := logging.GetTestLogger(t)
+		require.NotNil(t, dockerEnv.testEnv, "empty docker environment")
+		config := GenerateTestRMNConfig(t, testCfg.NumOfRMNNodes, deployedEnv, MustNetworksToRPCMap(dockerEnv.testEnv.EVMNetworks), testCfg.RMNConfDepth)
+		require.NotNil(t, dockerEnv.devEnvTestCfg.CCIP)
+		rmnCluster, err := devenv.NewRMNCluster(
+			t, l,
+			[]string{dockerEnv.testEnv.DockerNetwork.ID},
+			config,
+			dockerEnv.devEnvTestCfg.CCIP.RMNConfig.GetProxyImage(),
+			dockerEnv.devEnvTestCfg.CCIP.RMNConfig.GetProxyVersion(),
+			dockerEnv.devEnvTestCfg.CCIP.RMNConfig.GetAFN2ProxyImage(),
+			dockerEnv.devEnvTestCfg.CCIP.RMNConfig.GetAFN2ProxyVersion(),
+		)
+		require.NoError(t, err)
+		dockerEnv.UpdateDeployedEnvironment(deployedEnv)
+		return deployedEnv, *rmnCluster, dockerEnv
+	}
+	if testCfg.CreateJobAndContracts {
+		deployedEnv := testhelpers.NewEnvironmentWithJobsAndContracts(t, dockerEnv)
+		require.NotNil(t, dockerEnv.testEnv, "empty docker environment")
+		dockerEnv.UpdateDeployedEnvironment(deployedEnv)
+		return deployedEnv, devenv.RMNCluster{}, dockerEnv
+	}
+	if testCfg.CreateJob {
+		deployedEnv := testhelpers.NewEnvironmentWithJobs(t, dockerEnv)
+		require.NotNil(t, dockerEnv.testEnv, "empty docker environment")
+		dockerEnv.UpdateDeployedEnvironment(deployedEnv)
+		return deployedEnv, devenv.RMNCluster{}, dockerEnv
+	}
+	deployedEnv := testhelpers.NewEnvironment(t, dockerEnv)
+	require.NotNil(t, dockerEnv.testEnv, "empty docker environment")
+	dockerEnv.UpdateDeployedEnvironment(deployedEnv)
+	return deployedEnv, devenv.RMNCluster{}, dockerEnv
 }
 
 func MustNetworksToRPCMap(evmNetworks []*blockchain.EVMNetwork) map[uint64]string {
@@ -479,6 +553,10 @@ func CreateDockerEnv(t *testing.T, v1_6TestConfig *testhelpers.TestConfigs) (
 	}, env, cfg
 }
 
+// NodeImageSelector returns the docker image and version for the node at the given index.
+// Index 0..NoOfBootstraps-1 are bootstrap nodes, the rest are plugin nodes.
+type NodeImageSelector func(nodeIndex int) (image string, version string)
+
 // StartChainlinkNodes starts docker containers for chainlink nodes on the existing test environment based on provided test config
 // Once the nodes starts, it updates the devenv EnvironmentConfig with the node info
 // which includes chainlink API URL, email, password and internal IP
@@ -488,6 +566,23 @@ func StartChainlinkNodes(
 	registryConfig deployment.CapabilityRegistryConfig,
 	env *test_env.CLClusterTestEnv,
 	cfg tc.TestConfig,
+) error {
+	defaultImage := func(int) (string, string) {
+		return pointer.GetString(cfg.GetChainlinkImageConfig().Image),
+			pointer.GetString(cfg.GetChainlinkImageConfig().Version)
+	}
+	return StartChainlinkNodesWithImageSelector(t, envConfig, registryConfig, env, cfg, defaultImage)
+}
+
+// StartChainlinkNodesWithImageSelector is like StartChainlinkNodes but uses the
+// imageSelector to determine which docker image each node runs.
+func StartChainlinkNodesWithImageSelector(
+	t *testing.T,
+	envConfig *devenv.EnvironmentConfig,
+	registryConfig deployment.CapabilityRegistryConfig,
+	env *test_env.CLClusterTestEnv,
+	cfg tc.TestConfig,
+	imageSelector NodeImageSelector,
 ) error {
 	var evmNetworks []blockchain.EVMNetwork
 	for i := range env.EVMNetworks {
@@ -529,10 +624,11 @@ func StartChainlinkNodes(
 		if err != nil {
 			return err
 		}
+		image, version := imageSelector(i - 1)
 		ccipNode, err := test_env.NewClNode(
 			[]string{env.DockerNetwork.Name},
-			pointer.GetString(cfg.GetChainlinkImageConfig().Image),
-			pointer.GetString(cfg.GetChainlinkImageConfig().Version),
+			image,
+			version,
 			toml,
 			test_env.WithPgDBOptions(
 				ctftestenv.WithPostgresImageVersion(pointer.GetString(cfg.GetChainlinkImageConfig().PostgresVersion)),


### PR DESCRIPTION
This PR adds:
1. Mixed version test: the baseline image to bootstrap and even-indexed plugin nodes, and the PR image to odd-indexed plugin nodes. It then sends a message to verify compatibility.
3. Rolling upgrade test: all nodes start on baseline image and get upgraded one-by-one. A message is sent between each upgrade to verify upgrade compatibility.