### PR TITLE
Add datastore write API for ccip

### DIFF
--- a/deployment/ccip/changeset/cs_orchestrate_changesets.go
+++ b/deployment/ccip/changeset/cs_orchestrate_changesets.go
@@ -1,8 +1,12 @@
 package changeset
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
+	"maps"
+	"reflect"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/ccip-owner-contracts/gethwrappers"
@@ -10,10 +14,12 @@ import (
 	evmstate "github.com/smartcontractkit/cld-changesets/legacy/pkg/family/evm"
 	"github.com/smartcontractkit/mcms"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	tonstate "github.com/smartcontractkit/chainlink-ton/deployment/state"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 )
 
@@ -193,31 +199,536 @@ func orchestrateChangesetsPrecondition(e cldf.Environment, c OrchestrateChangese
 	return nil
 }
 
+// MergeChangesetOutput merges the source ChangesetOutput into the destination ChangesetOutput.
+//
+// The source's address book and data store are also published to the environment, so a
+// sub-changeset merged later can resolve contracts that an earlier one deployed.
+//
+// The address-book and data-store merge is validated in full before any of it is applied. If the
+// source cannot be merged, nothing is changed and the caller can fix the source and merge again
+// from the same starting point, rather than discovering the problem with the destination already
+// partly updated.
 func MergeChangesetOutput(e cldf.Environment, dest *cldf.ChangesetOutput, src cldf.ChangesetOutput) error {
-	err := cldf.MergeChangesetOutput(e, dest, src)
-	if err != nil {
-		return fmt.Errorf("failed to merge changeset output: %w", err)
+	if dest == nil {
+		return nil
 	}
 
-	// The following merges are not included in cldf.MergeChangesetOutput
-	// TODO @ccip-tooling: Open PR in chainlink-deployments-framework to include these merges
-	// 1. Merge DataStores
-	if dest.DataStore == nil {
-		dest.DataStore = src.DataStore
-	} else if src.DataStore != nil {
-		err := dest.DataStore.Merge(src.DataStore.Seal())
-		if err != nil {
-			return fmt.Errorf("failed to merge data store: %w", err)
-		}
+	plan, err := planChangesetMerge(e, *dest, src)
+	if err != nil {
+		return err
 	}
-	// 2. Merge Reports
+	if err := plan.applyAddressBookAndDataStore(e, dest, src); err != nil {
+		return err
+	}
+
+	// Reports are merged here.
 	if dest.Reports == nil {
 		dest.Reports = src.Reports
 	} else if src.Reports != nil {
 		dest.Reports = append(dest.Reports, src.Reports...)
 	}
 
+	src.AddressBook = nil //nolint:staticcheck // AddressBook is deprecated, but Phase 1 still uses it
+	src.DataStore = nil
+	if err := cldf.MergeChangesetOutput(e, dest, src); err != nil {
+		return fmt.Errorf("failed to merge changeset output: %w", err)
+	}
+
 	return nil
+}
+
+// changesetMergePlan is a validated merge of the address book and data store, ready to apply.
+// Building it mutates nothing, so a merge that turns out to be illegal is rejected before the
+// destination or the environment has been touched: the caller is never left holding a half merged
+// output.
+type changesetMergePlan struct {
+	// addressBook replaces dest.AddressBook. Nil when the source has no address book.
+	addressBook cldf.AddressBook
+	// envAddresses are the source's address book entries the environment does not have yet.
+	envAddresses []envAddress
+	// dataStore replaces dest.DataStore. Nil when the source has no data store.
+	dataStore datastore.MutableDataStore
+	// envRefs are the source's address refs to publish to the environment.
+	envRefs []datastore.AddressRef
+	// superseded are environment refs that envRefs replace, reported so a redeploy is visible
+	// rather than silent.
+	superseded []datastore.AddressRef
+}
+
+// envAddress is one address book entry bound for the environment.
+type envAddress struct {
+	chainSelector  uint64
+	address        string
+	typeAndVersion cldf.TypeAndVersion
+}
+
+// mergeAddressBookEntries merges address-book entries using the address rules of the chain
+// family. AddressBookMap keys are strings, so its native Merge method treats differently-cased EVM
+// spellings as different contracts even though they identify the same address.
+func mergeAddressBookEntries(dst cldf.AddressBook, entries map[uint64]map[string]cldf.TypeAndVersion) error {
+	for _, chainSelector := range sortedKeys(entries) {
+		for _, address := range sortedKeys(entries[chainSelector]) {
+			tv := entries[chainSelector][address]
+			knownAddresses, err := dst.AddressesForChain(chainSelector)
+			if err != nil && !errors.Is(err, cldf.ErrChainNotFound) {
+				return err
+			}
+
+			alreadyRecorded := false
+			for knownAddress, knownTV := range knownAddresses {
+				if !shared.AddressesEqual(chainSelector, knownAddress, address) {
+					continue
+				}
+				if !knownTV.Equal(tv) {
+					return fmt.Errorf("address %s is already recorded as %s, cannot merge it as %s", knownAddress, knownTV.String(), tv.String())
+				}
+				alreadyRecorded = true
+				break
+			}
+			if alreadyRecorded {
+				continue
+			}
+			if err := dst.Save(chainSelector, address, tv); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// planChangesetMerge validates the address-book and data-store merge against both the destination
+// and the environment and returns what applying it would change. It performs no mutation.
+func planChangesetMerge(env cldf.Environment, dest, src cldf.ChangesetOutput) (*changesetMergePlan, error) {
+	plan := &changesetMergePlan{}
+
+	if err := plan.planAddressBook(env, dest.AddressBook, src.AddressBook); err != nil { //nolint:staticcheck // AddressBook is deprecated, but Phase 1 still uses it
+		return nil, err
+	}
+
+	if err := plan.planDataStore(env, dest.DataStore, src.DataStore); err != nil {
+		return nil, err
+	}
+
+	return plan, nil
+}
+
+// planAddressBook stages the merged address book in a fresh book, so the destination is only
+// replaced once the whole merge is known to be legal, and works out which entries the
+// environment is still missing.
+func (p *changesetMergePlan) planAddressBook(env cldf.Environment, dest, src cldf.AddressBook) error {
+	if isNilStore(src) {
+		return nil
+	}
+
+	srcAddrs, err := src.Addresses()
+	if err != nil {
+		return fmt.Errorf("failed to read source address book: %w", err)
+	}
+
+	merged := cldf.NewMemoryAddressBook()
+	if !isNilStore(dest) {
+		destAddrs, readErr := dest.Addresses()
+		if readErr != nil {
+			return fmt.Errorf("failed to read destination address book: %w", readErr)
+		}
+		if err = mergeAddressBookEntries(merged, destAddrs); err != nil {
+			return fmt.Errorf("failed to stage destination address book: %w", err)
+		}
+	}
+	if err = mergeAddressBookEntries(merged, srcAddrs); err != nil {
+		return fmt.Errorf("failed to merge address book: %w", err)
+	}
+	p.addressBook = merged
+
+	if isNilStore(env.ExistingAddresses) {
+		return nil
+	}
+
+	envAddrs, err := env.ExistingAddresses.Addresses()
+	if err != nil {
+		return fmt.Errorf("failed to read environment address book: %w", err)
+	}
+
+	// An address the environment already records under the same type and version is not
+	// re-saved: AddressBookMap.Save rejects a repeated address, and a changeset that registers
+	// contracts the environment already knows about is doing so legitimately. An address
+	// recorded under a *different* type and version is a genuine disagreement and is rejected
+	// here, before anything is merged.
+	for _, chainSelector := range sortedKeys(srcAddrs) {
+		for _, address := range sortedKeys(srcAddrs[chainSelector]) {
+			tv := srcAddrs[chainSelector][address]
+
+			var known cldf.TypeAndVersion
+			found := false
+			for knownAddress, knownTV := range envAddrs[chainSelector] {
+				if shared.AddressesEqual(chainSelector, knownAddress, address) {
+					known = knownTV
+					found = true
+					break
+				}
+			}
+			if found {
+				if !known.Equal(tv) {
+					return fmt.Errorf(
+						"failed to merge address book: the environment records %s on chain %d as %s, the changeset as %s",
+						address, chainSelector, known.String(), tv.String(),
+					)
+				}
+
+				continue
+			}
+
+			p.envAddresses = append(p.envAddresses, envAddress{
+				chainSelector: chainSelector, address: address, typeAndVersion: tv,
+			})
+		}
+	}
+
+	return nil
+}
+
+// planDataStore stages the merged data store in a fresh store and validates every source record
+// against what the destination and the environment already hold.
+func (p *changesetMergePlan) planDataStore(env cldf.Environment, dest, src datastore.MutableDataStore) error {
+	if isNilStore(src) {
+		return nil
+	}
+
+	srcRefs, err := src.Addresses().Fetch()
+	if err != nil {
+		return fmt.Errorf("failed to read source data store: %w", err)
+	}
+
+	// Every key is built from a version, and semver's String has a value receiver, so a record
+	// with no version would panic rather than report itself. Reject it as the stores do.
+	for _, ref := range srcRefs {
+		if ref.Version == nil {
+			return fmt.Errorf("failed to merge data store: address %s on chain %d has no version: %w",
+				ref.Address, ref.ChainSelector, datastore.ErrAddressRefVersionRequired)
+		}
+	}
+
+	// Two sub-changesets of one run claiming the same key is a mistake, not a redeploy: only
+	// one of the two addresses can survive, and MutableDataStore.Merge upserts, so without
+	// this check the later one silently wins and an address is lost.
+	claimed := make(map[string]datastore.AddressRef, len(srcRefs))
+	for _, ref := range srcRefs {
+		key := ref.Key().String()
+		if earlier, taken := claimed[key]; taken {
+			if !shared.AddressesEqual(ref.ChainSelector, earlier.Address, ref.Address) {
+				return fmt.Errorf(
+					"failed to merge data store: addresses %s and %s both claim %s; give them distinct qualifiers",
+					earlier.Address, ref.Address, key,
+				)
+			}
+
+			continue
+		}
+		claimed[key] = ref
+	}
+
+	if !isNilStore(dest) {
+		destRefs, fetchErr := dest.Addresses().Fetch()
+		if fetchErr != nil {
+			return fmt.Errorf("failed to read destination data store: %w", fetchErr)
+		}
+
+		heldBy := make(map[string]string, len(destRefs))
+		for _, ref := range destRefs {
+			if ref.Version == nil {
+				continue
+			}
+			heldBy[ref.Key().String()] = ref.Address
+		}
+
+		for _, ref := range srcRefs {
+			if held, taken := heldBy[ref.Key().String()]; taken && !shared.AddressesEqual(ref.ChainSelector, held, ref.Address) {
+				return fmt.Errorf(
+					"failed to merge data store: addresses %s and %s both claim %s; give them distinct qualifiers",
+					held, ref.Address, ref.Key().String(),
+				)
+			}
+		}
+	}
+
+	if err = p.planMetadata(dest, src); err != nil {
+		return err
+	}
+
+	merged := datastore.NewMemoryDataStore()
+	if !isNilStore(dest) {
+		if err = merged.Merge(dest.Seal()); err != nil {
+			return fmt.Errorf("failed to stage destination data store: %w", err)
+		}
+	}
+	if err = merged.Merge(src.Seal()); err != nil {
+		return fmt.Errorf("failed to merge data store: %w", err)
+	}
+	p.dataStore = merged
+
+	if isNilStore(env.DataStore) {
+		return nil
+	}
+
+	// The environment is the state before this run, so a source ref taking over a key it holds
+	// is a redeploy superseding what was there, not a collision. It is recorded so the
+	// replacement is reported rather than silent.
+	envRefs, err := env.DataStore.Addresses().Fetch()
+	if err != nil {
+		return fmt.Errorf("failed to read environment data store: %w", err)
+	}
+
+	envHeldBy := make(map[string]datastore.AddressRef, len(envRefs))
+	for _, ref := range envRefs {
+		if ref.Version == nil {
+			continue
+		}
+		envHeldBy[ref.Key().String()] = ref
+	}
+
+	for _, ref := range srcRefs {
+		if held, taken := envHeldBy[ref.Key().String()]; taken && !shared.AddressesEqual(ref.ChainSelector, held.Address, ref.Address) {
+			p.superseded = append(p.superseded, held)
+		}
+	}
+	p.envRefs = srcRefs
+
+	return nil
+}
+
+// planMetadata rejects metadata the merge would overwrite with something different. The metadata
+// stores upsert, and the environment metadata is a single record that Merge simply re-sets, so two
+// sub-changesets disagreeing about a record would silently keep the later one. Identical records
+// merge as before.
+func (p *changesetMergePlan) planMetadata(dest, src datastore.MutableDataStore) error {
+	if isNilStore(dest) {
+		return nil
+	}
+
+	destChain, err := dest.ChainMetadata().Fetch()
+	if err != nil {
+		return fmt.Errorf("failed to read destination chain metadata: %w", err)
+	}
+
+	held := make(map[string]any, len(destChain))
+	for _, record := range destChain {
+		held[record.Key().String()] = record.Metadata
+	}
+
+	srcChain, err := src.ChainMetadata().Fetch()
+	if err != nil {
+		return fmt.Errorf("failed to read source chain metadata: %w", err)
+	}
+
+	for _, record := range srcChain {
+		if existing, taken := held[record.Key().String()]; taken && !reflect.DeepEqual(existing, record.Metadata) {
+			return fmt.Errorf("failed to merge data store: conflicting chain metadata for chain %d",
+				record.ChainSelector)
+		}
+	}
+
+	destContract, err := dest.ContractMetadata().Fetch()
+	if err != nil {
+		return fmt.Errorf("failed to read destination contract metadata: %w", err)
+	}
+
+	held = make(map[string]any, len(destContract))
+	for _, record := range destContract {
+		held[record.Key().String()] = record.Metadata
+	}
+
+	srcContract, err := src.ContractMetadata().Fetch()
+	if err != nil {
+		return fmt.Errorf("failed to read source contract metadata: %w", err)
+	}
+
+	for _, record := range srcContract {
+		if existing, taken := held[record.Key().String()]; taken && !reflect.DeepEqual(existing, record.Metadata) {
+			return fmt.Errorf("failed to merge data store: conflicting contract metadata for %s on chain %d",
+				record.Address, record.ChainSelector)
+		}
+	}
+
+	srcEnv, err := src.EnvMetadata().Get()
+	if err != nil {
+		if errors.Is(err, datastore.ErrEnvMetadataNotSet) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to read source environment metadata: %w", err)
+	}
+
+	destEnv, err := dest.EnvMetadata().Get()
+	if err != nil {
+		if errors.Is(err, datastore.ErrEnvMetadataNotSet) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to read destination environment metadata: %w", err)
+	}
+
+	if !reflect.DeepEqual(destEnv.Metadata, srcEnv.Metadata) {
+		return errors.New("failed to merge data store: conflicting environment metadata")
+	}
+
+	return nil
+}
+
+// applyAddressBookAndDataStore commits the validated address-book and data-store merge. Everything
+// it does was validated while the plan was built, so the remaining error paths are reported as
+// what they are: a store that changed under us.
+func (p *changesetMergePlan) applyAddressBookAndDataStore(env cldf.Environment, dest *cldf.ChangesetOutput, src cldf.ChangesetOutput) error {
+	for _, entry := range p.envAddresses {
+		if err := env.ExistingAddresses.Save(entry.chainSelector, entry.address, entry.typeAndVersion); err != nil {
+			return fmt.Errorf("failed to merge existing addresses to environment after validation: %w", err)
+		}
+	}
+
+	if len(p.envRefs) > 0 {
+		mutable, ok := env.DataStore.Addresses().(datastore.MutableAddressRefStore)
+		if !ok {
+			if env.Logger != nil {
+				env.Logger.Warnw("Environment data store is not writable; "+
+					"contracts deployed by this changeset will not be resolvable through env.DataStore",
+					"refs", len(p.envRefs))
+			}
+		} else {
+			for _, ref := range p.envRefs {
+				if err := mutable.Upsert(ref); err != nil {
+					return fmt.Errorf("failed to merge data store into environment after validation: %w", err)
+				}
+			}
+		}
+	}
+
+	// The environment also has to see the source's staged deletions and metadata, or a later
+	// sub-changeset would resolve stale records through env.DataStore.
+	if err := propagateSrcDataStoreToEnv(env, src.DataStore); err != nil {
+		return err
+	}
+
+	if env.Logger != nil {
+		for _, ref := range p.superseded {
+			env.Logger.Infow("Changeset output supersedes an existing address ref",
+				"key", ref.Key().String(), "previousAddress", ref.Address)
+		}
+	}
+
+	if p.addressBook != nil {
+		dest.AddressBook = p.addressBook //nolint:staticcheck // AddressBook is deprecated, but Phase 1 still uses it
+	}
+	if p.dataStore != nil {
+		dest.DataStore = p.dataStore
+	}
+
+	return nil
+}
+
+// propagateSrcDataStoreToEnv applies the source's staged deletions and metadata to the
+// environment's data store, so a sub-changeset merged later resolves the same state through
+// env.DataStore that the final ChangesetOutput carries. It mirrors MemoryDataStore.Merge's
+// deletion and metadata handling, writing through the environment store's mutable interfaces.
+// A store that is not memory-backed (and so cannot be mutated) is skipped with a warning, as in
+// the address-ref propagation above.
+func propagateSrcDataStoreToEnv(env cldf.Environment, src datastore.MutableDataStore) error {
+	if isNilStore(env.DataStore) || isNilStore(src) {
+		return nil
+	}
+
+	if srcAddr, ok := src.Addresses().(*datastore.MemoryAddressRefStore); ok {
+		if envAddr, ok := env.DataStore.Addresses().(datastore.MutableAddressRefStore); ok {
+			for _, dk := range srcAddr.DeletedRemoteKeys {
+				key, keyErr := datastore.NewAddressRefKeyFromString(dk)
+				if keyErr != nil {
+					return fmt.Errorf("failed to parse address ref deletion key %q: %w", dk, keyErr)
+				}
+				if err := envAddr.RemoteDelete(key); err != nil {
+					return fmt.Errorf("failed to propagate address ref deletion to environment: %w", err)
+				}
+				if err := envAddr.Delete(key); err != nil && !errors.Is(err, datastore.ErrAddressRefNotFound) {
+					return fmt.Errorf("failed to propagate address ref deletion to environment: %w", err)
+				}
+			}
+		} else if env.Logger != nil {
+			env.Logger.Warnw("Environment data store is not writable; " +
+				"address ref deletions from this changeset will not be visible through env.DataStore")
+		}
+	}
+
+	if srcChain, ok := src.ChainMetadata().(*datastore.MemoryChainMetadataStore); ok {
+		if envChain, ok := env.DataStore.ChainMetadata().(datastore.MutableChainMetadataStore); ok {
+			for _, record := range srcChain.Records {
+				if err := envChain.Upsert(record); err != nil {
+					return fmt.Errorf("failed to propagate chain metadata to environment: %w", err)
+				}
+			}
+			for _, dk := range srcChain.DeletedRemoteKeys {
+				key, keyErr := datastore.NewChainMetadataKeyFromString(dk)
+				if keyErr != nil {
+					return fmt.Errorf("failed to parse chain metadata deletion key %q: %w", dk, keyErr)
+				}
+				if err := envChain.RemoteDelete(key); err != nil {
+					return fmt.Errorf("failed to propagate chain metadata deletion to environment: %w", err)
+				}
+				if err := envChain.Delete(key); err != nil && !errors.Is(err, datastore.ErrChainMetadataNotFound) {
+					return fmt.Errorf("failed to propagate chain metadata deletion to environment: %w", err)
+				}
+			}
+		}
+	}
+
+	if srcContract, ok := src.ContractMetadata().(*datastore.MemoryContractMetadataStore); ok {
+		if envContract, ok := env.DataStore.ContractMetadata().(datastore.MutableContractMetadataStore); ok {
+			for _, record := range srcContract.Records {
+				if err := envContract.Upsert(record); err != nil {
+					return fmt.Errorf("failed to propagate contract metadata to environment: %w", err)
+				}
+			}
+			for _, dk := range srcContract.DeletedRemoteKeys {
+				key, keyErr := datastore.NewContractMetadataKeyFromString(dk)
+				if keyErr != nil {
+					return fmt.Errorf("failed to parse contract metadata deletion key %q: %w", dk, keyErr)
+				}
+				if err := envContract.RemoteDelete(key); err != nil {
+					return fmt.Errorf("failed to propagate contract metadata deletion to environment: %w", err)
+				}
+				if err := envContract.Delete(key); err != nil && !errors.Is(err, datastore.ErrContractMetadataNotFound) {
+					return fmt.Errorf("failed to propagate contract metadata deletion to environment: %w", err)
+				}
+			}
+		}
+	}
+
+	if srcEnv, ok := env.DataStore.EnvMetadata().(datastore.MutableEnvMetadataStore); ok {
+		envMeta, err := src.EnvMetadata().Get()
+		if err == nil {
+			if err := srcEnv.Set(envMeta); err != nil {
+				return fmt.Errorf("failed to propagate environment metadata to environment: %w", err)
+			}
+		} else if !errors.Is(err, datastore.ErrEnvMetadataNotSet) {
+			return fmt.Errorf("failed to read source environment metadata: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// isNilStore reports whether v is unset, including the case of a non-nil interface holding a
+// nil pointer. A changeset returning ChangesetOutput{DataStore: (*datastore.MemoryDataStore)(nil)}
+// passes an ordinary != nil check and then panics on first use.
+func isNilStore(v any) bool {
+	if v == nil {
+		return true
+	}
+
+	rv := reflect.ValueOf(v)
+
+	return rv.Kind() == reflect.Pointer && rv.IsNil()
+}
+
+// sortedKeys returns m's keys in order, so a merge reports the same problem first on every run.
+func sortedKeys[K cmp.Ordered, V any](m map[K]V) []K {
+	return slices.Sorted(maps.Keys(m))
 }
 
 // tonMCMSStateForProposalutils adapts chainlink-ton MCMS chain state into the

--- a/deployment/ccip/changeset/cs_orchestrate_changesets.go
+++ b/deployment/ccip/changeset/cs_orchestrate_changesets.go
@@ -315,6 +315,7 @@ func planChangesetMerge(env cldf.Environment, dest, src cldf.ChangesetOutput) (*
 // planAddressBook stages the merged address book in a fresh book, so the destination is only
 // replaced once the whole merge is known to be legal, and works out which entries the
 // environment is still missing.
+// The merged book consists of addresses in dest, src, and env.ExistingAddresses
 func (p *changesetMergePlan) planAddressBook(env cldf.Environment, dest, src cldf.AddressBook) error {
 	if isNilStore(src) {
 		return nil
@@ -406,6 +407,23 @@ func (p *changesetMergePlan) planDataStore(env cldf.Environment, dest, src datas
 			return fmt.Errorf("failed to merge data store: address %s on chain %d has no version: %w",
 				ref.Address, ref.ChainSelector, datastore.ErrAddressRefVersionRequired)
 		}
+	}
+
+	// MemoryDataStore keeps a record alongside a staged deletion until Merge applies it. Do not
+	// validate or publish those records: they are not part of the resulting store.
+	if srcRefsStore, ok := src.Addresses().(*datastore.MemoryAddressRefStore); ok && len(srcRefsStore.DeletedRemoteKeys) > 0 {
+		deleted := make(map[string]struct{}, len(srcRefsStore.DeletedRemoteKeys))
+		for _, key := range srcRefsStore.DeletedRemoteKeys {
+			deleted[key] = struct{}{}
+		}
+
+		activeRefs := srcRefs[:0]
+		for _, ref := range srcRefs {
+			if _, isDeleted := deleted[ref.Key().String()]; !isDeleted {
+				activeRefs = append(activeRefs, ref)
+			}
+		}
+		srcRefs = activeRefs
 	}
 
 	// Two sub-changesets of one run claiming the same key is a mistake, not a redeploy: only

--- a/deployment/ccip/changeset/merge_test.go
+++ b/deployment/ccip/changeset/merge_test.go
@@ -1,0 +1,536 @@
+package changeset
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+)
+
+// mergeTestEnvironment builds a minimal environment for merge tests: a memory address book, a
+// sealed memory datastore, and a test logger.
+func mergeTestEnvironment(t *testing.T) cldf.Environment {
+	t.Helper()
+
+	return cldf.Environment{
+		Logger:            logger.Test(t),
+		ExistingAddresses: cldf.NewMemoryAddressBook(),
+		DataStore:         datastore.NewMemoryDataStore().Seal(),
+	}
+}
+
+func routerRef(chainSelector uint64, addr string) datastore.AddressRef {
+	return datastore.AddressRef{
+		ChainSelector: chainSelector,
+		Address:       addr,
+		Type:          datastore.ContractType("Router"),
+		Version:       semver.MustParse("1.6.0"),
+	}
+}
+
+func TestMergeChangesetOutputMergesDataStoreAndReports(t *testing.T) {
+	t.Parallel()
+	e := mergeTestEnvironment(t)
+
+	dest := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+	require.NoError(t, dest.DataStore.Addresses().Add(routerRef(5009297550715157269, "0xaaa")))
+
+	src := cldf.ChangesetOutput{
+		DataStore: datastore.NewMemoryDataStore(),
+		Reports:   []operations.Report[any, any]{{ID: "report-1"}},
+	}
+	require.NoError(t, src.DataStore.Addresses().Add(datastore.AddressRef{
+		ChainSelector: 5009297550715157269,
+		Address:       "0xbbb",
+		Type:          datastore.ContractType("FeeQuoter"),
+		Version:       semver.MustParse("1.6.0"),
+	}))
+
+	require.NoError(t, MergeChangesetOutput(e, &dest, src))
+
+	got, err := dest.DataStore.Addresses().Fetch()
+	require.NoError(t, err)
+	require.Len(t, got, 2, "source datastore refs must be merged into the destination")
+	require.Len(t, dest.Reports, 1, "source reports must be appended to the destination")
+	require.Equal(t, "report-1", dest.Reports[0].ID)
+}
+
+func TestMergeChangesetOutputDoesNotAliasSourceDataStore(t *testing.T) {
+	t.Parallel()
+	e := mergeTestEnvironment(t)
+
+	first := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+	require.NoError(t, first.DataStore.Addresses().Add(routerRef(5009297550715157269, "0xaaa")))
+
+	second := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+	require.NoError(t, second.DataStore.Addresses().Add(datastore.AddressRef{
+		ChainSelector: 5009297550715157269,
+		Address:       "0xbbb",
+		Type:          datastore.ContractType("FeeQuoter"),
+		Version:       semver.MustParse("1.6.0"),
+	}))
+
+	var dest cldf.ChangesetOutput
+	require.NoError(t, MergeChangesetOutput(e, &dest, first))
+	require.NoError(t, MergeChangesetOutput(e, &dest, second))
+
+	destRefs, err := dest.DataStore.Addresses().Fetch()
+	require.NoError(t, err)
+	require.Len(t, destRefs, 2)
+
+	firstRefs, err := first.DataStore.Addresses().Fetch()
+	require.NoError(t, err)
+	require.Len(t, firstRefs, 1, "the first sub-changeset's own output must be untouched")
+	require.Equal(t, "0xaaa", firstRefs[0].Address)
+}
+
+func TestMergeChangesetOutputRejectsConflictingRefs(t *testing.T) {
+	t.Parallel()
+	e := mergeTestEnvironment(t)
+
+	ref := func(addr string) datastore.AddressRef {
+		return datastore.AddressRef{
+			ChainSelector: 5009297550715157269,
+			Address:       addr,
+			Type:          datastore.ContractType("BurnMintTokenPool"),
+			Version:       semver.MustParse("1.5.0"),
+			Qualifier:     "",
+		}
+	}
+
+	dest := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+	require.NoError(t, dest.DataStore.Addresses().Add(ref("0xaaa")))
+
+	src := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+	require.NoError(t, src.DataStore.Addresses().Add(ref("0xbbb")))
+
+	err := MergeChangesetOutput(e, &dest, src)
+	require.ErrorContains(t, err, "both claim")
+	require.ErrorContains(t, err, "distinct qualifiers")
+
+	// The same address under the same key is not a conflict, only a repeated write.
+	same := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+	require.NoError(t, same.DataStore.Addresses().Add(ref("0xaaa")))
+	require.NoError(t, MergeChangesetOutput(e, &dest, same))
+}
+
+func TestMergeChangesetOutputPropagatesDataStoreToEnv(t *testing.T) {
+	t.Parallel()
+	e := mergeTestEnvironment(t)
+
+	src := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+	require.NoError(t, src.DataStore.Addresses().Add(routerRef(5009297550715157269, "0xaaa")))
+
+	var dest cldf.ChangesetOutput
+	require.NoError(t, MergeChangesetOutput(e, &dest, src))
+
+	got, err := e.DataStore.Addresses().Get(
+		datastore.NewAddressRefKey(5009297550715157269, datastore.ContractType("Router"), semver.MustParse("1.6.0"), ""),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "0xaaa", got.Address)
+}
+
+func TestMergeChangesetOutputHandlesTypedNilDataStore(t *testing.T) {
+	t.Parallel()
+	e := mergeTestEnvironment(t)
+
+	var nilStore *datastore.MemoryDataStore
+
+	dest := cldf.ChangesetOutput{DataStore: nilStore}
+	src := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+	require.NoError(t, src.DataStore.Addresses().Add(routerRef(5009297550715157269, "0xaaa")))
+
+	require.NoError(t, MergeChangesetOutput(e, &dest, src))
+
+	destRefs, err := dest.DataStore.Addresses().Fetch()
+	require.NoError(t, err)
+	require.Len(t, destRefs, 1)
+
+	// A typed-nil source is a no-op rather than a panic.
+	require.NoError(t, MergeChangesetOutput(e, &dest, cldf.ChangesetOutput{DataStore: nilStore}))
+}
+
+func TestMergeChangesetOutputRejectsRefWithoutVersion(t *testing.T) {
+	t.Parallel()
+	e := mergeTestEnvironment(t)
+
+	src := datastore.NewMemoryDataStore()
+	src.AddressRefStore.Records = append(src.AddressRefStore.Records, datastore.AddressRef{
+		ChainSelector: 5009297550715157269,
+		Address:       "0xaaa",
+		Type:          datastore.ContractType("Router"),
+		Version:       nil,
+	})
+
+	dest := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+
+	err := MergeChangesetOutput(e, &dest, cldf.ChangesetOutput{DataStore: src})
+	require.ErrorIs(t, err, datastore.ErrAddressRefVersionRequired)
+	require.ErrorContains(t, err, "0xaaa")
+}
+
+func TestMergeChangesetOutputComparesAddressesExactly(t *testing.T) {
+	t.Parallel()
+	e := mergeTestEnvironment(t)
+
+	ref := func(addr string) datastore.AddressRef {
+		return datastore.AddressRef{
+			ChainSelector: 124615329519749607,
+			Address:       addr,
+			Type:          datastore.ContractType("TokenPool"),
+			Version:       semver.MustParse("1.0.0"),
+		}
+	}
+
+	dest := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+	require.NoError(t, dest.DataStore.Addresses().Add(ref("AbCdEf")))
+
+	src := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+	require.NoError(t, src.DataStore.Addresses().Add(ref("aBcDeF")))
+
+	require.ErrorContains(t, MergeChangesetOutput(e, &dest, src), "both claim")
+}
+
+func TestMergeChangesetOutputRejectsConflictingMetadata(t *testing.T) {
+	t.Parallel()
+	t.Run("chain metadata", func(t *testing.T) {
+		t.Parallel()
+		e := mergeTestEnvironment(t)
+
+		dest := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+		require.NoError(t, dest.DataStore.ChainMetadata().Add(datastore.ChainMetadata{
+			ChainSelector: 5009297550715157269, Metadata: map[string]any{"owner": "a"},
+		}))
+
+		src := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+		require.NoError(t, src.DataStore.ChainMetadata().Add(datastore.ChainMetadata{
+			ChainSelector: 5009297550715157269, Metadata: map[string]any{"owner": "b"},
+		}))
+
+		require.ErrorContains(t, MergeChangesetOutput(e, &dest, src), "conflicting chain metadata")
+	})
+
+	t.Run("contract metadata", func(t *testing.T) {
+		t.Parallel()
+		e := mergeTestEnvironment(t)
+
+		dest := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+		require.NoError(t, dest.DataStore.ContractMetadata().Add(datastore.ContractMetadata{
+			ChainSelector: 5009297550715157269, Address: "0xaaa", Metadata: map[string]any{"n": "1"},
+		}))
+
+		src := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+		require.NoError(t, src.DataStore.ContractMetadata().Add(datastore.ContractMetadata{
+			ChainSelector: 5009297550715157269, Address: "0xaaa", Metadata: map[string]any{"n": "2"},
+		}))
+
+		require.ErrorContains(t, MergeChangesetOutput(e, &dest, src), "conflicting contract metadata")
+	})
+
+	t.Run("environment metadata", func(t *testing.T) {
+		t.Parallel()
+		e := mergeTestEnvironment(t)
+
+		dest := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+		require.NoError(t, dest.DataStore.EnvMetadata().Set(datastore.EnvMetadata{
+			Metadata: map[string]any{"release": "a"},
+		}))
+
+		src := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+		require.NoError(t, src.DataStore.EnvMetadata().Set(datastore.EnvMetadata{
+			Metadata: map[string]any{"release": "b"},
+		}))
+
+		require.ErrorContains(t, MergeChangesetOutput(e, &dest, src), "conflicting environment metadata")
+	})
+
+	t.Run("identical metadata merges", func(t *testing.T) {
+		t.Parallel()
+		e := mergeTestEnvironment(t)
+
+		meta := map[string]any{"owner": "a"}
+
+		dest := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+		require.NoError(t, dest.DataStore.ChainMetadata().Add(datastore.ChainMetadata{
+			ChainSelector: 5009297550715157269, Metadata: meta,
+		}))
+
+		src := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+		require.NoError(t, src.DataStore.ChainMetadata().Add(datastore.ChainMetadata{
+			ChainSelector: 5009297550715157269, Metadata: meta,
+		}))
+
+		require.NoError(t, MergeChangesetOutput(e, &dest, src))
+	})
+}
+
+func TestMergeChangesetOutputLeavesNothingHalfMerged(t *testing.T) {
+	t.Parallel()
+	e := mergeTestEnvironment(t)
+
+	chainSelector := chainsel.TEST_90000001.Selector
+	addrA := "0x5B5BBb15ECE0a4Ed8cDab22F902e83F66aBe848f"
+	addrB := "0x6619Bad7fadbc282B1EF2F6cC078fCbE61478792"
+	tv := cldf.NewTypeAndVersion("Router", *semver.MustParse("1.6.0"))
+
+	ref := func(addr string) datastore.AddressRef {
+		return datastore.AddressRef{
+			ChainSelector: chainSelector,
+			Address:       addr,
+			Type:          datastore.ContractType("Router"),
+			Version:       semver.MustParse("1.6.0"),
+		}
+	}
+
+	// The destination already holds one Router; the source deploys a different one under the
+	// same key, which is the conflict that will reject the merge.
+	dest := cldf.ChangesetOutput{
+		AddressBook: cldf.NewMemoryAddressBook(), //nolint:staticcheck // Phase 1 merge still stages the address book
+		DataStore:   datastore.NewMemoryDataStore(),
+	}
+	require.NoError(t, dest.AddressBook.Save(chainSelector, addrA, tv)) //nolint:staticcheck // Phase 1 merge still stages the address book
+	require.NoError(t, dest.DataStore.Addresses().Add(ref(addrA)))
+
+	src := cldf.ChangesetOutput{
+		AddressBook: cldf.NewMemoryAddressBook(), //nolint:staticcheck // Phase 1 merge still stages the address book
+		DataStore:   datastore.NewMemoryDataStore(),
+	}
+	require.NoError(t, src.AddressBook.Save(chainSelector, addrB, tv)) //nolint:staticcheck // Phase 1 merge still stages the address book
+	require.NoError(t, src.DataStore.Addresses().Add(ref(addrB)))
+
+	require.Error(t, MergeChangesetOutput(e, &dest, src))
+
+	// The address book merge would have succeeded on its own, and used to run first. It must
+	// not have been applied.
+	destAddrs, err := dest.AddressBook.Addresses() //nolint:staticcheck // Phase 1 merge still stages the address book
+	require.NoError(t, err)
+	require.Len(t, destAddrs[chainSelector], 1, "destination address book must be unchanged")
+	require.Contains(t, destAddrs[chainSelector], addrA)
+
+	envAddrs, err := e.ExistingAddresses.Addresses()
+	require.NoError(t, err)
+	require.Empty(t, envAddrs, "environment address book must be unchanged")
+
+	envRefs, err := e.DataStore.Addresses().Fetch()
+	require.NoError(t, err)
+	require.Empty(t, envRefs, "environment data store must be unchanged")
+
+	destRefs, err := dest.DataStore.Addresses().Fetch()
+	require.NoError(t, err)
+	require.Len(t, destRefs, 1)
+	require.Equal(t, addrA, destRefs[0].Address)
+}
+
+func TestMergeChangesetOutputPublishesFirstMergeToEnv(t *testing.T) {
+	t.Parallel()
+	e := mergeTestEnvironment(t)
+
+	chainSelector := chainsel.TEST_90000001.Selector
+	addr := "0x5B5BBb15ECE0a4Ed8cDab22F902e83F66aBe848f"
+	tv := cldf.NewTypeAndVersion("Router", *semver.MustParse("1.6.0"))
+
+	src := cldf.ChangesetOutput{AddressBook: cldf.NewMemoryAddressBook()} //nolint:staticcheck // Phase 1 merge still stages the address book
+	require.NoError(t, src.AddressBook.Save(chainSelector, addr, tv))     //nolint:staticcheck // Phase 1 merge still stages the address book
+
+	var dest cldf.ChangesetOutput
+	require.NoError(t, MergeChangesetOutput(e, &dest, src))
+
+	envAddrs, err := e.ExistingAddresses.Addresses()
+	require.NoError(t, err)
+	require.Contains(t, envAddrs[chainSelector], addr)
+
+	// The destination is a copy, not the source's own book: merging again must not corrupt the
+	// first sub-changeset's output.
+	require.NotSame(t, src.AddressBook, dest.AddressBook) //nolint:staticcheck // Phase 1 merge still stages the address book
+}
+
+func TestMergeChangesetOutputToleratesKnownAddresses(t *testing.T) {
+	t.Parallel()
+	chainSelector := chainsel.TEST_90000001.Selector
+	addr := "0x5B5BBb15ECE0a4Ed8cDab22F902e83F66aBe848f"
+	tv := cldf.NewTypeAndVersion("Router", *semver.MustParse("1.6.0"))
+
+	t.Run("same type and version", func(t *testing.T) {
+		t.Parallel()
+		e := mergeTestEnvironment(t)
+		require.NoError(t, e.ExistingAddresses.Save(chainSelector, addr, tv))
+
+		src := cldf.ChangesetOutput{AddressBook: cldf.NewMemoryAddressBook()} //nolint:staticcheck // Phase 1 merge still stages the address book
+		require.NoError(t, src.AddressBook.Save(chainSelector, addr, tv))     //nolint:staticcheck // Phase 1 merge still stages the address book
+
+		var dest cldf.ChangesetOutput
+		require.NoError(t, MergeChangesetOutput(e, &dest, src))
+	})
+
+	t.Run("different type", func(t *testing.T) {
+		t.Parallel()
+		e := mergeTestEnvironment(t)
+		require.NoError(t, e.ExistingAddresses.Save(chainSelector, addr, tv))
+
+		src := cldf.ChangesetOutput{AddressBook: cldf.NewMemoryAddressBook()} //nolint:staticcheck // Phase 1 merge still stages the address book
+		require.NoError(t, src.AddressBook.Save(chainSelector, addr,          //nolint:staticcheck // Phase 1 merge still stages the address book
+			cldf.NewTypeAndVersion("FeeQuoter", *semver.MustParse("1.6.0"))))
+
+		var dest cldf.ChangesetOutput
+		err := MergeChangesetOutput(e, &dest, src)
+		require.ErrorContains(t, err, "the environment records")
+	})
+}
+
+func TestPlanDataStoreSupersessionUsesFamilyCasingRules(t *testing.T) {
+	t.Parallel()
+	chainSelector := chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector
+	checksummed := "0x5B5BBb15ECE0a4Ed8cDab22F902e83F66aBe848f"
+
+	srcWith := func(addr string) datastore.MutableDataStore {
+		src := datastore.NewMemoryDataStore()
+		require.NoError(t, src.Addresses().Add(datastore.AddressRef{
+			ChainSelector: chainSelector,
+			Address:       addr,
+			Type:          datastore.ContractType("Router"),
+			Version:       semver.MustParse("1.6.0"),
+		}))
+
+		return src
+	}
+
+	newEnv := func(t *testing.T) cldf.Environment {
+		t.Helper()
+
+		e := mergeTestEnvironment(t)
+		mutable, ok := e.DataStore.Addresses().(datastore.MutableAddressRefStore)
+		require.True(t, ok)
+		require.NoError(t, mutable.Upsert(datastore.AddressRef{
+			ChainSelector: chainSelector,
+			Address:       checksummed,
+			Type:          datastore.ContractType("Router"),
+			Version:       semver.MustParse("1.6.0"),
+		}))
+
+		return e
+	}
+
+	t.Run("same contract in the other casing is not a supersession", func(t *testing.T) {
+		t.Parallel()
+		plan := &changesetMergePlan{}
+		require.NoError(t, plan.planDataStore(newEnv(t), nil, srcWith("0x5b5bbb15ece0a4ed8cdab22f902e83f66abe848f")))
+		require.Empty(t, plan.superseded)
+	})
+
+	t.Run("a different address is a supersession", func(t *testing.T) {
+		t.Parallel()
+		plan := &changesetMergePlan{}
+		require.NoError(t, plan.planDataStore(newEnv(t), nil, srcWith("0x6619Bad7fadbc282B1EF2F6cC078fCbE61478792")))
+		require.Len(t, plan.superseded, 1)
+		require.Equal(t, checksummed, plan.superseded[0].Address)
+	})
+}
+
+func TestMergeChangesetOutputSupersedesEnvRef(t *testing.T) {
+	t.Parallel()
+	e := mergeTestEnvironment(t)
+
+	key := datastore.NewAddressRefKey(
+		5009297550715157269, datastore.ContractType("Router"), semver.MustParse("1.6.0"), "",
+	)
+
+	mutable, ok := e.DataStore.Addresses().(datastore.MutableAddressRefStore)
+	require.True(t, ok)
+	require.NoError(t, mutable.Upsert(datastore.AddressRef{
+		ChainSelector: 5009297550715157269,
+		Address:       "0xold",
+		Type:          datastore.ContractType("Router"),
+		Version:       semver.MustParse("1.6.0"),
+	}))
+
+	src := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+	require.NoError(t, src.DataStore.Addresses().Add(datastore.AddressRef{
+		ChainSelector: 5009297550715157269,
+		Address:       "0xnew",
+		Type:          datastore.ContractType("Router"),
+		Version:       semver.MustParse("1.6.0"),
+	}))
+
+	var dest cldf.ChangesetOutput
+	require.NoError(t, MergeChangesetOutput(e, &dest, src))
+
+	got, err := e.DataStore.Addresses().Get(key)
+	require.NoError(t, err)
+	require.Equal(t, "0xnew", got.Address)
+}
+
+func TestMergeChangesetOutputPropagatesMetadataToEnv(t *testing.T) {
+	t.Parallel()
+	e := mergeTestEnvironment(t)
+
+	chainMeta := datastore.ChainMetadata{ChainSelector: 5009297550715157269, Metadata: map[string]any{"owner": "ccip"}}
+	contractMeta := datastore.ContractMetadata{
+		ChainSelector: 5009297550715157269, Address: "0xaaa", Metadata: map[string]any{"n": "1"},
+	}
+	envMeta := datastore.EnvMetadata{Metadata: map[string]any{"release": "2026"}}
+
+	src := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+	require.NoError(t, src.DataStore.ChainMetadata().Add(chainMeta))
+	require.NoError(t, src.DataStore.ContractMetadata().Add(contractMeta))
+	require.NoError(t, src.DataStore.EnvMetadata().Set(envMeta))
+
+	var dest cldf.ChangesetOutput
+	require.NoError(t, MergeChangesetOutput(e, &dest, src))
+
+	gotChain, err := e.DataStore.ChainMetadata().Fetch()
+	require.NoError(t, err)
+	require.Len(t, gotChain, 1)
+	require.Equal(t, map[string]any{"owner": "ccip"}, gotChain[0].Metadata)
+
+	gotContract, err := e.DataStore.ContractMetadata().Fetch()
+	require.NoError(t, err)
+	require.Len(t, gotContract, 1)
+	require.Equal(t, "0xaaa", gotContract[0].Address)
+
+	gotEnv, err := e.DataStore.EnvMetadata().Get()
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"release": "2026"}, gotEnv.Metadata)
+}
+
+func TestMergeChangesetOutputPropagatesDeletionsToEnv(t *testing.T) {
+	t.Parallel()
+	e := mergeTestEnvironment(t)
+
+	key := datastore.NewAddressRefKey(
+		5009297550715157269, datastore.ContractType("Router"), semver.MustParse("1.6.0"), "",
+	)
+
+	// A contract already in the environment that a sub-changeset deletes.
+	mutable, ok := e.DataStore.Addresses().(datastore.MutableAddressRefStore)
+	require.True(t, ok)
+	require.NoError(t, mutable.Upsert(datastore.AddressRef{
+		ChainSelector: 5009297550715157269,
+		Address:       "0xold",
+		Type:          datastore.ContractType("Router"),
+		Version:       semver.MustParse("1.6.0"),
+	}))
+
+	src := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+	require.NoError(t, src.DataStore.Addresses().Add(datastore.AddressRef{
+		ChainSelector: 5009297550715157269,
+		Address:       "0xold",
+		Type:          datastore.ContractType("Router"),
+		Version:       semver.MustParse("1.6.0"),
+	}))
+	// Stage the deletion so the merge propagates it, as MemoryDataStore.Merge does.
+	require.NoError(t, src.DataStore.Addresses().RemoteDelete(key))
+
+	var dest cldf.ChangesetOutput
+	require.NoError(t, MergeChangesetOutput(e, &dest, src))
+
+	_, err := e.DataStore.Addresses().Get(key)
+	require.ErrorIs(t, err, datastore.ErrAddressRefNotFound, "the deleted ref must be gone from the environment")
+}

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_e2e.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_e2e.go
@@ -11,6 +11,7 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -98,7 +99,7 @@ func ProcessConfig[T any](
 		if err != nil {
 			return err
 		}
-		err = cldf.MergeChangesetOutput(*e, finalOutput, output)
+		err = changeset.MergeChangesetOutput(*e, finalOutput, output)
 		if err != nil {
 			return fmt.Errorf("failed to merge changeset output: %w", err)
 		}
@@ -321,42 +322,42 @@ func E2ETokenPoolv2(env cldf.Environment, cfg E2ETokenPoolConfigv2) (cldf.Change
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to add token pool and lookup table: %w", err)
 	}
-	if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+	if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running AddTokenPoolAndLookupTable: %w", err)
 	}
 	output, err = SetupTokenPoolForRemoteChain(e, remotePoolConfig)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to setup token pool for remote chain: %w", err)
 	}
-	if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+	if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running SetupTokenPoolForRemoteChain: %w", err)
 	}
 	output, err = RegisterTokenAdminRegistry(e, registerTokenAdminRegistryCfg)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to register token admin registry: %w", err)
 	}
-	if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+	if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running RegisterTokenAdminRegistry: %w", err)
 	}
 	output, err = AcceptAdminRoleTokenAdminRegistry(e, acceptAdminRoleTokenAdminRegistryCfg)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to accept admin role: %w", err)
 	}
-	if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+	if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running AcceptAdminRoleTokenAdminRegistry: %w", err)
 	}
 	output, err = SetPool(e, setPoolCfg)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to set pool: %w", err)
 	}
-	if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+	if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running SetPool: %w", err)
 	}
 	output, err = v1_5_1.ConfigureMultiplePoolLogic(e, evmToSolanaRemotePoolCfg)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to configure token pool contracts: %w", err)
 	}
-	if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+	if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running ConfigureTokenPoolContractsChangeset: %w", err)
 	}
 	// and finally lets transfer away the pool to timelock
@@ -365,7 +366,7 @@ func E2ETokenPoolv2(env cldf.Environment, cfg E2ETokenPoolConfigv2) (cldf.Change
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to transfer ccip to mcms with timelock: %w", err)
 		}
-		if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+		if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running TransferCCIPToMCMSWithTimelockSolana: %w", err)
 		}
 	}
@@ -390,11 +391,20 @@ func E2ETokenPoolv2(env cldf.Environment, cfg E2ETokenPoolConfigv2) (cldf.Change
 		}
 	}
 
-	ds, err := shared.PopulateDataStore(finalCSOut.AddressBook) //nolint:staticcheck //SA1019 ignoring deprecated
+	// Preserve the datastore accumulated by MergeChangesetOutput: it already carries the
+	// sub-changesets' semantic qualifiers, metadata, and deletions. Rebuilding it from the
+	// address book would discard all of that. The address book has no qualifiers, so it can only
+	// contribute the singleton refs the sub-changesets did not write to the datastore; merge
+	// those in rather than replacing the accumulated store.
+	singletons, err := shared.PopulateDataStore(finalCSOut.AddressBook) //nolint:staticcheck //SA1019 ignoring deprecated
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
-	finalCSOut.DataStore = ds
+	if finalCSOut.DataStore == nil {
+		finalCSOut.DataStore = singletons
+	} else if err := finalCSOut.DataStore.Merge(singletons.Seal()); err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address-book refs into DataStore: %w", err)
+	}
 	return *finalCSOut, nil
 }

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_e2e.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_e2e.go
@@ -12,6 +12,7 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -104,7 +105,7 @@ func ProcessConfig[T any](
 		if err != nil {
 			return err
 		}
-		err = cldf.MergeChangesetOutput(*e, finalOutput, output)
+		err = changeset.MergeChangesetOutput(*e, finalOutput, output)
 		if err != nil {
 			return fmt.Errorf("failed to merge changeset output: %w", err)
 		}
@@ -342,7 +343,7 @@ func E2ETokenPoolv2(env cldf.Environment, cfg E2ETokenPoolConfigv2) (cldf.Change
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to initialize global config for token pool: %w", err)
 		}
-		if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+		if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running InitGlobalConfigTokenPoolProgram: %w", err)
 		}
 	}
@@ -350,42 +351,42 @@ func E2ETokenPoolv2(env cldf.Environment, cfg E2ETokenPoolConfigv2) (cldf.Change
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to add token pool and lookup table: %w", err)
 	}
-	if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+	if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running AddTokenPoolAndLookupTable: %w", err)
 	}
 	output, err = SetupTokenPoolForRemoteChain(e, remotePoolConfig)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to setup token pool for remote chain: %w", err)
 	}
-	if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+	if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running SetupTokenPoolForRemoteChain: %w", err)
 	}
 	output, err = RegisterTokenAdminRegistry(e, registerTokenAdminRegistryCfg)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to register token admin registry: %w", err)
 	}
-	if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+	if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running RegisterTokenAdminRegistry: %w", err)
 	}
 	output, err = AcceptAdminRoleTokenAdminRegistry(e, acceptAdminRoleTokenAdminRegistryCfg)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to accept admin role: %w", err)
 	}
-	if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+	if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running AcceptAdminRoleTokenAdminRegistry: %w", err)
 	}
 	output, err = SetPool(e, setPoolCfg)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to set pool: %w", err)
 	}
-	if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+	if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running SetPool: %w", err)
 	}
 	output, err = v1_5_1.ConfigureMultiplePoolLogic(e, evmToSolanaRemotePoolCfg)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to configure token pool contracts: %w", err)
 	}
-	if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+	if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running ConfigureTokenPoolContractsChangeset: %w", err)
 	}
 	// and finally lets transfer away the pool to timelock
@@ -394,7 +395,7 @@ func E2ETokenPoolv2(env cldf.Environment, cfg E2ETokenPoolConfigv2) (cldf.Change
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to transfer ccip to mcms with timelock: %w", err)
 		}
-		if err = cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+		if err = changeset.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after running TransferCCIPToMCMSWithTimelockSolana: %w", err)
 		}
 	}
@@ -419,11 +420,20 @@ func E2ETokenPoolv2(env cldf.Environment, cfg E2ETokenPoolConfigv2) (cldf.Change
 		}
 	}
 
-	ds, err := shared.PopulateDataStore(finalCSOut.AddressBook) //nolint:staticcheck //SA1019 ignoring deprecated
+	// Preserve the datastore accumulated by MergeChangesetOutput: it already carries the
+	// sub-changesets' semantic qualifiers, metadata, and deletions. Rebuilding it from the
+	// address book would discard all of that. The address book has no qualifiers, so it can only
+	// contribute the singleton refs the sub-changesets did not write to the datastore; merge
+	// those in rather than replacing the accumulated store.
+	singletons, err := shared.PopulateDataStore(finalCSOut.AddressBook) //nolint:staticcheck //SA1019 ignoring deprecated
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
-	finalCSOut.DataStore = ds
+	if finalCSOut.DataStore == nil {
+		finalCSOut.DataStore = singletons
+	} else if err := finalCSOut.DataStore.Merge(singletons.Seal()); err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address-book refs into DataStore: %w", err)
+	}
 	return *finalCSOut, nil
 }

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -27,6 +27,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	ccipcommoncs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
@@ -332,7 +333,7 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy token pool for token %s: %w", token, err)
 			}
-			if err := cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+			if err := ccipcommoncs.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address book for token %s: %w", token, err)
 			}
 			newAddresses, err := output.AddressBook.Addresses() //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
@@ -366,7 +367,7 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 						return cldf.ChangesetOutput{}, fmt.Errorf("failed to run TransferToMCMSWithTimelock on chain with selector %d: %w", chainID, err)
 					}
 
-					if err := cldf.MergeChangesetOutput(e, finalCSOut, transferOwnershipProposalOutput); err != nil {
+					if err := ccipcommoncs.MergeChangesetOutput(e, finalCSOut, transferOwnershipProposalOutput); err != nil {
 						return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after transferring ownership of pool(s): %w", err)
 					}
 				}
@@ -382,7 +383,7 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to propose admin role for token %s: %w", token, err)
 		}
-		if err := cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+		if err := ccipcommoncs.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to changeset output after configuring token admin reg for token %s: %w",
 				token, err)
 		}
@@ -414,7 +415,7 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to accept admin role for token %s: %w", token, err)
 		}
-		if err := cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+		if err := ccipcommoncs.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address book for token %s: %w", token, err)
 		}
 		e.Logger.Infow("accepted admin role", "token", token, "config", updatedConfigureTokenAdminReg)
@@ -422,7 +423,7 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to set pool for token %s: %w", token, err)
 		}
-		if err := cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+		if err := ccipcommoncs.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address book for token %s: %w", token, err)
 		}
 		e.Logger.Infow("set pool", "token", token, "config", updatedConfigureTokenAdminReg)
@@ -444,7 +445,7 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to configure token pool for token %s: %w", token, err)
 		}
-		if err := cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+		if err := ccipcommoncs.MergeChangesetOutput(e, finalCSOut, output); err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after configuring token pool for token %s: %w", token, err)
 		}
 		e.Logger.Infow("configured token pool", "token", token)
@@ -465,12 +466,21 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 		finalCSOut.MCMSTimelockProposals = []mcms.TimelockProposal{*aggregatedProposals}
 	}
 
-	ds, err := shared.PopulateDataStore(finalCSOut.AddressBook) //nolint:staticcheck //SA1019 ignoring deprecated
+	// Preserve the datastore accumulated by MergeChangesetOutput: it already carries the
+	// sub-changesets' semantic qualifiers, metadata, and deletions. Rebuilding it from the
+	// address book would discard all of that. The address book has no qualifiers, so it can only
+	// contribute the singleton refs the sub-changesets did not write to the datastore; merge
+	// those in rather than replacing the accumulated store.
+	singletons, err := shared.PopulateDataStore(finalCSOut.AddressBook) //nolint:staticcheck //SA1019 ignoring deprecated
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
-	finalCSOut.DataStore = ds
+	if finalCSOut.DataStore == nil {
+		finalCSOut.DataStore = singletons
+	} else if err := finalCSOut.DataStore.Merge(singletons.Seal()); err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address-book refs into DataStore: %w", err)
+	}
 	return *finalCSOut, nil
 }
 

--- a/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools.go
@@ -22,6 +22,7 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 
+	ccipcommoncs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -1035,7 +1036,7 @@ func ConfigureMultiplePoolLogic(env cldf.Environment, c ConfigureMultipleTokenPo
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to configure token pool: %w", err)
 		}
-		err = cldf.MergeChangesetOutput(env, &finalOutput, output)
+		err = ccipcommoncs.MergeChangesetOutput(env, &finalOutput, output)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output: %w", err)
 		}

--- a/deployment/ccip/shared/addresses.go
+++ b/deployment/ccip/shared/addresses.go
@@ -1,0 +1,31 @@
+package shared
+
+import (
+	"strings"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+)
+
+// NormalizeAddress lower-cases an address only on families where case carries no meaning.
+//
+// EVM addresses are hex and are commonly written in EIP-55 checksum form, so the same contract
+// can appear in two casings and must compare equal. Solana and Sui addresses are case-sensitive,
+// where folding case would map two different contracts onto one value. An unknown selector is
+// left alone: preserving a distinction that does not exist is harmless, whereas erasing one that
+// does silently merges two contracts.
+func NormalizeAddress(chainSelector uint64, address string) string {
+	family, err := chainsel.GetSelectorFamily(chainSelector)
+	if err != nil || family != chainsel.FamilyEVM {
+		return address
+	}
+
+	return strings.ToLower(address)
+}
+
+// AddressesEqual reports whether two addresses on the same chain refer to the same contract,
+// using the case rules of that chain's family. Use it instead of == whenever an address that came
+// from one source is compared against an address that came from another, since only one of them
+// may be checksummed.
+func AddressesEqual(chainSelector uint64, a, b string) bool {
+	return NormalizeAddress(chainSelector, a) == NormalizeAddress(chainSelector, b)
+}

--- a/deployment/ccip/shared/preflight.go
+++ b/deployment/ccip/shared/preflight.go
@@ -1,0 +1,150 @@
+package shared
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+)
+
+// AddressRefConflict is two planned address refs that resolve to the same datastore key.
+type AddressRefConflict struct {
+	// Key is the datastore key both refs resolve to.
+	Key string
+	// First and Second are the two refs claiming it.
+	First  datastore.AddressRef
+	Second datastore.AddressRef
+}
+
+// AddressRefValidationError reports planned address refs that cannot be written to a datastore.
+// Returning it from VerifyPreconditions stops the changeset before it deploys anything.
+type AddressRefValidationError struct {
+	// Conflicts are pairs of planned refs sharing a key. Only one of the two addresses could
+	// survive being written, so the contracts need distinct qualifiers.
+	Conflicts []AddressRefConflict
+	// Versionless are planned refs with no version. A datastore key is built from the version,
+	// so such a ref has no key.
+	Versionless []datastore.AddressRef
+}
+
+// Error summarizes the problem. The individual refs are on the struct, for the caller to render.
+func (e *AddressRefValidationError) Error() string {
+	parts := make([]string, 0, 2)
+	if n := len(e.Conflicts); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d pairs of contracts share a datastore key", n))
+	}
+	if n := len(e.Versionless); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d refs have no version", n))
+	}
+
+	return "address refs cannot be written to the datastore: " + strings.Join(parts, ", ")
+}
+
+// ValidateAddressRefs checks that planned address refs can be written to env's datastore, and
+// is meant to be called from a changeset's VerifyPreconditions with the refs the changeset is
+// about to produce.
+//
+// The datastore keys contracts on (chain, type, version, qualifier), so two contracts of one
+// type and version on one chain need distinct qualifiers. Nothing in the framework can work
+// out those qualifiers for a changeset, and nothing else discovers the clash until the
+// changeset has already deployed: the refs are only written once Apply returns. A changeset
+// deploying more than one instance of a type should therefore declare its refs here first, so
+// a missing qualifier costs a failed precondition rather than orphaned contracts.
+//
+// A planned ref taking over a key that env's datastore already holds is not an error. The
+// environment is the state before this run, so replacing it is what a redeploy means; it is
+// logged so the replacement is visible. Use ValidateAddressRefsStrict to reject it instead.
+func ValidateAddressRefs(env deployment.Environment, planned []datastore.AddressRef) error {
+	return validatePlannedAddressRefs(env, planned, false)
+}
+
+// ValidateAddressRefsStrict is ValidateAddressRefs, and additionally rejects a planned ref that
+// would replace a different address already held under the same key in env's datastore. Use it
+// for a changeset that is only ever meant to deploy contracts that do not exist yet.
+func ValidateAddressRefsStrict(env deployment.Environment, planned []datastore.AddressRef) error {
+	return validatePlannedAddressRefs(env, planned, true)
+}
+
+// sameContract reports whether two refs sharing a key are one contract declared twice rather
+// than two contracts competing for the key.
+//
+// Only a known address can establish that. A changeset calling this from VerifyPreconditions has
+// not deployed yet, so its refs carry no address; two of them are then indistinguishable, and
+// treating them as one contract would let exactly the case this check exists for — two instances
+// of a type with no distinguishing qualifier — pass validation and fail after the deploy.
+func sameContract(a, b datastore.AddressRef) bool {
+	return a.Address != "" && AddressesEqual(a.ChainSelector, a.Address, b.Address)
+}
+
+func validatePlannedAddressRefs(env deployment.Environment, planned []datastore.AddressRef, strict bool) error {
+	problems := &AddressRefValidationError{}
+
+	claimed := make(map[string]datastore.AddressRef, len(planned))
+	for _, ref := range planned {
+		if ref.Version == nil {
+			problems.Versionless = append(problems.Versionless, ref)
+			continue
+		}
+
+		key := ref.Key().String()
+		if first, taken := claimed[key]; taken && !sameContract(first, ref) {
+			problems.Conflicts = append(problems.Conflicts, AddressRefConflict{
+				Key: key, First: first, Second: ref,
+			})
+
+			continue
+		}
+
+		claimed[key] = ref
+	}
+
+	if len(problems.Conflicts) > 0 || len(problems.Versionless) > 0 {
+		return fmt.Errorf("%w: %w", deployment.ErrInvalidConfig, problems)
+	}
+
+	if isNilStore(env.DataStore) {
+		return nil
+	}
+
+	envRefs, err := env.DataStore.Addresses().Fetch()
+	if err != nil {
+		return fmt.Errorf("failed to read environment data store: %w", err)
+	}
+
+	held := make(map[string]datastore.AddressRef, len(envRefs))
+	for _, ref := range envRefs {
+		if ref.Version == nil {
+			continue
+		}
+		held[ref.Key().String()] = ref
+	}
+
+	for key, ref := range claimed {
+		existing, taken := held[key]
+		if !taken || sameContract(existing, ref) {
+			continue
+		}
+
+		if strict {
+			return fmt.Errorf("%w: %s already holds %s, and the changeset would replace it with %s",
+				deployment.ErrInvalidEnvironment, key, existing.Address, ref.Address)
+		}
+
+		if env.Logger != nil {
+			env.Logger.Infow("Changeset will supersede an existing address ref",
+				"key", key, "previousAddress", existing.Address, "newAddress", ref.Address)
+		}
+	}
+
+	return nil
+}
+
+// AsAddressRefValidationError extracts the detail from an error returned by ValidateAddressRefs.
+func AsAddressRefValidationError(err error) (*AddressRefValidationError, bool) {
+	var target *AddressRefValidationError
+	ok := errors.As(err, &target)
+
+	return target, ok
+}

--- a/deployment/ccip/shared/preflight_test.go
+++ b/deployment/ccip/shared/preflight_test.go
@@ -1,0 +1,183 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+)
+
+const testChainSelector = 5009297550715157269
+
+// testEnvironment builds a minimal environment for preflight tests: a memory address book, a
+// sealed memory datastore, and a test logger. It mirrors the framework's NewNoopEnvironment
+// without pulling in the full engine test runtime.
+func testEnvironment(t *testing.T) deployment.Environment {
+	t.Helper()
+
+	return deployment.Environment{
+		Logger:            logger.Test(t),
+		ExistingAddresses: deployment.NewMemoryAddressBook(),
+		DataStore:         datastore.NewMemoryDataStore().Seal(),
+	}
+}
+
+func poolRef(addr, qualifier string) datastore.AddressRef {
+	return datastore.AddressRef{
+		ChainSelector: testChainSelector,
+		Address:       addr,
+		Type:          datastore.ContractType("BurnMintTokenPool"),
+		Version:       semver.MustParse("1.5.0"),
+		Qualifier:     qualifier,
+	}
+}
+
+// TestValidateAddressRefsRejectsSharedKey verifies the case the check exists for: a changeset
+// about to deploy two contracts of one type and version that have not been given distinct
+// qualifiers. Called from VerifyPreconditions this fails before anything is deployed.
+func TestValidateAddressRefsRejectsSharedKey(t *testing.T) {
+	t.Parallel()
+	e := testEnvironment(t)
+
+	err := ValidateAddressRefs(e, []datastore.AddressRef{
+		poolRef("0xaaa", ""),
+		poolRef("0xbbb", ""),
+	})
+
+	require.ErrorIs(t, err, deployment.ErrInvalidConfig)
+
+	detail, ok := AsAddressRefValidationError(err)
+	require.True(t, ok)
+	require.Len(t, detail.Conflicts, 1)
+	assert.Equal(t, "0xaaa", detail.Conflicts[0].First.Address)
+	assert.Equal(t, "0xbbb", detail.Conflicts[0].Second.Address)
+}
+
+// TestValidateAddressRefsAcceptsDistinctQualifiers verifies the same two contracts pass once
+// the caller has said which is which.
+func TestValidateAddressRefsAcceptsDistinctQualifiers(t *testing.T) {
+	t.Parallel()
+	e := testEnvironment(t)
+
+	require.NoError(t, ValidateAddressRefs(e, []datastore.AddressRef{
+		poolRef("0xaaa", "LINK"),
+		poolRef("0xbbb", "USDC"),
+	}))
+}
+
+// TestValidateAddressRefsRejectsVersionless verifies a ref with no version is reported: the
+// datastore key is built from the version, so such a ref has no key at all.
+func TestValidateAddressRefsRejectsVersionless(t *testing.T) {
+	t.Parallel()
+	e := testEnvironment(t)
+
+	err := ValidateAddressRefs(e, []datastore.AddressRef{{
+		ChainSelector: testChainSelector,
+		Address:       "0xaaa",
+		Type:          datastore.ContractType("Router"),
+	}})
+
+	detail, ok := AsAddressRefValidationError(err)
+	require.True(t, ok)
+	require.Len(t, detail.Versionless, 1)
+}
+
+// TestValidateAddressRefsRepeatedAddress verifies that the same address listed twice under one
+// key is not a conflict. It is one contract, declared twice.
+func TestValidateAddressRefsRepeatedAddress(t *testing.T) {
+	t.Parallel()
+	e := testEnvironment(t)
+
+	require.NoError(t, ValidateAddressRefs(e, []datastore.AddressRef{
+		poolRef("0xaaa", "LINK"),
+		poolRef("0xaaa", "LINK"),
+	}))
+}
+
+// TestValidateAddressRefsSupersedingEnv verifies that replacing a contract the environment
+// already holds is allowed by default, since that is what a redeploy is, and rejected by the
+// strict variant for changesets that only ever deploy new contracts.
+func TestValidateAddressRefsSupersedingEnv(t *testing.T) {
+	t.Parallel()
+	newEnv := func(t *testing.T) deployment.Environment {
+		t.Helper()
+
+		e := testEnvironment(t)
+		mutable, ok := e.DataStore.Addresses().(datastore.MutableAddressRefStore)
+		require.True(t, ok)
+		require.NoError(t, mutable.Upsert(poolRef("0xold", "LINK")))
+
+		return e
+	}
+
+	t.Run("allowed by default", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, ValidateAddressRefs(newEnv(t), []datastore.AddressRef{poolRef("0xnew", "LINK")}))
+	})
+
+	t.Run("rejected when strict", func(t *testing.T) {
+		t.Parallel()
+		err := ValidateAddressRefsStrict(newEnv(t), []datastore.AddressRef{poolRef("0xnew", "LINK")})
+		require.ErrorIs(t, err, deployment.ErrInvalidEnvironment)
+		assert.ErrorContains(t, err, "0xold")
+	})
+
+	t.Run("same address is not a replacement", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, ValidateAddressRefsStrict(newEnv(t), []datastore.AddressRef{poolRef("0xold", "LINK")}))
+	})
+}
+
+// TestValidateAddressRefsRejectsSharedKeyBeforeDeploy verifies the check works in the situation
+// it is documented for: called from VerifyPreconditions, where nothing has been deployed and the
+// planned refs therefore carry no address. Two instances of one type with no distinguishing
+// qualifier must be rejected here, not discovered once the contracts are already on chain.
+func TestValidateAddressRefsRejectsSharedKeyBeforeDeploy(t *testing.T) {
+	t.Parallel()
+	e := testEnvironment(t)
+
+	err := ValidateAddressRefs(e, []datastore.AddressRef{
+		poolRef("", ""),
+		poolRef("", ""),
+	})
+
+	require.ErrorIs(t, err, deployment.ErrInvalidConfig)
+
+	detail, ok := AsAddressRefValidationError(err)
+	require.True(t, ok)
+	require.Len(t, detail.Conflicts, 1)
+}
+
+// TestValidateAddressRefsAcceptsDistinctQualifiersBeforeDeploy verifies the same undeployed refs
+// pass once the caller has given them distinct qualifiers, so the rule above does not simply
+// reject every ref that has no address yet.
+func TestValidateAddressRefsAcceptsDistinctQualifiersBeforeDeploy(t *testing.T) {
+	t.Parallel()
+	e := testEnvironment(t)
+
+	require.NoError(t, ValidateAddressRefs(e, []datastore.AddressRef{
+		poolRef("", "LINK"),
+		poolRef("", "USDC"),
+	}))
+}
+
+// TestValidateAddressRefsStrictUndeployedOverEnv verifies that an undeployed ref claiming a key
+// the environment already holds is still caught by the strict variant. The address is unknown,
+// so it cannot be shown to be the contract already recorded there.
+func TestValidateAddressRefsStrictUndeployedOverEnv(t *testing.T) {
+	t.Parallel()
+	e := testEnvironment(t)
+	mutable, ok := e.DataStore.Addresses().(datastore.MutableAddressRefStore)
+	require.True(t, ok)
+	require.NoError(t, mutable.Upsert(poolRef("0xold", "LINK")))
+
+	err := ValidateAddressRefsStrict(e, []datastore.AddressRef{poolRef("", "LINK")})
+	require.ErrorIs(t, err, deployment.ErrInvalidEnvironment)
+	assert.ErrorContains(t, err, "0xold")
+}

--- a/deployment/ccip/shared/record.go
+++ b/deployment/ccip/shared/record.go
@@ -1,0 +1,288 @@
+package shared
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+)
+
+// DeployContractAndRecord is deployment.DeployContract, and additionally writes the datastore
+// ref for the contract as part of the same step.
+//
+// Recording the ref here rather than deriving it from the address book afterwards is what stops a
+// deployment succeeding and then failing to be recorded. A derived-at-the-end datastore is a
+// second computation over the results, so it can disagree with what was deployed, and it can only
+// fail once every contract already exists on chain at which point there is nothing useful left
+// to do about it. Written here, the ref lands at the same moment the address does.
+//
+// It also means the store is filled in incrementally, so a run that dies partway through still
+// has a datastore record of what it managed to deploy.
+//
+// The key is claimed BEFORE the transaction is sent, which is the whole point of the ordering
+// here. The datastore key is (chain, type, version, qualifier) and none of that depends on the
+// deployed address, so it can be established up front, because a conflict found
+// afterwards would leave a contract deployed and written to the address book with no datastore
+// ref, which is the inconsistency this helper exists to prevent. That is why tv and qualifier are
+// parameters rather than being read back off the deploy closure's result: the closure performs the
+// deployment, so anything it returns is only knowable too late.
+//
+// The qualifier says which instance of tv this is, since only the caller knows that. A chain
+// singleton passes "", anything deployed more than once on a chain e.g. (token pool or a lane) needs
+// a value, or the instances collide on one key.
+//
+// A caller that reserved its keys earlier (see ValidateAddressRefs) finds its own reservation here
+// and takes it. A caller that did not claims the key now. Either way a second contract arriving at
+// an occupied key fails before it is deployed, so nothing is ever stranded and the contract
+// already recorded there is never silently dropped.
+func DeployContractAndRecord[C any](
+	lggr logger.Logger,
+	chain cldf_evm.Chain,
+	addressBook deployment.AddressBook,
+	ds datastore.MutableDataStore,
+	tv deployment.TypeAndVersion,
+	qualifier string,
+	deploy func(chain cldf_evm.Chain) deployment.ContractDeploy[C],
+) (*deployment.ContractDeploy[C], error) {
+	// A nil store is a programming error rather than a shorthand for "skip the datastore":
+	// silently degrading to DeployContract would drop the ref this function exists to write.
+	if isNilStore(ds) {
+		return nil, errors.New("DeployContractAndRecord requires a datastore; use DeployContract to write only the address book")
+	}
+
+	version := tv.Version
+	ref := datastore.AddressRef{
+		ChainSelector: chain.Selector,
+		Type:          datastore.ContractType(tv.Type),
+		Version:       &version,
+		Qualifier:     qualifier,
+	}
+	if !tv.Labels.IsEmpty() {
+		ref.Labels = datastore.NewLabelSet(tv.Labels.List()...)
+	}
+
+	claimed, err := claimAddressRef(ds, ref)
+	if err != nil {
+		lggr.Errorw("Refusing to deploy: datastore key is already taken",
+			"Contract", tv.String(), "chain", chain.String(), "err", err)
+
+		return nil, err
+	}
+
+	// A failure from here on releases the reservation again but only one this call made: a
+	// reservation found already in place belongs to whoever made it. A leftover empty-address
+	// ref is not a record of progress (the address is the part that matters), and it would be
+	// merged and persisted as if it were one.
+	release := func() {
+		if !claimed {
+			return
+		}
+		if delErr := ds.Addresses().Delete(ref.Key()); delErr != nil {
+			lggr.Warnw("Failed to release the datastore key reservation after a failed deployment",
+				"Contract", tv.String(), "chain", chain.String(), "err", delErr)
+		}
+	}
+
+	// The deploy-and-confirm sequence of DeployContract is inlined rather than delegated to,
+	// because the declared type and version must be checked against what was deployed BEFORE
+	// the address book is written: a mismatch found afterwards would leave the address saved
+	// under the wrong type while the datastore key was reserved for the declared one.
+	contractDeploy := deploy(chain)
+	if contractDeploy.Err != nil {
+		lggr.Errorw("Failed to deploy contract", "chain", chain.String(), "err", contractDeploy.Err)
+		release()
+
+		return nil, contractDeploy.Err
+	}
+	if !chain.IsZkSyncVM {
+		if _, err = chain.Confirm(contractDeploy.Tx); err != nil {
+			lggr.Errorw("Failed to confirm deployment", "chain", chain.String(), "Contract", contractDeploy.Tv.String(), "err", err)
+			release()
+
+			return nil, err
+		}
+	}
+	lggr.Infow("Deployed contract", "Contract", contractDeploy.Tv.String(), "addr", contractDeploy.Address, "chain", chain.String())
+
+	if contractDeploy.Tv.String() != tv.String() {
+		release()
+
+		return nil, fmt.Errorf(
+			"deployed contract is %s but %s was declared to DeployContractAndRecord; the datastore ref was reserved for the declared type",
+			contractDeploy.Tv.String(), tv.String())
+	}
+
+	if err = addressBook.Save(chain.Selector, contractDeploy.Address.String(), contractDeploy.Tv); err != nil {
+		lggr.Errorw("Failed to save contract address", "Contract", contractDeploy.Tv.String(), "addr", contractDeploy.Address, "chain", chain.String(), "err", err)
+		release()
+
+		return nil, err
+	}
+
+	// The key is already held by this call, so filling in the address cannot conflict.
+	ref.Address = contractDeploy.Address.String()
+	if err := ds.Addresses().Upsert(ref); err != nil {
+		lggr.Errorw("Failed to record contract address ref",
+			"Contract", tv.String(), "addr", contractDeploy.Address,
+			"chain", chain.String(), "err", err)
+		release()
+
+		return nil, err
+	}
+
+	return &contractDeploy, nil
+}
+
+// RecordAddress records a contract whose address the caller already has, into both the address
+// book and the datastore, under a declared qualifier.
+//
+// It is the counterpart to DeployContractAndRecord for addresses that are not produced by an EVM
+// deployment: a Solana PDA or a Sui object is derived rather than deployed, and an imported
+// contract already exists. There is no transaction to order against here, so unlike the deploy
+// path this cannot fail "too late" — but it enforces the same rule, that a key already holding a
+// different contract (or an unowned empty reservation) is an error rather than an overwrite.
+//
+// Recording the same address twice is a no-op, so a re-run is safe. Addresses are compared with
+// the case rules of the chain's family, so a checksummed EVM address and its lower-case form are
+// recognised as one contract. A nil address book is an explicit opt-out of the legacy registry.
+func RecordAddress(
+	ab deployment.AddressBook,
+	ds datastore.MutableDataStore,
+	chainSelector uint64,
+	address string,
+	tv deployment.TypeAndVersion,
+	qualifier string,
+) error {
+	if isNilStore(ds) {
+		return errors.New("RecordAddress requires a datastore")
+	}
+
+	version := tv.Version
+	ref := datastore.AddressRef{
+		ChainSelector: chainSelector,
+		Address:       address,
+		Type:          datastore.ContractType(tv.Type),
+		Version:       &version,
+		Qualifier:     qualifier,
+	}
+	if !tv.Labels.IsEmpty() {
+		ref.Labels = datastore.NewLabelSet(tv.Labels.List()...)
+	}
+
+	// The key check comes before anything is written: a key already holding a different
+	// contract is an error, and raising it only after one registry was written would leave the
+	// two disagreeing. An empty-address reservation is a pending claim in the caller's private
+	// store (typically created by ReserveRefs), so it is this call's to fill.
+	existing, getErr := ds.Addresses().Get(ref.Key())
+	notFound := errors.Is(getErr, datastore.ErrAddressRefNotFound)
+	switch {
+	case notFound:
+		// The key is free; it is added once the address book has accepted the address.
+	case getErr != nil:
+		return fmt.Errorf("failed to read address ref %s: %w", ref.Key().String(), getErr)
+
+	case existing.Address == "" || AddressesEqual(chainSelector, existing.Address, address):
+		// An empty address is a reservation this run made (via ReserveRefs) to fill; an equal
+		// address is the same contract recorded twice. Either way the key is ours to write.
+
+	default:
+		// A different contract is genuinely occupied.
+		return fmt.Errorf(
+			"%w: %s already holds %s, so %s cannot be recorded under it; give the two contracts distinct qualifiers",
+			datastore.ErrAddressRefExists, ref.Key().String(), existing.Address, address)
+	}
+
+	// The address book write comes first: it is the write that can still fail here, and with
+	// the datastore untouched a failure leaves nothing to roll back.
+	if !isNilStore(ab) {
+		if err := saveAddressBookRecord(ab, chainSelector, address, tv); err != nil {
+			return err
+		}
+	}
+
+	if notFound {
+		return ds.Addresses().Add(ref)
+	}
+
+	return ds.Addresses().Upsert(ref)
+}
+
+// saveAddressBookRecord writes the address to the address book unless it is already there under
+// the same type and version, which is what makes a repeated RecordAddress a no-op rather than an
+// error: AddressBookMap.Save rejects a repeated address outright. The same address recorded
+// under a different type and version is a genuine disagreement, and is rejected before anything
+// is written.
+func saveAddressBookRecord(ab deployment.AddressBook, chainSelector uint64, address string, tv deployment.TypeAndVersion) error {
+	chainAddrs, err := ab.AddressesForChain(chainSelector)
+	if err != nil && !errors.Is(err, deployment.ErrChainNotFound) {
+		return fmt.Errorf("failed to read address book for chain %d: %w", chainSelector, err)
+	}
+
+	for recorded, known := range chainAddrs {
+		if !AddressesEqual(chainSelector, recorded, address) {
+			continue
+		}
+		if !known.Equal(tv) {
+			return fmt.Errorf(
+				"the address book records %s on chain %d as %s, so it cannot be recorded as %s",
+				recorded, chainSelector, known.String(), tv.String())
+		}
+
+		return nil
+	}
+
+	return ab.Save(chainSelector, address, tv)
+}
+
+// claimAddressRef takes ownership of ref's key ahead of the deployment. ref carries no address
+// yet, by design: the claim has to happen before the contract exists, so the only thing that can
+// be established here is the key. It reports whether it created the reservation, so the caller
+// can remove it again if the deployment goes on to fail.
+//
+// A key that already holds a deployed address is occupied and a second claim is refused before
+// the transaction is sent. An empty-address reservation is a pending claim: either one this call
+// just made, or one made earlier in the same run via ReserveRefs, which validates the whole key
+// set up front (no duplicate keys, every multi-instance member qualified) and hands the caller a
+// private store. Both are the caller's to fill.
+func claimAddressRef(ds datastore.MutableDataStore, ref datastore.AddressRef) (bool, error) {
+	existing, err := ds.Addresses().Get(ref.Key())
+	switch {
+	case errors.Is(err, datastore.ErrAddressRefNotFound):
+		if addErr := ds.Addresses().Add(ref); addErr != nil {
+			return false, addErr
+		}
+
+		return true, nil
+
+	case err != nil:
+		return false, fmt.Errorf("failed to read address ref %s: %w", ref.Key().String(), err)
+
+	// An empty address is a reservation in this private store (possibly from ReserveRefs), which
+	// is this caller's to fill rather than release.
+	case existing.Address == "":
+		return false, nil
+
+	default:
+		return false, fmt.Errorf(
+			"%w: %s already holds %s; give the two contracts distinct qualifiers",
+			datastore.ErrAddressRefExists, ref.Key().String(), existing.Address)
+	}
+}
+
+// isNilStore reports whether v is unset, including the case of a non-nil interface holding a
+// nil pointer. A changeset returning ChangesetOutput{DataStore: (*datastore.MemoryDataStore)(nil)}
+// passes an ordinary != nil check and then panics on first use.
+func isNilStore(v any) bool {
+	if v == nil {
+		return true
+	}
+
+	rv := reflect.ValueOf(v)
+
+	return rv.Kind() == reflect.Pointer && rv.IsNil()
+}

--- a/deployment/ccip/shared/record_test.go
+++ b/deployment/ccip/shared/record_test.go
@@ -1,0 +1,427 @@
+package shared
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+)
+
+const recordTestChainSelector = 5009297550715157269
+
+// recordTestRef builds a ref as claimAddressRef sees one: keyed, but with no address, because the
+// claim happens before the contract is deployed.
+func recordTestRef(qualifier string) datastore.AddressRef {
+	return datastore.AddressRef{
+		ChainSelector: recordTestChainSelector,
+		Type:          datastore.ContractType("BurnMintTokenPool"),
+		Version:       semver.MustParse("1.5.0"),
+		Qualifier:     qualifier,
+	}
+}
+
+func recordTestDeployed(qualifier, address string) datastore.AddressRef {
+	ref := recordTestRef(qualifier)
+	ref.Address = address
+
+	return ref
+}
+
+// A key nobody holds is claimed by the deployment that reaches it first.
+func TestClaimAddressRef_ClaimsFreeKey(t *testing.T) {
+	t.Parallel()
+	ds := datastore.NewMemoryDataStore()
+
+	ref := recordTestRef("LINK")
+	claimed, err := claimAddressRef(ds, ref)
+	require.NoError(t, err)
+	assert.True(t, claimed, "a claim on a free key creates the reservation")
+
+	got, err := ds.Addresses().Get(ref.Key())
+	require.NoError(t, err)
+	assert.Empty(t, got.Address, "a claim records the key, not an address")
+}
+
+// An empty-address reservation (e.g. made earlier by ReserveRefs in this private store) is this
+// caller's to fill, not a new claim and not a conflict.
+func TestClaimAddressRef_AcceptsOwnReservation(t *testing.T) {
+	t.Parallel()
+	ds := datastore.NewMemoryDataStore()
+
+	ref := recordTestRef("LINK")
+	require.NoError(t, ds.Addresses().Add(ref))
+
+	claimed, err := claimAddressRef(ds, ref)
+	require.NoError(t, err)
+	assert.False(t, claimed, "an existing reservation is not this call's to release")
+
+	refs, err := ds.Addresses().Fetch()
+	require.NoError(t, err)
+	assert.Len(t, refs, 1)
+}
+
+// A key already holding a deployed address cannot take a second contract. Crucially this is
+// raised before anything is deployed, so nothing is stranded by it.
+func TestClaimAddressRef_RejectsKeyHoldingADeployedContract(t *testing.T) {
+	t.Parallel()
+	ds := datastore.NewMemoryDataStore()
+
+	require.NoError(t, ds.Addresses().Add(recordTestDeployed("", "0xaaa")))
+
+	_, err := claimAddressRef(ds, recordTestRef(""))
+	require.ErrorIs(t, err, datastore.ErrAddressRefExists)
+	require.ErrorContains(t, err, "0xaaa")
+
+	// The contract already recorded is untouched.
+	got, getErr := ds.Addresses().Get(recordTestRef("").Key())
+	require.NoError(t, getErr)
+	assert.Equal(t, "0xaaa", got.Address)
+}
+
+// Distinct qualifiers are what let two instances of one type coexist.
+func TestClaimAddressRef_DistinctQualifiersCoexist(t *testing.T) {
+	t.Parallel()
+	ds := datastore.NewMemoryDataStore()
+
+	_, err := claimAddressRef(ds, recordTestRef("LINK"))
+	require.NoError(t, err)
+	_, err = claimAddressRef(ds, recordTestRef("USDC"))
+	require.NoError(t, err)
+
+	refs, err := ds.Addresses().Fetch()
+	require.NoError(t, err)
+	assert.Len(t, refs, 2)
+}
+
+// AddressesEqual has to fold case on EVM, where the same contract is routinely written both
+// checksummed and lower-case, and must not fold it on Solana, where case is significant.
+func TestAddressesEqual(t *testing.T) {
+	t.Parallel()
+	evm := chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector
+	solana := chainsel.SOLANA_DEVNET.Selector
+
+	checksummed := "0x0b9d5D9136855f6FEc3c0993feE6E9CE8a297846"
+	lowered := "0x0b9d5d9136855f6fec3c0993fee6e9ce8a297846"
+
+	assert.True(t, AddressesEqual(evm, checksummed, lowered),
+		"the same EVM contract written in two casings is one contract")
+	assert.False(t, AddressesEqual(evm, checksummed, "0x1234567890123456789012345678901234567890"))
+
+	assert.False(t, AddressesEqual(solana,
+		"So11111111111111111111111111111111111111112",
+		"so11111111111111111111111111111111111111112"),
+		"Solana addresses are case-sensitive, so these are two different accounts")
+
+	// An unrecognised selector keeps the distinction rather than erasing it.
+	assert.False(t, AddressesEqual(0, checksummed, lowered))
+}
+
+// The record tests run on a real EVM chain so the address book's validation applies.
+var (
+	recordSepoliaSelector = chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector
+	recordSepoliaAddr     = "0x5B5BBb15ECE0a4Ed8cDab22F902e83F66aBe848f"
+)
+
+func recordSepoliaTV() deployment.TypeAndVersion {
+	return deployment.NewTypeAndVersion(deployment.ContractType("BurnMintTokenPool"), *semver.MustParse("1.5.0"))
+}
+
+// recordSepoliaQualifier is the qualifier every record test writes: a token pool for the LINK
+// token, so the token symbol is the qualifier.
+const recordSepoliaQualifier = "LINK"
+
+func recordSepoliaKey(tv deployment.TypeAndVersion) datastore.AddressRefKey {
+	return datastore.NewAddressRefKey(
+		recordSepoliaSelector, datastore.ContractType(tv.Type), &tv.Version, recordSepoliaQualifier)
+}
+
+// The common case: one call, both registries hold the contract.
+func TestRecordAddress_WritesBothRegistries(t *testing.T) {
+	t.Parallel()
+	ab := deployment.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
+	tv := recordSepoliaTV()
+
+	require.NoError(t, RecordAddress(ab, ds, recordSepoliaSelector, recordSepoliaAddr, tv, "LINK"))
+
+	addrs, err := ab.AddressesForChain(recordSepoliaSelector)
+	require.NoError(t, err)
+	assert.Contains(t, addrs, recordSepoliaAddr)
+
+	ref, err := ds.Addresses().Get(recordSepoliaKey(tv))
+	require.NoError(t, err)
+	assert.Equal(t, recordSepoliaAddr, ref.Address)
+}
+
+// The doc comment promises a re-run is a no-op. AddressBookMap.Save rejects a repeated address
+// outright, so the second call has to recognise the entry as its own rather than save again.
+func TestRecordAddress_RepeatedRecordingIsNoOp(t *testing.T) {
+	t.Parallel()
+	ab := deployment.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
+	tv := recordSepoliaTV()
+
+	require.NoError(t, RecordAddress(ab, ds, recordSepoliaSelector, recordSepoliaAddr, tv, "LINK"))
+	require.NoError(t, RecordAddress(ab, ds, recordSepoliaSelector, recordSepoliaAddr, tv, "LINK"),
+		"recording the same contract twice must not fail")
+
+	addrs, err := ab.AddressesForChain(recordSepoliaSelector)
+	require.NoError(t, err)
+	assert.Len(t, addrs, 1)
+
+	refs, err := ds.Addresses().Fetch()
+	require.NoError(t, err)
+	assert.Len(t, refs, 1)
+}
+
+// A checksummed address and its lower-case form are one contract on EVM, so re-recording under
+// the other casing is the same no-op.
+func TestRecordAddress_CaseVariantIsTheSameContract(t *testing.T) {
+	t.Parallel()
+	ab := deployment.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
+	tv := recordSepoliaTV()
+	lowered := "0x5b5bbb15ece0a4ed8cdab22f902e83f66abe848f"
+
+	require.NoError(t, RecordAddress(ab, ds, recordSepoliaSelector, recordSepoliaAddr, tv, "LINK"))
+	require.NoError(t, RecordAddress(ab, ds, recordSepoliaSelector, lowered, tv, "LINK"))
+
+	addrs, err := ab.AddressesForChain(recordSepoliaSelector)
+	require.NoError(t, err)
+	assert.Len(t, addrs, 1)
+
+	refs, err := ds.Addresses().Fetch()
+	require.NoError(t, err)
+	assert.Len(t, refs, 1)
+}
+
+// A key already holding a different contract is refused before anything is written, so the
+// address book stays untouched.
+func TestRecordAddress_RefusingAConflictWritesNothing(t *testing.T) {
+	t.Parallel()
+	ab := deployment.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
+	tv := recordSepoliaTV()
+
+	other := recordSepoliaDeployed(tv, "0x6619Bad7fadbc282B1EF2F6cC078fCbE61478792")
+	require.NoError(t, ds.Addresses().Add(other))
+
+	err := RecordAddress(ab, ds, recordSepoliaSelector, recordSepoliaAddr, tv, "LINK")
+	require.ErrorIs(t, err, datastore.ErrAddressRefExists)
+
+	_, err = ab.AddressesForChain(recordSepoliaSelector)
+	require.ErrorIs(t, err, deployment.ErrChainNotFound, "the address book must be untouched")
+}
+
+func recordSepoliaDeployed(tv deployment.TypeAndVersion, address string) datastore.AddressRef {
+	return datastore.AddressRef{
+		ChainSelector: recordSepoliaSelector,
+		Address:       address,
+		Type:          datastore.ContractType(tv.Type),
+		Version:       &tv.Version,
+		Qualifier:     recordSepoliaQualifier,
+	}
+}
+
+// The address book already holding the address under a different type is a disagreement, not a
+// re-run, and is rejected before the datastore is written.
+func TestRecordAddress_AddressBookDisagreementWritesNothing(t *testing.T) {
+	t.Parallel()
+	ab := deployment.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
+	tv := recordSepoliaTV()
+
+	require.NoError(t, ab.Save(recordSepoliaSelector, recordSepoliaAddr,
+		deployment.NewTypeAndVersion(deployment.ContractType("Router"), *semver.MustParse("1.6.0"))))
+
+	err := RecordAddress(ab, ds, recordSepoliaSelector, recordSepoliaAddr, tv, "LINK")
+	require.ErrorContains(t, err, "the address book records")
+
+	refs, err := ds.Addresses().Fetch()
+	require.NoError(t, err)
+	assert.Empty(t, refs, "the datastore must be untouched")
+}
+
+// An empty-address reservation made earlier in the run (via ReserveRefs) belongs to this caller
+// and gets filled.
+func TestRecordAddress_FillsOwnReservation(t *testing.T) {
+	t.Parallel()
+	ab := deployment.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
+	tv := recordSepoliaTV()
+
+	require.NoError(t, ds.Addresses().Add(recordSepoliaDeployed(tv, "")))
+	require.NoError(t, RecordAddress(ab, ds, recordSepoliaSelector, recordSepoliaAddr, tv, "LINK"))
+
+	ref, err := ds.Addresses().Get(recordSepoliaKey(tv))
+	require.NoError(t, err)
+	assert.Equal(t, recordSepoliaAddr, ref.Address)
+
+	addrs, err := ab.AddressesForChain(recordSepoliaSelector)
+	require.NoError(t, err)
+	assert.Contains(t, addrs, recordSepoliaAddr)
+}
+
+// A nil address book is an explicit opt-out of the legacy registry, not an error.
+func TestRecordAddress_NilAddressBookWritesOnlyTheDataStore(t *testing.T) {
+	t.Parallel()
+	ds := datastore.NewMemoryDataStore()
+	tv := recordSepoliaTV()
+
+	require.NoError(t, RecordAddress(nil, ds, recordSepoliaSelector, recordSepoliaAddr, tv, "LINK"))
+
+	ref, err := ds.Addresses().Get(recordSepoliaKey(tv))
+	require.NoError(t, err)
+	assert.Equal(t, recordSepoliaAddr, ref.Address)
+}
+
+func TestRecordAddress_RequiresDataStore(t *testing.T) {
+	t.Parallel()
+	err := RecordAddress(deployment.NewMemoryAddressBook(), nil, recordSepoliaSelector, recordSepoliaAddr, recordSepoliaTV(), "LINK")
+	require.ErrorContains(t, err, "requires a datastore")
+}
+
+// recordDeployChain is a zkSync-flavoured test chain: the IsZkSyncVM flag skips transaction
+// confirmation, so deployment tests need no client.
+func recordDeployChain() cldf_evm.Chain {
+	return cldf_evm.Chain{Selector: recordSepoliaSelector, IsZkSyncVM: true}
+}
+
+// The happy path records the contract in both registries under the declared qualifier.
+func TestDeployContractAndRecord_WritesBothRegistries(t *testing.T) {
+	t.Parallel()
+	ab := deployment.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
+	tv := recordSepoliaTV()
+
+	got, err := DeployContractAndRecord(logger.Test(t), recordDeployChain(), ab, ds, tv, "LINK",
+		func(cldf_evm.Chain) deployment.ContractDeploy[any] {
+			return deployment.ContractDeploy[any]{Address: common.HexToAddress(recordSepoliaAddr), Tv: tv}
+		})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	addrs, err := ab.AddressesForChain(recordSepoliaSelector)
+	require.NoError(t, err)
+	assert.Contains(t, addrs, recordSepoliaAddr)
+
+	ref, err := ds.Addresses().Get(recordSepoliaKey(tv))
+	require.NoError(t, err)
+	assert.Equal(t, recordSepoliaAddr, ref.Address)
+}
+
+// A key already holding a deployed contract refuses the deploy before the closure runs: the
+// contract is never even sent.
+func TestDeployContractAndRecord_RefusesATakenKeyBeforeDeploying(t *testing.T) {
+	t.Parallel()
+	ab := deployment.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
+	tv := recordSepoliaTV()
+
+	require.NoError(t, ds.Addresses().Add(recordSepoliaDeployed(tv, "0x6619Bad7fadbc282B1EF2F6cC078fCbE61478792")))
+
+	deployed := false
+	_, err := DeployContractAndRecord(logger.Test(t), recordDeployChain(), ab, ds, tv, "LINK",
+		func(cldf_evm.Chain) deployment.ContractDeploy[any] {
+			deployed = true
+
+			return deployment.ContractDeploy[any]{Address: common.HexToAddress(recordSepoliaAddr), Tv: tv}
+		})
+	require.ErrorIs(t, err, datastore.ErrAddressRefExists)
+	assert.False(t, deployed, "the deploy closure must not run when the key is taken")
+}
+
+// A failed deployment takes its reservation with it: an empty-address ref left behind would be
+// merged and persisted as if it were a record of progress, and it is not one.
+func TestDeployContractAndRecord_DeployFailureReleasesTheReservation(t *testing.T) {
+	t.Parallel()
+	ab := deployment.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
+	tv := recordSepoliaTV()
+
+	_, err := DeployContractAndRecord(logger.Test(t), recordDeployChain(), ab, ds, tv, "LINK",
+		func(cldf_evm.Chain) deployment.ContractDeploy[any] {
+			return deployment.ContractDeploy[any]{Err: errors.New("deploy boom")}
+		})
+	require.ErrorContains(t, err, "deploy boom")
+
+	refs, err := ds.Addresses().Fetch()
+	require.NoError(t, err)
+	assert.Empty(t, refs, "the reservation must not survive the failed deployment")
+
+	_, err = ab.AddressesForChain(recordSepoliaSelector)
+	require.ErrorIs(t, err, deployment.ErrChainNotFound)
+}
+
+// A reservation this call did not make (e.g. from ReserveRefs) is not its to release: a failed
+// deployment must leave the reserved key in place.
+func TestDeployContractAndRecord_FailureKeepsAPreExistingReservation(t *testing.T) {
+	t.Parallel()
+	ab := deployment.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
+	tv := recordSepoliaTV()
+
+	require.NoError(t, ds.Addresses().Add(recordSepoliaDeployed(tv, "")))
+
+	_, err := DeployContractAndRecord(logger.Test(t), recordDeployChain(), ab, ds, tv, "LINK",
+		func(cldf_evm.Chain) deployment.ContractDeploy[any] {
+			return deployment.ContractDeploy[any]{Err: errors.New("deploy boom")}
+		})
+	require.ErrorContains(t, err, "deploy boom")
+
+	got, err := ds.Addresses().Get(recordSepoliaKey(tv))
+	require.NoError(t, err, "a reservation made earlier in the run is not this call's to release")
+	assert.Empty(t, got.Address)
+}
+
+// The deployed type and version are checked before the address book is written: a mismatch
+// leaves neither registry touched.
+func TestDeployContractAndRecord_TypeMismatchWritesNothing(t *testing.T) {
+	t.Parallel()
+	ab := deployment.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
+	tv := recordSepoliaTV()
+	deployed := deployment.NewTypeAndVersion(deployment.ContractType("Router"), *semver.MustParse("1.6.0"))
+
+	_, err := DeployContractAndRecord(logger.Test(t), recordDeployChain(), ab, ds, tv, "LINK",
+		func(cldf_evm.Chain) deployment.ContractDeploy[any] {
+			return deployment.ContractDeploy[any]{Address: common.HexToAddress(recordSepoliaAddr), Tv: deployed}
+		})
+	require.ErrorContains(t, err, "was declared to DeployContractAndRecord")
+
+	_, abErr := ab.AddressesForChain(recordSepoliaSelector)
+	require.ErrorIs(t, abErr, deployment.ErrChainNotFound, "the type check must come before the address book write")
+
+	refs, err := ds.Addresses().Fetch()
+	require.NoError(t, err)
+	assert.Empty(t, refs, "the reservation must not survive the mismatch")
+}
+
+// An address book rejection (here: the zero address) likewise leaves no datastore reservation.
+func TestDeployContractAndRecord_AddressBookFailureReleasesTheReservation(t *testing.T) {
+	t.Parallel()
+	ab := deployment.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
+	tv := recordSepoliaTV()
+
+	_, err := DeployContractAndRecord(logger.Test(t), recordDeployChain(), ab, ds, tv, "LINK",
+		func(cldf_evm.Chain) deployment.ContractDeploy[any] {
+			return deployment.ContractDeploy[any]{Address: common.Address{}, Tv: tv}
+		})
+	require.Error(t, err)
+
+	refs, err := ds.Addresses().Fetch()
+	require.NoError(t, err)
+	assert.Empty(t, refs, "the reservation must not survive the address book failure")
+}

--- a/deployment/ccip/shared/refs.go
+++ b/deployment/ccip/shared/refs.go
@@ -1,0 +1,67 @@
+package shared
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+)
+
+// ErrRefReservation is returned when the refs a changeset intends to write cannot all be held in
+// a datastore at once.
+var ErrRefReservation = errors.New("cannot reserve datastore refs")
+
+// ReserveRefs claims a datastore key for every ref a changeset is about to write and returns the
+// store holding the reservations.
+//
+// It is meant to run before anything is deployed. A ref is keyed on
+// (chain, type, version, qualifier) and none of that depends on the address, so the whole key set
+// is known up front: a changeset reserves its keys, deploys, then fills in each address with an
+// upsert into a key it already owns. That upsert cannot conflict, which is what removes the
+// post-deploy datastore step that could otherwise fail once the contracts already exist on chain.
+//
+// Passing the same refs to Validate and to the deployment is the point: the check and the write
+// are then the same computation rather than two that can drift apart.
+func ReserveRefs(refs []datastore.AddressRef) (*datastore.MemoryDataStore, error) {
+	// An empty qualifier is only valid for a chain singleton. datastore lookups that filter on
+	// type and version read an empty qualifier as an omitted filter, so an unqualified member of
+	// a multi-instance group would make every lookup for that group ambiguous. Count the group
+	// sizes first: reacting while writing would be too late, because by then one arbitrary member
+	// has already taken the key.
+	type typeVersion struct {
+		chain   uint64
+		ct      datastore.ContractType
+		version string
+	}
+	instances := make(map[typeVersion]int, len(refs))
+	for _, ref := range refs {
+		if ref.Version == nil {
+			continue
+		}
+		instances[typeVersion{ref.ChainSelector, ref.Type, ref.Version.String()}]++
+	}
+
+	ds := datastore.NewMemoryDataStore()
+	for _, ref := range refs {
+		if ref.Version == nil {
+			return nil, fmt.Errorf(
+				"%w: %s on chain %d has no version, so it has no datastore key",
+				ErrRefReservation, ref.Type, ref.ChainSelector)
+		}
+
+		if ref.Qualifier == "" && instances[typeVersion{ref.ChainSelector, ref.Type, ref.Version.String()}] > 1 {
+			return nil, fmt.Errorf(
+				"%w: chain %d has more than one %s %s and one of them has no qualifier; "+
+					"an empty qualifier reads as 'any' when resolving, so every instance needs a name",
+				ErrRefReservation, ref.ChainSelector, ref.Type, ref.Version)
+		}
+
+		if err := ds.Addresses().Add(ref); err != nil {
+			return nil, fmt.Errorf(
+				"%w: two refs claim (chain %d, %s %s, qualifier %q): %w",
+				ErrRefReservation, ref.ChainSelector, ref.Type, ref.Version, ref.Qualifier, err)
+		}
+	}
+
+	return ds, nil
+}


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
[CCIP-13348](https://smartcontract-it.atlassian.net/browse/CCIP-13348)

Introduces the CCIP-owned datastore write API and guarded changeset-output merge path required for the AddressBook retirement. This establishes one consistent write model before converting individual changesets. Datastore keys are now caller-defined and validated before writes occur.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->
This is the base PR of the stack.
### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

[CCIP-13348]: https://smartcontract-it.atlassian.net/browse/CCIP-13348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ