### PR TITLE
core/scripts/cre: add vault-dkg-decode tool

### DIFF
--- a/core/scripts/cre/vault-dkg-decode/README.md
+++ b/core/scripts/cre/vault-dkg-decode/README.md
@@ -1,0 +1,60 @@
+# vault-dkg-decode
+
+Decodes an exported vault DKG **result package** and prints the TDH2 master
+public key in the exact form CapReg stores it (the `VaultPublicKey`
+`stringValue`).
+
+Run this on every vault DKG **reshare** (or fresh dealing). On a reshare the
+master key (`G_bar`/`H`) is preserved but the per-recipient verification shares
+(`HArray`) are redistributed to the new committee — so CapReg's `VaultPublicKey`
+must be refreshed to the value this tool prints, or `secrets.get`
+decryption-share verification fails (`failed to verify decryption share`).
+
+## Get a result package
+
+Export it from any node that holds it (member of the instance's committee), via
+the node API. Authenticate first, then export and pull out `hexDKGResultPackage`:
+
+```bash
+# 1. authenticate to a cookie jar (node API email/password)
+curl -s -c cookies.txt -X POST "$NODE_URL/sessions" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"'"$NODE_EMAIL"'","password":"'"$NODE_PASSWORD"'"}'
+
+# 2. export and extract the hex (adjust the export path to your build)
+curl -s -b cookies.txt "$NODE_URL/.../export?instanceID=<instanceID>" \
+  | jq -r .hexDKGResultPackage > resultpkg.hex
+```
+
+## Decode
+
+```bash
+cd core/scripts/cre/vault-dkg-decode
+
+# full human-readable summary + the CapReg stringValue at the end
+go run . ./resultpkg.hex
+
+# or pipe straight from the export
+curl ... | jq -r .hexDKGResultPackage | go run . -
+
+# just the CapReg VaultPublicKey stringValue (what you paste into the
+# capability_registry_update_don input)
+go run . --capreg ./resultpkg.hex
+
+# just the decoded pubkey JSON
+go run . --json ./resultpkg.hex
+```
+
+## Field meaning
+
+| Field    | Meaning                                              | Reshare?              |
+|----------|------------------------------------------------------|-----------------------|
+| `Group`  | curve name (`P256`)                                  | never changes         |
+| `H`      | master public key — what secrets are encrypted to    | **stable**            |
+| `G_bar`  | deterministically-derived generator (from `H`)       | **stable**            |
+| `HArray` | per-recipient public verification shares (one/member)| **changes on reshare**|
+
+`G_bar` + `H` drive encryption (`secrets.create`/`update`), so they stay valid
+after a reshare. `HArray` verifies decryption shares (`secrets.get`), so a stale
+`HArray` in CapReg is what breaks reads after a reshare — republish the value
+this tool prints, then reboot the gateways to drop their cached master key.

--- a/core/scripts/cre/vault-dkg-decode/main.go
+++ b/core/scripts/cre/vault-dkg-decode/main.go
@@ -1,0 +1,146 @@
+// Command vault-dkg-decode decodes an exported vault DKG result package and
+// prints its contents, including the TDH2 master public key in the exact form
+// CapReg stores it (the VaultPublicKey `stringValue`).
+//
+// It is meant to be run whenever a vault DKG reshare (or fresh dealing) happens
+// so you can (a) confirm what the result package contains and (b) get the
+// CapReg-ready public-key value to publish. On a reshare the master key
+// (G_bar/H) is preserved but the per-recipient verification shares (HArray) are
+// redistributed to the new committee, so CapReg's VaultPublicKey MUST be
+// refreshed to the value this tool prints or `secrets.get` decryption-share
+// verification will fail.
+//
+// Usage:
+//
+//	# from a file containing the hex result package (no 0x / whitespace ok):
+//	go run . ./resultpkg.hex
+//
+//	# from stdin:
+//	cat resultpkg.hex | go run . -
+//	curl ... | jq -r .hexDKGResultPackage | go run . -
+//
+// Flags:
+//
+//	--capreg   print ONLY the CapReg VaultPublicKey stringValue (hex) and exit.
+//	           This is what you paste into the capability_registry_update_don
+//	           input's VaultPublicKey.stringValue.
+//	--json     print ONLY the decoded TDH2 public key JSON and exit.
+//
+// With no flag it prints a full human-readable summary followed by the CapReg
+// stringValue.
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/smartcontractkit/smdkg/dkgocr"
+	"github.com/smartcontractkit/smdkg/dkgocr/tdh2shim"
+)
+
+func main() {
+	capregOnly := flag.Bool("capreg", false, "print only the CapReg VaultPublicKey stringValue (hex) and exit")
+	jsonOnly := flag.Bool("json", false, "print only the decoded TDH2 public key JSON and exit")
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		fmt.Fprintln(os.Stderr, "usage: vault-dkg-decode [--capreg|--json] <hexfile|->")
+		fmt.Fprintln(os.Stderr, "  reads a hex-encoded DKG result package from a file, or from stdin if the arg is '-'")
+		os.Exit(2)
+	}
+
+	hexStr, err := readHexInput(flag.Arg(0))
+	must(err)
+	raw, err := hex.DecodeString(hexStr)
+	must(err)
+
+	rp := dkgocr.NewResultPackage()
+	must(rp.UnmarshalBinary(raw))
+
+	// The CapReg VaultPublicKey value: TDH2 pubkey marshaled to JSON, then the
+	// UTF-8 JSON bytes hex-encoded (this is exactly what CapReg stores as
+	// stringValue).
+	tdh2Pub, err := tdh2shim.TDH2PublicKeyFromDKGResult(rp)
+	must(err)
+	pkJSON, err := tdh2Pub.Marshal()
+	must(err)
+	capregStringValue := hex.EncodeToString(pkJSON)
+
+	if *capregOnly {
+		fmt.Println(capregStringValue)
+		return
+	}
+	if *jsonOnly {
+		fmt.Println(string(pkJSON))
+		return
+	}
+
+	cfg := rp.ReportingPluginConfig()
+	fmt.Println("== DKG result package ==")
+	fmt.Println("InstanceID          :", rp.InstanceID())
+	fmt.Println("Config.T (threshold):", cfg.T)
+	fmt.Println("Config #dealers     :", len(cfg.DealerPublicKeys))
+	fmt.Println("Config #recipients  :", len(cfg.RecipientPublicKeys))
+	if cfg.PreviousInstanceID != nil {
+		fmt.Println("PreviousInstanceID  :", *cfg.PreviousInstanceID, "  (=> RESHARE: master key preserved)")
+	} else {
+		fmt.Println("PreviousInstanceID  : <nil>   (=> FRESH dealing: new master key)")
+	}
+
+	mpk := rp.MasterPublicKey()
+	fmt.Printf("MasterPublicKey(raw): %x\n", []byte(mpk))
+	shares := rp.MasterPublicKeyShares()
+	fmt.Println("#MasterPubKeyShares :", len(shares), " (== HArray length == committee size)")
+
+	// Pretty-print the decoded pubkey fields so G_bar/H can be eyeballed
+	// against the previous instance (they must match on a reshare).
+	var m struct {
+		Group  string   `json:"Group"`
+		GBar   string   `json:"G_bar"`
+		H      string   `json:"H"`
+		HArray []string `json:"HArray"`
+	}
+	if json.Unmarshal(pkJSON, &m) == nil {
+		fmt.Println()
+		fmt.Println("== TDH2 public key (CapReg VaultPublicKey, decoded) ==")
+		fmt.Println("Group               :", m.Group)
+		fmt.Println("G_bar               :", m.GBar, " (stable across resharings)")
+		fmt.Println("H                   :", m.H, " (master public key; stable across resharings)")
+		fmt.Println("HArray entries      :", len(m.HArray), " (per-recipient verification shares; CHANGES on reshare)")
+	}
+
+	fmt.Println()
+	fmt.Println("== CapReg VaultPublicKey stringValue (paste into capability_registry_update_don) ==")
+	fmt.Println(capregStringValue)
+}
+
+// readHexInput returns the hex string from the given path, or from stdin if
+// path is "-". Any surrounding whitespace/newlines and a leading 0x are removed.
+func readHexInput(path string) (string, error) {
+	var b []byte
+	var err error
+	if path == "-" {
+		b, err = io.ReadAll(os.Stdin)
+	} else {
+		b, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return "", err
+	}
+	s := strings.TrimSpace(string(b))
+	s = strings.TrimPrefix(s, "0x")
+	s = strings.Join(strings.Fields(s), "") // strip any internal whitespace/newlines
+	return s, nil
+}
+
+func must(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ERROR:", err)
+		os.Exit(1)
+	}
+}

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/proof-of-reserve/cron-based v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink/system-tests/lib v0.0.0-00010101000000-000000000000
+	github.com/smartcontractkit/smdkg v0.0.0-20260819115032-4afa3ab56bc4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
@@ -562,7 +563,6 @@ require (
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect
 	github.com/smartcontractkit/libocr v0.0.0-20260810200708-618b5bf7f342 // indirect
 	github.com/smartcontractkit/mcms v0.55.0 // indirect
-	github.com/smartcontractkit/smdkg v0.0.0-20260819115032-4afa3ab56bc4 // indirect
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20251120172354-e8ec0386b06c // indirect
 	github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect


### PR DESCRIPTION
## What

Adds a standalone command `core/scripts/cre/vault-dkg-decode` that decodes an exported vault DKG **result package** and prints the TDH2 master public key in the exact form CapReg stores it (the `VaultPublicKey` `stringValue`).

It doubles as the **CapReg value generator** for a reshare:
- `go run . ./resultpkg.hex` — full human-readable summary (instance id, prev instance, T, dealer/recipient counts, master pubkey, G_bar/H/HArray) + the CapReg stringValue.
- `go run . --capreg ./resultpkg.hex` — just the hex `stringValue` to paste into a `capability_registry_update_don` input.
- `go run . --json ./resultpkg.hex` — just the decoded pubkey JSON.
- Accepts `-` to read the hex from stdin.

## Why

On a vault DKG **reshare** the master key (`G_bar`/`H`) is preserved but the per-recipient verification-key shares (`HArray`) are redistributed to the new committee. CapReg's `VaultPublicKey` must be refreshed to the reshared instance's value or `secrets.get` decryption-share verification fails (`failed to verify decryption share`). This tool produces that value directly from the exported result package, so the next reshare (staging or prod) doesn't need an ad-hoc script.
