### PR TITLE
Fix Go dependency download running in wrong directory in devenv-compat.yml

### DIFF
--- a/.github/workflows/devenv-compat.yml
+++ b/.github/workflows/devenv-compat.yml
@@ -162,6 +162,7 @@ jobs:
           cache-dependency-path: ${{ env.WORKING_DIR }}/go.sum
 
       - name: Download Go dependencies
+        working-directory: ${{ env.WORKING_DIR }}
         run: |
           go mod download
 

--- a/devenv/go.mod
+++ b/devenv/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink/devenv
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
## What

1. Adds `working-directory: ${{ env.WORKING_DIR }}` to the "Download Go dependencies" step in `.github/workflows/devenv-compat.yml`.
2. Bumps `devenv/go.mod`'s `go` directive `1.26.5` -> `1.26.6`.

## Why

The "Download Go dependencies" step ran `go mod download` with no working-directory set, so it executed against the repo root's `go.mod` instead of `${{ env.WORKING_DIR }}` (`devenv`) -- every other `run:` step in this job already scopes to `WORKING_DIR`, this one was the outlier.

"Set up Go" resolves its version from `devenv/go.mod` (`go-version-file`), but `go mod download` then read the *root* `go.mod`, which requires a newer Go version. Root's directive was bumped `1.26.5` -> `1.26.6` in #23510; `devenv/go.mod` was still `1.26.5`. Once the two diverged, this step started failing:

```
go: go.mod requires go >= 1.26.6 (running go 1.26.5; GOTOOLCHAIN=local)
```

This is what's currently failing the **Data Feeds v1 Upgrade Test** job on the v2.62.0-rc.0 canary run -- unrelated to the curl-pin PRs (#23530, #23531).

With the working-directory fix alone, the download step now correctly reads `devenv/go.mod` (`1.26.5`) and would pass -- but that leaves `devenv` on an older Go directive than root for no reason. Bumping `devenv/go.mod` to `1.26.6` keeps the two in sync going forward.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/devenv-compat.yml'))"` -- valid YAML.
- Confirmed every other `run:` step in this job ("Run compat test", "Attach CI Summary", "Collect Docker container logs") already sets `working-directory: ${{ env.WORKING_DIR }}`; this brings the download step in line.
- `go build ./...` in `devenv/` succeeds under `golang:1.26.6-bookworm` with the bumped directive.