### PR TITLE
Fix error classification for execution handler not found

### DIFF
--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -333,7 +333,7 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 	defer cancel()
 	handler, ok := h.executionHandlers.GetExecutionWithWait(waitCtx, params.WorkflowID, params.ExecutionID)
 	if !ok {
-		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInvalidParams, fmt.Errorf("execution handler for workflow %s execution %s not found", params.WorkflowID, params.ExecutionID))
+		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, fmt.Errorf("execution handler for workflow %s execution %s not found", params.WorkflowID, params.ExecutionID))
 	}
 
 	vaultResp, err := handler.GetRawSecrets(ctx, secretsRequest, teeKeyFetcher(params.EnclavePublicKey))
@@ -493,7 +493,7 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 	defer cancel()
 	handler, ok := h.executionHandlers.GetExecutionWithWait(waitCtx, params.WorkflowID, params.ExecutionID)
 	if !ok {
-		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInvalidParams, fmt.Errorf("execution handler for workflow %s execution %s not found", params.WorkflowID, params.ExecutionID))
+		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, fmt.Errorf("execution handler for workflow %s execution %s not found", params.WorkflowID, params.ExecutionID))
 	}
 
 	capResp, execErr := handler.CallCapability(ctx, sdkReq)

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -513,7 +513,7 @@ func TestHandler_HandleGatewayMessage(t *testing.T) {
 			},
 			checkResp: func(t *testing.T, resp *jsonrpc.Response[json.RawMessage]) {
 				require.NotNil(t, resp.Error)
-				assert.Equal(t, jsonrpc.ErrInvalidParams, resp.Error.Code)
+				assert.Equal(t, jsonrpc.ErrInternal, resp.Error.Code)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Fixes error classification in the confidential relay handler when an execution handler is not found, so it's treated as a user error instead of a system error.

## Changes

- `core/capabilities/confidentialrelay/handler.go`: reclassify the "execution handler not found" case.
- `handler_test.go`: update the expectation to match.

## Why

A missing execution handler is a workflow-author error (the workflow referenced a handler that doesn't exist), not an infrastructure failure — it shouldn't trigger system-error paging.
