### PR TITLE
Delete unused code from launcher.go

### DIFF
--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -11,7 +11,6 @@ import (
 	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
-	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/registry"
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -120,7 +119,7 @@ func NewLauncher(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create workflow DON binding gate limiter: %w", err)
 	}
-	workflowTagHashFlag, err := limits.MakeRangeLimiter[commonconfig.Timestamp](limitsFactory, cresettings.Default.PerWorkflow.FeatureRequestHashIncludeWorkflowTagActivePeriod)
+	workflowTagHashFlag, err := limits.MakeRangeLimiter(limitsFactory, cresettings.Default.PerWorkflow.FeatureRequestHashIncludeWorkflowTagActivePeriod)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create workflow tag hash flag limiter: %w", err)
 	}
@@ -367,7 +366,7 @@ func (w *launcher) onNewRegistry(ctx context.Context, localRegistry *registrysyn
 	belongsToACapabilityDON := len(myCapabilityDONs) > 0
 	if belongsToACapabilityDON {
 		for _, myDON := range myCapabilityDONs {
-			w.serveCapabilities(ctx, w.myPeerID, myDON, localRegistry, remoteWorkflowDONs)
+			w.serveCapabilities(ctx, w.myPeerID, myDON, remoteWorkflowDONs)
 		}
 	}
 
@@ -458,63 +457,9 @@ func (w *launcher) addRemoteCapabilities(ctx context.Context, myDON registrysync
 	}
 }
 
-type capabilityService interface {
-	capabilities.BaseCapability
-	remotetypes.Receiver
-	services.Service
-}
-
-func (w *launcher) addToRegistryAndSetDispatcher(ctx context.Context, capability registrysyncer.Capability, don registrysyncer.DON, newCapFn func(info capabilities.CapabilityInfo) (capabilityService, error)) error {
-	capabilityID := capability.ID
-	info, err := capabilities.NewRemoteCapabilityInfo(
-		capabilityID,
-		capability.CapabilityType,
-		"Remote Capability for "+capabilityID,
-		&don.DON,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create remote capability info: %w", err)
-	}
-	w.lggr.Debugw("Adding remote capability to registry", "id", info.ID, "don", info.DON)
-	cp, err := newCapFn(info)
-	if err != nil {
-		return fmt.Errorf("failed to instantiate capability %q: %w", capabilityID, err)
-	}
-
-	err = w.registry.Add(ctx, cp)
-	if err != nil {
-		// If the capability already exists, then it's either local
-		// or we've handled this in a previous syncer iteration,
-		// let's skip and move on to other capabilities.
-		if errors.Is(err, registry.ErrCapabilityAlreadyExists) {
-			return nil
-		}
-
-		return fmt.Errorf("failed to add capability to registry: %w", err)
-	}
-
-	err = w.dispatcher.SetReceiver(
-		capabilityID,
-		don.ID,
-		cp,
-	)
-	if err != nil {
-		return err
-	}
-	w.lggr.Debugw("Setting receiver for capability", "id", capabilityID, "donID", don.ID)
-	err = cp.Start(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to start capability: %w", err)
-	}
-	w.muSubServices.Lock()
-	defer w.muSubServices.Unlock()
-	w.subServices = append(w.subServices, cp)
-	return nil
-}
-
 // serveCapabilities exposes capabilities that are available on this node, as part of the given DON.
 // It is best effort, ensuring that valid capabilities are exposed even if some fail
-func (w *launcher) serveCapabilities(ctx context.Context, myPeerID p2ptypes.PeerID, don registrysyncer.DON, localRegistry *registrysyncer.LocalRegistry, remoteWorkflowDONs []registrysyncer.DON) {
+func (w *launcher) serveCapabilities(ctx context.Context, myPeerID p2ptypes.PeerID, don registrysyncer.DON, remoteWorkflowDONs []registrysyncer.DON) {
 	idsToDONs := map[uint32]capabilities.DON{}
 	for _, d := range remoteWorkflowDONs {
 		idsToDONs[d.ID] = d.DON
@@ -547,49 +492,6 @@ func (w *launcher) serveCapabilities(ctx context.Context, myPeerID p2ptypes.Peer
 		}
 		w.metrics.recordLocalCapabilityExposed(ctx, cid, resultSuccess)
 	}
-}
-
-func (w *launcher) addReceiver(ctx context.Context, capability registrysyncer.Capability, don registrysyncer.DON, newReceiverFn func(capability capabilities.BaseCapability, info capabilities.CapabilityInfo) (remotetypes.ReceiverService, error)) error {
-	capID := capability.ID
-	info, err := capabilities.NewRemoteCapabilityInfo(
-		capID,
-		capability.CapabilityType,
-		"Remote Capability for "+capability.ID,
-		&don.DON,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to instantiate remote capability for receiver: %w", err)
-	}
-	underlying, err := w.registry.Get(ctx, capability.ID)
-	if err != nil {
-		return fmt.Errorf("failed to get capability from registry: %w", err)
-	}
-
-	receiver, err := newReceiverFn(underlying, info)
-	if err != nil {
-		return fmt.Errorf("failed to instantiate receiver: %w", err)
-	}
-
-	w.lggr.Debugw("Enabling external access for capability", "id", capID, "donID", don.ID)
-	err = w.dispatcher.SetReceiver(capID, don.ID, receiver)
-	if errors.Is(err, remote.ErrReceiverExists) {
-		// If a receiver already exists, let's log the error for debug purposes, but
-		// otherwise short-circuit here. We've handled this capability in a previous iteration.
-		w.lggr.Debugw("receiver already exists for capability", "capabilityID", capID, "donID", don.ID, "error", err)
-		return nil
-	} else if err != nil {
-		return fmt.Errorf("failed to set receiver: %w", err)
-	}
-
-	err = receiver.Start(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to start receiver: %w", err)
-	}
-
-	w.muSubServices.Lock()
-	defer w.muSubServices.Unlock()
-	w.subServices = append(w.subServices, receiver)
-	return nil
 }
 
 func signersFor(don registrysyncer.DON, localRegistry *registrysyncer.LocalRegistry) ([][]byte, error) {


### PR DESCRIPTION
Deployment Validation: Existing chain canaries. If Launcher fails to set up remote capabilities in any way, those canaries will start failing.