### PR TITLE
Bump version to 2.63.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.63.0",
+  "version": "2.63.1",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps `package.json` version to 2.63.1 on the new hotfix branch, so release-pre's continue-branch flow resolves the correct release branch/tag going forward.

Related: RANE-5176, chainlink#23635 (cherry-picked directly onto release/2.63.1).