### PR TITLE
Add bridge-cache fallback for UseConnectionManager bridge tasks

### DIFF
--- a/.changeset/sharp-garlics-cry.md
+++ b/.changeset/sharp-garlics-cry.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#added add bridge-cache fallback for UseConnectionManager bridge tasks

--- a/core/services/pipeline/task.bridge.go
+++ b/core/services/pipeline/task.bridge.go
@@ -190,6 +190,15 @@ func (t *BridgeTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, inp
 		promBridgeLatency.WithLabelValues(t.Name, statusCodeGroup(statusCode)).Set(elapsed.Seconds())
 		promBridgeLatencyHist.WithLabelValues(t.Name, statusCodeGroup(statusCode)).Observe(float64(elapsed.Milliseconds()))
 
+		// Reuse the same cache-fallback path as the HTTP flow.
+		out := bridgeHTTPOutcome{
+			body:           responseBytes,
+			statusCode:     statusCode,
+			err:            obsErr,
+			cachedResponse: false,
+		}
+		out, earlyResult, earlyRunInfo := t.resolveFailureOrCache(overtimeCtx, lggr, url, out, cacheTTL)
+
 		if telemetryCh := GetTelemetryCh(ctx); telemetryCh != nil {
 			requestDataJSON, jsonErr := json.Marshal(lookupPayload)
 			if jsonErr != nil {
@@ -198,16 +207,17 @@ func (t *BridgeTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, inp
 			bt := &BridgeTelemetry{
 				Name:                   t.Name,
 				RequestData:            requestDataJSON,
-				ResponseData:           responseBytes,
-				ResponseStatusCode:     statusCode,
+				ResponseData:           out.body,
+				ResponseStatusCode:     out.statusCode,
+				LocalCacheHit:          out.cachedResponse,
 				RequestStartTimestamp:  start,
 				RequestFinishTimestamp: finish,
 				SpecID:                 t.specID,
 				DotID:                  t.DotID(),
 			}
-			if obsErr != nil {
+			if out.err != nil {
 				bt.ResponseError = new(string)
-				*bt.ResponseError = obsErr.Error()
+				*bt.ResponseError = out.err.Error()
 			}
 
 			bt.resolveStreamID(t, vars, lggr)
@@ -219,15 +229,24 @@ func (t *BridgeTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, inp
 			}
 		}
 
-		if obsErr != nil {
+		if earlyResult != nil {
 			lggr.Debugw("Bridge task: connection manager request failed",
-				"response", string(responseBytes),
+				"response", string(out.body),
 				"url", url.String(),
-				"error", obsErr,
+				"error", out.err,
 			)
-			return Result{Error: obsErr}, RunInfo{IsRetryable: true}
+			return *earlyResult, *earlyRunInfo
 		}
-		return Result{Value: string(responseBytes)}, runInfo
+
+		// Persist successful connection-manager responses so future failures can
+		// fall back to them.
+		if !out.cachedResponse && cacheTTL > 0 {
+			if upsertErr := t.orm.UpsertBridgeResponse(overtimeCtx, t.dotID, t.specID, out.body); upsertErr != nil {
+				lggr.Errorw("Bridge task: failed to upsert response in bridge cache", "err", upsertErr)
+			}
+		}
+
+		return Result{Value: string(out.body)}, runInfo
 	}
 
 	requestDataJSON, err := t.finalizeAndMarshalBridgeRequestData(lggr, vars, inputValues, &requestData, includeInputAtKey)

--- a/core/services/pipeline/task.bridge_test.go
+++ b/core/services/pipeline/task.bridge_test.go
@@ -323,6 +323,69 @@ func TestBridgeTask_UsesBridgeConnManagerHappyPath(t *testing.T) {
 	assert.Equal(t, int32(0), httpCalls.Load())
 }
 
+func TestBridgeTask_UsesBridgeConnManagerCacheFallback(t *testing.T) {
+	t.Parallel()
+
+	db := pgtest.NewSqlxDB(t)
+	cfg := configtest.NewTestGeneralConfig(t)
+
+	var httpCalls atomic.Int32
+	s1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpCalls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer s1.Close()
+
+	feedURL, err := url.ParseRequestURI(s1.URL)
+	require.NoError(t, err)
+
+	orm := bridges.NewORM(db)
+	_, bridge := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{
+		URL:                  feedURL.String(),
+		UseConnectionManager: true,
+	})
+
+	manager := bridgeconn.NewBridgeConnManager(logger.TestLogger(t))
+	seedable, ok := manager.(interface {
+		DisableEAConnDialingForTest()
+	})
+	require.True(t, ok)
+	seedable.DisableEAConnDialingForTest()
+
+	task := pipeline.BridgeTask{
+		BaseTask:    pipeline.NewBaseTask(0, "bridge", nil, nil, 0),
+		Name:        bridge.Name.String(),
+		RequestData: btcUSDPairing,
+		CacheTTL:    "30s",
+	}
+	c := clhttptest.NewTestLocalOnlyHTTPClient()
+	trORM := pipeline.NewORM(db, logger.TestLogger(t), cfg.JobPipeline().MaxSuccessfulRuns())
+	specID, err := trORM.CreateSpec(t.Context(), pipeline.Pipeline{}, *sqlutil.NewInterval(5 * time.Minute))
+	require.NoError(t, err)
+	task.HelperSetDependencies(cfg.JobPipeline(), cfg.WebServer(), orm, specID, uuid.UUID{}, c)
+	task.HelperSetBridgeConnManager(manager)
+
+	telemCh := make(chan any, 1)
+	ctx := pipeline.WithTelemetryCh(t.Context(), telemCh)
+
+	// No observation in the connection manager, so the live lookup will fail.
+	// Seed the bridge cache directly so the task can fall back to it.
+	require.NoError(t, orm.UpsertBridgeResponse(ctx, task.DotID(), specID, []byte(`{"data":{"result":"9700"}}`)))
+
+	result, runInfo := task.Run(ctx, logger.TestLogger(t), pipeline.NewVarsFrom(nil), nil)
+
+	assert.False(t, runInfo.IsPending)
+	assert.False(t, runInfo.IsRetryable)
+	require.NoError(t, result.Error)
+	assert.JSONEq(t, `{"data":{"result":"9700"}}`, result.Value.(string))
+	assert.Equal(t, int32(0), httpCalls.Load())
+
+	telem := <-telemCh
+	require.IsType(t, &pipeline.BridgeTelemetry{}, telem)
+	btelem := telem.(*pipeline.BridgeTelemetry)
+	assert.True(t, btelem.LocalCacheHit)
+}
+
 func TestBridgeTask_HandlesIntermittentFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Bridge tasks that use the connection-manager (`UseConnectionManager`) previously returned an error immediately when the in-memory observation was unavailable or expired. This PR makes them fall back to the persisted bridge response cache, matching the behavior of the HTTP bridge path.

## Changes

- `core/services/pipeline/task.bridge.go`
  - Reuse the existing `resolveFailureOrCache` helper for connection-manager failures instead of duplicating cache fallback logic.
  - Persist successful connection-manager responses to the bridge cache when `cacheTTL > 0`, so subsequent failures can fall back to them.
  - Emit telemetry after the fallback decision so `LocalCacheHit` and `ResponseData` reflect the final response.

- `core/services/pipeline/task.bridge_test.go`
  - Add `TestBridgeTask_UsesBridgeConnManagerCacheFallback` to verify that a missing observation is resolved from the seeded bridge cache and that telemetry reports the cache hit.

## Testing

- `go test ./core/services/pipeline -run TestBridgeTask_` passes.
- `go test ./core/services/pipeline` passes.