### PR TITLE
core/keystore: wrap duplicate-key Import error with ErrKeyExists for Solana and Stellar

### DIFF
--- a/.changeset/solana-stellar-key-exists.md
+++ b/.changeset/solana-stellar-key-exists.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix Solana and Stellar keystore `Import` now wrap the duplicate-key error with `keystore.ErrKeyExists`, so a node that re-imports its `ImportedSolKeys` / `ImportedStellarKeys` on restart skips the already-present key instead of exiting.

--- a/core/services/keystore/solana.go
+++ b/core/services/keystore/solana.go
@@ -128,7 +128,7 @@ func (ks *solana) Import(ctx context.Context, keyJSON []byte, password string) (
 		return solkey.Key{}, errors.Wrap(err, "SolanaKeyStore#ImportKey failed to decrypt key")
 	}
 	if _, found := ks.keyRing.Solana[key.ID()]; found {
-		return solkey.Key{}, fmt.Errorf("key with ID %s already exists", key.ID())
+		return solkey.Key{}, fmt.Errorf("%w: key with ID %s already exists", ErrKeyExists, key.ID())
 	}
 	return key, ks.safeAddKey(ctx, key)
 }

--- a/core/services/keystore/solana_test.go
+++ b/core/services/keystore/solana_test.go
@@ -67,7 +67,7 @@ func Test_SolanaKeyStore_E2E(t *testing.T) {
 		importedKey, err := ks.Import(ctx, exportJSON, cltest.Password)
 		require.NoError(t, err)
 		_, err = ks.Import(ctx, exportJSON, cltest.Password)
-		require.Error(t, err)
+		require.ErrorIs(t, err, keystore.ErrKeyExists)
 		_, err = ks.Import(ctx, []byte(""), cltest.Password)
 		require.Error(t, err)
 		require.Equal(t, key.ID(), importedKey.ID())

--- a/core/services/keystore/stellar.go
+++ b/core/services/keystore/stellar.go
@@ -105,7 +105,7 @@ func (ks *stellar) Import(ctx context.Context, keyJSON []byte, password string) 
 		return stellarkey.Key{}, errors.Wrap(err, "StellarKeyStore#ImportKey failed to decrypt key")
 	}
 	if _, found := ks.keyRing.Stellar[key.ID()]; found {
-		return stellarkey.Key{}, fmt.Errorf("key with ID %s already exists", key.ID())
+		return stellarkey.Key{}, fmt.Errorf("%w: key with ID %s already exists", ErrKeyExists, key.ID())
 	}
 	return key, ks.safeAddKey(ctx, key)
 }

--- a/core/services/keystore/stellar_test.go
+++ b/core/services/keystore/stellar_test.go
@@ -67,7 +67,7 @@ func Test_StellarKeyStore_E2E(t *testing.T) {
 		importedKey, err := ks.Import(ctx, exportJSON, cltest.Password)
 		require.NoError(t, err)
 		_, err = ks.Import(ctx, exportJSON, cltest.Password)
-		require.Error(t, err)
+		require.ErrorIs(t, err, keystore.ErrKeyExists)
 		_, err = ks.Import(ctx, []byte(""), cltest.Password)
 		require.Error(t, err)
 		require.Equal(t, key.ID(), importedKey.ID())


### PR DESCRIPTION
I was reading #23267, which fixed Aptos `Import` so the boot path in `core/cmd/shell_local.go` recognises a duplicate key through `errors.Is(err2, keystore.ErrKeyExists)` and continues instead of calling `s.errorOut`. That PR left the other keystores out on the grounds that they are not on the boot path, where only `EnsureKey` is called. For Solana and Stellar that is not the case: `runNode` loops over `s.Config.ImportedSolKeys()` and `s.Config.ImportedStellarKeys()`, calls `Import`, and relies on the exact same `errors.Is(err2, keystore.ErrKeyExists)` check. Both `Import` methods still return a bare `fmt.Errorf("key with ID %s already exists", ...)`, so the check is false and a node with imported Solana or Stellar keys fails on the second boot, once the key is already in the keyring.

The fix is the same one-liner as the Aptos one, applied to `solana.go` and `stellar.go`. The rendered message becomes `Key already exists: key with ID <id> already exists`, identical in shape to Aptos and DKG recipient. No existing test compares the Solana or Stellar string.

To lock it in, I tightened the duplicate `Import` assertion in `Test_SolanaKeyStore_E2E` and `Test_StellarKeyStore_E2E` from `require.Error` to `require.ErrorIs(t, err, keystore.ErrKeyExists)`. Against a local Postgres 16 prepared with `make testdb`, both tests fail without the change (`Target error should be in err chain: expected: "Key already exists"`) and pass with it. The rest of the Aptos, DKG recipient, P2P and Stellar keystore tests still pass. I only exercised the keystore level, not a full node restart with `[[Solana.Keys]]` secrets. The boot code uses the same `errors.Is` check the test now asserts.

A few other keystores (Cosmos, StarkNet, Sui, TON, Tron, OCR, OCR2, VRF, CSA, Workflow) have the same bare error. They are not imported at boot, and some of their tests compare the exact string, so I left them out to keep this change minimal.

### Requires
None.

### Supports
None.

AI tools used
