### PR TITLE
feat(githooks): implement pr-size calculation and split-pr skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ core/scripts/cre/environment/binaries/*
 .cursor/
 .gemini/
 opencode.json
+
+# Local git worktrees
+.worktrees/

--- a/tools/githooks/internal/prsize/prsize.go
+++ b/tools/githooks/internal/prsize/prsize.go
@@ -1,0 +1,479 @@
+package prsize
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/smartcontractkit/chainlink/v2/tools/githooks/internal/modules"
+	"github.com/smartcontractkit/chainlink/v2/tools/githooks/internal/ui"
+)
+
+// ErrLargePR indicates the PR diff exceeded the allowed line limit under FailOnLarge.
+var ErrLargePR = errors.New("diff is classified as LARGE")
+
+// EnvAllowLargePR is the environment variable used to bypass large PR size failure.
+const EnvAllowLargePR = "ALLOW_LARGE_PR"
+
+// Classification represents the size category of a PR diff.
+type Classification string
+
+const (
+	SizeSmall  Classification = "SMALL"
+	SizeMedium Classification = "MEDIUM"
+	SizeLarge  Classification = "LARGE"
+)
+
+// Strategy defines how lines changed are calculated from additions and deletions.
+type Strategy string
+
+const (
+	StrategyPerFileMax Strategy = "per-file-max"
+	StrategySum        Strategy = "sum"
+	StrategyMax        Strategy = "max"
+	StrategyWeighted   Strategy = "weighted"
+)
+
+// Default limits for diff classification.
+const (
+	DefaultSmallLimit  = 200
+	DefaultMediumLimit = 500
+)
+
+var lockfileNames = map[string]bool{
+	"go.sum":            true,
+	"package-lock.json": true,
+	"pnpm-lock.yaml":    true,
+	"yarn.lock":         true,
+	"gemfile.lock":      true,
+	"cargo.lock":        true,
+	"poetry.lock":       true,
+	"composer.lock":     true,
+	"flake.lock":        true,
+}
+
+// FileStat contains diff statistics for a single file.
+type FileStat struct {
+	Path      string
+	Additions int
+	Deletions int
+	IsBinary  bool
+}
+
+// DiffStat summarizes the diff analysis results.
+type DiffStat struct {
+	Files          []FileStat
+	IgnoredFiles   []string
+	FilesChanged   int
+	Additions      int
+	Deletions      int
+	EffectiveLines int
+	MergeBase      string
+	BaseRef        string
+	BranchName     string
+}
+
+// Config controls PR size calculation and reporting behavior.
+type Config struct {
+	RepoRoot           string
+	BaseRef            string
+	Strategy           Strategy
+	SmallLimit         int
+	MediumLimit        int
+	FailOnLarge        bool
+	AllowLargePR       bool
+	IgnoreLockfiles    bool
+	IgnoreGenerated    bool
+	IgnoreGlobs        []string
+	IncludeUncommitted bool
+	Stdout             io.Writer
+	Stderr             io.Writer
+	UI                 *ui.UI
+}
+
+func isLockfile(path string) bool {
+	base := strings.ToLower(filepath.Base(path))
+	return lockfileNames[base]
+}
+
+// CalculateEffectiveLines computes the effective lines changed based on the chosen strategy.
+func CalculateEffectiveLines(files []FileStat, strategy Strategy) int {
+	if len(files) == 0 {
+		return 0
+	}
+
+	switch strategy {
+	case StrategySum:
+		total := 0
+		for _, f := range files {
+			total += f.Additions + f.Deletions
+		}
+		return total
+
+	case StrategyMax:
+		totalAdd := 0
+		totalDel := 0
+		for _, f := range files {
+			totalAdd += f.Additions
+			totalDel += f.Deletions
+		}
+		return max(totalAdd, totalDel)
+
+	case StrategyWeighted:
+		totalAdd := 0
+		totalDel := 0
+		for _, f := range files {
+			totalAdd += f.Additions
+			totalDel += f.Deletions
+		}
+		return totalAdd + int(0.5*float64(totalDel))
+
+	case StrategyPerFileMax:
+		fallthrough
+	default:
+		total := 0
+		for _, f := range files {
+			total += max(f.Additions, f.Deletions)
+		}
+		return total
+	}
+}
+
+// Classify categorizes line count into Small, Medium, or Large.
+func Classify(lines int, cfg Config) Classification {
+	smallLimit := cfg.SmallLimit
+	if smallLimit <= 0 {
+		smallLimit = DefaultSmallLimit
+	}
+	mediumLimit := cfg.MediumLimit
+	if mediumLimit <= 0 {
+		mediumLimit = DefaultMediumLimit
+	}
+	if smallLimit > mediumLimit {
+		smallLimit = mediumLimit
+	}
+
+	if lines <= smallLimit {
+		return SizeSmall
+	}
+	if lines <= mediumLimit {
+		return SizeMedium
+	}
+	return SizeLarge
+}
+
+func resolveMergeBase(ctx context.Context, repoRoot, baseRef string) (string, error) {
+	if baseRef != "" {
+		cmd := exec.CommandContext(ctx, "git", "merge-base", baseRef, "HEAD")
+		cmd.Dir = repoRoot
+		out, err := cmd.Output()
+		if err == nil {
+			if sha := strings.TrimSpace(string(out)); sha != "" {
+				return sha, nil
+			}
+		}
+		return baseRef, nil
+	}
+
+	mb := modules.GetMergeBase(ctx, repoRoot)
+	return mb, nil
+}
+
+func checkGeneratedFiles(ctx context.Context, repoRoot string, files []string) (map[string]bool, error) {
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "check-attr", "--stdin", "linguist-generated")
+	cmd.Dir = repoRoot
+	cmd.Stdin = strings.NewReader(strings.Join(files, "\n") + "\n")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git check-attr failed: %w", err)
+	}
+
+	generatedMap := make(map[string]bool)
+	for line := range strings.SplitSeq(string(out), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		const prefix = ": linguist-generated: "
+		if filePath, val, found := strings.Cut(trimmed, prefix); found {
+			val = strings.TrimSpace(val)
+			if val == "true" || val == "set" || val == "1" {
+				generatedMap[strings.TrimSpace(filePath)] = true
+			}
+		}
+	}
+	return generatedMap, nil
+}
+
+// Analyze inspects git diff against the merge-base with the default branch and calculates stats.
+func Analyze(ctx context.Context, cfg Config) (*DiffStat, Classification, error) {
+	repoRoot := cfg.RepoRoot
+	if repoRoot == "" {
+		repoRoot = "."
+	}
+
+	mergeBase, err := resolveMergeBase(ctx, repoRoot, cfg.BaseRef)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to resolve merge-base: %w", err)
+	}
+
+	diffArgs := []string{"diff", "--numstat", mergeBase}
+	if !cfg.IncludeUncommitted {
+		diffArgs = append(diffArgs, "HEAD")
+	}
+
+	cmd := exec.CommandContext(ctx, "git", diffArgs...)
+	cmd.Dir = repoRoot
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if runErr := cmd.Run(); runErr != nil {
+		// If HEAD diff failed (e.g. initial commit or uncommitted only), fallback to diffing mergeBase
+		if cfg.IncludeUncommitted {
+			return nil, "", fmt.Errorf("git diff failed: %w (stderr: %s)", runErr, stderr.String())
+		}
+		cmd = exec.CommandContext(ctx, "git", "diff", "--numstat", mergeBase)
+		cmd.Dir = repoRoot
+		stdout.Reset()
+		stderr.Reset()
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if fallbackErr := cmd.Run(); fallbackErr != nil {
+			return nil, "", fmt.Errorf("git diff failed: %w (stderr: %s)", fallbackErr, stderr.String())
+		}
+	}
+
+	type rawDiffEntry struct {
+		filePath string
+		addStr   string
+		delStr   string
+	}
+
+	var rawEntries []rawDiffEntry
+	var allPaths []string
+
+	for line := range strings.SplitSeq(stdout.String(), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		parts := strings.Split(trimmed, "\t")
+		if len(parts) < 3 {
+			continue
+		}
+
+		addStr, delStr, filePath := parts[0], parts[1], parts[2]
+
+		// Handle renames formatted as "old => new" or "{dir => dir2}/file"
+		if idx := strings.LastIndex(filePath, " => "); idx != -1 {
+			filePath = strings.TrimSpace(filePath[idx+4:])
+			filePath = strings.TrimSuffix(filePath, "}")
+		}
+
+		rawEntries = append(rawEntries, rawDiffEntry{filePath: filePath, addStr: addStr, delStr: delStr})
+		allPaths = append(allPaths, filePath)
+	}
+
+	var generatedMap map[string]bool
+	if cfg.IgnoreGenerated && len(allPaths) > 0 {
+		generatedMap, err = checkGeneratedFiles(ctx, repoRoot, allPaths)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
+	var branchName string
+	branchCmd := exec.CommandContext(ctx, "git", "branch", "--show-current")
+	branchCmd.Dir = repoRoot
+	if branchOut, branchErr := branchCmd.Output(); branchErr == nil {
+		branchName = strings.TrimSpace(string(branchOut))
+	}
+	if branchName == "" {
+		refCmd := exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD")
+		refCmd.Dir = repoRoot
+		if refOut, refErr := refCmd.Output(); refErr == nil {
+			refStr := strings.TrimSpace(string(refOut))
+			if refStr != "HEAD" {
+				branchName = refStr
+			}
+		}
+	}
+
+	stat := &DiffStat{
+		MergeBase:  mergeBase,
+		BaseRef:    cfg.BaseRef,
+		BranchName: branchName,
+	}
+
+	for _, entry := range rawEntries {
+		filePath := entry.filePath
+
+		// Check gitattributes linguist-generated ignore
+		if cfg.IgnoreGenerated && generatedMap[filePath] {
+			stat.IgnoredFiles = append(stat.IgnoredFiles, filePath)
+			continue
+		}
+
+		// Check lockfile ignore
+		if cfg.IgnoreLockfiles && isLockfile(filePath) {
+			stat.IgnoredFiles = append(stat.IgnoredFiles, filePath)
+			continue
+		}
+
+		// Check custom ignore globs
+		matchedGlob := false
+		for _, glob := range cfg.IgnoreGlobs {
+			if matched, _ := filepath.Match(glob, filePath); matched {
+				matchedGlob = true
+				break
+			}
+		}
+		if matchedGlob {
+			stat.IgnoredFiles = append(stat.IgnoredFiles, filePath)
+			continue
+		}
+
+		fileStat := FileStat{Path: filePath}
+		if entry.addStr == "-" && entry.delStr == "-" {
+			fileStat.IsBinary = true
+		} else {
+			fileStat.Additions, _ = strconv.Atoi(entry.addStr)
+			fileStat.Deletions, _ = strconv.Atoi(entry.delStr)
+		}
+
+		stat.Files = append(stat.Files, fileStat)
+		stat.FilesChanged++
+		stat.Additions += fileStat.Additions
+		stat.Deletions += fileStat.Deletions
+	}
+
+	diffStrategy := cfg.Strategy
+	if diffStrategy == "" {
+		diffStrategy = StrategyPerFileMax
+	}
+	stat.EffectiveLines = CalculateEffectiveLines(stat.Files, diffStrategy)
+	classification := Classify(stat.EffectiveLines, cfg)
+
+	return stat, classification, nil
+}
+
+func isEnvTruthy(val string) bool {
+	val = strings.TrimSpace(strings.ToLower(val))
+	return val == "1" || val == "true" || val == "t" || val == "yes" || val == "y"
+}
+
+// FormatReport generates the human-readable diff size summary and guidance.
+func FormatReport(stat *DiffStat, class Classification, cfg Config) string {
+	u := cfg.UI
+	if u == nil {
+		w := cfg.Stdout
+		if w == nil {
+			w = io.Discard
+		}
+		u = ui.New(w)
+	}
+
+	var sb strings.Builder
+
+	mediumLimit := cfg.MediumLimit
+	if mediumLimit <= 0 {
+		mediumLimit = DefaultMediumLimit
+	}
+
+	diffStrategy := cfg.Strategy
+	if diffStrategy == "" {
+		diffStrategy = StrategyPerFileMax
+	}
+
+	formattedDiff := u.FormatDiff(stat.EffectiveLines, stat.Additions, stat.Deletions, stat.FilesChanged, string(diffStrategy))
+
+	if class != SizeLarge {
+		var classBadge string
+		switch class {
+		case SizeSmall:
+			classBadge = u.BadgeInfo(string(class))
+		case SizeMedium:
+			classBadge = u.BadgeWarning(string(class))
+		default:
+			classBadge = u.BadgeInfo(string(class))
+		}
+
+		okBadge := u.BadgeSuccess("OK")
+		fmt.Fprintf(&sb, "PR Diff Size: %s -> Classification: %s %s\n", formattedDiff, classBadge, okBadge)
+		if len(stat.IgnoredFiles) > 0 {
+			fmt.Fprintf(&sb, "  %s\n", u.Dim(fmt.Sprintf("(Excluded %d lock/ignored files)", len(stat.IgnoredFiles))))
+		}
+		return sb.String()
+	}
+
+	// Large diff report & prompt (Variation 1A with Pill Badge)
+	title := fmt.Sprintf("%s %s",
+		u.BadgeDangerPill("LARGE PR"),
+		u.Danger(fmt.Sprintf("(%d lines > %d limit)", stat.EffectiveLines, mediumLimit)),
+	)
+
+	diffLine := fmt.Sprintf("%s      %s / %s in %d files (%s)",
+		u.Bold("Diff:"),
+		u.Additions(stat.Additions),
+		u.Deletions(stat.Deletions),
+		stat.FilesChanged,
+		diffStrategy,
+	)
+	if len(stat.IgnoredFiles) > 0 {
+		diffLine += " • " + u.Dim(fmt.Sprintf("Excluded: %d lock/ignored files", len(stat.IgnoredFiles)))
+	}
+
+	bypassLine := fmt.Sprintf("%s    %s", u.Bold("Bypass:"), u.Dim("ALLOW_LARGE_PR=true git push"))
+	branch := stat.BranchName
+	if branch == "" || branch == "HEAD" {
+		branch = "this"
+	}
+	promptLine := fmt.Sprintf("%s %s", u.Bold("AI Prompt:"), fmt.Sprintf("Execute the skill @tools/githooks/skills/split-pr/SKILL.md to break %s branch up.", branch))
+
+	sb.WriteString(u.CompactWarningCard(title, []string{diffLine, bypassLine, promptLine}))
+	sb.WriteString("\n")
+
+	return sb.String()
+}
+
+// Run performs PR size analysis and reports results according to config.
+func Run(ctx context.Context, cfg Config) error {
+	if cfg.Stdout == nil {
+		cfg.Stdout = io.Discard
+	}
+	if cfg.Stderr == nil {
+		cfg.Stderr = io.Discard
+	}
+
+	stat, class, err := Analyze(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	report := FormatReport(stat, class, cfg)
+	if class == SizeLarge {
+		bypassed := cfg.AllowLargePR || isEnvTruthy(os.Getenv(EnvAllowLargePR))
+		if cfg.FailOnLarge && !bypassed {
+			fmt.Fprint(cfg.Stderr, report)
+			return fmt.Errorf("PR size check failed: %w (%d effective lines > %d limit)", ErrLargePR, stat.EffectiveLines, cfg.MediumLimit)
+		}
+		fmt.Fprint(cfg.Stdout, report)
+		return nil
+	}
+
+	fmt.Fprint(cfg.Stdout, report)
+	return nil
+}

--- a/tools/githooks/internal/prsize/prsize_bench_test.go
+++ b/tools/githooks/internal/prsize/prsize_bench_test.go
@@ -1,0 +1,55 @@
+package prsize_test
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink/v2/tools/githooks/internal/prsize"
+)
+
+func BenchmarkCalculateEffectiveLines(b *testing.B) {
+	files := make([]prsize.FileStat, 100)
+	for i := range files {
+		files[i] = prsize.FileStat{
+			Path:      "core/services/feature/file.go",
+			Additions: i * 2,
+			Deletions: i,
+		}
+	}
+
+	strategies := []prsize.Strategy{
+		prsize.StrategyPerFileMax,
+		prsize.StrategySum,
+		prsize.StrategyMax,
+		prsize.StrategyWeighted,
+	}
+
+	for _, strategy := range strategies {
+		b.Run(string(strategy), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = prsize.CalculateEffectiveLines(files, strategy)
+			}
+		})
+	}
+}
+
+func BenchmarkFormatReport(b *testing.B) {
+	stat := &prsize.DiffStat{
+		FilesChanged:   25,
+		Additions:      650,
+		Deletions:      120,
+		EffectiveLines: 700,
+		MergeBase:      "0123456789abcdef",
+		IgnoredFiles:   []string{"go.sum", "package-lock.json"},
+	}
+	cfg := prsize.Config{
+		SmallLimit:  200,
+		MediumLimit: 500,
+		Strategy:    prsize.StrategyPerFileMax,
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = prsize.FormatReport(stat, prsize.SizeLarge, cfg)
+	}
+}

--- a/tools/githooks/internal/prsize/prsize_test.go
+++ b/tools/githooks/internal/prsize/prsize_test.go
@@ -1,0 +1,436 @@
+package prsize_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/tools/githooks/internal/prsize"
+)
+
+// git runs a git command in dir and fails the test on error.
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	base := make([]string, 0, 6+len(args))
+	base = append(base, "-c", "commit.gpgsign=false", "-c", "user.email=test@example.com", "-c", "user.name=test")
+	cmd := exec.CommandContext(t.Context(), "git", append(base, args...)...) //nolint:gosec // test helper
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %s: %s", strings.Join(args, " "), out)
+	return strings.TrimSpace(string(out))
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o700))
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+}
+
+func generateLines(n int, prefix string) string {
+	var sb strings.Builder
+	for i := 1; i <= n; i++ {
+		sb.WriteString(prefix)
+		sb.WriteString(" line\n")
+	}
+	return sb.String()
+}
+
+func TestDiffCalculationStrategies(t *testing.T) {
+	t.Parallel()
+
+	files := []prsize.FileStat{
+		{Path: "core/services/app.go", Additions: 100, Deletions: 80},
+		{Path: "core/logger/logger.go", Additions: 50, Deletions: 10},
+		{Path: "README.md", Additions: 20, Deletions: 0},
+	}
+
+	tests := []struct {
+		strategy prsize.Strategy
+		expected int
+	}{
+		{
+			strategy: prsize.StrategyPerFileMax,
+			// max(100, 80) + max(50, 10) + max(20, 0) = 100 + 50 + 20 = 170
+			expected: 170,
+		},
+		{
+			strategy: prsize.StrategySum,
+			// (100 + 80) + (50 + 10) + (20 + 0) = 180 + 60 + 20 = 260
+			expected: 260,
+		},
+		{
+			strategy: prsize.StrategyMax,
+			// total adds: 170, total dels: 90 -> max(170, 90) = 170
+			expected: 170,
+		},
+		{
+			strategy: prsize.StrategyWeighted,
+			// total adds: 170 + 0.5 * 90 = 215
+			expected: 215,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.strategy), func(t *testing.T) {
+			t.Parallel()
+			got := prsize.CalculateEffectiveLines(files, tc.strategy)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestClassify(t *testing.T) {
+	t.Parallel()
+
+	cfg := prsize.Config{
+		SmallLimit:  200,
+		MediumLimit: 500,
+	}
+
+	tests := []struct {
+		lines    int
+		expected prsize.Classification
+	}{
+		{lines: 0, expected: prsize.SizeSmall},
+		{lines: 50, expected: prsize.SizeSmall},
+		{lines: 200, expected: prsize.SizeSmall},
+		{lines: 201, expected: prsize.SizeMedium},
+		{lines: 450, expected: prsize.SizeMedium},
+		{lines: 500, expected: prsize.SizeMedium},
+		{lines: 501, expected: prsize.SizeLarge},
+		{lines: 1200, expected: prsize.SizeLarge},
+	}
+
+	for _, tc := range tests {
+		got := prsize.Classify(tc.lines, cfg)
+		assert.Equal(t, tc.expected, got, "lines=%d", tc.lines)
+	}
+}
+
+func TestAnalyze_GitRepo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("classifies small diff correctly", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		git(t, dir, "init")
+		writeFile(t, dir, "base.go", generateLines(10, "base"))
+		git(t, dir, "add", ".")
+		git(t, dir, "commit", "-m", "initial commit")
+		baseSHA := git(t, dir, "rev-parse", "HEAD")
+
+		git(t, dir, "update-ref", "refs/remotes/origin/develop", baseSHA)
+		git(t, dir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/develop")
+
+		writeFile(t, dir, "feature.go", generateLines(50, "feature"))
+		git(t, dir, "add", ".")
+		git(t, dir, "commit", "-m", "small feature")
+
+		cfg := prsize.Config{
+			RepoRoot:        dir,
+			Strategy:        prsize.StrategyPerFileMax,
+			SmallLimit:      200,
+			MediumLimit:     500,
+			IgnoreLockfiles: true,
+		}
+
+		stat, class, err := prsize.Analyze(t.Context(), cfg)
+		require.NoError(t, err)
+		assert.Equal(t, prsize.SizeSmall, class)
+		assert.Equal(t, 50, stat.EffectiveLines)
+		assert.Equal(t, 50, stat.Additions)
+		assert.Equal(t, 0, stat.Deletions)
+		assert.Equal(t, 1, stat.FilesChanged)
+	})
+
+	t.Run("classifies medium diff correctly", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		git(t, dir, "init")
+		writeFile(t, dir, "base.go", generateLines(10, "base"))
+		git(t, dir, "add", ".")
+		git(t, dir, "commit", "-m", "initial commit")
+		baseSHA := git(t, dir, "rev-parse", "HEAD")
+
+		git(t, dir, "update-ref", "refs/remotes/origin/develop", baseSHA)
+		git(t, dir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/develop")
+
+		writeFile(t, dir, "feature.go", generateLines(350, "feature"))
+		git(t, dir, "add", ".")
+		git(t, dir, "commit", "-m", "medium feature")
+
+		cfg := prsize.Config{
+			RepoRoot:        dir,
+			Strategy:        prsize.StrategyPerFileMax,
+			SmallLimit:      200,
+			MediumLimit:     500,
+			IgnoreLockfiles: true,
+		}
+
+		stat, class, err := prsize.Analyze(t.Context(), cfg)
+		require.NoError(t, err)
+		assert.Equal(t, prsize.SizeMedium, class)
+		assert.Equal(t, 350, stat.EffectiveLines)
+		assert.Equal(t, 1, stat.FilesChanged)
+	})
+
+	t.Run("classifies large diff correctly and respects lockfile ignore", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		git(t, dir, "init")
+		writeFile(t, dir, "base.go", generateLines(10, "base"))
+		git(t, dir, "add", ".")
+		git(t, dir, "commit", "-m", "initial commit")
+		baseSHA := git(t, dir, "rev-parse", "HEAD")
+
+		git(t, dir, "update-ref", "refs/remotes/origin/develop", baseSHA)
+		git(t, dir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/develop")
+
+		// Add 100 lines of code and 1000 lines of go.sum lockfile
+		writeFile(t, dir, "feature.go", generateLines(100, "feature"))
+		writeFile(t, dir, "go.sum", generateLines(1000, "checksum"))
+		git(t, dir, "add", ".")
+		git(t, dir, "commit", "-m", "add feature and deps")
+
+		cfgWithIgnore := prsize.Config{
+			RepoRoot:        dir,
+			Strategy:        prsize.StrategyPerFileMax,
+			SmallLimit:      200,
+			MediumLimit:     500,
+			IgnoreLockfiles: true,
+		}
+
+		stat, class, err := prsize.Analyze(t.Context(), cfgWithIgnore)
+		require.NoError(t, err)
+		assert.Equal(t, prsize.SizeSmall, class)
+		assert.Equal(t, 100, stat.EffectiveLines)
+		assert.Len(t, stat.IgnoredFiles, 1)
+
+		cfgWithoutIgnore := prsize.Config{
+			RepoRoot:        dir,
+			Strategy:        prsize.StrategyPerFileMax,
+			SmallLimit:      200,
+			MediumLimit:     500,
+			IgnoreLockfiles: false,
+		}
+
+		stat2, class2, err2 := prsize.Analyze(t.Context(), cfgWithoutIgnore)
+		require.NoError(t, err2)
+		assert.Equal(t, prsize.SizeLarge, class2)
+		assert.Equal(t, 1100, stat2.EffectiveLines)
+		assert.Empty(t, stat2.IgnoredFiles)
+	})
+
+	t.Run("ignores generated changes defined in .gitattributes", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		git(t, dir, "init")
+		writeFile(t, dir, ".gitattributes", "*.generated.go linguist-generated=true\ngen/** linguist-generated\n")
+		writeFile(t, dir, "base.go", generateLines(10, "base"))
+		git(t, dir, "add", ".")
+		git(t, dir, "commit", "-m", "initial commit")
+		baseSHA := git(t, dir, "rev-parse", "HEAD")
+
+		git(t, dir, "update-ref", "refs/remotes/origin/develop", baseSHA)
+		git(t, dir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/develop")
+
+		writeFile(t, dir, "regular.go", generateLines(50, "regular"))
+		writeFile(t, dir, "service.generated.go", generateLines(800, "generated"))
+		writeFile(t, dir, "gen/docs.txt", generateLines(400, "docs"))
+		git(t, dir, "add", ".")
+		git(t, dir, "commit", "-m", "feature and generated code")
+
+		cfgWithGeneratedIgnore := prsize.Config{
+			RepoRoot:        dir,
+			Strategy:        prsize.StrategyPerFileMax,
+			SmallLimit:      200,
+			MediumLimit:     500,
+			IgnoreGenerated: true,
+		}
+
+		stat, class, err := prsize.Analyze(t.Context(), cfgWithGeneratedIgnore)
+		require.NoError(t, err)
+		assert.Equal(t, prsize.SizeSmall, class)
+		assert.Equal(t, 50, stat.EffectiveLines)
+		assert.ElementsMatch(t, []string{"gen/docs.txt", "service.generated.go"}, stat.IgnoredFiles)
+
+		cfgWithoutGeneratedIgnore := prsize.Config{
+			RepoRoot:        dir,
+			Strategy:        prsize.StrategyPerFileMax,
+			SmallLimit:      200,
+			MediumLimit:     500,
+			IgnoreGenerated: false,
+		}
+
+		stat2, class2, err2 := prsize.Analyze(t.Context(), cfgWithoutGeneratedIgnore)
+		require.NoError(t, err2)
+		assert.Equal(t, prsize.SizeLarge, class2)
+		assert.Equal(t, 1250, stat2.EffectiveLines)
+		assert.Empty(t, stat2.IgnoredFiles)
+	})
+}
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	git(t, dir, "init")
+	writeFile(t, dir, "base.go", generateLines(10, "base"))
+	git(t, dir, "add", ".")
+	git(t, dir, "commit", "-m", "initial commit")
+	baseSHA := git(t, dir, "rev-parse", "HEAD")
+
+	git(t, dir, "update-ref", "refs/remotes/origin/develop", baseSHA)
+	git(t, dir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/develop")
+
+	// Commit 600 lines -> Large
+	writeFile(t, dir, "huge.go", generateLines(600, "huge"))
+	git(t, dir, "add", ".")
+	git(t, dir, "commit", "-m", "large commit")
+
+	t.Run("warns on large diff when FailOnLarge is false", func(t *testing.T) {
+		t.Parallel()
+		var stdout, stderr bytes.Buffer
+		cfg := prsize.Config{
+			RepoRoot:        dir,
+			Strategy:        prsize.StrategyPerFileMax,
+			SmallLimit:      200,
+			MediumLimit:     500,
+			FailOnLarge:     false,
+			IgnoreLockfiles: true,
+			Stdout:          &stdout,
+			Stderr:          &stderr,
+		}
+
+		err := prsize.Run(t.Context(), cfg)
+		require.NoError(t, err)
+
+		out := stdout.String() + stderr.String()
+		assert.Contains(t, out, "LARGE PR")
+		assert.Contains(t, out, "Execute the skill @tools/githooks/skills/split-pr/SKILL.md to break")
+	})
+
+	t.Run("fails on large diff when FailOnLarge is true", func(t *testing.T) {
+		t.Parallel()
+		var stdout, stderr bytes.Buffer
+		cfg := prsize.Config{
+			RepoRoot:        dir,
+			Strategy:        prsize.StrategyPerFileMax,
+			SmallLimit:      200,
+			MediumLimit:     500,
+			FailOnLarge:     true,
+			IgnoreLockfiles: true,
+			Stdout:          &stdout,
+			Stderr:          &stderr,
+		}
+
+		err := prsize.Run(t.Context(), cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "PR size check failed")
+
+		out := stdout.String() + stderr.String()
+		assert.Contains(t, out, "LARGE PR")
+		assert.Contains(t, out, "Execute the skill @tools/githooks/skills/split-pr/SKILL.md to break")
+		assert.Contains(t, out, "ALLOW_LARGE_PR=true")
+	})
+}
+
+func TestRun_AllowLargePR(t *testing.T) {
+	dir := t.TempDir()
+	git(t, dir, "init")
+	writeFile(t, dir, "base.go", generateLines(10, "base"))
+	git(t, dir, "add", ".")
+	git(t, dir, "commit", "-m", "initial commit")
+	baseSHA := git(t, dir, "rev-parse", "HEAD")
+
+	git(t, dir, "update-ref", "refs/remotes/origin/develop", baseSHA)
+	git(t, dir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/develop")
+
+	writeFile(t, dir, "huge.go", generateLines(600, "huge"))
+	git(t, dir, "add", ".")
+	git(t, dir, "commit", "-m", "large commit")
+
+	t.Run("bypasses failure with ALLOW_LARGE_PR=true env var", func(t *testing.T) {
+		t.Setenv("ALLOW_LARGE_PR", "true")
+		var stdout, stderr bytes.Buffer
+		cfg := prsize.Config{
+			RepoRoot:        dir,
+			Strategy:        prsize.StrategyPerFileMax,
+			SmallLimit:      200,
+			MediumLimit:     500,
+			FailOnLarge:     true,
+			IgnoreLockfiles: true,
+			Stdout:          &stdout,
+			Stderr:          &stderr,
+		}
+
+		err := prsize.Run(t.Context(), cfg)
+		require.NoError(t, err)
+
+		out := stdout.String() + stderr.String()
+		assert.Contains(t, out, "LARGE PR")
+	})
+
+	t.Run("bypasses failure with ALLOW_LARGE_PR=1 env var", func(t *testing.T) {
+		t.Setenv("ALLOW_LARGE_PR", "1")
+		var stdout, stderr bytes.Buffer
+		cfg := prsize.Config{
+			RepoRoot:        dir,
+			Strategy:        prsize.StrategyPerFileMax,
+			SmallLimit:      200,
+			MediumLimit:     500,
+			FailOnLarge:     true,
+			IgnoreLockfiles: true,
+			Stdout:          &stdout,
+			Stderr:          &stderr,
+		}
+
+		err := prsize.Run(t.Context(), cfg)
+		require.NoError(t, err)
+	})
+
+	t.Run("bypasses failure with Config.AllowLargePR = true", func(t *testing.T) {
+		t.Setenv("ALLOW_LARGE_PR", "")
+		var stdout, stderr bytes.Buffer
+		cfg := prsize.Config{
+			RepoRoot:        dir,
+			Strategy:        prsize.StrategyPerFileMax,
+			SmallLimit:      200,
+			MediumLimit:     500,
+			FailOnLarge:     true,
+			AllowLargePR:    true,
+			IgnoreLockfiles: true,
+			Stdout:          &stdout,
+			Stderr:          &stderr,
+		}
+
+		err := prsize.Run(t.Context(), cfg)
+		require.NoError(t, err)
+	})
+
+	t.Run("fails when ALLOW_LARGE_PR=false", func(t *testing.T) {
+		t.Setenv("ALLOW_LARGE_PR", "false")
+		var stdout, stderr bytes.Buffer
+		cfg := prsize.Config{
+			RepoRoot:        dir,
+			Strategy:        prsize.StrategyPerFileMax,
+			SmallLimit:      200,
+			MediumLimit:     500,
+			FailOnLarge:     true,
+			IgnoreLockfiles: true,
+			Stdout:          &stdout,
+			Stderr:          &stderr,
+		}
+
+		err := prsize.Run(t.Context(), cfg)
+		require.Error(t, err)
+	})
+}

--- a/tools/githooks/skills/split-pr/SKILL.md
+++ b/tools/githooks/skills/split-pr/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: split-pr
+description: Break large git branches into small, reviewable pull requests.
+---
+
+# Split PR & Stacked PRs
+
+Use when branch is **LARGE** (>500 lines), touches multiple modules, or mixes refactoring with feature code.
+
+## 0. Rules
+
+- Commits must be signed with a touch-only GPG key. You must ask the user to make the commit, or prompt the user to tap their key.
+- Generated code doesn't count towards layer size; generated code must be fully up to date.
+- If `gh` or `gh stack` is unavailable, STOP! Prompt the user to install them before continuing.
+- **Lock Prevention**: Set `git config core.filesRefLockTimeout 5000` to avoid transient index lock failures from IDE file watchers.
+- **Worktree Isolation**: ALWAYS perform branch splitting inside an isolated worktree (`.worktrees/split-<ticket>`) so the main repository's `.git/index.lock` and IDE file watchers are never disturbed.
+
+## 1. Splitting Heuristics
+
+Order layers bottom (trunk-adjacent) to top:
+- **Layered Architecture**: Interfaces/types/schemas (bottom) -> Core service logic -> APIs/CLI/routes (top).
+- **Module / Package**: Slice by Go module (`deployment/`, `core/`, `tools/`).
+- **Refactor vs Feature**: Pure non-breaking refactor first -> new behavior on top.
+
+```text
+develop (trunk) <- layer-1-types <- layer-2-logic <- layer-3-cli (top)
+```
+
+## 2. Break Existing Branch into Stacked Layers
+
+### Option A: Isolated Worktree Flow (Recommended)
+Prevents `.git/index.lock` collisions and IDE buffer thrashing.
+
+```bash
+# 1. Ensure lock timeout is configured
+git config core.filesRefLockTimeout 5000
+
+# 2. Backup current branch
+git branch backup-<ticket>-feature
+
+# 3. Create and enter dedicated staging worktree
+git worktree add .worktrees/split-<ticket> origin/develop
+cd .worktrees/split-<ticket>
+
+# 4. Layer 1 (Bottom): Types/Interfaces / Foundation
+git checkout -b <ticket>/1-types origin/develop
+git checkout backup-<ticket>-feature -- path/to/types/ path/to/schemas/
+# Verify layer compiles & passes tests
+go test ./...
+git commit -m "feat(types): foundational interfaces"
+
+# 5. Layer 2: Core Logic
+git checkout -b <ticket>/2-logic <ticket>/1-types
+git checkout backup-<ticket>-feature -- path/to/services/
+go test ./...
+git commit -m "feat(services): implement core logic"
+
+# 6. Layer 3 (Top): APIs / CLI / Config
+git checkout -b <ticket>/3-cli <ticket>/2-logic
+git checkout backup-<ticket>-feature -- path/to/cli/
+go test ./...
+git commit -m "feat(cli): endpoints and wiring"
+
+# 7. Clean up worktree and return to main workspace
+cd -
+git worktree remove --force .worktrees/split-<ticket>
+```
+
+### Option B: Cherry-Pick Commits (Clean Commit History)
+Can also be executed inside an isolated worktree:
+```bash
+git worktree add .worktrees/split-<ticket> origin/develop && cd .worktrees/split-<ticket>
+git checkout -b <ticket>/1-types origin/develop && git cherry-pick <sha1> <sha2>
+git checkout -b <ticket>/2-logic <ticket>/1-types && git cherry-pick <sha3>
+git checkout -b <ticket>/3-cli <ticket>/2-logic && git cherry-pick <sha4>
+cd - && git worktree remove --force .worktrees/split-<ticket>
+```
+
+## 3. PR Description Format
+
+For each layer in the stack, generate a structured PR description using this format:
+
+```md
+## Intent
+
+Short summary of what the intent of changes are. How things ultimately affect the user.
+
+## Changes
+
+Bullet list of changes. Short description of what, longer explanation of why.
+```
+
+Apply descriptions after submission:
+```bash
+gh pr edit <ticket>/1-types --body "$LAYER_1_BODY"
+gh pr edit <ticket>/2-logic --body "$LAYER_2_BODY"
+gh pr edit <ticket>/3-cli --body "$LAYER_3_BODY"
+```
+
+## 4. Submit & Manage Stack with `gh stack`
+
+Always use non-interactive flags to prevent agent hangs (`--open` marks PRs ready for review):
+
+```bash
+# Initialize stack from existing branches (bottom to top)
+gh stack init <ticket>/1-types <ticket>/2-logic <ticket>/3-cli
+
+# Submit/update PRs non-interactively and publish as ready for review
+gh stack submit --auto --open
+
+# View stack state (JSON prevents TUI freeze)
+gh stack view --json
+
+# Navigate stack (never use interactive `gh stack switch`)
+gh stack bottom
+gh stack up
+gh stack down
+gh stack top
+
+# Edit lower layer & propagate changes upstack
+gh stack checkout <ticket>/1-types
+# ...make edits...
+git commit --amend --no-edit
+gh stack rebase --upstack
+gh stack submit --auto --open
+```
+
+## 5. Verification Checklist
+
+Before PR submission:
+- [ ] Generated code up to date: `make rm-mocked & make generate`
+- [ ] Each layer compiles and passes lints independently: `tools/githooks lint`
+- [ ] Unit tests pass per layer: `tools/githooks test`
+- [ ] Layer size is **SMALL** or **MEDIUM**: `tools/githooks pr-size`
+- [ ] Check that all commits are signed with a GPG key: `git log --show-signature`. If not, prompt the user to sign them.
+- [ ] PR descriptions drafted with `## Intent` and `## Changes` for each layer.
+


### PR DESCRIPTION
## Intent

Provide the core engine for analyzing Git diff sizes, identifying oversized branches before pushing, and guiding developers on breaking large PRs into reviewable stacked layers.

<img width="920" height="153" alt="image" src="https://github.com/user-attachments/assets/b89471fc-2ad2-4045-8407-d42bb2da3cfc" />

I used this PR as a dogfood example for the skill!

## Changes

- **Add `internal/prsize` package**: Calculates effective line diffs (additions/deletions) between HEAD and the default trunk branch using multiple configurable strategies (defaulting to `per-file-max`).
- **Ignore lockfiles and generated files**: Excludes machine-generated files and lockfiles (`go.sum`, `yarn.lock`, etc.) so diff counts reflect human-authored logic.
- **Add `split-pr` skill**: Standardizes the stacked PR workflow using isolated Git worktrees (`.worktrees/`) to prevent index lock contention and IDE workspace thrashing.
- **Add benchmark and comprehensive unit test suite**: Covers git parsing, ignore heuristics, size thresholds, and edge cases (164 tests).