### PR TITLE
fix: name audit logger service for health checks

### DIFF
--- a/.changeset/fix-audit-logger-startup.md
+++ b/.changeset/fix-audit-logger-startup.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix #nops Fix node startup when the audit logger is enabled by assigning the service a health-check name.

--- a/core/logger/audit/audit_logger.go
+++ b/core/logger/audit/audit_logger.go
@@ -21,6 +21,7 @@ import (
 )
 
 const (
+	auditLoggerName   = "AuditLogger"
 	bufferCapacity    = 2048
 	webRequestTimeout = 10
 )
@@ -91,7 +92,7 @@ func NewAuditLogger(logger logger.Logger, config config.AuditLogger) (AuditLogge
 
 	// Create new AuditLoggerService
 	auditLogger := AuditLoggerService{
-		logger:          logger.Helper(1),
+		logger:          logger.Named(auditLoggerName).Helper(1),
 		enabled:         true,
 		forwardToUrl:    forwardToUrl,
 		headers:         headers,

--- a/core/logger/audit/audit_logger_test.go
+++ b/core/logger/audit/audit_logger_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/urfave/cli"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+	commonservices "github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/logger/audit"
@@ -81,6 +82,17 @@ func (c Config) JsonWrapperKey() string {
 	return ""
 }
 
+func TestAuditLoggerRegistersForHealthChecks(t *testing.T) {
+	t.Parallel()
+
+	auditLogger, err := audit.NewAuditLogger(logger.TestLogger(t), Config{})
+	require.NoError(t, err)
+	require.Equal(t, "AuditLogger", auditLogger.Name())
+
+	healthChecker := commonservices.HealthCheckerConfig{}.New()
+	require.NoError(t, healthChecker.Register(auditLogger))
+}
+
 func TestCheckLoginAuditLog(t *testing.T) {
 	t.Parallel()
 
@@ -99,7 +111,7 @@ func TestCheckLoginAuditLog(t *testing.T) {
 	auditLoggerTestConfig := Config{}
 
 	// Create new AuditLoggerService
-	auditLogger, err := audit.NewAuditLogger(logger.Named("AuditLogger"), &auditLoggerTestConfig)
+	auditLogger, err := audit.NewAuditLogger(logger, &auditLoggerTestConfig)
 	assert.NoError(t, err)
 
 	// Cast to concrete type so we can swap out the internals


### PR DESCRIPTION
## Summary

Fixes #23571.

Enabling `AuditLogger` created an `AuditLoggerService` with the unnamed application logger. The service returned an empty value from `Name()`. The health checker rejects services with empty names, so application construction failed before the audit logger could start or contact its configured endpoint.

## Proposed solution

Assign the canonical `AuditLogger` name inside `NewAuditLogger` before applying the caller helper offset. Service naming is a health-reporting invariant, so the constructor now guarantees that every enabled audit logger can be registered regardless of how its caller configured the parent logger.

The existing audit flow test now passes an unnamed logger, which matches the production call path. A focused regression test creates an enabled audit logger from an unnamed logger and registers it with the real health checker. The test verifies both the canonical service name and successful registration.

The change also includes a patch changeset with the `#bugfix` and `#nops` release tags.

## Behavior after this change

When audit logging is enabled:

- The service reports `AuditLogger` as its health-check name.
- Application health registration succeeds.
- Node startup no longer depends on whether the audit endpoint is reachable.
- Existing asynchronous forwarding and health behavior remain unchanged.

## Validation

- `go test ./core/logger/audit -run '^TestAuditLoggerRegistersForHealthChecks$' -count=1`
- `go test -race ./core/logger/audit -run '^TestAuditLoggerRegistersForHealthChecks$' -count=1`
- `go vet ./core/logger/audit`
- `golangci-lint v2.13.1 run ./core/logger/audit/... --new-from-rev=origin/develop --max-same-issues=0 --max-issues-per-linter=0`
- `bash .github/scripts/check-changeset-tags.sh .changeset/fix-audit-logger-startup.md`
- `git diff --check`

The database-backed `TestCheckLoginAuditLog` test was compiled but not executed locally because the required PostgreSQL test database was not configured. Repository CI will run that test with its database environment.

### Requires

None.

### Supports

- #23571
