### PR TITLE
fix(ci): CI tools merge queue fix

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -48,7 +48,7 @@ jobs:
   tools-tests:
     name: Tools Unit Tests (${{ matrix.target.name }})
     needs: [matrix]
-    if: ${{ needs.matrix.outputs.matrix != '[]' && needs.matrix.outputs.matrix != '' }}
+    if: ${{ needs.matrix.outputs.matrix != '[]' && needs.matrix.outputs.matrix != '' && needs.matrix.outputs.matrix != 'null' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/tools/ci/cmd/tools.go
+++ b/tools/ci/cmd/tools.go
@@ -98,6 +98,9 @@ func runToolsMatrix(ctx context.Context, cmd *cobra.Command, opts *toolsMatrixOp
 		ChangedFiles: changedFileList,
 		All:          opts.all,
 	})
+	if filteredTargets == nil {
+		filteredTargets = []tools.Target{}
+	}
 
 	jsonData, err := json.Marshal(filteredTargets)
 	if err != nil {

--- a/tools/ci/cmd/tools_test.go
+++ b/tools/ci/cmd/tools_test.go
@@ -81,3 +81,28 @@ func TestToolsMatrixCmd_FilterChangedFiles(t *testing.T) {
 	require.Len(t, targets, 1)
 	assert.Equal(t, "tools/ci", targets[0].Name)
 }
+
+func TestToolsMatrixCmd_FilterChangedFiles_NoMatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "github_output")
+	require.NoError(t, os.WriteFile(outputPath, []byte{}, 0o600))
+
+	t.Setenv("GITHUB_OUTPUT", outputPath)
+
+	rootCmd := cmd.NewRootCmd()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"tools", "matrix", "--changed-files", "core/capabilities/launcher.go", "--json"})
+
+	err := rootCmd.ExecuteContext(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, "[]\n", out.String())
+
+	content, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "matrix")
+	assert.Contains(t, string(content), "[]")
+	assert.NotContains(t, string(content), "null")
+}

--- a/tools/ci/internal/tools/target.go
+++ b/tools/ci/internal/tools/target.go
@@ -115,7 +115,7 @@ func ComputeMatrix(targets []Target, opts MatrixOptions) []Target {
 		}
 	}
 
-	var matched []Target
+	matched := make([]Target, 0)
 	for _, target := range targets {
 		if targetIsChanged(target, targets, opts.ChangedFiles) {
 			matched = append(matched, target)

--- a/tools/ci/internal/tools/target_test.go
+++ b/tools/ci/internal/tools/target_test.go
@@ -1,6 +1,7 @@
 package tools_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -171,4 +172,10 @@ func TestComputeMatrix_UnrelatedChanges(t *testing.T) {
 		ChangedFiles: []string{"core/services/chainlink.go", "deployment/environment.go"},
 	})
 	assert.Empty(t, matrix)
+	assert.NotNil(t, matrix)
+	assert.Equal(t, []tools.Target{}, matrix)
+
+	jsonData, err := json.Marshal(matrix)
+	require.NoError(t, err)
+	assert.JSONEq(t, "[]", string(jsonData))
 }


### PR DESCRIPTION
## Intent

Fix issue where `CI Tools` workflow fails to properly run on some `merge_queue` and `push` events. [Example](https://github.com/smartcontractkit/chainlink/actions/runs/33859531575)