### PR TITLE
[Config Consolidation] DONTime Spec deprecation

### DIFF
--- a/core/capabilities/localcapmgr/manager.go
+++ b/core/capabilities/localcapmgr/manager.go
@@ -204,10 +204,11 @@ func (m *localCapabilityManager) buildDesiredState(myCapabilityDONs []registrysy
 func (m *localCapabilityManager) startCapability(ctx context.Context, info *capabilityInfo) (*runningCapability, error) {
 	start := time.Now()
 
+	// command is only meaningful for standard capabilities that launch a plugin
+	// binary (e.g. consensus, cron). OCR2-based capabilities (e.g. dontime) run
+	// in-process and do not need a binary, so an empty command is allowed there;
+	// the newServicesFn routes on capability ID and ignores it.
 	command := m.resolveCapabilityBinary(info.capID)
-	if command == "" {
-		return nil, fmt.Errorf("could not resolve capability binary for %s", info.capID)
-	}
 	configJSON, err := m.buildConfigJSON(info)
 	if err != nil {
 		return nil, fmt.Errorf("build config for %s: %w", info.capID, err)

--- a/core/scripts/cre/environment/configs/workflow-don-solana.toml
+++ b/core/scripts/cre/environment/configs/workflow-don-solana.toml
@@ -52,7 +52,7 @@
 
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS_DEFAULT = '{"PerWorkflow":{"LogLineLimit":"100kb"}}' }
   capabilities = ["cron", "http-action", "http-trigger", "consensus", "don-time"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 

--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don-confidential-workflows.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don-confidential-workflows.toml
@@ -71,7 +71,7 @@
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"VaultOrgIdAsSecretOwnerEnabled":false}}', CL_CRE_SETTINGS_DEFAULT = '{"RemoteExecutableWorkflowDONBindingEnabled":"true","PerWorkflow":{"ConfidentialWorkflows":{"Enabled":"true"}}}' }
   capabilities = ["consensus", "confidential-workflows", "confidential-relay", "cron", "http-action", "http-trigger", "don-time", "evm-1337"]
   exposes_remote_capabilities = true
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don-vault-stall-purge.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don-vault-stall-purge.toml
@@ -39,7 +39,7 @@
   supported_evm_chains = [1337, 2337]
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}', CL_CRE_SETTINGS_DEFAULT = '{"VaultPendingQueueStallThreshold":"3","VaultMaxObservationSizeLimit":"4kb","PerOwner":{"VaultCiphertextSizeLimit":"8kb"}}' }
   capabilities = ["cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don-vault-workflow-don-binding-enabled.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don-vault-workflow-don-binding-enabled.toml
@@ -41,7 +41,7 @@
   supported_evm_chains = [1337, 2337]
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}', CL_CRE_SETTINGS_DEFAULT = '{"RemoteExecutableWorkflowDONBindingEnabled":"true"}' }
   capabilities = ["cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
@@ -50,7 +50,7 @@
 
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
   capabilities = ["cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 

--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-multi-gateway-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-multi-gateway-don.toml
@@ -39,7 +39,7 @@
   supported_evm_chains = [1337, 2337]
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PropagateOrgIDInRequestMetadata":"true","PerOrg":{"BaseTriggerRetransmitEnabled":"true"}},"org":{"multi-don-test-org":{"PerWorkflow":{"HTTPAction":{"GatewayProxyDonID":"gateway_don_eu"}}}}}' }
   capabilities = ["cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/scripts/cre/environment/configs/workflow-gateway-don-aptos.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-don-aptos.toml
@@ -42,7 +42,7 @@
   # Workflow runtime limits still need both the EVM registry chain and the Aptos chain selector.
   env_vars = { CL_CRE_SETTINGS_DEFAULT = '{"PerWorkflow":{"CapabilityCallTimeout":"5m0s","ChainAllowed":{"Default":"false","Values":{"1337":"true","4457093679053095497":"true"}},"ExecutionTimestampsEnabled":"true","FeatureAptosWriteReportBlockTimestampActivePeriod":"[2020-01-01 00:00:00 +0000 UTC,2030-01-01 00:00:00 +0000 UTC]"}}' }
   capabilities = ["cron", "consensus", "aptos-4", "don-time"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/scripts/cre/environment/configs/workflow-gateway-don-cache-soak-test.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-don-cache-soak-test.toml
@@ -37,7 +37,7 @@
 
   env_vars = { CL_EVM_CMD = "" }
   capabilities = ["vault", "cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/scripts/cre/environment/configs/workflow-gateway-don-cache-test.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-don-cache-test.toml
@@ -37,7 +37,7 @@
 
   env_vars = { CL_EVM_CMD = "" }
   capabilities = ["vault", "cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/scripts/cre/environment/configs/workflow-gateway-don-grpc-source.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-don-grpc-source.toml
@@ -50,7 +50,7 @@
 
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node" }
   capabilities = ["vault", "cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 

--- a/core/scripts/cre/environment/configs/workflow-gateway-don-stellar.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-don-stellar.toml
@@ -38,7 +38,7 @@
   # Workflow runtime limits need both the EVM registry chain (1337) and the Stellar chain selector.
   env_vars = { CL_CRE_SETTINGS_DEFAULT = '{"PerWorkflow":{"CapabilityCallTimeout":"5m0s","ChainAllowed":{"Default":"false","Values":{"1337":"true","17301180955411967724":"true"}},"ExecutionTimestampsEnabled":"true","ChainRead":{"CallLimit":"32"}}}', CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
   capabilities = ["cron", "consensus", "don-time"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/scripts/cre/environment/configs/workflow-gateway-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-don.toml
@@ -46,7 +46,7 @@
 
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
   capabilities = ["vault", "cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/scripts/cre/environment/configs/workflow-gateway-sharded-5-dons.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-sharded-5-dons.toml
@@ -48,7 +48,7 @@
 
   env_vars = { CL_EVM_CMD = "" }
   capabilities = ["vault", "cron", "http-action", "http-trigger", "consensus", "don-time",  "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 
@@ -106,7 +106,7 @@
   env_vars = { CL_EVM_CMD = "" }
   # add "vault", "http-action", "http-trigger", when gateway can support more than 1 DON per service
   capabilities = ["cron", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 
@@ -135,7 +135,7 @@
   env_vars = { CL_EVM_CMD = "" }
   # add "vault", "http-action", "http-trigger", when gateway can support more than 1 DON per service
   capabilities = ["cron", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 
@@ -164,7 +164,7 @@
   env_vars = { CL_EVM_CMD = "" }
   # add "vault", "http-action", "http-trigger", when gateway can support more than 1 DON per service
   capabilities = ["cron", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 
@@ -193,7 +193,7 @@
   env_vars = { CL_EVM_CMD = "" }
   # add "vault", "http-action", "http-trigger", when gateway can support more than 1 DON per service
   capabilities = ["cron", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 
@@ -222,7 +222,7 @@
   env_vars = { CL_EVM_CMD = "" }
   # add "vault", "http-action", "http-trigger", when gateway can support more than 1 DON per service
   capabilities = ["cron", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 

--- a/core/scripts/cre/environment/configs/workflow-gateway-sharded-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-sharded-don.toml
@@ -46,7 +46,7 @@
 
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
   capabilities = ["vault", "cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 
@@ -107,7 +107,7 @@
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
   # add "vault", "http-action", "http-trigger", when gateway can support more than 1 DON per service
   capabilities = ["vault", "cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 

--- a/core/scripts/cre/environment/configs/workflow-gateway-sharded-manual.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-sharded-manual.toml
@@ -39,7 +39,7 @@
 
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
   capabilities = ["vault", "cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"
@@ -92,7 +92,7 @@
 
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
   capabilities = ["vault", "cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/scripts/cre/environment/configs/workflow-gateway-sharded-ringocr-overrides.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-sharded-ringocr-overrides.toml
@@ -39,7 +39,7 @@
 
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
   capabilities = ["vault", "cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"
@@ -92,7 +92,7 @@
 
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
   capabilities = ["vault", "cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337", "evm-2337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/scripts/cre/environment/configs/workflow-sharded-capabilities-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-sharded-capabilities-don.toml
@@ -60,7 +60,7 @@
 
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
   capabilities = ["cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"
@@ -116,7 +116,7 @@
 
   env_vars = { CL_EVM_CMD = "", OTEL_SERVICE_NAME = "chainlink-node", CL_CRE_SETTINGS = '{"global":{"PerOrg":{"BaseTriggerRetransmitEnabled":"true"}}}' }
   capabilities = ["cron", "http-action", "http-trigger", "consensus", "don-time", "evm-1337"]
-  registry_based_launch_allowlist = ["cron-trigger@1.0.0"]
+  registry_based_launch_allowlist = ["cron-trigger@1.0.0", "dontime@1.0.0"]
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -808,6 +808,7 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 				DefaultBootstrappers:           safeDefaultBootstrappers(cfg),
 				CapRegistryAddress:             safeExternalRegistryAddress(cfg),
 				CapRegistryChainID:             safeExternalRegistryChainID(cfg),
+				LocalCfg:                       cfg.Capabilities().Local(),
 			},
 			ocr2DelegateConfig,
 		)

--- a/core/services/cre/cre.go
+++ b/core/services/cre/cre.go
@@ -415,8 +415,19 @@ func newRegistrySyncerV2(
 		return nil, fmt.Errorf("could not configure syncer: %w", err)
 	}
 
-	registrySyncer.AddListener(wfLauncher, ocrConfigService)
-	return []commonsrv.Service{registrySyncer, ocrConfigService}, nil
+	return wireRegistrySyncerV2(registrySyncer, ocrConfigService, ocrConfigService, wfLauncher), nil
+}
+
+func wireRegistrySyncerV2(
+	registrySyncer registrysyncerV2.Syncer,
+	ocrConfigService commonsrv.Service,
+	ocrConfigListener registrysyncerV2.Listener,
+	wfLauncher registrysyncerV2.Listener,
+) []commonsrv.Service {
+	// The OCR config service must be started and receive each registry snapshot
+	// before capabilities using its dynamic config trackers are launched.
+	registrySyncer.AddListener(ocrConfigListener, wfLauncher)
+	return []commonsrv.Service{ocrConfigService, registrySyncer}
 }
 
 // newRegistrySyncer creates a registry syncer based on the external registry version

--- a/core/services/cre/cre_test.go
+++ b/core/services/cre/cre_test.go
@@ -1,6 +1,7 @@
 package cre
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,8 +9,19 @@ import (
 
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
+	"github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer"
+	registrysyncerV2 "github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer/v2"
+	registrysyncerV2Mocks "github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer/v2/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
+
+type registryListenerStub struct {
+	name string
+}
+
+func (*registryListenerStub) OnNewRegistry(context.Context, *registrysyncer.LocalRegistry) error {
+	return nil
+}
 
 // wfRegTestStub implements config.CapabilitiesWorkflowRegistry for tests.
 type wfRegTestStub struct {
@@ -97,6 +109,24 @@ func TestWorkflowRegistryConfigured(t *testing.T) {
 	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("0xdef"), 2))
 	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("", "https://example"), 2))
 	require.True(t, workflowRegistryConfigured(testWorkflowRegistry("", "", "grpc://x"), 2))
+}
+
+func TestWireRegistrySyncerV2(t *testing.T) {
+	t.Parallel()
+
+	registrySyncer := registrysyncerV2Mocks.NewRegistrySyncer(t)
+	ocrConfigService := registrysyncerV2Mocks.NewRegistrySyncer(t)
+	ocrConfigListener := &registryListenerStub{name: "OCR config service"}
+	wfLauncher := &registryListenerStub{name: "workflow launcher"}
+
+	registrySyncer.EXPECT().AddListener(ocrConfigListener, wfLauncher)
+
+	services := wireRegistrySyncerV2(registrySyncer, ocrConfigService, ocrConfigListener, wfLauncher)
+	require.Len(t, services, 2)
+	require.Same(t, ocrConfigService, services[0])
+	require.Same(t, registrySyncer, services[1])
+
+	var _ registrysyncerV2.Listener = (*registryListenerStub)(nil)
 }
 
 func TestNewLocalTestMetadataRegistry(t *testing.T) {

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -82,10 +84,13 @@ import (
 )
 
 const (
-	vaultCapabilityID            = "vault@1.0.0"
-	vaultOCRConfigKey            = "vault"
-	dkgOCRConfigKey              = "dkg"
-	dontimeCapabilityID          = "dontime@1.0.0"
+	vaultCapabilityID   = "vault@1.0.0"
+	vaultOCRConfigKey   = "vault"
+	dkgOCRConfigKey     = "dkg"
+	dontimeCapabilityID = "dontime@1.0.0"
+	// dontimeCapabilityPrefix matches any dontime version (e.g. "dontime@2.0.0"),
+	// so the registry-driven launch guard keeps working if the version changes.
+	dontimeCapabilityPrefix      = "dontime"
 	gaugeVaultDiskUsageBytes     = "platform_vault_disk_usage_bytes"
 	vaultDiskMonitorTickInterval = time.Minute
 )
@@ -151,6 +156,10 @@ type Delegate struct {
 	defaultBootstrappers []commontypes.BootstrapperLocator
 	capRegistryAddress   string
 	capRegistryChainID   string
+	// localCfg gates registry-driven launch: capabilities in its
+	// RegistryBasedLaunchAllowlist are started by LocalCapabilityManager,
+	// and ServicesForSpec rejects job specs for them to avoid double launch.
+	localCfg coreconfig.LocalCapabilities
 }
 
 type DelegateConfig interface {
@@ -286,6 +295,7 @@ type DelegateOpts struct {
 	DefaultBootstrappers []commontypes.BootstrapperLocator
 	CapRegistryAddress   string
 	CapRegistryChainID   string
+	LocalCfg             coreconfig.LocalCapabilities
 }
 
 func NewDelegate(
@@ -324,6 +334,7 @@ func NewDelegate(
 		defaultBootstrappers:           opts.DefaultBootstrappers,
 		capRegistryAddress:             opts.CapRegistryAddress,
 		capRegistryChainID:             opts.CapRegistryChainID,
+		localCfg:                       opts.LocalCfg,
 	}
 }
 
@@ -406,6 +417,26 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, jb job.Job) ([]job.Servi
 	spec := jb.OCR2OracleSpec
 	if spec == nil {
 		return nil, errors.Errorf("offchainreporting2.Delegate expects an *job.OCR2OracleSpec to be present, got %v", jb)
+	}
+
+	// Reject job specs for capabilities that are launched from the on-chain
+	// registry, so a capability is never started by both paths at once.
+	// Match on the "dontime" prefix rather than a pinned version so future
+	// dontime versions are covered too.
+	if d.localCfg != nil && spec.PluginType == types.DonTimePlugin {
+		for _, pattern := range d.localCfg.RegistryBasedLaunchAllowlist() {
+			re, reErr := regexp.Compile(pattern)
+			if reErr != nil {
+				continue // invalid pattern; config load already flags it
+			}
+			if re.MatchString(dontimeCapabilityID) || strings.Contains(pattern, dontimeCapabilityPrefix) {
+				return nil, fmt.Errorf(
+					"capability %q is in the RegistryBasedLaunchAllowlist and will be started from the on-chain registry; "+
+						"remove the job spec and let the LocalCapabilityManager handle it via [Capabilities.Local] TOML config",
+					dontimeCapabilityID,
+				)
+			}
+		}
 	}
 
 	transmitterID := spec.TransmitterID.String

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -642,7 +642,7 @@ func (d *Delegate) NewServices(
 		TransmitterID:      null.StringFrom(transmitterID),
 		Relay:              relay.NetworkEVM,
 		ChainID:            d.capRegistryChainID,
-		RelayConfig:        job.JSONConfig{"chainID": d.capRegistryChainID, "providerType": string(pluginType)},
+		RelayConfig:        registryOCR2RelayConfig(d.capRegistryChainID, pluginType, transmitterID),
 		P2PV2Bootstrappers: bootstrapPeersToStrings(bootstrapPeers),
 		OCRKeyBundleID:     null.StringFrom(kbID),
 		OnchainSigningStrategy: job.JSONConfig{
@@ -692,6 +692,14 @@ func (d *Delegate) NewServices(
 		return d.newDonTimePlugin(ctx, lggr, jb, bootstrapPeers, kb, ocrDB, lc, capabilityID)
 	default:
 		return nil, errors.Errorf("plugin type %s not supported for registry-driven launch", pluginType)
+	}
+}
+
+func registryOCR2RelayConfig(chainID string, pluginType types.OCR2PluginType, transmitterID string) job.JSONConfig {
+	return job.JSONConfig{
+		"chainID":                chainID,
+		"providerType":           string(pluginType),
+		"effectiveTransmitterID": transmitterID,
 	}
 }
 

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -543,7 +543,10 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, jb job.Job) ([]job.Servi
 		return d.newServicesVaultPlugin(ctx, lggr, jb, bootstrapPeers, kb, ocrDB, lc, d.capabilitiesRegistry, d.gatewayConnectorServiceWrapper, d.WorkflowRegistrySyncer, d.limitsFactory)
 
 	case types.DonTimePlugin:
-		return d.newDonTimePlugin(ctx, lggr, jb, bootstrapPeers, kb, ocrDB, lc)
+		// The job-spec path carries no registry capability ID, so fall back to
+		// the pinned constant; the registry-driven path (NewServices) passes the
+		// actual ID from the registry.
+		return d.newDonTimePlugin(ctx, lggr, jb, bootstrapPeers, kb, ocrDB, lc, dontimeCapabilityID)
 
 	case types.RingPlugin:
 		return d.newServicesRing(ctx, lggr, jb, bootstrapPeers, kb, ocrDB, lc)
@@ -675,7 +678,7 @@ func (d *Delegate) NewServices(
 
 	switch pluginType {
 	case types.DonTimePlugin:
-		return d.newDonTimePlugin(ctx, lggr, jb, bootstrapPeers, kb, ocrDB, lc)
+		return d.newDonTimePlugin(ctx, lggr, jb, bootstrapPeers, kb, ocrDB, lc, capabilityID)
 	default:
 		return nil, errors.Errorf("plugin type %s not supported for registry-driven launch", pluginType)
 	}
@@ -1013,6 +1016,7 @@ func (d *Delegate) newDonTimePlugin(
 	kb ocr2key.KeyBundle,
 	ocrDB *db,
 	lc ocrtypes.LocalConfig,
+	capabilityID string,
 ) (srvs []job.ServiceCtx, err error) {
 	spec := jb.OCR2OracleSpec
 
@@ -1086,20 +1090,22 @@ func (d *Delegate) newDonTimePlugin(
 		onchainKeyringAdapter = ocrcommon.NewOCR3OnchainKeyringAdapter(kb)
 	}
 
-	// Get config tracker and digester, optionally wrapping with OCRConfigService
+	// Get config tracker and digester, optionally wrapping with OCRConfigService.
+	// capabilityID is the registry capability ID (e.g. "dontime@1.0.0"); it keys
+	// the OCRConfigService cache, so it must match the ID the registry carries.
 	configTracker := provider.ContractConfigTracker()
 	configDigester := provider.OffchainConfigDigester()
 	if d.ocrConfigService != nil {
-		configTracker, err = d.ocrConfigService.GetConfigTracker(dontimeCapabilityID, capabilitiespb.OCR3ConfigDefaultKey, configTracker)
+		configTracker, err = d.ocrConfigService.GetConfigTracker(capabilityID, capabilitiespb.OCR3ConfigDefaultKey, configTracker)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get config tracker from OCRConfigService: %w", err)
 		}
-		configDigester, err = d.ocrConfigService.GetConfigDigester(dontimeCapabilityID, capabilitiespb.OCR3ConfigDefaultKey, configDigester)
+		configDigester, err = d.ocrConfigService.GetConfigDigester(capabilityID, capabilitiespb.OCR3ConfigDefaultKey, configDigester)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get config digester from OCRConfigService: %w", err)
 		}
 		lc = generic.AdjustLocalConfigForRegistryBasedConfig(lc)
-		lggr.Infow("Using dynamic OCR config from registry", "capabilityID", dontimeCapabilityID)
+		lggr.Infow("Using dynamic OCR config from registry", "capabilityID", capabilityID)
 	}
 
 	oracleArgs := libocr2.OCR3OracleArgs2[[]byte]{

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -651,6 +651,7 @@ func (d *Delegate) NewServices(
 		},
 		PluginConfig: job.JSONConfig{},
 	}
+	spec.RelayConfig.ApplyDefaultsOCR2(d.cfg.OCR2())
 
 	// Build local config from delegate defaults.
 	lc, err := validate.ToLocalConfig(d.cfg.OCR2(), d.cfg.Insecure(), *spec)
@@ -700,6 +701,7 @@ func registryOCR2RelayConfig(chainID string, pluginType types.OCR2PluginType, tr
 		"chainID":                chainID,
 		"providerType":           string(pluginType),
 		"effectiveTransmitterID": transmitterID,
+		"sendingKeys":            []string{transmitterID},
 	}
 }
 

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -621,16 +621,27 @@ func (d *Delegate) NewServices(
 		transmitterID = t
 	}
 
-	// Build local config from delegate defaults.
-	lc, err := validate.ToLocalConfig(d.cfg.OCR2(), d.cfg.Insecure(), job.OCR2OracleSpec{
-		PluginType:    pluginType,
-		TransmitterID: null.StringFrom(transmitterID),
-		Relay:         fmt.Sprintf("%s/%s", relay.NetworkEVM, d.capRegistryChainID),
+	// Build a synthetic job spec so the existing plugin service creation can be reused.
+	// Keep its relay fields equivalent to the legacy job template: RelayID expects the
+	// network and chain ID separately, and the provider still consumes RelayConfig.
+	spec := &job.OCR2OracleSpec{
+		PluginType:         pluginType,
+		ContractID:         d.capRegistryAddress,
+		TransmitterID:      null.StringFrom(transmitterID),
+		Relay:              relay.NetworkEVM,
+		ChainID:            d.capRegistryChainID,
+		RelayConfig:        job.JSONConfig{"chainID": d.capRegistryChainID, "providerType": string(pluginType)},
+		P2PV2Bootstrappers: bootstrapPeersToStrings(bootstrapPeers),
+		OCRKeyBundleID:     null.StringFrom(kbID),
 		OnchainSigningStrategy: job.JSONConfig{
 			"strategyName": "multi-chain",
 			"config":       map[string]any{"evm": kbID},
 		},
-	})
+		PluginConfig: job.JSONConfig{},
+	}
+
+	// Build local config from delegate defaults.
+	lc, err := validate.ToLocalConfig(d.cfg.OCR2(), d.cfg.Insecure(), *spec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build local config: %w", err)
 	}
@@ -640,23 +651,11 @@ func (d *Delegate) NewServices(
 
 	ocrDB := NewDB(d.ds, jobID, 0, lggr)
 
-	// Build a synthetic job spec so the existing newDonTimePlugin can be reused.
-	// This avoids duplicating the service-creation logic; the job spec fields
-	// that newDonTimePlugin reads are populated from the resolved config.
 	jb := job.Job{
-		ID:            jobID,
-		ExternalJobID: externalJobID,
-		Type:          job.OffchainReporting2,
-		OCR2OracleSpec: &job.OCR2OracleSpec{
-			PluginType:             pluginType,
-			ContractID:             d.capRegistryAddress,
-			TransmitterID:          null.StringFrom(transmitterID),
-			Relay:                  fmt.Sprintf("%s/%s", relay.NetworkEVM, d.capRegistryChainID),
-			P2PV2Bootstrappers:     bootstrapPeersToStrings(bootstrapPeers),
-			OCRKeyBundleID:         null.StringFrom(kbID),
-			OnchainSigningStrategy: job.JSONConfig{"strategyName": "multi-chain", "config": map[string]any{"evm": kbID}},
-			PluginConfig:           job.JSONConfig{},
-		},
+		ID:             jobID,
+		ExternalJobID:  externalJobID,
+		Type:           job.OffchainReporting2,
+		OCR2OracleSpec: spec,
 	}
 	if configJSON != "" {
 		jb.OCR2OracleSpec.PluginConfig = job.JSONConfig{}

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -589,15 +589,27 @@ func (d *Delegate) NewServices(
 	lggr := logger.Sugared(d.lggr.Named(string(job.OffchainReporting2)).Named(externalJobID.String()).With(lggrCtx.Args()...))
 	ctx = lggrCtx.ContextWithValues(ctx)
 
-	// Resolve OCR key bundle from keystore.
-	kbID, err := d.cfg.OCR2().KeyBundleID()
+	// Resolve the OCR key from the registry signer set. Nodes launched without a
+	// job spec do not necessarily configure OCR2.KeyBundleID.
+	kb, err := registryOCRKeyBundle(d.ks, registryOCRConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get default OCR2 key bundle ID: %w", err)
+		return nil, err
 	}
-	kb, err := d.ks.Get(kbID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get OCR2 key bundle: %w", err)
+	if kb == nil {
+		kbID, keyIDErr := d.cfg.OCR2().KeyBundleID()
+		if keyIDErr != nil {
+			return nil, fmt.Errorf("failed to get default OCR2 key bundle ID: %w", keyIDErr)
+		}
+		if kbID == "" {
+			return nil, errors.New("no EVM OCR2 key matches the registry config and OCR2.KeyBundleID is not configured")
+		}
+		configuredKB, getErr := d.ks.Get(kbID)
+		if getErr != nil {
+			return nil, fmt.Errorf("failed to get OCR2 key bundle: %w", getErr)
+		}
+		kb = configuredKB
 	}
+	kbID := kb.ID()
 
 	// Resolve bootstrap peers from TOML config defaults.
 	bootstrapPeers := d.defaultBootstrappers
@@ -681,6 +693,19 @@ func (d *Delegate) NewServices(
 	default:
 		return nil, errors.Errorf("plugin type %s not supported for registry-driven launch", pluginType)
 	}
+}
+
+func registryOCRKeyBundle(ks keystore.OCR2, registryOCRConfig *ocrtypes.ContractConfig) (ocr2key.KeyBundle, error) {
+	if registryOCRConfig == nil {
+		return nil, nil
+	}
+
+	bundles, err := ks.GetAllOfType(corekeys.EVM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get EVM OCR2 key bundles: %w", err)
+	}
+	kb, _ := generic.SelectOCRKeyBundleForConfig(bundles, registryOCRConfig)
+	return kb, nil
 }
 
 // bootstrapPeersToStrings converts BootstrapperLocator slice to string slice

--- a/core/services/ocr2/delegate_registry_test.go
+++ b/core/services/ocr2/delegate_registry_test.go
@@ -37,15 +37,17 @@ func TestRegistryOCRKeyBundle(t *testing.T) {
 func TestRegistryOCR2SpecRelayID(t *testing.T) {
 	t.Parallel()
 
+	transmitterID := "0x1234"
 	spec := job.OCR2OracleSpec{
 		Relay:       relay.NetworkEVM,
 		ChainID:     "1337",
-		RelayConfig: job.JSONConfig{"chainID": "1337", "providerType": string(commontypes.DonTimePlugin)},
+		RelayConfig: registryOCR2RelayConfig("1337", commontypes.DonTimePlugin, transmitterID),
 	}
 
 	relayID, err := spec.RelayID()
 	require.NoError(t, err)
 	assert.Equal(t, commontypes.RelayID{Network: relay.NetworkEVM, ChainID: "1337"}, relayID)
+	assert.Equal(t, transmitterID, spec.RelayConfig["effectiveTransmitterID"])
 }
 
 func TestNewServices_NilPeerWrapper(t *testing.T) {

--- a/core/services/ocr2/delegate_registry_test.go
+++ b/core/services/ocr2/delegate_registry_test.go
@@ -7,11 +7,32 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
+	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/ocr2key"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	keystoremocks "github.com/smartcontractkit/chainlink/v2/core/services/keystore/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 )
+
+func TestRegistryOCRKeyBundle(t *testing.T) {
+	t.Parallel()
+
+	key, err := ocr2key.New(corekeys.EVM)
+	require.NoError(t, err)
+	keyStore := keystoremocks.NewOCR2(t)
+	keyStore.EXPECT().GetAllOfType(corekeys.EVM).Return([]ocr2key.KeyBundle{key}, nil)
+
+	got, err := registryOCRKeyBundle(keyStore, &ocrtypes.ContractConfig{
+		Signers: []ocrtypes.OnchainPublicKey{key.PublicKey()},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, key.ID(), got.ID())
+}
 
 func TestRegistryOCR2SpecRelayID(t *testing.T) {
 	t.Parallel()

--- a/core/services/ocr2/delegate_registry_test.go
+++ b/core/services/ocr2/delegate_registry_test.go
@@ -9,7 +9,23 @@ import (
 
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 )
+
+func TestRegistryOCR2SpecRelayID(t *testing.T) {
+	t.Parallel()
+
+	spec := job.OCR2OracleSpec{
+		Relay:       relay.NetworkEVM,
+		ChainID:     "1337",
+		RelayConfig: job.JSONConfig{"chainID": "1337", "providerType": string(commontypes.DonTimePlugin)},
+	}
+
+	relayID, err := spec.RelayID()
+	require.NoError(t, err)
+	assert.Equal(t, commontypes.RelayID{Network: relay.NetworkEVM, ChainID: "1337"}, relayID)
+}
 
 func TestNewServices_NilPeerWrapper(t *testing.T) {
 	t.Parallel()

--- a/core/services/ocr2/delegate_registry_test.go
+++ b/core/services/ocr2/delegate_registry_test.go
@@ -48,6 +48,7 @@ func TestRegistryOCR2SpecRelayID(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, commontypes.RelayID{Network: relay.NetworkEVM, ChainID: "1337"}, relayID)
 	assert.Equal(t, transmitterID, spec.RelayConfig["effectiveTransmitterID"])
+	assert.Equal(t, []string{transmitterID}, spec.RelayConfig["sendingKeys"])
 }
 
 func TestNewServices_NilPeerWrapper(t *testing.T) {

--- a/core/services/ocr2/plugins/generic/oracle_factory_config.go
+++ b/core/services/ocr2/plugins/generic/oracle_factory_config.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 
 	gethCommon "github.com/ethereum/go-ethereum/common"
+
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"

--- a/core/services/ocr2/plugins/generic/oracle_factory_config.go
+++ b/core/services/ocr2/plugins/generic/oracle_factory_config.go
@@ -8,10 +8,12 @@ import (
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/ocr2key"
 	common "github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 )
 
 type ResolveOracleFactoryConfigParams struct {
@@ -106,8 +108,11 @@ func SelectOCRKeyBundleForConfig(bundles []ocr2key.KeyBundle, cc *ocrtypes.Contr
 	}
 	for _, kb := range bundles {
 		pub := kb.PublicKey()
+		multichainPub, err := ocrcommon.MarshalMultichainPublicKey(map[string]ocrtypes.OnchainPublicKey{
+			string(corekeys.EVM): pub,
+		})
 		for _, s := range cc.Signers {
-			if bytes.Equal(s, pub) {
+			if bytes.Equal(s, pub) || (err == nil && bytes.Equal(s, multichainPub)) {
 				return kb, true
 			}
 		}
@@ -119,8 +124,11 @@ func SelectOCRKeyBundleForConfig(bundles []ocr2key.KeyBundle, cc *ocrtypes.Contr
 // the on-chain OCR config. Signers[i] and Transmitters[i] describe the same oracle, so
 // locating this node's signer yields the transmitter the OCR config expects for it.
 func TransmitterForSigner(cc ocrtypes.ContractConfig, signer ocrtypes.OnchainPublicKey) (string, bool) {
+	multichainSigner, err := ocrcommon.MarshalMultichainPublicKey(map[string]ocrtypes.OnchainPublicKey{
+		string(corekeys.EVM): signer,
+	})
 	for i, s := range cc.Signers {
-		if bytes.Equal(s, signer) {
+		if bytes.Equal(s, signer) || (err == nil && bytes.Equal(s, multichainSigner)) {
 			if i < len(cc.Transmitters) {
 				return string(cc.Transmitters[i]), true
 			}

--- a/core/services/ocr2/plugins/generic/oracle_factory_config.go
+++ b/core/services/ocr2/plugins/generic/oracle_factory_config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 
+	gethCommon "github.com/ethereum/go-ethereum/common"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys"
@@ -130,7 +131,11 @@ func TransmitterForSigner(cc ocrtypes.ContractConfig, signer ocrtypes.OnchainPub
 	for i, s := range cc.Signers {
 		if bytes.Equal(s, signer) || (err == nil && bytes.Equal(s, multichainSigner)) {
 			if i < len(cc.Transmitters) {
-				return string(cc.Transmitters[i]), true
+				transmitter := string(cc.Transmitters[i])
+				if gethCommon.IsHexAddress(transmitter) {
+					transmitter = gethCommon.HexToAddress(transmitter).Hex()
+				}
+				return transmitter, true
 			}
 			return "", false
 		}

--- a/core/services/ocr2/plugins/generic/oracle_factory_config_test.go
+++ b/core/services/ocr2/plugins/generic/oracle_factory_config_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/keystore/corekeys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 )
 
 func TestResolveOracleFactoryConfig_fromCapRegistry(t *testing.T) {
@@ -144,6 +145,17 @@ func TestTransmitterForSigner(t *testing.T) {
 	}
 	_, ok = TransmitterForSigner(short, []byte("a"))
 	assert.False(t, ok)
+
+	multichainSigner, err := ocrcommon.MarshalMultichainPublicKey(map[string]ocrtypes.OnchainPublicKey{
+		string(corekeys.EVM): []byte("b"),
+	})
+	require.NoError(t, err)
+	got, ok = TransmitterForSigner(ocrtypes.ContractConfig{
+		Signers:      []ocrtypes.OnchainPublicKey{multichainSigner},
+		Transmitters: []ocrtypes.Account{"0xMultiChain"},
+	}, []byte("b"))
+	require.True(t, ok)
+	assert.Equal(t, "0xMultiChain", got)
 }
 
 func TestSelectOCRKeyBundleForConfig(t *testing.T) {
@@ -168,6 +180,16 @@ func TestSelectOCRKeyBundleForConfig(t *testing.T) {
 	noMatch := &ocrtypes.ContractConfig{Signers: []ocrtypes.OnchainPublicKey{[]byte("nope")}}
 	_, ok = SelectOCRKeyBundleForConfig([]ocr2key.KeyBundle{kb1, kb2}, noMatch)
 	assert.False(t, ok)
+
+	multichainSigner, err := ocrcommon.MarshalMultichainPublicKey(map[string]ocrtypes.OnchainPublicKey{
+		string(corekeys.EVM): kb2.PublicKey(),
+	})
+	require.NoError(t, err)
+	got, ok = SelectOCRKeyBundleForConfig([]ocr2key.KeyBundle{kb1, kb2}, &ocrtypes.ContractConfig{
+		Signers: []ocrtypes.OnchainPublicKey{multichainSigner},
+	})
+	require.True(t, ok)
+	assert.Equal(t, kb2.ID(), got.ID())
 }
 
 func TestDefaultTransmitterForChain_InvalidChainID(t *testing.T) {

--- a/core/services/ocr2/plugins/generic/oracle_factory_config_test.go
+++ b/core/services/ocr2/plugins/generic/oracle_factory_config_test.go
@@ -156,6 +156,13 @@ func TestTransmitterForSigner(t *testing.T) {
 	}, []byte("b"))
 	require.True(t, ok)
 	assert.Equal(t, "0xMultiChain", got)
+
+	got, ok = TransmitterForSigner(ocrtypes.ContractConfig{
+		Signers:      []ocrtypes.OnchainPublicKey{[]byte("a")},
+		Transmitters: []ocrtypes.Account{"736ea02dd58a4eff74565801cb9cf1d13ceb9134"},
+	}, []byte("a"))
+	require.True(t, ok)
+	assert.Equal(t, "0x736ea02Dd58A4EFF74565801cB9Cf1D13CEB9134", got)
 }
 
 func TestSelectOCRKeyBundleForConfig(t *testing.T) {

--- a/core/services/standardcapabilities/conversions/conversions.go
+++ b/core/services/standardcapabilities/conversions/conversions.go
@@ -95,6 +95,11 @@ func GetCommandFromCapabilityID(capabilityID string) string {
 		return "stellar"
 	case strings.HasPrefix(capabilityID, "consensus"):
 		return "consensus"
+	case strings.HasPrefix(capabilityID, "dontime"):
+		// dontime is an OCR2 plugin (pluginType = "dontime"), not a standard
+		// capability binary; it runs in-process via the OCR2 delegate. The
+		// mapping exists for completeness of the conversion table.
+		return "dontime"
 	case strings.HasPrefix(capabilityID, "cron-trigger"):
 		return "cron"
 	case strings.HasPrefix(capabilityID, "http-trigger"):

--- a/system-tests/lib/cre/don.go
+++ b/system-tests/lib/cre/don.go
@@ -121,19 +121,25 @@ type Don struct {
 
 	Flags []CapabilityFlag `toml:"flags" json:"flags"` // capabilities and roles
 
+	// RegistryBasedLaunchAllowlist is propagated from DonMetadata so feature
+	// PostEnvStartup hooks can skip job spec proposal for capabilities that
+	// the node launches from the on-chain registry instead.
+	RegistryBasedLaunchAllowlist []string `toml:"registry_based_launch_allowlist,omitempty" json:"registry_based_launch_allowlist,omitempty"`
+
 	capabilityConfigs    map[CapabilityFlag]CapabilityConfig
 	chainCapabilityIndex map[CapabilityFlag][]uint64
 }
 
 func (d *Don) Metadata() *DonMetadata {
 	dm := &DonMetadata{
-		Name:              d.Name,
-		ID:                d.ID,
-		Flags:             d.Flags,
-		ShardIndex:        d.ShardIndex,
-		DonFamily:         d.DonFamily,
-		NodesMetadata:     make([]*NodeMetadata, len(d.Nodes)),
-		CapabilityConfigs: d.capabilityConfigs,
+		Name:                         d.Name,
+		ID:                           d.ID,
+		Flags:                        d.Flags,
+		ShardIndex:                   d.ShardIndex,
+		DonFamily:                    d.DonFamily,
+		NodesMetadata:                make([]*NodeMetadata, len(d.Nodes)),
+		CapabilityConfigs:            d.capabilityConfigs,
+		RegistryBasedLaunchAllowlist: d.RegistryBasedLaunchAllowlist,
 		// caution: missing NodeSet field, since we don't have it here
 	}
 
@@ -236,14 +242,15 @@ func (d *Don) GetName() string {
 
 func NewDON(ctx context.Context, donMetadata *DonMetadata, ctfNodes []*clnode.Output) (*Don, error) {
 	don := &Don{
-		Nodes:                make([]*Node, len(donMetadata.NodesMetadata)),
-		Name:                 donMetadata.Name,
-		ID:                   donMetadata.ID,
-		Flags:                donMetadata.Flags,
-		ShardIndex:           donMetadata.ShardIndex,
-		DonFamily:            donMetadata.DonFamily,
-		capabilityConfigs:    donMetadata.ns.CapabilityConfigs,
-		chainCapabilityIndex: donMetadata.ns.chainCapabilityIndex,
+		Nodes:                        make([]*Node, len(donMetadata.NodesMetadata)),
+		Name:                         donMetadata.Name,
+		ID:                           donMetadata.ID,
+		Flags:                        donMetadata.Flags,
+		ShardIndex:                   donMetadata.ShardIndex,
+		DonFamily:                    donMetadata.DonFamily,
+		RegistryBasedLaunchAllowlist: donMetadata.RegistryBasedLaunchAllowlist,
+		capabilityConfigs:            donMetadata.ns.CapabilityConfigs,
+		chainCapabilityIndex:         donMetadata.ns.chainCapabilityIndex,
 	}
 
 	errgroup := errgroup.Group{}

--- a/system-tests/lib/cre/features/don_time/don_time.go
+++ b/system-tests/lib/cre/features/don_time/don_time.go
@@ -2,28 +2,17 @@ package dontime
 
 import (
 	"context"
-	"fmt"
-	"regexp"
-	"strconv"
 
-	"dario.cat/mergo"
-	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
-	cre_jobs "github.com/smartcontractkit/chainlink/deployment/cre/jobs"
-	cre_jobs_ops "github.com/smartcontractkit/chainlink/deployment/cre/jobs/operations"
-	job_types "github.com/smartcontractkit/chainlink/deployment/cre/jobs/types"
 	"github.com/smartcontractkit/chainlink/deployment/cre/ocr3"
-	"github.com/smartcontractkit/chainlink/deployment/cre/pkg/offchain"
 	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/contracts"
-	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/don/jobs"
 )
 
 const flag = cre.DONTimeCapability
@@ -63,121 +52,11 @@ func (o *DONTime) PreEnvStartup(
 }
 
 func (o *DONTime) PostEnvStartup(
-	ctx context.Context,
-	testLogger zerolog.Logger,
-	don *cre.Don,
-	dons *cre.Dons,
-	creEnv *cre.Environment,
+	_ context.Context,
+	_ zerolog.Logger,
+	_ *cre.Don,
+	_ *cre.Dons,
+	_ *cre.Environment,
 ) error {
-	// When dontime is in the DON's RegistryBasedLaunchAllowlist, the node's
-	// LocalCapabilityManager launches it from the on-chain registry and no
-	// job spec is needed (proposing one would be rejected by the delegate).
-	// Allowlist entries are regex patterns matched against the capability ID.
-	if isAllowlistedForRegistryLaunch(don.RegistryBasedLaunchAllowlist, donTimeLabelledName+"@1.0.0") {
-		testLogger.Info().Msg("dontime is allowlisted for registry-based launch; skipping job spec proposal")
-		return nil
-	}
-
-	jobErr := createJobs(
-		ctx,
-		creEnv,
-		don,
-		dons,
-	)
-	if jobErr != nil {
-		return fmt.Errorf("failed to create DON Time jobs: %w", jobErr)
-	}
-
 	return nil
-}
-
-func createJobs(
-	ctx context.Context,
-	creEnv *cre.Environment,
-	don *cre.Don,
-	dons *cre.Dons,
-) error {
-	specs := make(map[string][]string)
-
-	bootstrap, isBootstrap := dons.Bootstrap()
-	if !isBootstrap {
-		return errors.New("could not find bootstrap node in topology, exactly one bootstrap node is required")
-	}
-
-	_, ocrPeeringCfg, err := cre.PeeringCfgs(bootstrap)
-	if err != nil {
-		return errors.Wrap(err, "failed to get peering configs")
-	}
-
-	capRegVersion, ok := creEnv.ContractVersions[keystone_changeset.CapabilitiesRegistry.String()]
-	if !ok {
-		return errors.New("CapabilitiesRegistry version not found in contract versions")
-	}
-
-	workerInput := cre_jobs.ProposeJobSpecInput{
-		Domain:      offchain.ProductLabel,
-		Environment: creEnv.CldfEnvironment.Name,
-		DONName:     don.Name,
-		JobName:     "don-time-worker",
-		ExtraLabels: map[string]string{cre.CapabilityLabelKey: flag},
-		DONFilters: []offchain.TargetDONFilter{
-			{Key: offchain.FilterKeyDONName, Value: don.Name},
-		},
-		Template: job_types.OCR3,
-		Inputs: job_types.JobSpecInput{
-			"chainSelectorEVM":     creEnv.RegistryChainSelector,
-			"contractQualifier":    "",
-			"capRegVersion":        capRegVersion.String(),
-			"templateName":         "don-time",
-			"bootstrapperOCR3Urls": []string{ocrPeeringCfg.OCRBootstrapperPeerID + "@" + ocrPeeringCfg.OCRBootstrapperHost + ":" + strconv.Itoa(ocrPeeringCfg.Port)},
-		},
-	}
-	if creEnv.FreshExternalJobIDs {
-		workerInput.Inputs["externalJobID"] = uuid.NewString()
-	}
-
-	workerVerErr := cre_jobs.ProposeJobSpec{}.VerifyPreconditions(*creEnv.CldfEnvironment, workerInput)
-	if workerVerErr != nil {
-		return fmt.Errorf("precondition verification failed for Don Time worker job: %w", workerVerErr)
-	}
-
-	workerReport, workerErr := cre_jobs.ProposeJobSpec{}.Apply(*creEnv.CldfEnvironment, workerInput)
-	if workerErr != nil {
-		return fmt.Errorf("failed to propose Don Time worker job spec: %w", workerErr)
-	}
-
-	for _, r := range workerReport.Reports {
-		out, ok := r.Output.(cre_jobs_ops.ProposeOCR3JobOutput)
-		if !ok {
-			return fmt.Errorf("unable to cast to ProposeOCR3JobOutput, actual type: %T", r.Output)
-		}
-		mErr := mergo.Merge(&specs, out.Specs, mergo.WithAppendSlice)
-		if mErr != nil {
-			return fmt.Errorf("failed to merge worker job specs: %w", mErr)
-		}
-	}
-
-	approveErr := jobs.Approve(ctx, creEnv.CldfEnvironment.Offchain, dons, specs)
-	if approveErr != nil {
-		return fmt.Errorf("failed to approve Don Time jobs: %w", approveErr)
-	}
-
-	return nil
-}
-
-// isAllowlistedForRegistryLaunch reports whether the capability ID matches any
-// of the DON's RegistryBasedLaunchAllowlist regex patterns, mirroring how the
-// node's LocalCapabilityManager decides to launch a capability from the
-// on-chain registry instead of a job spec.
-func isAllowlistedForRegistryLaunch(patterns []string, capabilityID string) bool {
-	for _, pattern := range patterns {
-		re, err := regexp.Compile(pattern)
-		if err != nil {
-			continue // invalid pattern; the node would skip it too
-		}
-		if re.MatchString(capabilityID) {
-			return true
-		}
-	}
-	return false
 }

--- a/system-tests/lib/cre/features/don_time/don_time.go
+++ b/system-tests/lib/cre/features/don_time/don_time.go
@@ -3,6 +3,7 @@ package dontime
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 
 	"dario.cat/mergo"
@@ -68,6 +69,15 @@ func (o *DONTime) PostEnvStartup(
 	dons *cre.Dons,
 	creEnv *cre.Environment,
 ) error {
+	// When dontime is in the DON's RegistryBasedLaunchAllowlist, the node's
+	// LocalCapabilityManager launches it from the on-chain registry and no
+	// job spec is needed (proposing one would be rejected by the delegate).
+	// Allowlist entries are regex patterns matched against the capability ID.
+	if isAllowlistedForRegistryLaunch(don.RegistryBasedLaunchAllowlist, donTimeLabelledName+"@1.0.0") {
+		testLogger.Info().Msg("dontime is allowlisted for registry-based launch; skipping job spec proposal")
+		return nil
+	}
+
 	jobErr := createJobs(
 		ctx,
 		creEnv,
@@ -153,4 +163,21 @@ func createJobs(
 	}
 
 	return nil
+}
+
+// isAllowlistedForRegistryLaunch reports whether the capability ID matches any
+// of the DON's RegistryBasedLaunchAllowlist regex patterns, mirroring how the
+// node's LocalCapabilityManager decides to launch a capability from the
+// on-chain registry instead of a job spec.
+func isAllowlistedForRegistryLaunch(patterns []string, capabilityID string) bool {
+	for _, pattern := range patterns {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			continue // invalid pattern; the node would skip it too
+		}
+		if re.MatchString(capabilityID) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
[CRE-4501](https://smartcontract-it.atlassian.net/browse/CRE-4501)

**Deployment Validation**:

- After the full DON is upgraded, confirm each node logs launching OCR2 capability from registry with `capabilityID=dontime@1.0.0`.
- Existing DON Time canaries remain healthy.
- Metrics `platform_engine_dontime_timeouts_total` and `platform_engine_dontime_errors_total` do not increase.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-4501]: https://smartcontract-it.atlassian.net/browse/CRE-4501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ