### PR TITLE
Bump confidential compute plugins

### DIFF
--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -118,10 +118,10 @@ plugins:
 
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "34bb6309846ca29a7b36863a73f79626e068d810"
+      gitRef: "a9b2fdf09d03621b7b1996a60fbf5b1a0b7a42a6"
       installPath: "./cmd/confidential-http"
 
   confidential-workflows:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-workflows/capability"
-      gitRef: "34bb6309846ca29a7b36863a73f79626e068d810"
+      gitRef: "a9b2fdf09d03621b7b1996a60fbf5b1a0b7a42a6"
       installPath: "./cmd/confidential-workflows"

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -118,10 +118,10 @@ plugins:
 
   confidential-http:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-http/capability"
-      gitRef: "5e2ebc6d53d8e8db466048c8fd34e38dffff2b4c"
+      gitRef: "34bb6309846ca29a7b36863a73f79626e068d810"
       installPath: "./cmd/confidential-http"
 
   confidential-workflows:
     - moduleURI: "github.com/smartcontractkit/chainlink-confidential-compute/enclave/apps/confidential-workflows/capability"
-      gitRef: "5e2ebc6d53d8e8db466048c8fd34e38dffff2b4c"
+      gitRef: "34bb6309846ca29a7b36863a73f79626e068d810"
       installPath: "./cmd/confidential-workflows"


### PR DESCRIPTION
Points to the tip of release 1.4.3: https://github.com/smartcontractkit/chainlink-confidential-compute/commits/release/1.4.3/