### PR TITLE
[DX-5146] fix: save Docker logs if local CRE CLI tests fail

### DIFF
--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -296,6 +296,16 @@ jobs:
           printf -v data '{"name": "cre.local.startup.time", "github_username": "%s", "timestamp": "%s", "metadata": {"startup_seconds": %s, "is_ci": true, "runner": "self-hosted-ubuntu-24", "infra": "docker", "go_cache_hit": %s, "deps_download_seconds": %s}}' "$DX_ACTOR" "$EPOCHSECONDS" "${EXECUTION_TIME}" "${CACHE_HIT}" "${DEPS_DOWNLOAD_SECONDS}"
           curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${GETDX_SECRET_KEY}" -d "$data" https://api.getdx.com/events.track
 
+      - name: Save Smoke tests Docker logs
+        if: failure() || cancelled()
+        shell: bash
+        working-directory: core/scripts/cre/environment
+        run: |
+          mkdir -p logs
+          for c in $(docker ps -a --format '{{.Names}}'); do
+            docker logs "$c" > "logs/${c}.log" 2>&1
+          done
+
       - name: Upload all artifacts as single package
         if: failure()
         uses: actions/upload-artifact@v7

--- a/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
+++ b/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based/main.go
@@ -253,13 +253,6 @@ func getHTTPPrice(config types.WorkflowConfig, runtime cre.NodeRuntime) (priceOu
 
 	runtime.Logger().With().Info(fmt.Sprintf("Response is account name: %s, totalTrust: %.10f, ripcord: %v, updatedAt: %s", resp.AccountName, resp.TotalTrust, resp.Ripcord, resp.UpdatedAt.String()))
 
-	if resp.Ripcord {
-		runtime.Logger().With(
-			"feedID", config.FeedID,
-		).Info(fmt.Sprintf("ripcord flag set for feed ID %s", config.FeedID))
-		return priceOutput{}, sdk.BreakErr
-	}
-
 	return priceOutput{
 		FeedID:    feedID, // TrueUSD
 		Timestamp: uint32(resp.UpdatedAt.Unix()),


### PR DESCRIPTION
- don't check `ripcord` flag in the API response, we only care about getting some numeric value in the response

successful run: https://github.com/smartcontractkit/chainlink/actions/runs/33740310115/job/100600622331