### PR TITLE
CRE-5836: Remove legacy DAG guards and wasm host options from workflows

### DIFF
--- a/core/services/workflows/cmd/cre/utils/standalone_engine.go
+++ b/core/services/workflows/cmd/cre/utils/standalone_engine.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -63,16 +62,14 @@ func NewStandaloneEngine(
 	workflowSettingsCfgFn func(*cresettings.Workflows),
 ) (services.Service, []*sdkpb.TriggerSubscription, error) {
 	ctx = contexts.WithCRE(ctx, contexts.CRE{Owner: defaultOwner, Workflow: defaultWorkflowID})
-	labeler := custmsg.NewLabeler()
 	moduleConfig := &host.ModuleConfig{
 		Logger:                  lggr,
-		Labeler:                 labeler,
 		MaxCompressedBinarySize: defaultMaxUncompressedBinarySize,
 		IsUncompressed:          true,
 		Timeout:                 &defaultTimeout,
 	}
 
-	mainModule, err := host.NewModule(ctx, moduleConfig, binary, host.WithDeterminism())
+	mainModule, err := host.NewModule(ctx, moduleConfig, binary)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create module from config: %w", err)
 	}
@@ -128,10 +125,6 @@ func NewStandaloneEngine(
 		}
 
 		billingClient, _ = billing.NewWorkflowClient(lggr, billingClientAddr, clientOpts...)
-	}
-
-	if module.IsLegacyDAG() {
-		return nil, nil, errors.New("legacy DAG workflows are not supported")
 	}
 
 	secretsFetcher, err := NewFileBasedSecrets(secrets)

--- a/core/services/workflows/syncer/v2/handler.go
+++ b/core/services/workflows/syncer/v2/handler.go
@@ -852,12 +852,8 @@ func (h *eventHandler) engineFactoryFn(ctx context.Context, workflowID, owner st
 	lggr := logger.Named(h.lggr, "WorkflowEngine.Module")
 	lggr = logger.With(lggr, "workflowID", workflowID, "workflowName", name, "workflowOwner", owner)
 	var sdkName string
-	h.emitterMu.RLock()
-	labeler := h.emitter
-	h.emitterMu.RUnlock()
 	moduleConfig := &host.ModuleConfig{
 		Logger:                               lggr,
-		Labeler:                              labeler,
 		MemoryLimiter:                        h.engineLimiters.WASMMemorySize,
 		MaxCompressedBinaryLimiter:           h.engineLimiters.WASMCompressedBinarySize,
 		MaxDecompressedBinaryLimiter:         h.engineLimiters.WASMBinarySize,
@@ -878,16 +874,12 @@ func (h *eventHandler) engineFactoryFn(ctx context.Context, workflowID, owner st
 
 	h.lggr.Debugw("Creating module for workflowID", "workflowID", workflowID)
 
-	module, err := host.NewModule(ctx, moduleConfig, binary, host.WithDeterminism())
+	module, err := host.NewModule(ctx, moduleConfig, binary)
 	if err != nil {
 		return nil, err
 	}
 
 	h.lggr.Debugw("Finished creating module for workflowID", "workflowID", workflowID)
-
-	if module.IsLegacyDAG() { // V1 aka "DAG"
-		return nil, errors.New("legacy DAG workflows are not supported")
-	}
 
 	// V2 aka "NoDAG"
 	// Wrap the local WASM module in a RequirementSelectingModule that routes
@@ -965,7 +957,7 @@ func (h *eventHandler) createEngineModule(
 		if storeErr != nil {
 			h.lggr.Warnw("Failed to cache module binary to disk, LRU eviction disabled for this workflow", "workflowID", workflowID, "err", storeErr)
 		} else {
-			evictable := NewEvictableModule(module, moduleConfig, h.moduleStore, workflowID, h.moduleEngineVersion, nil, h.cacheMetrics, int64(len(binary)), host.WithDeterminism())
+			evictable := NewEvictableModule(module, moduleConfig, h.moduleStore, workflowID, h.moduleEngineVersion, nil, h.cacheMetrics, int64(len(binary)))
 			h.moduleLRU.Register(workflowID, evictable)
 			engineModule = evictable
 		}


### PR DESCRIPTION
Prepares chainlink for the removal of the legacy DAG WASM host from chainlink-common (CRE-5836): drops the WithDeterminism() module option, the ModuleConfig Labeler field and the IsLegacyDAG() rejection guards in the syncer handler and standalone engine.

The V2 host has a different random seed based on execution ID. Also V2 user-facing output flows via ExecutionHelper, not labeler.

The IsLegacyDAG() methods on EvictableModule, ConfidentialModule and test fakes are deliberately kept: the pinned chainlink-common still requires them on host.ModuleBase, and they remain harmless (unused extra methods) once the post-cleanup common lands. They are deleted together with the next common pin bump.

See https://github.com/smartcontractkit/chainlink-common/pull/2382

Deployment Validation: Existing canaries.