### PR TITLE
Convert Solana/non-EVM ccip changesets to the datastore write-at-site API

### DIFF
--- a/deployment/ccip/changeset/ccip-attestation-solana/cs_deploy_signer_registry_solana.go
+++ b/deployment/ccip/changeset/ccip-attestation-solana/cs_deploy_signer_registry_solana.go
@@ -23,6 +23,7 @@ import (
 	sol_binary "github.com/gagliardetto/binary"
 	sol_rpc "github.com/gagliardetto/solana-go/rpc"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 )
@@ -55,6 +56,7 @@ func DeployBaseSignerRegistryContractChangeset(e cldf.Environment, c DeployBaseS
 	chain := e.BlockChains.SolanaChains()[chainSel]
 
 	newAddresses := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 
 	programFileName := solutils.ProgBaseSignerRegistry + ".so"
 	programFilePath := filepath.Join(chain.ProgramsPath, programFileName)
@@ -69,14 +71,9 @@ func DeployBaseSignerRegistryContractChangeset(e cldf.Environment, c DeployBaseS
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to download release artifacts: %w", err)
 		}
 	}
-	_, err = deployBaseSignerRegistryContract(e, chain, newAddresses, c)
+	_, err = deployBaseSignerRegistryContract(e, chain, newAddresses, ds, c)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy base signer registry contract: %w", err)
-	}
-
-	ds, err := shared.PopulateDataStore(newAddresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{
@@ -124,7 +121,7 @@ func InitializeBaseSignerRegistryContractChangeset(e cldf.Environment, c Initial
 	return cldf.ChangesetOutput{}, nil
 }
 
-func deployBaseSignerRegistryContract(e cldf.Environment, chain cldf_solana.Chain, ab cldf.AddressBook, config DeployBaseSignerRegistryContractConfig,
+func deployBaseSignerRegistryContract(e cldf.Environment, chain cldf_solana.Chain, ab cldf.AddressBook, ds datastore.MutableDataStore, config DeployBaseSignerRegistryContractConfig,
 ) (solana.PublicKey, error) {
 	contractType := shared.SVMSignerRegistry
 	programName := solutils.ProgBaseSignerRegistry
@@ -140,7 +137,7 @@ func deployBaseSignerRegistryContract(e cldf.Environment, chain cldf_solana.Chai
 
 	e.Logger.Infow("Deployed program", "Program", contractType, "addr", programID, "chain", chain.String())
 	tv := cldf.NewTypeAndVersion(contractType, config.Version)
-	err = ab.Save(chain.Selector, programID, tv)
+	err = shared.RecordAddress(ab, ds, chain.Selector, programID, tv, "")
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("failed to save address: %w", err)
 	}

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_add_remote_chain.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_add_remote_chain.go
@@ -2,7 +2,6 @@ package solana
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -21,6 +20,7 @@ import (
 	solCommonUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -110,17 +110,13 @@ func AddRemoteChainToRouter(e cldf.Environment, cfg AddRemoteChainToRouterConfig
 	}
 
 	ab := cldf.NewMemoryAddressBook()
-	txns, err := doAddRemoteChainToRouter(e, s, cfg, ab)
+	ds := datastore.NewMemoryDataStore()
+	txns, err := doAddRemoteChainToRouter(e, s, cfg, ab, ds)
 	if err != nil {
-		ds, err2 := shared.PopulateDataStore(ab)
-		if err2 != nil {
-			err2 = fmt.Errorf("failed to populate in-memory DataStore: %w", err2)
-		}
-
 		return cldf.ChangesetOutput{
 			AddressBook: ab,
 			DataStore:   ds,
-		}, errors.Join(err, err2)
+		}, err
 	}
 
 	// create proposals for ixns
@@ -131,21 +127,11 @@ func AddRemoteChainToRouter(e cldf.Environment, cfg AddRemoteChainToRouterConfig
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}
 
-		ds, err := shared.PopulateDataStore(ab)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-		}
-
 		return cldf.ChangesetOutput{
 			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
 			AddressBook:           ab,
 			DataStore:             ds,
 		}, nil
-	}
-
-	ds, err := shared.PopulateDataStore(ab)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{AddressBook: ab, DataStore: ds}, nil
@@ -156,6 +142,7 @@ func doAddRemoteChainToRouter(
 	s stateview.CCIPOnChainState,
 	cfg AddRemoteChainToRouterConfig,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 ) ([]mcmsTypes.Transaction, error) {
 	txns := make([]mcmsTypes.Transaction, 0)
 	chainSel := cfg.ChainSelector
@@ -269,7 +256,7 @@ func doAddRemoteChainToRouter(
 			tv := cldf.NewTypeAndVersion(shared.RemoteDest, deployment.Version1_0_0)
 			remoteChainSelStr := strconv.FormatUint(remoteChainSel, 10)
 			tv.AddLabel(remoteChainSelStr)
-			err = ab.Save(chainSel, routerRemoteStatePDA.String(), tv)
+			err = shared.RecordAddress(ab, ds, chainSel, routerRemoteStatePDA.String(), tv, remoteChainSelStr)
 			if err != nil {
 				return txns, fmt.Errorf("failed to save dest chain state to address book: %w", err)
 			}
@@ -347,13 +334,12 @@ func AddRemoteChainToFeeQuoter(e cldf.Environment, cfg AddRemoteChainToFeeQuoter
 	}
 
 	ab := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 	txns, err := doAddRemoteChainToFeeQuoter(e, s, cfg, ab)
 	if err != nil {
-		ds, err2 := shared.PopulateDataStore(ab)
-		if err2 != nil {
-			err2 = fmt.Errorf("failed to populate in-memory DataStore: %w", err2)
-		}
-		return cldf.ChangesetOutput{AddressBook: ab, DataStore: ds}, errors.Join(err, err2)
+		// skipped: doAddRemoteChainToFeeQuoter does not save any lane/multi-instance refs,
+		// so the datastore needs no additional qualifier pass.
+		return cldf.ChangesetOutput{AddressBook: ab, DataStore: ds}, err //nolint:staticcheck // Phase 1 still returns the address book
 	}
 
 	// create proposals for ixns
@@ -363,10 +349,8 @@ func AddRemoteChainToFeeQuoter(e cldf.Environment, cfg AddRemoteChainToFeeQuoter
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}
-		ds, err := shared.PopulateDataStore(ab)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-		}
+		// skipped: doAddRemoteChainToFeeQuoter does not save any lane/multi-instance refs,
+		// so the datastore needs no additional qualifier pass.
 		return cldf.ChangesetOutput{
 			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
 			AddressBook:           ab,
@@ -374,11 +358,8 @@ func AddRemoteChainToFeeQuoter(e cldf.Environment, cfg AddRemoteChainToFeeQuoter
 		}, nil
 	}
 
-	ds, err := shared.PopulateDataStore(ab)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
-
+	// skipped: doAddRemoteChainToFeeQuoter does not save any lane/multi-instance refs,
+	// so the datastore needs no additional qualifier pass.
 	return cldf.ChangesetOutput{AddressBook: ab, DataStore: ds}, nil
 }
 
@@ -536,13 +517,14 @@ func AddRemoteChainToOffRamp(e cldf.Environment, cfg AddRemoteChainToOffRampConf
 	}
 
 	ab := cldf.NewMemoryAddressBook()
-	txns, err := doAddRemoteChainToOffRamp(e, s, cfg, ab)
+	ds := datastore.NewMemoryDataStore()
+	txns, err := doAddRemoteChainToOffRamp(e, s, cfg, ab, ds)
 	if err != nil {
-		ds, err2 := shared.PopulateDataStore(ab)
-		if err2 != nil {
-			err2 = fmt.Errorf("failed to populate in-memory DataStore: %w", err2)
-		}
-		return cldf.ChangesetOutput{AddressBook: ab, DataStore: ds}, errors.Join(err, err2)
+		return cldf.ChangesetOutput{
+			//nolint:staticcheck // SA1019: AddressBook is deprecated, migration to DataStore pending
+			AddressBook: ab,
+			DataStore:   ds,
+		}, err
 	}
 
 	// create proposals for ixns
@@ -552,20 +534,11 @@ func AddRemoteChainToOffRamp(e cldf.Environment, cfg AddRemoteChainToOffRampConf
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}
-		ds, err := shared.PopulateDataStore(ab)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-		}
 		return cldf.ChangesetOutput{
 			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
 			AddressBook:           ab,
 			DataStore:             ds,
 		}, nil
-	}
-
-	ds, err := shared.PopulateDataStore(ab)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{AddressBook: ab, DataStore: ds}, nil
@@ -576,6 +549,7 @@ func doAddRemoteChainToOffRamp(
 	s stateview.CCIPOnChainState,
 	cfg AddRemoteChainToOffRampConfig,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 ) ([]mcmsTypes.Transaction, error) {
 	txns := make([]mcmsTypes.Transaction, 0)
 	chainSel := cfg.ChainSelector
@@ -645,7 +619,7 @@ func doAddRemoteChainToOffRamp(
 			remoteChainSelStr := strconv.FormatUint(remoteChainSel, 10)
 			tv := cldf.NewTypeAndVersion(shared.RemoteSource, deployment.Version1_0_0)
 			tv.AddLabel(remoteChainSelStr)
-			err = ab.Save(chainSel, offRampRemoteStatePDA.String(), tv)
+			err = shared.RecordAddress(ab, ds, chainSel, offRampRemoteStatePDA.String(), tv, remoteChainSelStr)
 			if err != nil {
 				return txns, fmt.Errorf("failed to save source chain state to address book: %w", err)
 			}

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_deploy_chain.go
@@ -19,6 +19,7 @@ import (
 
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -171,6 +172,7 @@ func DeployChainContractsChangeset(e cldf.Environment, c DeployChainContractsCon
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid DeployChainContractsConfig: %w", err)
 	}
 	newAddresses := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 	err = v1_6.ValidateHomeChainState(e, c.HomeChainSelector, existingState)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -195,7 +197,7 @@ func DeployChainContractsChangeset(e cldf.Environment, c DeployChainContractsCon
 		e.Logger.Debugw("Skipping solana build as no build config provided")
 	}
 
-	batches, err := deployChainContractsSolana(e, chain, newAddresses, c)
+	batches, err := deployChainContractsSolana(e, chain, newAddresses, ds, c)
 	if err != nil {
 		e.Logger.Errorw("Failed to deploy CCIP contracts", "err", err, "newAddresses", newAddresses)
 		return cldf.ChangesetOutput{}, err
@@ -213,21 +215,11 @@ func DeployChainContractsChangeset(e cldf.Environment, c DeployChainContractsCon
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}
 
-		ds, err := shared.PopulateDataStore(newAddresses)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-		}
-
 		return cldf.ChangesetOutput{
 			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
 			AddressBook:           newAddresses,
 			DataStore:             ds,
 		}, nil
-	}
-
-	ds, err := shared.PopulateDataStore(newAddresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{
@@ -242,6 +234,7 @@ func DeployAndMaybeSaveToAddressBook(
 	e cldf.Environment,
 	chain cldf_solana.Chain,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	contractType cldf.ContractType,
 	version semver.Version,
 	isUpgrade bool,
@@ -265,7 +258,7 @@ func DeployAndMaybeSaveToAddressBook(
 		if metadata != "" {
 			tv.AddLabel(metadata)
 		}
-		err = ab.Save(chain.Selector, programID, tv)
+		err = shared.RecordAddress(ab, ds, chain.Selector, programID, tv, metadata)
 		if err != nil {
 			return solana.PublicKey{}, fmt.Errorf("failed to save address: %w", err)
 		}
@@ -277,6 +270,7 @@ func deployChainContractsSolana(
 	e cldf.Environment,
 	chain cldf_solana.Chain,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	config DeployChainContractsConfig,
 ) ([]mcmsTypes.BatchOperation, error) {
 	// we may need to gather instructions and submit them as part of MCMS
@@ -300,14 +294,14 @@ func deployChainContractsSolana(
 	var feeQuoterAddress solana.PublicKey
 	//nolint:gocritic // this is a false positive, we need to check if the address is zero
 	if chainState.FeeQuoter.IsZero() {
-		feeQuoterAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.FeeQuoter, deployment.Version1_0_0, false, "")
+		feeQuoterAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.FeeQuoter, deployment.Version1_0_0, false, "")
 		if err != nil {
 			return batches, fmt.Errorf("failed to deploy program: %w", err)
 		}
 	} else if config.UpgradeConfig.NewFeeQuoterVersion != nil {
 		// fee quoter updated in place
 		feeQuoterAddress = chainState.FeeQuoter
-		newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewFeeQuoterVersion, chainState.FeeQuoter, shared.FeeQuoter)
+		newTxns, err := generateUpgradeTxns(e, chain, ab, ds, config, config.UpgradeConfig.NewFeeQuoterVersion, chainState.FeeQuoter, shared.FeeQuoter)
 		if err != nil {
 			return batches, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
@@ -331,14 +325,14 @@ func deployChainContractsSolana(
 	//nolint:gocritic // this is a false positive, we need to check if the address is zero
 	if chainState.Router.IsZero() {
 		// deploy router
-		ccipRouterProgram, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.Router, deployment.Version1_0_0, false, "")
+		ccipRouterProgram, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.Router, deployment.Version1_0_0, false, "")
 		if err != nil {
 			return batches, fmt.Errorf("failed to deploy program: %w", err)
 		}
 	} else if config.UpgradeConfig.NewRouterVersion != nil {
 		// router updated in place
 		ccipRouterProgram = chainState.Router
-		newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewRouterVersion, chainState.Router, shared.Router)
+		newTxns, err := generateUpgradeTxns(e, chain, ab, ds, config, config.UpgradeConfig.NewRouterVersion, chainState.Router, shared.Router)
 		if err != nil {
 			return batches, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
@@ -362,7 +356,7 @@ func deployChainContractsSolana(
 	//nolint:gocritic // this is a false positive, we need to check if the address is zero
 	if chainState.OffRamp.IsZero() {
 		// deploy offramp
-		offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.OffRamp, deployment.Version1_0_0, false, "")
+		offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.OffRamp, deployment.Version1_0_0, false, "")
 		if err != nil {
 			return batches, fmt.Errorf("failed to deploy program: %w", err)
 		}
@@ -375,7 +369,7 @@ func deployChainContractsSolana(
 		offRampAddress = solanastateview.FindSolanaAddress(tv, existingAddresses)
 		if offRampAddress.IsZero() {
 			// deploy offramp, not upgraded in place so upgrade is false
-			offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.OffRamp, *config.UpgradeConfig.NewOffRampVersion, false, "")
+			offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.OffRamp, *config.UpgradeConfig.NewOffRampVersion, false, "")
 			if err != nil {
 				return batches, fmt.Errorf("failed to deploy program: %w", err)
 			}
@@ -408,7 +402,7 @@ func deployChainContractsSolana(
 				}
 			}
 		} else {
-			newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewOffRampVersion, chainState.OffRamp, shared.OffRamp)
+			newTxns, err := generateUpgradeTxns(e, chain, ab, ds, config, config.UpgradeConfig.NewOffRampVersion, chainState.OffRamp, shared.OffRamp)
 			if err != nil {
 				return batches, fmt.Errorf("failed to generate upgrade txns: %w", err)
 			}
@@ -431,13 +425,13 @@ func deployChainContractsSolana(
 	// RMN REMOTE DEPLOY
 	var rmnRemoteAddress solana.PublicKey
 	if chainState.RMNRemote.IsZero() {
-		rmnRemoteAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.RMNRemote, deployment.Version1_0_0, false, "")
+		rmnRemoteAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.RMNRemote, deployment.Version1_0_0, false, "")
 		if err != nil {
 			return batches, fmt.Errorf("failed to deploy program: %w", err)
 		}
 	} else if config.UpgradeConfig.NewRMNRemoteVersion != nil {
 		rmnRemoteAddress = chainState.RMNRemote
-		newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewRMNRemoteVersion, chainState.RMNRemote, shared.RMNRemote)
+		newTxns, err := generateUpgradeTxns(e, chain, ab, ds, config, config.UpgradeConfig.NewRMNRemoteVersion, chainState.RMNRemote, shared.RMNRemote)
 		if err != nil {
 			return batches, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
@@ -530,13 +524,13 @@ func deployChainContractsSolana(
 	}
 	//nolint:gocritic // this is a false positive, we need to check if the address is zero
 	if chainState.BurnMintTokenPools[metadata].IsZero() {
-		burnMintTokenPool, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.BurnMintTokenPool, deployment.Version1_0_0, false, metadata)
+		burnMintTokenPool, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.BurnMintTokenPool, deployment.Version1_0_0, false, metadata)
 		if err != nil {
 			return batches, fmt.Errorf("failed to deploy program: %w", err)
 		}
 	} else if config.UpgradeConfig.NewBurnMintTokenPoolVersion != nil {
 		burnMintTokenPool = chainState.BurnMintTokenPools[metadata]
-		newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewBurnMintTokenPoolVersion, chainState.BurnMintTokenPools[metadata], shared.BurnMintTokenPool)
+		newTxns, err := generateUpgradeTxns(e, chain, ab, ds, config, config.UpgradeConfig.NewBurnMintTokenPoolVersion, chainState.BurnMintTokenPools[metadata], shared.BurnMintTokenPool)
 		if err != nil {
 			return batches, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
@@ -559,13 +553,13 @@ func deployChainContractsSolana(
 	}
 	//nolint:gocritic // this is a false positive, we need to check if the address is zero
 	if chainState.LockReleaseTokenPools[metadata].IsZero() {
-		lockReleaseTokenPool, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.LockReleaseTokenPool, deployment.Version1_0_0, false, metadata)
+		lockReleaseTokenPool, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.LockReleaseTokenPool, deployment.Version1_0_0, false, metadata)
 		if err != nil {
 			return batches, fmt.Errorf("failed to deploy program: %w", err)
 		}
 	} else if config.UpgradeConfig.NewLockReleaseTokenPoolVersion != nil {
 		lockReleaseTokenPool = chainState.LockReleaseTokenPools[metadata]
-		newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewLockReleaseTokenPoolVersion, chainState.LockReleaseTokenPools[metadata], shared.LockReleaseTokenPool)
+		newTxns, err := generateUpgradeTxns(e, chain, ab, ds, config, config.UpgradeConfig.NewLockReleaseTokenPoolVersion, chainState.LockReleaseTokenPools[metadata], shared.LockReleaseTokenPool)
 		if err != nil {
 			return batches, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
@@ -583,6 +577,23 @@ func deployChainContractsSolana(
 
 	// MCMS
 	// this should selectively deploy and initialise anything if required
+	mcmsQualifier := ""
+	if config.MCMSWithTimelockConfig != nil && config.MCMSWithTimelockConfig.Qualifier != nil {
+		mcmsQualifier = *config.MCMSWithTimelockConfig.Qualifier
+	}
+	// Snapshot the addresses added so far so we can later qualify only the MCMS-related
+	// accounts (and not the chain-singleton programs) under the configured MCMS qualifier.
+	var mcmsAddrsBefore map[string]struct{}
+	if mcmsQualifier != "" {
+		existing, err := ab.AddressesForChain(chain.Selector)
+		if err != nil && !errors.Is(err, cldf.ErrChainNotFound) {
+			return batches, fmt.Errorf("failed to get existing addresses for chain %v: %w", chain.Selector, err)
+		}
+		mcmsAddrsBefore = make(map[string]struct{}, len(existing))
+		for addr := range existing {
+			mcmsAddrsBefore[addr] = struct{}{}
+		}
+	}
 	if config.MCMSWithTimelockConfig != nil {
 		_, err = solanaMCMS.DeployMCMSWithTimelockProgramsSolana(e, chain, ab, *config.MCMSWithTimelockConfig)
 		if err != nil {
@@ -600,7 +611,7 @@ func deployChainContractsSolana(
 	}
 	if config.UpgradeConfig.NewMCMVersion != nil {
 		e.Logger.Infow("Generate instruction for upgrading mcms", "chain", chain.String())
-		newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewMCMVersion, mcmState.McmProgram, types.ManyChainMultisigProgram)
+		newTxns, err := generateUpgradeTxns(e, chain, ab, ds, config, config.UpgradeConfig.NewMCMVersion, mcmState.McmProgram, types.ManyChainMultisigProgram)
 		if err != nil {
 			return batches, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
@@ -614,7 +625,7 @@ func deployChainContractsSolana(
 	}
 	if config.UpgradeConfig.NewAccessControllerVersion != nil {
 		e.Logger.Infow("Generating instruction for upgrading access controller", "chain", chain.String())
-		newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewAccessControllerVersion, mcmState.AccessControllerProgram, types.AccessControllerProgram)
+		newTxns, err := generateUpgradeTxns(e, chain, ab, ds, config, config.UpgradeConfig.NewAccessControllerVersion, mcmState.AccessControllerProgram, types.AccessControllerProgram)
 		if err != nil {
 			return batches, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
@@ -628,7 +639,7 @@ func deployChainContractsSolana(
 	}
 	if config.UpgradeConfig.NewTimelockVersion != nil {
 		e.Logger.Infow("Generate instruction for upgrading timelock", "chain", chain.String())
-		newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewTimelockVersion, mcmState.TimelockProgram, types.RBACTimelockProgram)
+		newTxns, err := generateUpgradeTxns(e, chain, ab, ds, config, config.UpgradeConfig.NewTimelockVersion, mcmState.TimelockProgram, types.RBACTimelockProgram)
 		if err != nil {
 			return batches, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
@@ -638,6 +649,23 @@ func deployChainContractsSolana(
 				ChainSelector: mcmsTypes.ChainSelector(chain.Selector),
 				Transactions:  newTxns,
 			})
+		}
+	}
+
+	// Qualify the MCMS program/access-controller/timelock/role accounts added by the MCMS
+	// deploy and any MCMS program upgrades under the configured MCMS qualifier, so they are
+	// resolvable in the datastore under that qualifier.
+	if mcmsAddrsBefore != nil {
+		after, err := ab.AddressesForChain(chain.Selector)
+		if err != nil {
+			return batches, fmt.Errorf("failed to get addresses for chain %v: %w", chain.Selector, err)
+		}
+		for addr := range after {
+			if _, ok := mcmsAddrsBefore[addr]; !ok {
+				if err := shared.RecordAddress(nil, ds, chain.Selector, addr, after[addr], mcmsQualifier); err != nil {
+					return batches, fmt.Errorf("failed to record MCMS ref %s: %w", addr, err)
+				}
+			}
 		}
 	}
 
@@ -871,6 +899,7 @@ func generateUpgradeTxns(
 	e cldf.Environment,
 	chain cldf_solana.Chain,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	config DeployChainContractsConfig,
 	newVersion *semver.Version,
 	programID solana.PublicKey,
@@ -878,7 +907,7 @@ func generateUpgradeTxns(
 ) ([]mcmsTypes.Transaction, error) {
 	e.Logger.Infow("Generating instruction for upgrading contract", "contractType", contractType)
 	txns := make([]mcmsTypes.Transaction, 0)
-	bufferProgram, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, contractType, *newVersion, true, "")
+	bufferProgram, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, contractType, *newVersion, true, "")
 	if err != nil {
 		return txns, fmt.Errorf("failed to deploy program: %w", err)
 	}

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_ops.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_ops.go
@@ -10,6 +10,7 @@ import (
 	solstate "github.com/smartcontractkit/cld-changesets/legacy/pkg/family/solana"
 
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 
@@ -443,18 +444,19 @@ func DeployReceiverForTest(e cldf.Environment, cfg DeployForTestConfig) (cldf.Ch
 	chainState := state.SolChains[cfg.ChainSelector]
 	chain := e.BlockChains.SolanaChains()[cfg.ChainSelector]
 	ab := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 
 	var receiverAddress solana.PublicKey
 	if !cfg.IsUpgrade {
 		//nolint:gocritic // this is a false positive, we need to check if the address is zero
 		if chainState.Receiver.IsZero() {
-			receiverAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.Receiver, deployment.Version1_0_0, false, "")
+			receiverAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.Receiver, deployment.Version1_0_0, false, "")
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy program: %w", err)
 			}
 		} else if cfg.ReceiverVersion != nil {
 			// this block is for re-deploying with a new version
-			receiverAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.Receiver, *cfg.ReceiverVersion, false, "")
+			receiverAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.Receiver, *cfg.ReceiverVersion, false, "")
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy program: %w", err)
 			}
@@ -482,7 +484,7 @@ func DeployReceiverForTest(e cldf.Environment, cfg DeployForTestConfig) (cldf.Ch
 	} else if cfg.IsUpgrade {
 		e.Logger.Infow("Deploying new receiver", "addr", chainState.Receiver.String())
 		// only support deployer key as upgrade authority. never transfer to timelock
-		_, err := generateUpgradeTxns(e, chain, ab, DeployChainContractsConfig{
+		_, err := generateUpgradeTxns(e, chain, ab, ds, DeployChainContractsConfig{
 			UpgradeConfig: UpgradeConfig{
 				SpillAddress:     chain.DeployerKey.PublicKey(),
 				UpgradeAuthority: chain.DeployerKey.PublicKey(),
@@ -491,11 +493,6 @@ func DeployReceiverForTest(e cldf.Environment, cfg DeployForTestConfig) (cldf.Ch
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
-	}
-
-	ds, err := shared.PopulateDataStore(ab)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_solana_token.go
@@ -10,6 +10,7 @@ import (
 
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -159,20 +160,16 @@ func DeploySolanaToken(e cldf.Environment, cfg DeploySolanaTokenConfig) (cldf.Ch
 	}
 
 	newAddresses := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 	tv := cldf.NewTypeAndVersion(cfg.TokenProgramName, deployment.Version1_0_0)
 	tv.AddLabel(cfg.TokenSymbol)
-	err = newAddresses.Save(cfg.ChainSelector, mint.String(), tv)
+	err = shared.RecordAddress(newAddresses, ds, cfg.ChainSelector, mint.String(), tv, cfg.TokenSymbol)
 	if err != nil {
 		e.Logger.Errorw("Failed to save token", "chain", chain.String(), "err", err)
 		return cldf.ChangesetOutput{}, err
 	}
 
 	e.Logger.Infow("Deployed contract", "Contract", tv.String(), "addr", mint.String(), "chain", chain.String())
-
-	ds, err := shared.PopulateDataStore(newAddresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
 
 	return cldf.ChangesetOutput{
 		AddressBook: newAddresses,

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
@@ -26,6 +26,7 @@ import (
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 	solTokenUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -106,6 +107,9 @@ type TokenPoolConfig struct {
 type AddTokenPoolAndLookupTableConfig struct {
 	ChainSelector    uint64
 	TokenPoolConfigs []TokenPoolConfig
+	// ForceDatastoreOverwrite is propagated to the lookup-table step; see
+	// TokenPoolLookupTableConfig.ForceDatastoreOverwrite.
+	ForceDatastoreOverwrite bool
 }
 
 type TokenPoolConfigWithMCM struct {
@@ -141,6 +145,22 @@ func (cfg NewMintTokenPoolConfig) Validate(e cldf.Environment, chainState solana
 	return chainState.ValidatePoolDeployment(&e, cfg.PoolType, cfg.ChainSelector, cfg.TokenPubKey, false, cfg.Metadata)
 }
 
+// PlannedRefs returns all lookup-table refs produced by this aggregate changeset. Keeping the
+// complete key set at the aggregate boundary prevents a later child validation from discovering a
+// duplicate after an earlier token-pool transaction has already been confirmed.
+func (cfg AddTokenPoolAndLookupTableConfig) PlannedRefs() []datastore.AddressRef {
+	refs := make([]datastore.AddressRef, 0, len(cfg.TokenPoolConfigs))
+	for _, tokenPoolCfg := range cfg.TokenPoolConfigs {
+		refs = append(refs, (TokenPoolLookupTableConfig{
+			ChainSelector: cfg.ChainSelector,
+			TokenPubKey:   tokenPoolCfg.TokenPubKey,
+			PoolType:      tokenPoolCfg.PoolType,
+			Metadata:      tokenPoolCfg.Metadata,
+		}).PlannedRefs()...)
+	}
+	return refs
+}
+
 func (cfg AddTokenPoolAndLookupTableConfig) Validate(e cldf.Environment, chainState solanastateview.CCIPChainState) error {
 	for _, tokenPoolCfg := range cfg.TokenPoolConfigs {
 		if err := chainState.CommonValidation(e, cfg.ChainSelector, tokenPoolCfg.TokenPubKey); err != nil {
@@ -152,6 +172,16 @@ func (cfg AddTokenPoolAndLookupTableConfig) Validate(e cldf.Environment, chainSt
 		if err := chainState.ValidatePoolDeployment(&e, tokenPoolCfg.PoolType, cfg.ChainSelector, tokenPoolCfg.TokenPubKey, false, tokenPoolCfg.Metadata); err != nil {
 			return err
 		}
+	}
+	if _, err := shared.ReserveRefs(cfg.PlannedRefs()); err != nil {
+		return fmt.Errorf("lookup table datastore refs conflict: %w", err)
+	}
+	validateRefs := shared.ValidateAddressRefsStrict
+	if cfg.ForceDatastoreOverwrite {
+		validateRefs = shared.ValidateAddressRefs
+	}
+	if err := validateRefs(e, cfg.PlannedRefs()); err != nil {
+		return fmt.Errorf("lookup table datastore refs conflict: %w", err)
 	}
 	return nil
 }
@@ -167,6 +197,10 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 	}
 	chain := e.BlockChains.SolanaChains()[cfg.ChainSelector]
 	addressBook := cldf.NewMemoryAddressBook()
+	ds, err := shared.ReserveRefs(cfg.PlannedRefs())
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("lookup table datastore refs conflict: %w", err)
+	}
 	routerProgramAddress, _, _ := chainState.GetRouterInfo()
 	rmnRemoteAddress := chainState.RMNRemote
 
@@ -282,10 +316,11 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 
 		// add token pool lookup table
 		csOutput, err := AddTokenPoolLookupTable(e, TokenPoolLookupTableConfig{
-			ChainSelector: cfg.ChainSelector,
-			TokenPubKey:   tokenPoolCfg.TokenPubKey,
-			PoolType:      tokenPoolCfg.PoolType,
-			Metadata:      tokenPoolCfg.Metadata,
+			ChainSelector:           cfg.ChainSelector,
+			TokenPubKey:             tokenPoolCfg.TokenPubKey,
+			PoolType:                tokenPoolCfg.PoolType,
+			Metadata:                tokenPoolCfg.Metadata,
+			ForceDatastoreOverwrite: cfg.ForceDatastoreOverwrite,
 		})
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to add token pool lookup table: %w", err)
@@ -294,11 +329,12 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address book: %w", err)
 		}
-	}
-
-	ds, err := shared.PopulateDataStore(addressBook)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
+		// The sub-changeset already recorded the lookup table under its own qualifier.
+		if csOutput.DataStore != nil {
+			if err := ds.Merge(csOutput.DataStore.Seal()); err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge lookup table datastore: %w", err)
+			}
+		}
 	}
 
 	return cldf.ChangesetOutput{
@@ -956,9 +992,40 @@ type TokenPoolLookupTableConfig struct {
 	TokenPubKey   solana.PublicKey
 	PoolType      cldf.ContractType
 	Metadata      string
+	// ForceDatastoreOverwrite permits this changeset to overwrite a lookup-table ref that already
+	// exists in the environment datastore. Without it, re-adding a lookup table for the same
+	// (mint, pool type, metadata) is rejected during validation rather than silently replacing it.
+	ForceDatastoreOverwrite bool
+}
+
+// PlannedRefs returns the datastore ref this changeset will write, derived from config alone so
+// it can be checked before the lookup table is created on chain. A lookup table is identified by
+// (mint, pool type, metadata), all of which are config fields.
+func (cfg TokenPoolLookupTableConfig) PlannedRefs() []datastore.AddressRef {
+	version := deployment.Version1_0_0
+	return []datastore.AddressRef{{
+		ChainSelector: cfg.ChainSelector,
+		Type:          datastore.ContractType(shared.TokenPoolLookupTable),
+		Version:       &version,
+		Qualifier:     shared.TokenPoolLookupTableQualifier(cfg.TokenPubKey.String(), cfg.PoolType.String(), cfg.Metadata),
+	}}
 }
 
 func (cfg TokenPoolLookupTableConfig) Validate(e cldf.Environment, chainState solanastateview.CCIPChainState) error {
+	// Reserve the keys to prove the refs can all be recorded, then check them against the
+	// environment. Both run before anything is deployed.
+	if _, err := shared.ReserveRefs(cfg.PlannedRefs()); err != nil {
+		return fmt.Errorf("lookup table datastore ref conflict: %w", err)
+	}
+	// Taking over a key the environment already holds is a redeploy: rejected unless the caller
+	// asked for it, in which case it is logged rather than passing unremarked.
+	validateRefs := shared.ValidateAddressRefsStrict
+	if cfg.ForceDatastoreOverwrite {
+		validateRefs = shared.ValidateAddressRefs
+	}
+	if err := validateRefs(e, cfg.PlannedRefs()); err != nil {
+		return fmt.Errorf("lookup table datastore ref conflict: %w", err)
+	}
 	if err := chainState.CommonValidation(e, cfg.ChainSelector, cfg.TokenPubKey); err != nil {
 		return err
 	}
@@ -1026,20 +1093,17 @@ func AddTokenPoolLookupTable(e cldf.Environment, cfg TokenPoolLookupTableConfig)
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to await slot change while extending lookup table: %w", err)
 	}
 	newAddressBook := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 	tv := cldf.NewTypeAndVersion(shared.TokenPoolLookupTable, deployment.Version1_0_0)
 	tv.Labels.Add(tokenPubKey.String())
 	tv.Labels.Add(cfg.PoolType.String())
 	tv.Labels.Add(cfg.Metadata)
-	if err := newAddressBook.Save(cfg.ChainSelector, table.String(), tv); err != nil {
+	if err := shared.RecordAddress(newAddressBook, ds, cfg.ChainSelector, table.String(), tv, shared.TokenPoolLookupTableQualifier(tokenPubKey.String(), cfg.PoolType.String(), cfg.Metadata)); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save tokenpool address lookup table: %w", err)
 	}
 	e.Logger.Infow("Added token pool lookup table", "token_pubkey", tokenPubKey.String())
 
-	ds, err := shared.PopulateDataStore(newAddressBook)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
-
+	// the token pool lookup table is qualified by its full identity (token mint, pool type, metadata)
 	return cldf.ChangesetOutput{
 		AddressBook: newAddressBook,
 		DataStore:   ds,

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_add_remote_chain.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_add_remote_chain.go
@@ -2,7 +2,6 @@ package solana
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -19,6 +18,7 @@ import (
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 
@@ -109,13 +109,14 @@ func AddRemoteChainToRouter(e cldf.Environment, cfg AddRemoteChainToRouterConfig
 	}
 
 	ab := cldf.NewMemoryAddressBook()
-	txns, err := doAddRemoteChainToRouter(e, s, cfg, ab)
+	ds := datastore.NewMemoryDataStore()
+	txns, err := doAddRemoteChainToRouter(e, s, cfg, ab, ds)
 	if err != nil {
-		ds, err2 := shared.PopulateDataStore(ab)
-		if err2 != nil {
-			err2 = fmt.Errorf("failed to populate in-memory DataStore: %w", err2)
-		}
-		return cldf.ChangesetOutput{AddressBook: ab, DataStore: ds}, errors.Join(err, err2)
+		return cldf.ChangesetOutput{
+			//nolint:staticcheck // SA1019: AddressBook is deprecated, migration to DataStore pending
+			AddressBook: ab,
+			DataStore:   ds,
+		}, err
 	}
 
 	// create proposals for ixns
@@ -125,20 +126,11 @@ func AddRemoteChainToRouter(e cldf.Environment, cfg AddRemoteChainToRouterConfig
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}
-		ds, err := shared.PopulateDataStore(ab)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-		}
 		return cldf.ChangesetOutput{
 			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
 			AddressBook:           ab,
 			DataStore:             ds,
 		}, nil
-	}
-
-	ds, err := shared.PopulateDataStore(ab)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{AddressBook: ab, DataStore: ds}, nil
@@ -149,6 +141,7 @@ func doAddRemoteChainToRouter(
 	s stateview.CCIPOnChainState,
 	cfg AddRemoteChainToRouterConfig,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 ) ([]mcmsTypes.Transaction, error) {
 	txns := make([]mcmsTypes.Transaction, 0)
 	chainSel := cfg.ChainSelector
@@ -278,7 +271,7 @@ func doAddRemoteChainToRouter(
 			tv := cldf.NewTypeAndVersion(shared.RemoteDest, deployment.Version1_0_0)
 			remoteChainSelStr := strconv.FormatUint(remoteChainSel, 10)
 			tv.AddLabel(remoteChainSelStr)
-			err = ab.Save(chainSel, routerRemoteStatePDA.String(), tv)
+			err = shared.RecordAddress(ab, ds, chainSel, routerRemoteStatePDA.String(), tv, remoteChainSelStr)
 			if err != nil {
 				return txns, fmt.Errorf("failed to save dest chain state to address book: %w", err)
 			}
@@ -356,13 +349,12 @@ func AddRemoteChainToFeeQuoter(e cldf.Environment, cfg AddRemoteChainToFeeQuoter
 	}
 
 	ab := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 	txns, err := doAddRemoteChainToFeeQuoter(e, s, cfg, ab)
 	if err != nil {
-		ds, err2 := shared.PopulateDataStore(ab)
-		if err2 != nil {
-			err2 = fmt.Errorf("failed to populate in-memory DataStore: %w", err2)
-		}
-		return cldf.ChangesetOutput{AddressBook: ab, DataStore: ds}, errors.Join(err, err2)
+		// skipped: doAddRemoteChainToFeeQuoter does not save any lane/multi-instance refs,
+		// so the datastore needs no additional qualifier pass.
+		return cldf.ChangesetOutput{AddressBook: ab, DataStore: ds}, err //nolint:staticcheck // Phase 1 still returns the address book
 	}
 
 	// create proposals for ixns
@@ -372,10 +364,8 @@ func AddRemoteChainToFeeQuoter(e cldf.Environment, cfg AddRemoteChainToFeeQuoter
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}
-		ds, err := shared.PopulateDataStore(ab)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-		}
+		// skipped: doAddRemoteChainToFeeQuoter does not save any lane/multi-instance refs,
+		// so the datastore needs no additional qualifier pass.
 		return cldf.ChangesetOutput{
 			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
 			AddressBook:           ab,
@@ -383,11 +373,8 @@ func AddRemoteChainToFeeQuoter(e cldf.Environment, cfg AddRemoteChainToFeeQuoter
 		}, nil
 	}
 
-	ds, err := shared.PopulateDataStore(ab)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
-
+	// skipped: doAddRemoteChainToFeeQuoter does not save any lane/multi-instance refs,
+	// so the datastore needs no additional qualifier pass.
 	return cldf.ChangesetOutput{AddressBook: ab, DataStore: ds}, nil
 }
 
@@ -553,14 +540,14 @@ func AddRemoteChainToOffRamp(e cldf.Environment, cfg AddRemoteChainToOffRampConf
 	}
 
 	ab := cldf.NewMemoryAddressBook()
-	txns, err := doAddRemoteChainToOffRamp(e, s, cfg, ab)
+	ds := datastore.NewMemoryDataStore()
+	txns, err := doAddRemoteChainToOffRamp(e, s, cfg, ab, ds)
 	if err != nil {
-		ds, err2 := shared.PopulateDataStore(ab)
-		if err2 != nil {
-			err2 = fmt.Errorf("failed to populate in-memory DataStore: %w", err2)
-		}
-
-		return cldf.ChangesetOutput{AddressBook: ab, DataStore: ds}, errors.Join(err, err2)
+		return cldf.ChangesetOutput{
+			//nolint:staticcheck // SA1019: AddressBook is deprecated, migration to DataStore pending
+			AddressBook: ab,
+			DataStore:   ds,
+		}, err
 	}
 
 	// create proposals for ixns
@@ -570,20 +557,11 @@ func AddRemoteChainToOffRamp(e cldf.Environment, cfg AddRemoteChainToOffRampConf
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}
-		ds, err := shared.PopulateDataStore(ab)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-		}
 		return cldf.ChangesetOutput{
 			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
 			AddressBook:           ab,
 			DataStore:             ds,
 		}, nil
-	}
-
-	ds, err := shared.PopulateDataStore(ab)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{AddressBook: ab, DataStore: ds}, nil
@@ -594,6 +572,7 @@ func doAddRemoteChainToOffRamp(
 	s stateview.CCIPOnChainState,
 	cfg AddRemoteChainToOffRampConfig,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 ) ([]mcmsTypes.Transaction, error) {
 	txns := make([]mcmsTypes.Transaction, 0)
 	chainSel := cfg.ChainSelector
@@ -673,7 +652,7 @@ func doAddRemoteChainToOffRamp(
 			remoteChainSelStr := strconv.FormatUint(remoteChainSel, 10)
 			tv := cldf.NewTypeAndVersion(shared.RemoteSource, deployment.Version1_0_0)
 			tv.AddLabel(remoteChainSelStr)
-			err = ab.Save(chainSel, offRampRemoteStatePDA.String(), tv)
+			err = shared.RecordAddress(ab, ds, chainSel, offRampRemoteStatePDA.String(), tv, remoteChainSelStr)
 			if err != nil {
 				return txns, fmt.Errorf("failed to save source chain state to address book: %w", err)
 			}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_deploy_chain.go
@@ -18,6 +18,7 @@ import (
 
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -170,6 +171,7 @@ func DeployChainContractsChangeset(e cldf.Environment, c DeployChainContractsCon
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid DeployChainContractsConfig: %w", err)
 	}
 	newAddresses := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 	err = v1_6.ValidateHomeChainState(e, c.HomeChainSelector, existingState)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -194,7 +196,7 @@ func DeployChainContractsChangeset(e cldf.Environment, c DeployChainContractsCon
 		e.Logger.Debugw("Skipping solana build as no build config provided")
 	}
 
-	batches, err := deployChainContractsSolana(e, chain, newAddresses, c)
+	batches, err := deployChainContractsSolana(e, chain, newAddresses, ds, c)
 	if err != nil {
 		e.Logger.Errorw("Failed to deploy CCIP contracts", "err", err, "newAddresses", newAddresses)
 		return cldf.ChangesetOutput{}, err
@@ -211,21 +213,12 @@ func DeployChainContractsChangeset(e cldf.Environment, c DeployChainContractsCon
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}
-		ds, err := shared.PopulateDataStore(newAddresses)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-		}
 
 		return cldf.ChangesetOutput{
 			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
 			AddressBook:           newAddresses,
 			DataStore:             ds,
 		}, nil
-	}
-
-	ds, err := shared.PopulateDataStore(newAddresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{
@@ -240,6 +233,7 @@ func DeployAndMaybeSaveToAddressBook(
 	e cldf.Environment,
 	chain cldf_solana.Chain,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	contractType cldf.ContractType,
 	version semver.Version,
 	isUpgrade bool,
@@ -261,7 +255,7 @@ func DeployAndMaybeSaveToAddressBook(
 		if metadata != "" {
 			tv.AddLabel(metadata)
 		}
-		err = ab.Save(chain.Selector, programID, tv)
+		err = shared.RecordAddress(ab, ds, chain.Selector, programID, tv, metadata)
 		if err != nil {
 			return solana.PublicKey{}, fmt.Errorf("failed to save address: %w", err)
 		}
@@ -280,12 +274,13 @@ func upgradeProgramIfConfigured(
 	newVersion *semver.Version,
 	programID solana.PublicKey,
 	contractType cldf.ContractType,
+	ds datastore.MutableDataStore,
 ) ([]mcmsTypes.BatchOperation, error) {
 	if newVersion == nil {
 		return batches, nil
 	}
 	e.Logger.Infow("Generating instruction for upgrading contract", "chain", chain.String(), "contractType", contractType)
-	newTxns, err := generateUpgradeTxns(e, chain, ab, config, newVersion, programID, contractType)
+	newTxns, err := generateUpgradeTxns(e, chain, ab, ds, config, newVersion, programID, contractType)
 	if err != nil {
 		return batches, fmt.Errorf("failed to generate upgrade txns: %w", err)
 	}
@@ -301,6 +296,7 @@ func resolveProgram(
 	e cldf.Environment,
 	chain cldf_solana.Chain,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	config DeployChainContractsConfig,
 	batches []mcmsTypes.BatchOperation,
 	contractType cldf.ContractType,
@@ -309,13 +305,13 @@ func resolveProgram(
 ) (address solana.PublicKey, justDeployed bool, outBatches []mcmsTypes.BatchOperation, err error) {
 	switch {
 	case existingAddress.IsZero():
-		address, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, contractType, deployment.Version1_0_0, false, "")
+		address, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, contractType, deployment.Version1_0_0, false, "")
 		if err != nil {
 			return solana.PublicKey{}, false, batches, fmt.Errorf("failed to deploy %s: %w", contractType, err)
 		}
 		return address, true, batches, nil
 	case newVersion != nil:
-		batches, err = upgradeProgramIfConfigured(e, chain, ab, config, batches, newVersion, existingAddress, contractType)
+		batches, err = upgradeProgramIfConfigured(e, chain, ab, config, batches, newVersion, existingAddress, contractType, ds)
 		if err != nil {
 			return existingAddress, false, batches, err
 		}
@@ -350,6 +346,7 @@ func deployChainContractsSolana(
 	e cldf.Environment,
 	chain cldf_solana.Chain,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	config DeployChainContractsConfig,
 ) ([]mcmsTypes.BatchOperation, error) {
 	// we may need to gather instructions and submit them as part of MCMS
@@ -371,7 +368,7 @@ func deployChainContractsSolana(
 
 	// FEE QUOTER DEPLOY
 	feeQuoterAddress, fqJustDeployed, batches, err := resolveProgram(
-		e, chain, ab, config, batches, shared.FeeQuoter, chainState.FeeQuoter, config.UpgradeConfig.NewFeeQuoterVersion)
+		e, chain, ab, ds, config, batches, shared.FeeQuoter, chainState.FeeQuoter, config.UpgradeConfig.NewFeeQuoterVersion)
 	if err != nil {
 		return batches, err
 	}
@@ -381,7 +378,7 @@ func deployChainContractsSolana(
 
 	// ROUTER DEPLOY
 	ccipRouterProgram, routerJustDeployed, batches, err := resolveProgram(
-		e, chain, ab, config, batches, shared.Router, chainState.Router, config.UpgradeConfig.NewRouterVersion)
+		e, chain, ab, ds, config, batches, shared.Router, chainState.Router, config.UpgradeConfig.NewRouterVersion)
 	if err != nil {
 		return batches, err
 	}
@@ -398,7 +395,7 @@ func deployChainContractsSolana(
 	//nolint:gocritic // this is a false positive, we need to check if the address is zero
 	if chainState.OffRamp.IsZero() {
 		// deploy offramp
-		offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.OffRamp, deployment.Version1_0_0, false, "")
+		offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.OffRamp, deployment.Version1_0_0, false, "")
 		if err != nil {
 			return batches, fmt.Errorf("failed to deploy program: %w", err)
 		}
@@ -412,7 +409,7 @@ func deployChainContractsSolana(
 		offRampAddress = solanastateview.FindSolanaAddress(tv, existingAddresses)
 		if offRampAddress.IsZero() {
 			// deploy offramp, not upgraded in place so upgrade is false
-			offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.OffRamp, *config.UpgradeConfig.NewOffRampVersion, false, "")
+			offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.OffRamp, *config.UpgradeConfig.NewOffRampVersion, false, "")
 			if err != nil {
 				return batches, fmt.Errorf("failed to deploy program: %w", err)
 			}
@@ -443,7 +440,7 @@ func deployChainContractsSolana(
 				}
 			}
 		} else {
-			newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewOffRampVersion, chainState.OffRamp, shared.OffRamp)
+			newTxns, err := generateUpgradeTxns(e, chain, ab, ds, config, config.UpgradeConfig.NewOffRampVersion, chainState.OffRamp, shared.OffRamp)
 			if err != nil {
 				return batches, fmt.Errorf("failed to generate upgrade txns: %w", err)
 			}
@@ -459,7 +456,7 @@ func deployChainContractsSolana(
 
 	// RMN REMOTE DEPLOY
 	rmnRemoteAddress, rmnJustDeployed, batches, err := resolveProgram(
-		e, chain, ab, config, batches, shared.RMNRemote, chainState.RMNRemote, config.UpgradeConfig.NewRMNRemoteVersion)
+		e, chain, ab, ds, config, batches, shared.RMNRemote, chainState.RMNRemote, config.UpgradeConfig.NewRMNRemoteVersion)
 	if err != nil {
 		return batches, err
 	}
@@ -553,11 +550,13 @@ func deployChainContractsSolana(
 		//nolint:gocritic // this is a false positive, we need to check if the address is zero
 		if chainState.BurnMintTokenPools[metadata].IsZero() {
 			e.Logger.Infow("Deploying new burn mint token pool", "metadata", metadata)
-			burnMintTokenPool, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.BurnMintTokenPool, deployment.Version1_0_0, false, metadata)
+			burnMintTokenPool, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.BurnMintTokenPool, deployment.Version1_0_0, false, metadata)
 			if err != nil {
 				return batches, fmt.Errorf("failed to deploy program: %w", err)
 			}
 			burnMintTokenPools = append(burnMintTokenPools, burnMintTokenPool)
+			// Solana pool programs are keyed by pool-set metadata (not token), so that is their
+			// datastore qualifier.
 		} else if config.UpgradeConfig.NewBurnMintTokenPoolVersion != nil {
 			e.Logger.Infow("Upgrading existing burn mint token pool", "addr", chainState.BurnMintTokenPools[metadata].String())
 			burnMintTokenPool := chainState.BurnMintTokenPools[metadata]
@@ -578,7 +577,7 @@ func deployChainContractsSolana(
 					return batches, fmt.Errorf("failed to build solana: %w", err)
 				}
 			}
-			newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewBurnMintTokenPoolVersion, chainState.BurnMintTokenPools[metadata], shared.BurnMintTokenPool)
+			newTxns, err := generateUpgradeTxns(e, chain, ab, ds, config, config.UpgradeConfig.NewBurnMintTokenPoolVersion, chainState.BurnMintTokenPools[metadata], shared.BurnMintTokenPool)
 			if err != nil {
 				return batches, fmt.Errorf("failed to generate upgrade txns: %w", err)
 			}
@@ -598,11 +597,13 @@ func deployChainContractsSolana(
 		//nolint:gocritic // this is a false positive, we need to check if the address is zero
 		if chainState.LockReleaseTokenPools[metadata].IsZero() {
 			e.Logger.Infow("Deploying new lock release token pool", "metadata", metadata)
-			lockReleaseTokenPool, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.LockReleaseTokenPool, deployment.Version1_0_0, false, metadata)
+			lockReleaseTokenPool, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.LockReleaseTokenPool, deployment.Version1_0_0, false, metadata)
 			if err != nil {
 				return batches, fmt.Errorf("failed to deploy program: %w", err)
 			}
 			lockReleaseTokenPools = append(lockReleaseTokenPools, lockReleaseTokenPool)
+			// Solana pool programs are keyed by pool-set metadata (not token), so that is their
+			// datastore qualifier.
 		} else if config.UpgradeConfig.NewLockReleaseTokenPoolVersion != nil {
 			e.Logger.Infow("Upgrading existing lock release token pool", "addr", chainState.LockReleaseTokenPools[metadata].String())
 			lockReleaseTokenPool := chainState.LockReleaseTokenPools[metadata]
@@ -623,7 +624,7 @@ func deployChainContractsSolana(
 					return batches, fmt.Errorf("failed to build solana: %w", err)
 				}
 			}
-			newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewLockReleaseTokenPoolVersion, chainState.LockReleaseTokenPools[metadata], shared.LockReleaseTokenPool)
+			newTxns, err := generateUpgradeTxns(e, chain, ab, ds, config, config.UpgradeConfig.NewLockReleaseTokenPoolVersion, chainState.LockReleaseTokenPools[metadata], shared.LockReleaseTokenPool)
 			if err != nil {
 				return batches, fmt.Errorf("failed to generate upgrade txns: %w", err)
 			}
@@ -639,13 +640,13 @@ func deployChainContractsSolana(
 	metadata := shared.CLLMetadata
 	switch {
 	case chainState.CCTPTokenPool.IsZero():
-		cctpTokenPool, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.CCTPTokenPool, deployment.Version1_0_0, false, metadata)
+		cctpTokenPool, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.CCTPTokenPool, deployment.Version1_0_0, false, metadata)
 		if err != nil {
 			return batches, fmt.Errorf("failed to deploy program: %w", err)
 		}
 	case config.UpgradeConfig.NewCCTPTokenPoolVersion != nil:
 		cctpTokenPool = chainState.CCTPTokenPool
-		newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewCCTPTokenPoolVersion, cctpTokenPool, shared.CCTPTokenPool)
+		newTxns, err := generateUpgradeTxns(e, chain, ab, ds, config, config.UpgradeConfig.NewCCTPTokenPoolVersion, cctpTokenPool, shared.CCTPTokenPool)
 		if err != nil {
 			return batches, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
@@ -673,6 +674,23 @@ func deployChainContractsSolana(
 
 	// MCMS
 	// this should selectively deploy and initialise anything if required
+	mcmsQualifier := ""
+	if config.MCMSWithTimelockConfig != nil && config.MCMSWithTimelockConfig.Qualifier != nil {
+		mcmsQualifier = *config.MCMSWithTimelockConfig.Qualifier
+	}
+	// Snapshot the addresses added so far so we can later qualify only the MCMS-related
+	// accounts (and not the chain-singleton programs) under the configured MCMS qualifier.
+	var mcmsAddrsBefore map[string]struct{}
+	if mcmsQualifier != "" {
+		existing, err := ab.AddressesForChain(chain.Selector)
+		if err != nil && !errors.Is(err, cldf.ErrChainNotFound) {
+			return batches, fmt.Errorf("failed to get existing addresses for chain %v: %w", chain.Selector, err)
+		}
+		mcmsAddrsBefore = make(map[string]struct{}, len(existing))
+		for addr := range existing {
+			mcmsAddrsBefore[addr] = struct{}{}
+		}
+	}
 	if config.MCMSWithTimelockConfig != nil {
 		_, err = solanaMCMS.DeployMCMSWithTimelockProgramsSolana(e, chain, ab, *config.MCMSWithTimelockConfig)
 		if err != nil {
@@ -688,17 +706,34 @@ func deployChainContractsSolana(
 	if err != nil {
 		return batches, fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
 	}
-	batches, err = upgradeProgramIfConfigured(e, chain, ab, config, batches, config.UpgradeConfig.NewMCMVersion, mcmState.McmProgram, types.ManyChainMultisigProgram)
+	batches, err = upgradeProgramIfConfigured(e, chain, ab, config, batches, config.UpgradeConfig.NewMCMVersion, mcmState.McmProgram, types.ManyChainMultisigProgram, ds)
 	if err != nil {
 		return batches, err
 	}
-	batches, err = upgradeProgramIfConfigured(e, chain, ab, config, batches, config.UpgradeConfig.NewAccessControllerVersion, mcmState.AccessControllerProgram, types.AccessControllerProgram)
+	batches, err = upgradeProgramIfConfigured(e, chain, ab, config, batches, config.UpgradeConfig.NewAccessControllerVersion, mcmState.AccessControllerProgram, types.AccessControllerProgram, ds)
 	if err != nil {
 		return batches, err
 	}
-	batches, err = upgradeProgramIfConfigured(e, chain, ab, config, batches, config.UpgradeConfig.NewTimelockVersion, mcmState.TimelockProgram, types.RBACTimelockProgram)
+	batches, err = upgradeProgramIfConfigured(e, chain, ab, config, batches, config.UpgradeConfig.NewTimelockVersion, mcmState.TimelockProgram, types.RBACTimelockProgram, ds)
 	if err != nil {
 		return batches, err
+	}
+
+	// Qualify the MCMS program/access-controller/timelock/role accounts added by the MCMS
+	// deploy and any MCMS program upgrades under the configured MCMS qualifier, so they are
+	// resolvable in the datastore under that qualifier.
+	if mcmsAddrsBefore != nil {
+		after, err := ab.AddressesForChain(chain.Selector)
+		if err != nil {
+			return batches, fmt.Errorf("failed to get addresses for chain %v: %w", chain.Selector, err)
+		}
+		for addr := range after {
+			if _, ok := mcmsAddrsBefore[addr]; !ok {
+				if err := shared.RecordAddress(nil, ds, chain.Selector, addr, after[addr], mcmsQualifier); err != nil {
+					return batches, fmt.Errorf("failed to record MCMS ref %s: %w", addr, err)
+				}
+			}
+		}
 	}
 
 	// BILLING
@@ -982,6 +1017,7 @@ func generateUpgradeTxns(
 	e cldf.Environment,
 	chain cldf_solana.Chain,
 	ab cldf.AddressBook,
+	ds datastore.MutableDataStore,
 	config DeployChainContractsConfig,
 	newVersion *semver.Version,
 	programID solana.PublicKey,
@@ -989,7 +1025,7 @@ func generateUpgradeTxns(
 ) ([]mcmsTypes.Transaction, error) {
 	e.Logger.Infow("Generating instruction for upgrading contract", "contractType", contractType)
 	txns := make([]mcmsTypes.Transaction, 0)
-	bufferProgram, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, contractType, *newVersion, true, "")
+	bufferProgram, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, contractType, *newVersion, true, "")
 	if err != nil {
 		return txns, fmt.Errorf("failed to deploy program: %w", err)
 	}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_ops.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_ops.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gagliardetto/solana-go"
 	solstate "github.com/smartcontractkit/cld-changesets/legacy/pkg/family/solana"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 
@@ -440,18 +441,19 @@ func DeployReceiverForTest(e cldf.Environment, cfg DeployForTestConfig) (cldf.Ch
 	chainState := state.SolChains[cfg.ChainSelector]
 	chain := e.BlockChains.SolanaChains()[cfg.ChainSelector]
 	ab := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 
 	var receiverAddress solana.PublicKey
 	if !cfg.IsUpgrade {
 		//nolint:gocritic // this is a false positive, we need to check if the address is zero
 		if chainState.Receiver.IsZero() {
-			receiverAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.Receiver, deployment.Version1_0_0, false, "")
+			receiverAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.Receiver, deployment.Version1_0_0, false, "")
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy program: %w", err)
 			}
 		} else if cfg.ReceiverVersion != nil {
 			// this block is for re-deploying with a new version
-			receiverAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, shared.Receiver, *cfg.ReceiverVersion, false, "")
+			receiverAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ds, shared.Receiver, *cfg.ReceiverVersion, false, "")
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy program: %w", err)
 			}
@@ -479,7 +481,7 @@ func DeployReceiverForTest(e cldf.Environment, cfg DeployForTestConfig) (cldf.Ch
 	} else if cfg.IsUpgrade {
 		e.Logger.Infow("Deploying new receiver", "addr", chainState.Receiver.String())
 		// only support deployer key as upgrade authority. never transfer to timelock
-		_, err := generateUpgradeTxns(e, chain, ab, DeployChainContractsConfig{
+		_, err := generateUpgradeTxns(e, chain, ab, ds, DeployChainContractsConfig{
 			UpgradeConfig: UpgradeConfig{
 				UpgradeAuthority: chain.DeployerKey.PublicKey(),
 			},
@@ -487,11 +489,6 @@ func DeployReceiverForTest(e cldf.Environment, cfg DeployForTestConfig) (cldf.Ch
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
-	}
-
-	ds, err := shared.PopulateDataStore(ab)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_solana_token.go
@@ -14,6 +14,7 @@ import (
 	mcmsTypes "github.com/smartcontractkit/mcms/types"
 
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 
@@ -187,9 +188,10 @@ func DeploySolanaToken(e cldf.Environment, cfg DeploySolanaTokenConfig) (cldf.Ch
 	}
 
 	newAddresses := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 	tv := cldf.NewTypeAndVersion(cfg.TokenProgramName, deployment.Version1_0_0)
 	tv.AddLabel(cfg.TokenSymbol)
-	err = newAddresses.Save(cfg.ChainSelector, mint.String(), tv)
+	err = shared.RecordAddress(newAddresses, ds, cfg.ChainSelector, mint.String(), tv, cfg.TokenSymbol)
 	if err != nil {
 		e.Logger.Errorw("Failed to save token", "chain", chain.String(), "err", err)
 		return cldf.ChangesetOutput{}, err
@@ -204,11 +206,6 @@ func DeploySolanaToken(e cldf.Environment, cfg DeploySolanaTokenConfig) (cldf.Ch
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
-	}
-
-	ds, err := shared.PopulateDataStore(newAddresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -33,6 +33,7 @@ import (
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 	solTokenUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -126,6 +127,9 @@ type AddTokenPoolAndLookupTableConfig struct {
 	ChainSelector    uint64
 	TokenPoolConfigs []TokenPoolConfig
 	MCMS             *cldfproposalutils.TimelockConfig
+	// ForceDatastoreOverwrite is propagated to the lookup-table step; see
+	// TokenPoolLookupTableConfig.ForceDatastoreOverwrite.
+	ForceDatastoreOverwrite bool
 }
 
 type TokenPoolConfigWithMCM struct {
@@ -181,6 +185,22 @@ func (cfg NewMintTokenPoolConfig) Validate(e cldf.Environment, chainState solana
 	return chainState.ValidatePoolDeployment(&e, cfg.PoolType, cfg.ChainSelector, cfg.TokenPubKey, false, cfg.Metadata)
 }
 
+// PlannedRefs returns all lookup-table refs produced by this aggregate changeset. Keeping the
+// complete key set at the aggregate boundary prevents a later child validation from discovering a
+// duplicate after an earlier token-pool transaction has already been confirmed.
+func (cfg AddTokenPoolAndLookupTableConfig) PlannedRefs() []datastore.AddressRef {
+	refs := make([]datastore.AddressRef, 0, len(cfg.TokenPoolConfigs))
+	for _, tokenPoolCfg := range cfg.TokenPoolConfigs {
+		refs = append(refs, (TokenPoolLookupTableConfig{
+			ChainSelector: cfg.ChainSelector,
+			TokenPubKey:   tokenPoolCfg.TokenPubKey,
+			PoolType:      tokenPoolCfg.PoolType,
+			Metadata:      tokenPoolCfg.Metadata,
+		}).PlannedRefs()...)
+	}
+	return refs
+}
+
 func (cfg AddTokenPoolAndLookupTableConfig) Validate(e cldf.Environment, chainState solanastateview.CCIPChainState) error {
 	for _, tokenPoolCfg := range cfg.TokenPoolConfigs {
 		if err := chainState.CommonValidation(e, cfg.ChainSelector, tokenPoolCfg.TokenPubKey); err != nil {
@@ -201,6 +221,16 @@ func (cfg AddTokenPoolAndLookupTableConfig) Validate(e cldf.Environment, chainSt
 			return err
 		}
 	}
+	if _, err := shared.ReserveRefs(cfg.PlannedRefs()); err != nil {
+		return fmt.Errorf("lookup table datastore refs conflict: %w", err)
+	}
+	validateRefs := shared.ValidateAddressRefsStrict
+	if cfg.ForceDatastoreOverwrite {
+		validateRefs = shared.ValidateAddressRefs
+	}
+	if err := validateRefs(e, cfg.PlannedRefs()); err != nil {
+		return fmt.Errorf("lookup table datastore refs conflict: %w", err)
+	}
 	return nil
 }
 
@@ -215,6 +245,10 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 	}
 	chain := e.BlockChains.SolanaChains()[cfg.ChainSelector]
 	addressBook := cldf.NewMemoryAddressBook()
+	ds, err := shared.ReserveRefs(cfg.PlannedRefs())
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("lookup table datastore refs conflict: %w", err)
+	}
 	routerProgramAddress, _, _ := chainState.GetRouterInfo()
 	rmnRemoteAddress := chainState.RMNRemote
 
@@ -393,6 +427,7 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 			Metadata:                 tokenPoolCfg.Metadata,
 			CCTPTokenMessengerMinter: tokenPoolCfg.CCTPTokenMessengerMinter,
 			CCTPMessageTransmitter:   tokenPoolCfg.CCTPMessageTransmitter,
+			ForceDatastoreOverwrite:  cfg.ForceDatastoreOverwrite,
 		})
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to add token pool lookup table: %w", err)
@@ -400,6 +435,12 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 		err = addressBook.Merge(csOutput.AddressBook) //nolint:staticcheck // SA1019: AddressBook is deprecated, migration to DataStore pending
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address book: %w", err)
+		}
+		// The sub-changeset already recorded the lookup table under its own qualifier.
+		if csOutput.DataStore != nil {
+			if err := ds.Merge(csOutput.DataStore.Seal()); err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge lookup table datastore: %w", err)
+			}
 		}
 	}
 
@@ -409,20 +450,11 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}
-		ds, err := shared.PopulateDataStore(addressBook)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-		}
 		return cldf.ChangesetOutput{
 			AddressBook:           addressBook,
 			DataStore:             ds,
 			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
 		}, nil
-	}
-
-	ds, err := shared.PopulateDataStore(addressBook)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{
@@ -882,10 +914,14 @@ func CreateTokenMultisig(e cldf.Environment, cfg CreateTokenMultisigConfig) (cld
 		return cldf.ChangesetOutput{}, err
 	}
 	newAddresses := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 	tv := cldf.NewTypeAndVersion("TokenMultisig", deployment.Version1_0_0)
 	tv.AddLabel(cfg.Metadata)
 	tv.AddLabel(cfg.TokenMint.String())
-	err = newAddresses.Save(cfg.ChainSelector, newMultisig.String(), tv)
+	// A multisig belongs to one (mint, pool-set), so both identify it. TokenMultisig is not yet
+	// in the qualifier convention's classification; this needs a section 3 decision before it is
+	// written to a real environment.
+	err = shared.RecordAddress(newAddresses, ds, cfg.ChainSelector, newMultisig.String(), tv, shared.QualifierFromParts(cfg.TokenMint.String(), cfg.Metadata))
 	if err != nil {
 		e.Logger.Errorw("Failed to save new token multisig", "chain", solChainState, "err", err)
 		return cldf.ChangesetOutput{}, err
@@ -893,6 +929,7 @@ func CreateTokenMultisig(e cldf.Environment, cfg CreateTokenMultisigConfig) (cld
 	e.Logger.Infow("Created multisig", "TokenMultisigAddress", newMultisig, "TokenMint", cfg.TokenMint)
 	return cldf.ChangesetOutput{
 		AddressBook: newAddresses,
+		DataStore:   ds,
 	}, nil
 }
 
@@ -1908,9 +1945,40 @@ type TokenPoolLookupTableConfig struct {
 	Metadata                 string
 	CCTPTokenMessengerMinter solana.PublicKey
 	CCTPMessageTransmitter   solana.PublicKey
+	// ForceDatastoreOverwrite permits this changeset to overwrite a lookup-table ref that already
+	// exists in the environment datastore. Without it, re-adding a lookup table for the same
+	// (mint, pool type, metadata) is rejected during validation rather than silently replacing it.
+	ForceDatastoreOverwrite bool
+}
+
+// PlannedRefs returns the datastore ref this changeset will write, derived from config alone so
+// it can be checked before the lookup table is created on chain. A lookup table is identified by
+// (mint, pool type, metadata), all of which are config fields.
+func (cfg TokenPoolLookupTableConfig) PlannedRefs() []datastore.AddressRef {
+	version := deployment.Version1_0_0
+	return []datastore.AddressRef{{
+		ChainSelector: cfg.ChainSelector,
+		Type:          datastore.ContractType(shared.TokenPoolLookupTable),
+		Version:       &version,
+		Qualifier:     shared.TokenPoolLookupTableQualifier(cfg.TokenPubKey.String(), cfg.PoolType.String(), cfg.Metadata),
+	}}
 }
 
 func (cfg TokenPoolLookupTableConfig) Validate(e cldf.Environment, chainState solanastateview.CCIPChainState) error {
+	// Reserve the keys to prove the refs can all be recorded, then check them against the
+	// environment. Both run before anything is deployed.
+	if _, err := shared.ReserveRefs(cfg.PlannedRefs()); err != nil {
+		return fmt.Errorf("lookup table datastore ref conflict: %w", err)
+	}
+	// Taking over a key the environment already holds is a redeploy: rejected unless the caller
+	// asked for it, in which case it is logged rather than passing unremarked.
+	validateRefs := shared.ValidateAddressRefsStrict
+	if cfg.ForceDatastoreOverwrite {
+		validateRefs = shared.ValidateAddressRefs
+	}
+	if err := validateRefs(e, cfg.PlannedRefs()); err != nil {
+		return fmt.Errorf("lookup table datastore ref conflict: %w", err)
+	}
 	if err := chainState.CommonValidation(e, cfg.ChainSelector, cfg.TokenPubKey); err != nil {
 		return err
 	}
@@ -2031,20 +2099,17 @@ func AddTokenPoolLookupTable(e cldf.Environment, cfg TokenPoolLookupTableConfig)
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to await slot change while extending lookup table: %w", err)
 	}
 	newAddressBook := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 	tv := cldf.NewTypeAndVersion(shared.TokenPoolLookupTable, deployment.Version1_0_0)
 	tv.Labels.Add(tokenPubKey.String())
 	tv.Labels.Add(cfg.PoolType.String())
 	tv.Labels.Add(cfg.Metadata)
-	if err := newAddressBook.Save(cfg.ChainSelector, table.String(), tv); err != nil {
+	if err := shared.RecordAddress(newAddressBook, ds, cfg.ChainSelector, table.String(), tv, shared.TokenPoolLookupTableQualifier(tokenPubKey.String(), cfg.PoolType.String(), cfg.Metadata)); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save tokenpool address lookup table: %w", err)
 	}
 	e.Logger.Infow("Added token pool lookup table", "token_pubkey", tokenPubKey.String())
 
-	ds, err := shared.PopulateDataStore(newAddressBook)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
-
+	// the token pool lookup table is qualified by its full identity (token mint, pool type, metadata)
 	return cldf.ChangesetOutput{
 		AddressBook: newAddressBook,
 		DataStore:   ds,

--- a/deployment/ccip/changeset/sui/cs_set_ocr3_offramp.go
+++ b/deployment/ccip/changeset/sui/cs_set_ocr3_offramp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/mcms"
 	"golang.org/x/crypto/blake2b"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
@@ -21,7 +22,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/internal"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 )
@@ -47,6 +47,7 @@ func (s SetOCR3Offramp) Apply(e cldf.Environment, config v1_6.SetOCR3OffRampConf
 	}
 
 	ab := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 
 	mcmsProposals := []mcms.TimelockProposal{}
 
@@ -215,11 +216,6 @@ func (s SetOCR3Offramp) Apply(e cldf.Environment, config v1_6.SetOCR3OffRampConf
 
 			mcmsProposals = append(mcmsProposals, result.Output)
 		}
-	}
-
-	ds, err := shared.PopulateDataStore(ab)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
 	}
 
 	return cldf.ChangesetOutput{


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
[CCIP-13350](https://smartcontract-it.atlassian.net/browse/CCIP-13350)

Migrates Solana and other non-EVM CCIP changesets to record datastore references at the write site. Derived addresses must be recorded immediately with an explicit qualifier. Aggregate changesets must validate their complete datastore key set before any on-chain side effects occur.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->
Second PR of the stack.

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

[CCIP-13350]: https://smartcontract-it.atlassian.net/browse/CCIP-13350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ