### PR TITLE
Fix Flaky `TestDonTimeProvider_GetDONTime_requestTimeout`

### DIFF
--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -455,7 +455,7 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 
 	var timeProvider TimeProvider = &types.LocalTimeProvider{}
 	if !e.cfg.UseLocalTimeProvider {
-		timeProvider = NewDonTimeProvider(e.cfg.DonTimeStore, e.cfg.WorkflowID, e.donTimeRequestTimeout(subCtx, e.cfg.LocalLimiters.DONTimeRequestTimeout), e.logger(), e.metrics)
+		timeProvider = NewDonTimeProvider(e.cfg.DonTimeStore, e.cfg.WorkflowID, e.donTimeRequestTimeout(subCtx, e.cfg.LocalLimiters.DONTimeRequestTimeout), e.logger(), e.metrics, e.cfg.Clock)
 	}
 
 	moduleExecuteMaxResponseSizeBytes, err := e.cfg.LocalLimiters.ExecutionResponse.Limit(ctx)
@@ -755,7 +755,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	var executionTimestamp time.Time
 	var executionDonTimeProvider TimeProvider
 	if tsErr := e.cfg.LocalLimiters.ExecutionTimestampsEnabled.AllowErr(ctx); tsErr == nil {
-		executionDonTimeProvider = NewDonTimeProvider(e.cfg.DonTimeStore, executionID, e.donTimeRequestTimeout(ctx, e.cfg.LocalLimiters.DONTimeRequestTimeout), lggr, e.metrics)
+		executionDonTimeProvider = NewDonTimeProvider(e.cfg.DonTimeStore, executionID, e.donTimeRequestTimeout(ctx, e.cfg.LocalLimiters.DONTimeRequestTimeout), lggr, e.metrics, e.cfg.Clock)
 		donTime, dtErr := executionDonTimeProvider.GetDONTime()
 		if dtErr != nil {
 			executionTimestamp = e.cfg.Clock.Now()
@@ -972,7 +972,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 			timeProvider = executionDonTimeProvider
 		} else {
 			lggr.Warnw("ExecutionTimestampsEnabled is false - creating a new DON time provider")
-			timeProvider = NewDonTimeProvider(e.cfg.DonTimeStore, executionID, e.donTimeRequestTimeout(execCtx, e.cfg.LocalLimiters.DONTimeRequestTimeout), lggr, e.metrics)
+			timeProvider = NewDonTimeProvider(e.cfg.DonTimeStore, executionID, e.donTimeRequestTimeout(execCtx, e.cfg.LocalLimiters.DONTimeRequestTimeout), lggr, e.metrics, e.cfg.Clock)
 		}
 	}
 

--- a/core/services/workflows/v2/time_provider.go
+++ b/core/services/workflows/v2/time_provider.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jonboulle/clockwork"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/dontime"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/monitoring"
@@ -24,6 +26,7 @@ type DonTimeProvider struct {
 	requestTimeout      time.Duration
 	lggr                logger.Logger
 	metrics             *monitoring.WorkflowsMetricLabeler
+	clock               clockwork.Clock
 }
 
 func NewDonTimeProvider(
@@ -32,7 +35,11 @@ func NewDonTimeProvider(
 	requestTimeout time.Duration,
 	lggr logger.Logger,
 	metrics *monitoring.WorkflowsMetricLabeler,
+	clock clockwork.Clock,
 ) TimeProvider {
+	if clock == nil {
+		clock = clockwork.NewRealClock()
+	}
 	return &DonTimeProvider{
 		workflowExecutionID: workflowExecutionID,
 		timeSeqNum:          0,
@@ -40,6 +47,7 @@ func NewDonTimeProvider(
 		requestTimeout:      requestTimeout,
 		lggr:                logger.Named(lggr, "TimeProvider"),
 		metrics:             metrics,
+		clock:               clock,
 	}
 }
 
@@ -56,13 +64,13 @@ func (tp *DonTimeProvider) GetDONTime() (time.Time, error) {
 	tp.recordDonTimeCall()
 
 	ch := tp.donTimeStore.RequestDonTime(tp.workflowExecutionID, tp.timeSeqNum)
-	timer := time.NewTimer(tp.requestTimeout)
+	timer := tp.clock.NewTimer(tp.requestTimeout)
 	defer timer.Stop()
 
 	select {
 	case donTimeResp := <-ch:
 		return tp.donTimeFromResponse(donTimeResp)
-	case <-timer.C:
+	case <-timer.Chan():
 		tp.donTimeStore.RemoveRequest(tp.workflowExecutionID)
 		tp.recordDonTimeTimeout()
 		return tp.donTimeFromResponse(dontime.Response{
@@ -70,7 +78,8 @@ func (tp *DonTimeProvider) GetDONTime() (time.Time, error) {
 			SeqNum:              tp.timeSeqNum,
 			Err: fmt.Errorf(
 				"timeout exceeded: could not process request before expiry, workflowExecutionID %s",
-				tp.workflowExecutionID),
+				tp.workflowExecutionID,
+			),
 		})
 	}
 }

--- a/core/services/workflows/v2/time_provider_test.go
+++ b/core/services/workflows/v2/time_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/dontime"
@@ -13,22 +14,26 @@ import (
 func TestDonTimeProvider_GetDONTime_requestTimeout(t *testing.T) {
 	t.Parallel()
 
+	fakeClock := clockwork.NewFakeClock()
 	store := dontime.NewStore(dontime.DefaultRequestTimeout)
-	provider := NewDonTimeProvider(store, "exec-id", 50*time.Millisecond, logger.TestLogger(t), nil)
+	provider := NewDonTimeProvider(store, "exec-id", 50*time.Millisecond, logger.TestLogger(t), nil, fakeClock)
 
-	start := time.Now()
-	_, err := provider.GetDONTime()
-	elapsed := time.Since(start)
+	callGetDONTime := func() {
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := provider.GetDONTime()
+			errCh <- err
+		}()
 
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, elapsed, 50*time.Millisecond)
-	require.Less(t, elapsed, 200*time.Millisecond)
+		err := fakeClock.BlockUntilContext(t.Context(), 1)
+		require.NoError(t, err)
+		fakeClock.Advance(50 * time.Millisecond)
+
+		require.NoError(t, <-errCh)
+	}
+
+	callGetDONTime()
 
 	// A timed-out request must not block subsequent sequence numbers.
-	start = time.Now()
-	_, err = provider.GetDONTime()
-	elapsed = time.Since(start)
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, elapsed, 50*time.Millisecond)
-	require.Less(t, elapsed, 200*time.Millisecond)
+	callGetDONTime()
 }


### PR DESCRIPTION
Fixes a flake in `TestDonTimeProvider_GetDONTime_requestTimeout` where an overloaded CI runner would hit issues with timing. To do so, we inject a `clockwork.Clock` for testing.

* [Test in Trunk](https://app.trunk.io/chainlink/flaky-tests/repo/0ec8ac39-2bf0-42e2-baaf-3f6cce784097/test/5cf994c7-5aee-5984-8361-d59b3d9558f4)
* [Recent flake](https://github.com/smartcontractkit/chainlink/actions/runs/33003473538/job/98291093010#step:17:331)