### PR TITLE
Added storage bytes metering reports

### DIFF
--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -844,7 +844,11 @@ type WorkflowSpec struct {
 	RegisteredAt  int64              `toml:"-" db:"registered_at"`
 	// Source records which workflow metadata source produced this spec (e.g.
 	// "ContractWorkflowSource").
-	Source      string `toml:"-" db:"source"`
+	Source string `toml:"-" db:"source"`
+	// StorageBytes is the workflow + config size in bytes. Set at registration
+	// and not cleared by pausing the workflow
+	StorageBytes int64 `toml:"-" db:"storage_bytes"`
+
 	sdkWorkflow *sdk.WorkflowSpec
 	rawSpec     []byte
 	config      []byte

--- a/core/services/workflows/artifacts/v2/orm.go
+++ b/core/services/workflows/artifacts/v2/orm.go
@@ -22,22 +22,27 @@ type WorkflowSpecsDS interface {
 	GetWorkflowSpec(ctx context.Context, id string) (*job.WorkflowSpec, error)
 
 	// ListWorkflowSpecs returns the persisted workflow specs. It projects only
-	// identity columns (workflow_id, workflow_owner, registered_at);
-	// other fields are left zero to keep returned batch size small
+	// identity columns and storage_bytes (workflow_id, workflow_owner,
+	// registered_at, storage_bytes); other fields are left zero to keep
+	// returned batch size small
 	ListWorkflowSpecs(ctx context.Context) ([]*job.WorkflowSpec, error)
 
 	// DeleteWorkflowSpec deletes the spec row for id. Idempotent: a missing row
-	// returns (nil, nil), not an error. The deleted row is returned so the
-	// caller can derive the generation-scoped metering event_id from the row's
-	// own persisted registered_at (every node emits the identical id regardless
-	// of local staleness).
+	// returns (nil, nil), not an error. The deleted row (including
+	// storage_bytes) is returned so the caller can derive the
+	// generation-scoped metering event_id from the row's own persisted
+	// registered_at and release the row's durable storage bytes (every node
+	// emits the identical id regardless of local staleness).
 	DeleteWorkflowSpec(ctx context.Context, id string) (*job.WorkflowSpec, error)
 
 	// PauseWorkflowSpec tombstones the spec row: status becomes paused and the
 	// heavy artifact payload (hex binary + config) is cleared in the same
 	// statement, freeing storage while the row itself remains the durable record
 	// that this registration generation is still held (level-neutral for
-	// metering). Idempotent; pausing an absent or already-paused row is a no-op.
+	// metering). storage_bytes is intentionally NOT cleared: storage is billed
+	// for the registration lifetime, so the delete-time delta can still release
+	// the original byte count. Idempotent; pausing an absent or already-paused
+	// row is a no-op.
 	PauseWorkflowSpec(ctx context.Context, id string) error
 
 	// DeleteWorkflowSpecs deletes workflow specs for the given workflow IDs in a single query.
@@ -82,43 +87,46 @@ func (orm *orm) UpsertWorkflowSpec(ctx context.Context, spec *job.WorkflowSpec) 
 				created_at,
 				updated_at,
 				spec_type,
-				attributes,
-				registered_at,
-				source
-			) VALUES (
-				:workflow,
-				:config,
-				:workflow_id,
-				:workflow_owner,
-				:workflow_name,
-				:workflow_tag,
-				:status,
-				:binary_url,
-				:config_url,
-				:created_at,
-				:updated_at,
-				:spec_type,
-				:attributes,
-				:registered_at,
-				:source
-			) ON CONFLICT (workflow_id) DO UPDATE
-			SET
-				workflow = EXCLUDED.workflow,
-				config = EXCLUDED.config,
-				workflow_owner = EXCLUDED.workflow_owner,
-				workflow_name = EXCLUDED.workflow_name,
-				workflow_tag = EXCLUDED.workflow_tag,
-				status = EXCLUDED.status,
-				binary_url = EXCLUDED.binary_url,
-				config_url = EXCLUDED.config_url,
-				created_at = EXCLUDED.created_at,
-				updated_at = EXCLUDED.updated_at,
-				spec_type = EXCLUDED.spec_type,
-				attributes = EXCLUDED.attributes,
-				registered_at = EXCLUDED.registered_at,
-				source = EXCLUDED.source
-			RETURNING id
-		`
+			attributes,
+			registered_at,
+			source,
+			storage_bytes
+		) VALUES (
+			:workflow,
+			:config,
+			:workflow_id,
+			:workflow_owner,
+			:workflow_name,
+			:workflow_tag,
+			:status,
+			:binary_url,
+			:config_url,
+			:created_at,
+			:updated_at,
+			:spec_type,
+			:attributes,
+			:registered_at,
+			:source,
+			:storage_bytes
+		) ON CONFLICT (workflow_id) DO UPDATE
+		SET
+			workflow = EXCLUDED.workflow,
+			config = EXCLUDED.config,
+			workflow_owner = EXCLUDED.workflow_owner,
+			workflow_name = EXCLUDED.workflow_name,
+			workflow_tag = EXCLUDED.workflow_tag,
+			status = EXCLUDED.status,
+			binary_url = EXCLUDED.binary_url,
+			config_url = EXCLUDED.config_url,
+			created_at = EXCLUDED.created_at,
+			updated_at = EXCLUDED.updated_at,
+			spec_type = EXCLUDED.spec_type,
+			attributes = EXCLUDED.attributes,
+			registered_at = EXCLUDED.registered_at,
+			source = EXCLUDED.source,
+			storage_bytes = EXCLUDED.storage_bytes
+		RETURNING id
+	`
 
 		now := time.Now().UTC()
 		spec.UpdatedAt = now
@@ -154,10 +162,11 @@ func (orm *orm) GetWorkflowSpec(ctx context.Context, id string) (*job.WorkflowSp
 }
 
 // ListWorkflowSpecs returns all persisted workflow specs, projecting the
-// identity columns needed by the orphan sweep and the metering snapshot path.
+// identity columns plus storage_bytes needed by the orphan sweep and the
+// metering snapshot path.
 func (orm *orm) ListWorkflowSpecs(ctx context.Context) ([]*job.WorkflowSpec, error) {
 	query := `
-		SELECT workflow_id, workflow_owner, registered_at, source
+		SELECT workflow_id, workflow_owner, registered_at, source, storage_bytes
 		FROM workflow_specs_v2
 	`
 
@@ -173,7 +182,7 @@ func (orm *orm) DeleteWorkflowSpec(ctx context.Context, id string) (*job.Workflo
 	query := `DELETE FROM workflow_specs_v2 WHERE workflow_id = $1
 		RETURNING id, workflow, config, workflow_id, workflow_owner, workflow_name,
 			workflow_tag, status, binary_url, config_url, created_at, updated_at,
-			spec_type, attributes, registered_at, source`
+			spec_type, attributes, registered_at, source, storage_bytes`
 	var spec job.WorkflowSpec
 	err := orm.ds.GetContext(ctx, &spec, query, id)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/core/services/workflows/artifacts/v2/orm_test.go
+++ b/core/services/workflows/artifacts/v2/orm_test.go
@@ -34,6 +34,7 @@ func Test_UpsertWorkflowSpec(t *testing.T) {
 			ConfigURL:     "http://example.com/config",
 			CreatedAt:     time.Now(),
 			SpecType:      job.WASMFile,
+			StorageBytes:  12,
 		}
 
 		_, err := orm.UpsertWorkflowSpec(ctx, spec)
@@ -44,6 +45,7 @@ func Test_UpsertWorkflowSpec(t *testing.T) {
 		err = db.Get(&dbSpec, `SELECT * FROM workflow_specs_v2 WHERE workflow_owner = $1 AND workflow_name = $2 AND workflow_tag = $3`, spec.WorkflowOwner, spec.WorkflowName, spec.WorkflowTag)
 		require.NoError(t, err)
 		require.Equal(t, spec.Workflow, dbSpec.Workflow)
+		require.Equal(t, int64(12), dbSpec.StorageBytes, "storage_bytes must round-trip on insert")
 	})
 
 	t.Run("updates existing spec", func(t *testing.T) {
@@ -65,13 +67,15 @@ func Test_UpsertWorkflowSpec(t *testing.T) {
 			ConfigURL:     "http://example.com/config",
 			CreatedAt:     time.Now(),
 			SpecType:      job.WASMFile,
+			StorageBytes:  12,
 		}
 
 		_, err := orm.UpsertWorkflowSpec(ctx, spec)
 		require.NoError(t, err)
 
-		// Update the status
+		// Update the status and the storage footprint
 		spec.Status = job.WorkflowSpecStatusPaused
+		spec.StorageBytes = 24
 
 		_, err = orm.UpsertWorkflowSpec(ctx, spec)
 		require.NoError(t, err)
@@ -82,6 +86,7 @@ func Test_UpsertWorkflowSpec(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, spec.Config, dbSpec.Config)
 		require.Equal(t, spec.Status, dbSpec.Status)
+		require.Equal(t, int64(24), dbSpec.StorageBytes, "storage_bytes must round-trip on conflict-update")
 	})
 
 	t.Run("sets CreatedAt to current time if zero value is provided", func(t *testing.T) {
@@ -191,6 +196,7 @@ func Test_DeleteWorkflowSpec(t *testing.T) {
 			SpecType:      job.WASMFile,
 			RegisteredAt:  1717171717,
 			Source:        "ContractWorkflowSource",
+			StorageBytes:  12,
 		}
 
 		id, err := orm.UpsertWorkflowSpec(ctx, spec)
@@ -202,7 +208,8 @@ func Test_DeleteWorkflowSpec(t *testing.T) {
 		require.NotNil(t, deletedSpec)
 
 		// The RETURNING clause must scan the full row back: the caller derives
-		// the metering delete event_id from the row's persisted registered_at.
+		// the metering delete event_id from the row's persisted registered_at
+		// and releases the row's durable storage bytes.
 		assert.Equal(t, spec.WorkflowID, deletedSpec.WorkflowID)
 		assert.Equal(t, spec.WorkflowOwner, deletedSpec.WorkflowOwner)
 		assert.Equal(t, spec.WorkflowName, deletedSpec.WorkflowName)
@@ -215,6 +222,7 @@ func Test_DeleteWorkflowSpec(t *testing.T) {
 		assert.Equal(t, spec.SpecType, deletedSpec.SpecType)
 		assert.Equal(t, int64(1717171717), deletedSpec.RegisteredAt)
 		assert.Equal(t, "ContractWorkflowSource", deletedSpec.Source)
+		assert.Equal(t, int64(12), deletedSpec.StorageBytes)
 
 		// Verify the record is deleted from the database
 		var dbSpec job.WorkflowSpec
@@ -300,6 +308,7 @@ func Test_PauseWorkflowSpec(t *testing.T) {
 			CreatedAt:     time.Now(),
 			SpecType:      job.WASMFile,
 			RegisteredAt:  1717171717,
+			StorageBytes:  12,
 		})
 		require.NoError(t, err)
 
@@ -311,6 +320,7 @@ func Test_PauseWorkflowSpec(t *testing.T) {
 		assert.Empty(t, paused.Workflow, "artifact payload must be cleared")
 		assert.Empty(t, paused.Config, "config payload must be cleared")
 		assert.Equal(t, int64(1717171717), paused.RegisteredAt, "registration generation must survive the tombstone")
+		assert.Equal(t, int64(12), paused.StorageBytes, "storage_bytes must survive the tombstone so the delete-time metering delta releases the registered footprint")
 		assert.Equal(t, "owner-123", paused.WorkflowOwner)
 
 		// Idempotent: pausing again is a no-op.
@@ -338,10 +348,11 @@ func Test_ListWorkflowSpecs(t *testing.T) {
 		owner        string
 		registeredAt int64
 		source       string
+		storageBytes int64
 	}{
-		"wf-1": {"owner-1", 100, "ContractWorkflowSource"},
-		"wf-2": {"owner-2", 200, "GRPCWorkflowSource"},
-		"wf-3": {"owner-3", 0, ""}, // pre-migration row: registered_at and source defaulted
+		"wf-1": {"owner-1", 100, "ContractWorkflowSource", 12},
+		"wf-2": {"owner-2", 200, "GRPCWorkflowSource", 34},
+		"wf-3": {"owner-3", 0, "", 0}, // pre-migration row: registered_at, source and storage_bytes defaulted
 	}
 	for id, w := range want {
 		_, err := orm.UpsertWorkflowSpec(ctx, &job.WorkflowSpec{
@@ -355,6 +366,7 @@ func Test_ListWorkflowSpecs(t *testing.T) {
 			SpecType:      job.WASMFile,
 			RegisteredAt:  w.registeredAt,
 			Source:        w.source,
+			StorageBytes:  w.storageBytes,
 		})
 		require.NoError(t, err)
 	}
@@ -368,6 +380,7 @@ func Test_ListWorkflowSpecs(t *testing.T) {
 		assert.Equal(t, w.owner, spec.WorkflowOwner)
 		assert.Equal(t, w.registeredAt, spec.RegisteredAt)
 		assert.Equal(t, w.source, spec.Source)
+		assert.Equal(t, w.storageBytes, spec.StorageBytes, "the metering snapshot projection must include storage_bytes")
 		// The projection deliberately omits the heavy artifact columns.
 		assert.Empty(t, spec.Workflow)
 		assert.Empty(t, spec.Config)

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -623,7 +623,7 @@ func (h *eventHandler) workflowRegisteredEvent(
 			return innerErr
 		}
 
-		h.specMeter.EmitSpecDelta(ctx, 1, payload.WorkflowID.Hex(), hex.EncodeToString(payload.WorkflowOwner),
+		h.specMeter.EmitSpecDelta(ctx, 1, newSpec.StorageBytes, payload.WorkflowID.Hex(), hex.EncodeToString(payload.WorkflowOwner),
 			resourcemanager.EventID("workflow-spec-register", payload.WorkflowID.Hex(), strconv.FormatUint(payload.CreatedAt, 10)))
 
 		spec = newSpec
@@ -638,7 +638,7 @@ func (h *eventHandler) workflowRegisteredEvent(
 		}
 		// A different spec's artifacts were persisted under this key: the newly
 		// stored spec is a fresh durable resource, so emit a +1 delta.
-		h.specMeter.EmitSpecDelta(ctx, 1, payload.WorkflowID.Hex(), hex.EncodeToString(payload.WorkflowOwner),
+		h.specMeter.EmitSpecDelta(ctx, 1, newSpec.StorageBytes, payload.WorkflowID.Hex(), hex.EncodeToString(payload.WorkflowOwner),
 			resourcemanager.EventID("workflow-spec-register", payload.WorkflowID.Hex(), strconv.FormatUint(payload.CreatedAt, 10)))
 
 		spec = newSpec
@@ -796,6 +796,7 @@ func (h *eventHandler) createWorkflowSpec(ctx context.Context, payload WorkflowR
 		Attributes:    payload.Attributes,
 		RegisteredAt:  int64(payload.CreatedAt), //nolint:gosec // G115: CreatedAt is a timestamp that cannot overflow int64
 		Source:        payload.Source,
+		StorageBytes:  int64(len(decodedBinary)) + int64(len(config)),
 	}
 
 	if _, err = h.workflowArtifactsStore.UpsertWorkflowSpec(ctx, entry); err != nil {
@@ -955,12 +956,13 @@ func (h *eventHandler) stopEngine(ctx context.Context, workflowID types.Workflow
 }
 
 // releaseSpecStorage deletes the persisted spec row and, iff a row was
-// actually removed, emits the -1 generation delta. RowsAffected is the
-// exactly-once gate: redeliveries observe no row and emit nothing; a transient
-// DELETE error returns before emission so the retry emits when the delete
-// lands. The event_id is derived AFTER the delete from the row's persisted
-// registered_at, so all nodes emit the identical id. Module-cache cleanup
-// always runs. owner may be empty; org resolution is fail-open.
+// actually removed, emits the -1 generation delta on both billing units
+// (workflow count and storage bytes). RowsAffected is the exactly-once gate: redeliveries
+// observe no row and emit nothing; a transient DELETE error returns before
+// emission so the retry emits when the delete lands. The event_id is derived
+// AFTER the delete from the row's persisted registered_at, so all nodes emit
+// the identical id. Module-cache cleanup always runs. owner may be empty; org
+// resolution is fail-open.
 func (h *eventHandler) releaseSpecStorage(ctx context.Context, workflowID, owner string) error {
 	deletedSpec, err := h.workflowArtifactsStore.DeleteWorkflowArtifacts(ctx, workflowID)
 	if err != nil {
@@ -971,7 +973,7 @@ func (h *eventHandler) releaseSpecStorage(ctx context.Context, workflowID, owner
 		if deletedSpec.RegisteredAt > 0 {
 			parts = append(parts, strconv.FormatInt(deletedSpec.RegisteredAt, 10))
 		}
-		h.specMeter.EmitSpecDelta(ctx, -1, workflowID, owner, resourcemanager.EventID("workflow-spec-delete", parts...))
+		h.specMeter.EmitSpecDelta(ctx, -1, deletedSpec.StorageBytes, workflowID, owner, resourcemanager.EventID("workflow-spec-delete", parts...))
 	}
 	h.cleanupModuleCache(workflowID)
 	return nil
@@ -982,11 +984,14 @@ func (h *eventHandler) releaseSpecStorage(ctx context.Context, workflowID, owner
 // Pause is level-neutral for metering: the spec row survives as a tombstone
 // (status=paused, artifact payload cleared to free storage) so the
 // registration generation stays metered until deletion — mirroring the
-// on-chain registry, which retains the paused registration. Emitting per-cycle
-// pause/activate deltas is impossible without drift: no DON-consistent
-// per-occurrence discriminator exists, so a -1 here would force the
-// re-activation +1 to reuse the register event_id and be dropped by consumer
-// dedup. Deltas therefore fire only at generation boundaries (register/delete).
+// on-chain registry, which retains the paused registration. This holds for
+// both billing units: the persisted storage_bytes is NOT cleared, so storage
+// is billed for the registration lifetime regardless of the freed payload.
+// Emitting per-cycle pause/activate deltas is impossible without drift: no
+// DON-consistent per-occurrence discriminator exists, so a -1 here would
+// force the re-activation +1 to reuse the register event_id and be dropped by
+// consumer dedup. Deltas therefore fire only at generation boundaries
+// (register/delete).
 func (h *eventHandler) workflowPausedEvent(
 	ctx context.Context,
 	payload WorkflowPausedEvent,

--- a/core/services/workflows/syncer/v2/handler_metering_test.go
+++ b/core/services/workflows/syncer/v2/handler_metering_test.go
@@ -158,12 +158,25 @@ func newMeteringTestHandler(t *testing.T, artifactsStore WorkflowArtifactsStore,
 	return h
 }
 
-// requireSpecDelta asserts that record is a workflow-syncer-v2 spec delta: a
-// METER_ACTION_UPDATE carrying a single utilization with the given signed value
-// and resource_id (= workflow_id). event_id must be the deterministic,
-// cross-node-identical id wantEventID (an opaque string that is never
-// format-validated).
+// requireSpecDelta asserts that record is a workflow-syncer-v2 spec delta on
+// the workflow-count billing unit: a METER_ACTION_UPDATE carrying a single
+// utilization with the given signed value and resource_id (= workflow_id).
+// event_id must be the deterministic, cross-node-identical id wantEventID (an
+// opaque string that is never format-validated).
 func requireSpecDelta(t *testing.T, record *meteringpb.MeterRecord, value, workflowID, wantEventID string) {
+	t.Helper()
+	requireSpecDeltaRecord(t, record, "operations", value, workflowID, wantEventID)
+}
+
+// requireSpecBytesDelta asserts that record is a workflow-syncer-v2 spec delta
+// on the storage billing unit: identical shape to requireSpecDelta except the
+// resource_type is "storage_bytes" and the value is a signed byte count.
+func requireSpecBytesDelta(t *testing.T, record *meteringpb.MeterRecord, value, workflowID, wantEventID string) {
+	t.Helper()
+	requireSpecDeltaRecord(t, record, "storage_bytes", value, workflowID, wantEventID)
+}
+
+func requireSpecDeltaRecord(t *testing.T, record *meteringpb.MeterRecord, resourceType, value, workflowID, wantEventID string) {
 	t.Helper()
 	require.NotNil(t, record.Identity)
 	assert.Equal(t, "workflow-syncer-v2", record.Identity.Service)
@@ -175,7 +188,7 @@ func requireSpecDelta(t *testing.T, record *meteringpb.MeterRecord, value, workf
 	require.Len(t, record.Utilizations, 1)
 	util := record.Utilizations[0]
 	assert.Equal(t, value, util.Value)
-	assert.Equal(t, "operations", util.ResourceType)
+	assert.Equal(t, resourceType, util.ResourceType)
 	// resource_id = workflow_id for the syncer (no shared physical resource).
 	assert.Equal(t, workflowID, util.ResourceId)
 	// event_id is the deterministic reconciliation-derived id, identical on every
@@ -183,12 +196,24 @@ func requireSpecDelta(t *testing.T, record *meteringpb.MeterRecord, value, workf
 	assert.Equal(t, wantEventID, util.EventId)
 }
 
+// meteringBytesEventID mirrors the production derivation of the storage-delta
+// event_id: the count-delta event_id hashed under the storage namespace, so
+// the two records of one transition never collide in the consumer dedup key
+// space while remaining deterministic and cross-node-identical.
+func meteringBytesEventID(countEventID string) string {
+	return resourcemanager.EventID("workflow-spec-storage-bytes", countEventID)
+}
+
+// meteringTestBytes is the durable storage footprint the stub artifacts store
+// reports: binary "binary" (6 bytes) + config "config" (6 bytes).
+const meteringTestBytes = int64(len("binary") + len("config"))
+
 func Test_meterRecords(t *testing.T) {
 	t.Parallel()
 
 	wfOwner := []byte{0xaa, 0xbb, 0xcc, 0xdd}
 
-	t.Run("registered event persisting a new spec emits +1", func(t *testing.T) {
+	t.Run("registered event persisting a new spec emits +1 and +storage bytes", func(t *testing.T) {
 		t.Parallel()
 		emitter := &recordingEmitter{}
 		h := newMeteringTestHandler(t, &stubWorkflowArtifactsStore{}, newMeteringResourceManager(t, true, emitter))
@@ -203,12 +228,13 @@ func Test_meterRecords(t *testing.T) {
 		require.NoError(t, err)
 
 		records := emitter.Records()
-		require.Len(t, records, 1)
-		requireSpecDelta(t, records[0], "1", wfID.Hex(),
-			resourcemanager.EventID("workflow-spec-register", wfID.Hex(), "0"))
+		require.Len(t, records, 2)
+		wantCountID := resourcemanager.EventID("workflow-spec-register", wfID.Hex(), "0")
+		requireSpecDelta(t, records[0], "1", wfID.Hex(), wantCountID)
+		requireSpecBytesDelta(t, records[1], "12", wfID.Hex(), meteringBytesEventID(wantCountID))
 	})
 
-	t.Run("reprocessed registered event emits the IDENTICAL event_id (cross-node dedup)", func(t *testing.T) {
+	t.Run("reprocessed registered event emits the IDENTICAL event_ids (cross-node dedup)", func(t *testing.T) {
 		t.Parallel()
 		emitter := &recordingEmitter{}
 		// The stub never returns a stored spec, so each call replays the
@@ -226,16 +252,26 @@ func Test_meterRecords(t *testing.T) {
 		require.NoError(t, h.workflowRegisteredEvent(t.Context(), event))
 		require.NoError(t, h.workflowRegisteredEvent(t.Context(), event))
 
+		// Each processing emits one count record + one storage record; the
+		// first pair is [count, bytes], the second [count, bytes].
 		records := emitter.Records()
-		require.Len(t, records, 2)
-		require.Len(t, records[0].Utilizations, 1)
-		require.Len(t, records[1].Utilizations, 1)
-		// The same reconciliation event MUST yield the identical event_id, so the
-		// billing consumer dedups reprocessing and cross-node duplicates. It is
-		// derived deterministically from the on-chain workflowID + CreatedAt.
+		require.Len(t, records, 4)
+		for _, r := range records {
+			require.Len(t, r.Utilizations, 1)
+		}
+		// The same reconciliation event MUST yield the identical event_id per
+		// billing unit, so the billing consumer dedups reprocessing and
+		// cross-node duplicates. Both are derived deterministically from the
+		// on-chain workflowID + CreatedAt.
 		want := resourcemanager.EventID("workflow-spec-register", types.WorkflowID{2}.Hex(), "123")
 		assert.Equal(t, want, records[0].Utilizations[0].GetEventId())
-		assert.Equal(t, records[0].Utilizations[0].GetEventId(), records[1].Utilizations[0].GetEventId())
+		assert.Equal(t, records[0].Utilizations[0].GetEventId(), records[2].Utilizations[0].GetEventId())
+		wantBytes := meteringBytesEventID(want)
+		assert.Equal(t, wantBytes, records[1].Utilizations[0].GetEventId())
+		assert.Equal(t, records[1].Utilizations[0].GetEventId(), records[3].Utilizations[0].GetEventId())
+		// The two billing units must never share an event_id, or consumer dedup
+		// would collapse the pair.
+		assert.NotEqual(t, records[0].Utilizations[0].GetEventId(), records[1].Utilizations[0].GetEventId())
 	})
 
 	t.Run("activating an already-stored spec emits nothing (status-only update)", func(t *testing.T) {
@@ -283,7 +319,7 @@ func Test_meterRecords(t *testing.T) {
 		assert.Empty(t, emitter.Records())
 	})
 
-	t.Run("deleted event emits -1 after artifacts are deleted", func(t *testing.T) {
+	t.Run("deleted event emits -1 and -storage bytes after artifacts are deleted", func(t *testing.T) {
 		t.Parallel()
 		wfID := types.WorkflowID{5}
 		emitter := &recordingEmitter{}
@@ -292,15 +328,17 @@ func Test_meterRecords(t *testing.T) {
 				WorkflowID:    wfID.Hex(),
 				Status:        job.WorkflowSpecStatusActive,
 				WorkflowOwner: "aabbccdd",
+				StorageBytes:  meteringTestBytes,
 			},
 		}, newMeteringResourceManager(t, true, emitter))
 
 		require.NoError(t, h.workflowDeletedEvent(t.Context(), WorkflowDeletedEvent{WorkflowID: wfID}, "aabbccdd"))
 
 		records := emitter.Records()
-		require.Len(t, records, 1)
-		requireSpecDelta(t, records[0], "-1", wfID.Hex(),
-			resourcemanager.EventID("workflow-spec-delete", wfID.Hex()))
+		require.Len(t, records, 2)
+		wantCountID := resourcemanager.EventID("workflow-spec-delete", wfID.Hex())
+		requireSpecDelta(t, records[0], "-1", wfID.Hex(), wantCountID)
+		requireSpecBytesDelta(t, records[1], "-12", wfID.Hex(), meteringBytesEventID(wantCountID))
 	})
 
 	t.Run("no record when persisting a new spec fails", func(t *testing.T) {
@@ -336,7 +374,7 @@ func Test_meterRecords(t *testing.T) {
 		assert.Empty(t, emitter.Records())
 	})
 
-	t.Run("no record while a delete is deferred by drain; exactly one on the successful retry", func(t *testing.T) {
+	t.Run("no record while a delete is deferred by drain; exactly one pair on the successful retry", func(t *testing.T) {
 		t.Parallel()
 		wfID := types.WorkflowID{8}
 		emitter := &recordingEmitter{}
@@ -345,6 +383,7 @@ func Test_meterRecords(t *testing.T) {
 				WorkflowID:    wfID.Hex(),
 				Status:        job.WorkflowSpecStatusActive,
 				WorkflowOwner: "aabbccdd",
+				StorageBytes:  meteringTestBytes,
 			},
 		}, newMeteringResourceManager(t, true, emitter))
 
@@ -360,9 +399,10 @@ func Test_meterRecords(t *testing.T) {
 		require.NoError(t, h.workflowDeletedEvent(t.Context(), WorkflowDeletedEvent{WorkflowID: wfID}, "aabbccdd"))
 
 		records := emitter.Records()
-		require.Len(t, records, 1)
-		requireSpecDelta(t, records[0], "-1", wfID.Hex(),
-			resourcemanager.EventID("workflow-spec-delete", wfID.Hex()))
+		require.Len(t, records, 2)
+		wantCountID := resourcemanager.EventID("workflow-spec-delete", wfID.Hex())
+		requireSpecDelta(t, records[0], "-1", wfID.Hex(), wantCountID)
+		requireSpecBytesDelta(t, records[1], "-12", wfID.Hex(), meteringBytesEventID(wantCountID))
 	})
 
 	t.Run("emit failure never fails event handling", func(t *testing.T) {
@@ -419,8 +459,8 @@ func Test_meterRecords(t *testing.T) {
 		wfID2 := types.WorkflowID{21}
 		store := &stubWorkflowArtifactsStore{
 			specs: []*job.WorkflowSpec{
-				{WorkflowID: wfID1.Hex(), WorkflowOwner: "aabbccdd"},
-				{WorkflowID: wfID2.Hex(), WorkflowOwner: "aabbccdd"},
+				{WorkflowID: wfID1.Hex(), WorkflowOwner: "aabbccdd", StorageBytes: 100},
+				{WorkflowID: wfID2.Hex(), WorkflowOwner: "aabbccdd", StorageBytes: 200},
 			},
 		}
 		h := newMeteringTestHandler(t, store, rm)
@@ -437,15 +477,23 @@ func Test_meterRecords(t *testing.T) {
 		snapshots := emitter.Snapshots()
 		require.Len(t, snapshots, 2)
 
+		// Each snapshot carries both billed dimensions of its spec: the
+		// workflow-count level (1) and the storage level (storage_bytes).
+		wantBytes := map[string]string{wfID1.Hex(): "100", wfID2.Hex(): "200"}
 		byWorkflowID := map[string]*meteringpb.MeterSnapshot{}
 		for _, snap := range snapshots {
 			require.NotNil(t, snap.Identity)
 			assert.Equal(t, "workflow-syncer-v2", snap.Identity.Service)
 			assert.Equal(t, "workflow_specs_v2", snap.Identity.ResourcePool)
-			require.Len(t, snap.Utilization, 1)
-			assert.Equal(t, "1", snap.Utilization[0].Value)
+			require.Len(t, snap.Utilization, 2)
+			countUtil, bytesUtil := snap.Utilization[0], snap.Utilization[1]
+			assert.Equal(t, "1", countUtil.Value)
+			assert.Equal(t, "operations", countUtil.ResourceType)
+			assert.Equal(t, "storage_bytes", bytesUtil.ResourceType)
+			assert.Equal(t, wantBytes[bytesUtil.ResourceId], bytesUtil.Value)
+			assert.Equal(t, countUtil.ResourceId, bytesUtil.ResourceId)
 			// resource_id = workflow_id fully identifies the resource; no labels.
-			byWorkflowID[snap.Utilization[0].ResourceId] = snap
+			byWorkflowID[countUtil.ResourceId] = snap
 		}
 		require.NotNil(t, byWorkflowID[wfID1.Hex()], "snapshot must contain an entry for the first persisted spec")
 		require.NotNil(t, byWorkflowID[wfID2.Hex()], "snapshot must contain an entry for the second persisted spec")
@@ -520,6 +568,7 @@ func redeliveredDeleteStore() *stubWorkflowArtifactsStore {
 			WorkflowID:    types.WorkflowID{5}.Hex(),
 			Status:        job.WorkflowSpecStatusActive,
 			WorkflowOwner: "aabbccdd",
+			StorageBytes:  meteringTestBytes,
 		},
 	}
 }
@@ -539,13 +588,15 @@ func Test_meterRecords_RedeliveredDeleteEmitsExactlyOneDelta(t *testing.T) {
 	require.NoError(t, h.Handle(t.Context(), deleteEvent)) // redelivery
 
 	records := emitter.Records()
-	require.Len(t, records, 1, "redelivered delete must not emit a second -1")
-	requireSpecDelta(t, records[0], "-1", wfID.Hex(),
-		resourcemanager.EventID("workflow-spec-delete", wfID.Hex()))
+	require.Len(t, records, 2, "redelivered delete must not emit a second -1 pair")
+	wantCountID := resourcemanager.EventID("workflow-spec-delete", wfID.Hex())
+	requireSpecDelta(t, records[0], "-1", wfID.Hex(), wantCountID)
+	requireSpecBytesDelta(t, records[1], "-12", wfID.Hex(), meteringBytesEventID(wantCountID))
 }
 
-// Pause and activate are level-neutral: neither emits a metering delta.
-// The +1 from register stays as the sole record through a pause→activate cycle.
+// Pause and activate are level-neutral: neither emits a metering delta on
+// either billing unit. The register pair (count + bytes) stays as the sole
+// records through a pause→activate cycle.
 func Test_meterRecords_PauseActivateCycleIsLevelNeutral(t *testing.T) {
 	t.Parallel()
 	emitter := &recordingEmitter{}
@@ -563,17 +614,19 @@ func Test_meterRecords_PauseActivateCycleIsLevelNeutral(t *testing.T) {
 	}
 
 	require.NoError(t, h.workflowRegisteredEvent(t.Context(), payload))
-	require.Len(t, emitter.Records(), 1)
+	require.Len(t, emitter.Records(), 2)
 	requireSpecDelta(t, emitter.Records()[0], "1", wfID.Hex(), wantEventID)
+	requireSpecBytesDelta(t, emitter.Records()[1], "12", wfID.Hex(), meteringBytesEventID(wantEventID))
 
 	require.NoError(t, h.workflowPausedEvent(t.Context(), WorkflowPausedEvent{WorkflowID: wfID}))
-	require.Len(t, emitter.Records(), 1, "pause must not emit a delta")
+	require.Len(t, emitter.Records(), 2, "pause must not emit a delta")
 
 	require.NoError(t, h.workflowActivatedEvent(t.Context(), WorkflowActivatedEvent(payload)))
-	require.Len(t, emitter.Records(), 1, "activate-after-pause must not emit a delta")
+	require.Len(t, emitter.Records(), 2, "activate-after-pause must not emit a delta")
 }
 
-// OrgId is resolved from the workflow owner and stamped on emitted records.
+// OrgId is resolved from the workflow owner and stamped on every emitted
+// record, on both billing units.
 func Test_meterRecords_OrgIdResolvedOnRecords(t *testing.T) {
 	t.Parallel()
 	emitter := &recordingEmitter{}
@@ -590,9 +643,11 @@ func Test_meterRecords_OrgIdResolvedOnRecords(t *testing.T) {
 	}))
 
 	records := emitter.Records()
-	require.Len(t, records, 1)
+	require.Len(t, records, 2)
 	require.Len(t, records[0].Utilizations, 1)
-	assert.Equal(t, "org-42", records[0].Utilizations[0].OrgId, "OrgId must be resolved and stamped on the record")
+	require.Len(t, records[1].Utilizations, 1)
+	assert.Equal(t, "org-42", records[0].Utilizations[0].OrgId, "OrgId must be resolved and stamped on the count record")
+	assert.Equal(t, "org-42", records[1].Utilizations[0].OrgId, "OrgId must be resolved and stamped on the storage record")
 }
 
 // don_id is folded into the metering identity once resolved and stamped on both
@@ -618,9 +673,10 @@ func Test_meterRecords_DonIDOnRecordAndSnapshot(t *testing.T) {
 		CreatedAt:     1,
 	}))
 	records := emitter.Records()
-	require.Len(t, records, 1)
+	require.Len(t, records, 2)
 	require.NotNil(t, records[0].Identity.GetDon())
 	assert.Equal(t, "7", records[0].Identity.GetDon().GetDonId(), "record identity must carry resolved don_id")
+	assert.Equal(t, "7", records[1].Identity.GetDon().GetDonId(), "storage record identity must carry resolved don_id")
 
 	entries := h.specMeter.GetUtilization(t.Context())
 	require.Len(t, entries, 1)
@@ -648,11 +704,13 @@ func Test_meterRecords_TransientDBErrorOnGetSpecEmitsNoDelta(t *testing.T) {
 	assert.Empty(t, emitter.Records(), "transient DB error must not take the new-spec path or emit a +1")
 }
 
-// A full register→pause→activate→delete cycle emits exactly two records:
-// one +1 at register and one -1 at delete. Pause and activate emit nothing.
-// The delete event_id carries the registered_at that flowed insert→RETURNING,
-// proving the generation-scoped id is DON-consistent.
-func Test_meterRecords_FullLifecycleEmitsExactlyTwoRecords(t *testing.T) {
+// A full register→pause→activate→delete cycle emits exactly four records:
+// a count+bytes +pair at register and a count+bytes -pair at delete. Pause and
+// activate emit nothing. The delete event_id carries the registered_at that
+// flowed insert→RETURNING, proving the generation-scoped id is DON-consistent.
+// The delete -bytes pair releases exactly the register +bytes value, so both
+// delta streams self-balance across the full lifecycle.
+func Test_meterRecords_FullLifecycleEmitsExactlyFourRecords(t *testing.T) {
 	t.Parallel()
 	emitter := &recordingEmitter{}
 	h := newMeteringTestHandler(t, &stubWorkflowArtifactsStore{persistUpserts: true}, newMeteringResourceManager(t, true, emitter))
@@ -673,15 +731,17 @@ func Test_meterRecords_FullLifecycleEmitsExactlyTwoRecords(t *testing.T) {
 	require.NoError(t, h.workflowDeletedEvent(t.Context(), WorkflowDeletedEvent{WorkflowID: wfID}, "aabbccdd"))
 
 	records := emitter.Records()
-	require.Len(t, records, 2, "exactly two records: +1 at register, -1 at delete")
-	requireSpecDelta(t, records[0], "1", wfID.Hex(),
-		resourcemanager.EventID("workflow-spec-register", wfID.Hex(), strconv.FormatUint(createdAt, 10)))
-	requireSpecDelta(t, records[1], "-1", wfID.Hex(),
-		resourcemanager.EventID("workflow-spec-delete", wfID.Hex(), strconv.FormatUint(createdAt, 10)))
+	require.Len(t, records, 4, "exactly four records: +pair at register, -pair at delete")
+	wantRegisterID := resourcemanager.EventID("workflow-spec-register", wfID.Hex(), strconv.FormatUint(createdAt, 10))
+	requireSpecDelta(t, records[0], "1", wfID.Hex(), wantRegisterID)
+	requireSpecBytesDelta(t, records[1], "12", wfID.Hex(), meteringBytesEventID(wantRegisterID))
+	wantDeleteID := resourcemanager.EventID("workflow-spec-delete", wfID.Hex(), strconv.FormatUint(createdAt, 10))
+	requireSpecDelta(t, records[2], "-1", wfID.Hex(), wantDeleteID)
+	requireSpecBytesDelta(t, records[3], "-12", wfID.Hex(), meteringBytesEventID(wantDeleteID))
 }
 
 // A transient delete error returns before emission (no -1); a successful retry
-// emits exactly one -1. This fixes the lost-−1 hazard from the old pre-read gate.
+// emits exactly one -pair. This fixes the lost-−1 hazard from the old pre-read gate.
 func Test_meterRecords_TransientDeleteErrorThenRetryEmitsOnce(t *testing.T) {
 	t.Parallel()
 	emitter := &recordingEmitter{}
@@ -692,6 +752,7 @@ func Test_meterRecords_TransientDeleteErrorThenRetryEmitsOnce(t *testing.T) {
 	h := newMeteringTestHandler(t, store, newMeteringResourceManager(t, true, emitter))
 
 	wfID := types.WorkflowID{77}
+	wantRegisterID := resourcemanager.EventID("workflow-spec-register", wfID.Hex(), "1")
 	require.NoError(t, h.workflowRegisteredEvent(t.Context(), WorkflowRegisteredEvent{
 		Status:        WorkflowStatusPaused,
 		WorkflowID:    wfID,
@@ -699,19 +760,22 @@ func Test_meterRecords_TransientDeleteErrorThenRetryEmitsOnce(t *testing.T) {
 		WorkflowName:  "wf-name",
 		CreatedAt:     1,
 	}))
-	require.Len(t, emitter.Records(), 1, "register emits +1")
+	require.Len(t, emitter.Records(), 2, "register emits +pair")
+	requireSpecDelta(t, emitter.Records()[0], "1", wfID.Hex(), wantRegisterID)
+	requireSpecBytesDelta(t, emitter.Records()[1], "12", wfID.Hex(), meteringBytesEventID(wantRegisterID))
 
 	err := h.workflowDeletedEvent(t.Context(), WorkflowDeletedEvent{WorkflowID: wfID}, "aabbccdd")
 	require.ErrorIs(t, err, assert.AnError)
-	assert.Empty(t, emitter.Records()[1:], "failed delete must not emit a -1")
+	assert.Empty(t, emitter.Records()[2:], "failed delete must not emit a -pair")
 
 	store.deleteErr = nil
 	require.NoError(t, h.workflowDeletedEvent(t.Context(), WorkflowDeletedEvent{WorkflowID: wfID}, "aabbccdd"))
 
 	records := emitter.Records()
-	require.Len(t, records, 2, "exactly one -1 after successful retry")
-	requireSpecDelta(t, records[1], "-1", wfID.Hex(),
-		resourcemanager.EventID("workflow-spec-delete", wfID.Hex(), "1"))
+	require.Len(t, records, 4, "exactly one -pair after successful retry")
+	wantDeleteID := resourcemanager.EventID("workflow-spec-delete", wfID.Hex(), "1")
+	requireSpecDelta(t, records[2], "-1", wfID.Hex(), wantDeleteID)
+	requireSpecBytesDelta(t, records[3], "-12", wfID.Hex(), meteringBytesEventID(wantDeleteID))
 }
 
 // A legacy row with RegisteredAt == 0 produces a delete event_id with no
@@ -725,15 +789,17 @@ func Test_meterRecords_LegacyRowDeleteUsesFallbackID(t *testing.T) {
 			Status:        job.WorkflowSpecStatusActive,
 			WorkflowOwner: "aabbccdd",
 			RegisteredAt:  0,
+			StorageBytes:  meteringTestBytes,
 		},
 	}, newMeteringResourceManager(t, true, emitter))
 
 	require.NoError(t, h.workflowDeletedEvent(t.Context(), WorkflowDeletedEvent{WorkflowID: types.WorkflowID{88}}, "aabbccdd"))
 
 	records := emitter.Records()
-	require.Len(t, records, 1)
-	requireSpecDelta(t, records[0], "-1", types.WorkflowID{88}.Hex(),
-		resourcemanager.EventID("workflow-spec-delete", types.WorkflowID{88}.Hex()))
+	require.Len(t, records, 2)
+	wantCountID := resourcemanager.EventID("workflow-spec-delete", types.WorkflowID{88}.Hex())
+	requireSpecDelta(t, records[0], "-1", types.WorkflowID{88}.Hex(), wantCountID)
+	requireSpecBytesDelta(t, records[1], "-12", types.WorkflowID{88}.Hex(), meteringBytesEventID(wantCountID))
 }
 
 // Identical event sequences with RM nil / disabled / erroring emitter produce
@@ -783,15 +849,18 @@ func Test_meterRecords_FailOpenEquivalence(t *testing.T) {
 	assert.Nil(t, errStore.spec, "spec should be deleted by the cycle")
 }
 
-// The orphan sweep releases a paused tombstone (no engine) with exactly one -1
-// carrying the generation delete-id. This is the sweep's new load-bearing case:
-// workflows deleted on-chain while paused have a tombstone but no engine. The
-// sweep dispatches an ordinary WorkflowDeleted event through Handle — the same
-// path as reconciliation-generated deletes.
+// The orphan sweep releases a paused tombstone (no engine) with exactly one
+// -pair carrying the generation delete-ids. This is the sweep's new
+// load-bearing case: workflows deleted on-chain while paused have a tombstone
+// but no engine. The sweep dispatches an ordinary WorkflowDeleted event
+// through Handle — the same path as reconciliation-generated deletes. The
+// -bytes record releases the ORIGINAL registered byte count even though pause
+// cleared the payload: the persisted storage_bytes survives tombstoning.
 func Test_meterRecords_SweepReleasesPausedTombstone(t *testing.T) {
 	t.Parallel()
 	emitter := &recordingEmitter{}
-	h := newMeteringTestHandler(t, &stubWorkflowArtifactsStore{persistUpserts: true}, newMeteringResourceManager(t, true, emitter))
+	store := &stubWorkflowArtifactsStore{persistUpserts: true}
+	h := newMeteringTestHandler(t, store, newMeteringResourceManager(t, true, emitter))
 
 	wfID := meteringwfID
 	createdAt := uint64(456)
@@ -803,13 +872,70 @@ func Test_meterRecords_SweepReleasesPausedTombstone(t *testing.T) {
 		CreatedAt:     createdAt,
 	}))
 	require.NoError(t, h.workflowPausedEvent(t.Context(), WorkflowPausedEvent{WorkflowID: wfID}))
+	// The tombstone must keep the registered byte count despite the cleared
+	// payload: that is what makes the delete-time -bytes delta exact.
+	require.NotNil(t, store.spec)
+	require.Empty(t, store.spec.Workflow)
+	require.Empty(t, store.spec.Config)
+	require.Equal(t, meteringTestBytes, store.spec.StorageBytes)
 	// After pause the engine is popped; the tombstone has no engine → sweep path.
 	require.NoError(t, h.Handle(t.Context(), Event{Name: WorkflowDeleted, Data: WorkflowDeletedEvent{WorkflowID: wfID}}))
 
 	records := emitter.Records()
-	require.Len(t, records, 2, "register +1 and sweep -1")
-	requireSpecDelta(t, records[0], "1", wfID.Hex(),
-		resourcemanager.EventID("workflow-spec-register", wfID.Hex(), strconv.FormatUint(createdAt, 10)))
-	requireSpecDelta(t, records[1], "-1", wfID.Hex(),
-		resourcemanager.EventID("workflow-spec-delete", wfID.Hex(), strconv.FormatUint(createdAt, 10)))
+	require.Len(t, records, 4, "register +pair and sweep -pair")
+	wantRegisterID := resourcemanager.EventID("workflow-spec-register", wfID.Hex(), strconv.FormatUint(createdAt, 10))
+	requireSpecDelta(t, records[0], "1", wfID.Hex(), wantRegisterID)
+	requireSpecBytesDelta(t, records[1], "12", wfID.Hex(), meteringBytesEventID(wantRegisterID))
+	wantDeleteID := resourcemanager.EventID("workflow-spec-delete", wfID.Hex(), strconv.FormatUint(createdAt, 10))
+	requireSpecDelta(t, records[2], "-1", wfID.Hex(), wantDeleteID)
+	requireSpecBytesDelta(t, records[3], "-12", wfID.Hex(), meteringBytesEventID(wantDeleteID))
+}
+
+// A paused tombstone keeps reporting its registered storage level in snapshots
+// (billing covers the registration lifetime), and the eventual delete releases
+// exactly those bytes: +N at register, 0 at pause/activate, -N at delete.
+func Test_meterRecords_TombstoneSnapshotAndDeleteReleaseRegisteredBytes(t *testing.T) {
+	t.Parallel()
+	emitter := &recordingEmitter{}
+	// specs simulates what the DB list query returns for the paused tombstone:
+	// identity columns plus storage_bytes (the payload columns are cleared).
+	store := &stubWorkflowArtifactsStore{
+		persistUpserts: true,
+		specs: []*job.WorkflowSpec{
+			{WorkflowID: meteringwfID.Hex(), WorkflowOwner: "aabbccdd", StorageBytes: meteringTestBytes},
+		},
+	}
+	h := newMeteringTestHandler(t, store, newMeteringResourceManager(t, true, emitter))
+
+	wfID := meteringwfID
+	createdAt := uint64(789)
+	require.NoError(t, h.workflowRegisteredEvent(t.Context(), WorkflowRegisteredEvent{
+		Status:        WorkflowStatusActive,
+		WorkflowID:    wfID,
+		WorkflowOwner: []byte{0xaa, 0xbb, 0xcc, 0xdd},
+		WorkflowName:  "wf-name",
+		CreatedAt:     createdAt,
+	}))
+	require.NoError(t, h.workflowPausedEvent(t.Context(), WorkflowPausedEvent{WorkflowID: wfID}))
+
+	// While paused, the snapshot path still reports both dimensions of the
+	// held registration: count 1 and the registered byte count.
+	entries := h.specMeter.GetUtilization(t.Context())
+	require.Len(t, entries, 1)
+	require.Len(t, entries[0].Utilizations, 2)
+	assert.Equal(t, "operations", entries[0].Utilizations[0].ResourceType)
+	assert.Equal(t, "1", entries[0].Utilizations[0].Value)
+	assert.Equal(t, "storage_bytes", entries[0].Utilizations[1].ResourceType)
+	assert.Equal(t, "12", entries[0].Utilizations[1].Value)
+
+	require.NoError(t, h.workflowDeletedEvent(t.Context(), WorkflowDeletedEvent{WorkflowID: wfID}, "aabbccdd"))
+
+	records := emitter.Records()
+	require.Len(t, records, 4)
+	wantRegisterID := resourcemanager.EventID("workflow-spec-register", wfID.Hex(), strconv.FormatUint(createdAt, 10))
+	requireSpecDelta(t, records[0], "1", wfID.Hex(), wantRegisterID)
+	requireSpecBytesDelta(t, records[1], "12", wfID.Hex(), meteringBytesEventID(wantRegisterID))
+	wantDeleteID := resourcemanager.EventID("workflow-spec-delete", wfID.Hex(), strconv.FormatUint(createdAt, 10))
+	requireSpecDelta(t, records[2], "-1", wfID.Hex(), wantDeleteID)
+	requireSpecBytesDelta(t, records[3], "-12", wfID.Hex(), meteringBytesEventID(wantDeleteID))
 }

--- a/core/services/workflows/syncer/v2/handler_test.go
+++ b/core/services/workflows/syncer/v2/handler_test.go
@@ -2287,13 +2287,16 @@ func Test_handler_SourceParity_PauseActivateCycle(t *testing.T) {
 			require.NoError(t, h.workflowDeletedEvent(t.Context(), WorkflowDeletedEvent{WorkflowID: wfID, Source: source}, "aabbccdd"))
 			assertStubState(t, store, false, "", true, 0)
 
-			// Both sources produce identical metering: one +1, one -1, same ids
+			// Both sources produce identical metering: one +pair at register,
+			// one -pair at delete, same ids per billing unit.
 			records := emitter.Records()
-			require.Len(t, records, 2)
-			requireSpecDelta(t, records[0], "1", wfID.Hex(),
-				resourcemanager.EventID("workflow-spec-register", wfID.Hex(), strconv.FormatUint(createdAt, 10)))
-			requireSpecDelta(t, records[1], "-1", wfID.Hex(),
-				resourcemanager.EventID("workflow-spec-delete", wfID.Hex(), strconv.FormatUint(createdAt, 10)))
+			require.Len(t, records, 4)
+			wantRegisterID := resourcemanager.EventID("workflow-spec-register", wfID.Hex(), strconv.FormatUint(createdAt, 10))
+			requireSpecDelta(t, records[0], "1", wfID.Hex(), wantRegisterID)
+			requireSpecBytesDelta(t, records[1], "12", wfID.Hex(), meteringBytesEventID(wantRegisterID))
+			wantDeleteID := resourcemanager.EventID("workflow-spec-delete", wfID.Hex(), strconv.FormatUint(createdAt, 10))
+			requireSpecDelta(t, records[2], "-1", wfID.Hex(), wantDeleteID)
+			requireSpecBytesDelta(t, records[3], "-12", wfID.Hex(), meteringBytesEventID(wantDeleteID))
 		})
 	}
 }

--- a/core/services/workflows/syncer/v2/spec_meter.go
+++ b/core/services/workflows/syncer/v2/spec_meter.go
@@ -25,13 +25,10 @@ import (
 const (
 	meterService      = "workflow-syncer-v2"
 	meterResourcePool = "workflow_specs_v2"
-	// meterResourceType is the workflow-count billing unit: one durable spec
-	// registration per workflow.
+	// meterResourceType is the workflow-count billing unit
 	meterResourceType = "operations"
 	// meterResourceTypeBytes is the storage billing unit: the durable storage
 	// footprint in bytes (raw decoded binary + config) held by a registration.
-	// Bytes are billed for the registration lifetime (register -> delete),
-	// surviving pause tombstoning.
 	meterResourceTypeBytes = "storage_bytes"
 	// meterBytesEventNamespace scopes the storage-delta event_ids so they never
 	// collide with the count-delta event_ids in the consumer's dedup key space.

--- a/core/services/workflows/syncer/v2/spec_meter.go
+++ b/core/services/workflows/syncer/v2/spec_meter.go
@@ -18,14 +18,24 @@ import (
 
 // Service-level metering identity constants for the workflow syncer. Service is
 // the stable service constant; ResourcePool identifies the workflow_specs_v2
-// pool. The billing unit (ResourceType) and per-resource id (ResourceID) are
+// pool. The billing units (ResourceTypes) and per-resource id (ResourceID) are
 // carried on each Utilization. The coarse deployment/node/DON dimensions
 // (product, tenant, environment, zone, don_id, node_id) are supplied at
 // construction via NewSpecMeter.
 const (
 	meterService      = "workflow-syncer-v2"
 	meterResourcePool = "workflow_specs_v2"
+	// meterResourceType is the workflow-count billing unit: one durable spec
+	// registration per workflow.
 	meterResourceType = "operations"
+	// meterResourceTypeBytes is the storage billing unit: the durable storage
+	// footprint in bytes (raw decoded binary + config) held by a registration.
+	// Bytes are billed for the registration lifetime (register -> delete),
+	// surviving pause tombstoning.
+	meterResourceTypeBytes = "storage_bytes"
+	// meterBytesEventNamespace scopes the storage-delta event_ids so they never
+	// collide with the count-delta event_ids in the consumer's dedup key space.
+	meterBytesEventNamespace = "workflow-spec-storage-bytes"
 )
 
 // SpecLister is the read-only view of durable workflow-spec storage the
@@ -118,10 +128,16 @@ func (sm *SpecMeter) SetWorkflowDon(don commoncap.DON) {
 	sm.resolvedDonID.Store(&donID)
 }
 
-// EmitSpecDelta emits one metering.v1.MeterRecord (METER_ACTION_UPDATE)
-// capturing a signed ±delta to the durable workflow_specs_v2 level for
-// workflowID
-func (sm *SpecMeter) EmitSpecDelta(ctx context.Context, delta int64, workflowID, owner, eventID string) {
+// EmitSpecDelta emits two metering.v1.MeterRecord (METER_ACTION_UPDATE)
+// messages capturing a signed ±delta to the durable workflow_specs_v2 level
+// for workflowID: one on the workflow-count billing unit (resource_type
+// "operations", value delta) and one on the storage billing unit
+// (resource_type "storage_bytes", value delta*storageBytes).
+//
+// The count record carries eventID exactly as supplied. The bytes record
+// carries a distinct but equally deterministic id derived from eventID, so the
+// two records for the same transition never collide
+func (sm *SpecMeter) EmitSpecDelta(ctx context.Context, delta, storageBytes int64, workflowID, owner, eventID string) {
 	if sm == nil {
 		return
 	}
@@ -136,6 +152,11 @@ func (sm *SpecMeter) EmitSpecDelta(ctx context.Context, delta int64, workflowID,
 	// resource_id = workflow_id (the syncer meters one durable spec per workflow).
 	sm.rm.EmitDelta(ctx, sm.baseIdentity(), eventID, delta, resourcemanager.UtilizationFields{
 		ResourceType: meterResourceType,
+		ResourceID:   workflowID,
+		OrgID:        orgID,
+	})
+	sm.rm.EmitDelta(ctx, sm.baseIdentity(), resourcemanager.EventID(meterBytesEventNamespace, eventID), delta*storageBytes, resourcemanager.UtilizationFields{
+		ResourceType: meterResourceTypeBytes,
 		ResourceID:   workflowID,
 		OrgID:        orgID,
 	})
@@ -162,6 +183,10 @@ func (sm *SpecMeter) baseIdentity() resourcemanager.ResourceIdentity {
 // SnapshotEntry per persisted workflow_specs_v2 spec. The durable resource is
 // the stored spec, NOT the running engine.
 //
+// Each entry carries two billed dimensions: the workflow-count level (value 1,
+// resource_type "operations") and the storage level (value storage_bytes,
+// resource_type "storage_bytes"
+
 // resource_id is the workflow_id; the organization is resolved fail-open from
 // the spec's stored owner through the org resolver. Must fail open.
 func (sm *SpecMeter) GetUtilization(ctx context.Context) []resourcemanager.SnapshotEntry {
@@ -189,6 +214,11 @@ func (sm *SpecMeter) GetUtilization(ctx context.Context) []resourcemanager.Snaps
 			Utilizations: []*meteringpb.Utilization{
 				resourcemanager.NewUtilizationInt(1, resourcemanager.UtilizationFields{
 					ResourceType: meterResourceType,
+					ResourceID:   spec.WorkflowID,
+					OrgID:        orgID,
+				}),
+				resourcemanager.NewUtilizationInt(spec.StorageBytes, resourcemanager.UtilizationFields{
+					ResourceType: meterResourceTypeBytes,
 					ResourceID:   spec.WorkflowID,
 					OrgID:        orgID,
 				}),

--- a/core/store/migrate/migrations/0306_workflow_specs_v2_storage_bytes.sql
+++ b/core/store/migrate/migrations/0306_workflow_specs_v2_storage_bytes.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- Durable storage footprint of each registered workflow spec, in bytes
+-- (raw decoded binary + config), for storage-based metering. Set at
+-- registration and intentionally NOT cleared by pause tombstoning: bytes are
+-- billed for the registration lifetime (register -> delete), so the value must
+-- survive payload clearing to keep deltas self-balancing and snapshots
+-- consistent. Pre-migration rows are backfilled from the persisted payload
+-- where it still exists; already-paused tombstones backfill to 0 (the original
+-- bytes are unrecoverable).
+ALTER TABLE workflow_specs_v2 ADD COLUMN storage_bytes bigint NOT NULL DEFAULT 0;
+UPDATE workflow_specs_v2 SET storage_bytes = OCTET_LENGTH(workflow)/2 + OCTET_LENGTH(config) WHERE workflow <> '';
+
+-- +goose Down
+ALTER TABLE workflow_specs_v2 DROP COLUMN storage_bytes;


### PR DESCRIPTION
Deployment Validation Strategy
1. Check to make sure workflow-spec-register event includes the storage bytes
2. Check to make sure workflow-spec-delete event includes the storage bytes