### PR TITLE
Fix stale gnupg pin blocking image build on release/2.63.0

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -115,7 +115,7 @@ ARG CHAINLINK_USER=root
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates=20260601~24.04.1 \
-    gnupg=2.4.4-2ubuntu17.4 \
+    gnupg=2.4.4-2ubuntu17.6 \
     lsb-release=12.0-2 \
     curl=8.5.0-2ubuntu10.13 \
     && rm -rf /var/lib/apt/lists/*

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -114,7 +114,7 @@ ARG CHAINLINK_USER=root
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates=20260601~24.04.1 \
-    gnupg=2.4.4-2ubuntu17.4 \
+    gnupg=2.4.4-2ubuntu17.6 \
     lsb-release=12.0-2 \
     curl=8.5.0-2ubuntu10.13 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Cherry-picks fcaafb9973 (#23645) from develop.

Ubuntu dropped `gnupg 2.4.4-2ubuntu17.4` from the archive, so the exact-version pin in `core/chainlink.Dockerfile` and `plugins/chainlink.Dockerfile` no longer resolves:

```
E: Version '2.4.4-2ubuntu17.4' for 'gnupg' was not found
```

This blocks `Build Chainlink Image`, `Build Chainlink Image (plugins)` and the dependent `ETH Smoke Tests` on the 2.63.0 merge-back in #23612.

Same fix already applied to `release/2.62.3` (#23649) and `release/2.63.1`.

Note this does not address `verify-version` on #23612, which fails on a chain-selectors version mismatch (v1.0.108 on the branch vs v1.0.109 upstream) and is unrelated.