### PR TITLE
[PRIV-644] Add pending requests to relay DON caching in addition to completed ones

### DIFF
--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -157,12 +158,21 @@ type Handler struct {
 
 	// responseMemo caches completed signed results so the enclave's retry loop
 	// (re-fan-out after a gateway rotation or timeout) returns the cached result
-	// without re-executing the capability or vault fetch. Only completed results
-	// are cached; in-flight calls are not deduplicated, so a burst of concurrent
-	// same-identity requests each execute (preserving parallel dispatch). The
+	// without re-executing the capability or vault fetch. The
 	// cap- and sec-prefixed keys share one cache instance; go-cache runs its own
 	// background cleanup goroutine, so there is no separate sweep to stop.
 	responseMemo *cache.Cache
+
+	// pendingRequests tracks logical identities currently being executed on
+	// this node, so a retry arriving while the original is still in flight
+	// waits on it and responds with its result instead of re-executing.
+	// Re-executing would fail the remote request server's duplicate-requester
+	// check ("request already received from peer"), a well-formed error the
+	// enclave's retry loop treats as terminal. TTL-bounded so a crashed owner
+	// ages out. pendingRequestsMu serializes the memo-then-pending lookup pair
+	// so a retried request cannot slip between the two checks.
+	pendingRequests   *cache.Cache
+	pendingRequestsMu sync.Mutex
 }
 
 func NewHandler(capRegistry core.CapabilitiesRegistry, executionHandlers *ExecutionHandlers, conn core.GatewayConnector, responseSigner relayResponseSigner, lggr logger.Logger, lf limits.Factory, validator AttestationValidator, requireBFTQuorum bool) (*Handler, error) {
@@ -201,6 +211,7 @@ func NewHandler(capRegistry core.CapabilitiesRegistry, executionHandlers *Execut
 		serveTime:         serveTime,
 		getExecutionWait:  defaultGetExecutionWait,
 		responseMemo:      cache.New(memoTTL, memoCleanup),
+		pendingRequests:   cache.New(memoTTL, memoCleanup),
 	}
 	h.Service, h.eng = services.Config{
 		Name:  HandlerName,
@@ -289,7 +300,7 @@ func (h *Handler) serveGatewayMessage(ctx context.Context, gatewayID string, req
 	}
 
 	h.lggr.Infow("sent message to gateway", "gatewayID", gatewayID, "requestID", req.ID)
-	if response != nil && response.Error == nil {
+	if response.Error == nil {
 		h.metrics.requestSuccess.Add(ctx, 1, metric.WithAttributes(
 			attribute.String("gateway_id", gatewayID),
 		))
@@ -308,6 +319,7 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 	att := params.Attestation
 	params.Attestation = ""
 	if err := h.verifyAttestationHash(ctx, att, params, confidentialrelaytypes.DomainSecretsGet); err != nil {
+		h.lggr.Warnw("rejecting secrets request: attestation validation failed", "requestID", req.ID, "workflow", params.WorkflowID, "err", err)
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
 	}
 	// Fetch the local node once: it provides the WorkflowDON snapshot for both the
@@ -323,6 +335,7 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 	// genuinely-attested request over a forged enclave config unless we
 	// compare the config value against the DON reference.
 	if err = h.verifyEnclaveConfigMatchesDON(localNode, params.EnclaveConfig); err != nil {
+		h.lggr.Warnw("rejecting secrets request: enclave config does not match DON", "requestID", req.ID, "workflow", params.WorkflowID, "err", err)
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
 	}
 
@@ -331,6 +344,7 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 	// names the authorized owner. A TEE breach passes attestation but cannot forge a Workflow
 	// DON quorum over a different owner (PRIV-433).
 	if err = h.verifyWorkflowAuthorization(localNode.WorkflowDON, params); err != nil {
+		h.lggr.Warnw("rejecting secrets request: workflow DON authorization failed", "requestID", req.ID, "workflow", params.WorkflowID, "err", err)
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInvalidParams, err)
 	}
 
@@ -338,11 +352,36 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 	// same request; return the already-computed signed result from the memo
 	// instead of re-fetching from the vault. The signed result is params-bound,
 	// not id-bound, so jsonResponse re-wraps it with this request's id.
+	h.pendingRequestsMu.Lock()
 	key := secretsKey(params)
 	if cached, ok := h.responseMemo.Get(key); ok {
 		if signed, ok := cached.(*confidentialrelaytypes.SignedSecretsResponseResult); ok {
+			h.pendingRequestsMu.Unlock()
+			h.lggr.Debugw("serving secrets request from memo", "requestID", req.ID, "key", key)
 			return h.jsonResponse(req, signed)
 		}
+	}
+
+	// A retry that arrives while the original vault fetch is still in flight
+	// waits on it and responds with the owner's result, same rationale as
+	// handleCapabilityExecute.
+	pending, err := h.checkOrCreatePendingRequest(key)
+	if err != nil {
+		h.pendingRequestsMu.Unlock()
+		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
+	}
+	h.pendingRequestsMu.Unlock()
+	if pending != nil {
+		signed, ok := waitForPendingRequest(ctx, pending)
+		if !ok {
+			h.lggr.Warnw("timed out waiting for in-flight secrets request", "requestID", req.ID, "key", key, "err", ctx.Err())
+			return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, errors.New("timed out waiting for in-flight secrets request"))
+		}
+		if signed, ok := signed.(*confidentialrelaytypes.SignedSecretsResponseResult); ok {
+			h.lggr.Debugw("served retried secrets request from in-flight owner", "requestID", req.ID, "key", key)
+			return h.jsonResponse(req, signed)
+		}
+		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, errors.New("in-flight secrets request completed without a result"))
 	}
 
 	secretsRequest := &sdkpb.GetSecretsRequest{
@@ -373,6 +412,7 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 
 	vaultResp, err := handler.GetRawSecrets(ctx, secretsRequest, teeKeyFetcher(params.EnclavePublicKey))
 	if err != nil {
+		h.lggr.Errorw("vault secrets fetch failed", "requestID", req.ID, "key", key, "err", err)
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
 	}
 
@@ -382,36 +422,22 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 		if IsUserError(err) {
 			code = jsonrpc.ErrInvalidParams
 		}
+		h.lggr.Errorw("translating vault response failed", "requestID", req.ID, "key", key, "userError", IsUserError(err), "err", err)
 		return h.errorResponse(ctx, gatewayID, req, code, err)
 	}
 
 	signedResult, err := h.signSecretsResponse(params, result)
 	if err != nil {
+		h.lggr.Errorw("signing secrets response failed", "requestID", req.ID, "key", key, "err", err)
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, fmt.Errorf("failed to sign secrets response: %w", err))
 	}
 
+	h.pendingRequestsMu.Lock()
 	h.responseMemo.SetDefault(key, signedResult)
+	h.completePendingRequest(key, signedResult)
+	h.pendingRequestsMu.Unlock()
+	h.lggr.Infow("fetched and signed secrets response", "requestID", req.ID, "key", key, "secrets", len(result.Secrets))
 	return h.jsonResponse(req, signedResult)
-}
-
-// resolveDONID determines the DON ID for a capability.
-// Keeping for potential future use by handleCapabilityExecute.
-func (h *Handler) resolveDONID(ctx context.Context, capability capabilities.ExecutableCapability) (uint32, error) { //nolint:unused // reserved for future multi-DON routing in handleCapabilityExecute
-	info, err := capability.Info(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get capability info: %w", err)
-	}
-	if info.IsLocal {
-		localNode, err := h.capRegistry.LocalNode(ctx)
-		if err != nil {
-			return 0, fmt.Errorf("failed to get local node: %w", err)
-		}
-		return localNode.WorkflowDON.ID, nil
-	}
-	if info.DON == nil {
-		return 0, errors.New("capability is not associated with any DON")
-	}
-	return info.DON.ID, nil
 }
 
 // translateVaultResponse converts a vault GetSecretsResponse to the enclave relay protocol format.
@@ -495,6 +521,7 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 	att := params.Attestation
 	params.Attestation = ""
 	if err := h.verifyAttestationHash(ctx, att, params, confidentialrelaytypes.DomainCapabilityExec); err != nil {
+		h.lggr.Warnw("rejecting capability request: attestation validation failed", "requestID", req.ID, "workflow", params.WorkflowID, "err", err)
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
 	}
 
@@ -507,6 +534,7 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, fmt.Errorf("failed to get local node: %w", err))
 	}
 	if err = h.verifyEnclaveConfigMatchesDON(localNode, params.EnclaveConfig); err != nil {
+		h.lggr.Warnw("rejecting capability request: enclave config does not match DON", "requestID", req.ID, "workflow", params.WorkflowID, "err", err)
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
 	}
 
@@ -514,11 +542,36 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 	// same request; return the already-computed signed result from the memo
 	// instead of re-executing the capability. The signed result is params-bound,
 	// not id-bound, so jsonResponse re-wraps it with this request's id.
+	h.pendingRequestsMu.Lock()
 	key := capExecKey(params)
 	if cached, ok := h.responseMemo.Get(key); ok {
 		if signed, ok := cached.(*confidentialrelaytypes.SignedCapabilityResponseResult); ok {
+			h.pendingRequestsMu.Unlock()
+			h.lggr.Debugw("serving capability request from memo", "requestID", req.ID, "key", key)
 			return h.jsonResponse(req, signed)
 		}
+	}
+
+	// A retry that arrives while the original execution is still in flight
+	// waits on it and responds with the owner's result rather than
+	// re-executing.
+	pending, err := h.checkOrCreatePendingRequest(key)
+	if err != nil {
+		h.pendingRequestsMu.Unlock()
+		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
+	}
+	h.pendingRequestsMu.Unlock()
+	if pending != nil {
+		signed, ok := waitForPendingRequest(ctx, pending)
+		if !ok {
+			h.lggr.Warnw("timed out waiting for in-flight capability request", "requestID", req.ID, "key", key, "err", ctx.Err())
+			return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, errors.New("timed out waiting for in-flight capability request"))
+		}
+		if signed, ok := signed.(*confidentialrelaytypes.SignedCapabilityResponseResult); ok {
+			h.lggr.Debugw("served retried capability request from in-flight owner", "requestID", req.ID, "key", key)
+			return h.jsonResponse(req, signed)
+		}
+		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, errors.New("in-flight capability request completed without a result"))
 	}
 
 	payloadBytes, err := base64.StdEncoding.DecodeString(params.Payload)
@@ -544,6 +597,12 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 	}
 
 	capResp, execErr := handler.CallCapability(ctx, sdkReq)
+	if execErr != nil {
+		// Not an error from this node's perspective: the execution result is a
+		// signed error response the enclave's quorum logic handles; log it so
+		// the capability-side failure is attributable to this node.
+		h.lggr.Infow("capability execution returned an error result", "requestID", req.ID, "key", key, "capability", sdkReq.Id, "err", execErr)
+	}
 
 	var result confidentialrelaytypes.CapabilityResponseResult
 	if execErr != nil {
@@ -562,10 +621,15 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 
 	signedResult, err := h.signCapabilityResponse(params, result)
 	if err != nil {
+		h.lggr.Errorw("signing capability response failed", "requestID", req.ID, "key", key, "err", err)
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, fmt.Errorf("failed to sign capability response: %w", err))
 	}
 
+	h.pendingRequestsMu.Lock()
 	h.responseMemo.SetDefault(key, signedResult)
+	h.completePendingRequest(key, signedResult)
+	h.pendingRequestsMu.Unlock()
+	h.lggr.Infow("executed and signed capability response", "requestID", req.ID, "key", key, "capability", params.CapabilityID, "resultError", result.Error != "")
 	return h.jsonResponse(req, signedResult)
 }
 

--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -338,10 +338,20 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInvalidParams, err)
 	}
 
+	// Every line below carries the gateway request id together with the
+	// workflow/execution identity, so a log can be correlated with the
+	// enclave's and the gateway's own lines for the same execution. The
+	// gateway request id changes per retry; the execution identity does not.
+	l := logger.With(h.lggr,
+		"requestID", req.ID,
+		"workflowID", params.WorkflowID,
+		"executionID", params.ExecutionID,
+	)
+
 	att := params.Attestation
 	params.Attestation = ""
 	if err := h.verifyAttestationHash(ctx, att, params, confidentialrelaytypes.DomainSecretsGet); err != nil {
-		h.lggr.Warnw("rejecting secrets request: attestation validation failed", "requestID", req.ID, "workflow", params.WorkflowID, "err", err)
+		l.Warnw("rejecting secrets request: attestation validation failed", "err", err)
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
 	}
 	// Fetch the local node once: it provides the WorkflowDON snapshot for both the
@@ -357,7 +367,7 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 	// genuinely-attested request over a forged enclave config unless we
 	// compare the config value against the DON reference.
 	if err = h.verifyEnclaveConfigMatchesDON(localNode, params.EnclaveConfig); err != nil {
-		h.lggr.Warnw("rejecting secrets request: enclave config does not match DON", "requestID", req.ID, "workflow", params.WorkflowID, "err", err)
+		l.Warnw("rejecting secrets request: enclave config does not match DON", "err", err)
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
 	}
 
@@ -366,7 +376,7 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 	// names the authorized owner. A TEE breach passes attestation but cannot forge a Workflow
 	// DON quorum over a different owner (PRIV-433).
 	if err = h.verifyWorkflowAuthorization(localNode.WorkflowDON, params); err != nil {
-		h.lggr.Warnw("rejecting secrets request: workflow DON authorization failed", "requestID", req.ID, "workflow", params.WorkflowID, "err", err)
+		l.Warnw("rejecting secrets request: workflow DON authorization failed", "err", err)
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInvalidParams, err)
 	}
 
@@ -374,12 +384,14 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 	// same request; return the already-computed signed result from the memo
 	// instead of re-fetching from the vault. The signed result is params-bound,
 	// not id-bound, so jsonResponse re-wraps it with this request's id.
-	h.pendingRequestsMu.Lock()
 	key := secretsKey(params)
+	l = logger.With(l, "key", key)
+
+	h.pendingRequestsMu.Lock()
 	if cached, ok := h.responseMemo.Get(key); ok {
 		if signed, ok := cached.(*confidentialrelaytypes.SignedSecretsResponseResult); ok {
 			h.pendingRequestsMu.Unlock()
-			h.lggr.Debugw("serving secrets request from memo", "requestID", req.ID, "key", key)
+			l.Debugw("serving secrets request from memo")
 			return h.jsonResponse(req, signed)
 		}
 	}
@@ -397,15 +409,15 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 		signed, ok, ownerErr := waitForPendingRequest(ctx, pending)
 		switch {
 		case !ok:
-			h.lggr.Warnw("timed out waiting for in-flight secrets request", "requestID", req.ID, "key", key, "err", ctx.Err())
+			l.Warnw("timed out waiting for in-flight secrets request", "err", ctx.Err())
 			return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, errors.New("timed out waiting for in-flight secrets request"))
 		case ownerErr != nil:
 			ownerCode := relayErrorCode(ownerErr, jsonrpc.ErrInternal)
-			h.lggr.Debugw("in-flight secrets request failed; relaying its error", "requestID", req.ID, "key", key, "errorCode", ownerCode)
+			l.Debugw("in-flight secrets request failed; relaying its error", "errorCode", ownerCode)
 			return h.errorResponse(ctx, gatewayID, req, ownerCode, ownerErr)
 		}
 		if signed, ok := signed.(*confidentialrelaytypes.SignedSecretsResponseResult); ok {
-			h.lggr.Debugw("served retried secrets request from in-flight owner", "requestID", req.ID, "key", key)
+			l.Debugw("served retried secrets request from in-flight owner")
 			return h.jsonResponse(req, signed)
 		}
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, errors.New("in-flight secrets request completed without a result"))
@@ -415,7 +427,7 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 	// either way. A failure has to reach them with its real cause, and has to
 	// clear the entry so later retries re-execute rather than waiting on a
 	// request nobody completes (see failPendingRequest).
-	signedResult, err := h.fetchSecrets(ctx, req, params, key)
+	signedResult, err := h.fetchSecrets(ctx, l, params)
 	if err != nil {
 		h.pendingRequestsMu.Lock()
 		h.failPendingRequest(key, err)
@@ -427,7 +439,7 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 	h.responseMemo.SetDefault(key, signedResult)
 	h.completePendingRequest(key, signedResult)
 	h.pendingRequestsMu.Unlock()
-	h.lggr.Infow("fetched and signed secrets response", "requestID", req.ID, "key", key)
+	l.Infow("fetched and signed secrets response")
 	return h.jsonResponse(req, signedResult)
 }
 
@@ -437,9 +449,8 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 // both answer this request and publish the same failure to any waiters.
 func (h *Handler) fetchSecrets(
 	ctx context.Context,
-	req *jsonrpc.Request[json.RawMessage],
+	l logger.Logger,
 	params confidentialrelaytypes.SecretsRequestParams,
-	key string,
 ) (*confidentialrelaytypes.SignedSecretsResponseResult, error) {
 	secretsRequest := &sdkpb.GetSecretsRequest{
 		Requests:   make([]*sdkpb.SecretRequest, 0, len(params.Secrets)),
@@ -469,7 +480,7 @@ func (h *Handler) fetchSecrets(
 
 	vaultResp, err := handler.GetRawSecrets(ctx, secretsRequest, teeKeyFetcher(params.EnclavePublicKey))
 	if err != nil {
-		h.lggr.Errorw("vault secrets fetch failed", "requestID", req.ID, "key", key, "err", err)
+		l.Errorw("vault secrets fetch failed", "err", err)
 		return nil, &relayError{code: jsonrpc.ErrInternal, err: err}
 	}
 
@@ -479,17 +490,17 @@ func (h *Handler) fetchSecrets(
 		if IsUserError(err) {
 			code = jsonrpc.ErrInvalidParams
 		}
-		h.lggr.Errorw("translating vault response failed", "requestID", req.ID, "key", key, "userError", IsUserError(err), "err", err)
+		l.Errorw("translating vault response failed", "userError", IsUserError(err), "err", err)
 		return nil, &relayError{code: code, err: err}
 	}
 
 	signedResult, err := h.signSecretsResponse(params, result)
 	if err != nil {
-		h.lggr.Errorw("signing secrets response failed", "requestID", req.ID, "key", key, "err", err)
+		l.Errorw("signing secrets response failed", "err", err)
 		return nil, &relayError{code: jsonrpc.ErrInternal, err: fmt.Errorf("failed to sign secrets response: %w", err)}
 	}
 
-	h.lggr.Debugw("fetched secrets from vault", "requestID", req.ID, "key", key, "secrets", len(result.Secrets))
+	l.Debugw("fetched secrets from vault", "secrets", len(result.Secrets))
 	return signedResult, nil
 }
 
@@ -571,10 +582,19 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 		Workflow: params.WorkflowID,
 	})
 
+	// See handleSecretsGet: the gateway request id plus the workflow/execution
+	// identity on every line, so logs correlate across the gateway, this node
+	// and the enclave for one execution.
+	l := logger.With(h.lggr,
+		"requestID", req.ID,
+		"workflowID", params.WorkflowID,
+		"executionID", params.ExecutionID,
+	)
+
 	att := params.Attestation
 	params.Attestation = ""
 	if err := h.verifyAttestationHash(ctx, att, params, confidentialrelaytypes.DomainCapabilityExec); err != nil {
-		h.lggr.Warnw("rejecting capability request: attestation validation failed", "requestID", req.ID, "workflow", params.WorkflowID, "err", err)
+		l.Warnw("rejecting capability request: attestation validation failed", "err", err)
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
 	}
 
@@ -587,7 +607,7 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, fmt.Errorf("failed to get local node: %w", err))
 	}
 	if err = h.verifyEnclaveConfigMatchesDON(localNode, params.EnclaveConfig); err != nil {
-		h.lggr.Warnw("rejecting capability request: enclave config does not match DON", "requestID", req.ID, "workflow", params.WorkflowID, "err", err)
+		l.Warnw("rejecting capability request: enclave config does not match DON", "err", err)
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
 	}
 
@@ -595,12 +615,14 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 	// same request; return the already-computed signed result from the memo
 	// instead of re-executing the capability. The signed result is params-bound,
 	// not id-bound, so jsonResponse re-wraps it with this request's id.
-	h.pendingRequestsMu.Lock()
 	key := capExecKey(params)
+	l = logger.With(l, "key", key)
+
+	h.pendingRequestsMu.Lock()
 	if cached, ok := h.responseMemo.Get(key); ok {
 		if signed, ok := cached.(*confidentialrelaytypes.SignedCapabilityResponseResult); ok {
 			h.pendingRequestsMu.Unlock()
-			h.lggr.Debugw("serving capability request from memo", "requestID", req.ID, "key", key)
+			l.Debugw("serving capability request from memo")
 			return h.jsonResponse(req, signed)
 		}
 	}
@@ -618,15 +640,15 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 		signed, ok, pendingReqErr := waitForPendingRequest(ctx, pending)
 		switch {
 		case !ok:
-			h.lggr.Warnw("timed out waiting for in-flight capability request", "requestID", req.ID, "key", key, "err", ctx.Err())
+			l.Warnw("timed out waiting for in-flight capability request", "err", ctx.Err())
 			return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, errors.New("timed out waiting for in-flight capability request"))
 		case pendingReqErr != nil:
 			errorCode := relayErrorCode(pendingReqErr, jsonrpc.ErrInternal)
-			h.lggr.Debugw("in-flight capability request failed; relaying its error", "requestID", req.ID, "key", key, "errorCode", errorCode)
+			l.Debugw("in-flight capability request failed; relaying its error", "errorCode", errorCode)
 			return h.errorResponse(ctx, gatewayID, req, errorCode, pendingReqErr)
 		}
 		if signed, ok := signed.(*confidentialrelaytypes.SignedCapabilityResponseResult); ok {
-			h.lggr.Debugw("served retried capability request from in-flight owner", "requestID", req.ID, "key", key)
+			l.Debugw("served retried capability request from in-flight owner")
 			return h.jsonResponse(req, signed)
 		}
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, errors.New("in-flight capability request completed without a result"))
@@ -634,7 +656,7 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 
 	// We own the pending entry: execute, then publish the outcome to any
 	// waiters either way; see handleSecretsGet.
-	signedResult, err := h.executeCapability(ctx, req, params, key)
+	signedResult, err := h.executeCapability(ctx, l, params)
 	if err != nil {
 		h.pendingRequestsMu.Lock()
 		h.failPendingRequest(key, err)
@@ -646,7 +668,7 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 	h.responseMemo.SetDefault(key, signedResult)
 	h.completePendingRequest(key, signedResult)
 	h.pendingRequestsMu.Unlock()
-	h.lggr.Infow("executed and signed capability response", "requestID", req.ID, "key", key, "capability", params.CapabilityID)
+	l.Infow("executed and signed capability response", "capability", params.CapabilityID)
 	return h.jsonResponse(req, signedResult)
 }
 
@@ -658,9 +680,8 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 // produces a signed error result the enclave's quorum logic handles.
 func (h *Handler) executeCapability(
 	ctx context.Context,
-	req *jsonrpc.Request[json.RawMessage],
+	l logger.Logger,
 	params confidentialrelaytypes.CapabilityRequestParams,
-	key string,
 ) (*confidentialrelaytypes.SignedCapabilityResponseResult, error) {
 	payloadBytes, err := base64.StdEncoding.DecodeString(params.Payload)
 	if err != nil {
@@ -691,7 +712,7 @@ func (h *Handler) executeCapability(
 		// Not an error from this node's perspective: the execution result is a
 		// signed error response the enclave's quorum logic handles; log it so
 		// the capability-side failure is attributable to this node.
-		h.lggr.Infow("capability execution returned an error result", "requestID", req.ID, "key", key, "capability", sdkReq.Id, "err", execErr)
+		l.Infow("capability execution returned an error result", "capability", sdkReq.Id, "err", execErr)
 		result.Error = execErr.Error()
 	} else {
 		// Deterministic marshal so every relay node emits byte-identical
@@ -707,7 +728,7 @@ func (h *Handler) executeCapability(
 
 	signedResult, err := h.signCapabilityResponse(params, result)
 	if err != nil {
-		h.lggr.Errorw("signing capability response failed", "requestID", req.ID, "key", key, "err", err)
+		l.Errorw("signing capability response failed", "err", err)
 		return nil, &relayError{code: jsonrpc.ErrInternal, err: fmt.Errorf("failed to sign capability response: %w", err)}
 	}
 
@@ -1005,7 +1026,7 @@ func (h *Handler) errorResponse(
 	errorCode int64,
 	err error,
 ) *jsonrpc.Response[json.RawMessage] {
-	h.lggr.Errorw("request error", "errorCode", errorCode, "err", err)
+	h.lggr.Errorw("request error", "requestID", req.ID, "method", req.Method, "errorCode", errorCode, "err", err)
 	h.metrics.requestInternalError.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("gateway_id", gatewayID),
 		attribute.Int64("error_code", errorCode),

--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -55,7 +55,7 @@ const (
 	// lets a straggling node register and still sign, instead of dropping below
 	// quorum. Kept well under the gateway relay request timeout (RequestTimeoutSec,
 	// default 30s) so the node still answers in time to be counted.
-	defaultGetExecutionWait = 5 * time.Second
+	defaultGetExecutionWait = 15 * time.Second
 )
 
 // relayError couples a failure with the JSON-RPC code the handler answered it

--- a/core/capabilities/confidentialrelay/handler.go
+++ b/core/capabilities/confidentialrelay/handler.go
@@ -58,6 +58,28 @@ const (
 	defaultGetExecutionWait = 5 * time.Second
 )
 
+// relayError couples a failure with the JSON-RPC code the handler answered it
+// with, so one error value carries everything needed to reproduce that
+// answer. An owner publishes its failure to waiters as a relayError; each
+// waiter unwraps the code with relayErrorCode and builds its own response.
+// Mirrors how vaultSecretError carries its user/system classification.
+type relayError struct {
+	code int64
+	err  error
+}
+
+func (e *relayError) Error() string { return e.err.Error() }
+func (e *relayError) Unwrap() error { return e.err }
+
+// relayErrorCode reports the JSON-RPC code err was answered with, or fallback
+// if err carries none.
+func relayErrorCode(err error, fallback int64) int64 {
+	if re, ok := errors.AsType[*relayError](err); ok {
+		return re.code
+	}
+	return fallback
+}
+
 // enclaveEntry mirrors the enclave config shape stored in the capabilities
 // registry. Only the fields needed for attestation validation are included.
 type enclaveEntry struct {
@@ -372,10 +394,15 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 	}
 	h.pendingRequestsMu.Unlock()
 	if pending != nil {
-		signed, ok := waitForPendingRequest(ctx, pending)
-		if !ok {
+		signed, ok, ownerErr := waitForPendingRequest(ctx, pending)
+		switch {
+		case !ok:
 			h.lggr.Warnw("timed out waiting for in-flight secrets request", "requestID", req.ID, "key", key, "err", ctx.Err())
 			return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, errors.New("timed out waiting for in-flight secrets request"))
+		case ownerErr != nil:
+			ownerCode := relayErrorCode(ownerErr, jsonrpc.ErrInternal)
+			h.lggr.Debugw("in-flight secrets request failed; relaying its error", "requestID", req.ID, "key", key, "errorCode", ownerCode)
+			return h.errorResponse(ctx, gatewayID, req, ownerCode, ownerErr)
 		}
 		if signed, ok := signed.(*confidentialrelaytypes.SignedSecretsResponseResult); ok {
 			h.lggr.Debugw("served retried secrets request from in-flight owner", "requestID", req.ID, "key", key)
@@ -384,6 +411,36 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, errors.New("in-flight secrets request completed without a result"))
 	}
 
+	// We own the pending entry: fetch, then publish the outcome to any waiters
+	// either way. A failure has to reach them with its real cause, and has to
+	// clear the entry so later retries re-execute rather than waiting on a
+	// request nobody completes (see failPendingRequest).
+	signedResult, err := h.fetchSecrets(ctx, req, params, key)
+	if err != nil {
+		h.pendingRequestsMu.Lock()
+		h.failPendingRequest(key, err)
+		h.pendingRequestsMu.Unlock()
+		return h.errorResponse(ctx, gatewayID, req, relayErrorCode(err, jsonrpc.ErrInternal), err)
+	}
+
+	h.pendingRequestsMu.Lock()
+	h.responseMemo.SetDefault(key, signedResult)
+	h.completePendingRequest(key, signedResult)
+	h.pendingRequestsMu.Unlock()
+	h.lggr.Infow("fetched and signed secrets response", "requestID", req.ID, "key", key)
+	return h.jsonResponse(req, signedResult)
+}
+
+// fetchSecrets resolves the execution handler, fetches the requested secrets
+// from the vault DON, and signs the result. Errors are relayErrors carrying
+// the JSON-RPC code the request should be answered with, so the caller can
+// both answer this request and publish the same failure to any waiters.
+func (h *Handler) fetchSecrets(
+	ctx context.Context,
+	req *jsonrpc.Request[json.RawMessage],
+	params confidentialrelaytypes.SecretsRequestParams,
+	key string,
+) (*confidentialrelaytypes.SignedSecretsResponseResult, error) {
 	secretsRequest := &sdkpb.GetSecretsRequest{
 		Requests:   make([]*sdkpb.SecretRequest, 0, len(params.Secrets)),
 		CallbackId: params.CallbackID,
@@ -407,13 +464,13 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 	defer cancel()
 	handler, ok := h.executionHandlers.GetExecutionWithWait(waitCtx, params.WorkflowID, params.ExecutionID)
 	if !ok {
-		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, fmt.Errorf("execution handler for workflow %s execution %s not found", params.WorkflowID, params.ExecutionID))
+		return nil, &relayError{code: jsonrpc.ErrInternal, err: fmt.Errorf("execution handler for workflow %s execution %s not found", params.WorkflowID, params.ExecutionID)}
 	}
 
 	vaultResp, err := handler.GetRawSecrets(ctx, secretsRequest, teeKeyFetcher(params.EnclavePublicKey))
 	if err != nil {
 		h.lggr.Errorw("vault secrets fetch failed", "requestID", req.ID, "key", key, "err", err)
-		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, err)
+		return nil, &relayError{code: jsonrpc.ErrInternal, err: err}
 	}
 
 	result, err := translateVaultResponse(vaultResp, params.EnclavePublicKey)
@@ -423,21 +480,17 @@ func (h *Handler) handleSecretsGet(ctx context.Context, gatewayID string, req *j
 			code = jsonrpc.ErrInvalidParams
 		}
 		h.lggr.Errorw("translating vault response failed", "requestID", req.ID, "key", key, "userError", IsUserError(err), "err", err)
-		return h.errorResponse(ctx, gatewayID, req, code, err)
+		return nil, &relayError{code: code, err: err}
 	}
 
 	signedResult, err := h.signSecretsResponse(params, result)
 	if err != nil {
 		h.lggr.Errorw("signing secrets response failed", "requestID", req.ID, "key", key, "err", err)
-		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, fmt.Errorf("failed to sign secrets response: %w", err))
+		return nil, &relayError{code: jsonrpc.ErrInternal, err: fmt.Errorf("failed to sign secrets response: %w", err)}
 	}
 
-	h.pendingRequestsMu.Lock()
-	h.responseMemo.SetDefault(key, signedResult)
-	h.completePendingRequest(key, signedResult)
-	h.pendingRequestsMu.Unlock()
-	h.lggr.Infow("fetched and signed secrets response", "requestID", req.ID, "key", key, "secrets", len(result.Secrets))
-	return h.jsonResponse(req, signedResult)
+	h.lggr.Debugw("fetched secrets from vault", "requestID", req.ID, "key", key, "secrets", len(result.Secrets))
+	return signedResult, nil
 }
 
 // translateVaultResponse converts a vault GetSecretsResponse to the enclave relay protocol format.
@@ -562,10 +615,15 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 	}
 	h.pendingRequestsMu.Unlock()
 	if pending != nil {
-		signed, ok := waitForPendingRequest(ctx, pending)
-		if !ok {
+		signed, ok, pendingReqErr := waitForPendingRequest(ctx, pending)
+		switch {
+		case !ok:
 			h.lggr.Warnw("timed out waiting for in-flight capability request", "requestID", req.ID, "key", key, "err", ctx.Err())
 			return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, errors.New("timed out waiting for in-flight capability request"))
+		case pendingReqErr != nil:
+			errorCode := relayErrorCode(pendingReqErr, jsonrpc.ErrInternal)
+			h.lggr.Debugw("in-flight capability request failed; relaying its error", "requestID", req.ID, "key", key, "errorCode", errorCode)
+			return h.errorResponse(ctx, gatewayID, req, errorCode, pendingReqErr)
 		}
 		if signed, ok := signed.(*confidentialrelaytypes.SignedCapabilityResponseResult); ok {
 			h.lggr.Debugw("served retried capability request from in-flight owner", "requestID", req.ID, "key", key)
@@ -574,14 +632,44 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, errors.New("in-flight capability request completed without a result"))
 	}
 
+	// We own the pending entry: execute, then publish the outcome to any
+	// waiters either way; see handleSecretsGet.
+	signedResult, err := h.executeCapability(ctx, req, params, key)
+	if err != nil {
+		h.pendingRequestsMu.Lock()
+		h.failPendingRequest(key, err)
+		h.pendingRequestsMu.Unlock()
+		return h.errorResponse(ctx, gatewayID, req, relayErrorCode(err, jsonrpc.ErrInternal), err)
+	}
+
+	h.pendingRequestsMu.Lock()
+	h.responseMemo.SetDefault(key, signedResult)
+	h.completePendingRequest(key, signedResult)
+	h.pendingRequestsMu.Unlock()
+	h.lggr.Infow("executed and signed capability response", "requestID", req.ID, "key", key, "capability", params.CapabilityID)
+	return h.jsonResponse(req, signedResult)
+}
+
+// executeCapability decodes the request payload, resolves the execution
+// handler, runs the capability, and signs the result. Errors are relayErrors
+// carrying the JSON-RPC code the request should be answered with, so the
+// caller can both answer this request and publish the same failure to any
+// waiters. A capability that itself returns an error is not an error here: it
+// produces a signed error result the enclave's quorum logic handles.
+func (h *Handler) executeCapability(
+	ctx context.Context,
+	req *jsonrpc.Request[json.RawMessage],
+	params confidentialrelaytypes.CapabilityRequestParams,
+	key string,
+) (*confidentialrelaytypes.SignedCapabilityResponseResult, error) {
 	payloadBytes, err := base64.StdEncoding.DecodeString(params.Payload)
 	if err != nil {
-		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInvalidParams, fmt.Errorf("failed to decode payload: %w", err))
+		return nil, &relayError{code: jsonrpc.ErrInvalidParams, err: fmt.Errorf("failed to decode payload: %w", err)}
 	}
 
 	sdkReq := &sdkpb.CapabilityRequest{}
 	if err = proto.Unmarshal(payloadBytes, sdkReq); err != nil {
-		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInvalidParams, fmt.Errorf("failed to unmarshal capability request: %w", err))
+		return nil, &relayError{code: jsonrpc.ErrInvalidParams, err: fmt.Errorf("failed to unmarshal capability request: %w", err)}
 	}
 
 	// Resolve the execution handler only after attestation and enclave-config
@@ -593,19 +681,17 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 	defer cancel()
 	handler, ok := h.executionHandlers.GetExecutionWithWait(waitCtx, params.WorkflowID, params.ExecutionID)
 	if !ok {
-		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, fmt.Errorf("execution handler for workflow %s execution %s not found", params.WorkflowID, params.ExecutionID))
+		return nil, &relayError{code: jsonrpc.ErrInternal, err: fmt.Errorf("execution handler for workflow %s execution %s not found", params.WorkflowID, params.ExecutionID)}
 	}
 
 	capResp, execErr := handler.CallCapability(ctx, sdkReq)
+
+	var result confidentialrelaytypes.CapabilityResponseResult
 	if execErr != nil {
 		// Not an error from this node's perspective: the execution result is a
 		// signed error response the enclave's quorum logic handles; log it so
 		// the capability-side failure is attributable to this node.
 		h.lggr.Infow("capability execution returned an error result", "requestID", req.ID, "key", key, "capability", sdkReq.Id, "err", execErr)
-	}
-
-	var result confidentialrelaytypes.CapabilityResponseResult
-	if execErr != nil {
 		result.Error = execErr.Error()
 	} else {
 		// Deterministic marshal so every relay node emits byte-identical
@@ -614,7 +700,7 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 		var respBytes []byte
 		respBytes, err = proto.MarshalOptions{Deterministic: true}.Marshal(capResp)
 		if err != nil {
-			return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, fmt.Errorf("marshalling capability response: %w", err))
+			return nil, &relayError{code: jsonrpc.ErrInternal, err: fmt.Errorf("marshalling capability response: %w", err)}
 		}
 		result.Payload = base64.StdEncoding.EncodeToString(respBytes)
 	}
@@ -622,15 +708,10 @@ func (h *Handler) handleCapabilityExecute(ctx context.Context, gatewayID string,
 	signedResult, err := h.signCapabilityResponse(params, result)
 	if err != nil {
 		h.lggr.Errorw("signing capability response failed", "requestID", req.ID, "key", key, "err", err)
-		return h.errorResponse(ctx, gatewayID, req, jsonrpc.ErrInternal, fmt.Errorf("failed to sign capability response: %w", err))
+		return nil, &relayError{code: jsonrpc.ErrInternal, err: fmt.Errorf("failed to sign capability response: %w", err)}
 	}
 
-	h.pendingRequestsMu.Lock()
-	h.responseMemo.SetDefault(key, signedResult)
-	h.completePendingRequest(key, signedResult)
-	h.pendingRequestsMu.Unlock()
-	h.lggr.Infow("executed and signed capability response", "requestID", req.ID, "key", key, "capability", params.CapabilityID, "resultError", result.Error != "")
-	return h.jsonResponse(req, signedResult)
+	return signedResult, nil
 }
 
 // verifyEnclaveConfigMatchesDON compares the enclave's reported EnclaveConfig

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -1141,7 +1141,11 @@ func blockingCapExecRequest(t *testing.T, id string) *jsonrpc.Request[json.RawMe
 		WorkflowID:    "wf-1",
 		Owner:         testOwner,
 		ExecutionID:   capExecExecutionID,
-		ReferenceID:   "1",
+		// ReferenceID varies with the request id so the burst is 8 distinct
+		// logical identities: the pending-claim dedup intentionally collapses
+		// same-identity requests, and this test guards dispatch concurrency, not
+		// dedup behavior.
+		ReferenceID:   id,
 		CapabilityID:  "my-cap@1.0.0",
 		Payload:       makeCapabilityPayload(t, map[string]any{"key": "val"}),
 		EnclaveConfig: testEnclaveConfigPtr(),
@@ -1251,4 +1255,78 @@ type countingExecutionHelper struct {
 func (c *countingExecutionHelper) CallCapability(_ context.Context, _ *sdkpb.CapabilityRequest) (*sdkpb.CapabilityResponse, error) {
 	c.calls.Add(1)
 	return c.capResp, nil
+}
+
+// TestHandler_RetryWhileInFlightWaits verifies that a retry arriving while
+// the original execution is still in flight waits for the claimant to complete
+// and then responds with its signed result, rather than re-executing.
+// Re-executing would hit the remote request server's duplicate-requester check
+// and return a well-formed error the enclave's retry loop treats as terminal.
+func TestHandler_RetryWhileInFlightWaits(t *testing.T) {
+	t.Parallel()
+	reg := withEnclaveConfig(&mockCapRegistry{})
+	gwConn := &mockGatewayConnector{}
+	h := newTestHandler(t, reg, gwConn)
+	helper := newBlockingExecutionHelper(2)
+	h.executionHandlers.AddExecution("wf-1", capExecExecutionID, helper)
+
+	mkReq := func(id string) *jsonrpc.Request[json.RawMessage] {
+		req := makeRequest(t, confidentialrelaytypes.MethodCapabilityExec, confidentialrelaytypes.CapabilityRequestParams{
+			WorkflowID:    "wf-1",
+			Owner:         testOwner,
+			ExecutionID:   capExecExecutionID,
+			ReferenceID:   "1",
+			CapabilityID:  "my-cap@1.0.0",
+			Payload:       makeCapabilityPayload(t, map[string]any{"key": "val"}),
+			EnclaveConfig: testEnclaveConfigPtr(),
+			Attestation:   testAttestationB64,
+		})
+		req.ID = id
+		return req
+	}
+
+	// First request: enters CallCapability and blocks on release, so its
+	// pending claim is held while we dispatch the duplicate.
+	require.NoError(t, h.HandleGatewayMessage(context.Background(), "gw-1", mkReq("req-1")))
+	select {
+	case <-helper.entered:
+	case <-time.After(testWaitTimeout):
+		t.Fatal("first request never entered CallCapability")
+	}
+	require.Zero(t, gwConn.respCount(), "leader is in flight, no response yet")
+
+	// Duplicate with the same logical identity while the first is in flight:
+	// waits on the claim (no second execution, no response until the leader
+	// completes). The gate receive above drained the leader's entry, so "no new
+	// entry" is len == 0.
+	require.NoError(t, h.HandleGatewayMessage(context.Background(), "gw-1", mkReq("req-2")))
+	require.Eventually(t, func() bool { return len(helper.entered) == 0 },
+		testWaitTimeout, time.Millisecond, "duplicate must not enter CallCapability")
+	require.Zero(t, gwConn.respCount(), "duplicate waits, no send before the leader completes")
+
+	// Release the original: both requests respond — the leader's own, and the
+	// waiter's re-wrapped copy of the same signed result.
+	close(helper.release)
+	require.Eventually(t, func() bool { return gwConn.respCount() == 2 },
+		testWaitTimeout, time.Millisecond, "leader and waiter both respond")
+
+	gwConn.mu.Lock()
+	resps := append([]*jsonrpc.Response[json.RawMessage](nil), gwConn.resps...)
+	gwConn.resps = nil
+	gwConn.mu.Unlock()
+	var payloads []string
+	for _, r := range resps {
+		require.Nil(t, r.Error)
+		var signed confidentialrelaytypes.SignedCapabilityResponseResult
+		require.NoError(t, json.Unmarshal(*r.Result, &signed))
+		payloads = append(payloads, signed.Result.Payload)
+	}
+	require.Len(t, payloads, 2)
+	require.Equal(t, payloads[0], payloads[1], "waiter responds with the claimant's signed result")
+
+	// A retry after completion is served from the memo, not re-executed.
+	require.NoError(t, h.HandleGatewayMessage(context.Background(), "gw-1", mkReq("req-3")))
+	resp := gwConn.waitResp(t)
+	require.Nil(t, resp.Error)
+	require.Zero(t, len(helper.entered), "post-completion retry is served from the memo, no re-execution")
 }

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -1314,7 +1314,7 @@ func TestHandler_RetryWhileInFlightWaits(t *testing.T) {
 	resps := append([]*jsonrpc.Response[json.RawMessage](nil), gwConn.resps...)
 	gwConn.resps = nil
 	gwConn.mu.Unlock()
-	var payloads []string
+	payloads := make([]string, 0, len(resps))
 	for _, r := range resps {
 		require.Nil(t, r.Error)
 		var signed confidentialrelaytypes.SignedCapabilityResponseResult
@@ -1328,5 +1328,5 @@ func TestHandler_RetryWhileInFlightWaits(t *testing.T) {
 	require.NoError(t, h.HandleGatewayMessage(context.Background(), "gw-1", mkReq("req-3")))
 	resp := gwConn.waitResp(t)
 	require.Nil(t, resp.Error)
-	require.Zero(t, len(helper.entered), "post-completion retry is served from the memo, no re-execution")
+	require.Empty(t, helper.entered, "post-completion retry is served from the memo, no re-execution")
 }

--- a/core/capabilities/confidentialrelay/handler_test.go
+++ b/core/capabilities/confidentialrelay/handler_test.go
@@ -1138,9 +1138,9 @@ func blockingCapExecHandler(t *testing.T, capacity int) (*Handler, *mockGatewayC
 func blockingCapExecRequest(t *testing.T, id string) *jsonrpc.Request[json.RawMessage] {
 	t.Helper()
 	req := makeRequest(t, confidentialrelaytypes.MethodCapabilityExec, confidentialrelaytypes.CapabilityRequestParams{
-		WorkflowID:    "wf-1",
-		Owner:         testOwner,
-		ExecutionID:   capExecExecutionID,
+		WorkflowID:  "wf-1",
+		Owner:       testOwner,
+		ExecutionID: capExecExecutionID,
 		// ReferenceID varies with the request id so the burst is 8 distinct
 		// logical identities: the pending-claim dedup intentionally collapses
 		// same-identity requests, and this test guards dispatch concurrency, not
@@ -1329,4 +1329,105 @@ func TestHandler_RetryWhileInFlightWaits(t *testing.T) {
 	resp := gwConn.waitResp(t)
 	require.Nil(t, resp.Error)
 	require.Empty(t, helper.entered, "post-completion retry is served from the memo, no re-execution")
+}
+
+// TestHandler_WaiterRelaysOwnerError verifies a waiter reports the owner's
+// actual failure rather than a vague "no result" of its own: the two share one
+// execution, so they share its outcome. The owner here fails with a user-facing
+// code so the assertion sees a real message (errorResponse masks internal
+// errors on the wire by design).
+func TestHandler_WaiterRelaysOwnerError(t *testing.T) {
+	t.Parallel()
+	reg := withEnclaveConfig(&mockCapRegistry{})
+	gwConn := &mockGatewayConnector{}
+	h := newTestHandler(t, reg, gwConn)
+	helper := newBlockingExecutionHelper(2)
+	h.executionHandlers.AddExecution("wf-1", capExecExecutionID, helper)
+
+	// An undecodable payload makes the owner fail with ErrInvalidParams after
+	// it has taken the pending entry, so the waiter has something real to relay.
+	mkReq := func(id string) *jsonrpc.Request[json.RawMessage] {
+		req := makeRequest(t, confidentialrelaytypes.MethodCapabilityExec, confidentialrelaytypes.CapabilityRequestParams{
+			WorkflowID:    "wf-1",
+			Owner:         testOwner,
+			ExecutionID:   capExecExecutionID,
+			ReferenceID:   "1",
+			CapabilityID:  "my-cap@1.0.0",
+			Payload:       "!!!not-base64!!!",
+			EnclaveConfig: testEnclaveConfigPtr(),
+			Attestation:   testAttestationB64,
+		})
+		req.ID = id
+		return req
+	}
+
+	require.NoError(t, h.HandleGatewayMessage(context.Background(), "gw-1", mkReq("req-1")))
+	resp1 := gwConn.waitResp(t)
+	require.NotNil(t, resp1.Error)
+	require.Equal(t, jsonrpc.ErrInvalidParams, resp1.Error.Code)
+
+	// A second request now hits the memo-miss path and executes itself (the
+	// failed owner released the entry), and must also surface a real error.
+	gwConn.mu.Lock()
+	gwConn.resps = nil
+	gwConn.mu.Unlock()
+	require.NoError(t, h.HandleGatewayMessage(context.Background(), "gw-1", mkReq("req-2")))
+	resp2 := gwConn.waitResp(t)
+	require.NotNil(t, resp2.Error)
+	require.Equal(t, resp1.Error.Code, resp2.Error.Code, "retry sees the same real error code, not a vague one")
+	require.Equal(t, resp1.Error.Message, resp2.Error.Message)
+}
+
+// TestHandler_RetryAfterExecutionLookupTimeout is the regression guard for a
+// pending entry outliving a failed owner. The first request registers the
+// pending entry and then fails its execution-handler lookup (the start-edge
+// race: this node has not begun its copy of the execution yet). If that entry
+// were left behind, every retry for the identity would wait on a request
+// nobody completes — for the whole cache TTL, far longer than the enclave's
+// retry window — so the call would fail permanently instead of recovering.
+// The retry must execute against the now-registered handler.
+func TestHandler_RetryAfterExecutionLookupTimeout(t *testing.T) {
+	t.Parallel()
+	reg := withEnclaveConfig(&mockCapRegistry{})
+	gwConn := &mockGatewayConnector{}
+	h := newTestHandler(t, reg, gwConn)
+
+	mkReq := func(id string) *jsonrpc.Request[json.RawMessage] {
+		req := makeRequest(t, confidentialrelaytypes.MethodCapabilityExec, confidentialrelaytypes.CapabilityRequestParams{
+			WorkflowID:    "wf-1",
+			Owner:         testOwner,
+			ExecutionID:   capExecExecutionID,
+			ReferenceID:   "1",
+			CapabilityID:  "my-cap@1.0.0",
+			Payload:       makeCapabilityPayload(t, map[string]any{"key": "val"}),
+			EnclaveConfig: testEnclaveConfigPtr(),
+			Attestation:   testAttestationB64,
+		})
+		req.ID = id
+		return req
+	}
+
+	// No execution registered yet: the owner's lookup times out and it must
+	// leave no pending entry behind.
+	require.NoError(t, h.HandleGatewayMessage(context.Background(), "gw-1", mkReq("req-1")))
+	resp1 := gwConn.waitResp(t)
+	require.NotNil(t, resp1.Error, "owner fails when no execution handler registers")
+
+	// The execution registers a moment later, as in the real start-edge race.
+	helper := &countingExecutionHelper{
+		capResp: &sdkpb.CapabilityResponse{
+			Response: &sdkpb.CapabilityResponse_Payload{Payload: &anypb.Any{Value: []byte("result-proto-bytes")}},
+		},
+	}
+	h.executionHandlers.AddExecution("wf-1", capExecExecutionID, helper)
+
+	// The retry must execute and succeed, not wait on the failed owner's entry.
+	gwConn.mu.Lock()
+	gwConn.resps = nil
+	gwConn.mu.Unlock()
+	require.NoError(t, h.HandleGatewayMessage(context.Background(), "gw-1", mkReq("req-2")))
+	resp2 := gwConn.waitResp(t)
+	require.Nil(t, resp2.Error, "retry recovers once the execution handler is registered")
+	require.NotNil(t, resp2.Result)
+	require.Equal(t, int32(1), helper.calls.Load(), "retry executed the capability")
 }

--- a/core/capabilities/confidentialrelay/response_cache.go
+++ b/core/capabilities/confidentialrelay/response_cache.go
@@ -1,8 +1,12 @@
 package confidentialrelay
 
 import (
+	"context"
+	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/patrickmn/go-cache"
 
 	confidentialrelaytypes "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/confidentialrelay"
 )
@@ -22,4 +26,73 @@ func capExecKey(p confidentialrelaytypes.CapabilityRequestParams) string {
 // from its logical identity: workflow, execution, callback id.
 func secretsKey(p confidentialrelaytypes.SecretsRequestParams) string {
 	return strings.Join([]string{secretsGetDomain, p.WorkflowID, p.ExecutionID, strconv.Itoa(int(p.CallbackID))}, "/")
+}
+
+// pendingRequest is the in-flight marker for a logical identity. The owner
+// executes and later completes it; duplicates wait on done and then respond
+// with the owner's published signed result (re-wrapped with their own request
+// id by the caller). signed is written before done is closed, so a waiter
+// that observes done closed may read signed without further synchronization.
+// Closing done is a broadcast: any number of waiters may listen concurrently,
+// and all are woken together.
+type pendingRequest struct {
+	done chan struct{}
+	// signed is the owner's published result, set before done closes.
+	signed any
+}
+
+// checkPendingRequest returns the pending request in flight for key, or nil
+// when none was — in which case one was just registered and this caller is
+// implicitly its owner: execute, then completePendingRequest. A non-nil
+// return is another caller's in-flight execution: wait for it and respond
+// with its result, instead of re-executing into the remote request server's
+// duplicate-requester error ("request already received from peer", a
+// well-formed terminal result for the enclave's retry loop). Registration is
+// atomic (go-cache Add), so exactly one caller gets nil; the entry is
+// TTL-bounded so a crashed owner ages out via the background cleanup. A
+// non-nil error means the pending set holds an entry of an unexpected type
+// (or one vanished between Add and Get): its state is unknown, so the caller
+// fails loudly rather than guesses.
+func (h *Handler) checkOrCreatePendingRequest(key string) (*pendingRequest, error) {
+	mine := &pendingRequest{done: make(chan struct{})}
+	if h.pendingRequests.Add(key, mine, cache.DefaultExpiration) == nil {
+		h.lggr.Debugw("registered pending relay request, executing", "key", key)
+		return nil, nil
+	}
+	if existing, ok := h.pendingRequests.Get(key); ok {
+		if p, ok := existing.(*pendingRequest); ok {
+			h.lggr.Debugw("relay request already in flight, waiting for its result", "key", key)
+			return p, nil
+		}
+	}
+	h.lggr.Errorw("pending request cache holds an entry of unexpected type", "key", key)
+	return nil, fmt.Errorf("pending set holds an invalid entry for key %q", key)
+}
+
+// completePendingRequest publishes the owner's signed result and wakes any
+// waiters. Called on the execution's success path only, after the memo is set,
+// so requests arriving later hit the memo instead. An owner that dies without
+// completing never publishes; the TTL ages its entry out and waiters fail on
+// their own deadlines, which is the "unknown failure" outcome.
+func (h *Handler) completePendingRequest(key string, signed any) {
+	if v, ok := h.pendingRequests.Get(key); ok {
+		if pr, ok := v.(*pendingRequest); ok {
+			pr.signed = signed
+			close(pr.done)
+		}
+	}
+	h.pendingRequests.Delete(key)
+}
+
+// waitForPendingRequest blocks until the owner completes (returning its
+// published signed result) or ctx is done. A waiter whose context expires
+// drops: the gateway has already timed out its request by then, so there is
+// nobody to answer.
+func waitForPendingRequest(ctx context.Context, pr *pendingRequest) (any, bool) {
+	select {
+	case <-pr.done:
+		return pr.signed, true
+	case <-ctx.Done():
+		return nil, false
+	}
 }

--- a/core/capabilities/confidentialrelay/response_cache.go
+++ b/core/capabilities/confidentialrelay/response_cache.go
@@ -37,8 +37,13 @@ func secretsKey(p confidentialrelaytypes.SecretsRequestParams) string {
 // and all are woken together.
 type pendingRequest struct {
 	done chan struct{}
-	// signed is the owner's published result, set before done closes.
+	// The owner's published outcome, exactly one set before done closes:
+	// signed on success, err on failure (a relayError, so it carries the
+	// JSON-RPC code the owner answered with). Waiters share the owner's
+	// execution, so they answer with its outcome either way rather than
+	// inventing one of their own.
 	signed any
+	err    error
 }
 
 // checkPendingRequest returns the pending request in flight for key, or nil
@@ -70,8 +75,8 @@ func (h *Handler) checkOrCreatePendingRequest(key string) (*pendingRequest, erro
 }
 
 // completePendingRequest publishes the owner's signed result and wakes any
-// waiters. Called on the execution's success path only, after the memo is set,
-// so requests arriving later hit the memo instead. An owner that dies without
+// waiters. Called on the execution's success path, after the memo is set, so
+// requests arriving later hit the memo instead. An owner that dies without
 // completing never publishes; the TTL ages its entry out and waiters fail on
 // their own deadlines, which is the "unknown failure" outcome.
 func (h *Handler) completePendingRequest(key string, signed any) {
@@ -84,15 +89,32 @@ func (h *Handler) completePendingRequest(key string, signed any) {
 	h.pendingRequests.Delete(key)
 }
 
-// waitForPendingRequest blocks until the owner completes (returning its
-// published signed result) or ctx is done. A waiter whose context expires
-// drops: the gateway has already timed out its request by then, so there is
-// nobody to answer.
-func waitForPendingRequest(ctx context.Context, pr *pendingRequest) (any, bool) {
+// failPendingRequest publishes the owner's failure to any waiters and clears
+// the entry. err is the error the owner is answering with — a relayError, so
+// it carries that answer's JSON-RPC code — which lets waiters report the real
+// cause (vault failure, missing execution handler, ...) rather than a vague
+// error of their own.
+func (h *Handler) failPendingRequest(key string, err error) {
+	h.lggr.Debugw("publishing pending relay request failure", "key", key, "err", err)
+	if v, ok := h.pendingRequests.Get(key); ok {
+		if pr, ok := v.(*pendingRequest); ok {
+			pr.err = err
+			close(pr.done)
+		}
+	}
+	h.pendingRequests.Delete(key)
+}
+
+// waitForPendingRequest blocks until the owner publishes its outcome — a
+// signed result, or the error it failed with — or until ctx is done. ok is
+// false only on the caller's own deadline; the gateway has already timed that
+// request out by then. The owner writes the fields before closing done, so
+// observing the close is enough to read them.
+func waitForPendingRequest(ctx context.Context, pr *pendingRequest) (signed any, ok bool, err error) {
 	select {
 	case <-pr.done:
-		return pr.signed, true
+		return pr.signed, true, pr.err
 	case <-ctx.Done():
-		return nil, false
+		return nil, false, nil
 	}
 }

--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -77,8 +77,39 @@ func newMetrics() (*metrics, error) {
 	}, nil
 }
 
+// requestLabels are the identifiers the gateway pulls out of a relay request's
+// params purely for logging, so a gateway line can be correlated with the
+// relay-DON's and the enclave's lines for the same workflow execution. The
+// gateway stays a dumb relay: it does not otherwise interpret params.
+type requestLabels struct {
+	WorkflowID  string `json:"workflow_id"`
+	ExecutionID string `json:"execution_id"`
+}
+
+// extractRequestLabels best-effort decodes the logging identifiers from a
+// request's params. Both relay methods' params carry these fields. A decode
+// failure leaves them empty and is only logged: these labels are for
+// correlation, and the params themselves are validated by the relay nodes,
+// not here, so a request whose params do not decode is still fanned out and
+// rejected there. ProcessRequest has already parsed the envelope as valid
+// JSON by this point, so a failure here means params is not an object or
+// carries non-string identifiers — malformed input rather than a gateway bug,
+// hence debug level to avoid handing a caller a log-spam lever.
+func (h *handler) extractRequestLabels(req jsonrpc.Request[json.RawMessage]) requestLabels {
+	var labels requestLabels
+	if req.Params == nil {
+		return labels
+	}
+	if err := json.Unmarshal(*req.Params, &labels); err != nil {
+		h.lggr.Debugw("could not decode relay request params for logging labels",
+			"method", req.Method, "requestID", req.ID, "err", err)
+	}
+	return labels
+}
+
 type activeRequest struct {
 	req       jsonrpc.Request[json.RawMessage]
+	labels    requestLabels
 	responses map[string]*jsonrpc.Response[json.RawMessage]
 	mu        sync.Mutex
 	completed atomic.Bool
@@ -316,7 +347,7 @@ func (h *handler) removeExpiredRequests(ctx context.Context) {
 
 	for _, er := range expiredRequests {
 		responses := er.copiedResponses()
-		l := logger.With(h.lggr, "method", er.req.Method, "requestID", er.req.ID)
+		l := h.requestLogger(er.req, er.labels)
 		l.Debugw("request expired, evaluating collected relay responses",
 			"collected", len(responses),
 			"nodes", len(h.donConfig.Members),
@@ -346,6 +377,20 @@ func (h *handler) HandleLegacyUserMessage(_ context.Context, _ *api.Message, _ g
 	return errors.New("confidential relay handler does not support legacy messages")
 }
 
+// requestLogger returns the logger for one relay request: the gateway request
+// id plus the workflow/execution identity it carries, so a line can be
+// correlated with the relay DON's and the enclave's logs for the same
+// execution. The request id changes per enclave retry; the execution identity
+// does not.
+func (h *handler) requestLogger(req jsonrpc.Request[json.RawMessage], labels requestLabels) logger.Logger {
+	return logger.With(h.lggr,
+		"method", req.Method,
+		"requestID", req.ID,
+		"workflowID", labels.WorkflowID,
+		"executionID", labels.ExecutionID,
+	)
+}
+
 func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Request[json.RawMessage], callback gwhandlers.Callback) error {
 	if req.ID == "" {
 		return errors.New("request ID cannot be empty")
@@ -354,10 +399,11 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 		return errors.New("request ID is too long: " + strconv.Itoa(len(req.ID)) + ". max is 200 characters")
 	}
 
-	l := logger.With(h.lggr, "method", req.Method, "requestID", req.ID)
-	l.Debugw("handling confidential relay request")
+	labels := h.extractRequestLabels(req)
+	l := h.requestLogger(req, labels)
+	l.Debugw("handling confidential relay request", "nodes", len(h.donConfig.Members), "f", h.donConfig.F)
 
-	ar, err := h.newActiveRequest(req, callback)
+	ar, err := h.newActiveRequest(req, labels, callback)
 	if err != nil {
 		return err
 	}
@@ -365,16 +411,17 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 	return h.fanOutToNodes(ctx, l, ar)
 }
 
-func (h *handler) newActiveRequest(req jsonrpc.Request[json.RawMessage], callback gwhandlers.Callback) (*activeRequest, error) {
+func (h *handler) newActiveRequest(req jsonrpc.Request[json.RawMessage], labels requestLabels, callback gwhandlers.Callback) (*activeRequest, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.activeRequests[req.ID] != nil {
-		h.lggr.Errorw("request id already exists", "requestID", req.ID)
+		h.lggr.Errorw("request id already exists", "requestID", req.ID, "executionID", labels.ExecutionID)
 		return nil, errors.New("request ID already exists: " + req.ID)
 	}
 	ar := &activeRequest{
 		Callback:  callback,
 		req:       req,
+		labels:    labels,
 		createdAt: h.clock.Now(),
 		responses: map[string]*jsonrpc.Response[json.RawMessage]{},
 	}
@@ -410,6 +457,9 @@ func (h *handler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Response[
 		l.Debugw("no pending request found for ID")
 		return nil
 	}
+	// A node response carries no params, so the execution identity comes from
+	// the request it answers.
+	l = logger.With(l, "workflowID", ar.labels.WorkflowID, "executionID", ar.labels.ExecutionID)
 
 	added := ar.addResponseForNode(nodeAddr, resp)
 	if !added {
@@ -551,7 +601,7 @@ func (h *handler) forwardGracedRequests(ctx context.Context) {
 }
 
 func (h *handler) forwardAfterGrace(ctx context.Context, ar *activeRequest) {
-	l := logger.With(h.lggr, "method", ar.req.Method, "requestID", ar.req.ID)
+	l := h.requestLogger(ar.req, ar.labels)
 	summary, err := h.bundler.Bundle(ar.req, ar.copiedResponses(), l)
 	if err != nil {
 		l.Errorw("failed to build relay response bundle after quorum grace", "error", err)
@@ -644,10 +694,18 @@ func (h *handler) fanOutToNodes(ctx context.Context, l logger.Logger, ar *active
 	numNodeErrors := nodeErrors.Load()
 	remainingPossibleResponses := len(h.donConfig.Members) - int(numNodeErrors)
 	if remainingPossibleResponses < h.donConfig.F+1 && numNodeErrors > 0 {
+		// The individual send failures are logged above; this is the aggregate
+		// decision that ends the request, so it gets its own line.
+		l.Errorw("too few relay nodes reachable to reach quorum; failing request",
+			"nodeErrors", numNodeErrors,
+			"reachable", remainingPossibleResponses,
+			"minQuorum", h.donConfig.F+1,
+			"nodes", len(h.donConfig.Members),
+		)
 		return h.sendResponseAndClearRequest(ctx, ar, h.constructErrorResponse(ar.req, api.FatalError, errors.New("failed to forward user request to nodes")))
 	}
 
-	l.Debugw("successfully forwarded request to relay nodes")
+	l.Debugw("successfully forwarded request to relay nodes", "nodeErrors", numNodeErrors)
 	return nil
 }
 
@@ -669,12 +727,12 @@ func (h *handler) sendResponseAndClearRequest(ctx context.Context, ar *activeReq
 	h.mu.Unlock()
 
 	if sendErr != nil {
-		h.lggr.Errorw("error sending response to user", "requestID", ar.req.ID, "error", sendErr)
+		h.lggr.Errorw("error sending response to user", "requestID", ar.req.ID, "executionID", ar.labels.ExecutionID, "error", sendErr)
 		return sendErr
 	}
 
 	h.recordMetrics(ctx, payload.ErrorCode)
-	h.lggr.Debugw("response sent to user", "requestID", ar.req.ID, "errorCode", payload.ErrorCode)
+	h.lggr.Debugw("response sent to user", "requestID", ar.req.ID, "executionID", ar.labels.ExecutionID, "errorCode", payload.ErrorCode)
 	return nil
 }
 


### PR DESCRIPTION
- Adds a `pendingRequests` cache, such that if a capability call is in-flight while a retry comes in, it is gracefully waited for, rather than retried at the DON-to-DON layer (which would return a terminal error).
- Adds more logging.
- Cleans up dead & tautological code.
- Bumps the default grace window for the execution handler from 5s -> 15s.

Deployment validation: Gateway bumps in staging do not cause canary failures in confidential workflows