### PR TITLE
Convert EVM ccip changesets to the datastore write-at-site API

### DIFF
--- a/deployment/ccip/changeset/ccip-attestation/cs_deploy_evm_signer_registry.go
+++ b/deployment/ccip/changeset/ccip-attestation/cs_deploy_evm_signer_registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
@@ -69,6 +70,7 @@ func signerRegistryDeploymentPrecondition(env cldf.Environment, config SignerReg
 
 func signerRegistryDeploymentLogic(e cldf.Environment, config SignerRegistryChangesetConfig) (cldf.ChangesetOutput, error) {
 	addressBook := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 
 	for _, chain := range e.BlockChains.EVMChains() {
 		// Only deploy on Base Mainnet and Base Sepolia
@@ -76,7 +78,7 @@ func signerRegistryDeploymentLogic(e cldf.Environment, config SignerRegistryChan
 			e.Logger.Infof("Skipping deployment on chain %s (selector: %d) - only deploying on Base chains", chain.String(), chain.ChainSelector())
 			continue
 		}
-		signerRegistry, err := cldf.DeployContract(e.Logger, chain, addressBook,
+		signerRegistry, err := shared.DeployContractAndRecord(e.Logger, chain, addressBook, ds, cldf.NewTypeAndVersion(shared.EVMSignerRegistry, deployment.Version1_0_0), "",
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*signer_registry.SignerRegistry] {
 				address, tx, signerRegistry, err := signer_registry.DeploySignerRegistry(
 					chain.DeployerKey,
@@ -99,11 +101,6 @@ func signerRegistryDeploymentLogic(e cldf.Environment, config SignerRegistryChan
 		}
 
 		e.Logger.Infof("Successfully deployed signer registry %s on %s", signerRegistry.Address.String(), chain.String())
-	}
-
-	ds, err := shared.PopulateDataStore(addressBook)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{AddressBook: addressBook, DataStore: ds}, nil

--- a/deployment/ccip/changeset/cs_prerequisites.go
+++ b/deployment/ccip/changeset/cs_prerequisites.go
@@ -35,6 +35,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/weth9"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
@@ -57,24 +58,15 @@ func DeployPrerequisitesChangeset(env cldf.Environment, cfg DeployPrerequisiteCo
 		return cldf.ChangesetOutput{}, fmt.Errorf("%w: %w", err, cldf.ErrInvalidConfig)
 	}
 	ab := cldf.NewMemoryAddressBook()
-	err = deployPrerequisiteChainContracts(env, ab, cfg)
+	ds := datastore.NewMemoryDataStore()
+	err = deployPrerequisiteChainContracts(env, ab, ds, cfg)
 	if err != nil {
 		env.Logger.Errorw("Failed to deploy prerequisite contracts", "err", err, "addressBook", ab)
-
-		ds, err := shared.PopulateDataStore(ab)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-		}
 
 		return cldf.ChangesetOutput{
 			AddressBook: ab,
 			DataStore:   ds,
 		}, fmt.Errorf("failed to deploy prerequisite contracts: %w", err)
-	}
-
-	ds, err := shared.PopulateDataStore(ab)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{
@@ -153,7 +145,7 @@ func WithLegacyDeploymentEnabled(cfg V1_5DeploymentConfig) PrerequisiteOpt {
 	}
 }
 
-func deployPrerequisiteChainContracts(e cldf.Environment, ab cldf.AddressBook, cfg DeployPrerequisiteConfig) error {
+func deployPrerequisiteChainContracts(e cldf.Environment, ab cldf.AddressBook, ds datastore.MutableDataStore, cfg DeployPrerequisiteConfig) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		e.Logger.Errorw("Failed to load existing onchain state", "err", err)
@@ -163,7 +155,9 @@ func deployPrerequisiteChainContracts(e cldf.Environment, ab cldf.AddressBook, c
 	for _, c := range cfg.Configs {
 		chain := e.BlockChains.EVMChains()[c.ChainSelector]
 		deployGrp.Go(func() error {
-			err := deployPrerequisiteContracts(e, ab, state, chain, c.Opts...)
+			// MemoryDataStore guards its own writes, so the per-chain goroutines record into it
+			// directly and no per-chain merge is needed.
+			err := deployPrerequisiteContracts(e, ab, ds, state, chain, c.Opts...)
 			if err != nil {
 				e.Logger.Errorw("Failed to deploy prerequisite contracts", "chain", chain.String(), "err", err)
 				return err
@@ -171,12 +165,14 @@ func deployPrerequisiteChainContracts(e cldf.Environment, ab cldf.AddressBook, c
 			return nil
 		})
 	}
+	// Refs recorded before a failure stay in ds, so the error path still returns a partial
+	// datastore for the chains that did deploy.
 	return deployGrp.Wait()
 }
 
 // deployPrerequisiteContracts deploys the contracts that can be ported from previous CCIP version to the new one.
 // This is only required for staging and test environments where the contracts are not already deployed.
-func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state stateview.CCIPOnChainState, chain cldf_evm.Chain, opts ...PrerequisiteOpt) error {
+func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, ds datastore.MutableDataStore, state stateview.CCIPOnChainState, chain cldf_evm.Chain, opts ...PrerequisiteOpt) error {
 	deployOpts := &DeployPrerequisiteContractsOpts{}
 	for _, opt := range opts {
 		if opt != nil {
@@ -236,7 +232,7 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 		rmnAddr = chainState.RMN.Address()
 	// if RMN is not found in state and LegacyDeploymentCfg is provided, deploy RMN contract based on the config
 	case deployOpts.LegacyDeploymentCfg != nil && deployOpts.LegacyDeploymentCfg.RMNConfig != nil:
-		rmn, err := cldf.DeployContract(lggr, chain, ab,
+		rmn, err := shared.DeployContractAndRecord(lggr, chain, ab, ds, cldf.NewTypeAndVersion(shared.RMN, deployment.Version1_5_0), "",
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*rmn_contract.RMNContract] {
 				var (
 					rmnAddress common.Address
@@ -263,7 +259,7 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 	default:
 		// otherwise deploy the mock RMN contract
 		if chainState.MockRMN == nil {
-			rmn, err := cldf.DeployContract(lggr, chain, ab,
+			rmn, err := shared.DeployContractAndRecord(lggr, chain, ab, ds, cldf.NewTypeAndVersion(shared.MockRMN, deployment.Version1_0_0), "",
 				func(chain cldf_evm.Chain) cldf.ContractDeploy[*mock_rmn_contract.MockRMNContract] {
 					var (
 						rmnAddress common.Address
@@ -291,7 +287,7 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 		}
 	}
 	if rmnProxy == nil {
-		RMNProxy, err := cldf.DeployContract(lggr, chain, ab,
+		RMNProxy, err := shared.DeployContractAndRecord(lggr, chain, ab, ds, cldf.NewTypeAndVersion(shared.ARMProxy, deployment.Version1_0_0), "",
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*rmn_proxy_contract.RMNProxy] {
 				var (
 					rmnProxyAddr common.Address
@@ -349,7 +345,7 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 		}
 	}
 	if tokenAdminReg == nil {
-		tokenAdminRegistry, err := cldf.DeployContract(e.Logger, chain, ab,
+		tokenAdminRegistry, err := shared.DeployContractAndRecord(e.Logger, chain, ab, ds, cldf.NewTypeAndVersion(shared.TokenAdminRegistry, deployment.Version1_5_0), "",
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*token_admin_registry.TokenAdminRegistry] {
 				var (
 					tokenAdminRegistryAddr common.Address
@@ -382,7 +378,7 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 		regAddresses = append(regAddresses, reg.Address())
 	}
 	if len(regAddresses) == 0 {
-		customRegistryModule, err := cldf.DeployContract(e.Logger, chain, ab,
+		customRegistryModule, err := shared.DeployContractAndRecord(e.Logger, chain, ab, ds, cldf.NewTypeAndVersion(shared.RegistryModule, deployment.Version1_6_0), "",
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*registry_module_owner_custom.RegistryModuleOwnerCustom] {
 				var (
 					regModAddr common.Address
@@ -440,7 +436,7 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 	}
 
 	if weth9Contract == nil {
-		weth, err := cldf.DeployContract(lggr, chain, ab,
+		weth, err := shared.DeployContractAndRecord(lggr, chain, ab, ds, cldf.NewTypeAndVersion(shared.WETH9, deployment.Version1_0_0), "",
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*weth9.WETH9] {
 				var (
 					weth9Addr common.Address
@@ -469,7 +465,7 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 
 	// if router is not already deployed, we deploy it
 	if r == nil {
-		routerContract, err := cldf.DeployContract(e.Logger, chain, ab,
+		routerContract, err := shared.DeployContractAndRecord(e.Logger, chain, ab, ds, cldf.NewTypeAndVersion(shared.Router, deployment.Version1_2_0), "",
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*router.Router] {
 				var (
 					routerAddr common.Address
@@ -516,7 +512,7 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 				return err
 			}
 			tokenPoolFactoryAddr = tpfReport.Output.Address
-			err = ab.Save(chain.ChainSelector(), tpfReport.Output.Address.Hex(), cldf.MustTypeAndVersionFromString(tpfReport.Output.TypeAndVersion))
+			err = shared.RecordAddress(ab, ds, chain.ChainSelector(), tpfReport.Output.Address.Hex(), cldf.MustTypeAndVersionFromString(tpfReport.Output.TypeAndVersion), "")
 			if err != nil {
 				return fmt.Errorf("failed to save address %s for chain %d: %w", tpfReport.Output.Address.Hex(), chain.ChainSelector(), err)
 			}
@@ -525,7 +521,7 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 			tokenPoolFactoryAddr = tokenPoolFactory.Address()
 		}
 
-		factoryBurnMintERC20, burnMintTokenPool, burnFromMintTokenPool, burnWithFromMintTokenPool, lockReleaseTokenPool, err = deployTokenPools(e.Logger, chain, ab, rmnProxy.Address(), r.Address(),
+		factoryBurnMintERC20, burnMintTokenPool, burnFromMintTokenPool, burnWithFromMintTokenPool, lockReleaseTokenPool, err = deployTokenPools(e.Logger, chain, ab, ds, rmnProxy.Address(), r.Address(),
 			factoryBurnMintERC20, burnMintTokenPool, burnFromMintTokenPool, burnWithFromMintTokenPool, lockReleaseTokenPool)
 		if err != nil {
 			return err
@@ -541,7 +537,7 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 		)
 	}
 	if deployOpts.Multicall3Enabled && mc3 == nil {
-		_, err := cldf.DeployContract(e.Logger, chain, ab,
+		_, err := shared.DeployContractAndRecord(e.Logger, chain, ab, ds, cldf.NewTypeAndVersion(shared.Multicall3, deployment.Version1_0_0), "",
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*multicall3.Multicall3] {
 				var (
 					multicall3Addr    common.Address
@@ -566,7 +562,7 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 		e.Logger.Info("ccip multicall already deployed", "chain", chain.String(), "addr", mc3.Address)
 	}
 	if deployOpts.USDCEnabled {
-		token, pool, messenger, transmitter, err1 := deployUSDC(e.Logger, chain, ab, rmnProxy.Address(), r.Address())
+		token, pool, messenger, transmitter, err1 := deployUSDC(e.Logger, chain, ab, ds, rmnProxy.Address(), r.Address())
 		if err1 != nil {
 			return err1
 		}
@@ -579,7 +575,7 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 		)
 	}
 	if deployOpts.LBTCEnabled {
-		token, pool, err1 := deployLBTC(e.Logger, chain, ab, rmnProxy.Address(), r.Address())
+		token, pool, err1 := deployLBTC(e.Logger, chain, ab, ds, rmnProxy.Address(), r.Address())
 		if err1 != nil {
 			return err1
 		}
@@ -590,7 +586,7 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 		)
 	}
 	if chainState.Receiver == nil {
-		_, err := cldf.DeployContract(e.Logger, chain, ab,
+		_, err := shared.DeployContractAndRecord(e.Logger, chain, ab, ds, cldf.NewTypeAndVersion(shared.CCIPReceiver, deployment.Version1_0_0), "",
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*maybe_revert_message_receiver.MaybeRevertMessageReceiver] {
 				var (
 					receiverAddr common.Address
@@ -622,7 +618,7 @@ func deployPrerequisiteContracts(e cldf.Environment, ab cldf.AddressBook, state 
 			if err1 != nil {
 				return fmt.Errorf("failed to get link token address for chain %s: %w", chain.String(), err1)
 			}
-			_, err := cldf.DeployContract(lggr, chain, ab,
+			_, err := shared.DeployContractAndRecord(lggr, chain, ab, ds, cldf.NewTypeAndVersion(shared.PriceRegistry, deployment.Version1_2_0), "",
 				func(chain cldf_evm.Chain) cldf.ContractDeploy[*price_registry_1_2_0.PriceRegistry] {
 					var (
 						priceRegAddr  common.Address
@@ -661,6 +657,7 @@ func deployTokenPools(
 	lggr logger.Logger,
 	chain cldf_evm.Chain,
 	addresses cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	rmnProxy common.Address,
 	router common.Address,
 	factoryBurnMintERC20 *factory_burn_mint_erc20.FactoryBurnMintERC20,
@@ -680,7 +677,7 @@ func deployTokenPools(
 	// are contracts that get deployed by the TokenPoolFactory.
 	// We deploy them here so that we can verify them. All subsequent user deployments would then be verified.
 	if factoryBurnMintERC20 == nil {
-		factoryBurnMintERC20ContractDeploy, err := cldf.DeployContract(lggr, chain, addresses,
+		factoryBurnMintERC20ContractDeploy, err := shared.DeployContractAndRecord(lggr, chain, addresses, ds, cldf.NewTypeAndVersion(shared.FactoryBurnMintERC20Token, deployment.Version1_6_2), string(shared.FactoryBurnMintERC20Symbol),
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*factory_burn_mint_erc20.FactoryBurnMintERC20] {
 				var (
 					factoryBurnMintERC20Addr common.Address
@@ -714,7 +711,7 @@ func deployTokenPools(
 		lggr.Infow("factory burn mint erc20 already deployed", "chain", chain.String(), "addr", factoryBurnMintERC20.Address)
 	}
 	if burnMintTokenPool == nil {
-		burnMintTokenPoolContractDeploy, err := cldf.DeployContract(lggr, chain, addresses,
+		burnMintTokenPoolContractDeploy, err := shared.DeployContractAndRecord(lggr, chain, addresses, ds, cldf.NewTypeAndVersion(shared.BurnMintTokenPool, deployment.Version1_5_1), string(shared.FactoryBurnMintERC20Symbol),
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_token_pool.BurnMintTokenPool] {
 				var (
 					burnMintTokenPoolAddr common.Address
@@ -747,7 +744,7 @@ func deployTokenPools(
 		lggr.Infow("burn mint token pool already deployed", "chain", chain.String(), "addr", factoryBurnMintERC20.Address)
 	}
 	if burnFromMintTokenPool == nil {
-		burnFromMintTokenPoolContractDeploy, err := cldf.DeployContract(lggr, chain, addresses,
+		burnFromMintTokenPoolContractDeploy, err := shared.DeployContractAndRecord(lggr, chain, addresses, ds, cldf.NewTypeAndVersion(shared.BurnFromMintTokenPool, deployment.Version1_5_1), string(shared.FactoryBurnMintERC20Symbol),
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_from_mint_token_pool.BurnFromMintTokenPool] {
 				var (
 					burnFromMintTokenPoolAddr common.Address
@@ -779,7 +776,7 @@ func deployTokenPools(
 		lggr.Infow("burn from mint token pool already deployed", "chain", chain.String(), "addr", factoryBurnMintERC20.Address)
 	}
 	if burnWithFromMintTokenPool == nil {
-		burnWithFromMintTokenPoolContractDeploy, err := cldf.DeployContract(lggr, chain, addresses,
+		burnWithFromMintTokenPoolContractDeploy, err := shared.DeployContractAndRecord(lggr, chain, addresses, ds, cldf.NewTypeAndVersion(shared.BurnWithFromMintTokenPool, deployment.Version1_5_1), string(shared.FactoryBurnMintERC20Symbol),
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_with_from_mint_token_pool.BurnWithFromMintTokenPool] {
 				var (
 					burnWithFromMintTokenPoolAddr common.Address
@@ -812,7 +809,7 @@ func deployTokenPools(
 		lggr.Infow("burn with from mint token pool already deployed", "chain", chain.String(), "addr", factoryBurnMintERC20.Address)
 	}
 	if lockReleaseTokenPool == nil {
-		lockReleaseTokenPoolContractDeploy, err := cldf.DeployContract(lggr, chain, addresses,
+		lockReleaseTokenPoolContractDeploy, err := shared.DeployContractAndRecord(lggr, chain, addresses, ds, cldf.NewTypeAndVersion(shared.LockReleaseTokenPool, deployment.Version1_5_1), string(shared.FactoryBurnMintERC20Symbol),
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*lock_release_token_pool.LockReleaseTokenPool] {
 				var (
 					lockReleaseTokenPoolAddr common.Address
@@ -853,6 +850,7 @@ func deployUSDC(
 	lggr logger.Logger,
 	chain cldf_evm.Chain,
 	addresses cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	rmnProxy common.Address,
 	router common.Address,
 ) (
@@ -862,7 +860,7 @@ func deployUSDC(
 	*mock_usdc_token_transmitter.MockE2EUSDCTransmitter,
 	error,
 ) {
-	token, err := cldf.DeployContract(lggr, chain, addresses,
+	token, err := shared.DeployContractAndRecord(lggr, chain, addresses, ds, cldf.NewTypeAndVersion(shared.USDCToken, deployment.Version1_0_0), string(shared.USDCSymbol),
 		func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
 			var (
 				tokenAddress  common.Address
@@ -902,7 +900,7 @@ func deployUSDC(
 		return nil, nil, nil, nil, err
 	}
 
-	transmitter, err := cldf.DeployContract(lggr, chain, addresses,
+	transmitter, err := shared.DeployContractAndRecord(lggr, chain, addresses, ds, cldf.NewTypeAndVersion(shared.USDCMockTransmitter, deployment.Version1_0_0), "",
 		func(chain cldf_evm.Chain) cldf.ContractDeploy[*mock_usdc_token_transmitter.MockE2EUSDCTransmitter] {
 			var (
 				transmitterAddress  common.Address
@@ -931,7 +929,7 @@ func deployUSDC(
 		return nil, nil, nil, nil, err
 	}
 
-	messenger, err := cldf.DeployContract(lggr, chain, addresses,
+	messenger, err := shared.DeployContractAndRecord(lggr, chain, addresses, ds, cldf.NewTypeAndVersion(shared.USDCTokenMessenger, deployment.Version1_0_0), "",
 		func(chain cldf_evm.Chain) cldf.ContractDeploy[*mock_usdc_token_messenger.MockE2EUSDCTokenMessenger] {
 			var (
 				messengerAddress  common.Address
@@ -959,7 +957,7 @@ func deployUSDC(
 		return nil, nil, nil, nil, err
 	}
 
-	tokenPool, err := cldf.DeployContract(lggr, chain, addresses,
+	tokenPool, err := shared.DeployContractAndRecord(lggr, chain, addresses, ds, cldf.NewTypeAndVersion(shared.USDCTokenPool, deployment.Version1_5_1), string(shared.USDCSymbol),
 		func(chain cldf_evm.Chain) cldf.ContractDeploy[*usdc_token_pool.USDCTokenPool] {
 			var (
 				tokenPoolAddress  common.Address
@@ -997,6 +995,7 @@ func deployLBTC(
 	lggr logger.Logger,
 	chain cldf_evm.Chain,
 	addresses cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	rmnProxy common.Address,
 	router common.Address,
 ) (
@@ -1004,7 +1003,7 @@ func deployLBTC(
 	*mock_lbtc_token_pool.MockE2ELBTCTokenPool,
 	error,
 ) {
-	token, err := cldf.DeployContract(lggr, chain, addresses,
+	token, err := shared.DeployContractAndRecord(lggr, chain, addresses, ds, cldf.NewTypeAndVersion(shared.BurnMintToken, deployment.Version1_0_0), string(shared.LBTCSymbol),
 		func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
 			var (
 				tokenAddress  common.Address
@@ -1044,7 +1043,7 @@ func deployLBTC(
 		return nil, nil, err
 	}
 
-	tokenPool, err := cldf.DeployContract(lggr, chain, addresses,
+	tokenPool, err := shared.DeployContractAndRecord(lggr, chain, addresses, ds, cldf.NewTypeAndVersion(shared.BurnMintTokenPool, deployment.Version1_5_1), string(shared.LBTCSymbol),
 		func(chain cldf_evm.Chain) cldf.ContractDeploy[*mock_lbtc_token_pool.MockE2ELBTCTokenPool] {
 			var (
 				tokenPoolAddress  common.Address

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -32,6 +32,7 @@ import (
 	cldf_evm_provider "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider"
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	cldf_sui "github.com/smartcontractkit/chainlink-deployments-framework/chain/sui"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/onchain"
@@ -771,12 +772,11 @@ func NewEnvironment(t *testing.T, tEnv TestEnvironment) DeployedEnv {
 	require.NotEmpty(t, dEnv.HomeChainSel)
 	require.NotEmpty(t, dEnv.Env.BlockChains.EVMChains())
 	ab := cldf.NewMemoryAddressBook()
-	crConfig := DeployTestContracts(t, lggr, ab, dEnv.HomeChainSel, dEnv.FeedChainSel, dEnv.Env.BlockChains.EVMChains(), tc.LinkPrice, tc.WethPrice)
+	ds := datastore.NewMemoryDataStore()
+	crConfig, _ := DeployTestContracts(t, lggr, ab, ds, dEnv.HomeChainSel, dEnv.FeedChainSel, dEnv.Env.BlockChains.EVMChains(), tc.LinkPrice, tc.WethPrice)
 	tEnv.StartNodes(t, crConfig)
 	dEnv = tEnv.DeployedEnvironment()
 	dEnv.Env.ExistingAddresses = ab
-	ds, err := shared.PopulateDataStore(ab)
-	require.NoError(t, err)
 	dEnv.Env.DataStore = ds.Seal()
 	return dEnv
 }

--- a/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
@@ -61,6 +61,7 @@ import (
 	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	cldftesthelpers "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils/testhelpers"
@@ -288,13 +289,14 @@ func WaitForEventFilterRegistrationOnLane(t *testing.T, onchainState stateview.C
 func DeployTestContracts(t *testing.T,
 	lggr logger.Logger,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	homeChainSel,
 	feedChainSel uint64,
 	chains map[uint64]cldf_evm.Chain,
 	linkPrice *big.Int,
 	wethPrice *big.Int,
-) deployment.CapabilityRegistryConfig {
-	capReg, err := cldf.DeployContract(lggr, chains[homeChainSel], ab,
+) (deployment.CapabilityRegistryConfig, map[shared.TokenSymbol]common.Address) {
+	capReg, err := shared.DeployContractAndRecord(lggr, chains[homeChainSel], ab, ds, cldf.NewTypeAndVersion(shared.CapabilitiesRegistry, deployment.Version1_0_0), "",
 		func(chain cldf_evm.Chain) cldf.ContractDeploy[*capabilities_registry.CapabilitiesRegistry] {
 			crAddr, tx, cr, err2 := capabilities_registry.DeployCapabilitiesRegistry(
 				chain.DeployerKey,
@@ -306,7 +308,7 @@ func DeployTestContracts(t *testing.T,
 		})
 	require.NoError(t, err)
 
-	_, err = DeployFeeds(lggr, ab, chains[feedChainSel], linkPrice, wethPrice)
+	feedSymbolToAddress, err := DeployFeeds(lggr, ab, ds, chains[feedChainSel], linkPrice, wethPrice)
 	require.NoError(t, err)
 
 	evmChainID, err := chainsel.ChainIdFromSelector(homeChainSel)
@@ -316,7 +318,7 @@ func DeployTestContracts(t *testing.T,
 		EVMChainID:  evmChainID,
 		Contract:    capReg.Address,
 		NetworkType: relay.NetworkEVM,
-	}
+	}, feedSymbolToAddress
 }
 
 func LatestBlock(ctx context.Context, env cldf.Environment, chainSelector uint64) (uint64, error) {
@@ -1332,10 +1334,11 @@ func ToPackedFee(execFee, daFee *big.Int) *big.Int {
 func DeployFeeds(
 	lggr logger.Logger,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	chain cldf_evm.Chain,
 	linkPrice *big.Int,
 	wethPrice *big.Int,
-) (map[string]common.Address, error) {
+) (map[shared.TokenSymbol]common.Address, error) {
 	linkTV := cldf.NewTypeAndVersion(shared.PriceFeed, deployment.Version1_0_0)
 	mockLinkFeed := func(chain cldf_evm.Chain) cldf.ContractDeploy[*aggregator_v3_interface.AggregatorV3Interface] {
 		linkFeed, tx, _, err1 := mock_v3_aggregator_contract.DeployMockV3Aggregator(
@@ -1364,33 +1367,33 @@ func DeployFeeds(
 		}
 	}
 
-	linkFeedAddress, linkFeedDescription, err := deploySingleFeed(lggr, ab, chain, mockLinkFeed, shared.LinkSymbol)
+	linkFeedAddress, _, err := deploySingleFeed(lggr, ab, ds, chain, mockLinkFeed, shared.LinkSymbol)
 	if err != nil {
 		return nil, err
 	}
 
-	wethFeedAddress, wethFeedDescription, err := deploySingleFeed(lggr, ab, chain, mockWethFeed, shared.WethSymbol)
+	wethFeedAddress, _, err := deploySingleFeed(lggr, ab, ds, chain, mockWethFeed, shared.WethSymbol)
 	if err != nil {
 		return nil, err
 	}
 
-	descriptionToAddress := map[string]common.Address{
-		linkFeedDescription: linkFeedAddress,
-		wethFeedDescription: wethFeedAddress,
-	}
-
-	return descriptionToAddress, nil
+	return map[shared.TokenSymbol]common.Address{
+		shared.LinkSymbol: linkFeedAddress,
+		shared.WethSymbol: wethFeedAddress,
+	}, nil
 }
 
 func deploySingleFeed(
 	lggr logger.Logger,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	chain cldf_evm.Chain,
 	deployFunc func(cldf_evm.Chain) cldf.ContractDeploy[*aggregator_v3_interface.AggregatorV3Interface],
 	symbol shared.TokenSymbol,
 ) (common.Address, string, error) {
 	// tokenTV := deployment.NewTypeAndVersion(PriceFeed, deployment.Version1_0_0)
-	mockTokenFeed, err := cldf.DeployContract(lggr, chain, ab, deployFunc)
+	mockTokenFeed, err := shared.DeployContractAndRecord(lggr, chain, ab, ds,
+		cldf.NewTypeAndVersion(shared.PriceFeed, deployment.Version1_0_0), string(symbol), deployFunc)
 	if err != nil {
 		lggr.Errorw("Failed to deploy token feed", "err", err, "symbol", symbol)
 		return common.Address{}, "", err

--- a/deployment/ccip/changeset/v1_5/cs_burn_mint_erc20_pausable_freezable_transparent.go
+++ b/deployment/ccip/changeset/v1_5/cs_burn_mint_erc20_pausable_freezable_transparent.go
@@ -18,7 +18,35 @@ type BurnMintERC20PausableFreezableTransparentChangesetConfig struct {
 	Tokens map[uint64][]string
 }
 
+// PlannedRefs returns every datastore key this changeset will write.
+func (c BurnMintERC20PausableFreezableTransparentChangesetConfig) PlannedRefs() []datastore.AddressRef {
+	version := deployment.Version1_5_0
+	refs := make([]datastore.AddressRef, 0)
+	for chainSelector, tokens := range c.Tokens {
+		for _, token := range tokens {
+			refs = append(refs, datastore.AddressRef{
+				ChainSelector: chainSelector,
+				Type:          datastore.ContractType(shared.BurnMintERC20PausableFreezableTransparentToken),
+				Version:       &version,
+				Qualifier:     token,
+			})
+		}
+	}
+	return refs
+}
+
+func (c BurnMintERC20PausableFreezableTransparentChangesetConfig) reserveRefs() (*datastore.MemoryDataStore, error) {
+	return shared.ReserveRefs(c.PlannedRefs())
+}
+
 func (c BurnMintERC20PausableFreezableTransparentChangesetConfig) Validate(e cldf.Environment) error {
+	if _, err := c.reserveRefs(); err != nil {
+		return fmt.Errorf("pausable token datastore refs conflict: %w", err)
+	}
+	if err := shared.ValidateAddressRefsStrict(e, c.PlannedRefs()); err != nil {
+		return fmt.Errorf("pausable token datastore refs conflict: %w", err)
+	}
+
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -52,7 +80,10 @@ func DeployBurnMintERC20PausableFreezableTransparent(e cldf.Environment, c BurnM
 	}
 
 	addressBook := cldf.NewMemoryAddressBook()
-	ds := datastore.NewMemoryDataStore()
+	ds, err := c.reserveRefs()
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("pausable token datastore refs conflict: %w", err)
+	}
 
 	for chainSelector, tokens := range c.Tokens {
 		chain := e.BlockChains.EVMChains()[chainSelector]

--- a/deployment/ccip/changeset/v1_5/cs_burn_mint_erc20_pausable_freezable_transparent.go
+++ b/deployment/ccip/changeset/v1_5/cs_burn_mint_erc20_pausable_freezable_transparent.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/1_5_0/burn_mint_erc20_pausable_freezable_transparent"
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -51,12 +52,13 @@ func DeployBurnMintERC20PausableFreezableTransparent(e cldf.Environment, c BurnM
 	}
 
 	addressBook := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 
 	for chainSelector, tokens := range c.Tokens {
 		chain := e.BlockChains.EVMChains()[chainSelector]
 
 		for _, token := range tokens {
-			_, err := cldf.DeployContract(e.Logger, chain, addressBook,
+			_, err := shared.DeployContractAndRecord(e.Logger, chain, addressBook, ds, cldf.NewTypeAndVersion(shared.BurnMintERC20PausableFreezableTransparentToken, deployment.Version1_5_0), token,
 				func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20_pausable_freezable_transparent.BurnMintERC20PausableFreezableTransparent] {
 					address, tx, transparent, err := burn_mint_erc20_pausable_freezable_transparent.DeployBurnMintERC20PausableFreezableTransparent(chain.DeployerKey, chain.Client)
 					return cldf.ContractDeploy[*burn_mint_erc20_pausable_freezable_transparent.BurnMintERC20PausableFreezableTransparent]{
@@ -73,11 +75,6 @@ func DeployBurnMintERC20PausableFreezableTransparent(e cldf.Environment, c BurnM
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy BurnMintERC20PausableFreezableTransparent for %s token on %s: %w", token, chain, err)
 			}
 		}
-	}
-
-	ds, err := shared.PopulateDataStore(addressBook)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{

--- a/deployment/ccip/changeset/v1_5/cs_burn_mint_erc20_transparent.go
+++ b/deployment/ccip/changeset/v1_5/cs_burn_mint_erc20_transparent.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/1_5_0/burn_mint_erc20_transparent"
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -66,12 +67,13 @@ func DeployBurnMintERC20Transparent(e cldf.Environment, c BurnMintERC20Transpare
 	}
 
 	addressBook := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 
 	for chainSelector, tokens := range c.Tokens {
 		chain := e.BlockChains.EVMChains()[chainSelector]
 
 		for token := range tokens {
-			_, err := cldf.DeployContract(e.Logger, chain, addressBook,
+			_, err := shared.DeployContractAndRecord(e.Logger, chain, addressBook, ds, cldf.NewTypeAndVersion(shared.BurnMintERC20TransparentToken, deployment.Version1_5_0), token,
 				func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20_transparent.BurnMintERC20Transparent] {
 					address, tx, transparent, err := burn_mint_erc20_transparent.DeployBurnMintERC20Transparent(chain.DeployerKey, chain.Client)
 					return cldf.ContractDeploy[*burn_mint_erc20_transparent.BurnMintERC20Transparent]{
@@ -88,11 +90,6 @@ func DeployBurnMintERC20Transparent(e cldf.Environment, c BurnMintERC20Transpare
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy BurnMintERC20Transparent for %s token on %s: %w", token, chain, err)
 			}
 		}
-	}
-
-	ds, err := shared.PopulateDataStore(addressBook)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -22,6 +22,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
@@ -305,7 +306,7 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 		//  1. Deploys tokens ( specifically TestTokens) optionally if DeployTokenConfig is provided and
 		//     populates the pool deployment configuration for each token.
 		if len(tokenDeployCfg) > 0 {
-			deployedTokens, ab, err := deployTokens(e, tokenDeployCfg)
+			deployedTokens, ab, tokenDS, err := deployTokens(e, tokenDeployCfg)
 			if err != nil {
 				return cldf.ChangesetOutput{}, err
 			}
@@ -315,6 +316,13 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 			e.Logger.Infow("deployed token and created pool deployment config", "token", token)
 			if err := finalCSOut.AddressBook.Merge(ab); err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address book for token %s: %w", token, err)
+			}
+			// The token datastore carries the deployed token refs keyed by token symbol; merge it
+			// into the accumulated output datastore so the qualifiers survive.
+			if finalCSOut.DataStore == nil {
+				finalCSOut.DataStore = tokenDS
+			} else if err := finalCSOut.DataStore.Merge(tokenDS.Seal()); err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge datastore for token %s: %w", token, err)
 			}
 			// populate the configuration for deploying and configuring token pools and token admin registry
 			if err := cfg.newConfigurePoolAndTokenAdminRegConfig(e, token, config.MCMS); err != nil {
@@ -484,13 +492,14 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 	return *finalCSOut, nil
 }
 
-func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfig) (map[uint64]common.Address, cldf.AddressBook, error) {
+func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfig) (map[uint64]common.Address, cldf.AddressBook, *datastore.MemoryDataStore, error) {
 	ab := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 	tokenAddresses := make(map[uint64]common.Address) // This will hold the token addresses for each chain.
 	for selector, cfg := range tokenDeployCfg {
 		switch cfg.Type {
 		case shared.BurnMintToken:
-			token, err := cldf.DeployContract(e.Logger, e.BlockChains.EVMChains()[selector], ab,
+			token, err := shared.DeployContractAndRecord(e.Logger, e.BlockChains.EVMChains()[selector], ab, ds, cldf.NewTypeAndVersion(cfg.Type, deployment.Version1_0_0), string(cfg.TokenSymbol),
 				func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
 					tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
 						e.BlockChains.EVMChains()[selector].DeployerKey,
@@ -510,19 +519,19 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 				},
 			)
 			if err != nil {
-				return nil, ab, fmt.Errorf("failed to deploy BurnMintERC677 token "+
+				return nil, ab, nil, fmt.Errorf("failed to deploy BurnMintERC677 token "+
 					"%s on chain %d: %w", cfg.TokenName, selector, err)
 			}
 			if err := addMinterAndMintTokenERC677(e, selector, token.Contract, e.BlockChains.EVMChains()[selector].DeployerKey.From,
 				new(big.Int).Mul(big.NewInt(1_000), big.NewInt(1_000_000_000))); err != nil {
-				return nil, ab, fmt.Errorf("failed to add minter and mint token "+
+				return nil, ab, nil, fmt.Errorf("failed to add minter and mint token "+
 					"%s on chain %d: %w", cfg.TokenName, selector, err)
 			}
 			if len(cfg.MintTokenForRecipients) > 0 {
 				for recipient, amount := range cfg.MintTokenForRecipients {
 					if err := addMinterAndMintTokenERC677(e, selector, token.Contract, recipient,
 						amount); err != nil {
-						return nil, ab, fmt.Errorf("failed to add minter and mint "+
+						return nil, ab, nil, fmt.Errorf("failed to add minter and mint "+
 							"token %s on chain %d: %w", cfg.TokenName, selector, err)
 					}
 				}
@@ -530,7 +539,7 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 
 			tokenAddresses[selector] = token.Address
 		case shared.ERC20Token:
-			token, err := cldf.DeployContract(e.Logger, e.BlockChains.EVMChains()[selector], ab,
+			token, err := shared.DeployContractAndRecord(e.Logger, e.BlockChains.EVMChains()[selector], ab, ds, cldf.NewTypeAndVersion(cfg.Type, deployment.Version1_0_0), string(cfg.TokenSymbol),
 				func(chain cldf_evm.Chain) cldf.ContractDeploy[*erc20.ERC20] {
 					tokenAddress, tx, token, err := erc20.DeployERC20(
 						e.BlockChains.EVMChains()[selector].DeployerKey,
@@ -548,11 +557,11 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 				},
 			)
 			if err != nil {
-				return nil, ab, fmt.Errorf("failed to deploy ERC20 token %s on chain %d: %w", cfg.TokenName, selector, err)
+				return nil, ab, nil, fmt.Errorf("failed to deploy ERC20 token %s on chain %d: %w", cfg.TokenName, selector, err)
 			}
 			tokenAddresses[selector] = token.Address
 		case shared.ERC677Token:
-			token, err := cldf.DeployContract(e.Logger, e.BlockChains.EVMChains()[selector], ab,
+			token, err := shared.DeployContractAndRecord(e.Logger, e.BlockChains.EVMChains()[selector], ab, ds, cldf.NewTypeAndVersion(cfg.Type, deployment.Version1_0_0), string(cfg.TokenSymbol),
 				func(chain cldf_evm.Chain) cldf.ContractDeploy[*erc677.ERC677] {
 					tokenAddress, tx, token, err := erc677.DeployERC677(
 						e.BlockChains.EVMChains()[selector].DeployerKey,
@@ -570,11 +579,11 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 				},
 			)
 			if err != nil {
-				return nil, ab, fmt.Errorf("failed to deploy ERC677 token %s on chain %d: %w", cfg.TokenName, selector, err)
+				return nil, ab, nil, fmt.Errorf("failed to deploy ERC677 token %s on chain %d: %w", cfg.TokenName, selector, err)
 			}
 			tokenAddresses[selector] = token.Address
 		case shared.ERC677TokenHelper:
-			token, err := cldf.DeployContract(e.Logger, e.BlockChains.EVMChains()[selector], ab,
+			token, err := shared.DeployContractAndRecord(e.Logger, e.BlockChains.EVMChains()[selector], ab, ds, cldf.NewTypeAndVersion(cfg.Type, deployment.Version1_0_0), string(cfg.TokenSymbol),
 				func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20_with_drip.BurnMintERC20WithDrip] {
 					tokenAddress, tx, token, err := burn_mint_erc20_with_drip.DeployBurnMintERC20WithDrip(
 						e.BlockChains.EVMChains()[selector].DeployerKey,
@@ -592,26 +601,26 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 				},
 			)
 			if err != nil {
-				return nil, ab, fmt.Errorf("failed to deploy ERC677 token %s on chain %d: %w", cfg.TokenName, selector, err)
+				return nil, ab, nil, fmt.Errorf("failed to deploy ERC677 token %s on chain %d: %w", cfg.TokenName, selector, err)
 			}
 
 			if err := addMinterAndMintTokenERC677Helper(e, selector, token.Contract, e.BlockChains.EVMChains()[selector].DeployerKey.From,
 				new(big.Int).Mul(big.NewInt(1_000), big.NewInt(1_000_000_000))); err != nil {
-				return nil, ab, fmt.Errorf("failed to add minter and mint token "+
+				return nil, ab, nil, fmt.Errorf("failed to add minter and mint token "+
 					"%s on chain %d: %w", cfg.TokenName, selector, err)
 			}
 			if len(cfg.MintTokenForRecipients) > 0 {
 				for recipient, amount := range cfg.MintTokenForRecipients {
 					if err := addMinterAndMintTokenERC677Helper(e, selector, token.Contract, recipient,
 						amount); err != nil {
-						return nil, ab, fmt.Errorf("failed to add minter and mint "+
+						return nil, ab, nil, fmt.Errorf("failed to add minter and mint "+
 							"token %s on chain %d: %w", cfg.TokenName, selector, err)
 					}
 				}
 			}
 			tokenAddresses[selector] = token.Address
 		case shared.BurnMintERC20Token:
-			token, err := cldf.DeployContract(e.Logger, e.BlockChains.EVMChains()[selector], ab,
+			token, err := shared.DeployContractAndRecord(e.Logger, e.BlockChains.EVMChains()[selector], ab, ds, cldf.NewTypeAndVersion(cfg.Type, deployment.Version1_0_0), string(cfg.TokenSymbol),
 				func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20] {
 					if cfg.MaxSupply == nil {
 						cfg.MaxSupply = big.NewInt(0)
@@ -638,27 +647,27 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 				},
 			)
 			if err != nil {
-				return nil, ab, fmt.Errorf("failed to deploy BurnMintERC20Token "+
+				return nil, ab, nil, fmt.Errorf("failed to deploy BurnMintERC20Token "+
 					"%s on chain %d: %w", cfg.TokenName, selector, err)
 			}
 
 			if err := setCCIPAdminForBurnMintERC20Token(e, selector, token.Contract, cfg.CCIPAdmin); err != nil {
-				return nil, ab, fmt.Errorf("failed to set CCIP admin for %s on chain %d: %w",
+				return nil, ab, nil, fmt.Errorf("failed to set CCIP admin for %s on chain %d: %w",
 					cfg.CCIPAdmin, selector, err)
 			}
 
 			if err := grantDefaultAdminRoleForBurnMintERC20Token(e, selector, token.Contract, cfg.CCIPAdmin); err != nil {
-				return nil, ab, fmt.Errorf("failed to grant default admin role for BurnMintERC20 token %s on chain %d: %w",
+				return nil, ab, nil, fmt.Errorf("failed to grant default admin role for BurnMintERC20 token %s on chain %d: %w",
 					cfg.TokenName, selector, err)
 			}
 
 			tokenAddresses[selector] = token.Address
 		default:
-			return nil, ab, fmt.Errorf("unsupported token %s type %s for deployment on chain %d", cfg.TokenName, cfg.Type, selector)
+			return nil, ab, nil, fmt.Errorf("unsupported token %s type %s for deployment on chain %d", cfg.TokenName, cfg.Type, selector)
 		}
 	}
 
-	return tokenAddresses, ab, nil
+	return tokenAddresses, ab, ds, nil
 }
 
 // addMinterAndMintTokenERC677 adds the minter role to the recipient and mints the specified amount of tokens to the recipient's address.

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pool_factory.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pool_factory.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
@@ -82,6 +83,7 @@ func deployTokenPoolFactoryPrecondition(e cldf.Environment, config DeployTokenPo
 
 func deployTokenPoolFactoryLogic(e cldf.Environment, config DeployTokenPoolFactoryConfig) (cldf.ChangesetOutput, error) {
 	addressBook := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
@@ -111,16 +113,11 @@ func deployTokenPoolFactoryLogic(e cldf.Environment, config DeployTokenPoolFacto
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy token pool factory: %w", err)
 		}
 
-		err = addressBook.Save(chainSel, tpfReport.Output.Address.Hex(), cldf.MustTypeAndVersionFromString(tpfReport.Output.TypeAndVersion))
+		err = shared.RecordAddress(addressBook, ds, chainSel, tpfReport.Output.Address.Hex(), cldf.MustTypeAndVersionFromString(tpfReport.Output.TypeAndVersion), "")
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to save address %s for chain %d: %w", tpfReport.Output.Address.Hex(), chainSel, err)
 		}
 		e.Logger.Infof("Successfully deployed token pool factory %s on %s", tpfReport.Output.Address.Hex(), chain.String())
-	}
-
-	ds, err := shared.PopulateDataStore(addressBook)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pools.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pools.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/burn_from_mint_token_pool"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -139,12 +140,93 @@ type DeployTokenPoolContractsConfig struct {
 	NewPools map[uint64]DeployTokenPoolInput
 	// IsTestRouter indicates whether or not the test router should be used.
 	IsTestRouter bool
+	// ForceDatastoreOverwrite permits this changeset to overwrite pool refs that already exist in
+	// the environment datastore. Without it, a redeploy over an existing (chain, type, version,
+	// TokenSymbol) entry is rejected during validation rather than silently replacing it.
+	ForceDatastoreOverwrite bool
+}
+
+// deployedTypeAndVersion returns the TypeAndVersion the pool will actually be deployed under.
+//
+// The version is not simply poolConfig.Version: several pool types are pinned to a version of
+// their own regardless of what the config asked for, and two more honour an explicit 1.6.1. The
+// datastore key is built from this version, so the rule has to live in one function that both the
+// key and the deployment read. Deriving the key from poolConfig.Version instead would key some
+// pools under a version they were never deployed at.
+func deployedTypeAndVersion(poolConfig DeployTokenPoolInput) cldf.TypeAndVersion {
+	version := shared.CurrentTokenPoolVersion
+
+	switch poolConfig.Type {
+	case shared.BurnMintTokenPool, shared.LockReleaseTokenPool:
+		if poolConfig.Version == deployment.Version1_6_1 {
+			version = deployment.Version1_6_1
+		}
+	case shared.BurnMintFastTransferTokenPool:
+		version = deployment.Version1_6_3Dev
+	case shared.BurnMintWithExternalMinterFastTransferTokenPool,
+		shared.HybridWithExternalMinterFastTransferTokenPool,
+		shared.BurnMintWithExternalMinterTokenPool,
+		shared.HybridWithExternalMinterTokenPool:
+		version = deployment.Version1_6_0
+	}
+
+	return cldf.NewTypeAndVersion(poolConfig.Type, version)
+}
+
+// plannedRefs returns the datastore ref for every pool this changeset will deploy.
+//
+// A ref is keyed on (chain, type, version, qualifier) and none of that depends on the address, so
+// the whole set is known before a single transaction is sent. This is the only place these keys
+// are derived: Validate checks them and reserveRefs claims them, so the check and the write are
+// the same computation rather than two that can drift apart.
+func (c DeployTokenPoolContractsConfig) plannedRefs() []datastore.AddressRef {
+	refs := make([]datastore.AddressRef, 0, len(c.NewPools))
+	for chainSelector, poolConfig := range c.NewPools {
+		tv := deployedTypeAndVersion(poolConfig)
+		version := tv.Version
+		refs = append(refs, datastore.AddressRef{
+			ChainSelector: chainSelector,
+			Type:          datastore.ContractType(tv.Type),
+			Version:       &version,
+			Qualifier:     string(c.TokenSymbol),
+		})
+	}
+
+	return refs
+}
+
+// reserveRefs claims every planned key. The deployment then fills each one in as it confirms, so
+// the store is complete by the time the changeset returns and there is no derivation step left
+// that could fail once the pools already exist on chain.
+func (c DeployTokenPoolContractsConfig) reserveRefs() (*datastore.MemoryDataStore, error) {
+	ds, err := shared.ReserveRefs(c.plannedRefs())
+	if err != nil {
+		return nil, fmt.Errorf("%s token pools: %w", c.TokenSymbol, err)
+	}
+
+	return ds, nil
 }
 
 func (c DeployTokenPoolContractsConfig) Validate(env cldf.Environment) error {
 	// Ensure that required fields are populated
 	if c.TokenSymbol == shared.TokenSymbol("") {
 		return errors.New("token symbol must be defined")
+	}
+
+	// Reserve the keys to prove the config can be recorded, then check them against the
+	// environment. Both run before anything is deployed.
+	if _, err := c.reserveRefs(); err != nil {
+		return err
+	}
+	refs := c.plannedRefs()
+	// Taking over a key the environment already holds is a redeploy. It is rejected unless the
+	// caller asked for it, in which case it is logged rather than passing unremarked.
+	validateRefs := shared.ValidateAddressRefsStrict
+	if c.ForceDatastoreOverwrite {
+		validateRefs = shared.ValidateAddressRefs
+	}
+	if err := validateRefs(env, refs); err != nil {
+		return fmt.Errorf("token pool datastore refs conflict: %w", err)
 	}
 
 	state, err := stateview.LoadOnchainState(env)
@@ -196,16 +278,22 @@ func DeployTokenPoolContractsChangeset(env cldf.Environment, c DeployTokenPoolCo
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
 
+	// Claim every datastore key before deploying. After this the store is only ever filled in,
+	// never re-keyed, so there is no post-deploy datastore step that can fail.
+	ds, err := c.reserveRefs()
+	if err != nil {
+		return cldf.ChangesetOutput{}, err
+	}
+
 	deployGrp := errgroup.Group{}
 
 	for chainSelector, poolConfig := range c.NewPools {
 		deployGrp.Go(func() error {
-			if poolConfig.Version.String() == "0.0.0" {
-				poolConfig.Version = shared.CurrentTokenPoolVersion
-			}
 			chain := env.BlockChains.EVMChains()[chainSelector]
 			chainState := state.Chains[chainSelector]
-			contract, err := deployTokenPool(env.Logger, chain, chainState, newAddresses, poolConfig, c.IsTestRouter)
+			// The ref is written by deployTokenPool at the moment the deployment confirms, onto
+			// the key this chain reserved above. Nothing is left to record afterwards.
+			contract, err := deployTokenPool(env.Logger, chain, chainState, newAddresses, ds, string(c.TokenSymbol), deployedTypeAndVersion(poolConfig), poolConfig, c.IsTestRouter)
 			if err != nil {
 				return fmt.Errorf("failed to deploy token pool contract: %w", err)
 			}
@@ -231,11 +319,9 @@ func DeployTokenPoolContractsChangeset(env cldf.Environment, c DeployTokenPoolCo
 			c.TokenSymbol, err)
 	}
 
-	ds, err := shared.PopulateDataStore(newAddresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
-
+	// No datastore is derived here. Every ref was keyed before the first transaction and filled
+	// in as each pool was confirmed, so by this point the store is already complete and there is
+	// nothing left that can fail.
 	return cldf.ChangesetOutput{
 		AddressBook: newAddresses,
 		DataStore:   ds,
@@ -248,6 +334,9 @@ func deployTokenPool(
 	chain cldf_evm.Chain,
 	chainState evm.CCIPChainState,
 	addressBook cldf.AddressBook,
+	ds datastore.MutableDataStore,
+	qualifier string,
+	tv cldf.TypeAndVersion,
 	poolConfig DeployTokenPoolInput,
 	isTestRouter bool,
 ) (*cldf.ContractDeploy[*token_pool.TokenPool], error) {
@@ -257,16 +346,14 @@ func deployTokenPool(
 	}
 	rmnProxy := chainState.RMNProxy
 
-	return cldf.DeployContract(logger, chain, addressBook,
+	return shared.DeployContractAndRecord(logger, chain, addressBook, ds, tv, qualifier,
 		func(chain cldf_evm.Chain) cldf.ContractDeploy[*token_pool.TokenPool] {
 			var tpAddr common.Address
 			var tx *types.Transaction
 			var err error
-			tokenPoolVersion := shared.CurrentTokenPoolVersion
 			switch poolConfig.Type {
 			case shared.BurnMintTokenPool:
 				if poolConfig.Version == deployment.Version1_6_1 {
-					tokenPoolVersion = deployment.Version1_6_1
 					tpAddr, tx, _, err = burn_mint_token_pool_v1_6_1.DeployBurnMintTokenPool(
 						chain.DeployerKey, chain.Client, poolConfig.TokenAddress, poolConfig.LocalTokenDecimals,
 						poolConfig.AllowList, rmnProxy.Address(), router.Address(),
@@ -289,7 +376,6 @@ func deployTokenPool(
 				)
 			case shared.LockReleaseTokenPool:
 				if poolConfig.Version == deployment.Version1_6_1 {
-					tokenPoolVersion = deployment.Version1_6_1
 					tpAddr, tx, _, err = lock_release_token_pool_v1_6_1.DeployLockReleaseTokenPool(
 						chain.DeployerKey, chain.Client, poolConfig.TokenAddress, poolConfig.LocalTokenDecimals,
 						poolConfig.AllowList, rmnProxy.Address(), router.Address(),
@@ -301,31 +387,26 @@ func deployTokenPool(
 					)
 				}
 			case shared.BurnMintFastTransferTokenPool:
-				tokenPoolVersion = deployment.Version1_6_3Dev
 				tpAddr, tx, _, err = fast_transfer_token_pool.DeployBurnMintFastTransferTokenPool(
 					chain.DeployerKey, chain.Client, poolConfig.TokenAddress, poolConfig.LocalTokenDecimals,
 					poolConfig.AllowList, rmnProxy.Address(), router.Address(), chain.Selector,
 				)
 			case shared.BurnMintWithExternalMinterFastTransferTokenPool:
-				tokenPoolVersion = deployment.Version1_6_0
 				tpAddr, tx, _, err = burn_mint_with_external_minter_fast_transfer_token_pool.DeployBurnMintWithExternalMinterFastTransferTokenPool(
 					chain.DeployerKey, chain.Client, poolConfig.ExternalMinter, poolConfig.TokenAddress, poolConfig.LocalTokenDecimals,
 					poolConfig.AllowList, rmnProxy.Address(), router.Address(),
 				)
 			case shared.HybridWithExternalMinterFastTransferTokenPool:
-				tokenPoolVersion = deployment.Version1_6_0
 				tpAddr, tx, _, err = hybrid_with_external_minter_fast_transfer_token_pool.DeployHybridWithExternalMinterFastTransferTokenPool(
 					chain.DeployerKey, chain.Client, poolConfig.ExternalMinter, poolConfig.TokenAddress, poolConfig.LocalTokenDecimals,
 					poolConfig.AllowList, rmnProxy.Address(), router.Address(),
 				)
 			case shared.BurnMintWithExternalMinterTokenPool:
-				tokenPoolVersion = deployment.Version1_6_0
 				tpAddr, tx, _, err = burn_mint_with_external_minter_token_pool.DeployBurnMintWithExternalMinterTokenPool(
 					chain.DeployerKey, chain.Client, poolConfig.TokenGovernor, poolConfig.TokenAddress, poolConfig.LocalTokenDecimals,
 					poolConfig.AllowList, rmnProxy.Address(), router.Address(),
 				)
 			case shared.HybridWithExternalMinterTokenPool:
-				tokenPoolVersion = deployment.Version1_6_0
 				tpAddr, tx, _, err = hybrid_with_external_minter_token_pool.DeployHybridWithExternalMinterTokenPool(
 					chain.DeployerKey, chain.Client, poolConfig.TokenGovernor, poolConfig.TokenAddress, poolConfig.LocalTokenDecimals,
 					poolConfig.AllowList, rmnProxy.Address(), router.Address(),
@@ -338,7 +419,7 @@ func deployTokenPool(
 			return cldf.ContractDeploy[*token_pool.TokenPool]{
 				Address:  tpAddr,
 				Contract: tp,
-				Tv:       cldf.NewTypeAndVersion(poolConfig.Type, tokenPoolVersion),
+				Tv:       tv,
 				Tx:       tx,
 				Err:      err,
 			}

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pools_version_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pools_version_test.go
@@ -1,0 +1,43 @@
+package v1_5_1
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/assert"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
+)
+
+// Pins deployedTypeAndVersion against the versions the deploy switch previously assigned inline.
+// The datastore key is built from this, so a pool keyed under a version it was not deployed at
+// would be unfindable.
+func TestDeployedTypeAndVersionMatchesDeploySwitch(t *testing.T) {
+	v161 := deployment.Version1_6_1
+	for _, tc := range []struct {
+		poolType    string
+		cfgVersion  semver.Version
+		wantVersion semver.Version
+	}{
+		{"BurnMintTokenPool", v161, deployment.Version1_6_1},
+		{"BurnMintTokenPool", semver.Version{}, shared.CurrentTokenPoolVersion},
+		{"LockReleaseTokenPool", v161, deployment.Version1_6_1},
+		{"LockReleaseTokenPool", semver.Version{}, shared.CurrentTokenPoolVersion},
+		{"BurnMintFastTransferTokenPool", semver.Version{}, deployment.Version1_6_3Dev},
+		{"BurnMintWithExternalMinterFastTransferTokenPool", semver.Version{}, deployment.Version1_6_0},
+		{"HybridWithExternalMinterFastTransferTokenPool", semver.Version{}, deployment.Version1_6_0},
+		{"BurnMintWithExternalMinterTokenPool", semver.Version{}, deployment.Version1_6_0},
+		{"HybridWithExternalMinterTokenPool", semver.Version{}, deployment.Version1_6_0},
+		{"BurnWithFromMintTokenPool", semver.Version{}, shared.CurrentTokenPoolVersion},
+		{"BurnFromMintTokenPool", semver.Version{}, shared.CurrentTokenPoolVersion},
+	} {
+		got := deployedTypeAndVersion(DeployTokenPoolInput{
+			Type:    cldf.ContractType(tc.poolType),
+			Version: tc.cfgVersion,
+		})
+		assert.Equal(t, tc.wantVersion.String(), got.Version.String(), "%s cfg=%s", tc.poolType, tc.cfgVersion)
+		assert.Equal(t, tc.poolType, string(got.Type))
+	}
+}

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/erc20"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -88,9 +89,56 @@ type DeployUSDCTokenPoolContractsConfig struct {
 	// USDCPools defines the per-chain configuration of each new USDC pool.
 	USDCPools    map[uint64]DeployUSDCTokenPoolInput
 	IsTestRouter bool
+	// ForceDatastoreOverwrite permits this changeset to overwrite pool refs that already exist in
+	// the environment datastore. Without it, a redeploy over an existing entry is rejected during
+	// validation rather than silently replacing it.
+	ForceDatastoreOverwrite bool
+}
+
+// PlannedRefs returns the datastore refs this changeset will write, derived from config alone so
+// they can be checked before anything is deployed. It is the single source of truth for these
+// keys: validation and the deployment both read it, so the check and the write cannot drift.
+func (c DeployUSDCTokenPoolContractsConfig) PlannedRefs() []datastore.AddressRef {
+	version := deployment.Version1_5_1
+	refs := make([]datastore.AddressRef, 0, len(c.USDCPools))
+	for chainSelector := range c.USDCPools {
+		refs = append(refs, datastore.AddressRef{
+			ChainSelector: chainSelector,
+			Type:          datastore.ContractType(shared.USDCTokenPool),
+			Version:       &version,
+			Qualifier:     string(shared.USDCSymbol),
+		})
+	}
+	return refs
+}
+
+// reserveRefs claims every planned key. The deployment fills each one in as it confirms, so the
+// store is complete when the changeset returns and no derivation step remains that could fail.
+func (c DeployUSDCTokenPoolContractsConfig) reserveRefs() (*datastore.MemoryDataStore, error) {
+	ds, err := shared.ReserveRefs(c.PlannedRefs())
+	if err != nil {
+		return nil, fmt.Errorf("USDC token pools: %w", err)
+	}
+
+	return ds, nil
 }
 
 func (c DeployUSDCTokenPoolContractsConfig) Validate(env cldf.Environment) error {
+	// Reserve the keys to prove the refs can all be recorded, then check them against the
+	// environment. Both run before anything is deployed.
+	if _, err := c.reserveRefs(); err != nil {
+		return fmt.Errorf("USDC token pool datastore refs conflict: %w", err)
+	}
+	// Taking over a key the environment already holds is a redeploy: rejected unless the caller
+	// asked for it, in which case it is logged rather than passing unremarked.
+	validateRefs := shared.ValidateAddressRefsStrict
+	if c.ForceDatastoreOverwrite {
+		validateRefs = shared.ValidateAddressRefs
+	}
+	if err := validateRefs(env, c.PlannedRefs()); err != nil {
+		return fmt.Errorf("USDC token pool datastore refs conflict: %w", err)
+	}
+
 	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -137,6 +185,13 @@ func DeployUSDCTokenPoolContractsChangeset(env cldf.Environment, c DeployUSDCTok
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
 
+	// Claim every datastore key before deploying. After this the store is only filled in, never
+	// re-keyed, so there is no post-deploy datastore step left that can fail.
+	ds, err := c.reserveRefs()
+	if err != nil {
+		return cldf.ChangesetOutput{}, err
+	}
+
 	for chainSelector, poolConfig := range c.USDCPools {
 		chain := env.BlockChains.EVMChains()[chainSelector]
 		chainState := state.Chains[chainSelector]
@@ -144,7 +199,9 @@ func DeployUSDCTokenPoolContractsChangeset(env cldf.Environment, c DeployUSDCTok
 		if c.IsTestRouter {
 			router = chainState.TestRouter
 		}
-		_, err := cldf.DeployContract(env.Logger, chain, newAddresses,
+		// The ref is written at the moment the deployment confirms, onto the key this chain
+		// reserved above. Nothing is left to record afterwards.
+		_, err := shared.DeployContractAndRecord(env.Logger, chain, newAddresses, ds, cldf.NewTypeAndVersion(shared.USDCTokenPool, deployment.Version1_5_1), string(shared.USDCSymbol),
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*usdc_token_pool.USDCTokenPool] {
 				poolAddress, tx, usdcTokenPool, err := usdc_token_pool.DeployUSDCTokenPool(
 					chain.DeployerKey, chain.Client, poolConfig.TokenMessenger, poolConfig.TokenAddress,
@@ -164,11 +221,8 @@ func DeployUSDCTokenPoolContractsChangeset(env cldf.Environment, c DeployUSDCTok
 		}
 	}
 
-	ds, err := shared.PopulateDataStore(newAddresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
-
+	// No datastore is derived here: every ref was keyed before the first transaction and filled
+	// in as each pool was confirmed, so the store is already complete.
 	return cldf.ChangesetOutput{
 		AddressBook: newAddresses,
 		DataStore:   ds,

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools_test.go
@@ -285,7 +285,7 @@ func TestDeployUSDCTokenPoolContracts(t *testing.T) {
 				)
 
 				if i > 0 {
-					require.ErrorContains(t, err, "already exists")
+					require.ErrorContains(t, err, "datastore refs conflict")
 				} else {
 					require.NoError(t, err)
 

--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
@@ -16,6 +16,7 @@ import (
 
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -23,7 +24,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_6"
 	ccipseq "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm/v1_6"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/don_id_claimer"
@@ -261,6 +261,7 @@ func addCandidatesForNewChainPrecondition(e cldf.Environment, c AddCandidatesFor
 
 func addCandidatesForNewChainLogic(e cldf.Environment, c AddCandidatesForNewChainConfig) (cldf.ChangesetOutput, error) {
 	newAddresses := cldf.NewMemoryAddressBook()
+	finalDS := datastore.NewMemoryDataStore()
 	var allProposals []mcmslib.TimelockProposal
 
 	if !c.SkipDeployments {
@@ -271,7 +272,7 @@ func addCandidatesForNewChainLogic(e cldf.Environment, c AddCandidatesForNewChai
 		}
 		err = runAndSaveAddresses(func() (cldf.ChangesetOutput, error) {
 			return changeset.SaveExistingContractsChangeset(e, c.NewChain.ExistingContracts)
-		}, newAddresses, e.ExistingAddresses)
+		}, newAddresses, e.ExistingAddresses, finalDS)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to run SaveExistingContractsChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
 		}
@@ -279,7 +280,7 @@ func addCandidatesForNewChainLogic(e cldf.Environment, c AddCandidatesForNewChai
 		// Deploy the prerequisite contracts to the new chain
 		err = runAndSaveAddresses(func() (cldf.ChangesetOutput, error) {
 			return changeset.DeployPrerequisitesChangeset(e, c.prerequisiteConfigForNewChain())
-		}, newAddresses, e.ExistingAddresses)
+		}, newAddresses, e.ExistingAddresses, finalDS)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to run DeployPrerequisitesChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
 		}
@@ -290,7 +291,7 @@ func addCandidatesForNewChainLogic(e cldf.Environment, c AddCandidatesForNewChai
 				return mcmschangesets.DeployMCMSWithTimelockV2(e, map[uint64]cldfproposalutils.MCMSWithTimelockConfig{
 					c.NewChain.Selector: *c.MCMSDeploymentConfig,
 				})
-			}, newAddresses, e.ExistingAddresses)
+			}, newAddresses, e.ExistingAddresses, finalDS)
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to run DeployMCMSWithTimelockV2 on chain with selector %d: %w", c.NewChain.Selector, err)
 			}
@@ -299,7 +300,7 @@ func addCandidatesForNewChainLogic(e cldf.Environment, c AddCandidatesForNewChai
 		// Deploy chain contracts to the new chain
 		err = runAndSaveAddresses(func() (cldf.ChangesetOutput, error) {
 			return DeployChainContractsChangeset(e, c.deploymentConfigForNewChain())
-		}, newAddresses, e.ExistingAddresses)
+		}, newAddresses, e.ExistingAddresses, finalDS)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to run DeployChainContractsChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
 		}
@@ -476,10 +477,13 @@ func addCandidatesForNewChainLogic(e cldf.Environment, c AddCandidatesForNewChai
 		}
 	}
 
-	ds, err := shared.PopulateDataStore(newAddresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
+	// The final datastore is the accumulated child datastores, each built by a child changeset
+	// from its own deployments with the correct qualifiers (tokens, MCMS, chain singletons).
+	// Imported existing contracts (SaveExistingContractsChangeset) are not keyed into the
+	// datastore — they have no caller-known qualifier — and remain resolvable through the address
+	// book. It is not reconstructed from the merged address book, which cannot carry qualifier
+	// information.
+	ds := finalDS
 
 	if proposal == nil {
 		return cldf.ChangesetOutput{AddressBook: newAddresses, DataStore: ds}, nil
@@ -983,7 +987,7 @@ func connectRampsAndRouters(
 // END ConnectNewChainChangeset
 // /////////////////////////////////
 
-func runAndSaveAddresses(fn func() (cldf.ChangesetOutput, error), newAddresses cldf.AddressBook, existingAddresses cldf.AddressBook) error {
+func runAndSaveAddresses(fn func() (cldf.ChangesetOutput, error), newAddresses cldf.AddressBook, existingAddresses cldf.AddressBook, finalDS *datastore.MemoryDataStore) error {
 	output, err := fn()
 	if err != nil {
 		return fmt.Errorf("failed to run changeset: %w", err)
@@ -995,6 +999,11 @@ func runAndSaveAddresses(fn func() (cldf.ChangesetOutput, error), newAddresses c
 	err = existingAddresses.Merge(output.AddressBook)
 	if err != nil {
 		return fmt.Errorf("failed to update existing address book: %w", err)
+	}
+	if output.DataStore != nil {
+		if err := finalDS.Merge(output.DataStore.Seal()); err != nil {
+			return fmt.Errorf("failed to merge child datastore: %w", err)
+		}
 	}
 
 	return nil

--- a/deployment/ccip/changeset/v1_6/cs_ccip_home.go
+++ b/deployment/ccip/changeset/v1_6/cs_ccip_home.go
@@ -1239,30 +1239,21 @@ func deployDonIDClaimerChangesetLogic(e cldf.Environment, _ DeployDonIDClaimerCo
 	}
 
 	ab := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 	homeChainSel, err := state.HomeChainSelector()
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get HomeChainSelector: %w", err)
 	}
 
 	chain := e.BlockChains.EVMChains()[homeChainSel]
-	err = deployDonIDClaimerContract(e, ab, state, chain)
+	err = deployDonIDClaimerContract(e, ab, ds, state, chain)
 	if err != nil {
 		e.Logger.Errorw("Failed to deploy donIDClaimer contract", "err", err, "addressBook", ab)
-
-		ds, err2 := shared.PopulateDataStore(ab)
-		if err2 != nil {
-			err2 = fmt.Errorf("failed to populate in-memory DataStore: %w", err2)
-		}
 
 		return cldf.ChangesetOutput{
 			AddressBook: ab,
 			DataStore:   ds,
-		}, fmt.Errorf("failed to deploy donIDClaimer contract: %w", errors.Join(err, err2))
-	}
-
-	ds, err := shared.PopulateDataStore(ab)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
+		}, fmt.Errorf("failed to deploy donIDClaimer contract: %w", err)
 	}
 
 	return cldf.ChangesetOutput{
@@ -1271,14 +1262,14 @@ func deployDonIDClaimerChangesetLogic(e cldf.Environment, _ DeployDonIDClaimerCo
 	}, nil
 }
 
-func deployDonIDClaimerContract(e cldf.Environment, ab cldf.AddressBook, state stateview.CCIPOnChainState, chain cldf_evm.Chain) error {
+func deployDonIDClaimerContract(e cldf.Environment, ab cldf.AddressBook, ds datastore.MutableDataStore, state stateview.CCIPOnChainState, chain cldf_evm.Chain) error {
 	chainState, chainExists := state.Chains[chain.Selector]
 	if !chainExists {
 		return fmt.Errorf("chain %s not found in existing state, deploy the prerequisites first", chain.String())
 	}
 
 	if state.Chains[chain.Selector].DonIDClaimer == nil {
-		_, err := cldf.DeployContract(e.Logger, chain, ab,
+		_, err := shared.DeployContractAndRecord(e.Logger, chain, ab, ds, cldf.NewTypeAndVersion(shared.DonIDClaimer, deployment.Version1_6_1), "",
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*don_id_claimer.DonIDClaimer] {
 				donIDClaimerAddr, tx2, donIDClaimerC, err2 := don_id_claimer.DeployDonIDClaimer(
 					chain.DeployerKey,

--- a/deployment/ccip/changeset/v1_6/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/v1_6/cs_deploy_chain.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
@@ -41,19 +42,16 @@ func DeployChainContractsChangeset(env cldf.Environment, c ccipseq.DeployChainCo
 		}, fmt.Errorf("failed to deploy CCIP contracts: %w", err)
 	}
 	addressBook := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 	for chainSel, addresses := range report.Output {
 		for address, typeAndVersion := range addresses {
-			err := addressBook.Save(chainSel, address, cldf.MustTypeAndVersionFromString(typeAndVersion))
+			err := shared.RecordAddress(addressBook, ds, chainSel, address, cldf.MustTypeAndVersionFromString(typeAndVersion), "")
 			if err != nil {
 				return cldf.ChangesetOutput{
 					Reports: report.ExecutionReports,
 				}, fmt.Errorf("failed to save address %s for chain %d: %w", address, chainSel, err)
 			}
 		}
-	}
-	ds, err := shared.PopulateDataStore(addressBook)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 	return cldf.ChangesetOutput{
 		Reports:     report.ExecutionReports,

--- a/deployment/ccip/changeset/v1_6/cs_deploy_registry_module.go
+++ b/deployment/ccip/changeset/v1_6/cs_deploy_registry_module.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Masterminds/semver/v3"
-
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -82,7 +80,10 @@ func DeployRegistryModuleChangeset(e cldf.Environment, cfg DeployRegistryModuleC
 
 		e.Logger.Infow("Deploying RegistryModuleOwnerCustom 1.6.0", "chain", chainSel)
 
-		registryModule, err := cldf.DeployContract(e.Logger, chain, addressBook,
+		tv := cldf.NewTypeAndVersion(shared.RegistryModule, deployment.Version1_6_0)
+		tv.Labels = cldf.NewLabelSet("RegistryModuleOwnerCustom 1.6.0")
+
+		registryModule, err := shared.DeployContractAndRecord(e.Logger, chain, addressBook, ds, tv, "",
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*registry_module_owner_custom.RegistryModuleOwnerCustom] {
 				regModAddr, tx, regMod, err2 := registry_module_owner_custom.DeployRegistryModuleOwnerCustom(
 					chain.DeployerKey,
@@ -94,27 +95,13 @@ func DeployRegistryModuleChangeset(e cldf.Environment, cfg DeployRegistryModuleC
 					Address:  regModAddr,
 					Contract: regMod,
 					Tx:       tx,
-					Tv:       cldf.NewTypeAndVersion(shared.RegistryModule, deployment.Version1_6_0),
+					Tv:       tv,
 					Err:      err2,
 				}
 			})
 
 		if err != nil {
 			return cldf.ChangesetOutput{DataStore: ds}, fmt.Errorf("failed to deploy registry module on chain %d: %w", chainSel, err)
-		}
-
-		// Add the address reference to the datastore
-		if err = ds.Addresses().Add(datastore.AddressRef{
-			ChainSelector: chainSel,
-			Address:       registryModule.Address.Hex(),
-			Type:          datastore.ContractType(shared.RegistryModule),
-			Version:       semver.MustParse("1.6.0"),
-			Labels: datastore.NewLabelSet(
-				"RegistryModuleOwnerCustom 1.6.0",
-			),
-		}); err != nil {
-			return cldf.ChangesetOutput{DataStore: ds},
-				fmt.Errorf("failed to save address ref for chain %d: %w", chainSel, err)
 		}
 
 		e.Logger.Infow("Successfully deployed RegistryModuleOwnerCustom 1.6.0",

--- a/deployment/ccip/changeset/v1_6/cs_home_chain.go
+++ b/deployment/ccip/changeset/v1_6/cs_home_chain.go
@@ -72,24 +72,19 @@ func DeployHomeChainChangeset(env cldf.Environment, cfg DeployHomeChainConfig) (
 		return cldf.ChangesetOutput{}, fmt.Errorf("%w: %w", err, cldf.ErrInvalidConfig)
 	}
 	ab := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 	// Note we also deploy the cap reg.
-	_, err = deployHomeChain(env.Logger, env, ab, env.ExistingAddresses, env.BlockChains.EVMChains()[cfg.HomeChainSel], cfg.RMNStaticConfig, cfg.RMNDynamicConfig, cfg.NodeOperators, cfg.NodeP2PIDsPerNodeOpAdmin)
+	_, err = deployHomeChain(env.Logger, env, ab, ds, env.ExistingAddresses, env.BlockChains.EVMChains()[cfg.HomeChainSel], cfg.RMNStaticConfig, cfg.RMNDynamicConfig, cfg.NodeOperators, cfg.NodeP2PIDsPerNodeOpAdmin)
 	if err != nil {
 		env.Logger.Errorw("Failed to deploy cap reg", "err", err, "addresses", env.ExistingAddresses)
-		ds, err2 := populateHomeChainDataStore(env.ExistingAddresses, ab)
-		if err2 != nil {
-			err2 = fmt.Errorf("failed to populate in-memory DataStore: %w", err2)
-		}
+		// Build the partial datastore from ab only so it stays consistent with the returned
+		// AddressBook; homeRefs refs are datastore-only on the success path and would otherwise
+		// appear in the datastore without a matching address-book entry on a partial output.
 
 		return cldf.ChangesetOutput{
 			AddressBook: ab,
 			DataStore:   ds,
-		}, errors.Join(err, err2)
-	}
-
-	ds, err := populateHomeChainDataStore(env.ExistingAddresses, ab)
-	if err != nil {
-		return cldf.ChangesetOutput{}, err
+		}, err
 	}
 
 	return cldf.ChangesetOutput{
@@ -98,40 +93,45 @@ func DeployHomeChainChangeset(env cldf.Environment, cfg DeployHomeChainConfig) (
 	}, nil
 }
 
-func populateHomeChainDataStore(existingAddresses cldf.AddressBook, ab cldf.AddressBook) (*datastore.MemoryDataStore, error) {
-	dsAb := cldf.NewMemoryAddressBook()
-	if existingAddresses != nil {
-		if err := dsAb.Merge(existingAddresses); err != nil {
-			return nil, fmt.Errorf("merge existing addresses for DataStore: %w", err)
-		}
-	}
-	if err := dsAb.Merge(ab); err != nil {
-		return nil, fmt.Errorf("merge new addresses for DataStore: %w", err)
-	}
-	ds, err := shared.PopulateDataStore(dsAb)
-	if err != nil {
-		return nil, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
-	return ds, nil
-}
-
+// saveExistingContractIfNeeded records a home-chain singleton ref. homeRefs is a datastore-only
+// book that always receives the ref so the output datastore can resolve existing home contracts
+// (CapabilitiesRegistry, CCIPHome, RMNHome) even when they were not deployed this run. ab is the
+// changeset's returned address book; the ref is only added there when it is not already present in
+// existingAddresses, so a repeated application stays idempotent (callers merge ab back into the
+// environment and AddressBook.Merge rejects duplicate addresses).
 func saveExistingContractIfNeeded(
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	existingAddresses cldf.AddressBook,
 	chainSelector uint64,
 	address common.Address,
 	tv cldf.TypeAndVersion,
 ) error {
+	// If the environment already contains this contract, only the datastore needs a new ref.
+	// Otherwise RecordAddress writes the address book first and the datastore second, so an
+	// address-book failure cannot leave the returned output with a datastore-only singleton.
 	if existingAddresses != nil {
 		addrs, err := existingAddresses.AddressesForChain(chainSelector)
 		if err == nil {
-			if _, exists := addrs[address.Hex()]; exists {
+			for recordedAddress, recordedTV := range addrs {
+				if !shared.AddressesEqual(chainSelector, recordedAddress, address.Hex()) {
+					continue
+				}
+				if !recordedTV.Equal(tv) {
+					return fmt.Errorf("existing address book records %s as %s, want %s", recordedAddress, recordedTV.String(), tv.String())
+				}
+				if err := shared.RecordAddress(nil, ds, chainSelector, address.Hex(), tv, ""); err != nil {
+					return fmt.Errorf("record %s: %w", tv.Type, err)
+				}
 				return nil
 			}
+		} else if !errors.Is(err, cldf.ErrChainNotFound) {
+			return fmt.Errorf("read existing address book for chain %d: %w", chainSelector, err)
 		}
 	}
-	if err := ab.Save(chainSelector, address.Hex(), tv); err != nil {
-		return fmt.Errorf("save existing %s to address book: %w", tv.Type, err)
+
+	if err := shared.RecordAddress(ab, ds, chainSelector, address.Hex(), tv, ""); err != nil {
+		return fmt.Errorf("record %s: %w", tv.Type, err)
 	}
 	return nil
 }
@@ -178,6 +178,7 @@ func deployCapReg(
 	lggr logger.Logger,
 	state stateview.CCIPOnChainState,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	existingAddresses cldf.AddressBook,
 	chain cldf_evm.Chain,
 ) (*cldf.ContractDeploy[*capabilities_registry.CapabilitiesRegistry], error) {
@@ -187,7 +188,7 @@ func deployCapReg(
 		if cr != nil {
 			lggr.Infow("Found CapabilitiesRegistry in chain state", "address", cr.Address().String())
 			tv := cldf.NewTypeAndVersion(shared.CapabilitiesRegistry, deployment.Version1_0_0)
-			if err := saveExistingContractIfNeeded(ab, existingAddresses, chain.Selector, cr.Address(), tv); err != nil {
+			if err := saveExistingContractIfNeeded(ab, ds, existingAddresses, chain.Selector, cr.Address(), tv); err != nil {
 				return nil, err
 			}
 			return &cldf.ContractDeploy[*capabilities_registry.CapabilitiesRegistry]{
@@ -195,7 +196,8 @@ func deployCapReg(
 			}, nil
 		}
 	}
-	capReg, err := cldf.DeployContract(lggr, chain, ab,
+	capReg, err := shared.DeployContractAndRecord(lggr, chain, ab, ds,
+		cldf.NewTypeAndVersion(shared.CapabilitiesRegistry, deployment.Version1_0_0), "",
 		func(chain cldf_evm.Chain) cldf.ContractDeploy[*capabilities_registry.CapabilitiesRegistry] {
 			crAddr, tx, cr, err2 := capabilities_registry.DeployCapabilitiesRegistry(
 				chain.DeployerKey,
@@ -224,6 +226,7 @@ func deployHomeChain(
 	lggr logger.Logger,
 	e cldf.Environment,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	existingAddresses cldf.AddressBook,
 	chain cldf_evm.Chain,
 	rmnHomeStatic rmn_home.RMNHomeStaticConfig,
@@ -237,7 +240,7 @@ func deployHomeChain(
 		return nil, fmt.Errorf("failed to load onchain state: %w", err)
 	}
 	// Deploy CapabilitiesRegistry, CCIPHome, RMNHome
-	capReg, err := deployCapReg(lggr, state, ab, existingAddresses, chain)
+	capReg, err := deployCapReg(lggr, state, ab, ds, existingAddresses, chain)
 	if err != nil {
 		return nil, err
 	}
@@ -252,13 +255,13 @@ func deployHomeChain(
 		ccipHome := state.Chains[chain.Selector].CCIPHome
 		lggr.Infow("CCIPHome already deployed", "addr", ccipHome.Address().String())
 		tv := cldf.NewTypeAndVersion(shared.CCIPHome, deployment.Version1_6_0)
-		if err := saveExistingContractIfNeeded(ab, existingAddresses, chain.Selector, ccipHome.Address(), tv); err != nil {
+		if err := saveExistingContractIfNeeded(ab, ds, existingAddresses, chain.Selector, ccipHome.Address(), tv); err != nil {
 			return nil, err
 		}
 		ccipHomeAddr = ccipHome.Address()
 	} else {
-		ccipHome, err := cldf.DeployContract(
-			lggr, chain, ab,
+		ccipHome, err := shared.DeployContractAndRecord(lggr, chain, ab, ds,
+			cldf.NewTypeAndVersion(shared.CCIPHome, deployment.Version1_6_0), "",
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*ccip_home.CCIPHome] {
 				ccAddr, tx, cc, err2 := ccip_home.DeployCCIPHome(
 					chain.DeployerKey,
@@ -283,12 +286,12 @@ func deployHomeChain(
 	if rmnHome != nil {
 		lggr.Infow("RMNHome already deployed", "addr", rmnHome.Address().String())
 		tv := cldf.NewTypeAndVersion(shared.RMNHome, deployment.Version1_6_0)
-		if err := saveExistingContractIfNeeded(ab, existingAddresses, chain.Selector, rmnHome.Address(), tv); err != nil {
+		if err := saveExistingContractIfNeeded(ab, ds, existingAddresses, chain.Selector, rmnHome.Address(), tv); err != nil {
 			return nil, err
 		}
 	} else {
-		rmnHomeContract, err := cldf.DeployContract(
-			lggr, chain, ab,
+		rmnHomeContract, err := shared.DeployContractAndRecord(lggr, chain, ab, ds,
+			cldf.NewTypeAndVersion(shared.RMNHome, deployment.Version1_6_0), "",
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*rmn_home.RMNHome] {
 				rmnAddr, tx, rmn, err2 := rmn_home.DeployRMNHome(
 					chain.DeployerKey,

--- a/deployment/ccip/changeset/v1_6/cs_token_governor.go
+++ b/deployment/ccip/changeset/v1_6/cs_token_governor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smartcontractkit/ccip-contract-examples/chains/evm/gobindings/generated/1_6_1/token_governor"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 
@@ -59,6 +60,29 @@ type TokenGovernor struct {
 type TokenGovernorChangesetConfig struct {
 	Tokens map[uint64]map[shared.TokenSymbol]TokenGovernor
 	MCMS   *cldfproposalutils.TimelockConfig
+	// ForceDatastoreOverwrite permits this changeset to overwrite governor refs that already exist
+	// in the environment datastore. Without it, a redeploy over an existing
+	// (chain, TokenGovernor, 1.6.0, symbol) entry is rejected during validation rather than
+	// silently replacing it.
+	ForceDatastoreOverwrite bool
+}
+
+// PlannedRefs returns the datastore refs this changeset will write, derived from config alone so
+// they can be checked before anything is deployed. Each governor is qualified by its token symbol.
+func (c TokenGovernorChangesetConfig) PlannedRefs() []datastore.AddressRef {
+	version := deployment.Version1_6_0
+	var refs []datastore.AddressRef
+	for chainSelector, tokens := range c.Tokens {
+		for token := range tokens {
+			refs = append(refs, datastore.AddressRef{
+				ChainSelector: chainSelector,
+				Type:          datastore.ContractType(shared.TokenGovernor),
+				Version:       &version,
+				Qualifier:     string(token),
+			})
+		}
+	}
+	return refs
 }
 
 type TokenGovernorGrantRole struct {
@@ -101,6 +125,21 @@ func (r TokenGovernorRole) String() string {
 
 // Validate validates the TokenGovernorChangesetConfig.
 func (c TokenGovernorChangesetConfig) Validate(env cldf.Environment) error {
+	// Reserve the keys to prove the refs can all be recorded, then check them against the
+	// environment. Both run before anything is deployed.
+	if _, err := shared.ReserveRefs(c.PlannedRefs()); err != nil {
+		return fmt.Errorf("token governor datastore refs conflict: %w", err)
+	}
+	// Taking over a key the environment already holds is a redeploy: rejected unless the caller
+	// asked for it, in which case it is logged rather than passing unremarked.
+	validateRefs := shared.ValidateAddressRefsStrict
+	if c.ForceDatastoreOverwrite {
+		validateRefs = shared.ValidateAddressRefs
+	}
+	if err := validateRefs(env, c.PlannedRefs()); err != nil {
+		return fmt.Errorf("token governor datastore refs conflict: %w", err)
+	}
+
 	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -275,6 +314,10 @@ func DeployTokenGovernor(env cldf.Environment, c TokenGovernorChangesetConfig) (
 
 	state, _ := stateview.LoadOnchainState(env)
 	newAddresses := cldf.NewMemoryAddressBook()
+	ds, err := shared.ReserveRefs(c.PlannedRefs())
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("token governor datastore refs conflict: %w", err)
+	}
 
 	for chainSelector, tokens := range c.Tokens {
 		chain := env.BlockChains.EVMChains()[chainSelector]
@@ -293,7 +336,7 @@ func DeployTokenGovernor(env cldf.Environment, c TokenGovernorChangesetConfig) (
 				return cldf.ChangesetOutput{}, fmt.Errorf("token governor already exists for %s", governor.Token)
 			}
 
-			_, err := cldf.DeployContract(env.Logger, chain, newAddresses,
+			_, err := shared.DeployContractAndRecord(env.Logger, chain, newAddresses, ds, cldf.NewTypeAndVersion(shared.TokenGovernor, deployment.Version1_6_0), string(token),
 				func(chain cldf_evm.Chain) cldf.ContractDeploy[*token_governor.TokenGovernor] {
 					tgAddress, tx, tokenGovernor, err := token_governor.DeployTokenGovernor(chain.DeployerKey, chain.Client, governor.Token, governor.InitialDelay, governor.InitialDefaultAdmin)
 					return cldf.ContractDeploy[*token_governor.TokenGovernor]{
@@ -309,11 +352,6 @@ func DeployTokenGovernor(env cldf.Environment, c TokenGovernorChangesetConfig) (
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy token governor on %s: %w", chain, err)
 			}
 		}
-	}
-
-	ds, err := shared.PopulateDataStore(newAddresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{

--- a/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes.go
+++ b/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes.go
@@ -238,20 +238,18 @@ func UpdateLanesLogic(e cldf.Environment, mcmsConfig *cldfproposalutils.Timelock
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
 
-	ds, err := shared.PopulateDataStore(e.ExistingAddresses)
+	// Resolve existing FeeQuoter candidates from a plain ref slice drawn from both the
+	// environment DataStore (qualified refs) and the existing address book (chain-singleton
+	// refs). Using a slice rather than a keyed datastore avoids collisions among multi-instance
+	// refs and works even when the environment DataStore is nil/empty.
+	fqCandidates, err := shared.CollectAddressRefs(e)
 	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate datastore from existing addresses: %w", err)
-	}
-	// Merge the environment's DataStore as feequoter v2 is only available in DS
-	if e.DataStore != nil {
-		if err := ds.Merge(e.DataStore); err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge environment datastore: %w", err)
-		}
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to collect address refs: %w", err)
 	}
 
 	feeQuoterDestsInput := configs.UpdateFeeQuoterDestsConfig.ToSequenceInput(state)
 	feeQuoterPricesInput := configs.UpdateFeeQuoterPricesConfig.ToSequenceInput(state)
-	feeQuoterVersionsByChain, v2FQAddresses, err := resolveFeeQuoterTargets(ds, &feeQuoterDestsInput, &feeQuoterPricesInput)
+	feeQuoterVersionsByChain, v2FQAddresses, err := resolveFeeQuoterTargets(fqCandidates, &feeQuoterDestsInput, &feeQuoterPricesInput)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -335,9 +333,15 @@ func UpdateLanesLogic(e cldf.Environment, mcmsConfig *cldfproposalutils.Timelock
 
 	var v2BatchOps []mcmstypes.BatchOperation
 	for _, chainSel := range v2FQChainSels {
+		existingFQRefs := make([]datastore.AddressRef, 0, len(fqCandidates))
+		for _, ref := range fqCandidates {
+			if ref.ChainSelector == chainSel {
+				existingFQRefs = append(existingFQRefs, ref)
+			}
+		}
 		fqUpdate := fqv2seq.FeeQuoterUpdate{
 			ChainSelector:     chainSel,
-			ExistingAddresses: ds.Addresses().Filter(datastore.AddressRefByChainSelector(chainSel)),
+			ExistingAddresses: existingFQRefs,
 		}
 		if dests, ok := feeQuoterDestsInput.UpdatesByChain[chainSel]; ok {
 			destCfgs, err := ConvertV16FeeQuoterDestUpdatesToV2(dests.CallInput)
@@ -509,7 +513,7 @@ func ConvertV16FeeQuoterPriceUpdatesToV2(in fee_quoter.InternalPriceUpdates) fqv
 }
 
 func resolveFeeQuoterTargets(
-	ds *datastore.MemoryDataStore,
+	addresses []datastore.AddressRef,
 	destsInput *ccipseqs.FeeQuoterApplyDestChainConfigUpdatesSequenceInput,
 	pricesInput *ccipseqs.FeeQuoterUpdatePricesSequenceInput,
 ) (map[uint64]semver.Version, map[uint64]common.Address, error) {
@@ -520,8 +524,7 @@ func resolveFeeQuoterTargets(
 		if _, ok := versionsByChain[chainSel]; ok {
 			return nil
 		}
-		chainAddresses := ds.Addresses().Filter(datastore.AddressRefByChainSelector(chainSel))
-		addr, version, err := resolveUpdateLanesFeeQuoterAddressAndVersion(chainAddresses, chainSel)
+		addr, version, err := resolveUpdateLanesFeeQuoterAddressAndVersion(addresses, chainSel)
 		if err != nil {
 			return fmt.Errorf("failed to resolve FeeQuoter target on chain %d: %w", chainSel, err)
 		}

--- a/deployment/ccip/changeset/v1_6_1/cs_transparent_upgradeable_proxy.go
+++ b/deployment/ccip/changeset/v1_6_1/cs_transparent_upgradeable_proxy.go
@@ -70,6 +70,17 @@ func (c TransparentUpgradeableProxyChangesetConfig) reserveRefs() (*datastore.Me
 	return shared.ReserveRefs(c.PlannedRefs())
 }
 
+func (c TransparentUpgradeableProxyChangesetConfig) validateDeployment(e cldf.Environment) error {
+	if _, err := c.reserveRefs(); err != nil {
+		return fmt.Errorf("transparent proxy datastore refs conflict: %w", err)
+	}
+	if err := shared.ValidateAddressRefsStrict(e, c.PlannedRefs()); err != nil {
+		return fmt.Errorf("transparent proxy datastore refs conflict: %w", err)
+	}
+
+	return c.Validate(e)
+}
+
 type TransparentUpgradeableProxyRole string
 
 const (
@@ -89,13 +100,6 @@ type TransparentUpgradeableProxyGrantRoleChangesetConfig struct {
 }
 
 func (c TransparentUpgradeableProxyChangesetConfig) Validate(e cldf.Environment) error {
-	if _, err := c.reserveRefs(); err != nil {
-		return fmt.Errorf("transparent proxy datastore refs conflict: %w", err)
-	}
-	if err := shared.ValidateAddressRefsStrict(e, c.PlannedRefs()); err != nil {
-		return fmt.Errorf("transparent proxy datastore refs conflict: %w", err)
-	}
-
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -177,7 +181,7 @@ func (c TransparentUpgradeableProxyGrantRoleChangesetConfig) Validate(e cldf.Env
 
 // DeployTransparentUpgradeableProxy deploys TransparentUpgradeableProxy contracts for the specified tokens on the specified chains.
 func DeployTransparentUpgradeableProxy(e cldf.Environment, c TransparentUpgradeableProxyChangesetConfig) (cldf.ChangesetOutput, error) {
-	if err := c.Validate(e); err != nil {
+	if err := c.validateDeployment(e); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid TransparentUpgradeableProxyChangesetConfig: %w", err)
 	}
 

--- a/deployment/ccip/changeset/v1_6_1/cs_transparent_upgradeable_proxy.go
+++ b/deployment/ccip/changeset/v1_6_1/cs_transparent_upgradeable_proxy.go
@@ -48,6 +48,28 @@ type TransparentUpgradeableProxyChangesetConfig struct {
 	MCMS   *cldfproposalutils.TimelockConfig
 }
 
+// PlannedRefs returns every datastore key this changeset will write. The qualifier is the
+// configured symbol, not the map key.
+func (c TransparentUpgradeableProxyChangesetConfig) PlannedRefs() []datastore.AddressRef {
+	version := deployment.Version1_6_1
+	refs := make([]datastore.AddressRef, 0)
+	for chainSelector, tokens := range c.Tokens {
+		for _, config := range tokens {
+			refs = append(refs, datastore.AddressRef{
+				ChainSelector: chainSelector,
+				Type:          datastore.ContractType(shared.TransparentUpgradeableProxy),
+				Version:       &version,
+				Qualifier:     config.Symbol,
+			})
+		}
+	}
+	return refs
+}
+
+func (c TransparentUpgradeableProxyChangesetConfig) reserveRefs() (*datastore.MemoryDataStore, error) {
+	return shared.ReserveRefs(c.PlannedRefs())
+}
+
 type TransparentUpgradeableProxyRole string
 
 const (
@@ -67,6 +89,13 @@ type TransparentUpgradeableProxyGrantRoleChangesetConfig struct {
 }
 
 func (c TransparentUpgradeableProxyChangesetConfig) Validate(e cldf.Environment) error {
+	if _, err := c.reserveRefs(); err != nil {
+		return fmt.Errorf("transparent proxy datastore refs conflict: %w", err)
+	}
+	if err := shared.ValidateAddressRefsStrict(e, c.PlannedRefs()); err != nil {
+		return fmt.Errorf("transparent proxy datastore refs conflict: %w", err)
+	}
+
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -153,7 +182,10 @@ func DeployTransparentUpgradeableProxy(e cldf.Environment, c TransparentUpgradea
 	}
 
 	addressBook := cldf.NewMemoryAddressBook()
-	ds := datastore.NewMemoryDataStore()
+	ds, err := c.reserveRefs()
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("transparent proxy datastore refs conflict: %w", err)
+	}
 
 	for chainSelector, tokens := range c.Tokens {
 		chain := e.BlockChains.EVMChains()[chainSelector]

--- a/deployment/ccip/changeset/v1_6_1/cs_transparent_upgradeable_proxy.go
+++ b/deployment/ccip/changeset/v1_6_1/cs_transparent_upgradeable_proxy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/ccip-contract-examples/chains/evm/gobindings/generated/1_6_1/transparent_upgradeable_proxy"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/1_5_0/burn_mint_erc20_transparent"
@@ -152,12 +153,13 @@ func DeployTransparentUpgradeableProxy(e cldf.Environment, c TransparentUpgradea
 	}
 
 	addressBook := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 
 	for chainSelector, tokens := range c.Tokens {
 		chain := e.BlockChains.EVMChains()[chainSelector]
 
 		for token, config := range tokens {
-			_, err := cldf.DeployContract(e.Logger, chain, addressBook,
+			_, err := shared.DeployContractAndRecord(e.Logger, chain, addressBook, ds, cldf.NewTypeAndVersion(shared.TransparentUpgradeableProxy, deployment.Version1_6_1), config.Symbol,
 				func(chain cldf_evm.Chain) cldf.ContractDeploy[*transparent_upgradeable_proxy.TransparentUpgradeableProxy] {
 					var errs []error
 
@@ -214,11 +216,6 @@ func DeployTransparentUpgradeableProxy(e cldf.Environment, c TransparentUpgradea
 		}
 	}
 
-	ds, err := shared.PopulateDataStore(addressBook)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
-
 	return cldf.ChangesetOutput{
 		AddressBook: addressBook,
 		DataStore:   ds,
@@ -233,6 +230,7 @@ func SaveProxyAdmin(e cldf.Environment, c TransparentUpgradeableProxyChangesetCo
 	}
 
 	addressBook := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 
 	for chainSelector, tokens := range c.Tokens {
 		chain := e.BlockChains.EVMChains()[chainSelector]
@@ -254,15 +252,10 @@ func SaveProxyAdmin(e cldf.Environment, c TransparentUpgradeableProxyChangesetCo
 			}
 
 			proxyAdmin := common.BytesToAddress(storageBytes)
-			if err := addressBook.Save(chainSelector, proxyAdmin.String(), cldf.NewTypeAndVersion(shared.ProxyAdmin, deployment.Version1_6_1)); err != nil {
+			if err := shared.RecordAddress(addressBook, ds, chainSelector, proxyAdmin.String(), cldf.NewTypeAndVersion(shared.ProxyAdmin, deployment.Version1_6_1), config.Symbol); err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to save ProxyAdmin at %s for %s token on %s: %w", proxyAdmin, config.Symbol, chain.Name(), err)
 			}
 		}
-	}
-
-	ds, err := shared.PopulateDataStore(addressBook)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{

--- a/deployment/ccip/changeset/v1_6_2/cs_deploy_cctp_message_transmitter_proxy.go
+++ b/deployment/ccip/changeset/v1_6_2/cs_deploy_cctp_message_transmitter_proxy.go
@@ -8,6 +8,7 @@ import (
 
 	cmtp "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_2/cctp_message_transmitter_proxy"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -63,6 +64,7 @@ func deployCCTPMessageTransmitterProxyContractLogic(env cldf.Environment, c Depl
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid DeployCCTPMessageTransmitterProxyContractConfig: %w", err)
 	}
 	newAddresses := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 
 	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
@@ -74,7 +76,7 @@ func deployCCTPMessageTransmitterProxyContractLogic(env cldf.Environment, c Depl
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get EVM chain state for chain selector %d: %w", chainSelector, err)
 		}
-		_, err = cldf.DeployContract(env.Logger, chain, newAddresses,
+		_, err = shared.DeployContractAndRecord(env.Logger, chain, newAddresses, ds, cldf.NewTypeAndVersion(shared.CCTPMessageTransmitterProxy, deployment.Version1_6_2), "",
 			func(chain cldf_evm.Chain) cldf.ContractDeploy[*cmtp.CCTPMessageTransmitterProxy] {
 				proxyAddress, tx, proxy, err := cmtp.DeployCCTPMessageTransmitterProxy(
 					chain.DeployerKey,          // auth
@@ -93,11 +95,6 @@ func deployCCTPMessageTransmitterProxyContractLogic(env cldf.Environment, c Depl
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy CCTPMessageTransmitterProxy on %s: %w", chain, err)
 		}
-	}
-
-	ds, err := shared.PopulateDataStore(newAddresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{

--- a/deployment/ccip/changeset/v1_6_2/cs_deploy_usdc_token_pools.go
+++ b/deployment/ccip/changeset/v1_6_2/cs_deploy_usdc_token_pools.go
@@ -16,6 +16,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/erc20"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -110,9 +111,46 @@ type DeployUSDCTokenPoolContractsConfig struct {
 	// USDCPools defines the per-chain configuration of each new USDC pool.
 	USDCPools    map[uint64]DeployUSDCTokenPoolInput
 	IsTestRouter bool
+	// ForceDatastoreOverwrite permits this changeset to overwrite pool refs that already exist in
+	// the environment datastore. Without it, a redeploy over an existing entry is rejected by the
+	// precondition rather than silently replacing it.
+	ForceDatastoreOverwrite bool
+}
+
+// PlannedRefs returns the datastore refs this changeset will write, derived from config alone so
+// they can be checked before anything is deployed. Both pool types are deployed at v1.6.2 and
+// qualified by the USDC symbol, so two entries for one chain collide unless their pool types
+// differ.
+func (c DeployUSDCTokenPoolContractsConfig) PlannedRefs() []datastore.AddressRef {
+	version := deployment.Version1_6_2
+	refs := make([]datastore.AddressRef, 0, len(c.USDCPools))
+	for chainSelector, poolConfig := range c.USDCPools {
+		refs = append(refs, datastore.AddressRef{
+			ChainSelector: chainSelector,
+			Type:          datastore.ContractType(poolConfig.PoolType),
+			Version:       &version,
+			Qualifier:     string(shared.USDCSymbol),
+		})
+	}
+	return refs
 }
 
 func deployUSDCTokenPoolContractsPrecondition(env cldf.Environment, c DeployUSDCTokenPoolContractsConfig) error {
+	// Reserve the keys to prove the refs can all be recorded, then check them against the
+	// environment. Both run before anything is deployed.
+	if _, err := shared.ReserveRefs(c.PlannedRefs()); err != nil {
+		return fmt.Errorf("USDC token pool datastore refs conflict: %w", err)
+	}
+	// Taking over a key the environment already holds is a redeploy: rejected unless the caller
+	// asked for it, in which case it is logged rather than passing unremarked.
+	validateRefs := shared.ValidateAddressRefsStrict
+	if c.ForceDatastoreOverwrite {
+		validateRefs = shared.ValidateAddressRefs
+	}
+	if err := validateRefs(env, c.PlannedRefs()); err != nil {
+		return fmt.Errorf("USDC token pool datastore refs conflict: %w", err)
+	}
+
 	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -142,6 +180,7 @@ func deployUSDCTokenPoolContractsLogic(env cldf.Environment, c DeployUSDCTokenPo
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid DeployUSDCTokenPoolContractsConfig: %w", err)
 	}
 	newAddresses := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 
 	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
@@ -161,9 +200,9 @@ func deployUSDCTokenPoolContractsLogic(env cldf.Environment, c DeployUSDCTokenPo
 		var deployErr error
 		switch poolConfig.PoolType {
 		case shared.USDCTokenPool:
-			deployErr = deployUSDCTokenPool(env.Logger, chain, newAddresses, poolConfig, chainState, router.Address())
+			deployErr = deployUSDCTokenPool(env.Logger, chain, newAddresses, ds, poolConfig, chainState, router.Address())
 		case shared.HybridLockReleaseUSDCTokenPool:
-			deployErr = deployHybridLockReleaseUSDCTokenPool(env.Logger, chain, newAddresses, poolConfig, chainState, router.Address())
+			deployErr = deployHybridLockReleaseUSDCTokenPool(env.Logger, chain, newAddresses, ds, poolConfig, chainState, router.Address())
 		default:
 			return cldf.ChangesetOutput{},
 				fmt.Errorf("failed to deploy %s on %s: unknown pool type", poolConfig.PoolType, chain)
@@ -173,19 +212,14 @@ func deployUSDCTokenPoolContractsLogic(env cldf.Environment, c DeployUSDCTokenPo
 		}
 	}
 
-	ds, err := shared.PopulateDataStore(newAddresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
-
 	return cldf.ChangesetOutput{
 		AddressBook: newAddresses,
 		DataStore:   ds,
 	}, nil
 }
 
-func deployUSDCTokenPool(lggr logger.Logger, chain cldf_evm.Chain, newAddresses *cldf.AddressBookMap, poolConfig DeployUSDCTokenPoolInput, chainState evm.CCIPChainState, routerAddr common.Address) error {
-	_, err := cldf.DeployContract(lggr, chain, newAddresses,
+func deployUSDCTokenPool(lggr logger.Logger, chain cldf_evm.Chain, newAddresses *cldf.AddressBookMap, ds datastore.MutableDataStore, poolConfig DeployUSDCTokenPoolInput, chainState evm.CCIPChainState, routerAddr common.Address) error {
+	_, err := shared.DeployContractAndRecord(lggr, chain, newAddresses, ds, cldf.NewTypeAndVersion(shared.USDCTokenPool, deployment.Version1_6_2), string(shared.USDCSymbol),
 		func(chain cldf_evm.Chain) cldf.ContractDeploy[*usdc_token_pool.USDCTokenPool] {
 			previousPoolAddress := poolConfig.PreviousPoolAddress
 
@@ -222,8 +256,8 @@ func deployUSDCTokenPool(lggr logger.Logger, chain cldf_evm.Chain, newAddresses 
 	return err
 }
 
-func deployHybridLockReleaseUSDCTokenPool(lggr logger.Logger, chain cldf_evm.Chain, newAddresses *cldf.AddressBookMap, poolConfig DeployUSDCTokenPoolInput, chainState evm.CCIPChainState, routerAddr common.Address) error {
-	_, err := cldf.DeployContract(lggr, chain, newAddresses,
+func deployHybridLockReleaseUSDCTokenPool(lggr logger.Logger, chain cldf_evm.Chain, newAddresses *cldf.AddressBookMap, ds datastore.MutableDataStore, poolConfig DeployUSDCTokenPoolInput, chainState evm.CCIPChainState, routerAddr common.Address) error {
+	_, err := shared.DeployContractAndRecord(lggr, chain, newAddresses, ds, cldf.NewTypeAndVersion(shared.HybridLockReleaseUSDCTokenPool, deployment.Version1_6_2), string(shared.USDCSymbol),
 		func(chain cldf_evm.Chain) cldf.ContractDeploy[*hybrid_lock_release_usdc_token_pool.HybridLockReleaseUSDCTokenPool] {
 			previousPoolAddress := poolConfig.PreviousPoolAddress
 

--- a/deployment/ccip/shared/helpers.go
+++ b/deployment/ccip/shared/helpers.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -151,4 +152,68 @@ func ResolveFeeQuoterAddressAndVersion(
 	}
 
 	return common.HexToAddress(bestRef.Address), *bestVersion, nil
+}
+
+// CollectAddressRefs returns a plain (unkeyed) slice of address refs drawn from both the
+// environment's datastore and its existing address book, including labels. It does not key or
+// dedup, so duplicate/multi-instance refs are all retained. Use it to resolve chain-singleton
+// contracts (e.g. FeeQuoter) over existing state without going through a keyed datastore. It
+// returns an error if either source cannot be read, so callers do not silently resolve from an
+// incomplete set.
+func CollectAddressRefs(e deployment.Environment) ([]datastore.AddressRef, error) {
+	var refs []datastore.AddressRef
+	if e.DataStore != nil {
+		r, err := e.DataStore.Addresses().Fetch()
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch address refs from environment datastore: %w", err)
+		}
+		refs = append(refs, r...)
+	}
+	if e.ExistingAddresses != nil {
+		addrs, err := e.ExistingAddresses.Addresses()
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch addresses from environment address book: %w", err)
+		}
+		for sel, chainAddresses := range addrs {
+			for addr, tv := range chainAddresses {
+				ref := datastore.AddressRef{
+					ChainSelector: sel,
+					Address:       addr,
+					Type:          datastore.ContractType(tv.Type),
+					Version:       &tv.Version,
+				}
+				if !tv.Labels.IsEmpty() {
+					ref.Labels = datastore.NewLabelSet(tv.Labels.List()...)
+				}
+				refs = append(refs, ref)
+			}
+		}
+	}
+	return refs, nil
+}
+
+// QualifierFromParts joins the parts that identify one instance into a datastore qualifier.
+//
+// Each part is quoted rather than joined on a bare separator: parts are often caller-supplied
+// free-form text, so a plain join would let ("A", "B/C") and ("A/B", "C") produce the same
+// qualifier and collide. Quoting escapes any separator inside a part, so distinct inputs always
+// yield distinct qualifiers.
+func QualifierFromParts(parts ...string) string {
+	quoted := make([]string, 0, len(parts))
+	for _, p := range parts {
+		quoted = append(quoted, fmt.Sprintf("%q", p))
+	}
+
+	return strings.Join(quoted, "/")
+}
+
+// TokenPoolLookupTableQualifier returns the datastore qualifier for a Solana token-pool lookup
+// table, which is uniquely identified by (token mint, pool type, metadata).
+//
+// Each component is quoted rather than joined on a bare separator. metadata is caller-supplied
+// free-form text, so a plain "a/b/c" join would let ("A", "B/C") and ("A/B", "C") produce the same
+// qualifier and collide in the datastore. Quoting escapes any separator inside a component, so
+// distinct inputs always yield distinct qualifiers.
+func TokenPoolLookupTableQualifier(tokenPubKey, poolType, metadata string) string {
+	return QualifierFromParts(tokenPubKey, poolType, metadata)
 }

--- a/deployment/environment/crib/ccip_deployer.go
+++ b/deployment/environment/crib/ccip_deployer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/p2pkey"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
@@ -989,7 +990,7 @@ func mustOCR(e *cldf.Environment, homeChainSel uint64, feedChainSel uint64, newD
 	execOCRConfigPerSelector := make(map[uint64]v1_6.CCIPOCRParams)
 	// Should be configured in the future based on the load test scenario
 	chainType := v1_6.Default
-	_, err := testhelpers.DeployFeeds(e.Logger, e.ExistingAddresses, e.BlockChains.EVMChains()[feedChainSel], testhelpers.DefaultLinkPrice, testhelpers.DefaultWethPrice)
+	_, err := testhelpers.DeployFeeds(e.Logger, e.ExistingAddresses, datastore.NewMemoryDataStore(), e.BlockChains.EVMChains()[feedChainSel], testhelpers.DefaultLinkPrice, testhelpers.DefaultWethPrice)
 	if err != nil {
 		return *e, fmt.Errorf("failed to deploy feeds: %w", err)
 	}


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
[CCIP-13349](https://smartcontract-it.atlassian.net/browse/CCIP-13349)

Migrates CCIP EVM changesets from direct framework deployment writes to the CCIP datastore write-at-site API. The datastore must be populated at the point where the contract is deployed, with the qualifier known by the caller. This removes the need to derive datastore entries from the AddressBook later.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->
This is the third PR of the stack.

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

[CCIP-13349]: https://smartcontract-it.atlassian.net/browse/CCIP-13349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ