### PR TITLE
[CRE] Remove obsolete proto fields

### DIFF
--- a/core/capabilities/remote/executable/endtoend_test.go
+++ b/core/capabilities/remote/executable/endtoend_test.go
@@ -271,9 +271,8 @@ func setupRemoteExecutableHarness(t *testing.T, underlying commoncap.ExecutableC
 		capabilityDispatcher := broker.NewDispatcherForNode(capabilityPeer)
 		capabilityNode := executable.NewServer(capInfo.ID, "", capabilityPeer, capabilityDispatcher, limits.NewGateLimiter(false), lggr)
 		cfg := &commoncap.RemoteExecutableConfig{
-			RequestHashExcludedAttributes: []string{},
-			RequestTimeout:                capabilityNodeResponseTimeout,
-			ServerMaxParallelRequests:     10,
+			RequestTimeout:            capabilityNodeResponseTimeout,
+			ServerMaxParallelRequests: 10,
 		}
 		require.NoError(t, capabilityNode.SetConfig(cfg, underlying, capInfo, capDonInfo, workflowDONs, nil))
 		servicetest.Run(t, capabilityNode)

--- a/core/capabilities/remote/executable/endtoend_test.go
+++ b/core/capabilities/remote/executable/endtoend_test.go
@@ -274,7 +274,7 @@ func setupRemoteExecutableHarness(t *testing.T, underlying commoncap.ExecutableC
 			RequestTimeout:            capabilityNodeResponseTimeout,
 			ServerMaxParallelRequests: 10,
 		}
-		require.NoError(t, capabilityNode.SetConfig(cfg, underlying, capInfo, capDonInfo, workflowDONs, nil))
+		require.NoError(t, capabilityNode.SetConfig(cfg, underlying, capInfo, capDonInfo, workflowDONs, executable.NewSimpleHasher(executable.OptInHasherConfig{})))
 		servicetest.Run(t, capabilityNode)
 		broker.RegisterReceiverNode(capabilityPeer, capabilityNode)
 	}

--- a/core/capabilities/remote/executable/hasher.go
+++ b/core/capabilities/remote/executable/hasher.go
@@ -20,44 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 )
 
-// V1 Capabilities only need a hasher for the ChainWrite Target.
-// This hasher excludes signatures from the Inputs map when hashing the request.
-type v1Hasher struct {
-	requestHashExcludedAttributes []string
-}
-
-func (r *v1Hasher) Hash(ctx context.Context, msg *types.MessageBody) ([32]byte, error) {
-	req, err := pb.UnmarshalCapabilityRequest(msg.Payload)
-	if err != nil {
-		return [32]byte{}, fmt.Errorf("failed to unmarshal capability request: %w", err)
-	}
-
-	// An attribute called StepDependency is used to define a data dependency between steps,
-	// and not to provide input values; we should therefore disregard it when hashing the request
-	if len(r.requestHashExcludedAttributes) == 0 {
-		r.requestHashExcludedAttributes = []string{"StepDependency"}
-	}
-
-	for _, path := range r.requestHashExcludedAttributes {
-		if req.Inputs != nil {
-			req.Inputs.DeleteAtPath(path)
-		}
-	}
-
-	reqBytes, err := pb.MarshalCapabilityRequest(req)
-	if err != nil {
-		return [32]byte{}, fmt.Errorf("failed to marshal capability request: %w", err)
-	}
-	hash := sha256.Sum256(reqBytes)
-	return hash, nil
-}
-
-func NewV1Hasher(requestHashExcludedAttributes []string) types.MessageHasher {
-	return &v1Hasher{
-		requestHashExcludedAttributes: requestHashExcludedAttributes,
-	}
-}
-
 // V2 Capabilities (Executables) default to a simple hasher that hashes an
 // explicit allowlist of metadata fields. WriteReport methods use a hasher that
 // also excludes signatures from the WriteReportRequest.

--- a/core/capabilities/remote/executable/server.go
+++ b/core/capabilities/remote/executable/server.go
@@ -103,7 +103,7 @@ func (r *server) SetConfig(remoteExecutableConfig *commoncap.RemoteExecutableCon
 	}
 	if messageHasher == nil {
 		r.lggr.Warn("no message hasher provided, using default V1 hasher")
-		messageHasher = NewV1Hasher(remoteExecutableConfig.RequestHashExcludedAttributes)
+		messageHasher = NewV1Hasher(nil)
 	}
 	if capInfo.ID == "" || capInfo.ID != r.capabilityID {
 		return fmt.Errorf("capability info provided does not match the server's capabilityID: %s != %s", capInfo.ID, r.capabilityID)

--- a/core/capabilities/remote/executable/server.go
+++ b/core/capabilities/remote/executable/server.go
@@ -102,8 +102,7 @@ func (r *server) SetConfig(remoteExecutableConfig *commoncap.RemoteExecutableCon
 		remoteExecutableConfig = &commoncap.RemoteExecutableConfig{}
 	}
 	if messageHasher == nil {
-		r.lggr.Warn("no message hasher provided, using default V1 hasher")
-		messageHasher = NewV1Hasher(nil)
+		return errors.New("message hasher must be provided")
 	}
 	if capInfo.ID == "" || capInfo.ID != r.capabilityID {
 		return fmt.Errorf("capability info provided does not match the server's capabilityID: %s != %s", capInfo.ID, r.capabilityID)

--- a/core/capabilities/remote/executable/server_test.go
+++ b/core/capabilities/remote/executable/server_test.go
@@ -86,44 +86,6 @@ func Test_Server_Execute_SlowCapabilityExecutionDoesNotImpactSubsequentCall(t *t
 	})
 }
 
-func Test_Server_DefaultExcludedAttributes(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	numCapabilityPeers := 4
-
-	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{},
-		&TestCapability{}, 10, 9, numCapabilityPeers, 3, 10*time.Minute, nil)
-
-	for idx, caller := range callers {
-		rawInputs := map[string]any{
-			"StepDependency": strconv.Itoa(idx),
-		}
-
-		inputs, err := values.NewMap(rawInputs)
-		require.NoError(t, err)
-
-		_, err = caller.Execute(t.Context(),
-			commoncap.CapabilityRequest{
-				Metadata: commoncap.RequestMetadata{
-					WorkflowID:          workflowID1,
-					WorkflowExecutionID: workflowExecutionID1,
-				},
-				Inputs: inputs,
-			})
-		require.NoError(t, err)
-	}
-
-	for _, caller := range callers {
-		for range numCapabilityPeers {
-			msg := <-caller.receivedMessages
-			assert.Equal(t, remotetypes.Error_OK, msg.Error)
-		}
-	}
-	closeServices(t, srvcs)
-}
-
 func Test_Server_Execute_RespondsAfterSufficientRequests(t *testing.T) {
 	t.Parallel()
 

--- a/core/capabilities/remote/executable/server_test.go
+++ b/core/capabilities/remote/executable/server_test.go
@@ -124,44 +124,6 @@ func Test_Server_DefaultExcludedAttributes(t *testing.T) {
 	closeServices(t, srvcs)
 }
 
-func Test_Server_ExcludesNonDeterministicInputAttributes(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	numCapabilityPeers := 4
-
-	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{RequestHashExcludedAttributes: []string{"signed_report.Signatures"}},
-		&TestCapability{}, 10, 9, numCapabilityPeers, 3, 10*time.Minute, nil)
-
-	for idx, caller := range callers {
-		rawInputs := map[string]any{
-			"signed_report": map[string]any{"Signatures": "sig" + strconv.Itoa(idx), "Price": 20},
-		}
-
-		inputs, err := values.NewMap(rawInputs)
-		require.NoError(t, err)
-
-		_, err = caller.Execute(t.Context(),
-			commoncap.CapabilityRequest{
-				Metadata: commoncap.RequestMetadata{
-					WorkflowID:          workflowID1,
-					WorkflowExecutionID: workflowExecutionID1,
-				},
-				Inputs: inputs,
-			})
-		require.NoError(t, err)
-	}
-
-	for _, caller := range callers {
-		for range numCapabilityPeers {
-			msg := <-caller.receivedMessages
-			assert.Equal(t, remotetypes.Error_OK, msg.Error)
-		}
-	}
-	closeServices(t, srvcs)
-}
-
 func Test_Server_Execute_RespondsAfterSufficientRequests(t *testing.T) {
 	t.Parallel()
 
@@ -260,7 +222,7 @@ func Test_Server_V2Request_ExcludesNonDeterministicInputAttributes(t *testing.T)
 
 	numCapabilityPeers := 4
 
-	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{RequestHashExcludedAttributes: []string{"signed_report.Signatures"}},
+	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{},
 		&TestCapability{}, 10, 9, numCapabilityPeers, 3, 10*time.Minute, &v2WriteChainMessageHasher{})
 
 	report := []byte("report01234")
@@ -505,9 +467,8 @@ func Test_Server_SetConfig(t *testing.T) {
 
 		server := executable.NewServer("test-capability-id", "test-method", peerID, dispatcher, limits.NewGateLimiter(false), lggr)
 		config := &commoncap.RemoteExecutableConfig{
-			RequestHashExcludedAttributes: []string{"test"},
-			RequestTimeout:                requestTimeout,
-			ServerMaxParallelRequests:     maxParallelRequests,
+			RequestTimeout:            requestTimeout,
+			ServerMaxParallelRequests: maxParallelRequests,
 		}
 
 		err := server.SetConfig(config, underlying, capInfo, localDonInfo, workflowDONs, nil)
@@ -642,9 +603,8 @@ func Test_Server_SetConfig_ConfigReplacement(t *testing.T) {
 
 	// Set initial config
 	config1 := &commoncap.RemoteExecutableConfig{
-		RequestHashExcludedAttributes: []string{"attr1"},
-		RequestTimeout:                5 * time.Second,
-		ServerMaxParallelRequests:     3,
+		RequestTimeout:            5 * time.Second,
+		ServerMaxParallelRequests: 3,
 	}
 	err := server.SetConfig(config1, underlying, capInfo, localDonInfo, workflowDONs, nil)
 	require.NoError(t, err)
@@ -654,9 +614,8 @@ func Test_Server_SetConfig_ConfigReplacement(t *testing.T) {
 
 	// Replace with new config
 	config2 := &commoncap.RemoteExecutableConfig{
-		RequestHashExcludedAttributes: []string{"attr2", "attr3"},
-		RequestTimeout:                10 * time.Second,
-		ServerMaxParallelRequests:     5,
+		RequestTimeout:            10 * time.Second,
+		ServerMaxParallelRequests: 5,
 	}
 	err = server.SetConfig(config2, underlying, capInfo, localDonInfo, workflowDONs, nil)
 	require.NoError(t, err)

--- a/core/capabilities/remote/executable/server_test.go
+++ b/core/capabilities/remote/executable/server_test.go
@@ -306,6 +306,9 @@ func testRemoteExecutableCapabilityServer(ctx context.Context, t *testing.T,
 	if config.ServerMaxParallelRequests == 0 {
 		config.ServerMaxParallelRequests = 10
 	}
+	if messageHasher == nil {
+		messageHasher = executable.NewSimpleHasher(executable.OptInHasherConfig{})
+	}
 
 	capabilityPeers := make([]p2ptypes.PeerID, numCapabilityPeers)
 	for i := range numCapabilityPeers {
@@ -461,6 +464,7 @@ func Test_Server_SetConfig(t *testing.T) {
 	underlying := &TestCapability{}
 	requestTimeout := 10 * time.Second
 	maxParallelRequests := uint32(5)
+	messageHasher := executable.NewSimpleHasher(executable.OptInHasherConfig{})
 
 	t.Run("valid config should succeed", func(t *testing.T) {
 		t.Parallel()
@@ -471,7 +475,7 @@ func Test_Server_SetConfig(t *testing.T) {
 			ServerMaxParallelRequests: maxParallelRequests,
 		}
 
-		err := server.SetConfig(config, underlying, capInfo, localDonInfo, workflowDONs, nil)
+		err := server.SetConfig(config, underlying, capInfo, localDonInfo, workflowDONs, messageHasher)
 		require.NoError(t, err)
 	})
 
@@ -484,7 +488,7 @@ func Test_Server_SetConfig(t *testing.T) {
 			CapabilityType: commoncap.CapabilityTypeTarget,
 		}
 
-		err := server.SetConfig(&commoncap.RemoteExecutableConfig{}, underlying, invalidCapInfo, localDonInfo, workflowDONs, nil)
+		err := server.SetConfig(&commoncap.RemoteExecutableConfig{}, underlying, invalidCapInfo, localDonInfo, workflowDONs, messageHasher)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "capability info provided does not match")
 	})
@@ -494,7 +498,7 @@ func Test_Server_SetConfig(t *testing.T) {
 
 		server := executable.NewServer("test-capability-id", "test-method", peerID, dispatcher, limits.NewGateLimiter(false), lggr)
 		err := server.SetConfig(&commoncap.RemoteExecutableConfig{}, nil, capInfo,
-			localDonInfo, workflowDONs, nil)
+			localDonInfo, workflowDONs, messageHasher)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "underlying capability cannot be nil")
 	})
@@ -512,12 +516,12 @@ func Test_Server_SetConfig(t *testing.T) {
 			RequestTimeout:            10 * time.Second,
 			ServerMaxParallelRequests: 5,
 		}
-		err := server.SetConfig(config, underlying, capInfo, emptyLocalDon, workflowDONs, nil)
+		err := server.SetConfig(config, underlying, capInfo, emptyLocalDon, workflowDONs, messageHasher)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "empty localDonInfo provided")
 	})
 
-	t.Run("nil message hasher should use default", func(t *testing.T) {
+	t.Run("nil message hasher should fail", func(t *testing.T) {
 		t.Parallel()
 
 		server := executable.NewServer("test-capability-id", "test-method", peerID, dispatcher, limits.NewGateLimiter(false), lggr)
@@ -526,7 +530,8 @@ func Test_Server_SetConfig(t *testing.T) {
 			ServerMaxParallelRequests: 5,
 		}
 		err := server.SetConfig(config, underlying, capInfo, localDonInfo, workflowDONs, nil)
-		require.NoError(t, err)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "message hasher must be provided")
 	})
 
 	t.Run("zero timeout should fail", func(t *testing.T) {
@@ -537,7 +542,7 @@ func Test_Server_SetConfig(t *testing.T) {
 			RequestTimeout:            0,
 			ServerMaxParallelRequests: 5,
 		}
-		err := server.SetConfig(config, underlying, capInfo, localDonInfo, workflowDONs, nil)
+		err := server.SetConfig(config, underlying, capInfo, localDonInfo, workflowDONs, messageHasher)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "RequestTimeout must be positive")
 	})
@@ -550,7 +555,7 @@ func Test_Server_SetConfig(t *testing.T) {
 			RequestTimeout:            10 * time.Second,
 			ServerMaxParallelRequests: 0,
 		}
-		err := server.SetConfig(config, underlying, capInfo, localDonInfo, workflowDONs, nil)
+		err := server.SetConfig(config, underlying, capInfo, localDonInfo, workflowDONs, messageHasher)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "ServerMaxParallelRequests must be positive")
 	})
@@ -564,7 +569,7 @@ func Test_Server_SetConfig(t *testing.T) {
 			RequestTimeout:            10 * time.Second,
 			ServerMaxParallelRequests: 5,
 		}
-		err := server.SetConfig(config, underlying, capInfo, localDonInfo, emptyWorkflowDONs, nil)
+		err := server.SetConfig(config, underlying, capInfo, localDonInfo, emptyWorkflowDONs, messageHasher)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "empty workflowDONs provided")
 	})
@@ -606,7 +611,8 @@ func Test_Server_SetConfig_ConfigReplacement(t *testing.T) {
 		RequestTimeout:            5 * time.Second,
 		ServerMaxParallelRequests: 3,
 	}
-	err := server.SetConfig(config1, underlying, capInfo, localDonInfo, workflowDONs, nil)
+	messageHasher := executable.NewSimpleHasher(executable.OptInHasherConfig{})
+	err := server.SetConfig(config1, underlying, capInfo, localDonInfo, workflowDONs, messageHasher)
 	require.NoError(t, err)
 
 	// Verify server can start with valid config
@@ -617,7 +623,7 @@ func Test_Server_SetConfig_ConfigReplacement(t *testing.T) {
 		RequestTimeout:            10 * time.Second,
 		ServerMaxParallelRequests: 5,
 	}
-	err = server.SetConfig(config2, underlying, capInfo, localDonInfo, workflowDONs, nil)
+	err = server.SetConfig(config2, underlying, capInfo, localDonInfo, workflowDONs, messageHasher)
 	require.NoError(t, err)
 }
 
@@ -676,7 +682,7 @@ func Test_Server_SetConfig_StartValidation(t *testing.T) {
 			ServerMaxParallelRequests: 5,
 		}
 		err := server.SetConfig(cfg, underlying, capInfo,
-			localDonInfo, workflowDONs, nil)
+			localDonInfo, workflowDONs, executable.NewSimpleHasher(executable.OptInHasherConfig{}))
 		require.NoError(t, err)
 
 		servicetest.Run(t, server)
@@ -725,7 +731,8 @@ func Test_Server_SetConfig_DONMembershipChange(t *testing.T) {
 			RequestTimeout:            10 * time.Second,
 			ServerMaxParallelRequests: 5,
 		}
-		err := server.SetConfig(config, underlying, capInfo, localDonInfo, workflowDONs, nil)
+		messageHasher := executable.NewSimpleHasher(executable.OptInHasherConfig{})
+		err := server.SetConfig(config, underlying, capInfo, localDonInfo, workflowDONs, messageHasher)
 		require.NoError(t, err)
 
 		// Set up workflow node before starting servers
@@ -755,7 +762,7 @@ func Test_Server_SetConfig_DONMembershipChange(t *testing.T) {
 				F:       0,
 			},
 		}
-		err = server.SetConfig(config, underlying, capInfo, localDonInfo, newWorkflowDONs, nil)
+		err = server.SetConfig(config, underlying, capInfo, localDonInfo, newWorkflowDONs, messageHasher)
 		require.NoError(t, err)
 
 		// Original request should still complete
@@ -803,7 +810,8 @@ func Test_Server_SetConfig_ShutdownRaces(t *testing.T) {
 		ServerMaxParallelRequests: 5,
 	}
 
-	err := server.SetConfig(config, underlying, capInfo, localDonInfo, workflowDONs, nil)
+	messageHasher := executable.NewSimpleHasher(executable.OptInHasherConfig{})
+	err := server.SetConfig(config, underlying, capInfo, localDonInfo, workflowDONs, messageHasher)
 	require.NoError(t, err)
 	err = server.Start(ctx)
 	require.NoError(t, err)
@@ -819,7 +827,7 @@ func Test_Server_SetConfig_ShutdownRaces(t *testing.T) {
 				RequestTimeout:            time.Duration(5+i) * time.Millisecond,
 				ServerMaxParallelRequests: 5,
 			}
-			_ = server.SetConfig(newConfig, underlying, capInfo, localDonInfo, workflowDONs, nil)
+			_ = server.SetConfig(newConfig, underlying, capInfo, localDonInfo, workflowDONs, messageHasher)
 			time.Sleep(1 * time.Millisecond)
 		}
 	}()
@@ -891,7 +899,8 @@ func Test_Server_Execute_WithConcurrentSetConfig(t *testing.T) {
 		RequestTimeout:            10 * time.Second,
 		ServerMaxParallelRequests: 10,
 	}
-	err := server.SetConfig(initialConfig, underlying, capInfo, capDonInfo, workflowDONs, nil)
+	messageHasher := executable.NewSimpleHasher(executable.OptInHasherConfig{})
+	err := server.SetConfig(initialConfig, underlying, capInfo, capDonInfo, workflowDONs, messageHasher)
 	require.NoError(t, err)
 
 	servicetest.Run(t, server)
@@ -926,7 +935,7 @@ func Test_Server_Execute_WithConcurrentSetConfig(t *testing.T) {
 				RequestTimeout:            time.Duration(10+i) * time.Second,
 				ServerMaxParallelRequests: uint32(5),
 			}
-			assert.NoError(t, server.SetConfig(newConfig, underlying, capInfo, capDonInfo, workflowDONs, nil))
+			assert.NoError(t, server.SetConfig(newConfig, underlying, capInfo, capDonInfo, workflowDONs, messageHasher))
 		}
 	})
 
@@ -1017,7 +1026,7 @@ func Test_Server_DuplicateRequestRemainsDedupedPastRequestTimeout(t *testing.T) 
 		},
 	}
 
-	require.NoError(t, server.SetConfig(cfg, TestCapability{}, capInfo, localDON, workflowDONs, nil))
+	require.NoError(t, server.SetConfig(cfg, TestCapability{}, capInfo, localDON, workflowDONs, executable.NewSimpleHasher(executable.OptInHasherConfig{})))
 	require.NoError(t, server.Start(ctx))
 	defer func() {
 		require.NoError(t, server.Close())

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.108
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260821001950-7520b255725e
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936
 	github.com/smartcontractkit/chainlink-common/keystore v1.3.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.120.1-0.20260828145648-3e1bcd2ac1da
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260810110946-8174b6bb7fc9
@@ -154,7 +154,7 @@ require (
 	github.com/buger/goterm v1.0.4 // indirect
 	github.com/buger/jsonparser v1.2.0 // indirect
 	github.com/buraksezer/consistent v0.10.0 // indirect
-	github.com/bytecodealliance/wasmtime-go/v48 v48.0.0 // indirect
+	github.com/bytecodealliance/wasmtime-go/v47 v47.0.0 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2 v2.70.2 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -318,8 +318,8 @@ github.com/bxcodec/faker v2.0.1+incompatible h1:P0KUpUw5w6WJXwrPfv35oc91i4d8nf40
 github.com/bxcodec/faker v2.0.1+incompatible/go.mod h1:BNzfpVdTwnFJ6GtfYTcQu6l6rHShT+veBxNCnjCx5XM=
 github.com/bytecodealliance/wasmtime-go/v39 v39.0.1 h1:RibaT47yiyCRxMOj/l2cvL8cWiWBSqDXHyqsa9sGcCE=
 github.com/bytecodealliance/wasmtime-go/v39 v39.0.1/go.mod h1:miR4NYIEBXeDNamZIzpskhJ0z/p8al+lwMWylQ/ZJb4=
-github.com/bytecodealliance/wasmtime-go/v48 v48.0.0 h1:VyeQvfh/6VrD8zhWo40Oci89GR7BAsvTSlH8p/UjhxU=
-github.com/bytecodealliance/wasmtime-go/v48 v48.0.0/go.mod h1:OD2DiFNkQi2jlvSm5Bjbd1g2jlw940u/GPDpQYoD2Hc=
+github.com/bytecodealliance/wasmtime-go/v47 v47.0.0 h1:PAe4o7Mq1VjSx81Dc+V4w1XvxLouFTB384N4ZT4o+7k=
+github.com/bytecodealliance/wasmtime-go/v47 v47.0.0/go.mod h1:icJLhTDV7EyKlZpeuBuJl4yoTMqhjUvNv1mewMJUvr4=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
@@ -1691,8 +1691,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260821001950-7520b255725e/go.mod h1:c++Ed0jeYn4w8WIfiAboRwN6ClRRVGglL0qwB/QjJvM=
 github.com/smartcontractkit/chainlink-ccv v0.9.1 h1:gu2X5unMqdLL/eBXcEcDAyhTKi7y41ljs/Uy/OAq57U=
 github.com/smartcontractkit/chainlink-ccv v0.9.1/go.mod h1:VtlwBhI1hxmO9BWDDDvE8p84CnaibSIkaDxEos6r9O8=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f h1:NZsL9LEwWSv1yz2mZNzhfqlFrjM4B5yy+sqeFZtK37g=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f/go.mod h1:wTx4k3Yka5bc5lBgQiPeoIbrqelvn2YKa4J8K2w7uok=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936 h1:DPxl0U3Jx0nsFy7WYAAkx9Jq7Pxas5Vun7QTj450vVI=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936/go.mod h1:ALYF2Nhwzih6NibArlTNXz9YrAS9t4v+b0TnE9N7GZ8=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0 h1:V05Rp9/dTc4Wyipsk1EYnW3riZyjDVKmhz3769JpnHU=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0/go.mod h1:vHV8BGm6TN7jBbMsWxq1Hqm3HbCtYFwzvKS0CCczxG8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260724142814-45996a1bcb72 h1:uWEwl7i2ryuRVoV4DmIKm6mqYevf1lH/8cQYhw/JXko=

--- a/core/services/registrysyncer/local_registry.go
+++ b/core/services/registrysyncer/local_registry.go
@@ -39,25 +39,6 @@ func (c CapabilityConfiguration) Unmarshal() (capabilities.CapabilityConfigurati
 		return capabilities.CapabilityConfiguration{}, fmt.Errorf("failed to unmarshal capability configuration: %w", err)
 	}
 
-	var remoteTriggerConfig *capabilities.RemoteTriggerConfig
-	var remoteTargetConfig *capabilities.RemoteTargetConfig
-
-	switch cconf.GetRemoteConfig().(type) {
-	case *capabilitiespb.CapabilityConfig_RemoteTriggerConfig:
-		prtc := cconf.GetRemoteTriggerConfig()
-		remoteTriggerConfig = &capabilities.RemoteTriggerConfig{
-			RegistrationRefresh:     prtc.RegistrationRefresh.AsDuration(),
-			RegistrationExpiry:      prtc.RegistrationExpiry.AsDuration(),
-			MinResponsesToAggregate: prtc.MinResponsesToAggregate,
-			MessageExpiry:           prtc.MessageExpiry.AsDuration(),
-		}
-	case *capabilitiespb.CapabilityConfig_RemoteTargetConfig:
-		prtc := cconf.GetRemoteTargetConfig()
-		remoteTargetConfig = &capabilities.RemoteTargetConfig{
-			RequestHashExcludedAttributes: prtc.RequestHashExcludedAttributes,
-		}
-	}
-
 	dc, err := values.FromMapValueProto(cconf.DefaultConfig)
 	if err != nil {
 		return capabilities.CapabilityConfiguration{}, fmt.Errorf("failed to unmarshal capability configuration: %w", err)
@@ -163,8 +144,6 @@ func (c CapabilityConfiguration) Unmarshal() (capabilities.CapabilityConfigurati
 		DefaultConfig:          dc,
 		RestrictedKeys:         cconf.RestrictedKeys,
 		RestrictedConfig:       rc,
-		RemoteTriggerConfig:    remoteTriggerConfig,
-		RemoteTargetConfig:     remoteTargetConfig,
 		CapabilityMethodConfig: methodConfigs,
 		LocalOnly:              cconf.LocalOnly,
 		Ocr3Configs:            ocr3Configs,

--- a/core/services/registrysyncer/orm_test.go
+++ b/core/services/registrysyncer/orm_test.go
@@ -4,13 +4,11 @@ import (
 	"encoding/hex"
 	"math/big"
 	"testing"
-	"time"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/smartcontractkit/libocr/ragep2p/types"
 
@@ -64,15 +62,6 @@ func generateState(t *testing.T) registrysyncer.LocalRegistry {
 
 	config := &capabilitiespb.CapabilityConfig{
 		DefaultConfig: values.Proto(values.EmptyMap()).GetMapValue(),
-		RemoteConfig: &capabilitiespb.CapabilityConfig_RemoteTriggerConfig{
-			RemoteTriggerConfig: &capabilitiespb.RemoteTriggerConfig{
-				RegistrationRefresh: durationpb.New(20 * time.Second),
-				RegistrationExpiry:  durationpb.New(60 * time.Second),
-				// F + 1
-				MinResponsesToAggregate: uint32(1) + 1,
-				MessageExpiry:           durationpb.New(120 * time.Second),
-			},
-		},
 	}
 	configb, err := proto.Marshal(config)
 	require.NoError(t, err)

--- a/core/services/registrysyncer/syncer_test.go
+++ b/core/services/registrysyncer/syncer_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	p2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
@@ -259,15 +258,6 @@ func TestReader_Integration(t *testing.T) {
 
 	config := &capabilitiespb.CapabilityConfig{
 		DefaultConfig: values.Proto(values.EmptyMap()).GetMapValue(),
-		RemoteConfig: &capabilitiespb.CapabilityConfig_RemoteTriggerConfig{
-			RemoteTriggerConfig: &capabilitiespb.RemoteTriggerConfig{
-				RegistrationRefresh: durationpb.New(20 * time.Second),
-				RegistrationExpiry:  durationpb.New(60 * time.Second),
-				// F + 1
-				MinResponsesToAggregate: uint32(1) + 1,
-				MessageExpiry:           durationpb.New(120 * time.Second),
-			},
-		},
 	}
 	configb, err := proto.Marshal(config)
 	if err != nil {
@@ -436,14 +426,6 @@ func TestSyncer_DBIntegration(t *testing.T) {
 
 	config := &capabilitiespb.CapabilityConfig{
 		DefaultConfig: values.Proto(values.EmptyMap()).GetMapValue(),
-		RemoteConfig: &capabilitiespb.CapabilityConfig_RemoteTriggerConfig{
-			RemoteTriggerConfig: &capabilitiespb.RemoteTriggerConfig{
-				RegistrationRefresh: durationpb.New(20 * time.Second),
-				RegistrationExpiry:  durationpb.New(60 * time.Second),
-				// F + 1
-				MinResponsesToAggregate: uint32(1) + 1,
-			},
-		},
 	}
 	configb, err := proto.Marshal(config)
 	require.NoError(t, err)

--- a/core/services/registrysyncer/v2/syncer_test.go
+++ b/core/services/registrysyncer/v2/syncer_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	p2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
@@ -262,14 +261,6 @@ func TestReader_Integration(t *testing.T) {
 	// Create capability configuration
 	config := &capabilitiespb.CapabilityConfig{
 		DefaultConfig: values.Proto(values.EmptyMap()).GetMapValue(),
-		RemoteConfig: &capabilitiespb.CapabilityConfig_RemoteTriggerConfig{
-			RemoteTriggerConfig: &capabilitiespb.RemoteTriggerConfig{
-				RegistrationRefresh:     durationpb.New(20 * time.Second),
-				RegistrationExpiry:      durationpb.New(60 * time.Second),
-				MinResponsesToAggregate: uint32(1) + 1,
-				MessageExpiry:           durationpb.New(120 * time.Second),
-			},
-		},
 	}
 	configb, err := proto.Marshal(config)
 	require.NoError(t, err)
@@ -479,13 +470,6 @@ func TestSyncer_V2_DBIntegration(t *testing.T) {
 	// Create capability configuration
 	config := &capabilitiespb.CapabilityConfig{
 		DefaultConfig: values.Proto(values.EmptyMap()).GetMapValue(),
-		RemoteConfig: &capabilitiespb.CapabilityConfig_RemoteTriggerConfig{
-			RemoteTriggerConfig: &capabilitiespb.RemoteTriggerConfig{
-				RegistrationRefresh:     durationpb.New(20 * time.Second),
-				RegistrationExpiry:      durationpb.New(60 * time.Second),
-				MinResponsesToAggregate: uint32(1) + 1,
-			},
-		},
 	}
 	configb, err := proto.Marshal(config)
 	require.NoError(t, err)
@@ -785,14 +769,6 @@ func TestReader_V2_FamilyOperations(t *testing.T) {
 	// Create capability configurations
 	capConfig := &capabilitiespb.CapabilityConfig{
 		DefaultConfig: values.Proto(values.EmptyMap()).GetMapValue(),
-		RemoteConfig: &capabilitiespb.CapabilityConfig_RemoteTriggerConfig{
-			RemoteTriggerConfig: &capabilitiespb.RemoteTriggerConfig{
-				RegistrationRefresh:     durationpb.New(20 * time.Second),
-				RegistrationExpiry:      durationpb.New(60 * time.Second),
-				MinResponsesToAggregate: uint32(1) + 1,
-				MessageExpiry:           durationpb.New(120 * time.Second),
-			},
-		},
 	}
 	configb, err := proto.Marshal(capConfig)
 	require.NoError(t, err)

--- a/deployment/cre/capabilities_registry/v2/changeset/configure_capabilities_registry_test.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/configure_capabilities_registry_test.go
@@ -656,12 +656,6 @@ func setupCapabilitiesRegistryWithMCMS(t *testing.T) *testFixture {
 	// Create capability configurations
 	configMap := map[string]any{
 		"defaultConfig": map[string]any{},
-		"remoteTriggerConfig": map[string]any{
-			"registrationRefresh":     "20s",
-			"registrationExpiry":      "60s",
-			"minResponsesToAggregate": 2,
-			"messageExpiry":           "120s",
-		},
 	}
 
 	DONs := []changeset.CapabilitiesRegistryNewDONParams{
@@ -807,12 +801,6 @@ func setupCapabilitiesRegistryTest(t *testing.T) *testFixture {
 	// Create capability configurations with readable config
 	configMap := map[string]any{
 		"defaultConfig": map[string]any{},
-		"remoteTriggerConfig": map[string]any{
-			"registrationRefresh":     "20s",
-			"registrationExpiry":      "60s",
-			"minResponsesToAggregate": 2,
-			"messageExpiry":           "120s",
-		},
 		"ocr3Configs": map[string]any{
 			"__default__": map[string]any{
 				"signers":               []any{"AQIDBA==", "BQYHCA=="},

--- a/deployment/cre/capabilities_registry/v2/changeset/update_don_test.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/update_don_test.go
@@ -130,12 +130,6 @@ func setupRegistryForUpdateDON(t *testing.T, isWorkflow, useMCMS bool) *updFixtu
 	// Initial DON config (workflow type used for both variants)
 	cfg := map[string]any{
 		"defaultConfig": map[string]any{},
-		"remoteTriggerConfig": map[string]any{
-			"registrationRefresh":     "20s",
-			"registrationExpiry":      "60s",
-			"minResponsesToAggregate": 2,
-			"messageExpiry":           "120s",
-		},
 	}
 	donName := "upd-don-v2"
 
@@ -232,13 +226,8 @@ func TestUpdateDONChangeset_ByName_Direct_Succeeds(t *testing.T) {
 
 	// New config to apply
 	newCfg := map[string]any{
-		"defaultConfig": map[string]any{},
-		"remoteTriggerConfig": map[string]any{
-			"registrationRefresh":     "25s", // changed value to detect update
-			"registrationExpiry":      "60s",
-			"minResponsesToAggregate": 2,
-			"messageExpiry":           "120s",
-		},
+		"defaultConfig":  map[string]any{},
+		"restrictedKeys": []any{"updated"}, // changed value to detect update
 	}
 	wantProto, err := pkg.CapabilityConfig(newCfg).MarshalProto()
 	require.NoError(t, err)
@@ -286,13 +275,8 @@ func TestUpdateDONChangeset_ByName_Direct_Succeeds_MCMS(t *testing.T) {
 
 	// New config to apply
 	newCfg := map[string]any{
-		"defaultConfig": map[string]any{},
-		"remoteTriggerConfig": map[string]any{
-			"registrationRefresh":     "25s", // changed value to detect update
-			"registrationExpiry":      "60s",
-			"minResponsesToAggregate": 2,
-			"messageExpiry":           "120s",
-		},
+		"defaultConfig":  map[string]any{},
+		"restrictedKeys": []any{"updated"}, // changed value to detect update
 	}
 
 	newName := fx.donName + "-renamed"

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260821001950-7520b255725e
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936
 	github.com/smartcontractkit/chainlink-common/keystore v1.3.0
 	github.com/smartcontractkit/chainlink-data-streams v1.1.1
 	github.com/smartcontractkit/chainlink-deployments-framework v0.120.1-0.20260828145648-3e1bcd2ac1da
@@ -168,7 +168,7 @@ require (
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
 	github.com/buger/jsonparser v1.2.0 // indirect
 	github.com/buraksezer/consistent v0.10.0 // indirect
-	github.com/bytecodealliance/wasmtime-go/v48 v48.0.0 // indirect
+	github.com/bytecodealliance/wasmtime-go/v47 v47.0.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -282,8 +282,8 @@ github.com/buraksezer/consistent v0.10.0 h1:hqBgz1PvNLC5rkWcEBVAL9dFMBWz6I0VgUCW
 github.com/buraksezer/consistent v0.10.0/go.mod h1:6BrVajWq7wbKZlTOUPs/XVfR8c0maujuPowduSpZqmw=
 github.com/bxcodec/faker v2.0.1+incompatible h1:P0KUpUw5w6WJXwrPfv35oc91i4d8nf40Nwln+M/+faA=
 github.com/bxcodec/faker v2.0.1+incompatible/go.mod h1:BNzfpVdTwnFJ6GtfYTcQu6l6rHShT+veBxNCnjCx5XM=
-github.com/bytecodealliance/wasmtime-go/v48 v48.0.0 h1:VyeQvfh/6VrD8zhWo40Oci89GR7BAsvTSlH8p/UjhxU=
-github.com/bytecodealliance/wasmtime-go/v48 v48.0.0/go.mod h1:OD2DiFNkQi2jlvSm5Bjbd1g2jlw940u/GPDpQYoD2Hc=
+github.com/bytecodealliance/wasmtime-go/v47 v47.0.0 h1:PAe4o7Mq1VjSx81Dc+V4w1XvxLouFTB384N4ZT4o+7k=
+github.com/bytecodealliance/wasmtime-go/v47 v47.0.0/go.mod h1:icJLhTDV7EyKlZpeuBuJl4yoTMqhjUvNv1mewMJUvr4=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
@@ -1410,8 +1410,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260821001950-7520
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260821001950-7520b255725e/go.mod h1:Dm/Abz0vr7F2v9TygUX947q8HIwJEJikDfSdanX1Cic=
 github.com/smartcontractkit/chainlink-ccv v0.9.1 h1:gu2X5unMqdLL/eBXcEcDAyhTKi7y41ljs/Uy/OAq57U=
 github.com/smartcontractkit/chainlink-ccv v0.9.1/go.mod h1:VtlwBhI1hxmO9BWDDDvE8p84CnaibSIkaDxEos6r9O8=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f h1:NZsL9LEwWSv1yz2mZNzhfqlFrjM4B5yy+sqeFZtK37g=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f/go.mod h1:wTx4k3Yka5bc5lBgQiPeoIbrqelvn2YKa4J8K2w7uok=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936 h1:DPxl0U3Jx0nsFy7WYAAkx9Jq7Pxas5Vun7QTj450vVI=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936/go.mod h1:ALYF2Nhwzih6NibArlTNXz9YrAS9t4v+b0TnE9N7GZ8=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0 h1:V05Rp9/dTc4Wyipsk1EYnW3riZyjDVKmhz3769JpnHU=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0/go.mod h1:vHV8BGm6TN7jBbMsWxq1Hqm3HbCtYFwzvKS0CCczxG8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260724142814-45996a1bcb72 h1:uWEwl7i2ryuRVoV4DmIKm6mqYevf1lH/8cQYhw/JXko=

--- a/deployment/keystone/changeset/internal/update_nodes_test.go
+++ b/deployment/keystone/changeset/internal/update_nodes_test.go
@@ -7,13 +7,11 @@ import (
 	"fmt"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -461,14 +459,6 @@ func TestUpdateNodes(t *testing.T) {
 			}
 			phonyCapCfg := &capabilitiespb.CapabilityConfig{
 				DefaultConfig: values.Proto(values.EmptyMap()).GetMapValue(),
-				RemoteConfig: &capabilitiespb.CapabilityConfig_RemoteTriggerConfig{
-					RemoteTriggerConfig: &capabilitiespb.RemoteTriggerConfig{
-						RegistrationRefresh: durationpb.New(20 * time.Second),
-						RegistrationExpiry:  durationpb.New(60 * time.Second),
-						// F + 1; assuming n = 3f+1
-						MinResponsesToAggregate: uint32(10),
-					},
-				},
 			}
 			initMap := make(map[p2pkey.PeerID][]kcr.CapabilitiesRegistryCapability)
 			for p2pID := range tt.args.req.P2pToUpdates {

--- a/deployment/keystone/changeset/test/registry.go
+++ b/deployment/keystone/changeset/test/registry.go
@@ -7,12 +7,10 @@ import (
 	"math"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -438,24 +436,6 @@ func GetDefaultCapConfig(t *testing.T, capability capabilities_registry.Capabili
 	t.Helper()
 	defaultCfg := &capabilitiespb.CapabilityConfig{
 		DefaultConfig: values.Proto(values.EmptyMap()).GetMapValue(),
-	}
-	switch capability.CapabilityType {
-	case uint8(0): // trigger
-		defaultCfg.RemoteConfig = &capabilitiespb.CapabilityConfig_RemoteTriggerConfig{
-			RemoteTriggerConfig: &capabilitiespb.RemoteTriggerConfig{
-				RegistrationRefresh:     durationpb.New(20 * time.Second),
-				RegistrationExpiry:      durationpb.New(60 * time.Second),
-				MinResponsesToAggregate: uint32(10),
-			},
-		}
-	case uint8(3): // target
-		defaultCfg.RemoteConfig = &capabilitiespb.CapabilityConfig_RemoteTargetConfig{
-			RemoteTargetConfig: &capabilitiespb.RemoteTargetConfig{
-				RequestHashExcludedAttributes: []string{"signed_report.Signatures"},
-			},
-		}
-	case uint8(2): // consensus
-	default:
 	}
 	return defaultCfg
 }

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc
 	github.com/smartcontractkit/chainlink-ccv v0.9.1
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936
 	github.com/smartcontractkit/chainlink-common/keystore v1.3.0
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260724142814-45996a1bcb72
 	github.com/smartcontractkit/chainlink-data-streams v1.1.1
@@ -181,7 +181,7 @@ require (
 	github.com/blendle/zapdriver v1.3.1 // indirect
 	github.com/block-vision/sui-go-sdk v1.2.1 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4 // indirect
-	github.com/bytecodealliance/wasmtime-go/v48 v48.0.0 // indirect
+	github.com/bytecodealliance/wasmtime-go/v47 v47.0.0 // indirect
 	github.com/bytedance/sonic v1.12.3 // indirect
 	github.com/bytedance/sonic/loader v0.2.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/buger/jsonparser v1.2.0 h1:4EFcvK1kD4jyj6YqNK6skK6w+y7FHHBR+XBCtxwu/6
 github.com/buger/jsonparser v1.2.0/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/buraksezer/consistent v0.10.0 h1:hqBgz1PvNLC5rkWcEBVAL9dFMBWz6I0VgUCW25rrZlU=
 github.com/buraksezer/consistent v0.10.0/go.mod h1:6BrVajWq7wbKZlTOUPs/XVfR8c0maujuPowduSpZqmw=
-github.com/bytecodealliance/wasmtime-go/v48 v48.0.0 h1:VyeQvfh/6VrD8zhWo40Oci89GR7BAsvTSlH8p/UjhxU=
-github.com/bytecodealliance/wasmtime-go/v48 v48.0.0/go.mod h1:OD2DiFNkQi2jlvSm5Bjbd1g2jlw940u/GPDpQYoD2Hc=
+github.com/bytecodealliance/wasmtime-go/v47 v47.0.0 h1:PAe4o7Mq1VjSx81Dc+V4w1XvxLouFTB384N4ZT4o+7k=
+github.com/bytecodealliance/wasmtime-go/v47 v47.0.0/go.mod h1:icJLhTDV7EyKlZpeuBuJl4yoTMqhjUvNv1mewMJUvr4=
 github.com/bytedance/sonic v1.12.3 h1:W2MGa7RCU1QTeYRTPE3+88mVC0yXmsRQRChiyVocVjU=
 github.com/bytedance/sonic v1.12.3/go.mod h1:B8Gt/XvtZ3Fqj+iSKMypzymZxw/FVwgIGKzMzT9r/rk=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
@@ -1118,8 +1118,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260415165642-49f23e4d76cc/go.mod h1:67YbnoglYD61Pz/jTVCgav9wFq7S35OU8UyQSvPllRw=
 github.com/smartcontractkit/chainlink-ccv v0.9.1 h1:gu2X5unMqdLL/eBXcEcDAyhTKi7y41ljs/Uy/OAq57U=
 github.com/smartcontractkit/chainlink-ccv v0.9.1/go.mod h1:VtlwBhI1hxmO9BWDDDvE8p84CnaibSIkaDxEos6r9O8=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f h1:NZsL9LEwWSv1yz2mZNzhfqlFrjM4B5yy+sqeFZtK37g=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f/go.mod h1:wTx4k3Yka5bc5lBgQiPeoIbrqelvn2YKa4J8K2w7uok=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936 h1:DPxl0U3Jx0nsFy7WYAAkx9Jq7Pxas5Vun7QTj450vVI=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936/go.mod h1:ALYF2Nhwzih6NibArlTNXz9YrAS9t4v+b0TnE9N7GZ8=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0 h1:V05Rp9/dTc4Wyipsk1EYnW3riZyjDVKmhz3769JpnHU=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0/go.mod h1:vHV8BGm6TN7jBbMsWxq1Hqm3HbCtYFwzvKS0CCczxG8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260724142814-45996a1bcb72 h1:uWEwl7i2ryuRVoV4DmIKm6mqYevf1lH/8cQYhw/JXko=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260821001950-7520b255725e
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936
 	github.com/smartcontractkit/chainlink-common/keystore v1.3.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.120.1-0.20260828145648-3e1bcd2ac1da
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260810110946-8174b6bb7fc9
@@ -64,7 +64,7 @@ require github.com/smartcontractkit/chainlink-protos/metering/go v0.0.0-20260729
 
 require (
 	cosmossdk.io/collections v0.4.0 // indirect
-	github.com/bytecodealliance/wasmtime-go/v48 v48.0.0 // indirect
+	github.com/bytecodealliance/wasmtime-go/v47 v47.0.0 // indirect
 	github.com/go-openapi/swag/cmdutils v0.28.0 // indirect
 	github.com/go-openapi/swag/conv v0.28.0 // indirect
 	github.com/go-openapi/swag/fileutils v0.28.0 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -271,8 +271,8 @@ github.com/buraksezer/consistent v0.10.0 h1:hqBgz1PvNLC5rkWcEBVAL9dFMBWz6I0VgUCW
 github.com/buraksezer/consistent v0.10.0/go.mod h1:6BrVajWq7wbKZlTOUPs/XVfR8c0maujuPowduSpZqmw=
 github.com/bxcodec/faker v2.0.1+incompatible h1:P0KUpUw5w6WJXwrPfv35oc91i4d8nf40Nwln+M/+faA=
 github.com/bxcodec/faker v2.0.1+incompatible/go.mod h1:BNzfpVdTwnFJ6GtfYTcQu6l6rHShT+veBxNCnjCx5XM=
-github.com/bytecodealliance/wasmtime-go/v48 v48.0.0 h1:VyeQvfh/6VrD8zhWo40Oci89GR7BAsvTSlH8p/UjhxU=
-github.com/bytecodealliance/wasmtime-go/v48 v48.0.0/go.mod h1:OD2DiFNkQi2jlvSm5Bjbd1g2jlw940u/GPDpQYoD2Hc=
+github.com/bytecodealliance/wasmtime-go/v47 v47.0.0 h1:PAe4o7Mq1VjSx81Dc+V4w1XvxLouFTB384N4ZT4o+7k=
+github.com/bytecodealliance/wasmtime-go/v47 v47.0.0/go.mod h1:icJLhTDV7EyKlZpeuBuJl4yoTMqhjUvNv1mewMJUvr4=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
@@ -1399,8 +1399,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260821001950-7520
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260821001950-7520b255725e/go.mod h1:Dm/Abz0vr7F2v9TygUX947q8HIwJEJikDfSdanX1Cic=
 github.com/smartcontractkit/chainlink-ccv v0.9.1 h1:gu2X5unMqdLL/eBXcEcDAyhTKi7y41ljs/Uy/OAq57U=
 github.com/smartcontractkit/chainlink-ccv v0.9.1/go.mod h1:VtlwBhI1hxmO9BWDDDvE8p84CnaibSIkaDxEos6r9O8=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f h1:NZsL9LEwWSv1yz2mZNzhfqlFrjM4B5yy+sqeFZtK37g=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f/go.mod h1:wTx4k3Yka5bc5lBgQiPeoIbrqelvn2YKa4J8K2w7uok=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936 h1:DPxl0U3Jx0nsFy7WYAAkx9Jq7Pxas5Vun7QTj450vVI=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936/go.mod h1:ALYF2Nhwzih6NibArlTNXz9YrAS9t4v+b0TnE9N7GZ8=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0 h1:V05Rp9/dTc4Wyipsk1EYnW3riZyjDVKmhz3769JpnHU=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0/go.mod h1:vHV8BGm6TN7jBbMsWxq1Hqm3HbCtYFwzvKS0CCczxG8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260724142814-45996a1bcb72 h1:uWEwl7i2ryuRVoV4DmIKm6mqYevf1lH/8cQYhw/JXko=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260821001950-7520b255725e
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936
 	github.com/smartcontractkit/chainlink-deployments-framework v0.120.1-0.20260828145648-3e1bcd2ac1da
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260810110946-8174b6bb7fc9
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.16.7
@@ -125,7 +125,7 @@ require (
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
 	github.com/buger/jsonparser v1.2.0 // indirect
 	github.com/buraksezer/consistent v0.10.0 // indirect
-	github.com/bytecodealliance/wasmtime-go/v48 v48.0.0 // indirect
+	github.com/bytecodealliance/wasmtime-go/v47 v47.0.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -325,8 +325,8 @@ github.com/buraksezer/consistent v0.10.0 h1:hqBgz1PvNLC5rkWcEBVAL9dFMBWz6I0VgUCW
 github.com/buraksezer/consistent v0.10.0/go.mod h1:6BrVajWq7wbKZlTOUPs/XVfR8c0maujuPowduSpZqmw=
 github.com/bxcodec/faker v2.0.1+incompatible h1:P0KUpUw5w6WJXwrPfv35oc91i4d8nf40Nwln+M/+faA=
 github.com/bxcodec/faker v2.0.1+incompatible/go.mod h1:BNzfpVdTwnFJ6GtfYTcQu6l6rHShT+veBxNCnjCx5XM=
-github.com/bytecodealliance/wasmtime-go/v48 v48.0.0 h1:VyeQvfh/6VrD8zhWo40Oci89GR7BAsvTSlH8p/UjhxU=
-github.com/bytecodealliance/wasmtime-go/v48 v48.0.0/go.mod h1:OD2DiFNkQi2jlvSm5Bjbd1g2jlw940u/GPDpQYoD2Hc=
+github.com/bytecodealliance/wasmtime-go/v47 v47.0.0 h1:PAe4o7Mq1VjSx81Dc+V4w1XvxLouFTB384N4ZT4o+7k=
+github.com/bytecodealliance/wasmtime-go/v47 v47.0.0/go.mod h1:icJLhTDV7EyKlZpeuBuJl4yoTMqhjUvNv1mewMJUvr4=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
@@ -1637,8 +1637,8 @@ github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260821001950-7520
 github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260821001950-7520b255725e/go.mod h1:Dm/Abz0vr7F2v9TygUX947q8HIwJEJikDfSdanX1Cic=
 github.com/smartcontractkit/chainlink-ccv v0.9.1 h1:gu2X5unMqdLL/eBXcEcDAyhTKi7y41ljs/Uy/OAq57U=
 github.com/smartcontractkit/chainlink-ccv v0.9.1/go.mod h1:VtlwBhI1hxmO9BWDDDvE8p84CnaibSIkaDxEos6r9O8=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f h1:NZsL9LEwWSv1yz2mZNzhfqlFrjM4B5yy+sqeFZtK37g=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f/go.mod h1:wTx4k3Yka5bc5lBgQiPeoIbrqelvn2YKa4J8K2w7uok=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936 h1:DPxl0U3Jx0nsFy7WYAAkx9Jq7Pxas5Vun7QTj450vVI=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936/go.mod h1:ALYF2Nhwzih6NibArlTNXz9YrAS9t4v+b0TnE9N7GZ8=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0 h1:V05Rp9/dTc4Wyipsk1EYnW3riZyjDVKmhz3769JpnHU=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0/go.mod h1:vHV8BGm6TN7jBbMsWxq1Hqm3HbCtYFwzvKS0CCczxG8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260724142814-45996a1bcb72 h1:uWEwl7i2ryuRVoV4DmIKm6mqYevf1lH/8cQYhw/JXko=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.108
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20260828090428-9828cc37ebc2
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936
 	github.com/smartcontractkit/chainlink-common/keystore v1.3.0
 	github.com/smartcontractkit/chainlink-confidential-compute v1.3.0
 	github.com/smartcontractkit/chainlink-deployments-framework v0.120.1-0.20260828145648-3e1bcd2ac1da
@@ -160,7 +160,7 @@ require (
 	github.com/buger/goterm v1.0.4 // indirect
 	github.com/buger/jsonparser v1.2.0 // indirect
 	github.com/buraksezer/consistent v0.10.0 // indirect
-	github.com/bytecodealliance/wasmtime-go/v48 v48.0.0 // indirect
+	github.com/bytecodealliance/wasmtime-go/v47 v47.0.0 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2 v2.70.2 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -315,8 +315,8 @@ github.com/bxcodec/faker v2.0.1+incompatible h1:P0KUpUw5w6WJXwrPfv35oc91i4d8nf40
 github.com/bxcodec/faker v2.0.1+incompatible/go.mod h1:BNzfpVdTwnFJ6GtfYTcQu6l6rHShT+veBxNCnjCx5XM=
 github.com/bytecodealliance/wasmtime-go/v39 v39.0.1 h1:RibaT47yiyCRxMOj/l2cvL8cWiWBSqDXHyqsa9sGcCE=
 github.com/bytecodealliance/wasmtime-go/v39 v39.0.1/go.mod h1:miR4NYIEBXeDNamZIzpskhJ0z/p8al+lwMWylQ/ZJb4=
-github.com/bytecodealliance/wasmtime-go/v48 v48.0.0 h1:VyeQvfh/6VrD8zhWo40Oci89GR7BAsvTSlH8p/UjhxU=
-github.com/bytecodealliance/wasmtime-go/v48 v48.0.0/go.mod h1:OD2DiFNkQi2jlvSm5Bjbd1g2jlw940u/GPDpQYoD2Hc=
+github.com/bytecodealliance/wasmtime-go/v47 v47.0.0 h1:PAe4o7Mq1VjSx81Dc+V4w1XvxLouFTB384N4ZT4o+7k=
+github.com/bytecodealliance/wasmtime-go/v47 v47.0.0/go.mod h1:icJLhTDV7EyKlZpeuBuJl4yoTMqhjUvNv1mewMJUvr4=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
@@ -1662,8 +1662,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260821001950-7520b255725e/go.mod h1:c++Ed0jeYn4w8WIfiAboRwN6ClRRVGglL0qwB/QjJvM=
 github.com/smartcontractkit/chainlink-ccv v0.9.1 h1:gu2X5unMqdLL/eBXcEcDAyhTKi7y41ljs/Uy/OAq57U=
 github.com/smartcontractkit/chainlink-ccv v0.9.1/go.mod h1:VtlwBhI1hxmO9BWDDDvE8p84CnaibSIkaDxEos6r9O8=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f h1:NZsL9LEwWSv1yz2mZNzhfqlFrjM4B5yy+sqeFZtK37g=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f/go.mod h1:wTx4k3Yka5bc5lBgQiPeoIbrqelvn2YKa4J8K2w7uok=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936 h1:DPxl0U3Jx0nsFy7WYAAkx9Jq7Pxas5Vun7QTj450vVI=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936/go.mod h1:ALYF2Nhwzih6NibArlTNXz9YrAS9t4v+b0TnE9N7GZ8=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0 h1:V05Rp9/dTc4Wyipsk1EYnW3riZyjDVKmhz3769JpnHU=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0/go.mod h1:vHV8BGm6TN7jBbMsWxq1Hqm3HbCtYFwzvKS0CCczxG8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260724142814-45996a1bcb72 h1:uWEwl7i2ryuRVoV4DmIKm6mqYevf1lH/8cQYhw/JXko=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/smartcontractkit/chain-selectors v1.0.108
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260624154507-ea7ff77a0ddb
-	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f
+	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936
 	github.com/smartcontractkit/chainlink-common/keystore v1.3.0
 	github.com/smartcontractkit/chainlink-confidential-compute v1.3.0
 	github.com/smartcontractkit/chainlink-confidential-compute/tests/testhelpers v0.0.0-20260812145307-d77342c53d7d
@@ -131,7 +131,7 @@ require (
 	github.com/beevik/ntp v1.5.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/buraksezer/consistent v0.10.0 // indirect
-	github.com/bytecodealliance/wasmtime-go/v48 v48.0.0 // indirect
+	github.com/bytecodealliance/wasmtime-go/v47 v47.0.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -359,8 +359,8 @@ github.com/bxcodec/faker v2.0.1+incompatible h1:P0KUpUw5w6WJXwrPfv35oc91i4d8nf40
 github.com/bxcodec/faker v2.0.1+incompatible/go.mod h1:BNzfpVdTwnFJ6GtfYTcQu6l6rHShT+veBxNCnjCx5XM=
 github.com/bytecodealliance/wasmtime-go/v39 v39.0.1 h1:RibaT47yiyCRxMOj/l2cvL8cWiWBSqDXHyqsa9sGcCE=
 github.com/bytecodealliance/wasmtime-go/v39 v39.0.1/go.mod h1:miR4NYIEBXeDNamZIzpskhJ0z/p8al+lwMWylQ/ZJb4=
-github.com/bytecodealliance/wasmtime-go/v48 v48.0.0 h1:VyeQvfh/6VrD8zhWo40Oci89GR7BAsvTSlH8p/UjhxU=
-github.com/bytecodealliance/wasmtime-go/v48 v48.0.0/go.mod h1:OD2DiFNkQi2jlvSm5Bjbd1g2jlw940u/GPDpQYoD2Hc=
+github.com/bytecodealliance/wasmtime-go/v47 v47.0.0 h1:PAe4o7Mq1VjSx81Dc+V4w1XvxLouFTB384N4ZT4o+7k=
+github.com/bytecodealliance/wasmtime-go/v47 v47.0.0/go.mod h1:icJLhTDV7EyKlZpeuBuJl4yoTMqhjUvNv1mewMJUvr4=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
@@ -1841,8 +1841,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260821001950-7520b255725e/go.mod h1:c++Ed0jeYn4w8WIfiAboRwN6ClRRVGglL0qwB/QjJvM=
 github.com/smartcontractkit/chainlink-ccv v0.9.1 h1:gu2X5unMqdLL/eBXcEcDAyhTKi7y41ljs/Uy/OAq57U=
 github.com/smartcontractkit/chainlink-ccv v0.9.1/go.mod h1:VtlwBhI1hxmO9BWDDDvE8p84CnaibSIkaDxEos6r9O8=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f h1:NZsL9LEwWSv1yz2mZNzhfqlFrjM4B5yy+sqeFZtK37g=
-github.com/smartcontractkit/chainlink-common v0.11.2-0.20260904233717-0a9e358dbb9f/go.mod h1:wTx4k3Yka5bc5lBgQiPeoIbrqelvn2YKa4J8K2w7uok=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936 h1:DPxl0U3Jx0nsFy7WYAAkx9Jq7Pxas5Vun7QTj450vVI=
+github.com/smartcontractkit/chainlink-common v0.11.2-0.20260909170844-aaa8dc536936/go.mod h1:ALYF2Nhwzih6NibArlTNXz9YrAS9t4v+b0TnE9N7GZ8=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0 h1:V05Rp9/dTc4Wyipsk1EYnW3riZyjDVKmhz3769JpnHU=
 github.com/smartcontractkit/chainlink-common/keystore v1.3.0/go.mod h1:vHV8BGm6TN7jBbMsWxq1Hqm3HbCtYFwzvKS0CCczxG8=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260724142814-45996a1bcb72 h1:uWEwl7i2ryuRVoV4DmIKm6mqYevf1lH/8cQYhw/JXko=


### PR DESCRIPTION
1. Update to common dep: https://github.com/smartcontractkit/chainlink-common/pull/2349
2. Remove obsolete v1 hasher.

Deployment Validation:
1. Existing chain canaries. If there are any problems with remote cap config, those canaries will start failing.
2. Verify there are no "received messages with the same id and different payloads" logs on chain cap nodes during deployment.