### PR TITLE
Bump version and update CHANGELOG for v2.62.3

### DIFF
--- a/.changeset/gray-newts-act.md
+++ b/.changeset/gray-newts-act.md
@@ -1,5 +1,0 @@
----
-"chainlink": minor
----
-
-#added Adding new experimental tasks in pipeline package. Anchor, Normalize, Sample, Staleness, WeightedMean.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog Chainlink Core
 
+## 2.62.3
+
+### Minor Changes
+
+- [#23647](https://github.com/smartcontractkit/chainlink/pull/23647) [`550a2a5`](https://github.com/smartcontractkit/chainlink/commit/550a2a58f10da500c833eb29fef5f4bc34fb58b5) - #added Adding new experimental tasks in pipeline package. Anchor, Normalize, Sample, Staleness, WeightedMean.
+
 ## 2.62.0
 
 ### Minor Changes


### PR DESCRIPTION
## Summary
- The release-pre workflow's own bot push to `release/2.62.3` was rejected by required status checks (Sigscanner Check, "changes must be made through a pull request"). Landing the changeset-consumption commit here via PR instead, per the failure playbook.
- Consumes `.changeset/gray-newts-act.md` (from #23647) and updates CHANGELOG.md.
- Manually corrected the CHANGELOG heading to `2.62.3` -- `pnpm changeset version` computed `2.63.0` since the changeset is typed `minor` (2.62.3 -> 2.63.0 is the semver-correct next minor), but this branch is pinned to ship as 2.62.3, not 2.63.0.

## Note
That version-label mismatch is a real gap in release-pre.yaml: any `continue-*` dispatch consuming a minor/major-typed changeset on an existing release branch will mislabel the CHANGELOG heading the same way. Worth a follow-up ticket, not fixed here.