### PR TITLE
[CRE] Improve logging in HTTP trigger handler

### DIFF
--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -43,11 +43,15 @@ type savedCallback struct {
 	handlers.Callback
 	requestStartTime time.Time
 	createdAt        time.Time
+	// processed is set once the aggregated response has been sent to the user.
+	// The entry stays in the callbacks map so late node responses can be told
+	// apart from unknown request IDs, and is removed later by the async reaper.
+	processed bool
 	// responseAggregators holds one IdenticalNodeResponseAggregator per shard the
 	// workflow is assigned to, keyed by shard donID. The first shard to reach its
 	// quorum produces the user response.
 	responseAggregators map[string]*aggregation.IdenticalNodeResponseAggregator
-	doneCh              chan struct{} // closed when callback is responded to. signals sendWithRetries to stop retrying
+	doneCh              chan struct{} // closed when callback is responded to (processed) or reaped unanswered. signals sendWithRetries to stop retrying
 }
 
 type httpTriggerHandler struct {
@@ -434,14 +438,19 @@ func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string
 	return doneCh, nil
 }
 
-// cleanupCallback removes a callback and signals sendWithRetries to stop.
+// cleanupCallback removes a callback and, if it was never processed, closes
+// doneCh to signal sendWithRetries to stop. When the entry was already
+// processed, doneCh was closed by markCallbackProcessed, so it is only
+// deleted here.
 // Must be called while holding callbacksMu lock.
 func (h *httpTriggerHandler) cleanupCallback(requestID string) {
 	saved, exists := h.callbacks[requestID]
 	if !exists {
 		return
 	}
-	close(saved.doneCh)
+	if !saved.processed {
+		close(saved.doneCh)
+	}
 	delete(h.callbacks, requestID)
 }
 
@@ -452,6 +461,10 @@ func (h *httpTriggerHandler) HandleNodeTriggerResponse(ctx context.Context, resp
 	saved, exists := h.callbacks[resp.ID]
 	if !exists {
 		return errors.New("callback not found for request ID: " + resp.ID)
+	}
+	if saved.processed {
+		h.lggr.Debugw("request already processed, ignoring late response", "requestID", resp.ID, "nodeAddr", nodeAddr)
+		return nil
 	}
 
 	// Route the response into the aggregator for the shard that owns this node.
@@ -486,12 +499,17 @@ func (h *httpTriggerHandler) HandleNodeTriggerResponse(ctx context.Context, resp
 		return err
 	}
 
-	// First shard to reach quorum wins: only after successfully sending the
-	// response, clean up the callback (closes doneCh, stopping all shard sends).
-	h.cleanupCallback(resp.ID)
+	// First shard to reach quorum wins: after successfully sending the response,
+	// mark the callback as processed and close doneCh, stopping all shard sends.
+	// The entry is kept in the map so late responses are recognized as such and
+	// is removed later by the periodic reaper.
+	saved.processed = true
+	close(saved.doneCh)
+	h.callbacks[resp.ID] = saved
 	latencyMs := time.Since(saved.requestStartTime).Milliseconds()
 	h.metrics.RecordRequestHandlerLatency(ctx, latencyMs, h.lggr)
 	h.metrics.IncrementRequestSuccess(ctx, h.lggr)
+	h.lggr.Debugw("Sent response to user", "requestID", resp.ID, "latencyMs", latencyMs)
 	return nil
 }
 
@@ -531,7 +549,9 @@ func (h *httpTriggerHandler) reapExpiredCallbacks(ctx context.Context) {
 	var expiredCount int
 	for reqID, callback := range h.callbacks {
 		if now.Sub(callback.createdAt) > time.Duration(h.config.CleanUpPeriodMs)*time.Millisecond {
-			h.metrics.IncrementRequestErrors(ctx, jsonrpc.ErrInternal, h.lggr)
+			if !callback.processed {
+				h.metrics.IncrementRequestErrors(ctx, jsonrpc.ErrInternal, h.lggr)
+			}
 			h.cleanupCallback(reqID)
 			expiredCount++
 		}

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
@@ -2120,10 +2120,13 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_StopsRetriesOnQuorum(t *tes
 			t.Fatal("Context cancelled waiting for HandleUserTriggerRequest to complete")
 		}
 
+		// After the response is sent, the callback is kept and marked processed
+		// (rather than removed) so that late responses are recognized.
 		handler.callbacksMu.Lock()
-		_, exists := handler.callbacks[req.ID]
+		saved, exists := handler.callbacks[req.ID]
 		handler.callbacksMu.Unlock()
-		require.False(t, exists, "callback should be removed after response is sent")
+		require.True(t, exists, "callback should be kept after response is sent so late responses are recognized")
+		require.True(t, saved.processed, "callback should be marked as processed after response is sent")
 
 		err = handler.Close()
 		require.NoError(t, err)
@@ -2173,7 +2176,8 @@ func createMultiShardTriggerHandler(t *testing.T, donName string, shardNodeSets 
 // TestHttpTriggerHandler_MultiShardQuorumRace verifies the core sharding
 // behavior: when a workflow is assigned to multiple shards, the FIRST shard to
 // reach quorum produces the user response. Late responses from the other shard
-// are rejected with "callback not found" after cleanup.
+// are recognized as already-processed (not errors) since the callback is kept
+// until the periodic reaper removes it.
 func TestHttpTriggerHandler_MultiShardQuorumRace(t *testing.T) {
 	t.Parallel()
 
@@ -2230,16 +2234,17 @@ func TestHttpTriggerHandler_MultiShardQuorumRace(t *testing.T) {
 	require.Equal(t, api.NoError, payload.ErrorCode)
 	require.NotEmpty(t, payload.RawResponse)
 
-	// Late response from shard 0 must be rejected: callback was already cleaned up.
+	// Late response from shard 0 is not an error: the request was already
+	// processed (shard 1 reached quorum first), so it is ignored with a debug log.
 	err = handler.HandleNodeTriggerResponse(t.Context(), nodeResp, "n1")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "callback not found")
+	require.NoError(t, err)
 
-	// Callback should no longer exist.
+	// Callback is kept and marked processed until the periodic reaper removes it.
 	handler.callbacksMu.Lock()
-	_, exists := handler.callbacks[req.ID]
+	saved, exists := handler.callbacks[req.ID]
 	handler.callbacksMu.Unlock()
-	require.False(t, exists)
+	require.True(t, exists, "callback should be kept after processing so late responses are recognized")
+	require.True(t, saved.processed, "callback should be marked as processed")
 }
 
 // TestHttpTriggerHandler_NodeResponseFromUnassignedShard verifies that a node


### PR DESCRIPTION
- distinguish requests that were already processed from ones that never existed
- debug-log successful processing with latency attribute