### PR TITLE
Gateway: Use OrgResolver for HTTPTrigger rate limit checks

### DIFF
--- a/core/scripts/gateway/run_gateway.go
+++ b/core/scripts/gateway/run_gateway.go
@@ -51,7 +51,7 @@ func main() {
 
 	lf := limits.Factory{Logger: lggr}
 	// Note: these nils are optional dependencies that are not needed for simple handlers.
-	handlerFactory := gateway.NewHandlerFactory(nil, nil, nil, nil, nil, lggr, lf, nil)
+	handlerFactory := gateway.NewHandlerFactory(nil, nil, nil, nil, nil, lggr, lf, nil, nil)
 	gw, err := gateway.NewGatewayFromConfig(&cfg, handlerFactory, lggr, lf)
 	if err != nil {
 		fmt.Println("error creating Gateway object:", err)

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -692,6 +692,7 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 				creServices.WorkflowRegistrySyncer,
 				globalLogger,
 				limitsFactory,
+				creServices.OrgResolver,
 			),
 			job.Stream: streams.NewDelegate(
 				globalLogger,

--- a/core/services/gateway/delegate.go
+++ b/core/services/gateway/delegate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/orgresolver"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
@@ -28,11 +29,12 @@ type Delegate struct {
 	capabilitiesRegistry   core.CapabilitiesRegistry
 	workflowRegistrySyncer workflowsyncerv2.WorkflowRegistrySyncer
 	lf                     limits.Factory
+	orgResolver            orgresolver.OrgResolver // optional; nil if the node isn't configured to resolve orgs (e.g. no Linking Service)
 }
 
 var _ job.Delegate = (*Delegate)(nil)
 
-func NewDelegate(legacyChains legacyevm.LegacyChainContainer, ks keystore.Eth, ds sqlutil.DataSource, capabilitiesRegistry core.CapabilitiesRegistry, workflowRegistrySyncer workflowsyncerv2.WorkflowRegistrySyncer, lggr logger.Logger, lf limits.Factory) *Delegate {
+func NewDelegate(legacyChains legacyevm.LegacyChainContainer, ks keystore.Eth, ds sqlutil.DataSource, capabilitiesRegistry core.CapabilitiesRegistry, workflowRegistrySyncer workflowsyncerv2.WorkflowRegistrySyncer, lggr logger.Logger, lf limits.Factory, orgResolver orgresolver.OrgResolver) *Delegate {
 	return &Delegate{
 		legacyChains:           legacyChains,
 		ks:                     ks,
@@ -41,6 +43,7 @@ func NewDelegate(legacyChains legacyevm.LegacyChainContainer, ks keystore.Eth, d
 		lggr:                   lggr,
 		workflowRegistrySyncer: workflowRegistrySyncer,
 		lf:                     lf,
+		orgResolver:            orgResolver,
 	}
 }
 
@@ -68,7 +71,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) (services 
 	if err != nil {
 		return nil, err
 	}
-	handlerFactory := NewHandlerFactory(d.legacyChains, d.ds, httpClient, d.capabilitiesRegistry, d.workflowRegistrySyncer, d.lggr, d.lf, network.NewHTTPClientFactory(gatewayConfig.HTTPClientConfig, d.lggr))
+	handlerFactory := NewHandlerFactory(d.legacyChains, d.ds, httpClient, d.capabilitiesRegistry, d.workflowRegistrySyncer, d.lggr, d.lf, network.NewHTTPClientFactory(gatewayConfig.HTTPClientConfig, d.lggr), d.orgResolver)
 	gateway, err := NewGatewayFromConfig(&gatewayConfig, handlerFactory, d.lggr, d.lf)
 	if err != nil {
 		return nil, err

--- a/core/services/gateway/gateway_test.go
+++ b/core/services/gateway/gateway_test.go
@@ -53,7 +53,7 @@ func (h *handlerFactory) NewHandler(handlerType gateway.HandlerType, _ json.RawM
 
 func newGatewayHandler(t *testing.T) gateway.HandlerFactory {
 	lggr := logger.Test(t)
-	return gateway.NewHandlerFactory(nil, nil, nil, nil, nil, lggr, limits.Factory{Logger: lggr}, nil)
+	return gateway.NewHandlerFactory(nil, nil, nil, nil, nil, lggr, limits.Factory{Logger: lggr}, nil, nil)
 }
 
 func TestGateway_NewGatewayFromConfig_NoServicesOrDONs(t *testing.T) {

--- a/core/services/gateway/handler_factory.go
+++ b/core/services/gateway/handler_factory.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jonboulle/clockwork"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/orgresolver"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
@@ -39,11 +40,12 @@ type handlerFactory struct {
 	workflowRegistrySyncer workflowsyncerv2.WorkflowRegistrySyncer
 	lf                     limits.Factory
 	httpClientFactory      network.HTTPClientFactory
+	orgResolver            orgresolver.OrgResolver // optional; nil if the node isn't configured to resolve orgs (e.g. no Linking Service)
 }
 
 var _ HandlerFactory = (*handlerFactory)(nil)
 
-func NewHandlerFactory(legacyChains legacyevm.LegacyChainContainer, ds sqlutil.DataSource, httpClient network.HTTPClient, capabilitiesRegistry core.CapabilitiesRegistry, workflowRegistrySyncer workflowsyncerv2.WorkflowRegistrySyncer, lggr logger.Logger, lf limits.Factory, httpClientFactory network.HTTPClientFactory) HandlerFactory {
+func NewHandlerFactory(legacyChains legacyevm.LegacyChainContainer, ds sqlutil.DataSource, httpClient network.HTTPClient, capabilitiesRegistry core.CapabilitiesRegistry, workflowRegistrySyncer workflowsyncerv2.WorkflowRegistrySyncer, lggr logger.Logger, lf limits.Factory, httpClientFactory network.HTTPClientFactory, orgResolver orgresolver.OrgResolver) HandlerFactory {
 	return &handlerFactory{
 		legacyChains,
 		ds,
@@ -53,6 +55,7 @@ func NewHandlerFactory(legacyChains legacyevm.LegacyChainContainer, ds sqlutil.D
 		workflowRegistrySyncer,
 		lf,
 		httpClientFactory,
+		orgResolver,
 	}
 }
 
@@ -81,7 +84,7 @@ func (hf *handlerFactory) NewHandler(
 	case WebAPICapabilitiesType:
 		return capabilities.NewHandler(handlerConfig, donConfig, don, hf.httpClient, hf.lggr)
 	case HTTPCapabilityType:
-		return v2.NewGatewayHandler(handlerConfig, shardedDONs, shardsConnMgrs, hf.httpClient, hf.lggr, hf.lf, hf.httpClientFactory)
+		return v2.NewGatewayHandler(handlerConfig, shardedDONs, shardsConnMgrs, hf.httpClient, hf.lggr, hf.lf, hf.httpClientFactory, hf.orgResolver)
 	case VaultHandlerType:
 		return vault.NewHandler(handlerConfig, donConfig, don, hf.capabilitiesRegistry, hf.workflowRegistrySyncer, hf.lggr, clockwork.NewRealClock(), hf.lf)
 	case ConfidentialRelayHandlerType:

--- a/core/services/gateway/handlers/capabilities/v2/http_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_handler.go
@@ -13,6 +13,7 @@ import (
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/orgresolver"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	gateway_common "github.com/smartcontractkit/chainlink-common/pkg/types/gateway"
@@ -117,7 +118,7 @@ type RetryConfig struct {
 	Multiplier float64 `json:"multiplier"`
 }
 
-func NewGatewayHandler(handlerConfig json.RawMessage, shardedDONs []config.ShardedDONConfig, shardsConnMgrs [][]handlers.DON, httpClient network.HTTPClient, lggr logger.Logger, lf limits.Factory, httpClientFactory network.HTTPClientFactory) (*gatewayHandler, error) {
+func NewGatewayHandler(handlerConfig json.RawMessage, shardedDONs []config.ShardedDONConfig, shardsConnMgrs [][]handlers.DON, httpClient network.HTTPClient, lggr logger.Logger, lf limits.Factory, httpClientFactory network.HTTPClientFactory, orgResolver orgresolver.OrgResolver) (*gatewayHandler, error) {
 	var cfg ServiceConfig
 	err := json.Unmarshal(handlerConfig, &cfg)
 	if err != nil {
@@ -166,7 +167,7 @@ func NewGatewayHandler(handlerConfig json.RawMessage, shardedDONs []config.Shard
 	}
 
 	metadataHandler := NewWorkflowMetadataHandler(lggr, cfg, shards, nodeAddrToShard, metrics)
-	triggerHandler := NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, metrics)
+	triggerHandler := NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, metrics, orgResolver)
 	return &gatewayHandler{
 		config:                 cfg,
 		shards:                 shards,

--- a/core/services/gateway/handlers/capabilities/v2/http_handler_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_handler_test.go
@@ -40,7 +40,7 @@ func TestNewGatewayHandler(t *testing.T) {
 		lggr := logger.Test(t)
 
 		shardedDONs, connMgrs := shardedArgs(donConfig, mockDon)
-		handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
+		handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory, nil)
 		require.NoError(t, err)
 		require.NotNil(t, handler)
 		require.NotNil(t, handler.responseCache)
@@ -56,7 +56,7 @@ func TestNewGatewayHandler(t *testing.T) {
 		lggr := logger.Test(t)
 
 		shardedDONs, connMgrs := shardedArgs(donConfig, mockDon)
-		handler, err := NewGatewayHandler(invalidConfig, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
+		handler, err := NewGatewayHandler(invalidConfig, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory, nil)
 		require.Error(t, err)
 		require.Nil(t, handler)
 	})
@@ -74,7 +74,7 @@ func TestNewGatewayHandler(t *testing.T) {
 		lggr := logger.Test(t)
 
 		shardedDONs, connMgrs := shardedArgs(donConfig, mockDon)
-		handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
+		handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory, nil)
 		require.NoError(t, err)
 		require.NotNil(t, handler)
 		require.Equal(t, defaultCleanUpPeriodMs, handler.config.CleanUpPeriodMs) // Default value
@@ -436,7 +436,7 @@ func TestGatewayHandler_Start_CallsDeleteExpired(t *testing.T) {
 	lggr := logger.Test(t)
 
 	shardedDONs, connMgrs := shardedArgs(donConfig, mockDon)
-	handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
+	handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory, nil)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
 	mockCache := newMockResponseCache()
@@ -499,7 +499,7 @@ func createTestHandlerWithConfig(t *testing.T, cfg ServiceConfig) *gatewayHandle
 	lggr := logger.Test(t)
 
 	shardedDONs, connMgrs := shardedArgs(donConfig, mockDon)
-	handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
+	handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory, nil)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
 
@@ -1222,7 +1222,7 @@ func TestNewGatewayHandler_MultiShardCreatesRateLimitersForAllMembers(t *testing
 	mockHTTPClient := httpmocks.NewHTTPClient(t)
 	lggr := logger.Test(t)
 
-	handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
+	handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory, nil)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
 
@@ -1272,7 +1272,7 @@ func TestGatewayHandler_SendResponseToNode_MultiShardRouting(t *testing.T) {
 	mockHTTPClient := httpmocks.NewHTTPClient(t)
 	lggr := logger.Test(t)
 
-	handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory)
+	handler, err := NewGatewayHandler(configBytes, shardedDONs, connMgrs, mockHTTPClient, lggr, limits.Factory{Logger: lggr}, defaultTestHTTPClientFactory, nil)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
 

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -16,6 +16,7 @@ import (
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/orgresolver"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	gateway_common "github.com/smartcontractkit/chainlink-common/pkg/types/gateway"
@@ -67,6 +68,7 @@ type httpTriggerHandler struct {
 	userRateLimiter         limits.RateLimiter
 	metrics                 *metrics.Metrics
 	wg                      sync.WaitGroup
+	orgResolver             orgresolver.OrgResolver // optional; nil if the node isn't configured to resolve orgs (e.g. no Linking Service)
 }
 
 type HTTPTriggerHandler interface {
@@ -75,7 +77,7 @@ type HTTPTriggerHandler interface {
 	HandleNodeTriggerResponse(ctx context.Context, resp *jsonrpc.Response[json.RawMessage], nodeAddr string) error
 }
 
-func NewHTTPTriggerHandler(lggr logger.Logger, cfg ServiceConfig, shards []*shardEndpoint, nodeAddrToShard map[string]*shardEndpoint, workflowMetadataHandler *WorkflowMetadataHandler, userRateLimiter limits.RateLimiter, metrics *metrics.Metrics) *httpTriggerHandler {
+func NewHTTPTriggerHandler(lggr logger.Logger, cfg ServiceConfig, shards []*shardEndpoint, nodeAddrToShard map[string]*shardEndpoint, workflowMetadataHandler *WorkflowMetadataHandler, userRateLimiter limits.RateLimiter, metrics *metrics.Metrics, orgResolver orgresolver.OrgResolver) *httpTriggerHandler {
 	return &httpTriggerHandler{
 		lggr:                    logger.Named(lggr, "RequestCallbacks"),
 		callbacks:               make(map[string]savedCallback),
@@ -86,6 +88,7 @@ func NewHTTPTriggerHandler(lggr logger.Logger, cfg ServiceConfig, shards []*shar
 		workflowMetadataHandler: workflowMetadataHandler,
 		userRateLimiter:         userRateLimiter,
 		metrics:                 metrics,
+		orgResolver:             orgResolver,
 	}
 }
 
@@ -372,6 +375,20 @@ func (h *httpTriggerHandler) authorizeRequest(ctx context.Context, workflowID st
 	return key, nil
 }
 
+// resolveOrgID resolves the organization ID for owner, or returns "" if it can't be resolved
+func (h *httpTriggerHandler) resolveOrgID(ctx context.Context, owner string) string {
+	if h.orgResolver == nil {
+		h.lggr.Warnw("OrgResolver is nil, continuing without an orgID", "workflowOwner", owner)
+		return ""
+	}
+	orgID, err := h.orgResolver.Get(ctx, owner)
+	if err != nil {
+		h.lggr.Warnw("Failed to resolve organization ID, continuing without it", "workflowOwner", owner, "err", err)
+		return ""
+	}
+	return orgID
+}
+
 func (h *httpTriggerHandler) checkRateLimit(ctx context.Context, workflowID, requestID string, callback handlers.Callback) error {
 	workflowRef, found := h.workflowMetadataHandler.GetWorkflowReference(workflowID)
 	if !found {
@@ -379,8 +396,8 @@ func (h *httpTriggerHandler) checkRateLimit(ctx context.Context, workflowID, req
 		return errors.New("workflow reference not found")
 	}
 
-	// TODO orgID https://smartcontract-it.atlassian.net/browse/CRE-1707
-	ctx = contexts.WithCRE(ctx, contexts.CRE{Owner: workflowRef.workflowOwner, Workflow: workflowID})
+	orgID := h.resolveOrgID(ctx, workflowRef.workflowOwner)
+	ctx = contexts.WithCRE(ctx, contexts.CRE{Owner: workflowRef.workflowOwner, Org: orgID, Workflow: workflowID})
 	if err := h.userRateLimiter.AllowErr(ctx); err != nil {
 		lggr := logger.With(h.lggr, platform.KeyWorkflowID, workflowID, platform.KeyWorkflowOwner, workflowRef.workflowOwner, "requestID", requestID, "err", err)
 		if errLimited, ok := errors.AsType[limits.ErrorRateLimited](err); ok {

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
@@ -17,6 +17,9 @@ import (
 
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	gateway_common "github.com/smartcontractkit/chainlink-common/pkg/types/gateway"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows"
@@ -943,7 +946,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_DeliversOnlyToRegisteredSha
 	require.NoError(t, err)
 	metadataHandler := NewWorkflowMetadataHandler(lggr, cfg, shards, nodeAddrToShard, testMetrics)
 	userRateLimiter := createTestUserRateLimiter()
-	handler := NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, testMetrics)
+	handler := NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, testMetrics, nil)
 
 	privateKey := createTestPrivateKey(t)
 	// Register workflow X on exactly 2 of the 3 shards (shard0 and shard1).
@@ -1863,7 +1866,7 @@ func newTestTriggerHandler(t *testing.T, lggr logger.Logger, cfg ServiceConfig, 
 		threshold := shard.f + 1
 		metadataHandler.aggs[shard.donID] = aggregation.NewWorkflowMetadataAggregator(metadataHandler.lggr, threshold, time.Duration(cfg.CleanUpPeriodMs)*time.Millisecond, testMetrics)
 	}
-	return NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, testMetrics)
+	return NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, testMetrics, nil)
 }
 
 func createTestTriggerHandler(t *testing.T) (*httpTriggerHandler, *handlermocks.DON) {
@@ -1901,7 +1904,7 @@ func createTestTriggerHandlerWithConfig(t *testing.T, cfg ServiceConfig) (*httpT
 
 	metadataHandler := NewWorkflowMetadataHandler(lggr, WithDefaults(cfg), shards, nodeAddrToShard, testMetrics)
 	userRateLimiter := createTestUserRateLimiter()
-	handler := NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, testMetrics)
+	handler := NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, testMetrics, nil)
 	return handler, mockDon
 }
 
@@ -2015,6 +2018,88 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_RateLimiting(t *testing.T) 
 		require.NoError(t, err)
 		requireUserErrorSent(t, r, jsonrpc.ErrLimitExceeded)
 	})
+}
+
+// stubOrgResolver is a minimal orgresolver.OrgResolver for tests: it maps owners to
+// orgs from a static table and never fails.
+type stubOrgResolver struct {
+	services.Service
+	orgByOwner map[string]string
+}
+
+func (s *stubOrgResolver) Get(_ context.Context, owner string) (string, error) {
+	return s.orgByOwner[owner], nil
+}
+
+// TestHttpTriggerHandler_CheckRateLimit_PerOrgOverride proves that a rate limit defined
+// at the org scope via settings (not hardcoded) is actually enforced end-to-end: the
+// handler resolves org through its OrgResolver and attaches it to the context, and the
+// settings hierarchy (workflow -> owner -> org -> global, see chainlink-common's
+// settings.Scope.rawKeys) then picks up an org-only override for a PerWorkflow-scoped
+// setting that has no workflow- or owner-level override of its own.
+func TestHttpTriggerHandler_CheckRateLimit_PerOrgOverride(t *testing.T) {
+	t.Parallel()
+
+	const (
+		restrictedOrg   = "org-restricted"
+		restrictedOwner = "0x1111111111111111111111111111111111aaaa"
+		restrictedWfID  = "0x1111"
+		normalOrg       = "org-normal"
+		normalOwner     = "0x2222222222222222222222222222222222bbbb"
+		normalWfID      = "0x2222"
+	)
+
+	// Only org-restricted gets an override (burst 0: deny everything); org-normal (and
+	// everything else) falls through to the global default (every 30s, burst 3).
+	getter, err := settings.NewJSONGetter([]byte(`{
+		"org": {
+			"org-restricted": {
+				"PerWorkflow": {
+					"HTTPTrigger": {
+						"RateLimit": "every1h:0"
+					}
+				}
+			}
+		}
+	}`))
+	require.NoError(t, err)
+
+	rateLimiter, err := limits.Factory{Settings: getter}.MakeRateLimiter(cresettings.Default.PerWorkflow.HTTPTrigger.RateLimit)
+	require.NoError(t, err)
+
+	orgResolver := &stubOrgResolver{orgByOwner: map[string]string{
+		restrictedOwner: restrictedOrg,
+		normalOwner:     normalOrg,
+	}}
+
+	metadataHandler := createTestMetadataHandler(t)
+	metadataHandler.workflowIDToRef[restrictedWfID] = workflowReference{workflowOwner: restrictedOwner, workflowName: "wf-restricted", workflowTag: "v1"}
+	metadataHandler.workflowIDToRef[normalWfID] = workflowReference{workflowOwner: normalOwner, workflowName: "wf-normal", workflowTag: "v1"}
+
+	testMetrics := createTestMetrics(t, &config.DONConfig{Members: []config.NodeConfig{{Address: "node1"}}})
+	handler := NewHTTPTriggerHandler(logger.Test(t), WithDefaults(ServiceConfig{}), nil, nil, metadataHandler, rateLimiter, testMetrics, orgResolver)
+
+	// The first check for each workflow creates its per-workflow-tenant limiter, seeded
+	// with the global default (burst 3) until the settings-backed value is first polled.
+	require.NoError(t, handler.checkRateLimit(t.Context(), restrictedWfID, "req-1", hc.NewCallback()))
+	require.NoError(t, handler.checkRateLimit(t.Context(), normalWfID, "req-2", hc.NewCallback()))
+
+	// chainlink-common's scoped RateLimiter refreshes settings-sourced values on a fixed
+	// poll interval (pkg/settings/limits.pollPeriod = 5s); wait past it so the org
+	// override is picked up. Deliberately not checking again in the meantime: that would
+	// burn through the default burst and could deny the next check for the wrong reason.
+	time.Sleep(6 * time.Second)
+
+	// org-restricted's override (burst 0) is now active: denied.
+	callback := hc.NewCallback()
+	err = handler.checkRateLimit(t.Context(), restrictedWfID, "req-3", callback)
+	require.Error(t, err)
+	payload, waitErr := callback.Wait(t.Context())
+	require.NoError(t, waitErr)
+	requireUserErrorSent(t, payload, jsonrpc.ErrLimitExceeded)
+
+	// org-normal has no override and still has burst left over from the global default: allowed.
+	require.NoError(t, handler.checkRateLimit(t.Context(), normalWfID, "req-4", hc.NewCallback()))
 }
 
 func TestHttpTriggerHandler_HandleUserTriggerRequest_StopsRetriesOnQuorum(t *testing.T) {
@@ -2170,7 +2255,7 @@ func createMultiShardTriggerHandler(t *testing.T, donName string, shardNodeSets 
 	require.NoError(t, err)
 	metadataHandler := NewWorkflowMetadataHandler(lggr, cfg, shards, nodeAddrToShard, testMetrics)
 	userRateLimiter := createTestUserRateLimiter()
-	handler := NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, testMetrics)
+	handler := NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, testMetrics, nil)
 	return handler, mockDons, shards
 }
 
@@ -2383,7 +2468,7 @@ func TestHttpTriggerHandler_MultiShardSendFailureResilience(t *testing.T) {
 	require.NoError(t, err)
 	metadataHandler := NewWorkflowMetadataHandler(lggr, cfg, shards, nodeAddrToShard, testMetrics)
 	userRateLimiter := createTestUserRateLimiter()
-	handler := NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, testMetrics)
+	handler := NewHTTPTriggerHandler(lggr, cfg, shards, nodeAddrToShard, metadataHandler, userRateLimiter, testMetrics, nil)
 
 	privateKey := createTestPrivateKey(t)
 	registerWorkflowOnShards(t, handler, workflowID, privateKey, shards[0], shards[1])

--- a/core/services/gateway/integration_tests/gateway_integration_test.go
+++ b/core/services/gateway/integration_tests/gateway_integration_test.go
@@ -189,7 +189,7 @@ func TestIntegration_Gateway_NoFullNodes_BasicConnectionAndMessage(t *testing.T)
 	}, lggr)
 	require.NoError(t, err)
 	lf := limits.Factory{Logger: lggr}
-	gateway, err := gateway.NewGatewayFromConfig(parseGatewayConfig(t, gatewayConfig), gateway.NewHandlerFactory(nil, nil, c, nil, nil, lggr, lf, nil), lggr, lf)
+	gateway, err := gateway.NewGatewayFromConfig(parseGatewayConfig(t, gatewayConfig), gateway.NewHandlerFactory(nil, nil, c, nil, nil, lggr, lf, nil, nil), lggr, lf)
 	require.NoError(t, err)
 	servicetest.Run(t, gateway)
 	userPort, nodePort := gateway.GetUserPort(), gateway.GetNodePort()


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/CRE-6399

Deployment Validation: 
1. Check dashboard: Limits: Workflow -> HTTPTrigger_RateLimit
2. Expect all limits to stay the same or go up. NOT go down.
3. Once LinkingService is configured for Gateway, confirm there are no logs "OrgResolver is nil, continuing without an orgID" or "Failed to resolve organization".