### PR TITLE
retire VaultJSONOmitUnpopulatedEnabled and VaultSignedResponseRequestIDEnabled flags

### DIFF
--- a/core/capabilities/vault/vaultutils/json.go
+++ b/core/capabilities/vault/vaultutils/json.go
@@ -12,13 +12,12 @@ import (
 
 // ToCanonicalJSON converts a protobuf message to a stable, deterministic
 // representation, including consistent sorting of keys and fields, and
-// consistent spacing. When omitUnpopulated is true, zero-value proto fields
-// are omitted from the JSON output.
-func ToCanonicalJSON(msg proto.Message, omitUnpopulated bool) ([]byte, error) {
+// consistent spacing. Zero-value proto fields are omitted from the JSON output.
+func ToCanonicalJSON(msg proto.Message) ([]byte, error) {
 	jsonb, err := protojson.MarshalOptions{
 		UseProtoNames:   false,
 		UseEnumNumbers:  false,
-		EmitUnpopulated: !omitUnpopulated,
+		EmitUnpopulated: false,
 	}.Marshal(msg)
 	if err != nil {
 		return nil, err

--- a/core/capabilities/vault/vaultutils/json_test.go
+++ b/core/capabilities/vault/vaultutils/json_test.go
@@ -19,7 +19,7 @@ func TestToCanonicalJSON(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	canonicalJSON, err := ToCanonicalJSON(testData, false)
+	canonicalJSON, err := ToCanonicalJSON(testData)
 	require.NoError(t, err)
 
 	expectedJSON := `{"field1":"value1","field2":42}`
@@ -32,7 +32,7 @@ func TestToCanonicalJSON(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	canonicalJSON, err = ToCanonicalJSON(testData, false)
+	canonicalJSON, err = ToCanonicalJSON(testData)
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedJSON, string(canonicalJSON)) //nolint:testifylint // testifylint requires use of assert.JSONEq which doesn't do a string match of the JSON, but does a structural match.
@@ -61,20 +61,13 @@ func TestToCanonicalJSON_OmitsEmptyFields(t *testing.T) {
 			},
 		}
 
-		withEmptyFields, err := ToCanonicalJSON(msg, false)
-		require.NoError(t, err)
-		assert.JSONEq(t, `{
-			"requestId":"owner::req-1",
-			"responses":[{"id":{"owner":"owner","namespace":"main","key":"secret1"},"success":true,"error":""}]
-		}`, string(withEmptyFields))
-
-		canonicalJSON, err := ToCanonicalJSON(msg, true)
+		canonicalJSON, err := ToCanonicalJSON(msg)
 		require.NoError(t, err)
 		assert.JSONEq(t, `{
 			"requestId":"owner::req-1",
 			"responses":[{"id":{"owner":"owner","namespace":"main","key":"secret1"},"success":true}]
 		}`, string(canonicalJSON))
-		assert.NotEqual(t, string(withEmptyFields), string(canonicalJSON))
+		assert.NotContains(t, string(canonicalJSON), `"error":""`)
 	})
 
 	t.Run("empty repeated field and empty top-level string", func(t *testing.T) {
@@ -84,14 +77,9 @@ func TestToCanonicalJSON_OmitsEmptyFields(t *testing.T) {
 			Responses: []*vaultcommon.CreateSecretResponse{},
 		}
 
-		withEmptyFields, err := ToCanonicalJSON(msg, false)
-		require.NoError(t, err)
-		assert.JSONEq(t, `{"responses":[],"requestId":""}`, string(withEmptyFields))
-
-		canonicalJSON, err := ToCanonicalJSON(msg, true)
+		canonicalJSON, err := ToCanonicalJSON(msg)
 		require.NoError(t, err)
 		assert.JSONEq(t, `{}`, string(canonicalJSON))
-		assert.NotEqual(t, string(withEmptyFields), string(canonicalJSON))
 	})
 
 	t.Run("empty repeated field only", func(t *testing.T) {
@@ -102,13 +90,8 @@ func TestToCanonicalJSON_OmitsEmptyFields(t *testing.T) {
 			Responses: []*vaultcommon.CreateSecretResponse{},
 		}
 
-		withEmptyFields, err := ToCanonicalJSON(msg, false)
-		require.NoError(t, err)
-		assert.JSONEq(t, `{"responses":[],"requestId":"owner::req-1"}`, string(withEmptyFields))
-
-		canonicalJSON, err := ToCanonicalJSON(msg, true)
+		canonicalJSON, err := ToCanonicalJSON(msg)
 		require.NoError(t, err)
 		assert.JSONEq(t, `{"requestId":"owner::req-1"}`, string(canonicalJSON))
-		assert.NotEqual(t, string(withEmptyFields), string(canonicalJSON))
 	})
 }

--- a/core/capabilities/vault/vaultutils/signed_payload_request_id_test.go
+++ b/core/capabilities/vault/vaultutils/signed_payload_request_id_test.go
@@ -16,7 +16,7 @@ func TestSignedPayloadRequestID(t *testing.T) {
 	payload, err := ToCanonicalJSON(&vaultcommon.CreateSecretsResponse{
 		RequestId: "owner::req-1",
 		Responses: []*vaultcommon.CreateSecretResponse{},
-	}, false)
+	})
 	require.NoError(t, err)
 
 	got, err := SignedPayloadRequestID(vaulttypes.MethodSecretsCreate, json.RawMessage(payload))

--- a/core/services/gateway/handlers/vault/aggregator.go
+++ b/core/services/gateway/handlers/vault/aggregator.go
@@ -20,7 +20,6 @@ import (
 	vaultcommon "github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaultutils"
 )
@@ -28,10 +27,9 @@ import (
 var errSignedPayloadRequestIDMismatch = errors.New("signed payload request id mismatch")
 
 type baseAggregator struct {
-	capabilitiesRegistry        capabilitiesRegistry
-	metrics                     *metrics
-	donID                       string
-	signedResponseRequestIDGate limits.GateLimiter
+	capabilitiesRegistry capabilitiesRegistry
+	metrics              *metrics
+	donID                string
 	// vaultHandlerDonID scopes registry lookup when several vault DONs exist.
 	//
 	// Source: gateway job TOML [[gatewayConfig.ShardedDONs]] DonName (see deployment/cre/jobs/pkg/gateway_job.go),
@@ -54,32 +52,14 @@ func methodSupportsSignedOCRValidation(method string) bool {
 	}
 }
 
-func (a *baseAggregator) signedResponseRequestIDEnabled(ctx context.Context, l logger.Logger) bool {
-	allowed, err := a.signedResponseRequestIDGate.Limit(ctx)
-	if err != nil {
-		l.Errorw("unexpected error evaluating CRE gate", "gate", "VaultSignedResponseRequestIDEnabled", "error", err)
-		return false
-	}
-	return allowed
-}
-
 func (a *baseAggregator) Aggregate(ctx context.Context, l logger.Logger, requestID string, resps map[string]jsonrpc.Response[json.RawMessage], currResp *jsonrpc.Response[json.RawMessage]) (*jsonrpc.Response[json.RawMessage], error) {
 	don, err := a.donForVaultCapability(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get DON for vault capability: %w", err)
 	}
 
-	if a.signedResponseRequestIDEnabled(ctx, l) {
-		if methodSupportsSignedOCRValidation(currResp.Method) {
-			currResp, err = a.validateUsingSignatures(ctx, l, don.DON, don.Nodes, requestID, currResp, true)
-			if err == nil {
-				return currResp, nil
-			}
-
-			l.Debugw("failed to validate signatures, falling back to quorum aggregation", "error", err)
-		}
-	} else {
-		currResp, err = a.validateUsingSignatures(ctx, l, don.DON, don.Nodes, requestID, currResp, false)
+	if methodSupportsSignedOCRValidation(currResp.Method) {
+		currResp, err = a.validateUsingSignatures(ctx, l, don.DON, don.Nodes, requestID, currResp)
 		if err == nil {
 			return currResp, nil
 		}
@@ -260,7 +240,7 @@ func (a *baseAggregator) recordSignedPayloadRequestIDMismatch(ctx context.Contex
 	))
 }
 
-func (a *baseAggregator) validateUsingSignatures(ctx context.Context, l logger.Logger, don capabilities.DON, nodes []capabilities.Node, requestID string, resp *jsonrpc.Response[json.RawMessage], validateSignedPayloadRequestID bool) (*jsonrpc.Response[json.RawMessage], error) {
+func (a *baseAggregator) validateUsingSignatures(ctx context.Context, l logger.Logger, don capabilities.DON, nodes []capabilities.Node, requestID string, resp *jsonrpc.Response[json.RawMessage]) (*jsonrpc.Response[json.RawMessage], error) {
 	if resp.Result == nil {
 		if resp.Error != nil {
 			return nil, errors.New("response has an error, cannot validate signatures. Error: " + resp.Error.Error())
@@ -282,10 +262,6 @@ func (a *baseAggregator) validateUsingSignatures(ctx context.Context, l logger.L
 	err = vaulttypes.ValidateSignatures(r, signers, int(don.F+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate signatures: %w", err)
-	}
-
-	if !validateSignedPayloadRequestID {
-		return resp, nil
 	}
 
 	payloadRequestID, err := vaultutils.SignedPayloadRequestID(resp.Method, r.Payload)

--- a/core/services/gateway/handlers/vault/aggregator_test.go
+++ b/core/services/gateway/handlers/vault/aggregator_test.go
@@ -14,18 +14,16 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/vault/vaulttypes"
 )
 
-func testAggregator(t *testing.T, mcr *mockCapabilitiesRegistry, signedResponseRequestIDEnabled bool) *baseAggregator {
+func testAggregator(t *testing.T, mcr *mockCapabilitiesRegistry) *baseAggregator {
 	t.Helper()
 	m, err := newMetrics()
 	require.NoError(t, err)
 	return &baseAggregator{
-		capabilitiesRegistry:        mcr,
-		metrics:                     m,
-		signedResponseRequestIDGate: limits.NewGateLimiter(signedResponseRequestIDEnabled),
+		capabilitiesRegistry: mcr,
+		metrics:              m,
 	}
 }
 
@@ -42,7 +40,7 @@ func makeNodes(t *testing.T, signers []string) []capabilities.Node {
 func TestAggregator_Valid_Signatures(t *testing.T) {
 	currResp, nodes := makeSignedCreateSecretsResponse(t, "1", 2)
 	mcr := &mockCapabilitiesRegistry{F: 1, Nodes: nodes}
-	agg := testAggregator(t, mcr, false)
+	agg := testAggregator(t, mcr)
 
 	responses := map[string]jsonrpc.Response[json.RawMessage]{
 		"a": currResp,
@@ -56,7 +54,7 @@ func TestAggregator_SignedResponseRequestIDMismatch(t *testing.T) {
 	t.Parallel()
 	currResp, nodes := makeSignedCreateSecretsResponse(t, "signed-for-other-request", 2)
 	mcr := &mockCapabilitiesRegistry{F: 1, Nodes: nodes}
-	agg := testAggregator(t, mcr, true)
+	agg := testAggregator(t, mcr)
 
 	responses := map[string]jsonrpc.Response[json.RawMessage]{
 		"a": currResp,
@@ -72,7 +70,7 @@ func TestAggregator_PublicKeyGet_SkipsSignatureValidation(t *testing.T) {
 	currResp.Method = vaulttypes.MethodPublicKeyGet
 
 	mcr := &mockCapabilitiesRegistry{F: 1, Nodes: nodes}
-	agg := testAggregator(t, mcr, true)
+	agg := testAggregator(t, mcr)
 
 	responses := map[string]jsonrpc.Response[json.RawMessage]{
 		"a": currResp,
@@ -89,7 +87,7 @@ func TestAggregator_SignedResponseMissingRequestID_Accepted(t *testing.T) {
 	payload := json.RawMessage([]byte(`{"responses":[{"error":"failed to verify ciphertext: cannot unmarshal data: unexpected end of JSON input","id":{"key":"W","namespace":"","owner":"foo"},"success":false}]}`))
 	currResp, nodes := makeSignedVaultResponse(t, vaulttypes.MethodSecretsCreate, "expected-request", payload, 2)
 	mcr := &mockCapabilitiesRegistry{F: 1, Nodes: nodes}
-	agg := testAggregator(t, mcr, true)
+	agg := testAggregator(t, mcr)
 
 	responses := map[string]jsonrpc.Response[json.RawMessage]{
 		"a": currResp,
@@ -143,7 +141,7 @@ func TestAggregator_Valid_FallsBackToQuorum(t *testing.T) {
 	}
 	nodes := makeNodes(t, signers)
 	mcr := &mockCapabilitiesRegistry{F: 1, Nodes: nodes}
-	agg := testAggregator(t, mcr, false)
+	agg := testAggregator(t, mcr)
 
 	currResp := jsonrpc.Response[json.RawMessage]{
 		Version: jsonrpc.JsonRpcVersion,
@@ -175,7 +173,7 @@ func TestAggregator_Valid_FallsBackToQuorum_ExcludesSignaturesInSha(t *testing.T
 	}
 	nodes := makeNodes(t, signers)
 	mcr := &mockCapabilitiesRegistry{F: 1, Nodes: nodes}
-	agg := testAggregator(t, mcr, false)
+	agg := testAggregator(t, mcr)
 
 	oldResp1 := newMessage(t)
 	oldResp2 := newMessage(t)
@@ -256,7 +254,7 @@ func TestValidateUsingQuorum_tiedMajoritiesPickDigestDeterministically(t *testin
 
 func TestAggregator_InsufficientResponses(t *testing.T) {
 	mcr := &mockCapabilitiesRegistry{F: 1}
-	agg := testAggregator(t, mcr, false)
+	agg := testAggregator(t, mcr)
 
 	rm := json.RawMessage([]byte(`{}`))
 	currResp := jsonrpc.Response[json.RawMessage]{
@@ -282,7 +280,7 @@ func TestAggregator_QuorumUnobtainable(t *testing.T) {
 	}
 	nodes := makeNodes(t, signers)
 	mcr := &mockCapabilitiesRegistry{F: 1, Nodes: nodes}
-	agg := testAggregator(t, mcr, false)
+	agg := testAggregator(t, mcr)
 
 	rm1 := json.RawMessage([]byte(`{}`))
 	resp1 := &jsonrpc.Response[json.RawMessage]{
@@ -341,9 +339,8 @@ func TestAggregator_MultipleRegistryDONs_SelectsByVaultHandlerDonName(t *testing
 	donMine := makeDONWithNodesForTest(t, "cre-reliability-vault", 2, 1, 0x20, 4)
 	mcr := &mockCapabilitiesRegistry{DONs: []capabilities.DONWithNodes{donOther, donMine}}
 	agg := &baseAggregator{
-		capabilitiesRegistry:        mcr,
-		vaultHandlerDonID:           "cre-reliability-vault",
-		signedResponseRequestIDGate: limits.NewGateLimiter(false),
+		capabilitiesRegistry: mcr,
+		vaultHandlerDonID:    "cre-reliability-vault",
 	}
 
 	rm := json.RawMessage([]byte(`{}`))
@@ -368,9 +365,8 @@ func TestAggregator_MultipleRegistryDONs_SelectsByIDWhenNameEmpty(t *testing.T) 
 	donMine := makeDONWithNodesForTest(t, "", 99, 1, 0x20, 4)
 	mcr := &mockCapabilitiesRegistry{DONs: []capabilities.DONWithNodes{donOther, donMine}}
 	agg := &baseAggregator{
-		capabilitiesRegistry:        mcr,
-		vaultHandlerDonID:           "99",
-		signedResponseRequestIDGate: limits.NewGateLimiter(false),
+		capabilitiesRegistry: mcr,
+		vaultHandlerDonID:    "99",
 	}
 
 	rm := json.RawMessage([]byte(`{}`))
@@ -395,9 +391,8 @@ func TestAggregator_MultipleRegistryDONs_NoMatchingVaultHandlerDonId(t *testing.
 	donB := makeDONWithNodesForTest(t, "don-b", 2, 1, 0x20, 4)
 	mcr := &mockCapabilitiesRegistry{DONs: []capabilities.DONWithNodes{donA, donB}}
 	agg := &baseAggregator{
-		capabilitiesRegistry:        mcr,
-		vaultHandlerDonID:           "unknown-vault",
-		signedResponseRequestIDGate: limits.NewGateLimiter(false),
+		capabilitiesRegistry: mcr,
+		vaultHandlerDonID:    "unknown-vault",
 	}
 
 	rm := json.RawMessage([]byte(`{}`))
@@ -417,9 +412,8 @@ func TestAggregator_MultipleRegistryDONs_AmbiguousMatchingVaultHandlerDonId(t *t
 	donB := makeDONWithNodesForTest(t, "same-name", 2, 1, 0x20, 4)
 	mcr := &mockCapabilitiesRegistry{DONs: []capabilities.DONWithNodes{donA, donB}}
 	agg := &baseAggregator{
-		capabilitiesRegistry:        mcr,
-		vaultHandlerDonID:           "same-name",
-		signedResponseRequestIDGate: limits.NewGateLimiter(false),
+		capabilitiesRegistry: mcr,
+		vaultHandlerDonID:    "same-name",
 	}
 
 	rm := json.RawMessage([]byte(`{}`))

--- a/core/services/gateway/handlers/vault/aggregator_test_helpers.go
+++ b/core/services/gateway/handlers/vault/aggregator_test_helpers.go
@@ -45,7 +45,7 @@ func makeSignedCreateSecretsResponse(t *testing.T, requestID string, numSigners 
 			},
 		},
 	}
-	payload, err := vaultutils.ToCanonicalJSON(createResp, false)
+	payload, err := vaultutils.ToCanonicalJSON(createResp)
 	require.NoError(t, err)
 
 	return makeSignedVaultResponse(t, vaulttypes.MethodSecretsCreate, requestID, json.RawMessage(payload), numSigners)

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -147,10 +147,9 @@ type handler struct {
 	nodeRateLimiter *ratelimit.RateLimiter
 	requestTimeout  time.Duration
 
-	writeMethodsEnabled            limits.GateLimiter
-	signedResponseRequestIDEnabled limits.GateLimiter
-	activeRequests                 map[string]*activeRequest
-	metrics                        *metrics
+	writeMethodsEnabled limits.GateLimiter
+	activeRequests      map[string]*activeRequest
+	metrics             *metrics
 
 	aggregator aggregator
 
@@ -244,32 +243,25 @@ func newHandlerWithAuthorizer(methodConfig json.RawMessage, donConfig *config.DO
 		return nil, fmt.Errorf("failed to create gateway vault request processor: %w", err)
 	}
 
-	signedResponseRequestIDEnabled, err := limits.MakeGateLimiter(limitsFactory, cresettings.Default.VaultSignedResponseRequestIDEnabled)
-	if err != nil {
-		return nil, fmt.Errorf("could not create VaultSignedResponseRequestIDEnabled limiter: %w", err)
-	}
-
 	return &handler{
-		methodConfig:                   cfg,
-		donConfig:                      donConfig,
-		don:                            don,
-		lggr:                           logger.Named(lggr, "VaultHandler:"+donConfig.DonId),
-		requestTimeout:                 time.Duration(cfg.RequestTimeoutSec) * time.Second,
-		nodeRateLimiter:                nodeRateLimiter,
-		writeMethodsEnabled:            writeMethodsEnabled,
-		signedResponseRequestIDEnabled: signedResponseRequestIDEnabled,
-		activeRequests:                 make(map[string]*activeRequest),
-		mu:                             sync.RWMutex{},
-		authorizer:                     authorizer,
-		jwtAuth:                        jwtAuth,
-		stopCh:                         make(services.StopChan),
-		metrics:                        metrics,
+		methodConfig:        cfg,
+		donConfig:           donConfig,
+		don:                 don,
+		lggr:                logger.Named(lggr, "VaultHandler:"+donConfig.DonId),
+		requestTimeout:      time.Duration(cfg.RequestTimeoutSec) * time.Second,
+		nodeRateLimiter:     nodeRateLimiter,
+		writeMethodsEnabled: writeMethodsEnabled,
+		activeRequests:      make(map[string]*activeRequest),
+		mu:                  sync.RWMutex{},
+		authorizer:          authorizer,
+		jwtAuth:             jwtAuth,
+		stopCh:              make(services.StopChan),
+		metrics:             metrics,
 		aggregator: &baseAggregator{
-			capabilitiesRegistry:        capabilitiesRegistry,
-			metrics:                     metrics,
-			donID:                       donConfig.DonId,
-			vaultHandlerDonID:           donConfig.DonId,
-			signedResponseRequestIDGate: signedResponseRequestIDEnabled,
+			capabilitiesRegistry: capabilitiesRegistry,
+			metrics:              metrics,
+			donID:                donConfig.DonId,
+			vaultHandlerDonID:    donConfig.DonId,
 		},
 		clock:            clock,
 		requestProcessor: requestProcessor,
@@ -319,7 +311,6 @@ func (h *handler) Close() error {
 			jwtAuthErr,
 			h.writeMethodsEnabled.Close(),
 			h.requestProcessor.Close(),
-			h.signedResponseRequestIDEnabled.Close(),
 		)
 	})
 }

--- a/core/services/gateway/handlers/vault/handler_test.go
+++ b/core/services/gateway/handlers/vault/handler_test.go
@@ -982,9 +982,8 @@ func TestVaultHandler_HandleNodeMessage_SignatureValidatedResponse_RejectsUnknow
 	nodes := makeNodes(t, signers)
 	mcr := &mockCapabilitiesRegistry{F: 1, Nodes: nodes}
 	h.(*handler).aggregator = &baseAggregator{
-		capabilitiesRegistry:        mcr,
-		vaultHandlerDonID:           h.(*handler).donConfig.DonId,
-		signedResponseRequestIDGate: limits.NewGateLimiter(true),
+		capabilitiesRegistry: mcr,
+		vaultHandlerDonID:    h.(*handler).donConfig.DonId,
 	}
 
 	ocrContext, err := hex.DecodeString("000ec4f6a2ba011e909eccf64628855b848e08876a1edd938a1372a9e51adff100000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000")
@@ -1058,9 +1057,8 @@ func TestVaultHandler_PublicKeyGet(t *testing.T) {
 	nodes := makeNodes(t, signers)
 	mcr := &mockCapabilitiesRegistry{F: 1, Nodes: nodes}
 	h.(*handler).aggregator = &baseAggregator{
-		capabilitiesRegistry:        mcr,
-		vaultHandlerDonID:           h.(*handler).donConfig.DonId,
-		signedResponseRequestIDGate: limits.NewGateLimiter(true),
+		capabilitiesRegistry: mcr,
+		vaultHandlerDonID:    h.(*handler).donConfig.DonId,
 	}
 
 	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -63,8 +63,6 @@ type ReportingPluginConfig struct {
 	MaxBlobPayloadBytes                    limits.BoundLimiter[pkgconfig.Size]
 	VaultForceEmptyOCRRounds               limits.GateLimiter
 	VaultOptimizationsEnabled              limits.GateLimiter
-	VaultJSONOmitUnpopulatedEnabled        limits.GateLimiter
-	VaultSignedResponseRequestIDEnabled    limits.GateLimiter
 	VaultGetSecretsRelaxedConsensusEnabled limits.GateLimiter
 	VaultIncludeInvalidPendingItemsEnabled limits.GateLimiter
 	VaultPendingQueueStallThreshold        limits.BoundLimiter[int]
@@ -192,11 +190,6 @@ func newReportingPluginConfigLimiters(factory limits.Factory) (*ReportingPluginC
 		return nil, fmt.Errorf("VaultOptimizationsEnabled: %w", err)
 	}
 
-	vaultJSONOmitUnpopulatedEnabled, err := limits.MakeGateLimiter(factory, cresettings.Default.VaultJSONOmitUnpopulatedEnabled)
-	if err != nil {
-		return nil, fmt.Errorf("VaultJSONOmitUnpopulatedEnabled: %w", err)
-	}
-
 	vaultGetSecretsRelaxedConsensusEnabled, err := limits.MakeGateLimiter(factory, cresettings.Default.VaultGetSecretsRelaxedConsensusEnabled)
 	if err != nil {
 		return nil, fmt.Errorf("VaultGetSecretsRelaxedConsensusEnabled: %w", err)
@@ -210,11 +203,6 @@ func newReportingPluginConfigLimiters(factory limits.Factory) (*ReportingPluginC
 	vaultPendingQueueStallThreshold, err := limits.MakeUpperBoundLimiter(factory, cresettings.Default.VaultPendingQueueStallThreshold)
 	if err != nil {
 		return nil, fmt.Errorf("VaultPendingQueueStallThreshold: %w", err)
-	}
-
-	vaultSignedResponseRequestIDEnabled, err := limits.MakeGateLimiter(factory, cresettings.Default.VaultSignedResponseRequestIDEnabled)
-	if err != nil {
-		return nil, fmt.Errorf("VaultSignedResponseRequestIDEnabled: %w", err)
 	}
 
 	maxBlobPayloadBytesLimiter, err := limits.MakeUpperBoundLimiter(factory, cresettings.Default.VaultMaxBlobPayloadSizeLimit)
@@ -233,8 +221,6 @@ func newReportingPluginConfigLimiters(factory limits.Factory) (*ReportingPluginC
 		MaxPendingQueueWriteSize:               maxPendingQueueWriteSizeLimiter,
 		VaultForceEmptyOCRRounds:               vaultForceEmptyOCRRounds,
 		VaultOptimizationsEnabled:              vaultOptimizationsEnabled,
-		VaultJSONOmitUnpopulatedEnabled:        vaultJSONOmitUnpopulatedEnabled,
-		VaultSignedResponseRequestIDEnabled:    vaultSignedResponseRequestIDEnabled,
 		VaultGetSecretsRelaxedConsensusEnabled: vaultGetSecretsRelaxedConsensusEnabled,
 		VaultIncludeInvalidPendingItemsEnabled: vaultIncludeInvalidPendingItemsEnabled,
 		VaultPendingQueueStallThreshold:        vaultPendingQueueStallThreshold,
@@ -332,27 +318,27 @@ func (r *ReportingPluginFactory) NewReportingPlugin(ctx context.Context, config 
 	r.lifecycle.SetConfigDigest(config.ConfigDigest.String())
 
 	return &ReportingPlugin{
-		lggr:                         r.lggr.Named("VaultReportingPlugin"),
-		store:                        r.store,
-		cfg:                          cfg,
-		metrics:                      metrics,
-		onchainCfg:                   config,
-		validator:                    validator,
-		lifecycle:                    r.lifecycle,
-		maxObservationBytes:          pluginLimits.MaxObservationBytes,
-		maxReportsPlusPrecursorBytes: pluginLimits.MaxReportsPlusPrecursorBytes,
-		unmarshalBlob: func(data []byte) (ocr3_1types.BlobHandle, error) {
-			handle := ocr3_1types.BlobHandle{}
-			err := handle.UnmarshalBinary(data)
-			return handle, err
-		},
-		marshalBlob: func(handle ocr3_1types.BlobHandle) ([]byte, error) {
-			return handle.MarshalBinary()
-		},
-	}, ocr3_1types.ReportingPluginInfo1{
-		Name:   "VaultReportingPlugin",
-		Limits: pluginLimits,
-	}, nil
+			lggr:                         r.lggr.Named("VaultReportingPlugin"),
+			store:                        r.store,
+			cfg:                          cfg,
+			metrics:                      metrics,
+			onchainCfg:                   config,
+			validator:                    validator,
+			lifecycle:                    r.lifecycle,
+			maxObservationBytes:          pluginLimits.MaxObservationBytes,
+			maxReportsPlusPrecursorBytes: pluginLimits.MaxReportsPlusPrecursorBytes,
+			unmarshalBlob: func(data []byte) (ocr3_1types.BlobHandle, error) {
+				handle := ocr3_1types.BlobHandle{}
+				err := handle.UnmarshalBinary(data)
+				return handle, err
+			},
+			marshalBlob: func(handle ocr3_1types.BlobHandle) ([]byte, error) {
+				return handle.MarshalBinary()
+			},
+		}, ocr3_1types.ReportingPluginInfo1{
+			Name:   "VaultReportingPlugin",
+			Limits: pluginLimits,
+		}, nil
 }
 
 type ReportingPlugin struct {
@@ -671,10 +657,6 @@ func (r *ReportingPlugin) optimizationsEnabled(ctx context.Context) bool {
 	return gateAllows(ctx, r.lggr, r.cfg.VaultOptimizationsEnabled, "VaultOptimizationsEnabled")
 }
 
-func (r *ReportingPlugin) jsonOmitUnpopulatedEnabled(ctx context.Context) bool {
-	return gateAllows(ctx, r.lggr, r.cfg.VaultJSONOmitUnpopulatedEnabled, "VaultJSONOmitUnpopulatedEnabled")
-}
-
 func (r *ReportingPlugin) getSecretsRelaxedConsensusEnabled(ctx context.Context) bool {
 	return gateAllows(ctx, r.lggr, r.cfg.VaultGetSecretsRelaxedConsensusEnabled, "VaultGetSecretsRelaxedConsensusEnabled")
 }
@@ -703,10 +685,6 @@ func (r *ReportingPlugin) shouldPurgePendingQueue(ctx context.Context) bool {
 
 	stalledObservationCount := r.pendingQueueStallTracker.getCount()
 	return stalledObservationCount >= stallThreshold
-}
-
-func (r *ReportingPlugin) signedResponseRequestIDEnabled(ctx context.Context) bool {
-	return gateAllows(ctx, r.lggr, r.cfg.VaultSignedResponseRequestIDEnabled, "VaultSignedResponseRequestIDEnabled")
 }
 
 type pendingQueueStore interface {
@@ -2778,10 +2756,8 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 			})
 		case vaultcommon.RequestType_CREATE_SECRETS:
 			createResp := proto.Clone(o.GetCreateSecretsResponse()).(*vaultcommon.CreateSecretsResponse)
-			if r.signedResponseRequestIDEnabled(ctx) {
-				createResp.RequestId = o.Id
-			}
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, createResp, r.jsonOmitUnpopulatedEnabled(ctx))
+			createResp.RequestId = o.Id
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, createResp)
 			if err != nil {
 				l.Errorw("failed to generate JSON report", "error", err, "requestID", o.Id)
 				continue
@@ -2792,10 +2768,8 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 			})
 		case vaultcommon.RequestType_UPDATE_SECRETS:
 			updateResp := proto.Clone(o.GetUpdateSecretsResponse()).(*vaultcommon.UpdateSecretsResponse)
-			if r.signedResponseRequestIDEnabled(ctx) {
-				updateResp.RequestId = o.Id
-			}
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, updateResp, r.jsonOmitUnpopulatedEnabled(ctx))
+			updateResp.RequestId = o.Id
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, updateResp)
 			if err != nil {
 				l.Errorw("failed to generate JSON report", "error", err, "requestID", o.Id)
 				continue
@@ -2806,10 +2780,8 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 			})
 		case vaultcommon.RequestType_DELETE_SECRETS:
 			deleteResp := proto.Clone(o.GetDeleteSecretsResponse()).(*vaultcommon.DeleteSecretsResponse)
-			if r.signedResponseRequestIDEnabled(ctx) {
-				deleteResp.RequestId = o.Id
-			}
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, deleteResp, r.jsonOmitUnpopulatedEnabled(ctx))
+			deleteResp.RequestId = o.Id
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, deleteResp)
 			if err != nil {
 				l.Errorw("failed to generate JSON report", "error", err, "requestID", o.Id)
 				continue
@@ -2820,10 +2792,8 @@ func (r *ReportingPlugin) Reports(ctx context.Context, seqNr uint64, reportsPlus
 			})
 		case vaultcommon.RequestType_LIST_SECRET_IDENTIFIERS:
 			listResp := proto.Clone(o.GetListSecretIdentifiersResponse()).(*vaultcommon.ListSecretIdentifiersResponse)
-			if r.signedResponseRequestIDEnabled(ctx) {
-				listResp.RequestId = o.Id
-			}
-			rep, err := r.generateJSONReport(o.Id, o.RequestType, listResp, r.jsonOmitUnpopulatedEnabled(ctx))
+			listResp.RequestId = o.Id
+			rep, err := r.generateJSONReport(o.Id, o.RequestType, listResp)
 			if err != nil {
 				l.Errorw("failed to generate JSON report", "error", err, "requestID", o.Id)
 				continue
@@ -2864,12 +2834,12 @@ func (r *ReportingPlugin) generateProtoReport(id string, requestType vaultcommon
 	return wrapReportWithKeyBundleInfo(rpb, rip)
 }
 
-func (r *ReportingPlugin) generateJSONReport(id string, requestType vaultcommon.RequestType, msg proto.Message, omitUnpopulated bool) (ocr3types.ReportWithInfo[[]byte], error) {
+func (r *ReportingPlugin) generateJSONReport(id string, requestType vaultcommon.RequestType, msg proto.Message) (ocr3types.ReportWithInfo[[]byte], error) {
 	if msg == nil {
 		return ocr3types.ReportWithInfo[[]byte]{}, errors.New("invalid report: response cannot be nil")
 	}
 
-	jsonb, err := vaultutils.ToCanonicalJSON(msg, omitUnpopulated)
+	jsonb, err := vaultutils.ToCanonicalJSON(msg)
 	if err != nil {
 		return ocr3types.ReportWithInfo[[]byte]{}, fmt.Errorf("failed to convert proto to canonical JSON: %w", err)
 	}

--- a/core/services/ocr2/plugins/vault/plugin_helpers_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_helpers_test.go
@@ -37,8 +37,6 @@ type testPluginBuildOpts struct {
 	batchSize                              int
 	maxBlobPayloadBytes                    int
 	vaultOptimizationsEnabled              bool
-	vaultJSONOmitUnpopulatedEnabled        bool
-	vaultSignedResponseRequestIDEnabled    bool
 	vaultGetSecretsRelaxedConsensusEnabled bool
 	vaultIncludeInvalidPendingItemsEnabled bool
 	vaultPendingQueueStallThreshold        int
@@ -83,10 +81,6 @@ func withVaultOptimizationsEnabled() testPluginOption {
 	return func(o *testPluginBuildOpts) { o.vaultOptimizationsEnabled = true }
 }
 
-func withVaultJSONOmitUnpopulatedEnabled() testPluginOption {
-	return func(o *testPluginBuildOpts) { o.vaultJSONOmitUnpopulatedEnabled = true }
-}
-
 func withVaultGetSecretsRelaxedConsensusEnabled() testPluginOption {
 	return func(o *testPluginBuildOpts) { o.vaultGetSecretsRelaxedConsensusEnabled = true }
 }
@@ -97,10 +91,6 @@ func withVaultIncludeInvalidPendingItemsEnabled() testPluginOption {
 
 func withVaultPendingQueueStallThreshold(n int) testPluginOption {
 	return func(o *testPluginBuildOpts) { o.vaultPendingQueueStallThreshold = n }
-}
-
-func withVaultSignedResponseRequestIDEnabled() testPluginOption {
-	return func(o *testPluginBuildOpts) { o.vaultSignedResponseRequestIDEnabled = true }
 }
 
 func withOnchainCfg(n int, f int) testPluginOption {
@@ -156,9 +146,6 @@ func newTestReportingPlugin(t *testing.T, opts ...testPluginOption) *ReportingPl
 	if o.vaultOptimizationsEnabled {
 		cfg.VaultOptimizationsEnabled = limits.NewGateLimiter(true)
 	}
-	if o.vaultJSONOmitUnpopulatedEnabled {
-		cfg.VaultJSONOmitUnpopulatedEnabled = limits.NewGateLimiter(true)
-	}
 	if o.vaultGetSecretsRelaxedConsensusEnabled {
 		cfg.VaultGetSecretsRelaxedConsensusEnabled = limits.NewGateLimiter(true)
 	}
@@ -172,9 +159,6 @@ func newTestReportingPlugin(t *testing.T, opts ...testPluginOption) *ReportingPl
 		)
 		require.NoError(t, err)
 		cfg.VaultPendingQueueStallThreshold = stallLimiter
-	}
-	if o.vaultSignedResponseRequestIDEnabled {
-		cfg.VaultSignedResponseRequestIDEnabled = limits.NewGateLimiter(true)
 	}
 	ctx := context.Background()
 	pl, err := initializePluginLimits(ctx, limits.Factory{Settings: cresettings.DefaultGetter})
@@ -285,8 +269,6 @@ func makeReportingPluginConfig(
 		MaxBlobPayloadBytes:                    maxBlobPayloadLimiter,
 		VaultForceEmptyOCRRounds:               limits.NewGateLimiter(false),
 		VaultOptimizationsEnabled:              limits.NewGateLimiter(false),
-		VaultJSONOmitUnpopulatedEnabled:        limits.NewGateLimiter(false),
-		VaultSignedResponseRequestIDEnabled:    limits.NewGateLimiter(false),
 		VaultGetSecretsRelaxedConsensusEnabled: limits.NewGateLimiter(false),
 		VaultIncludeInvalidPendingItemsEnabled: limits.NewGateLimiter(false),
 		VaultPendingQueueStallThreshold:        pendingQueueStallThresholdLimiter,

--- a/core/services/ocr2/plugins/vault/plugin_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_test.go
@@ -4583,7 +4583,7 @@ func TestPlugin_Reports(t *testing.T) {
 
 	_, pk, shares, err := tdh2easy.GenerateKeys(1, 3)
 	require.NoError(t, err)
-	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1), withVaultJSONOmitUnpopulatedEnabled(), withVaultSignedResponseRequestIDEnabled())
+	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1))
 
 	rs, err := r.Reports(t.Context(), uint64(1), osb)
 	require.NoError(t, err)
@@ -4602,7 +4602,7 @@ func TestPlugin_Reports(t *testing.T) {
 
 	signedResp := proto.Clone(resp).(*vaultcommon.CreateSecretsResponse)
 	signedResp.RequestId = vaulttypes.KeyFor(id)
-	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp, true)
+	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp)
 	require.NoError(t, err)
 	assert.Equal(t, expectedBytes, []byte(o1.ReportWithInfo.Report))
 
@@ -4655,21 +4655,7 @@ func TestPlugin_Reports_JSONReportOmitUnpopulated(t *testing.T) {
 	_, pk, shares, err := tdh2easy.GenerateKeys(1, 3)
 	require.NoError(t, err)
 
-	t.Run("json omit unpopulated enabled omits empty fields", func(t *testing.T) {
-		t.Parallel()
-
-		r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1), withVaultJSONOmitUnpopulatedEnabled())
-		rs, err := r.Reports(t.Context(), uint64(1), osb)
-		require.NoError(t, err)
-		require.Len(t, rs, 1)
-
-		expectedBytes, err := vaultutils.ToCanonicalJSON(resp, true)
-		require.NoError(t, err)
-		assert.Equal(t, expectedBytes, []byte(rs[0].ReportWithInfo.Report))
-		assert.NotContains(t, string(rs[0].ReportWithInfo.Report), `"error":""`)
-	})
-
-	t.Run("json omit unpopulated disabled keeps empty fields", func(t *testing.T) {
+	t.Run("json omits empty fields", func(t *testing.T) {
 		t.Parallel()
 
 		r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1))
@@ -4677,10 +4663,12 @@ func TestPlugin_Reports_JSONReportOmitUnpopulated(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, rs, 1)
 
-		expectedBytes, err := vaultutils.ToCanonicalJSON(resp, false)
+		signedResp := proto.Clone(resp).(*vaultcommon.CreateSecretsResponse)
+		signedResp.RequestId = vaulttypes.KeyFor(id)
+		expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp)
 		require.NoError(t, err)
 		assert.Equal(t, expectedBytes, []byte(rs[0].ReportWithInfo.Report))
-		assert.Contains(t, string(rs[0].ReportWithInfo.Report), `"error":""`)
+		assert.NotContains(t, string(rs[0].ReportWithInfo.Report), `"error":""`)
 	})
 }
 
@@ -5245,7 +5233,7 @@ func TestPlugin_Reports_UpdateSecretsRequest(t *testing.T) {
 
 	_, pk, shares, err := tdh2easy.GenerateKeys(1, 3)
 	require.NoError(t, err)
-	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1), withVaultJSONOmitUnpopulatedEnabled(), withVaultSignedResponseRequestIDEnabled())
+	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1))
 
 	rs, err := r.Reports(t.Context(), uint64(1), osb)
 	require.NoError(t, err)
@@ -5264,7 +5252,7 @@ func TestPlugin_Reports_UpdateSecretsRequest(t *testing.T) {
 
 	signedResp := proto.Clone(resp).(*vaultcommon.UpdateSecretsResponse)
 	signedResp.RequestId = vaulttypes.KeyFor(id)
-	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp, true)
+	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp)
 	require.NoError(t, err)
 	assert.Equal(t, expectedBytes, []byte(o.ReportWithInfo.Report))
 }
@@ -5643,7 +5631,7 @@ func TestPlugin_Reports_DeleteSecretsRequest(t *testing.T) {
 
 	_, pk, shares, err := tdh2easy.GenerateKeys(1, 3)
 	require.NoError(t, err)
-	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1), withVaultJSONOmitUnpopulatedEnabled(), withVaultSignedResponseRequestIDEnabled())
+	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1))
 
 	rs, err := r.Reports(t.Context(), uint64(1), osb)
 	require.NoError(t, err)
@@ -5662,7 +5650,7 @@ func TestPlugin_Reports_DeleteSecretsRequest(t *testing.T) {
 
 	signedResp := proto.Clone(resp).(*vaultcommon.DeleteSecretsResponse)
 	signedResp.RequestId = vaulttypes.KeyFor(id)
-	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp, true)
+	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp)
 	require.NoError(t, err)
 	assert.Equal(t, expectedBytes, []byte(o.ReportWithInfo.Report))
 }
@@ -5987,7 +5975,7 @@ func TestPlugin_Reports_ListSecretIdentifiersRequest(t *testing.T) {
 
 	_, pk, shares, err := tdh2easy.GenerateKeys(1, 3)
 	require.NoError(t, err)
-	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1), withVaultJSONOmitUnpopulatedEnabled(), withVaultSignedResponseRequestIDEnabled())
+	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1))
 
 	rs, err := r.Reports(t.Context(), uint64(1), osb)
 	require.NoError(t, err)
@@ -6006,7 +5994,7 @@ func TestPlugin_Reports_ListSecretIdentifiersRequest(t *testing.T) {
 
 	signedResp := proto.Clone(resp).(*vaultcommon.ListSecretIdentifiersResponse)
 	signedResp.RequestId = vaulttypes.KeyFor(id)
-	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp, true)
+	expectedBytes, err := vaultutils.ToCanonicalJSON(signedResp)
 	require.NoError(t, err)
 	assert.Equal(t, expectedBytes, []byte(o.ReportWithInfo.Report))
 }

--- a/system-tests/tests/smoke/cre/vault_don_test.go
+++ b/system-tests/tests/smoke/cre/vault_don_test.go
@@ -950,19 +950,9 @@ func TestVaultOptimizationsEnabled_CRESettingDefaultsDisabled(t *testing.T) {
 	require.False(t, cresettings.Default.VaultOptimizationsEnabled.DefaultValue)
 }
 
-func TestVaultJSONOmitUnpopulatedEnabled_CRESettingDefaultsDisabled(t *testing.T) {
-	t.Parallel()
-	require.False(t, cresettings.Default.VaultJSONOmitUnpopulatedEnabled.DefaultValue)
-}
-
 func TestVaultIncludeInvalidPendingItemsEnabled_CRESettingDefaultsDisabled(t *testing.T) {
 	t.Parallel()
 	require.False(t, cresettings.Default.VaultIncludeInvalidPendingItemsEnabled.DefaultValue)
-}
-
-func TestVaultSignedResponseRequestIDEnabled_CRESettingDefaultsDisabled(t *testing.T) {
-	t.Parallel()
-	require.False(t, cresettings.Default.VaultSignedResponseRequestIDEnabled.DefaultValue)
 }
 
 func TestVaultStaticTopologies_LoadExpectedConfig(t *testing.T) {

--- a/system-tests/tests/smoke/cre/vault_don_test_helpers.go
+++ b/system-tests/tests/smoke/cre/vault_don_test_helpers.go
@@ -561,10 +561,7 @@ func requireSignedPayloadRequestID(t *testing.T, method, userRequestID, authoriz
 
 	signedRequestID, err := vaultutils.SignedPayloadRequestID(method, payload)
 	require.NoError(t, err)
-	if signedRequestID == "" {
-		// VaultSignedResponseRequestIDEnabled is off on vault nodes; skip until the gate is enabled in the test stack.
-		return
-	}
+	require.NotEmpty(t, signedRequestID, "signed payload requestId should not be empty")
 
 	expectedSuffix := vaulttypes.RequestIDSeparator + userRequestID
 	require.True(t, strings.HasSuffix(signedRequestID, expectedSuffix),


### PR DESCRIPTION
Retires two tightly-coupled feature flags together:

**VaultJSONOmitUnpopulatedEnabled:** Always omits zero-value proto fields from canonical JSON output. Removed the `omitUnpopulated` parameter from `ToCanonicalJSON` and `generateJSONReport`.

**VaultSignedResponseRequestIDEnabled:** Always embeds the OCR outcome ID into signed response protos. Removed the gate from the gateway aggregator's `validateUsingSignatures`.

**Changes:**
- `vaultutils/json.go`: Removed `omitUnpopulated bool` param from `ToCanonicalJSON`
- `plugin.go`: Removed struct fields, limiters, accessors, conditionals
- `gateway/handler.go`, `gateway/aggregator.go`: Removed gate, limiter, field, and conditional
- All test files: Removed flag options, updated assertions
- chainlink-common: Added `// Deprecated` comments

Stacked on PR #23542.