### PR TITLE
Handle missing chains and report error

### DIFF
--- a/core/services/ccv/ccvcommitteeverifier/delegate.go
+++ b/core/services/ccv/ccvcommitteeverifier/delegate.go
@@ -91,9 +91,22 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) (services 
 		}
 		chainsInConfig = append(chainsInConfig, protocol.ChainSelector(parsed))
 	}
-	legacyChains, err := ccvcommon.GetLegacyChains(ctx, d.lggr, d.chainServices, chainsInConfig)
+	legacyChains, missingChains, err := ccvcommon.GetLegacyChains(ctx, d.lggr, d.chainServices, chainsInConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get legacy chains: %w", err)
+	}
+
+	missingChainsMonitor, err := ccvcommon.NewMissingChainsMonitor(
+		d.lggr,
+		"CCVCommitteeVerifier/"+decodedCfg.VerifierID,
+		missingChains,
+		ccvcommon.DefaultMissingChainsReportInterval,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create missing chains monitor: %w", err)
+	}
+	if missingChainsMonitor != nil {
+		services = append(services, missingChainsMonitor)
 	}
 
 	signingKeys, err := d.ocrKs.GetAllOfType(corekeys.EVM)

--- a/core/services/ccv/ccvcommon/common.go
+++ b/core/services/ccv/ccvcommon/common.go
@@ -3,7 +3,6 @@ package ccvcommon
 import (
 	"context"
 	"fmt"
-	"maps"
 	"slices"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
@@ -14,17 +13,34 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
-func GetLegacyChains(ctx context.Context, lggr logger.Logger, chainServices []commontypes.ChainService, chainsInConfig []protocol.ChainSelector) (map[protocol.ChainSelector]legacyevm.Chain, error) {
+// GetLegacyChains maps the chain services of the node to the chain selectors in the job
+// configuration. A chain service that the node cannot use is skipped, not an error, so that one
+// bad chain does not stop the whole job.
+//
+// The second return value holds the chain selectors from chainsInConfig that have no chain object.
+// Give this list to NewMissingChainsMonitor so that operators get a repeated alarm.
+//
+// An error occurs only when no chain in the configuration has a chain object, because a job with
+// no chains cannot do work.
+func GetLegacyChains(
+	ctx context.Context,
+	lggr logger.Logger,
+	chainServices []commontypes.ChainService,
+	chainsInConfig []protocol.ChainSelector,
+) (map[protocol.ChainSelector]legacyevm.Chain, []protocol.ChainSelector, error) {
 	chains := make(map[protocol.ChainSelector]legacyevm.Chain)
 	for _, c := range chainServices {
 		chainInfo, err := c.GetChainInfo(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get chain info for chain %s: %w", c.Name(), err)
+			lggr.Warnw("skipping chain service: failed to get chain info", "chain", c.Name(), "err", err)
+			continue
 		}
 
 		chain, ok := c.(legacyevm.Chain)
 		if !ok {
-			return nil, fmt.Errorf("failed to cast chain service %s to legacyevm.Chain (info: %+v), LOOPP mode is currently not supported", c.Name(), chainInfo)
+			lggr.Warnw("skipping chain service: failed to cast to legacyevm.Chain, LOOPP mode is currently not supported",
+				"chain", c.Name(), "chainInfo", chainInfo)
+			continue
 		}
 
 		id := chain.ID()
@@ -32,7 +48,8 @@ func GetLegacyChains(ctx context.Context, lggr logger.Logger, chainServices []co
 		// convert to selector
 		chain2, ok := chainselectors.ChainByEvmChainID(id.Uint64())
 		if !ok {
-			return nil, fmt.Errorf("failed to get chain selector for chain %s", id.String())
+			lggr.Warnw("skipping chain service: failed to get chain selector", "chain", c.Name(), "chainID", id.String())
+			continue
 		}
 
 		if !slices.Contains(chainsInConfig, protocol.ChainSelector(chain2.Selector)) {
@@ -42,10 +59,25 @@ func GetLegacyChains(ctx context.Context, lggr logger.Logger, chainServices []co
 
 		chains[protocol.ChainSelector(chain2.Selector)] = chain
 	}
-	// check if we got all the chains in the configuration
-	if len(chains) != len(chainsInConfig) {
-		// Don't error out here because we still wanna run with whatever we got.
-		lggr.Warnw("did not get all the chains in the configuration", "want", chainsInConfig, "got", slices.Collect(maps.Keys(chains)))
+
+	missing := MissingChains(chainsInConfig, chains)
+
+	if len(chains) == 0 && len(chainsInConfig) > 0 {
+		return nil, nil, fmt.Errorf("no chain object is available for any of the %d chains in the configuration: %v",
+			len(chainsInConfig), chainsInConfig)
 	}
-	return chains, nil
+
+	return chains, missing, nil
+}
+
+// MissingChains returns the chain selectors in chainsInConfig that are not keys of chains.
+func MissingChains[V any](chainsInConfig []protocol.ChainSelector, chains map[protocol.ChainSelector]V) []protocol.ChainSelector {
+	var missing []protocol.ChainSelector
+	for _, sel := range chainsInConfig {
+		if _, ok := chains[sel]; !ok {
+			missing = append(missing, sel)
+		}
+	}
+	slices.Sort(missing)
+	return slices.Compact(missing)
 }

--- a/core/services/ccv/ccvcommon/common_test.go
+++ b/core/services/ccv/ccvcommon/common_test.go
@@ -52,6 +52,7 @@ func selectorFor(t *testing.T, chainID uint64) protocol.ChainSelector {
 }
 
 func TestGetLegacyChains(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	lggr := logger.TestLogger(t)
 
@@ -59,6 +60,7 @@ func TestGetLegacyChains(t *testing.T) {
 	polySel := selectorFor(t, polygonMainnetChainID)
 
 	t.Run("skips a chain whose chain info fails and keeps the others", func(t *testing.T) {
+		t.Parallel()
 		bad := evmmocks.NewChain(t)
 		bad.EXPECT().GetChainInfo(mockAnyCtx()).Return(commontypes.ChainInfo{}, errors.New("boom"))
 		bad.EXPECT().Name().Return("bad").Maybe()
@@ -75,6 +77,7 @@ func TestGetLegacyChains(t *testing.T) {
 	})
 
 	t.Run("skips a chain service that is not a legacyevm.Chain", func(t *testing.T) {
+		t.Parallel()
 		chains, missing, err := GetLegacyChains(ctx, lggr,
 			[]commontypes.ChainService{
 				&plainChainService{name: "loopp"},
@@ -88,6 +91,7 @@ func TestGetLegacyChains(t *testing.T) {
 	})
 
 	t.Run("reports a config chain that has no chain service", func(t *testing.T) {
+		t.Parallel()
 		chains, missing, err := GetLegacyChains(ctx, lggr,
 			[]commontypes.ChainService{newMockChain(t, ethereumMainnetChainID)},
 			[]protocol.ChainSelector{ethSel, polySel})
@@ -98,6 +102,7 @@ func TestGetLegacyChains(t *testing.T) {
 	})
 
 	t.Run("errors when no config chain resolves", func(t *testing.T) {
+		t.Parallel()
 		_, _, err := GetLegacyChains(ctx, lggr,
 			[]commontypes.ChainService{newMockChain(t, ethereumMainnetChainID)},
 			[]protocol.ChainSelector{polySel})
@@ -106,6 +111,7 @@ func TestGetLegacyChains(t *testing.T) {
 	})
 
 	t.Run("no config chains is not an error", func(t *testing.T) {
+		t.Parallel()
 		chains, missing, err := GetLegacyChains(ctx, lggr, nil, nil)
 
 		require.NoError(t, err)
@@ -115,6 +121,7 @@ func TestGetLegacyChains(t *testing.T) {
 }
 
 func TestMissingChains(t *testing.T) {
+	t.Parallel()
 	chains := map[protocol.ChainSelector]struct{}{1: {}}
 
 	require.Equal(t, []protocol.ChainSelector{2, 3},

--- a/core/services/ccv/ccvcommon/common_test.go
+++ b/core/services/ccv/ccvcommon/common_test.go
@@ -1,0 +1,123 @@
+package ccvcommon
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
+	evmmocks "github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm/mocks"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+const (
+	ethereumMainnetChainID = 1
+	polygonMainnetChainID  = 137
+)
+
+// plainChainService is a ChainService that is not a legacyevm.Chain, as in LOOPP mode.
+type plainChainService struct {
+	commontypes.ChainService
+	name string
+}
+
+func (p *plainChainService) Name() string { return p.name }
+
+func (p *plainChainService) GetChainInfo(context.Context) (commontypes.ChainInfo, error) {
+	return commontypes.ChainInfo{}, nil
+}
+
+// newMockChain makes a legacyevm.Chain mock for the given EVM chain ID.
+func newMockChain(t *testing.T, chainID int64) *evmmocks.Chain {
+	c := evmmocks.NewChain(t)
+	c.EXPECT().GetChainInfo(mockAnyCtx()).Return(commontypes.ChainInfo{}, nil).Maybe()
+	c.EXPECT().ID().Return(big.NewInt(chainID)).Maybe()
+	c.EXPECT().Name().Return("chain-" + big.NewInt(chainID).String()).Maybe()
+	return c
+}
+
+func mockAnyCtx() context.Context { return context.Background() }
+
+func selectorFor(t *testing.T, chainID uint64) protocol.ChainSelector {
+	t.Helper()
+	c, ok := chainselectors.ChainByEvmChainID(chainID)
+	require.True(t, ok)
+	return protocol.ChainSelector(c.Selector)
+}
+
+func TestGetLegacyChains(t *testing.T) {
+	ctx := context.Background()
+	lggr := logger.TestLogger(t)
+
+	ethSel := selectorFor(t, ethereumMainnetChainID)
+	polySel := selectorFor(t, polygonMainnetChainID)
+
+	t.Run("skips a chain whose chain info fails and keeps the others", func(t *testing.T) {
+		bad := evmmocks.NewChain(t)
+		bad.EXPECT().GetChainInfo(mockAnyCtx()).Return(commontypes.ChainInfo{}, errors.New("boom"))
+		bad.EXPECT().Name().Return("bad").Maybe()
+
+		good := newMockChain(t, ethereumMainnetChainID)
+
+		chains, missing, err := GetLegacyChains(ctx, lggr,
+			[]commontypes.ChainService{bad, good}, []protocol.ChainSelector{ethSel, polySel})
+
+		require.NoError(t, err)
+		require.Len(t, chains, 1)
+		require.Contains(t, chains, ethSel)
+		require.Equal(t, []protocol.ChainSelector{polySel}, missing)
+	})
+
+	t.Run("skips a chain service that is not a legacyevm.Chain", func(t *testing.T) {
+		chains, missing, err := GetLegacyChains(ctx, lggr,
+			[]commontypes.ChainService{
+				&plainChainService{name: "loopp"},
+				newMockChain(t, ethereumMainnetChainID),
+			},
+			[]protocol.ChainSelector{ethSel})
+
+		require.NoError(t, err)
+		require.Len(t, chains, 1)
+		require.Empty(t, missing)
+	})
+
+	t.Run("reports a config chain that has no chain service", func(t *testing.T) {
+		chains, missing, err := GetLegacyChains(ctx, lggr,
+			[]commontypes.ChainService{newMockChain(t, ethereumMainnetChainID)},
+			[]protocol.ChainSelector{ethSel, polySel})
+
+		require.NoError(t, err)
+		require.Len(t, chains, 1)
+		require.Equal(t, []protocol.ChainSelector{polySel}, missing)
+	})
+
+	t.Run("errors when no config chain resolves", func(t *testing.T) {
+		_, _, err := GetLegacyChains(ctx, lggr,
+			[]commontypes.ChainService{newMockChain(t, ethereumMainnetChainID)},
+			[]protocol.ChainSelector{polySel})
+
+		require.ErrorContains(t, err, "no chain object is available")
+	})
+
+	t.Run("no config chains is not an error", func(t *testing.T) {
+		chains, missing, err := GetLegacyChains(ctx, lggr, nil, nil)
+
+		require.NoError(t, err)
+		require.Empty(t, chains)
+		require.Empty(t, missing)
+	})
+}
+
+func TestMissingChains(t *testing.T) {
+	chains := map[protocol.ChainSelector]struct{}{1: {}}
+
+	require.Equal(t, []protocol.ChainSelector{2, 3},
+		MissingChains([]protocol.ChainSelector{1, 3, 2, 3}, chains))
+	require.Empty(t, MissingChains([]protocol.ChainSelector{1}, chains))
+}

--- a/core/services/ccv/ccvcommon/missingchains.go
+++ b/core/services/ccv/ccvcommon/missingchains.go
@@ -1,0 +1,139 @@
+package ccvcommon
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+// DefaultMissingChainsReportInterval is the time between two reports of the same missing chain.
+const DefaultMissingChainsReportInterval = 5 * time.Minute
+
+const (
+	keyChainSelector = "chain_selector"
+	keyJobName       = "job_name"
+)
+
+// missingChainsMetrics holds the metric instruments of the MissingChainsMonitor.
+type missingChainsMetrics struct {
+	missingChain metric.Int64Gauge
+}
+
+func newMissingChainsMetrics() (*missingChainsMetrics, error) {
+	missingChain, err := beholder.GetMeter().Int64Gauge("ccv_missing_chain")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ccv_missing_chain gauge: %w", err)
+	}
+	return &missingChainsMetrics{missingChain: missingChain}, nil
+}
+
+// MissingChainsMonitor reports, at a regular interval, each chain that the job configuration names
+// but that has no chain object on this node. The report is a critical log line and a metric with a
+// chain_selector label.
+//
+// The monitor stays healthy. A missing chain is a configuration alarm, not a reason to restart the
+// job.
+type MissingChainsMonitor struct {
+	services.StateMachine
+	lggr     logger.Logger
+	name     string
+	metrics  *missingChainsMetrics
+	missing  []protocol.ChainSelector
+	interval time.Duration
+	stopCh   services.StopChan
+	wg       sync.WaitGroup
+}
+
+// NewMissingChainsMonitor makes a monitor for the given missing chain selectors. It returns a nil
+// monitor when no chain is missing, so that a correctly configured node starts no extra goroutine.
+// The caller must check for nil before it appends the monitor to a service list.
+func NewMissingChainsMonitor(
+	lggr logger.Logger,
+	name string,
+	missing []protocol.ChainSelector,
+	interval time.Duration,
+) (*MissingChainsMonitor, error) {
+	if len(missing) == 0 {
+		return nil, nil
+	}
+	if interval <= 0 {
+		interval = DefaultMissingChainsReportInterval
+	}
+	m, err := newMissingChainsMetrics()
+	if err != nil {
+		return nil, err
+	}
+	return &MissingChainsMonitor{
+		lggr:     lggr.Named("MissingChainsMonitor"),
+		name:     name,
+		metrics:  m,
+		missing:  missing,
+		interval: interval,
+		stopCh:   make(services.StopChan),
+	}, nil
+}
+
+func (m *MissingChainsMonitor) Start(ctx context.Context) error {
+	return m.StartOnce(m.Name(), func() error {
+		m.report(ctx)
+		m.wg.Go(m.reportLoop)
+		return nil
+	})
+}
+
+func (m *MissingChainsMonitor) Close() error {
+	return m.StopOnce(m.Name(), func() error {
+		close(m.stopCh)
+		m.wg.Wait()
+		return nil
+	})
+}
+
+func (m *MissingChainsMonitor) reportLoop() {
+	ctx, cancel := m.stopCh.NewCtx()
+	defer cancel()
+
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.report(ctx)
+		}
+	}
+}
+
+func (m *MissingChainsMonitor) report(ctx context.Context) {
+	for _, sel := range m.missing {
+		m.lggr.Criticalw(
+			"chain in the job configuration has no chain object on this node; the job continues without it",
+			"jobName", m.name,
+			"chainSelector", uint64(sel),
+		)
+		m.metrics.missingChain.Record(ctx, 1, metric.WithAttributes(
+			attribute.String(keyChainSelector, strconv.FormatUint(uint64(sel), 10)),
+			attribute.String(keyJobName, m.name),
+		))
+	}
+}
+
+func (m *MissingChainsMonitor) HealthReport() map[string]error {
+	return map[string]error{m.Name(): m.Ready()}
+}
+
+func (m *MissingChainsMonitor) Name() string {
+	return m.lggr.Name()
+}

--- a/core/services/ccv/ccvcommon/missingchains_test.go
+++ b/core/services/ccv/ccvcommon/missingchains_test.go
@@ -1,6 +1,7 @@
 package ccvcommon
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -13,12 +14,14 @@ import (
 )
 
 func TestNewMissingChainsMonitor_noMissingChains(t *testing.T) {
+	t.Parallel()
 	m, err := NewMissingChainsMonitor(logger.TestLogger(t), "job", nil, time.Second)
 	require.NoError(t, err)
 	require.Nil(t, m)
 }
 
 func TestMissingChainsMonitor_reportsEachChainRepeatedly(t *testing.T) {
+	t.Parallel()
 	lggr, logs := logger.TestLoggerObserved(t, zapcore.DPanicLevel)
 	missing := []protocol.ChainSelector{111, 222}
 
@@ -34,10 +37,17 @@ func TestMissingChainsMonitor_reportsEachChainRepeatedly(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 
 	for _, sel := range missing {
+		var selInt64 int64
+		if sel <= math.MaxInt64 {
+			selInt64 = int64(sel)
+		} else {
+			t.Fatalf("chain selector %v is not an int64", sel)
+		}
+
 		require.NotEmpty(t, logs.FilterField(zapcore.Field{
 			Key:     "chainSelector",
 			Type:    zapcore.Uint64Type,
-			Integer: int64(sel),
+			Integer: selInt64,
 		}).All(), "expected a critical log for chain selector %d", sel)
 	}
 

--- a/core/services/ccv/ccvcommon/missingchains_test.go
+++ b/core/services/ccv/ccvcommon/missingchains_test.go
@@ -1,0 +1,46 @@
+package ccvcommon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func TestNewMissingChainsMonitor_noMissingChains(t *testing.T) {
+	m, err := NewMissingChainsMonitor(logger.TestLogger(t), "job", nil, time.Second)
+	require.NoError(t, err)
+	require.Nil(t, m)
+}
+
+func TestMissingChainsMonitor_reportsEachChainRepeatedly(t *testing.T) {
+	lggr, logs := logger.TestLoggerObserved(t, zapcore.DPanicLevel)
+	missing := []protocol.ChainSelector{111, 222}
+
+	m, err := NewMissingChainsMonitor(lggr, "CCVExecutor/exec-1", missing, 10*time.Millisecond)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+
+	servicetest.Run(t, m)
+
+	// One report happens at start, so wait for a second round of both chains.
+	require.Eventually(t, func() bool {
+		return logs.FilterMessageSnippet("has no chain object on this node").Len() >= 2*len(missing)
+	}, 5*time.Second, 10*time.Millisecond)
+
+	for _, sel := range missing {
+		require.NotEmpty(t, logs.FilterField(zapcore.Field{
+			Key:     "chainSelector",
+			Type:    zapcore.Uint64Type,
+			Integer: int64(sel),
+		}).All(), "expected a critical log for chain selector %d", sel)
+	}
+
+	require.NoError(t, m.Ready(), "a missing chain must not make the monitor unhealthy")
+	require.NoError(t, m.HealthReport()[m.Name()])
+}

--- a/core/services/ccv/ccvexecutor/delegate.go
+++ b/core/services/ccv/ccvexecutor/delegate.go
@@ -82,7 +82,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) (services 
 		chainsInConfig = append(chainsInConfig, protocol.ChainSelector(parsed))
 	}
 
-	legacyChains, err := ccvcommon.GetLegacyChains(ctx, d.lggr, d.chainServices, chainsInConfig)
+	legacyChains, missingChains, err := ccvcommon.GetLegacyChains(ctx, d.lggr, d.chainServices, chainsInConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get legacy chains: %w", err)
 	}
@@ -90,22 +90,61 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) (services 
 	var roundRobins = make(map[protocol.ChainSelector]keys.RoundRobin, len(legacyChains))
 	var fromAddresses = make(map[protocol.ChainSelector][]common.Address, len(legacyChains))
 
+	// A chain that the keystore cannot serve is unusable for the executor, because it cannot
+	// transmit on it. Drop the chain and let the monitor report it, instead of stopping the job.
+	var unusable []protocol.ChainSelector
 	for chainSel := range legacyChains {
 		id, err3 := chainselectors.GetChainIDFromSelector(uint64(chainSel))
 		if err3 != nil {
-			return nil, fmt.Errorf("failed to get chain ID from selector (%d): %w", chainSel, err3)
+			d.lggr.Warnw("skipping chain: failed to get chain ID from selector", "chainSelector", chainSel, "err", err3)
+			unusable = append(unusable, chainSel)
+			continue
 		}
 		chainID, ok := new(big.Int).SetString(id, 10)
 		if !ok {
-			return nil, fmt.Errorf("failed to convert chain ID (%s) to big.Int: %w", id, err3)
+			d.lggr.Warnw("skipping chain: failed to convert chain ID to big.Int", "chainSelector", chainSel, "chainID", id)
+			unusable = append(unusable, chainSel)
+			continue
+		}
+
+		addressesForChain, err3 := d.ethKs.EnabledAddressesForChain(ctx, chainID)
+		if err3 != nil {
+			d.lggr.Warnw("skipping chain: failed to get addresses from eth keystore",
+				"chainSelector", chainSel, "chainID", chainID.String(), "err", err3)
+			unusable = append(unusable, chainSel)
+			continue
+		}
+		if len(addressesForChain) == 0 {
+			d.lggr.Warnw("skipping chain: no enabled address in the eth keystore",
+				"chainSelector", chainSel, "chainID", chainID.String())
+			unusable = append(unusable, chainSel)
+			continue
 		}
 
 		roundRobins[chainSel] = NewRoundRobin(d.ethKs, chainID)
-		addressesForChain, err3 := d.ethKs.EnabledAddressesForChain(ctx, chainID)
-		if err3 != nil {
-			return nil, fmt.Errorf("failed to get all addresses for chain %s from eth keystore: %w", chainID.String(), err3)
-		}
 		fromAddresses[chainSel] = addressesForChain
+	}
+	for _, chainSel := range unusable {
+		delete(legacyChains, chainSel)
+	}
+	missingChains = append(missingChains, unusable...)
+
+	if len(legacyChains) == 0 {
+		return nil, fmt.Errorf("no usable chain remains out of the %d chains in the configuration: %v",
+			len(chainsInConfig), chainsInConfig)
+	}
+
+	missingChainsMonitor, err := ccvcommon.NewMissingChainsMonitor(
+		d.lggr,
+		"CCVExecutor/"+decodedCfg.ExecutorID,
+		missingChains,
+		ccvcommon.DefaultMissingChainsReportInterval,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create missing chains monitor: %w", err)
+	}
+	if missingChainsMonitor != nil {
+		services = append(services, missingChainsMonitor)
 	}
 
 	// TODO: pass secrets as a separate param in the constructor.


### PR DESCRIPTION
Fix an issue where ccv jobs would not start if a job included a chain missing from chain-selector. We now properly skip those and emit loud logs to notify about the misconfiguration. Fixing this allow us to continue running the node with partial chain coverage instead of stopping everything