### PR TITLE
bumping aptos for non-evm billing

### DIFF
--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -108,7 +108,7 @@ plugins:
 
   capability-aptos:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/aptos"
-      gitRef: "0de7433796544b33fd29c66d592b3a913d59f7e2"
+      gitRef: "977e430d6ff4db1fba42a4d8a20bc92c8b2ceaba"
       installPath: "."
 
   capability-stellar:


### PR DESCRIPTION
Pulls in https://github.com/smartcontractkit/capabilities/commit/977e430d6ff4db1fba42a4d8a20bc92c8b2ceaba from Aug 21. EVM + Sol have been bumped to Sep 2, so they already include the fields we need to avoid treating them as evm-like num of decimals (18). Apt has 8 decimals, for instance.
