### PR TITLE
core/services/gateway/monitoring: preserve DON shard metric identity

### DIFF
--- a/core/services/gateway/monitoring/metrics.go
+++ b/core/services/gateway/monitoring/metrics.go
@@ -84,8 +84,8 @@ func (m *GatewayMetrics) RecordKeepalivePongsReceived(ctx context.Context, nodeA
 	))
 }
 
-func (m *GatewayMetrics) RecordDONConnectionState(ctx context.Context, donID string, connected, required, configured int) {
-	attrs := metric.WithAttributes(attribute.String("donID", donID))
+func (m *GatewayMetrics) RecordDONConnectionState(ctx context.Context, donShardID string, connected, required, configured int) {
+	attrs := metric.WithAttributes(attribute.String("donShardID", donShardID))
 	m.donConnectedNodes.Record(ctx, int64(connected), attrs)
 	m.donRequiredNodes.Record(ctx, int64(required), attrs)
 	m.donConfiguredNodes.Record(ctx, int64(configured), attrs)

--- a/core/services/gateway/monitoring/metrics_test.go
+++ b/core/services/gateway/monitoring/metrics_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/resource"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -14,7 +16,10 @@ import (
 
 func TestGatewayMetrics_RecordReadiness(t *testing.T) { //nolint:paralleltest // The test replaces the process-global Beholder client.
 	reader := sdkmetric.NewManualReader()
-	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	meterProvider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithResource(resource.NewSchemaless(attribute.String("donID", "cre-gateway-1"))),
+	)
 	t.Cleanup(func() { require.NoError(t, meterProvider.Shutdown(context.Background())) })
 
 	previousClient := beholder.GetClient()
@@ -26,14 +31,21 @@ func TestGatewayMetrics_RecordReadiness(t *testing.T) { //nolint:paralleltest //
 
 	metrics, err := NewGatewayMetrics()
 	require.NoError(t, err)
-	metrics.RecordDONConnectionState(t.Context(), "workflow_1_zone-a", 5, 7, 10)
+	metrics.RecordDONConnectionState(t.Context(), "workflow_1_zone-a", 4, 3, 4)
+	metrics.RecordDONConnectionState(t.Context(), "vault_1", 7, 5, 7)
 	metrics.RecordUserReady(t.Context(), true)
 
 	var resourceMetrics metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(t.Context(), &resourceMetrics))
-	requireGaugeValue(t, resourceMetrics, "platform_gateway_don_connected_nodes", 5, "workflow_1_zone-a")
-	requireGaugeValue(t, resourceMetrics, "platform_gateway_don_required_nodes", 7, "workflow_1_zone-a")
-	requireGaugeValue(t, resourceMetrics, "platform_gateway_don_configured_nodes", 10, "workflow_1_zone-a")
+	resourceDONID, ok := resourceMetrics.Resource.Set().Value("donID")
+	require.True(t, ok)
+	require.Equal(t, "cre-gateway-1", resourceDONID.AsString())
+	requireGaugeValue(t, resourceMetrics, "platform_gateway_don_connected_nodes", 4, "workflow_1_zone-a")
+	requireGaugeValue(t, resourceMetrics, "platform_gateway_don_connected_nodes", 7, "vault_1")
+	requireGaugeValue(t, resourceMetrics, "platform_gateway_don_required_nodes", 3, "workflow_1_zone-a")
+	requireGaugeValue(t, resourceMetrics, "platform_gateway_don_required_nodes", 5, "vault_1")
+	requireGaugeValue(t, resourceMetrics, "platform_gateway_don_configured_nodes", 4, "workflow_1_zone-a")
+	requireGaugeValue(t, resourceMetrics, "platform_gateway_don_configured_nodes", 7, "vault_1")
 	requireGaugeValue(t, resourceMetrics, "platform_gateway_user_ready", 1, "")
 
 	metrics.RecordUserReady(t.Context(), false)
@@ -50,14 +62,18 @@ func requireGaugeValue(t *testing.T, resourceMetrics metricdata.ResourceMetrics,
 			}
 			gauge, ok := metric.Data.(metricdata.Gauge[int64])
 			require.True(t, ok)
-			require.Len(t, gauge.DataPoints, 1)
-			require.Equal(t, want, gauge.DataPoints[0].Value)
-			if donID != "" {
-				attributeValue, ok := gauge.DataPoints[0].Attributes.Value("donID")
-				require.True(t, ok)
-				require.Equal(t, donID, attributeValue.AsString())
+			for _, dataPoint := range gauge.DataPoints {
+				if donID == "" {
+					require.Equal(t, want, dataPoint.Value)
+					return
+				}
+				attributeValue, ok := dataPoint.Attributes.Value("donShardID")
+				if ok && attributeValue.AsString() == donID {
+					require.Equal(t, want, dataPoint.Value)
+					return
+				}
 			}
-			return
+			t.Fatalf("metric %s has no datapoint for DON shard %s", name, donID)
 		}
 	}
 	t.Fatalf("metric %s not found", name)


### PR DESCRIPTION
Gateway connection metrics use a datapoint-level `donID` that collides with the resource-level gateway `donID`, collapsing multiple DON shards into one series. This renames the datapoint attribute to `donShardID`.