### PR TITLE
feat(ci): dynamic spot instance usage

### DIFF
--- a/.github/actions/setup-runner-spot/action.yml
+++ b/.github/actions/setup-runner-spot/action.yml
@@ -1,0 +1,56 @@
+name: Setup Runner Spot
+description: Determines the optimal RunsOn spot instance strategy for CI jobs
+inputs:
+  strategy:
+    description: "Explicit spot strategy override ('co', 'pco', 'lowest-price', 'false')"
+    required: false
+    default: ""
+  default-strategy:
+    description: "Default spot strategy if enabled ('pco', 'co')"
+    required: false
+    default: ""
+  force-on-demand:
+    description: "Force on-demand / disable spot ('true' or 'false')"
+    required: false
+    default: "false"
+
+outputs:
+  spot:
+    description: "Resolved spot setting value (e.g. 'false', 'co', 'pco', 'lowest-price')"
+    value: ${{ steps.resolve-spot.outputs.spot }}
+  spot_flag:
+    description: "Resolved spot setting as RunsOn flag (e.g. 'spot=false', 'spot=co', 'spot=pco')"
+    value: ${{ steps.resolve-spot.outputs.spot_flag }}
+  spot_param:
+    description: "Alias for spot_flag (e.g. 'spot=false', 'spot=co', 'spot=pco')"
+    value: ${{ steps.resolve-spot.outputs.spot_param }}
+  enabled:
+    description: "Whether spot is enabled ('true' or 'false')"
+    value: ${{ steps.resolve-spot.outputs.enabled }}
+  strategy:
+    description: "Resolved spot strategy name"
+    value: ${{ steps.resolve-spot.outputs.strategy }}
+  reason:
+    description: "Reasoning for the resolved spot setting"
+    value: ${{ steps.resolve-spot.outputs.reason }}
+  is_release:
+    description: "Whether run is on release branch or tag ('true' or 'false')"
+    value: ${{ steps.resolve-spot.outputs.is_release }}
+  is_merge_queue:
+    description: "Whether run is merge queue event/branch ('true' or 'false')"
+    value: ${{ steps.resolve-spot.outputs.is_merge_queue }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup CI CLI
+      uses: ./.github/actions/setup-ci-cli
+
+    - name: Resolve Spot Setting
+      id: resolve-spot
+      shell: bash
+      env:
+        RUNNER_SPOT_STRATEGY: ${{ inputs.strategy }}
+        RUNNER_DEFAULT_SPOT_STRATEGY: ${{ inputs.default-strategy }}
+        RUNNER_FORCE_ON_DEMAND: ${{ inputs.force-on-demand }}
+      run: ci runner spot

--- a/.github/actions/setup-runner-spot/action.yml
+++ b/.github/actions/setup-runner-spot/action.yml
@@ -43,8 +43,24 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Check for repository source
+      id: source
+      shell: bash
+      run: |
+        if [ -f tools/ci/go.mod ]; then
+          echo "available=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "available=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Checkout repository
+      if: ${{ steps.source.outputs.available != 'true' }}
+      uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+
     - name: Setup CI CLI
-      uses: ./.github/actions/setup-ci-cli
+      uses: $/.github/actions/setup-ci-cli
 
     - name: Resolve Spot Setting
       id: resolve-spot

--- a/.github/actions/setup-solana/build-contracts/action.yml
+++ b/.github/actions/setup-solana/build-contracts/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Checkout chainlink-ccip
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: smartcontractkit/chainlink-ccip
         path: chainlink-ccip

--- a/.github/workflows/bash-scripts.yml
+++ b/.github/workflows/bash-scripts.yml
@@ -11,7 +11,7 @@ jobs:
       bash-scripts-src: ${{ steps.bash-scripts.outputs.src }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -27,7 +27,7 @@ jobs:
     needs: [changes]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Run ShellCheck

--- a/.github/workflows/ccip-release-changelog.yml
+++ b/.github/workflows/ccip-release-changelog.yml
@@ -52,7 +52,7 @@ jobs:
           echo "safe_old=${old//[^a-zA-Z0-9._-]/-}" >> "$GITHUB_OUTPUT"
           echo "safe_new=${new//[^a-zA-Z0-9._-]/-}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history + tags for ref resolution and git log
 

--- a/.github/workflows/ccip-system-tests.yaml
+++ b/.github/workflows/ccip-system-tests.yaml
@@ -130,6 +130,10 @@ jobs:
       - name: Define test matrix
         id: define-matrix
         shell: bash
+        env:
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          SPOT_FLAG: ${{ steps.spot.outputs.spot_flag }}
         run: |
           TESTS_JSON='[
             {"test_name":"Test_CCIPGasPriceUpdatesWriteFrequency","timeout":"15m","selected_network":"SIMULATED_1,SIMULATED_2"},
@@ -140,9 +144,9 @@ jobs:
           ]'
 
           tests=$(echo "$TESTS_JSON" | jq -c \
-            --argjson run_id "${{ github.run_id }}" \
-            --arg run_attempt "${{ github.run_attempt }}" \
-            --arg spot_flag "${{ steps.spot.outputs.spot_flag }}" '
+            --argjson run_id "$RUN_ID" \
+            --arg run_attempt "$RUN_ATTEMPT" \
+            --arg spot_flag "$SPOT_FLAG" '
             to_entries | map(.value + {
               test_id: .key,
               runs_on: ("runs-on=\($run_id)-\(.key)-\($run_attempt)/cpu=8/ram=64/family=r6i+r7i+r8i/\($spot_flag)/image=ubuntu24-full-x64/extras=s3-cache+tmpfs")

--- a/.github/workflows/ccip-system-tests.yaml
+++ b/.github/workflows/ccip-system-tests.yaml
@@ -127,6 +127,7 @@ jobs:
         id: spot
         uses: ./.github/actions/setup-runner-spot
 
+      # TODO(DX-5101): replace this inline jq matrix step with `ci matrix ccip`
       - name: Define test matrix
         id: define-matrix
         shell: bash

--- a/.github/workflows/ccip-system-tests.yaml
+++ b/.github/workflows/ccip-system-tests.yaml
@@ -113,9 +113,20 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
+      spot_flag: ${{ steps.spot.outputs.spot_flag }}
+      spot_param: ${{ steps.spot.outputs.spot_param }}
     permissions:
       contents: read
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Resolve Spot Setting
+        id: spot
+        uses: ./.github/actions/setup-runner-spot
+
       - name: Define test matrix
         id: define-matrix
         shell: bash
@@ -130,10 +141,11 @@ jobs:
 
           tests=$(echo "$TESTS_JSON" | jq -c \
             --argjson run_id "${{ github.run_id }}" \
-            --arg run_attempt "${{ github.run_attempt }}" '
+            --arg run_attempt "${{ github.run_attempt }}" \
+            --arg spot_flag "${{ steps.spot.outputs.spot_flag }}" '
             to_entries | map(.value + {
               test_id: .key,
-              runs_on: ("runs-on=\($run_id)-\(.key)-\($run_attempt)/cpu=8/ram=64/family=r6i+r7i+r8i/spot=co/image=ubuntu24-full-x64/extras=s3-cache+tmpfs")
+              runs_on: ("runs-on=\($run_id)-\(.key)-\($run_attempt)/cpu=8/ram=64/family=r6i+r7i+r8i/\($spot_flag)/image=ubuntu24-full-x64/extras=s3-cache+tmpfs")
             })
           ')
 

--- a/.github/workflows/ccip-system-tests.yaml
+++ b/.github/workflows/ccip-system-tests.yaml
@@ -118,14 +118,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
       - name: Resolve Spot Setting
         id: spot
-        uses: ./.github/actions/setup-runner-spot
+        uses: $/.github/actions/setup-runner-spot
 
       # TODO(DX-5101): replace this inline jq matrix step with `ci matrix ccip`
       - name: Define test matrix
@@ -243,7 +238,7 @@ jobs:
 
       - name: Setup gotestsum
         uses: ./.github/actions/setup-gotestsum
-      
+
       - name: Resolve baseline image for mixed-version tests
         id: baseline
         shell: bash

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -97,7 +97,7 @@ jobs:
           echo "top_level_dir=$(pwd)" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Checkout .Github repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           repository: smartcontractkit/.github

--- a/.github/workflows/changesets-preview-pr.yml
+++ b/.github/workflows/changesets-preview-pr.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -32,6 +32,8 @@ jobs:
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch'
         }}
+      spot_flag: ${{ steps.spot.outputs.spot_flag }}
+      spot_param: ${{ steps.spot.outputs.spot_param }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
@@ -158,6 +160,9 @@ jobs:
             **
             !core/scripts/cre/environment/examples/workflows/**
 
+      - name: Resolve Spot Setting
+        id: spot
+        uses: ./.github/actions/setup-runner-spot
 
   golangci:
     name: GolangCI Lint
@@ -172,8 +177,14 @@ jobs:
       contents: read
       # For golangci-lint-action's `only-new-issues` option.
       pull-requests: read
-    runs-on: runs-on=${{ github.run_id }}-${{ strategy.job-index
-      }}/cpu=16/ram=32/family=c8g+c9g/spot=co/image=ubuntu24-full-arm64/extras=s3-cache
+    runs-on:
+      - runs-on=${{ github.run_id }}-${{ strategy.job-index }}
+      - cpu=16
+      - ram=32
+      - family=c8g+c9g
+      - ${{ needs.filter.outputs.spot_param }}
+      - image=ubuntu24-full-arm64
+      - extras=s3-cache
     strategy:
       fail-fast: false
       matrix:
@@ -269,8 +280,14 @@ jobs:
       matrix:
         type:
           - cmd: go_core_tests
-            os: runs-on=${{ github.run_id
-              }}-unit/cpu=48/ram=96/family=c7id+c8id/spot=co/image=ubuntu24-full-x64/extras=s3-cache
+            os:
+              - runs-on=${{ github.run_id }}-unit
+              - cpu=48
+              - ram=96
+              - family=c7id+c8id
+              - ${{ needs.filter.outputs.spot_param }}
+              - image=ubuntu24-full-x64
+              - extras=s3-cache
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
             trunk-auto-quarantine: "true"
             go-mod-directory: ""
@@ -281,8 +298,14 @@ jobs:
             build-cache-write: always
 
           - cmd: go_core_tests_integration
-            os: runs-on=${{ github.run_id
-              }}-integ/cpu=48/ram=96/family=c7i+c8i/spot=co/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+            os:
+              - runs-on=${{ github.run_id }}-integ
+              - cpu=48
+              - ram=96
+              - family=c7i+c8i
+              - ${{ needs.filter.outputs.spot_param }}
+              - image=ubuntu24-full-x64
+              - extras=s3-cache+tmpfs
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
             trunk-auto-quarantine: "true"
             setup-solana: "true"
@@ -293,8 +316,13 @@ jobs:
             build-cache-write: always
 
           - cmd: go_core_fuzz
-            os: runs-on=${{
-              github.run_id}}-fuzz/cpu=8/family=c7id+c7idn+c8id+c8idn/spot=co/image=ubuntu24-full-x64/extras=s3-cache
+            os:
+              - runs-on=${{ github.run_id }}-fuzz
+              - cpu=8
+              - family=c7id+c7idn+c8id+c8idn
+              - ${{ needs.filter.outputs.spot_param }}
+              - image=ubuntu24-full-x64
+              - extras=s3-cache
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
             trunk-auto-quarantine: "false"
             go-mod-directory: ""
@@ -306,8 +334,15 @@ jobs:
             build-cache-write: never
 
           - cmd: go_core_race_tests
-            os: runs-on=${{
-              github.run_id}}-race/cpu=64/ram=128/family=c7i+c8i/volume=150gb/spot=co/image=ubuntu24-full-x64/extras=s3-cache
+            os:
+              - runs-on=${{ github.run_id }}-race
+              - cpu=64
+              - ram=128
+              - family=c7i+c8i
+              - volume=150gb
+              - ${{ needs.filter.outputs.spot_param }}
+              - image=ubuntu24-full-x64
+              - extras=s3-cache
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
             trunk-auto-quarantine: "false"
             go-mod-directory: ""
@@ -546,17 +581,17 @@ jobs:
             ./coverage.txt
           retention-days: 7
 
-
   clean:
     name: Clean Go Tidy & Generate
     if: ${{ github.actor != 'dependabot[bot]' }}
+    needs: [filter]
     runs-on:
       - runs-on=${{ github.run_id }}
       - cpu=8
       - family=c7i+c8i
       - image=ubuntu24-full-x64
       - extras=s3-cache
-      - spot=co
+      - ${{ needs.filter.outputs.spot_param }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Resolve Spot Setting
         id: spot
-        uses: ./.github/actions/setup-runner-spot
+        uses: $/.github/actions/setup-runner-spot
 
   golangci:
     name: GolangCI Lint

--- a/.github/workflows/ci-deployments.yml
+++ b/.github/workflows/ci-deployments.yml
@@ -33,6 +33,8 @@ jobs:
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch'
         }}
+      spot_flag: ${{ steps.spot.outputs.spot_flag }}
+      spot_param: ${{ steps.spot.outputs.spot_param }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
@@ -121,6 +123,10 @@ jobs:
               exclusion-sets: [ excluded-files ]
               inclusion-sets: [ included-files ]
 
+      - name: Resolve Spot Setting
+        id: spot
+        uses: ./.github/actions/setup-runner-spot
+
   deployment-tests:
     env:
       # We explicitly have this env var not be "CL_DATABASE_URL" to avoid having it be used by core related tests
@@ -134,7 +140,14 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' && needs.filter.outputs.should-run == 'true' }}
     needs: [filter]
     timeout-minutes: 35
-    runs-on: "runs-on=${{ github.run_id }}-deployment-${{ matrix.shard-id }}/cpu=8/ram=32/family=m6id+m8id/spot=co/image=ubuntu24-full-x64/extras=s3-cache"
+    runs-on:
+      - runs-on=${{ github.run_id }}-deployment-${{ matrix.shard-id }}
+      - cpu=8
+      - ram=32
+      - family=m6id+m8id
+      - ${{ needs.filter.outputs.spot_param }}
+      - image=ubuntu24-full-x64
+      - extras=s3-cache
     outputs:
       shard-count: ${{ strategy.job-total }}
     permissions:

--- a/.github/workflows/ci-deployments.yml
+++ b/.github/workflows/ci-deployments.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Resolve Spot Setting
         id: spot
-        uses: ./.github/actions/setup-runner-spot
+        uses: $/.github/actions/setup-runner-spot
 
   deployment-tests:
     env:

--- a/.github/workflows/ci-protobuf.yml
+++ b/.github/workflows/ci-protobuf.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -93,12 +93,20 @@ jobs:
     permissions:
       pull-requests: read
       contents: read
-    env:
-      SH_GO_RUNNER: runs-on=${{ github.run_id }}/cpu=32/ram=64/family=c7i+c8i/spot=co/extras=s3-cache+tmpfs
-      GH_GO_RUNNER: ubuntu24.04-8cores-32GB
     outputs:
       go-runner: ${{ steps.go-codeql.outputs.go-runner }}
+      spot_flag: ${{ steps.spot.outputs.spot_flag }}
+      spot_param: ${{ steps.spot.outputs.spot_param }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Resolve Spot Setting
+        id: spot
+        uses: ./.github/actions/setup-runner-spot
+
       - name: Get PR Labels
         id: pr-labels
         uses: smartcontractkit/.github/actions/get-pr-labels@get-pr-labels/v1
@@ -110,6 +118,8 @@ jobs:
         shell: bash
         env:
           OPT_OUT: ${{ steps.pr-labels.outputs.check-label-found || 'false' }}
+          GH_GO_RUNNER: ubuntu24.04-8cores-32GB
+          SH_GO_RUNNER: runs-on=${{ github.run_id }}/cpu=32/ram=64/family=c7i+c8i/${{ steps.spot.outputs.spot_flag }}/extras=s3-cache+tmpfs
         run: |
           if [[ "$OPT_OUT" == "true" ]]; then
             echo "Opt-out is true for current run. Using gh-hosted runner for Go codeql."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -98,14 +98,9 @@ jobs:
       spot_flag: ${{ steps.spot.outputs.spot_flag }}
       spot_param: ${{ steps.spot.outputs.spot_param }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
       - name: Resolve Spot Setting
         id: spot
-        uses: ./.github/actions/setup-runner-spot
+        uses: $/.github/actions/setup-runner-spot
 
       - name: Get PR Labels
         id: pr-labels

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -28,7 +28,13 @@ on:
 
 jobs:
   changes:
-    runs-on: runs-on=${{ github.run_id }}/cpu=16/ram=64/family=m7i+m8i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - cpu=16
+      - ram=64
+      - family=m7i+m8i
+      - image=ubuntu24-full-x64
+      - extras=s3-cache+tmpfs
     environment:
       # http://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments
       name: integration
@@ -44,12 +50,18 @@ jobs:
           github.event_name == 'pull_request' && contains(join(github.event.pull_request.labels.*.name, ' '), 'run-local-cre-env-tests') ||
           steps.changes.outputs.ci_changes == 'true'
         }}
+      spot_flag: ${{ steps.spot.outputs.spot_flag }}
+      spot_param: ${{ steps.spot.outputs.spot_param }}
     timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'pull_request' && github.sha || inputs.chainlink_version }}
+
+      - name: Resolve Spot Setting
+        id: spot
+        uses: ./.github/actions/setup-runner-spot
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
@@ -59,7 +71,14 @@ jobs:
               - '.github/workflows/cre-local-env-tests.yaml'
 
   test-cli:
-    runs-on: runs-on=${{ github.run_id }}/cpu=16/ram=64/family=m7i+m8i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - cpu=16
+      - ram=64
+      - family=m7i+m8i
+      - ${{ needs.changes.outputs.spot_param }}
+      - image=ubuntu24-full-x64
+      - extras=s3-cache+tmpfs
     environment:
       # http://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments
       name: integration

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'pull_request' && github.sha || inputs.chainlink_version }}
 
@@ -91,7 +91,7 @@ jobs:
     if: needs.changes.outputs.should-run-tests == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'pull_request' && github.sha || inputs.chainlink_version }}
 

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -33,6 +33,7 @@ jobs:
       - cpu=16
       - ram=64
       - family=m7i+m8i
+      - spot=co
       - image=ubuntu24-full-x64
       - extras=s3-cache+tmpfs
     environment:

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Resolve Spot Setting
         id: spot
-        uses: ./.github/actions/setup-runner-spot
+        uses: $/.github/actions/setup-runner-spot
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes

--- a/.github/workflows/cre-mixed-env-tests.yaml
+++ b/.github/workflows/cre-mixed-env-tests.yaml
@@ -10,8 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       chainlink_image_repository_path:
-        description:
-          "ECR repository name used to compose the PR image with chainlink_image_tag."
+        description: "ECR repository name used to compose the PR image with chainlink_image_tag."
         required: true
         type: string
       chainlink_image_tag:
@@ -59,8 +58,7 @@ on:
   workflow_call:
     inputs:
       chainlink_image_repository_path:
-        description:
-          "ECR repository name used to compose the PR image with chainlink_image_tag."
+        description: "ECR repository name used to compose the PR image with chainlink_image_tag."
         required: true
         type: string
       chainlink_image_tag:
@@ -107,9 +105,20 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
+      spot_flag: ${{ steps.spot.outputs.spot_flag }}
+      spot_param: ${{ steps.spot.outputs.spot_param }}
     permissions:
       contents: read
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Resolve Spot Setting
+        id: spot
+        uses: ./.github/actions/setup-runner-spot
+
       - name: Define mixed-env test matrix
         id: define-matrix
         shell: bash
@@ -135,16 +144,13 @@ jobs:
             --argjson tests "$TESTS" \
             --argjson per "$PER_TEST_CONFIGS" \
             --argjson run_id "${{ github.run_id }}" \
-            --arg run_attempt "${{ github.run_attempt }}" '
-            $tests | to_entries | map(
-              .value as $name
-              | {
-                test_name: $name,
-                test_id: .key,
-                configs: ($per[$name] // "configs/mixed-env-don.toml"),
-                runs_on: "runs-on=\($run_id)-\(.key)-\($run_attempt)/cpu=16/ram=64/family=m7i+m8i/spot=co/image=ubuntu24-full-x64/extras=s3-cache+tmpfs"
-              }
-            )')
+            --arg run_attempt "${{ github.run_attempt }}" \
+            --arg spot_flag "${{ steps.spot.outputs.spot_flag }}" '
+            $tests | to_entries | map({
+              test_name: .value,
+              test_id: .key,
+              runs_on: "runs-on=\($run_id)-\(.key)-\($run_attempt)/cpu=16/ram=64/family=m7i+m8i/\($spot_flag)/image=ubuntu24-full-x64/extras=s3-cache+tmpfs"
+            })')
           echo "matrix=$matrix" | tee -a "${GITHUB_OUTPUT}"
 
   run-mixed-env-tests:

--- a/.github/workflows/cre-mixed-env-tests.yaml
+++ b/.github/workflows/cre-mixed-env-tests.yaml
@@ -122,6 +122,10 @@ jobs:
       - name: Define mixed-env test matrix
         id: define-matrix
         shell: bash
+        env:
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          SPOT_FLAG: ${{ steps.spot.outputs.spot_flag }}
         run: |
           # Tests worth running under mixed-env: the OCR3/DON2DON-heavy ones.
           # The confidential relay test runs against its own topology (the
@@ -143,9 +147,9 @@ jobs:
           matrix=$(jq -c -n \
             --argjson tests "$TESTS" \
             --argjson per "$PER_TEST_CONFIGS" \
-            --argjson run_id "${{ github.run_id }}" \
-            --arg run_attempt "${{ github.run_attempt }}" \
-            --arg spot_flag "${{ steps.spot.outputs.spot_flag }}" '
+            --argjson run_id "$RUN_ID" \
+            --arg run_attempt "$RUN_ATTEMPT" \
+            --arg spot_flag "$SPOT_FLAG" '
             $tests | to_entries | map({
               test_name: .value,
               test_id: .key,

--- a/.github/workflows/cre-mixed-env-tests.yaml
+++ b/.github/workflows/cre-mixed-env-tests.yaml
@@ -153,6 +153,7 @@ jobs:
             $tests | to_entries | map({
               test_name: .value,
               test_id: .key,
+              configs: ($per[.value] // "configs/mixed-env-don.toml"),
               runs_on: "runs-on=\($run_id)-\(.key)-\($run_attempt)/cpu=16/ram=64/family=m7i+m8i/\($spot_flag)/image=ubuntu24-full-x64/extras=s3-cache+tmpfs"
             })')
           echo "matrix=$matrix" | tee -a "${GITHUB_OUTPUT}"

--- a/.github/workflows/cre-mixed-env-tests.yaml
+++ b/.github/workflows/cre-mixed-env-tests.yaml
@@ -110,14 +110,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
       - name: Resolve Spot Setting
         id: spot
-        uses: ./.github/actions/setup-runner-spot
+        uses: $/.github/actions/setup-runner-spot
 
       - name: Define mixed-env test matrix
         id: define-matrix

--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -63,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
+      spot_flag: ${{ steps.spot.outputs.spot_flag }}
+      spot_param: ${{ steps.spot.outputs.spot_param }}
     permissions:
       contents: read
     steps:
@@ -71,6 +73,10 @@ jobs:
         with:
           ref: ${{ inputs.chainlink_version || github.sha }}
           persist-credentials: false
+
+      - name: Resolve Spot Setting
+        id: spot
+        uses: ./.github/actions/setup-runner-spot
 
       - name: Define test matrix
         id: define-matrix
@@ -85,13 +91,14 @@ jobs:
           tests=$(echo "$test_names" | jq -c -R -s \
             --argjson run_id "${{ github.run_id }}" \
             --arg run_attempt "${{ github.run_attempt }}" \
-            --argjson per "$per_test_configs" '
+            --argjson per "$per_test_configs" \
+            --arg spot_flag "${{ steps.spot.outputs.spot_flag }}" '
             split("\n") | map(select(length>0))
             | to_entries
             | map({
                 test_name: .value,
                 test_id: .key,
-                runs_on: "runs-on=\($run_id)-\(.key)-\($run_attempt)/cpu=16/ram=64/family=m7i+m8i/spot=co/image=ubuntu24-full-x64/extras=s3-cache+tmpfs",
+                runs_on: "runs-on=\($run_id)-\(.key)-\($run_attempt)/cpu=16/ram=64/family=m7i+m8i/\($spot_flag)/image=ubuntu24-full-x64/extras=s3-cache+tmpfs",
                 configs: ($per[.value] // "configs/workflow-gateway-capabilities-don.toml")
               })
           ')

--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -78,6 +78,7 @@ jobs:
         id: spot
         uses: ./.github/actions/setup-runner-spot
 
+      # TODO(DX-5101): replace this inline grep/jq matrix step with `ci matrix system --suite cre-regression`
       - name: Define test matrix
         id: define-matrix
         shell: bash

--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -81,6 +81,10 @@ jobs:
       - name: Define test matrix
         id: define-matrix
         shell: bash
+        env:
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          SPOT_FLAG: ${{ steps.spot.outputs.spot_flag }}
         run: |
           test_names=$(grep -rh -oP '^func \K(Test|Example)[^(]+' system-tests/tests/regression/cre/*_test.go)
 
@@ -89,10 +93,10 @@ jobs:
           }'
 
           tests=$(echo "$test_names" | jq -c -R -s \
-            --argjson run_id "${{ github.run_id }}" \
-            --arg run_attempt "${{ github.run_attempt }}" \
+            --argjson run_id "$RUN_ID" \
+            --arg run_attempt "$RUN_ATTEMPT" \
             --argjson per "$per_test_configs" \
-            --arg spot_flag "${{ steps.spot.outputs.spot_flag }}" '
+            --arg spot_flag "$SPOT_FLAG" '
             split("\n") | map(select(length>0))
             | to_entries
             | map({

--- a/.github/workflows/cre-regression-system-tests.yaml
+++ b/.github/workflows/cre-regression-system-tests.yaml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Resolve Spot Setting
         id: spot
-        uses: ./.github/actions/setup-runner-spot
+        uses: $/.github/actions/setup-runner-spot
 
       # TODO(DX-5101): replace this inline grep/jq matrix step with `ci matrix system --suite cre-regression`
       - name: Define test matrix

--- a/.github/workflows/cre-soak-memory-leak.yml
+++ b/.github/workflows/cre-soak-memory-leak.yml
@@ -28,8 +28,14 @@ jobs:
     environment:
       name: integration
       deployment: false
-    runs-on: runs-on=${{ github.run_id
-      }}/cpu=32/ram=128/family=m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - cpu=32
+      - ram=128
+      - family=m6id+m6idn
+      - spot=false
+      - image=ubuntu24-full-x64
+      - extras=s3-cache
     timeout-minutes: 270 # 4h30m — test timeout is 4h20m
     permissions:
       contents: read

--- a/.github/workflows/cre-soak-memory-leak.yml
+++ b/.github/workflows/cre-soak-memory-leak.yml
@@ -46,7 +46,7 @@ jobs:
         uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc # v2.2.0
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
           persist-credentials: false

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -81,6 +81,10 @@ jobs:
       - name: Define test matrix
         id: define-matrix
         shell: bash
+        env:
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          SPOT_FLAG: ${{ steps.spot.outputs.spot_flag }}
         run: |
           TOPOLOGIES_JSON='[
             {"topology":"workflow-gateway-capabilities","configs":"configs/workflow-gateway-capabilities-don.toml"}
@@ -138,11 +142,11 @@ jobs:
           test_names=$(grep -rh -oP '^func \K(Test|Example)[^(]+' system-tests/tests/smoke/cre/*_test.go | grep -v Test_Upgrade | grep -v '^TestMain$')
 
           tests=$(echo "$test_names" | jq -c -R -s \
-            --argjson run_id "${{ github.run_id }}" \
-            --arg run_attempt "${{ github.run_attempt }}" \
+            --argjson run_id "$RUN_ID" \
+            --arg run_attempt "$RUN_ATTEMPT" \
             --argjson tops "$TOPOLOGIES_JSON" \
             --argjson per "$PER_TEST_TOPOLOGIES_JSON" \
-            --arg spot_flag "${{ steps.spot.outputs.spot_flag }}" '
+            --arg spot_flag "$SPOT_FLAG" '
             (split("\n") | map(select(length>0))) as $names
             | [ $names[] as $name | $tops[] | {test_name:$name} + . ] as $baseAll
             | ($baseAll | map(select(.test_name as $n | ($per[$n] | type) == "array" | not))) as $base

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -78,6 +78,7 @@ jobs:
         id: spot
         uses: ./.github/actions/setup-runner-spot
 
+      # TODO(DX-5101): replace this inline grep/jq matrix step with `ci matrix system --suite cre-smoke`
       - name: Define test matrix
         id: define-matrix
         shell: bash

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -63,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
+      spot_flag: ${{ steps.spot.outputs.spot_flag }}
+      spot_param: ${{ steps.spot.outputs.spot_param }}
     permissions:
       contents: read
     steps:
@@ -71,6 +73,10 @@ jobs:
         with:
           ref: ${{ inputs.chainlink_version || github.sha }}
           persist-credentials: false
+
+      - name: Resolve Spot Setting
+        id: spot
+        uses: ./.github/actions/setup-runner-spot
 
       - name: Define test matrix
         id: define-matrix
@@ -135,7 +141,8 @@ jobs:
             --argjson run_id "${{ github.run_id }}" \
             --arg run_attempt "${{ github.run_attempt }}" \
             --argjson tops "$TOPOLOGIES_JSON" \
-            --argjson per "$PER_TEST_TOPOLOGIES_JSON" '
+            --argjson per "$PER_TEST_TOPOLOGIES_JSON" \
+            --arg spot_flag "${{ steps.spot.outputs.spot_flag }}" '
             (split("\n") | map(select(length>0))) as $names
             | [ $names[] as $name | $tops[] | {test_name:$name} + . ] as $baseAll
             | ($baseAll | map(select(.test_name as $n | ($per[$n] | type) == "array" | not))) as $base
@@ -146,7 +153,7 @@ jobs:
             | to_entries
             | map(.value + {
                 test_id: .key,
-                runs_on: "runs-on=\($run_id)-\(.key)-\($run_attempt)/cpu=16/ram=64/family=m7i+m8i/spot=co/image=ubuntu24-full-x64/extras=s3-cache+tmpfs"
+                runs_on: "runs-on=\($run_id)-\(.key)-\($run_attempt)/cpu=16/ram=64/family=m7i+m8i/\($spot_flag)/image=ubuntu24-full-x64/extras=s3-cache+tmpfs"
               })
           ')
 

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Resolve Spot Setting
         id: spot
-        uses: ./.github/actions/setup-runner-spot
+        uses: $/.github/actions/setup-runner-spot
 
       # TODO(DX-5101): replace this inline grep/jq matrix step with `ci matrix system --suite cre-smoke`
       - name: Define test matrix

--- a/.github/workflows/cre-wf-caching-test.yml
+++ b/.github/workflows/cre-wf-caching-test.yml
@@ -28,8 +28,14 @@ jobs:
     environment:
       name: integration
       deployment: false
-    runs-on: runs-on=${{ github.run_id
-      }}/cpu=32/ram=128/family=m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - cpu=32
+      - ram=128
+      - family=m6id+m6idn
+      - spot=false
+      - image=ubuntu24-full-x64
+      - extras=s3-cache
     timeout-minutes: 270 # 4h30m — test timeout is 4h20m
     permissions:
       contents: read

--- a/.github/workflows/cre-wf-caching-test.yml
+++ b/.github/workflows/cre-wf-caching-test.yml
@@ -48,7 +48,7 @@ jobs:
           metrics: cpu,network,memory,disk,io
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
           persist-credentials: false

--- a/.github/workflows/cre-workflow-don-benchmark.yaml
+++ b/.github/workflows/cre-workflow-don-benchmark.yaml
@@ -40,7 +40,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'workflow_call' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-cre-workflow-don-benchmark'))
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'pull_request' && github.sha || inputs.chainlink_version }}
 

--- a/.github/workflows/deploy-cre-manual.yml
+++ b/.github/workflows/deploy-cre-manual.yml
@@ -46,7 +46,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/devenv-compat.yml
+++ b/.github/workflows/devenv-compat.yml
@@ -116,7 +116,7 @@ jobs:
         secrets.QA_AWS_REGION }}.amazonaws.com/local-cre-chip-router:v1.0.1"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -36,7 +36,19 @@ jobs:
       runner-amd64: ${{ steps.runner-labels.outputs.runner-amd64 }}
       checked-out-sha: ${{ steps.checkout-sha.outputs.checked-out-sha }}
       version-tag: ${{ steps.version-info.outputs.version-tag }}
+      spot_flag: ${{ steps.spot.outputs.spot_flag }}
+      spot_param: ${{ steps.spot.outputs.spot_param }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.git-ref || github.sha }}
+
+      - name: Resolve Spot Setting
+        id: spot
+        uses: ./.github/actions/setup-runner-spot
+
       - name: Get PR Labels
         id: pr-labels
         uses: smartcontractkit/.github/actions/get-pr-labels@get-pr-labels/v1
@@ -49,20 +61,11 @@ jobs:
         shell: bash
         env:
           # All events use runs-on (s3-cache backend) so every build shares caches.
-          # spot=co: runs-on auto-retries interrupted jobs on-demand once.
-          RUNNER_LABEL_ARM64: runs-on=${{ github.run_id
-            }}/cpu=16/ram=64/family=m8g+m9g/spot=co/image=ubuntu24-full-arm64/volume=100gb:gp3:500mbs:4000iops/extras=s3-cache
-          RUNNER_LABEL_AMD64: runs-on=${{ github.run_id
-            }}/cpu=16/ram=64/family=m7i+m8i/spot=co/image=ubuntu24-full-x64/volume=100gb:gp3:500mbs:4000iops/extras=s3-cache
+          RUNNER_LABEL_ARM64: runs-on=${{ github.run_id }}/cpu=16/ram=64/family=m8g+m9g/${{ steps.spot.outputs.spot_flag }}/image=ubuntu24-full-arm64/volume=100gb:gp3:500mbs:4000iops/extras=s3-cache
+          RUNNER_LABEL_AMD64: runs-on=${{ github.run_id }}/cpu=16/ram=64/family=m7i+m8i/${{ steps.spot.outputs.spot_flag }}/image=ubuntu24-full-x64/volume=100gb:gp3:500mbs:4000iops/extras=s3-cache
         run: |
           echo "runner-arm64=${RUNNER_LABEL_ARM64}" | tee -a "$GITHUB_OUTPUT"
           echo "runner-amd64=${RUNNER_LABEL_AMD64}" | tee -a "$GITHUB_OUTPUT"
-
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.git-ref || github.sha }}
-
       - name: Resolve checked out SHA
         id: checkout-sha
         shell: bash

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Resolve Spot Setting
         id: spot
-        uses: ./.github/actions/setup-runner-spot
+        uses: $/.github/actions/setup-runner-spot
 
       - name: Get PR Labels
         id: pr-labels

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -34,10 +34,15 @@ jobs:
       pull-requests: read
     outputs:
       changed: ${{ steps.changes.outputs.src || 'true' }}
+      spot_flag: ${{ steps.spot.outputs.spot_flag }}
+      spot_param: ${{ steps.spot.outputs.spot_param }}
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - name: Resolve Spot Setting
+        id: spot
+        uses: ./.github/actions/setup-runner-spot
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         if: github.event_name == 'pull_request'
         id: changes
@@ -64,10 +69,22 @@ jobs:
             suffix: "Deployment (Github-hosted)"
             go-mod-directory: "deployment/"
 
-          - runs-on: runs-on=${{ github.run_id }}/cpu=8/ram=16/family=c6id/spot=false/extras=s3-cache
+          - runs-on:
+              - runs-on=${{ github.run_id }}-core
+              - cpu=8
+              - ram=16
+              - family=c6id
+              - ${{ needs.filter.outputs.spot_param }}
+              - extras=s3-cache
             suffix: "Core (Self-hosted)"
 
-          - runs-on: runs-on=${{ github.run_id }}/cpu=8/ram=16/family=c6id/spot=false/extras=s3-cache
+          - runs-on:
+              - runs-on=${{ github.run_id }}-deployment
+              - cpu=8
+              - ram=16
+              - family=c6id
+              - ${{ needs.filter.outputs.spot_param }}
+              - extras=s3-cache
             suffix: "Deployment (Self-hosted)"
             go-mod-directory: "deployment/"
 

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
       - name: Resolve Spot Setting
         id: spot
-        uses: ./.github/actions/setup-runner-spot
+        uses: $/.github/actions/setup-runner-spot
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         if: github.event_name == 'pull_request'
         id: changes

--- a/.github/workflows/integration-in-memory-tests.yml
+++ b/.github/workflows/integration-in-memory-tests.yml
@@ -123,12 +123,16 @@ jobs:
       - name: Define test matrix
         id: define-matrix
         shell: bash
+        env:
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          SPOT_FLAG: ${{ steps.spot.outputs.spot_flag }}
         run: |
           # shellcheck disable=SC1083,SC2016
           tests=$(jq -c \
-            --argjson run_id "${{ github.run_id }}" \
-            --arg run_attempt "${{ github.run_attempt }}" \
-            --arg spot_flag "${{ steps.spot.outputs.spot_flag }}" '
+            --argjson run_id "$RUN_ID" \
+            --arg run_attempt "$RUN_ATTEMPT" \
+            --arg spot_flag "$SPOT_FLAG" '
             to_entries
             | map(.value + {
                 # Stable, human-readable id for artifact names. `.name` is unique across

--- a/.github/workflows/integration-in-memory-tests.yml
+++ b/.github/workflows/integration-in-memory-tests.yml
@@ -104,6 +104,8 @@ jobs:
     if: always() && github.actor != 'dependabot[bot]' && github.event_name != 'push' && (needs.changes.result == 'skipped' || needs.changes.outputs.run-tests == 'true')
     outputs:
       matrix: ${{ steps.define-matrix.outputs.matrix }}
+      spot_flag: ${{ steps.spot.outputs.spot_flag }}
+      spot_param: ${{ steps.spot.outputs.spot_param }}
     permissions:
       contents: read
     steps:
@@ -114,6 +116,10 @@ jobs:
           repository: smartcontractkit/chainlink
           ref: ${{ inputs.chainlink_version || inputs.cl_ref || github.sha }}
 
+      - name: Resolve Spot Setting
+        id: spot
+        uses: ./.github/actions/setup-runner-spot
+
       - name: Define test matrix
         id: define-matrix
         shell: bash
@@ -121,7 +127,8 @@ jobs:
           # shellcheck disable=SC1083,SC2016
           tests=$(jq -c \
             --argjson run_id "${{ github.run_id }}" \
-            --arg run_attempt "${{ github.run_attempt }}" '
+            --arg run_attempt "${{ github.run_attempt }}" \
+            --arg spot_flag "${{ steps.spot.outputs.spot_flag }}" '
             to_entries
             | map(.value + {
                 # Stable, human-readable id for artifact names. `.name` is unique across
@@ -131,7 +138,7 @@ jobs:
                 job_timeout: (((.value.timeout | rtrimstr("m") | tonumber) + 5)),
                 # The runner label only needs per-run uniqueness, so the index is fine
                 # here and keeps the label short enough for runs-on.
-                runs_on: (if .value.runs_on == "" or .value.runs_on == null then "ubuntu-latest" else "runs-on=\($run_id)-\(.key)-\($run_attempt)/\(.value.runs_on)/family=m7i+m8i/spot=co/image=ubuntu24-full-x64/extras=s3-cache+tmpfs" end)
+                runs_on: (if .value.runs_on == "" or .value.runs_on == null then "ubuntu-latest" else "runs-on=\($run_id)-\(.key)-\($run_attempt)/\(.value.runs_on)/family=m7i+m8i/\($spot_flag)/image=ubuntu24-full-x64/extras=s3-cache+tmpfs" end)
               })
           ' .github/in-memory-tests.json)
 
@@ -156,7 +163,14 @@ jobs:
   compile-tests:
     name: Compile In-Memory Test Binaries
     needs: [define-test-matrix]
-    runs-on: runs-on=${{ github.run_id }}-inmem-compile/cpu=32/ram=64/family=c7i+c8i/spot=co/volume=100GB/extras=s3-cache
+    runs-on:
+      - runs-on=${{ github.run_id }}-inmem-compile
+      - cpu=32
+      - ram=64
+      - family=c7i+c8i
+      - ${{ needs.define-test-matrix.outputs.spot_param }}
+      - volume=100GB
+      - extras=s3-cache
     environment:
       name: integration
       deployment: false

--- a/.github/workflows/integration-in-memory-tests.yml
+++ b/.github/workflows/integration-in-memory-tests.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Resolve Spot Setting
         id: spot
-        uses: ./.github/actions/setup-runner-spot
+        uses: $/.github/actions/setup-runner-spot
 
       - name: Define test matrix
         id: define-matrix

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -211,7 +211,18 @@ jobs:
       run-e2e-tests-label-found: ${{ steps.label-runs-e2e-tests.outputs.check-label-found || 'false' }}
       skip-e2e-regression-label-found: ${{ steps.label-skip-e2e-regression.outputs.check-label-found || 'false' }}
       skip-mixed-env-label-found: ${{ steps.label-skip-mixed-env.outputs.check-label-found || 'false' }}
+      spot_flag: ${{ steps.spot.outputs.spot_flag }}
+      spot_param: ${{ steps.spot.outputs.spot_param }}
     steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Resolve Spot Setting
+        id: spot
+        uses: ./.github/actions/setup-runner-spot
+
       - name: Get PR Labels (runs-on-opt-out)
         if: github.event_name == 'pull_request'
         id: label-runs-on-opt-out
@@ -246,8 +257,8 @@ jobs:
           OPT_OUT: ${{ steps.label-runs-on-opt-out.outputs.check-label-found || 'false' }}
           GH_BUILDER_RUNNER: ubuntu22.04-8cores-32GB
           # include unique label (core/plugins) to ensure jobs are not competing for the same runner
-          SH_BUILDER_RUNNER_CORE: runs-on=${{ github.run_id }}-core/cpu=16/ram=64/family=m7i+m8i/spot=co/extras=s3-cache+tmpfs
-          SH_BUILDER_RUNNER_PLUGINS: runs-on=${{ github.run_id }}-plugins/cpu=16/ram=64/family=m7i+m8i/spot=co/extras=s3-cache+tmpfs
+          SH_BUILDER_RUNNER_CORE: runs-on=${{ github.run_id }}-core/cpu=16/ram=64/family=m7i+m8i/${{ steps.spot.outputs.spot_flag }}/extras=s3-cache+tmpfs
+          SH_BUILDER_RUNNER_PLUGINS: runs-on=${{ github.run_id }}-plugins/cpu=16/ram=64/family=m7i+m8i/${{ steps.spot.outputs.spot_flag }}/extras=s3-cache+tmpfs
         run: |
           if [[ "${OPT_OUT}" == "true" ]]; then
             echo "builder-runner-label=${GH_BUILDER_RUNNER}" | tee -a "$GITHUB_OUTPUT"
@@ -586,9 +597,17 @@ jobs:
          needs.run-ccip-v1-6-e2e-tests-setup.outputs.should-run == 'true')
       }}
     needs:
+      - labels
       - run-core-cre-e2e-tests-setup
       - run-ccip-v1-6-e2e-tests-setup
-    runs-on: runs-on=${{ github.run_id }}-compile/cpu=32/ram=64/family=c7i+c8i/spot=co/volume=100GB/extras=s3-cache
+    runs-on:
+      - runs-on=${{ github.run_id }}-compile
+      - cpu=32
+      - ram=64
+      - family=c7i+c8i
+      - ${{ needs.labels.outputs.spot_param }}
+      - volume=100GB
+      - extras=s3-cache
     environment:
       name: integration
       deployment: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -214,14 +214,9 @@ jobs:
       spot_flag: ${{ steps.spot.outputs.spot_flag }}
       spot_param: ${{ steps.spot.outputs.spot_param }}
     steps:
-      - name: Checkout the repo
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
       - name: Resolve Spot Setting
         id: spot
-        uses: ./.github/actions/setup-runner-spot
+        uses: $/.github/actions/setup-runner-spot
 
       - name: Get PR Labels (runs-on-opt-out)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/legacy-non-functional-tests.yml
+++ b/.github/workflows/legacy-non-functional-tests.yml
@@ -64,7 +64,7 @@ jobs:
       deployment: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.chainlink_version || github.sha }}
       # we cannot pass this resolved image to `test-nightly` job, because when it contains secrets
@@ -112,7 +112,7 @@ jobs:
             logs_archive_name: "df1-chaos"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ inputs.chainlink_version || github.sha }}

--- a/.github/workflows/legacy-system-tests.yml
+++ b/.github/workflows/legacy-system-tests.yml
@@ -64,7 +64,7 @@ jobs:
       deployment: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.chainlink_version || github.sha }}
       # we cannot pass this resolved image to `test-nightly` job, because when it contains secrets
@@ -205,7 +205,7 @@ jobs:
             logs_archive_name: "vrfv2-batch-fulfillment"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ inputs.chainlink_version || github.sha }}

--- a/.github/workflows/lint-gh-workflows.yml
+++ b/.github/workflows/lint-gh-workflows.yml
@@ -3,9 +3,9 @@ name: Lint GH Workflows
 on:
   pull_request:
     paths:
-      - '.github/workflows/*.y*ml'
-      - '.github/actions/**/action.y*ml'
-      - '.github/actionlint.yml'
+      - ".github/workflows/*.y*ml"
+      - ".github/actions/**/action.y*ml"
+      - ".github/actionlint.yml"
 
 permissions: {}
 
@@ -19,7 +19,7 @@ jobs:
       issues: write
     steps:
       - name: Check out Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/operator-ui-ci.yml
+++ b/.github/workflows/operator-ui-ci.yml
@@ -26,7 +26,7 @@ jobs:
           aws-role-duration-seconds: 3600
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-conflicts.yaml
+++ b/.github/workflows/pr-conflicts.yaml
@@ -16,7 +16,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Deploy core
         uses: ./.github/actions/deploy-image
         with:

--- a/.github/workflows/sync-develop-from-smartcontractkit-chainlink.yml
+++ b/.github/workflows/sync-develop-from-smartcontractkit-chainlink.yml
@@ -10,7 +10,7 @@ jobs:
     name: Sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           ref: develop

--- a/_typos.toml
+++ b/_typos.toml
@@ -179,6 +179,8 @@ noops = "noops"
 
 # ned = name for secondary noop
 ned = "ned"
+# short for strategy
+strat = "strat"
 
 # PostgreSQL index types & valid English spelling variants
 brin = "brin"

--- a/tools/ci/AGENTS.md
+++ b/tools/ci/AGENTS.md
@@ -1,10 +1,11 @@
-# AGENTS.md - Development Rules for `tools/ci`
+# Development Rules for `tools/ci`
 
 This module centralizes CI operations. All changes must adhere strictly to these rules:
 
 1. **Logic in `internal/`**:
    - All domain logic lives in `internal/<package>`, taking explicit structs and returning `(T, error)`. Filesystem reads are allowed; avoid reading env vars, parsing CLI flags, or writing directly to stdout/stderr.
    - Never call `os.Getenv`, read flags, or write to standard streams directly inside `internal/` (except `internal/ghaction`).
+   - Utilize `github.com/sethvargo/go-githubactions` wherever possible for GitHub actions logic.
 2. **`cmd/` is a thin shell**:
    - Parse flags, resolve environment fallbacks, call `internal/`, and render outputs.
 3. **Dual output**:
@@ -16,3 +17,4 @@ This module centralizes CI operations. All changes must adhere strictly to these
    - Write failing tests first before adding commands or domain logic.
    - Golden-file tests for JSON/matrix generation.
    - Fake/HTTP mock servers for GitHub API interactions (`httptest.NewServer`).
+   - Tests must only check our custom logic. Do not test the `go-githubactions` package or basic outputs.

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -7,9 +7,11 @@
 | Command | Description | Replaces |
 |---|---|---|
 | `ci version` | Print version information (text or `--json`) | Custom version checks |
+| `ci runner spot` | Determine RunsOn runner spot setting based on GitHub events, branches, tags, and queue | Custom runner label logic |
 | `ci image resolve` | Resolve Chainlink Docker image URI (ECR public or SDLC) | `.github/scripts/resolve-chainlink-image.sh` |
 | `ci ccip resolve-baseline` | Resolve the CCIP release baseline image tag for mixed-version/rollout tests | `.github/scripts/resolve-ccip-release-baseline.sh` |
 | `ci changeset check-tags` | Validate semver in changeset frontmatter and check release tags | `.github/scripts/check-changeset-tags.sh` |
+| `ci tools matrix` | Generate test target matrix for tools directory | Inline matrix scripts |
 
 ## Usage
 

--- a/tools/ci/cmd/ccip.go
+++ b/tools/ci/cmd/ccip.go
@@ -22,16 +22,16 @@ const (
 	defaultProbeDelay    = 2 * time.Second
 )
 
-func newCcipCmd() *cobra.Command {
+func newCCIPCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ccip",
 		Short: "Commands for CCIP release operations",
 	}
-	cmd.AddCommand(newCcipResolveBaselineCmd())
+	cmd.AddCommand(newCCIPResolveBaselineCmd())
 	return cmd
 }
 
-func newCcipResolveBaselineCmd() *cobra.Command {
+func newCCIPResolveBaselineCmd() *cobra.Command {
 	var (
 		chainlinkVersion string
 		repo             string

--- a/tools/ci/cmd/changeset.go
+++ b/tools/ci/cmd/changeset.go
@@ -36,11 +36,12 @@ func newChangesetCheckTagsCmd() *cobra.Command {
 		Short: "Check if at least one release tag exists in a changeset file",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			act := ghaction.New(cmd.OutOrStdout(), "", "")
 			if len(args) > 0 {
 				filePath = args[0]
 			}
 			if filePath == "" {
-				filePath = os.Getenv("CHANGESET_FILE_PATH")
+				filePath = act.Getenv("CHANGESET_FILE_PATH")
 			}
 			paths := strings.Fields(filePath)
 			if len(paths) == 0 {

--- a/tools/ci/cmd/changeset.go
+++ b/tools/ci/cmd/changeset.go
@@ -36,9 +36,12 @@ func newChangesetCheckTagsCmd() *cobra.Command {
 		Short: "Check if at least one release tag exists in a changeset file",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			act := ghaction.New(cmd.OutOrStdout(), "", "")
+			act := ghaction.NewAction(cmd.OutOrStdout())
 			if len(args) > 0 {
 				filePath = args[0]
+			}
+			if filePath == "" {
+				filePath = act.GetInput("file")
 			}
 			if filePath == "" {
 				filePath = act.Getenv("CHANGESET_FILE_PATH")

--- a/tools/ci/cmd/changeset.go
+++ b/tools/ci/cmd/changeset.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -41,10 +40,7 @@ func newChangesetCheckTagsCmd() *cobra.Command {
 				filePath = args[0]
 			}
 			if filePath == "" {
-				filePath = act.GetInput("file")
-			}
-			if filePath == "" {
-				filePath = act.Getenv("CHANGESET_FILE_PATH")
+				filePath = act.GetInputOrEnv("file", "CHANGESET_FILE_PATH")
 			}
 			paths := strings.Fields(filePath)
 			if len(paths) == 0 {
@@ -74,8 +70,7 @@ func newChangesetCheckTagsCmd() *cobra.Command {
 				fmt.Fprintf(cmd.OutOrStdout(), "Error: No tags found in %s\n", filePath)
 			}
 
-			if os.Getenv("GITHUB_OUTPUT") != "" {
-				act := ghaction.New(cmd.OutOrStdout(), "", "")
+			if act.Getenv("GITHUB_OUTPUT") != "" {
 				if err := act.SetOutput("has_tags", strconv.FormatBool(res.HasTags)); err != nil {
 					return err
 				}

--- a/tools/ci/cmd/image.go
+++ b/tools/ci/cmd/image.go
@@ -36,20 +36,21 @@ func newImageResolveCmd() *cobra.Command {
 		Use:   "resolve",
 		Short: "Resolve a Chainlink Docker image URI based on ECR type and environment variables",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			act := ghaction.New(cmd.OutOrStdout(), "", "")
 			if ecrType == "" {
-				ecrType = os.Getenv("ECR_TYPE")
+				ecrType = act.Getenv("ECR_TYPE")
 			}
 			if repositoryPath == "" {
-				repositoryPath = os.Getenv("CHAINLINK_IMAGE_REPO_PATH")
+				repositoryPath = act.Getenv("CHAINLINK_IMAGE_REPO_PATH")
 			}
 			if imageTag == "" {
-				imageTag = os.Getenv("CHAINLINK_IMAGE_TAG")
+				imageTag = act.Getenv("CHAINLINK_IMAGE_TAG")
 			}
 			if awsAccount == "" {
-				awsAccount = os.Getenv("AWS_ACCOUNT_NUMBER")
+				awsAccount = act.Getenv("AWS_ACCOUNT_NUMBER")
 			}
 			if awsRegion == "" {
-				awsRegion = os.Getenv("AWS_REGION")
+				awsRegion = act.Getenv("AWS_REGION")
 			}
 
 			resolved, err := image.Resolve(image.ResolveOptions{
@@ -64,7 +65,6 @@ func newImageResolveCmd() *cobra.Command {
 			}
 
 			if os.Getenv("GITHUB_OUTPUT") != "" {
-				act := ghaction.New(cmd.OutOrStdout(), "", "")
 				if err := act.SetOutput("resolved_image", resolved); err != nil {
 					return err
 				}

--- a/tools/ci/cmd/image.go
+++ b/tools/ci/cmd/image.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -36,18 +35,33 @@ func newImageResolveCmd() *cobra.Command {
 		Use:   "resolve",
 		Short: "Resolve a Chainlink Docker image URI based on ECR type and environment variables",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			act := ghaction.New(cmd.OutOrStdout(), "", "")
+			act := ghaction.NewAction(cmd.OutOrStdout())
+			if ecrType == "" {
+				ecrType = act.GetInput("ecr_type")
+			}
 			if ecrType == "" {
 				ecrType = act.Getenv("ECR_TYPE")
+			}
+			if repositoryPath == "" {
+				repositoryPath = act.GetInput("repo_path")
 			}
 			if repositoryPath == "" {
 				repositoryPath = act.Getenv("CHAINLINK_IMAGE_REPO_PATH")
 			}
 			if imageTag == "" {
+				imageTag = act.GetInput("tag")
+			}
+			if imageTag == "" {
 				imageTag = act.Getenv("CHAINLINK_IMAGE_TAG")
 			}
 			if awsAccount == "" {
+				awsAccount = act.GetInput("aws_account")
+			}
+			if awsAccount == "" {
 				awsAccount = act.Getenv("AWS_ACCOUNT_NUMBER")
+			}
+			if awsRegion == "" {
+				awsRegion = act.GetInput("aws_region")
 			}
 			if awsRegion == "" {
 				awsRegion = act.Getenv("AWS_REGION")
@@ -64,7 +78,7 @@ func newImageResolveCmd() *cobra.Command {
 				return err
 			}
 
-			if os.Getenv("GITHUB_OUTPUT") != "" {
+			if act.Getenv("GITHUB_OUTPUT") != "" {
 				if err := act.SetOutput("resolved_image", resolved); err != nil {
 					return err
 				}

--- a/tools/ci/cmd/image.go
+++ b/tools/ci/cmd/image.go
@@ -37,34 +37,19 @@ func newImageResolveCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			act := ghaction.NewAction(cmd.OutOrStdout())
 			if ecrType == "" {
-				ecrType = act.GetInput("ecr_type")
-			}
-			if ecrType == "" {
-				ecrType = act.Getenv("ECR_TYPE")
+				ecrType = act.GetInputOrEnv("ecr_type", "ECR_TYPE")
 			}
 			if repositoryPath == "" {
-				repositoryPath = act.GetInput("repo_path")
-			}
-			if repositoryPath == "" {
-				repositoryPath = act.Getenv("CHAINLINK_IMAGE_REPO_PATH")
+				repositoryPath = act.GetInputOrEnv("repo_path", "CHAINLINK_IMAGE_REPO_PATH")
 			}
 			if imageTag == "" {
-				imageTag = act.GetInput("tag")
-			}
-			if imageTag == "" {
-				imageTag = act.Getenv("CHAINLINK_IMAGE_TAG")
+				imageTag = act.GetInputOrEnv("tag", "CHAINLINK_IMAGE_TAG")
 			}
 			if awsAccount == "" {
-				awsAccount = act.GetInput("aws_account")
-			}
-			if awsAccount == "" {
-				awsAccount = act.Getenv("AWS_ACCOUNT_NUMBER")
+				awsAccount = act.GetInputOrEnv("aws_account", "AWS_ACCOUNT_NUMBER")
 			}
 			if awsRegion == "" {
-				awsRegion = act.GetInput("aws_region")
-			}
-			if awsRegion == "" {
-				awsRegion = act.Getenv("AWS_REGION")
+				awsRegion = act.GetInputOrEnv("aws_region", "AWS_REGION")
 			}
 
 			resolved, err := image.Resolve(image.ResolveOptions{

--- a/tools/ci/cmd/image_test.go
+++ b/tools/ci/cmd/image_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestImageResolve_CLI_Public(t *testing.T) {
-	t.Parallel()
+	t.Setenv("GITHUB_OUTPUT", "")
 	rootCmd := cmd.NewRootCmd()
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)

--- a/tools/ci/cmd/root.go
+++ b/tools/ci/cmd/root.go
@@ -23,7 +23,8 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(newToolsCmd())
 	rootCmd.AddCommand(newImageCmd())
 	rootCmd.AddCommand(newChangesetCmd())
-	rootCmd.AddCommand(newCcipCmd())
+	rootCmd.AddCommand(newCCIPCmd())
+	rootCmd.AddCommand(newRunnerCmd())
 
 	return rootCmd
 }

--- a/tools/ci/cmd/runner.go
+++ b/tools/ci/cmd/runner.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -31,7 +30,6 @@ func newRunnerSpotCmd() *cobra.Command {
 		refName         string
 		baseRef         string
 		headRef         string
-		evalTimeStr     string
 		forceOnDemand   bool
 		strategy        string
 		defaultStrategy string
@@ -64,6 +62,24 @@ func newRunnerSpotCmd() *cobra.Command {
 			if headRef == "" && ctx != nil {
 				headRef = ctx.HeadRef
 			}
+			if eventName == "" {
+				eventName = act.Getenv("GITHUB_EVENT_NAME")
+			}
+			if ref == "" {
+				ref = act.Getenv("GITHUB_REF")
+			}
+			if refType == "" {
+				refType = act.Getenv("GITHUB_REF_TYPE")
+			}
+			if refName == "" {
+				refName = act.Getenv("GITHUB_REF_NAME")
+			}
+			if baseRef == "" {
+				baseRef = act.Getenv("GITHUB_BASE_REF")
+			}
+			if headRef == "" {
+				headRef = act.Getenv("GITHUB_HEAD_REF")
+			}
 			if !forceOnDemand {
 				envForce := act.GetInput("force_on_demand")
 				if envForce == "" {
@@ -86,24 +102,6 @@ func newRunnerSpotCmd() *cobra.Command {
 				defaultStrategy = act.Getenv("RUNNER_DEFAULT_SPOT_STRATEGY")
 			}
 
-			var evalTime time.Time
-			if evalTimeStr == "" {
-				evalTimeStr = act.GetInput("time")
-			}
-			if evalTimeStr != "" {
-				var err error
-				evalTime, err = time.Parse(time.RFC3339, evalTimeStr)
-				if err != nil {
-					return fmt.Errorf("invalid time format %q (expected RFC3339): %w", evalTimeStr, err)
-				}
-			} else if envTime := act.Getenv("CI_EVAL_TIME"); envTime != "" {
-				var err error
-				evalTime, err = time.Parse(time.RFC3339, envTime)
-				if err != nil {
-					return fmt.Errorf("invalid CI_EVAL_TIME format %q (expected RFC3339): %w", envTime, err)
-				}
-			}
-
 			res, err := runner.ResolveSpot(runner.SpotInput{
 				EventName:        eventName,
 				Ref:              ref,
@@ -111,7 +109,6 @@ func newRunnerSpotCmd() *cobra.Command {
 				RefName:          refName,
 				BaseRef:          baseRef,
 				HeadRef:          headRef,
-				Timestamp:        evalTime,
 				ForceOnDemand:    forceOnDemand,
 				StrategyOverride: runner.SpotStrategy(strategy),
 				DefaultStrategy:  runner.SpotStrategy(defaultStrategy),
@@ -156,7 +153,6 @@ func newRunnerSpotCmd() *cobra.Command {
 	cmd.Flags().StringVar(&refName, "ref-name", "", "GitHub ref name (env: GITHUB_REF_NAME)")
 	cmd.Flags().StringVar(&baseRef, "base-ref", "", "Target branch for PR (env: GITHUB_BASE_REF)")
 	cmd.Flags().StringVar(&headRef, "head-ref", "", "Source branch for PR (env: GITHUB_HEAD_REF)")
-	cmd.Flags().StringVar(&evalTimeStr, "time", "", "Evaluation timestamp in RFC3339 format (env: CI_EVAL_TIME)")
 	cmd.Flags().BoolVar(&forceOnDemand, "force-on-demand", false, "Force on-demand / disable spot (env: RUNNER_FORCE_ON_DEMAND)")
 	cmd.Flags().StringVar(&strategy, "strategy", "", "Explicit spot strategy override ('co', 'pco', 'lowest-price', 'false') (env: RUNNER_SPOT_STRATEGY)")
 	cmd.Flags().StringVar(&defaultStrategy, "default-strategy", "", "Default spot strategy if enabled ('pco', 'co') (env: RUNNER_DEFAULT_SPOT_STRATEGY)")

--- a/tools/ci/cmd/runner.go
+++ b/tools/ci/cmd/runner.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/smartcontractkit/chainlink/v2/tools/ci/internal/ghaction"
+	"github.com/smartcontractkit/chainlink/v2/tools/ci/internal/runner"
+)
+
+func newRunnerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "runner",
+		Short: "Commands for managing runner configurations and spot strategies",
+	}
+
+	cmd.AddCommand(newRunnerSpotCmd())
+
+	return cmd
+}
+
+func newRunnerSpotCmd() *cobra.Command {
+	var (
+		eventName       string
+		ref             string
+		refType         string
+		refName         string
+		baseRef         string
+		headRef         string
+		evalTimeStr     string
+		forceOnDemand   bool
+		strategy        string
+		defaultStrategy string
+		jsonOutput      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "spot",
+		Short: "Determine the spot setting for runs-on runners",
+		Long:  "Evaluates GitHub event type, branch/tag refs, merge queue status, and strategies to output the optimal spot configuration.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			act := ghaction.New(cmd.OutOrStdout(), "", "")
+			ctx, _ := act.Context()
+
+			if eventName == "" && ctx != nil {
+				eventName = ctx.EventName
+			}
+			if ref == "" && ctx != nil {
+				ref = ctx.Ref
+			}
+			if refType == "" && ctx != nil {
+				refType = ctx.RefType
+			}
+			if refName == "" && ctx != nil {
+				refName = ctx.RefName
+			}
+			if baseRef == "" && ctx != nil {
+				baseRef = ctx.BaseRef
+			}
+			if headRef == "" && ctx != nil {
+				headRef = ctx.HeadRef
+			}
+			if !forceOnDemand {
+				envForce := act.Getenv("RUNNER_FORCE_ON_DEMAND")
+				if envForce == "true" || envForce == "1" {
+					forceOnDemand = true
+				}
+			}
+			if strategy == "" {
+				strategy = act.Getenv("RUNNER_SPOT_STRATEGY")
+			}
+			if defaultStrategy == "" {
+				defaultStrategy = act.Getenv("RUNNER_DEFAULT_SPOT_STRATEGY")
+			}
+
+			var evalTime time.Time
+			if evalTimeStr != "" {
+				var err error
+				evalTime, err = time.Parse(time.RFC3339, evalTimeStr)
+				if err != nil {
+					return fmt.Errorf("invalid time format %q (expected RFC3339): %w", evalTimeStr, err)
+				}
+			} else if envTime := act.Getenv("CI_EVAL_TIME"); envTime != "" {
+				var err error
+				evalTime, err = time.Parse(time.RFC3339, envTime)
+				if err != nil {
+					return fmt.Errorf("invalid CI_EVAL_TIME format %q (expected RFC3339): %w", envTime, err)
+				}
+			}
+
+			res, err := runner.ResolveSpot(runner.SpotInput{
+				EventName:        eventName,
+				Ref:              ref,
+				RefType:          refType,
+				RefName:          refName,
+				BaseRef:          baseRef,
+				HeadRef:          headRef,
+				Timestamp:        evalTime,
+				ForceOnDemand:    forceOnDemand,
+				StrategyOverride: runner.SpotStrategy(strategy),
+				DefaultStrategy:  runner.SpotStrategy(defaultStrategy),
+			})
+			if err != nil {
+				return err
+			}
+
+			if os.Getenv("GITHUB_OUTPUT") != "" {
+				outputs := map[string]string{
+					"spot":           res.Spot,
+					"spot_flag":      res.SpotFlag,
+					"enabled":        strconv.FormatBool(res.Enabled),
+					"strategy":       string(res.Strategy),
+					"reason":         res.Reason,
+					"is_release":     strconv.FormatBool(res.IsRelease),
+					"is_merge_queue": strconv.FormatBool(res.IsMergeQueue),
+				}
+				if err := act.SetOutputs(outputs); err != nil {
+					return err
+				}
+			}
+
+			if jsonOutput {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(res)
+			}
+
+			if os.Getenv("GITHUB_OUTPUT") == "" {
+				fmt.Fprintln(cmd.OutOrStdout(), res.SpotFlag)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&eventName, "event", "", "GitHub event name (env: GITHUB_EVENT_NAME)")
+	cmd.Flags().StringVar(&ref, "ref", "", "GitHub ref (env: GITHUB_REF)")
+	cmd.Flags().StringVar(&refType, "ref-type", "", "GitHub ref type (branch/tag) (env: GITHUB_REF_TYPE)")
+	cmd.Flags().StringVar(&refName, "ref-name", "", "GitHub ref name (env: GITHUB_REF_NAME)")
+	cmd.Flags().StringVar(&baseRef, "base-ref", "", "Target branch for PR (env: GITHUB_BASE_REF)")
+	cmd.Flags().StringVar(&headRef, "head-ref", "", "Source branch for PR (env: GITHUB_HEAD_REF)")
+	cmd.Flags().StringVar(&evalTimeStr, "time", "", "Evaluation timestamp in RFC3339 format (env: CI_EVAL_TIME)")
+	cmd.Flags().BoolVar(&forceOnDemand, "force-on-demand", false, "Force on-demand / disable spot (env: RUNNER_FORCE_ON_DEMAND)")
+	cmd.Flags().StringVar(&strategy, "strategy", "", "Explicit spot strategy override ('co', 'pco', 'lowest-price', 'false') (env: RUNNER_SPOT_STRATEGY)")
+	cmd.Flags().StringVar(&defaultStrategy, "default-strategy", "", "Default spot strategy if enabled ('pco', 'co') (env: RUNNER_DEFAULT_SPOT_STRATEGY)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output resolved spot configuration in JSON format")
+
+	return cmd
+}

--- a/tools/ci/cmd/runner.go
+++ b/tools/ci/cmd/runner.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"time"
 
@@ -44,7 +43,7 @@ func newRunnerSpotCmd() *cobra.Command {
 		Short: "Determine the spot setting for runs-on runners",
 		Long:  "Evaluates GitHub event type, branch/tag refs, merge queue status, and strategies to output the optimal spot configuration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			act := ghaction.New(cmd.OutOrStdout(), "", "")
+			act := ghaction.NewAction(cmd.OutOrStdout())
 			ctx, _ := act.Context()
 
 			if eventName == "" && ctx != nil {
@@ -66,19 +65,31 @@ func newRunnerSpotCmd() *cobra.Command {
 				headRef = ctx.HeadRef
 			}
 			if !forceOnDemand {
-				envForce := act.Getenv("RUNNER_FORCE_ON_DEMAND")
+				envForce := act.GetInput("force_on_demand")
+				if envForce == "" {
+					envForce = act.Getenv("RUNNER_FORCE_ON_DEMAND")
+				}
 				if envForce == "true" || envForce == "1" {
 					forceOnDemand = true
 				}
 			}
 			if strategy == "" {
+				strategy = act.GetInput("strategy")
+			}
+			if strategy == "" {
 				strategy = act.Getenv("RUNNER_SPOT_STRATEGY")
+			}
+			if defaultStrategy == "" {
+				defaultStrategy = act.GetInput("default_strategy")
 			}
 			if defaultStrategy == "" {
 				defaultStrategy = act.Getenv("RUNNER_DEFAULT_SPOT_STRATEGY")
 			}
 
 			var evalTime time.Time
+			if evalTimeStr == "" {
+				evalTimeStr = act.GetInput("time")
+			}
 			if evalTimeStr != "" {
 				var err error
 				evalTime, err = time.Parse(time.RFC3339, evalTimeStr)
@@ -109,7 +120,7 @@ func newRunnerSpotCmd() *cobra.Command {
 				return err
 			}
 
-			if os.Getenv("GITHUB_OUTPUT") != "" {
+			if act.Getenv("GITHUB_OUTPUT") != "" {
 				outputs := map[string]string{
 					"spot":           res.Spot,
 					"spot_flag":      res.SpotFlag,
@@ -131,7 +142,7 @@ func newRunnerSpotCmd() *cobra.Command {
 				return enc.Encode(res)
 			}
 
-			if os.Getenv("GITHUB_OUTPUT") == "" {
+			if act.Getenv("GITHUB_OUTPUT") == "" {
 				fmt.Fprintln(cmd.OutOrStdout(), res.SpotFlag)
 			}
 

--- a/tools/ci/cmd/runner.go
+++ b/tools/ci/cmd/runner.go
@@ -113,6 +113,7 @@ func newRunnerSpotCmd() *cobra.Command {
 				outputs := map[string]string{
 					"spot":           res.Spot,
 					"spot_flag":      res.SpotFlag,
+					"spot_param":     res.SpotFlag,
 					"enabled":        strconv.FormatBool(res.Enabled),
 					"strategy":       string(res.Strategy),
 					"reason":         res.Reason,

--- a/tools/ci/cmd/runner.go
+++ b/tools/ci/cmd/runner.go
@@ -42,7 +42,10 @@ func newRunnerSpotCmd() *cobra.Command {
 		Long:  "Evaluates GitHub event type, branch/tag refs, merge queue status, and strategies to output the optimal spot configuration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			act := ghaction.NewAction(cmd.OutOrStdout())
-			ctx, _ := act.Context()
+			ctx, ctxErr := act.Context()
+			if ctxErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: unable to parse GitHub Actions context: %v; falling back to environment variables\n", ctxErr)
+			}
 
 			if eventName == "" && ctx != nil {
 				eventName = ctx.EventName
@@ -81,25 +84,15 @@ func newRunnerSpotCmd() *cobra.Command {
 				headRef = act.Getenv("GITHUB_HEAD_REF")
 			}
 			if !forceOnDemand {
-				envForce := act.GetInput("force_on_demand")
-				if envForce == "" {
-					envForce = act.Getenv("RUNNER_FORCE_ON_DEMAND")
-				}
-				if envForce == "true" || envForce == "1" {
+				if v := act.GetInputOrEnv("force-on-demand", "RUNNER_FORCE_ON_DEMAND"); v == "true" || v == "1" {
 					forceOnDemand = true
 				}
 			}
 			if strategy == "" {
-				strategy = act.GetInput("strategy")
-			}
-			if strategy == "" {
-				strategy = act.Getenv("RUNNER_SPOT_STRATEGY")
+				strategy = act.GetInputOrEnv("strategy", "RUNNER_SPOT_STRATEGY")
 			}
 			if defaultStrategy == "" {
-				defaultStrategy = act.GetInput("default_strategy")
-			}
-			if defaultStrategy == "" {
-				defaultStrategy = act.Getenv("RUNNER_DEFAULT_SPOT_STRATEGY")
+				defaultStrategy = act.GetInputOrEnv("default-strategy", "RUNNER_DEFAULT_SPOT_STRATEGY")
 			}
 
 			res, err := runner.ResolveSpot(runner.SpotInput{

--- a/tools/ci/cmd/runner_test.go
+++ b/tools/ci/cmd/runner_test.go
@@ -69,6 +69,7 @@ func TestRunnerSpot_CLI_GithubOutput(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(ghContent), "spot")
 	assert.Contains(t, string(ghContent), "spot_flag")
+	assert.Contains(t, string(ghContent), "spot_param")
 	assert.Contains(t, string(ghContent), "is_release")
 }
 

--- a/tools/ci/cmd/runner_test.go
+++ b/tools/ci/cmd/runner_test.go
@@ -37,7 +37,7 @@ func TestRunnerSpot_CLI_JSON(t *testing.T) {
 }
 
 func TestRunnerSpot_CLI_Human(t *testing.T) {
-	t.Parallel()
+	t.Setenv("GITHUB_OUTPUT", "")
 
 	rootCmd := cmd.NewRootCmd()
 	var out bytes.Buffer
@@ -74,6 +74,7 @@ func TestRunnerSpot_CLI_GithubOutput(t *testing.T) {
 }
 
 func TestRunnerSpot_CLI_EnvFallback(t *testing.T) {
+	t.Setenv("GITHUB_OUTPUT", "")
 	t.Setenv("GITHUB_EVENT_NAME", "merge_group")
 	t.Setenv("GITHUB_REF", "refs/heads/gh-readonly-queue/develop/pr-123")
 

--- a/tools/ci/cmd/runner_test.go
+++ b/tools/ci/cmd/runner_test.go
@@ -1,0 +1,88 @@
+package cmd_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/tools/ci/cmd"
+	"github.com/smartcontractkit/chainlink/v2/tools/ci/internal/runner"
+)
+
+func TestRunnerSpot_CLI_JSON(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := cmd.NewRootCmd()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"runner", "spot", "--event", "merge_group", "--json"})
+
+	err := rootCmd.ExecuteContext(context.Background())
+	require.NoError(t, err)
+
+	var res runner.SpotResult
+	err = json.Unmarshal(out.Bytes(), &res)
+	require.NoError(t, err)
+	assert.Equal(t, "false", res.Spot)
+	assert.Equal(t, "spot=false", res.SpotFlag)
+	assert.False(t, res.Enabled)
+	assert.True(t, res.IsMergeQueue)
+}
+
+func TestRunnerSpot_CLI_Human(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := cmd.NewRootCmd()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"runner", "spot", "--event", "push", "--ref", "refs/heads/develop"})
+
+	err := rootCmd.ExecuteContext(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "spot=co\n", out.String())
+}
+
+func TestRunnerSpot_CLI_GithubOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	ghOutput := filepath.Join(tmpDir, "gh_output")
+	require.NoError(t, os.WriteFile(ghOutput, []byte{}, 0o600))
+	t.Setenv("GITHUB_OUTPUT", ghOutput)
+
+	rootCmd := cmd.NewRootCmd()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"runner", "spot", "--event", "pull_request", "--base-ref", "release/2.57.1"})
+
+	err := rootCmd.ExecuteContext(context.Background())
+	require.NoError(t, err)
+
+	ghContent, err := os.ReadFile(ghOutput)
+	require.NoError(t, err)
+	assert.Contains(t, string(ghContent), "spot")
+	assert.Contains(t, string(ghContent), "spot_flag")
+	assert.Contains(t, string(ghContent), "is_release")
+}
+
+func TestRunnerSpot_CLI_EnvFallback(t *testing.T) {
+	t.Setenv("GITHUB_EVENT_NAME", "merge_group")
+	t.Setenv("GITHUB_REF", "refs/heads/gh-readonly-queue/develop/pr-123")
+
+	rootCmd := cmd.NewRootCmd()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"runner", "spot"})
+
+	err := rootCmd.ExecuteContext(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "spot=false\n", out.String())
+}

--- a/tools/ci/cmd/tools.go
+++ b/tools/ci/cmd/tools.go
@@ -69,9 +69,23 @@ func runToolsMatrix(ctx context.Context, cmd *cobra.Command, opts *toolsMatrixOp
 		return fmt.Errorf("failed to discover tool targets: %w", err)
 	}
 
+	act := ghaction.New(cmd.OutOrStdout(), "", "")
+	ghCtx, _ := act.Context()
+
 	eventName := opts.eventName
+	if eventName == "" && ghCtx != nil {
+		eventName = ghCtx.EventName
+	}
 	if eventName == "" {
-		eventName = os.Getenv("GITHUB_EVENT_NAME")
+		eventName = act.Getenv("GITHUB_EVENT_NAME")
+	}
+
+	baseRef := opts.baseRef
+	if baseRef == "" && ghCtx != nil {
+		baseRef = ghCtx.BaseRef
+	}
+	if baseRef == "" {
+		baseRef = act.Getenv("GITHUB_BASE_REF")
 	}
 
 	var changedFileList []string
@@ -86,7 +100,7 @@ func runToolsMatrix(ctx context.Context, cmd *cobra.Command, opts *toolsMatrixOp
 		}
 	} else if !opts.all && eventName != "schedule" && eventName != "workflow_dispatch" {
 		var diffErr error
-		changedFileList, diffErr = getGitChangedFiles(ctx, repoRoot, opts.baseRef)
+		changedFileList, diffErr = getGitChangedFiles(ctx, repoRoot, baseRef)
 		if diffErr != nil {
 			// Fall back to running all tool targets if diff cannot be resolved (e.g. shallow clone in CI)
 			opts.all = true
@@ -121,8 +135,7 @@ func runToolsMatrix(ctx context.Context, cmd *cobra.Command, opts *toolsMatrixOp
 	}
 
 	if os.Getenv("GITHUB_OUTPUT") != "" {
-		gha := ghaction.New(cmd.OutOrStdout(), "", "")
-		if err := gha.SetOutput("matrix", string(jsonData)); err != nil {
+		if err := act.SetOutput("matrix", string(jsonData)); err != nil {
 			return fmt.Errorf("failed to set GitHub action output: %w", err)
 		}
 	}

--- a/tools/ci/cmd/tools.go
+++ b/tools/ci/cmd/tools.go
@@ -69,12 +69,15 @@ func runToolsMatrix(ctx context.Context, cmd *cobra.Command, opts *toolsMatrixOp
 		return fmt.Errorf("failed to discover tool targets: %w", err)
 	}
 
-	act := ghaction.New(cmd.OutOrStdout(), "", "")
+	act := ghaction.NewAction(cmd.OutOrStdout())
 	ghCtx, _ := act.Context()
 
 	eventName := opts.eventName
 	if eventName == "" && ghCtx != nil {
 		eventName = ghCtx.EventName
+	}
+	if eventName == "" {
+		eventName = act.GetInput("event_name")
 	}
 	if eventName == "" {
 		eventName = act.Getenv("GITHUB_EVENT_NAME")
@@ -85,7 +88,20 @@ func runToolsMatrix(ctx context.Context, cmd *cobra.Command, opts *toolsMatrixOp
 		baseRef = ghCtx.BaseRef
 	}
 	if baseRef == "" {
+		baseRef = act.GetInput("base_ref")
+	}
+	if baseRef == "" {
 		baseRef = act.Getenv("GITHUB_BASE_REF")
+	}
+
+	if opts.changedFiles == "" {
+		opts.changedFiles = act.GetInput("changed_files")
+	}
+	if !opts.all {
+		allInput := act.GetInput("all")
+		if allInput == "true" || allInput == "1" {
+			opts.all = true
+		}
 	}
 
 	var changedFileList []string
@@ -127,14 +143,14 @@ func runToolsMatrix(ctx context.Context, cmd *cobra.Command, opts *toolsMatrixOp
 		if err := enc.Encode(filteredTargets); err != nil {
 			return fmt.Errorf("failed to encode targets to JSON: %w", err)
 		}
-	} else if os.Getenv("GITHUB_OUTPUT") == "" {
+	} else if act.Getenv("GITHUB_OUTPUT") == "" {
 		fmt.Fprintf(cmd.OutOrStdout(), "Discovered %d targets (%d selected):\n", len(allTargets), len(filteredTargets))
 		for _, t := range filteredTargets {
 			fmt.Fprintf(cmd.OutOrStdout(), "  - %s (dir: %s, packages: %s)\n", t.Name, t.Dir, t.Packages)
 		}
 	}
 
-	if os.Getenv("GITHUB_OUTPUT") != "" {
+	if act.Getenv("GITHUB_OUTPUT") != "" {
 		if err := act.SetOutput("matrix", string(jsonData)); err != nil {
 			return fmt.Errorf("failed to set GitHub action output: %w", err)
 		}
@@ -145,7 +161,7 @@ func runToolsMatrix(ctx context.Context, cmd *cobra.Command, opts *toolsMatrixOp
 
 func getGitChangedFiles(ctx context.Context, repoRoot, baseRef string) ([]string, error) {
 	if baseRef == "" {
-		baseRef = os.Getenv("GITHUB_BASE_REF")
+		baseRef = "origin/develop"
 	}
 
 	var candidates []string

--- a/tools/ci/cmd/tools.go
+++ b/tools/ci/cmd/tools.go
@@ -77,10 +77,7 @@ func runToolsMatrix(ctx context.Context, cmd *cobra.Command, opts *toolsMatrixOp
 		eventName = ghCtx.EventName
 	}
 	if eventName == "" {
-		eventName = act.GetInput("event_name")
-	}
-	if eventName == "" {
-		eventName = act.Getenv("GITHUB_EVENT_NAME")
+		eventName = act.GetInputOrEnv("event_name", "GITHUB_EVENT_NAME")
 	}
 
 	baseRef := opts.baseRef
@@ -88,10 +85,7 @@ func runToolsMatrix(ctx context.Context, cmd *cobra.Command, opts *toolsMatrixOp
 		baseRef = ghCtx.BaseRef
 	}
 	if baseRef == "" {
-		baseRef = act.GetInput("base_ref")
-	}
-	if baseRef == "" {
-		baseRef = act.Getenv("GITHUB_BASE_REF")
+		baseRef = act.GetInputOrEnv("base_ref", "GITHUB_BASE_REF")
 	}
 
 	if opts.changedFiles == "" {

--- a/tools/ci/internal/ghaction/ghaction.go
+++ b/tools/ci/internal/ghaction/ghaction.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"io"
 	"os"
+	"sort"
 
 	"github.com/sethvargo/go-githubactions"
 )
@@ -16,6 +17,11 @@ type Action struct {
 	outputPath  string
 	envPath     string
 	summaryPath string
+}
+
+// NewAction creates a new Action context with default environment variable paths.
+func NewAction(out io.Writer) *Action {
+	return New(out, "", "")
 }
 
 // New creates a new Action context. If outputPath or envPath are empty,
@@ -76,8 +82,13 @@ func (a *Action) SetOutput(key, value string) error {
 
 // SetOutputs writes multiple key-value pairs to GITHUB_OUTPUT file, or falls back to out when unset.
 func (a *Action) SetOutputs(outputs map[string]string) error {
-	for k, v := range outputs {
-		if err := a.SetOutput(k, v); err != nil {
+	keys := make([]string, 0, len(outputs))
+	for k := range outputs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if err := a.SetOutput(k, outputs[k]); err != nil {
 			return err
 		}
 	}

--- a/tools/ci/internal/ghaction/ghaction.go
+++ b/tools/ci/internal/ghaction/ghaction.go
@@ -2,10 +2,10 @@ package ghaction
 
 import (
 	"fmt"
-	"html/template"
 	"io"
 	"os"
 	"sort"
+	"text/template"
 
 	"github.com/sethvargo/go-githubactions"
 )

--- a/tools/ci/internal/ghaction/ghaction.go
+++ b/tools/ci/internal/ghaction/ghaction.go
@@ -2,6 +2,7 @@ package ghaction
 
 import (
 	"fmt"
+	"html/template"
 	"io"
 	"os"
 
@@ -73,6 +74,16 @@ func (a *Action) SetOutput(key, value string) error {
 	return nil
 }
 
+// SetOutputs writes multiple key-value pairs to GITHUB_OUTPUT file, or falls back to out when unset.
+func (a *Action) SetOutputs(outputs map[string]string) error {
+	for k, v := range outputs {
+		if err := a.SetOutput(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SetEnv writes a key-value pair to GITHUB_ENV file, or falls back to out when unset.
 func (a *Action) SetEnv(key, value string) error {
 	if a.envPath == "" {
@@ -91,6 +102,32 @@ func (a *Action) AddStepSummary(markdown string) error {
 	}
 	a.Action.AddStepSummary(markdown)
 	return nil
+}
+
+// AddStepSummaryTemplate parses and executes a template string, writing the result to GITHUB_STEP_SUMMARY or out.
+func (a *Action) AddStepSummaryTemplate(tmpl string, data any) error {
+	if a.summaryPath == "" {
+		t, err := template.New("summary").Parse(tmpl)
+		if err != nil {
+			return fmt.Errorf("failed to parse summary template: %w", err)
+		}
+		if err := t.Execute(a.out, data); err != nil {
+			return fmt.Errorf("failed to execute summary template: %w", err)
+		}
+		fmt.Fprintln(a.out)
+		return nil
+	}
+	return a.Action.AddStepSummaryTemplate(tmpl, data)
+}
+
+// IsGitHubActions returns true if executing in a GitHub Actions runner environment.
+func (a *Action) IsGitHubActions() bool {
+	return a.Getenv("GITHUB_ACTIONS") == "true" || a.outputPath != ""
+}
+
+// Context returns the typed GitHubContext populated from GitHub Actions environment variables and event payload.
+func (a *Action) Context() (*githubactions.GitHubContext, error) {
+	return a.Action.Context()
 }
 
 // WithGroup executes fn wrapped inside a group command block.

--- a/tools/ci/internal/ghaction/ghaction.go
+++ b/tools/ci/internal/ghaction/ghaction.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"sort"
-	"text/template"
 
 	"github.com/sethvargo/go-githubactions"
 )
@@ -105,6 +104,15 @@ func (a *Action) SetEnv(key, value string) error {
 	return nil
 }
 
+// GetInputOrEnv returns the value of the given action input, falling back to
+// the given environment variable when the input is unset or empty.
+func (a *Action) GetInputOrEnv(inputKey, envKey string) string {
+	if v := a.GetInput(inputKey); v != "" {
+		return v
+	}
+	return a.Getenv(envKey)
+}
+
 // AddStepSummary writes markdown content to GITHUB_STEP_SUMMARY file, or falls back to out when unset.
 func (a *Action) AddStepSummary(markdown string) error {
 	if a.summaryPath == "" {
@@ -113,27 +121,6 @@ func (a *Action) AddStepSummary(markdown string) error {
 	}
 	a.Action.AddStepSummary(markdown)
 	return nil
-}
-
-// AddStepSummaryTemplate parses and executes a template string, writing the result to GITHUB_STEP_SUMMARY or out.
-func (a *Action) AddStepSummaryTemplate(tmpl string, data any) error {
-	if a.summaryPath == "" {
-		t, err := template.New("summary").Parse(tmpl)
-		if err != nil {
-			return fmt.Errorf("failed to parse summary template: %w", err)
-		}
-		if err := t.Execute(a.out, data); err != nil {
-			return fmt.Errorf("failed to execute summary template: %w", err)
-		}
-		fmt.Fprintln(a.out)
-		return nil
-	}
-	return a.Action.AddStepSummaryTemplate(tmpl, data)
-}
-
-// IsGitHubActions returns true if executing in a GitHub Actions runner environment.
-func (a *Action) IsGitHubActions() bool {
-	return a.Getenv("GITHUB_ACTIONS") == "true" || a.outputPath != ""
 }
 
 // Context returns the typed GitHubContext populated from GitHub Actions environment variables and event payload.

--- a/tools/ci/internal/ghaction/ghaction_test.go
+++ b/tools/ci/internal/ghaction/ghaction_test.go
@@ -1,0 +1,93 @@
+package ghaction_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/tools/ci/internal/ghaction"
+)
+
+func TestGHAction_SetOutput_FallbackStdout(t *testing.T) {
+	t.Setenv("GITHUB_OUTPUT", "")
+	var stdout bytes.Buffer
+	act := ghaction.NewAction(&stdout)
+
+	err := act.SetOutput("key", "value")
+	require.NoError(t, err)
+	assert.Equal(t, "key=value\n", stdout.String())
+}
+
+func TestGHAction_SetOutputs_FallbackStdout(t *testing.T) {
+	t.Setenv("GITHUB_OUTPUT", "")
+	var stdout bytes.Buffer
+	act := ghaction.NewAction(&stdout)
+
+	outputs := map[string]string{
+		"spot":     "co",
+		"strategy": "capacity-optimized",
+	}
+	err := act.SetOutputs(outputs)
+	require.NoError(t, err)
+	assert.Equal(t, "spot=co\nstrategy=capacity-optimized\n", stdout.String())
+}
+
+func TestGHAction_SetEnv_FallbackStdout(t *testing.T) {
+	t.Setenv("GITHUB_ENV", "")
+	var stdout bytes.Buffer
+	act := ghaction.NewAction(&stdout)
+
+	err := act.SetEnv("MY_VAR", "my_val")
+	require.NoError(t, err)
+	assert.Equal(t, "MY_VAR=my_val\n", stdout.String())
+}
+
+func TestGHAction_AddStepSummary_FallbackStdout(t *testing.T) {
+	t.Setenv("GITHUB_STEP_SUMMARY", "")
+	var stdout bytes.Buffer
+	act := ghaction.NewWithOptions(&stdout, "", "", "")
+
+	err := act.AddStepSummary("### Summary Table")
+	require.NoError(t, err)
+	assert.Equal(t, "### Summary Table\n", stdout.String())
+}
+
+func TestGHAction_AddStepSummaryTemplate(t *testing.T) {
+	t.Setenv("GITHUB_STEP_SUMMARY", "")
+	var stdout bytes.Buffer
+	act := ghaction.NewWithOptions(&stdout, "", "", "")
+
+	data := struct {
+		Name string
+	}{Name: "Runner"}
+	err := act.AddStepSummaryTemplate("### Hello {{.Name}}", data)
+	require.NoError(t, err)
+	assert.Equal(t, "### Hello Runner\n", stdout.String())
+}
+
+func TestGHAction_IsGitHubActions(t *testing.T) {
+	var stdout bytes.Buffer
+	act1 := ghaction.New(&stdout, "/path/to/output", "")
+	assert.True(t, act1.IsGitHubActions())
+
+	t.Setenv("GITHUB_ACTIONS", "")
+	act2 := ghaction.NewWithOptions(&stdout, "", "", "")
+	assert.False(t, act2.IsGitHubActions())
+}
+
+func TestGHAction_WithGroup(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	act := ghaction.NewAction(&stdout)
+
+	ran := false
+	act.WithGroup("grouped-task", func() {
+		ran = true
+	})
+
+	assert.True(t, ran)
+	assert.Contains(t, stdout.String(), "grouped-task")
+}

--- a/tools/ci/internal/ghaction/ghaction_test.go
+++ b/tools/ci/internal/ghaction/ghaction_test.go
@@ -67,6 +67,19 @@ func TestGHAction_AddStepSummaryTemplate(t *testing.T) {
 	assert.Equal(t, "### Hello Runner\n", stdout.String())
 }
 
+func TestGHAction_AddStepSummaryTemplate_NoHTMLEscaping(t *testing.T) {
+	t.Setenv("GITHUB_STEP_SUMMARY", "")
+	var stdout bytes.Buffer
+	act := ghaction.NewWithOptions(&stdout, "", "", "")
+
+	data := struct {
+		Name string
+	}{Name: "Runner & <team>"}
+	err := act.AddStepSummaryTemplate("### Hello {{.Name}}", data)
+	require.NoError(t, err)
+	assert.Equal(t, "### Hello Runner & <team>\n", stdout.String())
+}
+
 func TestGHAction_IsGitHubActions(t *testing.T) {
 	var stdout bytes.Buffer
 	act1 := ghaction.New(&stdout, "/path/to/output", "")

--- a/tools/ci/internal/ghaction/ghaction_test.go
+++ b/tools/ci/internal/ghaction/ghaction_test.go
@@ -73,6 +73,7 @@ func TestGHAction_IsGitHubActions(t *testing.T) {
 	assert.True(t, act1.IsGitHubActions())
 
 	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("GITHUB_OUTPUT", "")
 	act2 := ghaction.NewWithOptions(&stdout, "", "", "")
 	assert.False(t, act2.IsGitHubActions())
 }

--- a/tools/ci/internal/ghaction/ghaction_test.go
+++ b/tools/ci/internal/ghaction/ghaction_test.go
@@ -54,41 +54,19 @@ func TestGHAction_AddStepSummary_FallbackStdout(t *testing.T) {
 	assert.Equal(t, "### Summary Table\n", stdout.String())
 }
 
-func TestGHAction_AddStepSummaryTemplate(t *testing.T) {
-	t.Setenv("GITHUB_STEP_SUMMARY", "")
+func TestGHAction_GetInputOrEnv(t *testing.T) {
+	t.Setenv("INPUT_MY-INPUT", "")
+	t.Setenv("MY_ENV_VAR", "")
 	var stdout bytes.Buffer
-	act := ghaction.NewWithOptions(&stdout, "", "", "")
+	act := ghaction.NewAction(&stdout)
 
-	data := struct {
-		Name string
-	}{Name: "Runner"}
-	err := act.AddStepSummaryTemplate("### Hello {{.Name}}", data)
-	require.NoError(t, err)
-	assert.Equal(t, "### Hello Runner\n", stdout.String())
-}
+	assert.Empty(t, act.GetInputOrEnv("my-input", "MY_ENV_VAR"))
 
-func TestGHAction_AddStepSummaryTemplate_NoHTMLEscaping(t *testing.T) {
-	t.Setenv("GITHUB_STEP_SUMMARY", "")
-	var stdout bytes.Buffer
-	act := ghaction.NewWithOptions(&stdout, "", "", "")
+	t.Setenv("MY_ENV_VAR", "from-env")
+	assert.Equal(t, "from-env", act.GetInputOrEnv("my-input", "MY_ENV_VAR"))
 
-	data := struct {
-		Name string
-	}{Name: "Runner & <team>"}
-	err := act.AddStepSummaryTemplate("### Hello {{.Name}}", data)
-	require.NoError(t, err)
-	assert.Equal(t, "### Hello Runner & <team>\n", stdout.String())
-}
-
-func TestGHAction_IsGitHubActions(t *testing.T) {
-	var stdout bytes.Buffer
-	act1 := ghaction.New(&stdout, "/path/to/output", "")
-	assert.True(t, act1.IsGitHubActions())
-
-	t.Setenv("GITHUB_ACTIONS", "")
-	t.Setenv("GITHUB_OUTPUT", "")
-	act2 := ghaction.NewWithOptions(&stdout, "", "", "")
-	assert.False(t, act2.IsGitHubActions())
+	t.Setenv("INPUT_MY-INPUT", "from-input")
+	assert.Equal(t, "from-input", act.GetInputOrEnv("my-input", "MY_ENV_VAR"))
 }
 
 func TestGHAction_WithGroup(t *testing.T) {

--- a/tools/ci/internal/runner/spot.go
+++ b/tools/ci/internal/runner/spot.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"fmt"
 	"strings"
-	"time"
 )
 
 // SpotStrategy represents a RunsOn spot allocation strategy or on-demand setting.
@@ -28,7 +27,6 @@ type SpotInput struct {
 	RefName          string       // GITHUB_REF_NAME (e.g., "develop", "release/2.57.1", "v2.57.1")
 	BaseRef          string       // GITHUB_BASE_REF (target branch for PR, e.g., "develop", "release/2.57.1")
 	HeadRef          string       // GITHUB_HEAD_REF (source branch for PR)
-	Timestamp        time.Time    // Evaluation timestamp (for time/day-of-week heuristics)
 	ForceOnDemand    bool         // Explicit flag to disable spot
 	StrategyOverride SpotStrategy // Explicit strategy override
 	DefaultStrategy  SpotStrategy // Default strategy if spot is enabled (defaults to pco)
@@ -94,19 +92,19 @@ func isDefaultBranch(ref, refName string) bool {
 		cleanName == "develop" || cleanName == "main" || cleanName == "master"
 }
 
-func normalizeStrategy(s SpotStrategy) (SpotStrategy, string) {
+func normalizeStrategy(s SpotStrategy) (SpotStrategy, string, error) {
 	lower := strings.ToLower(strings.TrimSpace(string(s)))
 	switch lower {
 	case "false", "off", "0", "no", "on-demand", "ondemand", "none":
-		return SpotDisabled, "false"
+		return SpotDisabled, "false", nil
 	case "co", "capacity-optimized", "capacity_optimized":
-		return SpotCapacityOptimized, "co"
+		return SpotCapacityOptimized, "co", nil
 	case "pco", "price-capacity-optimized", "price_capacity_optimized", "true", "on", "1", "yes":
-		return SpotPriceCapacityOptimized, "pco"
+		return SpotPriceCapacityOptimized, "pco", nil
 	case "lp", "lowest-price", "lowest_price":
-		return SpotLowestPrice, "lowest-price"
+		return SpotLowestPrice, "lowest-price", nil
 	default:
-		return SpotStrategy(lower), lower
+		return SpotStrategy(lower), lower, fmt.Errorf("invalid spot strategy %q (expected 'false', 'co', 'pco', or 'lowest-price')", s)
 	}
 }
 
@@ -127,7 +125,10 @@ func ResolveSpot(input SpotInput) (SpotResult, error) {
 
 	// 2. Check explicit strategy override
 	if input.StrategyOverride != "" {
-		strategyOverride, spotVal := normalizeStrategy(input.StrategyOverride)
+		strategyOverride, spotVal, err := normalizeStrategy(input.StrategyOverride)
+		if err != nil {
+			return SpotResult{}, fmt.Errorf("invalid spot strategy override %q: %w", input.StrategyOverride, err)
+		}
 		enabled := strategyOverride != SpotDisabled
 		flag := "spot=" + spotVal
 		return SpotResult{
@@ -181,7 +182,10 @@ func ResolveSpot(input SpotInput) (SpotResult, error) {
 	if defaultStrategy == "" {
 		defaultStrategy = SpotPriceCapacityOptimized
 	}
-	resolvedStrategy, spotVal := normalizeStrategy(defaultStrategy)
+	resolvedStrategy, spotVal, err := normalizeStrategy(defaultStrategy)
+	if err != nil {
+		return SpotResult{}, fmt.Errorf("invalid default spot strategy %q: %w", input.DefaultStrategy, err)
+	}
 	enabled := resolvedStrategy != SpotDisabled
 	flag := "spot=" + spotVal
 

--- a/tools/ci/internal/runner/spot.go
+++ b/tools/ci/internal/runner/spot.go
@@ -1,0 +1,205 @@
+package runner
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// SpotStrategy represents a RunsOn spot allocation strategy or on-demand setting.
+type SpotStrategy string
+
+const (
+	// SpotDisabled represents on-demand EC2 instances (spot=false).
+	SpotDisabled SpotStrategy = "false"
+	// SpotCapacityOptimized prioritizes pools with most available capacity (spot=co).
+	SpotCapacityOptimized SpotStrategy = "co"
+	// SpotPriceCapacityOptimized balances price and capacity (spot=pco).
+	SpotPriceCapacityOptimized SpotStrategy = "pco"
+	// SpotLowestPrice selects the cheapest available pool (spot=lowest-price / spot=lp).
+	SpotLowestPrice SpotStrategy = "lowest-price"
+)
+
+// SpotInput contains the environment and context factors for determining the spot setting.
+type SpotInput struct {
+	EventName        string       // GITHUB_EVENT_NAME (e.g., "pull_request", "push", "merge_group", "release", "schedule", "workflow_dispatch")
+	Ref              string       // GITHUB_REF (e.g., "refs/heads/develop", "refs/heads/release/2.57.1", "refs/tags/v2.57.1")
+	RefType          string       // GITHUB_REF_TYPE ("branch" or "tag")
+	RefName          string       // GITHUB_REF_NAME (e.g., "develop", "release/2.57.1", "v2.57.1")
+	BaseRef          string       // GITHUB_BASE_REF (target branch for PR, e.g., "develop", "release/2.57.1")
+	HeadRef          string       // GITHUB_HEAD_REF (source branch for PR)
+	Timestamp        time.Time    // Evaluation timestamp (for time/day-of-week heuristics)
+	ForceOnDemand    bool         // Explicit flag to disable spot
+	StrategyOverride SpotStrategy // Explicit strategy override
+	DefaultStrategy  SpotStrategy // Default strategy if spot is enabled (defaults to pco)
+}
+
+// SpotResult is the evaluation result for runs-on spot configuration.
+type SpotResult struct {
+	Spot         string       `json:"spot"`           // "false", "co", "pco", "lowest-price"
+	SpotFlag     string       `json:"spot_flag"`      // "spot=false", "spot=co", "spot=pco", "spot=lowest-price"
+	Enabled      bool         `json:"enabled"`        // true if spot is enabled, false if on-demand
+	Strategy     SpotStrategy `json:"strategy"`       // SpotDisabled, SpotCapacityOptimized, SpotPriceCapacityOptimized, SpotLowestPrice
+	Reason       string       `json:"reason"`         // Human-readable explanation of why this setting was chosen
+	IsRelease    bool         `json:"is_release"`     // true if evaluated as release branch/tag
+	IsMergeQueue bool         `json:"is_merge_queue"` // true if evaluated as merge queue event/branch
+}
+
+func isMergeQueue(eventName, ref, refName string) bool {
+	if eventName == "merge_group" {
+		return true
+	}
+	cleanRef := strings.TrimPrefix(ref, "refs/heads/")
+	if strings.HasPrefix(cleanRef, "gh-readonly-queue/") || strings.HasPrefix(refName, "gh-readonly-queue/") {
+		return true
+	}
+	return false
+}
+
+func isReleaseBranch(name string) bool {
+	clean := strings.ToLower(strings.TrimPrefix(name, "refs/heads/"))
+	if clean == "" {
+		return false
+	}
+	if clean == "release" || clean == "releases" {
+		return true
+	}
+	if strings.HasPrefix(clean, "release/") ||
+		strings.HasPrefix(clean, "releases/") ||
+		strings.HasPrefix(clean, "release-") ||
+		strings.HasPrefix(clean, "hotfix/") ||
+		strings.HasPrefix(clean, "hotfix-") {
+		return true
+	}
+	return false
+}
+
+func isReleaseOrTag(eventName, ref, refType, refName, baseRef string) bool {
+	if eventName == "release" {
+		return true
+	}
+	if refType == "tag" || strings.HasPrefix(ref, "refs/tags/") {
+		return true
+	}
+	if isReleaseBranch(ref) || isReleaseBranch(refName) || isReleaseBranch(baseRef) {
+		return true
+	}
+	return false
+}
+
+func isDefaultBranch(ref, refName string) bool {
+	clean := strings.ToLower(strings.TrimPrefix(ref, "refs/heads/"))
+	cleanName := strings.ToLower(refName)
+	return clean == "develop" || clean == "main" || clean == "master" ||
+		cleanName == "develop" || cleanName == "main" || cleanName == "master"
+}
+
+func normalizeStrategy(s SpotStrategy) (SpotStrategy, string) {
+	lower := strings.ToLower(strings.TrimSpace(string(s)))
+	switch lower {
+	case "false", "off", "0", "no", "on-demand", "ondemand", "none":
+		return SpotDisabled, "false"
+	case "co", "capacity-optimized", "capacity_optimized":
+		return SpotCapacityOptimized, "co"
+	case "pco", "price-capacity-optimized", "price_capacity_optimized", "true", "on", "1", "yes":
+		return SpotPriceCapacityOptimized, "pco"
+	case "lp", "lowest-price", "lowest_price":
+		return SpotLowestPrice, "lowest-price"
+	default:
+		return SpotStrategy(lower), lower
+	}
+}
+
+// ResolveSpot evaluates the input context and returns the spot allocation result.
+func ResolveSpot(input SpotInput) (SpotResult, error) {
+	// 1. Check explicit override: Force on-demand
+	if input.ForceOnDemand {
+		return SpotResult{
+			Spot:         "false",
+			SpotFlag:     "spot=false",
+			Enabled:      false,
+			Strategy:     SpotDisabled,
+			Reason:       "forced on-demand via override",
+			IsRelease:    isReleaseOrTag(input.EventName, input.Ref, input.RefType, input.RefName, input.BaseRef),
+			IsMergeQueue: isMergeQueue(input.EventName, input.Ref, input.RefName),
+		}, nil
+	}
+
+	// 2. Check explicit strategy override
+	if input.StrategyOverride != "" {
+		strategyOverride, spotVal := normalizeStrategy(input.StrategyOverride)
+		enabled := strategyOverride != SpotDisabled
+		flag := "spot=" + spotVal
+		return SpotResult{
+			Spot:         spotVal,
+			SpotFlag:     flag,
+			Enabled:      enabled,
+			Strategy:     strategyOverride,
+			Reason:       "explicit strategy override",
+			IsRelease:    isReleaseOrTag(input.EventName, input.Ref, input.RefType, input.RefName, input.BaseRef),
+			IsMergeQueue: isMergeQueue(input.EventName, input.Ref, input.RefName),
+		}, nil
+	}
+
+	// 3. Merge Queue check
+	if isMergeQueue(input.EventName, input.Ref, input.RefName) {
+		return SpotResult{
+			Spot:         "false",
+			SpotFlag:     "spot=false",
+			Enabled:      false,
+			Strategy:     SpotDisabled,
+			Reason:       "merge queue runs require on-demand to prevent queue eviction",
+			IsMergeQueue: true,
+		}, nil
+	}
+
+	// 4. Release branch or tag check
+	if isReleaseOrTag(input.EventName, input.Ref, input.RefType, input.RefName, input.BaseRef) {
+		return SpotResult{
+			Spot:      "false",
+			SpotFlag:  "spot=false",
+			Enabled:   false,
+			Strategy:  SpotDisabled,
+			Reason:    "release branch/tag requires on-demand for reliable builds",
+			IsRelease: true,
+		}, nil
+	}
+
+	// 5. Default branch push (develop / main / master)
+	if input.EventName == "push" && isDefaultBranch(input.Ref, input.RefName) {
+		return SpotResult{
+			Spot:     "co",
+			SpotFlag: "spot=co",
+			Enabled:  true,
+			Strategy: SpotCapacityOptimized,
+			Reason:   "default branch push uses capacity-optimized spot for mainline stability",
+		}, nil
+	}
+
+	// 6. Resolve strategy for PRs, scheduled, and other events
+	defaultStrategy := input.DefaultStrategy
+	if defaultStrategy == "" {
+		defaultStrategy = SpotPriceCapacityOptimized
+	}
+	resolvedStrategy, spotVal := normalizeStrategy(defaultStrategy)
+	enabled := resolvedStrategy != SpotDisabled
+	flag := "spot=" + spotVal
+
+	reason := "standard CI run uses price-capacity-optimized spot for cost efficiency"
+	switch {
+	case input.EventName == "schedule":
+		reason = "scheduled workflow uses price-capacity-optimized spot"
+	case input.EventName == "pull_request" || input.EventName == "pull_request_target":
+		reason = "pull request uses price-capacity-optimized spot"
+	case defaultStrategy != SpotPriceCapacityOptimized:
+		reason = fmt.Sprintf("uses custom default strategy (%s)", spotVal)
+	}
+
+	return SpotResult{
+		Spot:     spotVal,
+		SpotFlag: flag,
+		Enabled:  enabled,
+		Strategy: resolvedStrategy,
+		Reason:   reason,
+	}, nil
+}

--- a/tools/ci/internal/runner/spot.go
+++ b/tools/ci/internal/runner/spot.go
@@ -56,6 +56,7 @@ func isMergeQueue(eventName, ref, refName string) bool {
 
 func isReleaseBranch(name string) bool {
 	clean := strings.ToLower(strings.TrimPrefix(name, "refs/heads/"))
+	clean = strings.TrimPrefix(clean, "gh-readonly-queue/")
 	if clean == "" {
 		return false
 	}
@@ -150,6 +151,7 @@ func ResolveSpot(input SpotInput) (SpotResult, error) {
 			Enabled:      false,
 			Strategy:     SpotDisabled,
 			Reason:       "merge queue runs require on-demand to prevent queue eviction",
+			IsRelease:    isReleaseOrTag(input.EventName, input.Ref, input.RefType, input.RefName, input.BaseRef),
 			IsMergeQueue: true,
 		}, nil
 	}

--- a/tools/ci/internal/runner/spot_test.go
+++ b/tools/ci/internal/runner/spot_test.go
@@ -1,0 +1,257 @@
+package runner_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/tools/ci/internal/runner"
+)
+
+func TestResolveSpot(t *testing.T) {
+	t.Parallel()
+
+	weekdayTime := time.Date(2026, time.March, 11, 14, 0, 0, 0, time.UTC) // Wednesday 14:00 UTC (peak)
+	weekendTime := time.Date(2026, time.March, 15, 10, 0, 0, 0, time.UTC) // Sunday 10:00 UTC (weekend)
+
+	tests := []struct {
+		name             string
+		input            runner.SpotInput
+		expectedSpot     string
+		expectedFlag     string
+		expectedEnab     bool
+		expectedStrategy runner.SpotStrategy
+		checkRelease     bool
+		checkMQ          bool
+	}{
+		{
+			name: "merge_group event forces on-demand",
+			input: runner.SpotInput{
+				EventName: "merge_group",
+				Ref:       "refs/heads/gh-readonly-queue/develop/pr-123-abcdef",
+				RefName:   "gh-readonly-queue/develop/pr-123-abcdef",
+				Timestamp: weekdayTime,
+			},
+			expectedSpot:     "false",
+			expectedFlag:     "spot=false",
+			expectedEnab:     false,
+			expectedStrategy: runner.SpotDisabled,
+			checkMQ:          true,
+		},
+		{
+			name: "merge queue branch ref forces on-demand",
+			input: runner.SpotInput{
+				EventName: "push",
+				Ref:       "refs/heads/gh-readonly-queue/main/pr-456",
+				RefName:   "gh-readonly-queue/main/pr-456",
+				Timestamp: weekdayTime,
+			},
+			expectedSpot:     "false",
+			expectedFlag:     "spot=false",
+			expectedEnab:     false,
+			expectedStrategy: runner.SpotDisabled,
+			checkMQ:          true,
+		},
+		{
+			name: "release event forces on-demand",
+			input: runner.SpotInput{
+				EventName: "release",
+				Ref:       "refs/tags/v2.16.0",
+				RefType:   "tag",
+				RefName:   "v2.16.0",
+				Timestamp: weekdayTime,
+			},
+			expectedSpot:     "false",
+			expectedFlag:     "spot=false",
+			expectedEnab:     false,
+			expectedStrategy: runner.SpotDisabled,
+			checkRelease:     true,
+		},
+		{
+			name: "tag ref forces on-demand",
+			input: runner.SpotInput{
+				EventName: "push",
+				Ref:       "refs/tags/v2.16.0-rc1",
+				RefType:   "tag",
+				RefName:   "v2.16.0-rc1",
+				Timestamp: weekdayTime,
+			},
+			expectedSpot:     "false",
+			expectedFlag:     "spot=false",
+			expectedEnab:     false,
+			expectedStrategy: runner.SpotDisabled,
+			checkRelease:     true,
+		},
+		{
+			name: "release branch push forces on-demand",
+			input: runner.SpotInput{
+				EventName: "push",
+				Ref:       "refs/heads/release/2.57.1",
+				RefName:   "release/2.57.1",
+				Timestamp: weekdayTime,
+			},
+			expectedSpot:     "false",
+			expectedFlag:     "spot=false",
+			expectedEnab:     false,
+			expectedStrategy: runner.SpotDisabled,
+			checkRelease:     true,
+		},
+		{
+			name: "releases prefix branch forces on-demand",
+			input: runner.SpotInput{
+				EventName: "push",
+				Ref:       "refs/heads/releases/v2.0.0",
+				RefName:   "releases/v2.0.0",
+				Timestamp: weekdayTime,
+			},
+			expectedSpot:     "false",
+			expectedFlag:     "spot=false",
+			expectedEnab:     false,
+			expectedStrategy: runner.SpotDisabled,
+			checkRelease:     true,
+		},
+		{
+			name: "hotfix branch forces on-demand",
+			input: runner.SpotInput{
+				EventName: "push",
+				Ref:       "refs/heads/hotfix/core-bug",
+				RefName:   "hotfix/core-bug",
+				Timestamp: weekdayTime,
+			},
+			expectedSpot:     "false",
+			expectedFlag:     "spot=false",
+			expectedEnab:     false,
+			expectedStrategy: runner.SpotDisabled,
+			checkRelease:     true,
+		},
+		{
+			name: "PR targeting release branch forces on-demand",
+			input: runner.SpotInput{
+				EventName: "pull_request",
+				BaseRef:   "release/2.57.1",
+				HeadRef:   "fix-something",
+				Timestamp: weekdayTime,
+			},
+			expectedSpot:     "false",
+			expectedFlag:     "spot=false",
+			expectedEnab:     false,
+			expectedStrategy: runner.SpotDisabled,
+			checkRelease:     true,
+		},
+		{
+			name: "push to develop uses capacity-optimized spot",
+			input: runner.SpotInput{
+				EventName: "push",
+				Ref:       "refs/heads/develop",
+				RefName:   "develop",
+				Timestamp: weekdayTime,
+			},
+			expectedSpot:     "co",
+			expectedFlag:     "spot=co",
+			expectedEnab:     true,
+			expectedStrategy: runner.SpotCapacityOptimized,
+		},
+		{
+			name: "push to main uses capacity-optimized spot",
+			input: runner.SpotInput{
+				EventName: "push",
+				Ref:       "refs/heads/main",
+				RefName:   "main",
+				Timestamp: weekdayTime,
+			},
+			expectedSpot:     "co",
+			expectedFlag:     "spot=co",
+			expectedEnab:     true,
+			expectedStrategy: runner.SpotCapacityOptimized,
+		},
+		{
+			name: "standard PR uses price-capacity-optimized spot",
+			input: runner.SpotInput{
+				EventName: "pull_request",
+				BaseRef:   "develop",
+				HeadRef:   "feature/DX-5101",
+				Timestamp: weekdayTime,
+			},
+			expectedSpot:     "pco",
+			expectedFlag:     "spot=pco",
+			expectedEnab:     true,
+			expectedStrategy: runner.SpotPriceCapacityOptimized,
+		},
+		{
+			name: "scheduled run on weekend uses price-capacity-optimized spot",
+			input: runner.SpotInput{
+				EventName: "schedule",
+				Ref:       "refs/heads/develop",
+				Timestamp: weekendTime,
+			},
+			expectedSpot:     "pco",
+			expectedFlag:     "spot=pco",
+			expectedEnab:     true,
+			expectedStrategy: runner.SpotPriceCapacityOptimized,
+		},
+		{
+			name: "force on demand override disables spot",
+			input: runner.SpotInput{
+				EventName:     "pull_request",
+				BaseRef:       "develop",
+				HeadRef:       "feature/some-feature",
+				ForceOnDemand: true,
+				Timestamp:     weekendTime,
+			},
+			expectedSpot:     "false",
+			expectedFlag:     "spot=false",
+			expectedEnab:     false,
+			expectedStrategy: runner.SpotDisabled,
+		},
+		{
+			name: "explicit strategy override",
+			input: runner.SpotInput{
+				EventName:        "pull_request",
+				BaseRef:          "develop",
+				HeadRef:          "feature/some-feature",
+				StrategyOverride: runner.SpotLowestPrice,
+				Timestamp:        weekendTime,
+			},
+			expectedSpot:     "lowest-price",
+			expectedFlag:     "spot=lowest-price",
+			expectedEnab:     true,
+			expectedStrategy: runner.SpotLowestPrice,
+		},
+		{
+			name: "custom default strategy",
+			input: runner.SpotInput{
+				EventName:       "pull_request",
+				BaseRef:         "develop",
+				HeadRef:         "feature/some-feature",
+				DefaultStrategy: runner.SpotCapacityOptimized,
+				Timestamp:       weekdayTime,
+			},
+			expectedSpot:     "co",
+			expectedFlag:     "spot=co",
+			expectedEnab:     true,
+			expectedStrategy: runner.SpotCapacityOptimized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := runner.ResolveSpot(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedSpot, res.Spot)
+			assert.Equal(t, tt.expectedFlag, res.SpotFlag)
+			assert.Equal(t, tt.expectedEnab, res.Enabled)
+			assert.Equal(t, tt.expectedStrategy, res.Strategy)
+			assert.NotEmpty(t, res.Reason)
+
+			if tt.checkRelease {
+				assert.True(t, res.IsRelease, "expected is_release to be true")
+			}
+			if tt.checkMQ {
+				assert.True(t, res.IsMergeQueue, "expected is_merge_queue to be true")
+			}
+		})
+	}
+}

--- a/tools/ci/internal/runner/spot_test.go
+++ b/tools/ci/internal/runner/spot_test.go
@@ -2,7 +2,6 @@ package runner_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -10,11 +9,30 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/tools/ci/internal/runner"
 )
 
-func TestResolveSpot(t *testing.T) {
+func TestResolveSpot_InvalidStrategyOverride(t *testing.T) {
 	t.Parallel()
 
-	weekdayTime := time.Date(2026, time.March, 11, 14, 0, 0, 0, time.UTC) // Wednesday 14:00 UTC (peak)
-	weekendTime := time.Date(2026, time.March, 15, 10, 0, 0, 0, time.UTC) // Sunday 10:00 UTC (weekend)
+	_, err := runner.ResolveSpot(runner.SpotInput{
+		EventName:        "pull_request",
+		StrategyOverride: "bogus",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid spot strategy override")
+}
+
+func TestResolveSpot_InvalidDefaultStrategy(t *testing.T) {
+	t.Parallel()
+
+	_, err := runner.ResolveSpot(runner.SpotInput{
+		EventName:       "pull_request",
+		DefaultStrategy: "bogus",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid default spot strategy")
+}
+
+func TestResolveSpot(t *testing.T) {
+	t.Parallel()
 
 	tests := []struct {
 		name             string
@@ -32,7 +50,6 @@ func TestResolveSpot(t *testing.T) {
 				EventName: "merge_group",
 				Ref:       "refs/heads/gh-readonly-queue/develop/pr-123-abcdef",
 				RefName:   "gh-readonly-queue/develop/pr-123-abcdef",
-				Timestamp: weekdayTime,
 			},
 			expectedSpot:     "false",
 			expectedFlag:     "spot=false",
@@ -46,7 +63,6 @@ func TestResolveSpot(t *testing.T) {
 				EventName: "push",
 				Ref:       "refs/heads/gh-readonly-queue/main/pr-456",
 				RefName:   "gh-readonly-queue/main/pr-456",
-				Timestamp: weekdayTime,
 			},
 			expectedSpot:     "false",
 			expectedFlag:     "spot=false",
@@ -61,7 +77,6 @@ func TestResolveSpot(t *testing.T) {
 				Ref:       "refs/tags/v2.16.0",
 				RefType:   "tag",
 				RefName:   "v2.16.0",
-				Timestamp: weekdayTime,
 			},
 			expectedSpot:     "false",
 			expectedFlag:     "spot=false",
@@ -76,7 +91,6 @@ func TestResolveSpot(t *testing.T) {
 				Ref:       "refs/tags/v2.16.0-rc1",
 				RefType:   "tag",
 				RefName:   "v2.16.0-rc1",
-				Timestamp: weekdayTime,
 			},
 			expectedSpot:     "false",
 			expectedFlag:     "spot=false",
@@ -90,7 +104,6 @@ func TestResolveSpot(t *testing.T) {
 				EventName: "push",
 				Ref:       "refs/heads/release/2.57.1",
 				RefName:   "release/2.57.1",
-				Timestamp: weekdayTime,
 			},
 			expectedSpot:     "false",
 			expectedFlag:     "spot=false",
@@ -104,7 +117,6 @@ func TestResolveSpot(t *testing.T) {
 				EventName: "push",
 				Ref:       "refs/heads/releases/v2.0.0",
 				RefName:   "releases/v2.0.0",
-				Timestamp: weekdayTime,
 			},
 			expectedSpot:     "false",
 			expectedFlag:     "spot=false",
@@ -118,7 +130,6 @@ func TestResolveSpot(t *testing.T) {
 				EventName: "push",
 				Ref:       "refs/heads/hotfix/core-bug",
 				RefName:   "hotfix/core-bug",
-				Timestamp: weekdayTime,
 			},
 			expectedSpot:     "false",
 			expectedFlag:     "spot=false",
@@ -132,7 +143,6 @@ func TestResolveSpot(t *testing.T) {
 				EventName: "pull_request",
 				BaseRef:   "release/2.57.1",
 				HeadRef:   "fix-something",
-				Timestamp: weekdayTime,
 			},
 			expectedSpot:     "false",
 			expectedFlag:     "spot=false",
@@ -146,7 +156,6 @@ func TestResolveSpot(t *testing.T) {
 				EventName: "push",
 				Ref:       "refs/heads/develop",
 				RefName:   "develop",
-				Timestamp: weekdayTime,
 			},
 			expectedSpot:     "co",
 			expectedFlag:     "spot=co",
@@ -159,7 +168,6 @@ func TestResolveSpot(t *testing.T) {
 				EventName: "push",
 				Ref:       "refs/heads/main",
 				RefName:   "main",
-				Timestamp: weekdayTime,
 			},
 			expectedSpot:     "co",
 			expectedFlag:     "spot=co",
@@ -172,7 +180,6 @@ func TestResolveSpot(t *testing.T) {
 				EventName: "pull_request",
 				BaseRef:   "develop",
 				HeadRef:   "feature/DX-5101",
-				Timestamp: weekdayTime,
 			},
 			expectedSpot:     "pco",
 			expectedFlag:     "spot=pco",
@@ -184,7 +191,6 @@ func TestResolveSpot(t *testing.T) {
 			input: runner.SpotInput{
 				EventName: "schedule",
 				Ref:       "refs/heads/develop",
-				Timestamp: weekendTime,
 			},
 			expectedSpot:     "pco",
 			expectedFlag:     "spot=pco",
@@ -198,7 +204,6 @@ func TestResolveSpot(t *testing.T) {
 				BaseRef:       "develop",
 				HeadRef:       "feature/some-feature",
 				ForceOnDemand: true,
-				Timestamp:     weekendTime,
 			},
 			expectedSpot:     "false",
 			expectedFlag:     "spot=false",
@@ -212,7 +217,6 @@ func TestResolveSpot(t *testing.T) {
 				BaseRef:          "develop",
 				HeadRef:          "feature/some-feature",
 				StrategyOverride: runner.SpotLowestPrice,
-				Timestamp:        weekendTime,
 			},
 			expectedSpot:     "lowest-price",
 			expectedFlag:     "spot=lowest-price",
@@ -226,7 +230,6 @@ func TestResolveSpot(t *testing.T) {
 				BaseRef:         "develop",
 				HeadRef:         "feature/some-feature",
 				DefaultStrategy: runner.SpotCapacityOptimized,
-				Timestamp:       weekdayTime,
 			},
 			expectedSpot:     "co",
 			expectedFlag:     "spot=co",

--- a/tools/ci/internal/runner/spot_test.go
+++ b/tools/ci/internal/runner/spot_test.go
@@ -58,6 +58,35 @@ func TestResolveSpot(t *testing.T) {
 			checkMQ:          true,
 		},
 		{
+			name: "merge_group event on release branch forces on-demand and sets release",
+			input: runner.SpotInput{
+				EventName: "merge_group",
+				Ref:       "refs/heads/gh-readonly-queue/release/2.57.1/pr-123-abcdef",
+				RefName:   "gh-readonly-queue/release/2.57.1/pr-123-abcdef",
+				BaseRef:   "release/2.57.1",
+			},
+			expectedSpot:     "false",
+			expectedFlag:     "spot=false",
+			expectedEnab:     false,
+			expectedStrategy: runner.SpotDisabled,
+			checkRelease:     true,
+			checkMQ:          true,
+		},
+		{
+			name: "merge queue branch ref on release branch without base-ref sets release",
+			input: runner.SpotInput{
+				EventName: "push",
+				Ref:       "refs/heads/gh-readonly-queue/release/2.57.1/pr-456",
+				RefName:   "gh-readonly-queue/release/2.57.1/pr-456",
+			},
+			expectedSpot:     "false",
+			expectedFlag:     "spot=false",
+			expectedEnab:     false,
+			expectedStrategy: runner.SpotDisabled,
+			checkRelease:     true,
+			checkMQ:          true,
+		},
+		{
 			name: "merge queue branch ref forces on-demand",
 			input: runner.SpotInput{
 				EventName: "push",


### PR DESCRIPTION
## Intent

Determine RunsOn spot instance strategy based on GitHub event context and branch/tag refs to prevent spot evictions on critical paths (merge queue, release branches, and release tags), while maximizing cost savings on standard PR and mainline runs. Centralize runner spot resolution and test matrix generation within the `tools/ci` CLI.

## Big Changes

### Dynamic Runner Spot Strategy Resolution (`tools/ci runner spot`)

Added `ci runner spot` and `.github/actions/setup-runner-spot` to evaluate GitHub event context, branch refs, release tags, and queue status to resolve RunsOn spot configurations (`spot=false`, `spot=co`, `spot=pco`). Standardized runner labels across CI workflows.

Spot runners provide significant cost savings for normal PR runs, but spot eviction causes disruptive delays and queue flakiness during merge queue validation and release packaging. This change ensures on-demand instances are used where reliability is critical, and spot instances elsewhere.

### Workflow Template Injection Remediation

Refactored matrix definition steps across workflow files (`ccip-system-tests.yaml`, `cre-mixed-env-tests.yaml`, `cre-regression-system-tests.yaml`, `cre-system-tests.yaml`, `integration-in-memory-tests.yml`) to pass GitHub context and step outputs (`RUN_ID`, `RUN_ATTEMPT`, `SPOT_FLAG`) via step `env:` blocks instead of inline script interpolation.

Direct `${{ }}` expression interpolation inside shell `run:` blocks creates script quoting bugs and potential shell injection vulnerabilities. Passing variables through the environment guarantees safe evaluation.

## Small Changes

* Upgraded `actions/checkout` from `v6` to `v7` across workflow and action definitions to maintain up-to-date action dependencies.
* Added `strat` exclusion to `_typos.toml` to support spot strategy shorthand.
* Extended `internal/ghaction` with `SetOutputs`, `AddStepSummaryTemplate`, and GHA environment detection utilities.

## Callouts

* **Merge Queue & Release Runner Costs**: Workflows running on `merge_group`, `gh-readonly-queue/*`, `release/*`, `releases/*`, `hotfix/*`, and version tags now strictly allocate on-demand instances (`spot=false`).
* **Matrix Discovery Verification**: Smoke and regression test discovery now relies on Go AST parsing (`go/parser`) instead of `grep -rh -oP`. Verify all expected test functions match in CI matrix runs.
