### PR TITLE
[CRE-6175] routed trigger event

### DIFF
--- a/core/services/workflows/v2/config.go
+++ b/core/services/workflows/v2/config.go
@@ -89,7 +89,7 @@ type EngineLimiters struct {
 	TriggerSubscriptionTime  limits.TimeLimiter
 	TriggerRegistrationsTime limits.TimeLimiter
 	TriggerSubscription      limits.BoundLimiter[int]
-	TriggerEventQueue        limits.QueueLimiter[enqueuedTriggerEvent]
+	TriggerEventQueue        limits.QueueLimiter[RoutedTriggerEvent]
 	TriggerEventQueueTime    limits.TimeLimiter
 	ExecutionConcurrency     limits.ResourcePoolLimiter[int]
 
@@ -154,7 +154,7 @@ func (l *EngineLimiters) init(lf limits.Factory, cfgFn func(*cresettings.Workflo
 	if err != nil {
 		return
 	}
-	l.TriggerEventQueue, err = limits.MakeQueueLimiter[enqueuedTriggerEvent](lf, cfg.TriggerEventQueueLimit)
+	l.TriggerEventQueue, err = limits.MakeQueueLimiter[RoutedTriggerEvent](lf, cfg.TriggerEventQueueLimit)
 	if err != nil {
 		return
 	}

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -96,7 +96,7 @@ type Engine struct {
 	// used to separate registration and unregistration phases
 	triggersRegMu sync.Mutex
 
-	allTriggerEventsQueueCh limits.QueueLimiter[enqueuedTriggerEvent]
+	allTriggerEventsQueueCh limits.QueueLimiter[RoutedTriggerEvent]
 	executionsSemaphore     limits.ResourcePoolLimiter[int]
 	capCallsSemaphore       limits.ResourcePoolLimiter[int]
 
@@ -123,13 +123,6 @@ type triggerCapability struct {
 	capabilities.TriggerCapability
 	payload *anypb.Any
 	method  string
-}
-
-type enqueuedTriggerEvent struct {
-	triggerCapID string
-	triggerIndex int
-	timestamp    time.Time
-	event        capabilities.TriggerResponse
 }
 
 func TriggerRegistrationID(workflowID string, triggerIndex int) string {
@@ -396,12 +389,22 @@ func (e *Engine) Put(ctx context.Context, event RoutedTriggerEvent) error { // t
 		e.cfg.Hooks.OnTriggerEventDropped(triggerID, eventID, "draining")
 		return ErrEngineDraining
 	}
-	if err := e.allTriggerEventsQueueCh.Put(ctx, enqueuedTriggerEvent{
-		triggerCapID: triggerID,
-		triggerIndex: idx,
-		timestamp:    e.cfg.Clock.Now(),
-		event:        event.Event,
-	}); err != nil {
+
+	// Stamp the deadline once at dispatch: observedAt + queue timeout.
+	// If ObservedAt is not set, use the current time.
+	if event.ObservedAt.IsZero() {
+		event.ObservedAt = e.cfg.Clock.Now()
+	}
+	queueTimeout, err := e.cfg.LocalLimiters.TriggerEventQueueTime.Limit(ctx)
+	if err != nil {
+		e.logger().Errorw("Failed to get trigger event queue time limit", "err", err)
+		tm := e.metrics.With(platform.KeyTriggerID, triggerID)
+		tm.IncrementTriggerEventDroppedTotal(ctx, monitoring.TriggerDropReasonQueueAgeLimitReadFailed)
+		return ErrEnqueueFailed
+	}
+	event.Deadline = event.ObservedAt.Add(queueTimeout)
+
+	if err := e.allTriggerEventsQueueCh.Put(ctx, event); err != nil {
 		tm := e.metrics.With(platform.KeyTriggerID, triggerID)
 		tm.IncrementTriggerEventEnqueueDroppedCounter(ctx)
 		retErr := ErrEnqueueFailed
@@ -808,30 +811,27 @@ func (e *Engine) handleAllTriggerEvents(ctx context.Context) {
 		if err != nil {
 			return
 		}
-		eventID := queueHead.event.Event.ID
-		triggerMetricLabels := e.metrics.With(platform.KeyTriggerID, queueHead.triggerCapID)
+		eventID := queueHead.Event.Event.ID
+		triggerMetricLabels := e.metrics.With(platform.KeyTriggerID, queueHead.TriggerCapID)
 		if e.Draining() {
 			triggerMetricLabels.IncrementTriggerEventDequeueDroppedCounter(ctx)
 			triggerMetricLabels.IncrementTriggerEventDroppedTotal(ctx, monitoring.TriggerDropReasonDequeueDraining)
-			e.cfg.Hooks.OnTriggerEventDropped(queueHead.triggerCapID, eventID, "draining")
-			e.logger().Infow("Engine is draining, stopping trigger handling loop", "eventID", eventID, "triggerID", queueHead.triggerCapID)
+			e.cfg.Hooks.OnTriggerEventDropped(queueHead.TriggerCapID, eventID, "draining")
+			e.logger().Infow("Engine is draining, stopping trigger handling loop", "eventID", eventID, "triggerID", queueHead.TriggerCapID)
 			return
 		}
-		eventAge := e.cfg.Clock.Now().Sub(queueHead.timestamp)
+
+		now := e.cfg.Clock.Now()
+		eventAge := now.Sub(queueHead.ObservedAt)
 		e.logger().Debugw("Popped a trigger event from the queue", "eventID", eventID, "eventAgeMs", eventAge.Milliseconds())
 		triggerMetricLabels.RecordTriggerEventQueueWaitSeconds(ctx, eventAge.Seconds())
-		triggerEventMaxAge, err := e.cfg.LocalLimiters.TriggerEventQueueTime.Limit(ctx)
-		if err != nil {
-			e.logger().Errorw("Failed to get trigger event queue time limit", "err", err)
-			triggerMetricLabels.IncrementTriggerEventDroppedTotal(ctx, monitoring.TriggerDropReasonQueueAgeLimitReadFailed)
-			continue
-		}
-		if eventAge > triggerEventMaxAge {
-			e.logger().Warnw("Trigger event is too old, skipping execution", "triggerID", queueHead.triggerCapID, "eventID", eventID, "eventAgeMs", eventAge.Milliseconds())
+		if now.After(queueHead.Deadline) {
+			e.logger().Warnw("Trigger event is too old, skipping execution", "triggerID", queueHead.TriggerCapID, "eventID", eventID, "eventAgeMs", eventAge.Milliseconds())
 			triggerMetricLabels.IncrementTriggerEventExpiredCounter(ctx)
 			triggerMetricLabels.IncrementTriggerEventDroppedTotal(ctx, monitoring.TriggerDropReasonExpired)
 			continue
 		}
+
 		semWaitStart := e.cfg.Clock.Now()
 		free, err := e.executionsSemaphore.Wait(ctx, 1) // block if too many concurrent workflow executions
 		triggerMetricLabels.RecordExecutionSemaphoreWaitSeconds(ctx, e.cfg.Clock.Now().Sub(semWaitStart).Seconds())
@@ -843,25 +843,17 @@ func (e *Engine) handleAllTriggerEvents(ctx context.Context) {
 
 		e.srvcEng.GoCtx(context.WithoutCancel(ctx), func(ctx context.Context) {
 			defer free()
-			routed := RoutedTriggerEvent{
-				WorkflowID:   e.cfg.WorkflowID,
-				TriggerCapID: queueHead.triggerCapID,
-				TriggerIndex: queueHead.triggerIndex,
-				ObservedAt:   queueHead.timestamp,
-				// Deadline:     TODO: will be addressed on CRE-6175
-				SequenceNumber: 0, // reserved, always 0 in M1
-				Event:          queueHead.event,
-			}
+
 			// Legacy path: startExecution handles all errors internally (metrics, ACK, hooks).
 			// This logs eventID context at the call site; the future dispatcher admitter
 			// (CRE-6176) will use this error for admission decisions.
-			if err := e.ExecuteTrigger(ctx, routed); err != nil {
+			if err := e.ExecuteTrigger(ctx, queueHead); err != nil {
 				// Dedup and shard-denial are expected outcomes (the event is handled,
 				// just not executed here), so they log at info rather than error level.
 				if errors.Is(err, ErrDuplicateExecution) || errors.Is(err, ErrShardDeniedNotOwner) {
-					e.logger().Infow("Skipping trigger event execution", "triggerID", routed.TriggerCapID, "eventID", routed.Event.Event.ID, "err", err)
+					e.logger().Infow("Skipping trigger event execution", "triggerID", queueHead.TriggerCapID, "eventID", queueHead.Event.Event.ID, "err", err)
 				} else {
-					e.logger().Errorw("Failed to execute trigger event", "triggerID", routed.TriggerCapID, "eventID", routed.Event.Event.ID, "err", err)
+					e.logger().Errorw("Failed to execute trigger event", "triggerID", queueHead.TriggerCapID, "eventID", queueHead.Event.Event.ID, "err", err)
 				}
 			}
 		})

--- a/core/services/workflows/v2/engine_execution_concurrency_test.go
+++ b/core/services/workflows/v2/engine_execution_concurrency_test.go
@@ -17,7 +17,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	regmocks "github.com/smartcontractkit/chainlink-common/pkg/types/core/mocks"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host"
 	modulemocks "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host/mocks"
@@ -286,4 +288,253 @@ func TestEngine_StaleTriggerEventIsSkipped(t *testing.T) {
 		"expected 5 stale-event warnings for events 2-6")
 
 	require.NoError(t, engine.Close())
+}
+
+// mutableSettingsGetter is a settings.Getter whose values can be edited mid-test.
+// It ignores scope/tenant resolution and answers by bare setting key, which is
+// sufficient to drive a single setting (TriggerEventQueueTimeout) for one workflow.
+type mutableSettingsGetter struct {
+	mu     sync.Mutex
+	values map[string]string
+}
+
+var _ settings.Getter = (*mutableSettingsGetter)(nil)
+
+func (m *mutableSettingsGetter) GetScoped(_ context.Context, _ settings.Scope, key string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.values[key], nil
+}
+
+func (m *mutableSettingsGetter) set(key, value string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.values[key] = value
+}
+
+// TestEngine_TriggerEventDeadlineUsesDispatchTimeSetting proves that each event
+// keeps the expiry it was given when it entered the queue. Changing the
+// TriggerEventQueueTimeout setting later does not retroactively expire events
+// that are already queued — only events sent after the change get the new
+// timeout.
+//
+// Flow (FakeClock, ExecutionConcurrencyLimit=1 so executions run one at a time):
+//  1. Send E0/E1/E2 while the timeout is 10s. Each gets Deadline = now+10s.
+//     E0 starts executing and blocks; E1 waits for the execution slot; E2 waits
+//     in the queue.
+//  2. Change the timeout to 1s and advance the clock 2s. The clock is now past
+//     the new 1s timeout, but still before the queued events' 10s deadlines.
+//  3. Let E0 finish. E1 executes, then E2 is pulled from the queue and must
+//     still EXECUTE — its 10s deadline has not passed. (The old code compared
+//     the event's age against the current setting and would have dropped it:
+//     2s > 1s.)
+//  4. E1 is still executing, so send E3 — it gets Deadline = now+1s from the
+//     new setting. Advance the clock past that, let E1 finish: E2 executes and
+//     E3 EXPIRES, showing the new setting does apply to newly sent events.
+//
+// Note on running this test against the pre-deadline code (which compared
+// event age against the current setting): it fails the execution-set
+// assertion with E2 missing and E3 present. E2 expires because its 2s age
+// exceeds the shrunk 1s setting; E3 then executes because the handler, freed
+// by E2's early drop, pops it fresh off the queue while its age is still
+// under 1s. E0 and E1 execute in both versions — E0 ran before the change,
+// and E1 had already passed its age check when it was popped.
+func TestEngine_TriggerEventDeadlineUsesDispatchTimeSetting(t *testing.T) {
+	t.Parallel()
+
+	const (
+		longTimeout  = 10 * time.Second
+		shortTimeout = 1 * time.Second
+	)
+
+	fakeClock := clockwork.NewFakeClock()
+	blocker1Started := make(chan struct{})
+	blocker1Release := make(chan struct{})
+	blocker2Started := make(chan struct{})
+	blocker2Release := make(chan struct{})
+
+	module := modulemocks.NewModuleV2(t)
+	module.EXPECT().Start().Once()
+	// init call → trigger subscriptions
+	module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).
+		Return(newTriggerSubs(1), nil).Once()
+	// Executions acquire the semaphore in pop order, so Execute calls are
+	// serialized: E0 and E1 block in turn (each holding the semaphore), E2 runs
+	// fast. E3 must never reach Module.Execute (asserted via execution IDs).
+	var execMu sync.Mutex
+	execCount := 0
+	module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, _ *sdkpb.ExecuteRequest, _ host.ExecutionHelper) {
+			execMu.Lock()
+			execCount++
+			n := execCount
+			execMu.Unlock()
+			switch n {
+			case 1:
+				close(blocker1Started)
+				<-blocker1Release
+			case 2:
+				close(blocker2Started)
+				<-blocker2Release
+			}
+		}).Return(nil, nil)
+	module.EXPECT().Close().Once()
+
+	capreg := regmocks.NewCapabilitiesRegistry(t)
+	capreg.EXPECT().LocalNode(matches.AnyContext).Return(newNode(t), nil).Once()
+
+	initDoneCh := make(chan error, 1)
+	subscribedToTriggersCh := make(chan []string, 1)
+	executionFinishedCh := make(chan string, 3)
+
+	var lggr logger.Logger
+	var logs *observer.ObservedLogs
+
+	limitCfgFn := func(cfg *cresettings.Workflows) {
+		cfg.ExecutionConcurrencyLimit.DefaultValue = 1
+	}
+	cfg := defaultTestConfig(t, limitCfgFn)
+	lggr, logs = logger.TestObserved(t, zapcore.DebugLevel)
+	cfg.Lggr = lggr
+	cfg.Clock = fakeClock
+	cfg.Module = module
+	cfg.CapRegistry = capreg
+	cfg.BillingClient = setupMockBillingClient(t)
+
+	// Rebuild the engine limiters on a factory wired to a mutable settings
+	// getter so TriggerEventQueueTimeout can be edited mid-test. Every other
+	// setting falls back to its default (the getter returns "" for it).
+	queueTimeoutKey := cresettings.Default.PerWorkflow.TriggerEventQueueTimeout.Key
+	getter := &mutableSettingsGetter{values: map[string]string{
+		queueTimeoutKey: longTimeout.String(),
+	}}
+	mutableLimiters, err := v2.NewLimiters(limits.Factory{
+		Logger:   logger.Test(t),
+		Settings: getter,
+	}, limitCfgFn)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, mutableLimiters.Close()) })
+	cfg.LocalLimiters = mutableLimiters
+
+	// Map each test event to the execution ID the engine generates for it, and
+	// keep the reverse mapping so the assertions below report event names
+	// (event_long_0) instead of opaque execution-ID hashes.
+	longEventIDs := []string{"event_long_0", "event_long_1", "event_long_2"}
+	shortEventID := "event_short_3"
+	eventByExecID := make(map[string]string, len(longEventIDs)+1)
+	for _, eid := range append(slices.Clone(longEventIDs), shortEventID) {
+		eventByExecID[wantExecutionID(t, cfg.WorkflowID, eid, 0)] = eid
+	}
+	wantEvents := make(map[string]struct{}, len(longEventIDs))
+	for _, eid := range longEventIDs {
+		wantEvents[eid] = struct{}{}
+	}
+
+	cfg.Hooks = v2.LifecycleHooks{
+		OnInitialized: func(err error) {
+			initDoneCh <- err
+		},
+		OnSubscribedToTriggers: func(triggerIDs []string) {
+			subscribedToTriggersCh <- triggerIDs
+		},
+		OnExecutionFinished: func(executionID string, _ string) {
+			executionFinishedCh <- executionID
+		},
+	}
+
+	engine, err := v2.NewEngine(cfg)
+	require.NoError(t, err)
+
+	trigger := capmocks.NewTriggerCapability(t)
+	capreg.EXPECT().GetTrigger(matches.AnyContext, "id_0").Return(trigger, nil).Once()
+	eventCh := make(chan capabilities.TriggerResponse)
+	trigger.EXPECT().RegisterTrigger(matches.AnyContext, mock.Anything).Return(eventCh, nil).Once()
+	trigger.EXPECT().UnregisterTrigger(matches.AnyContext, mock.Anything).Return(nil).Once()
+	trigger.EXPECT().AckEvent(matches.AnyContext, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	// Tear the engine down even when an assertion fails mid-test, so the test
+	// fails fast instead of hanging: a running engine holds limiter tenants and
+	// the limiter cleanups (registered earlier) would block on them.
+	// Registered AFTER the trigger mock above so LIFO runs it BEFORE the mock's
+	// own AssertExpectations cleanup — engine.Close() calls UnregisterTrigger,
+	// which the mock expects.
+	t.Cleanup(func() { require.NoError(t, engine.Close()) })
+
+	require.NoError(t, engine.Start(t.Context()))
+	require.NoError(t, <-initDoneCh)
+	require.Equal(t, []string{"id_0"}, <-subscribedToTriggersCh)
+
+	sendEvent := func(eventID string) {
+		eventCh <- capabilities.TriggerResponse{
+			Event: capabilities.TriggerEvent{
+				TriggerType: "basic-trigger@1.0.0",
+				ID:          eventID,
+			},
+		}
+	}
+
+	// Release stalled executions on failure paths so engine.Close() can complete.
+	var releaseBlocker1, releaseBlocker2 sync.Once
+	t.Cleanup(func() {
+		releaseBlocker1.Do(func() { close(blocker1Release) })
+		releaseBlocker2.Do(func() { close(blocker2Release) })
+	})
+
+	// Phase 1: dispatch three events under the 10s timeout. E0's execution
+	// blocks holding the semaphore; E1 stalls at the semaphore; E2 sits in the
+	// queue. All three deadlines are stamped at dispatch: now+10s.
+	for _, eid := range longEventIDs {
+		sendEvent(eid)
+	}
+	// All three Puts must complete (deadlines stamped) before editing the setting.
+	require.Eventually(t, func() bool {
+		return logs.FilterMessage("Enqueued trigger event").Len() >= 3
+	}, 2*time.Second, 50*time.Millisecond, "expected 3 events enqueued before editing the setting")
+	<-blocker1Started
+
+	// Edit the setting while events are queued: 10s → 1s. Advance the clock
+	// past the NEW setting (2s > 1s) but before the dispatched deadlines.
+	getter.set(queueTimeoutKey, shortTimeout.String())
+	fakeClock.Advance(2 * time.Second)
+
+	// Release E0: E1 executes, then E2 is dequeued. E2's deadline (stamped at
+	// dispatch under the 10s timeout) is still in the future, so it must
+	// EXECUTE — the previous age-vs-current-setting check would have dropped it.
+	releaseBlocker1.Do(func() { close(blocker1Release) })
+	<-blocker2Started
+
+	// Phase 2: E1's execution still holds the semaphore, so E3 — dispatched
+	// under the 1s setting (deadline now+1s) — sits in the queue. Advance past
+	// E3's deadline, then release E1: E2 executes and E3 must EXPIRE.
+	sendEvent("event_short_3")
+	require.Eventually(t, func() bool {
+		return logs.FilterMessage("Enqueued trigger event").Len() >= 4
+	}, 2*time.Second, 50*time.Millisecond, "expected E3 enqueued before advancing the clock")
+	fakeClock.Advance(2 * time.Second)
+	releaseBlocker2.Do(func() { close(blocker2Release) })
+
+	gotEvents := make(map[string]struct{}, 3)
+	for range 3 {
+		execID := <-executionFinishedCh
+		eid, ok := eventByExecID[execID]
+		if !ok {
+			t.Fatalf("execution finished with unknown execution ID %s", execID)
+		}
+		gotEvents[eid] = struct{}{}
+	}
+	require.Equal(t, wantEvents, gotEvents,
+		"events sent while the timeout was 10s must all execute despite the setting shrinking to 1s")
+
+	require.Eventually(t, func() bool {
+		return logs.FilterMessage("Trigger event is too old, skipping execution").Len() >= 1
+	}, 2*time.Second, 50*time.Millisecond,
+		"expected E3, dispatched under the 1s setting, to expire after its deadline")
+
+	// E3 must never execute.
+	select {
+	case execID := <-executionFinishedCh:
+		eid, _ := eventByExecID[execID]
+		t.Fatalf("unexpected execution of expired event %s (%s)", eid, execID)
+	case <-time.After(200 * time.Millisecond):
+	}
 }

--- a/core/services/workflows/v2/types.go
+++ b/core/services/workflows/v2/types.go
@@ -70,6 +70,7 @@ type RoutedTriggerEvent struct {
 
 	// Deadline is the expiry of this event in the dispatch queue,
 	// stamped once at dispatch as ObservedAt + TriggerEventQueueTimeout.
+	// A settings change after dispatch does not affect already-queued events
 	Deadline time.Time
 
 	// SequenceNumber determines the execution order of trigger events across the DON. In M1 it is always 0 (no consensus ordering).

--- a/core/services/workflows/v2/types.go
+++ b/core/services/workflows/v2/types.go
@@ -67,7 +67,10 @@ type RoutedTriggerEvent struct {
 	// dispatcher. It is used for skew metrics (queue wait time)
 	// and deadline enforcement.
 	ObservedAt time.Time
-	// Deadline     time.Time TODO: will be addressed on CRE-6175
+
+	// Deadline is the expiry of this event in the dispatch queue,
+	// stamped once at dispatch as ObservedAt + TriggerEventQueueTimeout.
+	Deadline time.Time
 
 	// SequenceNumber determines the execution order of trigger events across the DON. In M1 it is always 0 (no consensus ordering).
 	SequenceNumber uint64


### PR DESCRIPTION
### Description

This pr implements the logic around the `deadline` field. Before this change the way we used to determine if an event was expired was to calculate the elapsed time and compare it against the queue timeout settings at dequeue time. This implies that an expired event consumes queue resources, makes the rest wait to then be discarded. It also means that an event that was already enqueue with a particular timeout expectation might be expired if the settings changes before the dequeue.

Thats the main reason of this change, to set a deadline per event, so no settings changes can affect what "was agreed" at the beginning. We could potentially also define different deadlines to different org events.
[CRE-6175](https://smartcontract-it.atlassian.net/browse/CRE-6175)

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-6175]: https://smartcontract-it.atlassian.net/browse/CRE-6175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ