### PR TITLE
[CRE] Fix a bug in workflow re-activation

### DIFF
--- a/core/services/workflows/artifacts/v2/store.go
+++ b/core/services/workflows/artifacts/v2/store.go
@@ -129,8 +129,9 @@ func NewStore(lggr logger.Logger, orm WorkflowRegistryDS, fetchFn types.FetcherF
 // been cached already.  Before a workflow can be started this method must be called to ensure all artifacts used by the
 // workflow are available from the store.
 func (h *Store) FetchWorkflowArtifacts(ctx context.Context, workflowID, binaryURL, configURL string) ([]byte, []byte, error) {
-	// Check if the workflow spec is already stored in the database
-	if spec, err := h.orm.GetWorkflowSpec(ctx, workflowID); err == nil {
+	// Check if the workflow spec is already stored in the database.
+	// A row whose binary payload is empty is a pause tombstone - don't use it.
+	if spec, err := h.orm.GetWorkflowSpec(ctx, workflowID); err == nil && spec.Workflow != "" {
 		// there is no update in the BinaryURL or ConfigURL, lets decode the stored artifacts
 		decodedBinary, err := hex.DecodeString(spec.Workflow)
 		if err != nil {

--- a/core/services/workflows/artifacts/v2/store_test.go
+++ b/core/services/workflows/artifacts/v2/store_test.go
@@ -278,3 +278,75 @@ func Test_Store_FetchWorkflowArtifacts_SkipsRetrieving(t *testing.T) {
 	require.Equal(t, []byte(binaryData), binary)
 	require.Equal(t, []byte(configData), config)
 }
+
+// Test_Store_FetchWorkflowArtifacts_PauseTombstone covers re-activation after a pause.
+// PauseWorkflowSpec keeps the row but clears the artifact payload, so the row must not be
+// mistaken for a warm cache: returning the tombstone's empty binary/config makes the caller
+// persist empty artifacts and then fail activation with a workflowID mismatch.
+func Test_Store_FetchWorkflowArtifacts_PauseTombstone(t *testing.T) {
+	t.Parallel()
+	lggr := logger.TestLogger(t)
+	db := pgtest.NewSqlxDB(t)
+	orm := &orm{ds: db, lggr: lggr}
+
+	workflowID := "id-" + uuid.New().String()[:8]
+	encryptionKey, err := workflowkey.New()
+	require.NoError(t, err)
+
+	binaryURL := fmt.Sprintf("http://some-url-%s.com/binary.wasm", workflowID)
+	binaryData := "binary-data"
+	configURL := fmt.Sprintf("http://some-url-%s.com/config.yaml", workflowID)
+	configData := "config-data"
+	fetcher := &mockFetcher{
+		responseMap: map[string]mockFetchResp{
+			binaryURL: {Body: []byte(base64.StdEncoding.EncodeToString([]byte(binaryData)))},
+			configURL: {Body: []byte(configData)},
+		},
+	}
+
+	h, err := NewStore(
+		lggr,
+		orm,
+		fetcher.Fetch,
+		fetcher.RetrieveURL,
+		clockwork.NewFakeClock(),
+		encryptionKey,
+		custmsg.NewLabeler(),
+		limits.Factory{Logger: lggr},
+		WithConfig(StoreConfig{
+			ArtifactStorageHost: "storage.chain.link",
+		}),
+	)
+	require.NoError(t, err)
+
+	ctx := contexts.WithCRE(t.Context(), contexts.CRE{Workflow: workflowID})
+
+	// Active row with artifacts: served from the DB cache.
+	_, err = orm.UpsertWorkflowSpec(ctx, &job.WorkflowSpec{
+		Workflow:      hex.EncodeToString([]byte(binaryData)),
+		Config:        configData,
+		WorkflowID:    workflowID,
+		WorkflowOwner: "owner-1",
+		WorkflowName:  "name-1",
+		Status:        job.WorkflowSpecStatusActive,
+		BinaryURL:     binaryURL,
+		ConfigURL:     configURL,
+		CreatedAt:     time.Now(),
+		SpecType:      job.WASMFile,
+	})
+	require.NoError(t, err)
+
+	binary, config, err := h.FetchWorkflowArtifacts(ctx, workflowID, binaryURL, configURL)
+	require.NoError(t, err)
+	require.Equal(t, []byte(binaryData), binary)
+	require.Equal(t, []byte(configData), config)
+
+	// Pause tombstones the row; the next fetch must go back to the URLs rather than
+	// returning the cleared payload.
+	require.NoError(t, h.PauseWorkflowArtifacts(ctx, workflowID))
+
+	binary, config, err = h.FetchWorkflowArtifacts(ctx, workflowID, binaryURL, configURL)
+	require.NoError(t, err)
+	require.Equal(t, []byte(binaryData), binary, "tombstoned row must not be served as a cache hit")
+	require.Equal(t, []byte(configData), config)
+}

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -1120,7 +1120,7 @@ func (h *eventHandler) tryEngineCreate(ctx context.Context, spec *job.WorkflowSp
 		return nonRetryable(fmt.Errorf("invalid workflow id: %w", err))
 	}
 	if !types.WorkflowID(hash).Equal(wid) {
-		return nonRetryable(fmt.Errorf("workflowID mismatch: %x != %x", hash, wid))
+		return nonRetryable(fmt.Errorf("workflowID mismatch: %s != %s", types.WorkflowID(hash).Hex(), wid.Hex()))
 	}
 
 	// Start a new WorkflowEngine instance, and add it to local engine registry

--- a/core/services/workflows/syncer/v2/handler_test.go
+++ b/core/services/workflows/syncer/v2/handler_test.go
@@ -668,6 +668,66 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 				}
 			},
 		},
+		{
+			// Regression: pausing tombstones the spec row (status=paused, artifact payload
+			// cleared). Re-activation must refetch from the URLs; serving the tombstone as a
+			// cache hit restores empty artifacts and the activation dies on the workflowID
+			// check with a non-retryable "workflowID mismatch".
+			Name:             "re-activates a paused workflow by refetching cleared artifacts",
+			GiveConfig:       config,
+			ConfigURLFactory: configURLFactory,
+			BinaryURLFactory: binaryURLFactory,
+			GiveBinary:       binary,
+			WFOwner:          wfOwner,
+			fetcherFactory: func(wfID []byte) *mockFetcher {
+				wfIDString := hex.EncodeToString(wfID)
+				signedBinaryURL := binaryURLFactory(wfIDString) + signedURLParameter
+				signedConfigURL := configURLFactory(wfIDString) + signedURLParameter
+				return newMockFetcher(map[string]mockFetchResp{
+					wfIDString + "-ARTIFACT_TYPE_BINARY": {Body: []byte(signedBinaryURL), Err: nil},
+					wfIDString + "-ARTIFACT_TYPE_CONFIG": {Body: []byte(signedConfigURL), Err: nil},
+					signedBinaryURL:                      {Body: encodedBinary, Err: nil},
+					signedConfigURL:                      {Body: config, Err: nil},
+				})
+			},
+			engineFactoryFn: mockEngineFactory,
+			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredEvent, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID types.WorkflowID, fetcher *mockFetcher, binaryURL string, configURL string) {
+				defaultValidationFn(t, ctx, event, h, s, wfOwner, wfName, wfID, fetcher)
+
+				require.NoError(t, h.workflowPausedEvent(ctx, WorkflowPausedEvent{WorkflowID: wfID}))
+				paused, err := s.GetWorkflowSpec(ctx, wfID.Hex())
+				require.NoError(t, err)
+				require.Equal(t, job.WorkflowSpecStatusPaused, paused.Status)
+				require.Empty(t, paused.Workflow, "pause must clear the artifact payload")
+
+				require.NoError(t, h.workflowActivatedEvent(ctx, WorkflowActivatedEvent(event)))
+
+				restored, err := s.GetWorkflowSpec(ctx, wfID.Hex())
+				require.NoError(t, err)
+				require.Equal(t, job.WorkflowSpecStatusActive, restored.Status)
+				require.Equal(t, hex.EncodeToString(binary), restored.Workflow, "artifacts must be refetched, not restored empty")
+
+				engine, ok := h.engineRegistry.Get(wfID)
+				require.True(t, ok)
+				require.NoError(t, engine.Ready())
+
+				// One fetch for the initial activation, one for the post-pause restore.
+				require.Equal(t, 2, fetcher.Calls(binaryURL+signedURLParameter))
+				require.Equal(t, 2, fetcher.Calls(configURL+signedURLParameter))
+			},
+			Event: func(wfID []byte, wfName string, wfOwner []byte) WorkflowRegisteredEvent {
+				wfIDString := hex.EncodeToString(wfID)
+				return WorkflowRegisteredEvent{
+					Status:        WorkflowStatusActive,
+					WorkflowID:    [32]byte(wfID),
+					WorkflowOwner: wfOwner,
+					WorkflowName:  wfName,
+					WorkflowTag:   workflowTag,
+					BinaryURL:     binaryURLFactory(wfIDString),
+					ConfigURL:     configURLFactory(wfIDString),
+				}
+			},
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
The problem is that PauseWorkflowSpec inserts empty values to the db ("tombstone"). But then on re-activation, syncer reads those empty values from the DB and uses them.

Also fix logging IDs to avoid double hex-encoding.