### PR TITLE
Fix stale gnupg pin blocking image build on release/2.62.3

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -115,7 +115,7 @@ ARG CHAINLINK_USER=root
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates=20260601~24.04.1 \
-    gnupg=2.4.4-2ubuntu17.4 \
+    gnupg=2.4.4-2ubuntu17.6 \
     lsb-release=12.0-2 \
     curl=8.5.0-2ubuntu10.13 \
     && rm -rf /var/lib/apt/lists/*

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -114,7 +114,7 @@ ARG CHAINLINK_USER=root
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates=20260601~24.04.1 \
-    gnupg=2.4.4-2ubuntu17.4 \
+    gnupg=2.4.4-2ubuntu17.6 \
     lsb-release=12.0-2 \
     curl=8.5.0-2ubuntu10.13 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- The gnupg version pinned in both Dockerfiles (`2.4.4-2ubuntu17.4`) has been superseded in the Ubuntu 24.04 archive and no longer resolves, breaking the image build.
- Cherry-picks the fix already merged to develop in #23645 (bumps to `2.4.4-2ubuntu17.6`).

## Verification
- Reproduced locally: `apt-get install gnupg=2.4.4-2ubuntu17.4` fails with "Version not found"; `2.4.4-2ubuntu17.6` is the current archive version.
- Confirmed `ca-certificates`, `lsb-release`, and `curl` pins are all still valid -- gnupg was the only broken pin.