### PR TITLE
CRE-6266: Pin cron capability with scheduler leak fix, stop retrying unparseable schedules

### DIFF
--- a/core/services/workflows/syncer/v2/activation_errors.go
+++ b/core/services/workflows/syncer/v2/activation_errors.go
@@ -93,9 +93,10 @@ func isPermanentEngineInitError(err error) bool {
 			strings.Contains(msg, "invalid workflow name"),
 			strings.Contains(msg, "failed to decode workflow spec binary"),
 			strings.Contains(msg, "failed to decode owner"),
-			strings.Contains(msg, "invalid cron schedule"),
-			strings.Contains(msg, "cron schedule must specify"),
-			strings.Contains(msg, "interval exceeded"):
+			// cron failure when it can't parse the schedule
+			strings.Contains(msg, "failed to initialize job"),
+			// cron rejection when the schedule fires faster than the allowed minimum
+			strings.Contains(msg, "maximum fastest cron schedule"):
 			return true
 		}
 		err = errors.Unwrap(err)

--- a/core/services/workflows/syncer/v2/activation_errors_test.go
+++ b/core/services/workflows/syncer/v2/activation_errors_test.go
@@ -49,13 +49,15 @@ func Test_classifyActivationError(t *testing.T) {
 			want: ActivationNonRetryable,
 		},
 		{
-			name: "invalid cron schedule is non-retryable",
-			err:  fmt.Errorf("engine initialization failed: %w", errors.New("invalid cron schedule 'bad'")),
+			name: "failure parsing cron schedule",
+			err: fmt.Errorf("failed to register trigger %s: %w", "trigger_0",
+				errors.New("[3]InvalidArgument: failed to initialize job: gocron: CronJob: crontab parse failure\nprovided bad location moon: unknown time zone moon")),
 			want: ActivationNonRetryable,
 		},
 		{
-			name: "interval exceeded is non-retryable",
-			err:  fmt.Errorf("engine initialization failed: %w", errors.New("cron trigger interval exceeded")),
+			name: "cron schedule faster than the allowed minimum",
+			err: fmt.Errorf("failed to register trigger %s: %w", "trigger_0",
+				errors.New("[3]InvalidArgument: maximum fastest cron schedule is 30s")),
 			want: ActivationNonRetryable,
 		},
 		{

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -71,7 +71,7 @@ plugins:
 
   capability-cron:
     - moduleURI: "github.com/smartcontractkit/capabilities/cron"
-      gitRef: "977e430d6ff4db1fba42a4d8a20bc92c8b2ceaba"
+      gitRef: "127afb79d5b5bef542aca04b9308c787d483d3cf"
       installPath: "."
       flags: "-tags timetzdata"
 

--- a/system-tests/tests/smoke/cre/v2_durable_emitter_test.go
+++ b/system-tests/tests/smoke/cre/v2_durable_emitter_test.go
@@ -108,11 +108,12 @@ func ExecuteDurableEmitterTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 	// Deploy a cron workflow that fires every 5 seconds.
 	lggr.Info().Msg("Deploying cron workflow for durable emitter test...")
 	workflowConfig := crontypes.WorkflowConfig{
-		Schedule: "*/5 * * * * *",
+		// 30s is the minimal cron interval
+		Schedule: "*/30 * * * * *",
 	}
 	_ = t_helpers.CompileAndDeployWorkflow(t, testEnv, lggr, "durable-emitter-test", &workflowConfig, workflowFileLocation)
 
-	const minExpectedEvents int64 = 4
+	const minExpectedEvents int64 = 1
 	lggr.Info().Msg("Waiting for sustained durable event activity...")
 
 	require.Eventually(t, func() bool {
@@ -129,5 +130,5 @@ func ExecuteDurableEmitterTest(t *testing.T, testEnv *ttypes.TestEnvironment) {
 		t.Logf("chip_durable_events: +%d inserts, +%d deletes, %d pending", newInserts, newDeletes, pending)
 
 		return newInserts >= minExpectedEvents && newDeletes >= minExpectedEvents
-	}, 2*time.Minute, 5*time.Second, "expected at least %d insert+delete events", minExpectedEvents)
+	}, 1*time.Minute, 30*time.Second, "expected at least %d insert+delete events", minExpectedEvents)
 }


### PR DESCRIPTION
Pins capability-cron to smartcontractkit/capabilities@127afb79, which fixes a
goroutine leak in enforceFastestSchedule.

Also classifies the cron capability's "failed to initialize job" message as a permanent
 engine init error. This ensures we don't retry  cron schedule parse errors.
