### PR TITLE
Eliminate the shim qualifier minter from ccip deployment

### DIFF
--- a/deployment/ccip/changeset/crossfamily/v1_6/cs_add_evm_solana_lane.go
+++ b/deployment/ccip/changeset/crossfamily/v1_6/cs_add_evm_solana_lane.go
@@ -3,6 +3,7 @@ package v1_6
 import (
 	"fmt"
 	"math/big"
+	"strconv"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_3/fee_quoter"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
@@ -179,6 +181,7 @@ var (
 					return OpsOutput{
 						Proposals:   output.MCMSTimelockProposals,
 						AddressBook: output.AddressBook, //nolint:staticcheck //SA1019 ignoring deprecated
+						DataStore:   output.DataStore,
 					}, nil
 				},
 			), deps, deps.changesetInput.solanaRouterInput)
@@ -203,6 +206,7 @@ var (
 					return OpsOutput{
 						Proposals:   output.MCMSTimelockProposals,
 						AddressBook: output.AddressBook, //nolint:staticcheck //SA1019 ignoring deprecated
+						DataStore:   output.DataStore,
 					}, nil
 				},
 			), deps, deps.changesetInput.solanaOffRampInput)
@@ -227,6 +231,7 @@ var (
 					return OpsOutput{
 						Proposals:   output.MCMSTimelockProposals,
 						AddressBook: output.AddressBook, //nolint:staticcheck //SA1019 ignoring deprecated
+						DataStore:   output.DataStore,
 					}, nil
 				},
 			), deps, deps.changesetInput.solanaFeeQuoterInput)
@@ -250,6 +255,7 @@ var (
 			return OpsOutput{
 				Proposals:   postOpsReport.Output,
 				AddressBook: finalOutput.AddressBook,
+				DataStore:   finalOutput.DataStore,
 			}, err
 		},
 	)
@@ -271,6 +277,11 @@ type postOpsInput struct {
 type OpsOutput struct {
 	Proposals   []mcmslib.TimelockProposal
 	AddressBook cldf.AddressBook
+	// DataStore carries the lane refs the Solana sub-changesets record at the write site
+	// (RemoteDest/RemoteSource, qualified by the remote EVM chain selector). It is merged
+	// alongside the address book so the qualified refs reach the final changeset output
+	// instead of being re-derived from the address book — which could not carry qualifiers.
+	DataStore datastore.MutableDataStore
 }
 
 func (o *OpsOutput) Merge(other OpsOutput, env cldf.Environment) error {
@@ -279,12 +290,46 @@ func (o *OpsOutput) Merge(other OpsOutput, env cldf.Environment) error {
 	}
 	if o.AddressBook == nil {
 		o.AddressBook = other.AddressBook
+		if other.AddressBook != nil {
+			if err := env.ExistingAddresses.Merge(other.AddressBook); err != nil {
+				return fmt.Errorf("failed to merge existing addresses to environment: %w", err)
+			}
+		}
 	} else if other.AddressBook != nil {
 		if err := o.AddressBook.Merge(other.AddressBook); err != nil {
 			return fmt.Errorf("failed to merge address book: %w", err)
 		}
 		if err := env.ExistingAddresses.Merge(other.AddressBook); err != nil {
 			return fmt.Errorf("failed to merge existing addresses to environment: %w", err)
+		}
+	}
+	if other.DataStore != nil {
+		if o.DataStore == nil {
+			o.DataStore = datastore.NewMemoryDataStore()
+		}
+		if err := o.DataStore.Merge(other.DataStore.Seal()); err != nil {
+			return fmt.Errorf("failed to merge data store: %w", err)
+		}
+		// Publish to the environment as with the address book above, so an op later in the
+		// sequence resolves the refs an earlier one recorded. A sealed environment store is
+		// skipped: the refs still ride to the final output in o.DataStore.
+		if env.DataStore != nil {
+			mutable, ok := env.DataStore.Addresses().(datastore.MutableAddressRefStore)
+			if !ok {
+				if env.Logger != nil {
+					env.Logger.Warnw("Environment data store is not writable; lane refs will not be visible through env.DataStore until the changeset output is applied")
+				}
+			} else {
+				refs, err := other.DataStore.Addresses().Fetch()
+				if err != nil {
+					return fmt.Errorf("failed to read merged data store: %w", err)
+				}
+				for _, ref := range refs {
+					if err := mutable.Upsert(ref); err != nil {
+						return fmt.Errorf("failed to publish address ref to environment: %w", err)
+					}
+				}
+			}
 		}
 	}
 	if o.Proposals == nil {
@@ -312,6 +357,30 @@ type AddMultiEVMSolanaLaneConfig struct {
 	Configs             []AddRemoteChainE2EConfig
 	SolanaChainSelector uint64
 	MCMSConfig          *cldfproposalutils.TimelockConfig
+}
+
+// PlannedRefs returns the datastore refs this lane configuration writes: one RemoteDest and
+// one RemoteSource per remote EVM chain, keyed on the Solana chain and qualified by the remote
+// chain selector the same keys the write sites record in solana_v0_1_0. Declaring them up
+// front means a duplicated lane config fails validation, before any instruction is sent.
+func (multiCfg *AddMultiEVMSolanaLaneConfig) PlannedRefs() []datastore.AddressRef {
+	refs := make([]datastore.AddressRef, 0, 2*len(multiCfg.Configs))
+	version := semver.MustParse("1.0.0")
+	for _, cfg := range multiCfg.Configs {
+		qualifier := strconv.FormatUint(cfg.EVMChainSelector, 10)
+		for _, laneType := range []datastore.ContractType{
+			datastore.ContractType(shared.RemoteDest),
+			datastore.ContractType(shared.RemoteSource),
+		} {
+			refs = append(refs, datastore.AddressRef{
+				ChainSelector: multiCfg.SolanaChainSelector,
+				Type:          laneType,
+				Version:       version,
+				Qualifier:     qualifier,
+			})
+		}
+	}
+	return refs
 }
 
 func (multiCfg *AddMultiEVMSolanaLaneConfig) populateAndValidateIndividualCSConfig(env cldf.Environment, evmState stateview.CCIPOnChainState) (csInputs, error) {
@@ -492,6 +561,12 @@ func addEVMSolanaPreconditions(env cldf.Environment, input AddMultiEVMSolanaLane
 	if _, exists := solanaState.SolChains[input.SolanaChainSelector]; !exists {
 		return fmt.Errorf("failed to find Solana chain in state %d", input.SolanaChainSelector)
 	}
+	if _, err := shared.ReserveRefs(input.PlannedRefs()); err != nil {
+		return err
+	}
+	if err := shared.ValidateAddressRefs(env, input.PlannedRefs()); err != nil {
+		return fmt.Errorf("lane datastore refs conflict: %w", err)
+	}
 	return nil
 }
 
@@ -530,14 +605,12 @@ func addEVMAndSolanaLaneLogic(env cldf.Environment, input AddMultiEVMSolanaLaneC
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute addEVMAndSolanaLane sequence: %w", err)
 	}
 
-	ds, err := shared.PopulateDataStore(report.Output.AddressBook)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
-
+	// The lane refs were recorded at the write site (RemoteDest/RemoteSource, qualified by the
+	// remote EVM chain selector) and carried through the sequence's OpsOutput. Nothing is
+	// re-derived from the address book, which could not carry the qualifiers.
 	return cldf.ChangesetOutput{
 		MCMSTimelockProposals: report.Output.Proposals,
 		AddressBook:           report.Output.AddressBook,
-		DataStore:             ds,
+		DataStore:             report.Output.DataStore,
 	}, nil
 }

--- a/deployment/ccip/changeset/cs_orchestrate_changesets.go
+++ b/deployment/ccip/changeset/cs_orchestrate_changesets.go
@@ -407,6 +407,13 @@ func (p *changesetMergePlan) planDataStore(env cldf.Environment, dest, src datas
 			return fmt.Errorf("failed to merge data store: address %s on chain %d has no version: %w",
 				ref.Address, ref.ChainSelector, datastore.ErrAddressRefVersionRequired)
 		}
+		// An empty address is not a record of a deployed contract: it is a reservation
+		// (ReserveRefs) that the changeset never filled. Merged, it would persist as a ref that
+		// resolves to nothing and is mistaken for progress.
+		if ref.Address == "" {
+			return fmt.Errorf("failed to merge data store: %s has no address; a reserved key was never filled",
+				ref.Key().String())
+		}
 	}
 
 	// MemoryDataStore keeps a record alongside a staged deletion until Merge applies it. Do not

--- a/deployment/ccip/changeset/merge_test.go
+++ b/deployment/ccip/changeset/merge_test.go
@@ -177,6 +177,35 @@ func TestMergeChangesetOutputRejectsRefWithoutVersion(t *testing.T) {
 	require.ErrorContains(t, err, "0xaaa")
 }
 
+func TestMergeChangesetOutputRejectsEmptyAddressRef(t *testing.T) {
+	t.Parallel()
+	e := mergeTestEnvironment(t)
+
+	// A reserved-but-never-filled key (as ReserveRefs leaves behind when a changeset returns
+	// without deploying everything it planned) is a pending claim, not a record.
+	src := datastore.NewMemoryDataStore()
+	require.NoError(t, src.Addresses().Add(datastore.AddressRef{
+		ChainSelector: 5009297550715157269,
+		Address:       "",
+		Type:          datastore.ContractType("Router"),
+		Version:       semver.MustParse("1.6.0"),
+		Qualifier:     "",
+	}))
+
+	dest := cldf.ChangesetOutput{DataStore: datastore.NewMemoryDataStore()}
+
+	err := MergeChangesetOutput(e, &dest, cldf.ChangesetOutput{DataStore: src})
+	require.ErrorContains(t, err, "has no address")
+
+	envRefs, envErr := e.DataStore.Addresses().Fetch()
+	require.NoError(t, envErr)
+	require.Empty(t, envRefs, "the reservation must not reach the environment")
+
+	destRefs, destErr := dest.DataStore.Addresses().Fetch()
+	require.NoError(t, destErr)
+	require.Empty(t, destRefs, "the reservation must not reach the destination")
+}
+
 func TestMergeChangesetOutputComparesAddressesExactly(t *testing.T) {
 	t.Parallel()
 	e := mergeTestEnvironment(t)

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_e2e.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_e2e.go
@@ -391,20 +391,11 @@ func E2ETokenPoolv2(env cldf.Environment, cfg E2ETokenPoolConfigv2) (cldf.Change
 		}
 	}
 
-	// Preserve the datastore accumulated by MergeChangesetOutput: it already carries the
-	// sub-changesets' semantic qualifiers, metadata, and deletions. Rebuilding it from the
-	// address book would discard all of that. The address book has no qualifiers, so it can only
-	// contribute the singleton refs the sub-changesets did not write to the datastore; merge
-	// those in rather than replacing the accumulated store.
-	singletons, err := shared.PopulateDataStore(finalCSOut.AddressBook) //nolint:staticcheck //SA1019 ignoring deprecated
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
-
-	if finalCSOut.DataStore == nil {
-		finalCSOut.DataStore = singletons
-	} else if err := finalCSOut.DataStore.Merge(singletons.Seal()); err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address-book refs into DataStore: %w", err)
-	}
+	// Preserve the datastore accumulated by MergeChangesetOutput: it carries the
+	// sub-changesets' semantic qualifiers, metadata, and deletions. Every merged sub-changeset
+	// that produces an address writes it natively (AddTokenPoolAndLookupTable records the
+	// lookup tables under their full (mint, pool type, metadata) qualifier; the registry,
+	// remote-chain and ownership changesets deploy nothing). Rebuilding from the merged
+	// address book could only mint address-derived qualifiers, so nothing is re-derived.
 	return *finalCSOut, nil
 }

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_e2e.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_e2e.go
@@ -420,20 +420,11 @@ func E2ETokenPoolv2(env cldf.Environment, cfg E2ETokenPoolConfigv2) (cldf.Change
 		}
 	}
 
-	// Preserve the datastore accumulated by MergeChangesetOutput: it already carries the
-	// sub-changesets' semantic qualifiers, metadata, and deletions. Rebuilding it from the
-	// address book would discard all of that. The address book has no qualifiers, so it can only
-	// contribute the singleton refs the sub-changesets did not write to the datastore; merge
-	// those in rather than replacing the accumulated store.
-	singletons, err := shared.PopulateDataStore(finalCSOut.AddressBook) //nolint:staticcheck //SA1019 ignoring deprecated
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
-
-	if finalCSOut.DataStore == nil {
-		finalCSOut.DataStore = singletons
-	} else if err := finalCSOut.DataStore.Merge(singletons.Seal()); err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address-book refs into DataStore: %w", err)
-	}
+	// Preserve the datastore accumulated by MergeChangesetOutput: it carries the
+	// sub-changesets' semantic qualifiers, metadata, and deletions. Every merged sub-changeset
+	// that produces an address writes it natively (AddTokenPoolAndLookupTable records the
+	// lookup tables under their full (mint, pool type, metadata) qualifier; the global-config,
+	// registry, remote-chain and ownership changesets deploy nothing). Rebuilding from the
+	// merged address book could only mint address-derived qualifiers, so nothing is re-derived.
 	return *finalCSOut, nil
 }

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -474,21 +474,12 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 		finalCSOut.MCMSTimelockProposals = []mcms.TimelockProposal{*aggregatedProposals}
 	}
 
-	// Preserve the datastore accumulated by MergeChangesetOutput: it already carries the
-	// sub-changesets' semantic qualifiers, metadata, and deletions. Rebuilding it from the
-	// address book would discard all of that. The address book has no qualifiers, so it can only
-	// contribute the singleton refs the sub-changesets did not write to the datastore; merge
-	// those in rather than replacing the accumulated store.
-	singletons, err := shared.PopulateDataStore(finalCSOut.AddressBook) //nolint:staticcheck //SA1019 ignoring deprecated
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate in-memory DataStore: %w", err)
-	}
-
-	if finalCSOut.DataStore == nil {
-		finalCSOut.DataStore = singletons
-	} else if err := finalCSOut.DataStore.Merge(singletons.Seal()); err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address-book refs into DataStore: %w", err)
-	}
+	// Preserve the datastore accumulated by MergeChangesetOutput: it carries the
+	// sub-changesets' semantic qualifiers, metadata, and deletions. Every sub-changeset merged
+	// above writes it natively (deployTokens records each token under its symbol;
+	// DeployTokenPoolContractsChangeset records each pool under its symbol; the admin/config
+	// changesets deploy nothing). Rebuilding from the merged address book could only mint
+	// address-derived qualifiers, so nothing is re-derived.
 	return *finalCSOut, nil
 }
 

--- a/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/v1_5"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 )
@@ -456,9 +455,9 @@ func TestUpdateBidirectionalLanesChangesetWithV2FeeQuoter(t *testing.T) {
 	require.NoError(t, err, "must confirm v2 FeeQuoter deployment")
 
 	// AddressBook does NOT contain FeeQuoter v2
-	// Add FeeQuoter v2 only to the DataStore
-	ds, err := shared.PopulateDataStore(e.ExistingAddresses)
-	require.NoError(t, err, "must populate datastore from existing addresses")
+	// Add FeeQuoter v2 only to the DataStore. The existing chain singletons (incl. the v1
+	// FeeQuoter) are read from e.ExistingAddresses by CollectAddressRefs at runtime.
+	ds := datastore.NewMemoryDataStore()
 
 	err = ds.Addresses().Add(datastore.AddressRef{
 		ChainSelector: v2FQChainSel,
@@ -594,8 +593,10 @@ func TestUpdateBidirectionalLanesIdempotentWithV2FeeQuoter(t *testing.T) {
 	_, err = evmChain.Confirm(tx)
 	require.NoError(t, err, "must confirm v2 FeeQuoter deployment")
 
-	ds, err := shared.PopulateDataStore(e.ExistingAddresses)
-	require.NoError(t, err, "must populate datastore from existing addresses")
+	// AddressBook does NOT contain FeeQuoter v2; add it to the DataStore only. The existing
+	// chain singletons (incl. the v1 FeeQuoter) are read from e.ExistingAddresses by
+	// CollectAddressRefs at runtime.
+	ds := datastore.NewMemoryDataStore()
 
 	err = ds.Addresses().Add(datastore.AddressRef{
 		ChainSelector: v2FQChainSel,
@@ -837,9 +838,9 @@ func TestUpdateBidirectionalLanesChangesetWithV2FeeQuoterWithMCMS(t *testing.T) 
 	require.NoError(t, err, "must confirm v2 FeeQuoter deployment")
 
 	// AddressBook does NOT contain FeeQuoter v2
-	// Add FeeQuoter v2 only to the DataStore
-	ds, err := shared.PopulateDataStore(e.ExistingAddresses)
-	require.NoError(t, err, "must populate datastore from existing addresses")
+	// Add FeeQuoter v2 only to the DataStore. The existing chain singletons (incl. the v1
+	// FeeQuoter) are read from e.ExistingAddresses by CollectAddressRefs at runtime.
+	ds := datastore.NewMemoryDataStore()
 
 	err = ds.Addresses().Add(datastore.AddressRef{
 		ChainSelector: v2FQChainSel,

--- a/deployment/ccip/shared/helpers.go
+++ b/deployment/ccip/shared/helpers.go
@@ -85,40 +85,6 @@ func MustABIEncode(abiString string, args ...any) []byte {
 	return encoded
 }
 
-func PopulateDataStore(addressBook deployment.AddressBook) (*datastore.MemoryDataStore, error) {
-	addrs, err := addressBook.Addresses()
-	if err != nil {
-		return nil, err
-	}
-
-	ds := datastore.NewMemoryDataStore()
-	for chainselector, chainAddresses := range addrs {
-		for addr, typever := range chainAddresses {
-			ref := datastore.AddressRef{
-				ChainSelector: chainselector,
-				Address:       addr,
-				Type:          datastore.ContractType(typever.Type),
-				Version:       &typever.Version,
-				// Since the address book does not have a qualifier, we use the address and type as a
-				// unique identifier for the addressRef. Otherwise, we would have some clashes in the
-				// between address refs.
-				Qualifier: fmt.Sprintf("%s-%s", addr, typever.Type),
-			}
-
-			// If the address book has labels, we need to add them to the addressRef
-			if !typever.Labels.IsEmpty() {
-				ref.Labels = datastore.NewLabelSet(typever.Labels.List()...)
-			}
-
-			if err = ds.Addresses().Add(ref); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return ds, nil
-}
-
 // ResolveFeeQuoterAddressAndVersion returns the FeeQuoter with the highest semver for a chain.
 func ResolveFeeQuoterAddressAndVersion(
 	addresses []datastore.AddressRef,

--- a/deployment/ccip/shared/qualifier_test.go
+++ b/deployment/ccip/shared/qualifier_test.go
@@ -1,0 +1,31 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTokenPoolLookupTableQualifier verifies the composite LUT qualifier is unique per
+// (token mint, pool type, metadata).
+func TestTokenPoolLookupTableQualifier(t *testing.T) {
+	t.Parallel()
+	mint := "So11111111111111111111111111111111111111112"
+	a := TokenPoolLookupTableQualifier(mint, "BurnMintTokenPool", "CLL")
+	b := TokenPoolLookupTableQualifier(mint, "LockReleaseTokenPool", "CLL")
+	c := TokenPoolLookupTableQualifier(mint, "BurnMintTokenPool", "customPool9")
+	require.NotEqual(t, a, b)
+	require.NotEqual(t, a, c)
+	require.NotEqual(t, b, c)
+}
+
+// TestTokenPoolLookupTableQualifierIsUnambiguous verifies that a separator appearing inside a
+// caller-supplied component cannot make two distinct (mint, poolType, metadata) triples collide.
+func TestTokenPoolLookupTableQualifierIsUnambiguous(t *testing.T) {
+	t.Parallel()
+	mint := "So11111111111111111111111111111111111111112"
+	require.NotEqual(t,
+		TokenPoolLookupTableQualifier(mint, "BurnMintTokenPool", "a/b"),
+		TokenPoolLookupTableQualifier(mint, "BurnMintTokenPool/a", "b"),
+	)
+}

--- a/deployment/ccip/shared/stateview/state.go
+++ b/deployment/ccip/shared/stateview/state.go
@@ -33,7 +33,6 @@ import (
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf_chain_utils "github.com/smartcontractkit/chainlink-deployments-framework/chain/utils"
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 
@@ -299,16 +298,21 @@ func (c CCIPOnChainState) runSingleChainValidation(
 			chainState.RMNRemote.Address().Hex(), isRMNEnabledInRMNHomeBySourceChain[sel], isRMNEnabledInRmnRemote))
 	}
 	var fqV2 *fqv2ops.FeeQuoterContract
-	if ds, dsErr := ccipshared.PopulateDataStore(e.ExistingAddresses); dsErr == nil {
-		if e.DataStore != nil {
-			_ = ds.Merge(e.DataStore)
-		}
-		chainAddresses := ds.Addresses().Filter(datastore.AddressRefByChainSelector(sel))
-		if fqAddr, fqVer, fqErr := ccipshared.ResolveFeeQuoterAddressAndVersion(chainAddresses, sel); fqErr == nil && fqVer.Major() >= 2 {
-			if evmChain, ok := e.BlockChains.EVMChains()[sel]; ok {
-				if v2, bindErr := fqv2ops.NewFeeQuoterContract(fqAddr, evmChain.Client); bindErr == nil {
-					fqV2 = v2
-				}
+	// Resolve FeeQuoter candidates from a plain ref slice drawn from both the environment
+	// DataStore (qualified refs) and the existing address book (chain-singleton refs). Using a
+	// slice rather than a keyed datastore avoids collisions among multi-instance refs and works
+	// even when the environment DataStore is nil/empty.
+	candidates, err := ccipshared.CollectAddressRefs(e)
+	if err != nil {
+		// Return here rather than continuing with nil candidates: on a chain that does have a v2
+		// FeeQuoter, falling through would silently take the v1-only path and bury the real cause
+		// under a cascade of unrelated v1-vs-v2 mismatch errors.
+		return append(errs, fmt.Errorf("failed to collect address refs: %w", err))
+	}
+	if fqAddr, fqVer, fqErr := ccipshared.ResolveFeeQuoterAddressAndVersion(candidates, sel); fqErr == nil && fqVer.Major() >= 2 {
+		if evmChain, ok := e.BlockChains.EVMChains()[sel]; ok {
+			if v2, bindErr := fqv2ops.NewFeeQuoterContract(fqAddr, evmChain.Client); bindErr == nil {
+				fqV2 = v2
 			}
 		}
 	}


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
[CCIP-13351](https://smartcontract-it.atlassian.net/browse/CCIP-13351)

Removes the final CCIP datastore shim-qualification path and carries native datastore output through lanes, aggregators, and state validation. After write-at-site conversion, datastore entries should never be reconstructed from the AddressBook or assigned address-derived qualifiers.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->
This is the top PR of the stack.
### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

[CCIP-13351]: https://smartcontract-it.atlassian.net/browse/CCIP-13351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ