### PR TITLE
docs: bump README install Go version to 1.26.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ regarding Chainlink social accounts, news, and networking.
 
 ## Build Chainlink
 
-1. [Install Go 1.26.5](https://golang.org/doc/install), and add your GOPATH's [bin directory to your PATH](https://golang.org/doc/code.html#GOPATH)
+1. [Install Go 1.26.7](https://golang.org/doc/install), and add your GOPATH's [bin directory to your PATH](https://golang.org/doc/code.html#GOPATH)
    - Example Path for macOS `export PATH=$GOPATH/bin:$PATH` & `export GOPATH=/Users/$USER/go`
 2. Install [NodeJS v20](https://nodejs.org/en/download/package-manager/) & [pnpm v10 via npm](https://pnpm.io/installation#using-npm).
    - It might be easier long term to use [nvm](https://nodejs.org/en/download/package-manager/#nvm) to switch between node versions for different projects. For example, assuming $NODE_VERSION was set to a valid version of NodeJS, you could run: `nvm install $NODE_VERSION && nvm use $NODE_VERSION`


### PR DESCRIPTION
## Summary
README Build step still says Install Go 1.26.5, but tip `go.mod` / `.tool-versions` / Dockerfile use **1.26.7** (bumped in #23614 without updating README).

## Repro
```bash
TIP=3e5d31a999baebaecc559c006133bd7530891a5d
curl -sL https://raw.githubusercontent.com/smartcontractkit/chainlink/$TIP/README.md | rg -n 'Install Go'
curl -sL https://raw.githubusercontent.com/smartcontractkit/chainlink/$TIP/go.mod | head -3
curl -sL https://raw.githubusercontent.com/smartcontractkit/chainlink/$TIP/.tool-versions | head -1
```

## Change
`README.md`: `Install Go 1.26.5` → `Install Go 1.26.7`.
