### PR TITLE
fix(ci): integration-tests compile races and required-check gating

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -655,8 +655,23 @@ jobs:
           mkdir -p "$GITHUB_WORKSPACE/.gotmp"
           export GOTMPDIR="$GITHUB_WORKSPACE/.gotmp"
 
+          # Restored mod cache contains shallow VCS clones that can be in an
+          # inconsistent state after tar restore, breaking fetches of new
+          # pseudo-versions ("shallow file has changed since we read it").
+          # Drop them; only private repos re-clone, public zips stay cached.
+          rm -rf "$(go env GOMODCACHE)/cache/vcs"
+
           mkdir -p "$GITHUB_WORKSPACE/system-tests/tests/bin"
           mkdir -p "$GITHUB_WORKSPACE/integration-tests/bin"
+
+          # Pre-download dependencies sequentially to prevent parallel git fetch races
+          go mod download
+          if [[ "${SHOULD_RUN_CRE}" == "true" ]]; then
+            (cd "$GITHUB_WORKSPACE/system-tests/tests" && go mod download)
+          fi
+          if [[ "${SHOULD_RUN_CCIP}" == "true" ]]; then
+            (cd "$GITHUB_WORKSPACE/integration-tests" && go mod download)
+          fi
 
           cre_pid=""
           ccip_pid=""
@@ -666,7 +681,6 @@ jobs:
               set -euo pipefail
               echo "Compiling CRE tests and CLI in parallel..."
               cd "$GITHUB_WORKSPACE/system-tests/tests"
-              go mod download
               go test -c -ldflags="-s -w" -o ./bin/cre-smoke.test ./smoke/cre &
               p1=$!
               go test -c -ldflags="-s -w" -o ./bin/cre-regression.test ./regression/cre &
@@ -691,7 +705,6 @@ jobs:
               set -euo pipefail
               echo "Compiling CCIP tests in parallel..."
               cd "$GITHUB_WORKSPACE/integration-tests"
-              go mod download
               go test -c -tags embed -ldflags="-s -w" -o ./bin/ccip-smoke.test ./smoke/ccip
             ) &
             ccip_pid=$!

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -305,7 +305,7 @@ jobs:
               }}
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners
-        uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc # v2.2.0
+        uses: runs-on/action@efac073ea2507ec18797de3a81704201ade11d9d # v2.3.1
 
       - name: Check if image exists in ECR
         id: check-image-exists
@@ -611,7 +611,7 @@ jobs:
       contents: read
     steps:
       - name: Enable S3 Cache for Self-Hosted Runners
-        uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc # v2.2.0
+        uses: runs-on/action@efac073ea2507ec18797de3a81704201ade11d9d # v2.3.1
 
       - name: Setup GitHub token using GATI
         id: github-token
@@ -645,15 +645,13 @@ jobs:
 
       # No cache-hit short-circuit: ctf-setup-go@v0.4.0 exposes no `cache-hit` output,
       # and this job's purpose is to (re)populate the shared build cache regardless.
-      - name: Compile E2E tests
+      - name: Prep Go module cache & workspace
         shell: bash
-        env:
-          SHOULD_RUN_CRE: ${{ needs.run-core-cre-e2e-tests-setup.outputs.should-run }}
-          SHOULD_RUN_CCIP: ${{ needs.run-ccip-v1-6-e2e-tests-setup.outputs.should-run }}
         run: |
           set -euo pipefail
           mkdir -p "$GITHUB_WORKSPACE/.gotmp"
-          export GOTMPDIR="$GITHUB_WORKSPACE/.gotmp"
+          mkdir -p "$GITHUB_WORKSPACE/system-tests/tests/bin"
+          mkdir -p "$GITHUB_WORKSPACE/integration-tests/bin"
 
           # Restored mod cache contains shallow VCS clones that can be in an
           # inconsistent state after tar restore, breaking fetches of new
@@ -661,59 +659,47 @@ jobs:
           # Drop them; only private repos re-clone, public zips stay cached.
           rm -rf "$(go env GOMODCACHE)/cache/vcs"
 
-          mkdir -p "$GITHUB_WORKSPACE/system-tests/tests/bin"
-          mkdir -p "$GITHUB_WORKSPACE/integration-tests/bin"
-
           # Pre-download dependencies sequentially to prevent parallel git fetch races
           go mod download
-          if [[ "${SHOULD_RUN_CRE}" == "true" ]]; then
+          if [[ "${{ needs.run-core-cre-e2e-tests-setup.outputs.should-run }}" == "true" ]]; then
             (cd "$GITHUB_WORKSPACE/system-tests/tests" && go mod download)
           fi
-          if [[ "${SHOULD_RUN_CCIP}" == "true" ]]; then
+          if [[ "${{ needs.run-ccip-v1-6-e2e-tests-setup.outputs.should-run }}" == "true" ]]; then
             (cd "$GITHUB_WORKSPACE/integration-tests" && go mod download)
           fi
 
-          cre_pid=""
-          ccip_pid=""
+      - parallel:
+          - name: Compile CRE smoke test
+            if: needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'
+            working-directory: system-tests/tests
+            env:
+              GOTMPDIR: ${{ github.workspace }}/.gotmp
+            run: go test -c -ldflags="-s -w" -o ./bin/cre-smoke.test ./smoke/cre
 
-          if [[ "${SHOULD_RUN_CRE}" == "true" ]]; then
-            (
-              set -euo pipefail
-              echo "Compiling CRE tests and CLI in parallel..."
-              cd "$GITHUB_WORKSPACE/system-tests/tests"
-              go test -c -ldflags="-s -w" -o ./bin/cre-smoke.test ./smoke/cre &
-              p1=$!
-              go test -c -ldflags="-s -w" -o ./bin/cre-regression.test ./regression/cre &
-              p2=$!
-              (cd "$GITHUB_WORKSPACE/core/scripts/cre/environment" && go build -ldflags="-s -w" -o "$GITHUB_WORKSPACE/system-tests/tests/bin/cre-env" .) &
-              p3=$!
-              set +e
-              wait "$p1"; p1_exit=$?
-              wait "$p2"; p2_exit=$?
-              wait "$p3"; p3_exit=$?
-              set -e
-              if [[ "$p1_exit" -ne 0 || "$p2_exit" -ne 0 || "$p3_exit" -ne 0 ]]; then
-                echo "Compilation failed (cre-smoke=$p1_exit, cre-regression=$p2_exit, cre-env=$p3_exit)" >&2
-                exit 1
-              fi
-            ) &
-            cre_pid=$!
-          fi
+          - name: Compile CRE regression test
+            if: needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'
+            working-directory: system-tests/tests
+            env:
+              GOTMPDIR: ${{ github.workspace }}/.gotmp
+            run: go test -c -ldflags="-s -w" -o ./bin/cre-regression.test ./regression/cre
 
-          if [[ "${SHOULD_RUN_CCIP}" == "true" ]]; then
-            (
-              set -euo pipefail
-              echo "Compiling CCIP tests in parallel..."
-              cd "$GITHUB_WORKSPACE/integration-tests"
-              go test -c -tags embed -ldflags="-s -w" -o ./bin/ccip-smoke.test ./smoke/ccip
-            ) &
-            ccip_pid=$!
-          fi
+          - name: Compile CRE environment CLI
+            if: needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'
+            working-directory: core/scripts/cre/environment
+            env:
+              GOTMPDIR: ${{ github.workspace }}/.gotmp
+            run: go build -ldflags="-s -w" -o "$GITHUB_WORKSPACE/system-tests/tests/bin/cre-env" .
 
-          if [ -n "$cre_pid" ]; then wait "$cre_pid"; fi
-          if [ -n "$ccip_pid" ]; then wait "$ccip_pid"; fi
+          - name: Compile CCIP smoke test
+            if: needs.run-ccip-v1-6-e2e-tests-setup.outputs.should-run == 'true'
+            working-directory: integration-tests
+            env:
+              GOTMPDIR: ${{ github.workspace }}/.gotmp
+            run: go test -c -tags embed -ldflags="-s -w" -o ./bin/ccip-smoke.test ./smoke/ccip
 
-          rm -rf "$GITHUB_WORKSPACE/.gotmp"
+      - name: Cleanup tempdir
+        if: always()
+        run: rm -rf "$GITHUB_WORKSPACE/.gotmp"
 
       - name: Cache Pre-Compiled CRE Test Binaries
         if: needs.run-core-cre-e2e-tests-setup.outputs.should-run == 'true'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -647,6 +647,8 @@ jobs:
       # and this job's purpose is to (re)populate the shared build cache regardless.
       - name: Prep Go module cache & workspace
         shell: bash
+        env:
+          GOTMPDIR: ${{ github.workspace }}/.gotmp
         run: |
           set -euo pipefail
           mkdir -p "$GITHUB_WORKSPACE/.gotmp"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -756,6 +756,7 @@ jobs:
     needs:
       [
         build-chainlink,
+        compile-tests,
         run-ccip-v1-6-e2e-tests,
         run-core-cre-e2e-tests,
         run-core-cre-e2e-regression-tests,
@@ -765,6 +766,7 @@ jobs:
       - name: Check all E2E test results
         if: always()
         env:
+          COMPILE_RESULT: ${{ needs.compile-tests.result }}
           CCIP_RESULT: ${{ needs.run-ccip-v1-6-e2e-tests.result }}
           CRE_RESULT: ${{ needs.run-core-cre-e2e-tests.result }}
           CRE_REGRESSION_RESULT: ${{ needs.run-core-cre-e2e-regression-tests.result }}
@@ -790,6 +792,7 @@ jobs:
           }
 
           failed=0
+          check_result "Compile tests" "${COMPILE_RESULT}" || failed=1
           check_result "CCIP v1.6 E2E tests" "${CCIP_RESULT}" || failed=1
           check_result "Core CRE E2E tests" "${CRE_RESULT}" || failed=1
           check_result "Core CRE E2E regression tests" "${CRE_REGRESSION_RESULT}" || failed=1


### PR DESCRIPTION
# Fix integration-tests compile races and required-check gating

## Intent

Fix two bugs in the `integration-tests.yml` compile job: parallel test compilations racing on git fetches and shared VCS locks, and compile failures being invisible to the required check that gates the workflow.

## Big Changes

### Sequential dependency downloads and VCS cache cleanup

The `compile-tests` job now drops the restored Go module VCS cache (`$GOMODCACHE/cache/vcs`) and pre-downloads all module dependencies sequentially before launching the parallel test compilations.

The restored mod cache contains shallow VCS clones that can be in an inconsistent state after tar restore, breaking fetches of new pseudo-versions with `shallow file has changed since we read it`. Dropping them means only private repos re-clone; public zips stay cached. With dependencies pre-resolved, the parallel compilations no longer race on git fetches or VCS locks, which previously caused intermittent compile failures.

### Parallel compile steps via native `parallel:`

The compile job now uses GitHub Actions' native `parallel:` step group to run the CRE smoke, CRE regression, CRE environment CLI, and CCIP smoke compilations concurrently, replacing hand-rolled shell background jobs with manual `wait` and exit-code plumbing.

The native construct provides built-in failure propagation (a failed compile fails the job at the implicit wait), per-step logs, and per-step `if:` conditions, which is simpler and more debuggable than the previous subshell approach.

### Compile tests join the required check

`compile-tests` is now a dependency of the `check-e2e-test-results` gate job, and its result is checked alongside the E2E suites.

Previously a compile failure did not fail the required check, so a broken build could be masked by the test jobs' results (skipped or passing) and land on develop.

## Small Changes

- `rm -rf "$(go env GOMODCACHE)/cache/vcs"` runs before any compilation starts.
- `GOTMPDIR` is set on the prep step as well as each compile step, so `go mod download` tmp writes go to the workspace `.gotmp` dir instead of system tmp.
- Temp dir cleanup is now a separate `if: always()` step, so it runs even when a compile fails.
- `runs-on/action` bumped from v2.2.0 to v2.3.1 in both jobs that enable the S3 cache.

## Callouts

- **Compile gating semantics**: `check-e2e-test-results` treats a skipped `compile-tests` as a non-blocking warning (same as the test jobs), but a failure now fails the check. Confirm that matches expectations for PRs where no E2E suites trigger.
- **VCS cache drop tradeoff**: private-repo pseudo-versions re-clone on every run. This is cheap relative to the flaky `shallow file has changed` failures it eliminates, but worth watching if compile times regress.
- **New `parallel:` feature**: the step-level `parallel` key is a recent GitHub Actions addition (June 2026). Behavior of skipped sub-steps inside the group and failure propagation at the implicit wait should be watched on the first merge-queue or labeled runs.
