### PR TITLE
Pin curl to 8.5.0-2ubuntu10.13 in the base image

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -117,7 +117,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates=20260601~24.04.1 \
     gnupg=2.4.4-2ubuntu17.4 \
     lsb-release=12.0-2 \
-    curl \
+    curl=8.5.0-2ubuntu10.13 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Postgres for CLI tools, needed specifically for DB backups

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -117,7 +117,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates=20260601~24.04.1 \
     gnupg=2.4.4-2ubuntu17.4 \
     lsb-release=12.0-2 \
-    curl=8.5.0-2ubuntu10.12 \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Postgres for CLI tools, needed specifically for DB backups

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -116,7 +116,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates=20260601~24.04.1 \
     gnupg=2.4.4-2ubuntu17.4 \
     lsb-release=12.0-2 \
-    curl=8.5.0-2ubuntu10.12 \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Postgres for CLI tools, needed specifically for DB backups

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -116,7 +116,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates=20260601~24.04.1 \
     gnupg=2.4.4-2ubuntu17.4 \
     lsb-release=12.0-2 \
-    curl \
+    curl=8.5.0-2ubuntu10.13 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Postgres for CLI tools, needed specifically for DB backups


### PR DESCRIPTION
## What

Bumps the exact version pin on `curl` in `core/chainlink.Dockerfile` and `plugins/chainlink.Dockerfile` from `.11` to `.13`, leaving `ca-certificates`/`gnupg`/`lsb-release` pinned as-is.

## Why

Third occurrence of the same failure in days: #23461 bumped the pin from `.11` to `.12` after the archive moved; `.12` is already gone too, and `chainlink-solana`'s CI (which builds from this Dockerfile directly) was failing the same way. `.13` is the current version in the Ubuntu 24.04 `noble-updates`/`noble-security` archive.

## Verification

Ran the resulting `apt-get install` line against the live Ubuntu 24.04 archive in a local container -- installs cleanly, resolves `curl 8.5.0-2ubuntu10.13` and its `libcurl4t64` dependency together.