### PR TITLE
retire VaultGetSecretsRelaxedConsensusEnabled flag

### DIFF
--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don-vault-include-invalid-enabled.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don-vault-include-invalid-enabled.toml
@@ -1,5 +1,5 @@
 # Custom local CRE topology for Vault include-invalid pending items smoke coverage.
-# Enables VaultIncludeInvalidPendingItemsEnabled and VaultGetSecretsRelaxedConsensusEnabled (and VaultOptimizationsEnabled for wire-cap prefix behavior).
+# Enables VaultIncludeInvalidPendingItemsEnabled (and VaultOptimizationsEnabled for wire-cap prefix behavior).
 [chip_router]
   image = "local-cre-chip-router:v1.0.1"
 
@@ -37,7 +37,7 @@
   override_mode = "all"
   http_port_range_start = 10100
   supported_evm_chains = [1337, 2337]
-  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}', CL_CRE_SETTINGS_DEFAULT = '{"VaultIncludeInvalidPendingItemsEnabled":"true","VaultGetSecretsRelaxedConsensusEnabled":"true","VaultOptimizationsEnabled":"true"}' }
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}', CL_CRE_SETTINGS_DEFAULT = '{"VaultIncludeInvalidPendingItemsEnabled":"true","VaultOptimizationsEnabled":"true"}' }
   capabilities = ["cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337"]
   registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
 
@@ -62,7 +62,7 @@
   override_mode = "all"
   http_port_range_start = 10200
   supported_evm_chains = [1337, 2337]
-  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}', CL_CRE_SETTINGS_DEFAULT = '{"VaultIncludeInvalidPendingItemsEnabled":"true","VaultGetSecretsRelaxedConsensusEnabled":"true","VaultOptimizationsEnabled":"true"}' }
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}', CL_CRE_SETTINGS_DEFAULT = '{"VaultIncludeInvalidPendingItemsEnabled":"true","VaultOptimizationsEnabled":"true"}' }
   capabilities = ["vault", "evm-2337"]
 
   [nodesets.db]
@@ -85,7 +85,7 @@
   override_mode = "each"
   http_port_range_start = 10300
   supported_evm_chains = [1337, 2337]
-  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}', CL_CRE_SETTINGS_DEFAULT = '{"VaultIncludeInvalidPendingItemsEnabled":"true","VaultGetSecretsRelaxedConsensusEnabled":"true","VaultOptimizationsEnabled":"true"}' }
+  env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}', CL_CRE_SETTINGS_DEFAULT = '{"VaultIncludeInvalidPendingItemsEnabled":"true","VaultOptimizationsEnabled":"true"}' }
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -63,7 +63,6 @@ type ReportingPluginConfig struct {
 	MaxBlobPayloadBytes                    limits.BoundLimiter[pkgconfig.Size]
 	VaultForceEmptyOCRRounds               limits.GateLimiter
 	VaultOptimizationsEnabled              limits.GateLimiter
-	VaultGetSecretsRelaxedConsensusEnabled limits.GateLimiter
 	VaultIncludeInvalidPendingItemsEnabled limits.GateLimiter
 	VaultPendingQueueStallThreshold        limits.BoundLimiter[int]
 }
@@ -190,11 +189,6 @@ func newReportingPluginConfigLimiters(factory limits.Factory) (*ReportingPluginC
 		return nil, fmt.Errorf("VaultOptimizationsEnabled: %w", err)
 	}
 
-	vaultGetSecretsRelaxedConsensusEnabled, err := limits.MakeGateLimiter(factory, cresettings.Default.VaultGetSecretsRelaxedConsensusEnabled)
-	if err != nil {
-		return nil, fmt.Errorf("VaultGetSecretsRelaxedConsensusEnabled: %w", err)
-	}
-
 	vaultIncludeInvalidPendingItemsEnabled, err := limits.MakeGateLimiter(factory, cresettings.Default.VaultIncludeInvalidPendingItemsEnabled)
 	if err != nil {
 		return nil, fmt.Errorf("VaultIncludeInvalidPendingItemsEnabled: %w", err)
@@ -221,7 +215,6 @@ func newReportingPluginConfigLimiters(factory limits.Factory) (*ReportingPluginC
 		MaxPendingQueueWriteSize:               maxPendingQueueWriteSizeLimiter,
 		VaultForceEmptyOCRRounds:               vaultForceEmptyOCRRounds,
 		VaultOptimizationsEnabled:              vaultOptimizationsEnabled,
-		VaultGetSecretsRelaxedConsensusEnabled: vaultGetSecretsRelaxedConsensusEnabled,
 		VaultIncludeInvalidPendingItemsEnabled: vaultIncludeInvalidPendingItemsEnabled,
 		VaultPendingQueueStallThreshold:        vaultPendingQueueStallThreshold,
 	}, nil
@@ -655,10 +648,6 @@ func (r *ReportingPlugin) prepareLegacyObservationPendingQueueBlobs(
 
 func (r *ReportingPlugin) optimizationsEnabled(ctx context.Context) bool {
 	return gateAllows(ctx, r.lggr, r.cfg.VaultOptimizationsEnabled, "VaultOptimizationsEnabled")
-}
-
-func (r *ReportingPlugin) getSecretsRelaxedConsensusEnabled(ctx context.Context) bool {
-	return gateAllows(ctx, r.lggr, r.cfg.VaultGetSecretsRelaxedConsensusEnabled, "VaultGetSecretsRelaxedConsensusEnabled")
 }
 
 func (r *ReportingPlugin) includeInvalidPendingItemsEnabled(ctx context.Context) bool {
@@ -2050,7 +2039,7 @@ func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq 
 		// Once we have it, we can break, as mathematically only one
 		// sha can reach at least 2F+1 observaions.
 		chosen := []*vaultcommon.Observation{}
-		if r.getSecretsRelaxedConsensusEnabled(ctx) && len(obs) > 0 && obs[0].RequestType == vaultcommon.RequestType_GET_SECRETS {
+		if len(obs) > 0 && obs[0].RequestType == vaultcommon.RequestType_GET_SECRETS {
 			if chosen = r.chooseGetSecretsObservations(len(obs), shaToObs); chosen != nil {
 				r.lggr.Debugw("sufficient observations for sha", "requestType", "GetSecrets", "relaxedConsensus", true, "totalForID", len(obs), "count", len(chosen), "threshold", r.onchainCfg.F+1, "id", id)
 			}
@@ -2058,18 +2047,7 @@ func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq 
 			for _, sha := range slices.Sorted(maps.Keys(shaToObs)) {
 				obs := shaToObs[sha]
 
-				o := obs[0]
-				switch {
-				case o.RequestType == vaultcommon.RequestType_GET_SECRETS && len(obs) >= 2*r.onchainCfg.F+1:
-					// GetRequests required 2F+1 observations because we need exactly T=F+1 shares to reconstruct the secret.
-					// Since F shares can be fault, that means T+F=2F+1 shares are required, necessitating 2F+1 observations.
-					if r.optimizationsEnabled(ctx) {
-						chosen = shaToObs[sha][:2*r.onchainCfg.F+1]
-					} else {
-						chosen = shaToObs[sha]
-					}
-					l.Debugw("sufficient observations for sha", "sha", sha, "requestType", "GetSecrets", "count", len(obs), "threshold", 2*r.onchainCfg.F+1, "id", id)
-				case o.RequestType != vaultcommon.RequestType_GET_SECRETS && len(obs) >= r.onchainCfg.F+1:
+				if len(obs) >= r.onchainCfg.F+1 {
 					// F+1 means that at least 1 honest node has provided this observation, so that's enough for all other request
 					// types.
 					// Technically we could have two shas with F+1 observations. If that happens we'll pick the last one.

--- a/core/services/ocr2/plugins/vault/plugin_helpers_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_helpers_test.go
@@ -37,7 +37,6 @@ type testPluginBuildOpts struct {
 	batchSize                              int
 	maxBlobPayloadBytes                    int
 	vaultOptimizationsEnabled              bool
-	vaultGetSecretsRelaxedConsensusEnabled bool
 	vaultIncludeInvalidPendingItemsEnabled bool
 	vaultPendingQueueStallThreshold        int
 	marshalBlob                            func(ocr3_1types.BlobHandle) ([]byte, error)
@@ -79,10 +78,6 @@ func withMaxSecretsPerOwner(n int) testPluginOption {
 
 func withVaultOptimizationsEnabled() testPluginOption {
 	return func(o *testPluginBuildOpts) { o.vaultOptimizationsEnabled = true }
-}
-
-func withVaultGetSecretsRelaxedConsensusEnabled() testPluginOption {
-	return func(o *testPluginBuildOpts) { o.vaultGetSecretsRelaxedConsensusEnabled = true }
 }
 
 func withVaultIncludeInvalidPendingItemsEnabled() testPluginOption {
@@ -145,9 +140,6 @@ func newTestReportingPlugin(t *testing.T, opts ...testPluginOption) *ReportingPl
 	cfg := makeReportingPluginConfig(t, o.batchSize, o.publicKey, o.privateKeyShare, o.maxSecretsPerOwner, o.maxBlobPayloadBytes)
 	if o.vaultOptimizationsEnabled {
 		cfg.VaultOptimizationsEnabled = limits.NewGateLimiter(true)
-	}
-	if o.vaultGetSecretsRelaxedConsensusEnabled {
-		cfg.VaultGetSecretsRelaxedConsensusEnabled = limits.NewGateLimiter(true)
 	}
 	if o.vaultIncludeInvalidPendingItemsEnabled {
 		cfg.VaultIncludeInvalidPendingItemsEnabled = limits.NewGateLimiter(true)
@@ -269,7 +261,6 @@ func makeReportingPluginConfig(
 		MaxBlobPayloadBytes:                    maxBlobPayloadLimiter,
 		VaultForceEmptyOCRRounds:               limits.NewGateLimiter(false),
 		VaultOptimizationsEnabled:              limits.NewGateLimiter(false),
-		VaultGetSecretsRelaxedConsensusEnabled: limits.NewGateLimiter(false),
 		VaultIncludeInvalidPendingItemsEnabled: limits.NewGateLimiter(false),
 		VaultPendingQueueStallThreshold:        pendingQueueStallThresholdLimiter,
 	}

--- a/core/services/ocr2/plugins/vault/plugin_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_test.go
@@ -3507,13 +3507,13 @@ func TestPlugin_StateTransition_GetSecretsRequest_CombinesShares(t *testing.T) {
 	assert.Equal(t, 1, observed.FilterMessage("sufficient observations for sha").Len())
 }
 
-func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_ByzantineDivergentSHA(t *testing.T) {
+func TestPlugin_StateTransition_GetSecretsRequest_ByzantineDivergentSHA(t *testing.T) {
 	t.Parallel()
 	lggr, observed := logger.TestLoggerObserved(t, zapcore.DebugLevel)
 	_, pk, shares, err := tdh2easy.GenerateKeys(1, 3)
 	require.NoError(t, err)
 	// N=4, F=1: 2F+1=3, F+1=2. One Byzantine observation with a divergent SHA must not stall the GET.
-	r := newTestReportingPlugin(t, withLggr(lggr), withKeys(pk, shares[0]), withOnchainCfg(4, 1), withVaultGetSecretsRelaxedConsensusEnabled())
+	r := newTestReportingPlugin(t, withLggr(lggr), withKeys(pk, shares[0]), withOnchainCfg(4, 1))
 
 	seqNr := uint64(1)
 	kv := &kv{m: make(map[string]response)}
@@ -3573,10 +3573,10 @@ func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_ByzantineDive
 	assert.Equal(t, 1, observed.FilterMessage("sufficient observations for sha").Len())
 }
 
-func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_Disabled_NoOutcome(t *testing.T) {
+func TestPlugin_StateTransition_GetSecretsRequest_InsufficientTotal(t *testing.T) {
 	t.Parallel()
-	// Same byzantine-divergent-SHA scenario as above, but with the flag OFF: the legacy 2F+1
-	// same-SHA requirement is unmet (honest group is only F+1=2 < 2F+1=3), so no outcome.
+	// N=4, F=1: 2F+1=3. Only 2 observations total (both honest, same SHA). Request legitimacy
+	// (>= 2F+1) fails even though the same-SHA group meets F+1, so no outcome.
 	_, pk, shares, err := tdh2easy.GenerateKeys(1, 3)
 	require.NoError(t, err)
 	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1))
@@ -3602,67 +3602,6 @@ func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_Disabled_NoOu
 			}},
 		}
 	}
-	byzantineResp := func(share string) *vaultcommon.GetSecretsResponse {
-		return &vaultcommon.GetSecretsResponse{
-			Responses: []*vaultcommon.SecretResponse{{
-				Id: id,
-				Result: &vaultcommon.SecretResponse_Data{Data: &vaultcommon.SecretData{
-					EncryptedValue: "byzantine-encrypted-value",
-					EncryptedDecryptionKeyShares: []*vaultcommon.EncryptedShares{{
-						EncryptionKey: encKey, Shares: []string{share},
-					}},
-				}},
-			}},
-		}
-	}
-
-	obsb1 := marshalObservations(t, observation{id, req, honestResp("encrypted-share-1")})
-	obsb2 := marshalObservations(t, observation{id, req, honestResp("encrypted-share-2")})
-	obsbByz := marshalObservations(t, observation{id, req, byzantineResp("byzantine-share")})
-	reportPrecursor, err := r.StateTransition(
-		t.Context(), seqNr, types.AttributedQuery{},
-		[]types.AttributedObservation{
-			{Observer: 0, Observation: types.Observation(obsb1)},
-			{Observer: 1, Observation: types.Observation(obsb2)},
-			{Observer: 2, Observation: types.Observation(obsbByz)},
-		}, kv, nil,
-	)
-	require.NoError(t, err)
-
-	os := &vaultcommon.Outcomes{}
-	require.NoError(t, proto.Unmarshal(reportPrecursor, os))
-	assert.Empty(t, os.Outcomes)
-}
-
-func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_InsufficientTotal(t *testing.T) {
-	t.Parallel()
-	// N=4, F=1: 2F+1=3. Only 2 observations total (both honest, same SHA). Request legitimacy
-	// (>= 2F+1) fails even though the same-SHA group meets F+1, so no outcome.
-	_, pk, shares, err := tdh2easy.GenerateKeys(1, 3)
-	require.NoError(t, err)
-	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1), withVaultGetSecretsRelaxedConsensusEnabled())
-
-	seqNr := uint64(1)
-	kv := &kv{m: make(map[string]response)}
-
-	id := &vaultcommon.SecretIdentifier{Owner: "owner", Namespace: "main", Key: "secret"}
-	encKey := "my-encryption-key"
-	req := &vaultcommon.GetSecretsRequest{
-		Requests: []*vaultcommon.SecretRequest{{Id: id, EncryptionKeys: []string{encKey}}},
-	}
-	honestResp := func(share string) *vaultcommon.GetSecretsResponse {
-		return &vaultcommon.GetSecretsResponse{
-			Responses: []*vaultcommon.SecretResponse{{
-				Id: id,
-				Result: &vaultcommon.SecretResponse_Data{Data: &vaultcommon.SecretData{
-					EncryptedValue: "encrypted-value",
-					EncryptedDecryptionKeyShares: []*vaultcommon.EncryptedShares{{
-						EncryptionKey: encKey, Shares: []string{share},
-					}},
-				}},
-			}},
-		}
-	}
 
 	obsb1 := marshalObservations(t, observation{id, req, honestResp("encrypted-share-1")})
 	obsb2 := marshalObservations(t, observation{id, req, honestResp("encrypted-share-2")})
@@ -3680,13 +3619,13 @@ func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_InsufficientT
 	assert.Empty(t, os.Outcomes)
 }
 
-func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_NoFPlus1Group(t *testing.T) {
+func TestPlugin_StateTransition_GetSecretsRequest_NoFPlus1Group(t *testing.T) {
 	t.Parallel()
 	// N=4, F=1: 2F+1=3, F+1=2. Three observations each with a distinct SHA (no group reaches F+1=2).
 	// Share sufficiency fails even though total meets 2F+1, so no outcome.
 	_, pk, shares, err := tdh2easy.GenerateKeys(1, 3)
 	require.NoError(t, err)
-	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1), withVaultGetSecretsRelaxedConsensusEnabled())
+	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1))
 
 	seqNr := uint64(1)
 	kv := &kv{m: make(map[string]response)}
@@ -3728,13 +3667,13 @@ func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_NoFPlus1Group
 	assert.Empty(t, os.Outcomes)
 }
 
-func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_AggregatesAllSharesUpTo2FPlus1(t *testing.T) {
+func TestPlugin_StateTransition_GetSecretsRequest_AggregatesAllSharesUpTo2FPlus1(t *testing.T) {
 	t.Parallel()
 	// N=10, F=3: 2F+1=7, F+1=4. All 10 honest observations share a SHA (shares are stripped from
 	// the SHA). The winning group (10) is capped at 2F+1=7 shares.
 	_, pk, shares, err := tdh2easy.GenerateKeys(1, 4)
 	require.NoError(t, err)
-	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(10, 3), withVaultGetSecretsRelaxedConsensusEnabled())
+	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(10, 3))
 
 	seqNr := uint64(1)
 	kv := &kv{m: make(map[string]response)}
@@ -3775,7 +3714,7 @@ func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_AggregatesAll
 	assert.Len(t, got, twoFPlusOne)
 }
 
-func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_TieBreakPicksLexicographicallySmallestSHA(t *testing.T) {
+func TestPlugin_StateTransition_GetSecretsRequest_TieBreakPicksLexicographicallySmallestSHA(t *testing.T) {
 	t.Parallel()
 	// N=10, F=3: 2F+1=7, F+1=4. Two SHA groups each of size F+1=4 (total 8 >= 2F+1). Both groups
 	// qualify for share sufficiency; chooseGetSecretsObservations iterates SHAs in sorted order and
@@ -3785,7 +3724,7 @@ func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_TieBreakPicks
 	// across repeated invocations (guards against nondeterministic map iteration in the tie-break).
 	_, pk, shares, err := tdh2easy.GenerateKeys(1, 4)
 	require.NoError(t, err)
-	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(10, 3), withVaultGetSecretsRelaxedConsensusEnabled())
+	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(10, 3))
 
 	seqNr := uint64(1)
 	kv := &kv{m: make(map[string]response)}
@@ -3858,7 +3797,7 @@ func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_TieBreakPicks
 	assert.ElementsMatch(t, expectedShares, data.EncryptedDecryptionKeyShares[0].Shares)
 }
 
-func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_DeterministicAcrossInvocations(t *testing.T) {
+func TestPlugin_StateTransition_GetSecretsRequest_DeterministicAcrossInvocations(t *testing.T) {
 	t.Parallel()
 	// G1 determinism for the relaxed path. chooseGetSecretsObservations iterates a SHA->obs map
 	// and must select deterministically; OCR3.1 delivers identical attributed observations to
@@ -3868,7 +3807,7 @@ func TestPlugin_StateTransition_GetSecretsRequest_RelaxedConsensus_Deterministic
 	// A regression to unsorted map iteration (`range shaToObs`) would flake here.
 	_, pk, shares, err := tdh2easy.GenerateKeys(1, 4)
 	require.NoError(t, err)
-	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(10, 3), withVaultGetSecretsRelaxedConsensusEnabled())
+	r := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(10, 3))
 
 	seqNr := uint64(1)
 	kv := &kv{m: make(map[string]response)}


### PR DESCRIPTION
Retires the `VaultGetSecretsRelaxedConsensusEnabled` feature flag. GetSecrets observations now always use relaxed consensus (F+1 threshold via `chooseGetSecretsObservations`).

**Changes:**
- `plugin.go`: Removed struct field, limiter, accessor, and conditional in `stateTransition`; also removed the legacy 2F+1 same-SHA path for GetSecrets and simplified the `else` branch to a plain `if`
- `plugin_helpers_test.go`, `plugin_test.go`: Removed flag option and all test call sites; removed `Disabled_NoOutcome` test; renamed remaining tests
- Config TOML: Removed flag from `vault-include-invalid-enabled.toml`
- chainlink-common: Added `// Deprecated` comments

Stacked on PR #23543.