### PR TITLE
retire VaultGetSecretsShareAggregationIncludesPublicKeys flag

### DIFF
--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -56,19 +56,18 @@ type ReportingPluginConfig struct {
 	PrivateKeyShare *tdh2easy.PrivateShare
 
 	// Sourced from the offchain config
-	MaxSecretsPerOwner                                limits.BoundLimiter[int]
-	MaxShareLengthBytes                               limits.BoundLimiter[pkgconfig.Size]
-	MaxBatchSize                                      limits.BoundLimiter[int]
-	MaxPendingQueueWriteSize                          limits.BoundLimiter[int]
-	MaxBlobPayloadBytes                               limits.BoundLimiter[pkgconfig.Size]
-	VaultForceEmptyOCRRounds                          limits.GateLimiter
-	VaultOptimizationsEnabled                         limits.GateLimiter
-	VaultJSONOmitUnpopulatedEnabled                   limits.GateLimiter
-	VaultSignedResponseRequestIDEnabled               limits.GateLimiter
-	VaultGetSecretsShareAggregationIncludesPublicKeys limits.GateLimiter
-	VaultGetSecretsRelaxedConsensusEnabled            limits.GateLimiter
-	VaultIncludeInvalidPendingItemsEnabled            limits.GateLimiter
-	VaultPendingQueueStallThreshold                   limits.BoundLimiter[int]
+	MaxSecretsPerOwner                     limits.BoundLimiter[int]
+	MaxShareLengthBytes                    limits.BoundLimiter[pkgconfig.Size]
+	MaxBatchSize                           limits.BoundLimiter[int]
+	MaxPendingQueueWriteSize               limits.BoundLimiter[int]
+	MaxBlobPayloadBytes                    limits.BoundLimiter[pkgconfig.Size]
+	VaultForceEmptyOCRRounds               limits.GateLimiter
+	VaultOptimizationsEnabled              limits.GateLimiter
+	VaultJSONOmitUnpopulatedEnabled        limits.GateLimiter
+	VaultSignedResponseRequestIDEnabled    limits.GateLimiter
+	VaultGetSecretsRelaxedConsensusEnabled limits.GateLimiter
+	VaultIncludeInvalidPendingItemsEnabled limits.GateLimiter
+	VaultPendingQueueStallThreshold        limits.BoundLimiter[int]
 }
 
 func NewReportingPluginFactory(
@@ -193,11 +192,6 @@ func newReportingPluginConfigLimiters(factory limits.Factory) (*ReportingPluginC
 		return nil, fmt.Errorf("VaultOptimizationsEnabled: %w", err)
 	}
 
-	vaultGetSecretsShareAggregationIncludesPublicKeys, err := limits.MakeGateLimiter(factory, cresettings.Default.VaultGetSecretsShareAggregationIncludesPublicKeys)
-	if err != nil {
-		return nil, fmt.Errorf("VaultGetSecretsShareAggregationIncludesPublicKeys: %w", err)
-	}
-
 	vaultJSONOmitUnpopulatedEnabled, err := limits.MakeGateLimiter(factory, cresettings.Default.VaultJSONOmitUnpopulatedEnabled)
 	if err != nil {
 		return nil, fmt.Errorf("VaultJSONOmitUnpopulatedEnabled: %w", err)
@@ -234,17 +228,16 @@ func newReportingPluginConfigLimiters(factory limits.Factory) (*ReportingPluginC
 	}
 
 	return &ReportingPluginConfig{
-		MaxShareLengthBytes:                               maxShareLengthBytesLimiter,
-		MaxBlobPayloadBytes:                               maxBlobPayloadBytesLimiter,
-		MaxPendingQueueWriteSize:                          maxPendingQueueWriteSizeLimiter,
-		VaultForceEmptyOCRRounds:                          vaultForceEmptyOCRRounds,
-		VaultOptimizationsEnabled:                         vaultOptimizationsEnabled,
-		VaultJSONOmitUnpopulatedEnabled:                   vaultJSONOmitUnpopulatedEnabled,
-		VaultSignedResponseRequestIDEnabled:               vaultSignedResponseRequestIDEnabled,
-		VaultGetSecretsShareAggregationIncludesPublicKeys: vaultGetSecretsShareAggregationIncludesPublicKeys,
-		VaultGetSecretsRelaxedConsensusEnabled:            vaultGetSecretsRelaxedConsensusEnabled,
-		VaultIncludeInvalidPendingItemsEnabled:            vaultIncludeInvalidPendingItemsEnabled,
-		VaultPendingQueueStallThreshold:                   vaultPendingQueueStallThreshold,
+		MaxShareLengthBytes:                    maxShareLengthBytesLimiter,
+		MaxBlobPayloadBytes:                    maxBlobPayloadBytesLimiter,
+		MaxPendingQueueWriteSize:               maxPendingQueueWriteSizeLimiter,
+		VaultForceEmptyOCRRounds:               vaultForceEmptyOCRRounds,
+		VaultOptimizationsEnabled:              vaultOptimizationsEnabled,
+		VaultJSONOmitUnpopulatedEnabled:        vaultJSONOmitUnpopulatedEnabled,
+		VaultSignedResponseRequestIDEnabled:    vaultSignedResponseRequestIDEnabled,
+		VaultGetSecretsRelaxedConsensusEnabled: vaultGetSecretsRelaxedConsensusEnabled,
+		VaultIncludeInvalidPendingItemsEnabled: vaultIncludeInvalidPendingItemsEnabled,
+		VaultPendingQueueStallThreshold:        vaultPendingQueueStallThreshold,
 	}, nil
 }
 
@@ -676,10 +669,6 @@ func (r *ReportingPlugin) prepareLegacyObservationPendingQueueBlobs(
 
 func (r *ReportingPlugin) optimizationsEnabled(ctx context.Context) bool {
 	return gateAllows(ctx, r.lggr, r.cfg.VaultOptimizationsEnabled, "VaultOptimizationsEnabled")
-}
-
-func (r *ReportingPlugin) shareAggregationIncludesPublicKeys(ctx context.Context) bool {
-	return gateAllows(ctx, r.lggr, r.cfg.VaultGetSecretsShareAggregationIncludesPublicKeys, "VaultGetSecretsShareAggregationIncludesPublicKeys")
 }
 
 func (r *ReportingPlugin) jsonOmitUnpopulatedEnabled(ctx context.Context) bool {
@@ -1700,14 +1689,9 @@ func (r *ReportingPlugin) shaForObservation(ctx context.Context, o *vaultcommon.
 		cloned := proto.CloneOf(o)
 		for _, rsp := range cloned.GetGetSecretsResponse().Responses {
 			if rsp.GetData() != nil {
-				if r.shareAggregationIncludesPublicKeys(ctx) {
-					for _, es := range rsp.GetData().EncryptedDecryptionKeyShares {
-						es.Shares = nil
-						es.BinaryShares = nil
-					}
-				} else {
-					// Exclude the encrypted shares from the sha, as these need to be aggregated later.
-					rsp.GetData().EncryptedDecryptionKeyShares = nil
+				for _, es := range rsp.GetData().EncryptedDecryptionKeyShares {
+					es.Shares = nil
+					es.BinaryShares = nil
 				}
 			}
 		}

--- a/core/services/ocr2/plugins/vault/plugin_helpers_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_helpers_test.go
@@ -23,30 +23,29 @@ import (
 type testPluginOption func(*testPluginBuildOpts)
 
 type testPluginBuildOpts struct {
-	lggr                                    logger.Logger
-	store                                   *requests.Store[*vaulttypes.Request]
-	publicKey                               *tdh2easy.PublicKey
-	privateKeyShare                         *tdh2easy.PrivateShare
-	onchainCfg                              ocr3types.ReportingPluginConfig
-	maxSecretsPerOwner                      int
-	maxCiphertextLengthBytes                int
-	maxIdentifierOwnerLengthBytes           int
-	maxIdentifierNamespaceLengthBytes       int
-	maxIdentifierKeyLengthBytes             int
-	maxRequestBatchSize                     int
-	batchSize                               int
-	maxBlobPayloadBytes                     int
-	vaultOptimizationsEnabled               bool
-	vaultJSONOmitUnpopulatedEnabled         bool
-	vaultSignedResponseRequestIDEnabled     bool
-	vaultShareAggregationIncludesPublicKeys bool
-	vaultGetSecretsRelaxedConsensusEnabled  bool
-	vaultIncludeInvalidPendingItemsEnabled  bool
-	vaultPendingQueueStallThreshold         int
-	marshalBlob                             func(ocr3_1types.BlobHandle) ([]byte, error)
-	unmarshalBlob                           func([]byte) (ocr3_1types.BlobHandle, error)
-	maxObservationBytesOverride             int
-	maxReportsPlusPrecursorBytesOverride    int
+	lggr                                   logger.Logger
+	store                                  *requests.Store[*vaulttypes.Request]
+	publicKey                              *tdh2easy.PublicKey
+	privateKeyShare                        *tdh2easy.PrivateShare
+	onchainCfg                             ocr3types.ReportingPluginConfig
+	maxSecretsPerOwner                     int
+	maxCiphertextLengthBytes               int
+	maxIdentifierOwnerLengthBytes          int
+	maxIdentifierNamespaceLengthBytes      int
+	maxIdentifierKeyLengthBytes            int
+	maxRequestBatchSize                    int
+	batchSize                              int
+	maxBlobPayloadBytes                    int
+	vaultOptimizationsEnabled              bool
+	vaultJSONOmitUnpopulatedEnabled        bool
+	vaultSignedResponseRequestIDEnabled    bool
+	vaultGetSecretsRelaxedConsensusEnabled bool
+	vaultIncludeInvalidPendingItemsEnabled bool
+	vaultPendingQueueStallThreshold        int
+	marshalBlob                            func(ocr3_1types.BlobHandle) ([]byte, error)
+	unmarshalBlob                          func([]byte) (ocr3_1types.BlobHandle, error)
+	maxObservationBytesOverride            int
+	maxReportsPlusPrecursorBytesOverride   int
 }
 
 func withLggr(lggr logger.Logger) testPluginOption {
@@ -82,10 +81,6 @@ func withMaxSecretsPerOwner(n int) testPluginOption {
 
 func withVaultOptimizationsEnabled() testPluginOption {
 	return func(o *testPluginBuildOpts) { o.vaultOptimizationsEnabled = true }
-}
-
-func withVaultGetSecretsShareAggregationIncludesPublicKeys() testPluginOption {
-	return func(o *testPluginBuildOpts) { o.vaultShareAggregationIncludesPublicKeys = true }
 }
 
 func withVaultJSONOmitUnpopulatedEnabled() testPluginOption {
@@ -160,9 +155,6 @@ func newTestReportingPlugin(t *testing.T, opts ...testPluginOption) *ReportingPl
 	cfg := makeReportingPluginConfig(t, o.batchSize, o.publicKey, o.privateKeyShare, o.maxSecretsPerOwner, o.maxBlobPayloadBytes)
 	if o.vaultOptimizationsEnabled {
 		cfg.VaultOptimizationsEnabled = limits.NewGateLimiter(true)
-	}
-	if o.vaultShareAggregationIncludesPublicKeys {
-		cfg.VaultGetSecretsShareAggregationIncludesPublicKeys = limits.NewGateLimiter(true)
 	}
 	if o.vaultJSONOmitUnpopulatedEnabled {
 		cfg.VaultJSONOmitUnpopulatedEnabled = limits.NewGateLimiter(true)
@@ -284,21 +276,20 @@ func makeReportingPluginConfig(
 	require.NoError(t, err)
 
 	return &ReportingPluginConfig{
-		MaxBatchSize:                                      bsl,
-		MaxPendingQueueWriteSize:                          maxPendingQueueWriteSizeLimiter,
-		PublicKey:                                         publicKey,
-		PrivateKeyShare:                                   privateKeyShare,
-		MaxSecretsPerOwner:                                msl,
-		MaxShareLengthBytes:                               shareLimiter,
-		MaxBlobPayloadBytes:                               maxBlobPayloadLimiter,
-		VaultForceEmptyOCRRounds:                          limits.NewGateLimiter(false),
-		VaultOptimizationsEnabled:                         limits.NewGateLimiter(false),
-		VaultJSONOmitUnpopulatedEnabled:                   limits.NewGateLimiter(false),
-		VaultSignedResponseRequestIDEnabled:               limits.NewGateLimiter(false),
-		VaultGetSecretsShareAggregationIncludesPublicKeys: limits.NewGateLimiter(false),
-		VaultGetSecretsRelaxedConsensusEnabled:            limits.NewGateLimiter(false),
-		VaultIncludeInvalidPendingItemsEnabled:            limits.NewGateLimiter(false),
-		VaultPendingQueueStallThreshold:                   pendingQueueStallThresholdLimiter,
+		MaxBatchSize:                           bsl,
+		MaxPendingQueueWriteSize:               maxPendingQueueWriteSizeLimiter,
+		PublicKey:                              publicKey,
+		PrivateKeyShare:                        privateKeyShare,
+		MaxSecretsPerOwner:                     msl,
+		MaxShareLengthBytes:                    shareLimiter,
+		MaxBlobPayloadBytes:                    maxBlobPayloadLimiter,
+		VaultForceEmptyOCRRounds:               limits.NewGateLimiter(false),
+		VaultOptimizationsEnabled:              limits.NewGateLimiter(false),
+		VaultJSONOmitUnpopulatedEnabled:        limits.NewGateLimiter(false),
+		VaultSignedResponseRequestIDEnabled:    limits.NewGateLimiter(false),
+		VaultGetSecretsRelaxedConsensusEnabled: limits.NewGateLimiter(false),
+		VaultIncludeInvalidPendingItemsEnabled: limits.NewGateLimiter(false),
+		VaultPendingQueueStallThreshold:        pendingQueueStallThresholdLimiter,
 	}
 }
 

--- a/core/services/ocr2/plugins/vault/plugin_share_label_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_share_label_test.go
@@ -96,7 +96,7 @@ func TestPlugin_ValidateObservation_GetSecrets_EmbeddedRequestMismatchRejected(t
 	require.ErrorContains(t, err, "embedded GetSecrets request does not match pending queue request")
 }
 
-func TestPlugin_ShaForObservation_ShareAggregationIncludesPublicKeysFlag(t *testing.T) {
+func TestPlugin_ShaForObservation_GetSecrets_IncludesEncryptionKeysInSHA(t *testing.T) {
 	t.Parallel()
 	id := &vaultcommon.SecretIdentifier{Owner: "owner", Namespace: "main", Key: "secret"}
 	realKey := strings.Repeat("ab", 32)
@@ -131,22 +131,15 @@ func TestPlugin_ShaForObservation_ShareAggregationIncludesPublicKeysFlag(t *test
 	byzObs.Response = &vaultcommon.Observation_GetSecretsResponse{GetSecretsResponse: byzResp}
 
 	ctx := context.Background()
-	pluginOff := newTestReportingPlugin(t, withOnchainCfg(4, 1))
-	shaHonestOff, err := pluginOff.shaForObservation(ctx, honestObs)
+	plugin := newTestReportingPlugin(t, withOnchainCfg(4, 1))
+	shaHonest, err := plugin.shaForObservation(ctx, honestObs)
 	require.NoError(t, err)
-	shaByzOff, err := pluginOff.shaForObservation(ctx, byzObs)
+	shaByz, err := plugin.shaForObservation(ctx, byzObs)
 	require.NoError(t, err)
-	require.Equal(t, shaHonestOff, shaByzOff)
-
-	pluginOn := newTestReportingPlugin(t, withOnchainCfg(4, 1), withVaultGetSecretsShareAggregationIncludesPublicKeys())
-	shaHonestOn, err := pluginOn.shaForObservation(ctx, honestObs)
-	require.NoError(t, err)
-	shaByzOn, err := pluginOn.shaForObservation(ctx, byzObs)
-	require.NoError(t, err)
-	require.NotEqual(t, shaHonestOn, shaByzOn)
+	require.NotEqual(t, shaHonest, shaByz)
 }
 
-func TestPlugin_ShaForObservation_ShareAggregationIncludesPublicKeys_PermutedEntryOrder(t *testing.T) {
+func TestPlugin_ShaForObservation_GetSecrets_PermutedEntryOrder(t *testing.T) {
 	t.Parallel()
 	id := &vaultcommon.SecretIdentifier{Owner: "owner", Namespace: "main", Key: "secret"}
 	keyA := strings.Repeat("aa", 32)
@@ -180,7 +173,7 @@ func TestPlugin_ShaForObservation_ShareAggregationIncludesPublicKeys_PermutedEnt
 	}
 
 	ctx := context.Background()
-	plugin := newTestReportingPlugin(t, withOnchainCfg(4, 1), withVaultGetSecretsShareAggregationIncludesPublicKeys())
+	plugin := newTestReportingPlugin(t, withOnchainCfg(4, 1))
 
 	shaAB, err := plugin.shaForObservation(ctx, makeObs([]string{keyA, keyB}, []string{"share-a1", "share-b1"}))
 	require.NoError(t, err)
@@ -189,7 +182,7 @@ func TestPlugin_ShaForObservation_ShareAggregationIncludesPublicKeys_PermutedEnt
 	require.NotEqual(t, shaAB, shaCD)
 }
 
-func TestPlugin_ShaForObservation_ShareAggregationIncludesPublicKeys_DifferentShareBytesSameLabels(t *testing.T) {
+func TestPlugin_ShaForObservation_GetSecrets_DifferentShareBytesSameLabels(t *testing.T) {
 	t.Parallel()
 	id := &vaultcommon.SecretIdentifier{Owner: "owner", Namespace: "main", Key: "secret"}
 	encKey := strings.Repeat("ab", 32)
@@ -221,7 +214,7 @@ func TestPlugin_ShaForObservation_ShareAggregationIncludesPublicKeys_DifferentSh
 	}
 
 	ctx := context.Background()
-	plugin := newTestReportingPlugin(t, withOnchainCfg(4, 1), withVaultGetSecretsShareAggregationIncludesPublicKeys())
+	plugin := newTestReportingPlugin(t, withOnchainCfg(4, 1))
 
 	sha1, err := plugin.shaForObservation(ctx, makeObs("share-from-node-1"))
 	require.NoError(t, err)
@@ -230,7 +223,7 @@ func TestPlugin_ShaForObservation_ShareAggregationIncludesPublicKeys_DifferentSh
 	require.Equal(t, sha1, sha2)
 }
 
-func TestPlugin_StateTransition_GetSecretsRequest_ShareAggregationIncludesPublicKeys_CombinesShares(t *testing.T) {
+func TestPlugin_StateTransition_GetSecretsRequest_CombinesSharesByEncryptionKey(t *testing.T) {
 	t.Parallel()
 	lggr, observed := logger.TestLoggerObserved(t, zapcore.DebugLevel)
 	_, pk, shares, err := tdh2easy.GenerateKeys(1, 3)
@@ -239,7 +232,6 @@ func TestPlugin_StateTransition_GetSecretsRequest_ShareAggregationIncludesPublic
 		withLggr(lggr),
 		withKeys(pk, shares[0]),
 		withOnchainCfg(4, 1),
-		withVaultGetSecretsShareAggregationIncludesPublicKeys(),
 	)
 
 	id := &vaultcommon.SecretIdentifier{Owner: "owner", Namespace: "main", Key: "secret"}


### PR DESCRIPTION
Retires the `VaultGetSecretsShareAggregationIncludesPublicKeys` feature flag by resolving the conditional in `shaForObservation` to always include encryption keys (public keys) in the SHA computation. The flag's default in chainlink-common is marked as deprecated.

**Changes:**
- `plugin.go`: Removed struct field, limiter, accessor, and conditional; always zeroes Shares/BinaryShares but keeps EncryptionKey
- `plugin_helpers_test.go`, `plugin_share_label_test.go`: Removed flag option and updated test assertions
- chainlink-common: Added `// Deprecated` comments to settings.go, README.md

Stacked PR — subsequent flag retirements stack on top of this one.