### PR TITLE
CCIP-13458: Validate remote supply decimals in hybrid pool changesets

### DIFF
--- a/deployment/ccip/changeset/solana_v0_1_1/hybrid_supply_solana_test.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/hybrid_supply_solana_test.go
@@ -1,0 +1,75 @@
+package solana_test
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	linkchangesets "github.com/smartcontractkit/cld-changesets/tokens/link/changesets"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deploylink"
+)
+
+// TestVerifyRemoteDecimalsSolana covers shared.VerifyRemoteDecimals against a real SPL mint.
+//
+// It lives here because the Solana container harness does, and shared cannot import it
+// without an import cycle. Only a Solana container is started; the full CCIP environment is
+// not needed to read a mint.
+func TestVerifyRemoteDecimalsSolana(t *testing.T) {
+	t.Parallel()
+
+	const tokenDecimals = 6
+
+	selector := chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector
+	rt, err := runtime.New(t.Context(), runtime.WithEnvOpts(
+		environment.WithSolanaContainer(t, []uint64{selector}, t.TempDir(), map[string]string{}),
+	))
+	require.NoError(t, err)
+
+	mintKey, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+
+	require.NoError(t, rt.Exec(
+		runtime.ChangesetTask(deploylink.DeployLinkTokenChangeset{}, linkchangesets.DeployLinkTokenInput{
+			Solana: map[uint64]linkchangesets.SolanaLinkConfig{
+				selector: {TokenPrivKey: mintKey, TokenDecimals: tokenDecimals},
+			},
+		}),
+	))
+
+	env := rt.Environment()
+
+	// The pool stores a remote SVM token as the raw 32-byte mint pubkey.
+	mintBytes := mintKey.PublicKey().Bytes()
+
+	t.Run("Success - matching decimals verify", func(t *testing.T) {
+		t.Parallel()
+
+		verified, err := shared.VerifyRemoteDecimals(t.Context(), env, selector, mintBytes, tokenDecimals)
+		require.NoError(t, err)
+		require.True(t, verified, "a mint present in the environment should be verifiable")
+	})
+
+	t.Run("Failure - mismatched decimals", func(t *testing.T) {
+		t.Parallel()
+
+		verified, err := shared.VerifyRemoteDecimals(t.Context(), env, selector, mintBytes, 18)
+		require.Error(t, err)
+		require.False(t, verified)
+		require.Contains(t, err.Error(), "supplied 18 decimals but the remote token reports 6")
+	})
+
+	t.Run("Failure - wrong address length", func(t *testing.T) {
+		t.Parallel()
+
+		verified, err := shared.VerifyRemoteDecimals(t.Context(), env, selector, mintBytes[:20], tokenDecimals)
+		require.Error(t, err)
+		require.False(t, verified)
+		require.Contains(t, err.Error(), "expected a 32 byte SVM mint address")
+	})
+}

--- a/deployment/ccip/changeset/v1_5_1/cs_hybrid_token_pool_groups.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_hybrid_token_pool_groups.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
@@ -36,10 +37,20 @@ const (
 type GroupUpdateConfig struct {
 	RemoteChainSelector uint64
 	Group               Group
-	RemoteChainSupply   *big.Int
+
+	// RemoteChainSupply is the backing amount to mint or burn, in the LOCAL token's base
+	// units. Where the remote chain's decimals differ, this is not the remote supply.
+	RemoteChainSupply *big.Int
+
+	// RemoteSupply states the same supply in the remote chain's decimal domain, and is
+	// required whenever RemoteChainSupply is non-zero.
+	RemoteSupply *shared.RemoteSupply
 }
 
-func (g *GroupUpdateConfig) Validate(contract *hybrid_external.HybridWithExternalMinterFastTransferTokenPool) error {
+func (g *GroupUpdateConfig) Validate(
+	env cldf.Environment,
+	contract *hybrid_external.HybridWithExternalMinterFastTransferTokenPool,
+) error {
 	if err := cldf.IsValidChainSelector(g.RemoteChainSelector); err != nil {
 		return fmt.Errorf("invalid remote chain selector %d: %w", g.RemoteChainSelector, err)
 	}
@@ -61,6 +72,7 @@ func (g *GroupUpdateConfig) Validate(contract *hybrid_external.HybridWithExterna
 	if err != nil {
 		return fmt.Errorf("failed to check if chain %d is supported: %w", g.RemoteChainSelector, err)
 	}
+
 	if !supported {
 		return fmt.Errorf("remote chain %d is not supported by the token pool", g.RemoteChainSelector)
 	}
@@ -70,11 +82,45 @@ func (g *GroupUpdateConfig) Validate(contract *hybrid_external.HybridWithExterna
 	if err != nil {
 		return fmt.Errorf("failed to get current group for chain %d: %w", g.RemoteChainSelector, err)
 	}
+
 	if Group(currentGroup) == g.Group {
 		return fmt.Errorf("remote chain %d is already in group %d", g.RemoteChainSelector, g.Group)
 	}
 
-	return nil
+	// A group change that migrates no liquidity needs no remote supply.
+	if g.RemoteChainSupply.Sign() == 0 {
+		return nil
+	}
+
+	if g.RemoteSupply == nil {
+		return fmt.Errorf("remote chain %d: RemoteChainSupply is non-zero but no RemoteSupply was given, so the local amount cannot be derived", g.RemoteChainSelector)
+	}
+
+	opts := &bind.CallOpts{Context: env.GetContext()}
+
+	localDecimals, err := contract.GetTokenDecimals(opts)
+	if err != nil {
+		return fmt.Errorf("failed to read local token decimals from pool %s: %w", contract.Address(), err)
+	}
+
+	remoteToken, err := contract.GetRemoteToken(opts, g.RemoteChainSelector)
+	if err != nil {
+		return fmt.Errorf("failed to read remote token for chain %d: %w", g.RemoteChainSelector, err)
+	}
+
+	verified, err := shared.VerifyRemoteDecimals(env.GetContext(), env, g.RemoteChainSelector, remoteToken, g.RemoteSupply.Decimals)
+	if err != nil {
+		return err
+	}
+
+	if !verified {
+		env.Logger.Warnw("Remote token decimals could not be verified on chain, relying on the supplied value",
+			"remoteChainSelector", g.RemoteChainSelector,
+			"declaredDecimals", g.RemoteSupply.Decimals,
+		)
+	}
+
+	return shared.ValidateRemoteChainSupply(*g.RemoteSupply, g.RemoteChainSupply, localDecimals, g.RemoteChainSelector)
 }
 
 type HybridTokenPoolUpdateGroupsConfig struct {
@@ -140,7 +186,7 @@ func (c HybridTokenPoolUpdateGroupsConfig) Validate(env cldf.Environment) error 
 		}
 
 		for _, update := range groupUpdates {
-			err := update.Validate(pool)
+			err := update.Validate(env, pool)
 			if err != nil {
 				return fmt.Errorf("failed to validate group update for chain selector %d: %w", chainSelector, err)
 			}

--- a/deployment/ccip/changeset/v1_5_1/cs_hybrid_token_pool_groups.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_hybrid_token_pool_groups.go
@@ -11,7 +11,6 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-
 	"github.com/smartcontractkit/chainlink/deployment/ccip/internal/opsutils"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_5_1"
 	ccipseq "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm/v1_5_1"

--- a/deployment/ccip/changeset/v1_5_1/cs_hybrid_token_pool_groups_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_hybrid_token_pool_groups_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
@@ -15,8 +16,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
-
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
 )
 
 // configureHybridTokenPoolChains sets up supported chains for hybrid token pools
@@ -499,15 +498,15 @@ func TestHybridTokenPoolUpdateGroupsChangeset_NoOpUpdate(t *testing.T) {
 
 // setupHybridPoolsForDecimalTests brings up two chains with hybrid pools and the lane
 // between them.
-func setupHybridPoolsForDecimalTests(t *testing.T) (cldf.Environment, uint64, uint64) {
+func setupHybridPoolsForDecimalTests(t *testing.T) (env cldf.Environment, selectorA, selectorB uint64) {
 	t.Helper()
 
-	e, selectorA, selectorB, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), false)
+	env, selectorA, selectorB, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), false)
 
-	externalMinterA, _ := testhelpers.DeployTokenGovernor(t, e, selectorA, tokens[selectorA].Address)
-	externalMinterB, _ := testhelpers.DeployTokenGovernor(t, e, selectorB, tokens[selectorB].Address)
+	externalMinterA, _ := testhelpers.DeployTokenGovernor(t, env, selectorA, tokens[selectorA].Address)
+	externalMinterB, _ := testhelpers.DeployTokenGovernor(t, env, selectorB, tokens[selectorB].Address)
 
-	e = testhelpers.DeployTestTokenPools(t, e, map[uint64]v1_5_1.DeployTokenPoolInput{
+	env = testhelpers.DeployTestTokenPools(t, env, map[uint64]v1_5_1.DeployTokenPoolInput{
 		selectorA: {
 			Type:               shared.HybridWithExternalMinterFastTransferTokenPool,
 			TokenAddress:       tokens[selectorA].Address,
@@ -522,9 +521,9 @@ func setupHybridPoolsForDecimalTests(t *testing.T) (cldf.Environment, uint64, ui
 		},
 	}, false)
 
-	configureHybridTokenPoolChains(t, e, selectorA, selectorB, false)
+	configureHybridTokenPoolChains(t, env, selectorA, selectorB, false)
 
-	return e, selectorA, selectorB
+	return env, selectorA, selectorB
 }
 
 func hybridGroupConfig(selectorA, selectorB uint64, update v1_5_1.GroupUpdateConfig) v1_5_1.HybridTokenPoolUpdateGroupsConfig {
@@ -542,6 +541,7 @@ func hybridGroupConfig(selectorA, selectorB uint64, update v1_5_1.GroupUpdateCon
 // Both test chains use 18-decimal tokens, so a claim of 6 remote decimals is caught by the
 // remote-token cross-check.
 func TestHybridTokenPoolUpdateGroupsChangeset_RemoteSupplyErrors(t *testing.T) {
+	t.Parallel()
 	e, selectorA, selectorB := setupHybridPoolsForDecimalTests(t)
 
 	testCases := []struct {
@@ -597,6 +597,8 @@ func TestHybridTokenPoolUpdateGroupsChangeset_RemoteSupplyErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			config := hybridGroupConfig(selectorA, selectorB, tc.update)
 			_, err := commonchangeset.Apply(t, e, commonchangeset.Configure(v1_5_1.HybridTokenPoolUpdateGroupsChangeset, config))
 			require.Error(t, err)
@@ -608,6 +610,7 @@ func TestHybridTokenPoolUpdateGroupsChangeset_RemoteSupplyErrors(t *testing.T) {
 // Validate is exercised directly rather than through Apply: executing a migration needs a
 // token exposing mint(uint256) for TokenGovernor, which BurnMintERC677 does not have.
 func TestHybridTokenPoolUpdateGroupsChangeset_RemoteSupplyAccepted(t *testing.T) {
+	t.Parallel()
 	e, selectorA, selectorB := setupHybridPoolsForDecimalTests(t)
 
 	const remoteRawSupply = 1_000_000
@@ -625,6 +628,7 @@ func TestHybridTokenPoolUpdateGroupsChangeset_RemoteSupplyAccepted(t *testing.T)
 }
 
 func TestHybridTokenPoolUpdateGroupsChangeset_ZeroSupplyNeedsNoRemoteSupply(t *testing.T) {
+	t.Parallel()
 	e, selectorA, selectorB := setupHybridPoolsForDecimalTests(t)
 
 	state, err := stateview.LoadOnchainState(e)

--- a/deployment/ccip/changeset/v1_5_1/cs_hybrid_token_pool_groups_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_hybrid_token_pool_groups_test.go
@@ -496,3 +496,150 @@ func TestHybridTokenPoolUpdateGroupsChangeset_NoOpUpdate(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "is already in group 0")
 }
+
+// setupHybridPoolsForDecimalTests brings up two chains with hybrid pools and the lane
+// between them.
+func setupHybridPoolsForDecimalTests(t *testing.T) (cldf.Environment, uint64, uint64) {
+	t.Helper()
+
+	e, selectorA, selectorB, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), false)
+
+	externalMinterA, _ := testhelpers.DeployTokenGovernor(t, e, selectorA, tokens[selectorA].Address)
+	externalMinterB, _ := testhelpers.DeployTokenGovernor(t, e, selectorB, tokens[selectorB].Address)
+
+	e = testhelpers.DeployTestTokenPools(t, e, map[uint64]v1_5_1.DeployTokenPoolInput{
+		selectorA: {
+			Type:               shared.HybridWithExternalMinterFastTransferTokenPool,
+			TokenAddress:       tokens[selectorA].Address,
+			LocalTokenDecimals: testhelpers.LocalTokenDecimals,
+			ExternalMinter:     externalMinterA,
+		},
+		selectorB: {
+			Type:               shared.HybridWithExternalMinterFastTransferTokenPool,
+			TokenAddress:       tokens[selectorB].Address,
+			LocalTokenDecimals: testhelpers.LocalTokenDecimals,
+			ExternalMinter:     externalMinterB,
+		},
+	}, false)
+
+	configureHybridTokenPoolChains(t, e, selectorA, selectorB, false)
+
+	return e, selectorA, selectorB
+}
+
+func hybridGroupConfig(selectorA, selectorB uint64, update v1_5_1.GroupUpdateConfig) v1_5_1.HybridTokenPoolUpdateGroupsConfig {
+	update.RemoteChainSelector = selectorB
+	return v1_5_1.HybridTokenPoolUpdateGroupsConfig{
+		TokenSymbol:     testhelpers.TestTokenSymbol,
+		ContractType:    shared.HybridWithExternalMinterFastTransferTokenPool,
+		ContractVersion: shared.HybridWithExternalMinterFastTransferTokenPoolVersion,
+		Updates: map[uint64][]v1_5_1.GroupUpdateConfig{
+			selectorA: {update},
+		},
+	}
+}
+
+// Both test chains use 18-decimal tokens, so a claim of 6 remote decimals is caught by the
+// remote-token cross-check.
+func TestHybridTokenPoolUpdateGroupsChangeset_RemoteSupplyErrors(t *testing.T) {
+	e, selectorA, selectorB := setupHybridPoolsForDecimalTests(t)
+
+	testCases := []struct {
+		name       string
+		update     v1_5_1.GroupUpdateConfig
+		wantErrMsg string
+	}{
+		{
+			name: "Failure - missing remote supply",
+			update: v1_5_1.GroupUpdateConfig{
+				Group:             v1_5_1.BurnAndMint,
+				RemoteChainSupply: big.NewInt(1000),
+			},
+			wantErrMsg: "RemoteChainSupply is non-zero but no RemoteSupply was given",
+		},
+		{
+			name: "Failure - declared decimals do not match remote token",
+			update: v1_5_1.GroupUpdateConfig{
+				Group:             v1_5_1.BurnAndMint,
+				RemoteChainSupply: big.NewInt(1000),
+				RemoteSupply: &shared.RemoteSupply{
+					Decimals: 6,
+					Amount:   big.NewInt(1000),
+				},
+			},
+			wantErrMsg: "supplied 6 decimals but the remote token reports 18",
+		},
+		{
+			name: "Failure - supply does not match remote supply",
+			update: v1_5_1.GroupUpdateConfig{
+				Group:             v1_5_1.BurnAndMint,
+				RemoteChainSupply: big.NewInt(1000),
+				RemoteSupply: &shared.RemoteSupply{
+					Decimals: testhelpers.LocalTokenDecimals,
+					Amount:   big.NewInt(2000),
+				},
+			},
+			wantErrMsg: "requires 2000, but the update supplies 1000",
+		},
+		{
+			name: "Failure - nil remote supply amount",
+			update: v1_5_1.GroupUpdateConfig{
+				Group:             v1_5_1.BurnAndMint,
+				RemoteChainSupply: big.NewInt(1000),
+				RemoteSupply: &shared.RemoteSupply{
+					Decimals: testhelpers.LocalTokenDecimals,
+					Amount:   nil,
+				},
+			},
+			wantErrMsg: "must not be nil",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := hybridGroupConfig(selectorA, selectorB, tc.update)
+			_, err := commonchangeset.Apply(t, e, commonchangeset.Configure(v1_5_1.HybridTokenPoolUpdateGroupsChangeset, config))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErrMsg)
+		})
+	}
+}
+
+// Validate is exercised directly rather than through Apply: executing a migration needs a
+// token exposing mint(uint256) for TokenGovernor, which BurnMintERC677 does not have.
+func TestHybridTokenPoolUpdateGroupsChangeset_RemoteSupplyAccepted(t *testing.T) {
+	e, selectorA, selectorB := setupHybridPoolsForDecimalTests(t)
+
+	const remoteRawSupply = 1_000_000
+
+	config := hybridGroupConfig(selectorA, selectorB, v1_5_1.GroupUpdateConfig{
+		Group:             v1_5_1.BurnAndMint,
+		RemoteChainSupply: big.NewInt(remoteRawSupply),
+		RemoteSupply: &shared.RemoteSupply{
+			Decimals: testhelpers.LocalTokenDecimals,
+			Amount:   big.NewInt(remoteRawSupply),
+		},
+	})
+
+	require.NoError(t, config.Validate(e))
+}
+
+func TestHybridTokenPoolUpdateGroupsChangeset_ZeroSupplyNeedsNoRemoteSupply(t *testing.T) {
+	e, selectorA, selectorB := setupHybridPoolsForDecimalTests(t)
+
+	state, err := stateview.LoadOnchainState(e)
+	require.NoError(t, err)
+	pool := state.Chains[selectorA].HybridWithExternalMinterFastTransferTokenPools[testhelpers.TestTokenSymbol][shared.HybridWithExternalMinterFastTransferTokenPoolVersion]
+
+	config := hybridGroupConfig(selectorA, selectorB, v1_5_1.GroupUpdateConfig{
+		Group:             v1_5_1.BurnAndMint,
+		RemoteChainSupply: big.NewInt(0),
+	})
+
+	_, err = commonchangeset.Apply(t, e, commonchangeset.Configure(v1_5_1.HybridTokenPoolUpdateGroupsChangeset, config))
+	require.NoError(t, err)
+
+	currentGroup, err := pool.GetGroup(nil, selectorB)
+	require.NoError(t, err)
+	require.Equal(t, v1_5_1.BurnAndMint, v1_5_1.Group(currentGroup))
+}

--- a/deployment/ccip/changeset/v1_6/cs_hybrid_with_external_minter_token_pool.go
+++ b/deployment/ccip/changeset/v1_6/cs_hybrid_with_external_minter_token_pool.go
@@ -7,12 +7,12 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/smartcontractkit/ccip-contract-examples/chains/evm/gobindings/generated/1_6_1/hybrid_with_external_minter_token_pool"
 
 	cldfevm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
-
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"

--- a/deployment/ccip/changeset/v1_6/cs_hybrid_with_external_minter_token_pool.go
+++ b/deployment/ccip/changeset/v1_6/cs_hybrid_with_external_minter_token_pool.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/ccip-contract-examples/chains/evm/gobindings/generated/1_6_1/hybrid_with_external_minter_token_pool"
 
+	cldfevm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldfproposalutils "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalutils"
 
@@ -15,9 +17,16 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/evm"
 )
 
 var _ cldf.ChangeSet[ConfigureHybridWithExternalMinterTokenPoolConfig] = UpdateGroupsOnHybridWithExternalMinterTokenPool
+
+// Group values as defined by HybridTokenPoolAbstract.Group.
+const (
+	groupLockAndRelease uint8 = 0
+	groupBurnAndMint    uint8 = 1
+)
 
 type HybridGroupConfig struct {
 	// Type is the type of the token pool.
@@ -27,6 +36,10 @@ type HybridGroupConfig struct {
 	Version semver.Version `json:"version"`
 
 	Updates []hybrid_with_external_minter_token_pool.HybridTokenPoolAbstractGroupUpdate
+
+	// RemoteSupplies is keyed by remote chain selector and is required for every update
+	// carrying a non-zero RemoteChainSupply.
+	RemoteSupplies map[uint64]shared.RemoteSupply `json:"remoteSupplies"`
 }
 
 type ConfigureHybridWithExternalMinterTokenPoolConfig struct {
@@ -82,7 +95,12 @@ func (c ConfigureHybridWithExternalMinterTokenPoolConfig) Validate(env cldf.Envi
 			}
 		}
 
-		if err := poolUpdate.Validate(); err != nil {
+		pool, err := c.resolvePool(chainState, chain)
+		if err != nil {
+			return fmt.Errorf("failed to resolve pool on %s: %w", chain.String(), err)
+		}
+
+		if err := poolUpdate.Validate(env, pool, chain.String()); err != nil {
 			return fmt.Errorf("invalid pool update on %s: %w", chain.String(), err)
 		}
 	}
@@ -90,7 +108,32 @@ func (c ConfigureHybridWithExternalMinterTokenPoolConfig) Validate(env cldf.Envi
 	return nil
 }
 
-func (c HybridGroupConfig) Validate() error {
+// resolvePool returns the pool addressed by c, looked up by token symbol in state or bound
+// directly to the configured address.
+func (c ConfigureHybridWithExternalMinterTokenPoolConfig) resolvePool(
+	chainState evm.CCIPChainState,
+	chain cldfevm.Chain,
+) (*hybrid_with_external_minter_token_pool.HybridWithExternalMinterTokenPool, error) {
+	if c.TokenSymbol != "" {
+		pool, ok := chainState.HybridWithExternalMinterTokenPool[c.TokenSymbol][deployment.Version1_6_0]
+		if !ok {
+			return nil, fmt.Errorf("token pool does not exist with symbol %s", c.TokenSymbol)
+		}
+		return pool, nil
+	}
+
+	pool, err := hybrid_with_external_minter_token_pool.NewHybridWithExternalMinterTokenPool(c.Address, chain.Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create hybrid with external minter pool: %w", err)
+	}
+	return pool, nil
+}
+
+func (c HybridGroupConfig) Validate(
+	env cldf.Environment,
+	pool *hybrid_with_external_minter_token_pool.HybridWithExternalMinterTokenPool,
+	chainName string,
+) error {
 	if _, ok := shared.TokenPoolTypes[c.Type]; !ok {
 		return fmt.Errorf("%s is not a known token pool type", c.Type)
 	}
@@ -101,6 +144,91 @@ func (c HybridGroupConfig) Validate() error {
 
 	if c.Type != shared.HybridWithExternalMinterTokenPool {
 		return fmt.Errorf("token pool type %s is not supported", c.Type)
+	}
+
+	if len(c.Updates) == 0 {
+		return fmt.Errorf("no group updates specified for %s", chainName)
+	}
+
+	opts := &bind.CallOpts{Context: env.GetContext()}
+
+	localDecimals, err := pool.GetTokenDecimals(opts)
+	if err != nil {
+		return fmt.Errorf("failed to fetch local token decimals from pool %s: %w", pool.Address(), err)
+	}
+
+	seen := make(map[uint64]struct{}, len(c.Updates))
+
+	for _, update := range c.Updates {
+		if err := cldf.IsValidChainSelector(update.RemoteChainSelector); err != nil {
+			return fmt.Errorf("invalid remote chain selector %d: %w", update.RemoteChainSelector, err)
+		}
+
+		// updateGroups applies updates in order, so a duplicate would depend on the state
+		// left by the first entry.
+		if _, duplicate := seen[update.RemoteChainSelector]; duplicate {
+			return fmt.Errorf("remote chain %d appears more than once in the group updates", update.RemoteChainSelector)
+		}
+		seen[update.RemoteChainSelector] = struct{}{}
+
+		if update.Group != groupLockAndRelease && update.Group != groupBurnAndMint {
+			return fmt.Errorf("invalid group %d for remote chain %d, must be %d (LOCK_AND_RELEASE) or %d (BURN_AND_MINT)",
+				update.Group, update.RemoteChainSelector, groupLockAndRelease, groupBurnAndMint)
+		}
+
+		supported, err := pool.IsSupportedChain(opts, update.RemoteChainSelector)
+		if err != nil {
+			return fmt.Errorf("failed to check if chain %d is supported: %w", update.RemoteChainSelector, err)
+		}
+
+		if !supported {
+			return fmt.Errorf("remote chain %d is not supported by the token pool", update.RemoteChainSelector)
+		}
+
+		// The contract reverts with InvalidGroupUpdate on a no-op transition.
+		currentGroup, err := pool.GetGroup(opts, update.RemoteChainSelector)
+		if err != nil {
+			return fmt.Errorf("failed to read current group for chain %d: %w", update.RemoteChainSelector, err)
+		}
+
+		if currentGroup == update.Group {
+			return fmt.Errorf("remote chain %d is already in group %d", update.RemoteChainSelector, update.Group)
+		}
+
+		// A group change that migrates no liquidity needs no remote supply.
+		if update.RemoteChainSupply == nil || update.RemoteChainSupply.Sign() == 0 {
+			continue
+		}
+
+		if update.RemoteChainSupply.Sign() < 0 {
+			return fmt.Errorf("remote chain %d: RemoteChainSupply must not be negative", update.RemoteChainSelector)
+		}
+
+		remoteSupply, ok := c.RemoteSupplies[update.RemoteChainSelector]
+		if !ok {
+			return fmt.Errorf("remote chain %d: RemoteChainSupply is non-zero but no RemoteSupply was given, so the local amount cannot be derived", update.RemoteChainSelector)
+		}
+
+		remoteToken, err := pool.GetRemoteToken(opts, update.RemoteChainSelector)
+		if err != nil {
+			return fmt.Errorf("failed to read remote token for chain %d: %w", update.RemoteChainSelector, err)
+		}
+
+		verified, err := shared.VerifyRemoteDecimals(env.GetContext(), env, update.RemoteChainSelector, remoteToken, remoteSupply.Decimals)
+		if err != nil {
+			return err
+		}
+
+		if !verified {
+			env.Logger.Warnw("Remote token decimals could not be verified on chain, relying on the supplied value",
+				"remoteChainSelector", update.RemoteChainSelector,
+				"declaredDecimals", remoteSupply.Decimals,
+			)
+		}
+
+		if err := shared.ValidateRemoteChainSupply(remoteSupply, update.RemoteChainSupply, localDecimals, update.RemoteChainSelector); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -132,20 +260,9 @@ func UpdateGroupsOnHybridWithExternalMinterTokenPool(env cldf.Environment, c Con
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get deployer for %s", chain)
 		}
 
-		var pool *hybrid_with_external_minter_token_pool.HybridWithExternalMinterTokenPool
-
-		if c.TokenSymbol != "" {
-			poolFromTokenSymbol, ok := chainState.HybridWithExternalMinterTokenPool[c.TokenSymbol][deployment.Version1_6_0]
-			if !ok {
-				return cldf.ChangesetOutput{}, fmt.Errorf("token pool does not exist on %s with symbol %s", chain, c.TokenSymbol)
-			}
-
-			pool = poolFromTokenSymbol
-		} else {
-			pool, err = hybrid_with_external_minter_token_pool.NewHybridWithExternalMinterTokenPool(c.Address, chain.Client)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to create hybrid with external minter pool: %w", err)
-			}
+		pool, err := c.resolvePool(chainState, chain)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve pool on %s: %w", chain, err)
 		}
 
 		if _, err := pool.UpdateGroups(opts, tokenPool.Updates); err != nil {

--- a/deployment/ccip/shared/hybrid_supply.go
+++ b/deployment/ccip/shared/hybrid_supply.go
@@ -16,7 +16,6 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/erc20"
 )
 
@@ -277,19 +276,29 @@ func aptosFungibleAssetDecimals(
 		return 0, false, fmt.Errorf("failed to read decimals for fungible asset %s on %s: %w", metadataAddress.String(), remoteChain.String(), err)
 	}
 
-	if len(values) == 0 {
-		return 0, false, fmt.Errorf("remote chain %d: decimals view returned no value for fungible asset %s", remoteChainSelector, metadataAddress.String())
+	decimals, err := parseAptosDecimals(values)
+	if err != nil {
+		return 0, false, fmt.Errorf("remote chain %d: fungible asset %s: %w", remoteChainSelector, metadataAddress.String(), err)
 	}
 
-	// Aptos view results arrive as JSON numbers.
+	return decimals, true, nil
+}
+
+// parseAptosDecimals reads the single u8 returned by the decimals view, which the Aptos
+// client surfaces as a JSON number.
+func parseAptosDecimals(values []any) (uint8, error) {
+	if len(values) == 0 {
+		return 0, errors.New("decimals view returned no value")
+	}
+
 	decimals, ok := values[0].(float64)
 	if !ok {
-		return 0, false, fmt.Errorf("remote chain %d: decimals view returned %T, want a number", remoteChainSelector, values[0])
+		return 0, fmt.Errorf("decimals view returned %T, want a number", values[0])
 	}
 
-	if decimals < 0 || decimals > math.MaxUint8 {
-		return 0, false, fmt.Errorf("remote chain %d: decimals view returned %v, which is out of range", remoteChainSelector, decimals)
+	if decimals != math.Trunc(decimals) || decimals < 0 || decimals > math.MaxUint8 {
+		return 0, fmt.Errorf("decimals view returned %v, which is not a uint8", decimals)
 	}
 
-	return uint8(decimals), true, nil
+	return uint8(decimals), nil
 }

--- a/deployment/ccip/shared/hybrid_supply.go
+++ b/deployment/ccip/shared/hybrid_supply.go
@@ -1,0 +1,295 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+
+	aptoslib "github.com/aptos-labs/aptos-go-sdk"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/gagliardetto/solana-go"
+	solToken "github.com/gagliardetto/solana-go/programs/token"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/erc20"
+)
+
+// maxDecimalExponent is the largest power of ten that fits in a uint256, since
+// 10^77 < 2^256-1 < 10^78.
+//
+// Scaling up multiplies by 10^exponent, so an exponent above this cannot produce an
+// encodable amount. Scaling down only divides, where an exponent this large already
+// yields a remainder and is rejected as truncation; the bound is kept there to avoid
+// building a pointlessly large divisor.
+const maxDecimalExponent = 77
+
+// RemoteSupply is a token supply expressed in a remote chain's own decimal domain.
+//
+// A group update's RemoteChainSupply is denominated in the LOCAL token's base units,
+// because updateGroups mints it directly through the external minter. Stating the remote
+// supply separately lets the changeset derive the local amount and reject one that was
+// passed through without conversion.
+type RemoteSupply struct {
+	// Decimals is the token's decimal precision on the remote chain.
+	Decimals uint8 `json:"decimals"`
+
+	// Amount is the supply in the remote chain's smallest indivisible unit, exactly as the
+	// remote chain reports it, with no decimal point applied. For a 6-decimal token holding
+	// 1,206,841,810.125844 tokens this is 1206841810125844.
+	//
+	// Read it from totalSupply() on EVM, getTokenSupply on SVM, or the fungible asset's
+	// supply on Aptos.
+	Amount *big.Int `json:"amount"`
+}
+
+// NormalizeRemoteSupply converts an amount from a remote chain's decimal domain into the
+// local one, mirroring TokenPool._calculateLocalAmount so that migration backing and later
+// redemptions agree.
+//
+// Scaling down must be exact: a remainder means the remote supply has no local
+// representation, and truncating it would under-back the pool.
+func NormalizeRemoteSupply(amount *big.Int, remoteDecimals, localDecimals uint8) (*big.Int, error) {
+	if amount == nil {
+		return nil, errors.New("remote supply amount must not be nil")
+	}
+
+	if amount.Sign() < 0 {
+		return nil, fmt.Errorf("remote supply amount %s must not be negative", amount)
+	}
+
+	if remoteDecimals == localDecimals {
+		return new(big.Int).Set(amount), nil
+	}
+
+	if remoteDecimals > localDecimals {
+		return scaleDown(amount, remoteDecimals, localDecimals)
+	}
+
+	return scaleUp(amount, remoteDecimals, localDecimals)
+}
+
+func scaleDown(amount *big.Int, remoteDecimals, localDecimals uint8) (*big.Int, error) {
+	exponent := remoteDecimals - localDecimals
+	if exponent > maxDecimalExponent {
+		return nil, fmt.Errorf("cannot convert from %d to %d decimals, the scale factor exceeds uint256", remoteDecimals, localDecimals)
+	}
+
+	divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(exponent)), nil)
+
+	quotient, remainder := new(big.Int).QuoRem(amount, divisor, new(big.Int))
+	if remainder.Sign() != 0 {
+		return nil, fmt.Errorf("remote supply %s at %d decimals has no exact representation at %d local decimals", amount, remoteDecimals, localDecimals)
+	}
+
+	return quotient, nil
+}
+
+func scaleUp(amount *big.Int, remoteDecimals, localDecimals uint8) (*big.Int, error) {
+	exponent := localDecimals - remoteDecimals
+	if exponent > maxDecimalExponent {
+		return nil, fmt.Errorf("cannot convert from %d to %d decimals, the scale factor exceeds uint256", remoteDecimals, localDecimals)
+	}
+
+	multiplier := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(exponent)), nil)
+
+	localAmount := new(big.Int).Mul(amount, multiplier)
+	if localAmount.BitLen() > 256 {
+		return nil, fmt.Errorf("remote supply %s at %d decimals overflows uint256 at %d local decimals", amount, remoteDecimals, localDecimals)
+	}
+
+	return localAmount, nil
+}
+
+// ValidateRemoteChainSupply checks that suppliedLocalAmount is remoteSupply expressed in
+// local base units.
+//
+// This rejects a remote supply passed straight into a group update: with a 6-decimal remote
+// and an 18-decimal local token, the unconverted value under-backs the pool by 10^12.
+func ValidateRemoteChainSupply(
+	remoteSupply RemoteSupply,
+	suppliedLocalAmount *big.Int,
+	localDecimals uint8,
+	remoteChainSelector uint64,
+) error {
+	if suppliedLocalAmount == nil {
+		return fmt.Errorf("remote chain %d: RemoteChainSupply must not be nil", remoteChainSelector)
+	}
+
+	expected, err := NormalizeRemoteSupply(remoteSupply.Amount, remoteSupply.Decimals, localDecimals)
+	if err != nil {
+		return fmt.Errorf("remote chain %d: %w", remoteChainSelector, err)
+	}
+
+	if expected.Cmp(suppliedLocalAmount) != 0 {
+		return fmt.Errorf(
+			"remote chain %d: RemoteChainSupply must be in local base units (%d decimals), so remote supply %s at %d decimals requires %s, but the update supplies %s",
+			remoteChainSelector, localDecimals,
+			remoteSupply.Amount, remoteSupply.Decimals, expected, suppliedLocalAmount,
+		)
+	}
+
+	return nil
+}
+
+// VerifyRemoteDecimals cross-checks a supplied remote decimal precision against the remote
+// chain, and reports whether that check could actually be made.
+//
+// Decimals are not stored on the pool, so each family is read through its own interface.
+// verified is false when the remote chain is absent from the environment or its family is
+// unsupported, which leaves the supplied value as the only source of truth; the caller is
+// told rather than given a silent pass.
+func VerifyRemoteDecimals(
+	ctx context.Context,
+	env cldf.Environment,
+	remoteChainSelector uint64,
+	remoteTokenAddress []byte,
+	declaredDecimals uint8,
+) (verified bool, err error) {
+	if len(remoteTokenAddress) == 0 {
+		return false, nil
+	}
+
+	family, err := chain_selectors.GetSelectorFamily(remoteChainSelector)
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve chain family for remote chain %d: %w", remoteChainSelector, err)
+	}
+
+	var onchainDecimals uint8
+
+	switch family {
+	case chain_selectors.FamilyEVM:
+		onchainDecimals, verified, err = evmTokenDecimals(ctx, env, remoteChainSelector, remoteTokenAddress)
+	case chain_selectors.FamilySolana:
+		onchainDecimals, verified, err = solanaMintDecimals(ctx, env, remoteChainSelector, remoteTokenAddress)
+	case chain_selectors.FamilyAptos:
+		onchainDecimals, verified, err = aptosFungibleAssetDecimals(env, remoteChainSelector, remoteTokenAddress)
+	default:
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	if !verified {
+		return false, nil
+	}
+
+	if onchainDecimals != declaredDecimals {
+		return false, fmt.Errorf("remote chain %d: supplied %d decimals but the remote token reports %d", remoteChainSelector, declaredDecimals, onchainDecimals)
+	}
+
+	return true, nil
+}
+
+func evmTokenDecimals(
+	ctx context.Context,
+	env cldf.Environment,
+	remoteChainSelector uint64,
+	remoteTokenAddress []byte,
+) (uint8, bool, error) {
+	remoteChain, ok := env.BlockChains.EVMChains()[remoteChainSelector]
+	if !ok {
+		return 0, false, nil
+	}
+
+	// EVM token addresses are left-padded to 32 bytes on the pool.
+	tokenAddress := common.BytesToAddress(remoteTokenAddress)
+	if tokenAddress == (common.Address{}) {
+		return 0, false, nil
+	}
+
+	token, err := erc20.NewERC20(tokenAddress, remoteChain.Client)
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to bind erc20 at %s on %s: %w", tokenAddress, remoteChain.String(), err)
+	}
+
+	decimals, err := token.Decimals(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to read decimals from token %s on %s: %w", tokenAddress, remoteChain.String(), err)
+	}
+
+	return decimals, true, nil
+}
+
+// solanaMintDecimals reads the decimals field of the SPL mint account.
+func solanaMintDecimals(
+	ctx context.Context,
+	env cldf.Environment,
+	remoteChainSelector uint64,
+	remoteTokenAddress []byte,
+) (uint8, bool, error) {
+	remoteChain, ok := env.BlockChains.SolanaChains()[remoteChainSelector]
+	if !ok {
+		return 0, false, nil
+	}
+
+	if len(remoteTokenAddress) != solana.PublicKeyLength {
+		return 0, false, fmt.Errorf("remote chain %d: expected a %d byte SVM mint address, got %d bytes", remoteChainSelector, solana.PublicKeyLength, len(remoteTokenAddress))
+	}
+
+	mintAddress := solana.PublicKeyFromBytes(remoteTokenAddress)
+
+	var mint solToken.Mint
+	if err := remoteChain.GetAccountDataBorshInto(ctx, mintAddress, &mint); err != nil {
+		return 0, false, fmt.Errorf("failed to read mint %s on %s: %w", mintAddress, remoteChain.String(), err)
+	}
+
+	return mint.Decimals, true, nil
+}
+
+// aptosFungibleAssetDecimals calls 0x1::fungible_asset::decimals on the asset's metadata
+// object, which is what the pool stores as the remote token address.
+func aptosFungibleAssetDecimals(
+	env cldf.Environment,
+	remoteChainSelector uint64,
+	remoteTokenAddress []byte,
+) (uint8, bool, error) {
+	remoteChain, ok := env.BlockChains.AptosChains()[remoteChainSelector]
+	if !ok {
+		return 0, false, nil
+	}
+
+	var metadataAddress aptoslib.AccountAddress
+	if len(remoteTokenAddress) != len(metadataAddress) {
+		return 0, false, fmt.Errorf("remote chain %d: expected a %d byte Aptos metadata address, got %d bytes", remoteChainSelector, len(metadataAddress), len(remoteTokenAddress))
+	}
+
+	copy(metadataAddress[:], remoteTokenAddress)
+
+	values, err := remoteChain.Client.View(&aptoslib.ViewPayload{
+		Module:   aptoslib.ModuleId{Address: aptoslib.AccountOne, Name: "fungible_asset"},
+		Function: "decimals",
+		ArgTypes: []aptoslib.TypeTag{{Value: &aptoslib.StructTag{
+			Address: aptoslib.AccountOne,
+			Module:  "fungible_asset",
+			Name:    "Metadata",
+		}}},
+		Args: [][]byte{metadataAddress[:]},
+	})
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to read decimals for fungible asset %s on %s: %w", metadataAddress.String(), remoteChain.String(), err)
+	}
+
+	if len(values) == 0 {
+		return 0, false, fmt.Errorf("remote chain %d: decimals view returned no value for fungible asset %s", remoteChainSelector, metadataAddress.String())
+	}
+
+	// Aptos view results arrive as JSON numbers.
+	decimals, ok := values[0].(float64)
+	if !ok {
+		return 0, false, fmt.Errorf("remote chain %d: decimals view returned %T, want a number", remoteChainSelector, values[0])
+	}
+
+	if decimals < 0 || decimals > math.MaxUint8 {
+		return 0, false, fmt.Errorf("remote chain %d: decimals view returned %v, which is out of range", remoteChainSelector, decimals)
+	}
+
+	return uint8(decimals), true, nil
+}

--- a/deployment/ccip/shared/hybrid_supply_internal_test.go
+++ b/deployment/ccip/shared/hybrid_supply_internal_test.go
@@ -1,0 +1,99 @@
+package shared
+
+import (
+	"encoding/base64"
+	"testing"
+
+	bin "github.com/gagliardetto/binary"
+	solToken "github.com/gagliardetto/solana-go/programs/token"
+	"github.com/stretchr/testify/require"
+)
+
+// mainnetSPLMintAccount is the live account data of a 6-decimal SPL mint, captured from
+// Solana mainnet. It pins the layout the decimals read depends on.
+const mainnetSPLMintAccount = "AQAAAJqmjmC3XUgeV/3BTNcDsJeT3fWVS1LxIRu9+UDUwYbiKgCizQheBAAGAQEAAABpABO3JyzZq1lqrNeYIqP0v/TOjpRY5+Ltw3RArhK21A=="
+
+// TestSolanaMintDecode confirms a real mainnet mint account decodes to the expected
+// decimals, covering the layout assumption behind solanaMintDecimals.
+func TestSolanaMintDecode(t *testing.T) {
+	t.Parallel()
+
+	data, err := base64.StdEncoding.DecodeString(mainnetSPLMintAccount)
+	require.NoError(t, err)
+	require.Len(t, data, 82, "SPL mint accounts are 82 bytes")
+
+	var mint solToken.Mint
+	require.NoError(t, bin.NewBinDecoder(data).Decode(&mint))
+
+	require.Equal(t, uint8(6), mint.Decimals)
+	require.True(t, mint.IsInitialized)
+}
+
+func TestParseAptosDecimals(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		values     []any
+		want       uint8
+		wantErrMsg string
+	}{
+		{
+			// Shape returned by 0x1::fungible_asset::decimals on mainnet.
+			name:   "Success - single number",
+			values: []any{float64(6)},
+			want:   6,
+		},
+		{
+			name:   "Success - zero decimals",
+			values: []any{float64(0)},
+			want:   0,
+		},
+		{
+			name:   "Success - max uint8",
+			values: []any{float64(255)},
+			want:   255,
+		},
+		{
+			name:       "Failure - no values",
+			values:     nil,
+			wantErrMsg: "returned no value",
+		},
+		{
+			name:       "Failure - string instead of number",
+			values:     []any{"6"},
+			wantErrMsg: "want a number",
+		},
+		{
+			name:       "Failure - above uint8",
+			values:     []any{float64(256)},
+			wantErrMsg: "not a uint8",
+		},
+		{
+			name:       "Failure - negative",
+			values:     []any{float64(-1)},
+			wantErrMsg: "not a uint8",
+		},
+		{
+			name:       "Failure - fractional",
+			values:     []any{float64(6.5)},
+			wantErrMsg: "not a uint8",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseAptosDecimals(tc.values)
+			if tc.wantErrMsg != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/deployment/ccip/shared/hybrid_supply_test.go
+++ b/deployment/ccip/shared/hybrid_supply_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 )
 
@@ -107,19 +106,19 @@ func TestNormalizeRemoteSupply(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := shared.NormalizeRemoteSupply(tt.amount, tt.remoteDecimals, tt.localDecimals)
-			if tt.wantErrMsg != "" {
+			got, err := shared.NormalizeRemoteSupply(tc.amount, tc.remoteDecimals, tc.localDecimals)
+			if tc.wantErrMsg != "" {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.wantErrMsg)
+				require.Contains(t, err.Error(), tc.wantErrMsg)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Zero(t, tt.want.Cmp(got), "want %s, got %s", tt.want, got)
+			require.Zero(t, tc.want.Cmp(got), "want %s, got %s", tc.want, got)
 		})
 	}
 }
@@ -222,16 +221,16 @@ func TestValidateRemoteChainSupply(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			err := shared.ValidateRemoteChainSupply(
-				tt.remoteSupply, tt.suppliedLocal, tt.localDecimals, remoteChainSelector,
+				tc.remoteSupply, tc.suppliedLocal, tc.localDecimals, remoteChainSelector,
 			)
-			if tt.wantErrMsg != "" {
+			if tc.wantErrMsg != "" {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.wantErrMsg)
+				require.Contains(t, err.Error(), tc.wantErrMsg)
 				require.Contains(t, err.Error(), "124615329519749607", "error should name the remote chain")
 				return
 			}
@@ -290,21 +289,21 @@ func TestVerifyRemoteDecimals(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			verified, err := shared.VerifyRemoteDecimals(
-				t.Context(), cldf.Environment{}, tt.chainSelector, tt.tokenAddress, 6,
+				t.Context(), cldf.Environment{}, tc.chainSelector, tc.tokenAddress, 6,
 			)
-			if tt.wantErrMsg != "" {
+			if tc.wantErrMsg != "" {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.wantErrMsg)
+				require.Contains(t, err.Error(), tc.wantErrMsg)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tt.wantVerified, verified)
+			require.Equal(t, tc.wantVerified, verified)
 		})
 	}
 }

--- a/deployment/ccip/shared/hybrid_supply_test.go
+++ b/deployment/ccip/shared/hybrid_supply_test.go
@@ -1,0 +1,310 @@
+package shared_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
+)
+
+// sixDecimalSupply is a realistic supply for a 6-decimal token, used to exercise the
+// 6-to-18 boundary that a same-decimals test would miss.
+var sixDecimalSupply = big.NewInt(1_206_841_810_125_844)
+
+func mustBigInt(t *testing.T, s string) *big.Int {
+	t.Helper()
+	v, ok := new(big.Int).SetString(s, 10)
+	require.True(t, ok, "failed to parse %s", s)
+	return v
+}
+
+func TestNormalizeRemoteSupply(t *testing.T) {
+	t.Parallel()
+
+	maxUint256 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
+
+	tests := []struct {
+		name           string
+		amount         *big.Int
+		remoteDecimals uint8
+		localDecimals  uint8
+		want           *big.Int
+		wantErrMsg     string
+	}{
+		{
+			name:           "Success - equal decimals returns the amount unchanged",
+			amount:         big.NewInt(1000),
+			remoteDecimals: 18,
+			localDecimals:  18,
+			want:           big.NewInt(1000),
+		},
+		{
+			name:           "Success - six decimal remote scales up to eighteen decimal local",
+			amount:         sixDecimalSupply,
+			remoteDecimals: 6,
+			localDecimals:  18,
+			want:           mustBigInt(t, "1206841810125844000000000000"),
+		},
+		{
+			name:           "Success - eighteen decimal remote scales down to six decimal local",
+			amount:         mustBigInt(t, "1206841810125844000000000000"),
+			remoteDecimals: 18,
+			localDecimals:  6,
+			want:           sixDecimalSupply,
+		},
+		{
+			name:           "Success - zero supply across differing decimals",
+			amount:         big.NewInt(0),
+			remoteDecimals: 6,
+			localDecimals:  18,
+			want:           big.NewInt(0),
+		},
+		{
+			name:           "Failure - scaling down with a remainder",
+			amount:         big.NewInt(1_000_001),
+			remoteDecimals: 18,
+			localDecimals:  12,
+			wantErrMsg:     "no exact representation at 12 local decimals",
+		},
+		{
+			name:           "Failure - nil supply",
+			amount:         nil,
+			remoteDecimals: 6,
+			localDecimals:  18,
+			wantErrMsg:     "must not be nil",
+		},
+		{
+			name:           "Failure - negative supply",
+			amount:         big.NewInt(-1),
+			remoteDecimals: 6,
+			localDecimals:  18,
+			wantErrMsg:     "must not be negative",
+		},
+		{
+			name:           "Failure - scaling up past uint256",
+			amount:         maxUint256,
+			remoteDecimals: 6,
+			localDecimals:  18,
+			wantErrMsg:     "overflows uint256",
+		},
+		{
+			name:           "Failure - scale factor exceeds uint256 when scaling up",
+			amount:         big.NewInt(1),
+			remoteDecimals: 0,
+			localDecimals:  255,
+			wantErrMsg:     "scale factor exceeds uint256",
+		},
+		{
+			name:           "Failure - scale factor exceeds uint256 when scaling down",
+			amount:         big.NewInt(1),
+			remoteDecimals: 255,
+			localDecimals:  0,
+			wantErrMsg:     "scale factor exceeds uint256",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := shared.NormalizeRemoteSupply(tt.amount, tt.remoteDecimals, tt.localDecimals)
+			if tt.wantErrMsg != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Zero(t, tt.want.Cmp(got), "want %s, got %s", tt.want, got)
+		})
+	}
+}
+
+// TestNormalizeRemoteSupply_DoesNotMutateInput guards against aliasing a caller's big.Int.
+func TestNormalizeRemoteSupply_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	amount := new(big.Int).Set(sixDecimalSupply)
+
+	got, err := shared.NormalizeRemoteSupply(amount, 6, 18)
+	require.NoError(t, err)
+	require.Zero(t, sixDecimalSupply.Cmp(amount), "input was mutated")
+	require.NotSame(t, amount, got, "result aliases the input")
+
+	got, err = shared.NormalizeRemoteSupply(amount, 18, 18)
+	require.NoError(t, err)
+	require.NotSame(t, amount, got, "equal-decimals result aliases the input")
+}
+
+func TestValidateRemoteChainSupply(t *testing.T) {
+	t.Parallel()
+
+	const remoteChainSelector = 124_615_329_519_749_607
+
+	tests := []struct {
+		name          string
+		remoteSupply  shared.RemoteSupply
+		suppliedLocal *big.Int
+		localDecimals uint8
+		wantErrMsg    string
+	}{
+		{
+			name: "Success - correctly normalized six to eighteen decimals",
+			remoteSupply: shared.RemoteSupply{
+				Decimals: 6,
+				Amount:   sixDecimalSupply,
+			},
+			suppliedLocal: mustBigInt(t, "1206841810125844000000000000"),
+			localDecimals: 18,
+		},
+		{
+			// The unconverted value under-backs the pool by 10^12.
+			name: "Failure - remote supply passed through without conversion",
+			remoteSupply: shared.RemoteSupply{
+				Decimals: 6,
+				Amount:   sixDecimalSupply,
+			},
+			suppliedLocal: sixDecimalSupply,
+			localDecimals: 18,
+			wantErrMsg:    "requires 1206841810125844000000000000, but the update supplies 1206841810125844",
+		},
+		{
+			name: "Success - matching decimals accepts the supply unchanged",
+			remoteSupply: shared.RemoteSupply{
+				Decimals: 18,
+				Amount:   big.NewInt(1000),
+			},
+			suppliedLocal: big.NewInt(1000),
+			localDecimals: 18,
+		},
+		{
+			name: "Success - zero supply matches a zero update",
+			remoteSupply: shared.RemoteSupply{
+				Decimals: 6,
+				Amount:   big.NewInt(0),
+			},
+			suppliedLocal: big.NewInt(0),
+			localDecimals: 18,
+		},
+		{
+			name: "Failure - nil supplied amount",
+			remoteSupply: shared.RemoteSupply{
+				Decimals: 6,
+				Amount:   sixDecimalSupply,
+			},
+			suppliedLocal: nil,
+			localDecimals: 18,
+			wantErrMsg:    "must not be nil",
+		},
+		{
+			name: "Failure - nil remote supply amount",
+			remoteSupply: shared.RemoteSupply{
+				Decimals: 6,
+				Amount:   nil,
+			},
+			suppliedLocal: big.NewInt(1000),
+			localDecimals: 18,
+			wantErrMsg:    "must not be nil",
+		},
+		{
+			name: "Failure - off by one against a correct conversion",
+			remoteSupply: shared.RemoteSupply{
+				Decimals: 6,
+				Amount:   big.NewInt(1_000_000),
+			},
+			suppliedLocal: mustBigInt(t, "999999999999999999"),
+			localDecimals: 18,
+			wantErrMsg:    "requires 1000000000000000000, but the update supplies 999999999999999999",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := shared.ValidateRemoteChainSupply(
+				tt.remoteSupply, tt.suppliedLocal, tt.localDecimals, remoteChainSelector,
+			)
+			if tt.wantErrMsg != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErrMsg)
+				require.Contains(t, err.Error(), "124615329519749607", "error should name the remote chain")
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestVerifyRemoteDecimals(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ethereumSelector = uint64(5_009_297_550_715_157_269)
+		solanaSelector   = uint64(124_615_329_519_749_607)
+		aptosSelector    = uint64(4_741_433_654_826_277_614)
+	)
+
+	tokenAddress := make([]byte, 32)
+	tokenAddress[31] = 1
+
+	tests := []struct {
+		name          string
+		chainSelector uint64
+		tokenAddress  []byte
+		wantVerified  bool
+		wantErrMsg    string
+	}{
+		{
+			name:          "Success - empty remote token address is unverifiable",
+			chainSelector: ethereumSelector,
+			tokenAddress:  nil,
+		},
+		{
+			// Each family reports unverified rather than failing when its chain is absent,
+			// so a migration is never blocked by an environment that omits the remote.
+			name:          "Success - EVM chain absent from environment is unverifiable",
+			chainSelector: ethereumSelector,
+			tokenAddress:  tokenAddress,
+		},
+		{
+			name:          "Success - SVM chain absent from environment is unverifiable",
+			chainSelector: solanaSelector,
+			tokenAddress:  tokenAddress,
+		},
+		{
+			name:          "Success - Aptos chain absent from environment is unverifiable",
+			chainSelector: aptosSelector,
+			tokenAddress:  tokenAddress,
+		},
+		{
+			name:          "Failure - unknown chain selector",
+			chainSelector: 1,
+			tokenAddress:  tokenAddress,
+			wantErrMsg:    "failed to resolve chain family",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			verified, err := shared.VerifyRemoteDecimals(
+				t.Context(), cldf.Environment{}, tt.chainSelector, tt.tokenAddress, 6,
+			)
+			if tt.wantErrMsg != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantVerified, verified)
+		})
+	}
+}


### PR DESCRIPTION
`updateGroups` mints remoteChainSupply in the local token's base units, but the field name and doc comments describe the remote chain's supply. Input now states the remote supply together with its decimals, and the changeset derives the local amount and fails when it does not match. Decimals are cross-checks against EVM, Solana and Aptos remotes when the chain is in the environment.