### PR TITLE
Fix literal from addresses in ETHTx tasks

### DIFF
--- a/core/services/pipeline/task.eth_tx.go
+++ b/core/services/pipeline/task.eth_tx.go
@@ -50,6 +50,21 @@ type ETHKeyStore interface {
 	GetRoundRobinAddress(ctx context.Context, chainID *big.Int, addrs ...common.Address) (common.Address, error)
 }
 
+func literalAddressSlice(value string) GetterFunc {
+	return func() (any, error) {
+		value, err := NonemptyString(value)()
+		if err != nil {
+			return nil, err
+		}
+
+		var address AddressParam
+		if err := address.UnmarshalPipelineParam(value); err != nil {
+			return nil, ErrParameterEmpty
+		}
+		return []common.Address{common.Address(address)}, nil
+	}
+}
+
 var _ Task = (*ETHTxTask)(nil)
 
 func (t *ETHTxTask) Type() TaskType {
@@ -100,7 +115,7 @@ func (t *ETHTxTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, inpu
 		failOnRevert          BoolParam
 	)
 	err = stderrors.Join(
-		errors.Wrap(ResolveParam(&fromAddrs, From(VarExpr(t.From, vars), JSONWithVarExprs(t.From, vars, false), NonemptyString(t.From), nil)), "from"),
+		errors.Wrap(ResolveParam(&fromAddrs, From(VarExpr(t.From, vars), literalAddressSlice(t.From), JSONWithVarExprs(t.From, vars, false), NonemptyString(t.From), nil)), "from"),
 		errors.Wrap(ResolveParam(&toAddr, From(VarExpr(t.To, vars), NonemptyString(t.To))), "to"),
 		errors.Wrap(ResolveParam(&data, From(VarExpr(t.Data, vars), NonemptyString(t.Data))), "data"),
 		errors.Wrap(ResolveParam(&gasLimit, From(VarExpr(t.GasLimit, vars), NonemptyString(t.GasLimit), maximumGasLimit)), "gasLimit"),

--- a/core/services/pipeline/task.eth_tx_test.go
+++ b/core/services/pipeline/task.eth_tx_test.go
@@ -101,6 +101,49 @@ func TestETHTxTask(t *testing.T) {
 			pipeline.RunInfo{},
 		},
 		{
+			"happy (with literal from address)",
+			"0x882969652440ccf14a5dbb9bd53eb21cb1e11e5c",
+			"0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF",
+			"foobar",
+			"12345",
+			`{ "jobID": 321, "requestID": "0x5198616554d738d9485d1a7cf53b2f33e09c3bbc8fe9ac0020bd672cd2bc15d2", "requestTxHash": "0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8" }`,
+			`0`,
+			testutils.FixtureChainID.String(),
+			`{"CheckerType": "vrf_v2", "VRFCoordinatorAddress": "0x2E396ecbc8223Ebc16EC45136228AE5EDB649943"}`,
+			nil,
+			false,
+			pipeline.NewVarsFrom(nil),
+			nil,
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.MockEvmTxManager) {
+				data := []byte("foobar")
+				gasLimit := uint64(12345)
+				jobID := int32(321)
+				addr := common.HexToAddress("0x2E396ecbc8223Ebc16EC45136228AE5EDB649943")
+				txMeta := &txmgr.TxMeta{
+					JobID:         &jobID,
+					RequestID:     &reqID,
+					RequestTxHash: &reqTxHash,
+					FailOnRevert:  null.BoolFrom(false),
+				}
+				keyStore.On("GetRoundRobinAddress", mock.Anything, testutils.FixtureChainID, from).Return(from, nil)
+				txManager.On("CreateTransaction", mock.Anything, txmgr.TxRequest{
+					FromAddress:    from,
+					ToAddress:      to,
+					EncodedPayload: data,
+					FeeLimit:       gasLimit,
+					Meta:           txMeta,
+					Strategy:       txmgrcommon.NewSendEveryStrategy(),
+					Checker: txmgr.TransmitCheckerSpec{
+						CheckerType:           txmgr.TransmitCheckerTypeVRFV2,
+						VRFCoordinatorAddress: &addr,
+					},
+					SignalCallback: true,
+				}).Return(txmgr.Tx{}, nil)
+			},
+			nil, nil, "",
+			pipeline.RunInfo{},
+		},
+		{
 			"happy (with vars)",
 			`[ $(fromAddr) ]`,
 			"$(toAddr)",


### PR DESCRIPTION
Fixes #21768

### Requires

- None.

### Supports

- None.

## Summary

- Accept a literal EVM address for an `ethtx` task's `from` parameter.
- Preserve existing variable-expression and JSON-array `from` behavior.
- Add a regression case for the reported bare-address input.

## Testing

- `./tools/test/.bin/test --ai-output -v -count=1 -run '^TestETHTxTask$' ./core/services/pipeline`

## Risk assessment

Low. The change is limited to `ETHTxTask` parameter resolution and is covered by the focused task suite.

## Review focus

Please verify that `literalAddressSlice` recognizes only valid literal addresses and falls through to the existing JSON/variable resolvers for all other inputs.