### PR TITLE
Block dontime and vault from callCapability and add default call limiter

### DIFF
--- a/core/services/workflows/v2/capability_executor.go
+++ b/core/services/workflows/v2/capability_executor.go
@@ -38,10 +38,11 @@ type ExecutionHelper struct {
 	TimeProvider
 	SecretsFetcher
 
-	chainAllowed limits.GateLimiter
-	callLimiters map[capCall]limits.BoundLimiter[int]
-	mu           sync.Mutex
-	callCounts   map[limits.Limiter[int]]int
+	chainAllowed       limits.GateLimiter
+	callLimiters       map[capCall]limits.BoundLimiter[int]
+	defaultCallLimiter limits.BoundLimiter[int]
+	mu                 sync.Mutex
+	callCounts         map[limits.Limiter[int]]int
 
 	executionProfile *executionProfileCollector
 
@@ -52,6 +53,7 @@ type ExecutionHelper struct {
 
 func (c *ExecutionHelper) initLimiters(limiters *EngineLimiters) {
 	c.chainAllowed = limiters.ChainAllowed
+	c.defaultCallLimiter = limits.NewUpperBoundLimiter[int](defaultCapabilityCallLimit)
 	c.callLimiters = map[capCall]limits.BoundLimiter[int]{
 		{"consensus", "Simple"}: limiters.ConsensusCalls,
 		{"consensus", "Report"}: limiters.ConsensusCalls,
@@ -92,6 +94,8 @@ func (c *ExecutionHelper) initLimiters(limiters *EngineLimiters) {
 	}
 }
 
+const defaultCapabilityCallLimit = 5
+
 type capCall struct {
 	name   string
 	method string
@@ -113,22 +117,23 @@ func (c *ExecutionHelper) CallCapability(ctx context.Context, request *sdkpb.Cap
 	}
 
 	limiter, ok := c.callLimiters[capCall{name: capName, method: request.Method}]
-	if ok {
-		c.mu.Lock()
-		if c.callCounts == nil {
-			c.callCounts = make(map[limits.Limiter[int]]int)
-		}
-		cnt := c.callCounts[limiter] + 1
-		if err := limiter.Check(ctx, cnt); err != nil {
-			c.mu.Unlock()
-			return nil, caperrors.NewPublicUserError(
-				fmt.Errorf("capability call limit exceeded for %s.%s: %w", capName, request.Method, err),
-				caperrors.LimitExceeded,
-			)
-		}
-		c.callCounts[limiter] = cnt
-		c.mu.Unlock()
+	if !ok {
+		limiter = c.defaultCallLimiter
 	}
+	c.mu.Lock()
+	if c.callCounts == nil {
+		c.callCounts = make(map[limits.Limiter[int]]int)
+	}
+	cnt := c.callCounts[limiter] + 1
+	if err := limiter.Check(ctx, cnt); err != nil {
+		c.mu.Unlock()
+		return nil, caperrors.NewPublicUserError(
+			fmt.Errorf("capability call limit exceeded for %s.%s: %w", capName, request.Method, err),
+			caperrors.LimitExceeded,
+		)
+	}
+	c.callCounts[limiter] = cnt
+	c.mu.Unlock()
 
 	free, err := c.capCallsSemaphore.Wait(ctx, 1)
 	if err != nil {
@@ -335,10 +340,16 @@ func (c *ExecutionHelper) EmitUserMetric(ctx context.Context, metric *eventsv2.W
 	return events.EmitUserMetric(ctx, c.eventLabels(), metric)
 }
 
+// dontimeCapabilityID matches the capability ID registered by the OCR2 delegate
+// (core/services/ocr2/delegate.go).
+const dontimeCapabilityID = "dontime@1.0.0"
+
 // systemCapabilities lists capability IDs that are internal plumbing and must
 // not be callable from user workflow steps.
 var systemCapabilities = map[string]bool{
 	confidentialWorkflowsCapabilityID: true,
+	vaultcommon.CapabilityID:          true,
+	dontimeCapabilityID:               true,
 }
 
 func isSystemCapability(capID string) bool {

--- a/core/services/workflows/v2/capability_executor_test.go
+++ b/core/services/workflows/v2/capability_executor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/actions/vault"
 	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
 	commonlogger "github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings"
@@ -101,6 +102,81 @@ func TestExecutionHelper_SystemCapabilityResolvedBypass(t *testing.T) {
 	assert.Contains(t, err.Error(), "system-only")
 }
 
+// TestExecutionHelper_VaultAndDonTimeSystemCapabilitiesBlocked ensures the
+// vault and dontime capabilities cannot be invoked through the raw
+// CallCapability path, regardless of the requested version resolving to the
+// registered system-only one.
+func TestExecutionHelper_VaultAndDonTimeSystemCapabilitiesBlocked(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		registeredID string
+		requestID    string
+	}{
+		{"vault exact ID", vault.CapabilityID, vault.CapabilityID},
+		{"vault version-resolved", vault.CapabilityID, "vault@1.0.0-0"},
+		{"vault unversioned", vault.CapabilityID, "vault"},
+		{"dontime exact ID", "dontime@1.0.0", "dontime@1.0.0"},
+		{"dontime version-resolved", "dontime@1.0.0", "dontime@1.0.0-0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resolvedInfo := capabilities.CapabilityInfo{ID: tt.registeredID}
+			reg := stubRegistry{cap: stubExecutableCapability{CapabilityInfo: resolvedInfo}}
+
+			engine := &Engine{cfg: &EngineConfig{
+				Lggr:        logger.TestLogger(t),
+				CapRegistry: reg,
+			}}
+			engine.setLogger(commonlogger.Sugared(commonlogger.Test(t)))
+			exec := &ExecutionHelper{Engine: engine}
+
+			req := &sdk.CapabilityRequest{
+				Id:         tt.requestID,
+				Method:     "Execute",
+				CallbackId: 1,
+			}
+
+			_, err := exec.callCapability(t.Context(), req)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "system-only")
+		})
+	}
+}
+
+func TestIsSystemCapability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		capID string
+		want  bool
+	}{
+		{"confidential-workflows registered ID", confidentialWorkflowsCapabilityID, true},
+		{"vault registered ID", vault.CapabilityID, true},
+		{"dontime registered ID", dontimeCapabilityID, true},
+		{"confidential-workflows other version", "confidential-workflows@1.0.0", false},
+		{"vault other version", "vault@2.0.0", false},
+		{"vault unversioned", "vault", false},
+		{"vault with labels", "vault:ChainSelector:123@1.0.0", false},
+		{"dontime other version", "dontime@2.0.0", false},
+		{"confidential-http is not system-only", "confidential-http@1.0.0", false},
+		{"evm with labels is not system-only", "evm:ChainSelector:1@1.0.0", false},
+		{"empty ID", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isSystemCapability(tt.capID))
+		})
+	}
+}
+
 func TestExecutionHelper_ConfidentialHTTPPerWorkflowLimit(t *testing.T) {
 	t.Parallel()
 
@@ -143,6 +219,46 @@ func TestExecutionHelper_ConfidentialHTTPPerWorkflowLimit(t *testing.T) {
 	require.ErrorAs(t, err, &capErr, "expected per-workflow call limit exceedance to be classified as capability user error")
 	require.Equal(t, caperrors.OriginUser, capErr.Origin())
 	require.Equal(t, caperrors.LimitExceeded, capErr.Code())
+}
+
+// TestExecutionHelper_DefaultCallLimitForUnknownCapabilities ensures raw
+// CallCapability calls for (capability, method) pairs without a dedicated
+// limiter entry are bounded by the default call limit instead of unbounded.
+func TestExecutionHelper_DefaultCallLimitForUnknownCapabilities(t *testing.T) {
+	t.Parallel()
+
+	lggr := logger.TestLogger(t)
+	lf := limits.Factory{Logger: lggr}
+
+	limiters, err := NewLimiters(lf, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = limiters.Close() })
+
+	exec := &ExecutionHelper{}
+	exec.initLimiters(limiters)
+
+	require.NoError(t, exec.defaultCallLimiter.Check(t.Context(), defaultCapabilityCallLimit))
+	err = exec.defaultCallLimiter.Check(t.Context(), defaultCapabilityCallLimit+1)
+	require.ErrorContains(t, err, "limited: cannot use 6, limit is 5")
+
+	// Prime the counter to the default limit, then call an unknown capability
+	// through the raw path; the next call must be rejected.
+	exec.callCounts = make(map[limits.Limiter[int]]int)
+	exec.callCounts[exec.defaultCallLimiter] = defaultCapabilityCallLimit
+
+	req := &sdk.CapabilityRequest{
+		Id:         "future-capability@1.0.0",
+		Method:     "DoThing",
+		CallbackId: 1,
+	}
+
+	_, err = exec.CallCapability(t.Context(), req)
+	require.Error(t, err, "expected CallCapability to fail when the default call limit is exceeded for an unknown capability")
+	var capErr caperrors.Error
+	require.ErrorAs(t, err, &capErr, "expected default call limit exceedance to be classified as capability user error")
+	require.Equal(t, caperrors.OriginUser, capErr.Origin())
+	require.Equal(t, caperrors.LimitExceeded, capErr.Code())
+	require.ErrorContains(t, err, "capability call limit exceeded for future-capability.DoThing")
 }
 
 func TestUserMetricTypeSuffix(t *testing.T) {

--- a/core/services/workflows/v2/secrets.go
+++ b/core/services/workflows/v2/secrets.go
@@ -147,6 +147,19 @@ func (s *secretsFetcher) vaultGetSecretsMetadata(ctx context.Context, callbackID
 	return metadata, nil
 }
 
+// countSecretsCall reserves one call from the per-execution secrets call
+// budget shared by GetSecrets and GetRawSecrets.
+func (s *secretsFetcher) countSecretsCall(ctx context.Context) error {
+	s.callCounter.mu.Lock()
+	defer s.callCounter.mu.Unlock()
+	secretsCalled := s.callCounter.called + 1
+	if err := s.secretsCallsLimit.Check(ctx, secretsCalled); err != nil {
+		return err
+	}
+	s.callCounter.called = secretsCalled
+	return nil
+}
+
 func (s *secretsFetcher) GetSecrets(ctx context.Context, request *sdkpb.GetSecretsRequest) ([]*sdkpb.SecretResponse, error) {
 	ctx = contexts.WithCRE(ctx, contexts.CRE{
 		Org:      s.orgID,
@@ -163,19 +176,14 @@ func (s *secretsFetcher) GetSecrets(ctx context.Context, request *sdkpb.GetSecre
 	}
 	vaultRequestID := vault.BuildWorkflowGetSecretsRequestID(metadata)
 	s.lggr.Debugw("get secrets request received", "vaultRequestID", vaultRequestID, "metadata", metadata)
-	s.callCounter.mu.Lock()
-	secretsCalled := s.callCounter.called + 1
-	if err := s.secretsCallsLimit.Check(ctx, secretsCalled); err != nil {
-		s.callCounter.mu.Unlock()
+	if err = s.countSecretsCall(ctx); err != nil {
 		return nil, err
 	}
-	s.callCounter.called = secretsCalled
-	s.callCounter.mu.Unlock()
 	start := time.Now()
 	resp, err := func() ([]*sdkpb.SecretResponse, error) {
-		free, err := s.semaphore.Wait(ctx, 1)
-		if err != nil {
-			return nil, err
+		free, waitErr := s.semaphore.Wait(ctx, 1)
+		if waitErr != nil {
+			return nil, waitErr
 		}
 		defer free()
 		return s.getSecretsForBatchWithLocalFallback(ctx, request)
@@ -287,11 +295,26 @@ func (s *secretsFetcher) getSecretsForBatchWithLocalFallback(ctx context.Context
 	return combined, nil
 }
 
-// GetRawSecrets performs all of the work required to obtain secrets from the
-// Vault DON except decrypting their values: it resolves the vault capability,
-// loads this DON's encryption keys, executes the vault GetSecrets request, and
-// returns the raw (still encrypted) vault response.
+// GetRawSecrets obtains secrets from the Vault DON without decrypting their
+// values. Raw fetches are charged against the same per-execution secrets call
+// budget as GetSecrets.
 func (s *secretsFetcher) GetRawSecrets(ctx context.Context, request *sdkpb.GetSecretsRequest, fetcher host.EncryptionKeyFetcher) ([]*vault.SecretResponse, error) {
+	ctx = contexts.WithCRE(ctx, contexts.CRE{
+		Org:      s.orgID,
+		Owner:    s.workflowOwner,
+		Workflow: s.workflowID,
+	})
+	if err := s.countSecretsCall(ctx); err != nil {
+		return nil, err
+	}
+	return s.getRawSecrets(ctx, request, fetcher)
+}
+
+// getRawSecrets resolves the vault capability, loads this DON's encryption
+// keys, executes the vault GetSecrets request, and returns the raw (still
+// encrypted) vault response. Callers must have already reserved a call from
+// the per-execution secrets call budget via countSecretsCall.
+func (s *secretsFetcher) getRawSecrets(ctx context.Context, request *sdkpb.GetSecretsRequest, fetcher host.EncryptionKeyFetcher) ([]*vault.SecretResponse, error) {
 	vaultCap, err := s.capRegistry.GetExecutable(ctx, vault.CapabilityID)
 	if err != nil {
 		return nil, errors.New("failed to get vault capability: " + err.Error())
@@ -407,7 +430,7 @@ func (s *secretsFetcher) getVaultSecretsForBatch(ctx context.Context, request *s
 		return nil, errors.New("failed to extract vault public key from capability config: " + err.Error())
 	}
 
-	batchedVaultResponse, err := s.GetRawSecrets(ctx, request, s.encryptionKeyFetcher)
+	batchedVaultResponse, err := s.getRawSecrets(ctx, request, s.encryptionKeyFetcher)
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/workflows/v2/secrets_test.go
+++ b/core/services/workflows/v2/secrets_test.go
@@ -1022,6 +1022,78 @@ func TestSecretsFetcher_EnforcesSecretsCallsLimit(t *testing.T) {
 	require.ErrorContains(t, err, "limited: cannot use 2, limit is 1")
 }
 
+// TestSecretsFetcher_EnforcesSecretsCallsLimitOnRawSecrets ensures GetRawSecrets
+// (the enclave relay ingress path) is bounded by the same per-execution secrets
+// call budget as GetSecrets.
+func TestSecretsFetcher_EnforcesSecretsCallsLimitOnRawSecrets(t *testing.T) {
+	t.Parallel()
+
+	newFetcher := func(t *testing.T) RawSecretsFetcher {
+		t.Helper()
+		lggr := logger.TestLogger(t)
+		reg := coreCap.NewRegistry(lggr)
+		peer := RandomUTF8BytesWord()
+		workflowEncryptionKey := workflowkey.MustNewXXXTestingOnly(big.NewInt(1))
+
+		f, n := 2, 3
+		_, vaultPublicKey, _, err := tdh2easy.GenerateKeys(f, n)
+		require.NoError(t, err)
+		vaultPublicKeyBytes, err := vaultPublicKey.Marshal()
+		require.NoError(t, err)
+		reg.SetLocalRegistry(CreateLocalRegistryWith1Node(t, peer, workflowEncryptionKey.PublicKey(), vaultPublicKeyBytes))
+
+		return NewSecretsFetcher(
+			MetricsLabelerTest(t),
+			reg,
+			lggr,
+			limits.WorkflowResourcePoolLimiter[int](5),
+			limits.NewUpperBoundLimiter[int](1),
+			nil,
+			"",
+			"0x1111111111111111111111111111111111111111",
+			"wf",
+			"wfID",
+			"phaseID",
+			workflowkey.MustNewXXXTestingOnly(big.NewInt(1)),
+			nil,
+		)
+	}
+
+	req := &sdkpb.GetSecretsRequest{
+		Requests: []*sdkpb.SecretRequest{
+			{Id: "R1"},
+		},
+	}
+
+	t.Run("raw secrets calls are bounded", func(t *testing.T) {
+		t.Parallel()
+
+		sf := newFetcher(t)
+		keyFetcher := sf.(*secretsFetcher).encryptionKeyFetcher
+
+		// 1st call to occupy the only available slot in the limiter
+		_, _ = sf.GetRawSecrets(t.Context(), req, keyFetcher)
+
+		// second call should fail due to exceeding the bound limiter (limit == 1)
+		_, err := sf.GetRawSecrets(t.Context(), req, keyFetcher)
+		require.ErrorContains(t, err, "limited: cannot use 2, limit is 1")
+	})
+
+	t.Run("raw and normal secrets calls share the budget", func(t *testing.T) {
+		t.Parallel()
+
+		sf := newFetcher(t)
+		keyFetcher := sf.(*secretsFetcher).encryptionKeyFetcher
+
+		// GetSecrets internally fetches raw secrets without double counting
+		_, _ = sf.GetSecrets(t.Context(), req)
+
+		// the raw path must be charged against the same budget (limit == 1)
+		_, err := sf.GetRawSecrets(t.Context(), req, keyFetcher)
+		require.ErrorContains(t, err, "limited: cannot use 2, limit is 1")
+	})
+}
+
 func TestSecretsFetcher_VaultFirstThenLocalOverridesForVaultFailures(t *testing.T) {
 	t.Parallel()
 	lggr := logger.TestLogger(t)


### PR DESCRIPTION
Deployment Validation Strategy
1. Existing canaries