### PR TITLE
cleanup unused params and fix Close() resource leak

### DIFF
--- a/core/services/ocr2/plugins/vault/contribution_validation.go
+++ b/core/services/ocr2/plugins/vault/contribution_validation.go
@@ -79,7 +79,6 @@ func observationToErrContribution(o *vaultcommon.Observation, msg string) *vault
 // StateTransition-only and are intentionally not checked here.
 func (r *ReportingPlugin) validateContribution(
 	ctx context.Context,
-	_ ReadKVStore,
 	pendingItem *vaultcommon.StoredPendingQueueItem,
 	o *vaultcommon.Observation,
 ) error {

--- a/core/services/ocr2/plugins/vault/include_invalid_test.go
+++ b/core/services/ocr2/plugins/vault/include_invalid_test.go
@@ -522,7 +522,7 @@ func TestValidateContribution_GetSecretsOversizedShareRejected(t *testing.T) {
 		},
 	}
 
-	err = r.validateContribution(t.Context(), newTestReadStore(t, &kv{m: make(map[string]response)}), pendingItem, o)
+	err = r.validateContribution(t.Context(), pendingItem, o)
 	require.Error(t, err, "validateContribution must reject oversized shares so the self-check stamps an error contribution")
 	require.ErrorContains(t, err, "exceeds maximum size allowed")
 }

--- a/core/services/ocr2/plugins/vault/plugin.go
+++ b/core/services/ocr2/plugins/vault/plugin.go
@@ -757,9 +757,9 @@ func (r *ReportingPlugin) observePendingQueueItem(
 	case *vaultcommon.GetSecretsRequest:
 		r.observeGetSecrets(ctx, seqNr, req.Id, readKV, tp, o)
 	case *vaultcommon.CreateSecretsRequest:
-		r.observeCreateSecrets(ctx, seqNr, req.Id, readKV, tp, o)
+		r.observeCreateSecrets(ctx, seqNr, req.Id, tp, o)
 	case *vaultcommon.UpdateSecretsRequest:
-		r.observeUpdateSecrets(ctx, seqNr, req.Id, readKV, tp, o)
+		r.observeUpdateSecrets(ctx, seqNr, req.Id, tp, o)
 	case *vaultcommon.DeleteSecretsRequest:
 		r.observeDeleteSecrets(ctx, seqNr, req.Id, readKV, tp, o)
 	case *vaultcommon.ListSecretIdentifiersRequest:
@@ -772,8 +772,6 @@ func (r *ReportingPlugin) observePendingQueueItem(
 }
 
 func (r *ReportingPlugin) validatePendingQueueObservationsPrefix(
-	ctx context.Context,
-	seqNr uint64,
 	pendingQueueItems []*vaultcommon.StoredPendingQueueItem,
 	obs *vaultcommon.Observations,
 ) error {
@@ -813,7 +811,7 @@ func (r *ReportingPlugin) appendPendingQueueObservations(
 			}
 			r.requestLggr(seqNr, req.Id).Warnw("pending queue item observation failed; emitting error contribution", "error", err)
 		} else {
-			if cerr := r.validateContribution(ctx, readKV, req, o); cerr != nil {
+			if cerr := r.validateContribution(ctx, req, o); cerr != nil {
 				o = observationToErrContribution(o, userFacingError(cerr, "request is not valid"))
 				r.requestLggr(seqNr, req.Id).Warnw("pending queue item failed contribution self-check; emitting error contribution", "error", cerr)
 			}
@@ -1040,7 +1038,7 @@ func (r *ReportingPlugin) observeGetSecretsRequest(ctx context.Context, reader R
 	}, nil
 }
 
-func (r *ReportingPlugin) observeCreateSecrets(ctx context.Context, seqNr uint64, requestID string, reader ReadKVStore, req proto.Message, o *vaultcommon.Observation) {
+func (r *ReportingPlugin) observeCreateSecrets(ctx context.Context, seqNr uint64, requestID string, req proto.Message, o *vaultcommon.Observation) {
 	l := r.typedRequestLggr(seqNr, requestID, "CreateSecrets")
 	tp := req.(*vaultcommon.CreateSecretsRequest)
 	o.RequestType = vaultcommon.RequestType_CREATE_SECRETS
@@ -1080,7 +1078,7 @@ func (r *ReportingPlugin) observeCreateSecrets(ctx context.Context, seqNr uint64
 	}
 }
 
-func (r *ReportingPlugin) observeUpdateSecrets(ctx context.Context, seqNr uint64, requestID string, reader ReadKVStore, req proto.Message, o *vaultcommon.Observation) {
+func (r *ReportingPlugin) observeUpdateSecrets(ctx context.Context, seqNr uint64, requestID string, req proto.Message, o *vaultcommon.Observation) {
 	l := r.typedRequestLggr(seqNr, requestID, "UpdateSecrets")
 	tp := req.(*vaultcommon.UpdateSecretsRequest)
 	o.RequestType = vaultcommon.RequestType_UPDATE_SECRETS
@@ -1307,7 +1305,7 @@ func (r *ReportingPlugin) ValidateObservation(ctx context.Context, seqNr uint64,
 
 	idToObs := map[string]*vaultcommon.Observation{}
 	for _, o := range obs.Observations {
-		err := r.validateContribution(ctx, readKV, pendingQueueByID[o.Id], o)
+		err := r.validateContribution(ctx, pendingQueueByID[o.Id], o)
 		if err != nil {
 			valLggr.Debugw("validate observation failed", "requestID", o.Id, "error", err)
 			return errors.New("invalid observation: " + err.Error())
@@ -1327,7 +1325,7 @@ func (r *ReportingPlugin) ValidateObservation(ctx context.Context, seqNr uint64,
 	//   max observation byte limit.
 	// - that all pending queue items can be fetched as blobs.
 	if !gateAllows(ctx, r.lggr, r.cfg.VaultForceEmptyOCRRounds, "VaultForceEmptyOCRRounds") {
-		if err := r.validatePendingQueueObservationsPrefix(ctx, seqNr, pendingQueueItems, obs); err != nil {
+		if err := r.validatePendingQueueObservationsPrefix(pendingQueueItems, obs); err != nil {
 			return err
 		}
 	}
@@ -1495,7 +1493,7 @@ func shaForProto(msg proto.Message) (string, error) {
 	return fmt.Sprintf("%x", sha256.Sum256(protoBytes)), nil
 }
 
-func (r *ReportingPlugin) shaForObservation(ctx context.Context, o *vaultcommon.Observation) (string, error) {
+func (r *ReportingPlugin) shaForObservation(o *vaultcommon.Observation) (string, error) {
 	switch o.RequestType {
 	case vaultcommon.RequestType_GET_SECRETS:
 		cloned := proto.CloneOf(o)
@@ -1668,7 +1666,7 @@ func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq 
 		// of the entries matching a given sha.
 		shaToObs := map[string][]*vaultcommon.Observation{}
 		for _, ob := range obs {
-			sha, err := r.shaForObservation(ctx, ob)
+			sha, err := r.shaForObservation(ob)
 			if err != nil {
 				r.lggr.Errorw("failed to compute sha for observation", "error", err, "observation", ob)
 				continue
@@ -1717,7 +1715,7 @@ func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq 
 		item := pendingQueueByID[id]
 		guardFailed := false
 		for _, ob := range chosen {
-			if gerr := r.validateContribution(ctx, writeKV, item, ob); gerr != nil {
+			if gerr := r.validateContribution(ctx, item, ob); gerr != nil {
 				l.Warnw("state transition guard rejected chosen observation; skipping item",
 					"seqNr", seqNr, "id", id, "error", gerr)
 				guardFailed = true
@@ -1737,7 +1735,7 @@ func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq 
 		}
 		switch first.RequestType {
 		case vaultcommon.RequestType_GET_SECRETS:
-			r.stateTransitionGetSecrets(ctx, writeKV, chosen, o)
+			r.stateTransitionGetSecrets(chosen, o)
 		case vaultcommon.RequestType_CREATE_SECRETS:
 			r.stateTransitionCreateSecrets(ctx, writeKV, chosen, o)
 		case vaultcommon.RequestType_UPDATE_SECRETS:
@@ -1745,7 +1743,7 @@ func (r *ReportingPlugin) StateTransition(ctx context.Context, seqNr uint64, aq 
 		case vaultcommon.RequestType_DELETE_SECRETS:
 			r.stateTransitionDeleteSecrets(ctx, writeKV, chosen, o)
 		case vaultcommon.RequestType_LIST_SECRET_IDENTIFIERS:
-			r.stateTransitionListSecretIdentifiers(ctx, writeKV, chosen, o)
+			r.stateTransitionListSecretIdentifiers(chosen, o)
 		default:
 			l.Debugw("unknown request type, skipping...", "requestType", first.RequestType, "id", id)
 			continue
@@ -1909,7 +1907,7 @@ func sortKey(id string, nonce []byte) []byte {
 	return h.Sum(nil)
 }
 
-func (r *ReportingPlugin) stateTransitionGetSecrets(ctx context.Context, reader ReadKVStore, chosen []*vaultcommon.Observation, o *vaultcommon.Outcome) {
+func (r *ReportingPlugin) stateTransitionGetSecrets(chosen []*vaultcommon.Observation, o *vaultcommon.Outcome) {
 	// Next, we deal with the responses.
 	// For each request, we take the Id of the first observation
 	// then aggregate the encrypted shares across all observations.
@@ -1929,7 +1927,7 @@ func (r *ReportingPlugin) stateTransitionGetSecrets(ctx context.Context, reader 
 			}
 
 			if rsp.GetData() != nil {
-				r.aggregateGetSecretsShares(ctx, mergedResp, rsp)
+				r.aggregateGetSecretsShares(mergedResp, rsp)
 			}
 		}
 	}
@@ -1947,7 +1945,6 @@ func (r *ReportingPlugin) stateTransitionGetSecrets(ctx context.Context, reader 
 }
 
 func (r *ReportingPlugin) aggregateGetSecretsShares(
-	ctx context.Context,
 	mergedResp *vaultcommon.SecretResponse,
 	rsp *vaultcommon.SecretResponse,
 ) {
@@ -2244,7 +2241,7 @@ func (r *ReportingPlugin) stateTransitionDeleteSecretsRequest(ctx context.Contex
 	}, nil
 }
 
-func (r *ReportingPlugin) stateTransitionListSecretIdentifiers(ctx context.Context, store WriteKVStore, chosen []*vaultcommon.Observation, o *vaultcommon.Outcome) {
+func (r *ReportingPlugin) stateTransitionListSecretIdentifiers(chosen []*vaultcommon.Observation, o *vaultcommon.Outcome) {
 	// All of the logic for the ListSecretIdentifiers request is in the
 	// observation phase. This returns the observations in sorted order,
 	// so we can just take the first aggregated response and use it as the outcome.
@@ -2418,6 +2415,8 @@ func (r *ReportingPlugin) Close() error {
 		r.cfg.MaxShareLengthBytes.Close(),
 		r.cfg.MaxBatchSize.Close(),
 		r.cfg.MaxPendingQueueWriteSize.Close(),
+		r.cfg.MaxBlobPayloadBytes.Close(),
 		r.cfg.VaultForceEmptyOCRRounds.Close(),
+		r.cfg.VaultPendingQueueStallThreshold.Close(),
 	)
 }

--- a/core/services/ocr2/plugins/vault/plugin_share_label_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_share_label_test.go
@@ -130,11 +130,10 @@ func TestPlugin_ShaForObservation_GetSecrets_IncludesEncryptionKeysInSHA(t *test
 	byzObs := proto.Clone(honestObs).(*vaultcommon.Observation)
 	byzObs.Response = &vaultcommon.Observation_GetSecretsResponse{GetSecretsResponse: byzResp}
 
-	ctx := context.Background()
 	plugin := newTestReportingPlugin(t, withOnchainCfg(4, 1))
-	shaHonest, err := plugin.shaForObservation(ctx, honestObs)
+	shaHonest, err := plugin.shaForObservation(honestObs)
 	require.NoError(t, err)
-	shaByz, err := plugin.shaForObservation(ctx, byzObs)
+	shaByz, err := plugin.shaForObservation(byzObs)
 	require.NoError(t, err)
 	require.NotEqual(t, shaHonest, shaByz)
 }
@@ -172,12 +171,11 @@ func TestPlugin_ShaForObservation_GetSecrets_PermutedEntryOrder(t *testing.T) {
 		}
 	}
 
-	ctx := context.Background()
 	plugin := newTestReportingPlugin(t, withOnchainCfg(4, 1))
 
-	shaAB, err := plugin.shaForObservation(ctx, makeObs([]string{keyA, keyB}, []string{"share-a1", "share-b1"}))
+	shaAB, err := plugin.shaForObservation(makeObs([]string{keyA, keyB}, []string{"share-a1", "share-b1"}))
 	require.NoError(t, err)
-	shaCD, err := plugin.shaForObservation(ctx, makeObs([]string{keyB, keyA}, []string{"share-b2", "share-a2"}))
+	shaCD, err := plugin.shaForObservation(makeObs([]string{keyB, keyA}, []string{"share-b2", "share-a2"}))
 	require.NoError(t, err)
 	require.NotEqual(t, shaAB, shaCD)
 }
@@ -213,12 +211,11 @@ func TestPlugin_ShaForObservation_GetSecrets_DifferentShareBytesSameLabels(t *te
 		}
 	}
 
-	ctx := context.Background()
 	plugin := newTestReportingPlugin(t, withOnchainCfg(4, 1))
 
-	sha1, err := plugin.shaForObservation(ctx, makeObs("share-from-node-1"))
+	sha1, err := plugin.shaForObservation(makeObs("share-from-node-1"))
 	require.NoError(t, err)
-	sha2, err := plugin.shaForObservation(ctx, makeObs("share-from-node-2"))
+	sha2, err := plugin.shaForObservation(makeObs("share-from-node-2"))
 	require.NoError(t, err)
 	require.Equal(t, sha1, sha2)
 }

--- a/core/services/ocr2/plugins/vault/plugin_test.go
+++ b/core/services/ocr2/plugins/vault/plugin_test.go
@@ -3739,7 +3739,7 @@ func TestPlugin_StateTransition_GetSecretsRequest_TieBreakPicksLexicographically
 		obsb := marshalObservations(t, observation{id, req, resp(ciphertext, "irrelevant")})
 		op := &vaultcommon.Observations{}
 		require.NoError(t, proto.Unmarshal(obsb, op))
-		sha, err := r.shaForObservation(t.Context(), op.Observations[0])
+		sha, err := r.shaForObservation(op.Observations[0])
 		require.NoError(t, err)
 		return sha
 	}
@@ -6242,16 +6242,15 @@ func TestPlugin_StateTransition_OutcomesStoppedByPrecursorWireSize(t *testing.T)
 			},
 		}
 	}
-	ws := NewWriteStore(&kv{m: make(map[string]response)}, newTestMetrics(t))
 
 	rPrec := newTestReportingPlugin(t, withKeys(pk, shares[0]), withOnchainCfg(4, 1))
 
 	out1 := &vaultcommon.Outcome{Id: "list-1", RequestType: vaultcommon.RequestType_LIST_SECRET_IDENTIFIERS}
-	rPrec.stateTransitionListSecretIdentifiers(ctx, ws, []*vaultcommon.Observation{buildListObs("list-1")}, out1)
+	rPrec.stateTransitionListSecretIdentifiers([]*vaultcommon.Observation{buildListObs("list-1")}, out1)
 	sz1 := proto.Size(&vaultcommon.Outcomes{Outcomes: []*vaultcommon.Outcome{out1}})
 
 	out2 := &vaultcommon.Outcome{Id: "list-2", RequestType: vaultcommon.RequestType_LIST_SECRET_IDENTIFIERS}
-	rPrec.stateTransitionListSecretIdentifiers(ctx, ws, []*vaultcommon.Observation{buildListObs("list-2")}, out2)
+	rPrec.stateTransitionListSecretIdentifiers([]*vaultcommon.Observation{buildListObs("list-2")}, out2)
 	szBoth := proto.Size(&vaultcommon.Outcomes{Outcomes: []*vaultcommon.Outcome{out1, out2}})
 	require.Greater(t, szBoth, sz1)
 
@@ -7021,7 +7020,7 @@ func TestPlugin_ValidateObservation_GetSecrets_MismatchedResponseOwnerRejected(t
 		},
 	}
 
-	require.NoError(t, r.validateContribution(t.Context(), newTestReadStore(t, &kv{m: make(map[string]response)}), pendingItem, obs))
+	require.NoError(t, r.validateContribution(t.Context(), pendingItem, obs))
 }
 
 func TestPlugin_ValidateObservation_PanicsOnEmptyShares(t *testing.T) {


### PR DESCRIPTION
Cleanup pass after flag retirements:

**Unused parameters removed:**
- `validatePendingQueueObservationsPrefix`: removed `ctx`, `seqNr`
- `shaForObservation`: removed `ctx`
- `aggregateGetSecretsShares`: removed `ctx`
- `stateTransitionListSecretIdentifiers`: removed `ctx`, `store`
- `observeCreateSecrets`, `observeUpdateSecrets`: removed `reader`

**Resource leak fixed:**
- `Close()` now closes `MaxBlobPayloadBytes` and `VaultPendingQueueStallThreshold` limiters (were missing)

Stacked on PR #23546.