### PR TITLE
Classify user errors on relay bundles

### DIFF
--- a/core/services/gateway/handlers/confidentialrelay/bundler.go
+++ b/core/services/gateway/handlers/confidentialrelay/bundler.go
@@ -46,6 +46,7 @@ type BundleSummary struct {
 	undecodable int
 	total       int
 	nodeErrors  map[string]string
+	userError   *jsonrpc.WireError
 }
 
 func (s *BundleSummary) Response() *jsonrpc.Response[json.RawMessage] { return s.response }
@@ -53,6 +54,16 @@ func (s *BundleSummary) Signed() int                                  { return s
 func (s *BundleSummary) Error() int                                   { return s.errorCount }
 func (s *BundleSummary) Undecodable() int                             { return s.undecodable }
 func (s *BundleSummary) Total() int                                   { return s.total }
+
+// UserError returns the first user-level (ErrInvalidParams) node error observed,
+// or nil if there was none. A user error is deterministic across the DON, so a
+// single node reporting one identifies the cause for the whole request.
+func (s *BundleSummary) UserError() *jsonrpc.WireError {
+	if s == nil {
+		return nil
+	}
+	return s.userError
+}
 
 // NodeErrorsFormatted returns a stable, compact sample of node error messages
 // for structured logs.
@@ -74,6 +85,9 @@ func (s *BundleSummary) NodeErrorsFormatted() string {
 
 func (s *BundleSummary) addError(nodeAddr string, wireErr *jsonrpc.WireError) {
 	s.errorCount++
+	if wireErr != nil && wireErr.Code == jsonrpc.ErrInvalidParams && s.userError == nil {
+		s.userError = wireErr
+	}
 	if s.nodeErrors == nil {
 		s.nodeErrors = make(map[string]string)
 	}

--- a/core/services/gateway/handlers/confidentialrelay/bundler_test.go
+++ b/core/services/gateway/handlers/confidentialrelay/bundler_test.go
@@ -278,7 +278,7 @@ func TestBundleSummary_UserError(t *testing.T) {
 		s.addError("n2", &jsonrpc.WireError{Code: jsonrpc.ErrInternal, Message: "boom"})
 		got := s.UserError()
 		require.NotNil(t, got)
-		require.Equal(t, int64(jsonrpc.ErrInvalidParams), got.Code)
+		require.Equal(t, jsonrpc.ErrInvalidParams, got.Code)
 		require.Equal(t, "key does not exist", got.Message)
 	})
 

--- a/core/services/gateway/handlers/confidentialrelay/bundler_test.go
+++ b/core/services/gateway/handlers/confidentialrelay/bundler_test.go
@@ -2,6 +2,7 @@ package confidentialrelay
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -256,6 +257,54 @@ func TestBundler_unknownMethod(t *testing.T) {
 	summary, err := b.Bundle(req, map[string]jsonrpc.Response[json.RawMessage]{}, lggr)
 	require.Nil(t, summary)
 	require.ErrorIs(t, err, errUnknownMethod)
+}
+
+func TestBundleSummary_UserError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil when every error is system-level", func(t *testing.T) {
+		t.Parallel()
+		s := newBundleSummary(2)
+		s.addError("n0", &jsonrpc.WireError{Code: jsonrpc.ErrInternal, Message: "boom"})
+		s.addError("n1", nil)
+		require.Nil(t, s.UserError())
+	})
+
+	t.Run("captures one user error among system errors", func(t *testing.T) {
+		t.Parallel()
+		s := newBundleSummary(3)
+		s.addError("n0", &jsonrpc.WireError{Code: jsonrpc.ErrInternal, Message: "boom"})
+		s.addError("n1", &jsonrpc.WireError{Code: jsonrpc.ErrInvalidParams, Message: "key does not exist"})
+		s.addError("n2", &jsonrpc.WireError{Code: jsonrpc.ErrInternal, Message: "boom"})
+		got := s.UserError()
+		require.NotNil(t, got)
+		require.Equal(t, int64(jsonrpc.ErrInvalidParams), got.Code)
+		require.Equal(t, "key does not exist", got.Message)
+	})
+
+	t.Run("keeps the first user error", func(t *testing.T) {
+		t.Parallel()
+		s := newBundleSummary(2)
+		s.addError("n0", &jsonrpc.WireError{Code: jsonrpc.ErrInvalidParams, Message: "first"})
+		s.addError("n1", &jsonrpc.WireError{Code: jsonrpc.ErrInvalidParams, Message: "second"})
+		require.Equal(t, "first", s.UserError().Message)
+	})
+
+	t.Run("captured past the logged-sample cap", func(t *testing.T) {
+		t.Parallel()
+		s := newBundleSummary(maxLoggedNodeErrors + 1)
+		for i := range maxLoggedNodeErrors {
+			s.addError(fmt.Sprintf("n%d", i), &jsonrpc.WireError{Code: jsonrpc.ErrInternal, Message: "boom"})
+		}
+		s.addError("last", &jsonrpc.WireError{Code: jsonrpc.ErrInvalidParams, Message: "key does not exist"})
+		require.NotNil(t, s.UserError(), "the cap limits logged samples, not user-error detection")
+	})
+
+	t.Run("nil summary", func(t *testing.T) {
+		t.Parallel()
+		var s *BundleSummary
+		require.Nil(t, s.UserError())
+	})
 }
 
 func TestSanitizeNodeErrorMessage_Truncates(t *testing.T) {

--- a/core/services/gateway/handlers/confidentialrelay/handler.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler.go
@@ -507,6 +507,24 @@ func (h *handler) forwardBundleOrTerminateIfReady(ctx context.Context, l logger.
 		return h.forwardBundle(ctx, l, ar, summary)
 	}
 	if maxPossibleSigned < minQuorum {
+		// A user-level node error means the request is invalid for every node,
+		// so report it rather than the generic quorum failure.
+		if userErr := summary.UserError(); userErr != nil {
+			l.Warnw("relay quorum unreachable due to a user error; propagating node error",
+				"signed", summary.Signed(),
+				"minQuorum", minQuorum,
+				"collected", summary.Total(),
+				"nodes", nodes,
+				"remaining", remaining,
+				"expired", expired,
+				"errors", summary.Error(),
+				"undecodable", summary.Undecodable(),
+				"userErrorCode", userErr.Code,
+				"nodeErrors", summary.NodeErrorsFormatted(),
+			)
+			return h.sendResponseAndClearRequest(ctx, ar, h.constructErrorResponse(ar.req, api.InvalidParamsError,
+				errors.New(sanitizeNodeErrorMessage(userErr.Message))))
+		}
 		if expired {
 			l.Warnw("request expired before relay quorum was reached",
 				"signed", summary.Signed(),

--- a/core/services/gateway/handlers/confidentialrelay/handler_test.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler_test.go
@@ -357,7 +357,7 @@ func TestConfidentialRelayHandler_TerminalStateBelowQuorumFailsImmediately(t *te
 			Version: jsonrpc.JsonRpcVersion,
 			ID:      req.ID,
 			Method:  MethodCapabilityExec,
-			Error:   &jsonrpc.WireError{Code: -32602, Message: "execution handler not found"},
+			Error:   &jsonrpc.WireError{Code: jsonrpc.ErrInternal, Message: "execution handler not found"},
 		}
 		require.NoError(t, h.HandleNodeMessage(t.Context(), errResp, fmt.Sprintf("0x%04d", i)))
 	}
@@ -405,7 +405,63 @@ func TestConfidentialRelayHandler_QuorumUnreachableFailsImmediately(t *testing.T
 			Version: jsonrpc.JsonRpcVersion,
 			ID:      req.ID,
 			Method:  MethodCapabilityExec,
-			Error:   &jsonrpc.WireError{Code: -32602, Message: "execution handler not found"},
+			Error:   &jsonrpc.WireError{Code: jsonrpc.ErrInternal, Message: "execution handler not found"},
+		}
+		require.NoError(t, h.HandleNodeMessage(t.Context(), errResp, fmt.Sprintf("0x%04d", i)))
+	}
+	wg.Wait()
+	require.Nil(t, h.getActiveRequest(req.ID))
+}
+
+// A single user-level node error is enough to explain an unreachable quorum, so
+// the gateway returns that error and its code rather than the generic quorum
+// failure. Here one ErrInvalidParams arrives between two system errors.
+func TestConfidentialRelayHandler_QuorumUnreachablePropagatesUserError(t *testing.T) {
+	t.Parallel()
+	h, cb, don, _ := setupHandlerWithF(t, 4, 1) // F+1=2
+	don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	params := validCapParamsJSON("wf1")
+	req := jsonrpc.Request[json.RawMessage]{
+		ID:     "req-user-error",
+		Method: MethodCapabilityExec,
+		Params: &params,
+	}
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		resp, err := cb.Wait(t.Context())
+		if !assert.NoError(t, err) { //nolint:testifylint // require illegal inside wg.Go goroutine
+			return
+		}
+		assert.Equal(t, api.InvalidParamsError, resp.ErrorCode)
+		var jsonResp jsonrpc.Response[json.RawMessage]
+		if !assert.NoError(t, json.Unmarshal(resp.RawResponse, &jsonResp)) { //nolint:testifylint // require illegal inside wg.Go goroutine
+			return
+		}
+		if assert.NotNil(t, jsonResp.Error) {
+			assert.Equal(t, int64(jsonrpc.ErrInvalidParams), jsonResp.Error.Code)
+			assert.Contains(t, jsonResp.Error.Message, "key does not exist")
+			assert.NotContains(t, jsonResp.Error.Message, "relay quorum unreachable")
+		}
+	})
+
+	require.NoError(t, h.HandleJSONRPCUserMessage(t.Context(), req, cb))
+
+	nodeErrs := []struct {
+		code int64
+		msg  string
+	}{
+		{jsonrpc.ErrInternal, "node unavailable"},
+		{jsonrpc.ErrInvalidParams, "vault error for secret main/API_TOKEN: key does not exist"},
+		{jsonrpc.ErrInternal, "node unavailable"},
+	}
+	for i, ne := range nodeErrs {
+		errResp := &jsonrpc.Response[json.RawMessage]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      req.ID,
+			Method:  MethodCapabilityExec,
+			Error:   &jsonrpc.WireError{Code: ne.code, Message: ne.msg},
 		}
 		require.NoError(t, h.HandleNodeMessage(t.Context(), errResp, fmt.Sprintf("0x%04d", i)))
 	}

--- a/core/services/gateway/handlers/confidentialrelay/handler_test.go
+++ b/core/services/gateway/handlers/confidentialrelay/handler_test.go
@@ -440,7 +440,7 @@ func TestConfidentialRelayHandler_QuorumUnreachablePropagatesUserError(t *testin
 			return
 		}
 		if assert.NotNil(t, jsonResp.Error) {
-			assert.Equal(t, int64(jsonrpc.ErrInvalidParams), jsonResp.Error.Code)
+			assert.Equal(t, jsonrpc.ErrInvalidParams, jsonResp.Error.Code)
 			assert.Contains(t, jsonResp.Error.Message, "key does not exist")
 			assert.NotContains(t, jsonResp.Error.Message, "relay quorum unreachable")
 		}


### PR DESCRIPTION
If a user error is contained within an unsuccessful response bundle, forward only that user error. This enables the error to be classified as a user error by the enclave, and will prevent them from alerting.

Deployment validation: correct canary behavior in staging.