### PR TITLE
Fix NodeStatuses race

### DIFF
--- a/core/services/chainlink/relayer_chain_interoperators.go
+++ b/core/services/chainlink/relayer_chain_interoperators.go
@@ -388,8 +388,10 @@ func (rs *CoreRelayerChainInteroperators) NodeStatuses(ctx context.Context, offs
 		totalErr error
 		result   []types.NodeStatus
 	)
+	// Copy under the lock: Get inserts dummy relayers lazily, so the live map cannot be iterated unlocked.
+	relayers := rs.GetIDToRelayerMap()
 	if len(relayerIDs) == 0 {
-		keys := slices.Collect(maps.Keys(rs.loopRelayers))
+		keys := slices.Collect(maps.Keys(relayers))
 		slices.SortFunc(keys, func(a, b types.RelayID) int {
 			if c := strings.Compare(a.Network, b.Network); c != 0 {
 				return c
@@ -397,7 +399,7 @@ func (rs *CoreRelayerChainInteroperators) NodeStatuses(ctx context.Context, offs
 			return strings.Compare(a.ChainID, b.ChainID)
 		})
 		for _, key := range keys {
-			lr := rs.loopRelayers[key]
+			lr := relayers[key]
 			stats, _, total, err := lr.ListNodeStatuses(ctx, int32(limit), "")
 			if err != nil {
 				totalErr = errors.Join(totalErr, err)
@@ -408,7 +410,7 @@ func (rs *CoreRelayerChainInteroperators) NodeStatuses(ctx context.Context, offs
 		}
 	} else {
 		for _, rid := range relayerIDs {
-			lr, exist := rs.loopRelayers[rid]
+			lr, exist := relayers[rid]
 			if !exist {
 				totalErr = errors.Join(totalErr, fmt.Errorf("relayer %s does not exist", rid.Name()))
 				continue
@@ -469,11 +471,9 @@ func (rs *CoreRelayerChainInteroperators) List(filter FilterFn) RelayerChainInte
 // Returns a slice of [loop.Relayer]. A typically usage pattern to is
 // use [List(criteria)].Slice() for range based operations
 func (rs *CoreRelayerChainInteroperators) Slice() []loop.Relayer {
-	var result []loop.Relayer
-	for _, r := range rs.loopRelayers {
-		result = append(result, r)
-	}
-	return result
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return slices.Collect(maps.Values(rs.loopRelayers))
 }
 func (rs *CoreRelayerChainInteroperators) Services() (s []services.ServiceCtx) {
 	return rs.srvs

--- a/core/services/chainlink/relayer_chain_interoperators_internal_test.go
+++ b/core/services/chainlink/relayer_chain_interoperators_internal_test.go
@@ -1,0 +1,50 @@
+package chainlink
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
+)
+
+// Readers must not iterate loopRelayers while Get lazily inserts dummy relayers.
+// Run with -race: an unlocked read shows up as a data race or a concurrent map fault.
+func TestCoreRelayerChainInteroperators_ReadersDoNotRaceLazyGet(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	cr, err := NewCoreRelayerChainInteroperators(InitDummy(RelayerFactory{Logger: logger.Test(t)}))
+	require.NoError(t, err)
+
+	const n = 50
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(3)
+		id := types.RelayID{Network: relay.NetworkDummy, ChainID: strconv.Itoa(i)}
+		go func() {
+			defer wg.Done()
+			_, getErr := cr.Get(id)
+			assert.NoError(t, getErr)
+		}()
+		go func() {
+			defer wg.Done()
+			_, _, statusErr := cr.NodeStatuses(ctx, 0, 0)
+			assert.NoError(t, statusErr)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = cr.Slice()
+		}()
+	}
+	wg.Wait()
+
+	require.Len(t, cr.Slice(), n)
+	_, _, err = cr.NodeStatuses(ctx, 0, 0, types.RelayID{Network: relay.NetworkDummy, ChainID: "0"})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
`Get` lazily inserts dummy relayers into `loopRelayers` under `rs.mu`, but `NodeStatuses` and `Slice` iterated the same map without the lock. A chain or node listing request racing a `Get` for a new dummy chain ID can hit `fatal error: concurrent map iteration and map write`, which takes the node down.

- `NodeStatuses` works from the copy returned by `GetIDToRelayerMap` (taken under the lock), so relayer RPC calls keep running outside the lock as before.
- `Slice` takes the lock while collecting.

Test: concurrent `Get`/`NodeStatuses`/`Slice` against a dummy factory under `-race`. It reports a data race on `develop` and passes with this change.
